### PR TITLE
feat(reader): chapter map doubles as progress indicator with labels

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ChapterNavigationRail.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ChapterNavigationRail.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawWithCache
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.contentDescription
@@ -27,16 +28,18 @@ fun ChapterNavigationRail(
     if (segments.isEmpty()) return
 
     val barColor = MaterialTheme.colorScheme.surfaceVariant
-    val activeColor = MaterialTheme.colorScheme.primary.copy(alpha = 0.35f)
+    val fillColor = MaterialTheme.colorScheme.primary.copy(alpha = 0.85f)
     val dividerColor = MaterialTheme.colorScheme.outline
+    val activeOutlineColor = MaterialTheme.colorScheme.primary
     val cursorColor = MaterialTheme.colorScheme.primary
 
     val activeTitle = segments.getOrNull(activeIndex)?.title ?: ""
+    val clampedCursor = cursorPosition.coerceIn(0f, 1f)
 
     Box(
         modifier = modifier
             .fillMaxWidth()
-            .height(6.dp)
+            .height(8.dp)
             .testTag("chapter_navigation_rail")
             .semantics { contentDescription = "Active rail segment: $activeTitle" }
             .pointerInput(segments) {
@@ -48,15 +51,20 @@ fun ChapterNavigationRail(
             .drawWithCache {
                 val bounds = railSegmentBounds(segments, size.width)
                 onDrawBehind {
+                    // 1. Empty track.
                     drawRect(color = barColor)
-                    if (activeIndex in bounds.indices) {
-                        val (ax, aw) = bounds[activeIndex]
+
+                    // 2. Continuous progress underlay up to the cursor.
+                    val fillWidth = clampedCursor * size.width
+                    if (fillWidth > 0f) {
                         drawRect(
-                            color = activeColor,
-                            topLeft = Offset(ax, 0f),
-                            size = Size(aw, size.height),
+                            color = fillColor,
+                            topLeft = Offset(0f, 0f),
+                            size = Size(fillWidth, size.height),
                         )
                     }
+
+                    // 3. Chapter dividers (skip index 0 which is the start of the bar).
                     for (i in 1 until bounds.size) {
                         val x = bounds[i].first
                         drawLine(
@@ -66,7 +74,24 @@ fun ChapterNavigationRail(
                             strokeWidth = 1.dp.toPx(),
                         )
                     }
-                    val cx = cursorPosition.coerceIn(0f, 1f) * size.width
+
+                    // 4. Active-chapter outline.
+                    if (activeIndex in bounds.indices) {
+                        val (ax, aw) = bounds[activeIndex]
+                        val stroke = 1.5.dp.toPx()
+                        drawRect(
+                            color = activeOutlineColor,
+                            topLeft = Offset(ax + stroke / 2f, stroke / 2f),
+                            size = Size(
+                                width = (aw - stroke).coerceAtLeast(0f),
+                                height = (size.height - stroke).coerceAtLeast(0f),
+                            ),
+                            style = Stroke(width = stroke),
+                        )
+                    }
+
+                    // 5. Cursor.
+                    val cx = clampedCursor * size.width
                     drawLine(
                         color = cursorColor,
                         start = Offset(cx, 0f),

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -12,11 +12,15 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.animation.shrinkVertically
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.Column
+import androidx.compose.ui.graphics.Color
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -246,10 +250,14 @@ fun EpubReaderScreen(
         // absolute screen bottom — the system nav bar overlays it without shifting it up.
         // Rail state (cursorPosition at scroll framerate) is isolated inside the overlay so
         // EpubNavigatorView does not recompose on every scroll event.
-        if (state is ReaderState.Ready && formattingPrefs.showChapterMap) {
+        if (state is ReaderState.Ready &&
+            (formattingPrefs.showChapterMap || formattingPrefs.showReadingProgressLabels)
+        ) {
             EpubChapterRailOverlay(
                 viewModel = viewModel,
-                darkTheme = formattingPrefs.theme == ReaderTheme.Dark || formattingPrefs.theme == ReaderTheme.DarkDim,
+                showRail = formattingPrefs.showChapterMap,
+                showLabels = formattingPrefs.showReadingProgressLabels,
+                readerTheme = formattingPrefs.theme,
                 modifier = Modifier.align(Alignment.BottomCenter),
             )
         }
@@ -340,19 +348,95 @@ internal fun readerTopAppBarColors() = androidx.compose.material3.TopAppBarDefau
 @Composable
 private fun BoxScope.EpubChapterRailOverlay(
     viewModel: EpubReaderViewModel,
-    darkTheme: Boolean,
+    showRail: Boolean,
+    showLabels: Boolean,
+    readerTheme: ReaderTheme,
     modifier: Modifier = Modifier,
 ) {
     val railSegments by viewModel.railSegments.collectAsState()
     val activeRailSegmentIndex by viewModel.activeRailSegmentIndex.collectAsState()
     val cursorPosition by viewModel.railCursorPosition.collectAsState()
+    val darkTheme = readerTheme == ReaderTheme.Dark || readerTheme == ReaderTheme.DarkDim
     RiffleTheme(darkTheme = darkTheme) {
-        ChapterNavigationRail(
-            segments = railSegments,
-            activeIndex = activeRailSegmentIndex,
-            cursorPosition = cursorPosition,
-            onSegmentClick = viewModel::navigateToSegment,
-            modifier = modifier,
+        // Backdrop is the exact reader-theme page colour so the strip reads as page margin,
+        // not chrome — no visible band, and prose flowing behind the overlay is cleanly
+        // occluded instead of bleeding through the labels.
+        Column(
+            modifier = modifier
+                .fillMaxWidth()
+                .background(readerTheme.palette.background),
+        ) {
+            if (showLabels) {
+                ReadingProgressLabels(
+                    activeChapterIndex = activeRailSegmentIndex,
+                    chapterCount = railSegments.size,
+                    totalProgress = cursorPosition,
+                    readerTheme = readerTheme,
+                )
+            }
+            if (showRail) {
+                ChapterNavigationRail(
+                    segments = railSegments,
+                    activeIndex = activeRailSegmentIndex,
+                    cursorPosition = cursorPosition,
+                    onSegmentClick = viewModel::navigateToSegment,
+                )
+            }
+        }
+    }
+}
+
+// Reader-theme-paired label colour: page foreground at reduced alpha so the labels read
+// as continuation of the page, not chrome — and don't compete with actual body text.
+// Per-theme alpha because the same alpha across themes reads as different "loudness" depending
+// on the foreground/background contrast.
+private fun readerThemeLabelColor(theme: ReaderTheme): Color {
+    val alpha = when (theme) {
+        ReaderTheme.Light -> 0.65f
+        ReaderTheme.Dark -> 0.65f
+        ReaderTheme.DarkDim -> 0.85f
+        ReaderTheme.Sepia -> 0.70f
+    }
+    return theme.palette.foreground.copy(alpha = alpha)
+}
+
+@Composable
+private fun ReadingProgressLabels(
+    activeChapterIndex: Int,
+    chapterCount: Int,
+    totalProgress: Float,
+    readerTheme: ReaderTheme,
+) {
+    val chapterText = if (chapterCount > 0) {
+        "Chapter ${(activeChapterIndex + 1).coerceAtMost(chapterCount)} of $chapterCount"
+    } else {
+        ""
+    }
+    val pctText = "%.1f%%".format(totalProgress.coerceIn(0f, 1f) * 100f)
+    val textColor = readerThemeLabelColor(readerTheme)
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 12.dp, vertical = 2.dp)
+            .testTag("reading_progress_labels"),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = chapterText,
+            style = MaterialTheme.typography.labelSmall,
+            color = textColor,
+            modifier = Modifier
+                .weight(1f)
+                .testTag("reading_progress_chapter")
+                .semantics { contentDescription = "Reading progress: $chapterText" },
+        )
+        Text(
+            text = pctText,
+            style = MaterialTheme.typography.labelSmall,
+            color = textColor,
+            modifier = Modifier
+                .testTag("reading_progress_percent")
+                .semantics { contentDescription = "Total progress: $pctText" },
         )
     }
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/FormattingPanel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/FormattingPanel.kt
@@ -271,13 +271,28 @@ fun FormattingPanel(
                 modifier = Modifier.fillMaxWidth(),
             ) {
                 Text(
-                    "Chapter Map",
+                    "Chapter map",
                     style = MaterialTheme.typography.bodyLarge,
                     modifier = Modifier.weight(1f),
                 )
                 Switch(
                     checked = prefs.showChapterMap,
                     onCheckedChange = { onPrefsChange(prefs.copy(showChapterMap = it)) },
+                )
+            }
+
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text(
+                    "Reading progress labels",
+                    style = MaterialTheme.typography.bodyLarge,
+                    modifier = Modifier.weight(1f),
+                )
+                Switch(
+                    checked = prefs.showReadingProgressLabels,
+                    onCheckedChange = { onPrefsChange(prefs.copy(showReadingProgressLabels = it)) },
                 )
             }
 
@@ -440,19 +455,11 @@ private fun ReaderTheme.displayName(): String = when (this) {
 // preview swatch on the corresponding FilterChip so users can pick a theme by sight
 // rather than reading the label. The dot is filled with the background and outlined
 // in the foreground so Dark vs Dark dim are visually distinct.
-private fun ReaderTheme.swatchBackground(): Color = when (this) {
-    ReaderTheme.Light -> Color(0xFFFFFFFF)
-    ReaderTheme.Dark -> Color(0xFF1A1A1A)
-    ReaderTheme.DarkDim -> Color(0xFF1A1A1A)
-    ReaderTheme.Sepia -> Color(0xFFF5E6CC)
-}
+// Palette comes from ReaderThemePalette so this stays in lock-step with the chapter-rail
+// overlay backdrop and (transitively) Readium's actual page rendering.
+private fun ReaderTheme.swatchBackground(): Color = palette.background
 
-private fun ReaderTheme.swatchForeground(): Color = when (this) {
-    ReaderTheme.Light -> Color(0xFF1A1A1A)
-    ReaderTheme.Dark -> Color(0xFFFFFFFF)
-    ReaderTheme.DarkDim -> Color(0xFFAAAAAA) // matches DARK_DIM_TEXT_COLOR in the mapper
-    ReaderTheme.Sepia -> Color(0xFF5C4A2E)
-}
+private fun ReaderTheme.swatchForeground(): Color = palette.foreground
 
 @Composable
 private fun ThemeSwatch(theme: ReaderTheme) {

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/FormattingPreferencesMapper.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/FormattingPreferencesMapper.kt
@@ -2,6 +2,7 @@
 
 package com.riffle.app.feature.reader
 
+import androidx.compose.ui.graphics.toArgb
 import com.riffle.core.domain.FormattingPreferences
 import com.riffle.core.domain.ReaderFontFamily
 import com.riffle.core.domain.ReaderOrientation
@@ -16,7 +17,8 @@ import org.readium.r2.navigator.preferences.Spread
 import org.readium.r2.navigator.preferences.TextAlign
 import org.readium.r2.navigator.preferences.Theme
 
-private const val DARK_DIM_TEXT_COLOR: Int = 0xFFAAAAAA.toInt()
+// Single source: ReaderThemePalette.DARK_DIM_TEXT (Compose Color) → Readium Color (ARGB int).
+private val DARK_DIM_TEXT_COLOR: Int = DARK_DIM_TEXT.toArgb()
 
 fun FormattingPreferences.toEpubPreferences(
     isLandscape: Boolean = false,

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderThemePalette.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderThemePalette.kt
@@ -1,0 +1,44 @@
+package com.riffle.app.feature.reader
+
+import androidx.compose.ui.graphics.Color
+import com.riffle.core.domain.ReaderTheme
+
+// Single source of truth for what each reader theme paints. Readium owns the actual page
+// rendering (see FormattingPreferencesMapper.toEpubPreferences → Theme.LIGHT/DARK/SEPIA),
+// but the app surfaces this palette in three places that must stay in lock-step with what
+// Readium draws: the formatting-panel theme swatches, the chapter-rail overlay backdrop,
+// and the DarkDim foreground override the mapper hands back to Readium.
+//
+// Values mirror the `--RS__backgroundColor` / `--RS__textColor` declarations Readium ships
+// in its CSS (assets/readium/readium-css/ReadiumCSS-after.css inside readium-navigator.aar,
+// rules `readium-night-on` and `readium-sepia-on`; default values are from
+// ReadiumCSS-before.css). Update this table if you bump Readium and the colours move.
+data class ReaderThemePalette(
+    val background: Color,
+    val foreground: Color,
+)
+
+// Riffle's "dark dim" mode reuses Readium's Theme.DARK background but overrides the body
+// text colour to a softer grey. The override is passed to Readium via
+// EpubPreferences.textColor in FormattingPreferencesMapper.
+internal val DARK_DIM_TEXT: Color = Color(0xFFAAAAAA)
+
+val ReaderTheme.palette: ReaderThemePalette
+    get() = when (this) {
+        ReaderTheme.Light -> ReaderThemePalette(
+            background = Color(0xFFFFFFFF),
+            foreground = Color(0xFF121212),
+        )
+        ReaderTheme.Dark -> ReaderThemePalette(
+            background = Color(0xFF000000),
+            foreground = Color(0xFFFEFEFE),
+        )
+        ReaderTheme.DarkDim -> ReaderThemePalette(
+            background = Color(0xFF000000),
+            foreground = DARK_DIM_TEXT,
+        )
+        ReaderTheme.Sepia -> ReaderThemePalette(
+            background = Color(0xFFFAF4E8),
+            foreground = Color(0xFF121212),
+        )
+    }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/TypographyOverride.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/TypographyOverride.kt
@@ -20,8 +20,9 @@ import com.riffle.core.domain.FormattingPreferences
  */
 internal data class TypographyOverride(
     val userPropertyName: String,
-    val cssProperties: List<String>,
-    val cssValue: String,
+    // Each (property, value) pair becomes one CSS declaration with !important. List of pairs
+    // (not Map) because order matters in CSS and a property could appear twice if ever needed.
+    val declarations: List<Pair<String, String>>,
     val elements: String,
 )
 
@@ -33,22 +34,19 @@ internal data class TypographyOverride(
 internal val TYPOGRAPHY_OVERRIDES: Map<String, TypographyOverride> = mapOf(
     "lineSpacing" to TypographyOverride(
         userPropertyName = "--USER__lineHeight",
-        cssProperties = listOf("line-height"),
-        cssValue = "var(--USER__lineHeight)",
+        declarations = listOf("line-height" to "var(--USER__lineHeight)"),
         // Headings deliberately excluded — books style heading line-height tightly (often 1.0)
         // and forcing the body line-height onto them looks wrong.
         elements = "p, li, blockquote, dd, dt, figcaption",
     ),
     "justifyText" to TypographyOverride(
         userPropertyName = "--USER__textAlign",
-        cssProperties = listOf("text-align"),
-        cssValue = "var(--USER__textAlign)",
+        declarations = listOf("text-align" to "var(--USER__textAlign)"),
         elements = "p, li, blockquote, dd",
     ),
     "fontFamily" to TypographyOverride(
         userPropertyName = "--USER__fontFamily",
-        cssProperties = listOf("font-family"),
-        cssValue = "var(--USER__fontFamily)",
+        declarations = listOf("font-family" to "var(--USER__fontFamily)"),
         // `pre`/`code`/`kbd`/`samp` deliberately excluded so monospace code keeps its font.
         // Headings included so picking a reading font feels consistent across body and titles.
         elements = "body, p, li, blockquote, dd, dt, h1, h2, h3, h4, h5, h6, figcaption",
@@ -64,13 +62,17 @@ internal val TYPOGRAPHY_OVERRIDES: Map<String, TypographyOverride> = mapOf(
     // padding-bottom longhands win regardless of source order. In scroll mode (`readium-scroll-on`)
     // `:root` is `height: auto`, so this becomes whitespace at the start/end of each loaded
     // resource — still the desired "margin" semantics.
+    //
+    // Top stays at 0.5× the horizontal gutter (narrower than sides — conventional book
+    // typography). Bottom is 1.0× so the chapter-rail overlay has clear breathing room above
+    // the running text. Both scale with --USER__pageMargins, so cranking up margins keeps the
+    // top/bottom ratio constant.
     "margins" to TypographyOverride(
         userPropertyName = "--USER__pageMargins",
-        cssProperties = listOf("padding-top", "padding-bottom"),
-        // 0.5× of the horizontal gutter — book typography conventionally gives narrower
-        // top/bottom than side margins, and our reader already consumes vertical space with
-        // system insets, so a full 1× ratio would feel heavy.
-        cssValue = "calc(var(--RS__pageGutter) * var(--USER__pageMargins) * 0.5)",
+        declarations = listOf(
+            "padding-top" to "calc(var(--RS__pageGutter) * var(--USER__pageMargins) * 0.5)",
+            "padding-bottom" to "calc(var(--RS__pageGutter) * var(--USER__pageMargins) * 1.0)",
+        ),
         elements = "",  // empty → rule targets `:root` itself, not a descendant
     ),
 )
@@ -86,6 +88,7 @@ internal val EXCLUDED_FROM_TYPOGRAPHY_OVERRIDES: Map<String, String> = mapOf(
     "orientation" to "Layout/scroll mode, not a CSS property.",
     "doublePageSpread" to "Column-count layout mode, handled by RsProperties at fragment-creation time.",
     "showChapterMap" to "UI affordance outside the reader content; no CSS implication.",
+    "showReadingProgressLabels" to "UI affordance outside the reader content; no CSS implication.",
 )
 
 /**
@@ -111,8 +114,8 @@ internal fun typographyOverrideCss(): String =
                 .split(",")
                 .joinToString(",\n") { "$gate ${it.trim()}" }
         }
-        val declarations = override.cssProperties
-            .joinToString("\n          ") { "$it: ${override.cssValue} !important;" }
+        val declarations = override.declarations
+            .joinToString("\n          ") { (prop, value) -> "$prop: $value !important;" }
         """
         $selectorList {
           $declarations

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/TypographyOverrideTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/TypographyOverrideTest.kt
@@ -73,8 +73,9 @@ class TypographyOverrideTest {
     fun every_override_rule_is_gated_on_root_style_variable_presence() {
         val css = typographyOverrideCss()
         TYPOGRAPHY_OVERRIDES.values.forEach { override ->
+            val props = override.declarations.joinToString(", ") { it.first }
             assertTrue(
-                "Override for ${override.cssProperties} must be gated on :root[style*=\"${override.userPropertyName}\"]",
+                "Override for $props must be gated on :root[style*=\"${override.userPropertyName}\"]",
                 css.contains(":root[style*=\"${override.userPropertyName}\"]"),
             )
         }
@@ -87,8 +88,8 @@ class TypographyOverrideTest {
     fun every_override_uses_important() {
         val css = typographyOverrideCss()
         TYPOGRAPHY_OVERRIDES.values.forEach { override ->
-            override.cssProperties.forEach { property ->
-                val rule = Regex("${Regex.escape(property)}:\\s*${Regex.escape(override.cssValue)}\\s*!important")
+            override.declarations.forEach { (property, value) ->
+                val rule = Regex("${Regex.escape(property)}:\\s*${Regex.escape(value)}\\s*!important")
                 assertNotNull(
                     "Override for $property must use !important to beat publisher rules without it",
                     rule.find(css),

--- a/core/data/src/main/kotlin/com/riffle/core/data/BookFormattingPreferencesStoreImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/BookFormattingPreferencesStoreImpl.kt
@@ -23,6 +23,7 @@ class BookFormattingPreferencesStoreImpl @Inject constructor(
             margins = entity.margins,
             orientation = entity.orientation?.let { runCatching { ReaderOrientation.valueOf(it) }.getOrNull() },
             showChapterMap = entity.showChapterMap,
+            showReadingProgressLabels = entity.showReadingProgressLabels,
             doublePageSpread = entity.doublePageSpread,
             justifyText = entity.justifyText,
         )
@@ -43,6 +44,7 @@ class BookFormattingPreferencesStoreImpl @Inject constructor(
                 margins = overrides.margins,
                 orientation = overrides.orientation?.name,
                 showChapterMap = overrides.showChapterMap,
+                showReadingProgressLabels = overrides.showReadingProgressLabels,
                 doublePageSpread = overrides.doublePageSpread,
                 justifyText = overrides.justifyText,
             )

--- a/core/data/src/main/kotlin/com/riffle/core/data/FormattingPreferencesStoreImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/FormattingPreferencesStoreImpl.kt
@@ -35,6 +35,7 @@ class FormattingPreferencesStoreImpl @Inject constructor(
                 ?.let { runCatching { ReaderOrientation.valueOf(it) }.getOrNull() }
                 ?: ReaderOrientation.Horizontal,
             showChapterMap = prefs[KEY_SHOW_CHAPTER_MAP] ?: true,
+            showReadingProgressLabels = prefs[KEY_SHOW_READING_PROGRESS_LABELS] ?: true,
             doublePageSpread = prefs[KEY_DOUBLE_PAGE_SPREAD] ?: false,
             justifyText = prefs[KEY_JUSTIFY_TEXT] ?: false,
         )
@@ -49,6 +50,7 @@ class FormattingPreferencesStoreImpl @Inject constructor(
             prefs[KEY_MARGINS] = preferences.margins
             prefs[KEY_ORIENTATION] = preferences.orientation.name
             prefs[KEY_SHOW_CHAPTER_MAP] = preferences.showChapterMap
+            prefs[KEY_SHOW_READING_PROGRESS_LABELS] = preferences.showReadingProgressLabels
             prefs[KEY_DOUBLE_PAGE_SPREAD] = preferences.doublePageSpread
             prefs[KEY_JUSTIFY_TEXT] = preferences.justifyText
         }
@@ -62,6 +64,7 @@ class FormattingPreferencesStoreImpl @Inject constructor(
         val KEY_MARGINS = floatPreferencesKey("margins")
         val KEY_ORIENTATION = stringPreferencesKey("orientation")
         val KEY_SHOW_CHAPTER_MAP = booleanPreferencesKey("show_chapter_map")
+        val KEY_SHOW_READING_PROGRESS_LABELS = booleanPreferencesKey("show_reading_progress_labels")
         val KEY_DOUBLE_PAGE_SPREAD = booleanPreferencesKey("double_page_spread")
         val KEY_JUSTIFY_TEXT = booleanPreferencesKey("justify_text")
     }

--- a/core/data/src/main/kotlin/com/riffle/core/data/di/DatabaseModule.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/di/DatabaseModule.kt
@@ -41,6 +41,7 @@ object DatabaseModule {
                 RiffleDatabase.MIGRATION_13_14,
                 RiffleDatabase.MIGRATION_14_15,
                 RiffleDatabase.MIGRATION_15_16,
+                RiffleDatabase.MIGRATION_16_17,
             )
             .build()
 

--- a/core/database/schemas/com.riffle.core.database.RiffleDatabase/17.json
+++ b/core/database/schemas/com.riffle.core.database.RiffleDatabase/17.json
@@ -1,0 +1,428 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 17,
+    "identityHash": "a2cb146968a266f326a901ea0b7e7c97",
+    "entities": [
+      {
+        "tableName": "servers",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `url` TEXT NOT NULL, `displayName` TEXT NOT NULL, `isActive` INTEGER NOT NULL, `insecureConnectionAllowed` INTEGER NOT NULL, `username` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "isActive",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "insecureConnectionAllowed",
+            "columnName": "insecureConnectionAllowed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "username",
+            "columnName": "username",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "libraries",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `mediaType` TEXT NOT NULL, `serverId` TEXT NOT NULL, `isUnsupported` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaType",
+            "columnName": "mediaType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isUnsupported",
+            "columnName": "isUnsupported",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "library_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `title` TEXT NOT NULL, `author` TEXT NOT NULL, `coverUrl` TEXT, `readingProgress` REAL NOT NULL, `ebookFileIno` TEXT, `ebookFormat` TEXT NOT NULL, `description` TEXT, `seriesName` TEXT, `publishedYear` TEXT, `genres` TEXT NOT NULL, `publisher` TEXT, `lastOpenedAt` INTEGER, `addedAt` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "coverUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "readingProgress",
+            "columnName": "readingProgress",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ebookFileIno",
+            "columnName": "ebookFileIno",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "ebookFormat",
+            "columnName": "ebookFormat",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seriesName",
+            "columnName": "seriesName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "publishedYear",
+            "columnName": "publishedYear",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "genres",
+            "columnName": "genres",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "publisher",
+            "columnName": "publisher",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastOpenedAt",
+            "columnName": "lastOpenedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "series",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `name` TEXT NOT NULL, `coverUrl` TEXT, `bookCount` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "coverUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "bookCount",
+            "columnName": "bookCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "collections",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `name` TEXT NOT NULL, `bookCount` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookCount",
+            "columnName": "bookCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "series_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`seriesId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `sequenceOrder` REAL NOT NULL, PRIMARY KEY(`seriesId`, `itemId`))",
+        "fields": [
+          {
+            "fieldPath": "seriesId",
+            "columnName": "seriesId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sequenceOrder",
+            "columnName": "sequenceOrder",
+            "affinity": "REAL",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "seriesId",
+            "itemId"
+          ]
+        }
+      },
+      {
+        "tableName": "collection_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`collectionId` TEXT NOT NULL, `itemId` TEXT NOT NULL, PRIMARY KEY(`collectionId`, `itemId`))",
+        "fields": [
+          {
+            "fieldPath": "collectionId",
+            "columnName": "collectionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "collectionId",
+            "itemId"
+          ]
+        }
+      },
+      {
+        "tableName": "reading_positions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`itemId` TEXT NOT NULL, `cfi` TEXT NOT NULL, `localUpdatedAt` INTEGER NOT NULL, PRIMARY KEY(`itemId`))",
+        "fields": [
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cfi",
+            "columnName": "cfi",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localUpdatedAt",
+            "columnName": "localUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "itemId"
+          ]
+        }
+      },
+      {
+        "tableName": "book_formatting_preferences",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`itemId` TEXT NOT NULL, `fontSize` REAL, `theme` TEXT, `fontFamily` TEXT, `lineSpacing` REAL, `margins` REAL, `orientation` TEXT, `showChapterMap` INTEGER, `showReadingProgressLabels` INTEGER, `doublePageSpread` INTEGER, `justifyText` INTEGER, PRIMARY KEY(`itemId`))",
+        "fields": [
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fontSize",
+            "columnName": "fontSize",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "theme",
+            "columnName": "theme",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "fontFamily",
+            "columnName": "fontFamily",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lineSpacing",
+            "columnName": "lineSpacing",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "margins",
+            "columnName": "margins",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "orientation",
+            "columnName": "orientation",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "showChapterMap",
+            "columnName": "showChapterMap",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "showReadingProgressLabels",
+            "columnName": "showReadingProgressLabels",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "doublePageSpread",
+            "columnName": "doublePageSpread",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "justifyText",
+            "columnName": "justifyText",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "itemId"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'a2cb146968a266f326a901ea0b7e7c97')"
+    ]
+  }
+}

--- a/core/database/src/androidTest/kotlin/com/riffle/core/database/MigrationTest.kt
+++ b/core/database/src/androidTest/kotlin/com/riffle/core/database/MigrationTest.kt
@@ -407,6 +407,43 @@ class MigrationTest {
     }
 
     @Test
+    fun migration16To17() {
+        helper.createDatabase(TEST_DB, 16).use { db ->
+            // Existing row with sparse overrides — only showChapterMap is set.
+            db.execSQL(
+                "INSERT INTO book_formatting_preferences (itemId, fontSize, theme, fontFamily, lineSpacing, margins, orientation, showChapterMap, doublePageSpread, justifyText) " +
+                    "VALUES ('item1', NULL, NULL, NULL, NULL, NULL, NULL, 0, NULL, NULL)"
+            )
+        }
+
+        val db = helper.runMigrationsAndValidate(TEST_DB, 17, true, RiffleDatabase.MIGRATION_16_17)
+
+        // Pre-existing data preserved; new column defaults to NULL = follow global.
+        db.query(
+            "SELECT itemId, showChapterMap, showReadingProgressLabels FROM book_formatting_preferences WHERE itemId = 'item1'"
+        ).use { cursor ->
+            assertEquals(1, cursor.count)
+            cursor.moveToFirst()
+            assertEquals("item1", cursor.getString(0))
+            assertEquals(0, cursor.getInt(1))
+            assertTrue("showReadingProgressLabels should be null for legacy rows", cursor.isNull(2))
+        }
+
+        // New writes can populate the new column.
+        db.execSQL(
+            "INSERT INTO book_formatting_preferences (itemId, fontSize, theme, fontFamily, lineSpacing, margins, orientation, showChapterMap, showReadingProgressLabels, doublePageSpread, justifyText) " +
+                "VALUES ('item2', NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0, NULL, NULL)"
+        )
+        db.query(
+            "SELECT showReadingProgressLabels FROM book_formatting_preferences WHERE itemId = 'item2'"
+        ).use { cursor ->
+            assertEquals(1, cursor.count)
+            cursor.moveToFirst()
+            assertEquals(0, cursor.getInt(0))
+        }
+    }
+
+    @Test
     fun migrateFullChain() {
         helper.createDatabase(TEST_DB, 1).use { db ->
             db.execSQL(
@@ -415,7 +452,7 @@ class MigrationTest {
         }
 
         val db = helper.runMigrationsAndValidate(
-            TEST_DB, 16, true,
+            TEST_DB, 17, true,
             RiffleDatabase.MIGRATION_1_2,
             RiffleDatabase.MIGRATION_2_3,
             RiffleDatabase.MIGRATION_3_4,
@@ -431,6 +468,7 @@ class MigrationTest {
             RiffleDatabase.MIGRATION_13_14,
             RiffleDatabase.MIGRATION_14_15,
             RiffleDatabase.MIGRATION_15_16,
+            RiffleDatabase.MIGRATION_16_17,
         )
 
         db.query("SELECT url, displayName, username FROM servers WHERE id = 's1'").use { cursor ->

--- a/core/database/src/main/kotlin/com/riffle/core/database/BookFormattingPreferencesEntity.kt
+++ b/core/database/src/main/kotlin/com/riffle/core/database/BookFormattingPreferencesEntity.kt
@@ -13,6 +13,7 @@ data class BookFormattingPreferencesEntity(
     val margins: Float? = null,
     val orientation: String? = null,
     val showChapterMap: Boolean? = null,
+    val showReadingProgressLabels: Boolean? = null,
     val doublePageSpread: Boolean? = null,
     val justifyText: Boolean? = null,
 )

--- a/core/database/src/main/kotlin/com/riffle/core/database/RiffleDatabase.kt
+++ b/core/database/src/main/kotlin/com/riffle/core/database/RiffleDatabase.kt
@@ -17,7 +17,7 @@ import androidx.sqlite.db.SupportSQLiteDatabase
         ReadingPositionEntity::class,
         BookFormattingPreferencesEntity::class,
     ],
-    version = 16,
+    version = 17,
     exportSchema = true,
 )
 abstract class RiffleDatabase : RoomDatabase() {
@@ -203,6 +203,14 @@ abstract class RiffleDatabase : RoomDatabase() {
                 )
                 db.execSQL("DROP TABLE `book_formatting_preferences`")
                 db.execSQL("ALTER TABLE `book_formatting_preferences_new` RENAME TO `book_formatting_preferences`")
+            }
+        }
+
+        val MIGRATION_16_17 = object : Migration(16, 17) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL(
+                    "ALTER TABLE `book_formatting_preferences` ADD COLUMN `showReadingProgressLabels` INTEGER DEFAULT NULL"
+                )
             }
         }
     }

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/BookFormattingOverrides.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/BookFormattingOverrides.kt
@@ -8,6 +8,7 @@ data class BookFormattingOverrides(
     val margins: Float? = null,
     val orientation: ReaderOrientation? = null,
     val showChapterMap: Boolean? = null,
+    val showReadingProgressLabels: Boolean? = null,
     val doublePageSpread: Boolean? = null,
     val justifyText: Boolean? = null,
 ) {
@@ -19,6 +20,7 @@ data class BookFormattingOverrides(
             margins == null &&
             orientation == null &&
             showChapterMap == null &&
+            showReadingProgressLabels == null &&
             doublePageSpread == null &&
             justifyText == null
 
@@ -30,6 +32,7 @@ data class BookFormattingOverrides(
         margins = margins ?: global.margins,
         orientation = orientation ?: global.orientation,
         showChapterMap = showChapterMap ?: global.showChapterMap,
+        showReadingProgressLabels = showReadingProgressLabels ?: global.showReadingProgressLabels,
         doublePageSpread = doublePageSpread ?: global.doublePageSpread,
         justifyText = justifyText ?: global.justifyText,
     )
@@ -47,6 +50,7 @@ data class BookFormattingOverrides(
         margins = if (new.margins != previous.margins) new.margins else margins,
         orientation = if (new.orientation != previous.orientation) new.orientation else orientation,
         showChapterMap = if (new.showChapterMap != previous.showChapterMap) new.showChapterMap else showChapterMap,
+        showReadingProgressLabels = if (new.showReadingProgressLabels != previous.showReadingProgressLabels) new.showReadingProgressLabels else showReadingProgressLabels,
         doublePageSpread = if (new.doublePageSpread != previous.doublePageSpread) new.doublePageSpread else doublePageSpread,
         justifyText = if (new.justifyText != previous.justifyText) new.justifyText else justifyText,
     )

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/FormattingPreferences.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/FormattingPreferences.kt
@@ -8,6 +8,7 @@ data class FormattingPreferences(
     val margins: Float = DEFAULT_MARGINS,
     val orientation: ReaderOrientation = DEFAULT_ORIENTATION,
     val showChapterMap: Boolean = DEFAULT_SHOW_CHAPTER_MAP,
+    val showReadingProgressLabels: Boolean = DEFAULT_SHOW_READING_PROGRESS_LABELS,
     val doublePageSpread: Boolean = DEFAULT_DOUBLE_PAGE_SPREAD,
     val justifyText: Boolean = DEFAULT_JUSTIFY_TEXT,
 ) {
@@ -16,6 +17,7 @@ data class FormattingPreferences(
         const val DEFAULT_LINE_SPACING: Float = 1.2f
         const val DEFAULT_MARGINS: Float = 1.0f
         const val DEFAULT_SHOW_CHAPTER_MAP: Boolean = true
+        const val DEFAULT_SHOW_READING_PROGRESS_LABELS: Boolean = true
         const val DEFAULT_DOUBLE_PAGE_SPREAD: Boolean = false
         const val DEFAULT_JUSTIFY_TEXT: Boolean = false
         val DEFAULT_THEME: ReaderTheme = ReaderTheme.Light


### PR DESCRIPTION
## Summary
- Repaint the chapter rail so the same widget conveys both per-chapter position and total reading progress: continuous primary-color fill up to the cursor, dividers per chapter, outlined active chapter.
- Add a labels row above the rail — \"Chapter X of Y\" on the left, total percent on the right. Two independent toggles in the formatting panel (Chapter map / Reading progress labels) control the rail and the labels separately; both persist per-book.
- Introduce `ReaderThemePalette` as the single source of truth for reader theme background/foreground colors. Palette values now mirror Readium's actual `ReadiumCSS-after.css` declarations (corrects long-standing drift in the panel theme swatches). `DARK_DIM_TEXT_COLOR` in the mapper derives from the palette via `toArgb()` so the two can't desync.
- Widen the bottom page margin: `padding-top` stays at `0.5×` the horizontal gutter, `padding-bottom` is now `1.0×`. Both still scale with the user's Margins setting. Gives the rail overlay clear breathing room above the running text. Refactors `TypographyOverride` to carry per-property declarations (was one `cssValue` shared across N properties) so each side can have its own multiplier.
- DB: `RiffleDatabase` v16 → v17 with `MIGRATION_16_17` adding the nullable `showReadingProgressLabels` column to `book_formatting_preferences`. Schema v17 exported. `migrationTest16To17` added, full-chain test updated.

## Test plan
- [x] `:core:domain:test` ✅
- [x] `:app:testDebugUnitTest` (356 tests, includes `TypographyOverrideTest` contract suite) ✅
- [ ] `make harness-test` — env-blocked locally (competing emulators across workspaces); needs a clean re-run
- [x] `make harness-test-tablet`
- [x] Manual: toggle Chapter map / Reading progress labels independently in the formatting panel; verify per-book persistence after closing/reopening
- [x] Manual: switch between Light / Dark / Dim / Sepia and confirm the strip blends with the page (no visible band) and label text contrast looks right
- [x] Manual: nudge the Margins stepper up/down and confirm the bottom margin grows faster than top