### PR TITLE
Nav-bar scrim on gesture-nav, auto-resize reader title, Ko-fi typography

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/MainActivity.kt
+++ b/app/src/main/kotlin/com/riffle/app/MainActivity.kt
@@ -8,6 +8,10 @@ import android.view.ViewGroup
 import androidx.activity.SystemBarStyle
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
 import androidx.fragment.app.FragmentFactory
@@ -17,6 +21,7 @@ import com.riffle.app.feature.reader.VolumeKeyEventHandler
 import com.riffle.app.feature.reader.VolumeNavEvent
 import com.riffle.app.feature.reader.VolumeNavigationController
 import com.riffle.app.navigation.MainScreen
+import com.riffle.app.ui.BottomNavBarScrim
 import com.riffle.app.ui.theme.RiffleTheme
 import com.riffle.core.domain.VolumeKeyPreferencesStore
 import dagger.hilt.android.AndroidEntryPoint
@@ -52,15 +57,16 @@ class MainActivity : FragmentActivity() {
             .stateIn(lifecycleScope, SharingStarted.Eagerly, true)
         invertVolumeKeys = volumeKeyPreferencesStore.invertVolumeKeys
             .stateIn(lifecycleScope, SharingStarted.Eagerly, false)
-        // Status bar fully transparent; navigation bar gets a light translucent scrim so the
-        // home/back/recents icons stay legible over reader content without producing a solid
-        // strip when Immersive mode exits. The OS contrast scrim is disabled so only our
-        // explicit alpha values apply.
+        // Both system bars are fully transparent at the OS level. The app draws its own
+        // scrim under the nav-bar inset area (BottomNavBarScrim, applied globally in
+        // setContent below) so the look is identical across gesture-nav devices (where
+        // Android forces navigationBarColor transparent regardless of what we pass) and
+        // 3-button-nav devices. The OS contrast scrim is disabled so it can't double up
+        // with the app-drawn scrim.
         val transparent = android.graphics.Color.TRANSPARENT
-        val navScrim = android.graphics.Color.argb(0x99, 0, 0, 0) // ~60% black
         enableEdgeToEdge(
             statusBarStyle = SystemBarStyle.auto(transparent, transparent),
-            navigationBarStyle = SystemBarStyle.auto(navScrim, navScrim),
+            navigationBarStyle = SystemBarStyle.auto(transparent, transparent),
         )
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
             window.isNavigationBarContrastEnforced = false
@@ -68,7 +74,10 @@ class MainActivity : FragmentActivity() {
         }
         setContent {
             RiffleTheme {
-                MainScreen()
+                Box(Modifier.fillMaxSize()) {
+                    MainScreen()
+                    BottomNavBarScrim(modifier = Modifier.align(Alignment.BottomCenter))
+                }
             }
         }
     }

