### PR TITLE
build(harness): add make harness-test-tablet target (#21)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Running harness tests
 
-Always run harness tests via `make harness-test`. Never call `./gradlew :app:connectedDebugAndroidTest` directly — it targets all connected devices and will interfere with the developer's physical device. The Makefile target boots the "Harness Medium Phone" AVD, runs tests against it exclusively, then shuts it down.
+Always run harness tests via `make harness-test` (phone-form-factor tests) or `make harness-test-tablet` (tests annotated with `@TabletLayout`). Never call `./gradlew :app:connectedDebugAndroidTest` directly — it targets all connected devices and will interfere with the developer's physical device. Each target boots its dedicated AVD ("Harness Medium Phone" or "Harness Medium Tablet"), runs its filtered test subset against it exclusively, then shuts it down. The two subsets are mutually exclusive, so tests never double-run across targets.
 
 ## Feature progress
 

--- a/Makefile
+++ b/Makefile
@@ -106,24 +106,27 @@ clean: ## Clean build outputs
 install: wrapper fonts ## Build debug APK and install on connected device
 	./gradlew :app:installDebug
 
-AVD_NAME := Harness_Medium_Phone
+PHONE_AVD := Harness_Medium_Phone
+TABLET_AVD := Harness_Medium_Tablet
+TABLET_ANNOTATION := com.riffle.app.harness.TabletLayout
 
-.PHONY: harness-test
-harness-test: wrapper fonts ## Boot "Harness Medium Phone" AVD, run harness tests, then shut it down
-	@AVD_CONFIG=$$HOME/.android/avd/$(AVD_NAME).avd/config.ini; \
+# $(1) = AVD name, $(2) = extra gradle args (annotation include/exclude filter)
+define run_harness_tests
+	AVD_NAME="$(1)"; \
+	AVD_CONFIG=$$HOME/.android/avd/$$AVD_NAME.avd/config.ini; \
 	echo "Ensuring AVD heap is 1024 MB (was: $$(grep vm.heapSize $$AVD_CONFIG))..."; \
 	sed -i '' 's/^vm\.heapSize=.*/vm.heapSize=1024/' "$$AVD_CONFIG"; \
 	STALE=$$(for s in $$(adb devices 2>/dev/null | grep emulator | cut -f1); do \
 		name=$$(adb -s $$s emu avd name 2>/dev/null | head -1 | tr -d '\r'); \
-		[ "$$name" = "$(AVD_NAME)" ] && echo $$s; \
+		[ "$$name" = "$$AVD_NAME" ] && echo $$s; \
 	done); \
 	if [ -n "$$STALE" ]; then \
 		echo "Killing stale emulator $$STALE..."; \
 		adb -s $$STALE emu kill 2>/dev/null || true; \
 		until ! adb devices 2>/dev/null | grep -q "$$STALE"; do sleep 2; done; \
 	fi; \
-	echo "Starting emulator '$(AVD_NAME)'..."; \
-	emulator -avd "$(AVD_NAME)" -no-window -no-audio -no-boot-anim -no-snapshot-load \
+	echo "Starting emulator '$$AVD_NAME'..."; \
+	emulator -avd "$$AVD_NAME" -no-window -no-audio -no-boot-anim -no-snapshot-load \
 		&> /tmp/riffle-emulator.log & \
 	EMU_PID=$$!; \
 	echo "Waiting for emulator to boot (pid $$EMU_PID)..."; \
@@ -132,16 +135,25 @@ harness-test: wrapper fonts ## Boot "Harness Medium Phone" AVD, run harness test
 		sleep 2; \
 		SERIAL=$$(for s in $$(adb devices | grep emulator | cut -f1); do \
 			name=$$(adb -s $$s emu avd name 2>/dev/null | head -1 | tr -d '\r'); \
-			[ "$$name" = "$(AVD_NAME)" ] && echo $$s && break; \
+			[ "$$name" = "$$AVD_NAME" ] && echo $$s && break; \
 		done); \
 	done; \
 	until [ "$$(adb -s $$SERIAL shell getprop sys.boot_completed 2>/dev/null | tr -d '\r')" = "1" ]; do sleep 2; done; \
 	echo "Running harness tests on $$SERIAL..."; \
 	adb -s $$SERIAL shell pm clear com.riffle.app 2>/dev/null || true; \
-	ANDROID_SERIAL=$$SERIAL ./gradlew :app:connectedDebugAndroidTest; \
+	ANDROID_SERIAL=$$SERIAL ./gradlew :app:connectedDebugAndroidTest $(2); \
 	TEST_EXIT=$$?; \
 	echo "Shutting down emulator..."; \
 	adb -s $$SERIAL emu kill; \
 	wait $$EMU_PID 2>/dev/null || true; \
 	kill -9 $$EMU_PID 2>/dev/null || true; \
 	exit $$TEST_EXIT
+endef
+
+.PHONY: harness-test
+harness-test: wrapper fonts ## Boot "Harness Medium Phone" AVD, run non-tablet harness tests, then shut it down
+	@$(call run_harness_tests,$(PHONE_AVD),-Pandroid.testInstrumentationRunnerArguments.notAnnotation=$(TABLET_ANNOTATION))
+
+.PHONY: harness-test-tablet
+harness-test-tablet: wrapper fonts ## Boot "Harness Medium Tablet" AVD, run @TabletLayout tests only, then shut it down
+	@$(call run_harness_tests,$(TABLET_AVD),-Pandroid.testInstrumentationRunnerArguments.annotation=$(TABLET_ANNOTATION))


### PR DESCRIPTION
Closes #21.

## Summary

- Adds `make harness-test-tablet` mirroring the existing `harness-test` recipe via a shared shell macro (`define run_harness_tests`) parameterised by AVD name and an AndroidJUnitRunner annotation filter.
- `harness-test` boots `Harness_Medium_Phone` and now excludes `@TabletLayout` via `notAnnotation=…`.
- `harness-test-tablet` boots `Harness_Medium_Tablet` and runs only `@TabletLayout` via `annotation=…`.
- The two subsets are mutually exclusive — tests never double-run across targets.
- `CLAUDE.md` updated to mention both targets.

## Annotation FQN

I used `com.riffle.app.harness.TabletLayout`, matching the existing `com.riffle.app.harness.*` package where the other harness tests live. If #20 places the annotation elsewhere, only the `TABLET_ANNOTATION` variable at the top of the Makefile needs to change. Until #20 lands, `harness-test-tablet` runs zero tests, as the issue anticipates.

## CI

The acceptance criteria mention \"CI runs both targets (sequential or parallel, whichever the existing workflow supports).\" The current `.github/workflows/ci.yml` doesn't run `harness-test` at all (no AVD job), so there's nothing to extend — adding emulator-on-CI is a separate, sizeable piece of work. Flagging for visibility; happy to spin it out as its own issue if you want.

## Test plan

- [x] `make help` lists `harness-test-tablet`
- [x] `make -n harness-test-tablet` expands to the tablet AVD plus `-Pandroid.testInstrumentationRunnerArguments.annotation=com.riffle.app.harness.TabletLayout`
- [x] `make -n harness-test` expands to the phone AVD plus `-Pandroid.testInstrumentationRunnerArguments.notAnnotation=com.riffle.app.harness.TabletLayout`
- [ ] Once #20 lands and the first `@TabletLayout` test exists, run `make harness-test-tablet` end-to-end and confirm the tablet AVD boots, the test runs, and the AVD shuts down.
- [ ] Confirm `make harness-test` still passes the existing phone harness suite locally.