### PR TITLE
docs(readme): announce Storyteller server support (#34)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Riffle
 
-An Android ebook reader for [Audiobookshelf](https://www.audiobookshelf.org/) self-hosted servers.
+An Android ebook reader for [Audiobookshelf](https://www.audiobookshelf.org/) and [Storyteller](https://storyteller-platform.gitlab.io/storyteller) self-hosted servers.
 
 [![ko-fi](https://ko-fi.com/img/githubbutton_sm.svg)](https://ko-fi.com/pkmetski)
 
-Riffle lets you browse your ABS ebook library, read EPUB and PDF files, and sync reading progress — all from a clean, privacy-respecting Android app.
+Riffle lets you browse your ebook library, read EPUB and PDF files, and sync reading progress — all from a clean, privacy-respecting Android app.
 
 ## Features
 
@@ -35,7 +35,8 @@ Riffle lets you browse your ABS ebook library, read EPUB and PDF files, and sync
 - Offline detection and seamless offline reading
 
 ### Server & Sync
-- Audiobookshelf login with secure token storage and insecure-connection warnings
+- Audiobookshelf and Storyteller login with secure token storage and insecure-connection warnings
+- Storyteller Readaloud Library: browse every completed readaloud as a single library (reader-side narration playback is in progress)
 - Bidirectional progress sync with last-update-wins conflict resolution
 - Periodic auto-sync and offline queueing
 - Reading session time tracking
@@ -43,7 +44,7 @@ Riffle lets you browse your ABS ebook library, read EPUB and PDF files, and sync
 ## Requirements
 
 - Android 7.0 (API 24) or higher
-- A running [Audiobookshelf](https://www.audiobookshelf.org/) server
+- A running [Audiobookshelf](https://www.audiobookshelf.org/) or [Storyteller](https://storyteller-platform.gitlab.io/storyteller) server
 
 ## Distribution
 


### PR DESCRIPTION
## Summary

Closes issue #34. With slices 1–11 in main, Riffle now supports Storyteller servers as a peer to Audiobookshelf per ADR 0020:

- Explicit type picker in Add-Server.
- Bearer-token auth via \`POST /api/token\` (multipart form).
- Synthetic Readaloud Library auto-materialised at commit time, populated from \`GET /api/books?synced=true\`.
- Library Tab Bar collapsed to All Books only for Readaloud Libraries.
- Per-item detail with cover/title/authors; Read button stays present but disabled until reader-side bundle fetch lands.
- Multi-Storyteller-server coexistence with server-scoped library ids.
- Server removal cascade that purges the Readaloud Library and its items.

Updates the README accordingly:

- Header now mentions both Audiobookshelf and Storyteller.
- New "Storyteller Readaloud Library" bullet under Server & Sync.
- Login bullet covers both auth flows.
- Requirements lists either backend.

## Out of #34

- Reader-side readaloud playback (audio + highlight + background) lands with #37.
- ABS-borrowed metadata for Readaloud books (description, year, publisher, genres) is #36.
- Three-peer Progress Sync for matched books is #38.