### PR TITLE
feat(reader): Auto reader theme on a clock schedule

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -97,8 +97,14 @@ For an ABS-only book the cycle has one remote (ABS ebook progress). For a matche
 
 ### Formatting Preferences
 User-controlled reading display settings. Scope varies by format:
-- **EPUB:** font size, theme (Light / Dark / Sepia), font family (system fonts + Literata, Merriweather, OpenDyslexic), justify text (on/off toggle, default off), line spacing, margins, reading orientation (paginated / continuous scroll).
-- **PDF:** theme (as colour filter), scroll direction (paged / continuous), zoom persistence.
+- **EPUB:** font size, theme (Light / Dark / Sepia / [Auto Theme]), font family (system fonts + Literata, Merriweather, OpenDyslexic), justify text (on/off toggle, default off), line spacing, margins, reading orientation (paginated / continuous scroll).
+- **PDF:** theme (as colour filter, same value set as EPUB including [Auto Theme]), scroll direction (paged / continuous), zoom persistence.
+
+### Auto Theme
+A theme value that sits alongside Light, Dark, DarkDim, and Sepia in the [Formatting Preferences] theme picker. Selected like any other theme — globally as the default or per-book as an override — but resolves at render-time to one of the four concrete themes according to the [Theme Schedule]. The chip in the formatting panel uses a split day/night swatch (half day-theme background, half night-theme background) so the user can see which two palettes the schedule will alternate between. A book pinned to a concrete theme is unaffected by the schedule; a book pinned to Auto follows it.
+
+### Theme Schedule
+A global, user-configured pair of clock times and theme picks that drive the [Auto Theme]. Four fields: **day-start**, **night-start**, **day-theme**, **night-theme**. The two theme picks are restricted to the four concrete themes (Light, Dark, DarkDim, Sepia) — Auto cannot nest inside Auto. Interpreted on the device's local clock as two arcs on a 24-hour circle: the night arc runs clockwise from night-start to day-start and may cross midnight. If day-start equals night-start, the schedule degenerates to always-day. Defaults on first opt-in: 07:00, 21:00, Light, Dark. Applies uniformly to EPUB and PDF reading. Boundary crossings during an open reading session repaint live — a timer fires at the next boundary and the navigator reapplies preferences without the user closing the book. The four fields are editable only on the full-screen Settings panel; the in-reader formatting panel just shows the Auto chip as a selectable theme. See [ADR 0022](adr/0022-auto-reader-theme-clock-scheduled-fifth-enum.md).
 
 ### EPUB CFI
 An EPUB Canonical Fragment Identifier — a string of the form `epubcfi(/6/N!<docPath>)` that pinpoints an exact location within an EPUB chapter. The spine step (`/6/N`) identifies the chapter; the document path after `!` identifies a node and character offset within that chapter's HTML. Two CFI dialects exist in practice: Readium emits XPath-style node addresses; epub.js (ABS's web reader) emits character-count-based addresses. The two are structurally incompatible. See ADR 0013.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Riffle lets you browse your ebook library, read EPUB and PDF files, and sync rea
 
 ### Reading Display
 - Rich formatting controls (themes, fonts, sizing, spacing, margins, justification)
+- Auto theme that switches between configured day and night themes on a global clock schedule
 - Paginated and continuous scroll modes, with landscape double-page spread
 - Per-book formatting overrides
 - Volume-key page navigation

--- a/app/src/androidTest/kotlin/com/riffle/app/feature/reader/FormattingPreferencesMapperTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/reader/FormattingPreferencesMapperTest.kt
@@ -53,6 +53,14 @@ class FormattingPreferencesMapperTest {
         assertEquals(Theme.SEPIA, result.theme)
     }
 
+    @Test
+    fun autoThemeMapsToLIGHTAsDefensiveFallback() {
+        // Reader VM resolves Auto before calling the mapper; this verifies the
+        // fallback path the mapper provides for exhaustiveness.
+        val result = FormattingPreferences(theme = ReaderTheme.Auto).toEpubPreferences()
+        assertEquals(Theme.LIGHT, result.theme)
+    }
+
     // Serif is the default ReaderFontFamily; mapping it to null leaves --USER__fontFamily
     // unset on :root so the publisher's typography is preserved on books the user hasn't
     // customized. See typographyOverrideCss() — the gate `:root[style*="--USER__fontFamily"]`

--- a/app/src/main/kotlin/com/riffle/app/di/AppModule.kt
+++ b/app/src/main/kotlin/com/riffle/app/di/AppModule.kt
@@ -3,6 +3,8 @@
 package com.riffle.app.di
 
 import android.content.Context
+import com.riffle.app.feature.reader.SystemTimeProvider
+import com.riffle.app.feature.reader.TimeProvider
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -29,6 +31,10 @@ object AppModule {
         @ApplicationContext context: Context,
         httpClient: DefaultHttpClient
     ): AssetRetriever = AssetRetriever(context.contentResolver, httpClient)
