### PR TITLE
fix(release): pick single apksigner when multiple build-tools versions exist

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,7 +69,8 @@ jobs:
       - name: Verify APK is signed
         run: |
           APK=$(ls app/build/outputs/apk/release/*.apk | head -1)
-          "$ANDROID_HOME"/build-tools/*/apksigner verify --verbose "$APK"
+          APKSIGNER=$(ls -d "$ANDROID_HOME"/build-tools/*/apksigner | sort -V | tail -1)
+          "$APKSIGNER" verify --verbose "$APK"
 
       - name: Write F-Droid changelog
         env:


### PR DESCRIPTION
## Summary
- The release workflow's `Verify APK is signed` step failed on the v1.0.0 tag build (run [26635723770](https://github.com/pkmetski/riffle/actions/runs/26635723770/job/78495402315)) with `Unsupported command: /usr/local/lib/android/sdk/build-tools/35.0.0/apksigner`.
- Root cause: `"$ANDROID_HOME"/build-tools/*/apksigner` is a bare glob. The runner now has multiple build-tools versions installed, so the shell expanded it to two paths — the first was treated as the binary, the second as a command argument.
- Fix: resolve the glob to a single path (highest version) before invoking apksigner.

## Test plan
- [x] Reproduced locally with 5 build-tools versions: bare glob expands to 8 argv entries (apksigner sees a sibling path as its first arg → `Unsupported command`). Fix collapses to 4 entries with the highest-versioned apksigner as argv[0].
- [ ] Push a new tag once merged and confirm the `Verify APK is signed` step passes end-to-end.