### PR TITLE
feat(tablet): two-pane Library Item Detail Screen on Expanded

### DIFF
--- a/app/src/androidTest/kotlin/com/riffle/app/feature/library/LibraryItemDetailTabletLayoutTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/library/LibraryItemDetailTabletLayoutTest.kt
@@ -1,0 +1,100 @@
+package com.riffle.app.feature.library
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.getUnclippedBoundsInRoot
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.test.swipeUp
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.riffle.app.harness.TabletLayout
+import com.riffle.core.domain.EbookFormat
+import com.riffle.core.domain.LibraryItem
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Verifies the Library Item Detail Screen's tablet layout (ADR 0020): two panes
+ * within a single destination, left pane fixed and right pane scrolling
+ * independently.
+ */
+@TabletLayout
+@RunWith(AndroidJUnit4::class)
+class LibraryItemDetailTabletLayoutTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private val item = LibraryItem(
+        id = "i1",
+        libraryId = "lib1",
+        title = "A Test Book",
+        author = "Test Author",
+        coverUrl = null,
+        readingProgress = 0f,
+        isCached = false,
+        isDownloaded = false,
+        ebookFormat = EbookFormat.Epub,
+        description = LONG_DESCRIPTION,
+        seriesName = "A Series #1",
+        publishedYear = "2026",
+        genres = listOf("Fantasy", "Adventure"),
+        publisher = "Riffle Press",
+    )
+
+    @Test
+    fun bothPanesRenderAndScrollingRightPaneDoesNotMoveLeft() {
+        composeTestRule.setContent {
+            LibraryItemDetailContentTablet(
+                item = item,
+                isInToRead = false,
+                token = "",
+                downloadState = DownloadState.NotDownloaded,
+                onReadItem = {},
+                onMarkAsRead = {},
+                onMarkAsUnread = {},
+                onToggleToRead = {},
+                onDownload = {},
+                onRemove = {},
+            )
+        }
+
+        val leftPane = composeTestRule.onNodeWithTag(LIBRARY_ITEM_DETAIL_LEFT_PANE_TAG)
+        val rightPane = composeTestRule.onNodeWithTag(LIBRARY_ITEM_DETAIL_RIGHT_PANE_TAG)
+
+        leftPane.assertIsDisplayed()
+        rightPane.assertIsDisplayed()
+        // Left-pane content present.
+        composeTestRule.onNodeWithText("A Test Book").assertIsDisplayed()
+        composeTestRule.onNodeWithText("By Test Author").assertIsDisplayed()
+        // Right-pane content present.
+        composeTestRule.onNodeWithText("Summary").assertIsDisplayed()
+
+        val leftBeforeBounds = leftPane.getUnclippedBoundsInRoot()
+        val titleBeforeBounds = composeTestRule.onNodeWithText("A Test Book").getUnclippedBoundsInRoot()
+
+        rightPane.performTouchInput { swipeUp() }
+        composeTestRule.waitForIdle()
+
+        val leftAfterBounds = leftPane.getUnclippedBoundsInRoot()
+        val titleAfterBounds = composeTestRule.onNodeWithText("A Test Book").getUnclippedBoundsInRoot()
+
+        assert(leftBeforeBounds == leftAfterBounds) {
+            "Left pane bounds changed after scrolling right pane: before=$leftBeforeBounds after=$leftAfterBounds"
+        }
+        assert(titleBeforeBounds == titleAfterBounds) {
+            "Left-pane title moved after scrolling right pane: before=$titleBeforeBounds after=$titleAfterBounds"
+        }
+    }
+}
+
+private val LONG_DESCRIPTION = buildString {
+    repeat(80) {
+        append("Paragraph $it. ")
+        append("Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. ")
+        append("Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. ")
+        append('\n')
+    }
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemDetailScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemDetailScreen.kt
@@ -9,10 +9,12 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
@@ -32,6 +34,8 @@ import androidx.compose.material3.SnackbarResult
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.windowsizeclass.WindowSizeClass
+import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -45,6 +49,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -53,9 +58,13 @@ import coil.request.ImageRequest
 import com.riffle.core.domain.LibraryItem
 import kotlinx.coroutines.launch
 
+const val LIBRARY_ITEM_DETAIL_LEFT_PANE_TAG = "library_item_detail_left_pane"
+const val LIBRARY_ITEM_DETAIL_RIGHT_PANE_TAG = "library_item_detail_right_pane"
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun LibraryItemDetailScreen(
+    windowSizeClass: WindowSizeClass,
     onNavigateBack: () -> Unit,
     onReadItem: (LibraryItem) -> Unit,
     viewModel: LibraryItemDetailViewModel = hiltViewModel(),
@@ -115,31 +124,50 @@ fun LibraryItemDetailScreen(
             }
 
             is LibraryItemDetailUiState.Ready -> {
-                LibraryItemDetailContent(
-                    item = state.item,
-                    isInToRead = state.isInToRead,
-                    token = viewModel.authToken,
-                    downloadState = downloadState,
-                    onReadItem = { item -> viewModel.markOpened(); onReadItem(item) },
-                    onMarkAsRead = { viewModel.markAsRead() },
-                    onMarkAsUnread = { viewModel.markAsUnread() },
-                    onToggleToRead = { viewModel.toggleToRead() },
-                    onDownload = { viewModel.startDownload() },
-                    onRemove = {
-                        viewModel.removeDownload()
-                        scope.launch {
-                            val result = snackbarHostState.showSnackbar(
-                                message = "Download removed",
-                                actionLabel = "Undo",
-                                duration = SnackbarDuration.Short,
-                            )
-                            if (result == SnackbarResult.ActionPerformed) {
-                                viewModel.startDownload()
-                            }
+                val onRemoveWithUndo: () -> Unit = {
+                    viewModel.removeDownload()
+                    scope.launch {
+                        val result = snackbarHostState.showSnackbar(
+                            message = "Download removed",
+                            actionLabel = "Undo",
+                            duration = SnackbarDuration.Short,
+                        )
+                        if (result == SnackbarResult.ActionPerformed) {
+                            viewModel.startDownload()
                         }
-                    },
-                    modifier = Modifier.padding(padding),
-                )
+                    }
+                }
+                val isExpanded =
+                    windowSizeClass.widthSizeClass == WindowWidthSizeClass.Expanded
+                if (isExpanded) {
+                    LibraryItemDetailContentTablet(
+                        item = state.item,
+                        isInToRead = state.isInToRead,
+                        token = viewModel.authToken,
+                        downloadState = downloadState,
+                        onReadItem = { item -> viewModel.markOpened(); onReadItem(item) },
+                        onMarkAsRead = { viewModel.markAsRead() },
+                        onMarkAsUnread = { viewModel.markAsUnread() },
+                        onToggleToRead = { viewModel.toggleToRead() },
+                        onDownload = { viewModel.startDownload() },
+                        onRemove = onRemoveWithUndo,
+                        modifier = Modifier.padding(padding),
+                    )
+                } else {
+                    LibraryItemDetailContent(
+                        item = state.item,
+                        isInToRead = state.isInToRead,
+                        token = viewModel.authToken,
+                        downloadState = downloadState,
+                        onReadItem = { item -> viewModel.markOpened(); onReadItem(item) },
+                        onMarkAsRead = { viewModel.markAsRead() },
+                        onMarkAsUnread = { viewModel.markAsUnread() },
+                        onToggleToRead = { viewModel.toggleToRead() },
+                        onDownload = { viewModel.startDownload() },
+                        onRemove = onRemoveWithUndo,
+                        modifier = Modifier.padding(padding),
+                    )
+                }
             }
         }
     }
@@ -206,41 +234,17 @@ private fun LibraryItemDetailContent(
             )
         }
 
