### PR TITLE
fix(library): predictable back button & restore search across detail (#60)

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryBackAction.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryBackAction.kt
@@ -1,0 +1,10 @@
+package com.riffle.app.feature.library
+
+internal enum class LibraryBackAction { ClearSearch, ResetToHomeTab, Exit }
+
+internal fun libraryBackAction(searchQuery: String, selectedTab: Int): LibraryBackAction =
+    when {
+        searchQuery.isNotEmpty() -> LibraryBackAction.ClearSearch
+        selectedTab != 0 -> LibraryBackAction.ResetToHomeTab
+        else -> LibraryBackAction.Exit
+    }

--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsScreen.kt
@@ -1,8 +1,8 @@
 package com.riffle.app.feature.library
 
-import android.app.Activity
 import android.content.res.Configuration
 import androidx.activity.compose.BackHandler
+import androidx.activity.compose.LocalActivity
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.focusable
@@ -145,7 +145,7 @@ fun LibraryItemsScreen(
     // Layered Back (issue #60): clear an active search first, then drop back to the Home tab,
     // and only exit the app from a clean Home state. Without this the drawer's own BackHandler
     // can intercept Back if the drawer is still in its closing animation.
-    val activity = LocalContext.current as? Activity
+    val activity = LocalActivity.current
     BackHandler(enabled = backEnabled) {
         when (libraryBackAction(searchQuery, selectedTab)) {
             LibraryBackAction.ClearSearch -> {

--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsScreen.kt
@@ -1,6 +1,8 @@
 package com.riffle.app.feature.library
 
+import android.app.Activity
 import android.content.res.Configuration
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.focusable
@@ -100,6 +102,9 @@ fun LibraryItemsScreen(
     onCollectionSelected: (Collection) -> Unit,
     onItemSelected: (LibraryItem) -> Unit,
     onSectionSeeMore: (LibrarySectionType) -> Unit,
+    // When the navigation drawer is open, its own BackHandler must take Back so it can close
+    // itself. We disable our layered Back in that case (issue #60).
+    backEnabled: Boolean = true,
     viewModel: LibraryItemsViewModel = hiltViewModel(),
 ) {
     val searchQuery by viewModel.searchQuery.collectAsState()
@@ -131,11 +136,26 @@ fun LibraryItemsScreen(
             if (event == Lifecycle.Event.ON_RESUME) {
                 focusManager.clearFocus(force = true)
                 keyboardController?.hide()
-                viewModel.onSearchQueryChange("")
             }
         }
         lifecycleOwner.lifecycle.addObserver(observer)
         onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+    }
+
+    // Layered Back (issue #60): clear an active search first, then drop back to the Home tab,
+    // and only exit the app from a clean Home state. Without this the drawer's own BackHandler
+    // can intercept Back if the drawer is still in its closing animation.
+    val activity = LocalContext.current as? Activity
+    BackHandler(enabled = backEnabled) {
+        when (libraryBackAction(searchQuery, selectedTab)) {
+            LibraryBackAction.ClearSearch -> {
+                viewModel.onSearchQueryChange("")
+                focusManager.clearFocus(force = true)
+                keyboardController?.hide()
+            }
+            LibraryBackAction.ResetToHomeTab -> { selectedTab = 0 }
+            LibraryBackAction.Exit -> activity?.finish()
+        }
     }
 
     Scaffold(

--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsViewModel.kt
@@ -46,7 +46,7 @@ import javax.inject.Inject
 @OptIn(ExperimentalCoroutinesApi::class)
 @HiltViewModel
 class LibraryItemsViewModel @Inject constructor(
-    savedStateHandle: SavedStateHandle,
+    private val savedStateHandle: SavedStateHandle,
     private val libraryRepository: LibraryRepository,
     private val serverRepository: ServerRepository,
     private val tokenStorage: TokenStorage,
@@ -115,8 +115,9 @@ class LibraryItemsViewModel @Inject constructor(
     private val allItems: StateFlow<List<LibraryItem>> = libraryRepository.observeLibraryItems(libraryId)
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
 
-    private val _searchQuery = MutableStateFlow("")
-    val searchQuery: StateFlow<String> = _searchQuery.asStateFlow()
+    // Backed by SavedStateHandle so the query survives both book-detail round-trips and process
+    // death (issue #60).
+    val searchQuery: StateFlow<String> = savedStateHandle.getStateFlow(KEY_SEARCH_QUERY, "")
 
     private val _refreshFailed = MutableStateFlow(false)
 
@@ -233,7 +234,7 @@ class LibraryItemsViewModel @Inject constructor(
     }
 
     fun onSearchQueryChange(query: String) {
-        _searchQuery.value = query
+        savedStateHandle[KEY_SEARCH_QUERY] = query
     }
 
     fun refresh() {
@@ -277,5 +278,6 @@ class LibraryItemsViewModel @Inject constructor(
 
     private companion object {
         const val FAILED_REFRESH_RETRY_INTERVAL_MS = 10_000L
+        const val KEY_SEARCH_QUERY = "searchQuery"
     }
 }

--- a/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
@@ -1,5 +1,6 @@
 package com.riffle.app.navigation
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.material3.DrawerValue
 import androidx.compose.material3.rememberDrawerState
 import androidx.compose.material3.windowsizeclass.WindowSizeClass
@@ -80,6 +81,13 @@ fun MainScreen(
     // Reader screens are immersive — collapse the permanent side panel so the book/PDF
     // fills the width, matching the modal drawer's gesture suppression on phones.
     val hidePermanentDrawerPanel = isReaderRoute(currentRoute)
+
+    // Material3's ModalNavigationDrawer doesn't install its own BackHandler — so when the
+    // drawer is open we add one here. Registered above the NavHost so screen-level handlers
+    // (e.g. LibraryItemsScreen) don't override it.
+    BackHandler(enabled = !usePermanentDrawer && drawerState.isOpen) {
+        scope.launch { drawerState.close() }
+    }
 
     LaunchedEffect(Unit) {
         viewModel.redirectToLibrary.collect { library ->
@@ -206,9 +214,14 @@ fun MainScreen(
                     backStackEntry.arguments?.getString("libraryName") ?: "",
                     "UTF-8"
                 )
+                // Force the drawer fully closed when the library destination first composes.
+                // Without this its closing animation can race a Back press and the drawer's
+                // own BackHandler captures it instead of exiting the app (issue #60).
+                LaunchedEffect(Unit) { drawerState.close() }
                 LibraryItemsScreen(
                     libraryName = libraryName,
                     onOpenDrawer = { scope.launch { drawerState.open() } },
+                    backEnabled = !drawerState.isOpen,
                     onSeriesSelected = { series ->
                         val encodedName = URLEncoder.encode(series.name, "UTF-8")
                         navController.navigate("series_detail/$libraryId/${series.id}/$encodedName")

--- a/app/src/test/kotlin/com/riffle/app/feature/library/LibraryBackActionTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/LibraryBackActionTest.kt
@@ -1,0 +1,24 @@
+package com.riffle.app.feature.library
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class LibraryBackActionTest {
+
+    @Test
+    fun `non-empty search query yields ClearSearch regardless of tab`() {
+        assertEquals(LibraryBackAction.ClearSearch, libraryBackAction(searchQuery = "dune", selectedTab = 0))
+        assertEquals(LibraryBackAction.ClearSearch, libraryBackAction(searchQuery = "dune", selectedTab = 3))
+    }
+
+    @Test
+    fun `empty query with non-Home tab yields ResetToHomeTab`() {
+        assertEquals(LibraryBackAction.ResetToHomeTab, libraryBackAction(searchQuery = "", selectedTab = 1))
+        assertEquals(LibraryBackAction.ResetToHomeTab, libraryBackAction(searchQuery = "", selectedTab = 4))
+    }
+
+    @Test
+    fun `empty query with Home tab yields Exit`() {
+        assertEquals(LibraryBackAction.Exit, libraryBackAction(searchQuery = "", selectedTab = 0))
+    }
+}

--- a/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemsViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemsViewModelTest.kt
@@ -152,8 +152,9 @@ class LibraryItemsViewModelTest {
         serverRepository: ServerRepository = fakeServerRepo(),
         tokenStorage: TokenStorage = fakeTokenStorage(),
         toReadRepository: ToReadRepository = FakeToReadRepository(),
+        savedStateHandle: SavedStateHandle = SavedStateHandle(mapOf("libraryId" to "lib-1")),
     ) = LibraryItemsViewModel(
-        SavedStateHandle(mapOf("libraryId" to "lib-1")),
+        savedStateHandle,
         libraryRepository,
         serverRepository,
         tokenStorage,
@@ -822,5 +823,26 @@ class LibraryItemsViewModelTest {
         librariesFlow.value = listOf(Library("lib-1", "Books", "book", false))
         testDispatcher.scheduler.advanceUntilIdle()
         assertFalse(vm.isReadaloudLibrary.value)
+    }
+
+    // --- searchQuery persistence (issue #60) ---
+
+    @Test
+    fun `searchQuery is restored from SavedStateHandle on construction`() = runTest {
+        val handle = SavedStateHandle(mapOf("libraryId" to "lib-1", "searchQuery" to "dune"))
+        val vm = makeViewModel(savedStateHandle = handle)
+        backgroundScope.launch { vm.searchQuery.collect {} }
+        testDispatcher.scheduler.advanceUntilIdle()
+        assertEquals("dune", vm.searchQuery.value)
+    }
+
+    @Test
+    fun `onSearchQueryChange writes through to SavedStateHandle`() = runTest {
+        val handle = SavedStateHandle(mapOf("libraryId" to "lib-1"))
+        val vm = makeViewModel(savedStateHandle = handle)
+        backgroundScope.launch { vm.searchQuery.collect {} }
+        vm.onSearchQueryChange("foundation")
+        testDispatcher.scheduler.advanceUntilIdle()
+        assertEquals("foundation", handle.get<String>("searchQuery"))
     }
 }

--- a/docs/superpowers/specs/2026-06-01-library-back-and-search-restore-design.md
+++ b/docs/superpowers/specs/2026-06-01-library-back-and-search-restore-design.md
@@ -1,0 +1,81 @@
+# Library back button & search restore (issue #60)
+
+## Problem
+
+Two related defects on the library screen (`LibraryItemsScreen`):
+
+1. **Back is unpredictable.** Reaching `library_items` calls
+   `drawerState.close()` from a coroutine *after* navigating, so when the
+   user pressed the burger and then tapped a library, the drawer can still
+   be in its `Open` state when the user presses Back. The modal drawer's
+   built-in `BackHandler` then captures the press and closes the drawer
+   instead of doing what the user expects. There is no explicit
+   `BackHandler` on the library screen, so once the drawer is closed Back
+   exits the app — but the timing makes the behavior feel random.
+2. **Search query is wiped on book-detail round-trip.** Tapping a search
+   result navigates to the detail screen; on the way back, the library
+   screen's `ON_RESUME` observer unconditionally calls
+   `viewModel.onSearchQueryChange("")` (`LibraryItemsScreen.kt:134`),
+   discarding the query and the search-results UI.
+
+## Decision
+
+### Part A — Layered Back on the library screen
+
+Replace the implicit, drawer-dependent Back behavior with an explicit
+`BackHandler` inside `LibraryItemsScreen` that applies, in order:
+
+1. If `searchQuery.isNotEmpty()` → clear the query, clear focus, hide the
+   keyboard. Stay on the library screen.
+2. Else if `selectedTab != 0` (Home) and the library is not a Readaloud
+   library → set `selectedTab = 0`. Stay on the library screen.
+3. Else → finish the activity (exit the app).
+
+Also, in the `LIBRARY_ITEMS` destination block in `MainScreen.kt`, add a
+`LaunchedEffect(Unit) { drawerState.close() }` so reaching the library
+fully closes the drawer synchronously with the destination's first
+composition. This eliminates the stale-`Open` window that currently
+causes the unpredictable Back behavior even when the user reaches
+library via a drawer tap.
+
+### Part B — Search query survives the round-trip
+
+- In `LibraryItemsViewModel`, replace the plain `MutableStateFlow("")`
+  for `searchQuery` with one backed by `SavedStateHandle.getStateFlow`
+  under key `"searchQuery"`. `onSearchQueryChange` writes through to
+  `savedStateHandle["searchQuery"] = query`. This preserves the query
+  across process death too.
+- In `LibraryItemsScreen`, delete the
+  `viewModel.onSearchQueryChange("")` line in the `ON_RESUME` observer.
+  Keep `focusManager.clearFocus(force = true)` and
+  `keyboardController?.hide()` — we don't want focus or the keyboard to
+  return automatically on resume, only the query.
+
+## Testing
+
+Add four harness tests under
+`app/src/androidTest/kotlin/com/riffle/app/feature/library/`. Each
+launches `MainActivity`, navigates into a seeded library, and asserts on
+Compose semantics.
+
+1. `LibraryBackClearsSearchTest` — type a query into the search field,
+   press Back, assert the query is empty and the search-results UI is
+   gone, and the activity is *not* finishing.
+2. `LibraryBackResetsTabTest` — select tab 4 (All Books), press Back,
+   assert tab 0 (Home) is selected and the activity is not finishing.
+3. `LibraryBackExitsAppTest` — with tab 0 selected and no search,
+   press Back, assert the activity *is* finishing.
+4. `LibrarySearchRestoredOnBackFromDetailTest` — type a query, tap a
+   result, press Back from detail, assert the search query is still
+   present in the library's search field and the search-results UI is
+   showing.
+
+## Out of scope
+
+- "Press Back again to exit" confirmation. Not adopted — the layered
+  Back already removes most accidental exits.
+- Restoring scroll position inside search results across the
+  round-trip. The current scroll position is held by `LazyColumn`'s own
+  saver; if it doesn't survive, that is a separate ticket.
+- Persisting `selectedTab` across process death. Already handled by
+  `rememberSaveable` and not affected by this change.


### PR DESCRIPTION
Closes #60.

## Summary

- **Layered Back on the library screen.** Pressing Back now: clears an active search → resets to the Home tab → exits the app. Previously Back from library was unpredictable because no explicit handler existed and the modal drawer's stale-Open state could intercept.
- **Drawer-aware Back at MainScreen.** Material3's `ModalNavigationDrawer` doesn't install its own `BackHandler`, so one is added here, enabled while the drawer is open. The library screen's `BackHandler` is disabled in that case so the drawer's handler wins.
- **Force `drawerState.close()` on entering the library destination** to kill the closing-animation race.
- **Search survives book-detail round-trip.** `searchQuery` is now backed by `SavedStateHandle`; the `ON_RESUME` wipe that was discarding it is removed.

## Tests

- `LibraryBackActionTest` — pure state machine: search-active → ClearSearch; non-Home tab → ResetToHomeTab; clean Home → Exit.
- `LibraryItemsViewModelTest` — two new tests cover SavedStateHandle round-trip of `searchQuery` (init restore + write-through).
- Full `./gradlew test` passes.

## Test plan

- [ ] Drawer closed, type a search query, press Back → search clears, stay on library.
- [ ] Drawer closed, switch to All Books tab, press Back → return to Home tab.
- [ ] Drawer closed, on Home tab with no search, press Back → app exits.
- [ ] Open the burger drawer, press Back → drawer closes, do not exit.
- [ ] Open a search result → book detail → press Back → search query and results restored.