### PR TITLE
fix(reader): preserve immersive mode across phone sleep/resume

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ImmersiveModeState.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ImmersiveModeState.kt
@@ -2,6 +2,7 @@ package com.riffle.app.feature.reader
 
 import android.os.SystemClock
 import androidx.activity.compose.LocalActivity
+import androidx.annotation.VisibleForTesting
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.systemBars
 import androidx.compose.runtime.Composable
@@ -22,9 +23,32 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
 
+/**
+ * Thin abstraction over the system-bar controls used by [ImmersiveModeState].
+ *
+ * Exists so the state machine can be unit-tested without instantiating
+ * [WindowInsetsControllerCompat] (which requires an Android `Window`).
+ */
+internal interface SystemBarsController {
+    fun hide()
+    fun show()
+    fun setBehaviorDefault()
+}
+
+private class WindowInsetsBarsController(
+    private val delegate: WindowInsetsControllerCompat,
+) : SystemBarsController {
+    override fun hide() = delegate.hide(WindowInsetsCompat.Type.systemBars())
+    override fun show() = delegate.show(WindowInsetsCompat.Type.systemBars())
+    override fun setBehaviorDefault() {
+        delegate.systemBarsBehavior = WindowInsetsControllerCompat.BEHAVIOR_DEFAULT
+    }
+}
+
 @Stable
