### PR TITLE
fix(reader): apply Margins setting to top/bottom, raise max to 3.0×

### DIFF
--- a/app/src/androidTest/kotlin/com/riffle/app/feature/reader/TypographyOverrideWebViewTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/reader/TypographyOverrideWebViewTest.kt
@@ -111,6 +111,42 @@ class TypographyOverrideWebViewTest {
         }
     }
 
+    // Margins override targets :root (not body) so every column in paginated mode gets equal
+    // top/bottom whitespace. Without --USER__pageMargins set the gate doesn't match and :root
+    // padding stays at the fixture default. With it set, padding-top/bottom should resolve to
+    // calc(--RS__pageGutter * --USER__pageMargins * 0.5). We simulate Readium's gutter with
+    // an explicit --RS__pageGutter on :root so the calc has a concrete value.
+    @Test
+    fun marginsOverrideAppliesVerticalPaddingToRootWhenUserVariableIsSet() {
+        withFixture(hostileSboFixture) { webView ->
+            webView.evalSync("document.documentElement.style.setProperty('--RS__pageGutter', '20px')")
+            webView.evalSync("document.documentElement.style.setProperty('--USER__pageMargins', '2')")
+            webView.evalSync(typographyOverrideInjectionJs())
+            val paddingTop = webView.evalSync(
+                "window.getComputedStyle(document.documentElement).paddingTop"
+            ).toCssPx()
+            val paddingBottom = webView.evalSync(
+                "window.getComputedStyle(document.documentElement).paddingBottom"
+            ).toCssPx()
+            // 20px gutter × 2 (pageMargins) × 0.5 (vertical ratio) = 20px expected on each side.
+            assertEquals("padding-top should reflect --USER__pageMargins × gutter × 0.5", 20.0, paddingTop, 0.5)
+            assertEquals("padding-bottom should reflect --USER__pageMargins × gutter × 0.5", 20.0, paddingBottom, 0.5)
+        }
+    }
+
+    @Test
+    fun marginsOverrideIsInertWhenUserVariableIsNotSet() {
+        withFixture(hostileSboFixture) { webView ->
+            webView.evalSync("document.documentElement.style.setProperty('--RS__pageGutter', '20px')")
+            webView.evalSync(typographyOverrideInjectionJs())
+            // No --USER__pageMargins → gate doesn't match → :root padding stays at fixture default (0).
+            val paddingTop = webView.evalSync(
+                "window.getComputedStyle(document.documentElement).paddingTop"
+            ).toCssPx()
+            assertEquals("padding-top must be untouched when user hasn't customised margins", 0.0, paddingTop, 0.5)
+        }
+    }
+
     @Test
     fun repeatedInjectionDoesNotAccumulateStyleElements() {
         withFixture(hostileSboFixture) { webView ->

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/FormattingPanel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/FormattingPanel.kt
@@ -209,7 +209,7 @@ fun FormattingPanel(
             StepperRow(
                 label = "%.1f×".format(prefs.margins),
                 onDecrement = { onPrefsChange(prefs.copy(margins = (prefs.margins - 0.1f).coerceAtLeast(0.2f).round1())) },
-                onIncrement = { onPrefsChange(prefs.copy(margins = (prefs.margins + 0.1f).coerceAtMost(2.0f).round1())) },
+                onIncrement = { onPrefsChange(prefs.copy(margins = (prefs.margins + 0.1f).coerceAtMost(3.0f).round1())) },
                 decrementDescription = "Decrease margins",
                 incrementDescription = "Increase margins",
             )

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/TypographyOverride.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/TypographyOverride.kt
@@ -20,7 +20,8 @@ import com.riffle.core.domain.FormattingPreferences
  */
 internal data class TypographyOverride(
     val userPropertyName: String,
-    val cssProperty: String,
+    val cssProperties: List<String>,
+    val cssValue: String,
     val elements: String,
 )
 
@@ -32,22 +33,45 @@ internal data class TypographyOverride(
 internal val TYPOGRAPHY_OVERRIDES: Map<String, TypographyOverride> = mapOf(
     "lineSpacing" to TypographyOverride(
         userPropertyName = "--USER__lineHeight",
-        cssProperty = "line-height",
+        cssProperties = listOf("line-height"),
+        cssValue = "var(--USER__lineHeight)",
         // Headings deliberately excluded — books style heading line-height tightly (often 1.0)
         // and forcing the body line-height onto them looks wrong.
         elements = "p, li, blockquote, dd, dt, figcaption",
     ),
     "justifyText" to TypographyOverride(
         userPropertyName = "--USER__textAlign",
-        cssProperty = "text-align",
+        cssProperties = listOf("text-align"),
+        cssValue = "var(--USER__textAlign)",
         elements = "p, li, blockquote, dd",
     ),
     "fontFamily" to TypographyOverride(
         userPropertyName = "--USER__fontFamily",
-        cssProperty = "font-family",
+        cssProperties = listOf("font-family"),
+        cssValue = "var(--USER__fontFamily)",
         // `pre`/`code`/`kbd`/`samp` deliberately excluded so monospace code keeps its font.
         // Headings included so picking a reading font feels consistent across body and titles.
         elements = "body, p, li, blockquote, dd, dt, h1, h2, h3, h4, h5, h6, figcaption",
+    ),
+    // Readium's built-in rule (`:root[style*="--USER__pageMargins"] body { padding: 0 X !important }`)
+    // applies user margins only to body's left/right. We add a top/bottom margin on every page
+    // by padding the multicol container itself — `:root` — not `body`. Padding on body would
+    // only show on the very first/last column because body is fragmented as a single block
+    // across columns; padding on `:root` shrinks the column height (since `:root` has
+    // `height: 100vh` + `box-sizing: border-box`), so every column gets equal top/bottom
+    // whitespace. The selector `:root[style*="--USER__pageMargins"]` has higher specificity
+    // (0,2,0) than Readium's `:root { padding: 0 !important }` (0,1,0), so our padding-top /
+    // padding-bottom longhands win regardless of source order. In scroll mode (`readium-scroll-on`)
+    // `:root` is `height: auto`, so this becomes whitespace at the start/end of each loaded
+    // resource — still the desired "margin" semantics.
+    "margins" to TypographyOverride(
+        userPropertyName = "--USER__pageMargins",
+        cssProperties = listOf("padding-top", "padding-bottom"),
+        // 0.5× of the horizontal gutter — book typography conventionally gives narrower
+        // top/bottom than side margins, and our reader already consumes vertical space with
+        // system insets, so a full 1× ratio would feel heavy.
+        cssValue = "calc(var(--RS__pageGutter) * var(--USER__pageMargins) * 0.5)",
+        elements = "",  // empty → rule targets `:root` itself, not a descendant
     ),
 )
 
@@ -58,7 +82,6 @@ internal val TYPOGRAPHY_OVERRIDES: Map<String, TypographyOverride> = mapOf(
  */
 internal val EXCLUDED_FROM_TYPOGRAPHY_OVERRIDES: Map<String, String> = mapOf(
     "fontSize" to "Applied via root-em multiplier; a per-element override would flatten the publisher's size hierarchy.",
-    "margins" to "Implemented by Readium as container width, not a CSS property on text elements.",
     "theme" to "Multi-property (background, text colour, link colour, image filters) — handled by Readium's theme stylesheet, not a single override.",
     "orientation" to "Layout/scroll mode, not a CSS property.",
     "doublePageSpread" to "Column-count layout mode, handled by RsProperties at fragment-creation time.",
@@ -79,12 +102,20 @@ internal val EXCLUDED_FROM_TYPOGRAPHY_OVERRIDES: Map<String, String> = mapOf(
 internal fun typographyOverrideCss(): String =
     TYPOGRAPHY_OVERRIDES.values.joinToString("\n") { override ->
         val gate = """:root[style*="${override.userPropertyName}"]"""
-        val selectorList = override.elements
-            .split(",")
-            .joinToString(",\n") { "$gate ${it.trim()}" }
+        // Empty `elements` means the rule targets `:root` itself (used for margins, which
+        // pads the multicol container so every page gets top/bottom whitespace).
+        val selectorList = if (override.elements.isBlank()) {
+            gate
+        } else {
+            override.elements
+                .split(",")
+                .joinToString(",\n") { "$gate ${it.trim()}" }
+        }
+        val declarations = override.cssProperties
+            .joinToString("\n          ") { "$it: ${override.cssValue} !important;" }
         """
         $selectorList {
-          ${override.cssProperty}: var(${override.userPropertyName}) !important;
+          $declarations
         }
         """.trimIndent()
     }

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/TypographyOverrideTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/TypographyOverrideTest.kt
@@ -74,7 +74,7 @@ class TypographyOverrideTest {
         val css = typographyOverrideCss()
         TYPOGRAPHY_OVERRIDES.values.forEach { override ->
             assertTrue(
-                "Override for ${override.cssProperty} must be gated on :root[style*=\"${override.userPropertyName}\"]",
+                "Override for ${override.cssProperties} must be gated on :root[style*=\"${override.userPropertyName}\"]",
                 css.contains(":root[style*=\"${override.userPropertyName}\"]"),
             )
         }
@@ -87,12 +87,35 @@ class TypographyOverrideTest {
     fun every_override_uses_important() {
         val css = typographyOverrideCss()
         TYPOGRAPHY_OVERRIDES.values.forEach { override ->
-            val rule = Regex("${Regex.escape(override.cssProperty)}:\\s*var\\(${Regex.escape(override.userPropertyName)}\\)\\s*!important")
-            assertNotNull(
-                "Override for ${override.cssProperty} must use !important to beat publisher rules without it",
-                rule.find(css),
-            )
+            override.cssProperties.forEach { property ->
+                val rule = Regex("${Regex.escape(property)}:\\s*${Regex.escape(override.cssValue)}\\s*!important")
+                assertNotNull(
+                    "Override for $property must use !important to beat publisher rules without it",
+                    rule.find(css),
+                )
+            }
         }
+    }
+
+    // Regression guard: an earlier attempt at applying margins to top/bottom set
+    // `elements = "body"`, which silently did nothing because CSS multicol fragments body as a
+    // single block — padding-top only shows on the first column, padding-bottom only on the
+    // last. The fix targets `:root` (the multicol container) so every page gets equal
+    // vertical whitespace. Encoding it as a test so a future refactor doesn't quietly regress.
+    @Test
+    fun margins_override_targets_root_not_a_descendant() {
+        val override = TYPOGRAPHY_OVERRIDES.getValue("margins")
+        assertEquals(
+            "Margins must pad :root (multicol container); padding on body wouldn't show per-page",
+            "", override.elements,
+        )
+        val css = typographyOverrideCss()
+        // The rule for margins must be exactly the gate selector with no descendant —
+        // i.e. `:root[style*="--USER__pageMargins"] {`, not `... body {` or similar.
+        assertTrue(
+            "Margins rule must be scoped to :root itself, not a descendant. CSS was:\n$css",
+            css.contains(":root[style*=\"--USER__pageMargins\"] {"),
+        )
     }
 
     // Injection JS must be idempotent — onPageLoaded fires more than once per page during


### PR DESCRIPTION
## Summary
- The **Margins** stepper previously only moved left/right padding because Readium's built-in user-margins rule (`:root[style*=\"--USER__pageMargins\"] body { padding: 0 X !important }`) explicitly zeroes top/bottom.
- Inject a runtime rule that pads **`:root`** (the multicol container) top/bottom at **0.5×** the horizontal ratio, so every page in paginated mode gets equal vertical whitespace.
- Raise the stepper upper bound **2.0× → 3.0×** now that all four sides scale.

### Why `:root` and not `body`
CSS multicol on `html` fragments `body` as a single block across columns. Padding-top on `body` only shows at the very first column top; padding-bottom only at the very last column bottom. Padding on `:root` shrinks the column box itself (since `:root` has `height: 100vh` + `box-sizing: border-box`), so every page gets equal whitespace.

The selector `:root[style*=\"--USER__pageMargins\"]` has specificity (0,2,0), beating Readium's `:root { padding: 0 !important }` (0,1,0), so our longhand `padding-top` / `padding-bottom !important` wins regardless of source order.

### Why 0.5×
Book typography conventionally gives narrower top/bottom than side margins (side margins set line length, the legibility-critical dimension). The reader also already consumes vertical space with system insets, so a full 1× ratio would feel heavy.

### Refactor
`TypographyOverride` now carries `cssProperties: List<String>` and an explicit `cssValue` expression, since margins needs two longhands and a `calc()` rather than a single `var()` substitution. Existing entries (lineSpacing, justifyText, fontFamily) updated to the new shape.

## Test plan
- [x] Unit tests pass (`make test`)
- [x] Harness/instrumentation tests pass (`make harness-test`) — 127 tests, 0 failures
- [x] New `TypographyOverrideWebViewTest.marginsOverrideAppliesVerticalPaddingToRootWhenUserVariableIsSet` confirms computed `padding-top`/`padding-bottom` on `:root` resolves to `gutter × pageMargins × 0.5`
- [x] New regression-guard unit test asserts margins targets `:root` itself (not a descendant) — encodes the lesson that `elements = \"body\"` silently produces no per-page margin
- [ ] Manual sanity check on a real EPUB at margins 0.2×, 1.0×, and 3.0× in both paginated and scroll modes