### PR TITLE
feat(server): identify servers by product label

### DIFF
--- a/app/src/androidTest/kotlin/com/riffle/app/feature/navigation/PermanentNavigationDrawerTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/navigation/PermanentNavigationDrawerTest.kt
@@ -38,7 +38,6 @@ class PermanentNavigationDrawerTest {
         val server = Server(
             id = "s1",
             url = ServerUrl.parse("http://example.com")!!,
-            displayName = "Example",
             isActive = true,
             insecureConnectionAllowed = false,
             username = "alice",
@@ -81,7 +80,6 @@ class PermanentNavigationDrawerTest {
         val server = Server(
             id = "s1",
             url = ServerUrl.parse("http://example.com")!!,
-            displayName = "Example",
             isActive = true,
             insecureConnectionAllowed = false,
             username = "alice",

--- a/app/src/androidTest/kotlin/com/riffle/app/harness/WakeLockHarnessTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/harness/WakeLockHarnessTest.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.test.hasSetTextAction
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.performTextReplacement
@@ -21,6 +22,7 @@ import com.riffle.core.database.RiffleDatabase
 import com.riffle.core.domain.WakeLockPreferencesStore
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import org.junit.After
 import org.junit.Before
@@ -77,9 +79,19 @@ class WakeLockHarnessTest {
         composeTestRule.waitForIdle()
 
         composeTestRule.onNodeWithText("Keep screen on").assertExists()
+        // "Keep screen on" sits at the bottom of the panel's verticalScroll column;
+        // scroll it on-screen so the click hits the toggleable Row instead of being
+        // swallowed by clipped/empty space.
+        composeTestRule.onNodeWithText("Keep screen on").performScrollTo()
         // Toggle the switch off (it's on by default)
         composeTestRule.onNodeWithText("Keep screen on").performClick()
         composeTestRule.waitForIdle()
+        // Compose's waitForIdle does not wait for the DataStore write fired by the toggle's
+        // viewModelScope.launch. Poll the store directly so the preference is verified
+        // persisted before we navigate away — otherwise the reader may read the stale `true`.
+        composeTestRule.waitUntil(timeoutMillis = 5_000) {
+            runBlocking { wakeLockPreferencesStore.keepScreenOn.first() } == false
+        }
 
         // Two back-presses: the first dismisses the full-screen panel (consumed by its
         // BackHandler), the second leaves Settings and returns to the library.
@@ -91,9 +103,14 @@ class WakeLockHarnessTest {
         openFirstBook()
 
         composeTestRule.assertNoErrorState()
-        composeTestRule
-            .onNode(hasTestTag(ReaderSemanticMatchers.TAG_READER_READY) and hasContentDescription("wake-lock:off", substring = true))
-            .assertExists()
+        // `keepScreenOn` is exposed via SharingStarted.Eagerly with an initial value of `true`,
+        // so `reader_ready` first paints with wake-lock:on and recomposes once the DataStore
+        // flow delivers the persisted `false`. Wait for that descriptor instead of asserting now.
+        composeTestRule.waitUntil(timeoutMillis = 5_000) {
+            composeTestRule
+                .onAllNodes(hasTestTag(ReaderSemanticMatchers.TAG_READER_READY) and hasContentDescription("wake-lock:off", substring = true))
+                .fetchSemanticsNodes().isNotEmpty()
+        }
     }
 
     @Test

--- a/app/src/main/kotlin/com/riffle/app/feature/navigation/NavigationDrawerComposable.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/navigation/NavigationDrawerComposable.kt
@@ -185,13 +185,18 @@ private fun DrawerHeader(
     var headerWidth by remember { mutableStateOf(Dp.Unspecified) }
     val density = LocalDensity.current
 
+    // Same product type appearing more than once forces the host to appear in the supporting
+    // line so users can tell the two instances apart. With a single instance the host is noise.
+    val activeNeedsHost = activeServer != null &&
+        allServers.count { it.serverType == activeServer.serverType } > 1
+
     Box(modifier = Modifier
         .fillMaxWidth()
         .onSizeChanged { headerWidth = with(density) { it.width.toDp() } }
     ) {
         ListItem(
             headlineContent = {
-                val name = activeServer?.displayName ?: "No server"
+                val name = activeServer?.serverType?.label ?: "No server"
                 val username = activeServer?.username?.takeIf { it.isNotEmpty() }
                 if (username != null) {
                     Text(
@@ -208,12 +213,12 @@ private fun DrawerHeader(
                 }
             },
             supportingContent = {
-                val url = activeServer?.url?.value ?: ""
-                if (activeVersion != null) {
-                    Text("$url · $activeVersion")
-                } else {
-                    Text(url)
-                }
+                val host = activeServer?.url?.authority().orEmpty()
+                val support = buildSupportingLine(
+                    host = if (activeNeedsHost) host else null,
+                    version = activeVersion,
+                )
+                if (support != null) Text(support)
             },
             trailingContent = {
                 Icon(
@@ -229,6 +234,7 @@ private fun DrawerHeader(
             modifier = if (headerWidth != Dp.Unspecified) Modifier.width(headerWidth) else Modifier,
         ) {
             allServers.forEach { server ->
+                val needsHost = allServers.count { it.serverType == server.serverType } > 1
                 DropdownMenuItem(
                     text = {
                         Column {
@@ -236,7 +242,7 @@ private fun DrawerHeader(
                             if (username != null) {
                                 Text(
                                     buildAnnotatedString {
-                                        append(server.displayName)
+                                        append(server.serverType.label)
                                         append(" ")
                                         withStyle(SpanStyle(color = MaterialTheme.colorScheme.onSurfaceVariant)) {
                                             append("[$username]")
@@ -244,14 +250,19 @@ private fun DrawerHeader(
                                     }
                                 )
                             } else {
-                                Text(server.displayName)
+                                Text(server.serverType.label)
                             }
-                            val version = serverVersions[server.id]
-                            Text(
-                                text = if (version != null) "${server.url.value} · $version" else server.url.value,
-                                style = MaterialTheme.typography.bodySmall,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            val support = buildSupportingLine(
+                                host = if (needsHost) server.url.authority() else null,
+                                version = serverVersions[server.id],
                             )
+                            if (support != null) {
+                                Text(
+                                    text = support,
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                )
+                            }
                         }
                     },
                     leadingIcon = {
@@ -268,5 +279,19 @@ private fun DrawerHeader(
                 )
             }
         }
+    }
+}
+
+/**
+ * Drawer supporting line: `host · version`, `host`, `version`, or null if nothing to show.
+ * Storyteller never has a version (the repository returns null for it).
+ */
+private fun buildSupportingLine(host: String?, version: String?): String? {
+    val v = version?.let { "v$it" }
+    return when {
+        host != null && v != null -> "$host · $v"
+        host != null -> host
+        v != null -> v
+        else -> null
     }
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsScreen.kt
@@ -126,12 +126,12 @@ fun SettingsScreen(
                             }
                             append(server.url.value)
                             if (version != null) {
-                                append(" · ")
+                                append(" · v")
                                 append(version)
                             }
                         }
                         ListItem(
-                            headlineContent = { Text(server.displayName) },
+                            headlineContent = { Text(server.serverType.label) },
                             supportingContent = { Text(subtitle) },
                             trailingContent = if (server.isActive) {
                                 { Text("Active", style = MaterialTheme.typography.labelSmall) }
@@ -150,7 +150,7 @@ fun SettingsScreen(
                 HorizontalDivider()
 
                 if (libraryItems.isNotEmpty()) {
-                    val activeServerName = servers.firstOrNull { it.isActive }?.displayName ?: ""
+                    val activeServerName = servers.firstOrNull { it.isActive }?.serverType?.label ?: ""
                     Text(
                         text = "Libraries — $activeServerName",
                         style = MaterialTheme.typography.titleSmall,

--- a/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModelTest.kt
@@ -436,7 +436,6 @@ class LibraryItemDetailViewModelTest {
     private fun storytellerServer() = Server(
         id = "st-1",
         url = com.riffle.core.domain.ServerUrl.parse("http://media-server:8001")!!,
-        displayName = "Storyteller",
         isActive = true,
         insecureConnectionAllowed = false,
         username = "plamen",
@@ -446,7 +445,6 @@ class LibraryItemDetailViewModelTest {
     private fun absServer() = Server(
         id = "abs-1",
         url = com.riffle.core.domain.ServerUrl.parse("http://media-server:13378")!!,
-        displayName = "ABS",
         isActive = true,
         insecureConnectionAllowed = false,
         username = "plamen",

--- a/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemsViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemsViewModelTest.kt
@@ -566,7 +566,7 @@ class LibraryItemsViewModelTest {
         val vm = makeViewModel(
             serverRepository = object : ServerRepository {
                 override fun observeAll(): Flow<List<Server>> = MutableStateFlow(emptyList())
-                override suspend fun getActive() = Server("srv-1", ServerUrl.parse("http://localhost")!!, "Test", true, false, "")
+                override suspend fun getActive() = Server("srv-1", ServerUrl.parse("http://localhost")!!, true, false, "")
                 override suspend fun authenticate(url: ServerUrl, username: String, password: String, insecureAllowed: Boolean, serverType: com.riffle.core.domain.ServerType) =
                     throw UnsupportedOperationException()
                 override suspend fun commit(pending: com.riffle.core.domain.PendingServer, hiddenLibraryIds: Set<String>) =

--- a/app/src/test/kotlin/com/riffle/app/feature/navigation/HomeViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/navigation/HomeViewModelTest.kt
@@ -33,7 +33,6 @@ class HomeViewModelTest {
     private fun server(id: String, active: Boolean = false) = Server(
         id = id,
         url = ServerUrl.parse("https://$id.example.com")!!,
-        displayName = id,
         isActive = active,
         insecureConnectionAllowed = false,
         username = "",

--- a/app/src/test/kotlin/com/riffle/app/feature/navigation/NavigationDrawerViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/navigation/NavigationDrawerViewModelTest.kt
@@ -48,7 +48,6 @@ class NavigationDrawerViewModelTest {
     private fun server(id: String, active: Boolean = false) = Server(
         id = id,
         url = ServerUrl.parse("https://$id.example.com")!!,
-        displayName = id,
         isActive = active,
         insecureConnectionAllowed = false,
         username = "",

--- a/app/src/test/kotlin/com/riffle/app/feature/server/AddServerViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/server/AddServerViewModelTest.kt
@@ -45,7 +45,6 @@ class AddServerViewModelTest {
     private fun fakeServer() = Server(
         id = "s1",
         url = ServerUrl.parse("https://abs.example.com")!!,
-        displayName = "abs.example.com",
         isActive = true,
         insecureConnectionAllowed = false,
         username = "",
@@ -53,7 +52,6 @@ class AddServerViewModelTest {
 
     private fun fakePending() = PendingServer(
         url = ServerUrl.parse("https://abs.example.com")!!,
-        displayName = "abs.example.com",
         username = "admin",
         userId = "uid",
         token = "tok",
@@ -67,7 +65,6 @@ class AddServerViewModelTest {
             Server(
                 id = "s1",
                 url = ServerUrl.parse("https://abs.example.com")!!,
-                displayName = "abs.example.com",
                 isActive = true,
                 insecureConnectionAllowed = false,
                 username = "",

--- a/app/src/test/kotlin/com/riffle/app/feature/settings/SettingsViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/settings/SettingsViewModelTest.kt
@@ -74,7 +74,6 @@ class SettingsViewModelTest {
     private fun server(id: String, active: Boolean = false) = Server(
         id = id,
         url = ServerUrl.parse("https://$id.example.com")!!,
-        displayName = id,
         isActive = active,
         insecureConnectionAllowed = false,
         username = "",

--- a/core/data/src/main/kotlin/com/riffle/core/data/ServerRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/ServerRepositoryImpl.kt
@@ -72,7 +72,6 @@ class ServerRepositoryImpl @Inject constructor(
                     is NetworkLibrariesResult.Success -> AuthenticateResult.Success(
                         PendingServer(
                             url = url,
-                            displayName = displayNameFrom(url.value),
                             username = loginResult.username,
                             userId = loginResult.userId,
                             token = loginResult.token,
@@ -106,7 +105,6 @@ class ServerRepositoryImpl @Inject constructor(
         is NetworkStorytellerLoginResult.Success -> AuthenticateResult.Success(
             PendingServer(
                 url = url,
-                displayName = displayNameFrom(url.value),
                 username = username,
                 userId = "", // Storyteller's auth response doesn't expose a user id; identity is the username + token.
                 token = result.token,
@@ -138,7 +136,6 @@ class ServerRepositoryImpl @Inject constructor(
         val entity = ServerEntity(
             id = id,
             url = pending.url.value,
-            displayName = pending.displayName,
             isActive = false,                    // overridden inside transaction
             insecureConnectionAllowed = pending.insecureConnectionAllowed,
             username = pending.username,
@@ -188,6 +185,8 @@ class ServerRepositoryImpl @Inject constructor(
 
     override suspend fun getServerVersion(serverId: String): String? {
         val server = dao.getById(serverId)?.toDomain() ?: return null
+        // Storyteller exposes no /server-info endpoint; the UI deliberately shows no version for it.
+        if (server.serverType == ServerType.STORYTELLER) return null
         val token = tokenStorage.getToken(serverId) ?: return null
         return serverInfoApi.getServerInfo(
             baseUrl = server.url.value,
@@ -202,20 +201,12 @@ class ServerRepositoryImpl @Inject constructor(
         fun readaloudLibraryId(serverId: String): String = "readaloud:$serverId"
     }
 
-    private fun displayNameFrom(url: String): String =
-        try {
-            java.net.URI(url).host ?: url.substringAfter("://").substringBefore("/")
-        } catch (_: Exception) {
-            url.substringAfter("://").substringBefore("/")
-        }
-
     private fun ServerEntity.toDomain(): Server {
         val parsedUrl = ServerUrl.parse(url)
             ?: ServerUrl.parse("https://invalid.example.com")!!
         return Server(
             id = id,
             url = parsedUrl,
-            displayName = displayName,
             isActive = isActive,
             insecureConnectionAllowed = insecureConnectionAllowed,
             username = username,

--- a/core/data/src/main/kotlin/com/riffle/core/data/di/DatabaseModule.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/di/DatabaseModule.kt
@@ -45,6 +45,7 @@ object DatabaseModule {
                 RiffleDatabase.MIGRATION_17_18,
                 RiffleDatabase.MIGRATION_18_19,
                 RiffleDatabase.MIGRATION_19_20,
+                RiffleDatabase.MIGRATION_20_21,
             )
             .build()
 

--- a/core/data/src/test/kotlin/com/riffle/core/data/EpubPositionIntegrationTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/EpubPositionIntegrationTest.kt
@@ -68,7 +68,6 @@ class EpubPositionIntegrationTest {
             val activeServer = Server(
                 id = "server-1",
                 url = ServerUrl.parse(server.url("/").toString().trimEnd('/'))!!,
-                displayName = "Test",
                 isActive = true,
                 insecureConnectionAllowed = false,
                 username = "",

--- a/core/data/src/test/kotlin/com/riffle/core/data/EpubRepositoryTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/EpubRepositoryTest.kt
@@ -65,7 +65,6 @@ class EpubRepositoryTest {
         val activeServer = Server(
             id = "server-1",
             url = ServerUrl.parse(baseUrl)!!,
-            displayName = "Test",
             isActive = true,
             insecureConnectionAllowed = false,
             username = "",

--- a/core/data/src/test/kotlin/com/riffle/core/data/LibraryRepositoryTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/LibraryRepositoryTest.kt
@@ -271,7 +271,6 @@ class LibraryRepositoryTest {
     private fun activeServer(id: String = "s1") = Server(
         id = id,
         url = ServerUrl.parse("https://abs.example.com")!!,
-        displayName = "abs",
         isActive = true,
         insecureConnectionAllowed = false,
         username = "",
@@ -807,7 +806,6 @@ class LibraryRepositoryTest {
     private fun storytellerServer() = Server(
         id = "st-1",
         url = ServerUrl.parse("http://media-server:8001")!!,
-        displayName = "media-server",
         isActive = true,
         insecureConnectionAllowed = false,
         username = "plamen",

--- a/core/data/src/test/kotlin/com/riffle/core/data/PdfRepositoryTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/PdfRepositoryTest.kt
@@ -65,7 +65,6 @@ class PdfRepositoryTest {
         val activeServer = Server(
             id = "server-1",
             url = ServerUrl.parse(baseUrl)!!,
-            displayName = "Test",
             isActive = true,
             insecureConnectionAllowed = false,
             username = "",

--- a/core/data/src/test/kotlin/com/riffle/core/data/ProgressSyncCycleTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/ProgressSyncCycleTest.kt
@@ -61,7 +61,7 @@ class ProgressSyncCycleTest {
         ReadingSessionRepositoryImpl(
             api = api,
             serverRepository = object : ServerRepository {
-                val server = Server("s1", ServerUrl.parse("http://localhost")!!, "T", true, false, "")
+                val server = Server("s1", ServerUrl.parse("http://localhost")!!, true, false, "")
                 override fun observeAll(): Flow<List<Server>> = flowOf(listOf(server))
                 override suspend fun getActive(): Server = server
                 override suspend fun authenticate(url: ServerUrl, username: String, password: String, insecureAllowed: Boolean, serverType: com.riffle.core.domain.ServerType): AuthenticateResult = throw UnsupportedOperationException()

--- a/core/data/src/test/kotlin/com/riffle/core/data/ProgressSyncIntegrationTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/ProgressSyncIntegrationTest.kt
@@ -52,7 +52,6 @@ class ProgressSyncIntegrationTest {
             val activeServer = Server(
                 id = "server-1",
                 url = ServerUrl.parse(server.url("/").toString().trimEnd('/'))!!,
-                displayName = "Test",
                 isActive = true,
                 insecureConnectionAllowed = false,
                 username = "",

--- a/core/data/src/test/kotlin/com/riffle/core/data/ReadingSessionIntegrationTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/ReadingSessionIntegrationTest.kt
@@ -41,7 +41,6 @@ class ReadingSessionIntegrationTest {
             val activeServer = Server(
                 id = "server-1",
                 url = ServerUrl.parse(server.url("/").toString().trimEnd('/'))!!,
-                displayName = "Test",
                 isActive = true,
                 insecureConnectionAllowed = false,
                 username = "",

--- a/core/data/src/test/kotlin/com/riffle/core/data/SeriesIntegrationTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/SeriesIntegrationTest.kt
@@ -69,7 +69,6 @@ class SeriesIntegrationTest {
         fakeServerRepository.server = Server(
             id = "s1",
             url = ServerUrl.parse(serverUrl)!!,
-            displayName = "test",
             isActive = true,
             insecureConnectionAllowed = false,
             username = "",

--- a/core/data/src/test/kotlin/com/riffle/core/data/ServerRepositoryTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/ServerRepositoryTest.kt
@@ -238,7 +238,7 @@ class ServerRepositoryTest {
 
         val url = ServerUrl.parse("https://abs.example.com")!!
         val pending = PendingServer(
-            url = url, displayName = "abs.example.com",
+            url = url,
             username = "admin", userId = "uid-1", token = "tok-xyz",
             insecureConnectionAllowed = false,
             libraries = listOf(
@@ -251,7 +251,7 @@ class ServerRepositoryTest {
 
         assertTrue(result is CommitServerResult.Success)
         val server = (result as CommitServerResult.Success).server
-        assertEquals("abs.example.com", server.displayName)
+        assertEquals(url, server.url)
         assertTrue(server.isActive) // first server becomes active
         assertEquals("tok-xyz", tokens.getToken(server.id))
         assertEquals(2, libDao.allEntities().size)
@@ -305,7 +305,6 @@ class ServerRepositoryTest {
 
         val pending = PendingServer(
             url = ServerUrl.parse("http://media-server:8001")!!,
-            displayName = "media-server",
             username = "plamen", userId = "", token = "tok-st",
             insecureConnectionAllowed = false,
             libraries = listOf(Library(ServerRepositoryImpl.SYNTHETIC_READALOUD_LIBRARY_PLACEHOLDER_ID, "Readalouds", "readaloud", false)),
@@ -333,7 +332,6 @@ class ServerRepositoryTest {
 
         val pendingA = PendingServer(
             url = ServerUrl.parse("http://media-server:8001")!!,
-            displayName = "media-server",
             username = "plamen", userId = "", token = "tok-A",
             insecureConnectionAllowed = false,
             libraries = listOf(Library(ServerRepositoryImpl.SYNTHETIC_READALOUD_LIBRARY_PLACEHOLDER_ID, "Readalouds", "readaloud", false)),
@@ -341,7 +339,6 @@ class ServerRepositoryTest {
         )
         val pendingB = PendingServer(
             url = ServerUrl.parse("https://readalouds.example.com")!!,
-            displayName = "readalouds.example.com",
             username = "plamen", userId = "", token = "tok-B",
             insecureConnectionAllowed = false,
             libraries = listOf(Library(ServerRepositoryImpl.SYNTHETIC_READALOUD_LIBRARY_PLACEHOLDER_ID, "Readalouds", "readaloud", false)),
@@ -383,7 +380,6 @@ class ServerRepositoryTest {
 
         val pending = PendingServer(
             url = ServerUrl.parse("http://media-server:8001")!!,
-            displayName = "media-server",
             username = "plamen", userId = "", token = "tok-st",
             insecureConnectionAllowed = false,
             libraries = listOf(Library(ServerRepositoryImpl.SYNTHETIC_READALOUD_LIBRARY_PLACEHOLDER_ID, "Readalouds", "readaloud", false)),
@@ -409,7 +405,6 @@ class ServerRepositoryTest {
 
         val pending = PendingServer(
             url = ServerUrl.parse("http://media-server:8001")!!,
-            displayName = "media-server",
             username = "plamen", userId = "uid-1", token = "tok-st",
             insecureConnectionAllowed = false,
             libraries = emptyList(),
@@ -425,7 +420,7 @@ class ServerRepositoryTest {
 
     @Test
     fun `remove deletes server entity and token`() = runTest {
-        val entity = ServerEntity("srv-1", "https://abs.example.com", "abs.example.com", true, false, username = "")
+        val entity = ServerEntity("srv-1", "https://abs.example.com", true, false, username = "")
         val dao = fakeDao(entity)
         val tokens = fakeTokenStorage()
         tokens.tokens["srv-1"] = "tok"
@@ -440,7 +435,7 @@ class ServerRepositoryTest {
 
     @Test
     fun `remove cascades libraries and library_items for a Storyteller server`() = runTest {
-        val entity = ServerEntity("st-1", "http://media-server:8001", "media-server", true, false, username = "plamen", serverType = "STORYTELLER")
+        val entity = ServerEntity("st-1", "http://media-server:8001", true, false, username = "plamen", serverType = "STORYTELLER")
         val dao = fakeDao(entity)
         val tokens = fakeTokenStorage()
         tokens.tokens["st-1"] = "tok-st"
@@ -468,7 +463,7 @@ class ServerRepositoryTest {
 
     @Test
     fun `remove cascades libraries and library_items for an ABS server`() = runTest {
-        val entity = ServerEntity("abs-1", "https://abs.example.com", "abs.example.com", true, false, username = "u")
+        val entity = ServerEntity("abs-1", "https://abs.example.com", true, false, username = "u")
         val dao = fakeDao(entity)
         val tokens = fakeTokenStorage()
         tokens.tokens["abs-1"] = "tok"
@@ -494,8 +489,8 @@ class ServerRepositoryTest {
 
     @Test
     fun `setActive changes active server`() = runTest {
-        val e1 = ServerEntity("s1", "https://one.example.com", "one.example.com", true, false, username = "")
-        val e2 = ServerEntity("s2", "https://two.example.com", "two.example.com", false, false, username = "")
+        val e1 = ServerEntity("s1", "https://one.example.com", true, false, username = "")
+        val e2 = ServerEntity("s2", "https://two.example.com", false, false, username = "")
         val dao = fakeDao(e1, e2)
         val absApi = AbsApi { _, _, _, _ -> NetworkLoginResult.WrongCredentials("") }
         val repo = ServerRepositoryImpl(

--- a/core/data/src/test/kotlin/com/riffle/core/data/ToReadRepositoryTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/ToReadRepositoryTest.kt
@@ -30,7 +30,6 @@ class ToReadRepositoryTest {
     private val activeServer = Server(
         id = "s1",
         url = ServerUrl.parse("http://abs.local")!!,
-        displayName = "ABS",
         isActive = true,
         insecureConnectionAllowed = false,
         username = "u",

--- a/core/database/schemas/com.riffle.core.database.RiffleDatabase/21.json
+++ b/core/database/schemas/com.riffle.core.database.RiffleDatabase/21.json
@@ -1,0 +1,464 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 21,
+    "identityHash": "b07460a8af5e1b113a7a7453cf2f8052",
+    "entities": [
+      {
+        "tableName": "servers",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `url` TEXT NOT NULL, `isActive` INTEGER NOT NULL, `insecureConnectionAllowed` INTEGER NOT NULL, `username` TEXT NOT NULL, `serverType` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "isActive",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "insecureConnectionAllowed",
+            "columnName": "insecureConnectionAllowed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "username",
+            "columnName": "username",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverType",
+            "columnName": "serverType",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "libraries",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `mediaType` TEXT NOT NULL, `serverId` TEXT NOT NULL, `isUnsupported` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaType",
+            "columnName": "mediaType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isUnsupported",
+            "columnName": "isUnsupported",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "library_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `title` TEXT NOT NULL, `author` TEXT NOT NULL, `coverUrl` TEXT, `readingProgress` REAL NOT NULL, `ebookFileIno` TEXT, `ebookFormat` TEXT NOT NULL, `description` TEXT, `seriesName` TEXT, `publishedYear` TEXT, `genres` TEXT NOT NULL, `publisher` TEXT, `lastOpenedAt` INTEGER, `addedAt` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "coverUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "readingProgress",
+            "columnName": "readingProgress",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ebookFileIno",
+            "columnName": "ebookFileIno",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "ebookFormat",
+            "columnName": "ebookFormat",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seriesName",
+            "columnName": "seriesName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "publishedYear",
+            "columnName": "publishedYear",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "genres",
+            "columnName": "genres",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "publisher",
+            "columnName": "publisher",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastOpenedAt",
+            "columnName": "lastOpenedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "series",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `name` TEXT NOT NULL, `coverUrl` TEXT, `bookCount` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "coverUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "bookCount",
+            "columnName": "bookCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "collections",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `name` TEXT NOT NULL, `bookCount` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookCount",
+            "columnName": "bookCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "series_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`seriesId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `sequenceOrder` REAL NOT NULL, PRIMARY KEY(`seriesId`, `itemId`))",
+        "fields": [
+          {
+            "fieldPath": "seriesId",
+            "columnName": "seriesId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sequenceOrder",
+            "columnName": "sequenceOrder",
+            "affinity": "REAL",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "seriesId",
+            "itemId"
+          ]
+        }
+      },
+      {
+        "tableName": "collection_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`collectionId` TEXT NOT NULL, `itemId` TEXT NOT NULL, PRIMARY KEY(`collectionId`, `itemId`))",
+        "fields": [
+          {
+            "fieldPath": "collectionId",
+            "columnName": "collectionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "collectionId",
+            "itemId"
+          ]
+        }
+      },
+      {
+        "tableName": "reading_positions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`serverId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `cfi` TEXT NOT NULL, `localUpdatedAt` INTEGER NOT NULL, PRIMARY KEY(`serverId`, `itemId`), FOREIGN KEY(`serverId`) REFERENCES `servers`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cfi",
+            "columnName": "cfi",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localUpdatedAt",
+            "columnName": "localUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "serverId",
+            "itemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_reading_positions_serverId",
+            "unique": false,
+            "columnNames": [
+              "serverId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_reading_positions_serverId` ON `${TABLE_NAME}` (`serverId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "servers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "serverId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "book_formatting_preferences",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`itemId` TEXT NOT NULL, `fontSize` REAL, `theme` TEXT, `fontFamily` TEXT, `lineSpacing` REAL, `margins` REAL, `orientation` TEXT, `showChapterMap` INTEGER, `showReadingProgressLabels` INTEGER, `showCurrentChapterLabel` INTEGER, `doublePageSpread` INTEGER, `justifyText` INTEGER, PRIMARY KEY(`itemId`))",
+        "fields": [
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fontSize",
+            "columnName": "fontSize",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "theme",
+            "columnName": "theme",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "fontFamily",
+            "columnName": "fontFamily",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lineSpacing",
+            "columnName": "lineSpacing",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "margins",
+            "columnName": "margins",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "orientation",
+            "columnName": "orientation",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "showChapterMap",
+            "columnName": "showChapterMap",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "showReadingProgressLabels",
+            "columnName": "showReadingProgressLabels",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "showCurrentChapterLabel",
+            "columnName": "showCurrentChapterLabel",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "doublePageSpread",
+            "columnName": "doublePageSpread",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "justifyText",
+            "columnName": "justifyText",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "itemId"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'b07460a8af5e1b113a7a7453cf2f8052')"
+    ]
+  }
+}

--- a/core/database/src/androidTest/kotlin/com/riffle/core/database/MigrationTest.kt
+++ b/core/database/src/androidTest/kotlin/com/riffle/core/database/MigrationTest.kt
@@ -598,6 +598,41 @@ class MigrationTest {
     }
 
     @Test
+    fun migration20To21_dropsDisplayNameAndPreservesData() {
+        helper.createDatabase(TEST_DB, 20).use { db ->
+            db.execSQL(
+                "INSERT INTO servers (id, url, displayName, isActive, insecureConnectionAllowed, username, serverType) " +
+                    "VALUES ('s1', 'http://media-server:13378', 'media-server', 1, 0, 'plamen', 'AUDIOBOOKSHELF')"
+            )
+            db.execSQL(
+                "INSERT INTO servers (id, url, displayName, isActive, insecureConnectionAllowed, username, serverType) " +
+                    "VALUES ('s2', 'http://media-server:8001', 'media-server', 0, 1, 'plamen', 'STORYTELLER')"
+            )
+        }
+
+        val db = helper.runMigrationsAndValidate(TEST_DB, 21, true, RiffleDatabase.MIGRATION_20_21)
+
+        // displayName column is gone; every other column survives unchanged.
+        db.query("SELECT id, url, isActive, insecureConnectionAllowed, username, serverType FROM servers ORDER BY id").use { cursor ->
+            assertEquals(2, cursor.count)
+            cursor.moveToFirst()
+            assertEquals("s1", cursor.getString(0))
+            assertEquals("http://media-server:13378", cursor.getString(1))
+            assertEquals(1, cursor.getInt(2))
+            assertEquals(0, cursor.getInt(3))
+            assertEquals("plamen", cursor.getString(4))
+            assertEquals("AUDIOBOOKSHELF", cursor.getString(5))
+            cursor.moveToNext()
+            assertEquals("s2", cursor.getString(0))
+            assertEquals("http://media-server:8001", cursor.getString(1))
+            assertEquals(0, cursor.getInt(2))
+            assertEquals(1, cursor.getInt(3))
+            assertEquals("plamen", cursor.getString(4))
+            assertEquals("STORYTELLER", cursor.getString(5))
+        }
+    }
+
+    @Test
     fun migrateFullChain() {
         helper.createDatabase(TEST_DB, 1).use { db ->
             db.execSQL(
@@ -606,7 +641,7 @@ class MigrationTest {
         }
 
         val db = helper.runMigrationsAndValidate(
-            TEST_DB, 20, true,
+            TEST_DB, 21, true,
             RiffleDatabase.MIGRATION_1_2,
             RiffleDatabase.MIGRATION_2_3,
             RiffleDatabase.MIGRATION_3_4,
@@ -626,15 +661,15 @@ class MigrationTest {
             RiffleDatabase.MIGRATION_17_18,
             RiffleDatabase.MIGRATION_18_19,
             RiffleDatabase.MIGRATION_19_20,
+            RiffleDatabase.MIGRATION_20_21,
         )
 
-        db.query("SELECT url, displayName, username, serverType FROM servers WHERE id = 's1'").use { cursor ->
+        db.query("SELECT url, username, serverType FROM servers WHERE id = 's1'").use { cursor ->
             assertEquals(1, cursor.count)
             cursor.moveToFirst()
             assertEquals("http://localhost", cursor.getString(0))
-            assertEquals("My Server", cursor.getString(1))
-            assertEquals("", cursor.getString(2))
-            assertEquals("AUDIOBOOKSHELF", cursor.getString(3))
+            assertEquals("", cursor.getString(1))
+            assertEquals("AUDIOBOOKSHELF", cursor.getString(2))
         }
     }
 }

--- a/core/database/src/main/kotlin/com/riffle/core/database/RiffleDatabase.kt
+++ b/core/database/src/main/kotlin/com/riffle/core/database/RiffleDatabase.kt
@@ -17,7 +17,7 @@ import androidx.sqlite.db.SupportSQLiteDatabase
         ReadingPositionEntity::class,
         BookFormattingPreferencesEntity::class,
     ],
-    version = 20,
+    version = 21,
     exportSchema = true,
 )
 abstract class RiffleDatabase : RoomDatabase() {
@@ -257,6 +257,31 @@ abstract class RiffleDatabase : RoomDatabase() {
                 db.execSQL(
                     "ALTER TABLE `book_formatting_preferences` ADD COLUMN `showCurrentChapterLabel` INTEGER DEFAULT NULL"
                 )
+            }
+        }
+
+        // Servers are now identified by their ServerType (Audiobookshelf / Storyteller) in the UI,
+        // so the URL-host-derived displayName column has no consumers. Drop it.
+        val MIGRATION_20_21 = object : Migration(20, 21) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL(
+                    "CREATE TABLE IF NOT EXISTS `servers_new` (" +
+                        "`id` TEXT NOT NULL, " +
+                        "`url` TEXT NOT NULL, " +
+                        "`isActive` INTEGER NOT NULL, " +
+                        "`insecureConnectionAllowed` INTEGER NOT NULL, " +
+                        "`username` TEXT NOT NULL, " +
+                        "`serverType` TEXT NOT NULL DEFAULT 'AUDIOBOOKSHELF', " +
+                        "PRIMARY KEY(`id`))"
+                )
+                db.execSQL(
+                    "INSERT INTO `servers_new` " +
+                        "(id, url, isActive, insecureConnectionAllowed, username, serverType) " +
+                        "SELECT id, url, isActive, insecureConnectionAllowed, username, serverType " +
+                        "FROM `servers`"
+                )
+                db.execSQL("DROP TABLE `servers`")
+                db.execSQL("ALTER TABLE `servers_new` RENAME TO `servers`")
             }
         }
     }

--- a/core/database/src/main/kotlin/com/riffle/core/database/ServerDao.kt
+++ b/core/database/src/main/kotlin/com/riffle/core/database/ServerDao.kt
@@ -10,7 +10,7 @@ import kotlinx.coroutines.flow.Flow
 @Dao
 interface ServerDao {
 
-    @Query("SELECT * FROM servers ORDER BY isActive DESC, displayName ASC")
+    @Query("SELECT * FROM servers ORDER BY isActive DESC, serverType ASC, username ASC, url ASC")
     fun observeAll(): Flow<List<ServerEntity>>
 
     @Query("SELECT * FROM servers WHERE isActive = 1 LIMIT 1")

--- a/core/database/src/main/kotlin/com/riffle/core/database/ServerEntity.kt
+++ b/core/database/src/main/kotlin/com/riffle/core/database/ServerEntity.kt
@@ -7,7 +7,6 @@ import androidx.room.PrimaryKey
 data class ServerEntity(
     @PrimaryKey val id: String,
     val url: String,
-    val displayName: String,
     val isActive: Boolean,
     val insecureConnectionAllowed: Boolean,
     val username: String,

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/PendingServer.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/PendingServer.kt
@@ -7,7 +7,6 @@ package com.riffle.core.domain
  */
 data class PendingServer(
     val url: ServerUrl,
-    val displayName: String,
     val username: String,
     val userId: String,
     val token: String,

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/Server.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/Server.kt
@@ -3,7 +3,6 @@ package com.riffle.core.domain
 data class Server(
     val id: String,
     val url: ServerUrl,
-    val displayName: String,
     val isActive: Boolean,
     val insecureConnectionAllowed: Boolean,
     val username: String,

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/ServerType.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/ServerType.kt
@@ -1,8 +1,8 @@
 package com.riffle.core.domain
 
-enum class ServerType {
-    AUDIOBOOKSHELF,
-    STORYTELLER,
+enum class ServerType(val label: String) {
+    AUDIOBOOKSHELF("Audiobookshelf"),
+    STORYTELLER("Storyteller"),
     ;
 
     companion object {

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/ServerUrl.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/ServerUrl.kt
@@ -3,6 +3,20 @@ package com.riffle.core.domain
 @ConsistentCopyVisibility
 data class ServerUrl private constructor(val value: String) {
 
+    /** `host` or `host:port` extracted from [value]; falls back to a substring parse if java.net.URI rejects the input. */
+    fun authority(): String {
+        return try {
+            val uri = java.net.URI(value)
+            val host = uri.host ?: return fallbackAuthority()
+            if (uri.port > 0) "$host:${uri.port}" else host
+        } catch (_: Exception) {
+            fallbackAuthority()
+        }
+    }
+
+    private fun fallbackAuthority(): String =
+        value.substringAfter("://").substringBefore("/")
+
     companion object {
         private val ALLOWED_SCHEMES = setOf("http", "https")
 

--- a/core/domain/src/test/kotlin/com/riffle/core/domain/ServerUrlTest.kt
+++ b/core/domain/src/test/kotlin/com/riffle/core/domain/ServerUrlTest.kt
@@ -57,6 +57,26 @@ class ServerUrlTest {
     }
 
     @Test
+    fun `authority returns host for url without port`() {
+        assertEquals("abs.example.com", ServerUrl.parse("https://abs.example.com")!!.authority())
+    }
+
+    @Test
+    fun `authority returns host and port when port is present`() {
+        assertEquals("media-server:13378", ServerUrl.parse("http://media-server:13378")!!.authority())
+    }
+
+    @Test
+    fun `authority strips path`() {
+        assertEquals("abs.example.com", ServerUrl.parse("https://abs.example.com/audiobookshelf")!!.authority())
+    }
+
+    @Test
+    fun `authority handles ipv4 with port`() {
+        assertEquals("192.168.1.100:13378", ServerUrl.parse("http://192.168.1.100:13378")!!.authority())
+    }
+
+    @Test
     fun `two equal urls are equal`() {
         val a = ServerUrl.parse("https://abs.example.com")
         val b = ServerUrl.parse("https://abs.example.com")

--- a/core/network/src/main/kotlin/com/riffle/core/network/AbsApiClient.kt
+++ b/core/network/src/main/kotlin/com/riffle/core/network/AbsApiClient.kt
@@ -564,16 +564,17 @@ class AbsApiClient(private val httpClient: OkHttpClient) : AbsApi, AbsLibraryApi
         insecureAllowed: Boolean,
     ): String? = withContext(Dispatchers.IO) {
         val client = if (insecureAllowed) httpClient.trustAllCerts() else httpClient
+        // `/status` is unauthenticated and returns `{ serverVersion, app, isInit, ... }`.
+        // The previously-targeted `/api/server-info` does not exist on ABS (404 even with auth).
         val request = Request.Builder()
-            .url("$baseUrl/api/server-info")
-            .addHeader("Authorization", "Bearer $token")
+            .url("$baseUrl/status")
             .get()
             .build()
         try {
             val response = client.newCall(request).execute()
             if (!response.isSuccessful) return@withContext null
             val raw = response.body?.string() ?: return@withContext null
-            json.decodeFromString<AbsServerInfoResponse>(raw).version
+            json.decodeFromString<AbsServerInfoResponse>(raw).serverVersion
         } catch (_: Exception) {
             null
         }

--- a/core/network/src/main/kotlin/com/riffle/core/network/model/AbsServerInfoResponse.kt
+++ b/core/network/src/main/kotlin/com/riffle/core/network/model/AbsServerInfoResponse.kt
@@ -2,5 +2,7 @@ package com.riffle.core.network.model
 
 import kotlinx.serialization.Serializable
 
+// Shape returned by ABS's unauthenticated `/status` endpoint. The version field is
+// `serverVersion` — there is no `/api/server-info` endpoint (a misnomer in earlier specs).
 @Serializable
-internal data class AbsServerInfoResponse(val version: String)
+internal data class AbsServerInfoResponse(val serverVersion: String)

--- a/core/network/src/test/kotlin/com/riffle/core/network/AbsApiClientTest.kt
+++ b/core/network/src/test/kotlin/com/riffle/core/network/AbsApiClientTest.kt
@@ -72,4 +72,27 @@ class AbsApiClientTest {
         val result = client.login("http://127.0.0.1:1", "admin", "pass", false)
         assertTrue(result is NetworkLoginResult.NetworkError)
     }
+
+    // ABS exposes its version on the unauthenticated /status endpoint as `serverVersion`.
+    // The /api/server-info path used previously does not exist (returns 404 even with a valid token).
+    @Test
+    fun `getServerInfo hits status and parses serverVersion`() = runTest {
+        server.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setBody("""{"app":"audiobookshelf","serverVersion":"2.35.1","isInit":true,"language":"en-us"}""")
+                .addHeader("Content-Type", "application/json")
+        )
+        val version = client.getServerInfo(server.url("/").toString().trimEnd('/'), "tok", false)
+        assertEquals("2.35.1", version)
+        val request = server.takeRequest()
+        assertEquals("/status", request.path)
+    }
+
+    @Test
+    fun `getServerInfo returns null on 404`() = runTest {
+        server.enqueue(MockResponse().setResponseCode(404))
+        val version = client.getServerInfo(server.url("/").toString().trimEnd('/'), "tok", false)
+        assertEquals(null, version)
+    }
 }

--- a/docs/superpowers/specs/2026-05-31-server-switcher-product-name-design.md
+++ b/docs/superpowers/specs/2026-05-31-server-switcher-product-name-design.md
@@ -1,0 +1,134 @@
+# Server switcher: identify servers by product, not URL host
+
+## Problem
+
+The navigation drawer header and switcher dropdown render each server using a
+display name derived from the URL host (`media-server`, `abs.example.com`). When
+a user has both an Audiobookshelf and a Storyteller server on the same machine
+(e.g. `media-server:13378` and `media-server:8001`), the two entries are nearly
+indistinguishable. Settings → Servers has the same problem.
+
+Neither ABS nor Storyteller exposes a stable "server name" endpoint we can rely
+on, so the label must come from the locally-known `ServerType` instead of the
+network.
+
+## Decision
+
+Show the **product name** (`"Audiobookshelf"` or `"Storyteller"`) derived from
+`ServerType` as the primary identity of every server, everywhere a server is
+listed. Drop the URL-host-derived `Server.displayName`.
+
+## UI changes
+
+### Drawer header and switcher (`NavigationDrawerComposable.kt`)
+
+- **Headline:** `"<ServerType.label> [username]"` (e.g. `"Audiobookshelf [plamen]"`).
+- **Supporting line:**
+  - Single server of this type in the list → version only (or the line is
+    omitted if no version is available).
+  - More than one server of this type in the list → `"<host> · <version>"`,
+    where `host` is the URL authority (`media-server:13378`), not the full URL.
+    If no version is available, the line is just `<host>`.
+- Storyteller has no `/server-info` endpoint, so no version is ever fetched or
+  shown for Storyteller servers. The line collapses gracefully (see above).
+
+### Settings → Servers (`SettingsScreen.kt`)
+
+- **Headline:** `"<ServerType.label>"`.
+- **Supporting line:** `"<username> · <url> · <version>"` — the full URL is
+  always shown here (per user request: Settings is where you go to verify which
+  box you connected to). `version` is omitted if unknown (including all
+  Storyteller rows).
+- "Active" badge unchanged.
+
+## Code changes
+
+### `core/domain`
+
+- Add `ServerType.label: String` returning `"Audiobookshelf"` / `"Storyteller"`.
+  This is the single source of truth for the product name string.
+- Remove `Server.displayName: String` from the `Server` data class.
+
+### `core/database`
+
+- Drop the `displayName` column from `ServerEntity` via Room migration
+  `MIGRATION_19_20`.
+- Bump `RiffleDatabase.version` to 20, register the migration in `DataModule`,
+  export the schema JSON (KSP), add a `migration19To20` test in
+  `MigrationTest.kt` (validate the column is gone, rows preserved) and extend
+  `migrateFullChain`.
+
+### `core/data`
+
+- Remove `displayNameFrom(url)` and all writes/reads of `displayName` in
+  `ServerRepositoryImpl`. `Server` is constructed without it.
+- Update `ServerRepositoryTest` cases that currently assert
+  `displayName == "abs.example.com"` etc. — they should assert on `serverType`
+  / `url` instead.
+- Update every test stub of `ServerRepository` and every `Server(...)`
+  construction across the test suite to drop the `displayName` argument.
+
+### `app/feature/navigation`
+
+- `NavigationDrawerComposable.DrawerHeader` and the switcher `DropdownMenuItem`:
+  - Replace `activeServer.displayName` / `server.displayName` with
+    `server.serverType.label`.
+  - Compute `needsHostDisambiguation = allServers.count { it.serverType == server.serverType } > 1`
+    inside the composable and branch the supporting line as described above.
+  - Treat `serverType == STORYTELLER` as "no version available" (skip the
+    `serverVersions[server.id]` lookup, never render a version segment for it).
+
+### `app/feature/settings`
+
+- `SettingsScreen` server `ListItem`:
+  - `headlineContent` → `Text(server.serverType.label)`.
+  - `supportingContent` → `username · url · version` as described above; for
+    Storyteller servers the `· version` segment is omitted.
+- `SettingsScreen` libraries section currently uses `activeServer.displayName`
+  for the section header (`"Libraries — $activeServerName"`) — update to
+  `serverType.label`.
+
+### `NavigationDrawerViewModel` / `SettingsViewModel`
+
+- Continue fetching versions for ABS servers only (skip Storyteller rows
+  entirely — `serverRepository.getServerVersion` already returns `null` for
+  them, but we should avoid the call to keep the cache map clean and tests
+  honest).
+
+## Tests
+
+Unit / android tests touched:
+- `MigrationTest.migration19To20` (new) and `migrateFullChain` extension.
+- `ServerRepositoryTest` — drop `displayName` assertions, add a case verifying a
+  round-trip preserves `serverType`.
+- `NavigationDrawerViewModelTest`, `SettingsViewModelTest`,
+  `AddServerViewModelTest`, `HomeViewModelTest`,
+  `SeriesDetailViewModelTest`, `LibraryItemsViewModelTest`,
+  `LibraryItemDetailViewModelTest`, `CollectionDetailViewModelTest`,
+  `ToReadRepositoryTest`, `LibraryRepositoryTest`,
+  `EpubRepositoryTest`, `PdfRepositoryTest`,
+  `ReadingSessionIntegrationTest`, `ProgressSyncIntegrationTest`,
+  `ProgressSyncCycleTest`, `SeriesIntegrationTest`,
+  `EpubPositionIntegrationTest` — drop the `displayName` constructor argument
+  from every `Server(...)` they build (and from the `getServerVersion` stub
+  signature where applicable; signature is unchanged but the in-memory `Server`
+  objects need updating).
+- `PermanentNavigationDrawerTest`, `NavigationDrawerGestureTest` — update any
+  text assertions that look for the host string in the drawer to look for the
+  product label instead; verify the version chip appears for ABS and is absent
+  for Storyteller.
+
+## Out of scope
+
+- A user-given nickname per server (the `displayName` field could be repurposed
+  for this later — for now it is removed entirely; reintroduce if/when needed).
+- Fetching a Storyteller version. Storyteller rows never show a version in this
+  iteration.
+- Localising the product names. Both labels are proper nouns and stay in
+  English regardless of locale, matching how they're spelled in the projects
+  themselves.
+
+## Prototype
+
+Static HTML mockup at `.context/server-switcher-prototype.html` shows the
+final layout for both single-type and multi-type scenarios.


### PR DESCRIPTION
## Summary

- Replace URL-host-derived `Server.displayName` with the product label from `ServerType` (`Audiobookshelf` / `Storyteller`) in the navigation drawer header, the server switcher dropdown, and Settings → Servers. Disambiguate same-type duplicates with the URL authority.
- Fix the ABS version fetch: `/api/server-info` does not exist on Audiobookshelf — the silent 404 meant the version cache never populated. Switch to the documented unauthenticated `/status` endpoint and read `serverVersion`. Verified against ABS 2.35.1.
- Migration 20→21 drops the `displayName` column from `servers`.

## Drive-by fix

- `WakeLockHarnessTest.wakeLockIsOffWhenDisabledInSettings` was failing on `main` because `performClick` on the off-screen `Keep screen on` toggle didn't fire the toggleable Row's `onValueChange`. Scroll the toggle on-screen first, and poll the persisted preference value before navigating to the reader so the test isolates the read path from the write path.

## Test plan

- [x] `./gradlew test` — green
- [x] `make harness-test` — 128 tests green (was 1 failure on `main`)
- [x] `make harness-test-tablet` — 5 tests green
- [x] Manual: drawer now shows `Audiobookshelf [user]` with `v2.35.1` underneath; Settings shows `Audiobookshelf` over `user · http://media-server:13378 · v2.35.1`

Spec: `docs/superpowers/specs/2026-05-31-server-switcher-product-name-design.md`