### PR TITLE
fix(server): map placeholder readaloud id to materialised id when hiding (#34)

### DIFF
--- a/core/data/src/main/kotlin/com/riffle/core/data/ServerRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/ServerRepositoryImpl.kt
@@ -157,7 +157,13 @@ class ServerRepositoryImpl @Inject constructor(
                 )
             },
         )
-        hiddenLibraryIds.forEach { visibilityStore.hideLibrary(id, it) }
+        // Hidden ids arriving from the picker may still reference the synthetic placeholder
+        // for the Readaloud library; remap them to the materialised server-scoped id so the
+        // visibility preference attaches to the row that actually exists.
+        hiddenLibraryIds.forEach { hidden ->
+            val materialisedId = if (hidden == SYNTHETIC_READALOUD_LIBRARY_PLACEHOLDER_ID) readaloudLibraryId(id) else hidden
+            visibilityStore.hideLibrary(id, materialisedId)
+        }
         CommitServerResult.Success(inserted.toDomain())
     } catch (t: Throwable) {
         CommitServerResult.Failure(t)

--- a/core/data/src/test/kotlin/com/riffle/core/data/ServerRepositoryTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/ServerRepositoryTest.kt
@@ -264,6 +264,33 @@ class ServerRepositoryTest {
     }
 
     @Test
+    fun `commit Storyteller pending remaps hidden placeholder id to materialised library id`() = runTest {
+        val dao = fakeDao(); val tokens = fakeTokenStorage()
+        val libDao = fakeLibraryDao(); val visibility = fakeVisibilityStore()
+        val absApi = AbsApi { _, _, _, _ -> error("not called") }
+        val repo = ServerRepositoryImpl(dao, tokens, absApi, storytellerApiNotCalled, fakeServerInfoApi, libsApiNotCalled, libDao, visibility)
+
+        val pending = PendingServer(
+            url = ServerUrl.parse("http://media-server:8001")!!,
+            displayName = "media-server",
+            username = "plamen", userId = "", token = "tok-st",
+            insecureConnectionAllowed = false,
+            libraries = listOf(Library(ServerRepositoryImpl.SYNTHETIC_READALOUD_LIBRARY_PLACEHOLDER_ID, "Readalouds", "readaloud", false)),
+            serverType = ServerType.STORYTELLER,
+        )
+
+        val result = repo.commit(
+            pending,
+            hiddenLibraryIds = setOf(ServerRepositoryImpl.SYNTHETIC_READALOUD_LIBRARY_PLACEHOLDER_ID),
+        )
+
+        assertTrue(result is CommitServerResult.Success)
+        val server = (result as CommitServerResult.Success).server
+        val materialisedId = ServerRepositoryImpl.readaloudLibraryId(server.id)
+        assertEquals(setOf(materialisedId), visibility.hidden[server.id])
+    }
+
+    @Test
     fun `commit Storyteller pending materialises Readaloud library with server-scoped id`() = runTest {
         val dao = fakeDao(); val tokens = fakeTokenStorage()
         val libDao = fakeLibraryDao(); val visibility = fakeVisibilityStore()


### PR DESCRIPTION
## Summary

Slice 8 of issue #34. Closes a subtle commit-time bug where deselecting the Readaloud Library on the `SelectLibrariesScreen` would silently fail to hide it after the server was committed.

## What was wrong

\`PendingServer.libraries\` carries the Readaloud Library with a placeholder id (\`readaloud:pending\`) while it's still in-memory. \`ServerRepositoryImpl.commit\` materialises it as \`readaloud:\$serverId\` so multiple Storyteller Servers can coexist (slice 4 / 10).

The \`hiddenLibraryIds\` set passed into \`commit\` still referenced the placeholder id from the picker — without remapping, the visibility-preference write attached to a \`libraryId\` that never existed in the database, leaving the Readaloud Library visible despite the user's choice.

## Fix

Remap the placeholder id to the materialised id before writing the visibility preference. The standard ABS library flow is unchanged since their ids are real from the start.

## Test plan

- [x] \`make test\` green.
- [x] New unit test \`commit Storyteller pending remaps hidden placeholder id to materialised library id\` in \`ServerRepositoryTest\`.

Slice 8's other half — verifying that the Readaloud Library shows up in Settings → Manage Libraries and can be hidden / shown post-setup — is already covered by the existing visibility-prefs flow: \`observeByServerId\` returns the materialised \`LibraryEntity\` row regardless of \`mediaType\`, so the Settings UI iterates it identically to ABS libraries.