### PR TITLE
feat(server): skip library selection when server has one library

### DIFF
--- a/app/src/androidTest/kotlin/com/riffle/app/harness/EpubFootnoteHarnessTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/harness/EpubFootnoteHarnessTest.kt
@@ -130,11 +130,7 @@ class EpubFootnoteHarnessTest {
             composeTestRule.onAllNodesWithText("Connect anyway").fetchSemanticsNodes().isNotEmpty()
         }
         composeTestRule.onNodeWithText("Connect anyway").performClick()
-        // SelectLibrariesScreen appears with all libraries toggled on; tap Continue to commit.
-        composeTestRule.waitUntil(timeoutMillis = 15_000) {
-            composeTestRule.onAllNodesWithText("Continue").fetchSemanticsNodes().isNotEmpty()
-        }
-        composeTestRule.onNodeWithText("Continue").performClick()
+        // Single-library servers skip SelectLibrariesScreen: commit happens automatically.
         composeTestRule.waitUntil(timeoutMillis = 10_000) {
             composeTestRule.onAllNodesWithText("All Books").fetchSemanticsNodes().isNotEmpty() ||
                 composeTestRule.onAllNodesWithText(StubAbsServer.TEST_FOOTNOTE_ITEM_TITLE).fetchSemanticsNodes().isNotEmpty()

--- a/app/src/androidTest/kotlin/com/riffle/app/harness/EpubHarnessTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/harness/EpubHarnessTest.kt
@@ -215,14 +215,8 @@ class EpubHarnessTest {
             composeTestRule.onAllNodesWithText("Connect anyway").fetchSemanticsNodes().isNotEmpty()
         }
         composeTestRule.onNodeWithText("Connect anyway").performClick()
-        // After authentication succeeds, the new SelectLibrariesScreen appears with all
-        // libraries toggled on. Tap Continue to commit the server with everything selected.
-        composeTestRule.waitUntil(timeoutMillis = 15_000) {
-            composeTestRule.onAllNodesWithText("Continue").fetchSemanticsNodes().isNotEmpty()
-        }
-        composeTestRule.onNodeWithText("Continue").performClick()
-        // After commit, HomeScreen refreshes libraries and navigates directly to
-        // LibraryItemsScreen. Switch to All Books tab so items are visible.
+        // Single-library servers skip SelectLibrariesScreen: commit happens automatically and
+        // HomeScreen navigates directly to LibraryItemsScreen. Switch to All Books tab so items are visible.
         composeTestRule.waitUntil(timeoutMillis = 10_000) {
             composeTestRule.onAllNodesWithContentDescription("All Books").fetchSemanticsNodes().isNotEmpty()
         }

--- a/app/src/androidTest/kotlin/com/riffle/app/harness/PdfHarnessTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/harness/PdfHarnessTest.kt
@@ -147,13 +147,8 @@ class PdfHarnessTest {
             composeTestRule.onAllNodesWithText("Connect anyway").fetchSemanticsNodes().isNotEmpty()
         }
         composeTestRule.onNodeWithText("Connect anyway").performClick()
-        // SelectLibrariesScreen appears with all libraries toggled on; tap Continue to commit.
-        composeTestRule.waitUntil(timeoutMillis = 15_000) {
-            composeTestRule.onAllNodesWithText("Continue").fetchSemanticsNodes().isNotEmpty()
-        }
-        composeTestRule.onNodeWithText("Continue").performClick()
-        // After server is added, HomeScreen.getStartDestination() refreshes libraries and
-        // navigates directly to LibraryItemsScreen. Switch to All Books tab so items are visible.
+        // Single-library servers skip SelectLibrariesScreen: commit happens automatically and
+        // HomeScreen navigates directly to LibraryItemsScreen. Switch to All Books tab so items are visible.
         composeTestRule.waitUntil(timeoutMillis = 10_000) {
             composeTestRule.onAllNodesWithContentDescription("All Books").fetchSemanticsNodes().isNotEmpty()
         }

--- a/app/src/androidTest/kotlin/com/riffle/app/harness/SearchHarnessTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/harness/SearchHarnessTest.kt
@@ -207,11 +207,7 @@ class SearchHarnessTest {
             composeTestRule.onAllNodesWithText("Connect anyway").fetchSemanticsNodes().isNotEmpty()
         }
         composeTestRule.onNodeWithText("Connect anyway").performClick()
-        // SelectLibrariesScreen appears with all libraries toggled on; tap Continue to commit.
-        composeTestRule.waitUntil(timeoutMillis = 15_000) {
-            composeTestRule.onAllNodesWithText("Continue").fetchSemanticsNodes().isNotEmpty()
-        }
-        composeTestRule.onNodeWithText("Continue").performClick()
+        // Single-library servers skip SelectLibrariesScreen: commit happens automatically.
         composeTestRule.waitUntil(timeoutMillis = 10_000) {
             composeTestRule.onAllNodesWithContentDescription("All Books").fetchSemanticsNodes().isNotEmpty()
         }

--- a/app/src/androidTest/kotlin/com/riffle/app/harness/WakeLockHarnessTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/harness/WakeLockHarnessTest.kt
@@ -135,11 +135,7 @@ class WakeLockHarnessTest {
             composeTestRule.onAllNodesWithText("Connect anyway").fetchSemanticsNodes().isNotEmpty()
         }
         composeTestRule.onNodeWithText("Connect anyway").performClick()
-        // SelectLibrariesScreen appears with all libraries toggled on; tap Continue to commit.
-        composeTestRule.waitUntil(timeoutMillis = 15_000) {
-            composeTestRule.onAllNodesWithText("Continue").fetchSemanticsNodes().isNotEmpty()
-        }
-        composeTestRule.onNodeWithText("Continue").performClick()
+        // Single-library servers skip SelectLibrariesScreen: commit happens automatically.
         // Switch to All Books tab so items are visible.
         composeTestRule.waitUntil(timeoutMillis = 10_000) {
             composeTestRule.onAllNodesWithContentDescription("All Books").fetchSemanticsNodes().isNotEmpty()
@@ -171,11 +167,7 @@ class WakeLockHarnessTest {
             composeTestRule.onAllNodesWithText("Connect anyway").fetchSemanticsNodes().isNotEmpty()
         }
         composeTestRule.onNodeWithText("Connect anyway").performClick()
-        // SelectLibrariesScreen appears with all libraries toggled on; tap Continue to commit.
-        composeTestRule.waitUntil(timeoutMillis = 15_000) {
-            composeTestRule.onAllNodesWithText("Continue").fetchSemanticsNodes().isNotEmpty()
-        }
-        composeTestRule.onNodeWithText("Continue").performClick()
+        // Single-library servers skip SelectLibrariesScreen: commit happens automatically.
         // Switch to All Books tab so items are visible.
         composeTestRule.waitUntil(timeoutMillis = 10_000) {
             composeTestRule.onAllNodesWithContentDescription("All Books").fetchSemanticsNodes().isNotEmpty()
@@ -207,11 +199,7 @@ class WakeLockHarnessTest {
             composeTestRule.onAllNodesWithText("Connect anyway").fetchSemanticsNodes().isNotEmpty()
         }
         composeTestRule.onNodeWithText("Connect anyway").performClick()
-        // SelectLibrariesScreen appears with all libraries toggled on; tap Continue to commit.
-        composeTestRule.waitUntil(timeoutMillis = 15_000) {
-            composeTestRule.onAllNodesWithText("Continue").fetchSemanticsNodes().isNotEmpty()
-        }
-        composeTestRule.onNodeWithText("Continue").performClick()
+        // Single-library servers skip SelectLibrariesScreen: commit happens automatically.
         // Switch to All Books tab so items are visible.
         composeTestRule.waitUntil(timeoutMillis = 10_000) {
             composeTestRule.onAllNodesWithContentDescription("All Books").fetchSemanticsNodes().isNotEmpty()

--- a/app/src/main/kotlin/com/riffle/app/feature/server/AddServerScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/server/AddServerScreen.kt
@@ -55,10 +55,14 @@ fun AddServerScreen(
     windowSizeClass: WindowSizeClass,
     onNavigateBack: () -> Unit,
     onAuthenticated: (PendingServer) -> Unit,
+    onAutoCompleted: () -> Unit,
     viewModel: AddServerViewModel = hiltViewModel(),
 ) {
     LaunchedEffect(Unit) {
         viewModel.navigateToSelectLibraries.collect { onAuthenticated(it) }
+    }
+    LaunchedEffect(Unit) {
+        viewModel.navigateHome.collect { onAutoCompleted() }
     }
 
     viewModel.insecureWarning?.let { type ->

--- a/app/src/main/kotlin/com/riffle/app/feature/server/AddServerViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/server/AddServerViewModel.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.riffle.app.BuildConfig
 import com.riffle.core.domain.AuthenticateResult
+import com.riffle.core.domain.CommitServerResult
 import com.riffle.core.domain.InsecureConnectionType
 import com.riffle.core.domain.PendingServer
 import com.riffle.core.domain.ServerRepository
@@ -38,6 +39,9 @@ class AddServerViewModel @Inject constructor(
 
     private val _navigateToSelectLibraries = Channel<PendingServer>(Channel.CONFLATED)
     val navigateToSelectLibraries = _navigateToSelectLibraries.receiveAsFlow()
+
+    private val _navigateHome = Channel<Unit>(Channel.CONFLATED)
+    val navigateHome = _navigateHome.receiveAsFlow()
 
     fun updateServerType(type: ServerType) {
         if (serverType != type) {
@@ -96,7 +100,18 @@ class AddServerViewModel @Inject constructor(
         viewModelScope.launch {
             isLoading = true
             when (val result = repository.authenticate(serverUrl, username, password, insecureAllowed, serverType)) {
-                is AuthenticateResult.Success -> _navigateToSelectLibraries.send(result.pending)
+                is AuthenticateResult.Success -> {
+                    val pending = result.pending
+                    if (pending.libraries.size == 1) {
+                        when (val c = repository.commit(pending, hiddenLibraryIds = emptySet())) {
+                            is CommitServerResult.Success -> _navigateHome.send(Unit)
+                            is CommitServerResult.Failure ->
+                                error = "Couldn't save server: ${c.cause.message}"
+                        }
+                    } else {
+                        _navigateToSelectLibraries.send(pending)
+                    }
+                }
                 is AuthenticateResult.WrongCredentials -> error = result.message
                 is AuthenticateResult.NetworkError -> error = "Connection failed: ${result.cause.message}"
                 is AuthenticateResult.LibraryFetchFailed ->

--- a/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
@@ -155,6 +155,9 @@ fun MainScreen(
                             setupVm.pendingServer = pending
                             navController.navigate(SELECT_LIBRARIES)
                         },
+                        onAutoCompleted = {
+                            navController.navigate(HOME) { popUpTo(HOME) { inclusive = true } }
+                        },
                     )
                 }
                 composable(SELECT_LIBRARIES) { backStackEntry ->

--- a/app/src/test/kotlin/com/riffle/app/feature/server/AddServerViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/server/AddServerViewModelTest.kt
@@ -50,14 +50,22 @@ class AddServerViewModelTest {
         username = "",
     )
 
-    private fun fakePending() = PendingServer(
+    private fun fakePending(
+        libraries: List<Library> = listOf(
+            Library("lib-1", "Books", "book", false),
+            Library("lib-2", "Comics", "book", false),
+        ),
+    ) = PendingServer(
         url = ServerUrl.parse("https://abs.example.com")!!,
         username = "admin",
         userId = "uid",
         token = "tok",
         insecureConnectionAllowed = false,
-        libraries = listOf(Library("lib-1", "Books", "book", false)),
+        libraries = libraries,
     )
+
+    private fun singleLibraryPending() =
+        fakePending(libraries = listOf(Library("lib-1", "Books", "book", false)))
 
     private class RecordingRepository(
         private val authResult: AuthenticateResult,
@@ -141,6 +149,40 @@ class AddServerViewModelTest {
         assertSame(pending, emitted)
         assertEquals(0, repo.commitCallCount)
         assertNull(vm.error)
+    }
+
+    @Test
+    fun `onConnect success with single library auto-commits and emits navigateHome`() = runTest {
+        val pending = singleLibraryPending()
+        val repo = RecordingRepository(AuthenticateResult.Success(pending))
+        val vm = AddServerViewModel(repo)
+        vm.updateScheme("https://"); vm.updateHost("abs.example.com")
+        vm.username = "admin"
+        vm.password = "pass"
+        vm.onConnect()
+        testDispatcher.scheduler.advanceUntilIdle()
+        vm.navigateHome.first()
+        assertEquals(1, repo.commitCallCount)
+        assertNull(vm.error)
+    }
+
+    @Test
+    fun `onConnect success with single library surfaces commit failure as error`() = runTest {
+        val pending = singleLibraryPending()
+        val repo = RecordingRepository(
+            authResult = AuthenticateResult.Success(pending),
+            commitResult = CommitServerResult.Failure(RuntimeException("disk full")),
+        )
+        val vm = AddServerViewModel(repo)
+        vm.updateScheme("https://"); vm.updateHost("abs.example.com")
+        vm.username = "admin"
+        vm.password = "pass"
+        vm.onConnect()
+        testDispatcher.scheduler.advanceUntilIdle()
+        assertEquals(1, repo.commitCallCount)
+        assertNotNull(vm.error)
+        assertTrue(vm.error?.contains("disk full") == true)
+        assertFalse(vm.isLoading)
     }
 
     @Test


### PR DESCRIPTION
## Summary
- When `AddServerViewModel` gets `AuthenticateResult.Success` with exactly one library, it now auto-commits (`hiddenLibraryIds = emptySet()`) and emits a new `navigateHome` event, skipping `SelectLibrariesScreen`.
- Zero-library (empty-state) and multi-library flows are unchanged.
- `AddServerScreen` collects the new event; `MainScreen` routes it to HOME with the same `popUpTo` semantics as the multi-library finish.
- Harness `addServerAndBrowseLibrary()` helpers no longer tap the now-skipped "Continue" button.

## Test plan
- [x] `./gradlew test` — green (unit + integration).
- [ ] Harness suite (`make harness-test`) — locally flaky on this machine: two runs crashed mid-suite on different unrelated tests (`EpubHarnessTest.progressSyncSendsEpubCfiNotJson`, `PdfHarnessTest.pdfReaderHidesTopAppBarOnOpenAndShowsItOnCenterTap`), both with empty `<failure/>` + "Process crashed". Sibling tests using the same modified add-server helper pass, so failures look like AVD/process instability, not a regression. Worth a fresh run in CI / on a clean device.
- [ ] Manual: add a single-library ABS server → should land directly on the library after Connect, no Select Libraries step.
- [ ] Manual: add a multi-library server → SelectLibrariesScreen still appears.
- [ ] Manual: add a server with no book libraries → empty-state screen still appears with "Go back".