### PR TITLE
fix(tablet): hide permanent drawer panel while in reader

### DIFF
--- a/app/src/androidTest/kotlin/com/riffle/app/feature/navigation/PermanentNavigationDrawerTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/navigation/PermanentNavigationDrawerTest.kt
@@ -8,7 +8,9 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.platform.testTag
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.riffle.app.harness.TabletLayout
 import com.riffle.core.domain.Library
@@ -67,5 +69,51 @@ class PermanentNavigationDrawerTest {
         composeTestRule.onNodeWithText("Ebooks").assertIsDisplayed()
         composeTestRule.onNodeWithText("Downloads").assertIsDisplayed()
         composeTestRule.onNodeWithText("Settings").assertIsDisplayed()
+    }
+
+    /**
+     * Reader routes are immersive: when the host signals that the panel should be
+     * hidden (e.g. the current destination is the EPUB/PDF reader), the permanent
+     * drawer must not paint its sheet — the reader content takes the full width.
+     */
+    @Test
+    fun permanentDrawerHidesPanelWhenHideFlagSet() {
+        val server = Server(
+            id = "s1",
+            url = ServerUrl.parse("http://example.com")!!,
+            displayName = "Example",
+            isActive = true,
+            insecureConnectionAllowed = false,
+            username = "alice",
+        )
+        val libraries = listOf(
+            Library(id = "lib1", name = "Ebooks", mediaType = "book", isUnsupported = false),
+        )
+
+        composeTestRule.setContent {
+            RiffleNavigationDrawer(
+                drawerState = DrawerState(DrawerValue.Closed),
+                usePermanentDrawer = true,
+                hidePermanentDrawerPanel = true,
+                activeServer = server,
+                allServers = listOf(server),
+                visibleLibraries = libraries,
+                activeLibraryId = "lib1",
+                serverVersions = emptyMap(),
+                onServerSelected = {},
+                onLibrarySelected = {},
+                onDownloadsSelected = {},
+                onSettingsSelected = {},
+            ) {
+                Box(Modifier.fillMaxSize().testTag("reader-content"))
+            }
+        }
+
+        // Drawer items must be absent — the panel itself is not emitted.
+        composeTestRule.onNodeWithText("Ebooks").assertDoesNotExist()
+        composeTestRule.onNodeWithText("Downloads").assertDoesNotExist()
+        composeTestRule.onNodeWithText("Settings").assertDoesNotExist()
+        // Reader content is still rendered.
+        composeTestRule.onNodeWithTag("reader-content").assertIsDisplayed()
     }
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/navigation/NavigationDrawerComposable.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/navigation/NavigationDrawerComposable.kt
@@ -56,6 +56,7 @@ fun RiffleNavigationDrawer(
     drawerState: DrawerState,
     gesturesEnabled: Boolean = true,
     usePermanentDrawer: Boolean = false,
+    hidePermanentDrawerPanel: Boolean = false,
     activeServer: Server?,
     allServers: List<Server>,
     visibleLibraries: List<Library>,
@@ -86,7 +87,9 @@ fun RiffleNavigationDrawer(
         // permanent drawer pinned to the leading edge — no hamburger, no scrim.
         PermanentNavigationDrawer(
             drawerContent = {
-                PermanentDrawerSheet(modifier = Modifier.width(280.dp)) { sheetBody() }
+                if (!hidePermanentDrawerPanel) {
+                    PermanentDrawerSheet(modifier = Modifier.width(280.dp)) { sheetBody() }
+                }
             },
             content = content,
         )

--- a/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
@@ -64,7 +64,7 @@ fun MainScreen(
     // both render the phone UI. The threshold is evaluated at composition time so
     // configuration changes (rotation, foldable unfold, ChromeOS resize, split-screen)
     // re-evaluate automatically.
-    val usePermanentDrawer = windowSizeClass.widthSizeClass == WindowWidthSizeClass.Expanded
+    val isExpanded = windowSizeClass.widthSizeClass == WindowWidthSizeClass.Expanded
 
     val activeServer by viewModel.activeServer.collectAsState()
     val allServers by viewModel.allServers.collectAsState()
@@ -76,6 +76,10 @@ fun MainScreen(
         ?.takeIf { it.destination.route?.startsWith("library_items/") == true }
         ?.arguments?.getString("libraryId")
     val currentRoute = currentBackStack?.destination?.route
+    val usePermanentDrawer = isExpanded
+    // Reader screens are immersive — collapse the permanent side panel so the book/PDF
+    // fills the width, matching the modal drawer's gesture suppression on phones.
+    val hidePermanentDrawerPanel = isReaderRoute(currentRoute)
 
     LaunchedEffect(Unit) {
         viewModel.redirectToLibrary.collect { library ->
@@ -91,6 +95,7 @@ fun MainScreen(
         drawerState = drawerState,
         gesturesEnabled = !isReaderRoute(currentRoute),
         usePermanentDrawer = usePermanentDrawer,
+        hidePermanentDrawerPanel = hidePermanentDrawerPanel,
         activeServer = activeServer,
         allServers = allServers,
         visibleLibraries = visibleLibraries,


### PR DESCRIPTION
## Summary

On Expanded windows (≥840dp — tablets in landscape, and phones whose landscape width crosses the threshold, e.g. Pixel 6 at ~891dp), the `PermanentNavigationDrawer` introduced in #26 kept rendering its sheet beside the EPUB/PDF reader, eating ~280dp of reading surface. The user saw this as "the burger menu showing in reading mode in horizontal orientation."

Fix: when `isReaderRoute(currentRoute)`, skip emitting the `PermanentDrawerSheet` while keeping the `PermanentNavigationDrawer` wrapper composable in place — so the `NavHost` subtree (and Readium reader state) is not torn down when entering/leaving the reader. Mirrors the existing pattern at `MainScreen.kt:96` that disables modal-drawer gestures inside the reader.

## Test plan

- [x] Unit tests: `make test` — green
- [x] Tablet harness: `make harness-test-tablet` — both `PermanentNavigationDrawerTest` cases pass (the existing one + new `permanentDrawerHidesPanelWhenHideFlagSet`)
- [ ] Manual verification on a tablet in landscape: open a book, confirm the reader fills the full width and the nav panel reappears after `ArrowBack`
- [ ] Phone in landscape on a device with width ≥840dp: same check

Note on `make harness-test` (phone): two consecutive runs failed on `WakeLockHarnessTest.wakeLockIsOffWhenDisabledInSettings`; a run on unmodified `main` failed on a *different* test (`EpubHarnessTest.progressSyncSendsEpubCfiNotJson` with "Connection refused" to the live ABS server). The phone harness has pre-existing environment-dependent flakes unrelated to this change — Medium-width phones still use the modal drawer, so this PR doesn't touch any code path the phone harness exercises.