### PR TITLE
fix(sync): isolate reading progress per user + sync lastOpenedAt across devices

### DIFF
--- a/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModelTest.kt
@@ -159,6 +159,7 @@ class LibraryItemDetailViewModelTest {
         override suspend fun syncProgress(itemId: String, payload: SessionPayload): SyncSessionResult = SyncSessionResult.Success
         override suspend fun runSyncCycle(itemId: String, payload: SessionPayload): ProgressSyncCycleResult = ProgressSyncCycleResult.InSync
         override suspend fun setProgress(itemId: String, progress: Float) = Unit
+        override suspend fun touchOpenTimestamp(itemId: String) = Unit
     }
 
     private class FakeToReadRepository(

--- a/core/data/src/main/kotlin/com/riffle/core/data/EpubRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/EpubRepositoryImpl.kt
@@ -22,28 +22,28 @@ class EpubRepositoryImpl(
 ) : EpubRepository {
 
     override suspend fun openEpub(item: LibraryItem): EpubOpenResult {
+        val activeServer = serverRepository.getActive()
+            ?: return EpubOpenResult.NetworkError(IllegalStateException("No active server"))
         val local = downloadsStore.get(item.id) ?: cacheStore.get(item.id)
         val epubFile = if (local != null) {
             local
         } else {
-            val server = serverRepository.getActive()
-                ?: return EpubOpenResult.NetworkError(IllegalStateException("No active server"))
-            val token = tokenStorage.getToken(server.id)
+            val token = tokenStorage.getToken(activeServer.id)
                 ?: return EpubOpenResult.NetworkError(IllegalStateException("No token for server"))
             val ino = item.ebookFileIno ?: run {
-                when (val r = api.getItemEbookFileIno(server.url.value, item.id, token, server.insecureConnectionAllowed)) {
+                when (val r = api.getItemEbookFileIno(activeServer.url.value, item.id, token, activeServer.insecureConnectionAllowed)) {
                     is NetworkItemEbookInoResult.Success -> r.ino
                     is NetworkItemEbookInoResult.NetworkError -> return EpubOpenResult.NetworkError(r.cause)
                 }
             }
-            when (val result = api.downloadEpub(server.url.value, item.id, ino, token, server.insecureConnectionAllowed)) {
+            when (val result = api.downloadEpub(activeServer.url.value, item.id, ino, token, activeServer.insecureConnectionAllowed)) {
                 is NetworkEpubDownloadResult.Success -> result.body.use { body ->
                     cacheStore.save(item.id, body.byteStream())
                 }
                 is NetworkEpubDownloadResult.NetworkError -> return EpubOpenResult.NetworkError(result.cause)
             }
         }
-        val lastPosition = positionStore.load(item.id)
+        val lastPosition = positionStore.load(activeServer.id, item.id)
         return EpubOpenResult.Success(epubFile = epubFile, lastPosition = lastPosition)
     }
 
@@ -83,6 +83,7 @@ class EpubRepositoryImpl(
     override fun isCached(itemId: String): Boolean = cacheStore.get(itemId) != null
 
     override suspend fun saveReadingPosition(itemId: String, cfi: String) {
-        positionStore.save(itemId, cfi)
+        val serverId = serverRepository.getActive()?.id ?: return
+        positionStore.save(serverId, itemId, cfi)
     }
 }

--- a/core/data/src/main/kotlin/com/riffle/core/data/LibraryRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/LibraryRepositoryImpl.kt
@@ -17,6 +17,7 @@ import com.riffle.core.domain.Library
 import com.riffle.core.domain.LibraryItem
 import com.riffle.core.domain.LibraryRefreshResult
 import com.riffle.core.domain.LibraryRepository
+import com.riffle.core.domain.ReadingSessionRepository
 import com.riffle.core.domain.Series
 import com.riffle.core.domain.ServerRepository
 import com.riffle.core.domain.TokenStorage
@@ -41,6 +42,7 @@ class LibraryRepositoryImpl @Inject constructor(
     private val collectionDao: CollectionDao,
     private val serverRepository: ServerRepository,
     private val tokenStorage: TokenStorage,
+    private val readingSessionRepository: ReadingSessionRepository,
 ) : LibraryRepository {
 
     @OptIn(ExperimentalCoroutinesApi::class)
@@ -88,6 +90,10 @@ class LibraryRepositoryImpl @Inject constructor(
 
     override suspend fun markItemOpened(itemId: String) {
         libraryItemDao.updateLastOpenedAt(itemId, System.currentTimeMillis())
+        // Best-effort push so other devices see this open via mediaProgress.lastUpdate. Offline
+        // failures are intentionally swallowed — the local stamp lifts the server timestamp via
+        // max() on the next successful library refresh.
+        readingSessionRepository.touchOpenTimestamp(itemId)
     }
 
     override suspend fun updateReadingProgress(itemId: String, progress: Float) {
@@ -113,7 +119,7 @@ class LibraryRepositoryImpl @Inject constructor(
         val server = serverRepository.getActive() ?: return LibraryRefreshResult.NoActiveServer
         val token = tokenStorage.getToken(server.id) ?: return LibraryRefreshResult.NoActiveServer
         val serverProgressMap = when (val r = api.getUserProgress(server.url.value, token, server.insecureConnectionAllowed)) {
-            is NetworkUserProgressResult.Success -> r.progressByItemId
+            is NetworkUserProgressResult.Success -> r.byItemId
             is NetworkUserProgressResult.NetworkError -> emptyMap()
         }
         return when (val result = api.getLibraryItems(server.url.value, libraryId, token, server.insecureConnectionAllowed)) {
@@ -124,13 +130,14 @@ class LibraryRepositoryImpl @Inject constructor(
                     .sortedByDescending { it.isSupported }
                     .distinctBy { it.title.trim().lowercase() }
                     .map { item ->
+                        val serverProgress = serverProgressMap[item.id]
                         LibraryItemEntity(
                             id = item.id,
                             libraryId = item.libraryId,
                             title = item.title,
                             author = item.author,
                             coverUrl = "${server.url.value}/api/items/${item.id}/cover",
-                            readingProgress = serverProgressMap[item.id] ?: item.readingProgress ?: localProgressMap[item.id] ?: 0f,
+                            readingProgress = serverProgress?.ebookProgress ?: item.readingProgress ?: localProgressMap[item.id] ?: 0f,
                             ebookFileIno = item.ebookFileIno,
                             ebookFormat = item.ebookFormat.toStorageString(),
                             description = item.description,
@@ -138,7 +145,11 @@ class LibraryRepositoryImpl @Inject constructor(
                             publishedYear = item.publishedYear,
                             genres = item.genres.joinToString(","),
                             publisher = item.publisher,
-                            lastOpenedAt = lastOpenedAtMap[item.id],
+                            // Surface the most recent read activity across devices: pick whichever
+                            // of (local stamp, server's mediaProgress.lastUpdate) is later. Either
+                            // can lead — the local stamp wins between syncs on this device, the
+                            // server stamp wins once another device has read more recently.
+                            lastOpenedAt = mergeLastOpenedAt(lastOpenedAtMap[item.id], serverProgress?.lastUpdate),
                             addedAt = item.addedAt,
                         )
                     }
@@ -204,6 +215,13 @@ class LibraryRepositoryImpl @Inject constructor(
             }
             is NetworkCollectionResult.NetworkError -> LibraryRefreshResult.NetworkError(result.cause)
         }
+    }
+
+    private fun mergeLastOpenedAt(local: Long?, server: Long?): Long? {
+        val a = local ?: 0L
+        val b = server ?: 0L
+        val merged = maxOf(a, b)
+        return merged.takeIf { it > 0L }
     }
 
     private fun LibraryEntity.toDomain() = Library(id = id, name = name, mediaType = mediaType, isUnsupported = isUnsupported)

--- a/core/data/src/main/kotlin/com/riffle/core/data/PdfRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/PdfRepositoryImpl.kt
@@ -23,6 +23,8 @@ class PdfRepositoryImpl(
 ) : PdfRepository {
 
     override suspend fun openPdf(item: LibraryItem): PdfOpenResult {
+        val activeServer = serverRepository.getActive()
+            ?: return PdfOpenResult.NetworkError(IllegalStateException("No active server"))
         val local = (downloadsStore.get(item.id) ?: cacheStore.get(item.id))?.takeIf { it.isValidPdf() }
         if (local == null) {
             cacheStore.delete(item.id)
@@ -30,24 +32,22 @@ class PdfRepositoryImpl(
         val pdfFile = if (local != null) {
             local
         } else {
-            val server = serverRepository.getActive()
-                ?: return PdfOpenResult.NetworkError(IllegalStateException("No active server"))
-            val token = tokenStorage.getToken(server.id)
+            val token = tokenStorage.getToken(activeServer.id)
                 ?: return PdfOpenResult.NetworkError(IllegalStateException("No token for server"))
             val ino = item.ebookFileIno ?: run {
-                when (val r = api.getItemEbookFileIno(server.url.value, item.id, token, server.insecureConnectionAllowed)) {
+                when (val r = api.getItemEbookFileIno(activeServer.url.value, item.id, token, activeServer.insecureConnectionAllowed)) {
                     is NetworkItemEbookInoResult.Success -> r.ino
                     is NetworkItemEbookInoResult.NetworkError -> return PdfOpenResult.NetworkError(r.cause)
                 }
             }
-            when (val result = api.downloadEpub(server.url.value, item.id, ino, token, server.insecureConnectionAllowed)) {
+            when (val result = api.downloadEpub(activeServer.url.value, item.id, ino, token, activeServer.insecureConnectionAllowed)) {
                 is NetworkEpubDownloadResult.Success -> result.body.use { body ->
                     cacheStore.save(item.id, body.byteStream())
                 }
                 is NetworkEpubDownloadResult.NetworkError -> return PdfOpenResult.NetworkError(result.cause)
             }
         }
-        val lastPosition = positionStore.load(item.id)
+        val lastPosition = positionStore.load(activeServer.id, item.id)
         return PdfOpenResult.Success(pdfFile = pdfFile, lastPosition = lastPosition)
     }
 
@@ -87,7 +87,8 @@ class PdfRepositoryImpl(
     override fun isCached(itemId: String): Boolean = cacheStore.get(itemId) != null
 
     override suspend fun saveReadingPosition(itemId: String, locatorJson: String) {
-        positionStore.save(itemId, locatorJson)
+        val serverId = serverRepository.getActive()?.id ?: return
+        positionStore.save(serverId, itemId, locatorJson)
     }
 }
 

--- a/core/data/src/main/kotlin/com/riffle/core/data/ReadingPositionStoreImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/ReadingPositionStoreImpl.kt
@@ -9,25 +9,35 @@ class ReadingPositionStoreImpl @Inject constructor(
     private val dao: ReadingPositionDao,
 ) : ReadingPositionStore {
 
-    override suspend fun save(itemId: String, cfi: String) {
-        dao.upsert(ReadingPositionEntity(itemId = itemId, cfi = cfi, localUpdatedAt = System.currentTimeMillis()))
+    override suspend fun save(serverId: String, itemId: String, cfi: String) {
+        dao.upsert(
+            ReadingPositionEntity(
+                serverId = serverId,
+                itemId = itemId,
+                cfi = cfi,
+                localUpdatedAt = System.currentTimeMillis(),
+            )
+        )
     }
 
-    override suspend fun load(itemId: String): String? =
-        dao.getByItemId(itemId)?.cfi
+    override suspend fun load(serverId: String, itemId: String): String? =
+        dao.getByItemId(serverId, itemId)?.cfi
 
-    override suspend fun loadLocalUpdatedAt(itemId: String): Long =
-        dao.getByItemId(itemId)?.localUpdatedAt ?: 0L
+    override suspend fun loadLocalUpdatedAt(serverId: String, itemId: String): Long =
+        dao.getByItemId(serverId, itemId)?.localUpdatedAt ?: 0L
 
-    override suspend fun updateLocalTimestamp(itemId: String, millis: Long) {
+    override suspend fun updateLocalTimestamp(serverId: String, itemId: String, millis: Long) {
         // Use upsert so that a row is always created — the UPDATE-only query silently does nothing
         // when no row exists yet, leaving localUpdatedAt = 0 and causing the server to win every
         // subsequent sync cycle until the user has moved enough to trigger a position save.
-        val existing = dao.getByItemId(itemId)
-        dao.upsert(ReadingPositionEntity(
-            itemId = itemId,
-            cfi = existing?.cfi ?: "",
-            localUpdatedAt = millis,
-        ))
+        val existing = dao.getByItemId(serverId, itemId)
+        dao.upsert(
+            ReadingPositionEntity(
+                serverId = serverId,
+                itemId = itemId,
+                cfi = existing?.cfi ?: "",
+                localUpdatedAt = millis,
+            )
+        )
     }
 }

--- a/core/data/src/main/kotlin/com/riffle/core/data/ReadingSessionRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/ReadingSessionRepositoryImpl.kt
@@ -3,6 +3,7 @@ package com.riffle.core.data
 import com.riffle.core.domain.ProgressSyncCycleResult
 import com.riffle.core.domain.ReadingPositionStore
 import com.riffle.core.domain.ReadingSessionRepository
+import com.riffle.core.domain.Server
 import com.riffle.core.domain.ServerProgress
 import com.riffle.core.domain.ServerRepository
 import com.riffle.core.domain.SessionPayload
@@ -22,29 +23,30 @@ class ReadingSessionRepositoryImpl @Inject constructor(
 ) : ReadingSessionRepository {
 
     override suspend fun syncProgress(itemId: String, payload: SessionPayload): SyncSessionResult {
-        val (baseUrl, token) = resolveCredentials() ?: return SyncSessionResult.NetworkError(
+        val resolved = resolveServerAndToken() ?: return SyncSessionResult.NetworkError(
             IllegalStateException("No active server or token")
         )
-        return when (val r = api.syncEbookProgress(baseUrl, itemId, payload.toNetwork(), token, insecureAllowed())) {
+        val (server, token) = resolved
+        return when (val r = api.syncEbookProgress(server.url.value, itemId, payload.toNetwork(), token, server.insecureConnectionAllowed)) {
             is NetworkSyncSessionResult.Success -> SyncSessionResult.Success
             is NetworkSyncSessionResult.NetworkError -> SyncSessionResult.NetworkError(r.cause)
         }
     }
 
     override suspend fun runSyncCycle(itemId: String, payload: SessionPayload): ProgressSyncCycleResult {
-        val (baseUrl, token) = resolveCredentials() ?: return ProgressSyncCycleResult.Offline
-        val insecure = insecureAllowed()
+        val resolved = resolveServerAndToken() ?: return ProgressSyncCycleResult.Offline
+        val (server, token) = resolved
 
-        val serverProgress = when (val r = api.getProgress(baseUrl, itemId, token, insecure)) {
+        val serverProgress = when (val r = api.getProgress(server.url.value, itemId, token, server.insecureConnectionAllowed)) {
             is NetworkGetProgressResult.NetworkError -> return ProgressSyncCycleResult.Offline
             is NetworkGetProgressResult.Success -> r.progress
         }
 
-        val localUpdatedAt = positionStore.loadLocalUpdatedAt(itemId)
+        val localUpdatedAt = positionStore.loadLocalUpdatedAt(server.id, itemId)
 
         return when {
             serverProgress.lastUpdate > localUpdatedAt -> {
-                positionStore.updateLocalTimestamp(itemId, serverProgress.lastUpdate)
+                positionStore.updateLocalTimestamp(server.id, itemId, serverProgress.lastUpdate)
                 ProgressSyncCycleResult.ServerWins(
                     ServerProgress(
                         ebookLocation = serverProgress.ebookLocation,
@@ -54,10 +56,10 @@ class ReadingSessionRepositoryImpl @Inject constructor(
                 )
             }
             localUpdatedAt > serverProgress.lastUpdate -> {
-                val patchResult = api.syncEbookProgress(baseUrl, itemId, payload.toNetwork(), token, insecure)
+                val patchResult = api.syncEbookProgress(server.url.value, itemId, payload.toNetwork(), token, server.insecureConnectionAllowed)
                 if (patchResult is NetworkSyncSessionResult.Success) {
                     val ts = patchResult.lastUpdate.takeIf { it > 0L } ?: System.currentTimeMillis()
-                    positionStore.updateLocalTimestamp(itemId, ts)
+                    positionStore.updateLocalTimestamp(server.id, itemId, ts)
                 }
                 ProgressSyncCycleResult.LocalWins
             }
@@ -66,27 +68,25 @@ class ReadingSessionRepositoryImpl @Inject constructor(
     }
 
     override suspend fun setProgress(itemId: String, progress: Float) {
-        val cfi = positionStore.load(itemId) ?: ""
-        // Bump before credential check: marks the record dirty so the sync cycle pushes it
-        // even if we have no server right now (offline / no active server).
-        positionStore.updateLocalTimestamp(itemId, System.currentTimeMillis())
-        val (baseUrl, token) = resolveCredentials() ?: return
+        val server = serverRepository.getActive() ?: return
+        val cfi = positionStore.load(server.id, itemId) ?: ""
+        // Bump before token check: marks the record dirty so the sync cycle pushes it
+        // even if the token is missing right now.
+        positionStore.updateLocalTimestamp(server.id, itemId, System.currentTimeMillis())
+        val token = tokenStorage.getToken(server.id) ?: return
         api.syncEbookProgress(
-            baseUrl, itemId,
+            server.url.value, itemId,
             NetworkEbookProgressPayload(cfi, progress),
-            token, insecureAllowed(),
+            token, server.insecureConnectionAllowed,
         )
         // PATCH failure intentionally ignored — next sync cycle will push
     }
 
-    private suspend fun resolveCredentials(): Pair<String, String>? {
+    private suspend fun resolveServerAndToken(): Pair<Server, String>? {
         val server = serverRepository.getActive() ?: return null
         val token = tokenStorage.getToken(server.id) ?: return null
-        return server.url.value to token
+        return server to token
     }
-
-    private suspend fun insecureAllowed(): Boolean =
-        serverRepository.getActive()?.insecureConnectionAllowed ?: false
 
     private fun SessionPayload.toNetwork() = NetworkEbookProgressPayload(
         ebookLocation = ebookLocation,

--- a/core/data/src/main/kotlin/com/riffle/core/data/ReadingSessionRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/ReadingSessionRepositoryImpl.kt
@@ -67,6 +67,27 @@ class ReadingSessionRepositoryImpl @Inject constructor(
         }
     }
 
+    override suspend fun touchOpenTimestamp(itemId: String) {
+        val resolved = resolveServerAndToken() ?: return
+        val (server, token) = resolved
+        val serverProgress = when (val r = api.getProgress(server.url.value, itemId, token, server.insecureConnectionAllowed)) {
+            is NetworkGetProgressResult.Success -> r.progress
+            is NetworkGetProgressResult.NetworkError -> return
+        }
+        val patchResult = api.syncEbookProgress(
+            server.url.value, itemId,
+            NetworkEbookProgressPayload(
+                ebookLocation = serverProgress.ebookLocation,
+                ebookProgress = serverProgress.ebookProgress,
+            ),
+            token, server.insecureConnectionAllowed,
+        )
+        if (patchResult is NetworkSyncSessionResult.Success) {
+            val ts = patchResult.lastUpdate.takeIf { it > 0L } ?: System.currentTimeMillis()
+            positionStore.updateLocalTimestamp(server.id, itemId, ts)
+        }
+    }
+
     override suspend fun setProgress(itemId: String, progress: Float) {
         val server = serverRepository.getActive() ?: return
         val cfi = positionStore.load(server.id, itemId) ?: ""

--- a/core/data/src/main/kotlin/com/riffle/core/data/di/DatabaseModule.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/di/DatabaseModule.kt
@@ -43,6 +43,7 @@ object DatabaseModule {
                 RiffleDatabase.MIGRATION_15_16,
                 RiffleDatabase.MIGRATION_16_17,
                 RiffleDatabase.MIGRATION_17_18,
+                RiffleDatabase.MIGRATION_18_19,
             )
             .build()
 

--- a/core/data/src/test/kotlin/com/riffle/core/data/EpubPositionIntegrationTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/EpubPositionIntegrationTest.kt
@@ -149,11 +149,14 @@ class EpubPositionIntegrationTest {
     }
 
     private class InMemoryReadingPositionDao : ReadingPositionDao {
-        private val entities = mutableMapOf<String, ReadingPositionEntity>()
-        override suspend fun upsert(entity: ReadingPositionEntity) { entities[entity.itemId] = entity }
-        override suspend fun getByItemId(itemId: String): ReadingPositionEntity? = entities[itemId]
-        override suspend fun updateLocalTimestamp(itemId: String, millis: Long) {
-            entities[itemId]?.let { entities[itemId] = it.copy(localUpdatedAt = millis) }
+        private val entities = mutableMapOf<Pair<String, String>, ReadingPositionEntity>()
+        override suspend fun upsert(entity: ReadingPositionEntity) {
+            entities[entity.serverId to entity.itemId] = entity
+        }
+        override suspend fun getByItemId(serverId: String, itemId: String): ReadingPositionEntity? =
+            entities[serverId to itemId]
+        override suspend fun updateLocalTimestamp(serverId: String, itemId: String, millis: Long) {
+            entities[serverId to itemId]?.let { entities[serverId to itemId] = it.copy(localUpdatedAt = millis) }
         }
     }
 }

--- a/core/data/src/test/kotlin/com/riffle/core/data/EpubRepositoryTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/EpubRepositoryTest.kt
@@ -88,11 +88,13 @@ class EpubRepositoryTest {
     }
 
     private class FakePositionStore : ReadingPositionStore {
-        val store = mutableMapOf<String, String>()
-        override suspend fun save(itemId: String, cfi: String) { store[itemId] = cfi }
-        override suspend fun load(itemId: String): String? = store[itemId]
-        override suspend fun loadLocalUpdatedAt(itemId: String): Long = 0L
-        override suspend fun updateLocalTimestamp(itemId: String, millis: Long) = Unit
+        val store = mutableMapOf<Pair<String, String>, String>()
+        override suspend fun save(serverId: String, itemId: String, cfi: String) {
+            store[serverId to itemId] = cfi
+        }
+        override suspend fun load(serverId: String, itemId: String): String? = store[serverId to itemId]
+        override suspend fun loadLocalUpdatedAt(serverId: String, itemId: String): Long = 0L
+        override suspend fun updateLocalTimestamp(serverId: String, itemId: String, millis: Long) = Unit
     }
 
     private fun item(id: String = "item-1", ino: String? = "ino-42") = LibraryItem(
@@ -143,7 +145,7 @@ class EpubRepositoryTest {
     @Test
     fun `openEpub returns last saved reading position`() = runTest {
         cacheStore.save("item-1", epubBytes.inputStream())
-        positionStore.save("item-1", "epubcfi(/6/4!/4/1:0)")
+        positionStore.save("server-1", "item-1", "epubcfi(/6/4!/4/1:0)")
         val result = repo.openEpub(item()) as EpubOpenResult.Success
         assertEquals("epubcfi(/6/4!/4/1:0)", result.lastPosition)
     }

--- a/core/data/src/test/kotlin/com/riffle/core/data/LibraryRepositoryTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/LibraryRepositoryTest.kt
@@ -229,7 +229,30 @@ class LibraryRepositoryTest {
             override suspend fun getCollections(baseUrl: String, libraryId: String, token: String, insecureAllowed: Boolean) =
                 NetworkCollectionResult.Success(emptyList())
         },
-    ) = LibraryRepositoryImpl(api, libraryDao, libraryItemDao, seriesDao, collectionDao, fakeServerRepository, fakeTokenStorage)
+        readingSessionRepository: com.riffle.core.domain.ReadingSessionRepository = NoopReadingSessionRepository,
+    ) = LibraryRepositoryImpl(
+        api, libraryDao, libraryItemDao, seriesDao, collectionDao,
+        fakeServerRepository, fakeTokenStorage, readingSessionRepository,
+    )
+
+    private object NoopReadingSessionRepository : com.riffle.core.domain.ReadingSessionRepository {
+        override suspend fun syncProgress(itemId: String, payload: com.riffle.core.domain.SessionPayload) =
+            com.riffle.core.domain.SyncSessionResult.Success
+        override suspend fun runSyncCycle(itemId: String, payload: com.riffle.core.domain.SessionPayload) =
+            com.riffle.core.domain.ProgressSyncCycleResult.InSync
+        override suspend fun setProgress(itemId: String, progress: Float) = Unit
+        override suspend fun touchOpenTimestamp(itemId: String) = Unit
+    }
+
+    private class RecordingReadingSessionRepository : com.riffle.core.domain.ReadingSessionRepository {
+        val touchedItemIds = mutableListOf<String>()
+        override suspend fun syncProgress(itemId: String, payload: com.riffle.core.domain.SessionPayload) =
+            com.riffle.core.domain.SyncSessionResult.Success
+        override suspend fun runSyncCycle(itemId: String, payload: com.riffle.core.domain.SessionPayload) =
+            com.riffle.core.domain.ProgressSyncCycleResult.InSync
+        override suspend fun setProgress(itemId: String, progress: Float) = Unit
+        override suspend fun touchOpenTimestamp(itemId: String) { touchedItemIds += itemId }
+    }
 
     private fun activeServer(id: String = "s1") = Server(
         id = id,
@@ -375,6 +398,71 @@ class LibraryRepositoryTest {
         }
         makeRepo(libraryItemDao = dao, api = api).refreshLibraryItems("lib-1")
         assertEquals(2, dao.upserted.size)
+    }
+
+    @Test
+    fun `refreshLibraryItems lifts lastOpenedAt from server mediaProgress when newer than local`() = runTest {
+        fakeServerRepository.activeServer = activeServer()
+        fakeTokenStorage.tokens["s1"] = "tok"
+        val dao = FakeLibraryItemDao()
+        dao.upsertAll(listOf(
+            LibraryItemEntity("item-1", "lib-1", "My Book", "Author A", null, 0.4f, lastOpenedAt = 1_000L),
+        ))
+        val api = object : AbsLibraryApi {
+            override suspend fun getUserProgress(baseUrl: String, token: String, insecureAllowed: Boolean) =
+                com.riffle.core.network.NetworkUserProgressResult.Success(
+                    mapOf("item-1" to com.riffle.core.network.NetworkUserMediaProgress(ebookProgress = 0.4f, lastUpdate = 5_000L))
+                )
+            override suspend fun getLibraries(baseUrl: String, token: String, insecureAllowed: Boolean) =
+                NetworkLibrariesResult.Success(emptyList())
+            override suspend fun getLibraryItems(baseUrl: String, libraryId: String, token: String, insecureAllowed: Boolean) =
+                NetworkLibraryItemsResult.Success(listOf(
+                    NetworkLibraryItem("item-1", "lib-1", "My Book", "Author A", 0.4f, ebookFormat = EbookFormat.Epub)
+                ))
+            override suspend fun getSeries(baseUrl: String, libraryId: String, token: String, insecureAllowed: Boolean) =
+                NetworkSeriesResult.Success(emptyList())
+            override suspend fun getCollections(baseUrl: String, libraryId: String, token: String, insecureAllowed: Boolean) =
+                NetworkCollectionResult.Success(emptyList())
+        }
+        makeRepo(libraryItemDao = dao, api = api).refreshLibraryItems("lib-1")
+        assertEquals(5_000L, dao.upserted.last { it.id == "item-1" }.lastOpenedAt)
+    }
+
+    @Test
+    fun `refreshLibraryItems keeps local lastOpenedAt when newer than server mediaProgress`() = runTest {
+        fakeServerRepository.activeServer = activeServer()
+        fakeTokenStorage.tokens["s1"] = "tok"
+        val dao = FakeLibraryItemDao()
+        dao.upsertAll(listOf(
+            LibraryItemEntity("item-1", "lib-1", "My Book", "Author A", null, 0.4f, lastOpenedAt = 9_000L),
+        ))
+        val api = object : AbsLibraryApi {
+            override suspend fun getUserProgress(baseUrl: String, token: String, insecureAllowed: Boolean) =
+                com.riffle.core.network.NetworkUserProgressResult.Success(
+                    mapOf("item-1" to com.riffle.core.network.NetworkUserMediaProgress(ebookProgress = 0.4f, lastUpdate = 1_000L))
+                )
+            override suspend fun getLibraries(baseUrl: String, token: String, insecureAllowed: Boolean) =
+                NetworkLibrariesResult.Success(emptyList())
+            override suspend fun getLibraryItems(baseUrl: String, libraryId: String, token: String, insecureAllowed: Boolean) =
+                NetworkLibraryItemsResult.Success(listOf(
+                    NetworkLibraryItem("item-1", "lib-1", "My Book", "Author A", 0.4f, ebookFormat = EbookFormat.Epub)
+                ))
+            override suspend fun getSeries(baseUrl: String, libraryId: String, token: String, insecureAllowed: Boolean) =
+                NetworkSeriesResult.Success(emptyList())
+            override suspend fun getCollections(baseUrl: String, libraryId: String, token: String, insecureAllowed: Boolean) =
+                NetworkCollectionResult.Success(emptyList())
+        }
+        makeRepo(libraryItemDao = dao, api = api).refreshLibraryItems("lib-1")
+        assertEquals(9_000L, dao.upserted.last { it.id == "item-1" }.lastOpenedAt)
+    }
+
+    @Test
+    fun `markItemOpened pushes touchOpenTimestamp to the session repository`() = runTest {
+        fakeServerRepository.activeServer = activeServer()
+        fakeTokenStorage.tokens["s1"] = "tok"
+        val session = RecordingReadingSessionRepository()
+        makeRepo(readingSessionRepository = session).markItemOpened("item-42")
+        assertEquals(listOf("item-42"), session.touchedItemIds)
     }
 
     @Test

--- a/core/data/src/test/kotlin/com/riffle/core/data/PdfRepositoryTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/PdfRepositoryTest.kt
@@ -88,11 +88,13 @@ class PdfRepositoryTest {
     }
 
     private class FakePdfPositionStore : ReadingPositionStore {
-        val store = mutableMapOf<String, String>()
-        override suspend fun save(itemId: String, cfi: String) { store[itemId] = cfi }
-        override suspend fun load(itemId: String): String? = store[itemId]
-        override suspend fun loadLocalUpdatedAt(itemId: String): Long = 0L
-        override suspend fun updateLocalTimestamp(itemId: String, millis: Long) = Unit
+        val store = mutableMapOf<Pair<String, String>, String>()
+        override suspend fun save(serverId: String, itemId: String, cfi: String) {
+            store[serverId to itemId] = cfi
+        }
+        override suspend fun load(serverId: String, itemId: String): String? = store[serverId to itemId]
+        override suspend fun loadLocalUpdatedAt(serverId: String, itemId: String): Long = 0L
+        override suspend fun updateLocalTimestamp(serverId: String, itemId: String, millis: Long) = Unit
     }
 
     private fun item(id: String = "item-1", ino: String? = "ino-42") = LibraryItem(
@@ -143,7 +145,7 @@ class PdfRepositoryTest {
     @Test
     fun `openPdf returns last saved reading position`() = runTest {
         cacheStore.save("item-1", pdfBytes.inputStream())
-        positionStore.save("item-1", """{"href":"publication.pdf","type":"application/pdf","locations":{"position":5}}""")
+        positionStore.save("server-1", "item-1", """{"href":"publication.pdf","type":"application/pdf","locations":{"position":5}}""")
         val result = repo.openPdf(item()) as PdfOpenResult.Success
         assertEquals("""{"href":"publication.pdf","type":"application/pdf","locations":{"position":5}}""", result.lastPosition)
     }

--- a/core/data/src/test/kotlin/com/riffle/core/data/ProgressSyncCycleTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/ProgressSyncCycleTest.kt
@@ -273,4 +273,42 @@ class ProgressSyncCycleTest {
         assertNotNull(positionStore.updatedTimestamp)
         assertTrue(positionStore.updatedTimestamp!! > 0L)
     }
+
+    // --- touchOpenTimestamp ---
+
+    @Test
+    fun `touchOpenTimestamp PATCHes back the server's current ebookLocation to bump lastUpdate without clobbering position`() = runTest {
+        val positionStore = FakePositionStore(localUpdatedAt = 0L)
+        val recording = object : AbsSessionApi {
+            var patchPayload: NetworkEbookProgressPayload? = null
+            override suspend fun syncEbookProgress(
+                baseUrl: String, libraryItemId: String, payload: NetworkEbookProgressPayload,
+                token: String, insecureAllowed: Boolean,
+            ): NetworkSyncSessionResult {
+                patchPayload = payload
+                return NetworkSyncSessionResult.Success(7_777L)
+            }
+            override suspend fun getProgress(baseUrl: String, libraryItemId: String, token: String, insecureAllowed: Boolean) =
+                NetworkGetProgressResult.Success(NetworkServerProgress("server-cfi", ebookProgress = 0.42f, lastUpdate = 3_000L))
+        }
+
+        buildRepo(recording, positionStore).touchOpenTimestamp("item-1")
+
+        assertEquals("server-cfi", recording.patchPayload?.ebookLocation)
+        assertEquals(0.42f, recording.patchPayload?.ebookProgress)
+        assertEquals(7_777L, positionStore.updatedTimestamp)
+    }
+
+    @Test
+    fun `touchOpenTimestamp is a no-op when getProgress fails`() = runTest {
+        val positionStore = FakePositionStore(localUpdatedAt = 1_000L)
+        val api = FakeSessionApi(
+            getResult = NetworkGetProgressResult.NetworkError(IOException("offline")),
+        )
+
+        buildRepo(api, positionStore).touchOpenTimestamp("item-1")
+
+        assertEquals(0, api.patchCallCount)
+        assertEquals(null, positionStore.updatedTimestamp)
+    }
 }

--- a/core/data/src/test/kotlin/com/riffle/core/data/ProgressSyncCycleTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/ProgressSyncCycleTest.kt
@@ -30,10 +30,14 @@ class ProgressSyncCycleTest {
 
     private class FakePositionStore(var localUpdatedAt: Long = 0L) : ReadingPositionStore {
         var updatedTimestamp: Long? = null
-        override suspend fun save(itemId: String, cfi: String) = Unit
-        override suspend fun load(itemId: String): String? = null
-        override suspend fun loadLocalUpdatedAt(itemId: String): Long = localUpdatedAt
-        override suspend fun updateLocalTimestamp(itemId: String, millis: Long) { updatedTimestamp = millis }
+        var updatedServerId: String? = null
+        override suspend fun save(serverId: String, itemId: String, cfi: String) = Unit
+        override suspend fun load(serverId: String, itemId: String): String? = null
+        override suspend fun loadLocalUpdatedAt(serverId: String, itemId: String): Long = localUpdatedAt
+        override suspend fun updateLocalTimestamp(serverId: String, itemId: String, millis: Long) {
+            updatedServerId = serverId
+            updatedTimestamp = millis
+        }
     }
 
     private class FakeSessionApi(

--- a/core/data/src/test/kotlin/com/riffle/core/data/ProgressSyncIntegrationTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/ProgressSyncIntegrationTest.kt
@@ -218,4 +218,36 @@ class ProgressSyncIntegrationTest {
 
         assertEquals(3100L, positionStore.updatedTimestamp)
     }
+
+    // --- touchOpenTimestamp end-to-end (GET → PATCH-same-content → server bumps lastUpdate) ---
+
+    @Test
+    fun `touchOpenTimestamp PATCHes back the server's existing ebookLocation verbatim`() = runTest {
+        server.enqueue(json(200, """{"ebookLocation":"epubcfi(/6/8!/4/2/1:0)","ebookProgress":0.42,"lastUpdate":1000}"""))
+        server.enqueue(json(200, """{"ebookLocation":"epubcfi(/6/8!/4/2/1:0)","lastUpdate":9999}"""))
+
+        buildRepo().touchOpenTimestamp("item-1")
+
+        assertEquals(2, server.requestCount)
+        val getReq = server.takeRequest()
+        assertEquals("GET", getReq.method)
+        assertEquals("/api/me/progress/item-1", getReq.path)
+        val patchReq = server.takeRequest()
+        assertEquals("PATCH", patchReq.method)
+        assertEquals("/api/me/progress/item-1", patchReq.path)
+        val body = patchReq.body.readUtf8()
+        assertTrue("ebookLocation must be echoed verbatim: $body", body.contains("\"ebookLocation\":\"epubcfi(/6/8!/4/2/1:0)\""))
+        assertTrue("ebookProgress must be echoed verbatim: $body", body.contains("\"ebookProgress\":0.42"))
+        assertEquals(9999L, positionStore.updatedTimestamp)
+    }
+
+    @Test
+    fun `touchOpenTimestamp is a no-op when GET fails`() = runTest {
+        server.enqueue(MockResponse().setResponseCode(500).setBody("oops"))
+
+        buildRepo().touchOpenTimestamp("item-1")
+
+        assertEquals(1, server.requestCount)
+        assertEquals(null, positionStore.updatedTimestamp)
+    }
 }

--- a/core/data/src/test/kotlin/com/riffle/core/data/ProgressSyncIntegrationTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/ProgressSyncIntegrationTest.kt
@@ -40,10 +40,10 @@ class ProgressSyncIntegrationTest {
 
     private class RecordingPositionStore(var localUpdatedAt: Long = 0L) : ReadingPositionStore {
         var updatedTimestamp: Long? = null
-        override suspend fun save(itemId: String, cfi: String) = Unit
-        override suspend fun load(itemId: String): String? = null
-        override suspend fun loadLocalUpdatedAt(itemId: String): Long = localUpdatedAt
-        override suspend fun updateLocalTimestamp(itemId: String, millis: Long) { updatedTimestamp = millis }
+        override suspend fun save(serverId: String, itemId: String, cfi: String) = Unit
+        override suspend fun load(serverId: String, itemId: String): String? = null
+        override suspend fun loadLocalUpdatedAt(serverId: String, itemId: String): Long = localUpdatedAt
+        override suspend fun updateLocalTimestamp(serverId: String, itemId: String, millis: Long) { updatedTimestamp = millis }
     }
 
     private fun buildRepo() = ReadingSessionRepositoryImpl(

--- a/core/data/src/test/kotlin/com/riffle/core/data/ReadingPositionStoreTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/ReadingPositionStoreTest.kt
@@ -4,19 +4,23 @@ import com.riffle.core.database.ReadingPositionDao
 import com.riffle.core.database.ReadingPositionEntity
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNull
 import org.junit.Test
 
 class ReadingPositionStoreTest {
 
     private class FakeReadingPositionDao : ReadingPositionDao {
-        private val entities: MutableMap<String, ReadingPositionEntity> = mutableMapOf()
-        val store: Map<String, ReadingPositionEntity> get() = entities
-        fun seed(entity: ReadingPositionEntity) { entities[entity.itemId] = entity }
-        override suspend fun upsert(entity: ReadingPositionEntity) { entities[entity.itemId] = entity }
-        override suspend fun getByItemId(itemId: String): ReadingPositionEntity? = entities[itemId]
-        override suspend fun updateLocalTimestamp(itemId: String, millis: Long) {
-            entities[itemId]?.let { entities[itemId] = it.copy(localUpdatedAt = millis) }
+        private val entities: MutableMap<Pair<String, String>, ReadingPositionEntity> = mutableMapOf()
+        val store: Map<Pair<String, String>, ReadingPositionEntity> get() = entities
+        fun seed(entity: ReadingPositionEntity) { entities[entity.serverId to entity.itemId] = entity }
+        override suspend fun upsert(entity: ReadingPositionEntity) {
+            entities[entity.serverId to entity.itemId] = entity
+        }
+        override suspend fun getByItemId(serverId: String, itemId: String): ReadingPositionEntity? =
+            entities[serverId to itemId]
+        override suspend fun updateLocalTimestamp(serverId: String, itemId: String, millis: Long) {
+            entities[serverId to itemId]?.let { entities[serverId to itemId] = it.copy(localUpdatedAt = millis) }
         }
     }
 
@@ -24,32 +28,32 @@ class ReadingPositionStoreTest {
     fun `save persists the CFI for the given item`() = runTest {
         val dao = FakeReadingPositionDao()
         val store = ReadingPositionStoreImpl(dao)
-        store.save("item-1", "epubcfi(/6/4[chap01]!/4/2[body01]/1:0)")
-        assertEquals("epubcfi(/6/4[chap01]!/4/2[body01]/1:0)", dao.store["item-1"]?.cfi)
+        store.save("server-A", "item-1", "epubcfi(/6/4[chap01]!/4/2[body01]/1:0)")
+        assertEquals("epubcfi(/6/4[chap01]!/4/2[body01]/1:0)", dao.store["server-A" to "item-1"]?.cfi)
     }
 
     @Test
     fun `load returns the saved CFI`() = runTest {
         val dao = FakeReadingPositionDao().also {
-            it.seed(ReadingPositionEntity("item-1", "epubcfi(/6/2!/4/1:42)"))
+            it.seed(ReadingPositionEntity("server-A", "item-1", "epubcfi(/6/2!/4/1:42)"))
         }
         val store = ReadingPositionStoreImpl(dao)
-        assertEquals("epubcfi(/6/2!/4/1:42)", store.load("item-1"))
+        assertEquals("epubcfi(/6/2!/4/1:42)", store.load("server-A", "item-1"))
     }
 
     @Test
     fun `load returns null for an item with no saved position`() = runTest {
         val store = ReadingPositionStoreImpl(FakeReadingPositionDao())
-        assertNull(store.load("item-new"))
+        assertNull(store.load("server-A", "item-new"))
     }
 
     @Test
-    fun `save overwrites the previous position for the same item`() = runTest {
+    fun `save overwrites the previous position for the same server-item`() = runTest {
         val dao = FakeReadingPositionDao()
         val store = ReadingPositionStoreImpl(dao)
-        store.save("item-1", "epubcfi(/6/2!/4/1:10)")
-        store.save("item-1", "epubcfi(/6/2!/4/1:99)")
-        assertEquals("epubcfi(/6/2!/4/1:99)", store.load("item-1"))
+        store.save("server-A", "item-1", "epubcfi(/6/2!/4/1:10)")
+        store.save("server-A", "item-1", "epubcfi(/6/2!/4/1:99)")
+        assertEquals("epubcfi(/6/2!/4/1:99)", store.load("server-A", "item-1"))
     }
 
     @Test
@@ -57,9 +61,31 @@ class ReadingPositionStoreTest {
         val dao = FakeReadingPositionDao()
         val store = ReadingPositionStoreImpl(dao)
         val before = System.currentTimeMillis()
-        store.save("item-1", "cfi")
+        store.save("server-A", "item-1", "cfi")
         val after = System.currentTimeMillis()
-        val ts = dao.store["item-1"]?.localUpdatedAt ?: 0L
+        val ts = dao.store["server-A" to "item-1"]?.localUpdatedAt ?: 0L
         assert(ts in before..after) { "Expected timestamp in [$before..$after] but was $ts" }
+    }
+
+    @Test
+    fun `positions for the same itemId on different servers are isolated`() = runTest {
+        val dao = FakeReadingPositionDao()
+        val store = ReadingPositionStoreImpl(dao)
+
+        store.save("server-A", "item-1", "epubcfi(/6/2!/4/1:10)")
+        store.save("server-B", "item-1", "epubcfi(/6/8!/4/1:99)")
+
+        assertEquals("epubcfi(/6/2!/4/1:10)", store.load("server-A", "item-1"))
+        assertEquals("epubcfi(/6/8!/4/1:99)", store.load("server-B", "item-1"))
+        assertNotEquals(store.load("server-A", "item-1"), store.load("server-B", "item-1"))
+    }
+
+    @Test
+    fun `load on a different server returns null even when itemId is saved elsewhere`() = runTest {
+        val dao = FakeReadingPositionDao().also {
+            it.seed(ReadingPositionEntity("server-A", "item-1", "epubcfi(/6/2!/4/1:42)"))
+        }
+        val store = ReadingPositionStoreImpl(dao)
+        assertNull(store.load("server-B", "item-1"))
     }
 }

--- a/core/data/src/test/kotlin/com/riffle/core/data/ReadingSessionIntegrationTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/ReadingSessionIntegrationTest.kt
@@ -62,10 +62,10 @@ class ReadingSessionIntegrationTest {
             override suspend fun deleteToken(serverId: String) = Unit
         },
         positionStore = object : ReadingPositionStore {
-            override suspend fun save(itemId: String, cfi: String) = Unit
-            override suspend fun load(itemId: String): String? = null
-            override suspend fun loadLocalUpdatedAt(itemId: String): Long = 0L
-            override suspend fun updateLocalTimestamp(itemId: String, millis: Long) = Unit
+            override suspend fun save(serverId: String, itemId: String, cfi: String) = Unit
+            override suspend fun load(serverId: String, itemId: String): String? = null
+            override suspend fun loadLocalUpdatedAt(serverId: String, itemId: String): Long = 0L
+            override suspend fun updateLocalTimestamp(serverId: String, itemId: String, millis: Long) = Unit
         },
     )
 

--- a/core/data/src/test/kotlin/com/riffle/core/data/SeriesIntegrationTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/SeriesIntegrationTest.kt
@@ -136,7 +136,17 @@ class SeriesIntegrationTest {
         collectionDao = FakeCollectionDao(),
         serverRepository = fakeServerRepository,
         tokenStorage = fakeTokenStorage,
+        readingSessionRepository = NoopReadingSessionRepository,
     )
+
+    private object NoopReadingSessionRepository : com.riffle.core.domain.ReadingSessionRepository {
+        override suspend fun syncProgress(itemId: String, payload: com.riffle.core.domain.SessionPayload) =
+            com.riffle.core.domain.SyncSessionResult.Success
+        override suspend fun runSyncCycle(itemId: String, payload: com.riffle.core.domain.SessionPayload) =
+            com.riffle.core.domain.ProgressSyncCycleResult.InSync
+        override suspend fun setProgress(itemId: String, progress: Float) = Unit
+        override suspend fun touchOpenTimestamp(itemId: String) = Unit
+    }
 
     // JSON matching a real Audiobookshelf /api/libraries/{id}/series?minified=1 response
     private val oneSeriesJson = """

--- a/core/database/schemas/com.riffle.core.database.RiffleDatabase/19.json
+++ b/core/database/schemas/com.riffle.core.database.RiffleDatabase/19.json
@@ -1,0 +1,465 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 19,
+    "identityHash": "ce3b30b48039331a0b96db922484857b",
+    "entities": [
+      {
+        "tableName": "servers",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `url` TEXT NOT NULL, `displayName` TEXT NOT NULL, `isActive` INTEGER NOT NULL, `insecureConnectionAllowed` INTEGER NOT NULL, `username` TEXT NOT NULL, `serverType` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "isActive",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "insecureConnectionAllowed",
+            "columnName": "insecureConnectionAllowed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "username",
+            "columnName": "username",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverType",
+            "columnName": "serverType",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "libraries",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `mediaType` TEXT NOT NULL, `serverId` TEXT NOT NULL, `isUnsupported` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaType",
+            "columnName": "mediaType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isUnsupported",
+            "columnName": "isUnsupported",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "library_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `title` TEXT NOT NULL, `author` TEXT NOT NULL, `coverUrl` TEXT, `readingProgress` REAL NOT NULL, `ebookFileIno` TEXT, `ebookFormat` TEXT NOT NULL, `description` TEXT, `seriesName` TEXT, `publishedYear` TEXT, `genres` TEXT NOT NULL, `publisher` TEXT, `lastOpenedAt` INTEGER, `addedAt` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "coverUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "readingProgress",
+            "columnName": "readingProgress",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ebookFileIno",
+            "columnName": "ebookFileIno",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "ebookFormat",
+            "columnName": "ebookFormat",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seriesName",
+            "columnName": "seriesName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "publishedYear",
+            "columnName": "publishedYear",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "genres",
+            "columnName": "genres",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "publisher",
+            "columnName": "publisher",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastOpenedAt",
+            "columnName": "lastOpenedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "series",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `name` TEXT NOT NULL, `coverUrl` TEXT, `bookCount` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "coverUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "bookCount",
+            "columnName": "bookCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "collections",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `name` TEXT NOT NULL, `bookCount` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookCount",
+            "columnName": "bookCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "series_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`seriesId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `sequenceOrder` REAL NOT NULL, PRIMARY KEY(`seriesId`, `itemId`))",
+        "fields": [
+          {
+            "fieldPath": "seriesId",
+            "columnName": "seriesId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sequenceOrder",
+            "columnName": "sequenceOrder",
+            "affinity": "REAL",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "seriesId",
+            "itemId"
+          ]
+        }
+      },
+      {
+        "tableName": "collection_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`collectionId` TEXT NOT NULL, `itemId` TEXT NOT NULL, PRIMARY KEY(`collectionId`, `itemId`))",
+        "fields": [
+          {
+            "fieldPath": "collectionId",
+            "columnName": "collectionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "collectionId",
+            "itemId"
+          ]
+        }
+      },
+      {
+        "tableName": "reading_positions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`serverId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `cfi` TEXT NOT NULL, `localUpdatedAt` INTEGER NOT NULL, PRIMARY KEY(`serverId`, `itemId`), FOREIGN KEY(`serverId`) REFERENCES `servers`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cfi",
+            "columnName": "cfi",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localUpdatedAt",
+            "columnName": "localUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "serverId",
+            "itemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_reading_positions_serverId",
+            "unique": false,
+            "columnNames": [
+              "serverId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_reading_positions_serverId` ON `${TABLE_NAME}` (`serverId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "servers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "serverId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "book_formatting_preferences",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`itemId` TEXT NOT NULL, `fontSize` REAL, `theme` TEXT, `fontFamily` TEXT, `lineSpacing` REAL, `margins` REAL, `orientation` TEXT, `showChapterMap` INTEGER, `showReadingProgressLabels` INTEGER, `doublePageSpread` INTEGER, `justifyText` INTEGER, PRIMARY KEY(`itemId`))",
+        "fields": [
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fontSize",
+            "columnName": "fontSize",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "theme",
+            "columnName": "theme",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "fontFamily",
+            "columnName": "fontFamily",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lineSpacing",
+            "columnName": "lineSpacing",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "margins",
+            "columnName": "margins",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "orientation",
+            "columnName": "orientation",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "showChapterMap",
+            "columnName": "showChapterMap",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "showReadingProgressLabels",
+            "columnName": "showReadingProgressLabels",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "doublePageSpread",
+            "columnName": "doublePageSpread",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "justifyText",
+            "columnName": "justifyText",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "itemId"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'ce3b30b48039331a0b96db922484857b')"
+    ]
+  }
+}

--- a/core/database/src/androidTest/kotlin/com/riffle/core/database/MigrationTest.kt
+++ b/core/database/src/androidTest/kotlin/com/riffle/core/database/MigrationTest.kt
@@ -478,6 +478,89 @@ class MigrationTest {
     }
 
     @Test
+    fun migration18To19_backfillsActiveServerIdAndCascadeDeletes() {
+        helper.createDatabase(TEST_DB, 18).use { db ->
+            db.execSQL(
+                "INSERT INTO servers (id, url, displayName, isActive, insecureConnectionAllowed, username, serverType) " +
+                    "VALUES ('s1', 'http://localhost', 'Server 1', 1, 0, 'alice', 'AUDIOBOOKSHELF')"
+            )
+            db.execSQL(
+                "INSERT INTO servers (id, url, displayName, isActive, insecureConnectionAllowed, username, serverType) " +
+                    "VALUES ('s2', 'http://other', 'Server 2', 0, 0, 'bob', 'AUDIOBOOKSHELF')"
+            )
+            db.execSQL(
+                "INSERT INTO reading_positions (itemId, cfi, localUpdatedAt) VALUES ('item-1', 'epubcfi(/6/4!/4/1:0)', 12345)"
+            )
+            db.execSQL(
+                "INSERT INTO reading_positions (itemId, cfi, localUpdatedAt) VALUES ('item-2', 'epubcfi(/6/8!/4/1:42)', 67890)"
+            )
+        }
+
+        val db = helper.runMigrationsAndValidate(TEST_DB, 19, true, RiffleDatabase.MIGRATION_18_19)
+
+        // Pre-existing rows are attributed to the active server.
+        db.query("SELECT serverId, itemId, cfi, localUpdatedAt FROM reading_positions ORDER BY itemId").use { cursor ->
+            assertEquals(2, cursor.count)
+            cursor.moveToFirst()
+            assertEquals("s1", cursor.getString(0))
+            assertEquals("item-1", cursor.getString(1))
+            assertEquals("epubcfi(/6/4!/4/1:0)", cursor.getString(2))
+            assertEquals(12345L, cursor.getLong(3))
+            cursor.moveToNext()
+            assertEquals("s1", cursor.getString(0))
+            assertEquals("item-2", cursor.getString(1))
+            assertEquals("epubcfi(/6/8!/4/1:42)", cursor.getString(2))
+            assertEquals(67890L, cursor.getLong(3))
+        }
+
+        // Different servers can now hold distinct positions for the same itemId.
+        db.execSQL(
+            "INSERT INTO reading_positions (serverId, itemId, cfi, localUpdatedAt) " +
+                "VALUES ('s2', 'item-1', 'epubcfi(/6/4!/4/1:999)', 99999)"
+        )
+        db.query("SELECT cfi FROM reading_positions WHERE serverId = 's1' AND itemId = 'item-1'").use { cursor ->
+            cursor.moveToFirst()
+            assertEquals("epubcfi(/6/4!/4/1:0)", cursor.getString(0))
+        }
+        db.query("SELECT cfi FROM reading_positions WHERE serverId = 's2' AND itemId = 'item-1'").use { cursor ->
+            cursor.moveToFirst()
+            assertEquals("epubcfi(/6/4!/4/1:999)", cursor.getString(0))
+        }
+
+        // FK cascade: deleting a server wipes that server's positions but leaves others untouched.
+        db.execSQL("PRAGMA foreign_keys = ON")
+        db.execSQL("DELETE FROM servers WHERE id = 's2'")
+        db.query("SELECT COUNT(*) FROM reading_positions WHERE serverId = 's2'").use { cursor ->
+            cursor.moveToFirst()
+            assertEquals(0, cursor.getInt(0))
+        }
+        db.query("SELECT COUNT(*) FROM reading_positions WHERE serverId = 's1'").use { cursor ->
+            cursor.moveToFirst()
+            assertEquals(2, cursor.getInt(0))
+        }
+    }
+
+    @Test
+    fun migration18To19_dropsRowsWhenNoActiveServer() {
+        helper.createDatabase(TEST_DB, 18).use { db ->
+            db.execSQL(
+                "INSERT INTO servers (id, url, displayName, isActive, insecureConnectionAllowed, username, serverType) " +
+                    "VALUES ('s1', 'http://localhost', 'Server 1', 0, 0, 'alice', 'AUDIOBOOKSHELF')"
+            )
+            db.execSQL(
+                "INSERT INTO reading_positions (itemId, cfi, localUpdatedAt) VALUES ('orphan', 'epubcfi(/6/4!/4/1:0)', 1)"
+            )
+        }
+
+        val db = helper.runMigrationsAndValidate(TEST_DB, 19, true, RiffleDatabase.MIGRATION_18_19)
+
+        db.query("SELECT COUNT(*) FROM reading_positions").use { cursor ->
+            cursor.moveToFirst()
+            assertEquals(0, cursor.getInt(0))
+        }
+    }
+
+    @Test
     fun migrateFullChain() {
         helper.createDatabase(TEST_DB, 1).use { db ->
             db.execSQL(
@@ -486,7 +569,7 @@ class MigrationTest {
         }
 
         val db = helper.runMigrationsAndValidate(
-            TEST_DB, 18, true,
+            TEST_DB, 19, true,
             RiffleDatabase.MIGRATION_1_2,
             RiffleDatabase.MIGRATION_2_3,
             RiffleDatabase.MIGRATION_3_4,
@@ -504,6 +587,7 @@ class MigrationTest {
             RiffleDatabase.MIGRATION_15_16,
             RiffleDatabase.MIGRATION_16_17,
             RiffleDatabase.MIGRATION_17_18,
+            RiffleDatabase.MIGRATION_18_19,
         )
 
         db.query("SELECT url, displayName, username, serverType FROM servers WHERE id = 's1'").use { cursor ->

--- a/core/database/src/main/kotlin/com/riffle/core/database/ReadingPositionDao.kt
+++ b/core/database/src/main/kotlin/com/riffle/core/database/ReadingPositionDao.kt
@@ -11,9 +11,9 @@ interface ReadingPositionDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun upsert(entity: ReadingPositionEntity)
 
-    @Query("SELECT * FROM reading_positions WHERE itemId = :itemId LIMIT 1")
-    suspend fun getByItemId(itemId: String): ReadingPositionEntity?
+    @Query("SELECT * FROM reading_positions WHERE serverId = :serverId AND itemId = :itemId LIMIT 1")
+    suspend fun getByItemId(serverId: String, itemId: String): ReadingPositionEntity?
 
-    @Query("UPDATE reading_positions SET localUpdatedAt = :millis WHERE itemId = :itemId")
-    suspend fun updateLocalTimestamp(itemId: String, millis: Long)
+    @Query("UPDATE reading_positions SET localUpdatedAt = :millis WHERE serverId = :serverId AND itemId = :itemId")
+    suspend fun updateLocalTimestamp(serverId: String, itemId: String, millis: Long)
 }

--- a/core/database/src/main/kotlin/com/riffle/core/database/ReadingPositionEntity.kt
+++ b/core/database/src/main/kotlin/com/riffle/core/database/ReadingPositionEntity.kt
@@ -1,11 +1,25 @@
 package com.riffle.core.database
 
 import androidx.room.Entity
-import androidx.room.PrimaryKey
+import androidx.room.ForeignKey
+import androidx.room.Index
 
-@Entity(tableName = "reading_positions")
+@Entity(
+    tableName = "reading_positions",
+    primaryKeys = ["serverId", "itemId"],
+    foreignKeys = [
+        ForeignKey(
+            entity = ServerEntity::class,
+            parentColumns = ["id"],
+            childColumns = ["serverId"],
+            onDelete = ForeignKey.CASCADE,
+        ),
+    ],
+    indices = [Index("serverId")],
+)
 data class ReadingPositionEntity(
-    @PrimaryKey val itemId: String,
+    val serverId: String,
+    val itemId: String,
     val cfi: String,
     val localUpdatedAt: Long = 0,
 )

--- a/core/database/src/main/kotlin/com/riffle/core/database/RiffleDatabase.kt
+++ b/core/database/src/main/kotlin/com/riffle/core/database/RiffleDatabase.kt
@@ -17,7 +17,7 @@ import androidx.sqlite.db.SupportSQLiteDatabase
         ReadingPositionEntity::class,
         BookFormattingPreferencesEntity::class,
     ],
-    version = 18,
+    version = 19,
     exportSchema = true,
 )
 abstract class RiffleDatabase : RoomDatabase() {
@@ -176,9 +176,6 @@ abstract class RiffleDatabase : RoomDatabase() {
             }
         }
 
-        // Make all non-PK columns nullable so a per-book row can store sparse overrides — null
-        // on a column means "follow the global setting." Existing rows are preserved verbatim,
-        // which keeps customised books behaving the same; only new writes use the sparse form.
         val MIGRATION_15_16 = object : Migration(15, 16) {
             override fun migrate(db: SupportSQLiteDatabase) {
                 db.execSQL(
@@ -220,6 +217,38 @@ abstract class RiffleDatabase : RoomDatabase() {
         val MIGRATION_17_18 = object : Migration(17, 18) {
             override fun migrate(db: SupportSQLiteDatabase) {
                 db.execSQL("ALTER TABLE `servers` ADD COLUMN `serverType` TEXT NOT NULL DEFAULT 'AUDIOBOOKSHELF'")
+            }
+        }
+
+        // Scope reading_positions by serverId so the same itemId can hold distinct positions
+        // for different ABS accounts (or different servers). Rows from the previous schema are
+        // backfilled to the currently-active server when one exists; if there's no active server
+        // we drop the rows — they can't be attributed to any user, and the next sync will refetch.
+        // The new FK to servers(id) cascade-deletes positions when a server is removed.
+        val MIGRATION_18_19 = object : Migration(18, 19) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                val activeServerId: String? = db.query("SELECT id FROM servers WHERE isActive = 1 LIMIT 1").use { c ->
+                    if (c.moveToFirst()) c.getString(0) else null
+                }
+                db.execSQL(
+                    "CREATE TABLE IF NOT EXISTS `reading_positions_new` (" +
+                        "`serverId` TEXT NOT NULL, " +
+                        "`itemId` TEXT NOT NULL, " +
+                        "`cfi` TEXT NOT NULL, " +
+                        "`localUpdatedAt` INTEGER NOT NULL, " +
+                        "PRIMARY KEY(`serverId`, `itemId`), " +
+                        "FOREIGN KEY(`serverId`) REFERENCES `servers`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE)"
+                )
+                if (activeServerId != null) {
+                    db.execSQL(
+                        "INSERT INTO `reading_positions_new` (serverId, itemId, cfi, localUpdatedAt) " +
+                            "SELECT ?, itemId, cfi, localUpdatedAt FROM `reading_positions`",
+                        arrayOf<Any>(activeServerId),
+                    )
+                }
+                db.execSQL("DROP TABLE `reading_positions`")
+                db.execSQL("ALTER TABLE `reading_positions_new` RENAME TO `reading_positions`")
+                db.execSQL("CREATE INDEX IF NOT EXISTS `index_reading_positions_serverId` ON `reading_positions` (`serverId`)")
             }
         }
     }

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/ReadingPositionStore.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/ReadingPositionStore.kt
@@ -1,8 +1,8 @@
 package com.riffle.core.domain
 
 interface ReadingPositionStore {
-    suspend fun save(itemId: String, cfi: String)
-    suspend fun load(itemId: String): String?
-    suspend fun loadLocalUpdatedAt(itemId: String): Long
-    suspend fun updateLocalTimestamp(itemId: String, millis: Long)
+    suspend fun save(serverId: String, itemId: String, cfi: String)
+    suspend fun load(serverId: String, itemId: String): String?
+    suspend fun loadLocalUpdatedAt(serverId: String, itemId: String): Long
+    suspend fun updateLocalTimestamp(serverId: String, itemId: String, millis: Long)
 }

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/ReadingSessionRepository.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/ReadingSessionRepository.kt
@@ -4,4 +4,14 @@ interface ReadingSessionRepository {
     suspend fun syncProgress(itemId: String, payload: SessionPayload): SyncSessionResult
     suspend fun runSyncCycle(itemId: String, payload: SessionPayload): ProgressSyncCycleResult
     suspend fun setProgress(itemId: String, progress: Float)
+
+    /**
+     * Notify the ABS server that this user has just (re-)opened the item — used to drive the
+     * cross-device "In Progress" sort. Reads the server's current `mediaProgress` for the item
+     * and PATCHes back the same `ebookLocation` + `ebookProgress`, which bumps the server-side
+     * `lastUpdate` without ever clobbering a position another device may have advanced. Best
+     * effort: if offline or no active server, the call is a no-op — the local `lastOpenedAt`
+     * stamp survives and lifts the server timestamp via max() on the next successful refresh.
+     */
+    suspend fun touchOpenTimestamp(itemId: String)
 }

--- a/core/domain/src/test/kotlin/com/riffle/core/domain/ReadingSessionControllerTest.kt
+++ b/core/domain/src/test/kotlin/com/riffle/core/domain/ReadingSessionControllerTest.kt
@@ -23,6 +23,7 @@ class ReadingSessionControllerTest {
         override suspend fun syncProgress(itemId: String, payload: SessionPayload) = syncResult
         override suspend fun runSyncCycle(itemId: String, payload: SessionPayload): ProgressSyncCycleResult = ProgressSyncCycleResult.InSync
         override suspend fun setProgress(itemId: String, progress: Float) = Unit
+        override suspend fun touchOpenTimestamp(itemId: String) = Unit
     }
 
     @Test
@@ -38,6 +39,7 @@ class ReadingSessionControllerTest {
                 }
                 override suspend fun runSyncCycle(itemId: String, payload: SessionPayload): ProgressSyncCycleResult = ProgressSyncCycleResult.InSync
                 override suspend fun setProgress(itemId: String, progress: Float) = Unit
+                override suspend fun touchOpenTimestamp(itemId: String) = Unit
             },
             scope,
         )
@@ -84,6 +86,7 @@ class ReadingSessionControllerTest {
                 }
                 override suspend fun runSyncCycle(itemId: String, payload: SessionPayload): ProgressSyncCycleResult = ProgressSyncCycleResult.InSync
                 override suspend fun setProgress(itemId: String, progress: Float) = Unit
+                override suspend fun touchOpenTimestamp(itemId: String) = Unit
             },
             scope,
         )

--- a/core/network/src/main/kotlin/com/riffle/core/network/AbsApiClient.kt
+++ b/core/network/src/main/kotlin/com/riffle/core/network/AbsApiClient.kt
@@ -126,10 +126,15 @@ class AbsApiClient(private val httpClient: OkHttpClient) : AbsApi, AbsLibraryApi
                 IOException("Empty response body")
             )
             val parsed = json.decodeFromString<AbsMeResponse>(raw)
-            val progressMap = parsed.mediaProgress
+            val byItemId = parsed.mediaProgress
                 .filter { it.libraryItemId.isNotEmpty() }
-                .associate { it.libraryItemId to (it.ebookProgress ?: it.progress) }
-            NetworkUserProgressResult.Success(progressMap)
+                .associate {
+                    it.libraryItemId to NetworkUserMediaProgress(
+                        ebookProgress = it.ebookProgress ?: it.progress,
+                        lastUpdate = it.lastUpdate,
+                    )
+                }
+            NetworkUserProgressResult.Success(byItemId)
         } catch (e: Exception) {
             NetworkUserProgressResult.NetworkError(e)
         }

--- a/core/network/src/main/kotlin/com/riffle/core/network/AbsLibraryApi.kt
+++ b/core/network/src/main/kotlin/com/riffle/core/network/AbsLibraryApi.kt
@@ -1,7 +1,12 @@
 package com.riffle.core.network
 
+data class NetworkUserMediaProgress(
+    val ebookProgress: Float?,
+    val lastUpdate: Long?,
+)
+
 sealed class NetworkUserProgressResult {
-    data class Success(val progressByItemId: Map<String, Float>) : NetworkUserProgressResult()
+    data class Success(val byItemId: Map<String, NetworkUserMediaProgress>) : NetworkUserProgressResult()
     data class NetworkError(val cause: Throwable) : NetworkUserProgressResult()
 }
 
@@ -10,7 +15,7 @@ interface AbsLibraryApi {
         baseUrl: String,
         token: String,
         insecureAllowed: Boolean,
-    ): NetworkUserProgressResult = NetworkUserProgressResult.Success(emptyMap())
+    ): NetworkUserProgressResult = NetworkUserProgressResult.Success(emptyMap<String, NetworkUserMediaProgress>())
 
     suspend fun getLibraries(
         baseUrl: String,

--- a/core/network/src/main/kotlin/com/riffle/core/network/model/AbsMeResponse.kt
+++ b/core/network/src/main/kotlin/com/riffle/core/network/model/AbsMeResponse.kt
@@ -11,5 +11,6 @@ internal data class AbsMeResponse(
         val libraryItemId: String = "",
         val ebookProgress: Float? = null,
         val progress: Float = 0f,
+        val lastUpdate: Long? = null,
     )
 }

--- a/core/network/src/test/kotlin/com/riffle/core/network/AbsApiClientLibraryTest.kt
+++ b/core/network/src/test/kotlin/com/riffle/core/network/AbsApiClientLibraryTest.kt
@@ -169,4 +169,51 @@ class AbsApiClientLibraryTest {
         val success = result as NetworkLibraryItemsResult.Success
         assertNull(success.items[0].addedAt)
     }
+
+    // --- /api/me mediaProgress.lastUpdate (drives cross-device "In Progress" sort) ---
+
+    @Test
+    fun `getUserProgress parses lastUpdate from real-shaped mediaProgress entries`() = runTest {
+        // Body modelled on a real ABS /api/me response — extra fields ignored, lastUpdate captured.
+        server.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .addHeader("Content-Type", "application/json")
+                .setBody(
+                    """{"mediaProgress":[
+                        {"id":"p1","userId":"u","libraryItemId":"item-1","mediaItemType":"book",
+                         "progress":0.0,"ebookProgress":0.015625,"isFinished":false,
+                         "lastUpdate":1780170049396,"startedAt":1779780482497},
+                        {"id":"p2","userId":"u","libraryItemId":"item-2","mediaItemType":"book",
+                         "progress":0.0,"ebookProgress":0.5,"isFinished":false,
+                         "lastUpdate":1779642817411}
+                    ]}""".trimIndent()
+                )
+        )
+
+        val result = client.getUserProgress(server.url("/").toString().trimEnd('/'), "tok", false)
+
+        assertTrue(result is NetworkUserProgressResult.Success)
+        val byItemId = (result as NetworkUserProgressResult.Success).byItemId
+        assertEquals(2, byItemId.size)
+        assertEquals(1_780_170_049_396L, byItemId["item-1"]?.lastUpdate)
+        assertEquals(0.015625f, byItemId["item-1"]?.ebookProgress)
+        assertEquals(1_779_642_817_411L, byItemId["item-2"]?.lastUpdate)
+    }
+
+    @Test
+    fun `getUserProgress yields null lastUpdate when field is absent`() = runTest {
+        server.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .addHeader("Content-Type", "application/json")
+                .setBody("""{"mediaProgress":[{"libraryItemId":"item-1","ebookProgress":0.25}]}""")
+        )
+
+        val result = client.getUserProgress(server.url("/").toString().trimEnd('/'), "tok", false)
+
+        val byItemId = (result as NetworkUserProgressResult.Success).byItemId
+        assertNull(byItemId["item-1"]?.lastUpdate)
+        assertEquals(0.25f, byItemId["item-1"]?.ebookProgress)
+    }
 }


### PR DESCRIPTION
## Summary

Two related bugs in cross-device reading state, each fixed in a focused commit on this branch:

### 1. Reading positions were shared between users on the same server
`ReadingPositionEntity` was keyed solely by `itemId`. Two ABS accounts on one server (or, in theory, the same itemId across servers) saw each other's positions, and ADR-0008's last-update-wins sync could PATCH one user's position onto another user's server-side record.

- `reading_positions` now uses composite PK `(serverId, itemId)`, FK to `servers(id) ON DELETE CASCADE`, indexed on `serverId`.
- `ReadingPositionStore` / DAO / callers (`EpubRepositoryImpl`, `PdfRepositoryImpl`, `ReadingSessionRepositoryImpl`) all thread `serverId` explicitly via `serverRepository.getActive()`.
- Migration `18 → 19` backfills existing rows to the currently-active server, or drops them when none is active (next sync re-pulls). New `MigrationTest` cases + extended `migrateFullChain`.
- `book_formatting_preferences` left per-device by design — per project decision saved in agent memory.

### 2. "In Progress" sort didn't agree across devices
`lastOpenedAt` was stamped purely locally on the device that tapped Read. Device B never saw the update.

- **Pull**: `AbsMediaProgressDto` now surfaces `lastUpdate`. On refresh, `lastOpenedAt = max(local, server.mediaProgress.lastUpdate)`.
- **Push**: `LibraryRepositoryImpl.markItemOpened` also calls a new `ReadingSessionRepository.touchOpenTimestamp(itemId)`. It does a round-trip: `GET /api/me/progress/:id` → `PATCH` back the **same** `ebookLocation` + `ebookProgress`. ABS bumps server `lastUpdate` without ever clobbering a position another device has advanced (verified live against `media-server:13378`). Offline failures are swallowed; the local stamp lifts via `max()` on the next successful refresh.

## Test plan

- [x] `:core:network:test` — new `getUserProgress` wire-format tests for `mediaProgress.lastUpdate` parsing (present + absent).
- [x] `:core:data:testDebugUnitTest`
  - `ReadingPositionStoreTest` — new cross-server isolation test for same `itemId`.
  - `ProgressSyncCycleTest` — new `touchOpenTimestamp` PATCH-preserves-content + no-op-on-GET-failure.
  - `ProgressSyncIntegrationTest` — new e2e `touchOpenTimestamp` via MockWebServer.
  - `LibraryRepositoryTest` — refresh server-newer-wins, refresh local-newer-wins, `markItemOpened` delegates push.
- [x] `:core:database:testDebugUnitTest`
- [x] `:app:testDebugUnitTest`
- [x] `make harness-test` — 124/126 pass. Two failures are **pre-existing on `main`** and unrelated to this PR (no code path overlap):
  - `WakeLockHarnessTest.wakeLockIsOffWhenDisabledInSettings` (confirmed pre-existing on baseline earlier in the session).
  - `TypographyOverrideWebViewTest.marginsOverrideAppliesVerticalPaddingToRootWhenUserVariableIsSet` — EPUB CSS padding assertion (`expected:<20.0> but was:<40.0>`); this PR touches only the data/network/sync layer, no reader CSS or margins logic.
- [ ] Manual smoke on two devices: read on Device A, refresh on Device B, confirm "In Progress" reorders.
- [ ] Manual smoke on logout/login as a different ABS user on the same server: confirm positions don't leak across accounts.

## Verified against ABS

Live verification on `media-server:13378`:
- `GET /api/me` returns each `mediaProgress` entry with `lastUpdate: <millis>` matching the new DTO.
- `PATCH /api/me/progress/<id>` with identical `ebookLocation` + `ebookProgress` bumps `lastUpdate` server-side (1780170049396 → 1780220410221) without changing the stored position.