### PR TITLE
fix(release): open PR for changelog instead of pushing to protected main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,7 +69,8 @@ jobs:
       - name: Verify APK is signed
         run: |
           APK=$(ls app/build/outputs/apk/release/*.apk | head -1)
-          "$ANDROID_HOME"/build-tools/*/apksigner verify --verbose "$APK"
+          APKSIGNER=$(ls -d "$ANDROID_HOME"/build-tools/*/apksigner | sort -V | tail -1)
+          "$APKSIGNER" verify --verbose "$APK"
 
       - name: Write F-Droid changelog
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   release:
@@ -81,15 +82,30 @@ jobs:
           mkdir -p "$DIR"
           echo "Release v$NAME — see https://github.com/${{ github.repository }}/releases/tag/v$NAME" > "$DIR/$CODE.txt"
 
-      - name: Commit changelog back to main
+      - name: Open changelog PR against main
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NAME: ${{ steps.ver.outputs.name }}
+          CODE: ${{ steps.ver.outputs.code }}
         run: |
+          BRANCH="chore/fdroid-changelog-v$NAME"
           git config user.name 'github-actions[bot]'
           git config user.email 'github-actions[bot]@users.noreply.github.com'
           git fetch origin main
-          git checkout main
-          git add fastlane/metadata/android/en-US/changelogs/${{ steps.ver.outputs.code }}.txt
-          git commit -m "chore(fdroid): changelog for v${{ steps.ver.outputs.name }}" || echo "no change"
-          git push origin main
+          git checkout -B "$BRANCH" origin/main
+          git add "fastlane/metadata/android/en-US/changelogs/$CODE.txt"
+          if git diff --cached --quiet; then
+            echo "No changelog change to commit."
+            exit 0
+          fi
+          git commit -m "chore(fdroid): changelog for v$NAME"
+          git push -f origin "$BRANCH"
+          gh pr create \
+            --base main \
+            --head "$BRANCH" \
+            --title "chore(fdroid): changelog for v$NAME" \
+            --body "Auto-generated F-Droid changelog for release v$NAME." \
+            || echo "PR already exists for $BRANCH"
 
       - name: Upload APK to GitHub Release
         uses: softprops/action-gh-release@v3


### PR DESCRIPTION
## Summary
- After the apksigner fix landed (#12), the v1.0.1 tag build progressed further but failed at `Commit changelog back to main` with `GH006: Protected branch update failed` — `main` requires PRs.
- Switch the step to push the changelog to `chore/fdroid-changelog-vX.Y.Z` and open a PR via `gh pr create`.
- Add `pull-requests: write` to workflow permissions.

## Caveat
PRs opened by `GITHUB_TOKEN` do **not** trigger downstream workflow runs (a GitHub security guard against recursive CI). The auto-opened changelog PR will sit with no status checks, and since `main` requires checks, it can't merge as-is. Options:
1. Close & reopen the PR manually to kick off checks (simplest).
2. Push an empty commit to the PR branch to trigger checks.
3. Swap `GH_TOKEN` for a PAT stored as a secret (e.g. `RELEASE_PAT`) so the PR's commits are attributed to a real user and trigger workflows.

Option 3 is the cleanest long-term fix if this is frequent. Happy to follow up with a PAT-based change if you want.

## Test plan
- [ ] Merge, push a new tag, and confirm the workflow opens a PR instead of failing.
- [ ] Decide whether to adopt option 3 (PAT) so the changelog PR is auto-mergeable.