### PR TITLE
fix(to-read): back with per-user Playlists; add To Read tab

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -23,15 +23,21 @@ A per-Server, user-managed set of hidden Libraries. Determines which Libraries a
 A named, ordered grouping of Library Items within a Library. Defined on the ABS server (e.g. "The Stormlight Archive").
 
 ### Collection
-A user-defined, unordered grouping of Library Items within a Library. Distinct from Series — not necessarily sequential. One Collection per Library may be the **To Read** list.
+A user-defined, unordered grouping of Library Items within a Library. Distinct from Series — not necessarily sequential. Library-scoped on the ABS server: shared across all users with access to the Library.
+
+### Playlist
+A per-user, per-Library ordered list of Library Items on the ABS server. Unlike a Collection, a Playlist is scoped to `(userId, libraryId)` and is not visible to other users. Accepts any Library Item, including ebook-only items. **To Read** is backed by a Playlist (see [ADR 0019](adr/0019-to-read-as-playlist.md)).
 
 ### To Read
-A per-Library wishlist of Library Items the user intends to read. Implemented as a regular Collection named `To Read`, looked up by name and find-or-created on first use. Toggled via a bookmark icon on the Library Item Detail Screen (third 40dp circular icon in the action row, between mark-read and download). Filled bookmark = in the list, outline = not in the list.
+A per-user, per-Library wishlist of Library Items the user intends to read. Implemented as an ABS Playlist named `To Read`, looked up by name and find-or-created on first use (see [ADR 0019](adr/0019-to-read-as-playlist.md), which supersedes [ADR 0018](adr/0018-to-read-as-named-collection.md)). Toggled via a bookmark icon on the Library Item Detail Screen (third 40dp circular icon in the action row, between mark-read and download). Filled bookmark = in the list, outline = not in the list.
 
-Behaves like any other Collection — visible in the Collections Tab, editable from the ABS web UI, persists when empty. App-managed rules:
-- **Find-or-create by name.** If the user renames the collection on the server, the next toggle creates a new "To Read" collection; the renamed one is left alone.
-- **Per-Library, not global.** A user with multiple Libraries has one "To Read" collection per Library.
+Surfaced as a dedicated **To Read** tab in the library screen, positioned between Home and Series. The tab shows a grid of the user's queued Library Items; empty state reads "Nothing in To Read".
+
+App-managed rules:
+- **Find-or-create by name.** If the user renames the playlist on the server, the next toggle creates a new "To Read" playlist; the renamed one is left alone.
+- **Per-Library, not global.** A user with multiple Libraries has one "To Read" playlist per Library.
 - **Read transitions remove from To Read.** Any transition of a Library Item to the Read state — manual mark-read, or future auto-finish detection — removes the item from "To Read". The reverse is not enforced: toggling To Read on a Read book does not clear the Read flag (a legitimate re-read signal).
+- **Empty playlists are auto-deleted by ABS.** Removing the last item deletes the playlist server-side; the next add transparently creates a fresh one.
 - **Optimistic, no queueing.** Taps flip the icon immediately, fire the request, and revert with a snackbar on failure. Offline taps fail with a snackbar — there is no durable mutation queue (yet; see notes on a future unified sync mechanism).
 
 ### Library Item

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Riffle lets you browse your ABS ebook library, read EPUB and PDF files, and sync
 
 ### Library
 - Multi-server support with library visibility controls
-- Browse by Home, Series, Collections, and All Books
+- Browse by Home, To Read, Series, Collections, and All Books
 - Plex-style cover grid with book details
 - Read/unread and "To Read" toggles
 - Full-text library search