--- a/app/src/main/kotlin/com/riffle/app/feature/navigation/NavigationDrawerComposable.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/navigation/NavigationDrawerComposable.kt
@@ -105,7 +105,7 @@ fun RiffleNavigationDrawer(
                     val uriHandler = LocalUriHandler.current
                     Text(
                         text = "☕ Support on Ko-fi",
-                        style = MaterialTheme.typography.labelSmall,
+                        style = MaterialTheme.typography.bodyMedium,
                         color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f),
                         modifier = Modifier
                             .fillMaxWidth()

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/AutoResizeText.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/AutoResizeText.kt
@@ -1,0 +1,52 @@
+package com.riffle.app.feature.reader
+
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.TextUnit
+import androidx.compose.ui.unit.sp
+
+/**
+ * Text that shrinks its font size to fit the available width/height,
+ * falling back to ellipsis once it hits [minFontSize].
+ */
+@Composable
+fun AutoResizeText(
+    text: String,
+    style: TextStyle,
+    modifier: Modifier = Modifier,
+    maxLines: Int = 2,
+    minFontSize: TextUnit = 10.sp,
+) {
+    var resizedStyle by remember(text, style.fontSize, maxLines) { mutableStateOf(style) }
+    var readyToDraw by remember(text, style.fontSize, maxLines) { mutableStateOf(false) }
+
+    Text(
+        text = text,
+        style = resizedStyle,
+        maxLines = maxLines,
+        softWrap = maxLines > 1,
+        overflow = TextOverflow.Ellipsis,
+        modifier = modifier.drawWithContent { if (readyToDraw) drawContent() },
+        onTextLayout = { result ->
+            if (result.hasVisualOverflow) {
+                val next = resizedStyle.fontSize * 0.95f
+                if (next.value >= minFontSize.value) {
+                    resizedStyle = resizedStyle.copy(fontSize = next)
+                } else {
+                    resizedStyle = resizedStyle.copy(fontSize = minFontSize)
+                    readyToDraw = true
+                }
+            } else {
+                readyToDraw = true
+            }
+        },
+    )
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -270,7 +270,7 @@ fun EpubReaderScreen(
                 )
             } else {
                 TopAppBar(
-                    title = { Text(title, style = MaterialTheme.typography.titleMedium) },
+                    title = { AutoResizeText(title, style = MaterialTheme.typography.titleMedium) },
                     navigationIcon = {
                         IconButton(onClick = onNavigateBack) {
                             Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -318,12 +318,12 @@ fun EpubReaderScreen(
     }
 }
 
-// Reader TopAppBar palette: ~60% black scrim matching the system nav bar so both bars
-// read as translucent overlays on the page rather than opaque chrome.
+// Reader TopAppBar palette: same translucent black as the global nav-bar scrim so both
+// bars read as a single translucent overlay on the page rather than opaque chrome.
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 internal fun readerTopAppBarColors() = androidx.compose.material3.TopAppBarDefaults.topAppBarColors(
-    containerColor = androidx.compose.ui.graphics.Color.Black.copy(alpha = 0.6f),
+    containerColor = com.riffle.app.ui.bottomBarScrimColor(),
     titleContentColor = androidx.compose.ui.graphics.Color.White,
     navigationIconContentColor = androidx.compose.ui.graphics.Color.White,
     actionIconContentColor = androidx.compose.ui.graphics.Color.White,

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/PdfReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/PdfReaderScreen.kt
@@ -164,7 +164,7 @@ fun PdfReaderScreen(
             exit = slideOutVertically(targetOffsetY = { -it }) + shrinkVertically(shrinkTowards = Alignment.Top),
         ) {
             TopAppBar(
-                title = { Text(title, style = MaterialTheme.typography.titleMedium) },
+                title = { AutoResizeText(title, style = MaterialTheme.typography.titleMedium) },
                 navigationIcon = {
                     IconButton(onClick = onNavigateBack) {
                         Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")

--- a/app/src/main/kotlin/com/riffle/app/ui/SystemBarScrim.kt
+++ b/app/src/main/kotlin/com/riffle/app/ui/SystemBarScrim.kt
@@ -1,0 +1,30 @@
+package com.riffle.app.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.windowInsetsBottomHeight
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+
+// Translucent black used for the nav-bar scrim and the reader TopAppBar. ~60% alpha keeps
+// content faintly visible while giving system icons enough contrast to stay legible.
+fun bottomBarScrimColor(): Color = Color.Black.copy(alpha = 0.6f)
+
+// Paints a translucent strip under the OS navigation bar inset. Necessary because Android
+// forces navigationBarColor transparent on gesture-nav devices regardless of what we pass
+// to enableEdgeToEdge — without this scrim the gesture pill / nav buttons sit on bare app
+// content. Height tracks WindowInsets.navigationBars, so when bars are hidden (e.g. reader
+// immersive mode) the inset collapses to 0 and the scrim disappears automatically.
+@Composable
+fun BottomNavBarScrim(modifier: Modifier = Modifier) {
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .windowInsetsBottomHeight(WindowInsets.navigationBars)
+            .background(bottomBarScrimColor()),
+    )
+}


### PR DESCRIPTION
## Summary

Three independent changes bundled on this branch:

- **fix(ui): paint app-drawn scrim under nav bar on gesture-nav devices** — Android forces `navigationBarColor` transparent on gesture-nav devices regardless of what we pass to `enableEdgeToEdge`, so the previous translucent `SystemBarStyle` was a no-op on those devices and the gesture pill / nav buttons sat on bare content. Draw a 60% black scrim ourselves under the `WindowInsets.navigationBars` region at the app root. Applied globally so it's consistent on every screen (library, settings, reader), not just the reader. In reader immersive mode the system bar is hidden, the inset collapses to 0, and the scrim disappears automatically. Reader `TopAppBar` reuses the same color so both bars read as a single translucent overlay.
- **feat(reader): auto-shrink book title in TopAppBar** — long titles previously truncated at the base font size. New `AutoResizeText` iteratively shrinks font size by 5% until the text fits within `maxLines` (default 2), bottoming out at `minFontSize` (10sp) before ellipsizing. Applied to both EPUB and PDF reader top bars.
- **style(nav): bump Ko-fi support link** from `labelSmall` to `bodyMedium` so it matches the visual weight of other drawer items.

## Test plan

- [ ] Verify nav bar scrim is visible on a gesture-nav physical device on the library screen
- [ ] Verify nav bar scrim is visible on a 3-button-nav device on the library screen
- [ ] Open a reader, toggle immersive on/off — scrim should appear/disappear with the system bar
- [ ] Open an EPUB with a very long title, confirm the title shrinks to fit and only ellipsizes at the floor
- [ ] Open the navigation drawer, confirm the Ko-fi link is more prominent than before