### PR TITLE
fix(reader): justify text on EPUBs with high-specificity publisher CSS

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/TypographyOverride.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/TypographyOverride.kt
@@ -23,6 +23,11 @@ internal data class TypographyOverride(
     val cssProperties: List<String>,
     val cssValue: String,
     val elements: String,
+    // Number of times to repeat the `[style*="…"]` attribute selector on the `:root` gate.
+    // Each repetition adds (0,1,0) to specificity. Bump above 1 when Readium's own ReadiumCSS
+    // rule for the same property targets the element with higher specificity AND `!important`
+    // — in which case matching specificity is the only way to win the cascade.
+    val gateAttrReps: Int = 1,
 )
 
 /**
@@ -44,6 +49,14 @@ internal val TYPOGRAPHY_OVERRIDES: Map<String, TypographyOverride> = mapOf(
         cssProperties = listOf("text-align"),
         cssValue = "var(--USER__textAlign)",
         elements = "p, li, blockquote, dd",
+        // Readium's after.css forces `text-align: inherit !important` on `p, li, body` with
+        // selector `:root[a][b] :not(blockquote):not(figcaption) p` (specificity 0,2,4). With
+        // a single `[style*=…]` we'd land at (0,1,2) and lose, leaving `p` inheriting from
+        // its nearest div ancestor — which for publisher CSS like Safari Books Online's
+        // `#sbo-rt-content div { text-align: left }` (1,0,1, non-important) breaks justify
+        // on everything wrapped in a semantic div (blockquotes, sidebars, list items,
+        // callouts). 3 attribute reps → (0,3,2), beating Readium on the second component.
+        gateAttrReps = 3,
     ),
     "fontFamily" to TypographyOverride(
         userPropertyName = "--USER__fontFamily",
@@ -101,7 +114,8 @@ internal val EXCLUDED_FROM_TYPOGRAPHY_OVERRIDES: Map<String, String> = mapOf(
  */
 internal fun typographyOverrideCss(): String =
     TYPOGRAPHY_OVERRIDES.values.joinToString("\n") { override ->
-        val gate = """:root[style*="${override.userPropertyName}"]"""
+        val gate = """:root""" +
+            """[style*="${override.userPropertyName}"]""".repeat(override.gateAttrReps)
         // Empty `elements` means the rule targets `:root` itself (used for margins, which
         // pads the multicol container so every page gets top/bottom whitespace).
         val selectorList = if (override.elements.isBlank()) {

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/TypographyOverrideTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/TypographyOverrideTest.kt
@@ -118,6 +118,34 @@ class TypographyOverrideTest {
         )
     }
 
+    // Regression guard: text-align is the one user property where ReadiumCSS's own rule uses
+    // `text-align: inherit !important` on `p, li, body` at specificity (0,2,4). With a single
+    // `[style*=…]` gate our rule lands at (0,1,2) and loses — so `p` inherits from its nearest
+    // div ancestor, and publisher CSS like Safari Books Online's
+    // `#sbo-rt-content div { text-align: left }` (1,0,1) wins on that div, leaving paragraphs
+    // wrapped in semantic divs (blockquotes, sidebars, list items, callouts) left-aligned even
+    // when the user has chosen justify. The bumped reps push us to (0,3,2) which beats Readium.
+    @Test
+    fun justify_text_override_has_enough_specificity_to_beat_readium_inherit_rule() {
+        val override = TYPOGRAPHY_OVERRIDES.getValue("justifyText")
+        assertTrue(
+            "justifyText must repeat its gate attribute selector at least 3 times to beat " +
+                "Readium's (0,2,4) `text-align: inherit !important` rule on p/li/body. " +
+                "Lowering this will silently regress justify on O'Reilly / Safari Books Online " +
+                "EPUBs and any publisher whose CSS sets text-align on div ancestors of p.",
+            override.gateAttrReps >= 3,
+        )
+        val css = typographyOverrideCss()
+        // The selector must contain three back-to-back [style*=…] attribute selectors on :root.
+        assertTrue(
+            "Generated CSS must contain :root[style*=\"--USER__textAlign\"][style*=\"--USER__textAlign\"][style*=\"--USER__textAlign\"]. CSS was:\n$css",
+            css.contains(
+                ":root" +
+                    "[style*=\"--USER__textAlign\"]".repeat(3),
+            ),
+        )
+    }
+
     // Injection JS must be idempotent — onPageLoaded fires more than once per page during
     // reflow, and naive injection would accumulate <style> tags.
     @Test


### PR DESCRIPTION
## Summary

- Justify-text setting was silently ignored on O'Reilly Media books — blockquotes, sidebars, list items, and callouts stayed left-aligned even with the toggle on. Reported against *Lean Customer Development* (`00c67042-…`); a library survey turned up *AI Engineering* (`70e7d5a2-…`) as a second victim with the same publisher CSS.
- Root cause: Readium's own `:root[a][b] :not(blockquote):not(figcaption) p { text-align: inherit !important }` rule (specificity **0,2,4**) outranked our override at **0,1,2**, forcing `<p>` to inherit from its parent. O'Reilly wraps body text in `<div>` descendants of `#sbo-rt-content`, and the publisher rule `#sbo-rt-content div { text-align: left }` set those wrappers to `left` — so `<p>` inherited `left` instead of the `:root` value of `justify`.
- Fix: introduce a per-override `gateAttrReps` field that repeats the `[style*="--USER__…"]` attribute selector. Set it to **3** for `justifyText` only, taking the override to **0,3,2** and beating Readium directly on `<p>` — the inheritance chain stops mattering. All other overrides keep `gateAttrReps = 1` (unchanged behavior).

Fonts work today because Readium has no analogous `font-family: inherit !important` rule, and line-height's analogous rule lacks `!important`. Only text-align triggers the trap.

## Verification

- Reproduced the failure in headless Chrome by replaying the exact stylesheet stack (Readium before/default/after + the book's `core.css` + our injected override) against the chapter DOM. Three test paragraphs (`p_simple`, `p_in_div`, `p_in_li`) — only `p_simple` justified. With the patched gate, all three justify.

## Test plan

- [ ] Open *Lean Customer Development* (`00c67042-519f-49bb-993f-2d6ae20fd654`) on the harness device, toggle Justify Text → all body paragraphs, blockquote attributions, and itemizedlist paragraphs justify
- [ ] Toggle Justify Text off → text returns to publisher's `text-align: left`
- [ ] Open *AI Engineering* (`70e7d5a2-9415-4633-8df2-fabc00f42128`) → same justify behavior on body and sidebars
- [ ] Open a non-O'Reilly book (e.g. *God Emperor of Dune*) → justify still works, no regression on books that were already working
- [ ] `./gradlew :app:testDebugUnitTest --tests "com.riffle.app.feature.reader.TypographyOverrideTest"` passes (including the new regression test `justify_text_override_has_enough_specificity_to_beat_readium_inherit_rule`)