--- a/app/src/androidTest/kotlin/com/riffle/app/harness/StubAbsServer.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/harness/StubAbsServer.kt
@@ -31,6 +31,8 @@ class StubAbsServer {
         const val TEST_SERIES_NAME = "Test Series"
         const val TEST_COLLECTION_ID = "collection-test-1"
         const val TEST_COLLECTION_NAME = "Test Collection"
+        const val TEST_PLAYLIST_ID = "playlist-test-1"
+        const val TEST_PLAYLIST_NAME = "To Read"
         const val TEST_STANDALONE_ITEM_ID = "item-test-2"
         const val TEST_STANDALONE_ITEM_TITLE = "Test EPUB Standalone"
         const val TEST_STANDALONE_FILE_INO = "ino-test-2"
@@ -68,6 +70,10 @@ class StubAbsServer {
             request.path == "/api/libraries/$TEST_LIBRARY_ID/items" -> libraryItemsResponse()
             request.path == "/api/libraries/$TEST_LIBRARY_ID/series?limit=500" -> seriesResponse()
             request.path == "/api/libraries/$TEST_LIBRARY_ID/collections?limit=500" -> collectionsResponse()
+            request.path == "/api/libraries/$TEST_LIBRARY_ID/playlists?limit=500" -> playlistsResponse()
+            request.path == "/api/playlists" && request.method == "POST" -> playlistCreateResponse(request)
+            request.path?.matches(Regex("/api/playlists/[^/]+/item")) == true && request.method == "POST" -> playlistItemAddResponse()
+            request.path?.matches(Regex("/api/playlists/[^/]+/item/[^/]+")) == true && request.method == "DELETE" -> playlistItemRemoveResponse()
             request.path == "/api/items/$TEST_ITEM_ID" -> itemResponse()
             request.path == "/api/items/$TEST_ITEM_ID/ebook/$TEST_FILE_INO" -> epubFileResponse()
             request.path == "/api/items/$TEST_STANDALONE_ITEM_ID" -> standaloneItemResponse()
@@ -159,6 +165,24 @@ class StubAbsServer {
         200,
         """{"results":[{"id":"$TEST_COLLECTION_ID","libraryId":"$TEST_LIBRARY_ID","name":"$TEST_COLLECTION_NAME","books":[{"id":"$TEST_ITEM_ID","libraryId":"$TEST_LIBRARY_ID","media":{"metadata":{"title":"$TEST_ITEM_TITLE","authorName":"$TEST_ITEM_AUTHOR","genres":null},"ebookFormat":"epub","ebookFile":{"ino":"$TEST_FILE_INO"}},"userMediaProgress":null}]}]}"""
     )
+
+    private fun playlistsResponse() = json(
+        200,
+        """{"results":[]}"""
+    )
+
+    private fun playlistCreateResponse(request: RecordedRequest): MockResponse {
+        // Consume body to avoid leaving it on the wire; minimal valid playlist response.
+        request.body.readUtf8()
+        return json(
+            200,
+            """{"id":"playlist-new","libraryId":"$TEST_LIBRARY_ID","name":"$TEST_PLAYLIST_NAME","items":[]}"""
+        )
+    }
+
+    private fun playlistItemAddResponse() = json(200, "{}")
+
+    private fun playlistItemRemoveResponse() = json(200, "{}")
 
     private fun meResponse() = json(
         200,

--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModel.kt
@@ -77,6 +77,7 @@ class LibraryItemDetailViewModel @Inject constructor(
                 val item = repository.getItem(itemId)
                 if (item != null) {
                     _downloadState.value = deriveDownloadState(item)
+                    toReadRepository.refresh(item.libraryId)
                     val isInToRead = toReadRepository.isInToRead(item.id, item.libraryId)
                     LibraryItemDetailUiState.Ready(item = item, isInToRead = isInToRead)
                 } else {

--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsScreen.kt
@@ -32,6 +32,7 @@ import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Bookmark
 import androidx.compose.material.icons.filled.Folder
 import androidx.compose.material.icons.filled.FormatListNumbered
 import androidx.compose.material.icons.filled.GridView
@@ -109,6 +110,7 @@ fun LibraryItemsScreen(
     val recentlyAdded by viewModel.filteredRecentlyAdded.collectAsState()
     val series by viewModel.filteredSeries.collectAsState()
     val collections by viewModel.filteredCollections.collectAsState()
+    val toReadItems by viewModel.toReadItems.collectAsState()
     val collectionCoverUrls by viewModel.collectionCoverUrls.collectAsState()
     val isOffline by viewModel.isOffline.collectAsState()
     val isLoading by viewModel.isLoading.collectAsState()
@@ -178,20 +180,26 @@ fun LibraryItemsScreen(
                         onItemSelected = onItemSelected,
                         onSectionSeeMore = onSectionSeeMore,
                     )
-                    1 -> SeriesTabContent(
+                    1 -> ToReadTabContent(
+                        items = toReadItems,
+                        isLoading = isLoading,
+                        token = viewModel.authToken,
+                        onItemSelected = onItemSelected,
+                    )
+                    2 -> SeriesTabContent(
                         items = series,
                         isLoading = isLoading,
                         token = viewModel.authToken,
                         onSeriesSelected = onSeriesSelected,
                     )
-                    2 -> CollectionsTabContent(
+                    3 -> CollectionsTabContent(
                         items = collections,
                         isLoading = isLoading,
                         token = viewModel.authToken,
                         collectionCoverUrls = collectionCoverUrls,
                         onCollectionSelected = onCollectionSelected,
                     )
-                    3 -> AllBooksTabContent(
+                    4 -> AllBooksTabContent(
                         items = allBooks,
                         isLoading = isLoading,
                         token = viewModel.authToken,
@@ -816,16 +824,21 @@ private fun LibraryTabBar(selectedTab: Int, onTabSelected: (Int) -> Unit) {
         NavigationBarItem(
             selected = selectedTab == 1,
             onClick = { onTabSelected(1) },
-            icon = { Icon(Icons.Filled.FormatListNumbered, contentDescription = "Series") },
+            icon = { Icon(Icons.Filled.Bookmark, contentDescription = "To Read") },
         )
         NavigationBarItem(
             selected = selectedTab == 2,
             onClick = { onTabSelected(2) },
-            icon = { Icon(Icons.Filled.Folder, contentDescription = "Collections") },
+            icon = { Icon(Icons.Filled.FormatListNumbered, contentDescription = "Series") },
         )
         NavigationBarItem(
             selected = selectedTab == 3,
             onClick = { onTabSelected(3) },
+            icon = { Icon(Icons.Filled.Folder, contentDescription = "Collections") },
+        )
+        NavigationBarItem(
+            selected = selectedTab == 4,
+            onClick = { onTabSelected(4) },
             icon = { Icon(Icons.Filled.GridView, contentDescription = "All Books") },
         )
     }
@@ -961,6 +974,38 @@ private fun CollectionsTabContent(
                     token = token,
                     onClick = { onCollectionSelected(col) },
                 )
+            }
+        }
+    }
+}
+
+@Composable
+private fun ToReadTabContent(
+    items: List<LibraryItem>,
+    isLoading: Boolean,
+    token: String,
+    onItemSelected: (LibraryItem) -> Unit,
+) {
+    if (isLoading) return
+    if (items.isEmpty()) {
+        Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+            Text("Nothing in To Read")
+        }
+        return
+    }
+    LazyVerticalGrid(
+        columns = GridCells.Fixed(3),
+        contentPadding = PaddingValues(
+            start = 12.dp, end = 12.dp, bottom = 16.dp,
+        ),
+        modifier = Modifier.fillMaxSize(),
+    ) {
+        item(span = { GridItemSpan(maxLineSpan) }) {
+            SectionHeader("To Read (${items.size})")
+        }
+        items(items, key = { it.id }) { item ->
+            Box(modifier = Modifier.padding(4.dp)) {
+                BookCoverTile(item = item, token = token, onClick = { onItemSelected(item) })
             }
         }
     }

--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsViewModel.kt
@@ -15,6 +15,7 @@ import com.riffle.core.domain.LibraryRefreshResult
 import com.riffle.core.domain.LibraryRepository
 import com.riffle.core.domain.PdfRepository
 import com.riffle.core.domain.Series
+import com.riffle.core.data.ToReadRepository
 import com.riffle.core.domain.ServerRepository
 import com.riffle.core.domain.TokenStorage
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -49,6 +50,7 @@ class LibraryItemsViewModel @Inject constructor(
     private val epubRepository: EpubRepository,
     private val pdfRepository: PdfRepository,
     private val connectivityObserver: ConnectivityObserver,
+    private val toReadRepository: ToReadRepository,
 ) : ViewModel() {
 
     val libraryId: String = savedStateHandle.get<String>("libraryId") ?: ""
@@ -96,6 +98,9 @@ class LibraryItemsViewModel @Inject constructor(
 
     private val allBooks: StateFlow<List<LibraryItem>> = libraryRepository.observeAllBooks(libraryId)
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
+
+    val toReadItemIds: StateFlow<Set<String>> = toReadRepository.observeToReadItemIds(libraryId)
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptySet())
 
     private val allItems: StateFlow<List<LibraryItem>> = libraryRepository.observeLibraryItems(libraryId)
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
@@ -156,6 +161,12 @@ class LibraryItemsViewModel @Inject constructor(
         if (offline) items.filter { isAvailableOffline(it) } else items
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
 
+    val toReadItems: StateFlow<List<LibraryItem>> = combine(toReadItemIds, allBooks, isOffline) { ids, all, offline ->
+        val byId = all.associateBy { it.id }
+        val items = ids.mapNotNull { byId[it] }
+        if (offline) items.filter { isAvailableOffline(it) } else items
+    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
+
     var authToken: String by mutableStateOf("")
         private set
 
@@ -166,6 +177,7 @@ class LibraryItemsViewModel @Inject constructor(
                 authToken = tokenStorage.getToken(server.id) ?: ""
             }
             val refreshJob = launch { refresh() }
+            launch { toReadRepository.refresh(libraryId) }
             // Unblock the UI as soon as we have something meaningful to show:
             // either Room returns cached data quickly, or we wait for the network
             // refresh to complete so an empty state is known to be genuine.
@@ -186,7 +198,10 @@ class LibraryItemsViewModel @Inject constructor(
             connectivityObserver.isOnline
                 .drop(1)
                 .filter { it }
-                .collect { refresh() }
+                .collect {
+                    refresh()
+                    toReadRepository.refresh(libraryId)
+                }
         }
     }
 
@@ -199,7 +214,10 @@ class LibraryItemsViewModel @Inject constructor(
             val itemsDeferred = async { libraryRepository.refreshLibraryItems(libraryId) }
             val seriesDeferred = async { libraryRepository.refreshSeries(libraryId) }
             val collectionsDeferred = async { libraryRepository.refreshCollections(libraryId) }
+            // ToRead refresh runs alongside but its failure must NOT flip the offline banner.
+            val toReadDeferred = async { toReadRepository.refresh(libraryId) }
             val results = listOf(itemsDeferred.await(), seriesDeferred.await(), collectionsDeferred.await())
+            toReadDeferred.await()
             _refreshFailed.value = results.any { it is LibraryRefreshResult.NetworkError }
         }
     }

--- a/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModelTest.kt
@@ -33,6 +33,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.resetMain
@@ -168,6 +169,10 @@ class LibraryItemDetailViewModelTest {
         val state = mutableSetOf<String>().also { it += initial }
         val addCalls = mutableListOf<Pair<String, String>>()
         val removeCalls = mutableListOf<Pair<String, String>>()
+
+        override fun observeToReadItemIds(libraryId: String): Flow<Set<String>> = flowOf(state.toSet())
+
+        override suspend fun refresh(libraryId: String): Boolean = true
 
         override suspend fun isInToRead(libraryItemId: String, libraryId: String): Boolean =
             libraryItemId in state

--- a/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModelTest.kt
@@ -169,13 +169,19 @@ class LibraryItemDetailViewModelTest {
         val state = mutableSetOf<String>().also { it += initial }
         val addCalls = mutableListOf<Pair<String, String>>()
         val removeCalls = mutableListOf<Pair<String, String>>()
+        val callLog = mutableListOf<String>()
 
         override fun observeToReadItemIds(libraryId: String): Flow<Set<String>> = flowOf(state.toSet())
 
-        override suspend fun refresh(libraryId: String): Boolean = true
+        override suspend fun refresh(libraryId: String): Boolean {
+            callLog += "refresh"
+            return true
+        }
 
-        override suspend fun isInToRead(libraryItemId: String, libraryId: String): Boolean =
-            libraryItemId in state
+        override suspend fun isInToRead(libraryItemId: String, libraryId: String): Boolean {
+            callLog += "isInToRead"
+            return libraryItemId in state
+        }
 
         override suspend fun addToToRead(libraryItemId: String, libraryId: String): Boolean {
             addCalls += libraryItemId to libraryId
@@ -299,6 +305,18 @@ class LibraryItemDetailViewModelTest {
         testDispatcher.scheduler.advanceUntilIdle()
 
         assertEquals(DownloadState.NotDownloaded, vm.downloadState.value)
+    }
+
+    @Test
+    fun `init refreshes To Read before reading isInToRead`() = runTest {
+        val toRead = FakeToReadRepository()
+        val vm = makeVm(repo = fakeRepo(knownItem), toReadRepo = toRead)
+        backgroundScope.launch { vm.uiState.collect {} }
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        val refreshIdx = toRead.callLog.indexOf("refresh")
+        val isInIdx = toRead.callLog.indexOf("isInToRead")
+        assertTrue("expected refresh before isInToRead, got ${toRead.callLog}", refreshIdx in 0 until isInIdx)
     }
 
     // --- toggleToRead tests ---

--- a/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemsViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemsViewModelTest.kt
@@ -18,6 +18,7 @@ import com.riffle.core.domain.Series
 import com.riffle.core.domain.Server
 import com.riffle.core.domain.ServerRepository
 import com.riffle.core.domain.ServerUrl
+import com.riffle.core.data.ToReadRepository
 import com.riffle.core.domain.TokenStorage
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -31,6 +32,7 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 
@@ -120,6 +122,26 @@ class LibraryItemsViewModelTest {
         override val isOnline: StateFlow<Boolean> = state
     }
 
+    private class FakeToReadRepository(initial: Set<String> = emptySet()) : ToReadRepository {
+        val ids = MutableStateFlow(initial)
+        var refreshCount = 0
+        override fun observeToReadItemIds(libraryId: String): Flow<Set<String>> = ids
+        override suspend fun refresh(libraryId: String): Boolean {
+            refreshCount++
+            return true
+        }
+        override suspend fun isInToRead(libraryItemId: String, libraryId: String): Boolean =
+            libraryItemId in ids.value
+        override suspend fun addToToRead(libraryItemId: String, libraryId: String): Boolean {
+            ids.value = ids.value + libraryItemId
+            return true
+        }
+        override suspend fun removeFromToRead(libraryItemId: String, libraryId: String): Boolean {
+            ids.value = ids.value - libraryItemId
+            return true
+        }
+    }
+
     private fun makeViewModel(
         connectivityObserver: ConnectivityObserver = FakeConnectivityObserver(),
         epubRepository: EpubRepository = fakeEpubRepo(),
@@ -127,6 +149,7 @@ class LibraryItemsViewModelTest {
         libraryRepository: LibraryRepository = fakeRepo(),
         serverRepository: ServerRepository = fakeServerRepo(),
         tokenStorage: TokenStorage = fakeTokenStorage(),
+        toReadRepository: ToReadRepository = FakeToReadRepository(),
     ) = LibraryItemsViewModel(
         SavedStateHandle(mapOf("libraryId" to "lib-1")),
         libraryRepository,
@@ -135,6 +158,7 @@ class LibraryItemsViewModelTest {
         epubRepository,
         pdfRepository,
         connectivityObserver,
+        toReadRepository,
     )
 
     private fun series(name: String) = Series("id-$name", "lib-1", name, null, 1)
@@ -595,6 +619,66 @@ class LibraryItemsViewModelTest {
         recentlyAddedFlow.value = listOf(item("Dune", "Frank Herbert"), item("Foundation", "Isaac Asimov"))
         testDispatcher.scheduler.advanceUntilIdle()
         assertEquals(listOf(item("Dune", "Frank Herbert")), vm.filteredRecentlyAdded.value)
+    }
+
+    // --- toReadItems ---
+
+    @Test
+    fun `toReadItems is the intersection of toReadItemIds and allBooks when online`() = runTest {
+        val toRead = FakeToReadRepository(initial = setOf("id-Dune", "id-Foundation"))
+        val vm = makeViewModel(toReadRepository = toRead)
+        backgroundScope.launch { vm.toReadItems.collect {} }
+        allBooksFlow.value = listOf(
+            item("Dune", "Frank Herbert"),
+            item("Foundation", "Isaac Asimov"),
+            item("1984", "George Orwell"),
+        )
+        testDispatcher.scheduler.advanceUntilIdle()
+        assertEquals(
+            listOf(item("Dune", "Frank Herbert"), item("Foundation", "Isaac Asimov")),
+            vm.toReadItems.value,
+        )
+    }
+
+    @Test
+    fun `toReadItems when offline only includes available-offline items`() = runTest {
+        val toRead = FakeToReadRepository(initial = setOf("id-Dune", "id-Foundation"))
+        val vm = makeViewModel(
+            connectivityObserver = FakeConnectivityObserver(online = false),
+            epubRepository = fakeEpubRepoWithDownloads(setOf("id-Dune")),
+            toReadRepository = toRead,
+        )
+        backgroundScope.launch { vm.toReadItems.collect {} }
+        allBooksFlow.value = listOf(
+            item("Dune", "Frank Herbert"),
+            item("Foundation", "Isaac Asimov"),
+        )
+        testDispatcher.scheduler.advanceUntilIdle()
+        assertEquals(listOf(item("Dune", "Frank Herbert")), vm.toReadItems.value)
+    }
+
+    @Test
+    fun `init calls toReadRepository refresh`() = runTest {
+        val toRead = FakeToReadRepository()
+        val vm = makeViewModel(toReadRepository = toRead)
+        backgroundScope.launch { vm.isLoading.collect {} }
+        testDispatcher.scheduler.advanceUntilIdle()
+        assertTrue(toRead.refreshCount >= 1)
+    }
+
+    @Test
+    fun `toRead refresh failure does not flip the offline banner`() = runTest {
+        val toRead = object : ToReadRepository {
+            override fun observeToReadItemIds(libraryId: String) = MutableStateFlow<Set<String>>(emptySet())
+            override suspend fun refresh(libraryId: String): Boolean = false
+            override suspend fun isInToRead(libraryItemId: String, libraryId: String): Boolean = false
+            override suspend fun addToToRead(libraryItemId: String, libraryId: String): Boolean = true
+            override suspend fun removeFromToRead(libraryItemId: String, libraryId: String): Boolean = true
+        }
+        val vm = makeViewModel(toReadRepository = toRead)
+        backgroundScope.launch { vm.isOffline.collect {} }
+        testDispatcher.scheduler.advanceUntilIdle()
+        assertEquals(false, vm.isOffline.value)
     }
 
     @Test

--- a/core/data/src/main/kotlin/com/riffle/core/data/ToReadRepository.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/ToReadRepository.kt
@@ -1,26 +1,29 @@
 package com.riffle.core.data
 
-const val TO_READ_COLLECTION_NAME = "To Read"
+import kotlinx.coroutines.flow.Flow
+
+const val TO_READ_PLAYLIST_NAME = "To Read"
 
 /**
- * Manages the per-Library "To Read" Collection on the active ABS server.
+ * Manages the per-Library, per-User "To Read" Playlist on the active ABS server.
  *
- * The list is backed by a normal ABS Collection named [TO_READ_COLLECTION_NAME], looked
- * up by name and find-or-created on first use. See ADR 0018.
+ * Backed by a normal ABS Playlist named [TO_READ_PLAYLIST_NAME], looked up by name and
+ * find-or-created on first use. See ADR 0019.
+ *
+ * Playlists are scoped to (userId, libraryId) on the server, so each ABS account has its
+ * own independent To Read list.
+ *
+ * Cache: in-memory only. Call [refresh] once per library to populate before relying on
+ * [observeToReadItemIds] or [isInToRead] — typically from `LibraryItemsViewModel.init`.
  */
 interface ToReadRepository {
-    /** Returns true if [libraryItemId] is currently in the "To Read" collection of [libraryId]. */
+    /** Item-ids currently in the To Read playlist for [libraryId]. Empty before first refresh. */
+    fun observeToReadItemIds(libraryId: String): Flow<Set<String>>
+
+    /** Fetches the To Read playlist from the server and refreshes the in-memory cache. */
+    suspend fun refresh(libraryId: String): Boolean
+
     suspend fun isInToRead(libraryItemId: String, libraryId: String): Boolean
-
-    /**
-     * Adds [libraryItemId] to the "To Read" collection of [libraryId], creating the
-     * collection if it does not yet exist. Returns true on success.
-     */
     suspend fun addToToRead(libraryItemId: String, libraryId: String): Boolean
-
-    /**
-     * Removes [libraryItemId] from the "To Read" collection of [libraryId]. Returns true
-     * on success or if the collection / membership did not exist (a no-op success).
-     */
     suspend fun removeFromToRead(libraryItemId: String, libraryId: String): Boolean
 }

--- a/core/data/src/main/kotlin/com/riffle/core/data/ToReadRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/ToReadRepositoryImpl.kt
@@ -1,78 +1,106 @@
 package com.riffle.core.data
 
-import com.riffle.core.domain.Collection
-import com.riffle.core.domain.LibraryRepository
 import com.riffle.core.domain.ServerRepository
 import com.riffle.core.domain.TokenStorage
 import com.riffle.core.network.AbsLibraryApi
-import com.riffle.core.network.NetworkCollectionResult
-import com.riffle.core.network.NetworkCollectionWriteResult
-import kotlinx.coroutines.flow.first
+import com.riffle.core.network.NetworkPlaylistResult
+import com.riffle.core.network.NetworkPlaylistWriteResult
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 import javax.inject.Singleton
+
+/**
+ * In-memory To Read snapshot for a single library.
+ *
+ * `playlistId == null` means we know the server has no To Read playlist (so next add must create).
+ * After [ToReadRepositoryImpl.refresh] succeeds, the snapshot reflects the server's state.
+ */
+private data class ToReadSnapshot(val playlistId: String?, val itemIds: Set<String>)
 
 @Singleton
 class ToReadRepositoryImpl @Inject constructor(
     private val api: AbsLibraryApi,
     private val serverRepository: ServerRepository,
     private val tokenStorage: TokenStorage,
-    private val libraryRepository: LibraryRepository,
 ) : ToReadRepository {
 
-    override suspend fun isInToRead(libraryItemId: String, libraryId: String): Boolean {
-        val toRead = cachedToRead(libraryId) ?: return false
-        return libraryRepository.observeCollectionItems(toRead.id).first()
-            .any { it.id == libraryItemId }
+    private val cache = MutableStateFlow<Map<String, ToReadSnapshot>>(emptyMap())
+
+    override fun observeToReadItemIds(libraryId: String): Flow<Set<String>> =
+        cache.map { it[libraryId]?.itemIds ?: emptySet() }
+
+    override suspend fun refresh(libraryId: String): Boolean {
+        val session = resolveSession() ?: return false
+        val result = api.getPlaylists(session.baseUrl, libraryId, session.token, session.insecureAllowed)
+        if (result !is NetworkPlaylistResult.Success) return false
+        val match = result.playlists.firstOrNull { it.name == TO_READ_PLAYLIST_NAME }
+        val snapshot = ToReadSnapshot(
+            playlistId = match?.id,
+            itemIds = match?.items?.map { it.id }?.toSet() ?: emptySet(),
+        )
+        cache.value = cache.value + (libraryId to snapshot)
+        return true
     }
+
+    override suspend fun isInToRead(libraryItemId: String, libraryId: String): Boolean =
+        cache.value[libraryId]?.itemIds?.contains(libraryItemId) == true
 
     override suspend fun addToToRead(libraryItemId: String, libraryId: String): Boolean {
         val session = resolveSession() ?: return false
-        // Lookup order: prefer the local cache (instant, offline-tolerant). Only fall back to the
-        // network when the cache has no "To Read" — otherwise a stale cache could cause us to
-        // POST a duplicate To Read collection that already exists on the server.
-        val toReadId = cachedToRead(libraryId)?.id
-            ?: findToReadOnServer(session, libraryId)?.id
-        val result = if (toReadId == null) {
-            api.createCollection(
-                session.baseUrl, libraryId, TO_READ_COLLECTION_NAME, libraryItemId,
+        val before = cache.value[libraryId] ?: ToReadSnapshot(playlistId = null, itemIds = emptySet())
+        // Optimistic update
+        cache.value = cache.value + (libraryId to before.copy(itemIds = before.itemIds + libraryItemId))
+        val playlistId = before.playlistId
+        val ok = if (playlistId == null) {
+            val r = api.createPlaylist(
+                session.baseUrl, libraryId, TO_READ_PLAYLIST_NAME, libraryItemId,
                 session.token, session.insecureAllowed,
             )
+            if (r is NetworkPlaylistWriteResult.Success) {
+                val newId = r.playlist?.id
+                if (newId != null) {
+                    cache.value = cache.value + (libraryId to ToReadSnapshot(newId, before.itemIds + libraryItemId))
+                }
+                true
+            } else false
         } else {
-            api.addBookToCollection(
-                session.baseUrl, toReadId, libraryItemId, session.token, session.insecureAllowed,
+            val r = api.addBookToPlaylist(
+                session.baseUrl, playlistId, libraryItemId, session.token, session.insecureAllowed,
             )
+            r is NetworkPlaylistWriteResult.Success
         }
-        val ok = result is NetworkCollectionWriteResult.Success
-        if (ok) libraryRepository.refreshCollections(libraryId)
+        if (!ok) cache.value = cache.value + (libraryId to before)
         return ok
     }
 
     override suspend fun removeFromToRead(libraryItemId: String, libraryId: String): Boolean {
-        val toRead = cachedToRead(libraryId) ?: return true
         val session = resolveSession() ?: return false
-        val result = api.removeBookFromCollection(
-            session.baseUrl, toRead.id, libraryItemId, session.token, session.insecureAllowed,
+        val before = cache.value[libraryId] ?: return true
+        val playlistId = before.playlistId ?: return true
+        if (libraryItemId !in before.itemIds) return true
+        val remainingIds = before.itemIds - libraryItemId
+        // Optimistic update. If we're removing the last item, ABS auto-deletes the playlist
+        // server-side — drop our cached playlistId so the next addToToRead creates a fresh one.
+        val optimistic = if (remainingIds.isEmpty()) {
+            ToReadSnapshot(playlistId = null, itemIds = emptySet())
+        } else {
+            before.copy(itemIds = remainingIds)
+        }
+        cache.value = cache.value + (libraryId to optimistic)
+        val r = api.removeBookFromPlaylist(
+            session.baseUrl, playlistId, libraryItemId, session.token, session.insecureAllowed,
         )
-        val ok = result is NetworkCollectionWriteResult.Success
-        if (ok) libraryRepository.refreshCollections(libraryId)
+        val ok = r is NetworkPlaylistWriteResult.Success
+        if (!ok) cache.value = cache.value + (libraryId to before)
         return ok
     }
 
     private suspend fun resolveSession(): Session? {
         val server = serverRepository.getActive() ?: return null
         val token = tokenStorage.getToken(server.id) ?: return null
-        return Session(baseUrl = server.url.value, token = token, insecureAllowed = server.insecureConnectionAllowed)
-    }
-
-    private suspend fun cachedToRead(libraryId: String): Collection? =
-        libraryRepository.observeCollections(libraryId).first()
-            .firstOrNull { it.name == TO_READ_COLLECTION_NAME }
-
-    private suspend fun findToReadOnServer(session: Session, libraryId: String): Collection? {
-        val result = api.getCollections(session.baseUrl, libraryId, session.token, session.insecureAllowed)
-        if (result !is NetworkCollectionResult.Success) return null
-        val match = result.collections.firstOrNull { it.name == TO_READ_COLLECTION_NAME } ?: return null
-        return Collection(id = match.id, libraryId = match.libraryId, name = match.name, bookCount = match.items.size)
+        return Session(server.url.value, token, server.insecureConnectionAllowed)
     }
 
     private data class Session(val baseUrl: String, val token: String, val insecureAllowed: Boolean)

--- a/core/data/src/main/kotlin/com/riffle/core/data/ToReadRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/ToReadRepositoryImpl.kt
@@ -38,7 +38,7 @@ class ToReadRepositoryImpl @Inject constructor(
         val match = result.playlists.firstOrNull { it.name == TO_READ_PLAYLIST_NAME }
         val snapshot = ToReadSnapshot(
             playlistId = match?.id,
-            itemIds = match?.items?.map { it.id }?.toSet() ?: emptySet(),
+            itemIds = match?.bookIds ?: emptySet(),
         )
         cache.value = cache.value + (libraryId to snapshot)
         return true

--- a/core/data/src/test/kotlin/com/riffle/core/data/ToReadRepositoryTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/ToReadRepositoryTest.kt
@@ -2,26 +2,22 @@ package com.riffle.core.data
 
 import com.riffle.core.domain.AuthenticateResult
 import com.riffle.core.domain.CommitServerResult
-import com.riffle.core.domain.Collection
-import com.riffle.core.domain.PendingServer
-import com.riffle.core.domain.LibraryItem
 import com.riffle.core.domain.EbookFormat
-import com.riffle.core.domain.LibraryRefreshResult
-import com.riffle.core.domain.LibraryRepository
+import com.riffle.core.domain.PendingServer
 import com.riffle.core.domain.Server
 import com.riffle.core.domain.ServerRepository
 import com.riffle.core.domain.ServerUrl
 import com.riffle.core.domain.TokenStorage
 import com.riffle.core.network.AbsLibraryApi
-import com.riffle.core.network.NetworkCollection
-import com.riffle.core.network.NetworkCollectionResult
-import com.riffle.core.network.NetworkCollectionWriteResult
 import com.riffle.core.network.NetworkLibrariesResult
 import com.riffle.core.network.NetworkLibraryItem
 import com.riffle.core.network.NetworkLibraryItemsResult
+import com.riffle.core.network.NetworkPlaylist
+import com.riffle.core.network.NetworkPlaylistResult
+import com.riffle.core.network.NetworkPlaylistWriteResult
 import com.riffle.core.network.NetworkSeriesResult
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -42,89 +38,86 @@ class ToReadRepositoryTest {
 
     private fun makeRepo(
         api: AbsLibraryApi = FakeAbsApi(),
-        libraryRepository: FakeLibraryRepository = FakeLibraryRepository(),
         serverRepository: ServerRepository = FakeServerRepository(activeServer),
         tokenStorage: TokenStorage = FakeTokenStorage(mutableMapOf("s1" to "tok")),
-    ): ToReadRepositoryImpl = ToReadRepositoryImpl(
-        api = api,
-        serverRepository = serverRepository,
-        tokenStorage = tokenStorage,
-        libraryRepository = libraryRepository,
-    )
+    ) = ToReadRepositoryImpl(api, serverRepository, tokenStorage)
+
+    // ── refresh + observeToReadItemIds ────────────────────────────────────────
+
+    @Test
+    fun `refresh populates cache from server`() = runTest {
+        val api = FakeAbsApi(
+            playlistsByLibrary = mapOf("lib-1" to listOf(playlist("pl-A", "To Read", listOf("item-1", "item-2")))),
+        )
+        val repo = makeRepo(api)
+        assertTrue(repo.refresh("lib-1"))
+        assertEquals(setOf("item-1", "item-2"), repo.observeToReadItemIds("lib-1").first())
+    }
+
+    @Test
+    fun `refresh populates empty when no To Read playlist exists`() = runTest {
+        val api = FakeAbsApi(playlistsByLibrary = mapOf("lib-1" to emptyList()))
+        val repo = makeRepo(api)
+        assertTrue(repo.refresh("lib-1"))
+        assertEquals(emptySet<String>(), repo.observeToReadItemIds("lib-1").first())
+    }
+
+    @Test
+    fun `refresh returns false on network error and leaves cache untouched`() = runTest {
+        val api = object : FakeAbsApi() {
+            override suspend fun getPlaylists(baseUrl: String, libraryId: String, token: String, insecureAllowed: Boolean): NetworkPlaylistResult =
+                NetworkPlaylistResult.NetworkError(IOException("HTTP 500"))
+        }
+        val repo = makeRepo(api)
+        assertFalse(repo.refresh("lib-1"))
+        assertEquals(emptySet<String>(), repo.observeToReadItemIds("lib-1").first())
+    }
 
     // ── isInToRead ────────────────────────────────────────────────────────────
 
     @Test
-    fun `isInToRead returns true when book is in the cached To Read collection`() = runTest {
-        val lib = FakeLibraryRepository()
-        lib.setCollections("lib-1", listOf(collection("col-A", "To Read")))
-        lib.setCollectionItems("col-A", listOf(item("item-1")))
-        assertTrue(makeRepo(libraryRepository = lib).isInToRead("item-1", "lib-1"))
+    fun `isInToRead reads from cache after refresh`() = runTest {
+        val api = FakeAbsApi(
+            playlistsByLibrary = mapOf("lib-1" to listOf(playlist("pl-A", "To Read", listOf("item-1")))),
+        )
+        val repo = makeRepo(api)
+        repo.refresh("lib-1")
+        assertTrue(repo.isInToRead("item-1", "lib-1"))
+        assertFalse(repo.isInToRead("item-9", "lib-1"))
     }
 
     @Test
-    fun `isInToRead returns false when cached To Read collection has no such book`() = runTest {
-        val lib = FakeLibraryRepository()
-        lib.setCollections("lib-1", listOf(collection("col-A", "To Read")))
-        lib.setCollectionItems("col-A", listOf(item("item-9")))
-        assertFalse(makeRepo(libraryRepository = lib).isInToRead("item-1", "lib-1"))
-    }
-
-    @Test
-    fun `isInToRead returns false when no To Read collection is cached`() = runTest {
-        val lib = FakeLibraryRepository()
-        lib.setCollections("lib-1", emptyList())
-        assertFalse(makeRepo(libraryRepository = lib).isInToRead("item-1", "lib-1"))
-    }
-
-    @Test
-    fun `isInToRead does not hit the network`() = runTest {
-        val api = FakeAbsApi()
-        val lib = FakeLibraryRepository()
-        lib.setCollections("lib-1", listOf(collection("col-A", "To Read")))
-        lib.setCollectionItems("col-A", listOf(item("item-1")))
-        makeRepo(api = api, libraryRepository = lib).isInToRead("item-1", "lib-1")
-        assertEquals(0, api.getCollectionsCalls)
+    fun `isInToRead returns false before any refresh`() = runTest {
+        val api = FakeAbsApi(
+            playlistsByLibrary = mapOf("lib-1" to listOf(playlist("pl-A", "To Read", listOf("item-1")))),
+        )
+        assertFalse(makeRepo(api).isInToRead("item-1", "lib-1"))
     }
 
     // ── addToToRead ───────────────────────────────────────────────────────────
 
     @Test
-    fun `addToToRead adds to existing cached To Read collection without any GET`() = runTest {
-        val api = FakeAbsApi()
-        val lib = FakeLibraryRepository()
-        lib.setCollections("lib-1", listOf(collection("col-A", "To Read")))
-        val ok = makeRepo(api = api, libraryRepository = lib).addToToRead("item-1", "lib-1")
-        assertTrue(ok)
-        assertTrue(api.createCalls.isEmpty())
-        assertEquals(listOf("col-A" to "item-1"), api.addCalls)
-        assertEquals(0, api.getCollectionsCalls)
-    }
-
-    @Test
-    fun `addToToRead falls back to server lookup when cache has no To Read`() = runTest {
+    fun `addToToRead appends to existing playlist and updates cache optimistically`() = runTest {
         val api = FakeAbsApi(
-            collectionsByLibrary = mapOf(
-                "lib-1" to listOf(NetworkCollection("col-A", "lib-1", "To Read", emptyList())),
-            ),
+            playlistsByLibrary = mapOf("lib-1" to listOf(playlist("pl-A", "To Read", emptyList()))),
         )
-        val lib = FakeLibraryRepository().apply { setCollections("lib-1", emptyList()) }
-        val ok = makeRepo(api = api, libraryRepository = lib).addToToRead("item-1", "lib-1")
-        assertTrue(ok)
-        assertEquals(1, api.getCollectionsCalls)
+        val repo = makeRepo(api)
+        repo.refresh("lib-1")
+        assertTrue(repo.addToToRead("item-1", "lib-1"))
         assertTrue(api.createCalls.isEmpty())
-        assertEquals(listOf("col-A" to "item-1"), api.addCalls)
+        assertEquals(listOf("pl-A" to "item-1"), api.addCalls)
+        assertEquals(setOf("item-1"), repo.observeToReadItemIds("lib-1").first())
     }
 
     @Test
-    fun `addToToRead creates the collection when neither cache nor server has To Read`() = runTest {
-        val api = FakeAbsApi(collectionsByLibrary = mapOf("lib-1" to emptyList()))
-        val lib = FakeLibraryRepository().apply { setCollections("lib-1", emptyList()) }
-        val ok = makeRepo(api = api, libraryRepository = lib).addToToRead("item-1", "lib-1")
-        assertTrue(ok)
-        assertEquals(1, api.getCollectionsCalls)
+    fun `addToToRead creates playlist when cache is empty + no playlist on server`() = runTest {
+        val api = FakeAbsApi(playlistsByLibrary = mapOf("lib-1" to emptyList()))
+        val repo = makeRepo(api)
+        repo.refresh("lib-1")
+        assertTrue(repo.addToToRead("item-1", "lib-1"))
         assertEquals(listOf(Triple("lib-1", "To Read", "item-1")), api.createCalls)
         assertTrue(api.addCalls.isEmpty())
+        assertEquals(setOf("item-1"), repo.observeToReadItemIds("lib-1").first())
     }
 
     @Test
@@ -137,117 +130,98 @@ class ToReadRepositoryTest {
     }
 
     @Test
-    fun `addToToRead refreshes collections after successful add`() = runTest {
-        val lib = FakeLibraryRepository()
-        lib.setCollections("lib-1", listOf(collection("col-A", "To Read")))
-        makeRepo(libraryRepository = lib).addToToRead("item-1", "lib-1")
-        assertEquals(listOf("lib-1"), lib.refreshCollectionsCalls)
+    fun `addToToRead reverts cache when add fails`() = runTest {
+        val api = object : FakeAbsApi(
+            playlistsByLibrary = mapOf("lib-1" to listOf(playlist("pl-A", "To Read", emptyList()))),
+        ) {
+            override suspend fun addBookToPlaylist(
+                baseUrl: String, playlistId: String, libraryItemId: String,
+                token: String, insecureAllowed: Boolean,
+            ): NetworkPlaylistWriteResult = NetworkPlaylistWriteResult.NetworkError(IOException("HTTP 500"))
+        }
+        val repo = makeRepo(api)
+        repo.refresh("lib-1")
+        assertFalse(repo.addToToRead("item-1", "lib-1"))
+        assertEquals(emptySet<String>(), repo.observeToReadItemIds("lib-1").first())
     }
 
     @Test
-    fun `addToToRead does not refresh collections when the write fails`() = runTest {
-        val api = object : FakeAbsApi(collectionsByLibrary = mapOf("lib-1" to emptyList())) {
-            override suspend fun createCollection(
+    fun `addToToRead reverts cache when create fails`() = runTest {
+        val api = object : FakeAbsApi(playlistsByLibrary = mapOf("lib-1" to emptyList())) {
+            override suspend fun createPlaylist(
                 baseUrl: String, libraryId: String, name: String, initialBookId: String?,
                 token: String, insecureAllowed: Boolean,
-            ): NetworkCollectionWriteResult = NetworkCollectionWriteResult.NetworkError(IOException("HTTP 500"))
+            ): NetworkPlaylistWriteResult = NetworkPlaylistWriteResult.NetworkError(IOException("HTTP 500"))
         }
-        val lib = FakeLibraryRepository().apply { setCollections("lib-1", emptyList()) }
-        makeRepo(api = api, libraryRepository = lib).addToToRead("item-1", "lib-1")
-        assertTrue(lib.refreshCollectionsCalls.isEmpty())
-    }
-
-    @Test
-    fun `addToToRead returns false when create fails`() = runTest {
-        val api = object : FakeAbsApi(collectionsByLibrary = mapOf("lib-1" to emptyList())) {
-            override suspend fun createCollection(
-                baseUrl: String, libraryId: String, name: String, initialBookId: String?,
-                token: String, insecureAllowed: Boolean,
-            ): NetworkCollectionWriteResult = NetworkCollectionWriteResult.NetworkError(IOException("HTTP 500"))
-        }
-        val lib = FakeLibraryRepository().apply { setCollections("lib-1", emptyList()) }
-        assertFalse(makeRepo(api = api, libraryRepository = lib).addToToRead("item-1", "lib-1"))
-    }
-
-    @Test
-    fun `addToToRead returns false when add fails`() = runTest {
-        val api = object : FakeAbsApi() {
-            override suspend fun addBookToCollection(
-                baseUrl: String, collectionId: String, libraryItemId: String,
-                token: String, insecureAllowed: Boolean,
-            ): NetworkCollectionWriteResult = NetworkCollectionWriteResult.NetworkError(IOException("HTTP 500"))
-        }
-        val lib = FakeLibraryRepository()
-        lib.setCollections("lib-1", listOf(collection("col-A", "To Read")))
-        assertFalse(makeRepo(api = api, libraryRepository = lib).addToToRead("item-1", "lib-1"))
+        val repo = makeRepo(api)
+        repo.refresh("lib-1")
+        assertFalse(repo.addToToRead("item-1", "lib-1"))
+        assertEquals(emptySet<String>(), repo.observeToReadItemIds("lib-1").first())
     }
 
     // ── removeFromToRead ──────────────────────────────────────────────────────
 
     @Test
-    fun `removeFromToRead calls DELETE when cached collection exists`() = runTest {
-        val api = FakeAbsApi()
-        val lib = FakeLibraryRepository()
-        lib.setCollections("lib-1", listOf(collection("col-A", "To Read")))
-        val ok = makeRepo(api = api, libraryRepository = lib).removeFromToRead("item-1", "lib-1")
-        assertTrue(ok)
-        assertEquals(listOf("col-A" to "item-1"), api.removeCalls)
-        assertEquals(0, api.getCollectionsCalls)
+    fun `removeFromToRead calls DELETE and updates cache`() = runTest {
+        val api = FakeAbsApi(
+            playlistsByLibrary = mapOf("lib-1" to listOf(playlist("pl-A", "To Read", listOf("item-1")))),
+        )
+        val repo = makeRepo(api)
+        repo.refresh("lib-1")
+        assertTrue(repo.removeFromToRead("item-1", "lib-1"))
+        assertEquals(listOf("pl-A" to "item-1"), api.removeCalls)
+        assertEquals(emptySet<String>(), repo.observeToReadItemIds("lib-1").first())
     }
 
     @Test
-    fun `removeFromToRead returns true and makes no call when no cached To Read collection`() = runTest {
-        val api = FakeAbsApi()
-        val lib = FakeLibraryRepository().apply { setCollections("lib-1", emptyList()) }
-        val ok = makeRepo(api = api, libraryRepository = lib).removeFromToRead("item-1", "lib-1")
-        assertTrue(ok)
+    fun `removeFromToRead clears cached playlistId when last item is removed`() = runTest {
+        // ABS auto-deletes empty playlists server-side, so the cached id must be invalidated
+        // or the next add will POST to a dead playlist id.
+        val api = FakeAbsApi(
+            playlistsByLibrary = mapOf("lib-1" to listOf(playlist("pl-A", "To Read", listOf("item-1")))),
+        )
+        val repo = makeRepo(api)
+        repo.refresh("lib-1")
+        assertTrue(repo.removeFromToRead("item-1", "lib-1"))
+        // Next add must create a new playlist, not POST to the dead pl-A.
+        assertTrue(repo.addToToRead("item-2", "lib-1"))
+        assertEquals(listOf(Triple("lib-1", "To Read", "item-2")), api.createCalls)
+        assertTrue(api.addCalls.isEmpty())
+    }
+
+    @Test
+    fun `removeFromToRead returns true and makes no call when cache empty`() = runTest {
+        val api = FakeAbsApi(playlistsByLibrary = mapOf("lib-1" to emptyList()))
+        val repo = makeRepo(api)
+        repo.refresh("lib-1")
+        assertTrue(repo.removeFromToRead("item-1", "lib-1"))
         assertTrue(api.removeCalls.isEmpty())
-        assertEquals(0, api.getCollectionsCalls)
     }
 
     @Test
-    fun `removeFromToRead returns false when remove fails`() = runTest {
-        val api = object : FakeAbsApi() {
-            override suspend fun removeBookFromCollection(
-                baseUrl: String, collectionId: String, libraryItemId: String,
+    fun `removeFromToRead reverts cache when DELETE fails`() = runTest {
+        val api = object : FakeAbsApi(
+            playlistsByLibrary = mapOf("lib-1" to listOf(playlist("pl-A", "To Read", listOf("item-1")))),
+        ) {
+            override suspend fun removeBookFromPlaylist(
+                baseUrl: String, playlistId: String, libraryItemId: String,
                 token: String, insecureAllowed: Boolean,
-            ): NetworkCollectionWriteResult = NetworkCollectionWriteResult.NetworkError(IOException("HTTP 500"))
+            ): NetworkPlaylistWriteResult = NetworkPlaylistWriteResult.NetworkError(IOException("HTTP 500"))
         }
-        val lib = FakeLibraryRepository()
-        lib.setCollections("lib-1", listOf(collection("col-A", "To Read")))
-        assertFalse(makeRepo(api = api, libraryRepository = lib).removeFromToRead("item-1", "lib-1"))
-    }
-
-    @Test
-    fun `removeFromToRead refreshes collections after successful remove`() = runTest {
-        val lib = FakeLibraryRepository()
-        lib.setCollections("lib-1", listOf(collection("col-A", "To Read")))
-        makeRepo(libraryRepository = lib).removeFromToRead("item-1", "lib-1")
-        assertEquals(listOf("lib-1"), lib.refreshCollectionsCalls)
-    }
-
-    @Test
-    fun `removeFromToRead does not refresh when collection is missing`() = runTest {
-        val lib = FakeLibraryRepository().apply { setCollections("lib-1", emptyList()) }
-        makeRepo(libraryRepository = lib).removeFromToRead("item-1", "lib-1")
-        assertTrue(lib.refreshCollectionsCalls.isEmpty())
+        val repo = makeRepo(api)
+        repo.refresh("lib-1")
+        assertFalse(repo.removeFromToRead("item-1", "lib-1"))
+        assertEquals(setOf("item-1"), repo.observeToReadItemIds("lib-1").first())
     }
 
     // ── helpers ───────────────────────────────────────────────────────────────
 
-    private fun collection(id: String, name: String) =
-        Collection(id = id, libraryId = "lib-1", name = name, bookCount = 0)
-
-    private fun item(id: String) = LibraryItem(
-        id = id,
-        libraryId = "lib-1",
-        title = "T",
-        author = "A",
-        coverUrl = null,
-        readingProgress = 0f,
-        isCached = false,
-        isDownloaded = false,
-        ebookFormat = EbookFormat.Epub,
+    private fun playlist(id: String, name: String, itemIds: List<String>) = NetworkPlaylist(
+        id = id, libraryId = "lib-1", name = name,
+        items = itemIds.map { NetworkLibraryItem(
+            id = it, libraryId = "lib-1", title = "T", author = "A",
+            readingProgress = 0f, ebookFormat = EbookFormat.Epub,
+        ) },
     )
 }
 
@@ -269,55 +243,12 @@ private class FakeTokenStorage(private val tokens: MutableMap<String, String>) :
     override suspend fun deleteToken(serverId: String) { tokens.remove(serverId) }
 }
 
-private class FakeLibraryRepository : LibraryRepository {
-    val refreshCollectionsCalls = mutableListOf<String>()
-    private val collectionsByLibrary = mutableMapOf<String, MutableStateFlow<List<Collection>>>()
-    private val itemsByCollection = mutableMapOf<String, MutableStateFlow<List<LibraryItem>>>()
-
-    fun setCollections(libraryId: String, cols: List<Collection>) {
-        collectionsByLibrary.getOrPut(libraryId) { MutableStateFlow(emptyList()) }.value = cols
-    }
-
-    fun setCollectionItems(collectionId: String, items: List<LibraryItem>) {
-        itemsByCollection.getOrPut(collectionId) { MutableStateFlow(emptyList()) }.value = items
-    }
-
-    override suspend fun refreshCollections(libraryId: String): LibraryRefreshResult {
-        refreshCollectionsCalls += libraryId
-        return LibraryRefreshResult.Success
-    }
-
-    override fun observeCollections(libraryId: String) =
-        collectionsByLibrary.getOrPut(libraryId) { MutableStateFlow(emptyList()) }
-
-    override fun observeCollectionItems(collectionId: String) =
-        itemsByCollection.getOrPut(collectionId) { MutableStateFlow(emptyList()) }
-
-    override fun observeLibraries() = flowOf(emptyList<com.riffle.core.domain.Library>())
-    override fun observeLibraryItems(libraryId: String) = flowOf(emptyList<LibraryItem>())
-    override fun observeUngroupedLibraryItems(libraryId: String) = flowOf(emptyList<LibraryItem>())
-    override fun observeInProgressItems(libraryId: String) = flowOf(emptyList<LibraryItem>())
-    override fun observeFinishedItems(libraryId: String) = flowOf(emptyList<LibraryItem>())
-    override fun observeRecentlyAddedItems(libraryId: String) = flowOf(emptyList<LibraryItem>())
-    override fun observeAllBooks(libraryId: String) = flowOf(emptyList<LibraryItem>())
-    override fun observeSeries(libraryId: String) = flowOf(emptyList<com.riffle.core.domain.Series>())
-    override fun observeSeriesItems(seriesId: String) = flowOf(emptyList<LibraryItem>())
-    override suspend fun getItem(itemId: String): LibraryItem? = null
-    override suspend fun markItemOpened(itemId: String) {}
-    override suspend fun updateReadingProgress(itemId: String, progress: Float) {}
-    override suspend fun refreshLibraries(): LibraryRefreshResult = LibraryRefreshResult.Success
-    override suspend fun refreshLibraryItems(libraryId: String): LibraryRefreshResult = LibraryRefreshResult.Success
-    override suspend fun refreshSeries(libraryId: String): LibraryRefreshResult = LibraryRefreshResult.Success
-}
-
 private open class FakeAbsApi(
-    val collectionsByLibrary: Map<String, List<NetworkCollection>> = emptyMap(),
+    val playlistsByLibrary: Map<String, List<NetworkPlaylist>> = emptyMap(),
 ) : AbsLibraryApi {
     val createCalls = mutableListOf<Triple<String, String, String?>>()
     val addCalls = mutableListOf<Pair<String, String>>()
     val removeCalls = mutableListOf<Pair<String, String>>()
-    var getCollectionsCalls = 0
-        private set
 
     override suspend fun getLibraries(baseUrl: String, token: String, insecureAllowed: Boolean): NetworkLibrariesResult =
         NetworkLibrariesResult.Success(emptyList())
@@ -328,32 +259,33 @@ private open class FakeAbsApi(
     override suspend fun getSeries(baseUrl: String, libraryId: String, token: String, insecureAllowed: Boolean): NetworkSeriesResult =
         NetworkSeriesResult.Success(emptyList())
 
-    override suspend fun getCollections(baseUrl: String, libraryId: String, token: String, insecureAllowed: Boolean): NetworkCollectionResult {
-        getCollectionsCalls++
-        return NetworkCollectionResult.Success(collectionsByLibrary[libraryId].orEmpty())
-    }
+    override suspend fun getCollections(baseUrl: String, libraryId: String, token: String, insecureAllowed: Boolean) =
+        com.riffle.core.network.NetworkCollectionResult.Success(emptyList())
 
-    override suspend fun createCollection(
+    override suspend fun getPlaylists(baseUrl: String, libraryId: String, token: String, insecureAllowed: Boolean): NetworkPlaylistResult =
+        NetworkPlaylistResult.Success(playlistsByLibrary[libraryId].orEmpty())
+
+    override suspend fun createPlaylist(
         baseUrl: String, libraryId: String, name: String, initialBookId: String?,
         token: String, insecureAllowed: Boolean,
-    ): NetworkCollectionWriteResult {
+    ): NetworkPlaylistWriteResult {
         createCalls += Triple(libraryId, name, initialBookId)
-        return NetworkCollectionWriteResult.Success(NetworkCollection("col-new", libraryId, name, emptyList()))
+        return NetworkPlaylistWriteResult.Success(NetworkPlaylist("pl-new", libraryId, name, emptyList()))
     }
 
-    override suspend fun addBookToCollection(
-        baseUrl: String, collectionId: String, libraryItemId: String,
+    override suspend fun addBookToPlaylist(
+        baseUrl: String, playlistId: String, libraryItemId: String,
         token: String, insecureAllowed: Boolean,
-    ): NetworkCollectionWriteResult {
-        addCalls += collectionId to libraryItemId
-        return NetworkCollectionWriteResult.Success(null)
+    ): NetworkPlaylistWriteResult {
+        addCalls += playlistId to libraryItemId
+        return NetworkPlaylistWriteResult.Success(null)
     }
 
-    override suspend fun removeBookFromCollection(
-        baseUrl: String, collectionId: String, libraryItemId: String,
+    override suspend fun removeBookFromPlaylist(
+        baseUrl: String, playlistId: String, libraryItemId: String,
         token: String, insecureAllowed: Boolean,
-    ): NetworkCollectionWriteResult {
-        removeCalls += collectionId to libraryItemId
-        return NetworkCollectionWriteResult.Success(null)
+    ): NetworkPlaylistWriteResult {
+        removeCalls += playlistId to libraryItemId
+        return NetworkPlaylistWriteResult.Success(null)
     }
 }

--- a/core/data/src/test/kotlin/com/riffle/core/data/ToReadRepositoryTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/ToReadRepositoryTest.kt
@@ -222,6 +222,7 @@ class ToReadRepositoryTest {
             id = it, libraryId = "lib-1", title = "T", author = "A",
             readingProgress = 0f, ebookFormat = EbookFormat.Epub,
         ) },
+        bookIds = itemIds.toSet(),
     )
 }
 
@@ -270,7 +271,7 @@ private open class FakeAbsApi(
         token: String, insecureAllowed: Boolean,
     ): NetworkPlaylistWriteResult {
         createCalls += Triple(libraryId, name, initialBookId)
-        return NetworkPlaylistWriteResult.Success(NetworkPlaylist("pl-new", libraryId, name, emptyList()))
+        return NetworkPlaylistWriteResult.Success(NetworkPlaylist("pl-new", libraryId, name, emptyList(), emptySet()))
     }
 
     override suspend fun addBookToPlaylist(

--- a/core/network/src/main/kotlin/com/riffle/core/network/AbsApiClient.kt
+++ b/core/network/src/main/kotlin/com/riffle/core/network/AbsApiClient.kt
@@ -5,6 +5,7 @@ import com.riffle.core.domain.InsecureConnectionType
 import com.riffle.core.network.model.AbsCollectionBookRequest
 import com.riffle.core.network.model.AbsCollectionsResponse
 import com.riffle.core.network.model.AbsCreateCollectionRequest
+import com.riffle.core.network.model.AbsCreatePlaylistRequest
 import com.riffle.core.network.model.AbsEbookProgressRequest
 import com.riffle.core.network.model.AbsItemResponse
 import com.riffle.core.network.model.AbsLibrariesResponse
@@ -12,10 +13,13 @@ import com.riffle.core.network.model.AbsLibraryItemsResponse
 import com.riffle.core.network.model.AbsLoginRequest
 import com.riffle.core.network.model.AbsLoginResponse
 import com.riffle.core.network.model.AbsMeResponse
+import com.riffle.core.network.model.AbsPlaylistItemRequest
+import com.riffle.core.network.model.AbsPlaylistsResponse
 import com.riffle.core.network.model.AbsProgressResponse
 import com.riffle.core.network.model.AbsSeriesResponse
 import com.riffle.core.network.model.AbsServerInfoResponse
 import com.riffle.core.network.model.toNetworkCollection
+import com.riffle.core.network.model.toNetworkPlaylist
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.encodeToString
@@ -322,6 +326,108 @@ class AbsApiClient(private val httpClient: OkHttpClient) : AbsApi, AbsLibraryApi
             NetworkCollectionWriteResult.Success(collection)
         } catch (e: IOException) {
             NetworkCollectionWriteResult.NetworkError(e)
+        }
+    }
+
+    override suspend fun getPlaylists(
+        baseUrl: String,
+        libraryId: String,
+        token: String,
+        insecureAllowed: Boolean,
+    ): NetworkPlaylistResult = withContext(Dispatchers.IO) {
+        val client = if (insecureAllowed) httpClient.trustAllCerts() else httpClient
+        val request = Request.Builder()
+            .url("$baseUrl/api/libraries/$libraryId/playlists?limit=500")
+            .addHeader("Authorization", "Bearer $token")
+            .get()
+            .build()
+        try {
+            val response = client.newCall(request).execute()
+            val raw = response.body?.string() ?: return@withContext NetworkPlaylistResult.NetworkError(
+                IOException("Empty response body")
+            )
+            val parsed = json.decodeFromString<AbsPlaylistsResponse>(raw)
+            NetworkPlaylistResult.Success(parsed.results.map { it.toNetworkPlaylist() })
+        } catch (e: Exception) {
+            NetworkPlaylistResult.NetworkError(e)
+        }
+    }
+
+    override suspend fun createPlaylist(
+        baseUrl: String,
+        libraryId: String,
+        name: String,
+        initialBookId: String?,
+        token: String,
+        insecureAllowed: Boolean,
+    ): NetworkPlaylistWriteResult {
+        val payload = AbsCreatePlaylistRequest(
+            libraryId = libraryId,
+            name = name,
+            items = listOfNotNull(initialBookId?.let { AbsPlaylistItemRequest(it) }),
+        )
+        val body = json.encodeToString(AbsCreatePlaylistRequest.serializer(), payload)
+            .toRequestBody(jsonMediaType)
+        return executePlaylistWrite(
+            url = "$baseUrl/api/playlists",
+            token = token,
+            insecureAllowed = insecureAllowed,
+        ) { post(body) }
+    }
+
+    override suspend fun addBookToPlaylist(
+        baseUrl: String,
+        playlistId: String,
+        libraryItemId: String,
+        token: String,
+        insecureAllowed: Boolean,
+    ): NetworkPlaylistWriteResult {
+        val body = json.encodeToString(
+            AbsPlaylistItemRequest.serializer(),
+            AbsPlaylistItemRequest(libraryItemId),
+        ).toRequestBody(jsonMediaType)
+        return executePlaylistWrite(
+            url = "$baseUrl/api/playlists/$playlistId/item",
+            token = token,
+            insecureAllowed = insecureAllowed,
+        ) { post(body) }
+    }
+
+    override suspend fun removeBookFromPlaylist(
+        baseUrl: String,
+        playlistId: String,
+        libraryItemId: String,
+        token: String,
+        insecureAllowed: Boolean,
+    ): NetworkPlaylistWriteResult = executePlaylistWrite(
+        url = "$baseUrl/api/playlists/$playlistId/item/$libraryItemId",
+        token = token,
+        insecureAllowed = insecureAllowed,
+    ) { delete() }
+
+    private suspend fun executePlaylistWrite(
+        url: String,
+        token: String,
+        insecureAllowed: Boolean,
+        buildRequest: Request.Builder.() -> Unit,
+    ): NetworkPlaylistWriteResult = withContext(Dispatchers.IO) {
+        val client = if (insecureAllowed) httpClient.trustAllCerts() else httpClient
+        val request = Request.Builder()
+            .url(url)
+            .addHeader("Authorization", "Bearer $token")
+            .apply { buildRequest() }
+            .build()
+        try {
+            val response = client.newCall(request).execute()
+            val raw = response.body?.string().orEmpty()
+            if (!response.isSuccessful) {
+                return@withContext NetworkPlaylistWriteResult.NetworkError(IOException("HTTP ${response.code}"))
+            }
+            val playlist = if (raw.isBlank()) null else
+                json.decodeFromString(AbsPlaylistsResponse.AbsPlaylistDto.serializer(), raw).toNetworkPlaylist()
+            NetworkPlaylistWriteResult.Success(playlist)
+        } catch (e: IOException) {
+            NetworkPlaylistWriteResult.NetworkError(e)
         }
     }
 

--- a/core/network/src/main/kotlin/com/riffle/core/network/AbsLibraryApi.kt
+++ b/core/network/src/main/kotlin/com/riffle/core/network/AbsLibraryApi.kt
@@ -69,6 +69,38 @@ interface AbsLibraryApi {
         insecureAllowed: Boolean,
     ): NetworkCollectionWriteResult = throw UnsupportedOperationException("removeBookFromCollection not implemented")
 
+    suspend fun getPlaylists(
+        baseUrl: String,
+        libraryId: String,
+        token: String,
+        insecureAllowed: Boolean,
+    ): NetworkPlaylistResult = throw UnsupportedOperationException("getPlaylists not implemented")
+
+    suspend fun createPlaylist(
+        baseUrl: String,
+        libraryId: String,
+        name: String,
+        initialBookId: String?,
+        token: String,
+        insecureAllowed: Boolean,
+    ): NetworkPlaylistWriteResult = throw UnsupportedOperationException("createPlaylist not implemented")
+
+    suspend fun addBookToPlaylist(
+        baseUrl: String,
+        playlistId: String,
+        libraryItemId: String,
+        token: String,
+        insecureAllowed: Boolean,
+    ): NetworkPlaylistWriteResult = throw UnsupportedOperationException("addBookToPlaylist not implemented")
+
+    suspend fun removeBookFromPlaylist(
+        baseUrl: String,
+        playlistId: String,
+        libraryItemId: String,
+        token: String,
+        insecureAllowed: Boolean,
+    ): NetworkPlaylistWriteResult = throw UnsupportedOperationException("removeBookFromPlaylist not implemented")
+
     suspend fun getItemEbookFileIno(
         baseUrl: String,
         itemId: String,

--- a/core/network/src/main/kotlin/com/riffle/core/network/NetworkPlaylistResult.kt
+++ b/core/network/src/main/kotlin/com/riffle/core/network/NetworkPlaylistResult.kt
@@ -5,8 +5,9 @@ data class NetworkPlaylist(
     val libraryId: String,
     val name: String,
     val items: List<NetworkLibraryItem>,
+    val bookIds: Set<String>,
 ) {
-    val bookCount: Int get() = items.size
+    val bookCount: Int get() = bookIds.size
 }
 
 sealed class NetworkPlaylistResult {

--- a/core/network/src/main/kotlin/com/riffle/core/network/NetworkPlaylistResult.kt
+++ b/core/network/src/main/kotlin/com/riffle/core/network/NetworkPlaylistResult.kt
@@ -1,0 +1,15 @@
+package com.riffle.core.network
+
+data class NetworkPlaylist(
+    val id: String,
+    val libraryId: String,
+    val name: String,
+    val items: List<NetworkLibraryItem>,
+) {
+    val bookCount: Int get() = items.size
+}
+
+sealed class NetworkPlaylistResult {
+    data class Success(val playlists: List<NetworkPlaylist>) : NetworkPlaylistResult()
+    data class NetworkError(val cause: Throwable) : NetworkPlaylistResult()
+}

--- a/core/network/src/main/kotlin/com/riffle/core/network/NetworkPlaylistWriteResult.kt
+++ b/core/network/src/main/kotlin/com/riffle/core/network/NetworkPlaylistWriteResult.kt
@@ -1,0 +1,13 @@
+package com.riffle.core.network
+
+/**
+ * Result of a Playlist write operation (create, add item, remove item).
+ *
+ * On success, `playlist` is the resulting playlist state (for create + add).
+ * For remove, the server may or may not return the updated playlist — callers should
+ * not rely on its presence.
+ */
+sealed class NetworkPlaylistWriteResult {
+    data class Success(val playlist: NetworkPlaylist?) : NetworkPlaylistWriteResult()
+    data class NetworkError(val cause: Throwable) : NetworkPlaylistWriteResult()
+}

--- a/core/network/src/main/kotlin/com/riffle/core/network/model/AbsPlaylistWriteRequests.kt
+++ b/core/network/src/main/kotlin/com/riffle/core/network/model/AbsPlaylistWriteRequests.kt
@@ -1,0 +1,21 @@
+package com.riffle.core.network.model
+
+import kotlinx.serialization.Serializable
+
+/**
+ * POST /api/playlists body. `items` has no default value because kotlinx serialization
+ * omits default-equal fields when `encodeDefaults = false` (the project default), and ABS
+ * requires the field to always be present on the wire (even as an empty list).
+ */
+@Serializable
+internal data class AbsCreatePlaylistRequest(
+    val libraryId: String,
+    val name: String,
+    val items: List<AbsPlaylistItemRequest>,
+)
+
+/** POST /api/playlists/:id/item body. */
+@Serializable
+internal data class AbsPlaylistItemRequest(
+    val libraryItemId: String,
+)

--- a/core/network/src/main/kotlin/com/riffle/core/network/model/AbsPlaylistsResponse.kt
+++ b/core/network/src/main/kotlin/com/riffle/core/network/model/AbsPlaylistsResponse.kt
@@ -63,6 +63,7 @@ internal fun AbsPlaylistsResponse.AbsPlaylistDto.toNetworkPlaylist(): NetworkPla
         id = id,
         libraryId = libraryId,
         name = name,
+        bookIds = items.map { it.libraryItemId }.toSet(),
         items = items.mapNotNull { entry ->
             val li = entry.libraryItem ?: return@mapNotNull null
             val progress = li.userMediaProgress?.ebookProgress

--- a/core/network/src/main/kotlin/com/riffle/core/network/model/AbsPlaylistsResponse.kt
+++ b/core/network/src/main/kotlin/com/riffle/core/network/model/AbsPlaylistsResponse.kt
@@ -1,0 +1,85 @@
+package com.riffle.core.network.model
+
+import com.riffle.core.domain.EbookFormat
+import com.riffle.core.network.NetworkLibraryItem
+import com.riffle.core.network.NetworkPlaylist
+import kotlinx.serialization.Serializable
+
+@Serializable
+internal data class AbsPlaylistsResponse(val results: List<AbsPlaylistDto>) {
+
+    @Serializable
+    data class AbsPlaylistDto(
+        val id: String,
+        val libraryId: String,
+        val name: String,
+        val items: List<AbsPlaylistItemDto> = emptyList(),
+    )
+
+    @Serializable
+    data class AbsPlaylistItemDto(
+        val libraryItemId: String,
+        val libraryItem: AbsPlaylistLibraryItemDto? = null,
+    )
+
+    @Serializable
+    data class AbsPlaylistLibraryItemDto(
+        val id: String,
+        val libraryId: String,
+        val media: AbsPlaylistMediaDto,
+        val userMediaProgress: AbsPlaylistProgressDto? = null,
+    )
+
+    @Serializable
+    data class AbsPlaylistMediaDto(
+        val metadata: AbsPlaylistMetadataDto,
+        val ebookFormat: String? = null,
+        val ebookFile: AbsPlaylistEbookFileDto? = null,
+    )
+
+    @Serializable
+    data class AbsPlaylistEbookFileDto(val ino: String = "")
+
+    @Serializable
+    data class AbsPlaylistMetadataDto(
+        val title: String = "",
+        val authorName: String = "",
+        val description: String? = null,
+        val seriesName: String? = null,
+        val publishedYear: String? = null,
+        val genres: List<String> = emptyList(),
+        val publisher: String? = null,
+    )
+
+    @Serializable
+    data class AbsPlaylistProgressDto(
+        val progress: Float = 0f,
+        val ebookProgress: Float? = null,
+    )
+}
+
+internal fun AbsPlaylistsResponse.AbsPlaylistDto.toNetworkPlaylist(): NetworkPlaylist =
+    NetworkPlaylist(
+        id = id,
+        libraryId = libraryId,
+        name = name,
+        items = items.mapNotNull { entry ->
+            val li = entry.libraryItem ?: return@mapNotNull null
+            val progress = li.userMediaProgress?.ebookProgress
+                ?: li.userMediaProgress?.progress
+            NetworkLibraryItem(
+                id = li.id,
+                libraryId = li.libraryId,
+                title = li.media.metadata.title,
+                author = li.media.metadata.authorName,
+                readingProgress = progress,
+                ebookFormat = EbookFormat.from(li.media.ebookFormat),
+                ebookFileIno = li.media.ebookFile?.ino?.takeIf { it.isNotEmpty() },
+                description = li.media.metadata.description,
+                seriesName = li.media.metadata.seriesName,
+                publishedYear = li.media.metadata.publishedYear,
+                genres = li.media.metadata.genres,
+                publisher = li.media.metadata.publisher,
+            )
+        },
+    )

--- a/core/network/src/test/kotlin/com/riffle/core/network/AbsApiClientPlaylistsTest.kt
+++ b/core/network/src/test/kotlin/com/riffle/core/network/AbsApiClientPlaylistsTest.kt
@@ -1,0 +1,166 @@
+package com.riffle.core.network
+
+import kotlinx.coroutines.test.runTest
+import okhttp3.OkHttpClient
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class AbsApiClientPlaylistsTest {
+    private lateinit var server: MockWebServer
+    private lateinit var client: AbsApiClient
+
+    @Before
+    fun setUp() {
+        server = MockWebServer()
+        server.start()
+        client = AbsApiClient(OkHttpClient())
+    }
+
+    @After
+    fun tearDown() {
+        server.shutdown()
+    }
+
+    private fun baseUrl() = server.url("/").toString().trimEnd('/')
+
+    @Test
+    fun `getPlaylists issues GET with bearer token and parses response`() = runTest {
+        server.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setBody(
+                    """{"results":[{
+                        "id":"pl-1","libraryId":"lib-1","name":"To Read","items":[
+                          {"libraryItemId":"item-1","libraryItem":{
+                            "id":"item-1","libraryId":"lib-1",
+                            "media":{"metadata":{"title":"Book","authorName":"A"},"ebookFormat":"epub"}
+                          }}
+                        ]
+                    }]}""".trimIndent()
+                )
+                .addHeader("Content-Type", "application/json")
+        )
+
+        val result = client.getPlaylists(baseUrl(), "lib-1", "tok", false)
+
+        val recorded = server.takeRequest()
+        assertEquals("GET", recorded.method)
+        assertEquals("/api/libraries/lib-1/playlists?limit=500", recorded.path)
+        assertEquals("Bearer tok", recorded.getHeader("Authorization"))
+
+        assertTrue(result is NetworkPlaylistResult.Success)
+        val playlists = (result as NetworkPlaylistResult.Success).playlists
+        assertEquals(1, playlists.size)
+        assertEquals("pl-1", playlists[0].id)
+        assertEquals("To Read", playlists[0].name)
+        assertEquals(1, playlists[0].items.size)
+        assertEquals("item-1", playlists[0].items[0].id)
+    }
+
+    @Test
+    fun `createPlaylist posts libraryId name and initial item`() = runTest {
+        server.enqueue(
+            MockResponse().setResponseCode(200).setBody(
+                """{"id":"pl-1","libraryId":"lib-1","name":"To Read","items":[
+                    {"libraryItemId":"item-1","libraryItem":{
+                      "id":"item-1","libraryId":"lib-1",
+                      "media":{"metadata":{"title":"T","authorName":"A"},"ebookFormat":"epub"}
+                    }}
+                ]}""".trimIndent()
+            ).addHeader("Content-Type", "application/json")
+        )
+
+        val result = client.createPlaylist(baseUrl(), "lib-1", "To Read", "item-1", "tok", false)
+
+        val recorded = server.takeRequest()
+        assertEquals("POST", recorded.method)
+        assertEquals("/api/playlists", recorded.path)
+        assertEquals("Bearer tok", recorded.getHeader("Authorization"))
+        val body = recorded.body.readUtf8()
+        assertEquals(
+            """{"libraryId":"lib-1","name":"To Read","items":[{"libraryItemId":"item-1"}]}""",
+            body
+        )
+
+        assertTrue(result is NetworkPlaylistWriteResult.Success)
+        val playlist = (result as NetworkPlaylistWriteResult.Success).playlist
+        assertNotNull(playlist)
+        assertEquals("pl-1", playlist!!.id)
+        assertEquals(1, playlist.items.size)
+    }
+
+    @Test
+    fun `createPlaylist without initial book sends empty items array`() = runTest {
+        server.enqueue(
+            MockResponse().setResponseCode(200).setBody(
+                """{"id":"pl-1","libraryId":"lib-1","name":"To Read","items":[]}"""
+            ).addHeader("Content-Type", "application/json")
+        )
+
+        val result = client.createPlaylist(baseUrl(), "lib-1", "To Read", null, "tok", false)
+
+        val recorded = server.takeRequest()
+        assertEquals("POST", recorded.method)
+        assertEquals("/api/playlists", recorded.path)
+        val body = recorded.body.readUtf8()
+        assertEquals(
+            """{"libraryId":"lib-1","name":"To Read","items":[]}""",
+            body
+        )
+        assertTrue(result is NetworkPlaylistWriteResult.Success)
+        val playlist = (result as NetworkPlaylistWriteResult.Success).playlist
+        assertNotNull(playlist)
+        assertTrue(playlist!!.items.isEmpty())
+    }
+
+    @Test
+    fun `addBookToPlaylist posts libraryItemId to singular item endpoint`() = runTest {
+        server.enqueue(
+            MockResponse().setResponseCode(200).setBody(
+                """{"id":"pl-1","libraryId":"lib-1","name":"To Read","items":[
+                    {"libraryItemId":"item-1","libraryItem":{
+                      "id":"item-1","libraryId":"lib-1",
+                      "media":{"metadata":{"title":"T","authorName":"A"},"ebookFormat":"epub"}
+                    }}
+                ]}""".trimIndent()
+            ).addHeader("Content-Type", "application/json")
+        )
+
+        val result = client.addBookToPlaylist(baseUrl(), "pl-1", "item-1", "tok", false)
+
+        val recorded = server.takeRequest()
+        assertEquals("POST", recorded.method)
+        assertEquals("/api/playlists/pl-1/item", recorded.path)
+        assertEquals("Bearer tok", recorded.getHeader("Authorization"))
+        assertEquals("""{"libraryItemId":"item-1"}""", recorded.body.readUtf8())
+
+        assertTrue(result is NetworkPlaylistWriteResult.Success)
+        val playlist = (result as NetworkPlaylistWriteResult.Success).playlist
+        assertNotNull(playlist)
+        assertEquals("pl-1", playlist!!.id)
+    }
+
+    @Test
+    fun `removeBookFromPlaylist deletes singular item path`() = runTest {
+        server.enqueue(
+            MockResponse().setResponseCode(200).setBody(
+                """{"id":"pl-1","libraryId":"lib-1","name":"To Read","items":[]}"""
+            ).addHeader("Content-Type", "application/json")
+        )
+
+        val result = client.removeBookFromPlaylist(baseUrl(), "pl-1", "item-1", "tok", false)
+
+        val recorded = server.takeRequest()
+        assertEquals("DELETE", recorded.method)
+        assertEquals("/api/playlists/pl-1/item/item-1", recorded.path)
+        assertEquals("Bearer tok", recorded.getHeader("Authorization"))
+
+        assertTrue(result is NetworkPlaylistWriteResult.Success)
+    }
+}

--- a/core/network/src/test/kotlin/com/riffle/core/network/AbsApiClientPlaylistsTest.kt
+++ b/core/network/src/test/kotlin/com/riffle/core/network/AbsApiClientPlaylistsTest.kt
@@ -64,6 +64,31 @@ class AbsApiClientPlaylistsTest {
     }
 
     @Test
+    fun `getPlaylists includes bookIds even when libraryItem expansion is null`() = runTest {
+        server.enqueue(
+            MockResponse().setResponseCode(200).setBody(
+                """{"results":[{
+                    "id":"pl-1","libraryId":"lib-1","name":"To Read","items":[
+                      {"libraryItemId":"item-1","libraryItem":{
+                        "id":"item-1","libraryId":"lib-1",
+                        "media":{"metadata":{"title":"Book","authorName":"A"}}
+                      }},
+                      {"libraryItemId":"item-2","libraryItem":null}
+                    ]
+                }]}""".trimIndent()
+            ).addHeader("Content-Type", "application/json")
+        )
+
+        val result = client.getPlaylists(baseUrl(), "lib-1", "tok", false)
+
+        assertTrue(result is NetworkPlaylistResult.Success)
+        val pl = (result as NetworkPlaylistResult.Success).playlists.single()
+        assertEquals(setOf("item-1", "item-2"), pl.bookIds)
+        assertEquals(listOf("item-1"), pl.items.map { it.id })
+        assertEquals(2, pl.bookCount)
+    }
+
+    @Test
     fun `createPlaylist posts libraryId name and initial item`() = runTest {
         server.enqueue(
             MockResponse().setResponseCode(200).setBody(

--- a/docs/adr/0018-to-read-as-named-collection.md
+++ b/docs/adr/0018-to-read-as-named-collection.md
@@ -1,6 +1,6 @@
 # ADR 0018 — "To Read" implemented as a name-matched ABS Collection
 
-**Status:** Accepted
+**Status:** Superseded by [ADR 0019](0019-to-read-as-playlist.md). The "library-scoped Collection" reasoning held, but the deeper premise — that ABS Collections are user-defined groupings — turned out to be wrong: Collections are library-global and shared across all users with library access. See ADR 0019 for the playlist-backed implementation.
 
 ## Context
 

--- a/docs/adr/0019-to-read-as-playlist.md
+++ b/docs/adr/0019-to-read-as-playlist.md
@@ -1,0 +1,38 @@
+# ADR 0019 — "To Read" implemented as a name-matched ABS Playlist
+
+**Status:** Accepted (supersedes ADR 0018)
+
+## Context
+
+ADR 0018 implemented "To Read" as an ABS Collection named `To Read`, looked up by name. After shipping we observed that ABS Collections are **library-scoped, not user-scoped**: the `GET /api/libraries/:id/collections` endpoint returns the same collections to every authenticated user, and mutations are visible to all users with access to that library. Two accounts on the same server therefore shared a single "To Read" list, and the ADR-0018 Read→remove-from-To-Read invariant leaked across users.
+
+ABS has one per-user, server-persisted, arbitrary-book-list mechanism: **Playlists**. Playlists are scoped to `(userId, libraryId)`. The API endpoints (`GET /api/libraries/:id/playlists`, `POST /api/playlists`, `POST /api/playlists/:id/item`, `DELETE /api/playlists/:id/item/:libraryItemId`) accept any library item, including ebook-only items.
+
+## Decision
+
+**Implement "To Read" as a regular ABS Playlist named `To Read`, looked up by name and find-or-created on first use.** The find-or-create-by-name pattern from ADR 0018 carries over unchanged; only the backing storage flips from Collection to Playlist.
+
+The Read→remove-from-To-Read invariant (ADR 0018 rule 2) is preserved against the playlist instead of the collection.
+
+In-memory cache only (no Room table). A `MutableStateFlow<Map<libraryId, ToReadSnapshot>>` in `ToReadRepositoryImpl` holds the playlist id and member item-ids per library. `refresh(libraryId)` fetches the playlist and updates the snapshot; mutations are optimistic and revert on failure. Both `LibraryItemsViewModel.init` and `LibraryItemDetailViewModel` call `refresh` to keep the cache warm. Tradeoff: cache is empty after process death until the first refresh — acceptable because the only consumers (tab + detail screen) call `refresh` before they read.
+
+The list is surfaced as a new "To Read" tab in the library screen, positioned between Home and Series. The tab content is a grid of `LibraryItem`s, derived by joining the in-memory item-ids with the existing `observeAllBooks` Room cache.
+
+## Alternatives considered
+
+**Per-user-named Collection** (e.g. `To Read — {username}`). Rejected: clutters the Collections tab in the ABS web UI, exposes usernames to other users browsing collections, and still rides on library-global storage so a user with permission could mutate another user's list out-of-band.
+
+**Local-only Room storage keyed by (serverId, userId, itemId).** Rejected for this fix: invisible to the ABS web UI (loses the cross-client visibility property ADR 0018 valued), doesn't sync across Riffle installs without new sync infrastructure. Still a reasonable option if/when a unified sync layer lands.
+
+**Adding a Playlist Room cache symmetric to Collections.** Rejected for this fix: requires a new entity, DAO, migration, and refresh plumbing. Disproportionate scope for an asap correctness fix. In-memory caching covers the current call sites; Room persistence is a follow-up if To Read needs to survive process death (e.g. for an offline-first widget).
+
+## Consequences
+
+- **Per-account isolation.** Each ABS account on the same server now has its own To Read list. Cross-account leak fixed.
+- **Visible in the ABS web UI under Playlists.** The web UI renders playlists with audio-playback affordances even for ebook-only items. This is cosmetic and accepted as the cost of using the only per-user-scoped ABS mechanism that holds arbitrary book lists.
+- **Legacy "To Read" Collections on existing servers are abandoned.** Users with pre-ADR-0019 history have a stranded `To Read` Collection visible in the ABS web UI's Collections tab. The app does not delete it, migrate from it, or read from it. Users may delete it manually.
+- **One network round-trip per library entry and per detail-screen open.** Both ViewModels call `refresh` before reading; the cache is shared across the To Read tab and the detail screen for the lifetime of the process.
+- **To Read tab is a new top-level surface in the library view.** Lives between Home and Series. Empty state reads "Nothing in To Read".
+- **Rename behaviour matches ADR 0018** — a user-side rename of `To Read` creates a duplicate on next toggle.
+- **Empty playlists are auto-deleted by ABS.** Removing the last item from the playlist makes ABS delete the playlist itself. The repository handles this transparently by clearing its cached `playlistId` whenever a successful remove empties the cache; the next add creates a fresh playlist. No empty tile is left in the user's Playlists tab.
+- **Offline taps still fail loudly.** Same behaviour as ADR 0018 — no queueing, no silent retry.

--- a/docs/superpowers/plans/2026-05-30-to-read-as-playlist.md
+++ b/docs/superpowers/plans/2026-05-30-to-read-as-playlist.md
@@ -1,0 +1,1331 @@
+# To Read as Playlist — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move the "To Read" feature off ABS Collections (library-global, shared across accounts) onto ABS Playlists (per-user, server-scoped) so each ABS account has its own independent To Read list. Surface the list as a new "To Read" tab in the library view, sitting between Home and Series.
+
+**Architecture:** Add a parallel Playlist API surface in `core/network` (GET list, POST create, POST add item, DELETE remove item). Replace `ToReadRepositoryImpl`'s internals to hit the playlist endpoints, backed by an in-memory cache keyed by `libraryId` (a `MutableStateFlow<Map<String, ToReadSnapshot>>` holding the playlist id and member item-ids). The cache exposes `observeToReadItemIds(libraryId): Flow<Set<String>>` for reactive UI; the ViewModel combines that with the existing library-items Room cache to produce a `List<LibraryItem>` for the new tab. Optimistic updates: add/remove mutate the cache before the server confirms; on failure the cache reverts. The cache lives only in-memory (no Room migration) — acceptable scope for an asap fix; the tradeoff is that the To Read tab is empty until refreshed once per process lifetime. Collections stay in the codebase as a separate feature. Supersede ADR 0018 with ADR 0019. The pre-existing "To Read" ABS Collection on each user's server is abandoned — the new ADR documents this; users may delete it manually.
+
+**Tech Stack:** Kotlin, Room, OkHttp, kotlinx.serialization, JUnit4. Riffle's standard module layout (`core/network`, `core/data`, `app`).
+
+---
+
+## Background
+
+Discovered: ABS Collections are library-scoped, not user-scoped. Two accounts on the same ABS server share the same "To Read" Collection. Marking a book Read on account A removes it from account B's queue too. See conversation 2026-05-30 for the diagnosis.
+
+ABS Playlists are the only per-user, server-persisted, arbitrary-book-list storage mechanism ABS exposes. They are scoped to `(userId, libraryId)`. The API accepts any library item (no audio-only constraint at the protocol level). The ABS web UI presents playlists with audio-playback affordances — this is cosmetic and acceptable cost for an asap fix.
+
+## ABS endpoint reference
+
+Endpoints verified against the live server at `http://media-server:13378` on 2026-05-30 with the test account. The published docs at api.audiobookshelf.org disagree with the live server on the add/remove paths (docs say `/items` plural; live server returns 404 for plural and 200 for `/item` singular). **Use singular** — that's what the server actually accepts.
+
+- `GET /api/libraries/{libraryId}/playlists?limit=500` — returns the requesting user's playlists in that library. Response shape: `{ results: [{ id, libraryId, userId, name, items: [{ libraryItemId, libraryItem: {...} }] }] }`.
+- `POST /api/playlists` — body `{ libraryId, name, items: [{ libraryItemId }] }`. Returns the created playlist. Accepts `items: []` (creates an empty playlist).
+- `POST /api/playlists/{id}/item` — body `{ libraryItemId }`. Returns the updated playlist.
+- `DELETE /api/playlists/{id}/item/{libraryItemId}` — no body. Returns the updated playlist if items remain.
+
+**Server-side auto-delete:** removing the **last** item from a playlist causes ABS to delete the playlist itself (verified — subsequent `GET /api/playlists/{id}` returns 404). The repository must invalidate its cached `playlistId` whenever a successful `removeFromToRead` leaves the cached `itemIds` empty, so the next `addToToRead` creates a fresh playlist instead of POSTing to a dead id.
+
+The playlist `items[].libraryItem` shape mirrors `AbsCollectionsResponse.AbsCollectionBookDto` for fields we care about: `id`, `libraryId`, `media.metadata.{title, authorName, …}`, `media.ebookFormat`, `media.ebookFile.ino`, `userMediaProgress`.
+
+## File Structure
+
+**New:**
+- `core/network/src/main/kotlin/com/riffle/core/network/NetworkPlaylistResult.kt` — `NetworkPlaylist`, `NetworkPlaylistResult`.
+- `core/network/src/main/kotlin/com/riffle/core/network/NetworkPlaylistWriteResult.kt` — write result sealed class.
+- `core/network/src/main/kotlin/com/riffle/core/network/model/AbsPlaylistsResponse.kt` — wire DTOs + `toNetworkPlaylist()` mapper.
+- `core/network/src/main/kotlin/com/riffle/core/network/model/AbsPlaylistWriteRequests.kt` — `AbsCreatePlaylistRequest`, `AbsPlaylistItemRequest`.
+- `core/network/src/test/kotlin/com/riffle/core/network/AbsApiClientPlaylistsTest.kt` — MockWebServer tests for GET + writes.
+- `docs/adr/0019-to-read-as-playlist.md` — new ADR superseding 0018.
+
+**Modify:**
+- `core/network/src/main/kotlin/com/riffle/core/network/AbsLibraryApi.kt` — add 4 playlist methods (mirrors collection signatures).
+- `core/network/src/main/kotlin/com/riffle/core/network/AbsApiClient.kt` — implement playlist methods.
+- `core/data/src/main/kotlin/com/riffle/core/data/ToReadRepository.kt` — replace constant + add `observeToReadItemIds` / `refresh` to interface.
+- `core/data/src/main/kotlin/com/riffle/core/data/ToReadRepositoryImpl.kt` — swap internals to playlist API; in-memory cache; optimistic mutations.
+- `core/data/src/test/kotlin/com/riffle/core/data/ToReadRepositoryTest.kt` — rewrite to drive playlist API and verify in-memory cache behavior.
+- `app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsViewModel.kt` — expose `toReadItems: StateFlow<List<LibraryItem>>`; refresh in init + on connectivity restored.
+- `app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsScreen.kt` — add "To Read" tab at index 1; shift Series→2, Collections→3, AllBooks→4; add `ToReadTabContent` composable.
+- `app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemsViewModelTest.kt` — extend fake `ToReadRepository` + assert tab data flow.
+- `docs/adr/0018-to-read-as-named-collection.md` — flip status to "Superseded by ADR 0019".
+- `CONTEXT.md` — update the "To Read" glossary entry (mention tab + playlist backing).
+- `app/src/androidTest/kotlin/com/riffle/app/harness/StubAbsServer.kt` — add playlist endpoints.
+- `app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModelTest.kt` — only if fake-repo wiring breaks; likely needs the two new interface methods stubbed.
+
+---
+
+## Task 1: Add Playlist network DTOs
+
+**Files:**
+- Create: `core/network/src/main/kotlin/com/riffle/core/network/NetworkPlaylistResult.kt`
+- Create: `core/network/src/main/kotlin/com/riffle/core/network/NetworkPlaylistWriteResult.kt`
+- Create: `core/network/src/main/kotlin/com/riffle/core/network/model/AbsPlaylistsResponse.kt`
+- Create: `core/network/src/main/kotlin/com/riffle/core/network/model/AbsPlaylistWriteRequests.kt`
+
+- [ ] **Step 1: Create `NetworkPlaylistResult.kt`**
+
+```kotlin
+package com.riffle.core.network
+
+data class NetworkPlaylist(
+    val id: String,
+    val libraryId: String,
+    val name: String,
+    val items: List<NetworkLibraryItem>,
+) {
+    val bookCount: Int get() = items.size
+}
+
+sealed class NetworkPlaylistResult {
+    data class Success(val playlists: List<NetworkPlaylist>) : NetworkPlaylistResult()
+    data class NetworkError(val cause: Throwable) : NetworkPlaylistResult()
+}
+```
+
+- [ ] **Step 2: Create `NetworkPlaylistWriteResult.kt`**
+
+```kotlin
+package com.riffle.core.network
+
+sealed class NetworkPlaylistWriteResult {
+    data class Success(val playlist: NetworkPlaylist?) : NetworkPlaylistWriteResult()
+    data class NetworkError(val cause: Throwable) : NetworkPlaylistWriteResult()
+}
+```
+
+- [ ] **Step 3: Create `AbsPlaylistsResponse.kt`**
+
+Mirror `AbsCollectionsResponse.kt`. The playlist response has a different shape — items are wrapped in `{ libraryItemId, libraryItem: {...} }` rather than the collection's flat `books: [{...}]`.
+
+```kotlin
+package com.riffle.core.network.model
+
+import com.riffle.core.domain.EbookFormat
+import com.riffle.core.network.NetworkLibraryItem
+import com.riffle.core.network.NetworkPlaylist
+import kotlinx.serialization.Serializable
+
+@Serializable
+internal data class AbsPlaylistsResponse(val results: List<AbsPlaylistDto>) {
+
+    @Serializable
+    data class AbsPlaylistDto(
+        val id: String,
+        val libraryId: String,
+        val name: String,
+        val items: List<AbsPlaylistItemDto> = emptyList(),
+    )
+
+    @Serializable
+    data class AbsPlaylistItemDto(
+        val libraryItemId: String,
+        val libraryItem: AbsPlaylistLibraryItemDto? = null,
+    )
+
+    @Serializable
+    data class AbsPlaylistLibraryItemDto(
+        val id: String,
+        val libraryId: String,
+        val media: AbsPlaylistMediaDto,
+        val userMediaProgress: AbsPlaylistProgressDto? = null,
+    )
+
+    @Serializable
+    data class AbsPlaylistMediaDto(
+        val metadata: AbsPlaylistMetadataDto,
+        val ebookFormat: String? = null,
+        val ebookFile: AbsPlaylistEbookFileDto? = null,
+    )
+
+    @Serializable
+    data class AbsPlaylistEbookFileDto(val ino: String = "")
+
+    @Serializable
+    data class AbsPlaylistMetadataDto(
+        val title: String = "",
+        val authorName: String = "",
+        val description: String? = null,
+        val seriesName: String? = null,
+        val publishedYear: String? = null,
+        val genres: List<String> = emptyList(),
+        val publisher: String? = null,
+    )
+
+    @Serializable
+    data class AbsPlaylistProgressDto(
+        val progress: Float = 0f,
+        val ebookProgress: Float? = null,
+    )
+}
+
+internal fun AbsPlaylistsResponse.AbsPlaylistDto.toNetworkPlaylist(): NetworkPlaylist =
+    NetworkPlaylist(
+        id = id,
+        libraryId = libraryId,
+        name = name,
+        items = items.mapNotNull { entry ->
+            val li = entry.libraryItem ?: return@mapNotNull null
+            val progress = li.userMediaProgress?.ebookProgress
+                ?: li.userMediaProgress?.progress
+            NetworkLibraryItem(
+                id = li.id,
+                libraryId = li.libraryId,
+                title = li.media.metadata.title,
+                author = li.media.metadata.authorName,
+                readingProgress = progress,
+                ebookFormat = EbookFormat.from(li.media.ebookFormat),
+                ebookFileIno = li.media.ebookFile?.ino?.takeIf { it.isNotEmpty() },
+                description = li.media.metadata.description,
+                seriesName = li.media.metadata.seriesName,
+                publishedYear = li.media.metadata.publishedYear,
+                genres = li.media.metadata.genres,
+                publisher = li.media.metadata.publisher,
+            )
+        },
+    )
+```
+
+- [ ] **Step 4: Create `AbsPlaylistWriteRequests.kt`**
+
+```kotlin
+package com.riffle.core.network.model
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+internal data class AbsCreatePlaylistRequest(
+    val libraryId: String,
+    val name: String,
+    val items: List<AbsPlaylistItemRequest>,
+)
+
+@Serializable
+internal data class AbsPlaylistItemRequest(
+    val libraryItemId: String,
+)
+```
+
+- [ ] **Step 5: Compile**
+
+Run: `./gradlew :core:network:compileDebugKotlin`
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add core/network/src/main/kotlin/com/riffle/core/network/NetworkPlaylistResult.kt \
+        core/network/src/main/kotlin/com/riffle/core/network/NetworkPlaylistWriteResult.kt \
+        core/network/src/main/kotlin/com/riffle/core/network/model/AbsPlaylistsResponse.kt \
+        core/network/src/main/kotlin/com/riffle/core/network/model/AbsPlaylistWriteRequests.kt
+git commit -m "feat(network): add Playlist DTOs and result types"
+```
+
+---
+
+## Task 2: Extend `AbsLibraryApi` interface with playlist methods
+
+**Files:**
+- Modify: `core/network/src/main/kotlin/com/riffle/core/network/AbsLibraryApi.kt`
+
+- [ ] **Step 1: Add four playlist methods**
+
+Append below `removeBookFromCollection`:
+
+```kotlin
+    suspend fun getPlaylists(
+        baseUrl: String,
+        libraryId: String,
+        token: String,
+        insecureAllowed: Boolean,
+    ): NetworkPlaylistResult = throw UnsupportedOperationException("getPlaylists not implemented")
+
+    suspend fun createPlaylist(
+        baseUrl: String,
+        libraryId: String,
+        name: String,
+        initialBookId: String?,
+        token: String,
+        insecureAllowed: Boolean,
+    ): NetworkPlaylistWriteResult = throw UnsupportedOperationException("createPlaylist not implemented")
+
+    suspend fun addBookToPlaylist(
+        baseUrl: String,
+        playlistId: String,
+        libraryItemId: String,
+        token: String,
+        insecureAllowed: Boolean,
+    ): NetworkPlaylistWriteResult = throw UnsupportedOperationException("addBookToPlaylist not implemented")
+
+    suspend fun removeBookFromPlaylist(
+        baseUrl: String,
+        playlistId: String,
+        libraryItemId: String,
+        token: String,
+        insecureAllowed: Boolean,
+    ): NetworkPlaylistWriteResult = throw UnsupportedOperationException("removeBookFromPlaylist not implemented")
+```
+
+- [ ] **Step 2: Compile**
+
+Run: `./gradlew :core:network:compileDebugKotlin`
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add core/network/src/main/kotlin/com/riffle/core/network/AbsLibraryApi.kt
+git commit -m "feat(network): add playlist methods to AbsLibraryApi"
+```
+
+---
+
+## Task 3: Implement playlist methods in `AbsApiClient` (TDD via MockWebServer)
+
+**Files:**
+- Test: `core/network/src/test/kotlin/com/riffle/core/network/AbsApiClientPlaylistsTest.kt`
+- Modify: `core/network/src/main/kotlin/com/riffle/core/network/AbsApiClient.kt`
+
+> **Implementer note:** At execution time, open the existing `AbsApiClientCollectionsWriteTest.kt` and mirror its setup style for MockWebServer + httpClient construction. The test below assumes the same pattern.
+
+- [ ] **Step 1: Write the failing test for `getPlaylists`**
+
+> Endpoint shapes are already verified against the live server (see "ABS endpoint reference" at the top of this plan). Use `/item` singular for add/remove.
+
+Create `AbsApiClientPlaylistsTest.kt` following the layout of `AbsApiClientSeriesCollectionTest.kt`. Cover at minimum:
+
+```kotlin
+@Test
+fun `getPlaylists returns playlists parsed from response`() {
+    server.enqueue(MockResponse().setResponseCode(200).setBody(PLAYLISTS_JSON))
+    val result = runBlocking {
+        client.getPlaylists(server.url("").toString().trimEnd('/'), "lib-1", "tok", insecureAllowed = false)
+    }
+    val recorded = server.takeRequest()
+    assertEquals("GET", recorded.method)
+    assertEquals("/api/libraries/lib-1/playlists?limit=500", recorded.path)
+    assertEquals("Bearer tok", recorded.getHeader("Authorization"))
+    assertTrue(result is NetworkPlaylistResult.Success)
+    val playlists = (result as NetworkPlaylistResult.Success).playlists
+    assertEquals(1, playlists.size)
+    assertEquals("pl-1", playlists[0].id)
+    assertEquals("To Read", playlists[0].name)
+    assertEquals(listOf("item-1"), playlists[0].items.map { it.id })
+}
+
+private companion object {
+    const val PLAYLISTS_JSON = """
+    {"results":[{
+      "id":"pl-1","libraryId":"lib-1","name":"To Read","items":[
+        {"libraryItemId":"item-1","libraryItem":{
+          "id":"item-1","libraryId":"lib-1",
+          "media":{"metadata":{"title":"Book","authorName":"A"},"ebookFormat":"epub"}
+        }}
+      ]
+    }]}
+    """
+}
+```
+
+Add equivalent tests for `createPlaylist` (POST body shape), `addBookToPlaylist` (path + body), `removeBookFromPlaylist` (DELETE path). Use `AbsApiClientCollectionsWriteTest.kt` for the assertion idiom.
+
+- [ ] **Step 2: Run tests — verify they fail**
+
+Run: `./gradlew :core:network:test --tests "com.riffle.core.network.AbsApiClientPlaylistsTest"`
+Expected: failures with `UnsupportedOperationException("getPlaylists not implemented")` etc.
+
+- [ ] **Step 3: Implement the four methods in `AbsApiClient`**
+
+Insert after the collection implementations (around line 297 of `AbsApiClient.kt`):
+
+```kotlin
+    override suspend fun getPlaylists(
+        baseUrl: String,
+        libraryId: String,
+        token: String,
+        insecureAllowed: Boolean,
+    ): NetworkPlaylistResult = withContext(Dispatchers.IO) {
+        val client = if (insecureAllowed) httpClient.trustAllCerts() else httpClient
+        val request = Request.Builder()
+            .url("$baseUrl/api/libraries/$libraryId/playlists?limit=500")
+            .addHeader("Authorization", "Bearer $token")
+            .get()
+            .build()
+        try {
+            val response = client.newCall(request).execute()
+            val raw = response.body?.string() ?: return@withContext NetworkPlaylistResult.NetworkError(
+                IOException("Empty response body")
+            )
+            val parsed = json.decodeFromString<AbsPlaylistsResponse>(raw)
+            NetworkPlaylistResult.Success(parsed.results.map { it.toNetworkPlaylist() })
+        } catch (e: Exception) {
+            NetworkPlaylistResult.NetworkError(e)
+        }
+    }
+
+    override suspend fun createPlaylist(
+        baseUrl: String,
+        libraryId: String,
+        name: String,
+        initialBookId: String?,
+        token: String,
+        insecureAllowed: Boolean,
+    ): NetworkPlaylistWriteResult {
+        val payload = AbsCreatePlaylistRequest(
+            libraryId = libraryId,
+            name = name,
+            items = listOfNotNull(initialBookId?.let { AbsPlaylistItemRequest(it) }),
+        )
+        val body = json.encodeToString(AbsCreatePlaylistRequest.serializer(), payload)
+            .toRequestBody(jsonMediaType)
+        return executePlaylistWrite(
+            url = "$baseUrl/api/playlists",
+            token = token,
+            insecureAllowed = insecureAllowed,
+        ) { post(body) }
+    }
+
+    override suspend fun addBookToPlaylist(
+        baseUrl: String,
+        playlistId: String,
+        libraryItemId: String,
+        token: String,
+        insecureAllowed: Boolean,
+    ): NetworkPlaylistWriteResult {
+        val body = json.encodeToString(
+            AbsPlaylistItemRequest.serializer(),
+            AbsPlaylistItemRequest(libraryItemId),
+        ).toRequestBody(jsonMediaType)
+        return executePlaylistWrite(
+            url = "$baseUrl/api/playlists/$playlistId/item",
+            token = token,
+            insecureAllowed = insecureAllowed,
+        ) { post(body) }
+    }
+
+    override suspend fun removeBookFromPlaylist(
+        baseUrl: String,
+        playlistId: String,
+        libraryItemId: String,
+        token: String,
+        insecureAllowed: Boolean,
+    ): NetworkPlaylistWriteResult = executePlaylistWrite(
+        url = "$baseUrl/api/playlists/$playlistId/item/$libraryItemId",
+        token = token,
+        insecureAllowed = insecureAllowed,
+    ) { delete() }
+
+    private suspend fun executePlaylistWrite(
+        url: String,
+        token: String,
+        insecureAllowed: Boolean,
+        buildRequest: Request.Builder.() -> Unit,
+    ): NetworkPlaylistWriteResult = withContext(Dispatchers.IO) {
+        val client = if (insecureAllowed) httpClient.trustAllCerts() else httpClient
+        val request = Request.Builder()
+            .url(url)
+            .addHeader("Authorization", "Bearer $token")
+            .apply { buildRequest() }
+            .build()
+        try {
+            val response = client.newCall(request).execute()
+            val raw = response.body?.string().orEmpty()
+            if (!response.isSuccessful) {
+                return@withContext NetworkPlaylistWriteResult.NetworkError(IOException("HTTP ${response.code}"))
+            }
+            val playlist = if (raw.isBlank()) null else
+                json.decodeFromString(AbsPlaylistsResponse.AbsPlaylistDto.serializer(), raw).toNetworkPlaylist()
+            NetworkPlaylistWriteResult.Success(playlist)
+        } catch (e: IOException) {
+            NetworkPlaylistWriteResult.NetworkError(e)
+        }
+    }
+```
+
+- [ ] **Step 4: Run tests — verify they pass**
+
+Run: `./gradlew :core:network:test --tests "com.riffle.core.network.AbsApiClientPlaylistsTest"`
+Expected: BUILD SUCCESSFUL, all green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add core/network/src/main/kotlin/com/riffle/core/network/AbsApiClient.kt \
+        core/network/src/test/kotlin/com/riffle/core/network/AbsApiClientPlaylistsTest.kt
+git commit -m "feat(network): implement playlist endpoints on AbsApiClient"
+```
+
+---
+
+## Task 4: Rewrite `ToReadRepository` with in-memory cache + observable Flow (TDD)
+
+**Files:**
+- Modify: `core/data/src/main/kotlin/com/riffle/core/data/ToReadRepository.kt`
+- Modify: `core/data/src/main/kotlin/com/riffle/core/data/ToReadRepositoryImpl.kt`
+- Modify: `core/data/src/test/kotlin/com/riffle/core/data/ToReadRepositoryTest.kt`
+
+> **Design note:** The interface gains `observeToReadItemIds(libraryId): Flow<Set<String>>` and `refresh(libraryId): Boolean`. Implementation holds a `MutableStateFlow<Map<String, ToReadSnapshot>>` where `ToReadSnapshot(playlistId, itemIds)`. `refresh` performs `GET /api/libraries/:id/playlists`, finds the To Read playlist, and updates the snapshot. `isInToRead` reads from the cache (callers are responsible for calling `refresh` first — the ViewModel does this). Add/remove mutate the cache optimistically before the network call, and revert on failure. Cache is in-memory only — no Room table, no migration. Tradeoff: To Read tab is empty until the first refresh in each process; that refresh fires from `LibraryItemsViewModel.init`.
+
+- [ ] **Step 1: Update `ToReadRepository.kt` interface**
+
+Replace the file contents:
+
+```kotlin
+package com.riffle.core.data
+
+import kotlinx.coroutines.flow.Flow
+
+const val TO_READ_PLAYLIST_NAME = "To Read"
+
+/**
+ * Manages the per-Library, per-User "To Read" Playlist on the active ABS server.
+ *
+ * Backed by a normal ABS Playlist named [TO_READ_PLAYLIST_NAME], looked up by name and
+ * find-or-created on first use. See ADR 0019.
+ *
+ * Playlists are scoped to (userId, libraryId) on the server, so each ABS account has its
+ * own independent To Read list.
+ *
+ * Cache: in-memory only. Call [refresh] once per library to populate before relying on
+ * [observeToReadItemIds] or [isInToRead] — typically from `LibraryItemsViewModel.init`.
+ */
+interface ToReadRepository {
+    /** Item-ids currently in the To Read playlist for [libraryId]. Empty before first refresh. */
+    fun observeToReadItemIds(libraryId: String): Flow<Set<String>>
+
+    /** Fetches the To Read playlist from the server and refreshes the in-memory cache. */
+    suspend fun refresh(libraryId: String): Boolean
+
+    suspend fun isInToRead(libraryItemId: String, libraryId: String): Boolean
+    suspend fun addToToRead(libraryItemId: String, libraryId: String): Boolean
+    suspend fun removeFromToRead(libraryItemId: String, libraryId: String): Boolean
+}
+```
+
+- [ ] **Step 2: Rewrite `ToReadRepositoryTest.kt`**
+
+Replace the file. The tests drive the fake `AbsLibraryApi` directly and exercise the in-memory cache via `refresh` + `observeToReadItemIds`. Cover: refresh populates cache; isInToRead reads cache (no implicit network); add updates cache optimistically + reverts on failure; remove same; create-when-missing path. The full replacement:
+
+```kotlin
+package com.riffle.core.data
+
+import com.riffle.core.domain.AuthenticateResult
+import com.riffle.core.domain.CommitServerResult
+import com.riffle.core.domain.EbookFormat
+import com.riffle.core.domain.PendingServer
+import com.riffle.core.domain.Server
+import com.riffle.core.domain.ServerRepository
+import com.riffle.core.domain.ServerUrl
+import com.riffle.core.domain.TokenStorage
+import com.riffle.core.network.AbsLibraryApi
+import com.riffle.core.network.NetworkLibrariesResult
+import com.riffle.core.network.NetworkLibraryItem
+import com.riffle.core.network.NetworkLibraryItemsResult
+import com.riffle.core.network.NetworkPlaylist
+import com.riffle.core.network.NetworkPlaylistResult
+import com.riffle.core.network.NetworkPlaylistWriteResult
+import com.riffle.core.network.NetworkSeriesResult
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.IOException
+
+class ToReadRepositoryTest {
+
+    private val activeServer = Server(
+        id = "s1",
+        url = ServerUrl.parse("http://abs.local")!!,
+        displayName = "ABS",
+        isActive = true,
+        insecureConnectionAllowed = false,
+        username = "u",
+    )
+
+    private fun makeRepo(
+        api: AbsLibraryApi = FakeAbsApi(),
+        serverRepository: ServerRepository = FakeServerRepository(activeServer),
+        tokenStorage: TokenStorage = FakeTokenStorage(mutableMapOf("s1" to "tok")),
+    ) = ToReadRepositoryImpl(api, serverRepository, tokenStorage)
+
+    // ── refresh + observeToReadItemIds ────────────────────────────────────────
+
+    @Test
+    fun `refresh populates cache from server`() = runTest {
+        val api = FakeAbsApi(
+            playlistsByLibrary = mapOf("lib-1" to listOf(playlist("pl-A", "To Read", listOf("item-1", "item-2")))),
+        )
+        val repo = makeRepo(api)
+        assertTrue(repo.refresh("lib-1"))
+        assertEquals(setOf("item-1", "item-2"), repo.observeToReadItemIds("lib-1").first())
+    }
+
+    @Test
+    fun `refresh populates empty when no To Read playlist exists`() = runTest {
+        val api = FakeAbsApi(playlistsByLibrary = mapOf("lib-1" to emptyList()))
+        val repo = makeRepo(api)
+        assertTrue(repo.refresh("lib-1"))
+        assertEquals(emptySet<String>(), repo.observeToReadItemIds("lib-1").first())
+    }
+
+    @Test
+    fun `refresh returns false on network error and leaves cache untouched`() = runTest {
+        val api = object : FakeAbsApi() {
+            override suspend fun getPlaylists(baseUrl: String, libraryId: String, token: String, insecureAllowed: Boolean): NetworkPlaylistResult =
+                NetworkPlaylistResult.NetworkError(IOException("HTTP 500"))
+        }
+        val repo = makeRepo(api)
+        assertFalse(repo.refresh("lib-1"))
+        assertEquals(emptySet<String>(), repo.observeToReadItemIds("lib-1").first())
+    }
+
+    // ── isInToRead ────────────────────────────────────────────────────────────
+
+    @Test
+    fun `isInToRead reads from cache after refresh`() = runTest {
+        val api = FakeAbsApi(
+            playlistsByLibrary = mapOf("lib-1" to listOf(playlist("pl-A", "To Read", listOf("item-1")))),
+        )
+        val repo = makeRepo(api)
+        repo.refresh("lib-1")
+        assertTrue(repo.isInToRead("item-1", "lib-1"))
+        assertFalse(repo.isInToRead("item-9", "lib-1"))
+    }
+
+    @Test
+    fun `isInToRead returns false before any refresh`() = runTest {
+        val api = FakeAbsApi(
+            playlistsByLibrary = mapOf("lib-1" to listOf(playlist("pl-A", "To Read", listOf("item-1")))),
+        )
+        assertFalse(makeRepo(api).isInToRead("item-1", "lib-1"))
+    }
+
+    // ── addToToRead ───────────────────────────────────────────────────────────
+
+    @Test
+    fun `addToToRead appends to existing playlist and updates cache optimistically`() = runTest {
+        val api = FakeAbsApi(
+            playlistsByLibrary = mapOf("lib-1" to listOf(playlist("pl-A", "To Read", emptyList()))),
+        )
+        val repo = makeRepo(api)
+        repo.refresh("lib-1")
+        assertTrue(repo.addToToRead("item-1", "lib-1"))
+        assertTrue(api.createCalls.isEmpty())
+        assertEquals(listOf("pl-A" to "item-1"), api.addCalls)
+        assertEquals(setOf("item-1"), repo.observeToReadItemIds("lib-1").first())
+    }
+
+    @Test
+    fun `addToToRead creates playlist when cache is empty + no playlist on server`() = runTest {
+        val api = FakeAbsApi(playlistsByLibrary = mapOf("lib-1" to emptyList()))
+        val repo = makeRepo(api)
+        repo.refresh("lib-1")
+        assertTrue(repo.addToToRead("item-1", "lib-1"))
+        assertEquals(listOf(Triple("lib-1", "To Read", "item-1")), api.createCalls)
+        assertTrue(api.addCalls.isEmpty())
+        assertEquals(setOf("item-1"), repo.observeToReadItemIds("lib-1").first())
+    }
+
+    @Test
+    fun `addToToRead returns false when no active server`() = runTest {
+        val repo = makeRepo(
+            serverRepository = FakeServerRepository(activeServer = null),
+            tokenStorage = FakeTokenStorage(mutableMapOf()),
+        )
+        assertFalse(repo.addToToRead("item-1", "lib-1"))
+    }
+
+    @Test
+    fun `addToToRead reverts cache when add fails`() = runTest {
+        val api = object : FakeAbsApi(
+            playlistsByLibrary = mapOf("lib-1" to listOf(playlist("pl-A", "To Read", emptyList()))),
+        ) {
+            override suspend fun addBookToPlaylist(
+                baseUrl: String, playlistId: String, libraryItemId: String,
+                token: String, insecureAllowed: Boolean,
+            ): NetworkPlaylistWriteResult = NetworkPlaylistWriteResult.NetworkError(IOException("HTTP 500"))
+        }
+        val repo = makeRepo(api)
+        repo.refresh("lib-1")
+        assertFalse(repo.addToToRead("item-1", "lib-1"))
+        assertEquals(emptySet<String>(), repo.observeToReadItemIds("lib-1").first())
+    }
+
+    @Test
+    fun `addToToRead reverts cache when create fails`() = runTest {
+        val api = object : FakeAbsApi(playlistsByLibrary = mapOf("lib-1" to emptyList())) {
+            override suspend fun createPlaylist(
+                baseUrl: String, libraryId: String, name: String, initialBookId: String?,
+                token: String, insecureAllowed: Boolean,
+            ): NetworkPlaylistWriteResult = NetworkPlaylistWriteResult.NetworkError(IOException("HTTP 500"))
+        }
+        val repo = makeRepo(api)
+        repo.refresh("lib-1")
+        assertFalse(repo.addToToRead("item-1", "lib-1"))
+        assertEquals(emptySet<String>(), repo.observeToReadItemIds("lib-1").first())
+    }
+
+    // ── removeFromToRead ──────────────────────────────────────────────────────
+
+    @Test
+    fun `removeFromToRead calls DELETE and updates cache`() = runTest {
+        val api = FakeAbsApi(
+            playlistsByLibrary = mapOf("lib-1" to listOf(playlist("pl-A", "To Read", listOf("item-1")))),
+        )
+        val repo = makeRepo(api)
+        repo.refresh("lib-1")
+        assertTrue(repo.removeFromToRead("item-1", "lib-1"))
+        assertEquals(listOf("pl-A" to "item-1"), api.removeCalls)
+        assertEquals(emptySet<String>(), repo.observeToReadItemIds("lib-1").first())
+    }
+
+    @Test
+    fun `removeFromToRead clears cached playlistId when last item is removed`() = runTest {
+        // ABS auto-deletes empty playlists server-side, so the cached id must be invalidated
+        // or the next add will POST to a dead playlist id.
+        val api = FakeAbsApi(
+            playlistsByLibrary = mapOf("lib-1" to listOf(playlist("pl-A", "To Read", listOf("item-1")))),
+        )
+        val repo = makeRepo(api)
+        repo.refresh("lib-1")
+        assertTrue(repo.removeFromToRead("item-1", "lib-1"))
+        // Next add must create a new playlist, not POST to the dead pl-A.
+        assertTrue(repo.addToToRead("item-2", "lib-1"))
+        assertEquals(listOf(Triple("lib-1", "To Read", "item-2")), api.createCalls)
+        assertTrue(api.addCalls.isEmpty())
+    }
+
+    @Test
+    fun `removeFromToRead returns true and makes no call when cache empty`() = runTest {
+        val api = FakeAbsApi(playlistsByLibrary = mapOf("lib-1" to emptyList()))
+        val repo = makeRepo(api)
+        repo.refresh("lib-1")
+        assertTrue(repo.removeFromToRead("item-1", "lib-1"))
+        assertTrue(api.removeCalls.isEmpty())
+    }
+
+    @Test
+    fun `removeFromToRead reverts cache when DELETE fails`() = runTest {
+        val api = object : FakeAbsApi(
+            playlistsByLibrary = mapOf("lib-1" to listOf(playlist("pl-A", "To Read", listOf("item-1")))),
+        ) {
+            override suspend fun removeBookFromPlaylist(
+                baseUrl: String, playlistId: String, libraryItemId: String,
+                token: String, insecureAllowed: Boolean,
+            ): NetworkPlaylistWriteResult = NetworkPlaylistWriteResult.NetworkError(IOException("HTTP 500"))
+        }
+        val repo = makeRepo(api)
+        repo.refresh("lib-1")
+        assertFalse(repo.removeFromToRead("item-1", "lib-1"))
+        assertEquals(setOf("item-1"), repo.observeToReadItemIds("lib-1").first())
+    }
+
+    // ── helpers ───────────────────────────────────────────────────────────────
+
+    private fun playlist(id: String, name: String, itemIds: List<String>) = NetworkPlaylist(
+        id = id, libraryId = "lib-1", name = name,
+        items = itemIds.map { NetworkLibraryItem(
+            id = it, libraryId = "lib-1", title = "T", author = "A",
+            readingProgress = 0f, ebookFormat = EbookFormat.Epub,
+        ) },
+    )
+}
+
+private class FakeServerRepository(private val activeServer: Server?) : ServerRepository {
+    override fun observeAll() = MutableStateFlow(listOfNotNull(activeServer))
+    override suspend fun getActive(): Server? = activeServer
+    override suspend fun authenticate(url: ServerUrl, username: String, password: String, insecureAllowed: Boolean): AuthenticateResult =
+        AuthenticateResult.NetworkError(IOException())
+    override suspend fun commit(pending: PendingServer, hiddenLibraryIds: Set<String>): CommitServerResult =
+        CommitServerResult.Failure(IOException())
+    override suspend fun setActive(serverId: String) {}
+    override suspend fun remove(serverId: String) {}
+    override suspend fun getServerVersion(serverId: String): String? = null
+}
+
+private class FakeTokenStorage(private val tokens: MutableMap<String, String>) : TokenStorage {
+    override suspend fun saveToken(serverId: String, token: String) { tokens[serverId] = token }
+    override suspend fun getToken(serverId: String): String? = tokens[serverId]
+    override suspend fun deleteToken(serverId: String) { tokens.remove(serverId) }
+}
+
+private open class FakeAbsApi(
+    val playlistsByLibrary: Map<String, List<NetworkPlaylist>> = emptyMap(),
+) : AbsLibraryApi {
+    val createCalls = mutableListOf<Triple<String, String, String?>>()
+    val addCalls = mutableListOf<Pair<String, String>>()
+    val removeCalls = mutableListOf<Pair<String, String>>()
+
+    override suspend fun getLibraries(baseUrl: String, token: String, insecureAllowed: Boolean): NetworkLibrariesResult =
+        NetworkLibrariesResult.Success(emptyList())
+
+    override suspend fun getLibraryItems(baseUrl: String, libraryId: String, token: String, insecureAllowed: Boolean): NetworkLibraryItemsResult =
+        NetworkLibraryItemsResult.Success(emptyList())
+
+    override suspend fun getSeries(baseUrl: String, libraryId: String, token: String, insecureAllowed: Boolean): NetworkSeriesResult =
+        NetworkSeriesResult.Success(emptyList())
+
+    override suspend fun getCollections(baseUrl: String, libraryId: String, token: String, insecureAllowed: Boolean) =
+        com.riffle.core.network.NetworkCollectionResult.Success(emptyList())
+
+    override suspend fun getPlaylists(baseUrl: String, libraryId: String, token: String, insecureAllowed: Boolean): NetworkPlaylistResult =
+        NetworkPlaylistResult.Success(playlistsByLibrary[libraryId].orEmpty())
+
+    override suspend fun createPlaylist(
+        baseUrl: String, libraryId: String, name: String, initialBookId: String?,
+        token: String, insecureAllowed: Boolean,
+    ): NetworkPlaylistWriteResult {
+        createCalls += Triple(libraryId, name, initialBookId)
+        return NetworkPlaylistWriteResult.Success(NetworkPlaylist("pl-new", libraryId, name, emptyList()))
+    }
+
+    override suspend fun addBookToPlaylist(
+        baseUrl: String, playlistId: String, libraryItemId: String,
+        token: String, insecureAllowed: Boolean,
+    ): NetworkPlaylistWriteResult {
+        addCalls += playlistId to libraryItemId
+        return NetworkPlaylistWriteResult.Success(null)
+    }
+
+    override suspend fun removeBookFromPlaylist(
+        baseUrl: String, playlistId: String, libraryItemId: String,
+        token: String, insecureAllowed: Boolean,
+    ): NetworkPlaylistWriteResult {
+        removeCalls += playlistId to libraryItemId
+        return NetworkPlaylistWriteResult.Success(null)
+    }
+}
+```
+
+- [ ] **Step 3: Run tests — verify they fail**
+
+Run: `./gradlew :core:data:test --tests "com.riffle.core.data.ToReadRepositoryTest"`
+Expected: compilation errors (`TO_READ_COLLECTION_NAME` removed, `ToReadRepositoryImpl` constructor doesn't match) and/or test failures.
+
+- [ ] **Step 4: Rewrite `ToReadRepositoryImpl.kt`**
+
+Replace the file:
+
+```kotlin
+package com.riffle.core.data
+
+import com.riffle.core.domain.ServerRepository
+import com.riffle.core.domain.TokenStorage
+import com.riffle.core.network.AbsLibraryApi
+import com.riffle.core.network.NetworkPlaylistResult
+import com.riffle.core.network.NetworkPlaylistWriteResult
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * In-memory To Read snapshot for a single library.
+ *
+ * `playlistId == null` means we know the server has no To Read playlist (so next add must create).
+ * After [ToReadRepositoryImpl.refresh] succeeds, the snapshot reflects the server's state.
+ */
+private data class ToReadSnapshot(val playlistId: String?, val itemIds: Set<String>)
+
+@Singleton
+class ToReadRepositoryImpl @Inject constructor(
+    private val api: AbsLibraryApi,
+    private val serverRepository: ServerRepository,
+    private val tokenStorage: TokenStorage,
+) : ToReadRepository {
+
+    private val cache = MutableStateFlow<Map<String, ToReadSnapshot>>(emptyMap())
+
+    override fun observeToReadItemIds(libraryId: String): Flow<Set<String>> =
+        cache.map { it[libraryId]?.itemIds ?: emptySet() }
+
+    override suspend fun refresh(libraryId: String): Boolean {
+        val session = resolveSession() ?: return false
+        val result = api.getPlaylists(session.baseUrl, libraryId, session.token, session.insecureAllowed)
+        if (result !is NetworkPlaylistResult.Success) return false
+        val match = result.playlists.firstOrNull { it.name == TO_READ_PLAYLIST_NAME }
+        val snapshot = ToReadSnapshot(
+            playlistId = match?.id,
+            itemIds = match?.items?.map { it.id }?.toSet() ?: emptySet(),
+        )
+        cache.value = cache.value + (libraryId to snapshot)
+        return true
+    }
+
+    override suspend fun isInToRead(libraryItemId: String, libraryId: String): Boolean =
+        cache.value[libraryId]?.itemIds?.contains(libraryItemId) == true
+
+    override suspend fun addToToRead(libraryItemId: String, libraryId: String): Boolean {
+        val session = resolveSession() ?: return false
+        val before = cache.value[libraryId] ?: ToReadSnapshot(playlistId = null, itemIds = emptySet())
+        // Optimistic update
+        cache.value = cache.value + (libraryId to before.copy(itemIds = before.itemIds + libraryItemId))
+        val playlistId = before.playlistId
+        val ok = if (playlistId == null) {
+            val r = api.createPlaylist(
+                session.baseUrl, libraryId, TO_READ_PLAYLIST_NAME, libraryItemId,
+                session.token, session.insecureAllowed,
+            )
+            if (r is NetworkPlaylistWriteResult.Success) {
+                val newId = r.playlist?.id
+                if (newId != null) {
+                    cache.value = cache.value + (libraryId to ToReadSnapshot(newId, before.itemIds + libraryItemId))
+                }
+                true
+            } else false
+        } else {
+            val r = api.addBookToPlaylist(
+                session.baseUrl, playlistId, libraryItemId, session.token, session.insecureAllowed,
+            )
+            r is NetworkPlaylistWriteResult.Success
+        }
+        if (!ok) cache.value = cache.value + (libraryId to before)
+        return ok
+    }
+
+    override suspend fun removeFromToRead(libraryItemId: String, libraryId: String): Boolean {
+        val session = resolveSession() ?: return false
+        val before = cache.value[libraryId] ?: return true
+        val playlistId = before.playlistId ?: return true
+        if (libraryItemId !in before.itemIds) return true
+        val remainingIds = before.itemIds - libraryItemId
+        // Optimistic update. If we're removing the last item, ABS auto-deletes the playlist
+        // server-side — drop our cached playlistId so the next addToToRead creates a fresh one.
+        val optimistic = if (remainingIds.isEmpty()) {
+            ToReadSnapshot(playlistId = null, itemIds = emptySet())
+        } else {
+            before.copy(itemIds = remainingIds)
+        }
+        cache.value = cache.value + (libraryId to optimistic)
+        val r = api.removeBookFromPlaylist(
+            session.baseUrl, playlistId, libraryItemId, session.token, session.insecureAllowed,
+        )
+        val ok = r is NetworkPlaylistWriteResult.Success
+        if (!ok) cache.value = cache.value + (libraryId to before)
+        return ok
+    }
+
+    private suspend fun resolveSession(): Session? {
+        val server = serverRepository.getActive() ?: return null
+        val token = tokenStorage.getToken(server.id) ?: return null
+        return Session(server.url.value, token, server.insecureConnectionAllowed)
+    }
+
+    private data class Session(val baseUrl: String, val token: String, val insecureAllowed: Boolean)
+}
+```
+
+- [ ] **Step 5: Run tests — verify they pass**
+
+Run: `./gradlew :core:data:test --tests "com.riffle.core.data.ToReadRepositoryTest"`
+Expected: all tests pass.
+
+- [ ] **Step 6: Compile + run all core:data tests**
+
+Run: `./gradlew :core:data:test`
+Expected: BUILD SUCCESSFUL. Fix any unrelated compile breakage caused by `LibraryRepository` no longer being needed.
+
+- [ ] **Step 7: Update DI if needed**
+
+Open `core/data/src/main/kotlin/com/riffle/core/data/di/DataModule.kt`. If the binding for `ToReadRepository` listed `LibraryRepository` explicitly, no change is needed (Hilt will resolve constructor injection). Just verify the project builds:
+
+Run: `./gradlew :app:assembleDebug`
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add core/data/src/main/kotlin/com/riffle/core/data/ToReadRepository.kt \
+        core/data/src/main/kotlin/com/riffle/core/data/ToReadRepositoryImpl.kt \
+        core/data/src/test/kotlin/com/riffle/core/data/ToReadRepositoryTest.kt
+git commit -m "feat(data): back To Read with ABS Playlists instead of Collections"
+```
+
+---
+
+## Task 5: Wire `ToReadRepository.refresh` into both ViewModels
+
+**Files:**
+- Modify: `app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsViewModel.kt`
+- Modify: `app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModel.kt`
+- Modify: `app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemsViewModelTest.kt`
+- Modify: `app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModelTest.kt` (only to extend the fake `ToReadRepository`)
+
+> **Design note:** The new `ToReadRepository.isInToRead` reads from the in-memory cache and returns false before the first `refresh`. To keep parity with previous behavior, both ViewModels call `refresh(libraryId)` early:
+> - `LibraryItemsViewModel.init` — alongside `libraryRepository.refresh*` calls, and again on connectivity restored.
+> - `LibraryItemDetailViewModel` — call `refresh(item.libraryId)` before reading `isInToRead` when constructing the initial UI state.
+
+- [ ] **Step 1: Add `ToReadRepository` to `LibraryItemsViewModel` and expose `toReadItems`**
+
+Constructor: inject `toReadRepository: ToReadRepository`.
+
+Add fields below the existing `allBooks` state flow:
+
+```kotlin
+    val toReadItemIds: StateFlow<Set<String>> = toReadRepository.observeToReadItemIds(libraryId)
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptySet())
+
+    val toReadItems: StateFlow<List<LibraryItem>> = combine(toReadItemIds, allBooks, isOffline) { ids, all, offline ->
+        val byId = all.associateBy { it.id }
+        val items = ids.mapNotNull { byId[it] }
+        if (offline) items.filter { isAvailableOffline(it) } else items
+    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
+```
+
+> Reusing `allBooks` (the existing flow of every book in the library) gives us full `LibraryItem` objects with `coverUrl`, `isCached`, `isDownloaded` for free.
+
+- [ ] **Step 2: Refresh the To Read playlist in `LibraryItemsViewModel`**
+
+In `init`, alongside the existing `refresh()` call, also kick off:
+
+```kotlin
+        viewModelScope.launch { toReadRepository.refresh(libraryId) }
+```
+
+In the existing connectivity-restored block, also call `toReadRepository.refresh(libraryId)`.
+
+In the existing `fun refresh()` method, add `toReadRepository.refresh(libraryId)` as a fourth deferred call alongside `itemsDeferred`, `seriesDeferred`, `collectionsDeferred`. A network failure here should NOT flip the offline banner (To Read failures are non-critical).
+
+- [ ] **Step 3: Update `LibraryItemDetailViewModel` to refresh before reading**
+
+Find the existing line `val isInToRead = toReadRepository.isInToRead(item.id, item.libraryId)` and replace with:
+
+```kotlin
+                    toReadRepository.refresh(item.libraryId)
+                    val isInToRead = toReadRepository.isInToRead(item.id, item.libraryId)
+```
+
+- [ ] **Step 4: Extend the test fakes**
+
+In `LibraryItemDetailViewModelTest.kt`, the in-test `FakeToReadRepository` (or however the test stubs `ToReadRepository`) needs the two new methods:
+
+```kotlin
+override fun observeToReadItemIds(libraryId: String): Flow<Set<String>> = flowOf(emptySet())
+override suspend fun refresh(libraryId: String): Boolean = true
+```
+
+In `LibraryItemsViewModelTest.kt`, do the same — provide a fake that returns a controllable `MutableStateFlow<Set<String>>` for `observeToReadItemIds`.
+
+Add one new test in `LibraryItemsViewModelTest.kt` asserting `toReadItems` is the intersection of `toReadItemIds` and `allBooks`. Mirror the style of the existing `filteredCollections` test if there is one.
+
+- [ ] **Step 5: Run tests**
+
+Run: `./gradlew :app:testDebugUnitTest --tests "*LibraryItemsViewModelTest*" --tests "*LibraryItemDetailViewModelTest*"`
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsViewModel.kt \
+        app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModel.kt \
+        app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemsViewModelTest.kt \
+        app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModelTest.kt
+git commit -m "feat(library): expose To Read items + refresh through ViewModels"
+```
+
+---
+
+## Task 6: Add "To Read" tab to the library screen
+
+**Files:**
+- Modify: `app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsScreen.kt`
+
+> **Design:** Tab order becomes Home (0), **To Read (1, new)**, Series (2), Collections (3), All Books (4). The To Read tab content is a grid of book covers — reuse the existing `BookSectionGrid` (or whatever composable `AllBooksTabContent` uses for its grid). Empty state: centered "Nothing in To Read" message.
+
+- [ ] **Step 1: Add the tab to `LibraryTabBar`**
+
+In the `LibraryTabBar` composable (around line 809), insert a new `NavigationBarItem` at index 1, between Home and Series. Use `Icons.Filled.Bookmark` for the icon (import `androidx.compose.material.icons.filled.Bookmark`). Shift the existing items' indices: Series 1→2, Collections 2→3, All Books 3→4. The full updated composable:
+
+```kotlin
+@Composable
+private fun LibraryTabBar(selectedTab: Int, onTabSelected: (Int) -> Unit) {
+    NavigationBar {
+        NavigationBarItem(
+            selected = selectedTab == 0,
+            onClick = { onTabSelected(0) },
+            icon = { Icon(Icons.Filled.Home, contentDescription = "Home") },
+        )
+        NavigationBarItem(
+            selected = selectedTab == 1,
+            onClick = { onTabSelected(1) },
+            icon = { Icon(Icons.Filled.Bookmark, contentDescription = "To Read") },
+        )
+        NavigationBarItem(
+            selected = selectedTab == 2,
+            onClick = { onTabSelected(2) },
+            icon = { Icon(Icons.Filled.FormatListNumbered, contentDescription = "Series") },
+        )
+        NavigationBarItem(
+            selected = selectedTab == 3,
+            onClick = { onTabSelected(3) },
+            icon = { Icon(Icons.Filled.Folder, contentDescription = "Collections") },
+        )
+        NavigationBarItem(
+            selected = selectedTab == 4,
+            onClick = { onTabSelected(4) },
+            icon = { Icon(Icons.Filled.GridView, contentDescription = "All Books") },
+        )
+    }
+}
+```
+
+- [ ] **Step 2: Add the `when` branch for the new tab**
+
+Inside `LibraryItemsScreen`, in the `when (selectedTab)` block (around line 171), shift the existing branches and insert the new one:
+
+```kotlin
+                when (selectedTab) {
+                    0 -> HomeTabContent(
+                        inProgress = inProgress,
+                        recentlyAdded = recentlyAdded,
+                        finished = finished,
+                        isLoading = isLoading,
+                        token = viewModel.authToken,
+                        onItemSelected = onItemSelected,
+                        onSectionSeeMore = onSectionSeeMore,
+                    )
+                    1 -> ToReadTabContent(
+                        items = toReadItems,
+                        isLoading = isLoading,
+                        token = viewModel.authToken,
+                        onItemSelected = onItemSelected,
+                    )
+                    2 -> SeriesTabContent(
+                        items = series,
+                        isLoading = isLoading,
+                        token = viewModel.authToken,
+                        onSeriesSelected = onSeriesSelected,
+                    )
+                    3 -> CollectionsTabContent(
+                        items = collections,
+                        isLoading = isLoading,
+                        token = viewModel.authToken,
+                        collectionCoverUrls = collectionCoverUrls,
+                        onCollectionSelected = onCollectionSelected,
+                    )
+                    4 -> AllBooksTabContent(
+                        items = allBooks,
+                        isLoading = isLoading,
+                        token = viewModel.authToken,
+                        onItemSelected = onItemSelected,
+                    )
+                    else -> {}
+                }
+```
+
+Higher up where `allBooks`, `series`, etc. are collected from the ViewModel, also collect `toReadItems`:
+
+```kotlin
+    val toReadItems by viewModel.toReadItems.collectAsState()
+```
+
+- [ ] **Step 3: Add the `ToReadTabContent` composable**
+
+Add next to `AllBooksTabContent`. Mirror `AllBooksTabContent`'s structure — grid of book covers, same paddings and click handler. Replace the empty-state text with "Nothing in To Read".
+
+```kotlin
+@Composable
+private fun ToReadTabContent(
+    items: List<LibraryItem>,
+    isLoading: Boolean,
+    token: String,
+    onItemSelected: (LibraryItem) -> Unit,
+) {
+    if (isLoading) return
+    if (items.isEmpty()) {
+        Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+            Text("Nothing in To Read")
+        }
+        return
+    }
+    // Copy the body of AllBooksTabContent verbatim — same LazyVerticalGrid layout.
+    AllBooksTabContent(items = items, isLoading = false, token = token, onItemSelected = onItemSelected)
+}
+```
+
+> If `AllBooksTabContent`'s empty-state text is hard-coded inside it, just inline the grid here instead of delegating. The grid is small enough.
+
+- [ ] **Step 4: Build + visual sanity check**
+
+Run: `./gradlew :app:assembleDebug`
+Expected: BUILD SUCCESSFUL.
+
+Install on a device or emulator. Open a library. Confirm:
+- Bottom tab bar has 5 tabs (Home, bookmark icon, Series, Collections, All Books).
+- Tapping the bookmark tab shows the current user's To Read items, or "Nothing in To Read" if empty.
+- Tapping an item in the To Read tab navigates to the detail screen.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsScreen.kt
+git commit -m "feat(library): add To Read tab between Home and Series"
+```
+
+---
+
+## Task 7: Wire the stub server playlist endpoints (harness)
+
+**Files:**
+- Modify: `app/src/androidTest/kotlin/com/riffle/app/harness/StubAbsServer.kt`
+
+> Open the file at execution time to see the actual handler dispatch style. The instructions below describe the shape of the change; mirror the existing collection handlers.
+
+- [ ] **Step 1: Add playlist constants and JSON response**
+
+Add near `TEST_COLLECTION_ID`:
+
+```kotlin
+const val TEST_PLAYLIST_ID = "playlist-test-1"
+const val TEST_PLAYLIST_NAME = "To Read"
+```
+
+- [ ] **Step 2: Add request handlers**
+
+In the request-dispatching block (around the `request.path == "/api/libraries/$TEST_LIBRARY_ID/collections..."` line), add:
+
+```kotlin
+request.path == "/api/libraries/$TEST_LIBRARY_ID/playlists?limit=500" -> playlistsResponse()
+request.path == "/api/playlists" && request.method == "POST" -> playlistCreateResponse()
+request.path?.matches(Regex("/api/playlists/[^/]+/item")) == true && request.method == "POST" -> playlistItemAddResponse()
+request.path?.matches(Regex("/api/playlists/[^/]+/item/[^/]+")) == true && request.method == "DELETE" -> playlistItemRemoveResponse()
+```
+
+Provide minimal JSON bodies — for current harness tests, the simplest response is an empty playlists list (`{"results":[]}`) plus 200 OK for writes. Add fixture data only if a harness test needs To Read state to be present.
+
+- [ ] **Step 3: Run harness tests**
+
+Run: `make harness-test`
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/src/androidTest/kotlin/com/riffle/app/harness/StubAbsServer.kt
+git commit -m "test(harness): stub playlist endpoints"
+```
+
+---
+
+## Task 8: Write ADR 0019 and supersede ADR 0018
+
+**Files:**
+- Create: `docs/adr/0019-to-read-as-playlist.md`
+- Modify: `docs/adr/0018-to-read-as-named-collection.md`
+- Modify: `CONTEXT.md`
+
+- [ ] **Step 1: Write ADR 0019**
+
+Create `docs/adr/0019-to-read-as-playlist.md`:
+
+```markdown
+# ADR 0019 — "To Read" implemented as a name-matched ABS Playlist
+
+**Status:** Accepted (supersedes ADR 0018)
+
+## Context
+
+ADR 0018 implemented "To Read" as an ABS Collection named `To Read`, looked up by name. After shipping we observed that ABS Collections are **library-scoped, not user-scoped**: the `GET /api/libraries/:id/collections` endpoint returns the same collections to every authenticated user, and mutations are visible to all users with access to that library. Two accounts on the same server therefore shared a single "To Read" list, and the ADR-0018 Read→remove-from-To-Read invariant leaked across users.
+
+ABS has one per-user, server-persisted, arbitrary-book-list mechanism: **Playlists**. Playlists are scoped to `(userId, libraryId)`. The API endpoints (`GET /api/libraries/:id/playlists`, `POST /api/playlists`, `POST /api/playlists/:id/item`, `DELETE /api/playlists/:id/item/:libraryItemId`) accept any library item, including ebook-only items.
+
+## Decision
+
+**Implement "To Read" as a regular ABS Playlist named `To Read`, looked up by name and find-or-created on first use.** The find-or-create-by-name pattern from ADR 0018 carries over unchanged; only the backing storage flips from Collection to Playlist.
+
+The Read→remove-from-To-Read invariant (ADR 0018 rule 2) is preserved against the playlist instead of the collection.
+
+In-memory cache only (no Room table). A `MutableStateFlow<Map<libraryId, ToReadSnapshot>>` in `ToReadRepositoryImpl` holds the playlist id and member item-ids per library. `refresh(libraryId)` fetches the playlist and updates the snapshot; mutations are optimistic and revert on failure. Both `LibraryItemsViewModel.init` and `LibraryItemDetailViewModel` call `refresh` to keep the cache warm. Tradeoff: cache is empty after process death until the first refresh — acceptable because the only consumers (tab + detail screen) call `refresh` before they read.
+
+The list is surfaced as a new "To Read" tab in the library screen, positioned between Home and Series. The tab content is a grid of `LibraryItem`s, derived by joining the in-memory item-ids with the existing `observeAllBooks` Room cache.
+
+## Alternatives considered
+
+**Per-user-named Collection** (e.g. `To Read — {username}`). Rejected: clutters the Collections tab in the ABS web UI, exposes usernames to other users browsing collections, and still rides on library-global storage so a user with permission could mutate another user's list out-of-band.
+
+**Local-only Room storage keyed by (serverId, userId, itemId).** Rejected for this fix: invisible to the ABS web UI (loses the cross-client visibility property ADR 0018 valued), doesn't sync across Riffle installs without new sync infrastructure. Still a reasonable option if/when a unified sync layer lands.
+
+**Adding a Playlist Room cache symmetric to Collections.** Rejected for this fix: requires a new entity, DAO, migration, and refresh plumbing. Disproportionate scope for an asap correctness fix. In-memory caching covers the current call sites; Room persistence is a follow-up if To Read needs to survive process death (e.g. for an offline-first widget).
+
+## Consequences
+
+- **Per-account isolation.** Each ABS account on the same server now has its own To Read list. Cross-account leak fixed.
+- **Visible in the ABS web UI under Playlists.** The web UI renders playlists with audio-playback affordances even for ebook-only items. This is cosmetic and accepted as the cost of using the only per-user-scoped ABS mechanism that holds arbitrary book lists.
+- **Legacy "To Read" Collections on existing servers are abandoned.** Users with pre-ADR-0019 history have a stranded `To Read` Collection visible in the ABS web UI's Collections tab. The app does not delete it, migrate from it, or read from it. Users may delete it manually.
+- **One network round-trip per library entry and per detail-screen open.** Both ViewModels call `refresh` before reading; the cache is shared across the To Read tab and the detail screen for the lifetime of the process.
+- **To Read tab is a new top-level surface in the library view.** Lives between Home and Series. Empty state reads "Nothing in To Read".
+- **Rename behaviour matches ADR 0018** — a user-side rename of `To Read` creates a duplicate on next toggle.
+- **Empty playlists are auto-deleted by ABS.** Removing the last item from the playlist makes ABS delete the playlist itself. The repository handles this transparently by clearing its cached `playlistId` whenever a successful remove empties the cache; the next add creates a fresh playlist. No empty tile is left in the user's Playlists tab.
+- **Offline taps still fail loudly.** Same behaviour as ADR 0018 — no queueing, no silent retry.
+```
+
+- [ ] **Step 2: Flip ADR 0018 status**
+
+Edit the top of `docs/adr/0018-to-read-as-named-collection.md`. Change:
+
+```
+**Status:** Accepted
+```
+
+to:
+
+```
+**Status:** Superseded by [ADR 0019](0019-to-read-as-playlist.md). The "library-scoped Collection" reasoning held, but the deeper premise — that ABS Collections are user-defined groupings — turned out to be wrong: Collections are library-global and shared across all users with library access. See ADR 0019 for the playlist-backed implementation.
+```
+
+- [ ] **Step 3: Update `CONTEXT.md`**
+
+Open `CONTEXT.md`, find the "To Read" entry (grep for `To Read`), and update it to reference Playlists + ADR 0019 instead of Collections + ADR 0018. Keep the same general structure; just swap the mechanism and the ADR number.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/adr/0019-to-read-as-playlist.md docs/adr/0018-to-read-as-named-collection.md CONTEXT.md
+git commit -m "docs: ADR 0019 — To Read backed by Playlist (supersedes 0018)"
+```
+
+---
+
+## Task 9: End-to-end verification
+
+- [ ] **Step 1: Full build + unit tests**
+
+Run: `./gradlew test`
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 2: Harness tests**
+
+Run: `make harness-test`
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 3: Manual smoke test against the real ABS server**
+
+Install on the dev device. Verify:
+
+1. With user A logged in, open a book, tap To Read → icon flips on. Navigate back to the library → the **To Read tab** (between Home and Series) shows the book.
+2. Log out, log in as user B, open the same library → the To Read tab is empty (this is the bug we're fixing — proves per-user isolation works).
+3. As user B, tap To Read on a different book → flips on, appears in B's To Read tab, A's tab is unaffected.
+4. Mark a book Read on user A → it's removed from A's To Read tab but not B's.
+5. Open the ABS web UI under user A → the `To Read` playlist appears under Playlists.
+6. Tap an item in the To Read tab → detail screen opens with the bookmark on.
+
+If any of (1)–(6) fail, the fix is incomplete — diagnose before declaring done.
+
+- [ ] **Step 4: Final commit / PR prep**
+
+No code change at this step. Confirm the working tree is clean. The PR should reference ADR 0019 and note that pre-existing "To Read" ABS Collections are left untouched on the server.
+
+---
+
+## Self-review
+
+- Spec coverage: collection → playlist swap (Tasks 1–4), ViewModel wiring (5), UI tab (6), harness (7), docs (8), verification (9). ✓
+- Type consistency: `TO_READ_PLAYLIST_NAME`, `ToReadSnapshot`, `observeToReadItemIds`, `refresh(libraryId)` consistent across tasks. ✓
+- Tab ordering consistency: Home (0), To Read (1), Series (2), Collections (3), All Books (4) — applied in `LibraryTabBar` and the `when (selectedTab)` block in Task 6. ✓
+- Behaviour change documented in ADR: `isInToRead` no longer hits the network on its own; callers must `refresh` first. Task 5 wires both ViewModels accordingly. ✓
+- Endpoint shapes verified against live ABS server on 2026-05-30: `/item` singular for add/remove (docs incorrectly say plural). Recorded in "ABS endpoint reference".
+- ABS auto-deletes empty playlists. Task 4's `removeFromToRead` clears the cached `playlistId` when emptying; covered by the `clears cached playlistId when last item is removed` test.


### PR DESCRIPTION
## Summary

- **Bug fix:** "To Read" no longer leaks across ABS accounts on the same server. Backed by ABS Playlists (per-user, scoped to `userId` + `libraryId`) instead of Collections (library-global). ADR 0019 supersedes ADR 0018.
- **New tab:** "To Read" tab inserted between Home and Series in the library view (Bookmark icon). Content joins the playlist item-ids with the existing all-books cache.
- **Robustness:** `removeFromToRead` invalidates the cached `playlistId` when the playlist empties (ABS auto-deletes empty playlists server-side, verified against live ABS). `NetworkPlaylist.bookIds` carries the raw wire ids independent of DTO expansion, so `isInToRead` won't lie if ABS ever returns a stale reference.

## Approach

In-memory cache only — no Room table for playlists. `ToReadRepositoryImpl` holds a `MutableStateFlow<Map<libraryId, ToReadSnapshot>>` keyed by library, storing the playlist id and member item-ids. Mutations are optimistic and revert on failure. Both `LibraryItemsViewModel.init` and `LibraryItemDetailViewModel` call `refresh(libraryId)` before reading, so cache stays warm for the tab and the detail screen.

ABS endpoint shapes (singular `/item` vs plural `/items`) verified against the live server — published docs are wrong; commits include source verification notes.

## Legacy data

Pre-existing "To Read" ABS Collections on each user's server are abandoned. The app does not migrate from or read them. Users may delete the orphaned `To Read` Collection manually in the ABS web UI.

## Test plan

- [x] `./gradlew test` — all unit tests green across modules
- [x] `make harness-test` — 125 instrumented tests, 0 failed
- [x] **Manual smoke test on real ABS server** (couldn't run from here — see ADR 0019 / plan Task 9 Step 3):
  - User A taps To Read on a book → appears in A's To Read tab.
  - User B (same server/library): To Read tab is empty.
  - User B taps To Read on a different book → A's tab unaffected.
  - User A marks a book Read → removed from A's To Read, not B's.
  - ABS web UI under user A → `To Read` appears under Playlists.