### PR TITLE
fix(reader): stop chapter label flicker on untocced spine resources

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -419,8 +419,13 @@ class EpubReaderViewModel @Inject constructor(
     val activeRailSegmentIndex: StateFlow<Int> = combine(
         railSegments,
         currentLocatorHref,
-    ) { segments, href ->
-        if (href == null) 0 else findActiveSegmentIndex(segments, href)
+        state,
+    ) { segments, href, s ->
+        if (href == null) return@combine 0
+        val spineHrefs = (s as? ReaderState.Ready)?.publication?.readingOrder
+            ?.map { it.url().toString() }
+            .orEmpty()
+        findActiveSegmentIndex(segments, href, spineHrefs)
     }.stateIn(viewModelScope, SharingStarted.Eagerly, 0)
 
     // Cursor position within the rail (0..1). Active segment + within-chapter progression are

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/RailSegmentGenerator.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/RailSegmentGenerator.kt
@@ -26,13 +26,41 @@ private fun expandIfRedundant(entry: TocEntry, bookTitleNorm: String): List<Rail
 
 private fun String.normalize(): String = trim().lowercase().replace(Regex("\\s+"), " ")
 
-fun findActiveSegmentIndex(segments: List<RailSegment>, currentHref: String): Int {
+/**
+ * Resolve the rail segment that owns [currentHref].
+ *
+ * EPUB spines often contain resources with no TOC entry (separators, ornamental pages between
+ * parts). When the navigator emits a locator for such a resource, falling back to segment 0
+ * causes the chapter label to flicker to "Chapter 1" between adjacent chapters. Pass
+ * [spineHrefs] (the publication's reading order) so the fallback can pick the last segment
+ * whose spine position is at-or-before the current resource — the chapter the user is "inside"
+ * by spine order — instead of snapping to the book's first chapter.
+ */
+fun findActiveSegmentIndex(
+    segments: List<RailSegment>,
+    currentHref: String,
+    spineHrefs: List<String> = emptyList(),
+): Int {
     if (segments.isEmpty()) return 0
     val exact = segments.indexOfFirst { it.href == currentHref }
     if (exact >= 0) return exact
     val currentBase = currentHref.substringBefore('#')
     val baseMatch = segments.indexOfFirst { it.href.substringBefore('#') == currentBase }
-    return if (baseMatch >= 0) baseMatch else 0
+    if (baseMatch >= 0) return baseMatch
+    if (spineHrefs.isEmpty()) return 0
+    val spineBases = spineHrefs.map { it.substringBefore('#') }
+    val currentSpineIndex = spineBases.indexOf(currentBase)
+    if (currentSpineIndex < 0) return 0
+    var bestSegIdx = -1
+    var bestSpineIdx = -1
+    segments.forEachIndexed { i, seg ->
+        val segSpineIdx = spineBases.indexOf(seg.href.substringBefore('#'))
+        if (segSpineIdx in 0..currentSpineIndex && segSpineIdx > bestSpineIdx) {
+            bestSpineIdx = segSpineIdx
+            bestSegIdx = i
+        }
+    }
+    return if (bestSegIdx >= 0) bestSegIdx else 0
 }
 
 /**

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/RailSegmentGeneratorTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/RailSegmentGeneratorTest.kt
@@ -287,8 +287,41 @@ class RailSegmentGeneratorTest {
     }
 
     @Test
-    fun `returns 0 when href matches no segment`() {
+    fun `returns 0 when href matches no segment and no spine info`() {
         assertEquals(0, findActiveSegmentIndex(bookSegments, "unknown.xhtml"))
+    }
+
+    @Test
+    fun `unmatched href falls back to preceding chapter by spine order, not chapter 0`() {
+        // Spine has an intermezzo resource between chapter2 and chapter3 with no TOC entry.
+        // Without spine awareness the chapter label would flicker to "Chapter 1" when the
+        // navigator emits a locator for the intermezzo.
+        val spine = listOf(
+            "chapter1.xhtml",
+            "chapter2.xhtml",
+            "intermezzo.xhtml",
+            "chapter3.xhtml",
+        )
+        assertEquals(1, findActiveSegmentIndex(bookSegments, "intermezzo.xhtml", spine))
+    }
+
+    @Test
+    fun `unmatched href before first mapped segment returns 0`() {
+        // A pre-chapter1 resource (e.g. front-matter) with no TOC entry should map to 0.
+        val spine = listOf("frontmatter.xhtml", "chapter1.xhtml", "chapter2.xhtml", "chapter3.xhtml")
+        assertEquals(0, findActiveSegmentIndex(bookSegments, "frontmatter.xhtml", spine))
+    }
+
+    @Test
+    fun `unmatched href after last mapped segment returns last segment`() {
+        val spine = listOf("chapter1.xhtml", "chapter2.xhtml", "chapter3.xhtml", "appendix.xhtml")
+        assertEquals(2, findActiveSegmentIndex(bookSegments, "appendix.xhtml", spine))
+    }
+
+    @Test
+    fun `unmatched href not in spine returns 0`() {
+        val spine = listOf("chapter1.xhtml", "chapter2.xhtml", "chapter3.xhtml")
+        assertEquals(0, findActiveSegmentIndex(bookSegments, "unrelated.xhtml", spine))
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Reading-progress label oscillated between the real chapter (e.g. "Chapter 7 of 9 / 61.0%") and "Chapter 1 of 9 / 2.3%" while paginating through inter-part spine resources that have no TOC entry.
- `findActiveSegmentIndex` returned `0` whenever the locator's href didn't match a TOC segment, so an intermezzo page between Part 3 and Part 4 was labelled as the book's first chapter.
- Pass the publication's reading order in so the fallback picks the last TOC segment at-or-before the current spine position — the chapter the reader is "inside" by spine order.

## Diagnosis evidence
- Frames extracted from the screen recording show the navigator truly teleporting (with a loading spinner mid-transition), not a UI glitch.
- Direct ABS query for the affected book returned a single stable position (`ebookProgress: 0.6881`, one `lastUpdate`) — so sync wasn't the source of the oscillation.
- The existing test `returns 0 when href matches no segment` had encoded the buggy fallback explicitly; it's renamed and kept (still passes via the empty-`spineHrefs` default) and joined by new tests covering pre-first, mid, and post-last unmatched spine cases.

## Test plan
- [ ] `./gradlew test` (run locally — green)
- [ ] Reopen the affected book and paginate across the Part 3 → Part 4 boundary; the chapter label should remain on the correct chapter instead of snapping to "Chapter 1 of 9".
- [ ] Books whose entire spine is in the TOC continue to behave the same (covered by existing tests that don't pass `spineHrefs`).