-        if (item.isSupported) {
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                Button(
-                    onClick = { onReadItem(item) },
-                    enabled = downloadState !is DownloadState.InProgress,
-                    modifier = Modifier.weight(1f),
-                ) {
-                    Text("Read")
-                }
-                ReadToggleButton(
-                    isRead = item.readingProgress >= READ_PROGRESS_THRESHOLD,
-                    onMarkAsRead = onMarkAsRead,
-                    onMarkAsUnread = onMarkAsUnread,
-                )
-                ToReadToggleButton(
-                    isInToRead = isInToRead,
-                    onToggle = onToggleToRead,
-                )
-                DownloadButton(
-                    state = downloadState,
-                    onDownload = onDownload,
-                    onRemove = onRemove,
-                )
-            }
-        } else {
-            Text(
-                text = "No ebook file is available for this item on the server.",
-                style = MaterialTheme.typography.bodyLarge,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-        }
+        ActionRow(
+            item = item,
+            isInToRead = isInToRead,
+            downloadState = downloadState,
+            onReadItem = onReadItem,
+            onMarkAsRead = onMarkAsRead,
+            onMarkAsUnread = onMarkAsUnread,
+            onToggleToRead = onToggleToRead,
+            onDownload = onDownload,
+            onRemove = onRemove,
+        )
 
         Text(text = item.title, style = MaterialTheme.typography.headlineMedium)
         Text(text = "By ${item.author}", style = MaterialTheme.typography.titleLarge)
@@ -250,33 +254,172 @@ private fun LibraryItemDetailContent(
         }
 
         if (item.readingProgress > 0f) {
-            Column {
-                LinearProgressIndicator(
-                    progress = { item.readingProgress },
-                    modifier = Modifier.fillMaxWidth(),
-                )
-                Spacer(modifier = Modifier.height(4.dp))
-                Text(
-                    text = "${(item.readingProgress * 100).toInt()}% read",
-                    style = MaterialTheme.typography.bodyMedium,
-                )
-            }
+            ReadingProgressIndicator(progress = item.readingProgress)
         }
 
         item.description?.takeIf { it.isNotBlank() }?.let { desc ->
             CollapsibleDescription(desc)
         }
 
-        val metadataItems = buildList {
-            item.publishedYear?.let { add("Published: $it") }
-            if (item.genres.isNotEmpty()) add("Genres: ${item.genres.joinToString(", ")}")
-            item.publisher?.let { add("Publisher: $it") }
+        MetadataLines(item = item)
+    }
+}
+
+@Composable
+internal fun LibraryItemDetailContentTablet(
+    item: LibraryItem,
+    isInToRead: Boolean,
+    token: String,
+    downloadState: DownloadState,
+    onReadItem: (LibraryItem) -> Unit,
+    onMarkAsRead: () -> Unit,
+    onMarkAsUnread: () -> Unit,
+    onToggleToRead: () -> Unit,
+    onDownload: () -> Unit,
+    onRemove: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier.fillMaxSize(),
+    ) {
+        Column(
+            modifier = Modifier
+                .testTag(LIBRARY_ITEM_DETAIL_LEFT_PANE_TAG)
+                .width(360.dp)
+                .fillMaxHeight()
+                .padding(horizontal = 16.dp, vertical = 8.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            item.coverUrl?.let { url ->
+                // The left pane is non-scrolling (CONTEXT.md / ADR 0020), so the cover
+                // must yield height to the action row. weight(fill = false) lets the
+                // cover claim its aspect-ratio preferred size when there's room, but
+                // shrink in landscape so the Read button stays visible.
+                AsyncImage(
+                    model = ImageRequest.Builder(LocalContext.current)
+                        .data(url)
+                        .addHeader("Authorization", "Bearer $token")
+                        .build(),
+                    contentDescription = null,
+                    contentScale = ContentScale.Fit,
+                    modifier = Modifier
+                        .weight(1f, fill = false)
+                        .aspectRatio(2f / 3f)
+                        .align(Alignment.CenterHorizontally),
+                )
+            }
+            Text(text = item.title, style = MaterialTheme.typography.headlineMedium)
+            Text(text = "By ${item.author}", style = MaterialTheme.typography.titleLarge)
+            if (item.readingProgress > 0f) {
+                ReadingProgressIndicator(progress = item.readingProgress)
+            }
+            ActionRow(
+                item = item,
+                isInToRead = isInToRead,
+                downloadState = downloadState,
+                onReadItem = onReadItem,
+                onMarkAsRead = onMarkAsRead,
+                onMarkAsUnread = onMarkAsUnread,
+                onToggleToRead = onToggleToRead,
+                onDownload = onDownload,
+                onRemove = onRemove,
+            )
         }
-        if (metadataItems.isNotEmpty()) {
-            Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
-                metadataItems.forEach { line ->
-                    Text(text = line, style = MaterialTheme.typography.bodyMedium)
-                }
+        Column(
+            modifier = Modifier
+                .testTag(LIBRARY_ITEM_DETAIL_RIGHT_PANE_TAG)
+                .weight(1f)
+                .fillMaxHeight()
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 16.dp, vertical = 8.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            item.description?.takeIf { it.isNotBlank() }?.let { desc ->
+                CollapsibleDescription(desc)
+            }
+            item.seriesName?.let { series ->
+                Text(text = series, style = MaterialTheme.typography.bodyLarge)
+            }
+            MetadataLines(item = item)
+        }
+    }
+}
+
+@Composable
+private fun ActionRow(
+    item: LibraryItem,
+    isInToRead: Boolean,
+    downloadState: DownloadState,
+    onReadItem: (LibraryItem) -> Unit,
+    onMarkAsRead: () -> Unit,
+    onMarkAsUnread: () -> Unit,
+    onToggleToRead: () -> Unit,
+    onDownload: () -> Unit,
+    onRemove: () -> Unit,
+) {
+    if (item.isSupported) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Button(
+                onClick = { onReadItem(item) },
+                enabled = downloadState !is DownloadState.InProgress,
+                modifier = Modifier.weight(1f),
+            ) {
+                Text("Read")
+            }
+            ReadToggleButton(
+                isRead = item.readingProgress >= READ_PROGRESS_THRESHOLD,
+                onMarkAsRead = onMarkAsRead,
+                onMarkAsUnread = onMarkAsUnread,
+            )
+            ToReadToggleButton(
+                isInToRead = isInToRead,
+                onToggle = onToggleToRead,
+            )
+            DownloadButton(
+                state = downloadState,
+                onDownload = onDownload,
+                onRemove = onRemove,
+            )
+        }
+    } else {
+        Text(
+            text = "No ebook file is available for this item on the server.",
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+@Composable
+private fun ReadingProgressIndicator(progress: Float) {
+    Column {
+        LinearProgressIndicator(
+            progress = { progress },
+            modifier = Modifier.fillMaxWidth(),
+        )
+        Spacer(modifier = Modifier.height(4.dp))
+        Text(
+            text = "${(progress * 100).toInt()}% read",
+            style = MaterialTheme.typography.bodyMedium,
+        )
+    }
+}
+
+@Composable
+private fun MetadataLines(item: LibraryItem) {
+    val metadataItems = buildList {
+        item.publishedYear?.let { add("Published: $it") }
+        if (item.genres.isNotEmpty()) add("Genres: ${item.genres.joinToString(", ")}")
+        item.publisher?.let { add("Publisher: $it") }
+    }
+    if (metadataItems.isNotEmpty()) {
+        Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+            metadataItems.forEach { line ->
+                Text(text = line, style = MaterialTheme.typography.bodyMedium)
             }
         }
     }

--- a/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
@@ -291,6 +291,7 @@ fun MainScreen(
                 )
             ) {
                 LibraryItemDetailScreen(
+                    windowSizeClass = windowSizeClass,
                     onNavigateBack = { navController.popBackStack() },
                     onReadItem = { item ->
                         readerRouteFor(item)?.let { navController.navigate(it) }


### PR DESCRIPTION
## Summary
- Threads `WindowSizeClass` into `LibraryItemDetailScreen`; on `WindowWidthSizeClass.Expanded`, renders a two-pane layout — fixed-width (320dp) non-scrolling left pane (cover, title, author, progress, action row) and an independently scrolling right pane (description, series, year, genres, publisher). Compact/Medium retains the existing single-column scroll, unchanged in visible ordering.
- Extracts shared sub-blocks (`ActionRow`, `ReadingProgressIndicator`, `MetadataLines`) so both layouts use the same building blocks.
- Adds a `@TabletLayout` androidTest (`LibraryItemDetailTabletLayoutTest`) that verifies both panes render and that the left pane's bounds remain unchanged after a `swipeUp` on the right pane.

Per CONTEXT.md (Tablet Layout) and ADR 0020 — single-pane navigation, layout-only split within the destination.

Closes #22

## Test plan
- [x] `make test` — unit tests green
- [x] `make harness-test-tablet` — 2/2 green (includes new `LibraryItemDetailTabletLayoutTest`)
- [x] `make harness-test` — previously-failing tests re-run isolated and passed; earlier failures were AVD instability, not assertion failures
- [ ] Manual: Compact/Medium detail screen unchanged
- [ ] Manual: Expanded — verify left pane stays put while right pane scrolls