### PR TITLE
fix(library): retry refresh while server is unreachable

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/library/CollectionDetailViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/CollectionDetailViewModel.kt
@@ -16,9 +16,11 @@ import com.riffle.core.domain.PdfRepository
 import com.riffle.core.domain.ServerRepository
 import com.riffle.core.domain.TokenStorage
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.filter
@@ -73,17 +75,37 @@ class CollectionDetailViewModel @Inject constructor(
                 .filter { it }
                 .collect { refresh() }
         }
+        // Retry while the last refresh failed AND the device is online (server unreachable on
+        // an otherwise-healthy network). When the device itself is offline we skip polling —
+        // the on-reconnect listener above already triggers a refresh when connectivity returns.
+        viewModelScope.launch {
+            combine(_refreshFailed, connectivityObserver.isOnline) { failed, online -> failed && online }
+                .collectLatest { shouldPoll ->
+                    if (shouldPoll) {
+                        while (true) {
+                            delay(FAILED_REFRESH_RETRY_INTERVAL_MS)
+                            runRefresh()
+                        }
+                    }
+                }
+        }
     }
 
     fun refresh() {
-        viewModelScope.launch {
-            _refreshFailed.value = libraryRepository.refreshCollections(libraryId) is LibraryRefreshResult.NetworkError
-        }
+        viewModelScope.launch { runRefresh() }
+    }
+
+    private suspend fun runRefresh() {
+        _refreshFailed.value = libraryRepository.refreshCollections(libraryId) is LibraryRefreshResult.NetworkError
     }
 
     private fun isAvailableOffline(item: LibraryItem): Boolean = when (item.ebookFormat) {
         EbookFormat.Epub -> epubRepository.isDownloaded(item.id) || epubRepository.isCached(item.id)
         EbookFormat.Pdf -> pdfRepository.isDownloaded(item.id) || pdfRepository.isCached(item.id)
         else -> false
+    }
+
+    private companion object {
+        const val FAILED_REFRESH_RETRY_INTERVAL_MS = 10_000L
     }
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsViewModel.kt
@@ -21,11 +21,14 @@ import com.riffle.core.domain.TokenStorage
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.drop
@@ -203,6 +206,23 @@ class LibraryItemsViewModel @Inject constructor(
                     toReadRepository.refresh(libraryId)
                 }
         }
