### PR TITLE
fix(reader): dedupe rail segments sharing a spine resource

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/RailSegmentGenerator.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/RailSegmentGenerator.kt
@@ -2,7 +2,14 @@ package com.riffle.app.feature.reader
 
 fun buildRailSegments(tocEntries: List<TocEntry>, bookTitle: String = ""): List<RailSegment> {
     val bookTitleNorm = bookTitle.normalize()
-    return tocEntries.flatMap { expandIfRedundant(it, bookTitleNorm) }
+    val expanded = tocEntries.flatMap { expandIfRedundant(it, bookTitleNorm) }
+    // Collapse entries that point to the same spine resource via different fragments. The
+    // navigator's locator carries no fragment during natural reading, so only the first
+    // matching segment would ever become active; siblings would visually skip on chapter
+    // transitions. Keep the first occurrence per base href so the rail shows one segment
+    // per spine resource.
+    val seen = HashSet<String>(expanded.size)
+    return expanded.filter { seen.add(it.href.substringBefore('#')) }
 }
 
 private fun expandIfRedundant(entry: TocEntry, bookTitleNorm: String): List<RailSegment> {

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/RailSegmentGeneratorTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/RailSegmentGeneratorTest.kt
@@ -213,6 +213,47 @@ class RailSegmentGeneratorTest {
     }
 
     @Test
+    fun `top-level entries sharing a spine resource collapse to one segment`() {
+        // Regression: Asimov "Lucky Starr" books pair each chapter with a subtitle entry at
+        // the SAME TOC level, sharing the same spine resource via a fragment:
+        //   Chapter 1         → section4.xhtml
+        //   The Doomed Ship   → section4.xhtml#heading_id_3
+        // The fragment entry can never become the active segment (locator.href has no
+        // fragment during natural reading), so it visually "skips" when advancing chapters.
+        // The rail should show one segment per spine resource — keep the first, drop the rest.
+        val toc = listOf(
+            TocEntry("Chapter 1", "section4.xhtml"),
+            TocEntry("The Doomed Ship", "section4.xhtml#heading_id_3"),
+            TocEntry("Chapter 2", "section5.xhtml"),
+            TocEntry("Sub 2", "section5.xhtml#heading_id_3"),
+        )
+        assertEquals(
+            listOf(
+                RailSegment("Chapter 1", "section4.xhtml"),
+                RailSegment("Chapter 2", "section5.xhtml"),
+            ),
+            buildRailSegments(toc),
+        )
+    }
+
+    @Test
+    fun `fragment-only top-level entry is kept when no plain-href sibling exists`() {
+        // If the only entry pointing to a spine resource has a fragment, keep it — there's
+        // nothing to dedup it against, and dropping it would lose the resource entirely.
+        val toc = listOf(
+            TocEntry("Intro", "section1.xhtml#part1"),
+            TocEntry("Chapter 1", "section2.xhtml"),
+        )
+        assertEquals(
+            listOf(
+                RailSegment("Intro", "section1.xhtml#part1"),
+                RailSegment("Chapter 1", "section2.xhtml"),
+            ),
+            buildRailSegments(toc),
+        )
+    }
+
+    @Test
     fun `segments with duplicate titles but unique hrefs are all retained`() {
         val toc = listOf(
             TocEntry("EDDARD", "chapter_eddard1.xhtml"),


### PR DESCRIPTION
## Summary
- Some EPUBs (e.g. Asimov *Lucky Starr*) include a chapter + subtitle as sibling top-level navPoints sharing one spine resource via a `#fragment` (`Chapter 1 → section4.xhtml`, `The Doomed Ship → section4.xhtml#heading_id_3`).
- The fragment-anchored segment could never become active (the navigator's locator carries no fragment during natural reading), so it visually **skipped** on every chapter transition in the chapter-navigation rail.
- Fix collapses same-base-href entries to a single segment after expansion in `buildRailSegments`, so the rail shows one segment per spine resource.

## Test plan
- [x] Added `top-level entries sharing a spine resource collapse to one segment` (Lucky Starr pattern) to `RailSegmentGeneratorTest`.
- [x] Added `fragment-only top-level entry is kept when no plain-href sibling exists` to guard against dropping a resource only reachable via fragment.
- [x] `:app:testDebugUnitTest` green (42/42 in `RailSegmentGeneratorTest`).
- [x] `make harness-test` green (121 ran / 0 failed / 4 expected skips).
- [ ] Sanity-check the rail in the reader on Lucky Starr — Chapter → Chapter transitions should advance the highlight by one segment with no skipped gap.