### PR TITLE
feat(reader): add current chapter label and shrink chapter map

### DIFF
--- a/app/src/androidTest/kotlin/com/riffle/app/feature/library/LibraryItemDetailTabletLayoutTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/library/LibraryItemDetailTabletLayoutTest.kt
@@ -52,6 +52,7 @@ class LibraryItemDetailTabletLayoutTest {
                 isInToRead = false,
                 token = "",
                 downloadState = DownloadState.NotDownloaded,
+                isReadaloud = false,
                 onReadItem = {},
                 onMarkAsRead = {},
                 onMarkAsUnread = {},

--- a/app/src/androidTest/kotlin/com/riffle/app/feature/reader/TypographyOverrideWebViewTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/reader/TypographyOverrideWebViewTest.kt
@@ -128,9 +128,12 @@ class TypographyOverrideWebViewTest {
             val paddingBottom = webView.evalSync(
                 "window.getComputedStyle(document.documentElement).paddingBottom"
             ).toCssPx()
-            // 20px gutter × 2 (pageMargins) × 0.5 (vertical ratio) = 20px expected on each side.
+            // Top is 0.5× the horizontal gutter (narrower than sides — conventional book
+            // typography); bottom is 1.0× so the chapter-rail overlay has breathing room above
+            // the running text. See TypographyOverride.kt "margins" entry.
+            // 20px gutter × 2 (pageMargins) × 0.5 = 20px top; × 1.0 = 40px bottom.
             assertEquals("padding-top should reflect --USER__pageMargins × gutter × 0.5", 20.0, paddingTop, 0.5)
-            assertEquals("padding-bottom should reflect --USER__pageMargins × gutter × 0.5", 20.0, paddingBottom, 0.5)
+            assertEquals("padding-bottom should reflect --USER__pageMargins × gutter × 1.0", 40.0, paddingBottom, 0.5)
         }
     }
 

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ChapterNavigationRail.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ChapterNavigationRail.kt
@@ -29,7 +29,9 @@ fun ChapterNavigationRail(
 
     val barColor = MaterialTheme.colorScheme.surfaceVariant
     val fillColor = MaterialTheme.colorScheme.primary.copy(alpha = 0.85f)
-    val dividerColor = MaterialTheme.colorScheme.outline
+    // Foreground (onSurface) instead of `outline` so dividers read as crisp chapter
+    // boundaries on top of the filled track, not as soft chrome.
+    val dividerColor = MaterialTheme.colorScheme.onSurface
     val activeOutlineColor = MaterialTheme.colorScheme.primary
     val cursorColor = MaterialTheme.colorScheme.primary
 
@@ -39,7 +41,7 @@ fun ChapterNavigationRail(
     Box(
         modifier = modifier
             .fillMaxWidth()
-            .height(8.dp)
+            .height(5.dp)
             .testTag("chapter_navigation_rail")
             .semantics { contentDescription = "Active rail segment: $activeTitle" }
             .pointerInput(segments) {

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -56,7 +56,10 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.core.view.ViewCompat
@@ -251,12 +254,17 @@ fun EpubReaderScreen(
         // Rail state (cursorPosition at scroll framerate) is isolated inside the overlay so
         // EpubNavigatorView does not recompose on every scroll event.
         if (state is ReaderState.Ready &&
-            (formattingPrefs.showChapterMap || formattingPrefs.showReadingProgressLabels)
+            (
+                formattingPrefs.showChapterMap ||
+                    formattingPrefs.showReadingProgressLabels ||
+                    formattingPrefs.showCurrentChapterLabel
+                )
         ) {
             EpubChapterRailOverlay(
                 viewModel = viewModel,
                 showRail = formattingPrefs.showChapterMap,
-                showLabels = formattingPrefs.showReadingProgressLabels,
+                showProgressLabels = formattingPrefs.showReadingProgressLabels,
+                showChapterNameLabel = formattingPrefs.showCurrentChapterLabel,
                 readerTheme = formattingPrefs.theme,
                 modifier = Modifier.align(Alignment.BottomCenter),
             )
@@ -349,7 +357,8 @@ internal fun readerTopAppBarColors() = androidx.compose.material3.TopAppBarDefau
 private fun BoxScope.EpubChapterRailOverlay(
     viewModel: EpubReaderViewModel,
     showRail: Boolean,
-    showLabels: Boolean,
+    showProgressLabels: Boolean,
+    showChapterNameLabel: Boolean,
     readerTheme: ReaderTheme,
     modifier: Modifier = Modifier,
 ) {
@@ -366,12 +375,15 @@ private fun BoxScope.EpubChapterRailOverlay(
                 .fillMaxWidth()
                 .background(readerTheme.palette.background),
         ) {
-            if (showLabels) {
+            if (showProgressLabels || showChapterNameLabel) {
                 ReadingProgressLabels(
                     activeChapterIndex = activeRailSegmentIndex,
                     chapterCount = railSegments.size,
+                    activeChapterTitle = railSegments.getOrNull(activeRailSegmentIndex)?.title.orEmpty(),
                     totalProgress = cursorPosition,
                     readerTheme = readerTheme,
+                    showCountAndPercent = showProgressLabels,
+                    showChapterName = showChapterNameLabel,
                 )
             }
             if (showRail) {
@@ -404,10 +416,13 @@ private fun readerThemeLabelColor(theme: ReaderTheme): Color {
 private fun ReadingProgressLabels(
     activeChapterIndex: Int,
     chapterCount: Int,
+    activeChapterTitle: String,
     totalProgress: Float,
     readerTheme: ReaderTheme,
+    showCountAndPercent: Boolean,
+    showChapterName: Boolean,
 ) {
-    val chapterText = if (chapterCount > 0) {
+    val chapterCountText = if (chapterCount > 0) {
         "Chapter ${(activeChapterIndex + 1).coerceAtMost(chapterCount)} of $chapterCount"
     } else {
         ""
@@ -421,23 +436,47 @@ private fun ReadingProgressLabels(
             .testTag("reading_progress_labels"),
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        Text(
-            text = chapterText,
-            style = MaterialTheme.typography.labelSmall,
-            color = textColor,
-            modifier = Modifier
-                .weight(1f)
-                .testTag("reading_progress_chapter")
-                .semantics { contentDescription = "Reading progress: $chapterText" },
-        )
-        Text(
-            text = pctText,
-            style = MaterialTheme.typography.labelSmall,
-            color = textColor,
-            modifier = Modifier
-                .testTag("reading_progress_percent")
-                .semantics { contentDescription = "Total progress: $pctText" },
-        )
+        if (showCountAndPercent) {
+            Text(
+                text = chapterCountText,
+                style = MaterialTheme.typography.labelSmall,
+                color = textColor,
+                textAlign = TextAlign.Start,
+                maxLines = 1,
+                modifier = Modifier
+                    .weight(1f)
+                    .testTag("reading_progress_chapter")
+                    .semantics { contentDescription = "Reading progress: $chapterCountText" },
+            )
+        }
+        if (showChapterName) {
+            Text(
+                text = activeChapterTitle,
+                style = MaterialTheme.typography.labelSmall,
+                color = textColor,
+                textAlign = TextAlign.Center,
+                fontStyle = FontStyle.Italic,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier
+                    .weight(2f)
+                    .testTag("reading_progress_chapter_name")
+                    .semantics { contentDescription = "Current chapter: $activeChapterTitle" },
+            )
+        }
+        if (showCountAndPercent) {
+            Text(
+                text = pctText,
+                style = MaterialTheme.typography.labelSmall,
+                color = textColor,
+                textAlign = TextAlign.End,
+                maxLines = 1,
+                modifier = Modifier
+                    .weight(1f)
+                    .testTag("reading_progress_percent")
+                    .semantics { contentDescription = "Total progress: $pctText" },
+            )
+        }
     }
 }
 

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/FormattingPanel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/FormattingPanel.kt
@@ -296,6 +296,21 @@ fun FormattingPanel(
                 )
             }
 
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text(
+                    "Current chapter label",
+                    style = MaterialTheme.typography.bodyLarge,
+                    modifier = Modifier.weight(1f),
+                )
+                Switch(
+                    checked = prefs.showCurrentChapterLabel,
+                    onCheckedChange = { onPrefsChange(prefs.copy(showCurrentChapterLabel = it)) },
+                )
+            }
+
             Spacer(Modifier.height(8.dp))
             TextButton(
                 onClick = onReset,

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/FormattingPanel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/FormattingPanel.kt
@@ -5,6 +5,8 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.selection.toggleable
+import androidx.compose.ui.semantics.Role
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -344,7 +346,11 @@ fun FormattingPanel(
                 verticalAlignment = Alignment.CenterVertically,
                 modifier = Modifier
                     .fillMaxWidth()
-                    .clickable { onKeepScreenOnChange(!keepScreenOn) },
+                    .toggleable(
+                        value = keepScreenOn,
+                        role = Role.Switch,
+                        onValueChange = onKeepScreenOnChange,
+                    ),
             ) {
                 Column(modifier = Modifier.weight(1f)) {
                     Text("Keep screen on", style = MaterialTheme.typography.bodyLarge)
@@ -354,7 +360,7 @@ fun FormattingPanel(
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
                 }
-                Switch(checked = keepScreenOn, onCheckedChange = onKeepScreenOnChange)
+                Switch(checked = keepScreenOn, onCheckedChange = null)
             }
 
             Spacer(Modifier.height(4.dp))
@@ -363,7 +369,11 @@ fun FormattingPanel(
                 verticalAlignment = Alignment.CenterVertically,
                 modifier = Modifier
                     .fillMaxWidth()
-                    .clickable { onVolumeKeyNavigationEnabledChange(!volumeKeyNavigationEnabled) },
+                    .toggleable(
+                        value = volumeKeyNavigationEnabled,
+                        role = Role.Switch,
+                        onValueChange = onVolumeKeyNavigationEnabledChange,
+                    ),
             ) {
                 Column(modifier = Modifier.weight(1f)) {
                     Text("Volume key navigation", style = MaterialTheme.typography.bodyLarge)
@@ -373,10 +383,7 @@ fun FormattingPanel(
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
                 }
-                Switch(
-                    checked = volumeKeyNavigationEnabled,
-                    onCheckedChange = onVolumeKeyNavigationEnabledChange,
-                )
+                Switch(checked = volumeKeyNavigationEnabled, onCheckedChange = null)
             }
 
             Spacer(Modifier.height(4.dp))

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/TypographyOverride.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/TypographyOverride.kt
@@ -102,6 +102,7 @@ internal val EXCLUDED_FROM_TYPOGRAPHY_OVERRIDES: Map<String, String> = mapOf(
     "doublePageSpread" to "Column-count layout mode, handled by RsProperties at fragment-creation time.",
     "showChapterMap" to "UI affordance outside the reader content; no CSS implication.",
     "showReadingProgressLabels" to "UI affordance outside the reader content; no CSS implication.",
+    "showCurrentChapterLabel" to "UI affordance outside the reader content; no CSS implication.",
 )
 
 /**

--- a/core/data/src/main/kotlin/com/riffle/core/data/BookFormattingPreferencesStoreImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/BookFormattingPreferencesStoreImpl.kt
@@ -24,6 +24,7 @@ class BookFormattingPreferencesStoreImpl @Inject constructor(
             orientation = entity.orientation?.let { runCatching { ReaderOrientation.valueOf(it) }.getOrNull() },
             showChapterMap = entity.showChapterMap,
             showReadingProgressLabels = entity.showReadingProgressLabels,
+            showCurrentChapterLabel = entity.showCurrentChapterLabel,
             doublePageSpread = entity.doublePageSpread,
             justifyText = entity.justifyText,
         )
@@ -45,6 +46,7 @@ class BookFormattingPreferencesStoreImpl @Inject constructor(
                 orientation = overrides.orientation?.name,
                 showChapterMap = overrides.showChapterMap,
                 showReadingProgressLabels = overrides.showReadingProgressLabels,
+                showCurrentChapterLabel = overrides.showCurrentChapterLabel,
                 doublePageSpread = overrides.doublePageSpread,
                 justifyText = overrides.justifyText,
             )

--- a/core/data/src/main/kotlin/com/riffle/core/data/FormattingPreferencesStoreImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/FormattingPreferencesStoreImpl.kt
@@ -35,7 +35,8 @@ class FormattingPreferencesStoreImpl @Inject constructor(
                 ?.let { runCatching { ReaderOrientation.valueOf(it) }.getOrNull() }
                 ?: ReaderOrientation.Horizontal,
             showChapterMap = prefs[KEY_SHOW_CHAPTER_MAP] ?: true,
-            showReadingProgressLabels = prefs[KEY_SHOW_READING_PROGRESS_LABELS] ?: true,
+            showReadingProgressLabels = prefs[KEY_SHOW_READING_PROGRESS_LABELS] ?: false,
+            showCurrentChapterLabel = prefs[KEY_SHOW_CURRENT_CHAPTER_LABEL] ?: false,
             doublePageSpread = prefs[KEY_DOUBLE_PAGE_SPREAD] ?: false,
             justifyText = prefs[KEY_JUSTIFY_TEXT] ?: false,
         )
@@ -51,6 +52,7 @@ class FormattingPreferencesStoreImpl @Inject constructor(
             prefs[KEY_ORIENTATION] = preferences.orientation.name
             prefs[KEY_SHOW_CHAPTER_MAP] = preferences.showChapterMap
             prefs[KEY_SHOW_READING_PROGRESS_LABELS] = preferences.showReadingProgressLabels
+            prefs[KEY_SHOW_CURRENT_CHAPTER_LABEL] = preferences.showCurrentChapterLabel
             prefs[KEY_DOUBLE_PAGE_SPREAD] = preferences.doublePageSpread
             prefs[KEY_JUSTIFY_TEXT] = preferences.justifyText
         }
@@ -65,6 +67,7 @@ class FormattingPreferencesStoreImpl @Inject constructor(
         val KEY_ORIENTATION = stringPreferencesKey("orientation")
         val KEY_SHOW_CHAPTER_MAP = booleanPreferencesKey("show_chapter_map")
         val KEY_SHOW_READING_PROGRESS_LABELS = booleanPreferencesKey("show_reading_progress_labels")
+        val KEY_SHOW_CURRENT_CHAPTER_LABEL = booleanPreferencesKey("show_current_chapter_label")
         val KEY_DOUBLE_PAGE_SPREAD = booleanPreferencesKey("double_page_spread")
         val KEY_JUSTIFY_TEXT = booleanPreferencesKey("justify_text")
     }

--- a/core/data/src/main/kotlin/com/riffle/core/data/di/DatabaseModule.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/di/DatabaseModule.kt
@@ -44,6 +44,7 @@ object DatabaseModule {
                 RiffleDatabase.MIGRATION_16_17,
                 RiffleDatabase.MIGRATION_17_18,
                 RiffleDatabase.MIGRATION_18_19,
+                RiffleDatabase.MIGRATION_19_20,
             )
             .build()
 

--- a/core/database/schemas/com.riffle.core.database.RiffleDatabase/20.json
+++ b/core/database/schemas/com.riffle.core.database.RiffleDatabase/20.json
@@ -1,0 +1,470 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 20,
+    "identityHash": "783dca68e743ac0988d028a2070b8ca2",
+    "entities": [
+      {
+        "tableName": "servers",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `url` TEXT NOT NULL, `displayName` TEXT NOT NULL, `isActive` INTEGER NOT NULL, `insecureConnectionAllowed` INTEGER NOT NULL, `username` TEXT NOT NULL, `serverType` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "isActive",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "insecureConnectionAllowed",
+            "columnName": "insecureConnectionAllowed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "username",
+            "columnName": "username",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverType",
+            "columnName": "serverType",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "libraries",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `mediaType` TEXT NOT NULL, `serverId` TEXT NOT NULL, `isUnsupported` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaType",
+            "columnName": "mediaType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isUnsupported",
+            "columnName": "isUnsupported",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "library_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `title` TEXT NOT NULL, `author` TEXT NOT NULL, `coverUrl` TEXT, `readingProgress` REAL NOT NULL, `ebookFileIno` TEXT, `ebookFormat` TEXT NOT NULL, `description` TEXT, `seriesName` TEXT, `publishedYear` TEXT, `genres` TEXT NOT NULL, `publisher` TEXT, `lastOpenedAt` INTEGER, `addedAt` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "coverUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "readingProgress",
+            "columnName": "readingProgress",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ebookFileIno",
+            "columnName": "ebookFileIno",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "ebookFormat",
+            "columnName": "ebookFormat",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seriesName",
+            "columnName": "seriesName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "publishedYear",
+            "columnName": "publishedYear",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "genres",
+            "columnName": "genres",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "publisher",
+            "columnName": "publisher",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastOpenedAt",
+            "columnName": "lastOpenedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "series",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `name` TEXT NOT NULL, `coverUrl` TEXT, `bookCount` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "coverUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "bookCount",
+            "columnName": "bookCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "collections",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `name` TEXT NOT NULL, `bookCount` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookCount",
+            "columnName": "bookCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "series_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`seriesId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `sequenceOrder` REAL NOT NULL, PRIMARY KEY(`seriesId`, `itemId`))",
+        "fields": [
+          {
+            "fieldPath": "seriesId",
+            "columnName": "seriesId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sequenceOrder",
+            "columnName": "sequenceOrder",
+            "affinity": "REAL",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "seriesId",
+            "itemId"
+          ]
+        }
+      },
+      {
+        "tableName": "collection_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`collectionId` TEXT NOT NULL, `itemId` TEXT NOT NULL, PRIMARY KEY(`collectionId`, `itemId`))",
+        "fields": [
+          {
+            "fieldPath": "collectionId",
+            "columnName": "collectionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "collectionId",
+            "itemId"
+          ]
+        }
+      },
+      {
+        "tableName": "reading_positions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`serverId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `cfi` TEXT NOT NULL, `localUpdatedAt` INTEGER NOT NULL, PRIMARY KEY(`serverId`, `itemId`), FOREIGN KEY(`serverId`) REFERENCES `servers`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cfi",
+            "columnName": "cfi",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localUpdatedAt",
+            "columnName": "localUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "serverId",
+            "itemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_reading_positions_serverId",
+            "unique": false,
+            "columnNames": [
+              "serverId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_reading_positions_serverId` ON `${TABLE_NAME}` (`serverId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "servers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "serverId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "book_formatting_preferences",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`itemId` TEXT NOT NULL, `fontSize` REAL, `theme` TEXT, `fontFamily` TEXT, `lineSpacing` REAL, `margins` REAL, `orientation` TEXT, `showChapterMap` INTEGER, `showReadingProgressLabels` INTEGER, `showCurrentChapterLabel` INTEGER, `doublePageSpread` INTEGER, `justifyText` INTEGER, PRIMARY KEY(`itemId`))",
+        "fields": [
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fontSize",
+            "columnName": "fontSize",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "theme",
+            "columnName": "theme",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "fontFamily",
+            "columnName": "fontFamily",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lineSpacing",
+            "columnName": "lineSpacing",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "margins",
+            "columnName": "margins",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "orientation",
+            "columnName": "orientation",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "showChapterMap",
+            "columnName": "showChapterMap",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "showReadingProgressLabels",
+            "columnName": "showReadingProgressLabels",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "showCurrentChapterLabel",
+            "columnName": "showCurrentChapterLabel",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "doublePageSpread",
+            "columnName": "doublePageSpread",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "justifyText",
+            "columnName": "justifyText",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "itemId"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '783dca68e743ac0988d028a2070b8ca2')"
+    ]
+  }
+}

--- a/core/database/src/androidTest/kotlin/com/riffle/core/database/MigrationTest.kt
+++ b/core/database/src/androidTest/kotlin/com/riffle/core/database/MigrationTest.kt
@@ -561,6 +561,43 @@ class MigrationTest {
     }
 
     @Test
+    fun migration19To20() {
+        helper.createDatabase(TEST_DB, 19).use { db ->
+            // Existing row with sparse overrides — only showReadingProgressLabels set.
+            db.execSQL(
+                "INSERT INTO book_formatting_preferences (itemId, fontSize, theme, fontFamily, lineSpacing, margins, orientation, showChapterMap, showReadingProgressLabels, doublePageSpread, justifyText) " +
+                    "VALUES ('item1', NULL, NULL, NULL, NULL, NULL, NULL, NULL, 1, NULL, NULL)"
+            )
+        }
+
+        val db = helper.runMigrationsAndValidate(TEST_DB, 20, true, RiffleDatabase.MIGRATION_19_20)
+
+        // Pre-existing data preserved; new column defaults to NULL = follow global.
+        db.query(
+            "SELECT itemId, showReadingProgressLabels, showCurrentChapterLabel FROM book_formatting_preferences WHERE itemId = 'item1'"
+        ).use { cursor ->
+            assertEquals(1, cursor.count)
+            cursor.moveToFirst()
+            assertEquals("item1", cursor.getString(0))
+            assertEquals(1, cursor.getInt(1))
+            assertTrue("showCurrentChapterLabel should be null for legacy rows", cursor.isNull(2))
+        }
+
+        // New writes can populate the new column.
+        db.execSQL(
+            "INSERT INTO book_formatting_preferences (itemId, fontSize, theme, fontFamily, lineSpacing, margins, orientation, showChapterMap, showReadingProgressLabels, showCurrentChapterLabel, doublePageSpread, justifyText) " +
+                "VALUES ('item2', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 1, NULL, NULL)"
+        )
+        db.query(
+            "SELECT showCurrentChapterLabel FROM book_formatting_preferences WHERE itemId = 'item2'"
+        ).use { cursor ->
+            assertEquals(1, cursor.count)
+            cursor.moveToFirst()
+            assertEquals(1, cursor.getInt(0))
+        }
+    }
+
+    @Test
     fun migrateFullChain() {
         helper.createDatabase(TEST_DB, 1).use { db ->
             db.execSQL(
@@ -569,7 +606,7 @@ class MigrationTest {
         }
 
         val db = helper.runMigrationsAndValidate(
-            TEST_DB, 19, true,
+            TEST_DB, 20, true,
             RiffleDatabase.MIGRATION_1_2,
             RiffleDatabase.MIGRATION_2_3,
             RiffleDatabase.MIGRATION_3_4,
@@ -588,6 +625,7 @@ class MigrationTest {
             RiffleDatabase.MIGRATION_16_17,
             RiffleDatabase.MIGRATION_17_18,
             RiffleDatabase.MIGRATION_18_19,
+            RiffleDatabase.MIGRATION_19_20,
         )
 
         db.query("SELECT url, displayName, username, serverType FROM servers WHERE id = 's1'").use { cursor ->

--- a/core/database/src/main/kotlin/com/riffle/core/database/BookFormattingPreferencesEntity.kt
+++ b/core/database/src/main/kotlin/com/riffle/core/database/BookFormattingPreferencesEntity.kt
@@ -14,6 +14,7 @@ data class BookFormattingPreferencesEntity(
     val orientation: String? = null,
     val showChapterMap: Boolean? = null,
     val showReadingProgressLabels: Boolean? = null,
+    val showCurrentChapterLabel: Boolean? = null,
     val doublePageSpread: Boolean? = null,
     val justifyText: Boolean? = null,
 )

--- a/core/database/src/main/kotlin/com/riffle/core/database/RiffleDatabase.kt
+++ b/core/database/src/main/kotlin/com/riffle/core/database/RiffleDatabase.kt
@@ -17,7 +17,7 @@ import androidx.sqlite.db.SupportSQLiteDatabase
         ReadingPositionEntity::class,
         BookFormattingPreferencesEntity::class,
     ],
-    version = 19,
+    version = 20,
     exportSchema = true,
 )
 abstract class RiffleDatabase : RoomDatabase() {
@@ -249,6 +249,14 @@ abstract class RiffleDatabase : RoomDatabase() {
                 db.execSQL("DROP TABLE `reading_positions`")
                 db.execSQL("ALTER TABLE `reading_positions_new` RENAME TO `reading_positions`")
                 db.execSQL("CREATE INDEX IF NOT EXISTS `index_reading_positions_serverId` ON `reading_positions` (`serverId`)")
+            }
+        }
+
+        val MIGRATION_19_20 = object : Migration(19, 20) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL(
+                    "ALTER TABLE `book_formatting_preferences` ADD COLUMN `showCurrentChapterLabel` INTEGER DEFAULT NULL"
+                )
             }
         }
     }

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/BookFormattingOverrides.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/BookFormattingOverrides.kt
@@ -9,6 +9,7 @@ data class BookFormattingOverrides(
     val orientation: ReaderOrientation? = null,
     val showChapterMap: Boolean? = null,
     val showReadingProgressLabels: Boolean? = null,
+    val showCurrentChapterLabel: Boolean? = null,
     val doublePageSpread: Boolean? = null,
     val justifyText: Boolean? = null,
 ) {
@@ -21,6 +22,7 @@ data class BookFormattingOverrides(
             orientation == null &&
             showChapterMap == null &&
             showReadingProgressLabels == null &&
+            showCurrentChapterLabel == null &&
             doublePageSpread == null &&
             justifyText == null
 
@@ -33,6 +35,7 @@ data class BookFormattingOverrides(
         orientation = orientation ?: global.orientation,
         showChapterMap = showChapterMap ?: global.showChapterMap,
         showReadingProgressLabels = showReadingProgressLabels ?: global.showReadingProgressLabels,
+        showCurrentChapterLabel = showCurrentChapterLabel ?: global.showCurrentChapterLabel,
         doublePageSpread = doublePageSpread ?: global.doublePageSpread,
         justifyText = justifyText ?: global.justifyText,
     )
@@ -51,6 +54,7 @@ data class BookFormattingOverrides(
         orientation = if (new.orientation != previous.orientation) new.orientation else orientation,
         showChapterMap = if (new.showChapterMap != previous.showChapterMap) new.showChapterMap else showChapterMap,
         showReadingProgressLabels = if (new.showReadingProgressLabels != previous.showReadingProgressLabels) new.showReadingProgressLabels else showReadingProgressLabels,
+        showCurrentChapterLabel = if (new.showCurrentChapterLabel != previous.showCurrentChapterLabel) new.showCurrentChapterLabel else showCurrentChapterLabel,
         doublePageSpread = if (new.doublePageSpread != previous.doublePageSpread) new.doublePageSpread else doublePageSpread,
         justifyText = if (new.justifyText != previous.justifyText) new.justifyText else justifyText,
     )

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/FormattingPreferences.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/FormattingPreferences.kt
@@ -9,6 +9,7 @@ data class FormattingPreferences(
     val orientation: ReaderOrientation = DEFAULT_ORIENTATION,
     val showChapterMap: Boolean = DEFAULT_SHOW_CHAPTER_MAP,
     val showReadingProgressLabels: Boolean = DEFAULT_SHOW_READING_PROGRESS_LABELS,
+    val showCurrentChapterLabel: Boolean = DEFAULT_SHOW_CURRENT_CHAPTER_LABEL,
     val doublePageSpread: Boolean = DEFAULT_DOUBLE_PAGE_SPREAD,
     val justifyText: Boolean = DEFAULT_JUSTIFY_TEXT,
 ) {
@@ -17,7 +18,8 @@ data class FormattingPreferences(
         const val DEFAULT_LINE_SPACING: Float = 1.2f
         const val DEFAULT_MARGINS: Float = 1.0f
         const val DEFAULT_SHOW_CHAPTER_MAP: Boolean = true
-        const val DEFAULT_SHOW_READING_PROGRESS_LABELS: Boolean = true
+        const val DEFAULT_SHOW_READING_PROGRESS_LABELS: Boolean = false
+        const val DEFAULT_SHOW_CURRENT_CHAPTER_LABEL: Boolean = false
         const val DEFAULT_DOUBLE_PAGE_SPREAD: Boolean = false
         const val DEFAULT_JUSTIFY_TEXT: Boolean = false
         val DEFAULT_THEME: ReaderTheme = ReaderTheme.Light

--- a/core/domain/src/test/kotlin/com/riffle/core/domain/BookFormattingOverridesTest.kt
+++ b/core/domain/src/test/kotlin/com/riffle/core/domain/BookFormattingOverridesTest.kt
@@ -31,6 +31,15 @@ class BookFormattingOverridesTest {
         assertTrue(BookFormattingOverrides().isEmpty)
         assertFalse(BookFormattingOverrides(fontSize = 1.3f).isEmpty)
         assertFalse(BookFormattingOverrides(justifyText = true).isEmpty)
+        assertFalse(BookFormattingOverrides(showCurrentChapterLabel = true).isEmpty)
+    }
+
+    @Test
+    fun `applyTo threads showCurrentChapterLabel`() {
+        val effective = BookFormattingOverrides(showCurrentChapterLabel = true).applyTo(global)
+        assertTrue(effective.showCurrentChapterLabel)
+        // Untouched on the global side stays false (the default).
+        assertFalse(BookFormattingOverrides().applyTo(global).showCurrentChapterLabel)
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Shrinks the chapter rail height (8dp → 5dp) and switches divider color from `outline` to `onSurface` so boundaries read crisply on the filled track.
- Adds a new `showCurrentChapterLabel` formatting preference (Room migration 19→20, domain/data plumbing, FormattingPanel toggle) that renders the active chapter title as an italic, centered label between the existing reading-progress labels. Side labels render conditionally so the chapter name gets full row width when shown alone.
- Flips the default for `showReadingProgressLabels` from `true` → `false` so the new chapter-name label is the default rail companion.

## Test plan
- [x] `./gradlew test` passes
- [ ] `make harness-test` passes (phone)
- [ ] `make harness-test-tablet` passes
- [x] Open a book → chapter rail is visibly shorter, dividers crisp against the filled segment
- [x] Formatting panel → toggle "Current chapter label" on/off, verify italic centered label appears/disappears
- [x] Toggle "Reading progress labels" independently; verify center label expands to full width when side labels are off
- [x] Fresh install (or upgrade from v19) preserves existing per-book overrides; new column defaults to follow-global