+        // While a refresh is failing AND the device is online (i.e. server unreachable on an
+        // otherwise-healthy network), retry periodically so the banner clears on its own once
+        // the server returns. We do NOT poll when the device itself is offline — the
+        // on-reconnect listener above already triggers a refresh when connectivity returns —
+        // and we do NOT poll in the healthy state, since stale data on screen is still
+        // accurate until the user next interacts.
+        viewModelScope.launch {
+            combine(_refreshFailed, connectivityObserver.isOnline) { failed, online -> failed && online }
+                .collectLatest { shouldPoll ->
+                    if (shouldPoll) {
+                        while (true) {
+                            delay(FAILED_REFRESH_RETRY_INTERVAL_MS)
+                            runRefresh()
+                        }
+                    }
+                }
+        }
     }
 
     fun onSearchQueryChange(query: String) {
@@ -210,16 +230,18 @@ class LibraryItemsViewModel @Inject constructor(
     }
 
     fun refresh() {
-        viewModelScope.launch {
-            val itemsDeferred = async { libraryRepository.refreshLibraryItems(libraryId) }
-            val seriesDeferred = async { libraryRepository.refreshSeries(libraryId) }
-            val collectionsDeferred = async { libraryRepository.refreshCollections(libraryId) }
-            // ToRead refresh runs alongside but its failure must NOT flip the offline banner.
-            val toReadDeferred = async { toReadRepository.refresh(libraryId) }
-            val results = listOf(itemsDeferred.await(), seriesDeferred.await(), collectionsDeferred.await())
-            toReadDeferred.await()
-            _refreshFailed.value = results.any { it is LibraryRefreshResult.NetworkError }
-        }
+        viewModelScope.launch { runRefresh() }
+    }
+
+    private suspend fun runRefresh() = coroutineScope {
+        val itemsDeferred = async { libraryRepository.refreshLibraryItems(libraryId) }
+        val seriesDeferred = async { libraryRepository.refreshSeries(libraryId) }
+        val collectionsDeferred = async { libraryRepository.refreshCollections(libraryId) }
+        // ToRead refresh runs alongside but its failure must NOT flip the offline banner.
+        val toReadDeferred = async { toReadRepository.refresh(libraryId) }
+        val results = listOf(itemsDeferred.await(), seriesDeferred.await(), collectionsDeferred.await())
+        toReadDeferred.await()
+        _refreshFailed.value = results.any { it is LibraryRefreshResult.NetworkError }
     }
 
     private fun filterCollectionsOffline(collections: List<Collection>, offline: Boolean): Flow<List<Collection>> {
@@ -244,5 +266,9 @@ class LibraryItemsViewModel @Inject constructor(
         EbookFormat.Epub -> epubRepository.isDownloaded(item.id) || epubRepository.isCached(item.id)
         EbookFormat.Pdf -> pdfRepository.isDownloaded(item.id) || pdfRepository.isCached(item.id)
         else -> false
+    }
+
+    private companion object {
+        const val FAILED_REFRESH_RETRY_INTERVAL_MS = 10_000L
     }
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/library/SeriesDetailViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/SeriesDetailViewModel.kt
@@ -16,9 +16,11 @@ import com.riffle.core.domain.PdfRepository
 import com.riffle.core.domain.ServerRepository
 import com.riffle.core.domain.TokenStorage
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.filter
@@ -73,17 +75,37 @@ class SeriesDetailViewModel @Inject constructor(
                 .filter { it }
                 .collect { refresh() }
         }
+        // Retry while the last refresh failed AND the device is online (server unreachable on
+        // an otherwise-healthy network). When the device itself is offline we skip polling —
+        // the on-reconnect listener above already triggers a refresh when connectivity returns.
+        viewModelScope.launch {
+            combine(_refreshFailed, connectivityObserver.isOnline) { failed, online -> failed && online }
+                .collectLatest { shouldPoll ->
+                    if (shouldPoll) {
+                        while (true) {
+                            delay(FAILED_REFRESH_RETRY_INTERVAL_MS)
+                            runRefresh()
+                        }
+                    }
+                }
+        }
     }
 
     fun refresh() {
-        viewModelScope.launch {
-            _refreshFailed.value = libraryRepository.refreshSeries(libraryId) is LibraryRefreshResult.NetworkError
-        }
+        viewModelScope.launch { runRefresh() }
+    }
+
+    private suspend fun runRefresh() {
+        _refreshFailed.value = libraryRepository.refreshSeries(libraryId) is LibraryRefreshResult.NetworkError
     }
 
     private fun isAvailableOffline(item: LibraryItem): Boolean = when (item.ebookFormat) {
         EbookFormat.Epub -> epubRepository.isDownloaded(item.id) || epubRepository.isCached(item.id)
         EbookFormat.Pdf -> pdfRepository.isDownloaded(item.id) || pdfRepository.isCached(item.id)
         else -> false
+    }
+
+    private companion object {
+        const val FAILED_REFRESH_RETRY_INTERVAL_MS = 10_000L
     }
 }

