### PR TITLE
fix(matching): borrow ABS metadata onto Confirmed-matched Storyteller books

### DIFF
--- a/core/data/src/main/kotlin/com/riffle/core/data/ReadaloudMatchingService.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/ReadaloudMatchingService.kt
@@ -5,6 +5,7 @@ import com.riffle.core.database.MatchableItemRow
 import com.riffle.core.database.ReadaloudLinkDao
 import com.riffle.core.database.ReadaloudLinkEntity
 import com.riffle.core.domain.Confirmed
+import com.riffle.core.domain.EbookFormat
 import com.riffle.core.domain.MatchableAbsItem
 import com.riffle.core.domain.MatchableStorytellerBook
 import com.riffle.core.domain.ReadaloudMatcher
@@ -76,6 +77,40 @@ class ReadaloudMatchingService(
         }
 
         sweepStaleAutoLinks(freshAutoSlots)
+        backfillReadaloudMetadata(storytellerBooks)
+    }
+
+    /**
+     * Borrow the ABS-only metadata fields (description, publishedYear, publisher, genres) onto
+     * each Storyteller readaloud from its Confirmed-linked ABS Library Item (#65). A readaloud
+     * with no surviving link is cleared back to its own empty values so no stale ABS data
+     * lingers. Title/author/cover come from Storyteller's own API and are left untouched.
+     */
+    private suspend fun backfillReadaloudMetadata(storytellerBooks: List<MatchableItemRow>) {
+        for (book in storytellerBooks) {
+            // A readaloud can link to several ABS items (an ebook plus an audiobook stub of the
+            // same work). Borrow from the ebook — the supported format with the richer metadata —
+            // before any unsupported stub, then settle ties by libraryId for a stable choice.
+            val abs = readaloudLinkDao.findByStorytellerBook(book.serverId, book.itemId)
+                .mapNotNull { libraryItemDao.getById(it.absLibraryItemId) }
+                .sortedWith(
+                    compareBy(
+                        { if (it.ebookFormat == EbookFormat.Unsupported.toStorageString()) 1 else 0 },
+                        { it.libraryId },
+                    )
+                )
+                .firstOrNull()
+            libraryItemDao.updateReadaloudMetadata(
+                itemId = book.itemId,
+                // Overwrite the (possibly duplicated/malformed) Storyteller author when linked;
+                // null leaves it untouched so an unlinked readaloud keeps its own author.
+                author = abs?.author,
+                description = abs?.description,
+                publishedYear = abs?.publishedYear,
+                publisher = abs?.publisher,
+                genres = abs?.genres ?: "",
+            )
+        }
     }
 
     /**

--- a/core/data/src/test/kotlin/com/riffle/core/data/LibraryRepositoryTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/LibraryRepositoryTest.kt
@@ -151,6 +151,28 @@ class LibraryRepositoryTest {
 
         override suspend fun updateReadingProgress(itemId: String, progress: Float) {}
 
+        override suspend fun updateReadaloudMetadata(
+            itemId: String,
+            author: String?,
+            description: String?,
+            publishedYear: String?,
+            publisher: String?,
+            genres: String,
+        ) {
+            val entity = roomData.values.flatMap { it.value }.firstOrNull { it.id == itemId } ?: return
+            val updated = entity.copy(
+                author = author ?: entity.author,
+                description = description,
+                publishedYear = publishedYear,
+                publisher = publisher,
+                genres = genres,
+            )
+            roomData[entity.libraryId]?.let { flow ->
+                flow.value = flow.value.map { if (it.id == itemId) updated else it }
+            }
+            upserted += updated
+        }
+
         override suspend fun listMatchableByServerType(serverType: String): List<com.riffle.core.database.MatchableItemRow> = emptyList()
     }
 

--- a/core/data/src/test/kotlin/com/riffle/core/data/ReadaloudMatchingServiceTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/ReadaloudMatchingServiceTest.kt
@@ -163,6 +163,105 @@ class ReadaloudMatchingServiceTest {
         assertTrue(b.upserts.isEmpty())
     }
 
+    @Test
+    fun `Confirmed link backfills ABS metadata onto the Storyteller item`() = runTest {
+        val items = StubLibraryItemDao(
+            storyteller = listOf(row("st-1", "42", isbn = "9780261103573")),
+            abs = listOf(row("abs-1", "ebook", isbn = "9780261103573")),
+            entities = listOf(
+                absEntity(
+                    "ebook",
+                    description = "An epic tale",
+                    publishedYear = "1965",
+                    publisher = "Chilton",
+                    genres = "Sci-Fi,Adventure",
+                ),
+            ),
+        )
+        val links = RecordingReadaloudLinkDao()
+
+        ReadaloudMatchingService(items, links).reconcileLinks()
+
+        val update = items.metadataUpdates.single { it.itemId == "42" }
+        assertEquals("An epic tale", update.description)
+        assertEquals("1965", update.publishedYear)
+        assertEquals("Chilton", update.publisher)
+        assertEquals("Sci-Fi,Adventure", update.genres)
+    }
+
+    @Test
+    fun `Storyteller item with no link is cleared to empty metadata`() = runTest {
+        val items = StubLibraryItemDao(
+            storyteller = listOf(row("st-1", "42", title = "Dune", author = "Frank Herbert")),
+            abs = listOf(row("abs-9", "unrelated", title = "Atomic Habits", author = "James Clear")),
+        )
+        val links = RecordingReadaloudLinkDao()
+
+        ReadaloudMatchingService(items, links).reconcileLinks()
+
+        val update = items.metadataUpdates.single { it.itemId == "42" }
+        assertEquals(null, update.description)
+        assertEquals(null, update.publishedYear)
+        assertEquals(null, update.publisher)
+        assertEquals("", update.genres)
+    }
+
+    @Test
+    fun `Confirmed link overwrites the Storyteller author with the ABS author`() = runTest {
+        // Storyteller's API can return a duplicated/malformed author (e.g. "Andy Weir, Andy Weir;").
+        // The clean ABS author should win for matched books.
+        val items = StubLibraryItemDao(
+            storyteller = listOf(row("st-1", "42", title = "Project Hail Mary", author = "Andy Weir, Andy Weir;", isbn = "9780593135204")),
+            abs = listOf(row("abs-1", "ebook", isbn = "9780593135204")),
+            entities = listOf(absEntity("ebook", author = "Andy Weir")),
+        )
+        val links = RecordingReadaloudLinkDao()
+
+        ReadaloudMatchingService(items, links).reconcileLinks()
+
+        assertEquals("Andy Weir", items.metadataUpdates.single { it.itemId == "42" }.author)
+    }
+
+    @Test
+    fun `Storyteller item with no link keeps its own author`() = runTest {
+        // A null author in the update means COALESCE leaves the existing (Storyteller) author intact.
+        val items = StubLibraryItemDao(
+            storyteller = listOf(row("st-1", "42", title = "Dune", author = "Frank Herbert")),
+            abs = listOf(row("abs-9", "unrelated", title = "Atomic Habits", author = "James Clear")),
+        )
+        val links = RecordingReadaloudLinkDao()
+
+        ReadaloudMatchingService(items, links).reconcileLinks()
+
+        assertEquals(null, items.metadataUpdates.single { it.itemId == "42" }.author)
+    }
+
+    @Test
+    fun `metadata is borrowed from the ebook counterpart, not the audiobook stub`() = runTest {
+        // The Martian scenario: a readaloud links to both an ebook (rich metadata) and an
+        // audiobook stub (unsupported format). The displayed metadata should come from the ebook.
+        val items = StubLibraryItemDao(
+            storyteller = listOf(row("st-1", "42", title = "The Martian", author = "Andy Weir")),
+            abs = listOf(
+                // Audiobook stub listed first so a naive first-match would pick it.
+                row("abs-1", "audio-stub", title = "The Martian", author = "Andy Weir"),
+                row("abs-1", "books-ebook", title = "The Martian", author = "Andy Weir"),
+            ),
+            entities = listOf(
+                absEntity("audio-stub", description = "stub", publisher = "Audio Co", ebookFormat = "unsupported"),
+                absEntity("books-ebook", description = "the real synopsis", publisher = "Crown", genres = "Sci-Fi", ebookFormat = "epub"),
+            ),
+        )
+        val links = RecordingReadaloudLinkDao()
+
+        ReadaloudMatchingService(items, links).reconcileLinks()
+
+        val update = items.metadataUpdates.single { it.itemId == "42" }
+        assertEquals("the real synopsis", update.description)
+        assertEquals("Crown", update.publisher)
+        assertEquals("Sci-Fi", update.genres)
+    }
+
     private fun row(
         serverId: String,
         itemId: String,
@@ -172,10 +271,45 @@ class ReadaloudMatchingServiceTest {
         asin: String? = null,
     ) = MatchableItemRow(itemId, serverId, title, author, isbn, asin)
 
+    private fun absEntity(
+        itemId: String,
+        author: String = "Author",
+        description: String? = null,
+        publishedYear: String? = null,
+        publisher: String? = null,
+        genres: String = "",
+        ebookFormat: String = "epub",
+    ) = LibraryItemEntity(
+        id = itemId,
+        libraryId = "$itemId-lib",
+        title = "Title",
+        author = author,
+        coverUrl = null,
+        readingProgress = 0f,
+        ebookFormat = ebookFormat,
+        description = description,
+        publishedYear = publishedYear,
+        publisher = publisher,
+        genres = genres,
+    )
+
+    data class MetadataUpdate(
+        val itemId: String,
+        val author: String?,
+        val description: String?,
+        val publishedYear: String?,
+        val publisher: String?,
+        val genres: String,
+    )
+
     private class StubLibraryItemDao(
         private val storyteller: List<MatchableItemRow>,
         private val abs: List<MatchableItemRow>,
+        entities: List<LibraryItemEntity> = emptyList(),
     ) : LibraryItemDao {
+        private val byId = entities.associateBy { it.id }
+        val metadataUpdates = mutableListOf<MetadataUpdate>()
+
         override suspend fun listMatchableByServerType(serverType: String): List<MatchableItemRow> = when (serverType) {
             "STORYTELLER" -> storyteller
             "AUDIOBOOKSHELF" -> abs
@@ -188,10 +322,20 @@ class ReadaloudMatchingServiceTest {
         override fun observeRecentlyAdded(libraryId: String): Flow<List<LibraryItemEntity>> = flowOf(emptyList())
         override fun observeAllBooks(libraryId: String): Flow<List<LibraryItemEntity>> = flowOf(emptyList())
         override suspend fun upsertAll(items: List<LibraryItemEntity>) = Unit
-        override suspend fun getById(itemId: String): LibraryItemEntity? = null
+        override suspend fun getById(itemId: String): LibraryItemEntity? = byId[itemId]
         override suspend fun deleteByLibraryId(libraryId: String) = Unit
         override suspend fun updateLastOpenedAt(itemId: String, timestamp: Long) = Unit
         override suspend fun updateReadingProgress(itemId: String, progress: Float) = Unit
+        override suspend fun updateReadaloudMetadata(
+            itemId: String,
+            author: String?,
+            description: String?,
+            publishedYear: String?,
+            publisher: String?,
+            genres: String,
+        ) {
+            metadataUpdates += MetadataUpdate(itemId, author, description, publishedYear, publisher, genres)
+        }
         override suspend fun getLastOpenedAtMap(libraryId: String): List<LastOpenedAtRow> = emptyList()
         override suspend fun getReadingProgressMap(libraryId: String): List<ReadingProgressRow> = emptyList()
     }

--- a/core/data/src/test/kotlin/com/riffle/core/data/SeriesIntegrationTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/SeriesIntegrationTest.kt
@@ -118,6 +118,7 @@ class SeriesIntegrationTest {
         override suspend fun getLastOpenedAtMap(libraryId: String): List<LastOpenedAtRow> = emptyList()
         override suspend fun getReadingProgressMap(libraryId: String): List<ReadingProgressRow> = emptyList()
         override suspend fun updateReadingProgress(itemId: String, progress: Float) {}
+        override suspend fun updateReadaloudMetadata(itemId: String, author: String?, description: String?, publishedYear: String?, publisher: String?, genres: String) {}
         override suspend fun listMatchableByServerType(serverType: String): List<com.riffle.core.database.MatchableItemRow> = emptyList()
     }
 

--- a/core/data/src/test/kotlin/com/riffle/core/data/ServerRepositoryTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/ServerRepositoryTest.kt
@@ -133,6 +133,7 @@ class ServerRepositoryTest {
         override suspend fun getLastOpenedAtMap(libraryId: String) = emptyList<com.riffle.core.database.LastOpenedAtRow>()
         override suspend fun getReadingProgressMap(libraryId: String) = emptyList<com.riffle.core.database.ReadingProgressRow>()
         override suspend fun updateReadingProgress(itemId: String, progress: Float) {}
+        override suspend fun updateReadaloudMetadata(itemId: String, author: String?, description: String?, publishedYear: String?, publisher: String?, genres: String) {}
         override suspend fun listMatchableByServerType(serverType: String) = emptyList<com.riffle.core.database.MatchableItemRow>()
     }
 

--- a/core/database/src/main/kotlin/com/riffle/core/database/LibraryItemDao.kt
+++ b/core/database/src/main/kotlin/com/riffle/core/database/LibraryItemDao.kt
@@ -67,6 +67,29 @@ interface LibraryItemDao {
     @Query("UPDATE library_items SET readingProgress = :progress WHERE id = :itemId")
     suspend fun updateReadingProgress(itemId: String, progress: Float)
 
+    /**
+     * Borrow ABS metadata onto a single item. Used by the Storyteller↔ABS matcher to backfill a
+     * Confirmed-matched readaloud from its linked ABS item, and to clear the ABS-only fields back
+     * to their empty defaults when no link survives.
+     *
+     * [author] is COALESCEd: a non-null value overwrites the Storyteller author (which can be
+     * malformed/duplicated), while null leaves it untouched — so the readaloud keeps its own
+     * author when no link exists. The other four fields are always written (cleared to
+     * null/empty when no link), since the Storyteller defaults for those are empty anyway.
+     */
+    @Query(
+        "UPDATE library_items SET author = COALESCE(:author, author), description = :description, " +
+            "publishedYear = :publishedYear, publisher = :publisher, genres = :genres WHERE id = :itemId"
+    )
+    suspend fun updateReadaloudMetadata(
+        itemId: String,
+        author: String?,
+        description: String?,
+        publishedYear: String?,
+        publisher: String?,
+        genres: String,
+    )
+
     @Query("SELECT id, lastOpenedAt FROM library_items WHERE libraryId = :libraryId AND lastOpenedAt IS NOT NULL")
     suspend fun getLastOpenedAtMap(libraryId: String): List<LastOpenedAtRow>
 