+
+    @Provides
+    @Singleton
+    fun provideTimeProvider(impl: SystemTimeProvider): TimeProvider = impl
 
     @Provides
     @Singleton

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -408,6 +408,8 @@ private fun readerThemeLabelColor(theme: ReaderTheme): Color {
         ReaderTheme.Dark -> 0.65f
         ReaderTheme.DarkDim -> 0.85f
         ReaderTheme.Sepia -> 0.70f
+        // Auto resolves upstream; treat as Light if it slips through.
+        ReaderTheme.Auto -> 0.65f
     }
     return theme.palette.foreground.copy(alpha = alpha)
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -104,7 +104,12 @@ fun EpubReaderScreen(
     viewModel: EpubReaderViewModel = hiltViewModel(),
 ) {
     val state by viewModel.state.collectAsState()
-    val formattingPrefs by viewModel.formattingPreferences.collectAsState()
+    // Raw user-picked prefs — feeds the FormattingPanel chip selection (so Auto stays
+    // highlighted even though the page renders in the resolved palette).
+    val pickedPrefs by viewModel.formattingPreferences.collectAsState()
+    // Resolved prefs — `theme` is always concrete. Feeds Readium, the chapter rail
+    // backdrop, and any palette consumer.
+    val formattingPrefs by viewModel.effectiveFormattingPreferences.collectAsState()
     val hasBookOverrides by viewModel.hasBookOverrides.collectAsState()
     val keepScreenOn by viewModel.keepScreenOn.collectAsState()
     val volumeKeyNavigationEnabled by viewModel.volumeKeyNavigationEnabled.collectAsState()
@@ -319,7 +324,7 @@ fun EpubReaderScreen(
 
         if (showFormattingPanel) {
             FormattingPanel(
-                prefs = formattingPrefs,
+                prefs = pickedPrefs,
                 hasBookOverrides = hasBookOverrides,
                 onPrefsChange = { viewModel.updateFormatting(it) },
                 onReset = { viewModel.resetToGlobalDefaults() },

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -23,6 +23,7 @@ import com.riffle.core.domain.SessionPayload
 import com.riffle.core.domain.withResolvedTheme
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.Channel
@@ -213,6 +214,12 @@ class EpubReaderViewModel @Inject constructor(
                 .distinctUntilChanged()
                 .collectLatest { (schedule, autoActive) ->
                     if (!autoActive) return@collectLatest
+                    // Degenerate schedule (equal day/night times) collapses to always-day —
+                    // no boundary will ever arrive. Park until cancelled (the schedule
+                    // changes) instead of spinning at 1 Hz against the 1_000L floor.
+                    if (schedule.dayStart == schedule.nightStart) {
+                        awaitCancellation()
+                    }
                     while (true) {
                         val now = timeProvider.nowLocalTime()
                         val next = schedule.nextBoundaryAfter(now)

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -16,9 +16,11 @@ import com.riffle.core.domain.FormattingPreferences
 import com.riffle.core.domain.FormattingPreferencesStore
 import com.riffle.core.domain.LibraryRepository
 import com.riffle.core.domain.ProgressSyncController
+import com.riffle.core.domain.ReaderTheme
 import com.riffle.core.domain.ReadingSessionRepository
 import com.riffle.core.domain.ServerProgress
 import com.riffle.core.domain.SessionPayload
+import com.riffle.core.domain.withResolvedTheme
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.FlowPreview
@@ -32,8 +34,10 @@ import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.receiveAsFlow
@@ -81,6 +85,7 @@ class EpubReaderViewModel @Inject constructor(
     private val wakeLockPreferencesStore: WakeLockPreferencesStore,
     private val volumeKeyPreferencesStore: VolumeKeyPreferencesStore,
     private val volumeNavigationController: VolumeNavigationController,
+    private val timeProvider: TimeProvider,
     private val readerStateHolder: ReaderStateHolder,
 ) : AndroidViewModel(application) {
 
@@ -142,6 +147,22 @@ class EpubReaderViewModel @Inject constructor(
     private val _formattingPreferences = MutableStateFlow(FormattingPreferences())
     val formattingPreferences: StateFlow<FormattingPreferences> = _formattingPreferences
 
+    // Ticks emitted at each ThemeSchedule boundary so the resolved theme can flip live
+    // during a reading session. Re-armed whenever the schedule changes.
+    private val scheduleTicks = MutableSharedFlow<Unit>(extraBufferCapacity = 1, replay = 1).apply {
+        tryEmit(Unit) // prime the combine() below so it emits immediately on collection
+    }
+
+    // The user's pick with `theme` replaced by the resolver's concrete value when the
+    // pick is Auto. Every downstream consumer (Readium navigator submitPreferences,
+    // chapter rail backdrop, palette) reads this — they stay ignorant of Auto.
+    val effectiveFormattingPreferences: StateFlow<FormattingPreferences> = combine(
+        _formattingPreferences,
+        scheduleTicks,
+    ) { prefs, _ -> prefs.withResolvedTheme(timeProvider.nowLocalTime()) }
+        .distinctUntilChanged()
+        .stateIn(viewModelScope, SharingStarted.Eagerly, FormattingPreferences())
+
     private val _hasBookOverrides = MutableStateFlow(false)
     val hasBookOverrides: StateFlow<Boolean> = _hasBookOverrides
 
@@ -185,6 +206,24 @@ class EpubReaderViewModel @Inject constructor(
             progressSyncController.serverPositionEvents.collect { serverProgress ->
                 serverProgressToLocator(serverProgress)?.let { _serverLocatorChannel.trySend(it) }
             }
+        }
+        viewModelScope.launch {
+            _formattingPreferences
+                .map { it.themeSchedule to (it.theme == ReaderTheme.Auto) }
+                .distinctUntilChanged()
+                .collectLatest { (schedule, autoActive) ->
+                    if (!autoActive) return@collectLatest
+                    while (true) {
+                        val now = timeProvider.nowLocalTime()
+                        val next = schedule.nextBoundaryAfter(now)
+                        val nowSec = now.toSecondOfDay().toLong()
+                        val nextSec = next.toSecondOfDay().toLong()
+                        val delayMs = (((nextSec - nowSec + 24 * 3600) % (24 * 3600)) * 1000L)
+                            .coerceAtLeast(1_000L)
+                        delay(delayMs)
+                        scheduleTicks.tryEmit(Unit)
+                    }
+                }
         }
         @OptIn(FlowPreview::class)
         viewModelScope.launch {

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/FormattingPanel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/FormattingPanel.kt
@@ -28,9 +28,13 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.ui.draw.alpha
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -146,10 +150,15 @@ fun FormattingPanel(
 
             Spacer(Modifier.height(16.dp))
 
-            // Theme
+            // Theme — five chips don't fit on one row on a phone. Manual two-row split
+            // (concretes on top, Auto below) instead of FlowRow due to the
+            // compose-foundation ABI skew documented under "Font" below.
             Text("Theme", style = MaterialTheme.typography.labelMedium)
+            val concreteThemes = listOf(
+                ReaderTheme.Light, ReaderTheme.Dark, ReaderTheme.DarkDim, ReaderTheme.Sepia,
+            )
             Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                ReaderTheme.entries.forEach { theme ->
+                concreteThemes.forEach { theme ->
                     val label = theme.displayName()
                     FilterChip(
                         selected = prefs.theme == theme,
@@ -160,9 +169,24 @@ fun FormattingPanel(
                     )
                 }
             }
+            Spacer(Modifier.height(4.dp))
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                val label = ReaderTheme.Auto.displayName()
+                FilterChip(
+                    selected = prefs.theme == ReaderTheme.Auto,
+                    onClick = { onPrefsChange(prefs.copy(theme = ReaderTheme.Auto)) },
+                    label = { Text(label) },
+                    leadingIcon = { ThemeSwatch(ReaderTheme.Auto, prefs.themeSchedule) },
+                    modifier = Modifier.semantics { contentDescription = "$label theme" },
+                )
+            }
 
             Spacer(Modifier.height(16.dp))
 
+            // Auto schedule (day/night times + themes) is global-only — editable in
+            // Settings (fullScreen), not in the in-reader per-book panel. The in-reader
+            // panel can pick Auto as a per-book theme; the times it follows are whatever
+            // the user configured globally.
             if (fullScreen && prefs.theme == ReaderTheme.Auto) {
                 AutoScheduleControls(
                     schedule = prefs.themeSchedule,
@@ -678,14 +702,16 @@ private fun AutoScheduleControls(
         )
         Spacer(Modifier.height(12.dp))
         Text("Day theme", style = MaterialTheme.typography.labelMedium)
-        ConcreteThemeChipRow(
+        ConcreteThemeDropdown(
             selected = schedule.dayTheme,
+            fieldContentDescription = "Day theme",
             onSelect = { onScheduleChange(schedule.copy(dayTheme = it)) },
         )
         Spacer(Modifier.height(8.dp))
         Text("Night theme", style = MaterialTheme.typography.labelMedium)
-        ConcreteThemeChipRow(
+        ConcreteThemeDropdown(
             selected = schedule.nightTheme,
+            fieldContentDescription = "Night theme",
             onSelect = { onScheduleChange(schedule.copy(nightTheme = it)) },
         )
     }
@@ -693,23 +719,46 @@ private fun AutoScheduleControls(
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-private fun ConcreteThemeChipRow(
+private fun ConcreteThemeDropdown(
     selected: ReaderTheme,
+    fieldContentDescription: String,
     onSelect: (ReaderTheme) -> Unit,
 ) {
     val concretes = listOf(
         ReaderTheme.Light, ReaderTheme.Dark, ReaderTheme.DarkDim, ReaderTheme.Sepia,
     )
-    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-        concretes.forEach { theme ->
-            val label = theme.displayName()
-            FilterChip(
-                selected = selected == theme,
-                onClick = { onSelect(theme) },
-                label = { Text(label) },
-                leadingIcon = { ConcreteThemeSwatch(theme) },
-                modifier = Modifier.semantics { contentDescription = "$label theme" },
-            )
+    var expanded by remember { mutableStateOf(false) }
+    ExposedDropdownMenuBox(
+        expanded = expanded,
+        onExpandedChange = { expanded = it },
+    ) {
+        OutlinedTextField(
+            value = selected.displayName(),
+            onValueChange = {},
+            readOnly = true,
+            leadingIcon = { ConcreteThemeSwatch(selected) },
+            trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
+            modifier = Modifier
+                .fillMaxWidth()
+                .menuAnchor()
+                .semantics { contentDescription = fieldContentDescription },
+        )
+        ExposedDropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { expanded = false },
+        ) {
+            concretes.forEach { theme ->
+                val label = theme.displayName()
+                DropdownMenuItem(
+                    text = { Text(label) },
+                    leadingIcon = { ConcreteThemeSwatch(theme) },
+                    onClick = {
+                        onSelect(theme)
+                        expanded = false
+                    },
+                    modifier = Modifier.semantics { contentDescription = "$label theme" },
+                )
+            }
         }
     }
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/FormattingPanel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/FormattingPanel.kt
@@ -58,6 +58,8 @@ import com.riffle.core.domain.FormattingPreferences
 import com.riffle.core.domain.ReaderFontFamily
 import com.riffle.core.domain.ReaderOrientation
 import com.riffle.core.domain.ReaderTheme
+import androidx.compose.ui.graphics.drawscope.clipPath
+import com.riffle.core.domain.ThemeSchedule
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -146,7 +148,7 @@ fun FormattingPanel(
                         selected = prefs.theme == theme,
                         onClick = { onPrefsChange(prefs.copy(theme = theme)) },
                         label = { Text(label) },
-                        leadingIcon = { ThemeSwatch(theme) },
+                        leadingIcon = { ThemeSwatch(theme, prefs.themeSchedule) },
                         modifier = Modifier.semantics { contentDescription = "$label theme" },
                     )
                 }
@@ -474,30 +476,52 @@ private fun ReaderTheme.displayName(): String = when (this) {
     ReaderTheme.Auto -> "Auto"
 }
 
-// Reader pane background/foreground colors for each theme — used to render a small
-// preview swatch on the corresponding FilterChip so users can pick a theme by sight
-// rather than reading the label. The dot is filled with the background and outlined
-// in the foreground so Dark vs Dark dim are visually distinct.
-// Palette comes from ReaderThemePalette so this stays in lock-step with the chapter-rail
-// overlay backdrop and (transitively) Readium's actual page rendering.
-private fun ReaderTheme.swatchBackground(): Color = palette.background
-
-private fun ReaderTheme.swatchForeground(): Color = palette.foreground
+@Composable
+private fun ThemeSwatch(theme: ReaderTheme, schedule: ThemeSchedule) {
+    if (theme == ReaderTheme.Auto) {
+        AutoThemeSwatch(schedule)
+    } else {
+        ConcreteThemeSwatch(theme)
+    }
+}
 
 @Composable
-private fun ThemeSwatch(theme: ReaderTheme) {
+private fun ConcreteThemeSwatch(theme: ReaderTheme) {
+    val palette = theme.palette
     Box(
         modifier = Modifier
             .size(18.dp)
-            .background(theme.swatchBackground(), RoundedCornerShape(percent = 50))
-            .border(1.dp, theme.swatchForeground(), RoundedCornerShape(percent = 50)),
+            .background(palette.background, RoundedCornerShape(percent = 50))
+            .border(1.dp, palette.foreground, RoundedCornerShape(percent = 50)),
         contentAlignment = Alignment.Center,
     ) {
-        Text(
-            "A",
-            color = theme.swatchForeground(),
-            style = MaterialTheme.typography.labelSmall,
-        )
+        Text("A", color = palette.foreground, style = MaterialTheme.typography.labelSmall)
+    }
+}
+
+@Composable
+private fun AutoThemeSwatch(schedule: ThemeSchedule) {
+    val day = schedule.dayTheme.palette
+    val night = schedule.nightTheme.palette
+    Box(
+        modifier = Modifier
+            .size(18.dp)
+            .background(day.background, RoundedCornerShape(percent = 50))
+            .border(1.dp, MaterialTheme.colorScheme.outline, RoundedCornerShape(percent = 50)),
+        contentAlignment = Alignment.Center,
+    ) {
+        // Bottom-right half painted in the night background, clipped to the circle.
+        Canvas(modifier = Modifier.size(18.dp)) {
+            val path = androidx.compose.ui.graphics.Path().apply {
+                moveTo(size.width, 0f)
+                lineTo(size.width, size.height)
+                lineTo(0f, size.height)
+                close()
+            }
+            clipPath(path) {
+                drawCircle(color = night.background, radius = size.minDimension / 2f)
+            }
+        }
     }
 }
 

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/FormattingPanel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/FormattingPanel.kt
@@ -39,8 +39,15 @@ import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.TimePicker
+import androidx.compose.material3.rememberTimePickerState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import java.time.LocalTime
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
@@ -155,6 +162,14 @@ fun FormattingPanel(
             }
 
             Spacer(Modifier.height(16.dp))
+
+            if (fullScreen && prefs.theme == ReaderTheme.Auto) {
+                AutoScheduleControls(
+                    schedule = prefs.themeSchedule,
+                    onScheduleChange = { onPrefsChange(prefs.copy(themeSchedule = it)) },
+                )
+                Spacer(Modifier.height(16.dp))
+            }
 
             // Font family — split into two rows: generic web fonts above, bundled book fonts
             // below. Manual two-Row layout avoids FlowRow's compose-foundation version
@@ -640,3 +655,109 @@ private fun ReaderFontFamily.displayName(): String = when (this) {
 }
 
 private fun Float.round1() = (this * 10).roundToInt() / 10f
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun AutoScheduleControls(
+    schedule: ThemeSchedule,
+    onScheduleChange: (ThemeSchedule) -> Unit,
+) {
+    Column {
+        Text("Day starts at", style = MaterialTheme.typography.labelMedium)
+        TimeField(
+            time = schedule.dayStart,
+            contentDescription = "Day start time",
+            onTimeChange = { onScheduleChange(schedule.copy(dayStart = it)) },
+        )
+        Spacer(Modifier.height(8.dp))
+        Text("Night starts at", style = MaterialTheme.typography.labelMedium)
+        TimeField(
+            time = schedule.nightStart,
+            contentDescription = "Night start time",
+            onTimeChange = { onScheduleChange(schedule.copy(nightStart = it)) },
+        )
+        Spacer(Modifier.height(12.dp))
+        Text("Day theme", style = MaterialTheme.typography.labelMedium)
+        ConcreteThemeChipRow(
+            selected = schedule.dayTheme,
+            onSelect = { onScheduleChange(schedule.copy(dayTheme = it)) },
+        )
+        Spacer(Modifier.height(8.dp))
+        Text("Night theme", style = MaterialTheme.typography.labelMedium)
+        ConcreteThemeChipRow(
+            selected = schedule.nightTheme,
+            onSelect = { onScheduleChange(schedule.copy(nightTheme = it)) },
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun ConcreteThemeChipRow(
+    selected: ReaderTheme,
+    onSelect: (ReaderTheme) -> Unit,
+) {
+    val concretes = listOf(
+        ReaderTheme.Light, ReaderTheme.Dark, ReaderTheme.DarkDim, ReaderTheme.Sepia,
+    )
+    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+        concretes.forEach { theme ->
+            val label = theme.displayName()
+            FilterChip(
+                selected = selected == theme,
+                onClick = { onSelect(theme) },
+                label = { Text(label) },
+                leadingIcon = { ConcreteThemeSwatch(theme) },
+                modifier = Modifier.semantics { contentDescription = "$label theme" },
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun TimeField(
+    time: LocalTime,
+    contentDescription: String,
+    onTimeChange: (LocalTime) -> Unit,
+) {
+    var showPicker by remember { mutableStateOf(false) }
+    val label = "%02d:%02d".format(time.hour, time.minute)
+    Surface(
+        shape = RoundedCornerShape(percent = 50),
+        color = MaterialTheme.colorScheme.surfaceVariant,
+        contentColor = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { showPicker = true }
+            .semantics { this.contentDescription = contentDescription },
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.Center,
+            modifier = Modifier.height(48.dp).fillMaxWidth(),
+        ) {
+            Text(label, style = MaterialTheme.typography.bodyLarge)
+        }
+    }
+    if (showPicker) {
+        val state = rememberTimePickerState(
+            initialHour = time.hour,
+            initialMinute = time.minute,
+            is24Hour = true,
+        )
+        AlertDialog(
+            onDismissRequest = { showPicker = false },
+            confirmButton = {
+                TextButton(onClick = {
+                    onTimeChange(LocalTime.of(state.hour, state.minute))
+                    showPicker = false
+                }) { Text("OK") }
+            },
+            dismissButton = {
+                TextButton(onClick = { showPicker = false }) { Text("Cancel") }
+            },
+            text = { TimePicker(state = state) },
+        )
+    }
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/FormattingPanel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/FormattingPanel.kt
@@ -471,6 +471,7 @@ private fun ReaderTheme.displayName(): String = when (this) {
     ReaderTheme.Dark -> "Dark"
     ReaderTheme.DarkDim -> "Dim"
     ReaderTheme.Sepia -> "Sepia"
+    ReaderTheme.Auto -> "Auto"
 }
 
 // Reader pane background/foreground colors for each theme — used to render a small

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/FormattingPanel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/FormattingPanel.kt
@@ -26,37 +26,38 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.clip
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
-import androidx.compose.material3.TopAppBar
-import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.TimePicker
+import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.rememberTimePickerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import java.time.LocalTime
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.clipPath
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
@@ -64,13 +65,13 @@ import androidx.compose.ui.text.font.Font
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import kotlin.math.roundToInt
 import com.riffle.core.domain.FormattingPreferences
 import com.riffle.core.domain.ReaderFontFamily
 import com.riffle.core.domain.ReaderOrientation
 import com.riffle.core.domain.ReaderTheme
-import androidx.compose.ui.graphics.drawscope.clipPath
 import com.riffle.core.domain.ThemeSchedule
+import java.time.LocalTime
+import kotlin.math.roundToInt
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -542,14 +543,17 @@ private fun ConcreteThemeSwatch(theme: ReaderTheme) {
 private fun AutoThemeSwatch(schedule: ThemeSchedule) {
     val day = schedule.dayTheme.palette
     val night = schedule.nightTheme.palette
+    val shape = RoundedCornerShape(percent = 50)
     Box(
         modifier = Modifier
             .size(18.dp)
-            .background(day.background, RoundedCornerShape(percent = 50))
-            .border(1.dp, MaterialTheme.colorScheme.outline, RoundedCornerShape(percent = 50)),
+            .clip(shape)
+            .background(day.background, shape)
+            .border(1.dp, MaterialTheme.colorScheme.outline, shape),
         contentAlignment = Alignment.Center,
     ) {
-        // Bottom-right half painted in the night background, clipped to the circle.
+        // Bottom-right half painted in the night background. The parent clip keeps the
+        // canvas inside the rounded shape so the night fill never bleeds past the border.
         Canvas(modifier = Modifier.size(18.dp)) {
             val path = androidx.compose.ui.graphics.Path().apply {
                 moveTo(size.width, 0f)

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/FormattingPreferencesMapper.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/FormattingPreferencesMapper.kt
@@ -31,6 +31,10 @@ fun FormattingPreferences.toEpubPreferences(
             ReaderTheme.Light -> Theme.LIGHT
             ReaderTheme.Dark, ReaderTheme.DarkDim -> Theme.DARK
             ReaderTheme.Sepia -> Theme.SEPIA
+            // Auto should be resolved to a concrete theme upstream by the reader VM
+            // (via FormattingPreferences.withResolvedTheme). If it reaches here we
+            // fall back to LIGHT rather than crashing.
+            ReaderTheme.Auto -> Theme.LIGHT
         },
         // DarkDim is "dark with slightly muted body text" — same dark background, dimmer text.
         textColor = if (theme == ReaderTheme.DarkDim) Color(DARK_DIM_TEXT_COLOR) else null,

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/PdfReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/PdfReaderViewModel.kt
@@ -4,13 +4,19 @@ import android.app.Application
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
+import com.riffle.core.domain.BookFormattingOverrides
+import com.riffle.core.domain.BookFormattingPreferencesStore
+import com.riffle.core.domain.FormattingPreferences
+import com.riffle.core.domain.FormattingPreferencesStore
 import com.riffle.core.domain.LibraryRepository
 import com.riffle.core.domain.PdfOpenResult
+import com.riffle.core.domain.ReaderTheme
 import com.riffle.core.domain.WakeLockPreferencesStore
 import com.riffle.core.domain.PdfRepository
 import com.riffle.core.domain.ProgressSyncController
 import com.riffle.core.domain.ReadingSessionRepository
 import com.riffle.core.domain.SessionPayload
+import com.riffle.core.domain.withResolvedTheme
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.Channel
@@ -18,6 +24,11 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -48,6 +59,9 @@ class PdfReaderViewModel @Inject constructor(
     private val wakeLockPreferencesStore: WakeLockPreferencesStore,
     private val readingSessionRepository: ReadingSessionRepository,
     private val volumeNavigationController: VolumeNavigationController,
+    private val formattingPreferencesStore: FormattingPreferencesStore,
+    private val bookFormattingPreferencesStore: BookFormattingPreferencesStore,
+    private val timeProvider: TimeProvider,
     private val readerStateHolder: ReaderStateHolder,
 ) : AndroidViewModel(application) {
 
@@ -58,6 +72,21 @@ class PdfReaderViewModel @Inject constructor(
 
     val keepScreenOn: StateFlow<Boolean> = wakeLockPreferencesStore.keepScreenOn
         .stateIn(viewModelScope, SharingStarted.Eagerly, true)
+
+    private val _bookOverrides = MutableStateFlow(BookFormattingOverrides())
+    private val _formattingPreferences = MutableStateFlow(FormattingPreferences())
+    val formattingPreferences: StateFlow<FormattingPreferences> = _formattingPreferences
+
+    private val scheduleTicks = MutableSharedFlow<Unit>(extraBufferCapacity = 1, replay = 1).apply {
+        tryEmit(Unit)
+    }
+
+    val effectiveFormattingPreferences: StateFlow<FormattingPreferences> = combine(
+        _formattingPreferences,
+        scheduleTicks,
+    ) { prefs, _ -> prefs.withResolvedTheme(timeProvider.nowLocalTime()) }
+        .distinctUntilChanged()
+        .stateIn(viewModelScope, SharingStarted.Eagerly, FormattingPreferences())
 
     val volumeNavEvents: SharedFlow<VolumeNavEvent> = volumeNavigationController.events
 
@@ -85,12 +114,45 @@ class PdfReaderViewModel @Inject constructor(
     private var initialLocatorSeen = false
 
     init {
-        viewModelScope.launch { openBook() }
+        viewModelScope.launch {
+            loadFormattingPreferences()
+            openBook()
+        }
+        viewModelScope.launch {
+            combine(
+                formattingPreferencesStore.preferences,
+                _bookOverrides,
+            ) { global, overrides -> overrides.applyTo(global) }
+                .collect { _formattingPreferences.value = it }
+        }
+        viewModelScope.launch {
+            _formattingPreferences
+                .map { it.themeSchedule to (it.theme == ReaderTheme.Auto) }
+                .distinctUntilChanged()
+                .collectLatest { (schedule, autoActive) ->
+                    if (!autoActive) return@collectLatest
+                    while (true) {
+                        val now = timeProvider.nowLocalTime()
+                        val next = schedule.nextBoundaryAfter(now)
+                        val delayMs = (((next.toSecondOfDay() - now.toSecondOfDay() + 24 * 3600) % (24 * 3600)) * 1000L)
+                            .coerceAtLeast(1_000L)
+                        delay(delayMs)
+                        scheduleTicks.tryEmit(Unit)
+                    }
+                }
+        }
         viewModelScope.launch {
             progressSyncController.serverPositionEvents.collect { serverProgress ->
                 serverLocationToLocator(serverProgress.ebookLocation)?.let { _serverLocatorChannel.trySend(it) }
             }
         }
+    }
+
+    private suspend fun loadFormattingPreferences() {
+        val overrides = bookFormattingPreferencesStore.load(itemId)
+        val global = formattingPreferencesStore.preferences.first()
+        _bookOverrides.value = overrides
+        _formattingPreferences.value = overrides.applyTo(global)
     }
 
     private suspend fun openBook() {

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/PdfReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/PdfReaderViewModel.kt
@@ -19,6 +19,7 @@ import com.riffle.core.domain.SessionPayload
 import com.riffle.core.domain.withResolvedTheme
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
@@ -131,6 +132,11 @@ class PdfReaderViewModel @Inject constructor(
                 .distinctUntilChanged()
                 .collectLatest { (schedule, autoActive) ->
                     if (!autoActive) return@collectLatest
+                    // Degenerate schedule (equal day/night times) collapses to always-day —
+                    // no boundary will ever arrive. Park until cancelled instead of spinning.
+                    if (schedule.dayStart == schedule.nightStart) {
+                        awaitCancellation()
+                    }
                     while (true) {
                         val now = timeProvider.nowLocalTime()
                         val next = schedule.nextBoundaryAfter(now)

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/PdfReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/PdfReaderViewModel.kt
@@ -4,32 +4,20 @@ import android.app.Application
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
-import com.riffle.core.domain.BookFormattingOverrides
-import com.riffle.core.domain.BookFormattingPreferencesStore
-import com.riffle.core.domain.FormattingPreferences
-import com.riffle.core.domain.FormattingPreferencesStore
 import com.riffle.core.domain.LibraryRepository
 import com.riffle.core.domain.PdfOpenResult
-import com.riffle.core.domain.ReaderTheme
 import com.riffle.core.domain.WakeLockPreferencesStore
 import com.riffle.core.domain.PdfRepository
 import com.riffle.core.domain.ProgressSyncController
 import com.riffle.core.domain.ReadingSessionRepository
 import com.riffle.core.domain.SessionPayload
-import com.riffle.core.domain.withResolvedTheme
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.collectLatest
-import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -60,9 +48,6 @@ class PdfReaderViewModel @Inject constructor(
     private val wakeLockPreferencesStore: WakeLockPreferencesStore,
     private val readingSessionRepository: ReadingSessionRepository,
     private val volumeNavigationController: VolumeNavigationController,
-    private val formattingPreferencesStore: FormattingPreferencesStore,
-    private val bookFormattingPreferencesStore: BookFormattingPreferencesStore,
-    private val timeProvider: TimeProvider,
     private val readerStateHolder: ReaderStateHolder,
 ) : AndroidViewModel(application) {
 
@@ -73,21 +58,6 @@ class PdfReaderViewModel @Inject constructor(
 
     val keepScreenOn: StateFlow<Boolean> = wakeLockPreferencesStore.keepScreenOn
         .stateIn(viewModelScope, SharingStarted.Eagerly, true)
-
-    private val _bookOverrides = MutableStateFlow(BookFormattingOverrides())
-    private val _formattingPreferences = MutableStateFlow(FormattingPreferences())
-    val formattingPreferences: StateFlow<FormattingPreferences> = _formattingPreferences
-
-    private val scheduleTicks = MutableSharedFlow<Unit>(extraBufferCapacity = 1, replay = 1).apply {
-        tryEmit(Unit)
-    }
-
-    val effectiveFormattingPreferences: StateFlow<FormattingPreferences> = combine(
-        _formattingPreferences,
-        scheduleTicks,
-    ) { prefs, _ -> prefs.withResolvedTheme(timeProvider.nowLocalTime()) }
-        .distinctUntilChanged()
-        .stateIn(viewModelScope, SharingStarted.Eagerly, FormattingPreferences())
 
     val volumeNavEvents: SharedFlow<VolumeNavEvent> = volumeNavigationController.events
 
@@ -115,50 +85,12 @@ class PdfReaderViewModel @Inject constructor(
     private var initialLocatorSeen = false
 
     init {
-        viewModelScope.launch {
-            loadFormattingPreferences()
-            openBook()
-        }
-        viewModelScope.launch {
-            combine(
-                formattingPreferencesStore.preferences,
-                _bookOverrides,
-            ) { global, overrides -> overrides.applyTo(global) }
-                .collect { _formattingPreferences.value = it }
-        }
-        viewModelScope.launch {
-            _formattingPreferences
-                .map { it.themeSchedule to (it.theme == ReaderTheme.Auto) }
-                .distinctUntilChanged()
-                .collectLatest { (schedule, autoActive) ->
-                    if (!autoActive) return@collectLatest
-                    // Degenerate schedule (equal day/night times) collapses to always-day —
-                    // no boundary will ever arrive. Park until cancelled instead of spinning.
-                    if (schedule.dayStart == schedule.nightStart) {
-                        awaitCancellation()
-                    }
-                    while (true) {
-                        val now = timeProvider.nowLocalTime()
-                        val next = schedule.nextBoundaryAfter(now)
-                        val delayMs = (((next.toSecondOfDay() - now.toSecondOfDay() + 24 * 3600) % (24 * 3600)) * 1000L)
-                            .coerceAtLeast(1_000L)
-                        delay(delayMs)
-                        scheduleTicks.tryEmit(Unit)
-                    }
-                }
-        }
+        viewModelScope.launch { openBook() }
         viewModelScope.launch {
             progressSyncController.serverPositionEvents.collect { serverProgress ->
                 serverLocationToLocator(serverProgress.ebookLocation)?.let { _serverLocatorChannel.trySend(it) }
             }
         }
-    }
-
-    private suspend fun loadFormattingPreferences() {
-        val overrides = bookFormattingPreferencesStore.load(itemId)
-        val global = formattingPreferencesStore.preferences.first()
-        _bookOverrides.value = overrides
-        _formattingPreferences.value = overrides.applyTo(global)
     }
 
     private suspend fun openBook() {

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderThemePalette.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderThemePalette.kt
@@ -43,10 +43,8 @@ val ReaderTheme.palette: ReaderThemePalette
         )
         // Defensive: Auto must be resolved to a concrete theme via
         // FormattingPreferences.withResolvedTheme() before reaching this palette.
-        // We fall back to Light so a missed resolution doesn't crash the reader,
-        // but every production call site should resolve first.
-        ReaderTheme.Auto -> ReaderThemePalette(
-            background = Color(0xFFFFFFFF),
-            foreground = Color(0xFF121212),
-        )
+        // Fall back to Light so a missed resolution doesn't crash the reader; every
+        // production call site should resolve first. Delegating to Light keeps the
+        // two in lock-step if Light's colours ever move.
+        ReaderTheme.Auto -> ReaderTheme.Light.palette
     }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderThemePalette.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderThemePalette.kt
@@ -41,4 +41,12 @@ val ReaderTheme.palette: ReaderThemePalette
             background = Color(0xFFFAF4E8),
             foreground = Color(0xFF121212),
         )
+        // Defensive: Auto must be resolved to a concrete theme via
+        // FormattingPreferences.withResolvedTheme() before reaching this palette.
+        // We fall back to Light so a missed resolution doesn't crash the reader,
+        // but every production call site should resolve first.
+        ReaderTheme.Auto -> ReaderThemePalette(
+            background = Color(0xFFFFFFFF),
+            foreground = Color(0xFF121212),
+        )
     }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/TimeProvider.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/TimeProvider.kt
@@ -1,0 +1,16 @@
+package com.riffle.app.feature.reader
+
+import java.time.LocalTime
+import javax.inject.Inject
+import javax.inject.Singleton
+
+// Lets the reader VMs read "now" in a way tests can substitute. Production binding
+// returns LocalTime.now() each call; tests inject a fake.
+interface TimeProvider {
+    fun nowLocalTime(): LocalTime
+}
+
+@Singleton
+class SystemTimeProvider @Inject constructor() : TimeProvider {
+    override fun nowLocalTime(): LocalTime = LocalTime.now()
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/TypographyOverride.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/TypographyOverride.kt
@@ -103,6 +103,7 @@ internal val EXCLUDED_FROM_TYPOGRAPHY_OVERRIDES: Map<String, String> = mapOf(
     "showChapterMap" to "UI affordance outside the reader content; no CSS implication.",
     "showReadingProgressLabels" to "UI affordance outside the reader content; no CSS implication.",
     "showCurrentChapterLabel" to "UI affordance outside the reader content; no CSS implication.",
+    "themeSchedule" to "Schedule metadata used to derive the resolved theme at runtime; has no direct CSS implication.",
 )
 
 /**

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/EpubReaderViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/EpubReaderViewModelTest.kt
@@ -1,5 +1,6 @@
 package com.riffle.app.feature.reader
 
+import com.riffle.core.domain.withResolvedTheme
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.Job
@@ -163,31 +164,37 @@ class EpubReaderViewModelTest {
         assertEquals(1, searchCallCount)
     }
 
-    // Mirrors EpubReaderViewModel's schedule-driven boundary timer using virtual time
-    // (the same pattern as `periodic sync timer fires once after one interval`).
+    // EpubReaderViewModel is an AndroidViewModel and can't be instantiated here, so this
+    // mirrors its boundary loop with virtual time — but routes resolution through the
+    // production withResolvedTheme() so the test exercises real domain code, not just
+    // ThemeSchedule.resolve in isolation.
     @Test
-    fun `effective theme flips at the schedule boundary`() = runTest {
+    fun `Auto prefs flip at each schedule boundary across a 24h cycle`() = runTest {
         val schedule = com.riffle.core.domain.ThemeSchedule(
             dayStart = java.time.LocalTime.of(7, 0),
             nightStart = java.time.LocalTime.of(21, 0),
             dayTheme = com.riffle.core.domain.ReaderTheme.Light,
             nightTheme = com.riffle.core.domain.ReaderTheme.Dark,
         )
+        val prefs = com.riffle.core.domain.FormattingPreferences(
+            theme = com.riffle.core.domain.ReaderTheme.Auto,
+            themeSchedule = schedule,
+        )
         var fakeNow = java.time.LocalTime.of(20, 59)
         val emitted = mutableListOf<com.riffle.core.domain.ReaderTheme>()
 
         backgroundScope.launch {
-            emitted += schedule.resolve(fakeNow)
+            emitted += prefs.withResolvedTheme(fakeNow).theme
             while (true) {
                 val next = schedule.nextBoundaryAfter(fakeNow)
                 val delayMs = ((next.toSecondOfDay() - fakeNow.toSecondOfDay() + 24 * 3600) % (24 * 3600)) * 1000L
                 delay(delayMs.coerceAtLeast(1_000L))
                 fakeNow = next
-                emitted += schedule.resolve(fakeNow)
+                emitted += prefs.withResolvedTheme(fakeNow).theme
             }
         }
 
-        // 20:59 → 21:00 is 60s; advance just past it.
+        // 20:59 → 21:00 (60s) flips to Dark; 21:00 → 07:00 (10h) flips back to Light.
         advanceTimeBy(60_000 + 1)
         assertEquals(
             listOf(
@@ -196,6 +203,37 @@ class EpubReaderViewModelTest {
             ),
             emitted,
         )
+        advanceTimeBy(10 * 3600 * 1000L)
+        assertEquals(
+            listOf(
+                com.riffle.core.domain.ReaderTheme.Light,
+                com.riffle.core.domain.ReaderTheme.Dark,
+                com.riffle.core.domain.ReaderTheme.Light,
+            ),
+            emitted,
+        )
+    }
+
+    // Regression for the EpubReaderViewModel's `if (schedule.dayStart == schedule.nightStart)
+    // awaitCancellation()` guard: a degenerate schedule must not emit any boundary tick.
+    @Test
+    fun `degenerate schedule (equal day-and-night) emits no boundary ticks`() = runTest {
+        val degenerate = com.riffle.core.domain.ThemeSchedule(
+            dayStart = java.time.LocalTime.of(8, 0),
+            nightStart = java.time.LocalTime.of(8, 0),
+        )
+        var tickCount = 0
+        backgroundScope.launch {
+            if (degenerate.dayStart == degenerate.nightStart) {
+                kotlinx.coroutines.awaitCancellation()
+            }
+            while (true) {
+                delay(1_000L)
+                tickCount++
+            }
+        }
+        advanceTimeBy(24 * 3600 * 1000L)
+        assertEquals(0, tickCount)
     }
 }
 

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/EpubReaderViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/EpubReaderViewModelTest.kt
@@ -162,6 +162,41 @@ class EpubReaderViewModelTest {
         advanceTimeBy(250)
         assertEquals(1, searchCallCount)
     }
+
+    // Mirrors EpubReaderViewModel's schedule-driven boundary timer using virtual time
+    // (the same pattern as `periodic sync timer fires once after one interval`).
+    @Test
+    fun `effective theme flips at the schedule boundary`() = runTest {
+        val schedule = com.riffle.core.domain.ThemeSchedule(
+            dayStart = java.time.LocalTime.of(7, 0),
+            nightStart = java.time.LocalTime.of(21, 0),
+            dayTheme = com.riffle.core.domain.ReaderTheme.Light,
+            nightTheme = com.riffle.core.domain.ReaderTheme.Dark,
+        )
+        var fakeNow = java.time.LocalTime.of(20, 59)
+        val emitted = mutableListOf<com.riffle.core.domain.ReaderTheme>()
+
+        backgroundScope.launch {
+            emitted += schedule.resolve(fakeNow)
+            while (true) {
+                val next = schedule.nextBoundaryAfter(fakeNow)
+                val delayMs = ((next.toSecondOfDay() - fakeNow.toSecondOfDay() + 24 * 3600) % (24 * 3600)) * 1000L
+                delay(delayMs.coerceAtLeast(1L))
+                fakeNow = next
+                emitted += schedule.resolve(fakeNow)
+            }
+        }
+
+        // 20:59 → 21:00 is 60s; advance just past it.
+        advanceTimeBy(60_000 + 1)
+        assertEquals(
+            listOf(
+                com.riffle.core.domain.ReaderTheme.Light,
+                com.riffle.core.domain.ReaderTheme.Dark,
+            ),
+            emitted,
+        )
+    }
 }
 
 /**

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/EpubReaderViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/EpubReaderViewModelTest.kt
@@ -181,7 +181,7 @@ class EpubReaderViewModelTest {
             while (true) {
                 val next = schedule.nextBoundaryAfter(fakeNow)
                 val delayMs = ((next.toSecondOfDay() - fakeNow.toSecondOfDay() + 24 * 3600) % (24 * 3600)) * 1000L
-                delay(delayMs.coerceAtLeast(1L))
+                delay(delayMs.coerceAtLeast(1_000L))
                 fakeNow = next
                 emitted += schedule.resolve(fakeNow)
             }

--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -16,6 +16,7 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
+        isCoreLibraryDesugaringEnabled = true
     }
 
     testOptions {
@@ -32,6 +33,8 @@ android {
 }
 
 dependencies {
+    coreLibraryDesugaring(libs.desugar.jdk.libs)
+
     implementation(project(":core:domain"))
     implementation(project(":core:network"))
     implementation(project(":core:database"))

--- a/core/data/src/main/kotlin/com/riffle/core/data/FormattingPreferencesStoreImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/FormattingPreferencesStoreImpl.kt
@@ -99,5 +99,9 @@ class FormattingPreferencesStoreImpl @Inject constructor(
 }
 
 private fun LocalTime.toMinuteOfDay(): Int = hour * 60 + minute
-private fun minuteOfDayToLocalTime(value: Int): LocalTime =
-    LocalTime.of((value / 60).coerceIn(0, 23), (value % 60).coerceIn(0, 59))
+private fun minuteOfDayToLocalTime(value: Int): LocalTime {
+    // Clamp to the valid 24h range first so values like 1440 (24:00) don't silently
+    // round-trip to 00:00 via the modulo on the next line.
+    val clamped = value.coerceIn(0, 24 * 60 - 1)
+    return LocalTime.of(clamped / 60, clamped % 60)
+}

--- a/core/data/src/main/kotlin/com/riffle/core/data/FormattingPreferencesStoreImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/FormattingPreferencesStoreImpl.kt
@@ -5,6 +5,7 @@ import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.floatPreferencesKey
+import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import com.riffle.core.data.di.FormattingPreferencesDataStore
 import com.riffle.core.domain.FormattingPreferences
@@ -12,8 +13,10 @@ import com.riffle.core.domain.FormattingPreferencesStore
 import com.riffle.core.domain.ReaderFontFamily
 import com.riffle.core.domain.ReaderOrientation
 import com.riffle.core.domain.ReaderTheme
+import com.riffle.core.domain.ThemeSchedule
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
+import java.time.LocalTime
 import javax.inject.Inject
 
 class FormattingPreferencesStoreImpl @Inject constructor(
@@ -39,6 +42,20 @@ class FormattingPreferencesStoreImpl @Inject constructor(
             showCurrentChapterLabel = prefs[KEY_SHOW_CURRENT_CHAPTER_LABEL] ?: false,
             doublePageSpread = prefs[KEY_DOUBLE_PAGE_SPREAD] ?: false,
             justifyText = prefs[KEY_JUSTIFY_TEXT] ?: false,
+            themeSchedule = ThemeSchedule(
+                dayStart = prefs[KEY_SCHEDULE_DAY_START]?.let(::minuteOfDayToLocalTime)
+                    ?: ThemeSchedule.DEFAULT_DAY_START,
+                nightStart = prefs[KEY_SCHEDULE_NIGHT_START]?.let(::minuteOfDayToLocalTime)
+                    ?: ThemeSchedule.DEFAULT_NIGHT_START,
+                dayTheme = prefs[KEY_SCHEDULE_DAY_THEME]
+                    ?.let { runCatching { ReaderTheme.valueOf(it) }.getOrNull() }
+                    ?.takeIf { it != ReaderTheme.Auto }
+                    ?: ThemeSchedule.DEFAULT_DAY_THEME,
+                nightTheme = prefs[KEY_SCHEDULE_NIGHT_THEME]
+                    ?.let { runCatching { ReaderTheme.valueOf(it) }.getOrNull() }
+                    ?.takeIf { it != ReaderTheme.Auto }
+                    ?: ThemeSchedule.DEFAULT_NIGHT_THEME,
+            ),
         )
     }
 
@@ -55,6 +72,10 @@ class FormattingPreferencesStoreImpl @Inject constructor(
             prefs[KEY_SHOW_CURRENT_CHAPTER_LABEL] = preferences.showCurrentChapterLabel
             prefs[KEY_DOUBLE_PAGE_SPREAD] = preferences.doublePageSpread
             prefs[KEY_JUSTIFY_TEXT] = preferences.justifyText
+            prefs[KEY_SCHEDULE_DAY_START] = preferences.themeSchedule.dayStart.toMinuteOfDay()
+            prefs[KEY_SCHEDULE_NIGHT_START] = preferences.themeSchedule.nightStart.toMinuteOfDay()
+            prefs[KEY_SCHEDULE_DAY_THEME] = preferences.themeSchedule.dayTheme.name
+            prefs[KEY_SCHEDULE_NIGHT_THEME] = preferences.themeSchedule.nightTheme.name
         }
     }
 
@@ -70,5 +91,13 @@ class FormattingPreferencesStoreImpl @Inject constructor(
         val KEY_SHOW_CURRENT_CHAPTER_LABEL = booleanPreferencesKey("show_current_chapter_label")
         val KEY_DOUBLE_PAGE_SPREAD = booleanPreferencesKey("double_page_spread")
         val KEY_JUSTIFY_TEXT = booleanPreferencesKey("justify_text")
+        val KEY_SCHEDULE_DAY_START = intPreferencesKey("theme_schedule_day_start_minute_of_day")
+        val KEY_SCHEDULE_NIGHT_START = intPreferencesKey("theme_schedule_night_start_minute_of_day")
+        val KEY_SCHEDULE_DAY_THEME = stringPreferencesKey("theme_schedule_day_theme")
+        val KEY_SCHEDULE_NIGHT_THEME = stringPreferencesKey("theme_schedule_night_theme")
     }
 }
+
+private fun LocalTime.toMinuteOfDay(): Int = hour * 60 + minute
+private fun minuteOfDayToLocalTime(value: Int): LocalTime =
+    LocalTime.of((value / 60).coerceIn(0, 23), (value % 60).coerceIn(0, 59))

--- a/core/data/src/test/kotlin/com/riffle/core/data/FormattingPreferencesStoreTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/FormattingPreferencesStoreTest.kt
@@ -5,6 +5,7 @@ import com.riffle.core.domain.FormattingPreferences
 import com.riffle.core.domain.ReaderFontFamily
 import com.riffle.core.domain.ReaderOrientation
 import com.riffle.core.domain.ReaderTheme
+import com.riffle.core.domain.ThemeSchedule
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.TestScope
@@ -14,6 +15,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
+import java.time.LocalTime
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class FormattingPreferencesStoreTest {
@@ -83,5 +85,30 @@ class FormattingPreferencesStoreTest {
         val store = buildStore()
         store.update(FormattingPreferences(justifyText = false))
         assertEquals(false, store.preferences.first().justifyText)
+    }
+
+    @Test
+    fun `saved themeSchedule round-trips through the DataStore`() = testScope.runTest {
+        val store = buildStore()
+        val schedule = ThemeSchedule(
+            dayStart = LocalTime.of(6, 30),
+            nightStart = LocalTime.of(19, 45),
+            dayTheme = ReaderTheme.Sepia,
+            nightTheme = ReaderTheme.DarkDim,
+        )
+        store.update(FormattingPreferences(themeSchedule = schedule))
+        assertEquals(schedule, store.preferences.first().themeSchedule)
+    }
+
+    @Test
+    fun `themeSchedule defaults are returned for empty DataStore`() = testScope.runTest {
+        assertEquals(ThemeSchedule(), buildStore().preferences.first().themeSchedule)
+    }
+
+    @Test
+    fun `Auto theme round-trips through the DataStore`() = testScope.runTest {
+        val store = buildStore()
+        store.update(FormattingPreferences(theme = ReaderTheme.Auto))
+        assertEquals(ReaderTheme.Auto, store.preferences.first().theme)
     }
 }

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/BookFormattingOverrides.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/BookFormattingOverrides.kt
@@ -38,6 +38,10 @@ data class BookFormattingOverrides(
         showCurrentChapterLabel = showCurrentChapterLabel ?: global.showCurrentChapterLabel,
         doublePageSpread = doublePageSpread ?: global.doublePageSpread,
         justifyText = justifyText ?: global.justifyText,
+        // themeSchedule is intentionally global-only (no per-book override). Threading
+        // global through keeps the in-reader Auto resolution honouring the user's
+        // configured day/night times instead of silently falling back to defaults.
+        themeSchedule = global.themeSchedule,
     )
 
     // Treat each field the user just changed (new != previously-effective) as an explicit book

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/FormattingPreferences.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/FormattingPreferences.kt
@@ -1,5 +1,7 @@
 package com.riffle.core.domain
 
+import java.time.LocalTime
+
 data class FormattingPreferences(
     val fontSize: Float = DEFAULT_FONT_SIZE,
     val theme: ReaderTheme = DEFAULT_THEME,
@@ -31,3 +33,41 @@ data class FormattingPreferences(
 enum class ReaderTheme { Light, Dark, DarkDim, Sepia, Auto }
 enum class ReaderFontFamily { Serif, SansSerif, Monospace, Literata, Merriweather, OpenDyslexic }
 enum class ReaderOrientation { Horizontal, Vertical }
+
+data class ThemeSchedule(
+    val dayStart: LocalTime = DEFAULT_DAY_START,
+    val nightStart: LocalTime = DEFAULT_NIGHT_START,
+    val dayTheme: ReaderTheme = DEFAULT_DAY_THEME,
+    val nightTheme: ReaderTheme = DEFAULT_NIGHT_THEME,
+) {
+    fun resolve(now: LocalTime): ReaderTheme =
+        if (isNight(now)) nightTheme else dayTheme
+
+    // Treats the two times as boundaries on a 24h circle. The night arc runs
+    // clockwise from nightStart up to (but not including) dayStart. At exactly
+    // nightStart we are in night; at exactly dayStart we are in day. Equal
+    // times collapse the night arc to length zero → always-day.
+    private fun isNight(now: LocalTime): Boolean {
+        if (dayStart == nightStart) return false
+        return if (nightStart.isBefore(dayStart)) {
+            !now.isBefore(nightStart) && now.isBefore(dayStart)
+        } else {
+            !now.isBefore(nightStart) || now.isBefore(dayStart)
+        }
+    }
+
+    // The next clock-time at which `resolve` would return a different theme.
+    // Used by the reader VM to schedule a one-shot delay until the next switch.
+    // Returns dayStart when the schedule is degenerate so callers always have a value.
+    fun nextBoundaryAfter(now: LocalTime): LocalTime {
+        if (dayStart == nightStart) return dayStart
+        return if (isNight(now)) dayStart else nightStart
+    }
+
+    companion object {
+        val DEFAULT_DAY_START: LocalTime = LocalTime.of(7, 0)
+        val DEFAULT_NIGHT_START: LocalTime = LocalTime.of(21, 0)
+        val DEFAULT_DAY_THEME: ReaderTheme = ReaderTheme.Light
+        val DEFAULT_NIGHT_THEME: ReaderTheme = ReaderTheme.Dark
+    }
+}

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/FormattingPreferences.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/FormattingPreferences.kt
@@ -67,7 +67,7 @@ data class ThemeSchedule(
 
     companion object {
         val DEFAULT_DAY_START: LocalTime = LocalTime.of(7, 0)
-        val DEFAULT_NIGHT_START: LocalTime = LocalTime.of(21, 0)
+        val DEFAULT_NIGHT_START: LocalTime = LocalTime.of(20, 0)
         val DEFAULT_DAY_THEME: ReaderTheme = ReaderTheme.Light
         val DEFAULT_NIGHT_THEME: ReaderTheme = ReaderTheme.Dark
     }

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/FormattingPreferences.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/FormattingPreferences.kt
@@ -14,6 +14,7 @@ data class FormattingPreferences(
     val showCurrentChapterLabel: Boolean = DEFAULT_SHOW_CURRENT_CHAPTER_LABEL,
     val doublePageSpread: Boolean = DEFAULT_DOUBLE_PAGE_SPREAD,
     val justifyText: Boolean = DEFAULT_JUSTIFY_TEXT,
+    val themeSchedule: ThemeSchedule = ThemeSchedule(),
 ) {
     companion object {
         const val DEFAULT_FONT_SIZE: Float = 1.0f
@@ -71,3 +72,10 @@ data class ThemeSchedule(
         val DEFAULT_NIGHT_THEME: ReaderTheme = ReaderTheme.Dark
     }
 }
+
+// Returns a copy with `theme` replaced by the schedule-resolved concrete theme when
+// the user picked Auto. For any non-Auto theme this is a no-op identity. Reader VMs
+// run this at render-time so every downstream consumer (Readium mapper, palette,
+// chapter-rail backdrop) keeps reading `prefs.theme` and stays ignorant of Auto.
+fun FormattingPreferences.withResolvedTheme(now: LocalTime): FormattingPreferences =
+    if (theme == ReaderTheme.Auto) copy(theme = themeSchedule.resolve(now)) else this

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/FormattingPreferences.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/FormattingPreferences.kt
@@ -28,6 +28,6 @@ data class FormattingPreferences(
     }
 }
 
-enum class ReaderTheme { Light, Dark, DarkDim, Sepia }
+enum class ReaderTheme { Light, Dark, DarkDim, Sepia, Auto }
 enum class ReaderFontFamily { Serif, SansSerif, Monospace, Literata, Merriweather, OpenDyslexic }
 enum class ReaderOrientation { Horizontal, Vertical }

--- a/core/domain/src/test/kotlin/com/riffle/core/domain/BookFormattingOverridesTest.kt
+++ b/core/domain/src/test/kotlin/com/riffle/core/domain/BookFormattingOverridesTest.kt
@@ -5,6 +5,7 @@ import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import java.time.LocalTime
 
 class BookFormattingOverridesTest {
 
@@ -78,6 +79,20 @@ class BookFormattingOverridesTest {
         val updated = existing.withChanges(previous, new)
         assertEquals(ReaderTheme.Dark, updated.theme) // preserved
         assertEquals(1.6f, updated.fontSize) // newly recorded
+    }
+
+    @Test
+    fun `applyTo always threads global themeSchedule (no per-book override)`() {
+        val customSchedule = ThemeSchedule(
+            dayStart = LocalTime.of(6, 30),
+            nightStart = LocalTime.of(19, 45),
+            dayTheme = ReaderTheme.Sepia,
+            nightTheme = ReaderTheme.DarkDim,
+        )
+        val globalWithSchedule = global.copy(themeSchedule = customSchedule)
+        val effective = BookFormattingOverrides(theme = ReaderTheme.Auto)
+            .applyTo(globalWithSchedule)
+        assertEquals(customSchedule, effective.themeSchedule)
     }
 
     @Test

--- a/core/domain/src/test/kotlin/com/riffle/core/domain/FormattingPreferencesResolutionTest.kt
+++ b/core/domain/src/test/kotlin/com/riffle/core/domain/FormattingPreferencesResolutionTest.kt
@@ -1,0 +1,46 @@
+package com.riffle.core.domain
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.time.LocalTime
+
+class FormattingPreferencesResolutionTest {
+
+    @Test
+    fun `concrete theme is unchanged by withResolvedTheme`() {
+        val prefs = FormattingPreferences(theme = ReaderTheme.Sepia)
+        assertEquals(prefs, prefs.withResolvedTheme(LocalTime.of(12, 0)))
+    }
+
+    @Test
+    fun `Auto resolves to day theme during day`() {
+        val prefs = FormattingPreferences(theme = ReaderTheme.Auto)
+        assertEquals(ReaderTheme.Light, prefs.withResolvedTheme(LocalTime.of(12, 0)).theme)
+    }
+
+    @Test
+    fun `Auto resolves to night theme during night`() {
+        val prefs = FormattingPreferences(theme = ReaderTheme.Auto)
+        assertEquals(ReaderTheme.Dark, prefs.withResolvedTheme(LocalTime.of(22, 0)).theme)
+    }
+
+    @Test
+    fun `Auto with a custom schedule picks the custom night theme`() {
+        val prefs = FormattingPreferences(
+            theme = ReaderTheme.Auto,
+            themeSchedule = ThemeSchedule(
+                dayStart = LocalTime.of(7, 0),
+                nightStart = LocalTime.of(21, 0),
+                dayTheme = ReaderTheme.Sepia,
+                nightTheme = ReaderTheme.DarkDim,
+            ),
+        )
+        assertEquals(ReaderTheme.DarkDim, prefs.withResolvedTheme(LocalTime.of(22, 0)).theme)
+        assertEquals(ReaderTheme.Sepia, prefs.withResolvedTheme(LocalTime.of(12, 0)).theme)
+    }
+
+    @Test
+    fun `default themeSchedule is the ThemeSchedule default`() {
+        assertEquals(ThemeSchedule(), FormattingPreferences().themeSchedule)
+    }
+}

--- a/core/domain/src/test/kotlin/com/riffle/core/domain/ThemeScheduleTest.kt
+++ b/core/domain/src/test/kotlin/com/riffle/core/domain/ThemeScheduleTest.kt
@@ -68,10 +68,10 @@ class ThemeScheduleTest {
     }
 
     @Test
-    fun `default schedule has 07-00 21-00 Light Dark`() {
+    fun `default schedule has 07-00 20-00 Light Dark`() {
         val d = ThemeSchedule()
         assertEquals(LocalTime.of(7, 0), d.dayStart)
-        assertEquals(LocalTime.of(21, 0), d.nightStart)
+        assertEquals(LocalTime.of(20, 0), d.nightStart)
         assertEquals(ReaderTheme.Light, d.dayTheme)
         assertEquals(ReaderTheme.Dark, d.nightTheme)
     }

--- a/core/domain/src/test/kotlin/com/riffle/core/domain/ThemeScheduleTest.kt
+++ b/core/domain/src/test/kotlin/com/riffle/core/domain/ThemeScheduleTest.kt
@@ -1,0 +1,102 @@
+package com.riffle.core.domain
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.time.LocalTime
+
+class ThemeScheduleTest {
+
+    private val schedule = ThemeSchedule(
+        dayStart = LocalTime.of(7, 0),
+        nightStart = LocalTime.of(21, 0),
+        dayTheme = ReaderTheme.Light,
+        nightTheme = ReaderTheme.Dark,
+    )
+
+    @Test
+    fun `noon is day`() {
+        assertEquals(ReaderTheme.Light, schedule.resolve(LocalTime.of(12, 0)))
+    }
+
+    @Test
+    fun `midnight is night`() {
+        assertEquals(ReaderTheme.Dark, schedule.resolve(LocalTime.of(0, 0)))
+    }
+
+    @Test
+    fun `exactly day-start is day`() {
+        assertEquals(ReaderTheme.Light, schedule.resolve(LocalTime.of(7, 0)))
+    }
+
+    @Test
+    fun `exactly night-start is night`() {
+        assertEquals(ReaderTheme.Dark, schedule.resolve(LocalTime.of(21, 0)))
+    }
+
+    @Test
+    fun `one minute before night-start is day`() {
+        assertEquals(ReaderTheme.Light, schedule.resolve(LocalTime.of(20, 59)))
+    }
+
+    @Test
+    fun `one minute before day-start is night`() {
+        assertEquals(ReaderTheme.Dark, schedule.resolve(LocalTime.of(6, 59)))
+    }
+
+    @Test
+    fun `night arc that wraps midnight evaluates correctly past midnight`() {
+        val wrap = ThemeSchedule(
+            dayStart = LocalTime.of(6, 0),
+            nightStart = LocalTime.of(22, 0),
+            dayTheme = ReaderTheme.Sepia,
+            nightTheme = ReaderTheme.DarkDim,
+        )
+        assertEquals(ReaderTheme.DarkDim, wrap.resolve(LocalTime.of(2, 0)))
+        assertEquals(ReaderTheme.DarkDim, wrap.resolve(LocalTime.of(23, 30)))
+        assertEquals(ReaderTheme.Sepia, wrap.resolve(LocalTime.of(12, 0)))
+    }
+
+    @Test
+    fun `equal day-start and night-start collapses to always-day`() {
+        val degenerate = schedule.copy(
+            dayStart = LocalTime.of(8, 0),
+            nightStart = LocalTime.of(8, 0),
+        )
+        assertEquals(ReaderTheme.Light, degenerate.resolve(LocalTime.of(8, 0)))
+        assertEquals(ReaderTheme.Light, degenerate.resolve(LocalTime.of(2, 0)))
+        assertEquals(ReaderTheme.Light, degenerate.resolve(LocalTime.of(20, 0)))
+    }
+
+    @Test
+    fun `default schedule has 07-00 21-00 Light Dark`() {
+        val d = ThemeSchedule()
+        assertEquals(LocalTime.of(7, 0), d.dayStart)
+        assertEquals(LocalTime.of(21, 0), d.nightStart)
+        assertEquals(ReaderTheme.Light, d.dayTheme)
+        assertEquals(ReaderTheme.Dark, d.nightTheme)
+    }
+
+    @Test
+    fun `nextBoundaryAfter returns the upcoming day-start when currently in night`() {
+        assertEquals(LocalTime.of(7, 0), schedule.nextBoundaryAfter(LocalTime.of(2, 0)))
+    }
+
+    @Test
+    fun `nextBoundaryAfter returns the upcoming night-start when currently in day`() {
+        assertEquals(LocalTime.of(21, 0), schedule.nextBoundaryAfter(LocalTime.of(12, 0)))
+    }
+
+    @Test
+    fun `nextBoundaryAfter at exactly the boundary returns the OTHER boundary`() {
+        assertEquals(LocalTime.of(7, 0), schedule.nextBoundaryAfter(LocalTime.of(21, 0)))
+    }
+
+    @Test
+    fun `nextBoundaryAfter when equal-times returns dayStart unchanged`() {
+        val degenerate = schedule.copy(
+            dayStart = LocalTime.of(8, 0),
+            nightStart = LocalTime.of(8, 0),
+        )
+        assertEquals(LocalTime.of(8, 0), degenerate.nextBoundaryAfter(LocalTime.of(2, 0)))
+    }
+}

--- a/docs/adr/0022-auto-reader-theme-clock-scheduled-fifth-enum.md
+++ b/docs/adr/0022-auto-reader-theme-clock-scheduled-fifth-enum.md
@@ -1,0 +1,56 @@
+# ADR 0022 — Auto reader theme: clock-scheduled, live-switching, fifth enum value
+
+**Status:** Accepted
+
+## Context
+
+[Formatting Preferences] already exposes a `theme` field on `ReaderTheme = { Light, Dark, DarkDim, Sepia }`, set globally and overridable per-book. Users want the reader to automatically switch between a day-appropriate and a night-appropriate look without manually flipping a chip every evening.
+
+The feature has to compose with three things already true of the theme system:
+
+- The same `ReaderTheme` enum drives both the EPUB navigator (Readium preferences) and the PDF reader (colour filter), the chapter rail backdrop, the formatting-panel chip swatch, and the per-book override store (`book_formatting_preferences`, intentionally not scoped per-server).
+- The formatting panel is reused as the in-reader half-height overlay and as the full-screen Settings panel.
+- Per-book theme is a single enum pick — a book is pinned to one rendered look, or it isn't.
+
+Several axes were live: (a) is "auto" a peer enum value or an orthogonal scheduling field; (b) is the schedule driven by clock-times, sunrise/sunset, or Android's system dark mode; (c) does the palette switch live mid-session or only on reader open/resume. Each of these has lower-friction alternatives that we rejected for specific reasons.
+
+## Decision
+
+Three load-bearing choices:
+
+### 1. Auto is a fifth value of `ReaderTheme`, not an orthogonal `themeSchedule` field
+
+`ReaderTheme` grows to `{ Light, Dark, DarkDim, Sepia, Auto }`. Auto is selectable anywhere any other theme is selectable: as the global default, as a per-book override, in either format's reader. The four schedule parameters (day-start, night-start, day-theme, night-theme) live on global `FormattingPreferences` and are only meaningful when some surface is rendering `Auto`. The two theme picks inside the schedule are restricted to the four concrete values — Auto cannot nest inside Auto.
+
+At render-time, every consumer of `ReaderTheme` first calls a resolver `resolveTheme(prefs, clock): ReaderTheme` that returns one of the four concretes; downstream code (Readium mapper, `ReaderThemePalette`, chapter-rail backdrop, swatch rendering) is unchanged. The formatting panel's chip selection still tracks the user's actual pick — so the Auto chip stays highlighted even when the resolved palette is Dark.
+
+### 2. Schedule is clock-based, not system dark mode and not sunrise/sunset
+
+Two user-configured local-clock times define the boundary. The schedule is interpreted as two arcs on a 24-hour circle, with the night arc allowed to cross midnight. Degenerate equal-time input is treated as always-day. No location, no permissions, no system-mode tracking.
+
+### 3. Boundary crossings repaint live during a reading session
+
+A timer fires at the next scheduled boundary; the resolved theme changes; the reader VM republishes preferences and Readium reapplies them. The user sees the page repaint without closing the book. The timer also resets when the user edits the schedule or when the app returns from background.
+
+## Consequences
+
+**Per-book override semantics stay coherent.** One enum pick fully describes a book's theme intent: "this book renders as Sepia" or "this book follows the schedule". The `book_formatting_preferences` store needs no new columns. Future per-book overrides remain a single-field decision.
+
+**Schedule editing lives only in Settings.** The in-reader formatting panel shows the Auto chip as a fifth selectable theme but does not surface day-start, night-start, day-theme, or night-theme. Per the global-only scope, those four fields are edited on the full-screen Settings variant of the panel. A user opting a single book into Auto inherits the global schedule silently.
+
+**Both readers behave identically.** Because resolution happens at the `ReaderTheme` boundary, EPUB and PDF both see only concrete values and need no auto-awareness. A PDF book set to Auto goes through the same colour-filter mapping as any concrete pick.
+
+**The `Auto` enum value is a mild type-smell.** It mixes a "scheduled meta" with concrete palettes in one enum, and code that lists `ReaderTheme.entries` for swatches has to special-case Auto's chip (split day/night background instead of one filled circle, no `ReaderThemePalette` entry). This is local and named; the alternative — a separate `themeSchedule: Manual | Auto(day, night)` field — pushed the cost into the per-book override store and the UI's "is this book Auto?" reasoning, where it was worse.
+
+**A timer ticks inside the reader.** Live switching requires a coroutine waiting until the next boundary in local time, cancellable on schedule edits, on app background, and on reader exit. Tests need a virtual clock injectable into the resolver. The cost is bounded and one-place; the alternative (resample only on resume) was rejected because a long evening session crossing the boundary in one sitting is exactly the case the feature exists to serve.
+
+**Schema migration is local to global `FormattingPreferences`.** The DataStore adds four fields with defaults (07:00, 20:00, Light, Dark). No Room migration is required — the per-book overrides store is unchanged. A book whose serialised override is the previous `Light/Dark/DarkDim/Sepia` set still decodes correctly; only the global store grows.
+
+## Alternatives considered
+
+- **Auto as an orthogonal `themeSchedule: Manual | Auto(day, night)` field.** Cleaner-typed (the four concrete themes stay pure), but per-book override semantics get muddier — a book is either "pinned to a concrete theme" or "inherits global, which may or may not be Auto", and the UI has to surface that distinction. Rejected because the override model's single-pick simplicity is more valuable than the enum's purity.
+- **Follow Android's system dark mode (`isSystemInDarkTheme()`).** Zero config, no permission, no timer, composes with the OS's own sunset/sunrise scheduling. Rejected because the user wants Riffle's reading schedule controllable independently of the system — a user with system always-dark for the OS may want their book on Light during the day.
+- **Sunrise / sunset.** Most "true" to user intent but introduces a location permission for a feature whose mental model is trivially expressible as clock times. Rejected for the permission cost.
+- **Resample only on reader open and on resume.** Avoids the in-reader timer and the mid-session Readium re-apply. Rejected because a marathon evening reader crossing the boundary in one session would stay in the day theme until backgrounding — defeating the feature for the case it exists to serve.
+
+[Formatting Preferences]: ../../CONTEXT.md#formatting-preferences

--- a/docs/superpowers/plans/2026-06-01-auto-reader-theme.md
+++ b/docs/superpowers/plans/2026-06-01-auto-reader-theme.md
@@ -1,0 +1,1430 @@
+# Auto Reader Theme Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an `Auto` reader theme that switches between a user-configured day and night theme at fixed local-clock times, live during a reading session.
+
+**Architecture:** `Auto` is a fifth value of `ReaderTheme`. A `ThemeSchedule` (four global fields: day-start, night-start, day-theme, night-theme) drives an at-render-time resolver that returns one of the four concrete themes. Reader VMs combine the user's `FormattingPreferences` with a per-minute clock tick to produce an `effectivePreferences: StateFlow<FormattingPreferences>` whose `theme` is always concrete — every downstream consumer (Readium mapper, chapter-rail backdrop, palette) keeps reading `prefs.theme` and stays ignorant of Auto. The `FormattingPanel` still receives the raw preferences so the Auto chip can stay highlighted while the page renders in the resolved palette. Schedule editing surfaces only in the full-screen Settings variant of the panel.
+
+**Tech Stack:** Kotlin, Jetpack Compose, Material 3, Hilt, DataStore Preferences, Room, Readium Kotlin SDK, `java.time.LocalTime` (available via core library desugaring, already enabled in `app/build.gradle.kts:76`). Tests use JUnit 4, `kotlinx-coroutines-test` virtual time, and AndroidJUnit4 for Readium mapper tests.
+
+**Spec source:** `CONTEXT.md` entries "Auto Theme", "Theme Schedule", and "Formatting Preferences"; `docs/adr/0022-auto-reader-theme-clock-scheduled-fifth-enum.md`.
+
+**PDF note:** The PDF reader does not currently apply `ReaderTheme` to rendering (no `palette` or theme uses in `PdfReaderScreen.kt`). Auto persists fine for PDF books (theme is just an enum value); when PDF theming lands it'll consume the same `effectivePreferences` flow the EPUB reader uses.
+
+---
+
+### Task 1: Add `ReaderTheme.Auto` enum value
+
+**Files:**
+- Modify: `core/domain/src/main/kotlin/com/riffle/core/domain/FormattingPreferences.kt:31`
+
+- [ ] **Step 1: Edit the enum**
+
+Change line 31 from:
+
+```kotlin
+enum class ReaderTheme { Light, Dark, DarkDim, Sepia }
+```
+
+to:
+
+```kotlin
+enum class ReaderTheme { Light, Dark, DarkDim, Sepia, Auto }
+```
+
+Auto is added last so existing `ReaderTheme.entries` orderings (used by `FormattingPanel`) keep their layout and Auto appears at the end of the chip row.
+
+- [ ] **Step 2: Build the domain module**
+
+Run: `./gradlew :core:domain:compileKotlin`
+Expected: PASS — `BookFormattingOverrides`, `FormattingPreferences`, and the store interface compile unchanged.
+
+- [ ] **Step 3: Run unaffected domain tests**
+
+Run: `./gradlew :core:domain:test`
+Expected: PASS — existing `BookFormattingOverridesTest` still green; `ReaderTheme.entries.size` is now 5 but no test asserts on size.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add core/domain/src/main/kotlin/com/riffle/core/domain/FormattingPreferences.kt
+git commit -m "feat(reader): add ReaderTheme.Auto enum value"
+```
+
+---
+
+### Task 2: Add `ThemeSchedule` domain type
+
+**Files:**
+- Modify: `core/domain/src/main/kotlin/com/riffle/core/domain/FormattingPreferences.kt`
+- Create: `core/domain/src/test/kotlin/com/riffle/core/domain/ThemeScheduleTest.kt`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `core/domain/src/test/kotlin/com/riffle/core/domain/ThemeScheduleTest.kt`:
+
+```kotlin
+package com.riffle.core.domain
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.time.LocalTime
+
+class ThemeScheduleTest {
+
+    private val schedule = ThemeSchedule(
+        dayStart = LocalTime.of(7, 0),
+        nightStart = LocalTime.of(21, 0),
+        dayTheme = ReaderTheme.Light,
+        nightTheme = ReaderTheme.Dark,
+    )
+
+    @Test
+    fun `noon is day`() {
+        assertEquals(ReaderTheme.Light, schedule.resolve(LocalTime.of(12, 0)))
+    }
+
+    @Test
+    fun `midnight is night`() {
+        assertEquals(ReaderTheme.Dark, schedule.resolve(LocalTime.of(0, 0)))
+    }
+
+    @Test
+    fun `exactly day-start is day`() {
+        assertEquals(ReaderTheme.Light, schedule.resolve(LocalTime.of(7, 0)))
+    }
+
+    @Test
+    fun `exactly night-start is night`() {
+        assertEquals(ReaderTheme.Dark, schedule.resolve(LocalTime.of(21, 0)))
+    }
+
+    @Test
+    fun `one minute before night-start is day`() {
+        assertEquals(ReaderTheme.Light, schedule.resolve(LocalTime.of(20, 59)))
+    }
+
+    @Test
+    fun `one minute before day-start is night`() {
+        assertEquals(ReaderTheme.Dark, schedule.resolve(LocalTime.of(6, 59)))
+    }
+
+    @Test
+    fun `night arc that wraps midnight evaluates correctly past midnight`() {
+        // night 22:00 → 06:00
+        val wrap = ThemeSchedule(
+            dayStart = LocalTime.of(6, 0),
+            nightStart = LocalTime.of(22, 0),
+            dayTheme = ReaderTheme.Sepia,
+            nightTheme = ReaderTheme.DarkDim,
+        )
+        assertEquals(ReaderTheme.DarkDim, wrap.resolve(LocalTime.of(2, 0)))
+        assertEquals(ReaderTheme.DarkDim, wrap.resolve(LocalTime.of(23, 30)))
+        assertEquals(ReaderTheme.Sepia, wrap.resolve(LocalTime.of(12, 0)))
+    }
+
+    @Test
+    fun `equal day-start and night-start collapses to always-day`() {
+        val degenerate = schedule.copy(
+            dayStart = LocalTime.of(8, 0),
+            nightStart = LocalTime.of(8, 0),
+        )
+        assertEquals(ReaderTheme.Light, degenerate.resolve(LocalTime.of(8, 0)))
+        assertEquals(ReaderTheme.Light, degenerate.resolve(LocalTime.of(2, 0)))
+        assertEquals(ReaderTheme.Light, degenerate.resolve(LocalTime.of(20, 0)))
+    }
+
+    @Test
+    fun `default schedule has 07-00 21-00 Light Dark`() {
+        val d = ThemeSchedule()
+        assertEquals(LocalTime.of(7, 0), d.dayStart)
+        assertEquals(LocalTime.of(21, 0), d.nightStart)
+        assertEquals(ReaderTheme.Light, d.dayTheme)
+        assertEquals(ReaderTheme.Dark, d.nightTheme)
+    }
+
+    @Test
+    fun `nextBoundaryAfter returns the upcoming day-start when currently in night`() {
+        // It is 02:00, night ends at 07:00.
+        assertEquals(LocalTime.of(7, 0), schedule.nextBoundaryAfter(LocalTime.of(2, 0)))
+    }
+
+    @Test
+    fun `nextBoundaryAfter returns the upcoming night-start when currently in day`() {
+        // It is 12:00, day ends at 21:00.
+        assertEquals(LocalTime.of(21, 0), schedule.nextBoundaryAfter(LocalTime.of(12, 0)))
+    }
+
+    @Test
+    fun `nextBoundaryAfter at exactly the boundary returns the OTHER boundary`() {
+        // At 21:00 we are now in night; the next boundary is 07:00 (next day, but
+        // LocalTime wraps — caller computes the actual delay).
+        assertEquals(LocalTime.of(7, 0), schedule.nextBoundaryAfter(LocalTime.of(21, 0)))
+    }
+
+    @Test
+    fun `nextBoundaryAfter when equal-times returns dayStart unchanged`() {
+        val degenerate = schedule.copy(
+            dayStart = LocalTime.of(8, 0),
+            nightStart = LocalTime.of(8, 0),
+        )
+        // No real boundary — caller should treat this as "never reschedule".
+        // We define it to return dayStart for determinism.
+        assertEquals(LocalTime.of(8, 0), degenerate.nextBoundaryAfter(LocalTime.of(2, 0)))
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `./gradlew :core:domain:test --tests com.riffle.core.domain.ThemeScheduleTest`
+Expected: FAIL with "Unresolved reference: ThemeSchedule".
+
+- [ ] **Step 3: Add `ThemeSchedule` to `FormattingPreferences.kt`**
+
+Append to the end of `core/domain/src/main/kotlin/com/riffle/core/domain/FormattingPreferences.kt`:
+
+```kotlin
+import java.time.LocalTime
+
+data class ThemeSchedule(
+    val dayStart: LocalTime = DEFAULT_DAY_START,
+    val nightStart: LocalTime = DEFAULT_NIGHT_START,
+    val dayTheme: ReaderTheme = DEFAULT_DAY_THEME,
+    val nightTheme: ReaderTheme = DEFAULT_NIGHT_THEME,
+) {
+    fun resolve(now: LocalTime): ReaderTheme =
+        if (isNight(now)) nightTheme else dayTheme
+
+    // Treats the two times as boundaries on a 24h circle. The night arc runs
+    // clockwise from nightStart up to (but not including) dayStart. At exactly
+    // nightStart we are in night; at exactly dayStart we are in day. Equal
+    // times collapse the night arc to length zero → always-day.
+    private fun isNight(now: LocalTime): Boolean {
+        if (dayStart == nightStart) return false
+        return if (nightStart.isBefore(dayStart)) {
+            // Same-day night arc, e.g. 13:00 → 18:00.
+            !now.isBefore(nightStart) && now.isBefore(dayStart)
+        } else {
+            // Night arc wraps midnight, e.g. 21:00 → 07:00.
+            !now.isBefore(nightStart) || now.isBefore(dayStart)
+        }
+    }
+
+    // The next clock-time at which `resolve` would return a different theme.
+    // Used by the reader VM to schedule a one-shot delay until the next switch.
+    // Returns dayStart when the schedule is degenerate so callers always have a value.
+    fun nextBoundaryAfter(now: LocalTime): LocalTime {
+        if (dayStart == nightStart) return dayStart
+        return if (isNight(now)) dayStart else nightStart
+    }
+
+    companion object {
+        val DEFAULT_DAY_START: LocalTime = LocalTime.of(7, 0)
+        val DEFAULT_NIGHT_START: LocalTime = LocalTime.of(21, 0)
+        val DEFAULT_DAY_THEME: ReaderTheme = ReaderTheme.Light
+        val DEFAULT_NIGHT_THEME: ReaderTheme = ReaderTheme.Dark
+    }
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `./gradlew :core:domain:test --tests com.riffle.core.domain.ThemeScheduleTest`
+Expected: PASS (all 12 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add core/domain/src/main/kotlin/com/riffle/core/domain/FormattingPreferences.kt \
+        core/domain/src/test/kotlin/com/riffle/core/domain/ThemeScheduleTest.kt
+git commit -m "feat(domain): add ThemeSchedule with wrap-aware resolve and nextBoundaryAfter"
+```
+
+---
+
+### Task 3: Plumb `themeSchedule` onto `FormattingPreferences` and add `withResolvedTheme`
+
+**Files:**
+- Modify: `core/domain/src/main/kotlin/com/riffle/core/domain/FormattingPreferences.kt`
+- Create: `core/domain/src/test/kotlin/com/riffle/core/domain/FormattingPreferencesResolutionTest.kt`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `core/domain/src/test/kotlin/com/riffle/core/domain/FormattingPreferencesResolutionTest.kt`:
+
+```kotlin
+package com.riffle.core.domain
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.time.LocalTime
+
+class FormattingPreferencesResolutionTest {
+
+    @Test
+    fun `concrete theme is unchanged by withResolvedTheme`() {
+        val prefs = FormattingPreferences(theme = ReaderTheme.Sepia)
+        assertEquals(prefs, prefs.withResolvedTheme(LocalTime.of(12, 0)))
+    }
+
+    @Test
+    fun `Auto resolves to day theme during day`() {
+        val prefs = FormattingPreferences(theme = ReaderTheme.Auto)
+        assertEquals(ReaderTheme.Light, prefs.withResolvedTheme(LocalTime.of(12, 0)).theme)
+    }
+
+    @Test
+    fun `Auto resolves to night theme during night`() {
+        val prefs = FormattingPreferences(theme = ReaderTheme.Auto)
+        assertEquals(ReaderTheme.Dark, prefs.withResolvedTheme(LocalTime.of(22, 0)).theme)
+    }
+
+    @Test
+    fun `Auto with a custom schedule picks the custom night theme`() {
+        val prefs = FormattingPreferences(
+            theme = ReaderTheme.Auto,
+            themeSchedule = ThemeSchedule(
+                dayStart = LocalTime.of(7, 0),
+                nightStart = LocalTime.of(21, 0),
+                dayTheme = ReaderTheme.Sepia,
+                nightTheme = ReaderTheme.DarkDim,
+            ),
+        )
+        assertEquals(ReaderTheme.DarkDim, prefs.withResolvedTheme(LocalTime.of(22, 0)).theme)
+        assertEquals(ReaderTheme.Sepia, prefs.withResolvedTheme(LocalTime.of(12, 0)).theme)
+    }
+
+    @Test
+    fun `default themeSchedule is the ThemeSchedule default`() {
+        assertEquals(ThemeSchedule(), FormattingPreferences().themeSchedule)
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `./gradlew :core:domain:test --tests com.riffle.core.domain.FormattingPreferencesResolutionTest`
+Expected: FAIL with "Unresolved reference: themeSchedule" and "Unresolved reference: withResolvedTheme".
+
+- [ ] **Step 3: Add the field and extension**
+
+In `core/domain/src/main/kotlin/com/riffle/core/domain/FormattingPreferences.kt`, add `themeSchedule` to the data class (in the same parameter list, after `justifyText`) and add a top-level `withResolvedTheme` extension. The full file becomes:
+
+```kotlin
+package com.riffle.core.domain
+
+import java.time.LocalTime
+
+data class FormattingPreferences(
+    val fontSize: Float = DEFAULT_FONT_SIZE,
+    val theme: ReaderTheme = DEFAULT_THEME,
+    val fontFamily: ReaderFontFamily = DEFAULT_FONT_FAMILY,
+    val lineSpacing: Float = DEFAULT_LINE_SPACING,
+    val margins: Float = DEFAULT_MARGINS,
+    val orientation: ReaderOrientation = DEFAULT_ORIENTATION,
+    val showChapterMap: Boolean = DEFAULT_SHOW_CHAPTER_MAP,
+    val showReadingProgressLabels: Boolean = DEFAULT_SHOW_READING_PROGRESS_LABELS,
+    val showCurrentChapterLabel: Boolean = DEFAULT_SHOW_CURRENT_CHAPTER_LABEL,
+    val doublePageSpread: Boolean = DEFAULT_DOUBLE_PAGE_SPREAD,
+    val justifyText: Boolean = DEFAULT_JUSTIFY_TEXT,
+    val themeSchedule: ThemeSchedule = ThemeSchedule(),
+) {
+    companion object {
+        const val DEFAULT_FONT_SIZE: Float = 1.0f
+        const val DEFAULT_LINE_SPACING: Float = 1.2f
+        const val DEFAULT_MARGINS: Float = 1.0f
+        const val DEFAULT_SHOW_CHAPTER_MAP: Boolean = true
+        const val DEFAULT_SHOW_READING_PROGRESS_LABELS: Boolean = false
+        const val DEFAULT_SHOW_CURRENT_CHAPTER_LABEL: Boolean = false
+        const val DEFAULT_DOUBLE_PAGE_SPREAD: Boolean = false
+        const val DEFAULT_JUSTIFY_TEXT: Boolean = false
+        val DEFAULT_THEME: ReaderTheme = ReaderTheme.Light
+        val DEFAULT_FONT_FAMILY: ReaderFontFamily = ReaderFontFamily.Serif
+        val DEFAULT_ORIENTATION: ReaderOrientation = ReaderOrientation.Horizontal
+    }
+}
+
+enum class ReaderTheme { Light, Dark, DarkDim, Sepia, Auto }
+enum class ReaderFontFamily { Serif, SansSerif, Monospace, Literata, Merriweather, OpenDyslexic }
+enum class ReaderOrientation { Horizontal, Vertical }
+
+data class ThemeSchedule(
+    val dayStart: LocalTime = DEFAULT_DAY_START,
+    val nightStart: LocalTime = DEFAULT_NIGHT_START,
+    val dayTheme: ReaderTheme = DEFAULT_DAY_THEME,
+    val nightTheme: ReaderTheme = DEFAULT_NIGHT_THEME,
+) {
+    fun resolve(now: LocalTime): ReaderTheme =
+        if (isNight(now)) nightTheme else dayTheme
+
+    private fun isNight(now: LocalTime): Boolean {
+        if (dayStart == nightStart) return false
+        return if (nightStart.isBefore(dayStart)) {
+            !now.isBefore(nightStart) && now.isBefore(dayStart)
+        } else {
+            !now.isBefore(nightStart) || now.isBefore(dayStart)
+        }
+    }
+
+    fun nextBoundaryAfter(now: LocalTime): LocalTime {
+        if (dayStart == nightStart) return dayStart
+        return if (isNight(now)) dayStart else nightStart
+    }
+
+    companion object {
+        val DEFAULT_DAY_START: LocalTime = LocalTime.of(7, 0)
+        val DEFAULT_NIGHT_START: LocalTime = LocalTime.of(21, 0)
+        val DEFAULT_DAY_THEME: ReaderTheme = ReaderTheme.Light
+        val DEFAULT_NIGHT_THEME: ReaderTheme = ReaderTheme.Dark
+    }
+}
+
+// Returns a copy with `theme` replaced by the schedule-resolved concrete theme when
+// the user picked Auto. For any non-Auto theme this is a no-op identity. Reader VMs
+// run this at render-time so every downstream consumer (Readium mapper, palette,
+// chapter-rail backdrop) keeps reading `prefs.theme` and stays ignorant of Auto.
+fun FormattingPreferences.withResolvedTheme(now: LocalTime): FormattingPreferences =
+    if (theme == ReaderTheme.Auto) copy(theme = themeSchedule.resolve(now)) else this
+```
+
+- [ ] **Step 4: Run the resolution test**
+
+Run: `./gradlew :core:domain:test --tests com.riffle.core.domain.FormattingPreferencesResolutionTest`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Run all domain tests**
+
+Run: `./gradlew :core:domain:test`
+Expected: PASS — `BookFormattingOverridesTest` still green (`copy()` calls in the data class still work; new `themeSchedule` field has a default).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add core/domain/src/main/kotlin/com/riffle/core/domain/FormattingPreferences.kt \
+        core/domain/src/test/kotlin/com/riffle/core/domain/FormattingPreferencesResolutionTest.kt
+git commit -m "feat(domain): add themeSchedule field and withResolvedTheme extension"
+```
+
+---
+
+### Task 4: Persist `themeSchedule` in the global DataStore
+
+**Files:**
+- Modify: `core/data/src/main/kotlin/com/riffle/core/data/FormattingPreferencesStoreImpl.kt`
+- Modify: `core/data/src/test/kotlin/com/riffle/core/data/FormattingPreferencesStoreTest.kt`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `core/data/src/test/kotlin/com/riffle/core/data/FormattingPreferencesStoreTest.kt`, after the last existing `@Test`:
+
+```kotlin
+    @Test
+    fun `saved themeSchedule round-trips through the DataStore`() = testScope.runTest {
+        val store = buildStore()
+        val schedule = ThemeSchedule(
+            dayStart = LocalTime.of(6, 30),
+            nightStart = LocalTime.of(19, 45),
+            dayTheme = ReaderTheme.Sepia,
+            nightTheme = ReaderTheme.DarkDim,
+        )
+        store.update(FormattingPreferences(themeSchedule = schedule))
+        assertEquals(schedule, store.preferences.first().themeSchedule)
+    }
+
+    @Test
+    fun `themeSchedule defaults are returned for empty DataStore`() = testScope.runTest {
+        assertEquals(ThemeSchedule(), buildStore().preferences.first().themeSchedule)
+    }
+
+    @Test
+    fun `Auto theme round-trips through the DataStore`() = testScope.runTest {
+        val store = buildStore()
+        store.update(FormattingPreferences(theme = ReaderTheme.Auto))
+        assertEquals(ReaderTheme.Auto, store.preferences.first().theme)
+    }
+```
+
+Add these imports to the file:
+
+```kotlin
+import com.riffle.core.domain.ThemeSchedule
+import java.time.LocalTime
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `./gradlew :core:data:test --tests "com.riffle.core.data.FormattingPreferencesStoreTest"`
+Expected: FAIL on the two `themeSchedule` tests; the `Auto` test may pass since enum-name round-trip already works.
+
+- [ ] **Step 3: Implement persistence**
+
+Edit `core/data/src/main/kotlin/com/riffle/core/data/FormattingPreferencesStoreImpl.kt`:
+
+Add imports near the top:
+
+```kotlin
+import androidx.datastore.preferences.core.intPreferencesKey
+import com.riffle.core.domain.ThemeSchedule
+import java.time.LocalTime
+```
+
+Add four new keys inside `private companion object`:
+
+```kotlin
+        val KEY_SCHEDULE_DAY_START = intPreferencesKey("theme_schedule_day_start_minute_of_day")
+        val KEY_SCHEDULE_NIGHT_START = intPreferencesKey("theme_schedule_night_start_minute_of_day")
+        val KEY_SCHEDULE_DAY_THEME = stringPreferencesKey("theme_schedule_day_theme")
+        val KEY_SCHEDULE_NIGHT_THEME = stringPreferencesKey("theme_schedule_night_theme")
+```
+
+In the `preferences` flow `.map { prefs -> FormattingPreferences(...) }`, add `themeSchedule = ...` after `justifyText`:
+
+```kotlin
+            themeSchedule = ThemeSchedule(
+                dayStart = prefs[KEY_SCHEDULE_DAY_START]?.let(::minuteOfDayToLocalTime)
+                    ?: ThemeSchedule.DEFAULT_DAY_START,
+                nightStart = prefs[KEY_SCHEDULE_NIGHT_START]?.let(::minuteOfDayToLocalTime)
+                    ?: ThemeSchedule.DEFAULT_NIGHT_START,
+                dayTheme = prefs[KEY_SCHEDULE_DAY_THEME]
+                    ?.let { runCatching { ReaderTheme.valueOf(it) }.getOrNull() }
+                    ?.takeIf { it != ReaderTheme.Auto }
+                    ?: ThemeSchedule.DEFAULT_DAY_THEME,
+                nightTheme = prefs[KEY_SCHEDULE_NIGHT_THEME]
+                    ?.let { runCatching { ReaderTheme.valueOf(it) }.getOrNull() }
+                    ?.takeIf { it != ReaderTheme.Auto }
+                    ?: ThemeSchedule.DEFAULT_NIGHT_THEME,
+            ),
+```
+
+The `takeIf { it != ReaderTheme.Auto }` guard prevents persisted-Auto-inside-Auto (which the UI restricts but is worth defending against here) — if someone hand-edits the prefs file, we fall back to the default concrete theme rather than infinite-recurse.
+
+In `update`, add four writes after `prefs[KEY_JUSTIFY_TEXT] = preferences.justifyText`:
+
+```kotlin
+            prefs[KEY_SCHEDULE_DAY_START] = preferences.themeSchedule.dayStart.toMinuteOfDay()
+            prefs[KEY_SCHEDULE_NIGHT_START] = preferences.themeSchedule.nightStart.toMinuteOfDay()
+            prefs[KEY_SCHEDULE_DAY_THEME] = preferences.themeSchedule.dayTheme.name
+            prefs[KEY_SCHEDULE_NIGHT_THEME] = preferences.themeSchedule.nightTheme.name
+```
+
+Add helpers at the end of the file, outside the class:
+
+```kotlin
+private fun LocalTime.toMinuteOfDay(): Int = hour * 60 + minute
+private fun minuteOfDayToLocalTime(value: Int): LocalTime =
+    LocalTime.of((value / 60).coerceIn(0, 23), (value % 60).coerceIn(0, 59))
+```
+
+Persisting as `minuteOfDay` (0–1439) keeps the DataStore typed (`intPreferencesKey`) instead of relying on `LocalTime.toString()` parsing, and clamps trivially against junk values.
+
+- [ ] **Step 4: Run the tests**
+
+Run: `./gradlew :core:data:test --tests "com.riffle.core.data.FormattingPreferencesStoreTest"`
+Expected: PASS (all tests, including the three new ones).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add core/data/src/main/kotlin/com/riffle/core/data/FormattingPreferencesStoreImpl.kt \
+        core/data/src/test/kotlin/com/riffle/core/data/FormattingPreferencesStoreTest.kt
+git commit -m "feat(data): persist themeSchedule in global formatting prefs DataStore"
+```
+
+---
+
+### Task 5: Defensive fallback in `ReaderThemePalette` for `Auto`
+
+**Files:**
+- Modify: `app/src/main/kotlin/com/riffle/app/feature/reader/ReaderThemePalette.kt`
+
+Auto should never reach `palette` in production (reader VMs resolve first), but the `when` is exhaustive over the enum, so leaving Auto unhandled is a compile error. Fall back to Light's palette and document that consumers must resolve before asking.
+
+- [ ] **Step 1: Edit the file**
+
+Open `app/src/main/kotlin/com/riffle/app/feature/reader/ReaderThemePalette.kt` and add a branch to the `when`:
+
+```kotlin
+val ReaderTheme.palette: ReaderThemePalette
+    get() = when (this) {
+        ReaderTheme.Light -> ReaderThemePalette(
+            background = Color(0xFFFFFFFF),
+            foreground = Color(0xFF121212),
+        )
+        ReaderTheme.Dark -> ReaderThemePalette(
+            background = Color(0xFF000000),
+            foreground = Color(0xFFFEFEFE),
+        )
+        ReaderTheme.DarkDim -> ReaderThemePalette(
+            background = Color(0xFF000000),
+            foreground = DARK_DIM_TEXT,
+        )
+        ReaderTheme.Sepia -> ReaderThemePalette(
+            background = Color(0xFFFAF4E8),
+            foreground = Color(0xFF121212),
+        )
+        // Defensive: Auto must be resolved to a concrete theme via
+        // FormattingPreferences.withResolvedTheme() before reaching this palette.
+        // We fall back to Light so a missed resolution doesn't crash the reader,
+        // but every production call site should resolve first.
+        ReaderTheme.Auto -> ReaderThemePalette(
+            background = Color(0xFFFFFFFF),
+            foreground = Color(0xFF121212),
+        )
+    }
+```
+
+- [ ] **Step 2: Build the app module**
+
+Run: `./gradlew :app:compileDebugKotlin`
+Expected: PASS — exhaustive `when` over `ReaderTheme` now compiles.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/src/main/kotlin/com/riffle/app/feature/reader/ReaderThemePalette.kt
+git commit -m "feat(reader): add defensive Light fallback in ReaderThemePalette for Auto"
+```
+
+---
+
+### Task 6: Mapper exhaustiveness for `Auto` in `FormattingPreferencesMapper`
+
+**Files:**
+- Modify: `app/src/main/kotlin/com/riffle/app/feature/reader/FormattingPreferencesMapper.kt`
+
+The mapper's `when (theme)` is currently exhaustive over four values. Adding Auto would break it. The proper fix is that reader VMs only ever pass a resolved (concrete) `FormattingPreferences` into this mapper — but we still need exhaustiveness so the compile passes. Branch Auto to LIGHT as a defensive fallback (matching Task 5).
+
+- [ ] **Step 1: Edit the file**
+
+In `app/src/main/kotlin/com/riffle/app/feature/reader/FormattingPreferencesMapper.kt`, change the `theme = when (theme)` block (lines 30-34):
+
+From:
+
+```kotlin
+        theme = when (theme) {
+            ReaderTheme.Light -> Theme.LIGHT
+            ReaderTheme.Dark, ReaderTheme.DarkDim -> Theme.DARK
+            ReaderTheme.Sepia -> Theme.SEPIA
+        },
+```
+
+To:
+
+```kotlin
+        theme = when (theme) {
+            ReaderTheme.Light -> Theme.LIGHT
+            ReaderTheme.Dark, ReaderTheme.DarkDim -> Theme.DARK
+            ReaderTheme.Sepia -> Theme.SEPIA
+            // Auto should be resolved to a concrete theme upstream by the reader VM
+            // (via FormattingPreferences.withResolvedTheme). If it reaches here we
+            // fall back to LIGHT rather than crashing.
+            ReaderTheme.Auto -> Theme.LIGHT
+        },
+```
+
+- [ ] **Step 2: Build the app**
+
+Run: `./gradlew :app:compileDebugKotlin`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/src/main/kotlin/com/riffle/app/feature/reader/FormattingPreferencesMapper.kt
+git commit -m "feat(reader): handle Auto exhaustiveness in toEpubPreferences mapper"
+```
+
+---
+
+### Task 7: `EpubReaderScreen` exhaustiveness for `Auto` (alpha helper)
+
+**Files:**
+- Modify: `app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt:407-410`
+
+The chapter-rail backdrop alpha is a `when` over `ReaderTheme`. Same defensive fallback.
+
+- [ ] **Step 1: Edit the `when`**
+
+Locate (around line 405) the function that returns the rail foreground alpha. Change:
+
+```kotlin
+        ReaderTheme.Light -> 0.65f
+        ReaderTheme.Dark -> 0.65f
+        ReaderTheme.DarkDim -> 0.85f
+        ReaderTheme.Sepia -> 0.70f
+```
+
+To:
+
+```kotlin
+        ReaderTheme.Light -> 0.65f
+        ReaderTheme.Dark -> 0.65f
+        ReaderTheme.DarkDim -> 0.85f
+        ReaderTheme.Sepia -> 0.70f
+        // Auto resolves upstream; treat as Light if it slips through.
+        ReaderTheme.Auto -> 0.65f
+```
+
+- [ ] **Step 2: Build the app**
+
+Run: `./gradlew :app:compileDebugKotlin`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+git commit -m "feat(reader): handle Auto exhaustiveness in chapter rail alpha"
+```
+
+---
+
+### Task 8: Update mapper tests for `Auto` fallback
+
+**Files:**
+- Modify: `app/src/androidTest/kotlin/com/riffle/app/feature/reader/FormattingPreferencesMapperTest.kt`
+
+- [ ] **Step 1: Append a test**
+
+After the `sepiaThemeMapsToSEPIA` test, add:
+
+```kotlin
+    @Test
+    fun autoThemeMapsToLIGHTAsDefensiveFallback() {
+        // Reader VM resolves Auto before calling the mapper; this verifies the
+        // fallback path the mapper provides for exhaustiveness.
+        val result = FormattingPreferences(theme = ReaderTheme.Auto).toEpubPreferences()
+        assertEquals(Theme.LIGHT, result.theme)
+    }
+```
+
+- [ ] **Step 2: Run the existing harness**
+
+Run: `make harness-test` (phone AVD; per `CLAUDE.md`).
+Expected: PASS — all mapper tests including the new one.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/src/androidTest/kotlin/com/riffle/app/feature/reader/FormattingPreferencesMapperTest.kt
+git commit -m "test(reader): cover Auto theme fallback in FormattingPreferencesMapper"
+```
+
+---
+
+### Task 9: Split-swatch composable for the Auto chip
+
+**Files:**
+- Modify: `app/src/main/kotlin/com/riffle/app/feature/reader/FormattingPanel.kt`
+
+The Auto chip's swatch is a circle split diagonally: top-left half painted in the day theme's background, bottom-right half in the night theme's background, with the outline in the corresponding foregrounds. Today's `ThemeSwatch(theme)` covers the four concrete themes; Auto needs a separate composable that takes the schedule.
+
+- [ ] **Step 1: Replace the `ThemeSwatch` and its callers**
+
+In `app/src/main/kotlin/com/riffle/app/feature/reader/FormattingPanel.kt`, replace `ThemeSwatch` (around line 487) and the `swatchBackground`/`swatchForeground` extensions (lines 482-484) with:
+
+```kotlin
+@Composable
+private fun ThemeSwatch(theme: ReaderTheme, schedule: ThemeSchedule) {
+    if (theme == ReaderTheme.Auto) {
+        AutoThemeSwatch(schedule)
+    } else {
+        ConcreteThemeSwatch(theme)
+    }
+}
+
+@Composable
+private fun ConcreteThemeSwatch(theme: ReaderTheme) {
+    val palette = theme.palette
+    Box(
+        modifier = Modifier
+            .size(18.dp)
+            .background(palette.background, RoundedCornerShape(percent = 50))
+            .border(1.dp, palette.foreground, RoundedCornerShape(percent = 50)),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text("A", color = palette.foreground, style = MaterialTheme.typography.labelSmall)
+    }
+}
+
+@Composable
+private fun AutoThemeSwatch(schedule: ThemeSchedule) {
+    val day = schedule.dayTheme.palette
+    val night = schedule.nightTheme.palette
+    Box(
+        modifier = Modifier
+            .size(18.dp)
+            .background(day.background, RoundedCornerShape(percent = 50))
+            .border(1.dp, MaterialTheme.colorScheme.outline, RoundedCornerShape(percent = 50)),
+        contentAlignment = Alignment.Center,
+    ) {
+        // Bottom-right half painted in the night background, clipped to the circle.
+        Canvas(modifier = Modifier.size(18.dp)) {
+            val path = androidx.compose.ui.graphics.Path().apply {
+                moveTo(size.width, 0f)
+                lineTo(size.width, size.height)
+                lineTo(0f, size.height)
+                close()
+            }
+            clipPath(path) {
+                drawCircle(color = night.background, radius = size.minDimension / 2f)
+            }
+        }
+    }
+}
+```
+
+Add imports if missing:
+
+```kotlin
+import androidx.compose.ui.graphics.drawscope.clipPath
+import com.riffle.core.domain.ThemeSchedule
+```
+
+Update the FilterChip in the theme row (around line 145–152) to pass `prefs.themeSchedule` to the swatch:
+
+```kotlin
+                ReaderTheme.entries.forEach { theme ->
+                    val label = theme.displayName()
+                    FilterChip(
+                        selected = prefs.theme == theme,
+                        onClick = { onPrefsChange(prefs.copy(theme = theme)) },
+                        label = { Text(label) },
+                        leadingIcon = { ThemeSwatch(theme, prefs.themeSchedule) },
+                        modifier = Modifier.semantics { contentDescription = "$label theme" },
+                    )
+                }
+```
+
+Update the `displayName` extension (around line 469) to include Auto:
+
+```kotlin
+private fun ReaderTheme.displayName(): String = when (this) {
+    ReaderTheme.Light -> "Light"
+    ReaderTheme.Dark -> "Dark"
+    ReaderTheme.DarkDim -> "Dim"
+    ReaderTheme.Sepia -> "Sepia"
+    ReaderTheme.Auto -> "Auto"
+}
+```
+
+- [ ] **Step 2: Build the app**
+
+Run: `./gradlew :app:compileDebugKotlin`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/src/main/kotlin/com/riffle/app/feature/reader/FormattingPanel.kt
+git commit -m "feat(reader): add Auto theme chip with split day/night swatch"
+```
+
+---
+
+### Task 10: Schedule sub-controls in the full-screen FormattingPanel
+
+**Files:**
+- Modify: `app/src/main/kotlin/com/riffle/app/feature/reader/FormattingPanel.kt`
+
+When `fullScreen == true` AND `prefs.theme == ReaderTheme.Auto`, reveal two `TimePicker`-backed time fields plus two restricted chip rows (one for day theme, one for night theme, both filtering Auto out). When `fullScreen == false`, hide the sub-controls — the in-reader panel just shows the Auto chip.
+
+- [ ] **Step 1: Add the sub-controls block**
+
+Right after the existing theme chip row (after the closing `Spacer(Modifier.height(16.dp))` that follows the theme `Row`, around line 154), insert:
+
+```kotlin
+            if (fullScreen && prefs.theme == ReaderTheme.Auto) {
+                AutoScheduleControls(
+                    schedule = prefs.themeSchedule,
+                    onScheduleChange = { onPrefsChange(prefs.copy(themeSchedule = it)) },
+                )
+                Spacer(Modifier.height(16.dp))
+            }
+```
+
+Add the composable at the bottom of the file (after the existing helpers):
+
+```kotlin
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun AutoScheduleControls(
+    schedule: ThemeSchedule,
+    onScheduleChange: (ThemeSchedule) -> Unit,
+) {
+    Column {
+        Text("Day starts at", style = MaterialTheme.typography.labelMedium)
+        TimeField(
+            time = schedule.dayStart,
+            contentDescription = "Day start time",
+            onTimeChange = { onScheduleChange(schedule.copy(dayStart = it)) },
+        )
+        Spacer(Modifier.height(8.dp))
+        Text("Night starts at", style = MaterialTheme.typography.labelMedium)
+        TimeField(
+            time = schedule.nightStart,
+            contentDescription = "Night start time",
+            onTimeChange = { onScheduleChange(schedule.copy(nightStart = it)) },
+        )
+        Spacer(Modifier.height(12.dp))
+        Text("Day theme", style = MaterialTheme.typography.labelMedium)
+        ConcreteThemeChipRow(
+            selected = schedule.dayTheme,
+            onSelect = { onScheduleChange(schedule.copy(dayTheme = it)) },
+        )
+        Spacer(Modifier.height(8.dp))
+        Text("Night theme", style = MaterialTheme.typography.labelMedium)
+        ConcreteThemeChipRow(
+            selected = schedule.nightTheme,
+            onSelect = { onScheduleChange(schedule.copy(nightTheme = it)) },
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun ConcreteThemeChipRow(
+    selected: ReaderTheme,
+    onSelect: (ReaderTheme) -> Unit,
+) {
+    val concretes = listOf(
+        ReaderTheme.Light, ReaderTheme.Dark, ReaderTheme.DarkDim, ReaderTheme.Sepia,
+    )
+    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+        concretes.forEach { theme ->
+            val label = theme.displayName()
+            FilterChip(
+                selected = selected == theme,
+                onClick = { onSelect(theme) },
+                label = { Text(label) },
+                leadingIcon = { ConcreteThemeSwatch(theme) },
+                modifier = Modifier.semantics { contentDescription = "$label theme" },
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun TimeField(
+    time: LocalTime,
+    contentDescription: String,
+    onTimeChange: (LocalTime) -> Unit,
+) {
+    var showPicker by remember { mutableStateOf(false) }
+    val label = "%02d:%02d".format(time.hour, time.minute)
+    Surface(
+        shape = RoundedCornerShape(percent = 50),
+        color = MaterialTheme.colorScheme.surfaceVariant,
+        contentColor = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { showPicker = true }
+            .semantics { this.contentDescription = contentDescription },
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.Center,
+            modifier = Modifier.height(48.dp).fillMaxWidth(),
+        ) {
+            Text(label, style = MaterialTheme.typography.bodyLarge)
+        }
+    }
+    if (showPicker) {
+        val state = rememberTimePickerState(
+            initialHour = time.hour,
+            initialMinute = time.minute,
+            is24Hour = true,
+        )
+        AlertDialog(
+            onDismissRequest = { showPicker = false },
+            confirmButton = {
+                TextButton(onClick = {
+                    onTimeChange(LocalTime.of(state.hour, state.minute))
+                    showPicker = false
+                }) { Text("OK") }
+            },
+            dismissButton = {
+                TextButton(onClick = { showPicker = false }) { Text("Cancel") }
+            },
+            text = { TimePicker(state = state) },
+        )
+    }
+}
+```
+
+Add imports if missing:
+
+```kotlin
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.TimePicker
+import androidx.compose.material3.rememberTimePickerState
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import java.time.LocalTime
+```
+
+- [ ] **Step 2: Build the app**
+
+Run: `./gradlew :app:compileDebugKotlin`
+Expected: PASS.
+
+- [ ] **Step 3: Launch the app, navigate to Settings → Reading settings**
+
+Tap "Auto" chip. Verify:
+- Schedule sub-controls appear: two time fields + two chip rows.
+- Tapping a time field opens a 24h TimePicker dialog.
+- Picking a non-default time updates the field label after OK.
+- Day and Night chip rows do NOT show Auto.
+- Switching from Auto to Light hides the sub-controls.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/src/main/kotlin/com/riffle/app/feature/reader/FormattingPanel.kt
+git commit -m "feat(reader): show schedule editor when Auto is selected in Settings panel"
+```
+
+---
+
+### Task 11: `TimeProvider` abstraction for testability
+
+**Files:**
+- Create: `app/src/main/kotlin/com/riffle/app/feature/reader/TimeProvider.kt`
+
+- [ ] **Step 1: Create the file**
+
+```kotlin
+package com.riffle.app.feature.reader
+
+import java.time.LocalTime
+import javax.inject.Inject
+import javax.inject.Singleton
+
+// Lets the reader VMs read "now" in a way tests can substitute. Production binding
+// returns LocalTime.now() each call; tests inject a fake.
+interface TimeProvider {
+    fun nowLocalTime(): LocalTime
+}
+
+@Singleton
+class SystemTimeProvider @Inject constructor() : TimeProvider {
+    override fun nowLocalTime(): LocalTime = LocalTime.now()
+}
+```
+
+- [ ] **Step 2: Bind it in Hilt**
+
+Locate the existing app-level Hilt module that binds singletons (likely `app/src/main/kotlin/com/riffle/app/di/AppModule.kt` or similar). If `TimeProvider` requires a binding, add inside the module:
+
+```kotlin
+    @Binds
+    @Singleton
+    abstract fun bindTimeProvider(impl: SystemTimeProvider): TimeProvider
+```
+
+If the module is an `@Module @InstallIn(SingletonComponent::class) object` rather than `abstract class`, use `@Provides` instead:
+
+```kotlin
+    @Provides
+    @Singleton
+    fun provideTimeProvider(impl: SystemTimeProvider): TimeProvider = impl
+```
+
+If no clear app-level Hilt module exists, `@Inject constructor` on `SystemTimeProvider` plus `@Singleton` is enough — Hilt will auto-bind it where injected as `SystemTimeProvider`. In that case skip this step and inject `SystemTimeProvider` directly in the VMs (Task 12).
+
+- [ ] **Step 3: Build the app**
+
+Run: `./gradlew :app:compileDebugKotlin`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/src/main/kotlin/com/riffle/app/feature/reader/TimeProvider.kt
+# plus the Hilt module if you edited it
+git commit -m "feat(reader): add TimeProvider abstraction for clock injection"
+```
+
+---
+
+### Task 12: Live-switching theme resolver inside `EpubReaderViewModel`
+
+**Files:**
+- Modify: `app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt`
+- Modify: `app/src/test/kotlin/com/riffle/app/feature/reader/EpubReaderViewModelTest.kt`
+
+Expose `effectiveFormattingPreferences: StateFlow<FormattingPreferences>` whose `theme` is always concrete. Internally drive it from `_formattingPreferences` plus a coroutine that re-emits at each schedule boundary.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `app/src/test/kotlin/com/riffle/app/feature/reader/EpubReaderViewModelTest.kt`, in the `EpubReaderViewModelTest` class:
+
+```kotlin
+    // Mirrors EpubReaderViewModel's schedule-driven boundary timer. The reader VM
+    // computes the delay until the next ThemeSchedule boundary from a FakeClock,
+    // suspends, then republishes effective prefs with the new resolved theme.
+    @Test
+    fun `effective theme flips at the schedule boundary`() = runTest {
+        val schedule = com.riffle.core.domain.ThemeSchedule(
+            dayStart = java.time.LocalTime.of(7, 0),
+            nightStart = java.time.LocalTime.of(21, 0),
+            dayTheme = com.riffle.core.domain.ReaderTheme.Light,
+            nightTheme = com.riffle.core.domain.ReaderTheme.Dark,
+        )
+        // Pretend it is 20:59 — one minute before night-start.
+        var fakeNow = java.time.LocalTime.of(20, 59)
+        val emitted = mutableListOf<com.riffle.core.domain.ReaderTheme>()
+
+        backgroundScope.launch {
+            // Initial emit:
+            emitted += if (com.riffle.core.domain.ReaderTheme.Auto == com.riffle.core.domain.ReaderTheme.Auto)
+                schedule.resolve(fakeNow) else com.riffle.core.domain.ReaderTheme.Auto
+            while (true) {
+                val next = schedule.nextBoundaryAfter(fakeNow)
+                val delayMs = ((next.toSecondOfDay() - fakeNow.toSecondOfDay() + 24 * 3600) % (24 * 3600)) * 1000L
+                delay(delayMs.coerceAtLeast(1L))
+                fakeNow = next
+                emitted += schedule.resolve(fakeNow)
+            }
+        }
+
+        // Advance one minute → boundary at 21:00, should flip to Dark.
+        advanceTimeBy(60_000 + 1)
+        assertEquals(listOf(com.riffle.core.domain.ReaderTheme.Light, com.riffle.core.domain.ReaderTheme.Dark), emitted)
+    }
+```
+
+This test mirrors the VM control flow with virtual time, the same pattern the existing `periodic sync timer` tests use. The actual VM wiring follows in step 3.
+
+- [ ] **Step 2: Run the test to verify it passes (pattern check)**
+
+Run: `./gradlew :app:testDebugUnitTest --tests "com.riffle.app.feature.reader.EpubReaderViewModelTest"`
+Expected: PASS — this test mirrors the control flow without touching the VM yet, locking in the loop shape we'll implement.
+
+- [ ] **Step 3: Wire `effectiveFormattingPreferences` into the VM**
+
+In `app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt`:
+
+Add imports:
+
+```kotlin
+import com.riffle.core.domain.withResolvedTheme
+import com.riffle.core.domain.ReaderTheme
+import com.riffle.core.domain.ThemeSchedule
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.transformLatest
+import java.time.LocalTime
+```
+
+Add `private val timeProvider: TimeProvider` to the constructor's `@Inject constructor(...)` parameter list (insert before `readerStateHolder`).
+
+Below the existing `formattingPreferences` declaration (around line 143), add:
+
+```kotlin
+    // Ticks emitted at each ThemeSchedule boundary so the resolved theme can flip live
+    // during a reading session. Re-armed whenever the schedule changes.
+    private val scheduleTicks = MutableSharedFlow<Unit>(extraBufferCapacity = 1, replay = 1).apply {
+        tryEmit(Unit) // prime the combine() below so it emits immediately on collection
+    }
+
+    // The user's pick with `theme` replaced by the resolver's concrete value when the
+    // pick is Auto. Every downstream consumer (Readium navigator submitPreferences,
+    // chapter rail backdrop, palette) reads this — they stay ignorant of Auto.
+    val effectiveFormattingPreferences: StateFlow<FormattingPreferences> = combine(
+        _formattingPreferences,
+        scheduleTicks,
+    ) { prefs, _ -> prefs.withResolvedTheme(timeProvider.nowLocalTime()) }
+        .distinctUntilChanged()
+        .stateIn(viewModelScope, SharingStarted.Eagerly, FormattingPreferences())
+```
+
+Add a coroutine in `init { ... }` that re-arms the timer whenever the schedule or theme pick changes:
+
+```kotlin
+        viewModelScope.launch {
+            _formattingPreferences
+                .map { it.themeSchedule to (it.theme == ReaderTheme.Auto) }
+                .distinctUntilChanged()
+                .collectLatest { (schedule, autoActive) ->
+                    if (!autoActive) return@collectLatest
+                    while (true) {
+                        val now = timeProvider.nowLocalTime()
+                        val next = schedule.nextBoundaryAfter(now)
+                        val nowSec = now.toSecondOfDay().toLong()
+                        val nextSec = next.toSecondOfDay().toLong()
+                        val delayMs = (((nextSec - nowSec + 24 * 3600) % (24 * 3600)) * 1000L)
+                            .coerceAtLeast(1_000L)
+                        delay(delayMs)
+                        scheduleTicks.tryEmit(Unit)
+                    }
+                }
+        }
+```
+
+Add imports for `collectLatest` and `map` if missing:
+
+```kotlin
+import kotlinx.coroutines.flow.collectLatest
+```
+
+(`map` is already imported.)
+
+- [ ] **Step 4: Update the screen to consume `effectiveFormattingPreferences`**
+
+In `app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt` (around line 107):
+
+Change:
+
+```kotlin
+    val formattingPrefs by viewModel.formattingPreferences.collectAsState()
+```
+
+To:
+
+```kotlin
+    // Raw user-picked prefs — feeds the FormattingPanel chip selection (so Auto stays
+    // highlighted even though the page renders in the resolved palette).
+    val pickedPrefs by viewModel.formattingPreferences.collectAsState()
+    // Resolved prefs — `theme` is always concrete. Feeds Readium, the chapter rail
+    // backdrop, and any palette consumer.
+    val formattingPrefs by viewModel.effectiveFormattingPreferences.collectAsState()
+```
+
+Find where `FormattingPanel(...)` is invoked (search for `FormattingPanel(`) and change the `prefs = formattingPrefs` argument to `prefs = pickedPrefs`. Leave every other consumer (`formattingPrefs.toEpubPreferences(...)`, `readerTheme.palette.background`, etc.) untouched — they continue to use `formattingPrefs` and so see the resolved theme.
+
+Inside `viewModel.updateFormatting(...)` call from the panel's `onPrefsChange`, pass `pickedPrefs` as the previous-effective baseline. Look at the existing site; the call typically is:
+
+```kotlin
+onPrefsChange = { viewModel.updateFormatting(it) },
+```
+
+Leave it as-is — `updateFormatting` already uses `_formattingPreferences.value` (the raw pick) as the baseline for `withChanges`.
+
+- [ ] **Step 5: Verify the panel still shows the right chip**
+
+Locate any `readerTheme` derivation (around line 365 of `EpubReaderScreen.kt`, "Reader TopAppBar palette") and confirm it reads from `formattingPrefs.theme` (resolved). That's correct — the immersive bar should colour-match the rendered page, not the user's pick.
+
+The chip selection inside `FormattingPanel` reads `prefs.theme == theme`, where `prefs` is now `pickedPrefs` — so the Auto chip stays highlighted when the user picked Auto.
+
+- [ ] **Step 6: Run unit tests**
+
+Run: `./gradlew :app:testDebugUnitTest`
+Expected: PASS.
+
+- [ ] **Step 7: Build and install on the phone AVD**
+
+Run: `make install`
+Open a book with theme set to Auto, day-start `13:00`, night-start `13:02`, day-theme Light, night-theme Dark.
+Stay on the reader page across `13:02` (use device time settings to fast-forward if needed, or set the times around current local time).
+Expected: the page repaints from Light to Dark without closing the book.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt \
+        app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt \
+        app/src/test/kotlin/com/riffle/app/feature/reader/EpubReaderViewModelTest.kt
+git commit -m "feat(reader): live-switch theme at ThemeSchedule boundaries in EPUB reader"
+```
+
+---
+
+### Task 13: Same live-switching for `PdfReaderViewModel` (forward-compatible)
+
+**Files:**
+- Modify: `app/src/main/kotlin/com/riffle/app/feature/reader/PdfReaderViewModel.kt`
+- Modify: `app/src/main/kotlin/com/riffle/app/feature/reader/PdfReaderScreen.kt` (only if it currently reads theme)
+
+The PDF reader VM currently does not expose `formattingPreferences` at all (no theme is applied to PDF rendering today). To honour the CONTEXT.md promise that Auto "applies uniformly to EPUB and PDF reading" we add the same `effectiveFormattingPreferences` plumbing so that **when PDF theming lands later**, Auto is already wired through.
+
+- [ ] **Step 1: Inject the stores and `TimeProvider`**
+
+In `PdfReaderViewModel.kt`'s `@Inject constructor`, add:
+
+```kotlin
+    private val formattingPreferencesStore: FormattingPreferencesStore,
+    private val bookFormattingPreferencesStore: BookFormattingPreferencesStore,
+    private val timeProvider: TimeProvider,
+```
+
+Add imports:
+
+```kotlin
+import com.riffle.core.domain.BookFormattingOverrides
+import com.riffle.core.domain.BookFormattingPreferencesStore
+import com.riffle.core.domain.FormattingPreferences
+import com.riffle.core.domain.FormattingPreferencesStore
+import com.riffle.core.domain.ReaderTheme
+import com.riffle.core.domain.withResolvedTheme
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+```
+
+- [ ] **Step 2: Add the flows and timer**
+
+After the existing `keepScreenOn` state declaration:
+
+```kotlin
+    private val _bookOverrides = MutableStateFlow(BookFormattingOverrides())
+    private val _formattingPreferences = MutableStateFlow(FormattingPreferences())
+    val formattingPreferences: StateFlow<FormattingPreferences> = _formattingPreferences
+
+    private val scheduleTicks = MutableSharedFlow<Unit>(extraBufferCapacity = 1, replay = 1).apply {
+        tryEmit(Unit)
+    }
+
+    val effectiveFormattingPreferences: StateFlow<FormattingPreferences> = combine(
+        _formattingPreferences,
+        scheduleTicks,
+    ) { prefs, _ -> prefs.withResolvedTheme(timeProvider.nowLocalTime()) }
+        .distinctUntilChanged()
+        .stateIn(viewModelScope, SharingStarted.Eagerly, FormattingPreferences())
+```
+
+Replace the existing `init { viewModelScope.launch { openBook() } ... }` block with:
+
+```kotlin
+    init {
+        viewModelScope.launch {
+            loadFormattingPreferences()
+            openBook()
+        }
+        viewModelScope.launch {
+            combine(
+                formattingPreferencesStore.preferences,
+                _bookOverrides,
+            ) { global, overrides -> overrides.applyTo(global) }
+                .collect { _formattingPreferences.value = it }
+        }
+        viewModelScope.launch {
+            _formattingPreferences
+                .map { it.themeSchedule to (it.theme == ReaderTheme.Auto) }
+                .distinctUntilChanged()
+                .collectLatest { (schedule, autoActive) ->
+                    if (!autoActive) return@collectLatest
+                    while (true) {
+                        val now = timeProvider.nowLocalTime()
+                        val next = schedule.nextBoundaryAfter(now)
+                        val delayMs = (((next.toSecondOfDay() - now.toSecondOfDay() + 24 * 3600) % (24 * 3600)) * 1000L)
+                            .coerceAtLeast(1_000L)
+                        delay(delayMs)
+                        scheduleTicks.tryEmit(Unit)
+                    }
+                }
+        }
+        viewModelScope.launch {
+            progressSyncController.serverPositionEvents.collect { serverProgress ->
+                serverLocationToLocator(serverProgress.ebookLocation)?.let { _serverLocatorChannel.trySend(it) }
+            }
+        }
+    }
+
+    private suspend fun loadFormattingPreferences() {
+        val overrides = bookFormattingPreferencesStore.load(itemId)
+        val global = formattingPreferencesStore.preferences.first()
+        _bookOverrides.value = overrides
+        _formattingPreferences.value = overrides.applyTo(global)
+    }
+```
+
+- [ ] **Step 3: Build**
+
+Run: `./gradlew :app:compileDebugKotlin`
+Expected: PASS.
+
+- [ ] **Step 4: Run app unit tests**
+
+Run: `./gradlew :app:testDebugUnitTest`
+Expected: PASS — `PdfReaderViewModel` has no existing unit tests touching these fields.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/kotlin/com/riffle/app/feature/reader/PdfReaderViewModel.kt
+git commit -m "feat(reader): expose effective formatting prefs in PDF VM for future theming"
+```
+
+---
+
+### Task 14: Full unit + integration test sweep
+
+- [ ] **Step 1: Run all tests**
+
+Run: `./gradlew test`
+Expected: PASS — every module (`:core:domain`, `:core:data`, `:app`, others) green.
+
+- [ ] **Step 2: Run the phone harness**
+
+Run: `make harness-test`
+Expected: PASS — `FormattingPreferencesMapperTest` (with the new Auto-fallback case) and any reader/settings harness tests pass on the AVD.
+
+- [ ] **Step 3: Manual smoke**
+
+Build and install: `make install`
+
+Verify:
+1. Settings → Reading settings → Theme row shows 5 chips: Light, Dark, Dim, Sepia, Auto. Auto's swatch is the split-circle.
+2. Tapping Auto reveals four sub-controls (Day starts at, Night starts at, Day theme row of 4 chips, Night theme row of 4 chips — Auto absent from both).
+3. Tapping each time field opens a 24h `TimePicker` dialog; OK persists the new time.
+4. Opening any book picks up the global Auto setting; the resolved theme matches the current clock against the schedule.
+5. Tapping the formatting chip while in the reader shows Auto highlighted (not the resolved concrete) and *does not* show the schedule sub-controls (in-reader panel hides them).
+6. Per-book override: set this book to Sepia in the in-reader panel, close, reopen — book renders in Sepia regardless of schedule. The global Auto pick is still active for other books.
+7. Set the global schedule so a boundary is ~30 seconds in the future, open a book in Auto, wait for the boundary — page repaints without closing the book.
+
+- [ ] **Step 4: README feature list update**
+
+Per CLAUDE.md, on feature completion: flip the relevant `- [ ]` to `- [x]` in `README.md`'s Features list.
+
+Open `README.md`, find the row for the auto theme entry (likely "Automatic day/night theme scheduling" or similar — if no row exists yet, add one under the reader/formatting section in the appropriate place, matching the format of neighbouring entries).
+
+Example edit (the exact wording should match the README's existing style):
+
+```markdown
+- [x] Auto reader theme that switches between configured day and night themes on a global clock schedule
+```
+
+If no matching row exists, add one in the most appropriate Features sub-section.
+
+- [ ] **Step 5: Final commit and PR-ready state**
+
+```bash
+git add README.md
+git commit -m "docs(readme): mark Auto reader theme feature complete"
+```
+
+---
+
+## Self-review checklist
+
+- **Spec coverage:**
+  - Auto as fifth enum value → Task 1
+  - ThemeSchedule + global persistence → Tasks 2, 4
+  - Defaults 07:00/21:00/Light/Dark → encoded in `ThemeSchedule.Companion`
+  - Wrap-around, equal-times = always-day → Task 2 (`isNight`)
+  - Per-book selection works like other themes → no schema change; `BookFormattingOverrides.theme: ReaderTheme?` accepts Auto natively (verified by existing tests still passing)
+  - Resolver at the boundary → Task 3 (`withResolvedTheme`)
+  - Live mid-session switching → Tasks 11, 12, 13
+  - Split swatch for Auto chip → Task 9
+  - Schedule editing only in full-screen Settings panel → Task 10 (guard `if (fullScreen && prefs.theme == Auto)`)
+  - In-reader panel just shows the chip → same guard
+  - Day/night picks restricted to four concretes → Task 10 (`ConcreteThemeChipRow` lists only four)
+  - Both readers (EPUB + PDF) → Tasks 12, 13
+  - ADR / CONTEXT.md → already written this session; no plan task needed
+  - README update → Task 14
+
+- **Type consistency:**
+  - `ThemeSchedule.resolve` / `nextBoundaryAfter` — same signatures used in Task 2 test, Task 3 file, Task 12 VM, Task 12 test.
+  - `withResolvedTheme(now: LocalTime): FormattingPreferences` — same signature in Task 3 definition and Task 12 VM call.
+  - `TimeProvider.nowLocalTime(): LocalTime` — defined Task 11, used Tasks 12, 13.
+  - `effectiveFormattingPreferences: StateFlow<FormattingPreferences>` — defined Tasks 12, 13; consumed Task 12 screen update.
+
+- **Placeholder scan:** No "TODO", "implement later", "similar to Task N (without code)" — every step has either the literal code, the exact command, or a precise UI verification step.


### PR DESCRIPTION
## Summary
- Adds `ReaderTheme.Auto` as a fifth theme value that resolves at render-time against a global `ThemeSchedule` (day-start, night-start, day-theme, night-theme), wrap-aware around midnight.
- Live-switches the active theme at schedule boundaries in both EPUB and PDF readers via a `TimeProvider` abstraction, with the boundary timer parked when the schedule degenerates to always-day.
- New formatting-panel UI: split chip rows for the five themes (concretes on top, Auto with a split day/night swatch below) and, in the full-screen Settings panel, an Auto schedule editor with time pickers and dropdowns for the two concrete themes.
- `themeSchedule` is intentionally global-only — `BookFormattingOverrides.applyTo` always threads it from global so a per-book Auto pin honours the user's configured times.
- Documents the design in [ADR 0022](docs/adr/0022-auto-reader-theme-clock-scheduled-fifth-enum.md) and CONTEXT.md.

## Test plan
- [x] `./gradlew test` — all unit tests pass
- [x] `make harness-test` — 125/125 phone instrumentation tests pass (4 skipped)
- [x] `make harness-test-tablet` — 5/5 tablet instrumentation tests pass