### PR TITLE
Show footnote popup for EPUBs with dotted anchor IDs

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -72,8 +72,10 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import java.util.concurrent.ConcurrentHashMap
 import org.json.JSONObject
 import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
 import org.readium.r2.navigator.DecorableNavigator
 import org.readium.r2.navigator.Decoration
 import org.readium.r2.navigator.HyperlinkNavigator
@@ -392,6 +394,10 @@ private fun EpubNavigatorView(
     // without needing to be re-created when onTap changes.
     val currentOnTap by rememberUpdatedState(onTap)
     val currentOnFootnoteTapped by rememberUpdatedState(onFootnoteTapped)
+    val currentPublication by rememberUpdatedState(state.publication)
+    // ConcurrentHashMap: writes happen on Dispatchers.IO from the locator
+    // coroutine; reads happen on the JS binder thread inside resolveAnchorTap.
+    val footnoteDocCache = remember { ConcurrentHashMap<String, Document>() }
     val tapListener = remember {
         object : InputListener {
             override fun onTap(event: TapEvent): Boolean {
@@ -402,6 +408,9 @@ private fun EpubNavigatorView(
     }
     val fragmentListener = remember {
         object : EpubNavigatorFragment.Listener {
+            // Kept as a safety net for EPUBs where Readium's own footnote
+            // detection succeeds; the primary path is the JS bridge below,
+            // because Readium 3.0.0's selector breaks on dotted IDs.
             override fun shouldFollowInternalLink(
                 link: Link,
                 context: HyperlinkNavigator.LinkContext?,
@@ -418,20 +427,36 @@ private fun EpubNavigatorView(
     }
 
     // Injects the targeted typography overrides (see TypographyOverride.kt) into each newly
-    // loaded reflowable page. Required because some EPUBs use high-specificity publisher CSS
-    // (e.g. Safari Books Online's `#sbo-rt-content p { line-height: 125% }`) that beats
-    // Readium's own body-level user-property rules; without this injection, line-spacing /
-    // justify / fontFamily changes silently do nothing on those books. The injection JS is
-    // idempotent so repeated firings during reflow don't accumulate <style> tags.
+    // loaded reflowable page, plus the footnote-anchor install script. Both are idempotent
+    // (typography deduplicates by <style> tag, footnote by window.__riffleFootnoteInstalled),
+    // so repeated firings during reflow are harmless.
     val paginationListener = remember {
         object : EpubNavigatorFragment.PaginationListener {
             override fun onPageLoaded() {
                 val fragment = fragmentRef.value ?: return
                 coroutineScope.launch {
                     fragment.evaluateJavascript(typographyOverrideInjectionJs())
+                    fragment.evaluateJavascript(FootnoteAnchorBridge.INSTALL_SCRIPT)
                 }
             }
         }
+    }
+
+    // Tap on an in-document anchor inside the WebView → look up the target in
+    // the cached spine doc; if it's a footnote, show the popup and tell JS to
+    // preventDefault. Otherwise return false and let the WebView scroll.
+    DisposableEffect(Unit) {
+        FootnoteAnchorBridge.setHandler { fragmentId ->
+            val text = FootnoteResolver.resolveAnchorTap(
+                currentHrefHolder[0], footnoteDocCache, fragmentId,
+            ) ?: return@setHandler false
+            // Called from the JS binder thread; hop to main for Compose state.
+            coroutineScope.launch(Dispatchers.Main) {
+                currentOnFootnoteTapped(text)
+            }
+            true
+        }
+        onDispose { FootnoteAnchorBridge.setHandler(null) }
     }
 
     LaunchedEffect(onNavigationEvents) {
@@ -636,7 +661,11 @@ private fun EpubNavigatorView(
                     ).createFragmentFactory(
                         initialLocator = latestLocator() ?: state.initialLocator,
                         initialPreferences = formattingPrefs.toEpubPreferences(isLandscape, isFixedLayout),
-                        configuration = formattingPrefs.toFragmentConfiguration(isLandscape, isFixedLayout),
+                        configuration = formattingPrefs.toFragmentConfiguration(isLandscape, isFixedLayout).apply {
+                            registerJavascriptInterface(FootnoteAnchorBridge.JS_NAME) { _ ->
+                                FootnoteAnchorBridge.bridge
+                            }
+                        },
                         listener = fragmentListener,
                         paginationListener = paginationListener,
                     )
@@ -653,6 +682,16 @@ private fun EpubNavigatorView(
                         fragment.currentLocator.collect { locator ->
                             currentHrefHolder[0] = locator.href.toString()
                             onPositionChanged(locator)
+                            val key = locator.href.removeFragment().toString()
+                            if (key.isNotEmpty() && !footnoteDocCache.containsKey(key)) {
+                                launch(Dispatchers.IO) {
+                                    val bytes = currentPublication.get(locator.href.removeFragment())
+                                        ?.read()?.getOrNull() ?: return@launch
+                                    footnoteDocCache[key] = FootnoteResolver.parse(
+                                        String(bytes, Charsets.UTF_8)
+                                    )
+                                }
+                            }
                         }
                     }
                 }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/FootnoteAnchorBridge.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/FootnoteAnchorBridge.kt
@@ -1,0 +1,61 @@
+package com.riffle.app.feature.reader
+
+import android.webkit.JavascriptInterface
+
+// JS bridge that intercepts taps on in-document anchors before the browser
+// scrolls to the fragment. Works around Readium 3.0.0's broken footnote popup:
+// R2BasicWebView.handleFootnote uses `select("#$id")`, which Jsoup parses as
+// "id AND class" when the id contains a dot — common in O'Reilly-style EPUBs
+// (id="ftn.ch01fn01"). The selector matches nothing, the popup is skipped,
+// and the WebView falls back to its default same-document scroll.
+//
+// The registry holds a single Volatile handler swapped in by the active reader.
+// Multiple readers can't be open at once in this app, so collision is moot.
+internal object FootnoteAnchorBridge {
+    const val JS_NAME: String = "RiffleFootnoteBridge"
+
+    @Volatile
+    private var handler: ((String) -> Boolean)? = null
+
+    fun setHandler(h: ((String) -> Boolean)?) {
+        handler = h
+    }
+
+    val bridge: Bridge = Bridge()
+
+    class Bridge {
+        // Returns true when the anchor was a footnote and the popup will show
+        // (so the caller should preventDefault); false otherwise.
+        @JavascriptInterface
+        fun onAnchorTap(fragmentId: String): Boolean =
+            handler?.invoke(fragmentId) ?: false
+    }
+
+    // Injected once per loaded resource — idempotent thanks to the window flag.
+    val INSTALL_SCRIPT: String = """
+        (function(){
+          if (window.__riffleFootnoteInstalled) return 'already';
+          window.__riffleFootnoteInstalled = true;
+          var isAnchor = function(el) {
+            return !!el && el.nodeType === 1 && el.tagName &&
+              el.tagName.toLowerCase() === 'a';
+          };
+          document.addEventListener('click', function(e) {
+            var t = e.target;
+            while (t && t.nodeType === 1 && !isAnchor(t)) t = t.parentNode;
+            if (!isAnchor(t)) return;
+            var href = t.getAttribute('href');
+            if (!href || href.charAt(0) !== '#') return;
+            var id = href.substring(1);
+            if (!id) return;
+            try {
+              if (window.$JS_NAME.onAnchorTap(id)) {
+                e.preventDefault();
+                e.stopPropagation();
+              }
+            } catch (err) {}
+          }, true);
+          return 'installed';
+        })();
+    """.trimIndent()
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/FootnoteResolver.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/FootnoteResolver.kt
@@ -1,0 +1,74 @@
+package com.riffle.app.feature.reader
+
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+import org.jsoup.nodes.Element
+
+// Detects footnote-style link targets so the reader can show a popup even when
+// Readium's strict EPUB3 noteref classification doesn't fire. Real-world EPUBs
+// frequently mark only the first link with epub:type="noteref" while the
+// targets sit in a <section epub:type="footnotes"> or carry class="footnote".
+internal object FootnoteResolver {
+
+    private val FOOTNOTE_EPUB_TYPES = setOf(
+        "footnote", "endnote", "rearnote",
+        "footnotes", "endnotes", "rearnotes",
+        "doc-footnote", "doc-endnote",
+    )
+
+    private val FOOTNOTE_ROLES = setOf(
+        "doc-footnote", "doc-endnote",
+    )
+
+    private val FOOTNOTE_CLASSES = setOf(
+        "footnote", "endnote", "rearnote",
+        "footnotes", "endnotes", "rearnotes",
+    )
+
+    fun parse(html: String): Document = Jsoup.parse(html)
+
+    // Returns the footnote body text for [targetId] within [doc], or null if
+    // the element with that id does not look like a footnote.
+    //
+    // Implementation note: uses getElementById, NOT Jsoup CSS selectors. EPUB
+    // footnote IDs frequently contain a dot (O'Reilly's `ftn.ch01fn01` is the
+    // canonical example). Jsoup's `select("#ftn.ch01fn01")` parses that as
+    // "id=ftn AND class=ch01fn01" and matches nothing — exactly the Readium
+    // 3.0.0 bug this whole feature works around. Do not swap getElementById
+    // for select here.
+    fun extractFootnoteText(doc: Document, targetId: String): String? {
+        val element = doc.getElementById(targetId) ?: return null
+        if (!looksLikeFootnote(element)) return null
+        return element.text().trim().takeIf { it.isNotEmpty() }
+    }
+
+    // Resolves an anchor tap from the WebView to footnote popup text. Returns
+    // null when no popup should be shown (cache cold, no current spine,
+    // target is a regular cross-reference, etc.).
+    fun resolveAnchorTap(
+        currentHref: String?,
+        cache: Map<String, Document>,
+        fragmentId: String,
+    ): String? {
+        val href = currentHref ?: return null
+        val key = href.substringBefore('#')
+        val doc = cache[key] ?: return null
+        return extractFootnoteText(doc, fragmentId)
+    }
+
+    private fun looksLikeFootnote(element: Element): Boolean {
+        var node: Element? = element
+        while (node != null) {
+            if (matchesAny(node.attr("epub:type"), FOOTNOTE_EPUB_TYPES)) return true
+            if (matchesAny(node.attr("role"), FOOTNOTE_ROLES)) return true
+            if (node.classNames().any { it.lowercase() in FOOTNOTE_CLASSES }) return true
+            node = node.parent()
+        }
+        return false
+    }
+
+    private fun matchesAny(attr: String, allowed: Set<String>): Boolean {
+        if (attr.isEmpty()) return false
+        return attr.lowercase().split(Regex("\\s+")).any { it in allowed }
+    }
+}

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/FootnoteResolverTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/FootnoteResolverTest.kt
@@ -1,0 +1,186 @@
+package com.riffle.app.feature.reader
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class FootnoteResolverTest {
+
+    @Test
+    fun `target with epub-type footnote is detected`() {
+        val html = """
+            <html xmlns:epub="http://www.idpf.org/2007/ops"><body>
+              <aside epub:type="footnote" id="fn1"><p>Note one.</p></aside>
+            </body></html>
+        """.trimIndent()
+        val doc = FootnoteResolver.parse(html)
+        assertEquals("Note one.", FootnoteResolver.extractFootnoteText(doc, "fn1"))
+    }
+
+    // The Lean Customer Development EPUB ships ch01fn02..ch01fn08 without
+    // epub:type on the target div, relying solely on class="footnote" plus
+    // the surrounding <section epub:type="footnotes">. Both signals must work.
+    @Test
+    fun `target with only class footnote is detected`() {
+        val html = """
+            <html><body>
+              <section><div class="footnote" id="ftn.ch01fn02"><p>Body text.</p></div></section>
+            </body></html>
+        """.trimIndent()
+        val doc = FootnoteResolver.parse(html)
+        assertEquals("Body text.", FootnoteResolver.extractFootnoteText(doc, "ftn.ch01fn02"))
+    }
+
+    @Test
+    fun `target inside section with epub-type footnotes is detected`() {
+        val html = """
+            <html xmlns:epub="http://www.idpf.org/2007/ops"><body>
+              <section epub:type="footnotes">
+                <div id="ftn.ch01fn03"><p>Third note.</p></div>
+              </section>
+            </body></html>
+        """.trimIndent()
+        val doc = FootnoteResolver.parse(html)
+        assertEquals("Third note.", FootnoteResolver.extractFootnoteText(doc, "ftn.ch01fn03"))
+    }
+
+    @Test
+    fun `target with role doc-footnote is detected`() {
+        val html = """
+            <html><body>
+              <div role="doc-footnote" id="dfn1"><p>Aria note.</p></div>
+            </body></html>
+        """.trimIndent()
+        val doc = FootnoteResolver.parse(html)
+        assertEquals("Aria note.", FootnoteResolver.extractFootnoteText(doc, "dfn1"))
+    }
+
+    @Test
+    fun `regular cross-reference target returns null`() {
+        val html = """
+            <html><body>
+              <h2 id="sec1">Section One</h2>
+              <p>Some paragraph.</p>
+            </body></html>
+        """.trimIndent()
+        val doc = FootnoteResolver.parse(html)
+        assertNull(FootnoteResolver.extractFootnoteText(doc, "sec1"))
+    }
+
+    @Test
+    fun `missing target id returns null`() {
+        val doc = FootnoteResolver.parse("<html><body><p id=\"x\">Hi</p></body></html>")
+        assertNull(FootnoteResolver.extractFootnoteText(doc, "nope"))
+    }
+
+    @Test
+    fun `empty footnote body returns null`() {
+        val html = """<html><body><div class="footnote" id="fn1"></div></body></html>"""
+        val doc = FootnoteResolver.parse(html)
+        assertNull(FootnoteResolver.extractFootnoteText(doc, "fn1"))
+    }
+
+    // Regression for Readium 3.0.0's `select("#$id")` bug. Many EPUBs (O'Reilly
+    // toolchain in particular) emit `id="ftn.ch01fn01"`, where Jsoup's CSS
+    // selector parses the dot as a class separator and matches nothing.
+    // extractFootnoteText must use getElementById, not select.
+    @Test
+    fun `dotted target id is still found`() {
+        val html = """
+            <html xmlns:epub="http://www.idpf.org/2007/ops"><body>
+              <section epub:type="footnotes">
+                <div id="ftn.ch01fn01"><p>Dotted body.</p></div>
+              </section>
+            </body></html>
+        """.trimIndent()
+        val doc = FootnoteResolver.parse(html)
+        assertEquals("Dotted body.", FootnoteResolver.extractFootnoteText(doc, "ftn.ch01fn01"))
+    }
+
+    @Test
+    fun `resolveAnchorTap returns text on cache hit and footnote target`() {
+        val html = """
+            <html><body>
+              <div class="footnote" id="fn1"><p>Body.</p></div>
+            </body></html>
+        """.trimIndent()
+        val cache = mapOf("OEBPS/ch01.html" to FootnoteResolver.parse(html))
+        assertEquals(
+            "Body.",
+            FootnoteResolver.resolveAnchorTap("OEBPS/ch01.html", cache, "fn1"),
+        )
+    }
+
+    @Test
+    fun `resolveAnchorTap strips fragment from current href before lookup`() {
+        val html = """<html><body><div class="footnote" id="fn1">x</div></body></html>"""
+        val cache = mapOf("OEBPS/ch01.html" to FootnoteResolver.parse(html))
+        // currentHref may itself carry a fragment from the last locator emission.
+        assertNotNull(
+            FootnoteResolver.resolveAnchorTap("OEBPS/ch01.html#somewhere", cache, "fn1"),
+        )
+    }
+
+    @Test
+    fun `resolveAnchorTap returns null on cache miss`() {
+        assertNull(
+            FootnoteResolver.resolveAnchorTap("OEBPS/ch01.html", emptyMap(), "fn1"),
+        )
+    }
+
+    @Test
+    fun `resolveAnchorTap returns null when no current href`() {
+        val cache = mapOf("OEBPS/ch01.html" to FootnoteResolver.parse("<html/>"))
+        assertNull(FootnoteResolver.resolveAnchorTap(null, cache, "fn1"))
+    }
+
+    @Test
+    fun `resolveAnchorTap returns null for non-footnote target`() {
+        val html = """<html><body><h2 id="sec1">Section</h2></body></html>"""
+        val cache = mapOf("OEBPS/ch01.html" to FootnoteResolver.parse(html))
+        assertNull(FootnoteResolver.resolveAnchorTap("OEBPS/ch01.html", cache, "sec1"))
+    }
+
+    // Regression guard for the two install-script hazards burnt in this session:
+    //   1. anchor matching must be case-insensitive (XHTML keeps tagName lowercase)
+    //   2. listener must be capture-phase so it runs before Readium's bubble-phase ut()
+    @Test
+    fun `install script normalises tagName case`() {
+        assertTrue(
+            "INSTALL_SCRIPT must compare tagName case-insensitively (XHTML uses lowercase)",
+            FootnoteAnchorBridge.INSTALL_SCRIPT.contains("toLowerCase"),
+        )
+        assertFalse(
+            "INSTALL_SCRIPT must not compare to literal uppercase 'A'",
+            FootnoteAnchorBridge.INSTALL_SCRIPT.contains("=== 'A'") ||
+                FootnoteAnchorBridge.INSTALL_SCRIPT.contains("== 'A'"),
+        )
+    }
+
+    @Test
+    fun `install script registers click listener in capture phase`() {
+        // addEventListener('click', handler, true) — the trailing true is what makes
+        // our handler fire before Readium's bubble-phase ut() click handler.
+        val pattern = Regex("""addEventListener\(\s*['"]click['"]\s*,[^,]+,\s*true\s*\)""")
+        assertTrue(
+            "INSTALL_SCRIPT must register a capture-phase click listener",
+            pattern.containsMatchIn(FootnoteAnchorBridge.INSTALL_SCRIPT),
+        )
+    }
+
+    @Test
+    fun `class footnotes plural on container is detected`() {
+        val html = """
+            <html><body>
+              <div class="footnotes">
+                <div id="fnX"><p>Container plural.</p></div>
+              </div>
+            </body></html>
+        """.trimIndent()
+        val doc = FootnoteResolver.parse(html)
+        assertEquals("Container plural.", FootnoteResolver.extractFootnoteText(doc, "fnX"))
+    }
+}


### PR DESCRIPTION
## Summary

- Works around a Readium 3.0.0 bug where `R2BasicWebView.handleFootnote` uses Jsoup's `select(\"#$id\")`, which treats a dot in the id as a class separator. Common O'Reilly-style IDs like `ftn.ch01fn01` therefore match nothing and the footnote popup is skipped.
- New `FootnoteAnchorBridge` injects a capture-phase click listener via the existing `PaginationListener.onPageLoaded` (alongside the typography-override script) and bridges anchor taps into Kotlin.
- New `FootnoteResolver` looks the target up by `getElementById` and walks ancestors checking `epub:type`, ARIA `role`, and `class` — real-world EPUBs label only the first link as `noteref`, so we also accept class-only and section-only signals.
- Spine docs are parsed lazily on locator change and cached in a `ConcurrentHashMap` (the write is on `Dispatchers.IO`, the read is on the JS binder thread).

## Test plan

- [x] `make test` — passes
- [x] `make harness-test` — 125 tests, 4 pre-existing skips, 0 failures
- [ ] Manual: open an O'Reilly EPUB with `ftn.ch01fn01`-style IDs, tap a footnote anchor, confirm popup appears instead of scroll
- [ ] Manual: tap a regular cross-reference (non-footnote anchor), confirm WebView still scrolls