### PR TITLE
feat(storyteller): foundation — ADRs, serverType column, ServerType domain enum (#34)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -5,10 +5,23 @@
 ## Terms
 
 ### Server
-A user-configured Audiobookshelf server instance (URL + credentials). Multiple Servers can be added; the user switches between them manually. All local data (Cache, Downloads, Annotations) is scoped to a Server.
+A user-configured remote content source (URL + credentials). Two types exist: **ABS Server** (an Audiobookshelf instance) and **Storyteller Server** (a Storyteller instance — see [Storyteller Server]). Multiple Servers of either type can be added; the user switches between them manually via the Server Switcher. All local data (Cache, Downloads, Annotations, progress) is scoped to a Server. The reading experience (formatting, themes, navigation, sync) is identical regardless of Server type — a book from Storyteller is read like any other book, with optional Readaloud controls if available.
+
+### Storyteller Server
+A user-configured [Storyteller](https://storyteller-platform.gitlab.io/storyteller) server instance — a self-hosted service that aligns ebooks and audiobooks to produce EPUB 3 files with Media Overlays (SMIL). Behaves as a peer to ABS Server: surfaces its own Libraries, Library Items, and metadata; participates in the Navigation Drawer and Server Switcher exactly like ABS.
+
+**Riffle uses Storyteller exclusively as a Readaloud provider.** A Library Item from a Storyteller Server is always a completed [Readaloud] — the aligned EPUB + audio output of the Storyteller pipeline. Plain ebooks and plain audiobooks are out of scope for the Storyteller integration: ABS already covers those formats, and ingesting bare Storyteller content would duplicate that role with a strictly weaker reading/listening experience. Storyteller content that is **not yet a completed Readaloud** (uploaded but unaligned, in-progress alignment, alignment failed) is filtered out at the network layer and never appears in the Readaloud Library.
+
+### Readaloud
+Storyteller's term for an aligned ebook+audiobook: an EPUB 3 with Media Overlays (SMIL) that map text fragments to audio timestamps. When a book is a Readaloud, the reader exposes audio playback controls and visibly highlights the text segment being read; the book remains fully readable without playback. Every Library Item from a Storyteller Server is a Readaloud intrinsically. For a Library Item from an ABS Server, Readaloud playback becomes available when a behind-the-scenes match to a Storyteller book exists — the matching itself is not surfaced as a user concept.
 
 ### Library
-A top-level collection on the connected ABS server. Riffle surfaces all Libraries whose `mediaType` is `book` (podcast libraries are excluded). Because ABS does not expose a reliable library-level signal to distinguish ebook libraries from audiobook libraries, all book Libraries are shown. The user decides which Libraries are visible in the navigation drawer via Library Visibility Preferences.
+A navigation surface in Riffle for a set of Library Items. Every Library is backed by exactly one Server. For an [ABS Server], Riffle exposes each of the server's book Libraries 1:1 (`mediaType=book`; podcast libraries excluded). For a [Storyteller Server] — which has no native library concept — Riffle exposes a single synthetic Library: the [Readaloud Library]. The user decides which Libraries are visible in the Navigation Drawer via Library Visibility Preferences.
+
+### Readaloud Library
+A synthetic Library that surfaces all Library Items on a Storyteller Server. Present whenever a Storyteller Server is configured. Every Library Item in the Readaloud Library is a [Readaloud] by definition. A Storyteller book that is also matched to an item on an ABS Server appears both here and in its ABS Library — same book, two entry points; the reader is identical from either side. Name shown to the user TBD ("Readalouds" is the working label).
+
+For a Storyteller book that is **Confirmed-matched** to an ABS Library Item, the per-book **display metadata** shown in the Readaloud Library — cover, title, author, description, published year, publisher, genres — is sourced from the linked ABS item, not from Storyteller. **Taxonomy** (Series, Collections) remains sourced from each Library's own backing Server: the Readaloud Library's Series and Collections Tabs are always Storyteller-defined, regardless of any cross-Server matches.
 
 ### Navigation Drawer
 The primary navigation surface. Contains: the active Server name in a header (tappable → Server Switcher dropdown), the server-ordered list of visible Libraries for the active Server, a Downloads entry, and a Settings entry — in that order. Replaces the standalone LibraryListScreen and ServerListScreen as the main navigation entry point. On a fresh install with no Servers configured, the app opens directly to AddServerScreen; after the first Server is added, it navigates to the first Library in the Library Visibility Preferences list.
@@ -71,13 +84,16 @@ A server-side record of a single continuous reading period. Opened via the ABS A
 Aggregated reading data fetched from the ABS server — time spent reading, books finished, current streaks. Populated by Reading Sessions pushed from the app.
 
 ### Progress Sync
-Bidirectional reconciliation of reading position between the app and the ABS server. Applies to all supported formats (EPUB, PDF, and any future formats).
+Reconciliation of reading position between the app and every remote position holder for the open book. Applies to all supported formats (EPUB, PDF, and any future formats).
 
-- **Cycle:** on every periodic tick (~30 seconds) and immediately on reader resume, the app runs a GET-then-maybe-PATCH cycle for the open book.
-- **Inbound check (GET first):** fetch server position and its `lastUpdate` timestamp via `GET /api/me/progress/:libraryItemId`. Compare against `localUpdatedAt` — the local timestamp updated on every position change (page turn, scroll), persisted to the local DB.
-- **Last-update-wins:** if `server.lastUpdate > localUpdatedAt`, jump the reader to the server's position silently and set `localUpdatedAt = server.lastUpdate`. If `localUpdatedAt >= server.lastUpdate`, PATCH local position to server.
-- **Offline behaviour:** if the GET fails (server unreachable), skip the entire cycle — no PATCH is attempted. `localUpdatedAt` continues to advance with page turns. When connectivity returns the next cycle runs normally; `localUpdatedAt` will be newer than the server's stale timestamp, so local position is pushed.
-- **No conflict prompt:** there is no user-facing conflict resolution UI. The last-update-wins rule is applied silently in all cases.
+For an ABS-only book the cycle has one remote (ABS ebook progress). For a matched book with [Readaloud] there are three remote position holders: **ABS ebook progress** (CFI), **ABS audiobook progress** (seconds offset), and **Storyteller position** (Readium Locator anchored to Storyteller's publication). All three are first-class peers — any of them can win an inbound jump, and a local change is pushed to all three. Three-peer sync runs regardless of which side the user opened the book from (ABS or Readaloud), once the small sync prerequisites (Storyteller EPUB bundle + cross-EPUB index) are cached. Readaloud audio playback remains an explicit Readaloud-side action with its own download.
+
+- **Cycle:** every ~30 s and immediately on reader resume, run a GET-then-maybe-PATCH cycle for every applicable remote.
+- **Unified canonical position:** the reader has a single canonical position with a single `localUpdatedAt`. Each remote position is convertible to and from the canonical reader position (audiobook seconds ↔ text via SMIL; ABS-EPUB CFI ↔ Storyteller-EPUB position via the cross-EPUB index; Storyteller position is native).
+- **Inbound (last-update-wins, single winner):** fetch all applicable remotes and their `lastUpdate` timestamps. Identify the absolute newest among `{localUpdatedAt, ...remotes}`. If a remote wins, jump the reader to its converted canonical position once and set `localUpdatedAt = winner.lastUpdate`.
+- **Outbound:** PATCH every remote that is now stale relative to the canonical position. For a matched book that is one cycle → three writes (ABS ebook, ABS audiobook, Storyteller).
+- **Per-target failure isolation:** failures are isolated per remote. A GET failure for one target skips that target's inbound check only; the other targets still proceed. A PATCH failure leaves that target stale for the next cycle.
+- **No conflict prompt:** the last-update-wins rule is applied silently in all cases.
 
 ### Formatting Preferences
 User-controlled reading display settings. Scope varies by format:

--- a/core/data/src/main/kotlin/com/riffle/core/data/ServerRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/ServerRepositoryImpl.kt
@@ -11,6 +11,7 @@ import com.riffle.core.domain.LibraryVisibilityPreferencesStore
 import com.riffle.core.domain.PendingServer
 import com.riffle.core.domain.Server
 import com.riffle.core.domain.ServerRepository
+import com.riffle.core.domain.ServerType
 import com.riffle.core.domain.ServerUrl
 import com.riffle.core.domain.TokenStorage
 import com.riffle.core.network.AbsApi
@@ -89,6 +90,7 @@ class ServerRepositoryImpl @Inject constructor(
             isActive = false,                    // overridden inside transaction
             insecureConnectionAllowed = pending.insecureConnectionAllowed,
             username = pending.username,
+            serverType = pending.serverType.name,
         )
         val inserted = dao.upsertAsFirstIfNoActive(entity)
         tokenStorage.saveToken(id, pending.token)
@@ -145,6 +147,7 @@ class ServerRepositoryImpl @Inject constructor(
             isActive = isActive,
             insecureConnectionAllowed = insecureConnectionAllowed,
             username = username,
+            serverType = ServerType.fromStorageString(serverType),
         )
     }
 }

--- a/core/data/src/main/kotlin/com/riffle/core/data/di/DatabaseModule.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/di/DatabaseModule.kt
@@ -42,6 +42,7 @@ object DatabaseModule {
                 RiffleDatabase.MIGRATION_14_15,
                 RiffleDatabase.MIGRATION_15_16,
                 RiffleDatabase.MIGRATION_16_17,
+                RiffleDatabase.MIGRATION_17_18,
             )
             .build()
 

--- a/core/data/src/test/kotlin/com/riffle/core/data/ServerRepositoryTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/ServerRepositoryTest.kt
@@ -220,6 +220,29 @@ class ServerRepositoryTest {
     }
 
     @Test
+    fun `commit persists serverType STORYTELLER and round-trips it`() = runTest {
+        val dao = fakeDao(); val tokens = fakeTokenStorage()
+        val libDao = fakeLibraryDao(); val visibility = fakeVisibilityStore()
+        val absApi = AbsApi { _, _, _, _ -> error("not called") }
+        val repo = ServerRepositoryImpl(dao, tokens, absApi, fakeServerInfoApi, libsApiNotCalled, libDao, visibility)
+
+        val pending = PendingServer(
+            url = ServerUrl.parse("http://media-server:8001")!!,
+            displayName = "media-server",
+            username = "plamen", userId = "uid-1", token = "tok-st",
+            insecureConnectionAllowed = false,
+            libraries = emptyList(),
+            serverType = com.riffle.core.domain.ServerType.STORYTELLER,
+        )
+
+        val result = repo.commit(pending, hiddenLibraryIds = emptySet())
+
+        assertTrue(result is CommitServerResult.Success)
+        val server = (result as CommitServerResult.Success).server
+        assertEquals(com.riffle.core.domain.ServerType.STORYTELLER, server.serverType)
+    }
+
+    @Test
     fun `remove deletes server entity and token`() = runTest {
         val entity = ServerEntity("srv-1", "https://abs.example.com", "abs.example.com", true, false, username = "")
         val dao = fakeDao(entity)

--- a/core/database/schemas/com.riffle.core.database.RiffleDatabase/18.json
+++ b/core/database/schemas/com.riffle.core.database.RiffleDatabase/18.json
@@ -1,0 +1,434 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 18,
+    "identityHash": "131f43ac4ad804233669566d2694805a",
+    "entities": [
+      {
+        "tableName": "servers",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `url` TEXT NOT NULL, `displayName` TEXT NOT NULL, `isActive` INTEGER NOT NULL, `insecureConnectionAllowed` INTEGER NOT NULL, `username` TEXT NOT NULL, `serverType` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "isActive",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "insecureConnectionAllowed",
+            "columnName": "insecureConnectionAllowed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "username",
+            "columnName": "username",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverType",
+            "columnName": "serverType",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "libraries",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `mediaType` TEXT NOT NULL, `serverId` TEXT NOT NULL, `isUnsupported` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaType",
+            "columnName": "mediaType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isUnsupported",
+            "columnName": "isUnsupported",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "library_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `title` TEXT NOT NULL, `author` TEXT NOT NULL, `coverUrl` TEXT, `readingProgress` REAL NOT NULL, `ebookFileIno` TEXT, `ebookFormat` TEXT NOT NULL, `description` TEXT, `seriesName` TEXT, `publishedYear` TEXT, `genres` TEXT NOT NULL, `publisher` TEXT, `lastOpenedAt` INTEGER, `addedAt` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "coverUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "readingProgress",
+            "columnName": "readingProgress",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ebookFileIno",
+            "columnName": "ebookFileIno",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "ebookFormat",
+            "columnName": "ebookFormat",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seriesName",
+            "columnName": "seriesName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "publishedYear",
+            "columnName": "publishedYear",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "genres",
+            "columnName": "genres",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "publisher",
+            "columnName": "publisher",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastOpenedAt",
+            "columnName": "lastOpenedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "series",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `name` TEXT NOT NULL, `coverUrl` TEXT, `bookCount` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "coverUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "bookCount",
+            "columnName": "bookCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "collections",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `name` TEXT NOT NULL, `bookCount` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookCount",
+            "columnName": "bookCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "series_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`seriesId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `sequenceOrder` REAL NOT NULL, PRIMARY KEY(`seriesId`, `itemId`))",
+        "fields": [
+          {
+            "fieldPath": "seriesId",
+            "columnName": "seriesId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sequenceOrder",
+            "columnName": "sequenceOrder",
+            "affinity": "REAL",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "seriesId",
+            "itemId"
+          ]
+        }
+      },
+      {
+        "tableName": "collection_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`collectionId` TEXT NOT NULL, `itemId` TEXT NOT NULL, PRIMARY KEY(`collectionId`, `itemId`))",
+        "fields": [
+          {
+            "fieldPath": "collectionId",
+            "columnName": "collectionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "collectionId",
+            "itemId"
+          ]
+        }
+      },
+      {
+        "tableName": "reading_positions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`itemId` TEXT NOT NULL, `cfi` TEXT NOT NULL, `localUpdatedAt` INTEGER NOT NULL, PRIMARY KEY(`itemId`))",
+        "fields": [
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cfi",
+            "columnName": "cfi",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localUpdatedAt",
+            "columnName": "localUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "itemId"
+          ]
+        }
+      },
+      {
+        "tableName": "book_formatting_preferences",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`itemId` TEXT NOT NULL, `fontSize` REAL, `theme` TEXT, `fontFamily` TEXT, `lineSpacing` REAL, `margins` REAL, `orientation` TEXT, `showChapterMap` INTEGER, `showReadingProgressLabels` INTEGER, `doublePageSpread` INTEGER, `justifyText` INTEGER, PRIMARY KEY(`itemId`))",
+        "fields": [
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fontSize",
+            "columnName": "fontSize",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "theme",
+            "columnName": "theme",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "fontFamily",
+            "columnName": "fontFamily",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lineSpacing",
+            "columnName": "lineSpacing",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "margins",
+            "columnName": "margins",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "orientation",
+            "columnName": "orientation",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "showChapterMap",
+            "columnName": "showChapterMap",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "showReadingProgressLabels",
+            "columnName": "showReadingProgressLabels",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "doublePageSpread",
+            "columnName": "doublePageSpread",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "justifyText",
+            "columnName": "justifyText",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "itemId"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '131f43ac4ad804233669566d2694805a')"
+    ]
+  }
+}

--- a/core/database/src/androidTest/kotlin/com/riffle/core/database/MigrationTest.kt
+++ b/core/database/src/androidTest/kotlin/com/riffle/core/database/MigrationTest.kt
@@ -444,6 +444,40 @@ class MigrationTest {
     }
 
     @Test
+    fun migration17To18() {
+        helper.createDatabase(TEST_DB, 17).use { db ->
+            db.execSQL(
+                "INSERT INTO servers (id, url, displayName, isActive, insecureConnectionAllowed, username) " +
+                    "VALUES ('s1', 'http://localhost', 'My Server', 1, 0, 'plamen')"
+            )
+        }
+
+        val db = helper.runMigrationsAndValidate(TEST_DB, 18, true, RiffleDatabase.MIGRATION_17_18)
+
+        // Existing rows default to AUDIOBOOKSHELF — backfills the only Server type that existed before this migration.
+        db.query("SELECT id, url, displayName, username, serverType FROM servers WHERE id = 's1'").use { cursor ->
+            assertEquals(1, cursor.count)
+            cursor.moveToFirst()
+            assertEquals("s1", cursor.getString(0))
+            assertEquals("http://localhost", cursor.getString(1))
+            assertEquals("My Server", cursor.getString(2))
+            assertEquals("plamen", cursor.getString(3))
+            assertEquals("AUDIOBOOKSHELF", cursor.getString(4))
+        }
+
+        // New Storyteller rows can be inserted with the new value.
+        db.execSQL(
+            "INSERT INTO servers (id, url, displayName, isActive, insecureConnectionAllowed, username, serverType) " +
+                "VALUES ('s2', 'http://media-server:8001', 'My Storyteller', 0, 0, 'plamen', 'STORYTELLER')"
+        )
+        db.query("SELECT serverType FROM servers WHERE id = 's2'").use { cursor ->
+            assertEquals(1, cursor.count)
+            cursor.moveToFirst()
+            assertEquals("STORYTELLER", cursor.getString(0))
+        }
+    }
+
+    @Test
     fun migrateFullChain() {
         helper.createDatabase(TEST_DB, 1).use { db ->
             db.execSQL(
@@ -452,7 +486,7 @@ class MigrationTest {
         }
 
         val db = helper.runMigrationsAndValidate(
-            TEST_DB, 17, true,
+            TEST_DB, 18, true,
             RiffleDatabase.MIGRATION_1_2,
             RiffleDatabase.MIGRATION_2_3,
             RiffleDatabase.MIGRATION_3_4,
@@ -469,14 +503,16 @@ class MigrationTest {
             RiffleDatabase.MIGRATION_14_15,
             RiffleDatabase.MIGRATION_15_16,
             RiffleDatabase.MIGRATION_16_17,
+            RiffleDatabase.MIGRATION_17_18,
         )
 
-        db.query("SELECT url, displayName, username FROM servers WHERE id = 's1'").use { cursor ->
+        db.query("SELECT url, displayName, username, serverType FROM servers WHERE id = 's1'").use { cursor ->
             assertEquals(1, cursor.count)
             cursor.moveToFirst()
             assertEquals("http://localhost", cursor.getString(0))
             assertEquals("My Server", cursor.getString(1))
             assertEquals("", cursor.getString(2))
+            assertEquals("AUDIOBOOKSHELF", cursor.getString(3))
         }
     }
 }

--- a/core/database/src/main/kotlin/com/riffle/core/database/RiffleDatabase.kt
+++ b/core/database/src/main/kotlin/com/riffle/core/database/RiffleDatabase.kt
@@ -17,7 +17,7 @@ import androidx.sqlite.db.SupportSQLiteDatabase
         ReadingPositionEntity::class,
         BookFormattingPreferencesEntity::class,
     ],
-    version = 17,
+    version = 18,
     exportSchema = true,
 )
 abstract class RiffleDatabase : RoomDatabase() {
@@ -211,6 +211,15 @@ abstract class RiffleDatabase : RoomDatabase() {
                 db.execSQL(
                     "ALTER TABLE `book_formatting_preferences` ADD COLUMN `showReadingProgressLabels` INTEGER DEFAULT NULL"
                 )
+            }
+        }
+
+        // Generalises Server beyond Audiobookshelf: a Server is now either ABS or Storyteller
+        // (ADR 0020). Existing rows backfill to AUDIOBOOKSHELF — the only Server type that existed
+        // before this migration.
+        val MIGRATION_17_18 = object : Migration(17, 18) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("ALTER TABLE `servers` ADD COLUMN `serverType` TEXT NOT NULL DEFAULT 'AUDIOBOOKSHELF'")
             }
         }
     }

--- a/core/database/src/main/kotlin/com/riffle/core/database/ServerEntity.kt
+++ b/core/database/src/main/kotlin/com/riffle/core/database/ServerEntity.kt
@@ -11,4 +11,5 @@ data class ServerEntity(
     val isActive: Boolean,
     val insecureConnectionAllowed: Boolean,
     val username: String,
+    val serverType: String = "AUDIOBOOKSHELF",
 )

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/PendingServer.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/PendingServer.kt
@@ -13,4 +13,5 @@ data class PendingServer(
     val token: String,
     val insecureConnectionAllowed: Boolean,
     val libraries: List<Library>,
+    val serverType: ServerType = ServerType.AUDIOBOOKSHELF,
 )

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/Server.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/Server.kt
@@ -7,4 +7,5 @@ data class Server(
     val isActive: Boolean,
     val insecureConnectionAllowed: Boolean,
     val username: String,
+    val serverType: ServerType = ServerType.AUDIOBOOKSHELF,
 )

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/ServerType.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/ServerType.kt
@@ -1,0 +1,12 @@
+package com.riffle.core.domain
+
+enum class ServerType {
+    AUDIOBOOKSHELF,
+    STORYTELLER,
+    ;
+
+    companion object {
+        fun fromStorageString(value: String): ServerType =
+            entries.firstOrNull { it.name == value } ?: AUDIOBOOKSHELF
+    }
+}

--- a/docs/adr/0019-three-peer-unified-canonical-progress-sync.md
+++ b/docs/adr/0019-three-peer-unified-canonical-progress-sync.md
@@ -1,0 +1,70 @@
+# ADR 0019 — Three-peer unified-canonical Progress Sync
+
+**Status:** Accepted
+**Supersedes:** Extends [ADR 0008](0008-last-update-wins-progress-sync.md) for the matched-readaloud case; ADR 0008's two-peer rules remain in force for ABS-only books.
+
+## Context
+
+Storyteller integration introduces a third remote position holder for any book that is a readaloud matched across the two backends. Where ADR 0008 reconciles one local reader against one remote (ABS ebook progress), a matched book now has three independent remotes — each with its own clock and its own coordinate system:
+
+- **ABS ebook progress** — a CFI in the ABS-served EPUB plus a book-wide float.
+- **ABS audiobook progress** — a time offset (seconds) into the audiobook file.
+- **Storyteller position** — a position record native to Storyteller's `/api/v2/books/:id/positions` endpoint.
+
+All three change independently in the wild: a user can listen on ABS's audiobook app on their phone, read on Storyteller's web reader on a desktop, and read in Riffle on a tablet — concurrently across days. Riffle must reconcile incoming changes from any of them, and propagate outgoing changes to all of them, without the user being prompted.
+
+The two coordinate-conversion problems are themselves load-bearing:
+
+- **Audiobook seconds ↔ text position** is resolvable via the EPUB Media Overlay SMIL — the file Storyteller produces specifically for this purpose. Exact.
+- **ABS-EPUB CFI ↔ Storyteller-EPUB position** requires the cross-EPUB character-position index described in ADR 0013's translator generalised across two different EPUB files for the same logical book. Best-effort; landed-on as the chosen design after weighing it against "skip ABS ebook progress entirely" in [the Storyteller-integration design discussion].
+
+## Decision
+
+For every applicable remote position holder of the open book, Riffle runs a single reconciliation cycle every ~30 seconds and immediately on reader resume. The cycle uses a **single canonical reader position** and a **single `localUpdatedAt`** — it does not maintain per-remote local timestamps.
+
+**Cycle steps:**
+
+1. **Identify applicable remotes** for the open book:
+   - ABS-only book: `{ABS ebook}` (today's ADR 0008 case).
+   - Storyteller-only book: `{Storyteller}`.
+   - Confirmed-matched book, opened from **either** side, with sync prerequisites cached (Storyteller EPUB bundle present, cross-EPUB index built or buildable): `{ABS ebook, ABS audiobook, Storyteller}`. Side determines which EPUB the reader displays and what playback affordances are exposed (readaloud audio + highlight on the Readaloud side only — see ADR 0020), but it does **not** determine the sync remote set.
+   - Confirmed-matched book whose sync prerequisites are not yet cached: falls back to its side's single-peer set (`{ABS ebook}` on ABS side, `{Storyteller}` on Readaloud side) until the prerequisites arrive, then upgrades to the three-peer set on the next cycle.
+2. **GET each remote in parallel.** Per-target failures are isolated — a failing GET excludes that target from the inbound comparison only; the others still participate.
+3. **Inbound winner:** find the maximum `lastUpdate` among `{localUpdatedAt} ∪ {successful remotes}`. If a remote wins, convert its position to the canonical reader position (via SMIL or the cross-EPUB index as appropriate), jump the reader silently, and set `localUpdatedAt = winner.lastUpdate`.
+4. **Outbound:** for every remote that is now stale (its last seen `lastUpdate` is older than `localUpdatedAt`), derive its native coordinate from the canonical position and PATCH it. PATCH failures are isolated per target — a failed PATCH leaves that target stale for the next cycle.
+
+The canonical reader position is the Readium `Locator` on whichever EPUB the reader is currently displaying — the ABS EPUB when reading from the ABS side, the Storyteller EPUB when reading from the Readaloud side. Outbound translation to the other peers is symmetric: from ABS-EPUB CFI, push to ABS ebook directly, translate to Storyteller-EPUB position via the cross-EPUB index then PATCH Storyteller, and translate further to audio seconds via SMIL then PATCH ABS audiobook. The composed translation is the same machinery used on the Readaloud side, applied in the other direction.
+
+## Invariant
+
+> The cycle has one inbound winner and at most one reader jump per cycle. All outbound PATCHes within a cycle are derived from the same canonical position.
+
+## Alternatives considered
+
+**Three independent last-update-wins cycles in parallel** — each remote reconciled against its own local timestamp. Rejected: the reader could jump twice within one cycle if two remotes were newer with different positions, and three local timestamps drift from each other across partial failures.
+
+**ABS-as-source-of-truth (Storyteller is push-only)** — GET only ABS, PATCH ABS + push to Storyteller. Rejected because a user reading concurrently in Storyteller's own web reader is a legitimate scenario; we should not silently overwrite their position on next sync.
+
+**Storyteller-as-source-of-truth (ABS is push-only)** — symmetric inverse. Rejected for the same reason on the ABS side: ABS clients (web reader, ABS mobile apps) are also legitimate inbound writers, especially for ABS audiobook progress when the user listens on their phone.
+
+**Sync only audiobook progress to ABS (skip ABS ebook progress entirely)** — the SMIL gives us audio seconds exactly; skip the lossy cross-EPUB CFI translation. Rejected: ABS's web reader stores ebook position separately and other ABS clients would observe a drifting/stale ebook position for readalouds. The user's stated requirement is "any progress must be synced to audiobookshelf book and audiobook, and also storyteller's db."
+
+## Consequences
+
+- The sync cycle becomes per-remote-set rather than per-server, with the set computed from match state and prerequisite-cache state at reader-open time. Open-side determines what the reader *displays* and which playback affordances are visible; it does not determine the sync remote set.
+- `localUpdatedAt` remains a single value (no per-remote timestamps); each remote tracks its own last-seen `lastUpdate` only for staleness comparison within the cycle.
+- **Sync prerequisites for a matched book are decoupled from playback prerequisites.** Storyteller's position record is a Readium Locator anchored to *Storyteller's* publication manifest — pushing or interpreting one requires Storyteller's EPUB bundle (a few MB), but not its audio bundle (potentially multi-GB). The cross-EPUB character-position index requires the ABS EPUB too. Both prerequisites are small, so they are fetched **eagerly on Confirmed-match creation** (see ADR 0021), not lazily on first cross-domain need; the index is built the first time both EPUBs are local. The audio bundle remains opt-in via the explicit Readaloud-side "Download readaloud audio" action.
+
+### Cross-EPUB index lifecycle
+
+The index is built lazily, persisted in Room, and gracefully degrades when its inputs aren't reachable:
+
+- **When built:** triggered eagerly on Confirmed-match creation (auto-Confirm at Tiers 1/2 or user-Confirm via the review queue — see ADR 0021), and also rebuilt opportunistically on the first sync cycle that needs it if a prior build was deferred. Build steps: ensure both EPUBs are locally cached (fetch the Storyteller EPUB bundle and/or the ABS EPUB as needed); walk both chapter-by-chapter; emit per-chapter character maps.
+- **Where stored:** a `CrossEpubIndex` Room table keyed by `(absEpubChecksum, storytellerEpubChecksum)` with serialised per-chapter character maps.
+- **Invalidation:** if either side's checksum changes (the server re-uploaded the EPUB), the stored index becomes a miss; the next cycle rebuilds.
+- **Failure modes:** if either EPUB cannot be downloaded at build time, the build is deferred and the matched-book cycle gracefully degrades to single-peer for whichever side is open (`{ABS ebook}` from the ABS side, `{Storyteller}` from the Readaloud side) until the prerequisites become available. Per-target failure isolation applies within the three-peer cycle once prerequisites are present: a failed individual PATCH/GET doesn't poison the cycle.
+- **Independence from sync correctness:** missing prerequisites ⇒ degrade to single-peer; never push a wrong cross-domain position.
+- Partial connectivity is a normal case, not a degraded one. If ABS is unreachable but Storyteller is reachable, the cycle continues with `{Storyteller}` as its remote set, and the ABS targets stay stale until they're reachable again. The "skip the entire cycle on GET failure" rule from ADR 0008 is replaced by per-target isolation.
+- Audio-led canonical position: when audio plays in background, page turns can't update the canonical position because the reader isn't visible. The SMIL drives the canonical position from audio time; outbound PATCHes follow normally. Returning to the foreground jumps the visible page to the canonical position.
+- Reading Sessions are independent of this cycle (see the Storyteller-integration design): an ABS ebook session ticks whenever the reader is open, an ABS audiobook session ticks whenever audio plays, a Storyteller session ticks whenever either is true. Concurrent ticks are intentional.
+- ABS-only books are unaffected — their cycle reduces to ADR 0008's exact behaviour with no per-target rules of consequence.

--- a/docs/adr/0020-storyteller-as-peer-server-and-readaloud-library.md
+++ b/docs/adr/0020-storyteller-as-peer-server-and-readaloud-library.md
@@ -1,0 +1,88 @@
+# ADR 0020 — Storyteller as a peer Server type; Readaloud Library as its single navigation surface
+
+**Status:** Accepted
+
+## Context
+
+Storyteller is a self-hosted platform that aligns ebooks and audiobooks to produce EPUB 3 files with Media Overlays (SMIL). In Storyteller's own terminology, an aligned book is a **readaloud**. The integration goal is that a user with a Storyteller server gets readaloud playback on their books, with progress reconciled across Audiobookshelf and Storyteller.
+
+**Scope: Storyteller is consumed only for its readaloud output.** Riffle does not ingest plain ebooks or plain audiobooks from Storyteller; Audiobookshelf is the canonical source for those formats. Storyteller content that is not yet a completed readaloud (uploaded source files, in-progress alignment, failed alignment) is filtered out and never surfaces in the Readaloud Library. The Storyteller integration buys Riffle exactly one capability ABS lacks: synchronised audio + text playback. Anything outside that capability stays on the ABS side.
+
+Two structural shapes were available:
+
+- **Sidecar enrichment** — Storyteller attached to a single ABS Server in Settings, surfacing readaloud capabilities on matched ABS Library Items but contributing no Library Items of its own.
+- **Peer Server type** — Storyteller treated as a first-class Server alongside ABS, contributing its own Library Items and metadata.
+
+Storyteller exposes username+password → bearer token auth at `POST /api/v2/token`, identical in shape to the existing ABS auth flow Riffle already implements. Its book API is flat — there is no Library concept on the server — but it has first-class Series, Collections, and Tags, plus per-book metadata sufficient to populate a Library.
+
+A user may run Storyteller without ABS, run both, or run multiple of either type. The "behaves just like ABS books" requirement implies a uniform reading experience regardless of which Server a book came from.
+
+## Decision
+
+**Storyteller is a peer Server type.** The existing `Server` concept generalises: a Server is either an ABS Server or a Storyteller Server. Both types are added via the same Add-Server flow (URL + credentials → bearer token in Keystore); both appear in the Server Switcher; both contribute Libraries to the Navigation Drawer. The reading experience — formatting, themes, navigation, sync mechanics — is identical across types.
+
+A Storyteller Server contributes **exactly one synthetic Library: the Readaloud Library**, holding every completed readaloud on that Storyteller instance (in-progress, unaligned, and failed-alignment books are filtered out at the network layer). The Library Tab Bar's Home, Series, Collections, and All Books tabs are all populated from Storyteller's native entities (no Libraries on the server, but Series / Collections / Tags exist). Multiple Storyteller Servers each contribute their own Readaloud Library, disambiguated by Server name.
+
+**Matched books appear on both sides.** A Confirmed-matched book lives in its ABS Library *and* in the Readaloud Library. The reader behaviour and capabilities differ by entry point:
+
+- **ABS-side Read** opens the ABS-served EPUB. No readaloud controls. Fast — preserves today's ABS reading experience without modification.
+- **Readaloud-side Read** opens the Storyteller-served EPUB (with SMIL bindings). The reader exposes readaloud controls — a headphones icon in the TopAppBar opens a bottom mini-player.
+
+The matching link's purpose is **cross-Server progress sync** (per [ADR 0019](0019-three-peer-unified-canonical-progress-sync.md)) and **display-metadata sourcing**, not the collapse of entry points.
+
+**Metadata sourcing rule (Confirmed matches only):**
+
+- **Display fields** (cover, title, author, description, published year, publisher, genres) for a Confirmed-matched book come from the linked ABS Library Item wherever the book is displayed, including in the Readaloud Library.
+- **Taxonomy** (Series, Collections) for every Library is sourced from that Library's own backing Server. The Readaloud Library's Series and Collections tabs are always Storyteller-defined regardless of any cross-Server matches.
+
+## Alternatives considered
+
+**Sidecar enrichment attached to an ABS Server.** Rejected because it prevents Storyteller-only deployments (Storyteller user without ABS) and forces orphan Storyteller books into a synthetic Library inside an ABS Server's namespace, which awkwardly conflates two backends' identities.
+
+**Sidecar enrichment with no UI surface for Storyteller-only books.** Rejected because it makes the unmatched-Storyteller-book case invisible and unreadable.
+
+**Per-Library multi-Provider attachment** (a Riffle Library backed by 1+ Providers, mixed merging). Rejected as too configurable for v1: forces the user to think about provider attachment, breaks the implicit "Libraries come from the Server" model, and only adds value in the niche where a user wants to merge Storyteller orphans into a specific ABS Library.
+
+**Single merged view across Servers** (matched books deduplicated to a single visible row). Rejected because it requires the matching layer to be a hard correctness dependency of the *browsing* experience — a wrong match becomes a confusing display merge with no visible cause. Showing the book in both Libraries makes mismatches visible and survivable, and Library Visibility Preferences let the user hide one side if they prefer.
+
+**Storyteller's flat book list rendered without the Library Tab Bar.** Rejected because Storyteller does expose Series, Collections, and Tags as first-class entities; the four-tab pattern fits naturally and keeps cross-Server navigation visually consistent.
+
+**Surface Storyteller's bare ebooks and bare audiobooks too** (treat Storyteller as a general-purpose content provider). Rejected: ABS is Riffle's canonical source for plain ebooks and plain audiobooks, and Storyteller's plain-content surfaces are a strictly weaker version of that role (no per-chapter audio streaming, no native podcast/audiobook session model, no audiobook progress endpoint that ABS clients consume). Storyteller earns its slot in Riffle precisely by being the only path to readalouds; expanding its scope would duplicate ABS responsibilities without benefit and add UX edge cases (a Storyteller-only "plain ebook" that has no readaloud — what would distinguish it from an ABS plain ebook?).
+
+## Consequences
+
+- The `Server` domain term and the `Library` domain term are both generalised (already reflected in `CONTEXT.md`). All per-Server scoping that exists today (Cache, Downloads, Library Visibility Preferences, progress) applies to Storyteller Servers unchanged.
+- The Storyteller API client filters book listings to **completed readalouds only** at the network boundary (likely by `processingStatus`/equivalent — exact field nailed down at implementation). Non-readaloud Storyteller content never enters Riffle's data layer; downstream code can assume every Storyteller-sourced Library Item is a readaloud.
+- The Readaloud Library uses the same Library Tab Bar component as ABS Libraries. No Storyteller-only navigation chrome is introduced.
+- Tags are not surfaced in v1. Storyteller's Tags are a v2 addition (likely as Collections-like groupings or as a fifth tab).
+- A Storyteller-only deployment is fully supported: a user with no ABS Server sees one Storyteller Server in the drawer, one Readaloud Library, and the full reading + readaloud experience.
+- A user with both backends sees matched books in two Libraries. Library Visibility Preferences let them hide either side if they prefer one canonical entry point.
+- The ABS-side Read button for a matched book is **deliberately unchanged in its reader UI** — no readaloud controls, no headphones icon, no audio playback. The audiobook bundle (potentially multi-GB) is never fetched implicitly from ABS browsing; only the explicit Readaloud-side "Download readaloud audio" action triggers it.
+- **However, three-peer Progress Sync runs from either side** of a matched book once its small sync prerequisites are cached. Confirmed-match creation (ADR 0021) eagerly fetches the Storyteller EPUB bundle (few MB) and builds the cross-EPUB index in the background. Until those prerequisites land, the matched-book cycle gracefully degrades to single-peer for whichever side is open (see ADR 0019). This split — small sync prerequisites fetched silently, large audio bundle fetched only on explicit opt-in — preserves "no surprise multi-GB downloads" while still satisfying the requirement that reading from any side syncs to all three peers.
+- Multiple Storyteller Servers: each contributes its own Readaloud Library; matching scope is global across every configured ABS Server, not per pair.
+- Storyteller's bundle-based audio delivery (no per-chapter HTTP streaming via the mobile API path) constrains the Download model: audio is fetched as one Readium-audiobook archive per book, downloaded explicitly via a separate "Download readaloud audio" action on the Library Item Detail Screen. The EPUB bundle continues to follow the existing cache-on-open + explicit-download tiers.
+- This ADR does not specify the matching algorithm or its review UI — see [ADR 0021](0021-storyteller-abs-matching-with-review-queue.md).
+
+### Add-Server flow
+
+The Add-Server form opens with an explicit Server-type picker (segmented control: **Audiobookshelf** / **Storyteller**) above the URL and credentials fields. The two backends use the same shape (URL + username + password → bearer token in Keystore), but the picker determines which auth endpoint is called (`POST /login` for ABS vs `POST /api/v2/token` for Storyteller) and which type-specific help text is shown (e.g. ABS's "Allow insecure HTTP" warning). Auto-detection from the URL was rejected to avoid baking probe heuristics into onboarding for marginal UX gain.
+
+### Server removal cascade
+
+Removing any Server clears all ReadaloudLinks that involve it, in either direction:
+
+- Removing a **Storyteller Server** removes the Readaloud Library, all its Library Items' cached EPUB bundles and downloaded audio bundles, and every ReadaloudLink whose Storyteller side is on this Server. Matched ABS Library Items on the surviving ABS Servers revert to no-readaloud state.
+- Removing an **ABS Server** removes its Libraries and per-Server local data as today, and additionally clears every ReadaloudLink whose ABS side is on this Server. The Storyteller books on the surviving Storyteller Server that previously had Confirmed matches revert to Unmatched and their display metadata reverts from ABS-borrowed to Storyteller-native.
+
+The existing removal confirmation dialog gains a count line when applicable (e.g. "Removing this server will also clear 12 readaloud links"). There is no separate undo path — removal is final, consistent with the existing per-Server-removal contract.
+
+### Library Item Detail Screen — four cases
+
+The Detail Screen behaviour depends on which side it's reached from and whether a Confirmed ReadaloudLink exists. All four cases share Mark-Read and To Read affordances as today.
+
+- **Case 1 — ABS-side, no match.** Today's behaviour unchanged. Read button opens the ABS EPUB; Download Button manages the EPUB cache/download; no readaloud affordances.
+- **Case 2 — ABS-side, Confirmed match.** Same as Case 1, plus a footer line below the action row: "Readaloud available — open from *[Readaloud Library name]*" that tap-navigates to the matched Library Item on the Readaloud side. Reading progress shown is the unified canonical position from [ADR 0019](0019-three-peer-unified-canonical-progress-sync.md) — reading from the ABS side participates in three-peer sync once prerequisites are cached. **Library card badge:** a small readaloud glyph also appears on the ABS-side Library card in the grid, signalling availability before the user opens the Detail Screen.
+- **Case 3 — Readaloud-side, no match (Storyteller-only or Unmatched).** Display metadata is Storyteller-native. Read button opens the Storyteller EPUB with the headphones icon ready in the TopAppBar. Two independent download actions: **Download** (EPUB bundle) and **Download readaloud audio** (audiobook bundle). Footer: "Not linked to an ABS book — *Pair manually*" (the unmatched-pairing entry point from [ADR 0021](0021-storyteller-abs-matching-with-review-queue.md)). When neither bundle is present and the device is offline, the Read button is disabled with a "Connect to download book" tooltip.
+- **Case 4 — Readaloud-side, Confirmed match.** Same as Case 3, with display metadata sourced from the linked ABS item, and the footer changed to "Linked to: *[ABS title] · [Library]*" with an unlink icon. Reading progress shown is the unified canonical position from [ADR 0019](0019-three-peer-unified-canonical-progress-sync.md).
+
+**Download-action coupling (Cases 3 and 4):** EPUB-bundle and audiobook-bundle download states are independent on disk — either can be removed without removing the other. The acquire-side is forgiving: tapping **Download readaloud audio** when the EPUB bundle is not yet present fetches both, since the audiobook bundle alone is unplayable. Reading does not require the audiobook bundle.

--- a/docs/adr/0021-storyteller-abs-matching-with-review-queue.md
+++ b/docs/adr/0021-storyteller-abs-matching-with-review-queue.md
@@ -1,0 +1,77 @@
+# ADR 0021 — Client-side incremental Storyteller↔ABS matching with a review queue
+
+**Status:** Accepted
+
+## Context
+
+[ADR 0020](0020-storyteller-as-peer-server-and-readaloud-library.md) establishes Storyteller as a peer Server type contributing a Readaloud Library, and that a Confirmed-matched book has cross-Server progress sync ([ADR 0019](0019-three-peer-unified-canonical-progress-sync.md)) and ABS-sourced display metadata. The mechanism that produces those Confirmed matches must:
+
+- Pair Storyteller books with ABS Library Items automatically, with no user setup for the common case.
+- Avoid wrong matches at all costs. A wrong link corrupts three-way progress sync — Riffle would push the user's reading position into an unrelated ABS item, polluting that other book's progress on every ABS client. The asymmetric cost (wrong > missing) is the governing constraint.
+- Cope with imperfect metadata: ISBN/ASIN may be missing on either side, titles may differ in punctuation or subtitle inclusion, author name conventions vary ("Smith, John" vs "John Smith").
+- Give the user a way out when the auto-matcher can't decide, including when both sides have poor metadata.
+
+The matching layer is not a user-facing concept by default — the success case is invisible. But total invisibility forces the matcher to fail-closed on ambiguity (better no link than a wrong one), which would silently drop genuine matches. A bounded review surface is the relief valve.
+
+## Decision
+
+Matching runs **client-side in Riffle**, **incrementally** as Storyteller and ABS metadata flow in, with results persisted in the local database. The Storyteller input set is the **completed-readaloud set** surfaced by ADR 0020's network-layer filter — in-progress and unaligned Storyteller books are not matching candidates because they are not visible to Riffle at all. Each Storyteller readaloud carries a match state in `{Confirmed, Pending Review, Unmatched}`.
+
+### Auto-match ladder
+
+For each Storyteller book, candidates are sought across every configured ABS Server. The tiers, evaluated strongest to weakest, are:
+
+- **Tier 1 — exact identifier match → Confirmed.** ISBN-13 or ASIN, normalised (strip hyphens and whitespace; uppercase ASIN). If exactly one ABS item matches, the book is Confirmed.
+- **Tier 2 — exact normalised title + author → Confirmed.** Case-insensitive, whitespace-collapsed, punctuation-stripped; author normalisation treats "Smith, John" and "John Smith" as equivalent. If exactly one ABS item matches, the book is Confirmed.
+- **Tier 3 — fuzzy title + author above threshold → Pending Review.** Token-set similarity ≥ 0.85 on both title and author. All candidates above threshold are surfaced together for user decision.
+- **Tier 4 — no candidates → Unmatched.** No link is created; the book stays available for manual pairing.
+
+### Collisions
+
+If Tier 1 or Tier 2 produces **more than one** ABS candidate (e.g. the same ISBN on two configured ABS Servers, or two ABS items with identical normalised title+author), the result is demoted to **Pending Review**, not auto-Confirmed. A confident auto-link is only created when exactly one candidate clears the tier.
+
+### Review queue (Settings → Storyteller Server → Readaloud matches)
+
+The review surface shows three sections:
+
+- **Pending Review.** For each Storyteller book, the auto-matcher's candidate ABS items with their scores. Per-candidate actions: **Confirm**, **Dismiss this candidate**. Per-book action: **No match — don't ask again**.
+- **Unmatched.** Every Storyteller book the auto-matcher couldn't place. Per-book action: **Match manually...** — opens a picker that searches Library Items across every configured ABS Server.
+- **Confirmed.** Every Confirmed link, with the matched ABS title shown. Per-link action: **Unlink**.
+
+A secondary entry point is the **Readaloud-side Library Item Detail Screen**, which shows a small footer line: "Linked to: *[ABS title] · [Library]*" with an unlink icon when Confirmed, or "Not linked to an ABS book — *Pair manually*" when Unmatched.
+
+### Persistence and stability
+
+- A `ReadaloudLink` row in the local database records the pair (Storyteller book uuid, ABS Server uuid, ABS Library Item id) and a `userConfirmed` flag.
+- A `ReadaloudCandidate` row records each Pending-Review candidate.
+- A `ReadaloudDismissal` row records "No match — don't ask again" decisions and per-candidate dismissals to prevent re-surfacing.
+- `userConfirmed = true` links (both auto-Confirmed-by-collision-free-tier-1-or-2 and user-Confirmed) are treated as **sticky**: the auto-matcher does not re-evaluate or change them on subsequent runs. Auto-created links without user touch are stable but can be re-evaluated on metadata change.
+- **Confirm side-effect — sync-prerequisite fetch.** Creating a Confirmed `ReadaloudLink` (auto or user) enqueues a background fetch of the Storyteller EPUB bundle (few MB) for that book and a build of the `CrossEpubIndex` against the ABS EPUB (fetched if not already cached). These are ADR 0019's prerequisites for three-peer sync from either side. The audio bundle is not fetched here — it stays explicit-opt-in via the Readaloud-side action. Failure to fetch either small bundle is non-fatal: the matched book reverts to single-peer sync on whichever side the user reads from, and the fetch retries on the next refresh.
+- Incremental: matching evaluates only new/changed Storyteller books and only against new/changed ABS items. Library refresh and Server-add trigger re-evaluation of the affected scope.
+
+### Side of run
+
+Matching is local-only. Neither Storyteller nor ABS is asked to perform matching server-side. The two backends remain independent of each other; the Riffle client is the only place the cross-Server identity lives.
+
+## Alternatives considered
+
+**Auto-pick the highest-scoring candidate at Tier 3 (no review queue).** Rejected: the wrong-link cost (corrupted three-way sync into an unrelated ABS item) is higher than the missing-link cost (single book unsynced). Demoting to Pending preserves the user's data integrity.
+
+**Server-side matching (Riffle backend or Storyteller plugin).** Rejected: introduces a third component, requires either backend to take a dependency on the other, and the on-device matching cost is negligible.
+
+**Single global confidence score** rather than a tier ladder. Rejected: identifier matches and title-author matches have qualitatively different reliability and should not be averaged. Tiers are explicit.
+
+**Pure invisible matching (no review surface).** Rejected: forces Tier 3 to fail-closed entirely, silently dropping genuine matches with imperfect metadata on either side.
+
+**Always require manual matching.** Rejected: defeats the purpose of "behind the scenes" matching for the high-confidence case which is the majority of well-curated libraries.
+
+## Consequences
+
+- Riffle's local database gains three tables (`ReadaloudLink`, `ReadaloudCandidate`, `ReadaloudDismissal`) with a Room migration.
+- A new Settings surface is needed per Storyteller Server (the Readaloud matches review queue).
+- The Readaloud Library Item Detail Screen gains the link-state footer.
+- Matching is bounded work per refresh — candidate searches use indexed metadata fields, evaluated incrementally. No background sweep of the full library on every open.
+- The matching algorithm itself is intentionally conservative in v1. Richer signals — narrator name, series + position, audiobook duration vs estimated word count, language — are deferred. The data model accommodates them as added scoring inputs without a schema change.
+- A wrong auto-Confirm at Tiers 1 or 2 (e.g. duplicate ISBN entries on ABS with one being a typo) is correctable from the Confirmed section of the review queue via Unlink.
+- Re-running the matcher does not disturb user decisions: Confirmed-by-user links are sticky, Dismissals persist.
+- Matching is independent of [ADR 0019](0019-three-peer-unified-canonical-progress-sync.md) — it produces the link state that ADR 0019's cycle reads to decide its remote set.


### PR DESCRIPTION
## Summary

Foundation slice of issue #34 — generalises Riffle's `Server` concept beyond Audiobookshelf so a Storyteller Server can land alongside ABS in subsequent PRs. No user-visible behaviour change.

- **ADRs + CONTEXT** (`docs(storyteller): foundation ADRs and CONTEXT updates`): adds [ADR 0019](docs/adr/0019-three-peer-unified-canonical-progress-sync.md) (three-peer canonical progress sync), [ADR 0020](docs/adr/0020-storyteller-as-peer-server-and-readaloud-library.md) (Storyteller as a peer Server type with the Readaloud Library), [ADR 0021](docs/adr/0021-storyteller-abs-matching-with-review-queue.md) (Storyteller↔ABS matching with review queue). Generalises the `Server`, `Library`, `Readaloud`, and `Progress Sync` terms in `CONTEXT.md`.
- **Slice 1** (`feat(data): add serverType column to servers`): Room migration 16→17 adds a `serverType TEXT NOT NULL DEFAULT 'AUDIOBOOKSHELF'` column to the `servers` table. Existing rows backfill to `AUDIOBOOKSHELF` — the only Server type that existed before this migration. Includes a per-migration test and `migrateFullChain` update per the project's migration discipline.
- **Slice 2** (`feat(domain): introduce ServerType and plumb through Server/PendingServer`): adds the `ServerType` domain enum (`AUDIOBOOKSHELF`, `STORYTELLER`) and plumbs it through `Server`, `PendingServer`, and the `ServerRepositoryImpl` entity↔domain mapping. Round-trip test added.

## Test plan

- [x] `make build` green
- [x] `make test` green (`core:data` test added)
- [x] `make harness-test` green (115 instrumented tests, including the new `migration16To17` and the extended `migrateFullChain`)

## Remaining slices of #34 (separate PRs)

3. StorytellerApiClient in `core/network`
4. Add-Server type picker UI (Audiobookshelf / Storyteller)
5. Materialize the Readaloud Library + drawer entry on commit
6. Server Switcher renders Storyteller server
7. Library Tab Bar populated from Storyteller (Home / Series / Collections / All)
8. Library Visibility Preferences includes the Readaloud Library
9. Library Item Detail with Storyteller metadata; Read button disabled
10. Multiple Storyteller Servers — disambiguation
11. Server removal cascade for Storyteller