### PR TITLE
Add Ko-fi support link to navigation drawer

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/navigation/NavigationDrawerComposable.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/navigation/NavigationDrawerComposable.kt
@@ -37,6 +37,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.style.TextAlign
@@ -100,6 +101,17 @@ fun RiffleNavigationDrawer(
                         icon = { Icon(Icons.Default.Settings, contentDescription = null) },
                         selected = false,
                         onClick = onSettingsSelected,
+                    )
+                    val uriHandler = LocalUriHandler.current
+                    Text(
+                        text = "☕ Support on Ko-fi",
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f),
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clickable { uriHandler.openUri("https://ko-fi.com/pkmetski") }
+                            .padding(top = 8.dp, bottom = 2.dp),
+                        textAlign = TextAlign.Center,
                     )
                     Text(
                         text = "Riffle v${BuildConfig.VERSION_NAME}",


### PR DESCRIPTION
## Summary
- Adds a small "☕ Support on Ko-fi" link above the version label at the bottom of the navigation drawer, opening https://ko-fi.com/pkmetski via `LocalUriHandler`.

## Test plan
- [ ] Open the drawer; verify the Ko-fi line appears just above the version footer.
- [ ] Tap it and confirm the Ko-fi page opens in the browser.