### PR TITLE
fix(library): handle ABS non-2xx responses without crashing

### DIFF
--- a/core/network/src/main/kotlin/com/riffle/core/network/AbsApiClient.kt
+++ b/core/network/src/main/kotlin/com/riffle/core/network/AbsApiClient.kt
@@ -154,6 +154,10 @@ class AbsApiClient(private val httpClient: OkHttpClient) : AbsApi, AbsLibraryApi
             .build()
         try {
             val response = client.newCall(request).execute()
+            if (!response.isSuccessful) {
+                response.body?.close()
+                return@withContext NetworkLibraryItemsResult.NetworkError(IOException("HTTP ${response.code}"))
+            }
             val raw = response.body?.string() ?: return@withContext NetworkLibraryItemsResult.NetworkError(
                 IOException("Empty response body")
             )
@@ -177,7 +181,7 @@ class AbsApiClient(private val httpClient: OkHttpClient) : AbsApi, AbsLibraryApi
                     addedAt = dto.addedAt,
                 )
             })
-        } catch (e: IOException) {
+        } catch (e: Exception) {
             NetworkLibraryItemsResult.NetworkError(e)
         }
     }

--- a/core/network/src/test/kotlin/com/riffle/core/network/AbsApiClientLibraryTest.kt
+++ b/core/network/src/test/kotlin/com/riffle/core/network/AbsApiClientLibraryTest.kt
@@ -145,6 +145,22 @@ class AbsApiClientLibraryTest {
     }
 
     @Test
+    fun `getLibraryItems returns NetworkError on 404 with plain-text body`() = runTest {
+        // ABS returns plain text "Library not found" with HTTP 404 when a stale/removed library
+        // id is queried. Parsing that body as JSON used to crash the app on the library screen.
+        server.enqueue(
+            MockResponse()
+                .setResponseCode(404)
+                .setBody("Library not found")
+                .addHeader("Content-Type", "text/plain")
+        )
+        val result = client.getLibraryItems(
+            server.url("/").toString().trimEnd('/'), "lib-gone", "tok", false
+        )
+        assertTrue(result is NetworkLibraryItemsResult.NetworkError)
+    }
+
+    @Test
     fun `getLibraryItems parses addedAt timestamp`() = runTest {
         server.enqueue(
             MockResponse()


### PR DESCRIPTION
## Summary

- The library screen crashes with `JsonDecodingException: Unexpected JSON token at offset 0: Expected start of the object '{', but had 'L' instead` / `JSON input: Library not found` when ABS returns a 404 plain-text body for a stale/removed library id.
- Root cause: `AbsApiClient.getLibraryItems` decodes the body unconditionally and only catches `IOException`, so the `SerializationException` escapes and crashes the app.
- Fix: check `response.isSuccessful` before decoding and broaden the catch to `Exception`, matching the sibling endpoints (`getSeries`, `getCollections`, `getUserProgress`). The failure now flows through `LibraryRefreshResult.NetworkError`, which flips the offline banner — same UX as any other server failure.
- Latent since PR #37; only started getting hit now that multi-server / Readaloud placeholder library ids can refer to libraries that don't exist server-side.

## Test plan

- [x] Added regression test `getLibraryItems returns NetworkError on 404 with plain-text body` reproducing the exact wire shape from the crash report.
- [ ] `./gradlew :core:network:test`
- [ ] Manual: trigger by pointing the app at a server where a cached library was deleted; confirm offline banner appears instead of a crash.