--- a/app/src/test/kotlin/com/riffle/app/feature/library/CollectionDetailViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/CollectionDetailViewModelTest.kt
@@ -202,11 +202,14 @@ class CollectionDetailViewModelTest {
     @Test
     fun `polls every 10 seconds while refresh is failing`() = runTest {
         var refreshCount = 0
+        var result: LibraryRefreshResult = LibraryRefreshResult.NetworkError(RuntimeException("boom"))
         val vm = makeVm(
-            libraryRepository = countingRepo({ LibraryRefreshResult.NetworkError(RuntimeException("boom")) }) { refreshCount++ },
+            libraryRepository = countingRepo({ result }) { refreshCount++ },
         )
         backgroundScope.launch { vm.isOffline.collect {} }
-        testDispatcher.scheduler.advanceUntilIdle()
+        // advanceUntilIdle() would hang here — once _refreshFailed is true the polling
+        // coroutine schedules an endless delay→refresh chain, so the scheduler is never idle.
+        testDispatcher.scheduler.runCurrent()
         assertEquals(true, vm.isOffline.value)
         val baseline = refreshCount
         testDispatcher.scheduler.advanceTimeBy(10_001)
@@ -215,6 +218,11 @@ class CollectionDetailViewModelTest {
         testDispatcher.scheduler.advanceTimeBy(10_000)
         testDispatcher.scheduler.runCurrent()
         assertEquals(baseline + 2, refreshCount)
+        // Stop polling before runTest tears down — its scheduler-drain step would otherwise
+        // chase the endless delay→refresh chain and time out.
+        result = LibraryRefreshResult.Success
+        testDispatcher.scheduler.advanceTimeBy(10_001)
+        testDispatcher.scheduler.runCurrent()
     }
 
     @Test
@@ -242,7 +250,7 @@ class CollectionDetailViewModelTest {
             libraryRepository = countingRepo({ result }) { refreshCount++ },
         )
         backgroundScope.launch { vm.isOffline.collect {} }
-        testDispatcher.scheduler.advanceUntilIdle()
+        testDispatcher.scheduler.runCurrent()
         assertEquals(true, vm.isOffline.value)
 
         result = LibraryRefreshResult.Success

--- a/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemsViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemsViewModelTest.kt
@@ -729,11 +729,14 @@ class LibraryItemsViewModelTest {
     @Test
     fun `polls every 10 seconds while refresh is failing`() = runTest {
         var refreshCount = 0
+        var result: LibraryRefreshResult = LibraryRefreshResult.NetworkError(RuntimeException("boom"))
         val vm = makeViewModel(
-            libraryRepository = countingRepo({ LibraryRefreshResult.NetworkError(RuntimeException("boom")) }) { refreshCount++ },
+            libraryRepository = countingRepo({ result }) { refreshCount++ },
         )
         backgroundScope.launch { vm.isOffline.collect {} }
-        testDispatcher.scheduler.advanceUntilIdle()
+        // advanceUntilIdle() would hang here — once _refreshFailed is true the polling
+        // coroutine schedules an endless delay→refresh chain, so the scheduler is never idle.
+        testDispatcher.scheduler.runCurrent()
         assertEquals(true, vm.isOffline.value)
         val baseline = refreshCount
         testDispatcher.scheduler.advanceTimeBy(10_001)
@@ -742,6 +745,11 @@ class LibraryItemsViewModelTest {
         testDispatcher.scheduler.advanceTimeBy(10_000)
         testDispatcher.scheduler.runCurrent()
         assertEquals(baseline + 2, refreshCount)
+        // Stop polling before runTest tears down — its scheduler-drain step would otherwise
+        // chase the endless delay→refresh chain and time out.
+        result = LibraryRefreshResult.Success
+        testDispatcher.scheduler.advanceTimeBy(10_001)
+        testDispatcher.scheduler.runCurrent()
     }
 
     @Test
@@ -768,7 +776,7 @@ class LibraryItemsViewModelTest {
             libraryRepository = countingRepo({ result }) { refreshCount++ },
         )
         backgroundScope.launch { vm.isOffline.collect {} }
-        testDispatcher.scheduler.advanceUntilIdle()
+        testDispatcher.scheduler.runCurrent()
         assertEquals(true, vm.isOffline.value)
 
         result = LibraryRefreshResult.Success

--- a/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemsViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemsViewModelTest.kt
@@ -681,6 +681,107 @@ class LibraryItemsViewModelTest {
         assertEquals(false, vm.isOffline.value)
     }
 
+    // --- periodic retry while refresh is failing ---
+
+    private fun countingRepo(
+        refreshResult: () -> LibraryRefreshResult,
+        onRefreshCall: () -> Unit = {},
+    ): LibraryRepository = object : LibraryRepository {
+        override fun observeLibraries(): Flow<List<Library>> = MutableStateFlow(emptyList())
+        override fun observeLibraryItems(libraryId: String): Flow<List<LibraryItem>> = allItemsFlow
+        override fun observeUngroupedLibraryItems(libraryId: String): Flow<List<LibraryItem>> = itemsFlow
+        override fun observeInProgressItems(libraryId: String): Flow<List<LibraryItem>> = inProgressFlow
+        override fun observeFinishedItems(libraryId: String): Flow<List<LibraryItem>> = finishedFlow
+        override fun observeRecentlyAddedItems(libraryId: String): Flow<List<LibraryItem>> = recentlyAddedFlow
+        override fun observeAllBooks(libraryId: String): Flow<List<LibraryItem>> = allBooksFlow
+        override fun observeSeries(libraryId: String): Flow<List<Series>> = seriesFlow
+        override fun observeCollections(libraryId: String): Flow<List<Collection>> = collectionsFlow
+        override fun observeSeriesItems(seriesId: String): Flow<List<LibraryItem>> =
+            seriesItemsBySeriesId.getOrPut(seriesId) { MutableStateFlow(emptyList()) }
+        override fun observeCollectionItems(collectionId: String): Flow<List<LibraryItem>> =
+            collectionItemsByCollectionId.getOrPut(collectionId) { MutableStateFlow(emptyList()) }
+        override suspend fun getItem(itemId: String): LibraryItem? = null
+        override suspend fun markItemOpened(itemId: String) {}
+        override suspend fun updateReadingProgress(itemId: String, progress: Float) {}
+        override suspend fun refreshLibraries() = LibraryRefreshResult.Success
+        override suspend fun refreshLibraryItems(libraryId: String): LibraryRefreshResult {
+            onRefreshCall(); return refreshResult()
+        }
+        override suspend fun refreshSeries(libraryId: String) = refreshResult()
+        override suspend fun refreshCollections(libraryId: String) = refreshResult()
+    }
+
+    @Test
+    fun `does not poll while refresh keeps succeeding`() = runTest {
+        var refreshCount = 0
+        val vm = makeViewModel(
+            libraryRepository = countingRepo({ LibraryRefreshResult.Success }) { refreshCount++ },
+        )
+        backgroundScope.launch { vm.isOffline.collect {} }
+        testDispatcher.scheduler.advanceUntilIdle()
+        val baseline = refreshCount
+        // Idle for far longer than the retry interval — no extra refreshes should fire.
+        testDispatcher.scheduler.advanceTimeBy(60_000)
+        testDispatcher.scheduler.runCurrent()
+        assertEquals(baseline, refreshCount)
+    }
+
+    @Test
+    fun `polls every 10 seconds while refresh is failing`() = runTest {
+        var refreshCount = 0
+        val vm = makeViewModel(
+            libraryRepository = countingRepo({ LibraryRefreshResult.NetworkError(RuntimeException("boom")) }) { refreshCount++ },
+        )
+        backgroundScope.launch { vm.isOffline.collect {} }
+        testDispatcher.scheduler.advanceUntilIdle()
+        assertEquals(true, vm.isOffline.value)
+        val baseline = refreshCount
+        testDispatcher.scheduler.advanceTimeBy(10_001)
+        testDispatcher.scheduler.runCurrent()
+        assertEquals(baseline + 1, refreshCount)
+        testDispatcher.scheduler.advanceTimeBy(10_000)
+        testDispatcher.scheduler.runCurrent()
+        assertEquals(baseline + 2, refreshCount)
+    }
+
+    @Test
+    fun `does not poll while device is offline`() = runTest {
+        var refreshCount = 0
+        val vm = makeViewModel(
+            libraryRepository = countingRepo({ LibraryRefreshResult.NetworkError(RuntimeException("boom")) }) { refreshCount++ },
+            connectivityObserver = FakeConnectivityObserver(online = false),
+        )
+        backgroundScope.launch { vm.isOffline.collect {} }
+        testDispatcher.scheduler.advanceUntilIdle()
+        assertEquals(true, vm.isOffline.value)
+        val baseline = refreshCount
+        testDispatcher.scheduler.advanceTimeBy(60_000)
+        testDispatcher.scheduler.runCurrent()
+        assertEquals(baseline, refreshCount)
+    }
+
+    @Test
+    fun `polling stops once a retry succeeds`() = runTest {
+        var refreshCount = 0
+        var result: LibraryRefreshResult = LibraryRefreshResult.NetworkError(RuntimeException("boom"))
+        val vm = makeViewModel(
+            libraryRepository = countingRepo({ result }) { refreshCount++ },
+        )
+        backgroundScope.launch { vm.isOffline.collect {} }
+        testDispatcher.scheduler.advanceUntilIdle()
+        assertEquals(true, vm.isOffline.value)
+
+        result = LibraryRefreshResult.Success
+        testDispatcher.scheduler.advanceTimeBy(10_001)
+        testDispatcher.scheduler.runCurrent()
+        assertEquals(false, vm.isOffline.value)
+
+        val countAfterRecovery = refreshCount
+        testDispatcher.scheduler.advanceTimeBy(60_000)
+        testDispatcher.scheduler.runCurrent()
+        assertEquals(countAfterRecovery, refreshCount)
+    }
+
     @Test
     fun `filteredRecentlyAdded when offline cap still applies after filtering`() = runTest {
         val downloadedIds = (1..60).map { "id-Book $it" }.toSet()

--- a/app/src/test/kotlin/com/riffle/app/feature/library/SeriesDetailViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/SeriesDetailViewModelTest.kt
@@ -139,9 +139,12 @@ class SeriesDetailViewModelTest {
     @Test
     fun `polls every 10 seconds while refresh is failing`() = runTest {
         var refreshCount = 0
-        val vm = makeVm(countingRepo({ LibraryRefreshResult.NetworkError(RuntimeException("boom")) }) { refreshCount++ })
+        var result: LibraryRefreshResult = LibraryRefreshResult.NetworkError(RuntimeException("boom"))
+        val vm = makeVm(countingRepo({ result }) { refreshCount++ })
         backgroundScope.launch { vm.isOffline.collect {} }
-        testDispatcher.scheduler.advanceUntilIdle()
+        // advanceUntilIdle() would hang here — once _refreshFailed is true the polling
+        // coroutine schedules an endless delay→refresh chain, so the scheduler is never idle.
+        testDispatcher.scheduler.runCurrent()
         assertEquals(true, vm.isOffline.value)
         val baseline = refreshCount
         testDispatcher.scheduler.advanceTimeBy(10_001)
@@ -150,6 +153,11 @@ class SeriesDetailViewModelTest {
         testDispatcher.scheduler.advanceTimeBy(10_000)
         testDispatcher.scheduler.runCurrent()
         assertEquals(baseline + 2, refreshCount)
+        // Stop polling before runTest tears down — its scheduler-drain step would otherwise
+        // chase the endless delay→refresh chain and time out.
+        result = LibraryRefreshResult.Success
+        testDispatcher.scheduler.advanceTimeBy(10_001)
+        testDispatcher.scheduler.runCurrent()
     }
 
     @Test
@@ -174,7 +182,7 @@ class SeriesDetailViewModelTest {
         var result: LibraryRefreshResult = LibraryRefreshResult.NetworkError(RuntimeException("boom"))
         val vm = makeVm(countingRepo({ result }) { refreshCount++ })
         backgroundScope.launch { vm.isOffline.collect {} }
-        testDispatcher.scheduler.advanceUntilIdle()
+        testDispatcher.scheduler.runCurrent()
         assertEquals(true, vm.isOffline.value)
 
         result = LibraryRefreshResult.Success

--- a/app/src/test/kotlin/com/riffle/app/feature/library/SeriesDetailViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/SeriesDetailViewModelTest.kt
@@ -35,14 +35,14 @@ import org.junit.Before
 import org.junit.Test
 
 @OptIn(ExperimentalCoroutinesApi::class)
-class CollectionDetailViewModelTest {
+class SeriesDetailViewModelTest {
 
     private val testDispatcher = StandardTestDispatcher()
 
     @Before fun setUp() { Dispatchers.setMain(testDispatcher) }
     @After fun tearDown() { Dispatchers.resetMain() }
 
-    private val collectionItemsFlow = MutableStateFlow<List<LibraryItem>>(emptyList())
+    private val seriesItemsFlow = MutableStateFlow<List<LibraryItem>>(emptyList())
 
     private fun countingRepo(
         refreshResult: () -> LibraryRefreshResult,
@@ -57,37 +57,16 @@ class CollectionDetailViewModelTest {
         override fun observeAllBooks(libraryId: String): Flow<List<LibraryItem>> = MutableStateFlow(emptyList())
         override fun observeSeries(libraryId: String): Flow<List<Series>> = MutableStateFlow(emptyList())
         override fun observeCollections(libraryId: String): Flow<List<Collection>> = MutableStateFlow(emptyList())
-        override fun observeSeriesItems(seriesId: String): Flow<List<LibraryItem>> = MutableStateFlow(emptyList())
-        override fun observeCollectionItems(collectionId: String): Flow<List<LibraryItem>> = collectionItemsFlow
+        override fun observeSeriesItems(seriesId: String): Flow<List<LibraryItem>> = seriesItemsFlow
+        override fun observeCollectionItems(collectionId: String): Flow<List<LibraryItem>> = MutableStateFlow(emptyList())
         override suspend fun getItem(itemId: String): LibraryItem? = null
         override suspend fun markItemOpened(itemId: String) {}
         override suspend fun updateReadingProgress(itemId: String, progress: Float) {}
         override suspend fun refreshLibraries() = LibraryRefreshResult.Success
         override suspend fun refreshLibraryItems(libraryId: String) = LibraryRefreshResult.Success
-        override suspend fun refreshSeries(libraryId: String) = LibraryRefreshResult.Success
-        override suspend fun refreshCollections(libraryId: String): LibraryRefreshResult {
+        override suspend fun refreshSeries(libraryId: String): LibraryRefreshResult {
             onRefreshCall(); return refreshResult()
         }
-    }
-
-    private fun fakeRepo(): LibraryRepository = object : LibraryRepository {
-        override fun observeLibraries(): Flow<List<Library>> = MutableStateFlow(emptyList())
-        override fun observeLibraryItems(libraryId: String): Flow<List<LibraryItem>> = MutableStateFlow(emptyList())
-        override fun observeUngroupedLibraryItems(libraryId: String): Flow<List<LibraryItem>> = MutableStateFlow(emptyList())
-        override fun observeInProgressItems(libraryId: String): Flow<List<LibraryItem>> = MutableStateFlow(emptyList())
-        override fun observeFinishedItems(libraryId: String): Flow<List<LibraryItem>> = MutableStateFlow(emptyList())
-        override fun observeRecentlyAddedItems(libraryId: String): Flow<List<LibraryItem>> = MutableStateFlow(emptyList())
-        override fun observeAllBooks(libraryId: String): Flow<List<LibraryItem>> = MutableStateFlow(emptyList())
-        override fun observeSeries(libraryId: String): Flow<List<Series>> = MutableStateFlow(emptyList())
-        override fun observeCollections(libraryId: String): Flow<List<Collection>> = MutableStateFlow(emptyList())
-        override fun observeSeriesItems(seriesId: String): Flow<List<LibraryItem>> = MutableStateFlow(emptyList())
-        override fun observeCollectionItems(collectionId: String): Flow<List<LibraryItem>> = collectionItemsFlow
-        override suspend fun getItem(itemId: String): LibraryItem? = null
-        override suspend fun markItemOpened(itemId: String) {}
-        override suspend fun updateReadingProgress(itemId: String, progress: Float) {}
-        override suspend fun refreshLibraries() = LibraryRefreshResult.Success
-        override suspend fun refreshLibraryItems(libraryId: String) = LibraryRefreshResult.Success
-        override suspend fun refreshSeries(libraryId: String) = LibraryRefreshResult.Success
         override suspend fun refreshCollections(libraryId: String) = LibraryRefreshResult.Success
     }
 
@@ -109,11 +88,11 @@ class CollectionDetailViewModelTest {
         override suspend fun deleteToken(serverId: String) {}
     }
 
-    private class FakeEpubRepository(private val downloadedIds: Set<String> = emptySet()) : EpubRepository {
+    private class FakeEpubRepository : EpubRepository {
         override suspend fun openEpub(item: LibraryItem) = EpubOpenResult.Offline
         override suspend fun downloadEpub(item: LibraryItem) = EpubDownloadResult.Success
         override suspend fun removeDownload(itemId: String) {}
-        override fun isDownloaded(itemId: String): Boolean = itemId in downloadedIds
+        override fun isDownloaded(itemId: String): Boolean = false
         override fun isCached(itemId: String): Boolean = false
         override suspend fun saveReadingPosition(itemId: String, cfi: String) {}
     }
@@ -133,64 +112,22 @@ class CollectionDetailViewModelTest {
     }
 
     private fun makeVm(
+        libraryRepository: LibraryRepository,
         connectivityObserver: ConnectivityObserver = FakeConnectivityObserver(),
-        epubRepository: EpubRepository = FakeEpubRepository(),
-        libraryRepository: LibraryRepository = fakeRepo(),
-    ) = CollectionDetailViewModel(
-        savedStateHandle = SavedStateHandle(mapOf("collectionId" to "col-1", "libraryId" to "lib-1")),
+    ) = SeriesDetailViewModel(
+        savedStateHandle = SavedStateHandle(mapOf("seriesId" to "ser-1", "libraryId" to "lib-1")),
         libraryRepository = libraryRepository,
         serverRepository = noOpServerRepo,
         tokenStorage = noOpTokenStorage,
-        epubRepository = epubRepository,
+        epubRepository = FakeEpubRepository(),
         pdfRepository = FakePdfRepository(),
         connectivityObserver = connectivityObserver,
     )
 
-    private fun item(id: String) = LibraryItem(
-        id = id, libraryId = "lib-1", title = id, author = "Author", coverUrl = null,
-        readingProgress = 0f, isCached = false, isDownloaded = false, ebookFormat = EbookFormat.Epub,
-    )
-
-    @Test
-    fun `when online all collection items are returned`() = runTest {
-        val vm = makeVm(connectivityObserver = FakeConnectivityObserver(online = true))
-        backgroundScope.launch { vm.items.collect {} }
-        collectionItemsFlow.value = listOf(item("a"), item("b"), item("c"))
-        testDispatcher.scheduler.advanceUntilIdle()
-        assertEquals(3, vm.items.value.size)
-        assertEquals(false, vm.isOffline.value)
-    }
-
-    @Test
-    fun `when offline only locally available items are returned`() = runTest {
-        val vm = makeVm(
-            connectivityObserver = FakeConnectivityObserver(online = false),
-            epubRepository = FakeEpubRepository(downloadedIds = setOf("a")),
-        )
-        backgroundScope.launch { vm.items.collect {} }
-        backgroundScope.launch { vm.isOffline.collect {} }
-        collectionItemsFlow.value = listOf(item("a"), item("b"), item("c"))
-        testDispatcher.scheduler.advanceUntilIdle()
-        assertEquals(listOf(item("a")), vm.items.value)
-        assertEquals(true, vm.isOffline.value)
-    }
-
-    @Test
-    fun `when offline and no items are downloaded the list is empty`() = runTest {
-        val vm = makeVm(connectivityObserver = FakeConnectivityObserver(online = false))
-        backgroundScope.launch { vm.items.collect {} }
-        backgroundScope.launch { vm.isOffline.collect {} }
-        collectionItemsFlow.value = listOf(item("a"), item("b"))
-        testDispatcher.scheduler.advanceUntilIdle()
-        assertEquals(emptyList<LibraryItem>(), vm.items.value)
-    }
-
     @Test
     fun `does not poll while refresh keeps succeeding`() = runTest {
         var refreshCount = 0
-        val vm = makeVm(
-            libraryRepository = countingRepo({ LibraryRefreshResult.Success }) { refreshCount++ },
-        )
+        val vm = makeVm(countingRepo({ LibraryRefreshResult.Success }) { refreshCount++ })
         backgroundScope.launch { vm.isOffline.collect {} }
         testDispatcher.scheduler.advanceUntilIdle()
         val baseline = refreshCount
@@ -202,9 +139,7 @@ class CollectionDetailViewModelTest {
     @Test
     fun `polls every 10 seconds while refresh is failing`() = runTest {
         var refreshCount = 0
-        val vm = makeVm(
-            libraryRepository = countingRepo({ LibraryRefreshResult.NetworkError(RuntimeException("boom")) }) { refreshCount++ },
-        )
+        val vm = makeVm(countingRepo({ LibraryRefreshResult.NetworkError(RuntimeException("boom")) }) { refreshCount++ })
         backgroundScope.launch { vm.isOffline.collect {} }
         testDispatcher.scheduler.advanceUntilIdle()
         assertEquals(true, vm.isOffline.value)
@@ -220,10 +155,9 @@ class CollectionDetailViewModelTest {
     @Test
     fun `does not poll while device is offline`() = runTest {
         var refreshCount = 0
-        val connectivity = FakeConnectivityObserver(online = false)
         val vm = makeVm(
-            connectivityObserver = connectivity,
             libraryRepository = countingRepo({ LibraryRefreshResult.NetworkError(RuntimeException("boom")) }) { refreshCount++ },
+            connectivityObserver = FakeConnectivityObserver(online = false),
         )
         backgroundScope.launch { vm.isOffline.collect {} }
         testDispatcher.scheduler.advanceUntilIdle()
@@ -238,9 +172,7 @@ class CollectionDetailViewModelTest {
     fun `polling stops once a retry succeeds`() = runTest {
         var refreshCount = 0
         var result: LibraryRefreshResult = LibraryRefreshResult.NetworkError(RuntimeException("boom"))
-        val vm = makeVm(
-            libraryRepository = countingRepo({ result }) { refreshCount++ },
-        )
+        val vm = makeVm(countingRepo({ result }) { refreshCount++ })
         backgroundScope.launch { vm.isOffline.collect {} }
         testDispatcher.scheduler.advanceUntilIdle()
         assertEquals(true, vm.isOffline.value)
@@ -254,20 +186,5 @@ class CollectionDetailViewModelTest {
         testDispatcher.scheduler.advanceTimeBy(60_000)
         testDispatcher.scheduler.runCurrent()
         assertEquals(countAfterRecovery, refreshCount)
-    }
-
-    @Test
-    fun `items refilter when connectivity changes from offline to online`() = runTest {
-        val connectivity = FakeConnectivityObserver(online = false)
-        val vm = makeVm(connectivityObserver = connectivity, epubRepository = FakeEpubRepository(setOf("a")))
-        backgroundScope.launch { vm.items.collect {} }
-        collectionItemsFlow.value = listOf(item("a"), item("b"))
-        testDispatcher.scheduler.advanceUntilIdle()
-        assertEquals(listOf(item("a")), vm.items.value)
-
-        connectivity.state.value = true
-        testDispatcher.scheduler.advanceUntilIdle()
-        assertEquals(listOf(item("a"), item("b")), vm.items.value)
-        assertEquals(false, vm.isOffline.value)
     }
 }


### PR DESCRIPTION
## Summary
- The library/series/collection offline banner is driven by two independent signals: **device connectivity** (OS callbacks) and **server reachability** (last refresh result). When the device was online but the ABS server was unreachable, nothing re-checked — the banner only cleared after navigating away and back, which recreated the ViewModel.
- Added a polling coroutine in `LibraryItemsViewModel`, `SeriesDetailViewModel`, and `CollectionDetailViewModel` that retries `refresh()` every 10s while `_refreshFailed && deviceOnline`. Stops automatically when a refresh succeeds, so the healthy steady state pays zero extra requests.
- Device-offline case still relies on the existing on-reconnect listener — no point polling when the OS can wake us when the network returns.

## Test plan
- [x] New unit tests in all three view-model test classes cover: no polling while healthy, polling every 10s while failing, polling stops once a retry succeeds.
- [ ] Manual: open library, stop ABS server → banner appears; restart server → banner clears within ~10s without navigating away.