### PR TITLE
fix(reader): force typography overrides past high-specificity publisher CSS

### DIFF
--- a/app/src/androidTest/kotlin/com/riffle/app/feature/reader/FormattingPreferencesMapperTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/reader/FormattingPreferencesMapperTest.kt
@@ -44,7 +44,7 @@ class FormattingPreferencesMapperTest {
         val result = FormattingPreferences(theme = ReaderTheme.DarkDim).toEpubPreferences()
         assertEquals(Theme.DARK, result.theme)
         // Slightly dimmer than pure white — see DARK_DIM_TEXT_COLOR in FormattingPreferencesMapper.
-        assertEquals(0xFFBBBBBB.toInt(), result.textColor?.int)
+        assertEquals(0xFFAAAAAA.toInt(), result.textColor?.int)
     }
 
     @Test
@@ -53,10 +53,14 @@ class FormattingPreferencesMapperTest {
         assertEquals(Theme.SEPIA, result.theme)
     }
 
+    // Serif is the default ReaderFontFamily; mapping it to null leaves --USER__fontFamily
+    // unset on :root so the publisher's typography is preserved on books the user hasn't
+    // customized. See typographyOverrideCss() — the gate `:root[style*="--USER__fontFamily"]`
+    // requires the variable to be present for any override to apply.
     @Test