### PR DESCRIPTION
## What & why

Closes #65. Confirmed-matched Storyteller readalouds previously showed their own (empty) `description`/`publishedYear`/`publisher`/`genres` and a duplicated/malformed author from Storyteller's API (e.g. "Andy Weir, Andy Weir;"). #36 shipped the link, footer, and badge, but the metadata-borrowing half of its acceptance criterion was never implemented.

## Change

Added a `backfillReadaloudMetadata()` step to `ReadaloudMatchingService.reconcileLinks()` — which already runs on every trigger that drives matching (ABS refresh, Storyteller refresh, library refresh). For each Storyteller book it:

- finds its Confirmed `ReadaloudLink`(s), picks the best ABS counterpart (the supported **ebook** over an audiobook stub, ties broken by library), and copies `description`/`publishedYear`/`publisher`/`genres` onto the Storyteller `LibraryItemEntity`;
- **clears** those four fields back to empty when no link survives, so no stale ABS data lingers;
- **overwrites the author** from ABS *only when linked* (via `COALESCE(:author, author)` in the new `LibraryItemDao.updateReadaloudMetadata` query), so an unlinked readaloud keeps its own author.

Every surface (Readaloud grid card, Library Item Detail Screen) reads the enriched entity, so there are no per-surface changes. Title/cover come from Storyteller's own API and are untouched; Series/Collections taxonomy is unchanged.

## Tests

- New `ReadaloudMatchingServiceTest` cases: confirmed link → 4 fields surface; no link → fields cleared; author overwritten when linked; author kept when unlinked; ebook counterpart wins over audiobook stub.
- `gradle test` (all unit/integration modules): green.
- `make harness-test` (129 phone tests) and `make harness-test-tablet` (5 tablet tests): green.

No schema/migration change (the new DAO method is a query over an existing column).