### PR TITLE
feat(library): disable Read button and downloads for Readaloud detail (#34)

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemDetailScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemDetailScreen.kt
@@ -145,6 +145,7 @@ fun LibraryItemDetailScreen(
                         isInToRead = state.isInToRead,
                         token = viewModel.authToken,
                         downloadState = downloadState,
+                        isReadaloud = state.isReadaloud,
                         onReadItem = { item -> viewModel.markOpened(); onReadItem(item) },
                         onMarkAsRead = { viewModel.markAsRead() },
                         onMarkAsUnread = { viewModel.markAsUnread() },
@@ -159,6 +160,7 @@ fun LibraryItemDetailScreen(
                         isInToRead = state.isInToRead,
                         token = viewModel.authToken,
                         downloadState = downloadState,
+                        isReadaloud = state.isReadaloud,
                         onReadItem = { item -> viewModel.markOpened(); onReadItem(item) },
                         onMarkAsRead = { viewModel.markAsRead() },
                         onMarkAsUnread = { viewModel.markAsUnread() },
@@ -203,6 +205,7 @@ private fun LibraryItemDetailContent(
     isInToRead: Boolean,
     token: String,
     downloadState: DownloadState,
+    isReadaloud: Boolean,
     onReadItem: (LibraryItem) -> Unit,
     onMarkAsRead: () -> Unit,
     onMarkAsUnread: () -> Unit,
@@ -238,6 +241,7 @@ private fun LibraryItemDetailContent(
             item = item,
             isInToRead = isInToRead,
             downloadState = downloadState,
+            isReadaloud = isReadaloud,
             onReadItem = onReadItem,
             onMarkAsRead = onMarkAsRead,
             onMarkAsUnread = onMarkAsUnread,
@@ -271,6 +275,7 @@ internal fun LibraryItemDetailContentTablet(
     isInToRead: Boolean,
     token: String,
     downloadState: DownloadState,
+    isReadaloud: Boolean,
     onReadItem: (LibraryItem) -> Unit,
     onMarkAsRead: () -> Unit,
     onMarkAsUnread: () -> Unit,
@@ -317,6 +322,7 @@ internal fun LibraryItemDetailContentTablet(
                 item = item,
                 isInToRead = isInToRead,
                 downloadState = downloadState,
+                isReadaloud = isReadaloud,
                 onReadItem = onReadItem,
                 onMarkAsRead = onMarkAsRead,
                 onMarkAsUnread = onMarkAsUnread,
@@ -350,6 +356,7 @@ private fun ActionRow(
     item: LibraryItem,
     isInToRead: Boolean,
     downloadState: DownloadState,
+    isReadaloud: Boolean,
     onReadItem: (LibraryItem) -> Unit,
     onMarkAsRead: () -> Unit,
     onMarkAsUnread: () -> Unit,
@@ -363,27 +370,31 @@ private fun ActionRow(
             horizontalArrangement = Arrangement.spacedBy(8.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
+            // Readaloud items: Read button stays present but disabled; reader-side bundle fetch
+            // is #35 and #37. Markers and downloads are hidden — they require those slices first.
             Button(
                 onClick = { onReadItem(item) },
-                enabled = downloadState !is DownloadState.InProgress,
+                enabled = !isReadaloud && downloadState !is DownloadState.InProgress,
                 modifier = Modifier.weight(1f),
             ) {
-                Text("Read")
+                Text(if (isReadaloud) "Read (coming soon)" else "Read")
             }
-            ReadToggleButton(
-                isRead = item.readingProgress >= READ_PROGRESS_THRESHOLD,
-                onMarkAsRead = onMarkAsRead,
-                onMarkAsUnread = onMarkAsUnread,
-            )
-            ToReadToggleButton(
-                isInToRead = isInToRead,
-                onToggle = onToggleToRead,
-            )
-            DownloadButton(
-                state = downloadState,
-                onDownload = onDownload,
-                onRemove = onRemove,
-            )
+            if (!isReadaloud) {
+                ReadToggleButton(
+                    isRead = item.readingProgress >= READ_PROGRESS_THRESHOLD,
+                    onMarkAsRead = onMarkAsRead,
+                    onMarkAsUnread = onMarkAsUnread,
+                )
+                ToReadToggleButton(
+                    isInToRead = isInToRead,
+                    onToggle = onToggleToRead,
+                )
+                DownloadButton(
+                    state = downloadState,
+                    onDownload = onDownload,
+                    onRemove = onRemove,
+                )
+            }
         }
     } else {
         Text(

--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModel.kt
@@ -16,6 +16,7 @@ import com.riffle.core.domain.PdfRepository
 import com.riffle.core.domain.ReadingSessionRepository
 import com.riffle.core.data.ToReadRepository
 import com.riffle.core.domain.ServerRepository
+import com.riffle.core.domain.ServerType
 import com.riffle.core.domain.TokenStorage
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -31,6 +32,10 @@ sealed interface LibraryItemDetailUiState {
     data class Ready(
         val item: LibraryItem,
         val isInToRead: Boolean = false,
+        // True when the item belongs to a Storyteller-backed (Readaloud) Library. In this slice the
+        // Read button is disabled and the EPUB/audio downloads are hidden — reader-side bundle
+        // fetch lands in #35 and #37 per ADR 0020.
+        val isReadaloud: Boolean = false,
     ) : LibraryItemDetailUiState
     data object Error : LibraryItemDetailUiState
 }
@@ -73,13 +78,14 @@ class LibraryItemDetailViewModel @Inject constructor(
             if (server != null) {
                 authToken = tokenStorage.getToken(server.id) ?: ""
             }
+            val isReadaloud = server?.serverType == ServerType.STORYTELLER
             _uiState.value = try {
                 val item = repository.getItem(itemId)
                 if (item != null) {
                     _downloadState.value = deriveDownloadState(item)
-                    toReadRepository.refresh(item.libraryId)
-                    val isInToRead = toReadRepository.isInToRead(item.id, item.libraryId)
-                    LibraryItemDetailUiState.Ready(item = item, isInToRead = isInToRead)
+                    if (!isReadaloud) toReadRepository.refresh(item.libraryId)
+                    val isInToRead = if (isReadaloud) false else toReadRepository.isInToRead(item.id, item.libraryId)
+                    LibraryItemDetailUiState.Ready(item = item, isInToRead = isInToRead, isReadaloud = isReadaloud)
                 } else {
                     LibraryItemDetailUiState.Error
                 }

--- a/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModelTest.kt
@@ -203,16 +203,29 @@ class LibraryItemDetailViewModelTest {
         epubRepository: EpubRepository = FakeEpubRepository(),
         pdfRepository: PdfRepository = FakePdfRepository(),
         toReadRepo: ToReadRepository = FakeToReadRepository(),
+        serverRepository: ServerRepository = noOpServerRepo,
     ) = LibraryItemDetailViewModel(
         savedStateHandle = SavedStateHandle(mapOf("itemId" to itemId)),
         repository = repo,
-        serverRepository = noOpServerRepo,
+        serverRepository = serverRepository,
         tokenStorage = noOpTokenStorage,
         epubRepository = epubRepository,
         pdfRepository = pdfRepository,
         sessionRepository = noOpSessionRepository,
         toReadRepository = toReadRepo,
     )
+
+    private fun serverRepoReturning(server: Server) = object : ServerRepository {
+        override fun observeAll(): Flow<List<Server>> = MutableStateFlow(listOf(server))
+        override suspend fun getActive(): Server? = server
+        override suspend fun authenticate(url: ServerUrl, username: String, password: String, insecureAllowed: Boolean, serverType: com.riffle.core.domain.ServerType): AuthenticateResult =
+            AuthenticateResult.WrongCredentials()
+        override suspend fun commit(pending: PendingServer, hiddenLibraryIds: Set<String>): CommitServerResult =
+            CommitServerResult.Failure(IOException())
+        override suspend fun setActive(serverId: String) {}
+        override suspend fun remove(serverId: String) {}
+        override suspend fun getServerVersion(serverId: String): String? = null
+    }
 
     // --- existing uiState tests ---
 
@@ -416,5 +429,59 @@ class LibraryItemDetailViewModelTest {
 
         assertEquals(1.0f, (vm.uiState.value as Ready).item.readingProgress, 0.0001f)
         assertTrue((vm.uiState.value as Ready).isInToRead)
+    }
+
+    // --- Readaloud (Storyteller) detail mode ---
+
+    private fun storytellerServer() = Server(
+        id = "st-1",
+        url = com.riffle.core.domain.ServerUrl.parse("http://media-server:8001")!!,
+        displayName = "Storyteller",
+        isActive = true,
+        insecureConnectionAllowed = false,
+        username = "plamen",
+        serverType = com.riffle.core.domain.ServerType.STORYTELLER,
+    )
+
+    private fun absServer() = Server(
+        id = "abs-1",
+        url = com.riffle.core.domain.ServerUrl.parse("http://media-server:13378")!!,
+        displayName = "ABS",
+        isActive = true,
+        insecureConnectionAllowed = false,
+        username = "plamen",
+        serverType = com.riffle.core.domain.ServerType.AUDIOBOOKSHELF,
+    )
+
+    @Test
+    fun `isReadaloud true when active server is Storyteller`() = runTest {
+        val vm = makeVm(repo = fakeRepo(knownItem), serverRepository = serverRepoReturning(storytellerServer()))
+        backgroundScope.launch { vm.uiState.collect {} }
+        testDispatcher.scheduler.advanceUntilIdle()
+        assertTrue((vm.uiState.value as Ready).isReadaloud)
+    }
+
+    @Test
+    fun `isReadaloud false when active server is Audiobookshelf`() = runTest {
+        val vm = makeVm(repo = fakeRepo(knownItem), serverRepository = serverRepoReturning(absServer()))
+        backgroundScope.launch { vm.uiState.collect {} }
+        testDispatcher.scheduler.advanceUntilIdle()
+        assertFalse((vm.uiState.value as Ready).isReadaloud)
+    }
+
+    @Test
+    fun `Readaloud detail does not invoke toReadRepository - no ABS-side playlists`() = runTest {
+        val toRead = FakeToReadRepository()
+        val vm = makeVm(
+            repo = fakeRepo(knownItem),
+            toReadRepo = toRead,
+            serverRepository = serverRepoReturning(storytellerServer()),
+        )
+        backgroundScope.launch { vm.uiState.collect {} }
+        testDispatcher.scheduler.advanceUntilIdle()
+        // refresh and isInToRead both touch the ABS playlists API and would 404 against
+        // Storyteller — confirm both are skipped for Readaloud detail.
+        assertTrue("toReadRepository should not be called for Readaloud items, was: ${toRead.callLog}", toRead.callLog.isEmpty())
+        assertFalse((vm.uiState.value as Ready).isInToRead)
     }
 }


### PR DESCRIPTION
## Summary

Slice 9 of issue #34 — makes the Library Item Detail Screen reflect that a Storyteller-backed (Readaloud) item is browsable but not yet readable.

\`LibraryItemDetailViewModel\` checks the active server's \`serverType\`. When it is \`STORYTELLER\` the new \`UiState.Ready.isReadaloud\` flag is true and:
- \`toReadRepository.refresh\` / \`isInToRead\` are skipped — Storyteller has no playlists endpoint and would 404 otherwise.
- \`isInToRead\` is forced to false (To Read is ABS-only).

\`LibraryItemDetailScreen\` routes the flag into \`ActionRow\`:
- The Read button stays present but disabled, with a \`Read (coming soon)\` label. Reader-side bundle fetch lands in #35 and #37 per ADR 0020.
- The Mark-Read / To Read / Download buttons are hidden — none of them apply until the reader and bundle download arrive.

Metadata rendering is unchanged. For a Storyteller item the \`LibraryItem\` only carries cover / title / author (slice 5); the description, seriesName, etc. blocks simply render nothing because the corresponding fields are null. That matches the ADR 0020 metadata sourcing rule: Storyteller-native display is cover + title + authors; richer fields only come from a Confirmed match via #36.

## Test plan

- [x] \`make test\` green.
- [x] Three new unit tests in \`LibraryItemDetailViewModelTest\`:
  - \`isReadaloud true when active server is Storyteller\`.
  - \`isReadaloud false when active server is Audiobookshelf\`.
  - \`Readaloud detail does not invoke toReadRepository\` — guards against 404s on missing playlists endpoint.

## Remaining slices of #34

10. Multiple Storyteller Servers — disambiguation (e.g. \"Readalouds · Local\" vs \"Readalouds · Remote\").
11. Server removal cascade for Storyteller — confirmation copy + cascade of Readaloud library + items + downloads.