### PR TITLE
feat(tablet): max-width container for list/form screens on Expanded

### DIFF
--- a/app/src/androidTest/kotlin/com/riffle/app/ui/TabletContentWidthContainerNoOpTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/ui/TabletContentWidthContainerNoOpTest.kt
@@ -1,0 +1,71 @@
+package com.riffle.app.ui
+
+import androidx.activity.ComponentActivity
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSizeClassApi
+import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
+import androidx.compose.material3.windowsizeclass.calculateWindowSizeClass
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.getUnclippedBoundsInRoot
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onRoot
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Verifies that TabletContentWidthContainer is a transparent pass-through on
+ * the phone layout (Compact width bucket). Pairs with [TabletContentWidthContainerTest]
+ * which covers the Expanded path on the tablet AVD.
+ *
+ * No `@TabletLayout` annotation: this runs on the Harness Medium Phone AVD via
+ * `make harness-test` and is excluded from the tablet target.
+ */
+@OptIn(ExperimentalMaterial3WindowSizeClassApi::class)
+@RunWith(AndroidJUnit4::class)
+class TabletContentWidthContainerNoOpTest {
+
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+    @Test
+    fun onCompact_contentFillsAvailableWidth() {
+        composeTestRule.setContent {
+            val sizeClass = calculateWindowSizeClass(composeTestRule.activity)
+            // Sanity: the phone AVD really is below the Expanded threshold.
+            check(sizeClass.widthSizeClass != WindowWidthSizeClass.Expanded) {
+                "phone AVD unexpectedly resolved to Expanded; check harness config"
+            }
+            TabletContentWidthContainer(
+                windowSizeClass = sizeClass,
+                modifier = Modifier.fillMaxSize(),
+            ) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .background(Color.Red)
+                        .testTag("content"),
+                )
+            }
+        }
+
+        val rootBounds = composeTestRule.onRoot().getUnclippedBoundsInRoot()
+        val contentBounds = composeTestRule.onNodeWithTag("content").getUnclippedBoundsInRoot()
+
+        val rootWidth = (rootBounds.right - rootBounds.left).value
+        val contentWidth = (contentBounds.right - contentBounds.left).value
+        assertEquals(
+            "content should fill the full available width on Compact (no cap applied)",
+            rootWidth,
+            contentWidth,
+            0.5f,
+        )
+    }
+}