-class ImmersiveModeState(
-    private val controller: WindowInsetsControllerCompat,
+class ImmersiveModeState internal constructor(
+    private val controller: SystemBarsController,
+    private val clock: () -> Long,
 ) {
     var isImmersive by mutableStateOf(false)
         internal set
@@ -46,12 +70,12 @@ class ImmersiveModeState(
     // auto-dismiss on page turns; the user must tap to re-enter immersive.
     fun toggle() {
         if (isImmersive) {
-            lastToggleMs = SystemClock.elapsedRealtime()
+            lastToggleMs = clock()
             // systemBarsHidden must be cleared before isImmersive so that any
             // dismissOverlay() call racing on the same frame cannot re-hide the bar.
             systemBarsHidden = false
             isImmersive = false
-            controller.show(WindowInsetsCompat.Type.systemBars())
+            controller.show()
             onUserImmersiveChanged?.invoke(false)
         } else {
             hide()
@@ -63,20 +87,25 @@ class ImmersiveModeState(
     // so position changes in normal (bars-visible) mode don't dismiss the overlay.
     // Suppressed for TOGGLE_COOLDOWN_MS after the user taps to reveal the bar.
     fun dismissOverlay() {
-        val now = SystemClock.elapsedRealtime()
+        val now = clock()
         if (systemBarsHidden && now - lastToggleMs > TOGGLE_COOLDOWN_MS) isImmersive = true
     }
 
-    internal fun hide() {
-        // Guard: only call controller.hide() if bars are not already hidden.
-        // On some API levels, calling hide() on already-hidden bars triggers a native crash
-        // in the WebView/Chromium renderer stack. The toggle() call-path can reach hide()
-        // while systemBarsHidden is true (user revealed TopAppBar then tapped again), so
-        // we must be idempotent here.
+    // Guard: only call controller.hide() if bars are not already hidden.
+    // On some API levels, calling hide() on already-hidden bars triggers a native crash
+    // in the WebView/Chromium renderer stack. The toggle() call-path can reach hide()
+    // while systemBarsHidden is true (user revealed TopAppBar then tapped again), so
+    // we must be idempotent here.
+    //
+    // Pass force = true when the tracked flag may be stale relative to the OS (e.g. after
+    // returning from sleep, where the system may have restored bars while we still believe
+    // them hidden). The flag is reset before the guard so controller.hide() actually runs.
+    internal fun hide(force: Boolean = false) {
+        if (force) systemBarsHidden = false
         if (!systemBarsHidden) {
             systemBarsHidden = true
-            controller.systemBarsBehavior = WindowInsetsControllerCompat.BEHAVIOR_DEFAULT
-            controller.hide(WindowInsetsCompat.Type.systemBars())
+            controller.setBehaviorDefault()
+            controller.hide()
         }
         isImmersive = true
     }
@@ -84,7 +113,7 @@ class ImmersiveModeState(
     internal fun show() {
         systemBarsHidden = false
         isImmersive = false
-        controller.show(WindowInsetsCompat.Type.systemBars())
+        controller.show()
     }
 
     // Called when the system restores bars externally (edge-swipe with BEHAVIOR_DEFAULT).
@@ -96,19 +125,32 @@ class ImmersiveModeState(
         isImmersive = false
     }
 
+    @VisibleForTesting
+    internal val systemBarsHiddenForTest: Boolean
+        get() = systemBarsHidden
+
     companion object {
         // After the user taps to reveal the TopAppBar, suppress auto-dismiss for this long
         // so that a locator event arriving in the same Compose frame doesn't immediately
         // undo the reveal before the enter animation can start.
         const val TOGGLE_COOLDOWN_MS = 500L
+
+        // After ON_RESUME, ignore a 0→positive topInset transition for this window.
+        // While the activity was paused, the system may have restored the bars on its own;
+        // that change should not be treated as an edge-swipe restore.
+        const val RESUME_SUPPRESSION_MS = 500L
     }
 }
 
 @Composable
 fun rememberImmersiveModeState(): ImmersiveModeState {
     val window = checkNotNull(LocalActivity.current).window
-    val controller = remember(window) { WindowInsetsControllerCompat(window, window.decorView) }
-    val state = remember(controller) { ImmersiveModeState(controller) }
+    val controller = remember(window) {
+        WindowInsetsBarsController(WindowInsetsControllerCompat(window, window.decorView))
+    }
+    val state = remember(controller) {
+        ImmersiveModeState(controller, clock = SystemClock::elapsedRealtime)
+    }
 
     // Persists across rotation. Default true = always enter immersive on first open.
     // Only updated by user-initiated toggle()s — NOT by onBarsRestoredExternally().
@@ -127,10 +169,19 @@ fun rememberImmersiveModeState(): ImmersiveModeState {
     // Re-enter immersive on resume from phone sleep if user hadn't explicitly turned it off.
     val lifecycle = LocalLifecycleOwner.current.lifecycle
     val currentSavedIsImmersive by rememberUpdatedState(savedIsImmersive)
+    // Timestamp of the last ON_RESUME. Used to suppress the topInset watcher briefly so a
+    // system-initiated bar restore that happened during sleep isn't mistaken for an edge-swipe.
+    val lastResumeMs = remember { mutableStateOf(0L) }
     DisposableEffect(lifecycle) {
         val observer = LifecycleEventObserver { _, event ->
-            if (event == Lifecycle.Event.ON_RESUME && currentSavedIsImmersive) {
-                state.hide()
+            if (event == Lifecycle.Event.ON_RESUME) {
+                lastResumeMs.value = SystemClock.elapsedRealtime()
+                if (currentSavedIsImmersive) {
+                    // During sleep the OS may have restored the system bars even though our
+                    // tracked flag still says hidden. force = true resyncs the flag so the
+                    // idempotency guard doesn't skip controller.hide() and leave the nav bar visible.
+                    state.hide(force = true)
+                }
             }
         }
         lifecycle.addObserver(observer)
@@ -150,7 +201,16 @@ fun rememberImmersiveModeState(): ImmersiveModeState {
     LaunchedEffect(topInset) {
         val wasHidden = prevTopInset.value == 0
         prevTopInset.value = topInset
-        if (topInset > 0 && wasHidden) state.onBarsRestoredExternally()
+        if (topInset > 0 && wasHidden) {
+            // Suppress within RESUME_SUPPRESSION_MS of ON_RESUME: the 0→positive transition
+            // came from the system restoring bars during sleep, not from an edge-swipe.
+            // The ON_RESUME observer already called hide() in that case if appropriate.
+            val now = SystemClock.elapsedRealtime()
+            if (lastResumeMs.value != 0L && now - lastResumeMs.value < ImmersiveModeState.RESUME_SUPPRESSION_MS) {
+                return@LaunchedEffect
+            }
+            state.onBarsRestoredExternally()
+        }
     }
 
     // Always restore system bars when the reader screen leaves the composition.

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ImmersiveModeStateTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ImmersiveModeStateTest.kt
@@ -1,0 +1,197 @@
+package com.riffle.app.feature.reader
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class ImmersiveModeStateTest {
+
+    private class FakeController : SystemBarsController {
+        var hideCount = 0
+        var showCount = 0
+        var setBehaviorDefaultCount = 0
+
+        override fun hide() {
+            hideCount++
+        }
+
+        override fun show() {
+            showCount++
+        }
+
+        override fun setBehaviorDefault() {
+            setBehaviorDefaultCount++
+        }
+    }
+
+    private lateinit var controller: FakeController
+    private var nowMs = 0L
+    private lateinit var state: ImmersiveModeState
+
+    @Before
+    fun setUp() {
+        controller = FakeController()
+        nowMs = 0L
+        state = ImmersiveModeState(controller, clock = { nowMs })
+    }
+
+    @Test
+    fun `initial state is not immersive`() {
+        assertFalse(state.isImmersive)
+        assertFalse(state.systemBarsHiddenForTest)
+        assertEquals(0, controller.hideCount)
+        assertEquals(0, controller.showCount)
+    }
+
+    @Test
+    fun `hide enters immersive and hides system bars`() {
+        state.hide()
+
+        assertTrue(state.isImmersive)
+        assertTrue(state.systemBarsHiddenForTest)
+        assertEquals(1, controller.hideCount)
+        assertEquals(1, controller.setBehaviorDefaultCount)
+    }
+
+    @Test
+    fun `hide is idempotent so duplicate calls do not invoke controller hide again`() {
+        // Calling controller.hide() on already-hidden bars crashes the WebView on some API
+        // levels (see comment in ImmersiveModeState.hide). Verify the guard prevents that.
+        state.hide()
+        state.hide()
+        state.hide()
+
+        assertEquals(1, controller.hideCount)
+        assertTrue(state.isImmersive)
+    }
+
+    @Test
+    fun `hide force re-invokes controller hide even when flag says hidden`() {
+        // This is the sleep-resume bug fix: when the OS restores bars during sleep without
+        // our tracker observing it, the flag is stale. force=true must re-call controller.hide()
+        // so the nav bar actually gets re-hidden on resume.
+        state.hide()
+        assertEquals(1, controller.hideCount)
+
+        state.hide(force = true)
+
+        assertEquals(2, controller.hideCount)
+        assertTrue(state.isImmersive)
+        assertTrue(state.systemBarsHiddenForTest)
+    }
+
+    @Test
+    fun `toggle from non-immersive enters immersive`() {
+        state.toggle()
+
+        assertTrue(state.isImmersive)
+        assertEquals(1, controller.hideCount)
+    }
+
+    @Test
+    fun `toggle from immersive exits immersive and shows bars`() {
+        state.hide()
+        controller.hideCount = 0 // ignore the prior hide call for clarity
+
+        state.toggle()
+
+        assertFalse(state.isImmersive)
+        assertFalse(state.systemBarsHiddenForTest)
+        assertEquals(1, controller.showCount)
+    }
+
+    @Test
+    fun `toggle notifies onUserImmersiveChanged with the new state`() {
+        val changes = mutableListOf<Boolean>()
+        state.onUserImmersiveChanged = { changes += it }
+
+        state.toggle() // enter
+        state.toggle() // exit
+
+        assertEquals(listOf(true, false), changes)
+    }
+
+    @Test
+    fun `dismissOverlay does nothing when bars are visible`() {
+        state.dismissOverlay()
+
+        assertFalse(state.isImmersive)
+    }
+
+    @Test
+    fun `dismissOverlay hides AppBar when bars are hidden and cooldown elapsed`() {
+        state.hide()
+        // hide() does not stamp lastToggleMs, so any future time satisfies the cooldown.
+        nowMs = ImmersiveModeState.TOGGLE_COOLDOWN_MS + 1
+
+        state.isImmersive = false // simulate user-revealed AppBar without restoring bars
+        state.dismissOverlay()
+
+        assertTrue(state.isImmersive)
+    }
+
+    @Test
+    fun `dismissOverlay is suppressed within TOGGLE_COOLDOWN_MS after toggle`() {
+        // Toggle to immersive stamps lastToggleMs via the exit-side branch only. Stamping
+        // happens when exiting immersive, so reproduce that path: hide via toggle, then exit
+        // via toggle (stamps clock), then re-enter immersive via toggle, then dismissOverlay
+        // should still be suppressed within the cooldown of the *exit* tap.
+        nowMs = 1_000
+        state.toggle() // enter immersive (no stamp)
+        nowMs = 2_000
+        state.toggle() // exit immersive — stamps lastToggleMs = 2_000
+        nowMs = 2_100   // 100 ms after the tap — within cooldown
+        state.toggle() // re-enter immersive (hide), no new stamp
+
+        // Simulate a locator event arriving while still in the cooldown window.
+        state.isImmersive = false // pretend the AppBar is visible
+        state.dismissOverlay()
+
+        // Within cooldown: AppBar should NOT be re-hidden.
+        assertFalse(state.isImmersive)
+    }
+
+    @Test
+    fun `onBarsRestoredExternally clears immersive and hidden flags`() {
+        state.hide()
+        assertTrue(state.systemBarsHiddenForTest)
+
+        state.onBarsRestoredExternally()
+
+        assertFalse(state.isImmersive)
+        assertFalse(state.systemBarsHiddenForTest)
+        // Note: does NOT call controller.show() — the OS already restored the bars.
+        assertEquals(0, controller.showCount)
+    }
+
+    @Test
+    fun `show resets state and calls controller show`() {
+        state.hide()
+
+        state.show()
+
+        assertFalse(state.isImmersive)
+        assertFalse(state.systemBarsHiddenForTest)
+        assertEquals(1, controller.showCount)
+    }
+
+    @Test
+    fun `sleep-resume flow keeps nav bar hidden when immersive before sleep`() {
+        // Reproduces the bug scenario:
+        //   1. User is immersive (bars hidden via controller.hide()).
+        //   2. Phone sleeps; OS restores bars without our tracker observing.
+        //   3. On ON_RESUME the composable calls hide(force = true) because savedIsImmersive.
+        // Without force = true the guard would skip controller.hide() and the nav bar would
+        // stay visible. With force = true, controller.hide() runs again.
+        state.hide()
+        assertEquals(1, controller.hideCount)
+
+        // ON_RESUME with savedIsImmersive=true must re-issue controller.hide().
+        state.hide(force = true)
+
+        assertEquals(2, controller.hideCount)
+        assertTrue(state.isImmersive)
+    }
+}


### PR DESCRIPTION
## Summary

- Fix a bug where entering immersive mode in the reader, sleeping the phone, and waking it left immersive mode partially exited — either the top app bar or the nav bar would reappear instead of staying hidden.
- Extract a small `SystemBarsController` abstraction and inject a clock so `ImmersiveModeState` is unit-testable without a real `WindowInsetsControllerCompat`.
- Add 13 unit tests covering the full state machine plus the sleep/resume regression.

## Root cause

When the screen sleeps in immersive mode, the OS may restore the system bars without our tracked `systemBarsHidden` flag observing it. On resume:

1. The `topInset` watcher saw a stale 0→positive transition and called `onBarsRestoredExternally()` — exiting immersive in state and showing the floating TopAppBar.
2. The `ON_RESUME` observer called `state.hide()`, but the idempotency guard (which exists because `controller.hide()` on already-hidden bars can crash the WebView on some API levels) saw the stale flag and skipped the real `controller.hide()` call — leaving the nav bar visible at the OS level.

## Fixes

- Stamp `lastResumeMs` in the `ON_RESUME` observer and suppress the `topInset` watcher for `RESUME_SUPPRESSION_MS` (500 ms) so a system-induced bar restore during sleep isn't mistaken for an edge-swipe.
- Add `hide(force = true)` that resyncs the tracked flag before the guard, ensuring `controller.hide()` actually re-runs after sleep. Called from the `ON_RESUME` observer.

## Test plan

- [x] `./gradlew :app:testDebugUnitTest` — 13 new tests, all pass.
- [ ] Manual on physical device: open a book, tap to enter immersive (both bars hidden), lock the phone, unlock — both bars stay hidden, TopAppBar stays hidden.
- [ ] Manual on physical device: open a book, tap to exit immersive (both bars visible), lock, unlock — bars stay visible.
- [ ] Manual on physical device: in immersive, edge-swipe up — TopAppBar appears (regression check for the `topInset` watcher).