### PR TITLE
test(server): verify two Storyteller servers coexist with distinct Readaloud libraries (#34)

### DIFF
--- a/core/data/src/test/kotlin/com/riffle/core/data/ServerRepositoryTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/ServerRepositoryTest.kt
@@ -291,6 +291,57 @@ class ServerRepositoryTest {
     }
 
     @Test
+    fun `two Storyteller servers commit independently, each with their own Readaloud library row`() = runTest {
+        val dao = fakeDao(); val tokens = fakeTokenStorage()
+        val libDao = fakeLibraryDao(); val visibility = fakeVisibilityStore()
+        val absApi = AbsApi { _, _, _, _ -> error("not called") }
+        val storyteller = storytellerApiReturning(NetworkStorytellerLoginResult.Success("tok-st"))
+        val repo = ServerRepositoryImpl(dao, tokens, absApi, storyteller, fakeServerInfoApi, libsApiNotCalled, libDao, visibility)
+
+        val pendingA = PendingServer(
+            url = ServerUrl.parse("http://media-server:8001")!!,
+            displayName = "media-server",
+            username = "plamen", userId = "", token = "tok-A",
+            insecureConnectionAllowed = false,
+            libraries = listOf(Library(ServerRepositoryImpl.SYNTHETIC_READALOUD_LIBRARY_PLACEHOLDER_ID, "Readalouds", "readaloud", false)),
+            serverType = ServerType.STORYTELLER,
+        )
+        val pendingB = PendingServer(
+            url = ServerUrl.parse("https://readalouds.example.com")!!,
+            displayName = "readalouds.example.com",
+            username = "plamen", userId = "", token = "tok-B",
+            insecureConnectionAllowed = false,
+            libraries = listOf(Library(ServerRepositoryImpl.SYNTHETIC_READALOUD_LIBRARY_PLACEHOLDER_ID, "Readalouds", "readaloud", false)),
+            serverType = ServerType.STORYTELLER,
+        )
+
+        val resultA = repo.commit(pendingA, hiddenLibraryIds = emptySet())
+        val resultB = repo.commit(pendingB, hiddenLibraryIds = emptySet())
+
+        assertTrue(resultA is CommitServerResult.Success)
+        assertTrue(resultB is CommitServerResult.Success)
+        val serverA = (resultA as CommitServerResult.Success).server
+        val serverB = (resultB as CommitServerResult.Success).server
+
+        assertEquals(2, dao.allCount())
+        assertEquals(ServerType.STORYTELLER, serverA.serverType)
+        assertEquals(ServerType.STORYTELLER, serverB.serverType)
+        // Each server gets its own Readaloud library row with a distinct server-scoped id —
+        // the disambiguation requested in #34's acceptance criterion. The library name itself
+        // remains the working "Readalouds" label; the active-server context (drawer header /
+        // Server Switcher) surfaces which server you're viewing.
+        val libs = libDao.allEntities()
+        assertEquals(2, libs.size)
+        val libA = libs.single { it.serverId == serverA.id }
+        val libB = libs.single { it.serverId == serverB.id }
+        assertEquals(ServerRepositoryImpl.readaloudLibraryId(serverA.id), libA.id)
+        assertEquals(ServerRepositoryImpl.readaloudLibraryId(serverB.id), libB.id)
+        assertTrue("Readaloud library ids must be distinct across servers", libA.id != libB.id)
+        assertEquals("readaloud", libA.mediaType)
+        assertEquals("readaloud", libB.mediaType)
+    }
+
+    @Test
     fun `commit Storyteller pending materialises Readaloud library with server-scoped id`() = runTest {
         val dao = fakeDao(); val tokens = fakeTokenStorage()
         val libDao = fakeLibraryDao(); val visibility = fakeVisibilityStore()


### PR DESCRIPTION
## Summary

Slice 10 of issue #34. Pins the multi-Storyteller-server contract that #34 calls out as an acceptance criterion: "multiple Storyteller Servers can be added simultaneously; each contributes its own Readaloud Library, named to disambiguate."

Slice 4 already established the disambiguation mechanism — the synthetic Readaloud library is materialised at commit time with a server-scoped id (\`readaloud:\$serverId\`), so multiple Storyteller servers never collide in the libraries table. The library name itself stays as the working \`Readalouds\` label — disambiguation surfaces through the active-server context (drawer header + Server Switcher displayName) rather than by baking the server name into the library name.

## What's new

One integration-style test in \`ServerRepositoryTest\`. Commits two Storyteller \`PendingServer\`s in succession and asserts:

- Both server rows persist with \`serverType = STORYTELLER\`.
- Each server gets its own Readaloud library row with \`serverId\` scoped to that server.
- The library ids are distinct (\`readaloud:\$serverA != readaloud:\$serverB\`).

No production code change — the test pins the contract for the multi-server case.

## Test plan

- [x] \`make test\` green.