--- a/app/src/androidTest/kotlin/com/riffle/app/ui/TabletContentWidthContainerTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/ui/TabletContentWidthContainerTest.kt
@@ -1,0 +1,87 @@
+package com.riffle.app.ui
+
+import androidx.activity.ComponentActivity
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSizeClassApi
+import androidx.compose.material3.windowsizeclass.calculateWindowSizeClass
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.getUnclippedBoundsInRoot
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onRoot
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.riffle.app.harness.TabletLayout
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import kotlin.math.abs
+
+/**
+ * Verifies that TabletContentWidthContainer caps content width at 600dp and
+ * centres it horizontally when the WindowSizeClass is Expanded (ADR 0019).
+ *
+ * The WindowSizeClass is derived from the actual host Activity, so this test
+ * also exercises the size-class calculation wiring — it relies on the
+ * Harness Medium Tablet AVD resolving to the Expanded width bucket
+ * (`make harness-test-tablet`). Settings is the representative screen called
+ * out in the issue; its layout is a Scaffold-wrapped scrolling Column wrapped
+ * by this container, which is structurally what this test exercises.
+ */
+@OptIn(ExperimentalMaterial3WindowSizeClassApi::class)
+@TabletLayout
+@RunWith(AndroidJUnit4::class)
+class TabletContentWidthContainerTest {
+
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+    @Test
+    fun onExpanded_contentIsCappedAt600dpAndCentred() {
+        composeTestRule.setContent {
+            val sizeClass = calculateWindowSizeClass(composeTestRule.activity)
+            TabletContentWidthContainer(
+                windowSizeClass = sizeClass,
+                modifier = Modifier.fillMaxSize(),
+            ) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .background(Color.Red)
+                        .testTag("content"),
+                )
+            }
+        }
+
+        val rootBounds = composeTestRule.onRoot().getUnclippedBoundsInRoot()
+        val contentBounds = composeTestRule.onNodeWithTag("content").getUnclippedBoundsInRoot()
+
+        // Sanity: the AVD really is in the Expanded bucket. If this fails the
+        // harness AVD has been reconfigured below 840dp and the test would
+        // otherwise silently exercise the no-op path.
+        assertTrue(
+            "tablet AVD root should be in the Expanded width bucket (was ${rootBounds.right - rootBounds.left})",
+            (rootBounds.right - rootBounds.left).value >= 840f,
+        )
+
+        val contentWidth = (contentBounds.right - contentBounds.left).value
+        assertEquals(
+            "content width should be capped at 600dp",
+            600f,
+            contentWidth,
+            0.5f,
+        )
+
+        val leftGap = (contentBounds.left - rootBounds.left).value
+        val rightGap = (rootBounds.right - contentBounds.right).value
+        assertTrue(
+            "content should be centred horizontally (leftGap=$leftGap, rightGap=$rightGap)",
+            abs(leftGap - rightGap) < 1f,
+        )
+    }
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/downloads/DownloadsScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/downloads/DownloadsScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.windowsizeclass.WindowSizeClass
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -35,11 +36,13 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.riffle.app.ui.TabletContentWidthContainer
 import com.riffle.core.domain.LibraryItem
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun DownloadsScreen(
+    windowSizeClass: WindowSizeClass,
     onNavigateBack: () -> Unit,
     onItemSelected: (LibraryItem) -> Unit,
     viewModel: DownloadsViewModel = hiltViewModel(),
@@ -76,50 +79,53 @@ fun DownloadsScreen(
             )
         }
     ) { padding ->
-        LazyColumn(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(padding),
+        TabletContentWidthContainer(
+            windowSizeClass = windowSizeClass,
+            modifier = Modifier.fillMaxSize().padding(padding),
         ) {
-            item {
-                SectionHeader(
-                    title = "Downloaded",
-                    actionLabel = if (uiState.downloadedItems.isNotEmpty()) "Remove all" else null,
-                    onAction = { showRemoveAllDownloadsDialog = true },
-                )
-            }
-            if (uiState.downloadedItems.isEmpty()) {
+            LazyColumn(
+                modifier = Modifier.fillMaxSize(),
+            ) {
                 item {
-                    EmptySection("No downloaded books")
-                }
-            } else {
-                items(uiState.downloadedItems, key = { it.id }) { item ->
-                    LocalItemRow(
-                        item = item,
-                        pillColor = PillColor.Downloaded,
-                        onClick = { onItemSelected(item) },
+                    SectionHeader(
+                        title = "Downloaded",
+                        actionLabel = if (uiState.downloadedItems.isNotEmpty()) "Remove all" else null,
+                        onAction = { showRemoveAllDownloadsDialog = true },
                     )
                 }
-            }
+                if (uiState.downloadedItems.isEmpty()) {
+                    item {
+                        EmptySection("No downloaded books")
+                    }
+                } else {
+                    items(uiState.downloadedItems, key = { it.id }) { item ->
+                        LocalItemRow(
+                            item = item,
+                            pillColor = PillColor.Downloaded,
+                            onClick = { onItemSelected(item) },
+                        )
+                    }
+                }
 
-            item {
-                SectionHeader(
-                    title = "Cached",
-                    actionLabel = if (uiState.cachedItems.isNotEmpty()) "Clear all" else null,
-                    onAction = { viewModel.clearAllCached() },
-                )
-            }
-            if (uiState.cachedItems.isEmpty()) {
                 item {
-                    EmptySection("No cached books")
-                }
-            } else {
-                items(uiState.cachedItems, key = { it.id }) { item ->
-                    LocalItemRow(
-                        item = item,
-                        pillColor = PillColor.Cached,
-                        onClick = { onItemSelected(item) },
+                    SectionHeader(
+                        title = "Cached",
+                        actionLabel = if (uiState.cachedItems.isNotEmpty()) "Clear all" else null,
+                        onAction = { viewModel.clearAllCached() },
                     )
+                }
+                if (uiState.cachedItems.isEmpty()) {
+                    item {
+                        EmptySection("No cached books")
+                    }
+                } else {
+                    items(uiState.cachedItems, key = { it.id }) { item ->
+                        LocalItemRow(
+                            item = item,
+                            pillColor = PillColor.Cached,
+                            onClick = { onItemSelected(item) },
+                        )
+                    }
                 }
             }
         }

--- a/app/src/main/kotlin/com/riffle/app/feature/server/AddServerScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/server/AddServerScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.windowsizeclass.WindowSizeClass
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -40,12 +41,14 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.riffle.app.ui.TabletContentWidthContainer
 import com.riffle.core.domain.InsecureConnectionType
 import com.riffle.core.domain.PendingServer
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun AddServerScreen(
+    windowSizeClass: WindowSizeClass,
     onNavigateBack: () -> Unit,
     onAuthenticated: (PendingServer) -> Unit,
     viewModel: AddServerViewModel = hiltViewModel(),
@@ -74,74 +77,78 @@ fun AddServerScreen(
             )
         },
     ) { padding ->
-        Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(padding)
-                .padding(24.dp),
-            verticalArrangement = Arrangement.spacedBy(16.dp),
+        TabletContentWidthContainer(
+            windowSizeClass = windowSizeClass,
+            modifier = Modifier.fillMaxSize().padding(padding),
         ) {
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                var schemeExpanded by remember { mutableStateOf(false) }
-                Box {
-                    OutlinedButton(onClick = { schemeExpanded = true }) {
-                        Text(viewModel.scheme)
-                        Icon(Icons.Default.ArrowDropDown, contentDescription = "Choose scheme")
-                    }
-                    DropdownMenu(
-                        expanded = schemeExpanded,
-                        onDismissRequest = { schemeExpanded = false },
-                    ) {
-                        listOf("https://", "http://").forEach { option ->
-                            DropdownMenuItem(
-                                text = { Text(option) },
-                                onClick = {
-                                    viewModel.updateScheme(option)
-                                    schemeExpanded = false
-                                },
-                            )
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(24.dp),
+                verticalArrangement = Arrangement.spacedBy(16.dp),
+            ) {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    var schemeExpanded by remember { mutableStateOf(false) }
+                    Box {
+                        OutlinedButton(onClick = { schemeExpanded = true }) {
+                            Text(viewModel.scheme)
+                            Icon(Icons.Default.ArrowDropDown, contentDescription = "Choose scheme")
+                        }
+                        DropdownMenu(
+                            expanded = schemeExpanded,
+                            onDismissRequest = { schemeExpanded = false },
+                        ) {
+                            listOf("https://", "http://").forEach { option ->
+                                DropdownMenuItem(
+                                    text = { Text(option) },
+                                    onClick = {
+                                        viewModel.updateScheme(option)
+                                        schemeExpanded = false
+                                    },
+                                )
+                            }
                         }
                     }
+                    Spacer(Modifier.width(8.dp))
+                    OutlinedTextField(
+                        value = viewModel.host,
+                        onValueChange = { viewModel.updateHost(it) },
+                        label = { Text("Server URL") },
+                        placeholder = { Text("abs.example.com") },
+                        modifier = Modifier.weight(1f),
+                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Uri),
+                        singleLine = true,
+                    )
                 }
-                Spacer(Modifier.width(8.dp))
                 OutlinedTextField(
-                    value = viewModel.host,
-                    onValueChange = { viewModel.updateHost(it) },
-                    label = { Text("Server URL") },
-                    placeholder = { Text("abs.example.com") },
-                    modifier = Modifier.weight(1f),
-                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Uri),
+                    value = viewModel.username,
+                    onValueChange = { viewModel.username = it },
+                    label = { Text("Username") },
+                    modifier = Modifier.fillMaxWidth(),
                     singleLine = true,
                 )
-            }
-            OutlinedTextField(
-                value = viewModel.username,
-                onValueChange = { viewModel.username = it },
-                label = { Text("Username") },
-                modifier = Modifier.fillMaxWidth(),
-                singleLine = true,
-            )
-            OutlinedTextField(
-                value = viewModel.password,
-                onValueChange = { viewModel.password = it },
-                label = { Text("Password") },
-                modifier = Modifier.fillMaxWidth(),
-                visualTransformation = PasswordVisualTransformation(),
-                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
-                singleLine = true,
-            )
-            viewModel.error?.let {
-                Text(it, color = MaterialTheme.colorScheme.error, style = MaterialTheme.typography.bodySmall)
-            }
-            if (viewModel.isLoading) {
-                CircularProgressIndicator(modifier = Modifier.align(Alignment.CenterHorizontally))
-            } else {
-                Button(
-                    onClick = viewModel::onConnect,
+                OutlinedTextField(
+                    value = viewModel.password,
+                    onValueChange = { viewModel.password = it },
+                    label = { Text("Password") },
                     modifier = Modifier.fillMaxWidth(),
-                    enabled = viewModel.host.isNotBlank() && viewModel.username.isNotBlank() && viewModel.password.isNotBlank(),
-                ) {
-                    Text("Connect")
+                    visualTransformation = PasswordVisualTransformation(),
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
+                    singleLine = true,
+                )
+                viewModel.error?.let {
+                    Text(it, color = MaterialTheme.colorScheme.error, style = MaterialTheme.typography.bodySmall)
+                }
+                if (viewModel.isLoading) {
+                    CircularProgressIndicator(modifier = Modifier.align(Alignment.CenterHorizontally))
+                } else {
+                    Button(
+                        onClick = viewModel::onConnect,
+                        modifier = Modifier.fillMaxWidth(),
+                        enabled = viewModel.host.isNotBlank() && viewModel.username.isNotBlank() && viewModel.password.isNotBlank(),
+                    ) {
+                        Text("Connect")
+                    }
                 }
             }
         }

--- a/app/src/main/kotlin/com/riffle/app/feature/server/SelectLibrariesScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/server/SelectLibrariesScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.windowsizeclass.WindowSizeClass
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
@@ -29,11 +30,13 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.riffle.app.ui.TabletContentWidthContainer
 import com.riffle.core.domain.PendingServer
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SelectLibrariesScreen(
+    windowSizeClass: WindowSizeClass,
     pending: PendingServer,
     onNavigateBack: () -> Unit,
     onContinueComplete: () -> Unit,
@@ -60,59 +63,64 @@ fun SelectLibrariesScreen(
         },
         snackbarHost = { SnackbarHost(snackbarHostState) },
     ) { padding ->
-        if (viewModel.libraries.isEmpty()) {
-            Column(
-                modifier = Modifier.fillMaxSize().padding(padding).padding(24.dp),
-                verticalArrangement = Arrangement.spacedBy(16.dp),
-                horizontalAlignment = Alignment.CenterHorizontally,
-            ) {
-                Text(
-                    "This server doesn't expose any book libraries.",
-                    style = MaterialTheme.typography.bodyLarge,
-                )
-                Button(onClick = onNavigateBack) { Text("Go back") }
-            }
-        } else {
-            Column(
-                modifier = Modifier.fillMaxSize().padding(padding),
-            ) {
-                Text(
-                    text = "Choose which libraries to show in Riffle. You can change this later in Settings.",
-                    style = MaterialTheme.typography.bodyMedium,
-                    modifier = Modifier.padding(horizontal = 24.dp, vertical = 16.dp),
-                )
-
-                LazyColumn(modifier = Modifier.weight(1f)) {
-                    items(viewModel.libraries, key = { it.id }) { lib ->
-                        ListItem(
-                            headlineContent = { Text(lib.name) },
-                            trailingContent = {
-                                Switch(
-                                    checked = lib.id in viewModel.selectedIds,
-                                    onCheckedChange = { viewModel.toggle(lib.id) },
-                                )
-                            },
-                        )
-                        HorizontalDivider()
-                    }
-                }
-
+        TabletContentWidthContainer(
+            windowSizeClass = windowSizeClass,
+            modifier = Modifier.fillMaxSize().padding(padding),
+        ) {
+            if (viewModel.libraries.isEmpty()) {
                 Column(
-                    modifier = Modifier.fillMaxWidth().padding(24.dp),
-                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                    modifier = Modifier.fillMaxSize().padding(24.dp),
+                    verticalArrangement = Arrangement.spacedBy(16.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally,
                 ) {
-                    if (viewModel.selectedIds.isEmpty()) {
-                        Text(
-                            "Select at least one library",
-                            color = MaterialTheme.colorScheme.error,
-                            style = MaterialTheme.typography.bodySmall,
-                        )
+                    Text(
+                        "This server doesn't expose any book libraries.",
+                        style = MaterialTheme.typography.bodyLarge,
+                    )
+                    Button(onClick = onNavigateBack) { Text("Go back") }
+                }
+            } else {
+                Column(
+                    modifier = Modifier.fillMaxSize(),
+                ) {
+                    Text(
+                        text = "Choose which libraries to show in Riffle. You can change this later in Settings.",
+                        style = MaterialTheme.typography.bodyMedium,
+                        modifier = Modifier.padding(horizontal = 24.dp, vertical = 16.dp),
+                    )
+
+                    LazyColumn(modifier = Modifier.weight(1f)) {
+                        items(viewModel.libraries, key = { it.id }) { lib ->
+                            ListItem(
+                                headlineContent = { Text(lib.name) },
+                                trailingContent = {
+                                    Switch(
+                                        checked = lib.id in viewModel.selectedIds,
+                                        onCheckedChange = { viewModel.toggle(lib.id) },
+                                    )
+                                },
+                            )
+                            HorizontalDivider()
+                        }
                     }
-                    Button(
-                        onClick = viewModel::onContinue,
-                        enabled = viewModel.canContinue,
-                        modifier = Modifier.fillMaxWidth(),
-                    ) { Text("Continue") }
+
+                    Column(
+                        modifier = Modifier.fillMaxWidth().padding(24.dp),
+                        verticalArrangement = Arrangement.spacedBy(8.dp),
+                    ) {
+                        if (viewModel.selectedIds.isEmpty()) {
+                            Text(
+                                "Select at least one library",
+                                color = MaterialTheme.colorScheme.error,
+                                style = MaterialTheme.typography.bodySmall,
+                            )
+                        }
+                        Button(
+                            onClick = viewModel::onContinue,
+                            enabled = viewModel.canContinue,
+                            modifier = Modifier.fillMaxWidth(),
+                        ) { Text("Continue") }
+                    }
                 }
             }
         }

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.rememberSwipeToDismissBoxState
+import androidx.compose.material3.windowsizeclass.WindowSizeClass
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -42,6 +43,7 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.riffle.app.feature.reader.FormattingPanel
+import com.riffle.app.ui.TabletContentWidthContainer
 import kotlinx.coroutines.launch
 import java.text.DateFormat
 import java.util.Date
@@ -49,6 +51,7 @@ import java.util.Date
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SettingsScreen(
+    windowSizeClass: WindowSizeClass,
     onNavigateBack: () -> Unit,
     onNavigateToAddServer: () -> Unit,
     viewModel: SettingsViewModel = hiltViewModel(),
@@ -86,150 +89,154 @@ fun SettingsScreen(
             )
         },
     ) { padding ->
-        Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(padding)
-                .verticalScroll(rememberScrollState()),
+        TabletContentWidthContainer(
+            windowSizeClass = windowSizeClass,
+            modifier = Modifier.fillMaxSize().padding(padding),
         ) {
-            Text(
-                text = "Servers",
-                style = MaterialTheme.typography.titleSmall,
-                modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
-            )
-            HorizontalDivider()
-            servers.forEach { server ->
-                val dismissState = rememberSwipeToDismissBoxState(
-                    confirmValueChange = { value ->
-                        if (value == SwipeToDismissBoxValue.EndToStart) {
-                            viewModel.removeServer(server.id)
-                            true
-                        } else false
-                    }
-                )
-                SwipeToDismissBox(
-                    state = dismissState,
-                    backgroundContent = {},
-                ) {
-                    val username = server.username.takeIf { it.isNotEmpty() }
-                    val version = serverVersions[server.id]
-                    val subtitle = buildString {
-                        if (username != null) {
-                            append(username)
-                            append(" · ")
-                        }
-                        append(server.url.value)
-                        if (version != null) {
-                            append(" · ")
-                            append(version)
-                        }
-                    }
-                    ListItem(
-                        headlineContent = { Text(server.displayName) },
-                        supportingContent = { Text(subtitle) },
-                        trailingContent = if (server.isActive) {
-                            { Text("Active", style = MaterialTheme.typography.labelSmall) }
-                        } else null,
-                    )
-                }
-            }
-            Button(
-                onClick = onNavigateToAddServer,
+            Column(
                 modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 16.dp, vertical = 8.dp),
+                    .fillMaxSize()
+                    .verticalScroll(rememberScrollState()),
             ) {
-                Text("Add Server")
-            }
-            HorizontalDivider()
-
-            if (libraryItems.isNotEmpty()) {
-                val activeServerName = servers.firstOrNull { it.isActive }?.displayName ?: ""
                 Text(
-                    text = "Libraries — $activeServerName",
+                    text = "Servers",
                     style = MaterialTheme.typography.titleSmall,
                     modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
                 )
                 HorizontalDivider()
-                libraryItems.forEach { item ->
+                servers.forEach { server ->
+                    val dismissState = rememberSwipeToDismissBoxState(
+                        confirmValueChange = { value ->
+                            if (value == SwipeToDismissBoxValue.EndToStart) {
+                                viewModel.removeServer(server.id)
+                                true
+                            } else false
+                        }
+                    )
+                    SwipeToDismissBox(
+                        state = dismissState,
+                        backgroundContent = {},
+                    ) {
+                        val username = server.username.takeIf { it.isNotEmpty() }
+                        val version = serverVersions[server.id]
+                        val subtitle = buildString {
+                            if (username != null) {
+                                append(username)
+                                append(" · ")
+                            }
+                            append(server.url.value)
+                            if (version != null) {
+                                append(" · ")
+                                append(version)
+                            }
+                        }
+                        ListItem(
+                            headlineContent = { Text(server.displayName) },
+                            supportingContent = { Text(subtitle) },
+                            trailingContent = if (server.isActive) {
+                                { Text("Active", style = MaterialTheme.typography.labelSmall) }
+                            } else null,
+                        )
+                    }
+                }
+                Button(
+                    onClick = onNavigateToAddServer,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 8.dp),
+                ) {
+                    Text("Add Server")
+                }
+                HorizontalDivider()
+
+                if (libraryItems.isNotEmpty()) {
+                    val activeServerName = servers.firstOrNull { it.isActive }?.displayName ?: ""
+                    Text(
+                        text = "Libraries — $activeServerName",
+                        style = MaterialTheme.typography.titleSmall,
+                        modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+                    )
+                    HorizontalDivider()
+                    libraryItems.forEach { item ->
+                        ListItem(
+                            headlineContent = { Text(item.library.name) },
+                            trailingContent = {
+                                Switch(
+                                    checked = item.isVisible,
+                                    onCheckedChange = { visible ->
+                                        val serverId = servers.firstOrNull { it.isActive }?.id ?: return@Switch
+                                        viewModel.setLibraryVisible(serverId, item.library.id, visible)
+                                    },
+                                    enabled = item.switchEnabled,
+                                )
+                            },
+                        )
+                    }
+                    HorizontalDivider()
+                }
+
+                Text(
+                    text = "Reading",
+                    style = MaterialTheme.typography.titleSmall,
+                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+                )
+                HorizontalDivider()
+                ListItem(
+                    modifier = Modifier.clickable { showFormattingPanel = true },
+                    headlineContent = { Text("Reading settings") },
+                    supportingContent = { Text("Font, theme, spacing, screen wake, volume keys") },
+                    trailingContent = {
+                        TextButton(onClick = { showFormattingPanel = true }) { Text("Edit") }
+                    },
+                )
+                HorizontalDivider()
+
+                Text(
+                    text = "Crash reports",
+                    style = MaterialTheme.typography.titleSmall,
+                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+                )
+                HorizontalDivider()
+                if (report == null) {
                     ListItem(
-                        headlineContent = { Text(item.library.name) },
+                        headlineContent = { Text("No crashes recorded") },
+                        supportingContent = { Text("The app has not crashed since installation") },
+                    )
+                } else {
+                    val timestamp = DateFormat.getDateTimeInstance().format(Date(report.timestampMillis))
+                    ListItem(
+                        headlineContent = { Text("Last crash") },
+                        supportingContent = { Text(timestamp) },
                         trailingContent = {
-                            Switch(
-                                checked = item.isVisible,
-                                onCheckedChange = { visible ->
-                                    val serverId = servers.firstOrNull { it.isActive }?.id ?: return@Switch
-                                    viewModel.setLibraryVisible(serverId, item.library.id, visible)
-                                },
-                                enabled = item.switchEnabled,
-                            )
+                            Row {
+                                TextButton(onClick = {
+                                    scope.launch {
+                                        clipboard.setClipEntry(
+                                            ClipEntry(ClipData.newPlainText("crash report", report.content))
+                                        )
+                                    }
+                                }) {
+                                    Text("Copy")
+                                }
+                                TextButton(onClick = { expanded = !expanded }) {
+                                    Text(if (expanded) "Hide" else "Show")
+                                }
+                            }
                         },
                     )
+                    if (expanded) {
+                        Text(
+                            text = report.content,
+                            style = MaterialTheme.typography.bodySmall.copy(fontFamily = FontFamily.Monospace),
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = 16.dp, vertical = 8.dp)
+                                .horizontalScroll(rememberScrollState()),
+                        )
+                    }
                 }
                 HorizontalDivider()
             }
-
-            Text(
-                text = "Reading",
-                style = MaterialTheme.typography.titleSmall,
-                modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
-            )
-            HorizontalDivider()
-            ListItem(
-                modifier = Modifier.clickable { showFormattingPanel = true },
-                headlineContent = { Text("Reading settings") },
-                supportingContent = { Text("Font, theme, spacing, screen wake, volume keys") },
-                trailingContent = {
-                    TextButton(onClick = { showFormattingPanel = true }) { Text("Edit") }
-                },
-            )
-            HorizontalDivider()
-
-            Text(
-                text = "Crash reports",
-                style = MaterialTheme.typography.titleSmall,
-                modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
-            )
-            HorizontalDivider()
-            if (report == null) {
-                ListItem(
-                    headlineContent = { Text("No crashes recorded") },
-                    supportingContent = { Text("The app has not crashed since installation") },
-                )
-            } else {
-                val timestamp = DateFormat.getDateTimeInstance().format(Date(report.timestampMillis))
-                ListItem(
-                    headlineContent = { Text("Last crash") },
-                    supportingContent = { Text(timestamp) },
-                    trailingContent = {
-                        Row {
-                            TextButton(onClick = {
-                                scope.launch {
-                                    clipboard.setClipEntry(
-                                        ClipEntry(ClipData.newPlainText("crash report", report.content))
-                                    )
-                                }
-                            }) {
-                                Text("Copy")
-                            }
-                            TextButton(onClick = { expanded = !expanded }) {
-                                Text(if (expanded) "Hide" else "Show")
-                            }
-                        }
-                    },
-                )
-                if (expanded) {
-                    Text(
-                        text = report.content,
-                        style = MaterialTheme.typography.bodySmall.copy(fontFamily = FontFamily.Monospace),
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(horizontal = 16.dp, vertical = 8.dp)
-                            .horizontalScroll(rememberScrollState()),
-                    )
-                }
-            }
-            HorizontalDivider()
         }
     }
 

--- a/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
@@ -142,6 +142,7 @@ fun MainScreen(
                     }
                     val setupVm: ServerSetupViewModel = hiltViewModel(parentEntry)
                     AddServerScreen(
+                        windowSizeClass = windowSizeClass,
                         onNavigateBack = {
                             navController.navigate(HOME) { popUpTo(HOME) { inclusive = true } }
                         },
@@ -162,6 +163,7 @@ fun MainScreen(
                     } else {
                         SelectLibrariesScreen(
                             pending = pending,
+                            windowSizeClass = windowSizeClass,
                             onNavigateBack = { navController.popBackStack() },
                             onContinueComplete = {
                                 navController.navigate(HOME) { popUpTo(HOME) { inclusive = true } }
@@ -172,12 +174,14 @@ fun MainScreen(
             }
             composable(SETTINGS) {
                 SettingsScreen(
+                    windowSizeClass = windowSizeClass,
                     onNavigateBack = { navController.popBackStack() },
                     onNavigateToAddServer = { navController.navigate(ADD_SERVER) },
                 )
             }
             composable(DOWNLOADS) {
                 DownloadsScreen(
+                    windowSizeClass = windowSizeClass,
                     onNavigateBack = { navController.popBackStack() },
                     onItemSelected = { item ->
                         val encodedId = URLEncoder.encode(item.id, "UTF-8")

--- a/app/src/main/kotlin/com/riffle/app/ui/TabletContentWidthContainer.kt
+++ b/app/src/main/kotlin/com/riffle/app/ui/TabletContentWidthContainer.kt
@@ -1,0 +1,45 @@
+package com.riffle.app.ui
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.material3.windowsizeclass.WindowSizeClass
+import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+/**
+ * Width-cap container for single-column list/form screens on the Tablet Layout
+ * (ADR 0019: Material 3 Expanded size class, ≥ 840dp). On Expanded the content
+ * is capped at [MaxContentWidth] and centred horizontally in the available
+ * pane. On Compact and Medium the container is a transparent pass-through that
+ * forwards [modifier] to a single [Box] wrapper — visually identical to having
+ * the modifier applied directly to the caller's root layout.
+ *
+ * Used by Settings, Downloads, AddServer, and Library Visibility Preferences
+ * (SelectLibrariesScreen). Not used by the in-reader TOC and Formatting
+ * Preferences sheets, which already render as constrained sheet surfaces.
+ */
+@Composable
+fun TabletContentWidthContainer(
+    windowSizeClass: WindowSizeClass,
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit,
+) {
+    if (windowSizeClass.widthSizeClass == WindowWidthSizeClass.Expanded) {
+        Box(modifier = modifier, contentAlignment = Alignment.TopCenter) {
+            Box(modifier = Modifier.widthIn(max = MaxContentWidth).fillMaxSize()) {
+                content()
+            }
+        }
+    } else {
+        // Intentional wrapper Box even on the no-op path so callers can pass a
+        // single modifier (typically `fillMaxSize().padding(scaffoldPadding)`)
+        // and get the same effect as applying it directly to their root layout.
+        Box(modifier = modifier) { content() }
+    }
+}
+
+private val MaxContentWidth = 600.dp


### PR DESCRIPTION
## Summary

- Introduces `TabletContentWidthContainer`, a size-class-aware composable that caps content at 600dp and centres it horizontally on Material 3 Expanded (ADR 0019). On Compact/Medium it is a transparent pass-through (single `Box` wrapper forwarding the caller's modifier).
- Applies it to the four single-column list/form screens: Settings, Downloads, AddServer, and SelectLibraries (Library Visibility Preferences). The in-reader TOC and Formatting Preferences sheets are deliberately not wrapped — they already render as constrained sheet surfaces.
- `WindowSizeClass` is plumbed from `MainScreen` to each screen, matching the pattern established in #26.

## Test plan

- [x] `make harness-test-tablet` passes — `TabletContentWidthContainerTest` (uses the real activity-derived `WindowSizeClass`, asserts 600dp cap and horizontal centring on the tablet AVD).
- [x] `make harness-test` passes (128/128, 4 skipped) — `TabletContentWidthContainerNoOpTest` verifies the container fills the full width on Compact.
- [x] `make test` passes (unit).
- [x] `make build` clean.

Closes #23