### PR TITLE
fix(reader): translucent system bars instead of opaque white strip in Immersive exit

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/MainActivity.kt
+++ b/app/src/main/kotlin/com/riffle/app/MainActivity.kt
@@ -1,9 +1,11 @@
 package com.riffle.app
 
+import android.os.Build
 import android.os.Bundle
 import android.view.KeyEvent
 import android.view.View
 import android.view.ViewGroup
+import androidx.activity.SystemBarStyle
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.fragment.app.Fragment
@@ -50,7 +52,20 @@ class MainActivity : FragmentActivity() {
             .stateIn(lifecycleScope, SharingStarted.Eagerly, true)
         invertVolumeKeys = volumeKeyPreferencesStore.invertVolumeKeys
             .stateIn(lifecycleScope, SharingStarted.Eagerly, false)
-        enableEdgeToEdge()
+        // Status bar fully transparent; navigation bar gets a light translucent scrim so the
+        // home/back/recents icons stay legible over reader content without producing a solid
+        // strip when Immersive mode exits. The OS contrast scrim is disabled so only our
+        // explicit alpha values apply.
+        val transparent = android.graphics.Color.TRANSPARENT
+        val navScrim = android.graphics.Color.argb(0x99, 0, 0, 0) // ~60% black
+        enableEdgeToEdge(
+            statusBarStyle = SystemBarStyle.auto(transparent, transparent),
+            navigationBarStyle = SystemBarStyle.auto(navScrim, navScrim),
+        )
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            window.isNavigationBarContrastEnforced = false
+            window.isStatusBarContrastEnforced = false
+        }
         setContent {
             RiffleTheme {
                 MainScreen()

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -17,7 +17,6 @@ import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -164,16 +163,18 @@ fun EpubReaderScreen(
     // TopAppBar floats as an overlay so its show/hide never resizes the content area —
     // eliminates the compound flicker that Scaffold's topBar slot caused by reflowing the
     // WebView simultaneously with the system-bar animation.
+    //
+    // The WebView is intentionally NOT padded by navigationBarsPadding: with transparent
+    // system bars (see MainActivity.enableEdgeToEdge + themes.xml), the page extends edge
+    // to edge and the nav bar floats over the last sliver of content. Padding would carve
+    // out a solid strip behind the bar that doesn't blend with any reader theme — exactly
+    // the "white/black bar" the user reported when exiting Immersive mode.
     Box(modifier = Modifier.fillMaxSize()) {
-        // navigationBarsPadding only — status bar insets are consumed at the AndroidView
-        // root (see ViewCompat.setOnApplyWindowInsetsListener in EpubNavigatorView) so
-        // they never reach Readium's WebViews. The floating TopAppBar carries its own
+        // Status bar insets are consumed at the AndroidView root (see
+        // ViewCompat.setOnApplyWindowInsetsListener in EpubNavigatorView) so they never
+        // reach Readium's WebViews. The floating TopAppBar carries its own
         // TopAppBarDefaults.windowInsets to position itself below the status bar when visible.
-        Box(
-            modifier = Modifier
-                .fillMaxSize()
-                .navigationBarsPadding(),
-        ) {
+        Box(modifier = Modifier.fillMaxSize()) {
             when (val s = state) {
                 ReaderState.Loading -> {
                     CircularProgressIndicator(
@@ -288,6 +289,7 @@ fun EpubReaderScreen(
                             }
                         }
                     },
+                    colors = readerTopAppBarColors(),
                 )
             }
         }
@@ -315,6 +317,17 @@ fun EpubReaderScreen(
         }
     }
 }
+
+// Reader TopAppBar palette: ~60% black scrim matching the system nav bar so both bars
+// read as translucent overlays on the page rather than opaque chrome.
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun readerTopAppBarColors() = androidx.compose.material3.TopAppBarDefaults.topAppBarColors(
+    containerColor = androidx.compose.ui.graphics.Color.Black.copy(alpha = 0.6f),
+    titleContentColor = androidx.compose.ui.graphics.Color.White,
+    navigationIconContentColor = androidx.compose.ui.graphics.Color.White,
+    actionIconContentColor = androidx.compose.ui.graphics.Color.White,
+)
 
 // Isolated scope: cursorPosition updates only recompose this composable, not sibling EpubNavigatorView.
 @Composable

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/PdfReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/PdfReaderScreen.kt
@@ -170,6 +170,7 @@ fun PdfReaderScreen(
                         Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
                     }
                 },
+                colors = readerTopAppBarColors(),
             )
         }
     }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/SearchTopBar.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/SearchTopBar.kt
@@ -59,6 +59,7 @@ fun SearchTopBar(
 
     TopAppBar(
         windowInsets = TopAppBarDefaults.windowInsets,
+        colors = readerTopAppBarColors(),
         navigationIcon = {
             IconButton(onClick = onNavigateBack) {
                 Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
@@ -68,7 +69,7 @@ fun SearchTopBar(
             TextField(
                 value = query,
                 onValueChange = onQueryChange,
-                placeholder = { Text("Search in book…") },
+                placeholder = { Text("Search in book…", color = Color.White.copy(alpha = 0.6f)) },
                 singleLine = true,
                 keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
                 keyboardActions = KeyboardActions(onSearch = {}),
@@ -77,6 +78,9 @@ fun SearchTopBar(
                     unfocusedContainerColor = Color.Transparent,
                     focusedIndicatorColor = Color.Transparent,
                     unfocusedIndicatorColor = Color.Transparent,
+                    focusedTextColor = Color.White,
+                    unfocusedTextColor = Color.White,
+                    cursorColor = Color.White,
                 ),
                 modifier = Modifier
                     .fillMaxWidth()
@@ -88,7 +92,7 @@ fun SearchTopBar(
             Text(
                 text = countText,
                 style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                color = Color.White.copy(alpha = 0.7f),
                 modifier = Modifier
                     .padding(end = 4.dp)
                     .testTag(SearchTopBarTags.COUNT),

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,4 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <style name="Theme.Riffle" parent="android:Theme.Material.Light.NoActionBar" />
+    <style name="Theme.Riffle" parent="android:Theme.Material.Light.NoActionBar">
+        <!-- Required on the AOSP Material parent so enableEdgeToEdge() can actually
+             control the system bar colors at runtime; without it the platform composites
+             its own opaque backgrounds. -->
+        <item name="android:windowDrawsSystemBarBackgrounds">true</item>
+    </style>
 </resources>


### PR DESCRIPTION
## Summary
- Status bar is now fully transparent; navigation bar uses a ~60% black scrim so home/back/recents icons stay legible without producing an opaque strip when exiting Immersive mode.
- Reader top bars (EPUB, PDF, search) adopt the same scrim/white-content palette so both system bars read as translucent overlays on the page.
- Adds `android:windowDrawsSystemBarBackgrounds=true` to `Theme.Riffle` so `enableEdgeToEdge()` can actually control system bar colors at runtime; disables OS contrast enforcement on Q+ so only our alpha values apply.
- Removes `navigationBarsPadding` from the EPUB WebView container so content extends edge-to-edge under the translucent nav bar (avoids the reported white/black bar artifact).

## Test plan
- [x] Open an EPUB, enter Immersive mode, then tap to exit — verify no opaque white/black strip appears at the bottom.
- [x] Verify nav icons remain legible over light and dark page themes.
- [x] Open the search top bar in the reader; placeholder, text, and supporting text should be readable on the scrim.
- [x] Repeat for the PDF reader.