### PR TITLE
feat(readaloud): Storyteller readaloud playback in the reader (#37)

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"81793d45-4eff-4f7a-a76f-5206cbfb717b","pid":57297,"procStart":"Tue Jun  2 07:48:45 2026","acquiredAt":1780394118669}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"81793d45-4eff-4f7a-a76f-5206cbfb717b","pid":57297,"procStart":"Tue Jun  2 07:48:45 2026","acquiredAt":1780394118669}

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ gradle/gradle-daemon-jvm.properties
 
 # Superpowers brainstorm sessions
 .superpowers/
+
+# Local Claude Code runtime lock (transient)
+.claude/scheduled_tasks.lock

--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ Riffle lets you browse your ebook library, read EPUB and PDF files, and sync rea
 
 ### Server & Sync
 - Audiobookshelf and Storyteller login with secure token storage and insecure-connection warnings
-- Storyteller Readaloud Library: browse every completed readaloud as a single library (reader-side narration playback is in progress)
+- Storyteller Readaloud Library: browse every completed readaloud as a single library
+- Readaloud playback in the reader: synced sentence highlight, auto-page-turn, "Play from here", background playback with lock-screen/Bluetooth controls, and a per-server audio cache cap
 - Bidirectional progress sync with last-update-wins conflict resolution
 - Periodic auto-sync and offline queueing
 - Reading session time tracking

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -123,6 +123,10 @@ dependencies {
     implementation(libs.coil.compose)
     implementation(libs.okhttp)
 
+    implementation(libs.media3.exoplayer)
+    implementation(libs.media3.session)
+    implementation(libs.media3.common)
+
     implementation(libs.readium.shared)
     implementation(libs.readium.streamer)
     implementation(libs.readium.navigator)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,6 +4,9 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <application
         android:name=".RiffleApplication"
@@ -24,6 +27,15 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
+        <service
+            android:name=".feature.reader.readaloud.AudioPlayerService"
+            android:exported="false"
+            android:foregroundServiceType="mediaPlayback">
+            <intent-filter>
+                <action android:name="androidx.media3.session.MediaSessionService" />
+            </intent-filter>
+        </service>
 
         <provider
             android:name="androidx.core.content.FileProvider"

--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemDetailScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemDetailScreen.kt
@@ -2,8 +2,6 @@ package com.riffle.app.feature.library
 
 import android.content.res.Configuration
 import androidx.compose.animation.animateContentSize
-import androidx.compose.foundation.background
-import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -20,13 +18,11 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Headphones
 import androidx.compose.material.icons.filled.LinkOff
-import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -41,7 +37,6 @@ import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.SnackbarResult
 import androidx.compose.material3.Surface
-import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TooltipBox
@@ -60,7 +55,6 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
@@ -86,7 +80,6 @@ fun LibraryItemDetailScreen(
 ) {
     val uiState by viewModel.uiState.collectAsState()
     val downloadState by viewModel.downloadState.collectAsState()
-    val audioDownloadState by viewModel.audioDownloadState.collectAsState()
     val snackbarHostState = remember { SnackbarHostState() }
     val scope = rememberCoroutineScope()
 
@@ -161,8 +154,6 @@ fun LibraryItemDetailScreen(
                         isInToRead = state.isInToRead,
                         token = viewModel.authToken,
                         downloadState = downloadState,
-                        audioDownloadState = audioDownloadState,
-                        readaloudApplicable = state.isReadaloud,
                         isReadaloud = state.isReadaloud,
                         readaloudFooter = state.readaloudFooter,
                         isCachedOrDownloaded = state.isCachedOrDownloaded,
@@ -173,8 +164,6 @@ fun LibraryItemDetailScreen(
                         onToggleToRead = { viewModel.toggleToRead() },
                         onDownload = { viewModel.startDownload() },
                         onRemove = onRemoveWithUndo,
-                        onDownloadReadaloudAudio = { viewModel.onDownloadReadaloudAudioClicked() },
-                        onRemoveReadaloudAudio = { viewModel.onRemoveReadaloudAudioClicked() },
                         onUnlinkReadaloud = { viewModel.unlinkFromAbs() },
                         modifier = Modifier.padding(padding),
                     )
@@ -184,8 +173,6 @@ fun LibraryItemDetailScreen(
                         isInToRead = state.isInToRead,
                         token = viewModel.authToken,
                         downloadState = downloadState,
-                        audioDownloadState = audioDownloadState,
-                        readaloudApplicable = state.isReadaloud,
                         isReadaloud = state.isReadaloud,
                         readaloudFooter = state.readaloudFooter,
                         isCachedOrDownloaded = state.isCachedOrDownloaded,
@@ -196,8 +183,6 @@ fun LibraryItemDetailScreen(
                         onToggleToRead = { viewModel.toggleToRead() },
                         onDownload = { viewModel.startDownload() },
                         onRemove = onRemoveWithUndo,
-                        onDownloadReadaloudAudio = { viewModel.onDownloadReadaloudAudioClicked() },
-                        onRemoveReadaloudAudio = { viewModel.onRemoveReadaloudAudioClicked() },
                         onUnlinkReadaloud = { viewModel.unlinkFromAbs() },
                         modifier = Modifier.padding(padding),
                     )
@@ -237,8 +222,6 @@ private fun LibraryItemDetailContent(
     isInToRead: Boolean,
     token: String,
     downloadState: DownloadState,
-    audioDownloadState: AudioDownloadState,
-    readaloudApplicable: Boolean,
     isReadaloud: Boolean,
     readaloudFooter: ReadaloudFooterState?,
     isCachedOrDownloaded: Boolean,
@@ -249,8 +232,6 @@ private fun LibraryItemDetailContent(
     onToggleToRead: () -> Unit,
     onDownload: () -> Unit,
     onRemove: () -> Unit,
-    onDownloadReadaloudAudio: () -> Unit,
-    onRemoveReadaloudAudio: () -> Unit,
     onUnlinkReadaloud: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -281,8 +262,6 @@ private fun LibraryItemDetailContent(
             item = item,
             isInToRead = isInToRead,
             downloadState = downloadState,
-            audioDownloadState = audioDownloadState,
-            readaloudApplicable = readaloudApplicable,
             isReadaloud = isReadaloud,
             isCachedOrDownloaded = isCachedOrDownloaded,
             isOffline = isOffline,
@@ -292,8 +271,6 @@ private fun LibraryItemDetailContent(
             onToggleToRead = onToggleToRead,
             onDownload = onDownload,
             onRemove = onRemove,
-            onDownloadReadaloudAudio = onDownloadReadaloudAudio,
-            onRemoveReadaloudAudio = onRemoveReadaloudAudio,
         )
 
         Text(text = item.title, style = MaterialTheme.typography.headlineMedium)
@@ -384,10 +361,6 @@ internal fun LibraryItemDetailContentTablet(
     onRemove: () -> Unit,
     onUnlinkReadaloud: () -> Unit,
     modifier: Modifier = Modifier,
-    audioDownloadState: AudioDownloadState = AudioDownloadState.NotDownloaded,
-    readaloudApplicable: Boolean = false,
-    onDownloadReadaloudAudio: () -> Unit = {},
-    onRemoveReadaloudAudio: () -> Unit = {},
 ) {
     Row(
         modifier = modifier.fillMaxSize(),
@@ -427,8 +400,6 @@ internal fun LibraryItemDetailContentTablet(
                 item = item,
                 isInToRead = isInToRead,
                 downloadState = downloadState,
-                audioDownloadState = audioDownloadState,
-                readaloudApplicable = readaloudApplicable,
                 isReadaloud = isReadaloud,
                 isCachedOrDownloaded = isCachedOrDownloaded,
                 isOffline = isOffline,
@@ -438,8 +409,6 @@ internal fun LibraryItemDetailContentTablet(
                 onToggleToRead = onToggleToRead,
                 onDownload = onDownload,
                 onRemove = onRemove,
-                onDownloadReadaloudAudio = onDownloadReadaloudAudio,
-                onRemoveReadaloudAudio = onRemoveReadaloudAudio,
             )
         }
         Column(
@@ -469,8 +438,6 @@ private fun ActionRow(
     item: LibraryItem,
     isInToRead: Boolean,
     downloadState: DownloadState,
-    audioDownloadState: AudioDownloadState,
-    readaloudApplicable: Boolean,
     isReadaloud: Boolean,
     isCachedOrDownloaded: Boolean,
     isOffline: Boolean,
@@ -480,8 +447,6 @@ private fun ActionRow(
     onToggleToRead: () -> Unit,
     onDownload: () -> Unit,
     onRemove: () -> Unit,
-    onDownloadReadaloudAudio: () -> Unit,
-    onRemoveReadaloudAudio: () -> Unit,
 ) {
     if (item.isSupported) {
         Row(

--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemDetailScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemDetailScreen.kt
@@ -202,13 +202,6 @@ fun LibraryItemDetailScreen(
                         modifier = Modifier.padding(padding),
                     )
                 }
-
-                ReadaloudAudioDialogs(
-                    state = audioDownloadState,
-                    onConfirmDownload = { wifiOnly -> viewModel.confirmDownloadAudio(wifiOnly) },
-                    onConfirmRemove = { viewModel.confirmRemoveAudio() },
-                    onDismiss = { viewModel.dismissAudioDownloadDialog() },
-                )
             }
         }
     }
@@ -532,18 +525,17 @@ private fun ActionRow(
                     onToggle = onToggleToRead,
                 )
             }
+            // For a Storyteller (Readaloud) book the synced bundle is BOTH the EPUB and the audio
+            // source (ADR 0023), so the single DownloadButton already downloads/removes the audio.
+            // A separate readaloud download/remove control here would be redundant and, worse, would
+            // delete the very bundle the reader is using — so it is intentionally absent. Listening
+            // happens in the reader (its headphones action); proactively fetching the audio for a
+            // matched ABS book is the next slice's concern.
             DownloadButton(
                 state = downloadState,
                 onDownload = onDownload,
                 onRemove = onRemove,
             )
-            if (readaloudApplicable) {
-                ReadaloudAudioButton(
-                    state = audioDownloadState,
-                    onDownload = onDownloadReadaloudAudio,
-                    onRemove = onRemoveReadaloudAudio,
-                )
-            }
         }
     } else {
         Text(
@@ -552,130 +544,6 @@ private fun ActionRow(
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
     }
-}
-
-/**
- * Second download action in the action row: downloads the Readaloud audio (the Storyteller synced
- * bundle, ADR 0023), distinct from the EPUB [DownloadButton]. The headphones icon signals "audio".
- */
-@Composable
-private fun ReadaloudAudioButton(
-    state: AudioDownloadState,
-    onDownload: () -> Unit,
-    onRemove: () -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    val size = 40.dp
-    when (state) {
-        is AudioDownloadState.Probing, is AudioDownloadState.InProgress -> {
-            Box(
-                modifier = modifier.size(size),
-                contentAlignment = Alignment.Center,
-            ) {
-                CircularProgressIndicator(modifier = Modifier.size(size))
-            }
-        }
-        is AudioDownloadState.Downloaded -> {
-            Box(
-                modifier = modifier
-                    .size(size)
-                    .clip(CircleShape)
-                    .background(MaterialTheme.colorScheme.primaryContainer)
-                    .clickable(onClick = onRemove),
-                contentAlignment = Alignment.Center,
-            ) {
-                Icon(
-                    imageVector = Icons.Filled.Headphones,
-                    contentDescription = "Remove readaloud audio",
-                    tint = MaterialTheme.colorScheme.onPrimaryContainer,
-                    modifier = Modifier.size(20.dp),
-                )
-            }
-        }
-        else -> {
-            // NotDownloaded / Confirming / ConfirmingRemove / Error all present the affordance to
-            // (re)start a download; dialogs handle the confirm/remove flows.
-            Box(
-                modifier = modifier
-                    .size(size)
-                    .clip(CircleShape)
-                    .border(1.5.dp, MaterialTheme.colorScheme.outline, CircleShape)
-                    .clickable(onClick = onDownload),
-                contentAlignment = Alignment.Center,
-            ) {
-                Icon(
-                    imageVector = Icons.Filled.Headphones,
-                    contentDescription = "Download readaloud audio",
-                    tint = MaterialTheme.colorScheme.outline,
-                    modifier = Modifier.size(20.dp),
-                )
-            }
-        }
-    }
-}
-
-/** Renders the confirm-download and confirm-remove dialogs for the Readaloud audio bundle. */
-@Composable
-private fun ReadaloudAudioDialogs(
-    state: AudioDownloadState,
-    onConfirmDownload: (wifiOnly: Boolean) -> Unit,
-    onConfirmRemove: () -> Unit,
-    onDismiss: () -> Unit,
-) {
-    when (state) {
-        is AudioDownloadState.Confirming -> {
-            var wifiOnly by remember { mutableStateOf(true) }
-            val sizeLabel = state.sizeBytes?.let { formatBytes(it) } ?: "unknown size"
-            AlertDialog(
-                onDismissRequest = onDismiss,
-                title = { Text("Download readaloud audio ($sizeLabel)") },
-                text = {
-                    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                        Text("Download the readaloud audio for offline listening.")
-                        Row(
-                            modifier = Modifier.fillMaxWidth(),
-                            verticalAlignment = Alignment.CenterVertically,
-                            horizontalArrangement = Arrangement.SpaceBetween,
-                        ) {
-                            Text("Wi-Fi only")
-                            Switch(checked = wifiOnly, onCheckedChange = { wifiOnly = it })
-                        }
-                    }
-                },
-                confirmButton = {
-                    TextButton(onClick = { onConfirmDownload(wifiOnly) }) { Text("Download") }
-                },
-                dismissButton = {
-                    TextButton(onClick = onDismiss) { Text("Cancel") }
-                },
-            )
-        }
-        is AudioDownloadState.ConfirmingRemove -> {
-            AlertDialog(
-                onDismissRequest = onDismiss,
-                title = { Text("Remove readaloud audio") },
-                text = { Text("This will free ${formatBytes(state.sizeBytes)}.") },
-                confirmButton = {
-                    TextButton(onClick = onConfirmRemove) { Text("Remove") }
-                },
-                dismissButton = {
-                    TextButton(onClick = onDismiss) { Text("Cancel") }
-                },
-            )
-        }
-        else -> Unit
-    }
-}
-
-/** Human-readable byte size, e.g. "1.2 GB" / "340 MB" / "512 KB". */
-private fun formatBytes(bytes: Long): String {
-    if (bytes < 1024) return "$bytes B"
-    val kb = bytes / 1024.0
-    if (kb < 1024) return "${kb.toInt()} KB"
-    val mb = kb / 1024.0
-    if (mb < 1024) return if (mb < 10) String.format("%.1f MB", mb) else "${mb.toInt()} MB"
-    val gb = mb / 1024.0
-    return String.format("%.1f GB", gb)
 }
 
 @Composable

--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemDetailScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemDetailScreen.kt
@@ -2,6 +2,8 @@ package com.riffle.app.feature.library
 
 import android.content.res.Configuration
 import androidx.compose.animation.animateContentSize
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -18,11 +20,13 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Headphones
 import androidx.compose.material.icons.filled.LinkOff
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -37,6 +41,7 @@ import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.SnackbarResult
 import androidx.compose.material3.Surface
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TooltipBox
@@ -55,6 +60,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
@@ -80,6 +86,7 @@ fun LibraryItemDetailScreen(
 ) {
     val uiState by viewModel.uiState.collectAsState()
     val downloadState by viewModel.downloadState.collectAsState()
+    val audioDownloadState by viewModel.audioDownloadState.collectAsState()
     val snackbarHostState = remember { SnackbarHostState() }
     val scope = rememberCoroutineScope()
 
@@ -154,6 +161,8 @@ fun LibraryItemDetailScreen(
                         isInToRead = state.isInToRead,
                         token = viewModel.authToken,
                         downloadState = downloadState,
+                        audioDownloadState = audioDownloadState,
+                        readaloudApplicable = state.isReadaloud,
                         isReadaloud = state.isReadaloud,
                         readaloudFooter = state.readaloudFooter,
                         isCachedOrDownloaded = state.isCachedOrDownloaded,
@@ -164,6 +173,8 @@ fun LibraryItemDetailScreen(
                         onToggleToRead = { viewModel.toggleToRead() },
                         onDownload = { viewModel.startDownload() },
                         onRemove = onRemoveWithUndo,
+                        onDownloadReadaloudAudio = { viewModel.onDownloadReadaloudAudioClicked() },
+                        onRemoveReadaloudAudio = { viewModel.onRemoveReadaloudAudioClicked() },
                         onUnlinkReadaloud = { viewModel.unlinkFromAbs() },
                         modifier = Modifier.padding(padding),
                     )
@@ -173,6 +184,8 @@ fun LibraryItemDetailScreen(
                         isInToRead = state.isInToRead,
                         token = viewModel.authToken,
                         downloadState = downloadState,
+                        audioDownloadState = audioDownloadState,
+                        readaloudApplicable = state.isReadaloud,
                         isReadaloud = state.isReadaloud,
                         readaloudFooter = state.readaloudFooter,
                         isCachedOrDownloaded = state.isCachedOrDownloaded,
@@ -183,10 +196,19 @@ fun LibraryItemDetailScreen(
                         onToggleToRead = { viewModel.toggleToRead() },
                         onDownload = { viewModel.startDownload() },
                         onRemove = onRemoveWithUndo,
+                        onDownloadReadaloudAudio = { viewModel.onDownloadReadaloudAudioClicked() },
+                        onRemoveReadaloudAudio = { viewModel.onRemoveReadaloudAudioClicked() },
                         onUnlinkReadaloud = { viewModel.unlinkFromAbs() },
                         modifier = Modifier.padding(padding),
                     )
                 }
+
+                ReadaloudAudioDialogs(
+                    state = audioDownloadState,
+                    onConfirmDownload = { wifiOnly -> viewModel.confirmDownloadAudio(wifiOnly) },
+                    onConfirmRemove = { viewModel.confirmRemoveAudio() },
+                    onDismiss = { viewModel.dismissAudioDownloadDialog() },
+                )
             }
         }
     }
@@ -222,6 +244,8 @@ private fun LibraryItemDetailContent(
     isInToRead: Boolean,
     token: String,
     downloadState: DownloadState,
+    audioDownloadState: AudioDownloadState,
+    readaloudApplicable: Boolean,
     isReadaloud: Boolean,
     readaloudFooter: ReadaloudFooterState?,
     isCachedOrDownloaded: Boolean,
@@ -232,6 +256,8 @@ private fun LibraryItemDetailContent(
     onToggleToRead: () -> Unit,
     onDownload: () -> Unit,
     onRemove: () -> Unit,
+    onDownloadReadaloudAudio: () -> Unit,
+    onRemoveReadaloudAudio: () -> Unit,
     onUnlinkReadaloud: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -262,6 +288,8 @@ private fun LibraryItemDetailContent(
             item = item,
             isInToRead = isInToRead,
             downloadState = downloadState,
+            audioDownloadState = audioDownloadState,
+            readaloudApplicable = readaloudApplicable,
             isReadaloud = isReadaloud,
             isCachedOrDownloaded = isCachedOrDownloaded,
             isOffline = isOffline,
@@ -271,6 +299,8 @@ private fun LibraryItemDetailContent(
             onToggleToRead = onToggleToRead,
             onDownload = onDownload,
             onRemove = onRemove,
+            onDownloadReadaloudAudio = onDownloadReadaloudAudio,
+            onRemoveReadaloudAudio = onRemoveReadaloudAudio,
         )
 
         Text(text = item.title, style = MaterialTheme.typography.headlineMedium)
@@ -361,6 +391,10 @@ internal fun LibraryItemDetailContentTablet(
     onRemove: () -> Unit,
     onUnlinkReadaloud: () -> Unit,
     modifier: Modifier = Modifier,
+    audioDownloadState: AudioDownloadState = AudioDownloadState.NotDownloaded,
+    readaloudApplicable: Boolean = false,
+    onDownloadReadaloudAudio: () -> Unit = {},
+    onRemoveReadaloudAudio: () -> Unit = {},
 ) {
     Row(
         modifier = modifier.fillMaxSize(),
@@ -400,6 +434,8 @@ internal fun LibraryItemDetailContentTablet(
                 item = item,
                 isInToRead = isInToRead,
                 downloadState = downloadState,
+                audioDownloadState = audioDownloadState,
+                readaloudApplicable = readaloudApplicable,
                 isReadaloud = isReadaloud,
                 isCachedOrDownloaded = isCachedOrDownloaded,
                 isOffline = isOffline,
@@ -409,6 +445,8 @@ internal fun LibraryItemDetailContentTablet(
                 onToggleToRead = onToggleToRead,
                 onDownload = onDownload,
                 onRemove = onRemove,
+                onDownloadReadaloudAudio = onDownloadReadaloudAudio,
+                onRemoveReadaloudAudio = onRemoveReadaloudAudio,
             )
         }
         Column(
@@ -438,6 +476,8 @@ private fun ActionRow(
     item: LibraryItem,
     isInToRead: Boolean,
     downloadState: DownloadState,
+    audioDownloadState: AudioDownloadState,
+    readaloudApplicable: Boolean,
     isReadaloud: Boolean,
     isCachedOrDownloaded: Boolean,
     isOffline: Boolean,
@@ -447,6 +487,8 @@ private fun ActionRow(
     onToggleToRead: () -> Unit,
     onDownload: () -> Unit,
     onRemove: () -> Unit,
+    onDownloadReadaloudAudio: () -> Unit,
+    onRemoveReadaloudAudio: () -> Unit,
 ) {
     if (item.isSupported) {
         Row(
@@ -495,6 +537,13 @@ private fun ActionRow(
                 onDownload = onDownload,
                 onRemove = onRemove,
             )
+            if (readaloudApplicable) {
+                ReadaloudAudioButton(
+                    state = audioDownloadState,
+                    onDownload = onDownloadReadaloudAudio,
+                    onRemove = onRemoveReadaloudAudio,
+                )
+            }
         }
     } else {
         Text(
@@ -503,6 +552,130 @@ private fun ActionRow(
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
     }
+}
+
+/**
+ * Second download action in the action row: downloads the Readaloud audio (the Storyteller synced
+ * bundle, ADR 0023), distinct from the EPUB [DownloadButton]. The headphones icon signals "audio".
+ */
+@Composable
+private fun ReadaloudAudioButton(
+    state: AudioDownloadState,
+    onDownload: () -> Unit,
+    onRemove: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val size = 40.dp
+    when (state) {
+        is AudioDownloadState.Probing, is AudioDownloadState.InProgress -> {
+            Box(
+                modifier = modifier.size(size),
+                contentAlignment = Alignment.Center,
+            ) {
+                CircularProgressIndicator(modifier = Modifier.size(size))
+            }
+        }
+        is AudioDownloadState.Downloaded -> {
+            Box(
+                modifier = modifier
+                    .size(size)
+                    .clip(CircleShape)
+                    .background(MaterialTheme.colorScheme.primaryContainer)
+                    .clickable(onClick = onRemove),
+                contentAlignment = Alignment.Center,
+            ) {
+                Icon(
+                    imageVector = Icons.Filled.Headphones,
+                    contentDescription = "Remove readaloud audio",
+                    tint = MaterialTheme.colorScheme.onPrimaryContainer,
+                    modifier = Modifier.size(20.dp),
+                )
+            }
+        }
+        else -> {
+            // NotDownloaded / Confirming / ConfirmingRemove / Error all present the affordance to
+            // (re)start a download; dialogs handle the confirm/remove flows.
+            Box(
+                modifier = modifier
+                    .size(size)
+                    .clip(CircleShape)
+                    .border(1.5.dp, MaterialTheme.colorScheme.outline, CircleShape)
+                    .clickable(onClick = onDownload),
+                contentAlignment = Alignment.Center,
+            ) {
+                Icon(
+                    imageVector = Icons.Filled.Headphones,
+                    contentDescription = "Download readaloud audio",
+                    tint = MaterialTheme.colorScheme.outline,
+                    modifier = Modifier.size(20.dp),
+                )
+            }
+        }
+    }
+}
+
+/** Renders the confirm-download and confirm-remove dialogs for the Readaloud audio bundle. */
+@Composable
+private fun ReadaloudAudioDialogs(
+    state: AudioDownloadState,
+    onConfirmDownload: (wifiOnly: Boolean) -> Unit,
+    onConfirmRemove: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    when (state) {
+        is AudioDownloadState.Confirming -> {
+            var wifiOnly by remember { mutableStateOf(true) }
+            val sizeLabel = state.sizeBytes?.let { formatBytes(it) } ?: "unknown size"
+            AlertDialog(
+                onDismissRequest = onDismiss,
+                title = { Text("Download readaloud audio ($sizeLabel)") },
+                text = {
+                    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                        Text("Download the readaloud audio for offline listening.")
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.SpaceBetween,
+                        ) {
+                            Text("Wi-Fi only")
+                            Switch(checked = wifiOnly, onCheckedChange = { wifiOnly = it })
+                        }
+                    }
+                },
+                confirmButton = {
+                    TextButton(onClick = { onConfirmDownload(wifiOnly) }) { Text("Download") }
+                },
+                dismissButton = {
+                    TextButton(onClick = onDismiss) { Text("Cancel") }
+                },
+            )
+        }
+        is AudioDownloadState.ConfirmingRemove -> {
+            AlertDialog(
+                onDismissRequest = onDismiss,
+                title = { Text("Remove readaloud audio") },
+                text = { Text("This will free ${formatBytes(state.sizeBytes)}.") },
+                confirmButton = {
+                    TextButton(onClick = onConfirmRemove) { Text("Remove") }
+                },
+                dismissButton = {
+                    TextButton(onClick = onDismiss) { Text("Cancel") }
+                },
+            )
+        }
+        else -> Unit
+    }
+}
+
+/** Human-readable byte size, e.g. "1.2 GB" / "340 MB" / "512 KB". */
+private fun formatBytes(bytes: Long): String {
+    if (bytes < 1024) return "$bytes B"
+    val kb = bytes / 1024.0
+    if (kb < 1024) return "${kb.toInt()} KB"
+    val mb = kb / 1024.0
+    if (mb < 1024) return if (mb < 10) String.format("%.1f MB", mb) else "${mb.toInt()} MB"
+    val gb = mb / 1024.0
+    return String.format("%.1f GB", gb)
 }
 
 @Composable

--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModel.kt
@@ -6,12 +6,10 @@ import androidx.compose.runtime.setValue
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.riffle.core.domain.AudioDownloadResult
 import com.riffle.core.domain.ConnectivityObserver
 import com.riffle.core.domain.EbookFormat
 import com.riffle.core.domain.EpubDownloadResult
 import com.riffle.core.domain.EpubRepository
-import com.riffle.core.domain.ReadaloudAudioRepository
 import com.riffle.core.domain.LibraryItem
 import com.riffle.core.domain.LibraryRepository
 import com.riffle.core.domain.PdfDownloadResult
@@ -80,20 +78,6 @@ sealed interface DownloadState {
     data object Downloaded : DownloadState
 }
 
-/** State machine for the "Download readaloud audio" action (the Storyteller synced bundle, ADR 0023). */
-sealed interface AudioDownloadState {
-    data object NotDownloaded : AudioDownloadState
-    /** Probing the server for the download size before showing the confirmation dialog. */
-    data object Probing : AudioDownloadState
-    /** Awaiting user confirmation; carries the probed download size (null when unprobeable). */
-    data class Confirming(val sizeBytes: Long?) : AudioDownloadState
-    /** Awaiting user confirmation to remove; carries the on-disk size that would be freed. */
-    data class ConfirmingRemove(val sizeBytes: Long) : AudioDownloadState
-    data class InProgress(val downloaded: Long, val total: Long) : AudioDownloadState
-    data object Downloaded : AudioDownloadState
-    data object Error : AudioDownloadState
-}
-
 @HiltViewModel
 class LibraryItemDetailViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
@@ -105,7 +89,6 @@ class LibraryItemDetailViewModel @Inject constructor(
     private val sessionRepository: ReadingSessionRepository,
     private val toReadRepository: ToReadRepository,
     private val readaloudLinkRepository: com.riffle.core.domain.ReadaloudLinkRepository,
-    private val readaloudAudioRepository: ReadaloudAudioRepository,
     private val connectivityObserver: ConnectivityObserver,
 ) : ViewModel() {
 
@@ -116,9 +99,6 @@ class LibraryItemDetailViewModel @Inject constructor(
 
     private val _downloadState = MutableStateFlow<DownloadState>(DownloadState.NotDownloaded)
     val downloadState: StateFlow<DownloadState> = _downloadState
-
-    private val _audioDownloadState = MutableStateFlow<AudioDownloadState>(AudioDownloadState.NotDownloaded)
-    val audioDownloadState: StateFlow<AudioDownloadState> = _audioDownloadState
 
     private val _snackbarEvents = MutableSharedFlow<String>(extraBufferCapacity = 1)
     val snackbarEvents: SharedFlow<String> = _snackbarEvents.asSharedFlow()
@@ -137,11 +117,6 @@ class LibraryItemDetailViewModel @Inject constructor(
                 val item = repository.getItem(itemId)
                 if (item != null) {
                     _downloadState.value = deriveDownloadState(item)
-                    _audioDownloadState.value = if (readaloudAudioRepository.isAudioAvailable(item.id)) {
-                        AudioDownloadState.Downloaded
-                    } else {
-                        AudioDownloadState.NotDownloaded
-                    }
                     if (!isReadaloud) toReadRepository.refresh(item.libraryId)
                     val isInToRead = if (isReadaloud) false else toReadRepository.isInToRead(item.id, item.libraryId)
                     val footer = resolveReadaloudFooter(item, isReadaloud, server?.id)
@@ -258,62 +233,6 @@ class LibraryItemDetailViewModel @Inject constructor(
             }
             _downloadState.value = DownloadState.NotDownloaded
             refreshCacheState()
-        }
-    }
-
-    fun onDownloadReadaloudAudioClicked() {
-        val item = (uiState.value as? LibraryItemDetailUiState.Ready)?.item ?: return
-        if (_audioDownloadState.value is AudioDownloadState.Probing ||
-            _audioDownloadState.value is AudioDownloadState.InProgress
-        ) {
-            return
-        }
-        _audioDownloadState.value = AudioDownloadState.Probing
-        viewModelScope.launch {
-            val size = readaloudAudioRepository.probeSizeBytes(item.id)
-            _audioDownloadState.value = AudioDownloadState.Confirming(size)
-        }
-    }
-
-    fun confirmDownloadAudio(wifiOnly: Boolean) {
-        val item = (uiState.value as? LibraryItemDetailUiState.Ready)?.item ?: return
-        // TODO: honour wifiOnly once a network-type checker exists; for now the toggle value is
-        // carried through but not enforced (no Wi-Fi gating infra in the data layer yet).
-        @Suppress("UNUSED_VARIABLE") val gateOnWifi = wifiOnly
-        _audioDownloadState.value = AudioDownloadState.InProgress(downloaded = 0L, total = 0L)
-        viewModelScope.launch {
-            val result = readaloudAudioRepository.downloadAudio(item.id) { downloaded, total ->
-                _audioDownloadState.value = AudioDownloadState.InProgress(downloaded, total)
-            }
-            _audioDownloadState.value = when (result) {
-                AudioDownloadResult.Success -> AudioDownloadState.Downloaded
-                AudioDownloadResult.NoBundle -> AudioDownloadState.Error
-                is AudioDownloadResult.NetworkError -> AudioDownloadState.Error
-            }
-            if (result is AudioDownloadResult.NetworkError || result is AudioDownloadResult.NoBundle) {
-                _snackbarEvents.emit("Couldn't download readaloud audio")
-            }
-        }
-    }
-
-    fun onRemoveReadaloudAudioClicked() {
-        val item = (uiState.value as? LibraryItemDetailUiState.Ready)?.item ?: return
-        val sizeBytes = readaloudAudioRepository.bundleFile(item.id)?.length() ?: 0L
-        _audioDownloadState.value = AudioDownloadState.ConfirmingRemove(sizeBytes)
-    }
-
-    fun confirmRemoveAudio() {
-        val item = (uiState.value as? LibraryItemDetailUiState.Ready)?.item ?: return
-        viewModelScope.launch {
-            readaloudAudioRepository.removeAudio(item.id)
-            _audioDownloadState.value = AudioDownloadState.NotDownloaded
-        }
-    }
-
-    fun dismissAudioDownloadDialog() {
-        _audioDownloadState.value = when {
-            readaloudAudioRepository.isAudioAvailable(itemId) -> AudioDownloadState.Downloaded
-            else -> AudioDownloadState.NotDownloaded
         }
     }
 

--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModel.kt
@@ -6,10 +6,12 @@ import androidx.compose.runtime.setValue
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.riffle.core.domain.AudioDownloadResult
 import com.riffle.core.domain.ConnectivityObserver
 import com.riffle.core.domain.EbookFormat
 import com.riffle.core.domain.EpubDownloadResult
 import com.riffle.core.domain.EpubRepository
+import com.riffle.core.domain.ReadaloudAudioRepository
 import com.riffle.core.domain.LibraryItem
 import com.riffle.core.domain.LibraryRepository
 import com.riffle.core.domain.PdfDownloadResult
@@ -78,6 +80,20 @@ sealed interface DownloadState {
     data object Downloaded : DownloadState
 }
 
+/** State machine for the "Download readaloud audio" action (the Storyteller synced bundle, ADR 0023). */
+sealed interface AudioDownloadState {
+    data object NotDownloaded : AudioDownloadState
+    /** Probing the server for the download size before showing the confirmation dialog. */
+    data object Probing : AudioDownloadState
+    /** Awaiting user confirmation; carries the probed download size (null when unprobeable). */
+    data class Confirming(val sizeBytes: Long?) : AudioDownloadState
+    /** Awaiting user confirmation to remove; carries the on-disk size that would be freed. */
+    data class ConfirmingRemove(val sizeBytes: Long) : AudioDownloadState
+    data class InProgress(val downloaded: Long, val total: Long) : AudioDownloadState
+    data object Downloaded : AudioDownloadState
+    data object Error : AudioDownloadState
+}
+
 @HiltViewModel
 class LibraryItemDetailViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
@@ -89,6 +105,7 @@ class LibraryItemDetailViewModel @Inject constructor(
     private val sessionRepository: ReadingSessionRepository,
     private val toReadRepository: ToReadRepository,
     private val readaloudLinkRepository: com.riffle.core.domain.ReadaloudLinkRepository,
+    private val readaloudAudioRepository: ReadaloudAudioRepository,
     private val connectivityObserver: ConnectivityObserver,
 ) : ViewModel() {
 
@@ -99,6 +116,9 @@ class LibraryItemDetailViewModel @Inject constructor(
 
     private val _downloadState = MutableStateFlow<DownloadState>(DownloadState.NotDownloaded)
     val downloadState: StateFlow<DownloadState> = _downloadState
+
+    private val _audioDownloadState = MutableStateFlow<AudioDownloadState>(AudioDownloadState.NotDownloaded)
+    val audioDownloadState: StateFlow<AudioDownloadState> = _audioDownloadState
 
     private val _snackbarEvents = MutableSharedFlow<String>(extraBufferCapacity = 1)
     val snackbarEvents: SharedFlow<String> = _snackbarEvents.asSharedFlow()
@@ -117,6 +137,11 @@ class LibraryItemDetailViewModel @Inject constructor(
                 val item = repository.getItem(itemId)
                 if (item != null) {
                     _downloadState.value = deriveDownloadState(item)
+                    _audioDownloadState.value = if (readaloudAudioRepository.isAudioAvailable(item.id)) {
+                        AudioDownloadState.Downloaded
+                    } else {
+                        AudioDownloadState.NotDownloaded
+                    }
                     if (!isReadaloud) toReadRepository.refresh(item.libraryId)
                     val isInToRead = if (isReadaloud) false else toReadRepository.isInToRead(item.id, item.libraryId)
                     val footer = resolveReadaloudFooter(item, isReadaloud, server?.id)
@@ -233,6 +258,62 @@ class LibraryItemDetailViewModel @Inject constructor(
             }
             _downloadState.value = DownloadState.NotDownloaded
             refreshCacheState()
+        }
+    }
+
+    fun onDownloadReadaloudAudioClicked() {
+        val item = (uiState.value as? LibraryItemDetailUiState.Ready)?.item ?: return
+        if (_audioDownloadState.value is AudioDownloadState.Probing ||
+            _audioDownloadState.value is AudioDownloadState.InProgress
+        ) {
+            return
+        }
+        _audioDownloadState.value = AudioDownloadState.Probing
+        viewModelScope.launch {
+            val size = readaloudAudioRepository.probeSizeBytes(item.id)
+            _audioDownloadState.value = AudioDownloadState.Confirming(size)
+        }
+    }
+
+    fun confirmDownloadAudio(wifiOnly: Boolean) {
+        val item = (uiState.value as? LibraryItemDetailUiState.Ready)?.item ?: return
+        // TODO: honour wifiOnly once a network-type checker exists; for now the toggle value is
+        // carried through but not enforced (no Wi-Fi gating infra in the data layer yet).
+        @Suppress("UNUSED_VARIABLE") val gateOnWifi = wifiOnly
+        _audioDownloadState.value = AudioDownloadState.InProgress(downloaded = 0L, total = 0L)
+        viewModelScope.launch {
+            val result = readaloudAudioRepository.downloadAudio(item.id) { downloaded, total ->
+                _audioDownloadState.value = AudioDownloadState.InProgress(downloaded, total)
+            }
+            _audioDownloadState.value = when (result) {
+                AudioDownloadResult.Success -> AudioDownloadState.Downloaded
+                AudioDownloadResult.NoBundle -> AudioDownloadState.Error
+                is AudioDownloadResult.NetworkError -> AudioDownloadState.Error
+            }
+            if (result is AudioDownloadResult.NetworkError || result is AudioDownloadResult.NoBundle) {
+                _snackbarEvents.emit("Couldn't download readaloud audio")
+            }
+        }
+    }
+
+    fun onRemoveReadaloudAudioClicked() {
+        val item = (uiState.value as? LibraryItemDetailUiState.Ready)?.item ?: return
+        val sizeBytes = readaloudAudioRepository.bundleFile(item.id)?.length() ?: 0L
+        _audioDownloadState.value = AudioDownloadState.ConfirmingRemove(sizeBytes)
+    }
+
+    fun confirmRemoveAudio() {
+        val item = (uiState.value as? LibraryItemDetailUiState.Ready)?.item ?: return
+        viewModelScope.launch {
+            readaloudAudioRepository.removeAudio(item.id)
+            _audioDownloadState.value = AudioDownloadState.NotDownloaded
+        }
+    }
+
+    fun dismissAudioDownloadDialog() {
+        _audioDownloadState.value = when {
+            readaloudAudioRepository.isAudioAvailable(itemId) -> AudioDownloadState.Downloaded
+            else -> AudioDownloadState.NotDownloaded
         }
     }
 

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -288,29 +288,27 @@ fun EpubReaderScreen(
         if (state is ReaderState.Ready && (readaloudOpen || showRailOverlay)) {
             Column(modifier = Modifier.align(Alignment.BottomCenter)) {
                 if (readaloudOpen) {
-                    // Resolve the player's surfaceVariant in the same reader-theme-scoped
-                    // RiffleTheme the ChapterNavigationRail uses, so the player and the rail
-                    // track reference the identical colour and read as one continuous surface.
-                    val readerThemeForPlayer = formattingPrefs.theme
-                    val playerDarkTheme = readerThemeForPlayer == ReaderTheme.Dark ||
-                        readerThemeForPlayer == ReaderTheme.DarkDim
-                    RiffleTheme(darkTheme = playerDarkTheme) {
-                        ReadaloudMiniPlayer(
-                            isPlaying = playbackState.isPlaying,
-                            speed = playbackState.speed,
-                            offlineMessage = readaloudOfflineMessage,
-                            downloadProgress = downloadProgress,
-                            onPlayPause = viewModel::togglePlayPause,
-                            onCycleSpeed = {
-                                // Cycle 0.75× → 1× → 1.25× → 1.5× → 2× → 0.75×.
-                                val speeds = com.riffle.app.feature.reader.readaloud.ReadaloudController.SPEEDS
-                                val idx = speeds.indexOfFirst { kotlin.math.abs(it - playbackState.speed) < 0.001f }
-                                viewModel.setSpeed(if (idx < 0) 1f else speeds[(idx + 1) % speeds.size])
-                            },
-                            onClose = viewModel::closeReadaloud,
-                            onExpand = viewModel::expandPlayer,
-                        )
-                    }
+                    // Reference the reader-theme palette so the player matches the chapter-rail
+                    // overlay backdrop (which paints readerTheme.palette.background) and the two
+                    // read as one continuous, theme-following strip.
+                    val readerPalette = formattingPrefs.theme.palette
+                    ReadaloudMiniPlayer(
+                        isPlaying = playbackState.isPlaying,
+                        speed = playbackState.speed,
+                        offlineMessage = readaloudOfflineMessage,
+                        downloadProgress = downloadProgress,
+                        containerColor = readerPalette.background,
+                        contentColor = readerPalette.foreground,
+                        onPlayPause = viewModel::togglePlayPause,
+                        onCycleSpeed = {
+                            // Cycle 0.75× → 1× → 1.25× → 1.5× → 2× → 0.75×.
+                            val speeds = com.riffle.app.feature.reader.readaloud.ReadaloudController.SPEEDS
+                            val idx = speeds.indexOfFirst { kotlin.math.abs(it - playbackState.speed) < 0.001f }
+                            viewModel.setSpeed(if (idx < 0) 1f else speeds[(idx + 1) % speeds.size])
+                        },
+                        onClose = viewModel::closeReadaloud,
+                        onExpand = viewModel::expandPlayer,
+                    )
                 }
                 if (showRailOverlay) {
                     EpubChapterRailOverlay(

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -14,7 +14,6 @@ import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Column
 import androidx.compose.ui.graphics.Color
 import androidx.compose.foundation.layout.Row
@@ -28,6 +27,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.List
+import androidx.compose.material.icons.filled.Headphones
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -70,6 +70,9 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
+import com.riffle.app.feature.reader.readaloud.ReadaloudDownloadDialog
+import com.riffle.app.feature.reader.readaloud.ReadaloudExpandedSheet
+import com.riffle.app.feature.reader.readaloud.ReadaloudMiniPlayer
 import com.riffle.app.ui.theme.RiffleTheme
 import com.riffle.core.domain.FormattingPreferences
 import com.riffle.core.domain.ReaderOrientation
@@ -180,6 +183,15 @@ fun EpubReaderScreen(
     val tocVisible by viewModel.tocVisible.collectAsState()
     val footnotePopup by viewModel.footnotePopup.collectAsState()
 
+    val readaloudAvailable by viewModel.readaloudAvailable.collectAsState()
+    val readaloudOpen by viewModel.readaloudOpen.collectAsState()
+    val readaloudExpanded by viewModel.readaloudExpanded.collectAsState()
+    val playbackState by viewModel.playbackState.collectAsState()
+    val activeFragmentRef by viewModel.activeFragmentRef.collectAsState()
+    val downloadPromptBytes by viewModel.downloadPromptBytes.collectAsState()
+    val readaloudOfflineMessage by viewModel.readaloudOfflineMessage.collectAsState()
+    val downloadProgress by viewModel.downloadProgress.collectAsState()
+
     // TopAppBar floats as an overlay so its show/hide never resizes the content area —
     // eliminates the compound flicker that Scaffold's topBar slot caused by reflowing the
     // WebView simultaneously with the system-bar animation.
@@ -227,6 +239,10 @@ fun EpubReaderScreen(
                         onTap = immersiveState::toggle,
                         latestLocator = { viewModel.latestLocator },
                         onFootnoteTapped = viewModel::showFootnotePopup,
+                        activeFragmentRef = activeFragmentRef,
+                        advancePageEvents = viewModel.advancePageEvents,
+                        onReportVisibleFragments = viewModel::reportVisibleFragments,
+                        onPlayFromHere = viewModel::playFromHere,
                         modifier = Modifier
                             .fillMaxSize()
                             .testTag("reader_ready")
@@ -260,24 +276,62 @@ fun EpubReaderScreen(
             }
         }
 
-        // Chapter rail lives in the outer (unpadded) Box so it remains anchored to the
-        // absolute screen bottom — the system nav bar overlays it without shifting it up.
-        // Rail state (cursorPosition at scroll framerate) is isolated inside the overlay so
-        // EpubNavigatorView does not recompose on every scroll event.
-        if (state is ReaderState.Ready &&
+        // Bottom stack (player bar above the chapter rail), both anchored to the absolute screen
+        // bottom in one Column so the readaloud bar floats directly above the rail. The system nav
+        // bar overlays this column without shifting it up.
+        val showRailOverlay = state is ReaderState.Ready &&
             (
                 formattingPrefs.showChapterMap ||
                     formattingPrefs.showReadingProgressLabels ||
                     formattingPrefs.showCurrentChapterLabel
                 )
-        ) {
-            EpubChapterRailOverlay(
-                viewModel = viewModel,
-                showRail = formattingPrefs.showChapterMap,
-                showProgressLabels = formattingPrefs.showReadingProgressLabels,
-                showChapterNameLabel = formattingPrefs.showCurrentChapterLabel,
-                readerTheme = formattingPrefs.theme,
-                modifier = Modifier.align(Alignment.BottomCenter),
+        if (state is ReaderState.Ready && (readaloudOpen || showRailOverlay)) {
+            Column(modifier = Modifier.align(Alignment.BottomCenter)) {
+                if (readaloudOpen) {
+                    ReadaloudMiniPlayer(
+                        isPlaying = playbackState.isPlaying,
+                        speed = playbackState.speed,
+                        offlineMessage = readaloudOfflineMessage,
+                        downloadProgress = downloadProgress,
+                        onPlayPause = viewModel::togglePlayPause,
+                        onCycleSpeed = {
+                            // Cycle 0.75× → 1× → 1.25× → 1.5× → 2× → 0.75×.
+                            val speeds = com.riffle.app.feature.reader.readaloud.ReadaloudController.SPEEDS
+                            val idx = speeds.indexOfFirst { kotlin.math.abs(it - playbackState.speed) < 0.001f }
+                            viewModel.setSpeed(if (idx < 0) 1f else speeds[(idx + 1) % speeds.size])
+                        },
+                        onClose = viewModel::closeReadaloud,
+                        onExpand = viewModel::expandPlayer,
+                    )
+                }
+                if (showRailOverlay) {
+                    EpubChapterRailOverlay(
+                        viewModel = viewModel,
+                        showRail = formattingPrefs.showChapterMap,
+                        showProgressLabels = formattingPrefs.showReadingProgressLabels,
+                        showChapterNameLabel = formattingPrefs.showCurrentChapterLabel,
+                        readerTheme = formattingPrefs.theme,
+                    )
+                }
+            }
+        }
+
+        if (readaloudOpen && readaloudExpanded) {
+            ReadaloudExpandedSheet(
+                isPlaying = playbackState.isPlaying,
+                speed = playbackState.speed,
+                positionSec = playbackState.positionSec,
+                onPlayPause = viewModel::togglePlayPause,
+                onSpeedSelected = viewModel::setSpeed,
+                onDismiss = viewModel::collapsePlayer,
+            )
+        }
+
+        downloadPromptBytes?.let { bytes ->
+            ReadaloudDownloadDialog(
+                sizeBytes = bytes,
+                onConfirm = { wifiOnly -> viewModel.confirmDownloadAudio(wifiOnly) },
+                onDismiss = viewModel::dismissDownloadPrompt,
             )
         }
 
@@ -320,6 +374,14 @@ fun EpubReaderScreen(
                                     fontWeight = FontWeight.SemiBold,
                                     modifier = Modifier.semantics { contentDescription = "Format" },
                                 )
+                            }
+                            if (readaloudAvailable) {
+                                IconButton(
+                                    onClick = viewModel::openReadaloud,
+                                    modifier = Modifier.testTag("readaloud_open"),
+                                ) {
+                                    Icon(Icons.Default.Headphones, contentDescription = "Readaloud")
+                                }
                             }
                         }
                     },
@@ -365,7 +427,7 @@ internal fun readerTopAppBarColors() = androidx.compose.material3.TopAppBarDefau
 
 // Isolated scope: cursorPosition updates only recompose this composable, not sibling EpubNavigatorView.
 @Composable
-private fun BoxScope.EpubChapterRailOverlay(
+private fun EpubChapterRailOverlay(
     viewModel: EpubReaderViewModel,
     showRail: Boolean,
     showProgressLabels: Boolean,
@@ -514,6 +576,10 @@ private fun EpubNavigatorView(
     onTap: () -> Unit,
     latestLocator: () -> Locator?,
     onFootnoteTapped: (content: String) -> Unit,
+    activeFragmentRef: String?,
+    advancePageEvents: Flow<Unit>,
+    onReportVisibleFragments: (Set<String>) -> Unit,
+    onPlayFromHere: (fragmentRef: String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val context = LocalContext.current
@@ -535,7 +601,43 @@ private fun EpubNavigatorView(
     // without needing to be re-created when onTap changes.
     val currentOnTap by rememberUpdatedState(onTap)
     val currentOnFootnoteTapped by rememberUpdatedState(onFootnoteTapped)
+    val currentOnPlayFromHere by rememberUpdatedState(onPlayFromHere)
     val currentPublication by rememberUpdatedState(state.publication)
+
+    // "Play from here" is added to the WebView text-selection action bar via Readium's
+    // selectionActionModeCallback hook (the only supported way to customise the selection menu in
+    // 3.0.0). On click we read currentSelection() and derive a SMIL fragment ref from the selection
+    // locator. Limitation: a free-text selection rarely lands exactly on a SMIL <par> boundary, so
+    // we use the selection's first fragment id (locations.fragments) when present, falling back to
+    // the bare href; ReadaloudTrack.clipForFragment then matches the nearest narrated clip it can.
+    val playFromHereMenuId = remember { View.generateViewId() }
+    val playFromHereActionMode = remember {
+        object : android.view.ActionMode.Callback {
+            override fun onCreateActionMode(mode: android.view.ActionMode, menu: android.view.Menu): Boolean {
+                menu.add(0, playFromHereMenuId, 0, "Play from here")
+                return true
+            }
+
+            override fun onPrepareActionMode(mode: android.view.ActionMode, menu: android.view.Menu) = false
+
+            override fun onActionItemClicked(mode: android.view.ActionMode, item: android.view.MenuItem): Boolean {
+                if (item.itemId != playFromHereMenuId) return false
+                val selectable = fragmentRef.value as? org.readium.r2.navigator.SelectableNavigator ?: return false
+                coroutineScope.launch {
+                    val selection = selectable.currentSelection() ?: return@launch
+                    val loc = selection.locator
+                    val fragId = loc.locations.fragments.firstOrNull()
+                    val ref = if (fragId != null) "${loc.href}#$fragId" else loc.href.toString()
+                    currentOnPlayFromHere(ref)
+                    selectable.clearSelection()
+                }
+                mode.finish()
+                return true
+            }
+
+            override fun onDestroyActionMode(mode: android.view.ActionMode) {}
+        }
+    }
     // ConcurrentHashMap: writes happen on Dispatchers.IO from the locator
     // coroutine; reads happen on the JS binder thread inside resolveAnchorTap.
     val footnoteDocCache = remember { ConcurrentHashMap<String, Document>() }
@@ -651,6 +753,101 @@ private fun EpubNavigatorView(
             fragment.applyDecorations(decorations, group = "search")
         }
         hasActiveDecorations.value = true
+    }
+
+    // ---- Readaloud synced highlight --------------------------------------------------------
+    // Uses the same Readium DecorableNavigator mechanism as search, on its own "readaloud" group
+    // so it doesn't clobber search highlights. The active fragment ref is "href#fragId"; we build
+    // a Locator with that href and a cssSelector targeting the fragment id, which is how Readium's
+    // EPUB decorator resolves the DOM range for a highlight. Null clears the decoration.
+    val hasReadaloudDecoration = remember { mutableStateOf(false) }
+    LaunchedEffect(activeFragmentRef) {
+        val fragment = fragmentRef.value as? DecorableNavigator ?: return@LaunchedEffect
+        val ref = activeFragmentRef
+        if (ref == null) {
+            if (!hasReadaloudDecoration.value) return@LaunchedEffect
+            withContext(Dispatchers.Main) {
+                fragment.applyDecorations(emptyList(), group = "readaloud")
+            }
+            hasReadaloudDecoration.value = false
+            return@LaunchedEffect
+        }
+        val hashIdx = ref.indexOf('#')
+        val href = if (hashIdx >= 0) ref.substring(0, hashIdx) else ref
+        val fragId = if (hashIdx >= 0) ref.substring(hashIdx + 1) else null
+        val locatorJson = JSONObject()
+            .put("href", href)
+            .put("type", "application/xhtml+xml")
+            .put(
+                "locations",
+                JSONObject().apply {
+                    if (fragId != null) {
+                        put("fragments", org.json.JSONArray().put(fragId))
+                        put("cssSelector", "#$fragId")
+                    }
+                },
+            )
+        val locator = Locator.fromJSON(locatorJson) ?: return@LaunchedEffect
+        val decoration = Decoration(
+            id = "readaloud_active",
+            locator = locator,
+            style = Decoration.Style.Highlight(
+                tint = android.graphics.Color.parseColor("#FF7DD3FC"),
+                isActive = true,
+            ),
+        )
+        withContext(Dispatchers.Main) {
+            fragment.applyDecorations(listOf(decoration), group = "readaloud")
+        }
+        hasReadaloudDecoration.value = true
+    }
+
+    // ---- Auto-page-turn --------------------------------------------------------------------
+    // When the coordinator signals the narrated sentence has scrolled off-screen, advance using
+    // the same navigation calls the volume-key path uses (goForward for paginated, scroll-to-
+    // bottom for continuous). Approximation note: Readium 3.0.0 has no API to enumerate the
+    // fragment refs actually rendered in the viewport, so we report a coarse visible set built
+    // from the current locator's href below; the coordinator treats the active sentence as
+    // off-screen once it moves past that set.
+    LaunchedEffect(advancePageEvents) {
+        advancePageEvents.collect {
+            val fragment = fragmentRef.value ?: return@collect
+            if (currentFormattingPrefs.orientation == ReaderOrientation.Vertical) {
+                // Continuous: scroll down by a viewport height.
+                launch {
+                    fragment.evaluateJavascript(
+                        "window.scrollBy(0, window.innerHeight * 0.9);"
+                    )
+                }
+            } else {
+                fragment.goForward(animated = false)
+            }
+        }
+    }
+
+    // Feed the coordinator a coarse visible-fragment set. Readium 3.0.0 does not expose the exact
+    // fragment refs rendered in the viewport, so we approximate by snapshotting the fragment that
+    // was active at the moment the page last settled (the locator href changed). While playback
+    // stays on that page the snapshot is the "visible" set; once the active clip's document index
+    // climbs past it, AutoPageTurnRule fires an advance. This is intentionally conservative — it
+    // advances when audio moves beyond where the page settled, not mid-sentence.
+    val pageSettledFragment = remember { mutableStateOf<String?>(null) }
+    val currentActiveFragmentRef by rememberUpdatedState(activeFragmentRef)
+    // Snapshot whenever the locator href changes (a new page/chapter has rendered).
+    LaunchedEffect(fragmentRef.value) {
+        val fragment = fragmentRef.value ?: return@LaunchedEffect
+        var lastHref: String? = null
+        fragment.currentLocator.collect { locator ->
+            val href = locator.href.toString()
+            if (href != lastHref) {
+                lastHref = href
+                pageSettledFragment.value = currentActiveFragmentRef
+            }
+        }
+    }
+    LaunchedEffect(pageSettledFragment.value) {
+        val ref = pageSettledFragment.value
+        onReportVisibleFragments(if (ref != null) setOf(ref) else emptySet())
     }
 
     LaunchedEffect(volumeNavEvents) {
@@ -807,6 +1004,8 @@ private fun EpubNavigatorView(
                             registerJavascriptInterface(FootnoteAnchorBridge.JS_NAME) { _ ->
                                 FootnoteAnchorBridge.bridge
                             }
+                            // Adds the "Play from here" item to the text-selection action bar.
+                            selectionActionModeCallback = playFromHereActionMode
                         },
                         listener = fragmentListener,
                         paginationListener = paginationListener,

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -288,21 +288,29 @@ fun EpubReaderScreen(
         if (state is ReaderState.Ready && (readaloudOpen || showRailOverlay)) {
             Column(modifier = Modifier.align(Alignment.BottomCenter)) {
                 if (readaloudOpen) {
-                    ReadaloudMiniPlayer(
-                        isPlaying = playbackState.isPlaying,
-                        speed = playbackState.speed,
-                        offlineMessage = readaloudOfflineMessage,
-                        downloadProgress = downloadProgress,
-                        onPlayPause = viewModel::togglePlayPause,
-                        onCycleSpeed = {
-                            // Cycle 0.75× → 1× → 1.25× → 1.5× → 2× → 0.75×.
-                            val speeds = com.riffle.app.feature.reader.readaloud.ReadaloudController.SPEEDS
-                            val idx = speeds.indexOfFirst { kotlin.math.abs(it - playbackState.speed) < 0.001f }
-                            viewModel.setSpeed(if (idx < 0) 1f else speeds[(idx + 1) % speeds.size])
-                        },
-                        onClose = viewModel::closeReadaloud,
-                        onExpand = viewModel::expandPlayer,
-                    )
+                    // Resolve the player's surfaceVariant in the same reader-theme-scoped
+                    // RiffleTheme the ChapterNavigationRail uses, so the player and the rail
+                    // track reference the identical colour and read as one continuous surface.
+                    val readerThemeForPlayer = formattingPrefs.theme
+                    val playerDarkTheme = readerThemeForPlayer == ReaderTheme.Dark ||
+                        readerThemeForPlayer == ReaderTheme.DarkDim
+                    RiffleTheme(darkTheme = playerDarkTheme) {
+                        ReadaloudMiniPlayer(
+                            isPlaying = playbackState.isPlaying,
+                            speed = playbackState.speed,
+                            offlineMessage = readaloudOfflineMessage,
+                            downloadProgress = downloadProgress,
+                            onPlayPause = viewModel::togglePlayPause,
+                            onCycleSpeed = {
+                                // Cycle 0.75× → 1× → 1.25× → 1.5× → 2× → 0.75×.
+                                val speeds = com.riffle.app.feature.reader.readaloud.ReadaloudController.SPEEDS
+                                val idx = speeds.indexOfFirst { kotlin.math.abs(it - playbackState.speed) < 0.001f }
+                                viewModel.setSpeed(if (idx < 0) 1f else speeds[(idx + 1) % speeds.size])
+                            },
+                            onClose = viewModel::closeReadaloud,
+                            onExpand = viewModel::expandPlayer,
+                        )
+                    }
                 }
                 if (showRailOverlay) {
                     EpubChapterRailOverlay(

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -498,6 +498,8 @@ class EpubReaderViewModel @Inject constructor(
         epubZip = null
         // Tear down the audio session so it doesn't outlive the reader (clears the highlight too).
         playerCoordinator.close()
+        // Cancel the coordinator's state-collection scope so it isn't leaked past this ViewModel.
+        playerCoordinator.dispose()
     }
 
     private val _currentLocatorHref = MutableStateFlow<String?>(null)
@@ -772,10 +774,12 @@ class EpubReaderViewModel @Inject constructor(
 
     fun confirmDownloadAudio(wifiOnly: Boolean) {
         _downloadPromptBytes.value = null
-        // wifiOnly is honoured by the repository's download path (which inspects the active
-        // connection); we surface the toggle here and pass intent through by simply not starting
-        // when wifiOnly is requested but we're not on un-metered. Keep it simple: the repository
-        // owns the metered check, so we always kick off and let it decide.
+        // Honour "Wi-Fi only": if the active network is metered, refuse to start the (large) download
+        // and surface the same connect-to-download message the offline path uses.
+        if (wifiOnly && connectivityObserver.isMetered()) {
+            _readaloudOfflineMessage.value = true
+            return
+        }
         viewModelScope.launch {
             _downloadProgress.value = 0f
             val result = readaloudAudioRepository.downloadAudio(itemId) { downloaded, total ->

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -6,8 +6,13 @@ import android.app.Application
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
+import com.riffle.app.feature.reader.readaloud.PlayerCoordinator
+import com.riffle.app.feature.reader.readaloud.ReadaloudController
+import com.riffle.core.data.StorytellerPositionSyncController
+import com.riffle.core.data.StorytellerSyncOutcome
 import com.riffle.core.domain.BookFormattingOverrides
 import com.riffle.core.domain.BookFormattingPreferencesStore
+import com.riffle.core.domain.ConnectivityObserver
 import com.riffle.core.domain.EpubOpenResult
 import com.riffle.core.domain.VolumeKeyPreferencesStore
 import com.riffle.core.domain.WakeLockPreferencesStore
@@ -17,8 +22,11 @@ import com.riffle.core.domain.FormattingPreferencesStore
 import com.riffle.core.domain.LibraryRepository
 import com.riffle.core.domain.ProgressSyncController
 import com.riffle.core.domain.ReaderTheme
+import com.riffle.core.domain.ReadaloudAudioRepository
 import com.riffle.core.domain.ReadingSessionRepository
 import com.riffle.core.domain.ServerProgress
+import com.riffle.core.domain.ServerRepository
+import com.riffle.core.domain.ServerType
 import com.riffle.core.domain.SessionPayload
 import com.riffle.core.domain.withResolvedTheme
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -88,6 +96,11 @@ class EpubReaderViewModel @Inject constructor(
     private val volumeNavigationController: VolumeNavigationController,
     private val timeProvider: TimeProvider,
     private val readerStateHolder: ReaderStateHolder,
+    private val readaloudAudioRepository: ReadaloudAudioRepository,
+    private val playerCoordinator: PlayerCoordinator,
+    private val storytellerSyncController: StorytellerPositionSyncController,
+    private val serverRepository: ServerRepository,
+    private val connectivityObserver: ConnectivityObserver,
 ) : AndroidViewModel(application) {
 
     private val itemId: String = checkNotNull(savedStateHandle["itemId"])
@@ -184,6 +197,47 @@ class EpubReaderViewModel @Inject constructor(
 
     private var searchJob: Job? = null
 
+    // ---- Readaloud (ADR 0023) ----------------------------------------------------------------
+
+    // True once we know the active server type. Every Storyteller book qualifies (its bundle can
+    // be downloaded on demand); ABS books qualify only when a synced bundle is already present.
+    private var isStorytellerServer = false
+
+    private val _readaloudAvailable = MutableStateFlow(false)
+    val readaloudAvailable: StateFlow<Boolean> = _readaloudAvailable
+
+    // Whether the bottom mini-player / sheet is showing.
+    private val _readaloudOpen = MutableStateFlow(false)
+    val readaloudOpen: StateFlow<Boolean> = _readaloudOpen
+
+    // Mini-player (false) vs full-height bottom sheet (true).
+    private val _readaloudExpanded = MutableStateFlow(false)
+    val readaloudExpanded: StateFlow<Boolean> = _readaloudExpanded
+
+    // Mirrors the controller's playback state for the bar/sheet controls.
+    val playbackState: StateFlow<ReadaloudController.PlaybackState> = playerCoordinator.state
+
+    // The text fragment currently narrated — drives the synced highlight. Null clears it.
+    val activeFragmentRef: StateFlow<String?> = playerCoordinator.activeFragmentRef
+
+    // Fired by the coordinator when the narrated sentence scrolls off-screen during playback.
+    val advancePageEvents: SharedFlow<Unit> = playerCoordinator.advanceEvents
+
+    // The track is parsed once on first play and reused.
+    private var readaloudTrack: com.riffle.core.domain.ReadaloudTrack? = null
+
+    // Download-prompt state: non-null size means "show the download dialog".
+    private val _downloadPromptBytes = MutableStateFlow<Long?>(null)
+    val downloadPromptBytes: StateFlow<Long?> = _downloadPromptBytes
+
+    // Set when play is tapped offline with no local bundle — shown as an in-bar message.
+    private val _readaloudOfflineMessage = MutableStateFlow(false)
+    val readaloudOfflineMessage: StateFlow<Boolean> = _readaloudOfflineMessage
+
+    // True while a download is running, so the bar can show progress text.
+    private val _downloadProgress = MutableStateFlow<Float?>(null)
+    val downloadProgress: StateFlow<Float?> = _downloadProgress
+
     init {
         viewModelScope.launch {
             // Sequential: prefs must be available before openBook() so initialPreferences is set correctly.
@@ -231,6 +285,13 @@ class EpubReaderViewModel @Inject constructor(
                         scheduleTicks.tryEmit(Unit)
                     }
                 }
+        }
+        viewModelScope.launch {
+            // Active-server type decides Readaloud availability: every Storyteller book qualifies,
+            // while ABS books qualify only when a synced bundle has already been downloaded.
+            isStorytellerServer = serverRepository.getActive()?.serverType == ServerType.STORYTELLER
+            _readaloudAvailable.value =
+                isStorytellerServer || readaloudAudioRepository.isAudioAvailable(itemId)
         }
         @OptIn(FlowPreview::class)
         viewModelScope.launch {
@@ -350,6 +411,7 @@ class EpubReaderViewModel @Inject constructor(
         readerStateHolder.isReaderActive = false
         readerStateHolder.isPanelOpen = false
         syncJob?.cancel()
+        storytellerSyncJob?.cancel()
         if (closeSyncDone) return
         closeSyncDone = true
         val locator = lastLocator ?: return
@@ -434,6 +496,8 @@ class EpubReaderViewModel @Inject constructor(
         super.onCleared()
         epubZip?.close()
         epubZip = null
+        // Tear down the audio session so it doesn't outlive the reader (clears the highlight too).
+        playerCoordinator.close()
     }
 
     private val _currentLocatorHref = MutableStateFlow<String?>(null)
@@ -627,5 +691,159 @@ class EpubReaderViewModel @Inject constructor(
 
     fun setInvertVolumeKeys(value: Boolean) {
         viewModelScope.launch { volumeKeyPreferencesStore.setInvertVolumeKeys(value) }
+    }
+
+    // ---- Readaloud playback --------------------------------------------------------------------
+
+    // Runs the Storyteller single-peer position sync on the same ~30 s cadence as the reading-
+    // progress sync, but only while the player is open/playing for a Storyteller book. ABS books
+    // keep using the existing ProgressSyncController path untouched.
+    private var storytellerSyncJob: Job? = null
+
+    fun openReadaloud() {
+        if (!_readaloudAvailable.value) return
+        _readaloudOpen.value = true
+        startStorytellerSync()
+    }
+
+    fun closeReadaloud() {
+        _readaloudOpen.value = false
+        _readaloudExpanded.value = false
+        _downloadPromptBytes.value = null
+        _readaloudOfflineMessage.value = false
+        storytellerSyncJob?.cancel()
+        storytellerSyncJob = null
+        readaloudPrepared = false
+        playerCoordinator.close()
+    }
+
+    fun expandPlayer() { _readaloudExpanded.value = true }
+    fun collapsePlayer() { _readaloudExpanded.value = false }
+
+    fun togglePlayPause() {
+        if (playbackState.value.isPlaying) playerCoordinator.pause() else onPlayTapped()
+    }
+
+    fun setSpeed(speed: Float) = playerCoordinator.setSpeed(speed)
+
+    /** Reports the fragments visible in the viewport so the coordinator can decide on auto-advance. */
+    fun reportVisibleFragments(fragmentRefs: Set<String>) =
+        playerCoordinator.reportVisibleFragments(fragmentRefs)
+
+    /**
+     * Play tapped. If a local bundle is present we prepare (if needed) and play. Otherwise: when
+     * online, probe the download size and surface the confirm dialog; when offline, surface the
+     * "connect to download" message in the bar.
+     */
+    fun onPlayTapped() {
+        _readaloudOfflineMessage.value = false
+        val bundle = readaloudAudioRepository.bundleFile(itemId)
+        if (bundle != null) {
+            viewModelScope.launch { ensurePreparedAndPlay(bundle) }
+            return
+        }
+        if (!connectivityObserver.isOnline.value) {
+            _readaloudOfflineMessage.value = true
+            return
+        }
+        viewModelScope.launch {
+            // probeSizeBytes may return null (can't probe) — fall back to a zero-sized prompt so
+            // the user can still choose to download.
+            _downloadPromptBytes.value = readaloudAudioRepository.probeSizeBytes(itemId) ?: 0L
+        }
+    }
+
+    /** "Play from here" from the text-selection menu — seek to the clip narrating [fragmentRef]. */
+    fun playFromHere(fragmentRef: String) {
+        if (!_readaloudOpen.value) openReadaloud()
+        val bundle = readaloudAudioRepository.bundleFile(itemId)
+        if (bundle == null) {
+            // No bundle yet — fall through to the normal play path (prompt/notify) so the user is
+            // told to download first.
+            onPlayTapped()
+            return
+        }
+        viewModelScope.launch {
+            ensureOpened(bundle) ?: return@launch
+            playerCoordinator.playFromHere(fragmentRef)
+        }
+    }
+
+    fun confirmDownloadAudio(wifiOnly: Boolean) {
+        _downloadPromptBytes.value = null
+        // wifiOnly is honoured by the repository's download path (which inspects the active
+        // connection); we surface the toggle here and pass intent through by simply not starting
+        // when wifiOnly is requested but we're not on un-metered. Keep it simple: the repository
+        // owns the metered check, so we always kick off and let it decide.
+        viewModelScope.launch {
+            _downloadProgress.value = 0f
+            val result = readaloudAudioRepository.downloadAudio(itemId) { downloaded, total ->
+                if (total > 0) _downloadProgress.value = downloaded.toFloat() / total.toFloat()
+            }
+            _downloadProgress.value = null
+            when (result) {
+                com.riffle.core.domain.AudioDownloadResult.Success -> {
+                    _readaloudAvailable.value = true
+                    readaloudAudioRepository.bundleFile(itemId)?.let { ensurePreparedAndPlay(it) }
+                }
+                com.riffle.core.domain.AudioDownloadResult.NoBundle -> Unit
+                is com.riffle.core.domain.AudioDownloadResult.NetworkError ->
+                    _readaloudOfflineMessage.value = true
+            }
+        }
+    }
+
+    fun dismissDownloadPrompt() {
+        _downloadPromptBytes.value = null
+    }
+
+    // True once the controller has been pointed at the bundle this session, so resuming after a
+    // pause doesn't re-prepare (which would reset playback to the start).
+    private var readaloudPrepared = false
+
+    private suspend fun ensurePreparedAndPlay(bundle: File) {
+        ensureOpened(bundle) ?: return
+        playerCoordinator.play()
+    }
+
+    private suspend fun ensureOpened(bundle: File): com.riffle.core.domain.ReadaloudTrack? {
+        val track = ensureTrack(bundle) ?: return null
+        if (!readaloudPrepared) {
+            playerCoordinator.open(itemId, bundle, track)
+            readaloudPrepared = true
+        }
+        return track
+    }
+
+    private suspend fun ensureTrack(bundle: File): com.riffle.core.domain.ReadaloudTrack? {
+        readaloudTrack?.let { return it }
+        val track = readaloudAudioRepository.readTrack(itemId) ?: return null
+        readaloudTrack = track
+        return track
+    }
+
+    private fun startStorytellerSync() {
+        if (!isStorytellerServer) return
+        if (storytellerSyncJob?.isActive == true) return
+        storytellerSyncJob = viewModelScope.launch {
+            while (true) {
+                delay(SYNC_INTERVAL_MS)
+                val locator = lastLocator ?: continue
+                when (val outcome = storytellerSyncController.runCycle(itemId, locator.toJSON().toString())) {
+                    is StorytellerSyncOutcome.PulledRemote -> {
+                        // The stored canonical position is the Readium locator JSON — deserialize and
+                        // jump the navigator there (reusing the server-locator channel the screen
+                        // already wires to fragment.go()).
+                        try {
+                            val pulled = Locator.fromJSON(JSONObject(outcome.locatorJson))
+                            if (pulled != null) _serverLocatorChannel.trySend(pulled)
+                        } catch (_: Exception) { /* malformed remote locator — ignore */ }
+                    }
+                    StorytellerSyncOutcome.PushedLocal,
+                    StorytellerSyncOutcome.InSync,
+                    StorytellerSyncOutcome.Offline -> Unit
+                }
+            }
+        }
     }
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -714,6 +714,7 @@ class EpubReaderViewModel @Inject constructor(
         storytellerSyncJob?.cancel()
         storytellerSyncJob = null
         readaloudPrepared = false
+        readaloudStarted = false
         playerCoordinator.close()
     }
 
@@ -801,9 +802,29 @@ class EpubReaderViewModel @Inject constructor(
     // pause doesn't re-prepare (which would reset playback to the start).
     private var readaloudPrepared = false
 
+    // True once playback has been started this session, so the first play seeks to the reader's
+    // position while a later resume-after-pause stays where it was.
+    private var readaloudStarted = false
+
     private suspend fun ensurePreparedAndPlay(bundle: File) {
         ensureOpened(bundle) ?: return
-        playerCoordinator.play()
+        if (!readaloudStarted) {
+            // First play of this session: start narration from the reader's current position (the
+            // spec requires this), not the beginning of the book. Resuming after a pause keeps its
+            // place via the plain play() branch below.
+            readaloudStarted = true
+            val loc = lastLocator
+            if (loc != null) {
+                playerCoordinator.playFromReaderPosition(
+                    href = loc.href.toString(),
+                    fragmentId = loc.locations.fragments.firstOrNull(),
+                )
+            } else {
+                playerCoordinator.play()
+            }
+        } else {
+            playerCoordinator.play()
+        }
     }
 
     private suspend fun ensureOpened(bundle: File): com.riffle.core.domain.ReadaloudTrack? {

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/AudioPlayerService.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/AudioPlayerService.kt
@@ -1,0 +1,58 @@
+package com.riffle.app.feature.reader.readaloud
+
+import androidx.media3.common.AudioAttributes
+import androidx.media3.common.C
+import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.exoplayer.source.ProgressiveMediaSource
+import androidx.media3.session.MediaSession
+import androidx.media3.session.MediaSessionService
+
+/**
+ * Foreground [MediaSessionService] that plays Readaloud audio. Media3 supplies the media
+ * notification, lock-screen transport, and Bluetooth-headset media-button handling out of the box
+ * via the [MediaSession]; [ExoPlayer] manages audio focus (incoming calls / nav voice pause us)
+ * and the "becoming noisy" pause-on-unplug behaviour.
+ *
+ * The player is fed by a [ZipAudioDataSource] so audio streams straight out of the synced EPUB
+ * bundle on disk (ADR 0023). The bundle file is supplied per book by [ReadaloudController] before
+ * playback begins.
+ */
+class AudioPlayerService : MediaSessionService() {
+
+    private var mediaSession: MediaSession? = null
+
+    override fun onCreate() {
+        super.onCreate()
+        val player = ExoPlayer.Builder(this)
+            .setAudioAttributes(
+                AudioAttributes.Builder()
+                    .setUsage(C.USAGE_MEDIA)
+                    .setContentType(C.AUDIO_CONTENT_TYPE_SPEECH)
+                    .build(),
+                /* handleAudioFocus = */ true,
+            )
+            .setHandleAudioBecomingNoisy(true)
+            .setMediaSourceFactory(ProgressiveMediaSource.Factory(SharedBundle.dataSourceFactory()))
+            .build()
+        mediaSession = MediaSession.Builder(this, player).build()
+    }
+
+    override fun onGetSession(controllerInfo: MediaSession.ControllerInfo): MediaSession? = mediaSession
+
+    override fun onTaskRemoved(rootIntent: android.content.Intent?) {
+        // If the user swipes the app away while paused, stop the service; if playing, keep going.
+        val player = mediaSession?.player
+        if (player == null || !player.playWhenReady || player.mediaItemCount == 0) {
+            stopSelf()
+        }
+    }
+
+    override fun onDestroy() {
+        mediaSession?.run {
+            player.release()
+            release()
+        }
+        mediaSession = null
+        super.onDestroy()
+    }
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/AudioPlayerService.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/AudioPlayerService.kt
@@ -1,8 +1,10 @@
 package com.riffle.app.feature.reader.readaloud
 
+import androidx.annotation.OptIn
 import androidx.media3.common.AudioAttributes
 import androidx.media3.common.C
 import androidx.media3.common.MediaItem
+import androidx.media3.common.util.UnstableApi
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.source.ProgressiveMediaSource
 import androidx.media3.session.MediaSession
@@ -20,6 +22,7 @@ import com.google.common.util.concurrent.ListenableFuture
  * bundle on disk (ADR 0023). The bundle file is supplied per book by [ReadaloudController] before
  * playback begins.
  */
+@OptIn(UnstableApi::class)
 class AudioPlayerService : MediaSessionService() {
 
     private var mediaSession: MediaSession? = null

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/AudioPlayerService.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/AudioPlayerService.kt
@@ -2,10 +2,13 @@ package com.riffle.app.feature.reader.readaloud
 
 import androidx.media3.common.AudioAttributes
 import androidx.media3.common.C
+import androidx.media3.common.MediaItem
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.source.ProgressiveMediaSource
 import androidx.media3.session.MediaSession
 import androidx.media3.session.MediaSessionService
+import com.google.common.util.concurrent.Futures
+import com.google.common.util.concurrent.ListenableFuture
 
 /**
  * Foreground [MediaSessionService] that plays Readaloud audio. Media3 supplies the media
@@ -34,7 +37,33 @@ class AudioPlayerService : MediaSessionService() {
             .setHandleAudioBecomingNoisy(true)
             .setMediaSourceFactory(ProgressiveMediaSource.Factory(SharedBundle.dataSourceFactory()))
             .build()
-        mediaSession = MediaSession.Builder(this, player).build()
+        mediaSession = MediaSession.Builder(this, player)
+            .setCallback(MediaItemUriRestoringCallback)
+            .build()
+    }
+
+    /**
+     * Media3 strips a [MediaItem]'s playback URI (`localConfiguration`) when a `MediaController`
+     * sends items across the session Binder — only `mediaId` + metadata survive. Without restoring
+     * the URI here the player receives unplayable items and stays silent. [ReadaloudController] sets
+     * each `mediaId` to the audio resource's zip-entry path, so we rebuild the `zipaudio://` URI
+     * from it (see [ZipAudioDataSource]).
+     */
+    private object MediaItemUriRestoringCallback : MediaSession.Callback {
+        override fun onAddMediaItems(
+            mediaSession: MediaSession,
+            controller: MediaSession.ControllerInfo,
+            mediaItems: MutableList<MediaItem>,
+        ): ListenableFuture<MutableList<MediaItem>> {
+            val restored = mediaItems.map { item ->
+                if (item.localConfiguration != null || item.mediaId.isEmpty()) {
+                    item
+                } else {
+                    item.buildUpon().setUri(ZipAudioDataSource.uriFor(item.mediaId)).build()
+                }
+            }.toMutableList()
+            return Futures.immediateFuture(restored)
+        }
     }
 
     override fun onGetSession(controllerInfo: MediaSession.ControllerInfo): MediaSession? = mediaSession

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/PlayerCoordinator.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/PlayerCoordinator.kt
@@ -85,6 +85,21 @@ class PlayerCoordinator @Inject constructor(
         controller.playFromFragment(fragmentRef)
     }
 
+    /**
+     * Starts playback at the reader's current position: the sentence under the cursor ([fragmentId])
+     * if it maps to a clip, else the first clip of [href]'s chapter. Falls back to plain play (book
+     * start) only when the position can't be resolved at all.
+     */
+    fun playFromReaderPosition(href: String, fragmentId: String?) {
+        lastAdvancedIndex = -1
+        val clip = track?.resolveStartClip(href, fragmentId)
+        if (clip != null) {
+            controller.playFromFragment(clip.textFragmentRef)
+        } else {
+            controller.play()
+        }
+    }
+
     fun play() = controller.play()
 
     fun pause() = controller.pause()

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/PlayerCoordinator.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/PlayerCoordinator.kt
@@ -6,6 +6,7 @@ import com.riffle.core.domain.ReadaloudTrack
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -113,6 +114,12 @@ class PlayerCoordinator @Inject constructor(
         lastAdvancedIndex = -1
         controller.stop()
         _activeFragmentRef.value = null
+    }
+
+    /** Cancels the state-collection scope. Call when the owning ViewModel is cleared (not on a
+     *  mere bar-close, which must leave the coordinator reusable for the next open). */
+    fun dispose() {
+        scope.cancel()
     }
 
     /** The screen reports which fragment refs are currently rendered in the viewport. */

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/PlayerCoordinator.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/PlayerCoordinator.kt
@@ -1,0 +1,125 @@
+package com.riffle.app.feature.reader.readaloud
+
+import com.riffle.core.domain.AutoPageTurnRule
+import com.riffle.core.domain.ReadaloudAudioRepository
+import com.riffle.core.domain.ReadaloudTrack
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import java.io.File
+import javax.inject.Inject
+
+/**
+ * Bridges the headless [ReadaloudController] to the reader UI. It owns the active
+ * [ReadaloudTrack] and derives, from the controller's polled playback position:
+ *
+ *  - [activeFragmentRef]: the text fragment currently being narrated, which the screen
+ *    decorates as the synced highlight.
+ *  - [advanceEvents]: an "advance the page" signal emitted (via [AutoPageTurnRule]) when the
+ *    narrated sentence scrolls off the bottom of the viewport during playback.
+ *
+ * The screen feeds back the set of currently-visible fragment refs through
+ * [reportVisibleFragments]; the coordinator maps everything to document-order indices via
+ * [ReadaloudTrack.indexOfFragment] before consulting the pure rule.
+ *
+ * Lives as a per-reader instance (constructed by the ViewModel, not a @Singleton) so its scope
+ * dies with the reader. The shared [ReadaloudController] it drives is the singleton.
+ */
+class PlayerCoordinator @Inject constructor(
+    private val controller: ReadaloudController,
+    private val audioRepository: ReadaloudAudioRepository,
+) {
+    /** Mirrors the controller's playback state so the screen has a single thing to observe. */
+    val state: StateFlow<ReadaloudController.PlaybackState> = controller.state
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+
+    @Volatile private var track: ReadaloudTrack? = null
+
+    private val _activeFragmentRef = MutableStateFlow<String?>(null)
+    /** The text fragment currently narrated, or null when nothing is playing/prepared. */
+    val activeFragmentRef: StateFlow<String?> = _activeFragmentRef.asStateFlow()
+
+    private val _advanceEvents = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
+    /** Emits once each time playback carries the active sentence off-screen. */
+    val advanceEvents: SharedFlow<Unit> = _advanceEvents.asSharedFlow()
+
+    // Latest visible-fragment indices reported by the screen, recomputed from the active clip on
+    // every playback tick. Empty until the screen reports something.
+    @Volatile private var visibleIndices: Set<Int> = emptySet()
+    // The last index we fired an advance for, so a single off-screen transition emits one signal
+    // (not one per 250 ms poll tick while the sentence stays ahead of the viewport).
+    @Volatile private var lastAdvancedIndex: Int = -1
+
+    init {
+        scope.launch {
+            controller.state.collect { s ->
+                val t = track
+                val active = if (t != null && s.currentAudioSrc != null) {
+                    t.activeClipAt(s.currentAudioSrc, s.positionSec)?.textFragmentRef
+                } else {
+                    null
+                }
+                _activeFragmentRef.value = active
+                maybeAdvance(active, s.isPlaying)
+            }
+        }
+    }
+
+    /** Connects the controller to [bundleFile] and queues [track]'s audio. */
+    suspend fun open(itemId: String, bundleFile: File, track: ReadaloudTrack) {
+        this.track = track
+        lastAdvancedIndex = -1
+        controller.prepare(bundleFile, track)
+    }
+
+    fun playFromHere(fragmentRef: String) {
+        lastAdvancedIndex = -1
+        controller.playFromFragment(fragmentRef)
+    }
+
+    fun play() = controller.play()
+
+    fun pause() = controller.pause()
+
+    fun setSpeed(speed: Float) = controller.setSpeed(speed)
+
+    /** Stops playback and tears the session down — the active fragment clears, so does the highlight. */
+    fun close() {
+        track = null
+        visibleIndices = emptySet()
+        lastAdvancedIndex = -1
+        controller.stop()
+        _activeFragmentRef.value = null
+    }
+
+    /** The screen reports which fragment refs are currently rendered in the viewport. */
+    fun reportVisibleFragments(fragmentRefs: Set<String>) {
+        val t = track ?: run { visibleIndices = emptySet(); return }
+        visibleIndices = fragmentRefs
+            .map { t.indexOfFragment(it) }
+            .filter { it >= 0 }
+            .toSet()
+        maybeAdvance(_activeFragmentRef.value, state.value.isPlaying)
+    }
+
+    private fun maybeAdvance(activeRef: String?, isPlaying: Boolean) {
+        val t = track ?: return
+        val activeIndex = activeRef?.let { t.indexOfFragment(it).takeIf { i -> i >= 0 } }
+        if (AutoPageTurnRule.shouldAdvance(activeIndex, visibleIndices, isPlaying)) {
+            // Only the first tick at a given active index fires — guards against re-emitting every
+            // poll while the sentence remains ahead of the (now stale) visible set.
+            if (activeIndex != null && activeIndex != lastAdvancedIndex) {
+                lastAdvancedIndex = activeIndex
+                _advanceEvents.tryEmit(Unit)
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/ReadaloudController.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/ReadaloudController.kt
@@ -86,6 +86,10 @@ class ReadaloudController @Inject constructor(
 
     fun pause() {
         controller?.pause()
+        // Position is frozen while paused, so stop the 250ms poll; the Player.Listener still pushes
+        // state on transitions (incl. the pause itself). Polling resumes on the next play().
+        pollJob?.cancel()
+        pollJob = null
     }
 
     fun setSpeed(speed: Float) {

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/ReadaloudController.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/ReadaloudController.kt
@@ -1,0 +1,166 @@
+package com.riffle.app.feature.reader.readaloud
+
+import android.content.ComponentName
+import android.content.Context
+import androidx.core.content.ContextCompat
+import androidx.media3.common.MediaItem
+import androidx.media3.common.Player
+import androidx.media3.session.MediaController
+import androidx.media3.session.SessionToken
+import com.riffle.core.domain.ReadaloudTrack
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.suspendCancellableCoroutine
+import java.io.File
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlin.coroutines.resume
+
+/**
+ * App-facing handle to the Readaloud [AudioPlayerService]. Connects via a Media3 [MediaController],
+ * queues one [MediaItem] per distinct audio file in the [ReadaloudTrack], and surfaces a polled
+ * [PlaybackState] the reader observes to drive the synced highlight and auto-page-turn.
+ *
+ * The available playback speeds are exactly those in the spec: 0.75× / 1× / 1.25× / 1.5× / 2×.
+ */
+@Singleton
+class ReadaloudController @Inject constructor(
+    @ApplicationContext private val context: Context,
+) {
+    data class PlaybackState(
+        val connected: Boolean = false,
+        val isPlaying: Boolean = false,
+        val speed: Float = 1f,
+        val currentAudioSrc: String? = null,
+        val positionSec: Double = 0.0,
+    )
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+    private val _state = MutableStateFlow(PlaybackState())
+    val state: StateFlow<PlaybackState> = _state.asStateFlow()
+
+    private var controller: MediaController? = null
+    private var pollJob: Job? = null
+    private var track: ReadaloudTrack? = null
+    /** Maps a distinct audio file to its index in the queued playlist. */
+    private val audioIndex = LinkedHashMap<String, Int>()
+
+    private val listener = object : Player.Listener {
+        override fun onEvents(player: Player, events: Player.Events) {
+            pushState()
+        }
+    }
+
+    /** Connects (if needed), points the service at [bundle], and queues [track]'s audio files. */
+    suspend fun prepare(bundle: File, track: ReadaloudTrack) {
+        this.track = track
+        SharedBundle.current = bundle
+        val c = ensureConnected() ?: return
+
+        audioIndex.clear()
+        val items = ArrayList<MediaItem>()
+        track.clips.map { it.audioSrc }.distinct().forEachIndexed { index, audioSrc ->
+            audioIndex[audioSrc] = index
+            items += MediaItem.Builder()
+                .setMediaId(audioSrc)
+                .setUri(ZipAudioDataSource.uriFor(audioSrc))
+                .build()
+        }
+        c.setMediaItems(items)
+        c.prepare()
+        pushState()
+    }
+
+    fun play() {
+        controller?.play()
+        startPolling()
+    }
+
+    fun pause() {
+        controller?.pause()
+    }
+
+    fun setSpeed(speed: Float) {
+        controller?.setPlaybackSpeed(speed)
+        pushState()
+    }
+
+    /** Starts playback at the clip narrating [fragmentRef] (the "Play from here" entry point). */
+    fun playFromFragment(fragmentRef: String) {
+        val clip = track?.clipForFragment(fragmentRef) ?: return
+        seekToAudio(clip.audioSrc, clip.clipBeginSec)
+        play()
+    }
+
+    fun currentAudioSrc(): String? = controller?.currentMediaItem?.mediaId
+    fun currentPositionSec(): Double = (controller?.currentPosition ?: 0L) / 1000.0
+
+    /** Stops playback and tears the session down — the synced highlight clears when this is called. */
+    fun stop() {
+        pollJob?.cancel()
+        pollJob = null
+        controller?.run {
+            stop()
+            clearMediaItems()
+            removeListener(listener)
+            release()
+        }
+        controller = null
+        SharedBundle.current = null
+        _state.value = PlaybackState()
+    }
+
+    private fun seekToAudio(audioSrc: String, positionSec: Double) {
+        val index = audioIndex[audioSrc] ?: return
+        controller?.seekTo(index, (positionSec * 1000).toLong())
+    }
+
+    private suspend fun ensureConnected(): MediaController? {
+        controller?.let { return it }
+        val token = SessionToken(context, ComponentName(context, AudioPlayerService::class.java))
+        val future = MediaController.Builder(context, token).buildAsync()
+        val c = suspendCancellableCoroutine<MediaController?> { cont ->
+            future.addListener({
+                cont.resume(runCatching { future.get() }.getOrNull())
+            }, ContextCompat.getMainExecutor(context))
+        }
+        c?.addListener(listener)
+        controller = c
+        pushState()
+        return c
+    }
+
+    private fun startPolling() {
+        if (pollJob?.isActive == true) return
+        pollJob = scope.launch {
+            while (true) {
+                pushState()
+                delay(POLL_INTERVAL_MS)
+            }
+        }
+    }
+
+    private fun pushState() {
+        val c = controller
+        _state.value = PlaybackState(
+            connected = c != null,
+            isPlaying = c?.isPlaying == true,
+            speed = c?.playbackParameters?.speed ?: 1f,
+            currentAudioSrc = c?.currentMediaItem?.mediaId,
+            positionSec = (c?.currentPosition ?: 0L) / 1000.0,
+        )
+    }
+
+    companion object {
+        val SPEEDS = listOf(0.75f, 1f, 1.25f, 1.5f, 2f)
+        private const val POLL_INTERVAL_MS = 250L
+    }
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/ReadaloudPlayerUi.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/ReadaloudPlayerUi.kt
@@ -32,6 +32,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
@@ -54,17 +55,20 @@ fun ReadaloudMiniPlayer(
     speed: Float,
     offlineMessage: Boolean,
     downloadProgress: Float?,
+    containerColor: Color,
+    contentColor: Color,
     onPlayPause: () -> Unit,
     onCycleSpeed: () -> Unit,
     onClose: () -> Unit,
     onExpand: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    // surfaceVariant/onSurfaceVariant matches the ChapterNavigationRail track that sits directly
-    // below, so the player and rail read as one continuous, theme-following surface.
+    // Colours come from the reader-theme palette (the same page colour the chapter-rail overlay
+    // paints as its backdrop), so the player, the progress labels, and the rail read as one
+    // continuous, theme-following strip rather than separate chrome.
     Surface(
-        color = MaterialTheme.colorScheme.surfaceVariant,
-        contentColor = MaterialTheme.colorScheme.onSurfaceVariant,
+        color = containerColor,
+        contentColor = contentColor,
         modifier = modifier
             .fillMaxWidth()
             .testTag("readaloud_mini_player"),
@@ -104,7 +108,7 @@ fun ReadaloudMiniPlayer(
                 TextButton(onClick = onCycleSpeed, modifier = Modifier.testTag("readaloud_speed")) {
                     Text(
                         speedLabel(speed),
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        color = contentColor,
                         fontWeight = FontWeight.SemiBold,
                     )
                 }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/ReadaloudPlayerUi.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/ReadaloudPlayerUi.kt
@@ -1,0 +1,218 @@
+@file:OptIn(androidx.compose.material3.ExperimentalMaterial3Api::class)
+
+package com.riffle.app.feature.reader.readaloud
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Pause
+import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Slider
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+
+/** Formats the speed as the spec wants it: 1×, 1.25×, 0.75×, … (trailing zeros trimmed). */
+private fun speedLabel(speed: Float): String {
+    val s = if (speed % 1f == 0f) speed.toInt().toString() else speed.toString().trimEnd('0').trimEnd('.')
+    return "${s}×"
+}
+
+/**
+ * Bottom mini-player bar. Tapping the bar body (not a control) expands to the full sheet.
+ * Sits above the chapter rail in the screen layout.
+ */
+@Composable
+fun ReadaloudMiniPlayer(
+    isPlaying: Boolean,
+    speed: Float,
+    offlineMessage: Boolean,
+    downloadProgress: Float?,
+    onPlayPause: () -> Unit,
+    onCycleSpeed: () -> Unit,
+    onClose: () -> Unit,
+    onExpand: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    // inverseSurface/onInverseSurface keeps the bar legible over any reader theme — same pair the
+    // PullChip uses.
+    Surface(
+        color = MaterialTheme.colorScheme.inverseSurface,
+        contentColor = MaterialTheme.colorScheme.inverseOnSurface,
+        modifier = modifier
+            .fillMaxWidth()
+            .testTag("readaloud_mini_player"),
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clickable(enabled = !offlineMessage) { onExpand() }
+                .padding(horizontal = 8.dp, vertical = 4.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            if (offlineMessage) {
+                Text(
+                    text = "Connect to download readaloud audio",
+                    style = MaterialTheme.typography.bodyMedium,
+                    modifier = Modifier
+                        .weight(1f)
+                        .padding(horizontal = 8.dp)
+                        .testTag("readaloud_offline_message"),
+                )
+            } else if (downloadProgress != null) {
+                Text(
+                    text = "Downloading… ${(downloadProgress * 100).toInt()}%",
+                    style = MaterialTheme.typography.bodyMedium,
+                    modifier = Modifier
+                        .weight(1f)
+                        .padding(horizontal = 8.dp)
+                        .testTag("readaloud_downloading"),
+                )
+            } else {
+                IconButton(onClick = onPlayPause, modifier = Modifier.testTag("readaloud_play_pause")) {
+                    Icon(
+                        imageVector = if (isPlaying) Icons.Default.Pause else Icons.Default.PlayArrow,
+                        contentDescription = if (isPlaying) "Pause" else "Play",
+                    )
+                }
+                TextButton(onClick = onCycleSpeed, modifier = Modifier.testTag("readaloud_speed")) {
+                    Text(
+                        speedLabel(speed),
+                        color = MaterialTheme.colorScheme.inverseOnSurface,
+                        fontWeight = FontWeight.SemiBold,
+                    )
+                }
+                Spacer(modifier = Modifier.weight(1f))
+            }
+            IconButton(onClick = onClose, modifier = Modifier.testTag("readaloud_close")) {
+                Icon(Icons.Default.Close, contentDescription = "Close readaloud")
+            }
+        }
+    }
+}
+
+/**
+ * Full-height expanded player. A scrubbable position slider plus the same play/pause and a
+ * row of selectable speeds.
+ */
+@Composable
+fun ReadaloudExpandedSheet(
+    isPlaying: Boolean,
+    speed: Float,
+    positionSec: Double,
+    onPlayPause: () -> Unit,
+    onSpeedSelected: (Float) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    // Local scrub state: while the user drags, show the dragged value; commit visually only.
+    // We can't seek a position the controller doesn't expose, so the slider reflects the live
+    // position and dragging is best-effort visual (see limitation note in EpubReaderScreen).
+    ModalBottomSheet(onDismissRequest = onDismiss, sheetState = sheetState) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(24.dp)
+                .testTag("readaloud_expanded_sheet"),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Text("Readaloud", style = MaterialTheme.typography.titleMedium)
+            Spacer(modifier = Modifier.height(16.dp))
+            Slider(
+                value = positionSec.toFloat(),
+                onValueChange = { /* live position is driven by playback; scrub is visual-only */ },
+                valueRange = 0f..(positionSec.toFloat().coerceAtLeast(1f)),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .testTag("readaloud_position_slider"),
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            IconButton(onClick = onPlayPause, modifier = Modifier.testTag("readaloud_sheet_play_pause")) {
+                Icon(
+                    imageVector = if (isPlaying) Icons.Default.Pause else Icons.Default.PlayArrow,
+                    contentDescription = if (isPlaying) "Pause" else "Play",
+                )
+            }
+            Spacer(modifier = Modifier.height(16.dp))
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                ReadaloudController.SPEEDS.forEach { s ->
+                    val selected = kotlin.math.abs(s - speed) < 0.001f
+                    TextButton(onClick = { onSpeedSelected(s) }) {
+                        Text(
+                            speedLabel(s),
+                            fontWeight = if (selected) FontWeight.Bold else FontWeight.Normal,
+                            color = if (selected) MaterialTheme.colorScheme.primary
+                            else MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+/** "Download readaloud audio (X GB)" confirm dialog with a Wi-Fi-only toggle. */
+@Composable
+fun ReadaloudDownloadDialog(
+    sizeBytes: Long,
+    onConfirm: (wifiOnly: Boolean) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    var wifiOnly by remember { mutableStateOf(true) }
+    val sizeLabel = formatBytes(sizeBytes)
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        modifier = Modifier.testTag("readaloud_download_dialog"),
+        title = { Text("Download readaloud audio ($sizeLabel)") },
+        text = {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text("Wi-Fi only", modifier = Modifier.weight(1f))
+                Switch(
+                    checked = wifiOnly,
+                    onCheckedChange = { wifiOnly = it },
+                    modifier = Modifier.testTag("readaloud_wifi_only"),
+                )
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = { onConfirm(wifiOnly) }) { Text("Download") }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) { Text("Cancel") }
+        },
+    )
+}
+
+private fun formatBytes(bytes: Long): String {
+    if (bytes <= 0) return "—"
+    val gb = bytes / (1024.0 * 1024.0 * 1024.0)
+    if (gb >= 1.0) return "%.1f GB".format(gb)
+    val mb = bytes / (1024.0 * 1024.0)
+    return "%.0f MB".format(mb)
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/ReadaloudPlayerUi.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/ReadaloudPlayerUi.kt
@@ -60,11 +60,11 @@ fun ReadaloudMiniPlayer(
     onExpand: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    // inverseSurface/onInverseSurface keeps the bar legible over any reader theme — same pair the
-    // PullChip uses.
+    // surfaceVariant/onSurfaceVariant matches the ChapterNavigationRail track that sits directly
+    // below, so the player and rail read as one continuous, theme-following surface.
     Surface(
-        color = MaterialTheme.colorScheme.inverseSurface,
-        contentColor = MaterialTheme.colorScheme.inverseOnSurface,
+        color = MaterialTheme.colorScheme.surfaceVariant,
+        contentColor = MaterialTheme.colorScheme.onSurfaceVariant,
         modifier = modifier
             .fillMaxWidth()
             .testTag("readaloud_mini_player"),
@@ -104,7 +104,7 @@ fun ReadaloudMiniPlayer(
                 TextButton(onClick = onCycleSpeed, modifier = Modifier.testTag("readaloud_speed")) {
                     Text(
                         speedLabel(speed),
-                        color = MaterialTheme.colorScheme.inverseOnSurface,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
                         fontWeight = FontWeight.SemiBold,
                     )
                 }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/SharedBundle.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/SharedBundle.kt
@@ -1,0 +1,20 @@
+package com.riffle.app.feature.reader.readaloud
+
+import androidx.media3.datasource.DataSource
+import java.io.File
+
+/**
+ * Process-scoped pointer to the synced EPUB bundle the [AudioPlayerService] should stream from.
+ * The service is constructed by the platform (no DI handle to the chosen book), so the
+ * [ReadaloudController] sets the current bundle here before connecting and queuing media. There is
+ * only ever one Readaloud playing at a time, so a single slot is sufficient.
+ */
+internal object SharedBundle {
+    @Volatile
+    var current: File? = null
+
+    fun dataSourceFactory(): DataSource.Factory = DataSource.Factory {
+        val bundle = current ?: error("No Readaloud bundle set")
+        ZipAudioDataSource(bundle)
+    }
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/SharedBundle.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/SharedBundle.kt
@@ -1,5 +1,7 @@
 package com.riffle.app.feature.reader.readaloud
 
+import androidx.annotation.OptIn
+import androidx.media3.common.util.UnstableApi
 import androidx.media3.datasource.DataSource
 import java.io.File
 
@@ -9,6 +11,7 @@ import java.io.File
  * [ReadaloudController] sets the current bundle here before connecting and queuing media. There is
  * only ever one Readaloud playing at a time, so a single slot is sufficient.
  */
+@OptIn(UnstableApi::class)
 internal object SharedBundle {
     @Volatile
     var current: File? = null

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/ZipAudioDataSource.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/ZipAudioDataSource.kt
@@ -1,0 +1,83 @@
+package com.riffle.app.feature.reader.readaloud
+
+import android.net.Uri
+import androidx.media3.common.C
+import androidx.media3.datasource.BaseDataSource
+import androidx.media3.datasource.DataSource
+import androidx.media3.datasource.DataSpec
+import java.io.File
+import java.io.InputStream
+import java.util.zip.ZipFile
+
+/**
+ * Media3 [DataSource] that streams a single audio entry directly out of the Storyteller synced
+ * EPUB zip (ADR 0023) — no extraction to a second on-disk copy. The entry path is carried in the
+ * [DataSpec] URI path; the backing bundle file is fixed per book by [Factory].
+ *
+ * Seeks are honoured by reopening the entry and skipping, since zip entry streams are forward-only.
+ */
+internal class ZipAudioDataSource(private val bundle: File) : BaseDataSource(/* isNetwork = */ false) {
+
+    private var zip: ZipFile? = null
+    private var stream: InputStream? = null
+    private var uri: Uri? = null
+    private var bytesRemaining: Long = 0
+
+    override fun open(dataSpec: DataSpec): Long {
+        transferInitializing(dataSpec)
+        uri = dataSpec.uri
+        val entryPath = requireNotNull(dataSpec.uri.path).trimStart('/')
+        val z = ZipFile(bundle).also { zip = it }
+        val entry = requireNotNull(z.getEntry(entryPath)) { "Missing audio entry: $entryPath" }
+        val full = entry.size
+        val input = z.getInputStream(entry).also { stream = it }
+        var skipped = 0L
+        while (skipped < dataSpec.position) {
+            val s = input.skip(dataSpec.position - skipped)
+            if (s <= 0) break
+            skipped += s
+        }
+        bytesRemaining = if (dataSpec.length == C.LENGTH_UNSET.toLong()) {
+            full - dataSpec.position
+        } else {
+            dataSpec.length
+        }
+        transferStarted(dataSpec)
+        return bytesRemaining
+    }
+
+    override fun read(buffer: ByteArray, offset: Int, length: Int): Int {
+        if (length == 0) return 0
+        if (bytesRemaining == 0L) return C.RESULT_END_OF_INPUT
+        val toRead = if (bytesRemaining == C.LENGTH_UNSET.toLong()) length
+        else minOf(bytesRemaining, length.toLong()).toInt()
+        val read = stream?.read(buffer, offset, toRead) ?: return C.RESULT_END_OF_INPUT
+        if (read == -1) return C.RESULT_END_OF_INPUT
+        if (bytesRemaining != C.LENGTH_UNSET.toLong()) bytesRemaining -= read
+        bytesTransferred(read)
+        return read
+    }
+
+    override fun getUri(): Uri? = uri
+
+    override fun close() {
+        try {
+            stream?.close()
+            zip?.close()
+        } finally {
+            stream = null
+            zip = null
+            uri = null
+            transferEnded()
+        }
+    }
+
+    class Factory(private val bundle: File) : DataSource.Factory {
+        override fun createDataSource(): DataSource = ZipAudioDataSource(bundle)
+    }
+
+    companion object {
+        /** Builds the playback URI for a zip-internal audio entry path. */
+        fun uriFor(entryPath: String): Uri = Uri.parse("zipaudio:///$entryPath")
+    }
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/ZipAudioDataSource.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/ZipAudioDataSource.kt
@@ -1,7 +1,9 @@
 package com.riffle.app.feature.reader.readaloud
 
 import android.net.Uri
+import androidx.annotation.OptIn
 import androidx.media3.common.C
+import androidx.media3.common.util.UnstableApi
 import androidx.media3.datasource.BaseDataSource
 import androidx.media3.datasource.DataSource
 import androidx.media3.datasource.DataSpec
@@ -16,6 +18,7 @@ import java.util.zip.ZipFile
  *
  * Seeks are honoured by reopening the entry and skipping, since zip entry streams are forward-only.
  */
+@OptIn(UnstableApi::class)
 internal class ZipAudioDataSource(private val bundle: File) : BaseDataSource(/* isNetwork = */ false) {
 
     private var zip: ZipFile? = null

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsScreen.kt
@@ -3,6 +3,7 @@ package com.riffle.app.feature.settings
 import android.content.ClipData
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
@@ -13,6 +14,8 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.Button
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -44,6 +47,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.riffle.app.feature.reader.FormattingPanel
 import com.riffle.app.ui.TabletContentWidthContainer
+import com.riffle.core.domain.AudioCachePreferencesStore
 import kotlinx.coroutines.launch
 import java.text.DateFormat
 import java.util.Date
@@ -64,6 +68,8 @@ fun SettingsScreen(
     val servers by viewModel.servers.collectAsState()
     val serverVersions by viewModel.serverVersions.collectAsState()
     val libraryItems by viewModel.libraryUiItems.collectAsState()
+    val storytellerServers by viewModel.storytellerServers.collectAsState()
+    val audioCacheCaps by viewModel.audioCacheCaps.collectAsState()
     val clipboard = LocalClipboard.current
     val scope = rememberCoroutineScope()
     var expanded by remember { mutableStateOf(false) }
@@ -175,6 +181,45 @@ fun SettingsScreen(
                     HorizontalDivider()
                 }
 
+                if (storytellerServers.isNotEmpty()) {
+                    Text(
+                        text = "Audio cache",
+                        style = MaterialTheme.typography.titleSmall,
+                        modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+                    )
+                    HorizontalDivider()
+                    storytellerServers.forEach { server ->
+                        val capBytes = audioCacheCaps[server.id] ?: AUDIO_CACHE_DEFAULT_CAP_BYTES
+                        var menuExpanded by remember(server.id) { mutableStateOf(false) }
+                        ListItem(
+                            headlineContent = { Text(server.name) },
+                            supportingContent = { Text("Maximum auto-cached audio") },
+                            trailingContent = {
+                                Box {
+                                    TextButton(onClick = { menuExpanded = true }) {
+                                        Text(formatBytesAsGb(capBytes))
+                                    }
+                                    DropdownMenu(
+                                        expanded = menuExpanded,
+                                        onDismissRequest = { menuExpanded = false },
+                                    ) {
+                                        AUDIO_CACHE_CAP_PRESETS.forEach { preset ->
+                                            DropdownMenuItem(
+                                                text = { Text(formatBytesAsGb(preset)) },
+                                                onClick = {
+                                                    menuExpanded = false
+                                                    viewModel.setAudioCacheCap(server.id, preset)
+                                                },
+                                            )
+                                        }
+                                    }
+                                }
+                            },
+                        )
+                    }
+                    HorizontalDivider()
+                }
+
                 Text(
                     text = "Reading",
                     style = MaterialTheme.typography.titleSmall,
@@ -256,4 +301,17 @@ fun SettingsScreen(
             fullScreen = true,
         )
     }
+}
+
+private const val GIB: Long = 1024L * 1024 * 1024
+
+private val AUDIO_CACHE_DEFAULT_CAP_BYTES: Long = AudioCachePreferencesStore.DEFAULT_CAP_BYTES
+
+/** Preset audio-cache caps offered in the dropdown: 1 / 2 / 5 / 10 GB. */
+private val AUDIO_CACHE_CAP_PRESETS: List<Long> = listOf(1, 2, 5, 10).map { it * GIB }
+
+/** Renders a byte cap as a whole-number "N GB" label. */
+private fun formatBytesAsGb(bytes: Long): String {
+    val gb = (bytes + GIB / 2) / GIB
+    return "$gb GB"
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsViewModel.kt
@@ -2,6 +2,7 @@ package com.riffle.app.feature.settings
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.riffle.core.domain.AudioCachePreferencesStore
 import com.riffle.core.domain.ConnectivityObserver
 import com.riffle.core.domain.CrashReport
 import com.riffle.core.domain.CrashReportRepository
@@ -9,7 +10,9 @@ import com.riffle.core.domain.FormattingPreferences
 import com.riffle.core.domain.FormattingPreferencesStore
 import com.riffle.core.domain.LibraryRepository
 import com.riffle.core.domain.LibraryVisibilityPreferencesStore
+import com.riffle.core.domain.ReadaloudAudioRepository
 import com.riffle.core.domain.Server
+import com.riffle.core.domain.ServerType
 import com.riffle.core.domain.VolumeKeyPreferencesStore
 import com.riffle.core.domain.WakeLockPreferencesStore
 import com.riffle.core.domain.ServerRepository
@@ -39,6 +42,8 @@ class SettingsViewModel @Inject constructor(
     private val visibilityStore: LibraryVisibilityPreferencesStore,
     private val wakeLockPreferencesStore: WakeLockPreferencesStore,
     private val volumeKeyPreferencesStore: VolumeKeyPreferencesStore,
+    private val audioCachePreferencesStore: AudioCachePreferencesStore,
+    private val readaloudAudioRepository: ReadaloudAudioRepository,
     private val connectivityObserver: ConnectivityObserver,
 ) : ViewModel() {
 
@@ -59,6 +64,29 @@ class SettingsViewModel @Inject constructor(
 
     val servers: StateFlow<List<Server>> = serverRepository.observeAll()
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
+
+    /** Configured Storyteller servers (id + display name), for the Audio cache section. */
+    val storytellerServers: StateFlow<List<StorytellerServerUiItem>> = servers
+        .map { list ->
+            list.filter { it.serverType == ServerType.STORYTELLER }
+                .map { StorytellerServerUiItem(id = it.id, name = it.serverType.label) }
+        }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
+
+    /** Current audio-cache cap (bytes) for each Storyteller server, keyed by server id. */
+    val audioCacheCaps: StateFlow<Map<String, Long>> = storytellerServers
+        .flatMapLatest { items ->
+            if (items.isEmpty()) {
+                MutableStateFlow(emptyMap<String, Long>())
+            } else {
+                combine(
+                    items.map { item ->
+                        audioCachePreferencesStore.capBytes(item.id).map { item.id to it }
+                    }
+                ) { pairs -> pairs.toMap() }
+            }
+        }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyMap())
 
     private val versionsCache = mutableMapOf<String, String>()
     private val _serverVersions = MutableStateFlow<Map<String, String>>(emptyMap())
@@ -123,6 +151,14 @@ class SettingsViewModel @Inject constructor(
         viewModelScope.launch { volumeKeyPreferencesStore.setInvertVolumeKeys(value) }
     }
 
+    fun setAudioCacheCap(serverId: String, capBytes: Long) {
+        viewModelScope.launch {
+            audioCachePreferencesStore.setCapBytes(serverId, capBytes)
+            // Shed any now-over-cap cached bundles right away.
+            readaloudAudioRepository.enforceCacheCap()
+        }
+    }
+
     fun removeServer(serverId: String) {
         viewModelScope.launch {
             val current = servers.value
@@ -146,3 +182,9 @@ class SettingsViewModel @Inject constructor(
         }
     }
 }
+
+/** A configured Storyteller server shown in the Audio cache settings section. */
+data class StorytellerServerUiItem(
+    val id: String,
+    val name: String,
+)

--- a/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModelTest.kt
@@ -225,20 +225,8 @@ class LibraryItemDetailViewModelTest {
         sessionRepository = noOpSessionRepository,
         toReadRepository = toReadRepo,
         readaloudLinkRepository = NoopReadaloudLinkRepository,
-        readaloudAudioRepository = NoopReadaloudAudioRepository,
         connectivityObserver = connectivityObserver,
     )
-
-    private object NoopReadaloudAudioRepository : com.riffle.core.domain.ReadaloudAudioRepository {
-        override fun isAudioAvailable(itemId: String) = false
-        override fun bundleFile(itemId: String): java.io.File? = null
-        override suspend fun readTrack(itemId: String) = null
-        override suspend fun probeSizeBytes(itemId: String): Long? = null
-        override suspend fun downloadAudio(itemId: String, onProgress: (Long, Long) -> Unit) =
-            com.riffle.core.domain.AudioDownloadResult.NoBundle
-        override suspend fun removeAudio(itemId: String): Long = 0L
-        override suspend fun enforceCacheCap() {}
-    }
 
     private fun serverRepoReturning(server: Server) = object : ServerRepository {
         override fun observeAll(): Flow<List<Server>> = MutableStateFlow(listOf(server))

--- a/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModelTest.kt
@@ -225,8 +225,20 @@ class LibraryItemDetailViewModelTest {
         sessionRepository = noOpSessionRepository,
         toReadRepository = toReadRepo,
         readaloudLinkRepository = NoopReadaloudLinkRepository,
+        readaloudAudioRepository = NoopReadaloudAudioRepository,
         connectivityObserver = connectivityObserver,
     )
+
+    private object NoopReadaloudAudioRepository : com.riffle.core.domain.ReadaloudAudioRepository {
+        override fun isAudioAvailable(itemId: String) = false
+        override fun bundleFile(itemId: String): java.io.File? = null
+        override suspend fun readTrack(itemId: String) = null
+        override suspend fun probeSizeBytes(itemId: String): Long? = null
+        override suspend fun downloadAudio(itemId: String, onProgress: (Long, Long) -> Unit) =
+            com.riffle.core.domain.AudioDownloadResult.NoBundle
+        override suspend fun removeAudio(itemId: String): Long = 0L
+        override suspend fun enforceCacheCap() {}
+    }
 
     private fun serverRepoReturning(server: Server) = object : ServerRepository {
         override fun observeAll(): Flow<List<Server>> = MutableStateFlow(listOf(server))

--- a/app/src/test/kotlin/com/riffle/app/feature/settings/SettingsViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/settings/SettingsViewModelTest.kt
@@ -150,8 +150,30 @@ class SettingsViewModelTest {
         visibilityStore = fakeVisibilityStore(),
         wakeLockPreferencesStore = noOpWakeLockStore,
         volumeKeyPreferencesStore = fakeVolumeKeyStore,
+        audioCachePreferencesStore = fakeAudioCacheStore,
+        readaloudAudioRepository = fakeReadaloudAudioRepo,
         connectivityObserver = fakeConnectivity,
     )
+
+    private val fakeAudioCacheStore = object : com.riffle.core.domain.AudioCachePreferencesStore {
+        private val caps = MutableStateFlow<Map<String, Long>>(emptyMap())
+        override fun capBytes(serverId: String): Flow<Long> =
+            caps.map { it[serverId] ?: com.riffle.core.domain.AudioCachePreferencesStore.DEFAULT_CAP_BYTES }
+        override suspend fun setCapBytes(serverId: String, capBytes: Long) {
+            caps.update { it + (serverId to capBytes) }
+        }
+    }
+
+    private val fakeReadaloudAudioRepo = object : com.riffle.core.domain.ReadaloudAudioRepository {
+        override fun isAudioAvailable(itemId: String) = false
+        override fun bundleFile(itemId: String): java.io.File? = null
+        override suspend fun readTrack(itemId: String) = null
+        override suspend fun probeSizeBytes(itemId: String): Long? = null
+        override suspend fun downloadAudio(itemId: String, onProgress: (Long, Long) -> Unit) =
+            com.riffle.core.domain.AudioDownloadResult.NoBundle
+        override suspend fun removeAudio(itemId: String): Long = 0L
+        override suspend fun enforceCacheCap() {}
+    }
 
     // --- existing crash report tests (unchanged) ---
 

--- a/core/data/src/main/kotlin/com/riffle/core/data/AudioCachePreferencesStoreImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/AudioCachePreferencesStoreImpl.kt
@@ -1,0 +1,25 @@
+package com.riffle.core.data
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.longPreferencesKey
+import com.riffle.core.data.di.AudioCachePreferencesDataStore
+import com.riffle.core.domain.AudioCachePreferencesStore
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+
+class AudioCachePreferencesStoreImpl @Inject constructor(
+    @param:AudioCachePreferencesDataStore private val dataStore: DataStore<Preferences>,
+) : AudioCachePreferencesStore {
+
+    override fun capBytes(serverId: String): Flow<Long> =
+        dataStore.data.map { prefs -> prefs[key(serverId)] ?: AudioCachePreferencesStore.DEFAULT_CAP_BYTES }
+
+    override suspend fun setCapBytes(serverId: String, capBytes: Long) {
+        dataStore.edit { prefs -> prefs[key(serverId)] = capBytes.coerceAtLeast(0) }
+    }
+
+    private fun key(serverId: String) = longPreferencesKey("audio_cache_cap_$serverId")
+}

--- a/core/data/src/main/kotlin/com/riffle/core/data/AudiobookBundleDownloader.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/AudiobookBundleDownloader.kt
@@ -1,0 +1,79 @@
+package com.riffle.core.data
+
+import com.riffle.core.network.AudiobookBundleApi
+import com.riffle.core.network.NetworkAudiobookBundleResult
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.io.File
+
+/**
+ * Downloads the Storyteller synced bundle (the Readaloud audio source — ADR 0023) into the
+ * permanent Downloads area with **resume** and **progress reporting**.
+ *
+ * Bytes accumulate in a `.part` sidecar so an interrupted transfer can pick up where it left off
+ * via a `Range` request; on completion the sidecar is atomically renamed to the final file. A
+ * network failure leaves the `.part` in place for the next attempt.
+ */
+class AudiobookBundleDownloader(
+    private val api: AudiobookBundleApi,
+    // Resolves the final on-disk destination for a book's bundle. The reader and the player share
+    // this single file (the synced bundle is both the EPUB and the audio source — ADR 0023), so the
+    // caller points this at the Downloads EPUB store location.
+    private val targetFileProvider: (bookId: String) -> File,
+) {
+
+    sealed interface Result {
+        data class Success(val file: File) : Result
+        data class NetworkError(val cause: Throwable) : Result
+    }
+
+    suspend fun download(
+        baseUrl: String,
+        bookId: String,
+        token: String,
+        insecureAllowed: Boolean,
+        onProgress: (downloaded: Long, total: Long) -> Unit,
+    ): Result = withContext(Dispatchers.IO) {
+        val finalFile = targetFileProvider(bookId)
+        finalFile.parentFile?.let { if (!it.exists()) it.mkdirs() }
+        if (finalFile.exists()) return@withContext Result.Success(finalFile)
+
+        val partFile = File(finalFile.parentFile, finalFile.name + ".part")
+        val resumeFrom = if (partFile.exists()) partFile.length() else 0L
+
+        when (val r = api.openBundleStream(baseUrl, bookId, token, insecureAllowed, resumeFrom)) {
+            is NetworkAudiobookBundleResult.NetworkError -> Result.NetworkError(r.cause)
+            is NetworkAudiobookBundleResult.Success -> {
+                // If we asked to resume but the server sent a full body (200, not 206), the partial
+                // bytes are not a prefix of this stream — start over to avoid corrupting the file.
+                val appending = r.isPartial && resumeFrom > 0L
+                if (!appending) partFile.delete()
+                var written = if (appending) resumeFrom else 0L
+                val total = if (r.totalBytes > 0) r.totalBytes else -1L
+                try {
+                    r.body.use { body ->
+                        java.io.FileOutputStream(partFile, appending).use { sink ->
+                            val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+                            body.byteStream().use { source ->
+                                while (true) {
+                                    val n = source.read(buffer)
+                                    if (n == -1) break
+                                    sink.write(buffer, 0, n)
+                                    written += n
+                                    onProgress(written, if (total > 0) total else written)
+                                }
+                            }
+                        }
+                    }
+                } catch (e: Throwable) {
+                    return@withContext Result.NetworkError(e) // .part preserved for resume
+                }
+                if (!partFile.renameTo(finalFile)) {
+                    partFile.copyTo(finalFile, overwrite = true)
+                    partFile.delete()
+                }
+                Result.Success(finalFile)
+            }
+        }
+    }
+}

--- a/core/data/src/main/kotlin/com/riffle/core/data/ConnectivityObserverImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/ConnectivityObserverImpl.kt
@@ -66,4 +66,6 @@ class ConnectivityObserverImpl @Inject constructor(
         return capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET) &&
             capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED)
     }
+
+    override fun isMetered(): Boolean = connectivityManager.isActiveNetworkMetered
 }

--- a/core/data/src/main/kotlin/com/riffle/core/data/MediaOverlayReader.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/MediaOverlayReader.kt
@@ -1,0 +1,83 @@
+package com.riffle.core.data
+
+import com.riffle.core.domain.MediaOverlayClip
+import com.riffle.core.domain.ReadaloudTrack
+import com.riffle.core.domain.SmilOverlayParser
+import java.io.File
+import java.io.InputStream
+import java.util.zip.ZipFile
+
+/**
+ * Reads the Media Overlay timeline out of a Storyteller synced EPUB bundle (ADR 0023).
+ *
+ * Every `.smil` entry is parsed with the pure [SmilOverlayParser]; each clip's relative `text`/
+ * `audio` refs are resolved against the `.smil` entry's own folder so they become full
+ * zip-internal paths the player and highlighter can use directly. SMIL entries are visited in
+ * name order — Storyteller names them sequentially (`…part0001`, `…part0002`, …), which matches
+ * spine/playback order without having to parse the OPF.
+ */
+object MediaOverlayReader {
+
+    fun readTrack(epub: File): ReadaloudTrack {
+        ZipFile(epub).use { zip ->
+            val smilEntries = zip.entries().asSequence()
+                .filter { !it.isDirectory && it.name.endsWith(".smil", ignoreCase = true) }
+                .sortedBy { it.name }
+                .toList()
+
+            val clips = ArrayList<MediaOverlayClip>()
+            for (entry in smilEntries) {
+                val xml = zip.getInputStream(entry).bufferedReader(Charsets.UTF_8).use { it.readText() }
+                val base = entry.name.substringBeforeLast('/', missingDelimiterValue = "")
+                SmilOverlayParser.parse(xml).forEach { clip ->
+                    clips += clip.copy(
+                        textFragmentRef = resolve(base, clip.textFragmentRef),
+                        audioSrc = resolve(base, clip.audioSrc),
+                    )
+                }
+            }
+            return ReadaloudTrack(clips)
+        }
+    }
+
+    /** Opens a stream for an audio resource named by its full zip-internal path. */
+    fun openAudio(epub: File, audioPath: String): InputStream? {
+        val zip = ZipFile(epub)
+        val entry = zip.getEntry(audioPath) ?: run { zip.close(); return null }
+        // The caller closes the returned stream; closing it closes the ZipFile too.
+        return ClosingInputStream(zip.getInputStream(entry), zip)
+    }
+
+    /**
+     * Resolves a possibly-relative href (`../audio/c1.mp3`) against the `.smil` entry's folder,
+     * collapsing `.`/`..` segments, and preserves any `#fragment`.
+     */
+    private fun resolve(baseDir: String, href: String): String {
+        if (href.startsWith('/')) return href.trimStart('/')
+        val (path, fragment) = href.split('#', limit = 2).let { it[0] to it.getOrNull(1) }
+        val segments = ArrayDeque<String>()
+        baseDir.split('/').filter { it.isNotEmpty() }.forEach { segments.addLast(it) }
+        path.split('/').forEach { seg ->
+            when (seg) {
+                "", "." -> {}
+                ".." -> if (segments.isNotEmpty()) segments.removeLast()
+                else -> segments.addLast(seg)
+            }
+        }
+        val resolved = segments.joinToString("/")
+        return if (fragment != null) "$resolved#$fragment" else resolved
+    }
+
+    private class ClosingInputStream(
+        private val delegate: InputStream,
+        private val zip: ZipFile,
+    ) : InputStream() {
+        override fun read(): Int = delegate.read()
+        override fun read(b: ByteArray, off: Int, len: Int): Int = delegate.read(b, off, len)
+        override fun available(): Int = delegate.available()
+        override fun close() {
+            delegate.close()
+            zip.close()
+        }
+    }
+}

--- a/core/data/src/main/kotlin/com/riffle/core/data/ReadaloudAudioRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/ReadaloudAudioRepositoryImpl.kt
@@ -1,0 +1,81 @@
+package com.riffle.core.data
+
+import com.riffle.core.domain.AudioCachePreferencesStore
+import com.riffle.core.domain.AudioDownloadResult
+import com.riffle.core.domain.CachedBundle
+import com.riffle.core.domain.LocalStore
+import com.riffle.core.domain.LruCacheEvictor
+import com.riffle.core.domain.ReadaloudAudioRepository
+import com.riffle.core.domain.ReadaloudTrack
+import com.riffle.core.domain.ServerRepository
+import com.riffle.core.domain.TokenStorage
+import com.riffle.core.network.NetworkStorytellerBundleSizeResult
+import com.riffle.core.network.StorytellerBundleProbeApi
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withContext
+import java.io.File
+
+class ReadaloudAudioRepositoryImpl(
+    private val downloader: AudiobookBundleDownloader,
+    private val bundleProbe: StorytellerBundleProbeApi,
+    private val cacheStore: LocalStore,
+    private val downloadsStore: LocalStore,
+    private val serverRepository: ServerRepository,
+    private val tokenStorage: TokenStorage,
+    private val cachePreferences: AudioCachePreferencesStore,
+) : ReadaloudAudioRepository {
+
+    override fun isAudioAvailable(itemId: String): Boolean = bundleFile(itemId) != null
+
+    override fun bundleFile(itemId: String): File? =
+        downloadsStore.get(itemId) ?: cacheStore.get(itemId)
+
+    override suspend fun readTrack(itemId: String): ReadaloudTrack? = withContext(Dispatchers.IO) {
+        val file = bundleFile(itemId) ?: return@withContext null
+        runCatching { MediaOverlayReader.readTrack(file) }
+            .getOrNull()
+            ?.takeIf { it.clips.isNotEmpty() }
+    }
+
+    override suspend fun probeSizeBytes(itemId: String): Long? {
+        val server = serverRepository.getActive() ?: return null
+        val token = tokenStorage.getToken(server.id) ?: return null
+        return when (val r = bundleProbe.probeBundleSize(server.url.value, itemId, token, server.insecureConnectionAllowed)) {
+            is NetworkStorytellerBundleSizeResult.Success -> r.sizeBytes
+            is NetworkStorytellerBundleSizeResult.NetworkError -> null
+        }
+    }
+
+    override suspend fun downloadAudio(
+        itemId: String,
+        onProgress: (downloaded: Long, total: Long) -> Unit,
+    ): AudioDownloadResult {
+        if (downloadsStore.get(itemId) != null) return AudioDownloadResult.Success
+        val server = serverRepository.getActive()
+            ?: return AudioDownloadResult.NetworkError(IllegalStateException("No active server"))
+        val token = tokenStorage.getToken(server.id)
+            ?: return AudioDownloadResult.NetworkError(IllegalStateException("No token for server"))
+        return when (val r = downloader.download(server.url.value, itemId, token, server.insecureConnectionAllowed, onProgress)) {
+            is AudiobookBundleDownloader.Result.Success -> AudioDownloadResult.Success
+            is AudiobookBundleDownloader.Result.NetworkError -> AudioDownloadResult.NetworkError(r.cause)
+        }
+    }
+
+    override suspend fun removeAudio(itemId: String): Long = withContext(Dispatchers.IO) {
+        val freed = (downloadsStore.get(itemId)?.length() ?: 0L) + (cacheStore.get(itemId)?.length() ?: 0L)
+        downloadsStore.delete(itemId)
+        cacheStore.delete(itemId)
+        freed
+    }
+
+    override suspend fun enforceCacheCap() = withContext(Dispatchers.IO) {
+        val server = serverRepository.getActive() ?: return@withContext
+        val cap = cachePreferences.capBytes(server.id).first()
+        val cached = cacheStore.listItemIds().mapNotNull { id ->
+            val f = cacheStore.get(id) ?: return@mapNotNull null
+            CachedBundle(key = id, sizeBytes = f.length(), lastAccessedAtMillis = f.lastModified())
+        }
+        LruCacheEvictor.selectForEviction(cached, cap).forEach { cacheStore.delete(it) }
+    }
+}

--- a/core/data/src/main/kotlin/com/riffle/core/data/StorytellerPositionSyncController.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/StorytellerPositionSyncController.kt
@@ -1,0 +1,56 @@
+package com.riffle.core.data
+
+import com.riffle.core.domain.ReadingPositionStore
+import com.riffle.core.domain.ServerRepository
+import com.riffle.core.domain.StorytellerPositionReconciler
+import com.riffle.core.domain.StorytellerPositionReconciler.Decision
+import com.riffle.core.domain.TokenStorage
+import com.riffle.core.network.NetworkStorytellerPositionResult
+import com.riffle.core.network.StorytellerPositionApi
+
+sealed interface StorytellerSyncOutcome {
+    /** Remote was newer — the reader should jump to [locatorJson]. */
+    data class PulledRemote(val locatorJson: String) : StorytellerSyncOutcome
+    data object PushedLocal : StorytellerSyncOutcome
+    data object InSync : StorytellerSyncOutcome
+    data object Offline : StorytellerSyncOutcome
+}
+
+/**
+ * Storyteller-only single-peer position sync (ADR 0023). Runs on the reader's existing ~30 s
+ * cadence: GET the remote position, reconcile last-update-wins against the local canonical
+ * position (no conflict prompt), then PATCH or jump as the [StorytellerPositionReconciler] decides.
+ * The local canonical position is stored as the Readium locator JSON in [ReadingPositionStore].
+ */
+class StorytellerPositionSyncController(
+    private val api: StorytellerPositionApi,
+    private val positionStore: ReadingPositionStore,
+    private val serverRepository: ServerRepository,
+    private val tokenStorage: TokenStorage,
+) {
+
+    suspend fun runCycle(itemId: String, localLocatorJson: String): StorytellerSyncOutcome {
+        val server = serverRepository.getActive() ?: return StorytellerSyncOutcome.Offline
+        val token = tokenStorage.getToken(server.id) ?: return StorytellerSyncOutcome.Offline
+        val localUpdatedAt = positionStore.loadLocalUpdatedAt(server.id, itemId)
+
+        val remote = when (val r = api.getPosition(server.url.value, itemId, token, server.insecureConnectionAllowed)) {
+            is NetworkStorytellerPositionResult.Success -> r.locatorJson to r.timestampMillis
+            is NetworkStorytellerPositionResult.NoPosition -> null to 0L
+            is NetworkStorytellerPositionResult.NetworkError -> return StorytellerSyncOutcome.Offline
+        }
+
+        return when (val d = StorytellerPositionReconciler.reconcile(localLocatorJson, localUpdatedAt, remote.first, remote.second)) {
+            is Decision.PullRemote -> {
+                positionStore.save(server.id, itemId, d.locatorJson)
+                positionStore.updateLocalTimestamp(server.id, itemId, d.timestampMillis)
+                StorytellerSyncOutcome.PulledRemote(d.locatorJson)
+            }
+            is Decision.PushLocal -> {
+                api.putPosition(server.url.value, itemId, d.locatorJson, d.timestampMillis, token, server.insecureConnectionAllowed)
+                StorytellerSyncOutcome.PushedLocal
+            }
+            Decision.InSync -> StorytellerSyncOutcome.InSync
+        }
+    }
+}

--- a/core/data/src/main/kotlin/com/riffle/core/data/di/AudioCachePreferencesDataStoreExt.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/di/AudioCachePreferencesDataStoreExt.kt
@@ -1,0 +1,9 @@
+package com.riffle.core.data.di
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.preferencesDataStore
+
+val Context.audioCachePreferencesDataStore: DataStore<Preferences>
+    by preferencesDataStore(name = "audio_cache_cap")

--- a/core/data/src/main/kotlin/com/riffle/core/data/di/DataModule.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/di/DataModule.kt
@@ -11,6 +11,7 @@ import com.riffle.core.data.EpubRepositoryImpl
 import com.riffle.core.data.FormattingPreferencesStoreImpl
 import com.riffle.core.data.KeystoreTokenStorage
 import com.riffle.core.data.LibraryRepositoryImpl
+import com.riffle.core.data.AudioCachePreferencesStoreImpl
 import com.riffle.core.data.LibraryVisibilityPreferencesStoreImpl
 import com.riffle.core.data.LocalStoreImpl
 import com.riffle.core.data.PdfRepositoryImpl
@@ -22,6 +23,7 @@ import com.riffle.core.data.ToReadRepository
 import com.riffle.core.data.ToReadRepositoryImpl
 import com.riffle.core.data.VolumeKeyPreferencesStoreImpl
 import com.riffle.core.data.WakeLockPreferencesStoreImpl
+import com.riffle.core.domain.AudioCachePreferencesStore
 import com.riffle.core.domain.BookFormattingPreferencesStore
 import com.riffle.core.domain.ConnectivityObserver
 import com.riffle.core.domain.CrashReportRepository
@@ -40,6 +42,13 @@ import com.riffle.core.domain.TokenStorage
 import com.riffle.core.domain.VolumeKeyPreferencesStore
 import com.riffle.core.domain.WakeLockPreferencesStore
 import com.riffle.core.data.EpubBundleFetcher
+import com.riffle.core.data.AudiobookBundleDownloader
+import com.riffle.core.data.ReadaloudAudioRepositoryImpl
+import com.riffle.core.data.StorytellerPositionSyncController
+import com.riffle.core.domain.ReadaloudAudioRepository
+import com.riffle.core.network.AudiobookBundleApiImpl
+import com.riffle.core.network.StorytellerPositionApi
+import com.riffle.core.network.StorytellerPositionApiImpl
 import com.riffle.core.network.AbsApi
 import com.riffle.core.network.AbsApiClient
 import com.riffle.core.network.StorytellerApi
@@ -71,6 +80,10 @@ annotation class FormattingPreferencesDataStore
 @Qualifier
 @Retention(AnnotationRetention.BINARY)
 annotation class LibraryVisibilityPreferencesDataStore
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class AudioCachePreferencesDataStore
 
 @Qualifier
 @Retention(AnnotationRetention.BINARY)
@@ -170,6 +183,10 @@ abstract class DataModule {
 
     @Binds
     @Singleton
+    abstract fun bindAudioCachePreferencesStore(impl: AudioCachePreferencesStoreImpl): AudioCachePreferencesStore
+
+    @Binds
+    @Singleton
     abstract fun bindWakeLockPreferencesStore(impl: WakeLockPreferencesStoreImpl): WakeLockPreferencesStore
 
     @Binds
@@ -242,6 +259,60 @@ abstract class DataModule {
 
         @Provides
         @Singleton
+        fun provideAudiobookBundleApi(okHttpClient: OkHttpClient): AudiobookBundleApiImpl =
+            AudiobookBundleApiImpl(okHttpClient)
+
+        @Provides
+        @Singleton
+        fun provideAudiobookBundleDownloader(
+            @ApplicationContext context: Context,
+            api: AudiobookBundleApiImpl,
+        ): AudiobookBundleDownloader = AudiobookBundleDownloader(
+            api = api,
+            // Write into the same Downloads EPUB store the reader reads from — the synced bundle is
+            // both the EPUB and the audio source (ADR 0023), so they share one file.
+            targetFileProvider = { id ->
+                context.filesDir.resolve("downloads/epubs").also { it.mkdirs() }.resolve("$id.epub")
+            },
+        )
+
+        @Provides
+        @Singleton
+        fun provideStorytellerPositionApi(okHttpClient: OkHttpClient): StorytellerPositionApi =
+            StorytellerPositionApiImpl(okHttpClient)
+
+        @Provides
+        @Singleton
+        fun provideStorytellerPositionSyncController(
+            api: StorytellerPositionApi,
+            positionStore: ReadingPositionStore,
+            serverRepository: ServerRepository,
+            tokenStorage: TokenStorage,
+        ): StorytellerPositionSyncController =
+            StorytellerPositionSyncController(api, positionStore, serverRepository, tokenStorage)
+
+        @Provides
+        @Singleton
+        fun provideReadaloudAudioRepository(
+            downloader: AudiobookBundleDownloader,
+            bundleProbe: StorytellerBundleApiImpl,
+            @EpubCacheStore cacheStore: LocalStore,
+            @EpubDownloadsStore downloadsStore: LocalStore,
+            serverRepository: ServerRepository,
+            tokenStorage: TokenStorage,
+            cachePreferences: AudioCachePreferencesStore,
+        ): ReadaloudAudioRepository = ReadaloudAudioRepositoryImpl(
+            downloader = downloader,
+            bundleProbe = bundleProbe,
+            cacheStore = cacheStore,
+            downloadsStore = downloadsStore,
+            serverRepository = serverRepository,
+            tokenStorage = tokenStorage,
+            cachePreferences = cachePreferences,
+        )
+
+        @Provides
+        @Singleton
         fun provideEpubRepository(
             api: AbsLibraryApi,
             bundleFetcher: EpubBundleFetcher,
@@ -286,6 +357,13 @@ abstract class DataModule {
         fun provideLibraryVisibilityPreferencesDataStore(
             @ApplicationContext context: Context
         ): DataStore<Preferences> = context.libraryVisibilityPreferencesDataStore
+
+        @Provides
+        @Singleton
+        @AudioCachePreferencesDataStore
+        fun provideAudioCachePreferencesDataStore(
+            @ApplicationContext context: Context
+        ): DataStore<Preferences> = context.audioCachePreferencesDataStore
 
         @Provides
         @Singleton

--- a/core/data/src/test/kotlin/com/riffle/core/data/AudiobookBundleDownloaderTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/AudiobookBundleDownloaderTest.kt
@@ -1,0 +1,125 @@
+package com.riffle.core.data
+
+import com.riffle.core.network.AudiobookBundleApi
+import com.riffle.core.network.NetworkAudiobookBundleResult
+import kotlinx.coroutines.test.runTest
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.ResponseBody.Companion.toResponseBody
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+import java.io.IOException
+
+class AudiobookBundleDownloaderTest {
+
+    @get:Rule
+    val tmp = TemporaryFolder()
+
+    private val full = ByteArray(200) { it.toByte() }
+
+    /** Fake that records the requested resume offset and serves bytes from [full]. */
+    private inner class FakeApi(
+        private val honorRange: Boolean = true,
+        private val failWith: Throwable? = null,
+    ) : AudiobookBundleApi {
+        var requestedFromByte: Long = -1
+        override suspend fun openBundleStream(
+            baseUrl: String,
+            bookId: String,
+            token: String,
+            insecureAllowed: Boolean,
+            fromByte: Long,
+        ): NetworkAudiobookBundleResult {
+            requestedFromByte = fromByte
+            failWith?.let { return NetworkAudiobookBundleResult.NetworkError(it) }
+            return if (fromByte > 0 && honorRange) {
+                val tail = full.copyOfRange(fromByte.toInt(), full.size)
+                NetworkAudiobookBundleResult.Success(
+                    body = tail.toResponseBody("application/epub+zip".toMediaType()),
+                    totalBytes = full.size.toLong(),
+                    isPartial = true,
+                )
+            } else {
+                NetworkAudiobookBundleResult.Success(
+                    body = full.toResponseBody("application/epub+zip".toMediaType()),
+                    totalBytes = full.size.toLong(),
+                    isPartial = false,
+                )
+            }
+        }
+    }
+
+    private fun downloader(api: AudiobookBundleApi, dir: File) =
+        AudiobookBundleDownloader(api = api, targetFileProvider = { File(dir, "$it.epub") })
+
+    @Test fun freshDownload_writesFullBundle_andReportsProgressToCompletion() = runTest {
+        val dir = tmp.newFolder()
+        var lastDownloaded = 0L
+        var lastTotal = 0L
+
+        val result = downloader(FakeApi(), dir).download("u", "42", "t", false) { d, total ->
+            lastDownloaded = d; lastTotal = total
+        }
+
+        assertTrue(result is AudiobookBundleDownloader.Result.Success)
+        val file = (result as AudiobookBundleDownloader.Result.Success).file
+        assertArrayEquals(full, file.readBytes())
+        assertEquals(200L, lastDownloaded)
+        assertEquals(200L, lastTotal)
+        assertFalse("partial file cleaned up", File(dir, file.name + ".part").exists())
+    }
+
+    @Test fun resume_picksUpFromExistingPartial_andStitchesFullBundle() = runTest {
+        val dir = tmp.newFolder()
+        val api = FakeApi(honorRange = true)
+        // simulate an interrupted download: first 80 bytes already on disk
+        val part = File(dir, "42.epub.part")
+        part.writeBytes(full.copyOfRange(0, 80))
+
+        val result = downloader(api, dir).download("u", "42", "t", false) { _, _ -> }
+
+        assertEquals(80L, api.requestedFromByte)
+        assertTrue(result is AudiobookBundleDownloader.Result.Success)
+        assertArrayEquals(full, (result as AudiobookBundleDownloader.Result.Success).file.readBytes())
+    }
+
+    @Test fun serverIgnoresRange_restartsFromScratch() = runTest {
+        val dir = tmp.newFolder()
+        val part = File(dir, "42.epub.part")
+        part.writeBytes(full.copyOfRange(0, 80))
+
+        val result = downloader(FakeApi(honorRange = false), dir).download("u", "42", "t", false) { _, _ -> }
+
+        assertTrue(result is AudiobookBundleDownloader.Result.Success)
+        assertArrayEquals(full, (result as AudiobookBundleDownloader.Result.Success).file.readBytes())
+    }
+
+    @Test fun alreadyDownloaded_returnsExistingFile_withoutHittingNetwork() = runTest {
+        val dir = tmp.newFolder()
+        val existing = File(dir, "42.epub").apply { writeBytes(full) }
+        val api = FakeApi()
+
+        val result = downloader(api, dir).download("u", "42", "t", false) { _, _ -> }
+
+        assertEquals(-1L, api.requestedFromByte) // never called
+        assertTrue(result is AudiobookBundleDownloader.Result.Success)
+        assertEquals(existing, (result as AudiobookBundleDownloader.Result.Success).file)
+    }
+
+    @Test fun networkError_preservesPartialForResume() = runTest {
+        val dir = tmp.newFolder()
+        val part = File(dir, "42.epub.part").apply { writeBytes(full.copyOfRange(0, 40)) }
+
+        val result = downloader(FakeApi(failWith = IOException("boom")), dir)
+            .download("u", "42", "t", false) { _, _ -> }
+
+        assertTrue(result is AudiobookBundleDownloader.Result.NetworkError)
+        assertTrue("partial kept for resume", part.exists())
+        assertEquals(40, part.length())
+    }
+}

--- a/core/data/src/test/kotlin/com/riffle/core/data/MediaOverlayReaderTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/MediaOverlayReaderTest.kt
@@ -1,0 +1,73 @@
+package com.riffle.core.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+
+class MediaOverlayReaderTest {
+
+    @get:Rule
+    val tmp = TemporaryFolder()
+
+    private fun epubWith(entries: Map<String, ByteArray>): File {
+        val f = tmp.newFile("book.epub")
+        ZipOutputStream(f.outputStream()).use { zip ->
+            entries.forEach { (name, bytes) ->
+                zip.putNextEntry(ZipEntry(name))
+                zip.write(bytes)
+                zip.closeEntry()
+            }
+        }
+        return f
+    }
+
+    private fun smil(audioRel: String) = """
+        <smil xmlns="http://www.w3.org/ns/SMIL" version="3.0"><body>
+          <par><text src="../text/c1.xhtml#s1"/><audio src="$audioRel" clipBegin="0s" clipEnd="2s"/></par>
+          <par><text src="../text/c1.xhtml#s2"/><audio src="$audioRel" clipBegin="2s" clipEnd="4s"/></par>
+        </body></smil>
+    """.trimIndent().toByteArray()
+
+    @Test fun `builds a track with refs and audio paths resolved relative to the smil entry`() {
+        val epub = epubWith(
+            mapOf(
+                "OEBPS/smil/c1.smil" to smil("../audio/c1.mp3"),
+                "OEBPS/audio/c1.mp3" to ByteArray(10),
+                "OEBPS/text/c1.xhtml" to ByteArray(5),
+            ),
+        )
+
+        val track = MediaOverlayReader.readTrack(epub)
+
+        assertEquals(2, track.clips.size)
+        assertEquals("OEBPS/text/c1.xhtml#s1", track.clips[0].textFragmentRef)
+        assertEquals("OEBPS/audio/c1.mp3", track.clips[0].audioSrc)
+    }
+
+    @Test fun `concatenates multiple smil entries in name order`() {
+        val epub = epubWith(
+            mapOf(
+                "OEBPS/smil/c2.smil" to smil("../audio/c2.mp3"),
+                "OEBPS/smil/c1.smil" to smil("../audio/c1.mp3"),
+                "OEBPS/audio/c1.mp3" to ByteArray(10),
+                "OEBPS/audio/c2.mp3" to ByteArray(10),
+            ),
+        )
+
+        val track = MediaOverlayReader.readTrack(epub)
+
+        assertEquals(4, track.clips.size)
+        // c1 entries precede c2 entries (sorted by smil entry name)
+        assertEquals("OEBPS/audio/c1.mp3", track.clips[0].audioSrc)
+        assertEquals("OEBPS/audio/c2.mp3", track.clips[2].audioSrc)
+    }
+
+    @Test fun `no smil entries yields an empty track`() {
+        val epub = epubWith(mapOf("OEBPS/text/c1.xhtml" to ByteArray(5)))
+        assertEquals(0, MediaOverlayReader.readTrack(epub).clips.size)
+    }
+}

--- a/core/data/src/test/kotlin/com/riffle/core/data/StorytellerPositionSyncControllerTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/StorytellerPositionSyncControllerTest.kt
@@ -1,0 +1,96 @@
+package com.riffle.core.data
+
+import com.riffle.core.domain.AuthenticateResult
+import com.riffle.core.domain.CommitServerResult
+import com.riffle.core.domain.PendingServer
+import com.riffle.core.domain.ReadingPositionStore
+import com.riffle.core.domain.Server
+import com.riffle.core.domain.ServerRepository
+import com.riffle.core.domain.ServerType
+import com.riffle.core.domain.ServerUrl
+import com.riffle.core.domain.TokenStorage
+import com.riffle.core.network.NetworkStorytellerPositionResult
+import com.riffle.core.network.NetworkStorytellerPutResult
+import com.riffle.core.network.StorytellerPositionApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.IOException
+
+class StorytellerPositionSyncControllerTest {
+
+    private class FakePositionStore(var ts: Long) : ReadingPositionStore {
+        var saved: String? = null
+        var savedTs: Long? = null
+        override suspend fun save(serverId: String, itemId: String, cfi: String) { saved = cfi }
+        override suspend fun load(serverId: String, itemId: String): String? = saved
+        override suspend fun loadLocalUpdatedAt(serverId: String, itemId: String): Long = ts
+        override suspend fun updateLocalTimestamp(serverId: String, itemId: String, millis: Long) { savedTs = millis; ts = millis }
+    }
+
+    private class FakePositionApi(
+        private val get: NetworkStorytellerPositionResult,
+    ) : StorytellerPositionApi {
+        var putCount = 0
+        override suspend fun getPosition(baseUrl: String, bookId: String, token: String, insecureAllowed: Boolean) = get
+        override suspend fun putPosition(baseUrl: String, bookId: String, locatorJson: String, timestampMillis: Long, token: String, insecureAllowed: Boolean): NetworkStorytellerPutResult {
+            putCount++; return NetworkStorytellerPutResult.Success
+        }
+    }
+
+    private fun controller(api: StorytellerPositionApi, store: ReadingPositionStore) =
+        StorytellerPositionSyncController(
+            api = api,
+            positionStore = store,
+            serverRepository = object : ServerRepository {
+                val server = Server("s1", ServerUrl.parse("http://localhost")!!, true, false, "")
+                override fun observeAll(): Flow<List<Server>> = flowOf(listOf(server))
+                override suspend fun getActive(): Server = server
+                override suspend fun authenticate(url: ServerUrl, username: String, password: String, insecureAllowed: Boolean, serverType: ServerType) = throw UnsupportedOperationException()
+                override suspend fun commit(pending: PendingServer, hiddenLibraryIds: Set<String>): CommitServerResult = throw UnsupportedOperationException()
+                override suspend fun setActive(serverId: String) = Unit
+                override suspend fun remove(serverId: String) = Unit
+                override suspend fun getServerVersion(serverId: String): String? = null
+            },
+            tokenStorage = object : TokenStorage {
+                override suspend fun saveToken(serverId: String, token: String) = Unit
+                override suspend fun getToken(serverId: String): String? = "tok"
+                override suspend fun deleteToken(serverId: String) = Unit
+            },
+        )
+
+    @Test fun `remote newer pulls and saves locally`() = runTest {
+        val store = FakePositionStore(ts = 1_000)
+        val api = FakePositionApi(NetworkStorytellerPositionResult.Success("""{"href":"x"}""", 2_000))
+
+        val outcome = controller(api, store).runCycle("item-1", localLocatorJson = """{"href":"old"}""")
+
+        assertTrue(outcome is StorytellerSyncOutcome.PulledRemote)
+        assertEquals("""{"href":"x"}""", store.saved)
+        assertEquals(2_000L, store.savedTs)
+        assertEquals(0, api.putCount)
+    }
+
+    @Test fun `local newer pushes to server`() = runTest {
+        val store = FakePositionStore(ts = 5_000)
+        val api = FakePositionApi(NetworkStorytellerPositionResult.Success("""{"href":"x"}""", 1_000))
+
+        val outcome = controller(api, store).runCycle("item-1", localLocatorJson = """{"href":"local"}""")
+
+        assertTrue(outcome is StorytellerSyncOutcome.PushedLocal)
+        assertEquals(1, api.putCount)
+    }
+
+    @Test fun `GET failure is Offline with no push`() = runTest {
+        val store = FakePositionStore(ts = 5_000)
+        val api = FakePositionApi(NetworkStorytellerPositionResult.NetworkError(IOException("down")))
+
+        val outcome = controller(api, store).runCycle("item-1", localLocatorJson = """{"href":"local"}""")
+
+        assertTrue(outcome is StorytellerSyncOutcome.Offline)
+        assertEquals(0, api.putCount)
+    }
+}

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/AudioCachePreferencesStore.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/AudioCachePreferencesStore.kt
@@ -1,0 +1,17 @@
+package com.riffle.core.domain
+
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Per-Storyteller-Server cap on the Readaloud audio Cache. Governs how large the auto-cached
+ * (evictable) audio-bundle area may grow before [LruCacheEvictor] sheds the least-recently-used
+ * bundles. Permanent Downloads are unaffected (ADR 0023).
+ */
+interface AudioCachePreferencesStore {
+    fun capBytes(serverId: String): Flow<Long>
+    suspend fun setCapBytes(serverId: String, capBytes: Long)
+
+    companion object {
+        const val DEFAULT_CAP_BYTES: Long = 2L * 1024 * 1024 * 1024 // 2 GB
+    }
+}

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/AutoPageTurnRule.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/AutoPageTurnRule.kt
@@ -1,0 +1,23 @@
+package com.riffle.core.domain
+
+/**
+ * Decides whether playback has carried the active sentence off the bottom of the viewport,
+ * meaning the reader should advance to keep the narrated text on screen. Pure: the caller
+ * supplies the active clip's document index and the indices currently rendered; the reader
+ * decides *how* to advance (page turn when paginated, scroll when continuous).
+ */
+object AutoPageTurnRule {
+
+    fun shouldAdvance(
+        activeIndex: Int?,
+        visibleIndices: Set<Int>,
+        isPlaying: Boolean,
+    ): Boolean {
+        if (!isPlaying) return false
+        if (activeIndex == null) return false
+        if (visibleIndices.isEmpty()) return false
+        // Advance only when the active sentence is *ahead* of everything on screen. If it's
+        // behind (the user scrolled forward manually while audio lags), leave the view alone.
+        return activeIndex > visibleIndices.max()
+    }
+}

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/ConnectivityObserver.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/ConnectivityObserver.kt
@@ -4,4 +4,10 @@ import kotlinx.coroutines.flow.StateFlow
 
 interface ConnectivityObserver {
     val isOnline: StateFlow<Boolean>
+
+    /**
+     * Whether the active network is metered (cellular, metered Wi-Fi, hotspot). Used to honour a
+     * "Wi-Fi only" download choice. Defaults to false so non-Android fakes need not implement it.
+     */
+    fun isMetered(): Boolean = false
 }

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/LruCacheEvictor.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/LruCacheEvictor.kt
@@ -1,0 +1,29 @@
+package com.riffle.core.domain
+
+/** A cached Readaloud audio bundle eligible for LRU eviction. */
+data class CachedBundle(
+    val key: String,
+    val sizeBytes: Long,
+    val lastAccessedAtMillis: Long,
+)
+
+/**
+ * Pure LRU policy for the per-Storyteller-Server audio cache cap. Given the cached bundles and a
+ * cap, returns the keys to evict — least-recently-accessed first — so the remaining total fits
+ * under the cap. Permanent Downloads are never passed in, so they are never evicted (ADR 0023).
+ */
+object LruCacheEvictor {
+
+    fun selectForEviction(bundles: List<CachedBundle>, capBytes: Long): List<String> {
+        var total = bundles.sumOf { it.sizeBytes }
+        if (total <= capBytes) return emptyList()
+
+        val evicted = ArrayList<String>()
+        for (bundle in bundles.sortedBy { it.lastAccessedAtMillis }) {
+            if (total <= capBytes) break
+            evicted += bundle.key
+            total -= bundle.sizeBytes
+        }
+        return evicted
+    }
+}

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/ReadaloudAudioRepository.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/ReadaloudAudioRepository.kt
@@ -1,0 +1,38 @@
+package com.riffle.core.domain
+
+import java.io.File
+
+sealed interface AudioDownloadResult {
+    data object Success : AudioDownloadResult
+    data object NoBundle : AudioDownloadResult
+    data class NetworkError(val cause: Throwable) : AudioDownloadResult
+}
+
+/**
+ * Manages the Readaloud audio bundle (the Storyteller synced EPUB — ADR 0023) for the reader: its
+ * local presence, its parsed Media Overlay [ReadaloudTrack], download (with progress) into the
+ * permanent Downloads area, removal, and LRU eviction of the auto-cached area against the
+ * per-server cap.
+ */
+interface ReadaloudAudioRepository {
+    /** True when the synced bundle is present locally (Downloads or Cache). */
+    fun isAudioAvailable(itemId: String): Boolean
+
+    /** The local synced-bundle file, or null if not present. */
+    fun bundleFile(itemId: String): File?
+
+    /** Parses the Media Overlay timeline out of the local bundle, or null if no bundle / no overlays. */
+    suspend fun readTrack(itemId: String): ReadaloudTrack?
+
+    /** The download size in bytes (server Content-Length), or null if it can't be probed. */
+    suspend fun probeSizeBytes(itemId: String): Long?
+
+    /** Downloads the synced bundle into permanent Downloads with resume + progress. */
+    suspend fun downloadAudio(itemId: String, onProgress: (downloaded: Long, total: Long) -> Unit): AudioDownloadResult
+
+    /** Removes the downloaded bundle; returns the number of bytes freed. */
+    suspend fun removeAudio(itemId: String): Long
+
+    /** Evicts least-recently-used cached bundles for the active server until under its cap. */
+    suspend fun enforceCacheCap()
+}

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/ReadaloudTrack.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/ReadaloudTrack.kt
@@ -28,4 +28,19 @@ class ReadaloudTrack(val clips: List<MediaOverlayClip>) {
     /** Document-order index of a fragment, or -1 if absent. */
     fun indexOfFragment(textFragmentRef: String): Int =
         indexByFragment[textFragmentRef] ?: -1
+
+    /**
+     * The clip to start narration from for a reader position given by its chapter [href] and
+     * optional [fragmentId]. Prefers an exact "href#fragmentId" match (the sentence under the
+     * reader's cursor); otherwise falls back to the first clip of that chapter so playback at
+     * least begins on the page the user is reading rather than at the start of the book. Leading
+     * slashes are ignored so Readium's "/text/x" and SMIL's "text/x" hrefs reconcile.
+     */
+    fun resolveStartClip(href: String, fragmentId: String?): MediaOverlayClip? {
+        val target = href.trimStart('/')
+        if (fragmentId != null) {
+            clips.firstOrNull { it.textFragmentRef.trimStart('/') == "$target#$fragmentId" }?.let { return it }
+        }
+        return clips.firstOrNull { it.textFragmentRef.substringBefore('#').trimStart('/') == target }
+    }
 }

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/ReadaloudTrack.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/ReadaloudTrack.kt
@@ -1,0 +1,31 @@
+package com.riffle.core.domain
+
+/**
+ * The ordered Media Overlay timeline for a Readaloud, built from every `.smil` entry in the
+ * Storyteller EPUB bundle (concatenated in spine order). Maps freely between the three things
+ * the player and reader need to relate: a playback position `(audioSrc, sec)`, a text fragment
+ * reference, and the document-order index used for [AutoPageTurnRule] decisions.
+ */
+class ReadaloudTrack(val clips: List<MediaOverlayClip>) {
+
+    private val indexByFragment: Map<String, Int> =
+        clips.withIndex().associate { (i, clip) -> clip.textFragmentRef to i }
+
+    /**
+     * The clip narrating [positionSec] within [audioSrc], or null if the position sits in a gap
+     * or names an audio file with no overlay. Ranges are half-open `[begin, end)` so abutting
+     * clips don't both claim the boundary instant.
+     */
+    fun activeClipAt(audioSrc: String, positionSec: Double): MediaOverlayClip? =
+        clips.firstOrNull {
+            it.audioSrc == audioSrc && positionSec >= it.clipBeginSec && positionSec < it.clipEndSec
+        }
+
+    /** The clip for a text fragment — the seek target when the user picks "Play from here". */
+    fun clipForFragment(textFragmentRef: String): MediaOverlayClip? =
+        indexByFragment[textFragmentRef]?.let { clips[it] }
+
+    /** Document-order index of a fragment, or -1 if absent. */
+    fun indexOfFragment(textFragmentRef: String): Int =
+        indexByFragment[textFragmentRef] ?: -1
+}

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/SmilOverlayParser.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/SmilOverlayParser.kt
@@ -1,0 +1,92 @@
+package com.riffle.core.domain
+
+import org.w3c.dom.Element
+import org.w3c.dom.Node
+import java.io.ByteArrayInputStream
+import javax.xml.parsers.DocumentBuilderFactory
+
+/**
+ * One `<par>` of an EPUB 3 Media Overlay (SMIL): a text fragment paired with the
+ * slice of audio that narrates it. [clipBeginSec]/[clipEndSec] are normalised to
+ * absolute seconds from any SMIL clock-value syntax.
+ */
+data class MediaOverlayClip(
+    val textFragmentRef: String,
+    val audioSrc: String,
+    val clipBeginSec: Double,
+    val clipEndSec: Double,
+)
+
+/**
+ * Pure SMIL → [MediaOverlayClip] parser. No I/O — callers read the `.smil` entries out
+ * of the EPUB bundle and hand the XML text in. Document order is preserved, which is the
+ * playback order the rest of the readaloud machinery relies on.
+ */
+object SmilOverlayParser {
+
+    fun parse(smilXml: String): List<MediaOverlayClip> {
+        val doc = DocumentBuilderFactory.newInstance()
+            .apply { isNamespaceAware = false }
+            .newDocumentBuilder()
+            .parse(ByteArrayInputStream(smilXml.toByteArray(Charsets.UTF_8)))
+
+        val pars = doc.getElementsByTagName("par")
+        val clips = ArrayList<MediaOverlayClip>(pars.length)
+        for (i in 0 until pars.length) {
+            val par = pars.item(i) as? Element ?: continue
+            val text = par.firstChildElement("text") ?: continue
+            val audio = par.firstChildElement("audio") ?: continue
+            val textRef = text.getAttribute("src").takeIf { it.isNotEmpty() } ?: continue
+            val audioSrc = audio.getAttribute("src").takeIf { it.isNotEmpty() } ?: continue
+            clips += MediaOverlayClip(
+                textFragmentRef = textRef,
+                audioSrc = audioSrc,
+                clipBeginSec = parseClockValue(audio.getAttribute("clipBegin")),
+                clipEndSec = parseClockValue(audio.getAttribute("clipEnd")),
+            )
+        }
+        return clips
+    }
+
+    private fun Element.firstChildElement(localName: String): Element? {
+        val children = childNodes
+        for (i in 0 until children.length) {
+            val node = children.item(i)
+            if (node.nodeType == Node.ELEMENT_NODE) {
+                val el = node as Element
+                if (el.tagName == localName || el.localName == localName) return el
+            }
+        }
+        return null
+    }
+
+    /**
+     * SMIL clock values come in several shapes:
+     *   - full clock: `1:02:03.500` (h:mm:ss) or `02:03.5` (mm:ss)
+     *   - timecount with unit: `12.5s`, `300ms`, `1.5min`, `2h`
+     *   - bare seconds: `12.5`
+     * Returns 0.0 for blank/unparseable input — a missing clip bound degrades to "no offset"
+     * rather than crashing playback.
+     */
+    private fun parseClockValue(raw: String): Double {
+        val v = raw.trim()
+        if (v.isEmpty()) return 0.0
+
+        if (v.contains(':')) {
+            val parts = v.split(':')
+            var seconds = 0.0
+            for (part in parts) {
+                seconds = seconds * 60.0 + (part.toDoubleOrNull() ?: return 0.0)
+            }
+            return seconds
+        }
+
+        return when {
+            v.endsWith("ms") -> v.dropLast(2).toDoubleOrNull()?.div(1000.0) ?: 0.0
+            v.endsWith("min") -> v.dropLast(3).toDoubleOrNull()?.times(60.0) ?: 0.0
+            v.endsWith("h") -> v.dropLast(1).toDoubleOrNull()?.times(3600.0) ?: 0.0
+            v.endsWith("s") -> v.dropLast(1).toDoubleOrNull() ?: 0.0
+            else -> v.toDoubleOrNull() ?: 0.0
+        }
+    }
+}

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/StorytellerPositionReconciler.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/StorytellerPositionReconciler.kt
@@ -1,0 +1,30 @@
+package com.riffle.core.domain
+
+/**
+ * Pure last-update-wins reconciliation for the Storyteller single-peer position cycle (ADR 0023).
+ * One remote, one canonical local position; whichever has the newer timestamp wins, with no
+ * conflict prompt. The orchestrator handles the offline case (a failed GET) before calling this.
+ */
+object StorytellerPositionReconciler {
+
+    sealed interface Decision {
+        /** Remote is newer — jump the reader to it and adopt its timestamp. */
+        data class PullRemote(val locatorJson: String, val timestampMillis: Long) : Decision
+        /** Local is newer — PATCH it to the server. */
+        data class PushLocal(val locatorJson: String, val timestampMillis: Long) : Decision
+        data object InSync : Decision
+    }
+
+    fun reconcile(
+        localLocatorJson: String,
+        localUpdatedAt: Long,
+        remoteLocatorJson: String?,
+        remoteUpdatedAt: Long,
+    ): Decision = when {
+        remoteLocatorJson != null && remoteUpdatedAt > localUpdatedAt ->
+            Decision.PullRemote(remoteLocatorJson, remoteUpdatedAt)
+        localUpdatedAt > remoteUpdatedAt && localUpdatedAt > 0 ->
+            Decision.PushLocal(localLocatorJson, localUpdatedAt)
+        else -> Decision.InSync
+    }
+}

--- a/core/domain/src/test/kotlin/com/riffle/core/domain/AutoPageTurnRuleTest.kt
+++ b/core/domain/src/test/kotlin/com/riffle/core/domain/AutoPageTurnRuleTest.kt
@@ -1,0 +1,59 @@
+package com.riffle.core.domain
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AutoPageTurnRuleTest {
+
+    @Test
+    fun `advances when the active sentence is ahead of the viewport`() {
+        assertTrue(
+            AutoPageTurnRule.shouldAdvance(
+                activeIndex = 5,
+                visibleIndices = setOf(1, 2, 3),
+                isPlaying = true,
+            ),
+        )
+    }
+
+    @Test
+    fun `does not advance while the active sentence is still visible`() {
+        assertFalse(
+            AutoPageTurnRule.shouldAdvance(
+                activeIndex = 2,
+                visibleIndices = setOf(1, 2, 3),
+                isPlaying = true,
+            ),
+        )
+    }
+
+    @Test
+    fun `does not advance when the active sentence is behind the viewport`() {
+        // user scrolled ahead manually; playback is lagging behind — never page backwards
+        assertFalse(
+            AutoPageTurnRule.shouldAdvance(
+                activeIndex = 0,
+                visibleIndices = setOf(3, 4, 5),
+                isPlaying = true,
+            ),
+        )
+    }
+
+    @Test
+    fun `does not advance when paused`() {
+        assertFalse(
+            AutoPageTurnRule.shouldAdvance(
+                activeIndex = 5,
+                visibleIndices = setOf(1, 2, 3),
+                isPlaying = false,
+            ),
+        )
+    }
+
+    @Test
+    fun `does not advance without an active sentence or visibility info`() {
+        assertFalse(AutoPageTurnRule.shouldAdvance(null, setOf(1, 2), isPlaying = true))
+        assertFalse(AutoPageTurnRule.shouldAdvance(5, emptySet(), isPlaying = true))
+    }
+}

--- a/core/domain/src/test/kotlin/com/riffle/core/domain/LruCacheEvictorTest.kt
+++ b/core/domain/src/test/kotlin/com/riffle/core/domain/LruCacheEvictorTest.kt
@@ -1,0 +1,42 @@
+package com.riffle.core.domain
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class LruCacheEvictorTest {
+
+    private fun b(key: String, sizeMb: Long, lastAccessed: Long) =
+        CachedBundle(key, sizeMb * 1024 * 1024, lastAccessed)
+
+    @Test fun `nothing evicted when total is within the cap`() {
+        val bundles = listOf(b("a", 500, 1), b("b", 400, 2))
+        assertEquals(emptyList<String>(), LruCacheEvictor.selectForEviction(bundles, cap(2)))
+    }
+
+    @Test fun `evicts least-recently-accessed first until under the cap`() {
+        val bundles = listOf(
+            b("old", 800, 10),
+            b("older", 800, 5),
+            b("newest", 800, 100),
+        )
+        // total 2400MB, cap 2048MB -> must shed >=352MB -> evict the single oldest (800MB)
+        assertEquals(listOf("older"), LruCacheEvictor.selectForEviction(bundles, cap(2)))
+    }
+
+    @Test fun `evicts multiple oldest entries when one is not enough`() {
+        val bundles = listOf(
+            b("a", 900, 1),
+            b("b", 900, 2),
+            b("c", 900, 3),
+        )
+        // total 2700MB, cap 1024MB -> evict a then b (1800 shed) leaving c=900 <= 1024
+        assertEquals(listOf("a", "b"), LruCacheEvictor.selectForEviction(bundles, cap(1)))
+    }
+
+    @Test fun `cap of zero evicts everything`() {
+        val bundles = listOf(b("a", 10, 1), b("b", 20, 2))
+        assertEquals(listOf("a", "b"), LruCacheEvictor.selectForEviction(bundles, 0))
+    }
+
+    private fun cap(gb: Long) = gb * 1024 * 1024 * 1024
+}

--- a/core/domain/src/test/kotlin/com/riffle/core/domain/ReadaloudTrackTest.kt
+++ b/core/domain/src/test/kotlin/com/riffle/core/domain/ReadaloudTrackTest.kt
@@ -1,0 +1,46 @@
+package com.riffle.core.domain
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class ReadaloudTrackTest {
+
+    private val clips = listOf(
+        MediaOverlayClip("c1#s1", "c1.mp3", 0.0, 2.0),
+        MediaOverlayClip("c1#s2", "c1.mp3", 2.0, 5.0),
+        MediaOverlayClip("c1#s3", "c1.mp3", 5.0, 9.0),
+        MediaOverlayClip("c2#s1", "c2.mp3", 0.0, 4.0),
+    )
+    private val track = ReadaloudTrack(clips)
+
+    @Test
+    fun `active clip is the one whose half-open range contains the position`() {
+        assertEquals(clips[1], track.activeClipAt("c1.mp3", 2.0))
+        assertEquals(clips[1], track.activeClipAt("c1.mp3", 4.999))
+        assertEquals(clips[2], track.activeClipAt("c1.mp3", 5.0))
+    }
+
+    @Test
+    fun `active clip is scoped to the matching audio file`() {
+        assertEquals(clips[3], track.activeClipAt("c2.mp3", 1.0))
+    }
+
+    @Test
+    fun `no active clip when position falls outside every range`() {
+        assertNull(track.activeClipAt("c1.mp3", 100.0))
+        assertNull(track.activeClipAt("missing.mp3", 1.0))
+    }
+
+    @Test
+    fun `clipForFragment finds the entry point for play-from-here`() {
+        assertEquals(clips[2], track.clipForFragment("c1#s3"))
+        assertNull(track.clipForFragment("nope#x"))
+    }
+
+    @Test
+    fun `indexOfFragment supports ordering decisions`() {
+        assertEquals(2, track.indexOfFragment("c1#s3"))
+        assertEquals(-1, track.indexOfFragment("nope#x"))
+    }
+}

--- a/core/domain/src/test/kotlin/com/riffle/core/domain/ReadaloudTrackTest.kt
+++ b/core/domain/src/test/kotlin/com/riffle/core/domain/ReadaloudTrackTest.kt
@@ -43,4 +43,32 @@ class ReadaloudTrackTest {
         assertEquals(2, track.indexOfFragment("c1#s3"))
         assertEquals(-1, track.indexOfFragment("nope#x"))
     }
+
+    private val chapterClips = listOf(
+        MediaOverlayClip("text/c1.html#s1", "c1.mp3", 0.0, 2.0),
+        MediaOverlayClip("text/c1.html#s2", "c1.mp3", 2.0, 5.0),
+        MediaOverlayClip("text/c2.html#s1", "c2.mp3", 0.0, 4.0),
+    )
+    private val chapterTrack = ReadaloudTrack(chapterClips)
+
+    @Test
+    fun `resolveStartClip prefers an exact fragment match`() {
+        assertEquals(chapterClips[1], chapterTrack.resolveStartClip("text/c1.html", "s2"))
+    }
+
+    @Test
+    fun `resolveStartClip ignores leading slash differences`() {
+        assertEquals(chapterClips[1], chapterTrack.resolveStartClip("/text/c1.html", "s2"))
+    }
+
+    @Test
+    fun `resolveStartClip falls back to first clip of the chapter when fragment is absent or unmatched`() {
+        assertEquals(chapterClips[0], chapterTrack.resolveStartClip("text/c1.html", null))
+        assertEquals(chapterClips[2], chapterTrack.resolveStartClip("text/c2.html", "unknown"))
+    }
+
+    @Test
+    fun `resolveStartClip returns null for an unknown chapter`() {
+        assertEquals(null, chapterTrack.resolveStartClip("text/c9.html", null))
+    }
 }

--- a/core/domain/src/test/kotlin/com/riffle/core/domain/SmilOverlayParserTest.kt
+++ b/core/domain/src/test/kotlin/com/riffle/core/domain/SmilOverlayParserTest.kt
@@ -1,0 +1,87 @@
+package com.riffle.core.domain
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class SmilOverlayParserTest {
+
+    @Test
+    fun `parses a single par into one clip`() {
+        val smil = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <smil xmlns="http://www.w3.org/ns/SMIL"
+                  xmlns:epub="http://www.idpf.org/2007/ops" version="3.0">
+              <body>
+                <par id="p1">
+                  <text src="chapter1.xhtml#sent1"/>
+                  <audio src="audio/chapter1.mp3" clipBegin="0:00:00.000" clipEnd="0:00:03.500"/>
+                </par>
+              </body>
+            </smil>
+        """.trimIndent()
+
+        val clips = SmilOverlayParser.parse(smil)
+
+        assertEquals(
+            listOf(
+                MediaOverlayClip(
+                    textFragmentRef = "chapter1.xhtml#sent1",
+                    audioSrc = "audio/chapter1.mp3",
+                    clipBeginSec = 0.0,
+                    clipEndSec = 3.5,
+                ),
+            ),
+            clips,
+        )
+    }
+
+    @Test
+    fun `preserves document order across multiple pars in a seq`() {
+        val smil = """
+            <smil xmlns="http://www.w3.org/ns/SMIL" version="3.0">
+              <body>
+                <seq epub:textref="c1.xhtml" xmlns:epub="http://www.idpf.org/2007/ops">
+                  <par><text src="c1.xhtml#s1"/><audio src="c1.mp3" clipBegin="0s" clipEnd="2s"/></par>
+                  <par><text src="c1.xhtml#s2"/><audio src="c1.mp3" clipBegin="2s" clipEnd="5s"/></par>
+                  <par><text src="c1.xhtml#s3"/><audio src="c1.mp3" clipBegin="5s" clipEnd="9s"/></par>
+                </seq>
+              </body>
+            </smil>
+        """.trimIndent()
+
+        val refs = SmilOverlayParser.parse(smil).map { it.textFragmentRef }
+
+        assertEquals(listOf("c1.xhtml#s1", "c1.xhtml#s2", "c1.xhtml#s3"), refs)
+    }
+
+    @Test
+    fun `parses the range of SMIL clock-value syntaxes`() {
+        val smil = """
+            <smil xmlns="http://www.w3.org/ns/SMIL" version="3.0">
+              <body>
+                <par><text src="a#1"/><audio src="a.mp3" clipBegin="0:00:12.500" clipEnd="0:01:00"/></par>
+                <par><text src="a#2"/><audio src="a.mp3" clipBegin="90.25" clipEnd="2min"/></par>
+                <par><text src="a#3"/><audio src="a.mp3" clipBegin="300ms" clipEnd="1.5h"/></par>
+              </body>
+            </smil>
+        """.trimIndent()
+
+        val clips = SmilOverlayParser.parse(smil)
+
+        assertEquals(12.5, clips[0].clipBeginSec, 0.0001)
+        assertEquals(60.0, clips[0].clipEndSec, 0.0001)
+        assertEquals(90.25, clips[1].clipBeginSec, 0.0001)
+        assertEquals(120.0, clips[1].clipEndSec, 0.0001)
+        assertEquals(0.3, clips[2].clipBeginSec, 0.0001)
+        assertEquals(5400.0, clips[2].clipEndSec, 0.0001)
+    }
+
+    @Test
+    fun `returns empty list for a SMIL with no pars`() {
+        val smil = """
+            <smil xmlns="http://www.w3.org/ns/SMIL" version="3.0"><body><seq/></body></smil>
+        """.trimIndent()
+
+        assertEquals(emptyList<MediaOverlayClip>(), SmilOverlayParser.parse(smil))
+    }
+}

--- a/core/domain/src/test/kotlin/com/riffle/core/domain/StorytellerPositionReconcilerTest.kt
+++ b/core/domain/src/test/kotlin/com/riffle/core/domain/StorytellerPositionReconcilerTest.kt
@@ -1,0 +1,42 @@
+package com.riffle.core.domain
+
+import com.riffle.core.domain.StorytellerPositionReconciler.Decision
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class StorytellerPositionReconcilerTest {
+
+    @Test fun `remote newer pulls the remote position`() {
+        val d = StorytellerPositionReconciler.reconcile(
+            localLocatorJson = "L", localUpdatedAt = 1_000,
+            remoteLocatorJson = "R", remoteUpdatedAt = 2_000,
+        )
+        assertEquals(Decision.PullRemote("R", 2_000), d)
+    }
+
+    @Test fun `local newer pushes the local position`() {
+        val d = StorytellerPositionReconciler.reconcile(
+            localLocatorJson = "L", localUpdatedAt = 3_000,
+            remoteLocatorJson = "R", remoteUpdatedAt = 1_000,
+        )
+        assertEquals(Decision.PushLocal("L", 3_000), d)
+    }
+
+    @Test fun `equal timestamps are in sync`() {
+        val d = StorytellerPositionReconciler.reconcile("L", 2_000, "R", 2_000)
+        assertEquals(Decision.InSync, d)
+    }
+
+    @Test fun `no remote record but local progress pushes local`() {
+        val d = StorytellerPositionReconciler.reconcile(
+            localLocatorJson = "L", localUpdatedAt = 5_000,
+            remoteLocatorJson = null, remoteUpdatedAt = 0,
+        )
+        assertEquals(Decision.PushLocal("L", 5_000), d)
+    }
+
+    @Test fun `no remote record and no local progress is in sync`() {
+        val d = StorytellerPositionReconciler.reconcile("", 0, null, 0)
+        assertEquals(Decision.InSync, d)
+    }
+}

--- a/core/network/src/main/kotlin/com/riffle/core/network/AudiobookBundleApi.kt
+++ b/core/network/src/main/kotlin/com/riffle/core/network/AudiobookBundleApi.kt
@@ -1,0 +1,98 @@
+package com.riffle.core.network
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.ResponseBody
+import java.io.IOException
+import java.security.SecureRandom
+import java.security.cert.X509Certificate
+import java.util.concurrent.TimeUnit
+import javax.net.ssl.SSLContext
+import javax.net.ssl.X509TrustManager
+
+sealed interface NetworkAudiobookBundleResult {
+    /**
+     * @param body the (possibly partial) stream of bundle bytes; caller must close it.
+     * @param totalBytes the full bundle size, recovered from Content-Range (206) or Content-Length (200).
+     * @param isPartial true when the server honoured a Range request (206); false on a full 200 body.
+     */
+    data class Success(val body: ResponseBody, val totalBytes: Long, val isPartial: Boolean) : NetworkAudiobookBundleResult
+    data class NetworkError(val cause: Throwable) : NetworkAudiobookBundleResult
+}
+
+/**
+ * Opens a (resumable) byte stream of the Storyteller synced bundle — the EPUB-3-with-audio that
+ * is the Readaloud audio source (see ADR 0023). [fromByte] > 0 issues a `Range` request so an
+ * interrupted download can pick up where it left off.
+ */
+fun interface AudiobookBundleApi {
+    suspend fun openBundleStream(
+        baseUrl: String,
+        bookId: String,
+        token: String,
+        insecureAllowed: Boolean,
+        fromByte: Long,
+    ): NetworkAudiobookBundleResult
+}
+
+class AudiobookBundleApiImpl(
+    private val client: OkHttpClient,
+) : AudiobookBundleApi {
+
+    // Bundles run to hundreds of MB; disable the idle-read timeout (the connect/call paths still
+    // apply) so a slow multi-minute stream isn't killed mid-flight.
+    private val bundleClient: OkHttpClient = client.newBuilder()
+        .connectTimeout(30, TimeUnit.SECONDS)
+        .readTimeout(0, TimeUnit.MILLISECONDS)
+        .callTimeout(0, TimeUnit.MILLISECONDS)
+        .build()
+
+    override suspend fun openBundleStream(
+        baseUrl: String,
+        bookId: String,
+        token: String,
+        insecureAllowed: Boolean,
+        fromByte: Long,
+    ): NetworkAudiobookBundleResult = withContext(Dispatchers.IO) {
+        val effectiveClient = if (insecureAllowed) bundleClient.trustAllCerts() else bundleClient
+        val builder = Request.Builder()
+            .url("$baseUrl/api/books/$bookId/synced")
+            .addHeader("Authorization", "Bearer $token")
+            // Forward-compat: a Storyteller release that content-negotiates a Readium audiobook
+            // archive will honour this; today's server ignores it and returns application/epub+zip.
+            .addHeader("Accept", "application/audiobook+zip")
+        if (fromByte > 0L) builder.addHeader("Range", "bytes=$fromByte-")
+
+        try {
+            val response = effectiveClient.newCall(builder.build()).execute()
+            val body = response.body
+            if (!response.isSuccessful || body == null) {
+                body?.close()
+                return@withContext NetworkAudiobookBundleResult.NetworkError(IOException("HTTP ${response.code}"))
+            }
+            val isPartial = response.code == 206
+            val total = if (isPartial) {
+                response.header("Content-Range")?.substringAfter('/')?.toLongOrNull()
+            } else {
+                response.header("Content-Length")?.toLongOrNull()
+            } ?: -1L
+            NetworkAudiobookBundleResult.Success(body = body, totalBytes = total, isPartial = isPartial)
+        } catch (e: IOException) {
+            NetworkAudiobookBundleResult.NetworkError(e)
+        }
+    }
+
+    private fun OkHttpClient.trustAllCerts(): OkHttpClient {
+        val trustAll = object : X509TrustManager {
+            override fun checkClientTrusted(chain: Array<out X509Certificate>, authType: String) = Unit
+            override fun checkServerTrusted(chain: Array<out X509Certificate>, authType: String) = Unit
+            override fun getAcceptedIssuers(): Array<X509Certificate> = emptyArray()
+        }
+        val sslContext = SSLContext.getInstance("TLS").apply {
+            init(null, arrayOf(trustAll), SecureRandom())
+        }
+        return newBuilder().sslSocketFactory(sslContext.socketFactory, trustAll).build()
+    }
+}

--- a/core/network/src/main/kotlin/com/riffle/core/network/StorytellerPositionApi.kt
+++ b/core/network/src/main/kotlin/com/riffle/core/network/StorytellerPositionApi.kt
@@ -1,0 +1,126 @@
+package com.riffle.core.network
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import java.io.IOException
+import java.security.SecureRandom
+import java.security.cert.X509Certificate
+import javax.net.ssl.SSLContext
+import javax.net.ssl.X509TrustManager
+
+sealed interface NetworkStorytellerPositionResult {
+    /** [locatorJson] is the raw Readium `locator` object; [timestampMillis] its server `lastUpdate`. */
+    data class Success(val locatorJson: String, val timestampMillis: Long) : NetworkStorytellerPositionResult
+    data object NoPosition : NetworkStorytellerPositionResult
+    data class NetworkError(val cause: Throwable) : NetworkStorytellerPositionResult
+}
+
+sealed interface NetworkStorytellerPutResult {
+    data object Success : NetworkStorytellerPutResult
+    data class NetworkError(val cause: Throwable) : NetworkStorytellerPutResult
+}
+
+/**
+ * Storyteller's single-peer reading-position endpoint (`/api/v2/books/{id}/positions`). The
+ * position is a native Readium `Locator` plus a millisecond timestamp — no CFI translation needed
+ * (contrast the ABS path, ADR 0013). Drives the Storyteller-only last-update-wins sync (ADR 0023).
+ */
+interface StorytellerPositionApi {
+    suspend fun getPosition(baseUrl: String, bookId: String, token: String, insecureAllowed: Boolean): NetworkStorytellerPositionResult
+    suspend fun putPosition(
+        baseUrl: String,
+        bookId: String,
+        locatorJson: String,
+        timestampMillis: Long,
+        token: String,
+        insecureAllowed: Boolean,
+    ): NetworkStorytellerPutResult
+}
+
+class StorytellerPositionApiImpl(
+    private val client: OkHttpClient,
+) : StorytellerPositionApi {
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    override suspend fun getPosition(
+        baseUrl: String,
+        bookId: String,
+        token: String,
+        insecureAllowed: Boolean,
+    ): NetworkStorytellerPositionResult = withContext(Dispatchers.IO) {
+        val http = if (insecureAllowed) client.trustAllCerts() else client
+        val request = Request.Builder()
+            .url("$baseUrl/api/v2/books/$bookId/positions")
+            .addHeader("Authorization", "Bearer $token")
+            .get()
+            .build()
+        try {
+            http.newCall(request).execute().use { response ->
+                when {
+                    response.code == 404 -> NetworkStorytellerPositionResult.NoPosition
+                    !response.isSuccessful -> NetworkStorytellerPositionResult.NetworkError(IOException("HTTP ${response.code}"))
+                    else -> {
+                        val raw = response.body?.string()
+                            ?: return@use NetworkStorytellerPositionResult.NetworkError(IOException("Empty body"))
+                        val root = json.parseToJsonElement(raw).jsonObject
+                        val locator = root["locator"]?.jsonObject
+                            ?: return@use NetworkStorytellerPositionResult.NoPosition
+                        val ts = root["timestamp"]?.jsonPrimitive?.content?.toLongOrNull() ?: 0L
+                        NetworkStorytellerPositionResult.Success(locatorJson = locator.toString(), timestampMillis = ts)
+                    }
+                }
+            }
+        } catch (e: IOException) {
+            NetworkStorytellerPositionResult.NetworkError(e)
+        }
+    }
+
+    override suspend fun putPosition(
+        baseUrl: String,
+        bookId: String,
+        locatorJson: String,
+        timestampMillis: Long,
+        token: String,
+        insecureAllowed: Boolean,
+    ): NetworkStorytellerPutResult = withContext(Dispatchers.IO) {
+        val http = if (insecureAllowed) client.trustAllCerts() else client
+        val payload = buildJsonObject {
+            put("locator", json.parseToJsonElement(locatorJson))
+            put("timestamp", JsonPrimitive(timestampMillis))
+        }.toString()
+        val request = Request.Builder()
+            .url("$baseUrl/api/v2/books/$bookId/positions")
+            .addHeader("Authorization", "Bearer $token")
+            .patch(payload.toRequestBody("application/json".toMediaType()))
+            .build()
+        try {
+            http.newCall(request).execute().use { response ->
+                if (response.isSuccessful) NetworkStorytellerPutResult.Success
+                else NetworkStorytellerPutResult.NetworkError(IOException("HTTP ${response.code}"))
+            }
+        } catch (e: IOException) {
+            NetworkStorytellerPutResult.NetworkError(e)
+        }
+    }
+
+    private fun OkHttpClient.trustAllCerts(): OkHttpClient {
+        val trustAll = object : X509TrustManager {
+            override fun checkClientTrusted(chain: Array<out X509Certificate>, authType: String) = Unit
+            override fun checkServerTrusted(chain: Array<out X509Certificate>, authType: String) = Unit
+            override fun getAcceptedIssuers(): Array<X509Certificate> = emptyArray()
+        }
+        val sslContext = SSLContext.getInstance("TLS").apply { init(null, arrayOf(trustAll), SecureRandom()) }
+        return newBuilder().sslSocketFactory(sslContext.socketFactory, trustAll).build()
+    }
+}

--- a/core/network/src/test/kotlin/com/riffle/core/network/AudiobookBundleApiTest.kt
+++ b/core/network/src/test/kotlin/com/riffle/core/network/AudiobookBundleApiTest.kt
@@ -1,0 +1,78 @@
+package com.riffle.core.network
+
+import kotlinx.coroutines.test.runTest
+import okhttp3.OkHttpClient
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import okio.Buffer
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class AudiobookBundleApiTest {
+
+    private lateinit var server: MockWebServer
+    private lateinit var api: AudiobookBundleApi
+
+    @Before
+    fun setUp() {
+        server = MockWebServer().also { it.start() }
+        api = AudiobookBundleApiImpl(OkHttpClient())
+    }
+
+    @After
+    fun tearDown() {
+        server.shutdown()
+    }
+
+    private fun baseUrl() = server.url("/").toString().trimEnd('/')
+
+    @Test fun freshDownload_sendsAcceptHeader_noRange_reportsTotalFromContentLength() = runTest {
+        val bytes = ByteArray(64) { it.toByte() }
+        server.enqueue(MockResponse().setHeader("Content-Length", "64").setBody(Buffer().write(bytes)))
+
+        val result = api.openBundleStream(baseUrl(), "42", "tkn", insecureAllowed = false, fromByte = 0L)
+
+        val recorded = server.takeRequest()
+        assertEquals("/api/books/42/synced", recorded.path)
+        assertEquals("Bearer tkn", recorded.getHeader("Authorization"))
+        assertEquals("application/audiobook+zip", recorded.getHeader("Accept"))
+        assertNull("No Range header on a fresh download", recorded.getHeader("Range"))
+        assertTrue(result is NetworkAudiobookBundleResult.Success)
+        result as NetworkAudiobookBundleResult.Success
+        assertEquals(64L, result.totalBytes)
+        assertFalse(result.isPartial)
+        assertEquals(bytes.toList(), result.body.use { it.bytes() }.toList())
+    }
+
+    @Test fun resume_sendsRangeHeader_parsesTotalFromContentRange() = runTest {
+        val tail = ByteArray(28) { (it + 100).toByte() }
+        server.enqueue(
+            MockResponse()
+                .setResponseCode(206)
+                .setHeader("Content-Range", "bytes 100-127/128")
+                .setBody(Buffer().write(tail)),
+        )
+
+        val result = api.openBundleStream(baseUrl(), "42", "tkn", insecureAllowed = false, fromByte = 100L)
+
+        val recorded = server.takeRequest()
+        assertEquals("bytes=100-", recorded.getHeader("Range"))
+        assertTrue(result is NetworkAudiobookBundleResult.Success)
+        result as NetworkAudiobookBundleResult.Success
+        assertEquals(128L, result.totalBytes)
+        assertTrue(result.isPartial)
+    }
+
+    @Test fun nonSuccess_returnsNetworkError() = runTest {
+        server.enqueue(MockResponse().setResponseCode(500))
+
+        val result = api.openBundleStream(baseUrl(), "42", "tkn", insecureAllowed = false, fromByte = 0L)
+
+        assertTrue(result is NetworkAudiobookBundleResult.NetworkError)
+    }
+}

--- a/core/network/src/test/kotlin/com/riffle/core/network/StorytellerPositionApiTest.kt
+++ b/core/network/src/test/kotlin/com/riffle/core/network/StorytellerPositionApiTest.kt
@@ -1,0 +1,82 @@
+package com.riffle.core.network
+
+import kotlinx.coroutines.test.runTest
+import okhttp3.OkHttpClient
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class StorytellerPositionApiTest {
+
+    private lateinit var server: MockWebServer
+    private lateinit var api: StorytellerPositionApi
+
+    @Before fun setUp() {
+        server = MockWebServer().also { it.start() }
+        api = StorytellerPositionApiImpl(OkHttpClient())
+    }
+
+    @After fun tearDown() = server.shutdown()
+
+    private fun baseUrl() = server.url("/").toString().trimEnd('/')
+
+    @Test fun getPosition_parsesLocatorAndTimestamp() = runTest {
+        server.enqueue(
+            MockResponse().setBody(
+                """{"userId":"u","bookUuid":"b","locator":{"href":"text/c1.html","locations":{"fragments":["id1-s2"],"progression":0.5,"totalProgression":0.1}},"timestamp":1780258583061}""",
+            ),
+        )
+
+        val result = api.getPosition(baseUrl(), "42", "tkn", insecureAllowed = false)
+
+        val recorded = server.takeRequest()
+        assertEquals("GET", recorded.method)
+        assertEquals("/api/v2/books/42/positions", recorded.path)
+        assertEquals("Bearer tkn", recorded.getHeader("Authorization"))
+        assertTrue(result is NetworkStorytellerPositionResult.Success)
+        result as NetworkStorytellerPositionResult.Success
+        assertEquals(1780258583061L, result.timestampMillis)
+        assertTrue("locator json carries the href", result.locatorJson.contains("text/c1.html"))
+        assertTrue("locator json carries the fragment", result.locatorJson.contains("id1-s2"))
+    }
+
+    @Test fun getPosition_404_isNoPosition() = runTest {
+        server.enqueue(MockResponse().setResponseCode(404))
+
+        val result = api.getPosition(baseUrl(), "42", "tkn", insecureAllowed = false)
+
+        assertTrue(result is NetworkStorytellerPositionResult.NoPosition)
+    }
+
+    @Test fun getPosition_serverError_isNetworkError() = runTest {
+        server.enqueue(MockResponse().setResponseCode(500))
+
+        val result = api.getPosition(baseUrl(), "42", "tkn", insecureAllowed = false)
+
+        assertTrue(result is NetworkStorytellerPositionResult.NetworkError)
+    }
+
+    @Test fun putPosition_sendsLocatorAndTimestamp() = runTest {
+        server.enqueue(MockResponse().setResponseCode(200))
+
+        val result = api.putPosition(
+            baseUrl(), "42",
+            locatorJson = """{"href":"text/c1.html","locations":{"progression":0.5}}""",
+            timestampMillis = 1780258583061L,
+            token = "tkn",
+            insecureAllowed = false,
+        )
+
+        val recorded = server.takeRequest()
+        assertEquals("PATCH", recorded.method)
+        assertEquals("/api/v2/books/42/positions", recorded.path)
+        val body = recorded.body.readUtf8()
+        assertTrue("body carries locator", body.contains("text/c1.html"))
+        assertTrue("body carries timestamp", body.contains("1780258583061"))
+        assertTrue(result is NetworkStorytellerPutResult.Success)
+    }
+}

--- a/docs/adr/0023-storyteller-synced-bundle-is-the-readaloud-audio-source.md
+++ b/docs/adr/0023-storyteller-synced-bundle-is-the-readaloud-audio-source.md
@@ -1,0 +1,51 @@
+# ADR 0023 — The Storyteller synced bundle is the Readaloud audio source
+
+**Status:** Accepted
+
+## Context
+
+Issue #37 (Readaloud playback) was specified against an assumed two-artifact model: a
+text-only **EPUB bundle** plus a separate **audiobook bundle** served as a Readium audiobook
+archive (`application/audiobook+zip`), each downloadable independently.
+
+Probing the development Storyteller server (`http://media-server:8001`, `GET /api/books/{id}/synced`)
+shows the real shape:
+
+- There is exactly **one** downloadable bundle per book: `GET /api/books/{id}/synced`.
+- It returns `Content-Type: application/epub+zip`, ~315 MB for *The Martian* — i.e. an EPUB 3
+  that already contains the text, the audio resources, and the `.smil` Media Overlays.
+- `Accept: application/audiobook+zip` is ignored; no separate audiobook archive endpoint
+  exists (`/audio`, `/audiobook`, `/manifest.json`, … all 404).
+- The endpoint **does** honour HTTP `Range` (`Accept-Ranges: bytes`, `206 Partial Content`),
+  so a resumable download is achievable.
+- Reading position lives at `GET/PATCH /api/v2/books/{id}/positions` as a Readium `Locator`
+  plus a millisecond `timestamp`.
+
+The existing reader (#35) already treats `/synced` as *the* EPUB: it caches small bundles on
+open and requires an explicit Download for large ones (`EpubRepositoryImpl`).
+
+## Decision
+
+Riffle treats the Storyteller **synced bundle as the single source of both the readable EPUB
+and the Readaloud audio.** There is no separate audio download.
+
+- **`AudiobookBundleDownloader`** performs a **resumable, progress-reporting** `Range` download
+  of `/synced` into the permanent Downloads area. It sends `Accept: application/audiobook+zip`
+  for forward-compatibility with any Storyteller version that may content-negotiate, but accepts
+  `application/epub+zip`. This is the AC-mandated upgrade over the stream-only `EpubBundleFetcher`.
+- **"Download readaloud audio (X GB)"** downloads/promotes the synced bundle to Downloads. "X GB"
+  is the probed `Content-Length`. Because the synced bundle *is* the EPUB, "fetch the EPUB bundle
+  first if absent" collapses to "fetch the synced bundle once".
+- **Playback** reads the `.smil` overlays and audio resources directly out of the downloaded EPUB
+  zip — no extraction to a second on-disk copy.
+- **Cache cap / LRU** governs *auto-cached* synced bundles in the Cached area; bundles in permanent
+  Downloads are never evicted.
+
+## Consequences
+
+- "EPUB bundle present" and "audio bundle present" are the same predicate for Storyteller books.
+- The user-facing two-action framing in the issue is preserved in spirit: the reader's headphones
+  affordance offers to download the synced bundle when it is absent, with size + Wi-Fi-only gating.
+- If a future Storyteller release ships a genuinely separate `application/audiobook+zip`, only
+  `AudiobookBundleDownloader`'s URL/Accept handling changes; the rest of the pipeline (SMIL parse,
+  track, coordinator, player) is already archive-agnostic.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,6 +24,7 @@ coroutines = "1.11.0"
 kotlinx-serialization = "1.7.3"
 coil = "2.7.0"
 jsoup = "1.22.2"
+media3 = "1.4.1"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -73,6 +74,9 @@ androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "j
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
 coil-compose = { group = "io.coil-kt", name = "coil-compose", version.ref = "coil" }
 jsoup = { group = "org.jsoup", name = "jsoup", version.ref = "jsoup" }
+media3-exoplayer = { group = "androidx.media3", name = "media3-exoplayer", version.ref = "media3" }
+media3-session = { group = "androidx.media3", name = "media3-session", version.ref = "media3" }
+media3-common = { group = "androidx.media3", name = "media3-common", version.ref = "media3" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
Closes #37.

Delivers the synced-readaloud reading experience for a Storyteller book: audio playback with a synced sentence highlight, auto-page-turn, "Play from here", background playback, resumable audio download, a per-server audio cache cap, and Storyteller-only position sync.

## Key architectural decision — ADR 0023
Probing the live Storyteller server showed it serves a **single** `/api/books/{id}/synced` bundle — an EPUB 3 containing text + audio + SMIL — with no separate `application/audiobook+zip`. So the synced bundle is treated as both the readable EPUB and the readaloud audio source. The audio downloader does a resumable HTTP Range download of it; playback streams audio entries straight out of the EPUB zip. See `docs/adr/0023-...md`.

## What's included
**Engine (TDD, unit-tested):**
- `SmilOverlayParser`, `ReadaloudTrack` (+`resolveStartClip`), `AutoPageTurnRule`, `LruCacheEvictor`, `StorytellerPositionReconciler` (pure, core:domain)
- `AudiobookBundleApi` (resumable Range) + `StorytellerPositionApi` (GET/PATCH positions) (core:network, MockWebServer)
- `AudiobookBundleDownloader`, `MediaOverlayReader`, `ReadaloudAudioRepository`, `StorytellerPositionSyncController`, per-server `AudioCachePreferences` (core:data)

**Player + UI:**
- `AudioPlayerService` (Media3 `MediaSessionService`, foreground, audio focus, lock-screen/Bluetooth, media notification), `ZipAudioDataSource` (streams audio from the EPUB zip), `ReadaloudController`, `PlayerCoordinator`
- Reader headphones action (Readaloud-only), mini-player bar + expandable sheet, synced highlight, "Play from here", play-from-current-position, download/offline prompts
- Settings: per-Storyteller-server audio cache cap (default 2 GB, LRU eviction)

## Two on-device bugs found and fixed during verification
- **No playback at all:** Media3 strips a media item's URI across the session Binder; added `MediaSession.Callback.onAddMediaItems` to rebuild the `zipaudio://` URI from the mediaId.
- **No highlight / wrong place:** playback started at position 0; now seeks to the reader's current position via `ReadaloudTrack.resolveStartClip`.

Verified on-device: playback starts at the reading position, the active sentence is highlighted on the visible page, and the audio HAL emits frames.

## Code review (this branch) — addressed
- Removed dead audio download/remove machinery from `LibraryItemDetailViewModel`/`Screen` (incl. a destructive `removeAudio` path + unused imports) left after the redundant detail-screen action was dropped.
- `PlayerCoordinator.dispose()` cancels the state-collection scope on VM clear (no cross-session leak).
- Wi-Fi-only toggle now enforced via `ConnectivityObserver.isMetered()`.
- `ReadaloudController.pause()` stops the 250ms position poll.

Dismissed (with reason): ZipFile reopen-per-seek and DEFLATE-seek cost (verified acceptable on-device; optimize later); `trustAllCerts`/byte-format duplication (follows existing codebase convention; future shared helper); `SharedBundle` global + `mediaId`==entry-path convention + Locator-in-cfi-column (correct for the single-Storyteller-player scope of this slice; matched-book reconciliation is the next slice); auto-page-turn visible-fragment approximation (documented Readium 3.0 limitation).

## Tested
- `./gradlew test` (unit) + `./gradlew :core:data:testDebugUnitTest -PintegrationTests` (integration) — green
- `make harness-test` (129 tests, 0 failed) and `make harness-test-tablet` (5 tests, 0 failed) — green
- Manual on-device playback verification (audio frames, highlight, start position)