### PR TITLE
feat(library): collapse Library Tab Bar to All Books for Readaloud Libraries (#34)

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsScreen.kt
@@ -114,6 +114,7 @@ fun LibraryItemsScreen(
     val collectionCoverUrls by viewModel.collectionCoverUrls.collectAsState()
     val isOffline by viewModel.isOffline.collectAsState()
     val isLoading by viewModel.isLoading.collectAsState()
+    val isReadaloudLibrary by viewModel.isReadaloudLibrary.collectAsState()
 
     var selectedTab by rememberSaveable { mutableIntStateOf(0) }
 
@@ -147,7 +148,9 @@ fun LibraryItemsScreen(
             )
         },
         bottomBar = {
-            if (searchQuery.isEmpty()) {
+            // Readaloud Libraries (Storyteller) collapse to All Books only — the multi-tab bar
+            // is hidden because Storyteller exposes no Series, Collections, or To Read source.
+            if (searchQuery.isEmpty() && !isReadaloudLibrary) {
                 LibraryTabBar(selectedTab = selectedTab, onTabSelected = { selectedTab = it })
             }
         },
@@ -167,6 +170,14 @@ fun LibraryItemsScreen(
                     token = viewModel.authToken,
                     onSeriesSelected = onSeriesSelected,
                     onCollectionSelected = onCollectionSelected,
+                    onItemSelected = onItemSelected,
+                )
+            } else if (isReadaloudLibrary) {
+                // Readaloud Library: only the All Books tab exists, rendered directly.
+                AllBooksTabContent(
+                    items = allBooks,
+                    isLoading = isLoading,
+                    token = viewModel.authToken,
                     onItemSelected = onItemSelected,
                 )
             } else {

--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsViewModel.kt
@@ -58,6 +58,13 @@ class LibraryItemsViewModel @Inject constructor(
 
     val libraryId: String = savedStateHandle.get<String>("libraryId") ?: ""
 
+    // Readaloud Libraries (ADR 0020) collapse the Library Tab Bar to All Books only — Storyteller
+    // exposes no Series, Collections, or To Read source.
+    val isReadaloudLibrary: StateFlow<Boolean> = libraryRepository.observeLibraries()
+        .map { libs -> libs.firstOrNull { it.id == libraryId }?.mediaType == "readaloud" }
+        .distinctUntilChanged()
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), false)
+
     val series: StateFlow<List<Series>> = libraryRepository.observeSeries(libraryId)
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
 

--- a/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemsViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemsViewModelTest.kt
@@ -32,6 +32,7 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -57,9 +58,10 @@ class LibraryItemsViewModelTest {
     private val allBooksFlow = MutableStateFlow<List<LibraryItem>>(emptyList())
     private val collectionItemsByCollectionId = mutableMapOf<String, MutableStateFlow<List<LibraryItem>>>()
     private val seriesItemsBySeriesId = mutableMapOf<String, MutableStateFlow<List<LibraryItem>>>()
+    private val librariesFlow = MutableStateFlow<List<Library>>(emptyList())
 
     private fun fakeRepo(): LibraryRepository = object : LibraryRepository {
-        override fun observeLibraries(): Flow<List<Library>> = MutableStateFlow(emptyList())
+        override fun observeLibraries(): Flow<List<Library>> = librariesFlow
         override fun observeLibraryItems(libraryId: String): Flow<List<LibraryItem>> = allItemsFlow
         override fun observeUngroupedLibraryItems(libraryId: String): Flow<List<LibraryItem>> = itemsFlow
         override fun observeInProgressItems(libraryId: String): Flow<List<LibraryItem>> = inProgressFlow
@@ -802,5 +804,23 @@ class LibraryItemsViewModelTest {
         recentlyAddedFlow.value = (1..60).map { i -> item("Book $i", "Author") }
         testDispatcher.scheduler.advanceUntilIdle()
         assertEquals(50, vm.filteredRecentlyAdded.value.size)
+    }
+
+    @Test
+    fun `isReadaloudLibrary true when the active library has mediaType readaloud`() = runTest {
+        val vm = makeViewModel()
+        backgroundScope.launch { vm.isReadaloudLibrary.collect {} }
+        librariesFlow.value = listOf(Library("lib-1", "Readalouds", "readaloud", false))
+        testDispatcher.scheduler.advanceUntilIdle()
+        assertTrue(vm.isReadaloudLibrary.value)
+    }
+
+    @Test
+    fun `isReadaloudLibrary false for a standard ABS library`() = runTest {
+        val vm = makeViewModel()
+        backgroundScope.launch { vm.isReadaloudLibrary.collect {} }
+        librariesFlow.value = listOf(Library("lib-1", "Books", "book", false))
+        testDispatcher.scheduler.advanceUntilIdle()
+        assertFalse(vm.isReadaloudLibrary.value)
     }
 }


### PR DESCRIPTION
## Summary

Combined slices 6 + 7 of issue #34.

- **Slice 6** (Server Switcher renders Storyteller server) is a free win: the existing switcher iterates `Server` entities and renders `server.displayName` regardless of `serverType`, so a Storyteller server appears alongside ABS servers with no code change. No screenshot adjustment needed.
- **Slice 7** narrows the Library Tab Bar to All Books only for Storyteller-backed (Readaloud) Libraries, per ADR 0020.

`LibraryItemsViewModel` exposes a new `StateFlow<Boolean>` `isReadaloudLibrary` derived from `observeLibraries()`: true when the library matching `libraryId` has `mediaType == "readaloud"`.

`LibraryItemsScreen` reacts to the flow:
- `bottomBar` hides the `LibraryTabBar` entirely for Readaloud Libraries — a single tab makes the bar redundant.
- The content area skips the `when (selectedTab)` switch and renders `AllBooksTabContent` directly when `isReadaloudLibrary` is true.

ABS libraries continue to render the full Home / To Read / Series / Collections / All Books tab bar unchanged.

## Why the tab collapse

Per ADR 0020, the Storyteller REST API exposes no Series, Collections, or Tags endpoints, and there is no equivalent of ABS's playlists/To Read source. The Home tab (In Progress / Recently Added / Finished) needs progress data that the Storyteller positions endpoint won't supply until #38. So the only meaningful tab for a Readaloud Library today is All Books, sourced from `GET /api/books?synced=true` (slice 5).

## Test plan

- [x] `make test` green.
- [x] Two new unit tests in `LibraryItemsViewModelTest`:
  - `isReadaloudLibrary true when the active library has mediaType readaloud`.
  - `isReadaloudLibrary false for a standard ABS library`.

## Remaining slices of #34

8. Library Visibility Preferences includes the Readaloud Library (verify-only — likely free).
9. Library Item Detail Screen with Storyteller metadata (cover/title/authors); Read button disabled.
10. Multiple Storyteller Servers — disambiguation.
11. Server removal cascade for Storyteller.