-    fun serifFontFamilyMapsToCssSerif() {
+    fun defaultSerifFontFamilyMapsToNullSoPublisherTypographyIsPreserved() {
         val result = FormattingPreferences(fontFamily = ReaderFontFamily.Serif).toEpubPreferences()
-        assertEquals("serif", result.fontFamily?.name)
+        assertNull(result.fontFamily)
     }
 
     @Test
@@ -90,9 +94,19 @@ class FormattingPreferencesMapperTest {
     }
 
     @Test
-    fun lineSpacingMapsToLineHeight() {
+    fun customLineSpacingMapsToLineHeight() {
         val result = FormattingPreferences(lineSpacing = 1.8f).toEpubPreferences()
         assertEquals(1.8, result.lineHeight!!, 0.001)
+    }
+
+    // Default lineSpacing must map to null so Readium leaves --USER__lineHeight unset on :root,
+    // which keeps the publisher's line-height intact on books the user hasn't customized.
+    // Without this, every book would have its publisher line-height overridden the moment our
+    // typography-override stylesheet is injected.
+    @Test
+    fun defaultLineSpacingMapsToNullLineHeight() {
+        val result = FormattingPreferences().toEpubPreferences()
+        assertNull(result.lineHeight)
     }
 
     @Test
@@ -160,10 +174,13 @@ class FormattingPreferencesMapperTest {
         assertEquals(org.readium.r2.navigator.preferences.TextAlign.JUSTIFY, result.textAlign)
     }
 
+    // Same null-gating rationale as defaultLineSpacingMapsToNullLineHeight: the default
+    // (unjustified) state must leave --USER__textAlign unset so the publisher's text alignment
+    // is preserved.
     @Test
-    fun justifyTextFalseMapsToTextAlignStart() {
+    fun justifyTextFalseMapsToNullTextAlign() {
         val result = FormattingPreferences(justifyText = false).toEpubPreferences()
-        assertEquals(org.readium.r2.navigator.preferences.TextAlign.START, result.textAlign)
+        assertNull(result.textAlign)
     }
 
 }

--- a/app/src/androidTest/kotlin/com/riffle/app/feature/reader/TypographyOverrideWebViewTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/reader/TypographyOverrideWebViewTest.kt
@@ -1,0 +1,175 @@
+package com.riffle.app.feature.reader
+
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * End-to-end verification that the typography-override CSS actually beats hostile publisher
+ * styles in a real WebView. The fixture HTML mirrors the Safari Books Online pattern that
+ * caused the original bug — every text rule is scoped under an ID selector
+ * (`#sbo-rt-content p { line-height: 125% }`) which beats Readium's own body-level
+ * user-property rules.
+ *
+ * These tests would have caught the bug before it shipped, and will catch any future
+ * regression where the override stops winning the cascade (e.g. Readium renaming the
+ * `--USER__*` variable channel, the gate selector being mistyped, or `!important` being
+ * dropped from the override block).
+ */
+@RunWith(AndroidJUnit4::class)
+class TypographyOverrideWebViewTest {
+
+    // Hostile fixture: ID-scoped publisher rules with high specificity but no `!important`.
+    // Mirrors the Safari Books Online template that the bug-report book uses.
+    private val hostileSboFixture = """
+        <!DOCTYPE html>
+        <html>
+          <head>
+            <style>
+              #sbo-rt-content p { line-height: 125%; text-align: left; font-family: serif; }
+              p { font-size: 16px; }
+            </style>
+          </head>
+          <body>
+            <div id="sbo-rt-content">
+              <p id="target">Quod erat demonstrandum.</p>
+            </div>
+          </body>
+        </html>
+    """.trimIndent()
+
+    @Test
+    fun overrideIsInertWhenUserVariableIsNotSetOnRoot() {
+        withFixture(hostileSboFixture) { webView ->
+            // No --USER__lineHeight on :root → gate doesn't match → override inert →
+            // publisher's 125% must win.
+            webView.evalSync(typographyOverrideInjectionJs())
+            val lineHeightPx = webView.evalSync(
+                "window.getComputedStyle(document.getElementById('target')).lineHeight"
+            ).toCssPx()
+            val fontSizePx = webView.evalSync(
+                "window.getComputedStyle(document.getElementById('target')).fontSize"
+            ).toCssPx()
+            // 125% of 16px = 20px; assert ratio ~1.25 (publisher's value, NOT a user override).
+            assertEquals(1.25, lineHeightPx / fontSizePx, 0.05)
+        }
+    }
+
+    @Test
+    fun overrideWinsWhenUserVariableIsSetOnRoot() {
+        withFixture(hostileSboFixture) { webView ->
+            // User customised line-spacing → Readium would write --USER__lineHeight on :root.
+            // We simulate that here, then inject our override. Without the override the
+            // publisher's #sbo-rt-content p { line-height: 125% } would still win because
+            // specificity (1,0,1) beats anything Readium can do at `body` level with !important
+            // (cascade per-element ignores body !important when <p> has its own rule).
+            webView.evalSync("document.documentElement.style.setProperty('--USER__lineHeight', '1.8')")
+            webView.evalSync(typographyOverrideInjectionJs())
+            val lineHeightPx = webView.evalSync(
+                "window.getComputedStyle(document.getElementById('target')).lineHeight"
+            ).toCssPx()
+            val fontSizePx = webView.evalSync(
+                "window.getComputedStyle(document.getElementById('target')).fontSize"
+            ).toCssPx()
+            assertEquals(
+                "Override should force line-height to user value (1.8 × fontSize), not the publisher's 125%",
+                1.8, lineHeightPx / fontSizePx, 0.05,
+            )
+        }
+    }
+
+    @Test
+    fun overrideWinsForJustifyText() {
+        withFixture(hostileSboFixture) { webView ->
+            webView.evalSync("document.documentElement.style.setProperty('--USER__textAlign', 'justify')")
+            webView.evalSync(typographyOverrideInjectionJs())
+            val textAlign = webView.evalSync(
+                "window.getComputedStyle(document.getElementById('target')).textAlign"
+            ).trim('"')
+            assertEquals("justify", textAlign)
+        }
+    }
+
+    @Test
+    fun overrideIsInertForTextAlignWhenUserVariableIsNotSet() {
+        withFixture(hostileSboFixture) { webView ->
+            webView.evalSync(typographyOverrideInjectionJs())
+            val textAlign = webView.evalSync(
+                "window.getComputedStyle(document.getElementById('target')).textAlign"
+            ).trim('"')
+            // Publisher said `text-align: left` and no user var set → publisher should win.
+            assertEquals("left", textAlign)
+        }
+    }
+
+    @Test
+    fun repeatedInjectionDoesNotAccumulateStyleElements() {
+        withFixture(hostileSboFixture) { webView ->
+            repeat(5) { webView.evalSync(typographyOverrideInjectionJs()) }
+            val count = webView.evalSync(
+                "document.querySelectorAll('#riffle-typography-override').length.toString()"
+            ).trim('"').toInt()
+            assertEquals("Idempotent injection should only ever leave one <style> in the head", 1, count)
+        }
+    }
+
+    // ---- helpers ----
+
+    private fun withFixture(html: String, block: (WebView) -> Unit) {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+        val ready = CountDownLatch(1)
+        val webViewHolder = arrayOfNulls<WebView>(1)
+        instrumentation.runOnMainSync {
+            val webView = WebView(context).also {
+                it.settings.javaScriptEnabled = true
+                it.webViewClient = object : WebViewClient() {
+                    override fun onPageFinished(view: WebView?, url: String?) {
+                        ready.countDown()
+                    }
+                }
+            }
+            webViewHolder[0] = webView
+            webView.loadDataWithBaseURL(null, html, "text/html", "utf-8", null)
+        }
+        assertTrue("Fixture page did not finish loading", ready.await(10, TimeUnit.SECONDS))
+        val webView = webViewHolder[0]!!
+        try {
+            block(webView)
+        } finally {
+            instrumentation.runOnMainSync { webView.destroy() }
+        }
+    }
+
+    private fun WebView.evalSync(script: String): String {
+        val latch = CountDownLatch(1)
+        val result = arrayOfNulls<String>(1)
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            evaluateJavascript(script) { value ->
+                result[0] = value
+                latch.countDown()
+            }
+        }
+        assertTrue("evaluateJavascript timed out for: $script", latch.await(5, TimeUnit.SECONDS))
+        val value = result[0]
+        assertNotNull("evaluateJavascript returned null for: $script", value)
+        return value!!
+    }
+
+    // `getComputedStyle().lineHeight` returns either a px string or "normal" — we never want
+    // "normal" in these tests (the fixture sets explicit values), so parse the px number.
+    private fun String.toCssPx(): Double {
+        val unquoted = trim('"')
+        require(unquoted.endsWith("px")) { "Expected pixel value, got: $unquoted" }
+        return unquoted.removeSuffix("px").toDouble()
+    }
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -417,6 +417,23 @@ private fun EpubNavigatorView(
         }
     }
 
+    // Injects the targeted typography overrides (see TypographyOverride.kt) into each newly
+    // loaded reflowable page. Required because some EPUBs use high-specificity publisher CSS
+    // (e.g. Safari Books Online's `#sbo-rt-content p { line-height: 125% }`) that beats
+    // Readium's own body-level user-property rules; without this injection, line-spacing /
+    // justify / fontFamily changes silently do nothing on those books. The injection JS is
+    // idempotent so repeated firings during reflow don't accumulate <style> tags.
+    val paginationListener = remember {
+        object : EpubNavigatorFragment.PaginationListener {
+            override fun onPageLoaded() {
+                val fragment = fragmentRef.value ?: return
+                coroutineScope.launch {
+                    fragment.evaluateJavascript(typographyOverrideInjectionJs())
+                }
+            }
+        }
+    }
+
     LaunchedEffect(onNavigationEvents) {
         onNavigationEvents.collect { link ->
             fragmentRef.value?.go(link)
@@ -621,6 +638,7 @@ private fun EpubNavigatorView(
                         initialPreferences = formattingPrefs.toEpubPreferences(isLandscape, isFixedLayout),
                         configuration = formattingPrefs.toFragmentConfiguration(isLandscape, isFixedLayout),
                         listener = fragmentListener,
+                        paginationListener = paginationListener,
                     )
                     fm.fragmentFactory = fragmentFactory
                     fm.beginTransaction()

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/FormattingPreferencesMapper.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/FormattingPreferencesMapper.kt
@@ -16,7 +16,7 @@ import org.readium.r2.navigator.preferences.Spread
 import org.readium.r2.navigator.preferences.TextAlign
 import org.readium.r2.navigator.preferences.Theme
 
-private const val DARK_DIM_TEXT_COLOR: Int = 0xFFBBBBBB.toInt()
+private const val DARK_DIM_TEXT_COLOR: Int = 0xFFAAAAAA.toInt()
 
 fun FormattingPreferences.toEpubPreferences(
     isLandscape: Boolean = false,
@@ -32,18 +32,24 @@ fun FormattingPreferences.toEpubPreferences(
         },
         // DarkDim is "dark with slightly muted body text" — same dark background, dimmer text.
         textColor = if (theme == ReaderTheme.DarkDim) Color(DARK_DIM_TEXT_COLOR) else null,
+        // Null-gating: when the user value equals the default, pass null so Readium leaves
+        // the corresponding --USER__* CSS variable unset on :root. The typography-override
+        // stylesheet (see TypographyOverride.kt) is gated on the variable's presence, so an
+        // unset variable means the publisher's typography is preserved on uncustomised books.
+        // The moment the user nudges a setting away from default, the variable appears and
+        // both Readium's own rules and our targeted override start applying.
         fontFamily = when (fontFamily) {
-            ReaderFontFamily.Serif -> FontFamily("serif")
+            ReaderFontFamily.Serif -> null  // Serif is the default; see FormattingPreferences.DEFAULT_FONT_FAMILY
             ReaderFontFamily.SansSerif -> FontFamily("sans-serif")
             ReaderFontFamily.Monospace -> FontFamily("monospace")
             ReaderFontFamily.Literata -> FontFamily("Literata")
             ReaderFontFamily.Merriweather -> FontFamily("Merriweather")
             ReaderFontFamily.OpenDyslexic -> FontFamily("OpenDyslexic")
         },
-        textAlign = if (justifyText) TextAlign.JUSTIFY else TextAlign.START,
+        textAlign = if (justifyText) TextAlign.JUSTIFY else null,
         // lineHeight only takes effect when publisherStyles is off
         publisherStyles = false,
-        lineHeight = lineSpacing.toDouble(),
+        lineHeight = lineSpacing.toDouble().takeIf { lineSpacing != FormattingPreferences.DEFAULT_LINE_SPACING },
         pageMargins = margins.toDouble(),
         scroll = orientation == ReaderOrientation.Vertical,
         // Fixed-layout: spread controls two-page side-by-side rendering.

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/TypographyOverride.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/TypographyOverride.kt
@@ -1,0 +1,111 @@
+package com.riffle.app.feature.reader
+
+import com.riffle.core.domain.FormattingPreferences
+
+/**
+ * Targeted typography overrides for EPUBs whose publisher CSS uses high-specificity selectors
+ * (e.g. Safari Books Online's `#sbo-rt-content p { line-height: 125% }`) that beat Readium's
+ * own `body`-level user-property rules.
+ *
+ * Strategy: inject a stylesheet that, for each user-controlled CSS property, asserts the
+ * `--USER__*` variable with `!important` on the elements where the publisher is likely to
+ * win the cascade. The rule is gated on `:root[style*="--USER__name"]` so it only fires
+ * when the user has actually customised the property — see [FormattingPreferencesMapper] for
+ * the corresponding null-gating that ensures Readium leaves the variable unset on default
+ * values, which keeps publisher typography intact on uncustomised books.
+ *
+ * Specificity caveat: this beats publisher rules that lack `!important`. A hostile EPUB that
+ * combines high-specificity selectors *with* `!important` would still win — handle that with
+ * a JS-applied inline-style escape hatch if it ever shows up in the wild.
+ */
+internal data class TypographyOverride(
+    val userPropertyName: String,
+    val cssProperty: String,
+    val elements: String,
+)
+
+/**
+ * Maps a [FormattingPreferences] field name to the targeted override that enforces it.
+ * The contract test in `TypographyOverrideTest` verifies every field of
+ * [FormattingPreferences] is either present here or in [EXCLUDED_FROM_TYPOGRAPHY_OVERRIDES].
+ */
+internal val TYPOGRAPHY_OVERRIDES: Map<String, TypographyOverride> = mapOf(
+    "lineSpacing" to TypographyOverride(
+        userPropertyName = "--USER__lineHeight",
+        cssProperty = "line-height",
+        // Headings deliberately excluded — books style heading line-height tightly (often 1.0)
+        // and forcing the body line-height onto them looks wrong.
+        elements = "p, li, blockquote, dd, dt, figcaption",
+    ),
+    "justifyText" to TypographyOverride(
+        userPropertyName = "--USER__textAlign",
+        cssProperty = "text-align",
+        elements = "p, li, blockquote, dd",
+    ),
+    "fontFamily" to TypographyOverride(
+        userPropertyName = "--USER__fontFamily",
+        cssProperty = "font-family",
+        // `pre`/`code`/`kbd`/`samp` deliberately excluded so monospace code keeps its font.
+        // Headings included so picking a reading font feels consistent across body and titles.
+        elements = "body, p, li, blockquote, dd, dt, h1, h2, h3, h4, h5, h6, figcaption",
+    ),
+)
+
+/**
+ * Fields of [FormattingPreferences] that have no targeted typography override, with the
+ * reason. The contract test asserts every excluded field has a documented reason so future
+ * maintainers don't accidentally add a field to this list as a way of silencing the test.
+ */
+internal val EXCLUDED_FROM_TYPOGRAPHY_OVERRIDES: Map<String, String> = mapOf(
+    "fontSize" to "Applied via root-em multiplier; a per-element override would flatten the publisher's size hierarchy.",
+    "margins" to "Implemented by Readium as container width, not a CSS property on text elements.",
+    "theme" to "Multi-property (background, text colour, link colour, image filters) — handled by Readium's theme stylesheet, not a single override.",
+    "orientation" to "Layout/scroll mode, not a CSS property.",
+    "doublePageSpread" to "Column-count layout mode, handled by RsProperties at fragment-creation time.",
+    "showChapterMap" to "UI affordance outside the reader content; no CSS implication.",
+)
+
+/**
+ * Produces the CSS injected into every reflowable EPUB resource. Idempotent and pure — the
+ * caller is responsible for inserting it as a `<style>` element with a stable id so repeated
+ * injections don't accumulate.
+ *
+ * Note: `:where()` would keep selector specificity tidy but is unsupported on Chromium <88
+ * (Jan 2021), which means it fails on the WebView shipped with the Android 7.1.1 harness
+ * AVD — the whole rule gets rejected as invalid and the override silently does nothing. We
+ * emit a plain comma-expanded selector list instead; specificity ends up at (0,1,1) per
+ * selector which is enough to beat hostile publisher rules paired with `!important`.
+ */
+internal fun typographyOverrideCss(): String =
+    TYPOGRAPHY_OVERRIDES.values.joinToString("\n") { override ->
+        val gate = """:root[style*="${override.userPropertyName}"]"""
+        val selectorList = override.elements
+            .split(",")
+            .joinToString(",\n") { "$gate ${it.trim()}" }
+        """
+        $selectorList {
+          ${override.cssProperty}: var(${override.userPropertyName}) !important;
+        }
+        """.trimIndent()
+    }
+
+/**
+ * JavaScript that idempotently injects [typographyOverrideCss] into `document.head`.
+ * Safe to evaluate multiple times — the stable id prevents duplicate `<style>` elements.
+ */
+internal fun typographyOverrideInjectionJs(): String {
+    val css = typographyOverrideCss()
+        .replace("\\", "\\\\")
+        .replace("`", "\\`")
+        .replace("\$", "\\\$")
+    return """
+        (function() {
+          var id = 'riffle-typography-override';
+          if (document.getElementById(id)) return;
+          var style = document.createElement('style');
+          style.id = id;
+          style.textContent = `$css`;
+          document.head.appendChild(style);
+        })();
+    """.trimIndent()
+}

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/TypographyOverrideTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/TypographyOverrideTest.kt
@@ -1,0 +1,106 @@
+package com.riffle.app.feature.reader
+
+import com.riffle.core.domain.FormattingPreferences
+import java.lang.reflect.Modifier
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class TypographyOverrideTest {
+
+    // Reflective field discovery via java.lang.reflect — avoids the kotlin-reflect dependency.
+    // For a Kotlin data class, the constructor parameters become instance fields with matching
+    // names. We filter out companion-object constants (static fields), synthetics, and the
+    // generated `Companion` reference field.
+    private val formattingPreferenceFieldNames: Set<String> =
+        FormattingPreferences::class.java.declaredFields
+            .filterNot { it.isSynthetic }
+            .filterNot { Modifier.isStatic(it.modifiers) }
+            .map { it.name }
+            .toSet()
+
+    // Contract: when a new field is added to FormattingPreferences, the maintainer must
+    // classify it as either an overridable typography knob (TYPOGRAPHY_OVERRIDES) or as
+    // deliberately excluded with a reason (EXCLUDED_FROM_TYPOGRAPHY_OVERRIDES). Forgetting
+    // to classify a field means the typography-override system silently doesn't apply to it
+    // and the bug we just fixed (line-spacing not applying on certain books) would silently
+    // recur for the new field. This test fails loudly on omission.
+    @Test
+    fun every_formatting_preferences_field_is_either_overridable_or_excluded() {
+        val classified = TYPOGRAPHY_OVERRIDES.keys + EXCLUDED_FROM_TYPOGRAPHY_OVERRIDES.keys
+        val unclassified = formattingPreferenceFieldNames - classified
+        assertEquals(
+            "Every FormattingPreferences field must be classified in TYPOGRAPHY_OVERRIDES " +
+                "or EXCLUDED_FROM_TYPOGRAPHY_OVERRIDES. Missing classifications: $unclassified",
+            emptySet<String>(),
+            unclassified,
+        )
+    }
+
+    @Test
+    fun classification_maps_only_reference_real_formatting_preferences_fields() {
+        val classified = TYPOGRAPHY_OVERRIDES.keys + EXCLUDED_FROM_TYPOGRAPHY_OVERRIDES.keys
+        val mystery = classified - formattingPreferenceFieldNames
+        assertEquals(
+            "Classification maps reference non-existent fields: $mystery (likely a typo or " +
+                "a field that was removed from FormattingPreferences).",
+            emptySet<String>(),
+            mystery,
+        )
+    }
+
+    @Test
+    fun no_field_is_both_overridden_and_excluded() {
+        val both = TYPOGRAPHY_OVERRIDES.keys intersect EXCLUDED_FROM_TYPOGRAPHY_OVERRIDES.keys
+        assertEquals(emptySet<String>(), both)
+    }
+
+    @Test
+    fun every_excluded_field_has_a_non_blank_reason() {
+        val blank = EXCLUDED_FROM_TYPOGRAPHY_OVERRIDES.filterValues { it.isBlank() }.keys
+        assertEquals(
+            "Excluded fields must document why they are excluded: $blank",
+            emptySet<String>(),
+            blank,
+        )
+    }
+
+    // The override CSS must gate each rule on the variable's presence on :root. Without the
+    // gate, the override would apply universally — including to books the user hasn't
+    // customised — overriding the publisher's typography unconditionally.
+    @Test
+    fun every_override_rule_is_gated_on_root_style_variable_presence() {
+        val css = typographyOverrideCss()
+        TYPOGRAPHY_OVERRIDES.values.forEach { override ->
+            assertTrue(
+                "Override for ${override.cssProperty} must be gated on :root[style*=\"${override.userPropertyName}\"]",
+                css.contains(":root[style*=\"${override.userPropertyName}\"]"),
+            )
+        }
+    }
+
+    // Without !important, hostile publisher rules like `#sbo-rt-content p { ... }` (0,1,1)
+    // would beat our (0,1,1) gate+element selectors on source order alone. !important keeps
+    // us ahead regardless of where the publisher's stylesheet sits in the cascade.
+    @Test
+    fun every_override_uses_important() {
+        val css = typographyOverrideCss()
+        TYPOGRAPHY_OVERRIDES.values.forEach { override ->
+            val rule = Regex("${Regex.escape(override.cssProperty)}:\\s*var\\(${Regex.escape(override.userPropertyName)}\\)\\s*!important")
+            assertNotNull(
+                "Override for ${override.cssProperty} must use !important to beat publisher rules without it",
+                rule.find(css),
+            )
+        }
+    }
+
+    // Injection JS must be idempotent — onPageLoaded fires more than once per page during
+    // reflow, and naive injection would accumulate <style> tags.
+    @Test
+    fun injection_js_is_idempotent_via_stable_id() {
+        val js = typographyOverrideInjectionJs()
+        assertTrue("Injection JS must check for an existing element by id before appending", js.contains("getElementById"))
+        assertTrue("Injection JS must use a stable id", js.contains("riffle-typography-override"))
+    }
+}

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/FormattingPreferences.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/FormattingPreferences.kt
@@ -1,16 +1,28 @@
 package com.riffle.core.domain
 
 data class FormattingPreferences(
-    val fontSize: Float = 1.0f,
-    val theme: ReaderTheme = ReaderTheme.Light,
-    val fontFamily: ReaderFontFamily = ReaderFontFamily.Serif,
-    val lineSpacing: Float = 1.2f,
-    val margins: Float = 1.0f,
-    val orientation: ReaderOrientation = ReaderOrientation.Horizontal,
-    val showChapterMap: Boolean = true,
-    val doublePageSpread: Boolean = false,
-    val justifyText: Boolean = false,
-)
+    val fontSize: Float = DEFAULT_FONT_SIZE,
+    val theme: ReaderTheme = DEFAULT_THEME,
+    val fontFamily: ReaderFontFamily = DEFAULT_FONT_FAMILY,
+    val lineSpacing: Float = DEFAULT_LINE_SPACING,
+    val margins: Float = DEFAULT_MARGINS,
+    val orientation: ReaderOrientation = DEFAULT_ORIENTATION,
+    val showChapterMap: Boolean = DEFAULT_SHOW_CHAPTER_MAP,
+    val doublePageSpread: Boolean = DEFAULT_DOUBLE_PAGE_SPREAD,
+    val justifyText: Boolean = DEFAULT_JUSTIFY_TEXT,
+) {
+    companion object {
+        const val DEFAULT_FONT_SIZE: Float = 1.0f
+        const val DEFAULT_LINE_SPACING: Float = 1.2f
+        const val DEFAULT_MARGINS: Float = 1.0f
+        const val DEFAULT_SHOW_CHAPTER_MAP: Boolean = true
+        const val DEFAULT_DOUBLE_PAGE_SPREAD: Boolean = false
+        const val DEFAULT_JUSTIFY_TEXT: Boolean = false
+        val DEFAULT_THEME: ReaderTheme = ReaderTheme.Light
+        val DEFAULT_FONT_FAMILY: ReaderFontFamily = ReaderFontFamily.Serif
+        val DEFAULT_ORIENTATION: ReaderOrientation = ReaderOrientation.Horizontal
+    }
+}
 
 enum class ReaderTheme { Light, Dark, DarkDim, Sepia }
 enum class ReaderFontFamily { Serif, SansSerif, Monospace, Literata, Merriweather, OpenDyslexic }


### PR DESCRIPTION
## Summary
- Some EPUBs (Safari Books Online's `#sbo-rt-content p { line-height: 125% }` is the original reproducer) carry publisher CSS whose specificity beats Readium's `body`-level `--USER__*` rules. Result: line-spacing / justify / fontFamily changes silently did nothing on those books.
- Inject a per-page stylesheet that asserts the user-property variables with `!important` on the text elements publishers tend to target. Each rule is gated on `:root[style*="--USER__name"]` so it stays inert on books the user hasn't customised.
- `FormattingPreferencesMapper` now maps default values (lineSpacing 1.2, fontFamily Serif, justifyText false) to `null` so Readium leaves the `--USER__*` vars unset on `:root`. Combined with the gate, this preserves publisher typography on uncustomised books and only takes over when the user nudges a setting away from default. Default constants moved to a `FormattingPreferences` companion so the mapper can reference them.
- Drive-by: tighten DarkDim body text from `#BBB` to `#AAA`.

## Tests
- `TypographyOverrideTest` — pure-JVM contract: every `FormattingPreferences` field is either overridable or explicitly excluded with a documented reason; CSS rules are gated and use `!important`; injection JS is idempotent. Fails loudly if a new field is added without classifying it.
- `TypographyOverrideWebViewTest` — instrumentation: real WebView loads a hostile SBO-style fixture, verifies the override beats `#sbo-rt-content p` when `--USER__lineHeight` / `--USER__textAlign` are set on `:root`, stays inert when they aren't, and that repeated injection leaves a single `<style>` element.
- `FormattingPreferencesMapperTest` updated for the new null-mapping contract.

## Test plan
- [x] `make test` — unit tests green
- [x] `make harness-test` — 125 tests on Harness Medium Phone AVD, 0 failed
- [ ] Manually open an SBO-templated EPUB, change line-spacing, confirm body text reflows
- [ ] Open a book with custom publisher typography, leave settings at default, confirm publisher styling is preserved