### PR TITLE
fix(sync): stop touchOpenTimestamp from clobbering server-side progress

### DIFF
--- a/core/data/src/main/kotlin/com/riffle/core/data/ReadingSessionRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/ReadingSessionRepositoryImpl.kt
@@ -74,7 +74,14 @@ class ReadingSessionRepositoryImpl @Inject constructor(
             is NetworkGetProgressResult.Success -> r.progress
             is NetworkGetProgressResult.NetworkError -> return
         }
-        val patchResult = api.syncEbookProgress(
+        // Deliberately do NOT bump positionStore.localUpdatedAt here. Matching the server's
+        // post-PATCH lastUpdate without also writing the server's cfi locally would create a
+        // "local in sync but cfi empty" state: the next runSyncCycle would see equal stamps
+        // and return InSync, the reader would open at page 1, and the next local save would
+        // PATCH first-page state over the real server position. Leaving local untouched lets
+        // the first runSyncCycle after this call see server > local and trigger ServerWins,
+        // restoring the saved position to the navigator.
+        api.syncEbookProgress(
             server.url.value, itemId,
             NetworkEbookProgressPayload(
                 ebookLocation = serverProgress.ebookLocation,
@@ -82,10 +89,6 @@ class ReadingSessionRepositoryImpl @Inject constructor(
             ),
             token, server.insecureConnectionAllowed,
         )
-        if (patchResult is NetworkSyncSessionResult.Success) {
-            val ts = patchResult.lastUpdate.takeIf { it > 0L } ?: System.currentTimeMillis()
-            positionStore.updateLocalTimestamp(server.id, itemId, ts)
-        }
     }
 
     override suspend fun setProgress(itemId: String, progress: Float) {

--- a/core/data/src/test/kotlin/com/riffle/core/data/ProgressSyncCycleTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/ProgressSyncCycleTest.kt
@@ -37,6 +37,7 @@ class ProgressSyncCycleTest {
         override suspend fun updateLocalTimestamp(serverId: String, itemId: String, millis: Long) {
             updatedServerId = serverId
             updatedTimestamp = millis
+            localUpdatedAt = millis
         }
     }
 
@@ -277,7 +278,7 @@ class ProgressSyncCycleTest {
     // --- touchOpenTimestamp ---
 
     @Test
-    fun `touchOpenTimestamp PATCHes back the server's current ebookLocation to bump lastUpdate without clobbering position`() = runTest {
+    fun `touchOpenTimestamp PATCHes back the server's current ebookLocation without writing local timestamp`() = runTest {
         val positionStore = FakePositionStore(localUpdatedAt = 0L)
         val recording = object : AbsSessionApi {
             var patchPayload: NetworkEbookProgressPayload? = null
@@ -296,7 +297,35 @@ class ProgressSyncCycleTest {
 
         assertEquals("server-cfi", recording.patchPayload?.ebookLocation)
         assertEquals(0.42f, recording.patchPayload?.ebookProgress)
-        assertEquals(7_777L, positionStore.updatedTimestamp)
+        // Local timestamps stay untouched — this is what allows the next sync cycle to
+        // recognise the server as the source of truth and pull the saved position.
+        assertEquals(null, positionStore.updatedTimestamp)
+        assertEquals(0L, positionStore.localUpdatedAt)
+    }
+
+    @Test
+    fun `touchOpenTimestamp leaves localUpdatedAt untouched so the next sync cycle pulls server progress`() = runTest {
+        // Regression: touchOpenTimestamp used to bump local's updatedAt to the server's new
+        // lastUpdate without writing the server's cfi/progress locally. The empty local cfi
+        // + matching timestamp made the next runSyncCycle return InSync — the reader opened
+        // at page 1 and any subsequent local save overwrote the real server position.
+        // The contract is now: touchOpenTimestamp doesn't touch local timestamps, so the
+        // first sync cycle after it sees server > local and ServerWins fires, restoring the
+        // saved position.
+        val positionStore = FakePositionStore(localUpdatedAt = 0L)
+        val api = FakeSessionApi(
+            getResult = NetworkGetProgressResult.Success(
+                NetworkServerProgress("server-cfi", ebookProgress = 0.42f, lastUpdate = 3_000L)
+            ),
+            patchResult = NetworkSyncSessionResult.Success(7_777L),
+        )
+        val repo = buildRepo(api, positionStore)
+
+        repo.touchOpenTimestamp("item-1")
+        val result = repo.runSyncCycle("item-1", payload = SessionPayload("", 0f))
+
+        assertTrue(result is ProgressSyncCycleResult.ServerWins)
+        assertEquals("server-cfi", (result as ProgressSyncCycleResult.ServerWins).serverProgress.ebookLocation)
     }
 
     @Test

--- a/core/data/src/test/kotlin/com/riffle/core/data/ProgressSyncIntegrationTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/ProgressSyncIntegrationTest.kt
@@ -237,7 +237,10 @@ class ProgressSyncIntegrationTest {
         val body = patchReq.body.readUtf8()
         assertTrue("ebookLocation must be echoed verbatim: $body", body.contains("\"ebookLocation\":\"epubcfi(/6/8!/4/2/1:0)\""))
         assertTrue("ebookProgress must be echoed verbatim: $body", body.contains("\"ebookProgress\":0.42"))
-        assertEquals(9999L, positionStore.updatedTimestamp)
+        // The PATCH bumps the server's lastUpdate. We deliberately do not echo that timestamp
+        // into the local store — leaving local stale guarantees the next runSyncCycle sees
+        // server > local, fires ServerWins, and restores the saved position to the navigator.
+        assertEquals(null, positionStore.updatedTimestamp)
     }
 
     @Test


### PR DESCRIPTION
## Summary

Books with progress on the ABS server were opening at page 1 on devices that hadn't already opened them in Riffle (fresh install, test account, second device, …) — and then Riffle's first-page state would PATCH back over the real server position on the next sync cycle.

Root cause: `ReadingSessionRepositoryImpl.touchOpenTimestamp` was bumping `reading_positions.localUpdatedAt` to the server's post-PATCH `lastUpdate` *without* also writing the server's cfi locally. That created a "local in sync but cfi empty" state:

1. Reader opens → `positionStore.load` returns `""` → `initialLocator = null`. Navigator opens at page 1.
2. `progressSyncController.sync` runs → `runSyncCycle` sees equal timestamps → `InSync`. Server's real position is never pulled.
3. Navigator's first `onPositionChanged` flips `initialLocatorSeen = true`. The next emission (any scroll/page turn/layout) writes first-page cfi with `localUpdatedAt = now`.
4. Next sync cycle: local > server → `LocalWins` → PATCHes first-page progress over the real server position.

Triggered by the typical Read-button flow: `LibraryItemDetailScreen` calls `viewModel.markOpened()` before navigating to the reader, which fans out to `touchOpenTimestamp`.

Bug was introduced in c26a5f4 (#43 "fix(sync): isolate reading progress per user + sync lastOpenedAt across devices").

## Fix

Drop the `positionStore.updateLocalTimestamp(...)` call from `touchOpenTimestamp`. The PATCH still bumps the server's `lastUpdate` (which is what the cross-device "In Progress" sort needs), but local stays stale. The first `runSyncCycle` after that call now sees server > local, fires `ServerWins`, and emits the saved locator to the navigator.

## Tests

- New `ProgressSyncCycleTest` regression test runs `touchOpenTimestamp` + `runSyncCycle` and asserts `ServerWins` with the server's `ebookLocation`. Verified RED first, then GREEN after the fix.
- `FakePositionStore.updateLocalTimestamp` now actually mutates `localUpdatedAt` — the old shape silently masked the bug by recording calls without affecting subsequent loads.
- Existing `touchOpenTimestamp …` tests in `ProgressSyncCycleTest` and `ProgressSyncIntegrationTest` flipped to assert the new contract (no local-timestamp write).

## Test plan

- [ ] On a clean install / test account, open a book that has saved progress on the ABS server. Reader resumes at the saved position (not page 1).
- [ ] Read a bit further, close, reopen — local position is preserved.
- [ ] On another device that's ahead of this one, open the same book — Riffle pulls the fresher server position instead of pushing its stale local one.
- [ ] `./gradlew test` is green.