### PR TITLE
feat(matching): Storyteller readaloud review queue, fuzzy matching, manual pairing (#39)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ gradle/gradle-daemon-jvm.properties
 # Generated files
 **/build/
 **/.gradle/
+.kotlin/
 
 # Keystore files
 *.jks

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Riffle lets you browse your ebook library, read EPUB and PDF files, and sync rea
 - Audiobookshelf and Storyteller login with secure token storage and insecure-connection warnings
 - Storyteller Readaloud Library: browse every completed readaloud as a single library
 - Readaloud playback in the reader: synced sentence highlight, auto-page-turn, "Play from here", background playback with lock-screen/Bluetooth controls, and a per-server audio cache cap
+- Automatic Storyteller↔Audiobookshelf matching with a Settings review queue: high-confidence pairs auto-confirm, fuzzy matches go to Pending Review, and a manual picker pairs anything the matcher can't place
 - Bidirectional progress sync with last-update-wins conflict resolution
 - Periodic auto-sync and offline queueing
 - Reading session time tracking

--- a/app/src/androidTest/kotlin/com/riffle/app/di/TestDatabaseModule.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/di/TestDatabaseModule.kt
@@ -7,6 +7,8 @@ import com.riffle.core.database.BookFormattingPreferencesDao
 import com.riffle.core.database.CollectionDao
 import com.riffle.core.database.LibraryDao
 import com.riffle.core.database.LibraryItemDao
+import com.riffle.core.database.ReadaloudCandidateDao
+import com.riffle.core.database.ReadaloudDismissalDao
 import com.riffle.core.database.ReadaloudLinkDao
 import com.riffle.core.database.ReadingPositionDao
 import com.riffle.core.database.RiffleDatabase
@@ -72,4 +74,12 @@ object TestDatabaseModule {
     @Provides
     @Singleton
     fun provideReadaloudLinkDao(db: RiffleDatabase): ReadaloudLinkDao = db.readaloudLinkDao()
+
+    @Provides
+    @Singleton
+    fun provideReadaloudCandidateDao(db: RiffleDatabase): ReadaloudCandidateDao = db.readaloudCandidateDao()
+
+    @Provides
+    @Singleton
+    fun provideReadaloudDismissalDao(db: RiffleDatabase): ReadaloudDismissalDao = db.readaloudDismissalDao()
 }

--- a/app/src/main/kotlin/com/riffle/app/RiffleApplication.kt
+++ b/app/src/main/kotlin/com/riffle/app/RiffleApplication.kt
@@ -4,12 +4,12 @@ import android.app.Application
 import android.content.Context
 import coil.ImageLoader
 import coil.ImageLoaderFactory
+import coil.disk.DiskCache
 import dagger.hilt.android.HiltAndroidApp
-import okhttp3.Cache
+import okhttp3.Interceptor
 import okhttp3.OkHttpClient
 import org.acra.ReportField
 import org.acra.ktx.initAcra
-import java.io.File
 
 @HiltAndroidApp
 class RiffleApplication : Application(), ImageLoaderFactory {
@@ -29,18 +29,39 @@ class RiffleApplication : Application(), ImageLoaderFactory {
 
     override fun newImageLoader(): ImageLoader =
         ImageLoader.Builder(this)
-            .okHttpClient {
-                OkHttpClient.Builder()
-                    .cache(Cache(File(cacheDir, "image_cache"), 100L * 1024 * 1024))
-                    .addNetworkInterceptor { chain ->
-                        // Serve cached covers instantly; revalidate silently after 1 day.
-                        // Stale copies are acceptable for up to 7 days (covers rarely change).
-                        chain.proceed(chain.request())
-                            .newBuilder()
-                            .header("Cache-Control", "max-age=86400, stale-while-revalidate=604800")
-                            .build()
-                    }
+            .okHttpClient { imageLoaderOkHttpClient() }
+            .diskCache {
+                DiskCache.Builder()
+                    .directory(cacheDir.resolve("image_cache"))
+                    .maxSizeBytes(IMAGE_DISK_CACHE_MAX_BYTES)
                     .build()
             }
             .build()
 }
+
+/** 100 MB cap for the on-disk cover cache. */
+internal const val IMAGE_DISK_CACHE_MAX_BYTES = 100L * 1024 * 1024
+
+/**
+ * Serves cached covers instantly and revalidates silently after a day; stale copies are acceptable
+ * for up to 7 days (covers rarely change). Coil's DiskCache reads these response headers to decide
+ * freshness, so the policy applies without an OkHttp disk cache.
+ */
+internal val coverCacheControlInterceptor = Interceptor { chain ->
+    chain.proceed(chain.request())
+        .newBuilder()
+        .header("Cache-Control", "max-age=86400, stale-while-revalidate=604800")
+        .build()
+}
+
+/**
+ * OkHttp client for the cover [ImageLoader]. Deliberately carries **no** OkHttp `Cache`: Coil's own
+ * DiskCache owns `cacheDir/image_cache`. An OkHttp `Cache` and Coil's `DiskCache` are two separate
+ * `DiskLruCache` writers, and pointing both at that one directory corrupts the journal
+ * ("unexpected journal header"), wiping the cover cache on launch. Keeping a single writer for the
+ * directory is the fix — see RiffleImageLoaderTest.
+ */
+internal fun imageLoaderOkHttpClient(): OkHttpClient =
+    OkHttpClient.Builder()
+        .addNetworkInterceptor(coverCacheControlInterceptor)
+        .build()

--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemDetailScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemDetailScreen.kt
@@ -76,6 +76,8 @@ fun LibraryItemDetailScreen(
     windowSizeClass: WindowSizeClass,
     onNavigateBack: () -> Unit,
     onReadItem: (LibraryItem) -> Unit,
+    onReviewReadaloud: (String) -> Unit = {},
+    onPairReadaloud: (String, String) -> Unit = { _, _ -> },
     viewModel: LibraryItemDetailViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsState()
@@ -165,6 +167,8 @@ fun LibraryItemDetailScreen(
                         onDownload = { viewModel.startDownload() },
                         onRemove = onRemoveWithUndo,
                         onUnlinkReadaloud = { viewModel.unlinkFromAbs() },
+                        onReviewReadaloud = onReviewReadaloud,
+                        onPairReadaloud = onPairReadaloud,
                         modifier = Modifier.padding(padding),
                     )
                 } else {
@@ -184,6 +188,8 @@ fun LibraryItemDetailScreen(
                         onDownload = { viewModel.startDownload() },
                         onRemove = onRemoveWithUndo,
                         onUnlinkReadaloud = { viewModel.unlinkFromAbs() },
+                        onReviewReadaloud = onReviewReadaloud,
+                        onPairReadaloud = onPairReadaloud,
                         modifier = Modifier.padding(padding),
                     )
                 }
@@ -233,6 +239,8 @@ private fun LibraryItemDetailContent(
     onDownload: () -> Unit,
     onRemove: () -> Unit,
     onUnlinkReadaloud: () -> Unit,
+    onReviewReadaloud: (String) -> Unit = {},
+    onPairReadaloud: (String, String) -> Unit = { _, _ -> },
     modifier: Modifier = Modifier,
 ) {
     Column(
@@ -290,16 +298,41 @@ private fun LibraryItemDetailContent(
 
         MetadataLines(item = item)
 
-        readaloudFooter?.let { ReadaloudFooter(state = it, onUnlink = onUnlinkReadaloud) }
+        readaloudFooter?.let {
+            ReadaloudFooter(
+                state = it,
+                onUnlink = onUnlinkReadaloud,
+                onReviewReadaloud = onReviewReadaloud,
+                onPairReadaloud = onPairReadaloud,
+            )
+        }
     }
 }
 
 @Composable
-private fun ReadaloudFooter(state: ReadaloudFooterState, onUnlink: () -> Unit) {
+private fun ReadaloudFooter(
+    state: ReadaloudFooterState,
+    onUnlink: () -> Unit,
+    onReviewReadaloud: (String) -> Unit = {},
+    onPairReadaloud: (String, String) -> Unit = { _, _ -> },
+) {
+    // Tap-navigation targets per ADR 0021: Pending Review opens the review queue; Unmatched opens
+    // the manual-pair picker for this book.
+    val rowClick: (() -> Unit)? = when (state) {
+        is ReadaloudFooterState.ReadaloudPendingReview -> {
+            { onReviewReadaloud(state.storytellerServerId) }
+        }
+        is ReadaloudFooterState.ReadaloudUnmatched -> {
+            { onPairReadaloud(state.storytellerServerId, state.storytellerBookId) }
+        }
+        else -> null
+    }
     Surface(
         tonalElevation = 1.dp,
         shape = RoundedCornerShape(8.dp),
-        modifier = Modifier.fillMaxWidth(),
+        modifier = Modifier
+            .fillMaxWidth()
+            .then(if (rowClick != null) Modifier.clickable(onClick = rowClick) else Modifier),
     ) {
         Row(
             modifier = Modifier.padding(horizontal = 12.dp, vertical = 10.dp),
@@ -328,6 +361,18 @@ private fun ReadaloudFooter(state: ReadaloudFooterState, onUnlink: () -> Unit) {
                                 style = MaterialTheme.typography.bodyMedium,
                             )
                         }
+                    }
+                    is ReadaloudFooterState.ReadaloudPendingReview -> {
+                        Text(
+                            text = "Possible matches — Review",
+                            style = MaterialTheme.typography.bodyMedium,
+                        )
+                    }
+                    is ReadaloudFooterState.ReadaloudUnmatched -> {
+                        Text(
+                            text = "Not linked to an ABS book — Pair manually",
+                            style = MaterialTheme.typography.bodyMedium,
+                        )
                     }
                 }
             }
@@ -360,6 +405,8 @@ internal fun LibraryItemDetailContentTablet(
     onDownload: () -> Unit,
     onRemove: () -> Unit,
     onUnlinkReadaloud: () -> Unit,
+    onReviewReadaloud: (String) -> Unit = {},
+    onPairReadaloud: (String, String) -> Unit = { _, _ -> },
     modifier: Modifier = Modifier,
 ) {
     Row(
@@ -427,7 +474,14 @@ internal fun LibraryItemDetailContentTablet(
                 Text(text = series, style = MaterialTheme.typography.bodyLarge)
             }
             MetadataLines(item = item)
-            readaloudFooter?.let { ReadaloudFooter(state = it, onUnlink = onUnlinkReadaloud) }
+            readaloudFooter?.let {
+                ReadaloudFooter(
+                    state = it,
+                    onUnlink = onUnlinkReadaloud,
+                    onReviewReadaloud = onReviewReadaloud,
+                    onPairReadaloud = onPairReadaloud,
+                )
+            }
         }
     }
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModel.kt
@@ -70,6 +70,18 @@ sealed interface ReadaloudFooterState {
     ) : ReadaloudFooterState {
         data class AbsTarget(val absTitle: String, val absLibraryName: String)
     }
+
+    /** Readaloud side, Tier 3: "Possible matches — Review" → opens the Pending Review queue. */
+    data class ReadaloudPendingReview(
+        val storytellerServerId: String,
+        val storytellerBookId: String,
+    ) : ReadaloudFooterState
+
+    /** Readaloud side, Tier 4: "Not linked to an ABS book — Pair manually" → opens the picker. */
+    data class ReadaloudUnmatched(
+        val storytellerServerId: String,
+        val storytellerBookId: String,
+    ) : ReadaloudFooterState
 }
 
 sealed interface DownloadState {
@@ -89,6 +101,7 @@ class LibraryItemDetailViewModel @Inject constructor(
     private val sessionRepository: ReadingSessionRepository,
     private val toReadRepository: ToReadRepository,
     private val readaloudLinkRepository: com.riffle.core.domain.ReadaloudLinkRepository,
+    private val readaloudReviewRepository: com.riffle.core.domain.ReadaloudReviewRepository,
     private val connectivityObserver: ConnectivityObserver,
 ) : ViewModel() {
 
@@ -243,7 +256,15 @@ class LibraryItemDetailViewModel @Inject constructor(
             // Readaloud-side unlink drops every ABS row paired with this readaloud (each
             // ABS slot has its own row under the ABS-keyed schema).
             readaloudLinkRepository.unlinkStorytellerBook(footer.storytellerServerId, footer.storytellerBookId)
-            _uiState.value = current.copy(readaloudFooter = null)
+            // Recompute the footer so the "Pair manually" / "Review" prompt appears immediately
+            // instead of the footer vanishing until the screen is reopened.
+            val newFooter = if (readaloudReviewRepository.hasPendingCandidates(footer.storytellerServerId, footer.storytellerBookId)) {
+                ReadaloudFooterState.ReadaloudPendingReview(footer.storytellerServerId, footer.storytellerBookId)
+            } else {
+                ReadaloudFooterState.ReadaloudUnmatched(footer.storytellerServerId, footer.storytellerBookId)
+            }
+            val latest = _uiState.value as? LibraryItemDetailUiState.Ready ?: return@launch
+            _uiState.value = latest.copy(readaloudFooter = newFooter)
         }
     }
 
@@ -257,7 +278,15 @@ class LibraryItemDetailViewModel @Inject constructor(
             // A readaloud can have multiple ABS rows (ebook + audiobook stub). Surface
             // every counterpart, ebooks first so the most useful target leads the list.
             val links = readaloudLinkRepository.findByStorytellerBook(serverId, item.id)
-            if (links.isEmpty()) return null
+            if (links.isEmpty()) {
+                // No Confirmed link: surface either the Pending Review queue (Tier 3 candidates
+                // exist) or the Unmatched "pair manually" prompt (Tier 4).
+                return if (readaloudReviewRepository.hasPendingCandidates(serverId, item.id)) {
+                    ReadaloudFooterState.ReadaloudPendingReview(serverId, item.id)
+                } else {
+                    ReadaloudFooterState.ReadaloudUnmatched(serverId, item.id)
+                }
+            }
             val targets = links
                 .mapNotNull { link ->
                     val absItem = repository.getItem(link.absLibraryItemId) ?: return@mapNotNull null

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsNavEvent.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsNavEvent.kt
@@ -2,4 +2,5 @@ package com.riffle.app.feature.settings
 
 sealed class SettingsNavEvent {
     data object NavigateToAddServer : SettingsNavEvent()
+    data class NavigateToReadaloudMatches(val serverId: String) : SettingsNavEvent()
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material3.Button
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
@@ -58,6 +59,7 @@ fun SettingsScreen(
     windowSizeClass: WindowSizeClass,
     onNavigateBack: () -> Unit,
     onNavigateToAddServer: () -> Unit,
+    onNavigateToReadaloudMatches: (String) -> Unit = {},
     viewModel: SettingsViewModel = hiltViewModel(),
 ) {
     val report = viewModel.lastCrashReport
@@ -79,6 +81,7 @@ fun SettingsScreen(
         viewModel.navigationEvents.collect { event ->
             when (event) {
                 is SettingsNavEvent.NavigateToAddServer -> onNavigateToAddServer()
+                is SettingsNavEvent.NavigateToReadaloudMatches -> onNavigateToReadaloudMatches(event.serverId)
             }
         }
     }
@@ -215,6 +218,29 @@ fun SettingsScreen(
                                     }
                                 }
                             },
+                        )
+                    }
+                    HorizontalDivider()
+                }
+
+                if (storytellerServers.isNotEmpty()) {
+                    Text(
+                        text = "Readaloud matches",
+                        style = MaterialTheme.typography.titleSmall,
+                        modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+                    )
+                    HorizontalDivider()
+                    storytellerServers.forEach { server ->
+                        ListItem(
+                            headlineContent = { Text(server.name) },
+                            supportingContent = { Text("Review and pair Storyteller readalouds with ABS books") },
+                            trailingContent = {
+                                Icon(
+                                    Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                                    contentDescription = null,
+                                )
+                            },
+                            modifier = Modifier.clickable { viewModel.openReadaloudMatches(server.id) },
                         )
                     }
                     HorizontalDivider()

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsViewModel.kt
@@ -175,6 +175,12 @@ class SettingsViewModel @Inject constructor(
         }
     }
 
+    fun openReadaloudMatches(serverId: String) {
+        viewModelScope.launch {
+            _navigationEvents.send(SettingsNavEvent.NavigateToReadaloudMatches(serverId))
+        }
+    }
+
     fun setLibraryVisible(serverId: String, libraryId: String, visible: Boolean) {
         viewModelScope.launch {
             if (visible) visibilityStore.showLibrary(serverId, libraryId)

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/readaloud/ReadaloudMatchesScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/readaloud/ReadaloudMatchesScreen.kt
@@ -1,0 +1,361 @@
+package com.riffle.app.feature.settings.readaloud
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.painter.ColorPainter
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.hilt.navigation.compose.hiltViewModel
+import coil.compose.AsyncImage
+import coil.request.ImageRequest
+import androidx.compose.ui.platform.LocalContext
+import com.riffle.core.domain.AbsCandidate
+import com.riffle.core.domain.AbsPickerItem
+import com.riffle.core.domain.ConfirmedReadaloud
+import com.riffle.core.domain.PendingReadaloud
+import com.riffle.core.domain.UnmatchedReadaloud
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ReadaloudMatchesScreen(
+    onNavigateBack: () -> Unit,
+    viewModel: ReadaloudMatchesViewModel = hiltViewModel(),
+) {
+    val review by viewModel.review.collectAsState()
+    val tokens by viewModel.tokensByServer.collectAsState()
+
+    // When opened from a readaloud's "Pair manually" footer, hold the book id whose picker is open.
+    var pairingBookId by remember { mutableStateOf(viewModel.pairBookId) }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Readaloud matches") },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding),
+        ) {
+            sectionHeader("Pending Review (${review.pending.size})")
+            if (review.pending.isEmpty()) {
+                emptyRow("Nothing waiting for review.")
+            } else {
+                items(review.pending, key = { it.storytellerBookId }) { book ->
+                    PendingReadaloudCard(
+                        book = book,
+                        tokens = tokens,
+                        onConfirm = { candidate -> viewModel.confirm(book, candidate) },
+                        onDismissCandidate = { candidate -> viewModel.dismissCandidate(book, candidate) },
+                        onNoMatch = { viewModel.dismissBook(book) },
+                    )
+                    HorizontalDivider()
+                }
+            }
+
+            sectionHeader("Unmatched (${review.unmatched.size})")
+            if (review.unmatched.isEmpty()) {
+                emptyRow("Every readaloud is matched or under review.")
+            } else {
+                items(review.unmatched, key = { it.storytellerBookId }) { book ->
+                    UnmatchedReadaloudRow(
+                        book = book,
+                        tokens = tokens,
+                        onMatchManually = { pairingBookId = book.storytellerBookId },
+                    )
+                    HorizontalDivider()
+                }
+            }
+
+            sectionHeader("Confirmed (${review.confirmed.size})")
+            if (review.confirmed.isEmpty()) {
+                emptyRow("No confirmed links yet.")
+            } else {
+                items(review.confirmed, key = { it.storytellerBookId }) { link ->
+                    ConfirmedReadaloudRow(
+                        link = link,
+                        onUnlink = { viewModel.unlinkBook(link) },
+                    )
+                    HorizontalDivider()
+                }
+            }
+        }
+    }
+
+    pairingBookId?.let { bookId ->
+        val query by viewModel.pickerQuery.collectAsState()
+        val results by viewModel.pickerResults.collectAsState()
+        // Reactively reflects links as they're added/removed so the picker can stay open and let
+        // the user attach several ABS items (e.g. ebook + audiobook) to one readaloud.
+        val linkedItemIds = review.confirmed
+            .firstOrNull { it.storytellerBookId == bookId }
+            ?.targets?.map { it.absLibraryItemId }?.toSet()
+            ?: emptySet()
+        AbsPickerDialog(
+            query = query,
+            results = results,
+            tokens = tokens,
+            linkedItemIds = linkedItemIds,
+            onQueryChange = viewModel::onPickerQueryChange,
+            onLink = { item -> viewModel.pairManually(bookId, item) },
+            onUnlink = { item -> viewModel.unlinkAbsItem(item) },
+            onDismiss = { pairingBookId = null },
+        )
+    }
+}
+
+private fun LazyListScope.sectionHeader(title: String) {
+    item(key = "header:$title") {
+        Text(
+            text = title,
+            style = MaterialTheme.typography.titleSmall,
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 8.dp),
+        )
+        HorizontalDivider()
+    }
+}
+
+private fun LazyListScope.emptyRow(text: String) {
+    item(key = "empty:$text") {
+        Text(
+            text = text,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 12.dp),
+        )
+    }
+}
+
+@Composable
+private fun PendingReadaloudCard(
+    book: PendingReadaloud,
+    tokens: Map<String, String>,
+    onConfirm: (AbsCandidate) -> Unit,
+    onDismissCandidate: (AbsCandidate) -> Unit,
+    onNoMatch: () -> Unit,
+) {
+    Column(modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 12.dp)) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Cover(coverUrl = book.coverUrl, token = null)
+            Spacer(Modifier.width(12.dp))
+            Column(Modifier.weight(1f)) {
+                Text(book.title, style = MaterialTheme.typography.titleMedium, maxLines = 2, overflow = TextOverflow.Ellipsis)
+                Text(book.author, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            }
+        }
+        Spacer(Modifier.height(8.dp))
+        book.candidates.forEach { candidate ->
+            CandidateRow(
+                candidate = candidate,
+                token = tokens[candidate.absServerId],
+                onConfirm = { onConfirm(candidate) },
+                onDismiss = { onDismissCandidate(candidate) },
+            )
+        }
+        Spacer(Modifier.height(4.dp))
+        TextButton(onClick = onNoMatch) {
+            Text("No match — don't ask again")
+        }
+    }
+}
+
+@Composable
+private fun CandidateRow(
+    candidate: AbsCandidate,
+    token: String?,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(vertical = 6.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Cover(coverUrl = candidate.coverUrl, token = token)
+        Spacer(Modifier.width(12.dp))
+        Column(Modifier.weight(1f)) {
+            Text(candidate.absTitle, style = MaterialTheme.typography.bodyMedium, maxLines = 2, overflow = TextOverflow.Ellipsis)
+            Text(
+                "${candidate.absAuthor} · ${candidate.absLibraryName} · ${(candidate.score * 100).toInt()}%",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Row {
+                Button(onClick = onConfirm) { Text("Confirm") }
+                Spacer(Modifier.width(8.dp))
+                OutlinedButton(onClick = onDismiss) { Text("Dismiss") }
+            }
+        }
+    }
+}
+
+@Composable
+private fun UnmatchedReadaloudRow(
+    book: UnmatchedReadaloud,
+    tokens: Map<String, String>,
+    onMatchManually: () -> Unit,
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Cover(coverUrl = book.coverUrl, token = null)
+        Spacer(Modifier.width(12.dp))
+        Column(Modifier.weight(1f)) {
+            Text(book.title, style = MaterialTheme.typography.titleMedium, maxLines = 2, overflow = TextOverflow.Ellipsis)
+            Text(book.author, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+        }
+        OutlinedButton(onClick = onMatchManually) { Text("Match manually…") }
+    }
+}
+
+@Composable
+private fun ConfirmedReadaloudRow(
+    link: ConfirmedReadaloud,
+    onUnlink: () -> Unit,
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Column(Modifier.weight(1f)) {
+            Text(link.title, style = MaterialTheme.typography.titleMedium, maxLines = 2, overflow = TextOverflow.Ellipsis)
+            link.targets.forEach { target ->
+                Text(
+                    "Linked to: ${target.absTitle} · ${target.absLibraryName}",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+        TextButton(onClick = onUnlink) { Text("Unlink") }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun AbsPickerDialog(
+    query: String,
+    results: List<AbsPickerItem>,
+    tokens: Map<String, String>,
+    linkedItemIds: Set<String>,
+    onQueryChange: (String) -> Unit,
+    onLink: (AbsPickerItem) -> Unit,
+    onUnlink: (AbsPickerItem) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    Dialog(onDismissRequest = onDismiss) {
+        Surface(shape = RoundedCornerShape(12.dp), tonalElevation = 2.dp) {
+            Column(modifier = Modifier.fillMaxWidth().padding(16.dp)) {
+                Text("Match manually", style = MaterialTheme.typography.titleMedium)
+                Text(
+                    "A readaloud can link to more than one book (e.g. an ebook and an audiobook).",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Spacer(Modifier.height(8.dp))
+                OutlinedTextField(
+                    value = query,
+                    onValueChange = onQueryChange,
+                    label = { Text("Search ABS by title or author") },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                Spacer(Modifier.height(8.dp))
+                LazyColumn(modifier = Modifier.fillMaxWidth().height(360.dp)) {
+                    items(results, key = { it.absServerId + "/" + it.absLibraryItemId }) { item ->
+                        val isLinked = item.absLibraryItemId in linkedItemIds
+                        Row(
+                            modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            Cover(coverUrl = item.coverUrl, token = tokens[item.absServerId])
+                            Spacer(Modifier.width(12.dp))
+                            Column(Modifier.weight(1f)) {
+                                Text(item.title, style = MaterialTheme.typography.bodyMedium, maxLines = 2, overflow = TextOverflow.Ellipsis)
+                                Text(
+                                    "${item.author} · ${item.libraryName}",
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                )
+                            }
+                            Spacer(Modifier.width(8.dp))
+                            if (isLinked) {
+                                OutlinedButton(onClick = { onUnlink(item) }) { Text("Unlink") }
+                            } else {
+                                Button(onClick = { onLink(item) }) { Text("Link") }
+                            }
+                        }
+                        HorizontalDivider()
+                    }
+                }
+                Spacer(Modifier.height(8.dp))
+                Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
+                    TextButton(onClick = onDismiss) { Text("Done") }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun Cover(coverUrl: String?, token: String?) {
+    AsyncImage(
+        model = ImageRequest.Builder(LocalContext.current)
+            .data(coverUrl)
+            .apply { if (token != null) addHeader("Authorization", "Bearer $token") }
+            .crossfade(true)
+            .build(),
+        placeholder = ColorPainter(MaterialTheme.colorScheme.surfaceVariant),
+        error = ColorPainter(MaterialTheme.colorScheme.surfaceVariant),
+        contentDescription = null,
+        contentScale = ContentScale.Crop,
+        modifier = Modifier
+            .size(width = 40.dp, height = 60.dp)
+            .clip(RoundedCornerShape(4.dp)),
+    )
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/readaloud/ReadaloudMatchesViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/readaloud/ReadaloudMatchesViewModel.kt
@@ -1,0 +1,121 @@
+package com.riffle.app.feature.settings.readaloud
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.riffle.core.domain.AbsCandidate
+import com.riffle.core.domain.AbsPickerItem
+import com.riffle.core.domain.ConfirmedReadaloud
+import com.riffle.core.domain.PendingReadaloud
+import com.riffle.core.domain.ReadaloudReview
+import com.riffle.core.domain.ReadaloudReviewRepository
+import com.riffle.core.domain.ServerRepository
+import com.riffle.core.domain.TokenStorage
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@OptIn(FlowPreview::class)
+@HiltViewModel
+class ReadaloudMatchesViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle,
+    private val reviewRepository: ReadaloudReviewRepository,
+    private val serverRepository: ServerRepository,
+    private val tokenStorage: TokenStorage,
+) : ViewModel() {
+
+    private val serverId: String = savedStateHandle.get<String>("serverId") ?: ""
+
+    /** Set when the screen was opened from a readaloud's "Pair manually" footer link. */
+    val pairBookId: String? = savedStateHandle.get<String>("pairBookId")?.takeIf { it.isNotEmpty() }
+
+    val review: StateFlow<ReadaloudReview> = reviewRepository.observeReview(serverId)
+        .stateIn(
+            viewModelScope,
+            SharingStarted.WhileSubscribed(5_000),
+            ReadaloudReview(emptyList(), emptyList(), emptyList()),
+        )
+
+    /** Per-server auth tokens so cover thumbnails across every ABS Server render. */
+    private val _tokensByServer = MutableStateFlow<Map<String, String>>(emptyMap())
+    val tokensByServer: StateFlow<Map<String, String>> = _tokensByServer.asStateFlow()
+
+    private val _pickerQuery = MutableStateFlow("")
+    val pickerQuery: StateFlow<String> = _pickerQuery.asStateFlow()
+
+    private val _pickerResults = MutableStateFlow<List<AbsPickerItem>>(emptyList())
+    val pickerResults: StateFlow<List<AbsPickerItem>> = _pickerResults.asStateFlow()
+
+    init {
+        viewModelScope.launch {
+            // One snapshot is enough; tokens don't change while this screen is open.
+            val map = mutableMapOf<String, String>()
+            serverRepository.observeAll().first().forEach { server ->
+                tokenStorage.getToken(server.id)?.let { map[server.id] = it }
+            }
+            _tokensByServer.value = map
+        }
+        viewModelScope.launch {
+            _pickerQuery
+                .debounce(200)
+                .collect { query -> _pickerResults.value = reviewRepository.searchAbsItems(query) }
+        }
+    }
+
+    fun confirm(book: PendingReadaloud, candidate: AbsCandidate) {
+        viewModelScope.launch {
+            reviewRepository.confirmCandidate(
+                book.storytellerServerId, book.storytellerBookId,
+                candidate.absServerId, candidate.absLibraryItemId,
+            )
+        }
+    }
+
+    fun dismissCandidate(book: PendingReadaloud, candidate: AbsCandidate) {
+        viewModelScope.launch {
+            reviewRepository.dismissCandidate(
+                book.storytellerServerId, book.storytellerBookId,
+                candidate.absServerId, candidate.absLibraryItemId,
+            )
+        }
+    }
+
+    fun dismissBook(book: PendingReadaloud) {
+        viewModelScope.launch {
+            reviewRepository.dismissBook(book.storytellerServerId, book.storytellerBookId)
+        }
+    }
+
+    fun unlinkBook(link: ConfirmedReadaloud) {
+        viewModelScope.launch {
+            reviewRepository.unlinkBook(link.storytellerServerId, link.storytellerBookId)
+        }
+    }
+
+    /** Detach a single ABS item from a readaloud (used by the picker's per-row Unlink). */
+    fun unlinkAbsItem(item: AbsPickerItem) {
+        viewModelScope.launch {
+            reviewRepository.unlinkAbsItem(item.absServerId, item.absLibraryItemId)
+        }
+    }
+
+    fun onPickerQueryChange(query: String) {
+        _pickerQuery.value = query
+    }
+
+    fun pairManually(storytellerBookId: String, item: AbsPickerItem) {
+        viewModelScope.launch {
+            reviewRepository.pairManually(
+                serverId, storytellerBookId, item.absServerId, item.absLibraryItemId,
+            )
+        }
+    }
+}

--- a/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
@@ -35,6 +35,7 @@ import com.riffle.app.feature.server.AddServerScreen
 import com.riffle.app.feature.server.SelectLibrariesScreen
 import com.riffle.app.feature.server.ServerSetupViewModel
 import com.riffle.app.feature.settings.SettingsScreen
+import com.riffle.app.feature.settings.readaloud.ReadaloudMatchesScreen
 import kotlinx.coroutines.launch
 import java.net.URLDecoder
 import java.net.URLEncoder
@@ -44,6 +45,7 @@ private const val SERVER_SETUP_GRAPH = "server_setup"
 private const val ADD_SERVER = "add_server"
 private const val SELECT_LIBRARIES = "select_libraries"
 private const val SETTINGS = "settings"
+private const val READALOUD_MATCHES = "readaloud_matches/{serverId}?pairBookId={pairBookId}"
 private const val DOWNLOADS = "downloads"
 private const val LIBRARY_ITEMS = "library_items/{libraryId}/{libraryName}"
 private const val LIBRARY_SECTION = "library_section/{libraryId}/{libraryName}/{sectionType}"
@@ -193,6 +195,24 @@ fun MainScreen(
                     windowSizeClass = windowSizeClass,
                     onNavigateBack = { navController.popBackStack() },
                     onNavigateToAddServer = { navController.navigate(ADD_SERVER) },
+                    onNavigateToReadaloudMatches = { serverId ->
+                        val encoded = URLEncoder.encode(serverId, "UTF-8")
+                        navController.navigate("readaloud_matches/$encoded")
+                    },
+                )
+            }
+            composable(
+                route = READALOUD_MATCHES,
+                arguments = listOf(
+                    navArgument("serverId") { type = NavType.StringType },
+                    navArgument("pairBookId") {
+                        type = NavType.StringType
+                        defaultValue = ""
+                    },
+                ),
+            ) {
+                ReadaloudMatchesScreen(
+                    onNavigateBack = { navController.popBackStack() },
                 )
             }
             composable(DOWNLOADS) {
@@ -316,6 +336,15 @@ fun MainScreen(
                     onNavigateBack = { navController.popBackStack() },
                     onReadItem = { item ->
                         readerRouteFor(item)?.let { navController.navigate(it) }
+                    },
+                    onReviewReadaloud = { serverId ->
+                        val encoded = URLEncoder.encode(serverId, "UTF-8")
+                        navController.navigate("readaloud_matches/$encoded")
+                    },
+                    onPairReadaloud = { serverId, bookId ->
+                        val encodedServer = URLEncoder.encode(serverId, "UTF-8")
+                        val encodedBook = URLEncoder.encode(bookId, "UTF-8")
+                        navController.navigate("readaloud_matches/$encodedServer?pairBookId=$encodedBook")
                     },
                 )
             }

--- a/app/src/test/kotlin/com/riffle/app/RiffleImageLoaderTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/RiffleImageLoaderTest.kt
@@ -1,0 +1,63 @@
+package com.riffle.app
+
+import okhttp3.Call
+import okhttp3.Connection
+import okhttp3.Interceptor
+import okhttp3.Protocol
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.ResponseBody.Companion.toResponseBody
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class RiffleImageLoaderTest {
+
+    @Test
+    fun `cover OkHttp client has no disk Cache so it cannot collide with Coil's DiskCache`() {
+        // The bug: an OkHttp Cache at cacheDir/image_cache shares the directory with Coil's own
+        // DiskCache, corrupting the DiskLruCache journal. The fix keeps a single writer — no
+        // OkHttp Cache on this client. Re-adding `.cache(...)` would reintroduce the corruption.
+        assertNull(imageLoaderOkHttpClient().cache)
+    }
+
+    @Test
+    fun `cover OkHttp client keeps exactly the revalidation network interceptor`() {
+        val interceptors = imageLoaderOkHttpClient().networkInterceptors
+        assertEquals(listOf(coverCacheControlInterceptor), interceptors)
+    }
+
+    @Test
+    fun `revalidation interceptor rewrites Cache-Control so Coil can cache and revalidate covers`() {
+        val request = Request.Builder().url("https://abs.example/cover.jpg").build()
+        val upstream = Response.Builder()
+            .request(request)
+            .protocol(Protocol.HTTP_1_1)
+            .code(200)
+            .message("OK")
+            // Server sends no caching headers — without the interceptor covers wouldn't cache.
+            .body("img".toResponseBody(null))
+            .build()
+
+        val result = coverCacheControlInterceptor.intercept(FakeChain(request, upstream))
+
+        assertEquals("max-age=86400, stale-while-revalidate=604800", result.header("Cache-Control"))
+    }
+
+    /** Minimal [Interceptor.Chain] that returns a canned response for the request. */
+    private class FakeChain(
+        private val request: Request,
+        private val response: Response,
+    ) : Interceptor.Chain {
+        override fun request(): Request = request
+        override fun proceed(request: Request): Response = response
+        override fun connection(): Connection? = null
+        override fun call(): Call = throw UnsupportedOperationException()
+        override fun connectTimeoutMillis(): Int = 0
+        override fun withConnectTimeout(timeout: Int, unit: java.util.concurrent.TimeUnit) = this
+        override fun readTimeoutMillis(): Int = 0
+        override fun withReadTimeout(timeout: Int, unit: java.util.concurrent.TimeUnit) = this
+        override fun writeTimeoutMillis(): Int = 0
+        override fun withWriteTimeout(timeout: Int, unit: java.util.concurrent.TimeUnit) = this
+    }
+}

--- a/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModelTest.kt
@@ -225,6 +225,7 @@ class LibraryItemDetailViewModelTest {
         sessionRepository = noOpSessionRepository,
         toReadRepository = toReadRepo,
         readaloudLinkRepository = NoopReadaloudLinkRepository,
+        readaloudReviewRepository = NoopReadaloudReviewRepository,
         connectivityObserver = connectivityObserver,
     )
 

--- a/app/src/test/kotlin/com/riffle/app/feature/library/NoopReadaloudReviewRepository.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/NoopReadaloudReviewRepository.kt
@@ -1,0 +1,20 @@
+package com.riffle.app.feature.library
+
+import com.riffle.core.domain.AbsPickerItem
+import com.riffle.core.domain.ReadaloudReview
+import com.riffle.core.domain.ReadaloudReviewRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+
+internal object NoopReadaloudReviewRepository : ReadaloudReviewRepository {
+    override fun observeReview(storytellerServerId: String): Flow<ReadaloudReview> =
+        flowOf(ReadaloudReview(emptyList(), emptyList(), emptyList()))
+    override suspend fun hasPendingCandidates(storytellerServerId: String, storytellerBookId: String): Boolean = false
+    override suspend fun confirmCandidate(storytellerServerId: String, storytellerBookId: String, absServerId: String, absLibraryItemId: String) = Unit
+    override suspend fun dismissCandidate(storytellerServerId: String, storytellerBookId: String, absServerId: String, absLibraryItemId: String) = Unit
+    override suspend fun dismissBook(storytellerServerId: String, storytellerBookId: String) = Unit
+    override suspend fun unlinkBook(storytellerServerId: String, storytellerBookId: String) = Unit
+    override suspend fun unlinkAbsItem(absServerId: String, absLibraryItemId: String) = Unit
+    override suspend fun pairManually(storytellerServerId: String, storytellerBookId: String, absServerId: String, absLibraryItemId: String) = Unit
+    override suspend fun searchAbsItems(query: String): List<AbsPickerItem> = emptyList()
+}

--- a/core/data/src/main/kotlin/com/riffle/core/data/ReadaloudMatchingService.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/ReadaloudMatchingService.kt
@@ -2,10 +2,14 @@ package com.riffle.core.data
 
 import com.riffle.core.database.LibraryItemDao
 import com.riffle.core.database.MatchableItemRow
+import com.riffle.core.database.ReadaloudCandidateDao
+import com.riffle.core.database.ReadaloudCandidateEntity
+import com.riffle.core.database.ReadaloudDismissalDao
+import com.riffle.core.database.ReadaloudDismissalEntity
 import com.riffle.core.database.ReadaloudLinkDao
 import com.riffle.core.database.ReadaloudLinkEntity
-import com.riffle.core.domain.Confirmed
 import com.riffle.core.domain.EbookFormat
+import com.riffle.core.domain.MatchOutcome
 import com.riffle.core.domain.MatchableAbsItem
 import com.riffle.core.domain.MatchableStorytellerBook
 import com.riffle.core.domain.ReadaloudMatcher
@@ -14,27 +18,36 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 /**
- * Drives the Storyteller↔ABS auto-matcher and persists results into [ReadaloudLinkDao].
+ * Drives the Storyteller↔ABS auto-matcher ([ReadaloudMatcher]) and persists its verdicts, per
+ * the full ADR 0021 ladder:
  *
- * Schema is ABS-keyed (one row per ABS Library Item), so a Storyteller readaloud that
- * matches both an ebook entry and an audiobook stub in two different ABS libraries
- * produces two rows. Each ABS slot is independently sticky on [ReadaloudLinkEntity.userConfirmed].
+ *  - **Confirmed** (Tier 1/2) → one [ReadaloudLinkEntity] per ABS slot. Schema is ABS-keyed, so
+ *    a readaloud matching both an ebook entry and an audiobook stub produces two rows. Each slot
+ *    is independently sticky on [ReadaloudLinkEntity.userConfirmed].
+ *  - **Pending Review** (Tier 3) → one [ReadaloudCandidateEntity] per surviving fuzzy candidate.
+ *  - **Unmatched** (Tier 4) → nothing persisted.
  *
- * The reconciler:
- *  - writes/refreshes one row per (readaloud, ABS candidate) the matcher confirms,
- *  - preserves any pre-existing user-Confirmed row (never overwrites or deletes it),
- *  - sweeps auto-Confirmed rows whose ABS slot no longer survives the current pass.
+ * User decisions are sticky and never re-evaluated:
+ *  - A readaloud with any user-Confirmed link is left entirely alone (no re-match, no candidates).
+ *  - A per-book "No match — don't ask again" ([ReadaloudDismissalEntity.SCOPE_BOOK]) keeps the
+ *    book Unmatched — the matcher never proposes candidates for it.
+ *  - A per-candidate dismissal ([ReadaloudDismissalEntity.SCOPE_CANDIDATE]) drops that one pair
+ *    from Pending Review on every subsequent run.
  */
 @Singleton
 class ReadaloudMatchingService(
     private val libraryItemDao: LibraryItemDao,
     private val readaloudLinkDao: ReadaloudLinkDao,
+    private val readaloudCandidateDao: ReadaloudCandidateDao,
+    private val readaloudDismissalDao: ReadaloudDismissalDao,
     private val clock: () -> Long,
 ) {
     @Inject constructor(
         libraryItemDao: LibraryItemDao,
         readaloudLinkDao: ReadaloudLinkDao,
-    ) : this(libraryItemDao, readaloudLinkDao, System::currentTimeMillis)
+        readaloudCandidateDao: ReadaloudCandidateDao,
+        readaloudDismissalDao: ReadaloudDismissalDao,
+    ) : this(libraryItemDao, readaloudLinkDao, readaloudCandidateDao, readaloudDismissalDao, System::currentTimeMillis)
 
     suspend fun reconcileLinks() {
         val storytellerBooks = libraryItemDao.listMatchableByServerType(ServerType.STORYTELLER.name)
@@ -42,41 +55,77 @@ class ReadaloudMatchingService(
 
         val candidates = absItems.map { it.toAbsCandidate() }
         val now = clock()
-        // Track every ABS PK the current pass auto-Confirmed. Used to sweep stale rows.
+        // Track every ABS PK the current pass auto-Confirmed (or a sticky user slot), to sweep
+        // stale rows. Fresh Pending-Review candidate rows are collected then written wholesale.
         val freshAutoSlots = mutableSetOf<Pair<String, String>>()
+        val freshCandidates = mutableListOf<ReadaloudCandidateEntity>()
 
         for (book in storytellerBooks) {
-            val matches = ReadaloudMatcher.match(book.toStorytellerBook(), candidates)
-            for (match in matches) {
-                val slot = match.absServerUuid to match.absLibraryItemId
-                val existing = readaloudLinkDao.findByAbsItem(match.absServerUuid, match.absLibraryItemId)
-                if (existing?.userConfirmed == true) {
-                    // Sticky: the user owns this slot. The auto-matcher must not touch it,
-                    // even if it'd now point somewhere else. Mark fresh only when the
-                    // user-confirmed row already points to the matcher's verdict, so the
-                    // sweep below doesn't wipe an unrelated user choice.
-                    if (existing.storytellerServerId == book.serverId && existing.storytellerBookId == book.itemId) {
-                        freshAutoSlots += slot
+            val existingLinks = readaloudLinkDao.findByStorytellerBook(book.serverId, book.itemId)
+            // Sticky: a user-Confirmed readaloud is left untouched — no re-match, no candidates.
+            // Keep its slots fresh so the stale sweep below doesn't delete them.
+            if (existingLinks.any { it.userConfirmed }) {
+                existingLinks.filter { it.userConfirmed }
+                    .forEach { freshAutoSlots += it.absServerId to it.absLibraryItemId }
+                continue
+            }
+            // Sticky: "No match — don't ask again" keeps the book Unmatched forever.
+            if (readaloudDismissalDao.isBookDismissed(book.serverId, book.itemId)) continue
+
+            when (val outcome = ReadaloudMatcher.match(book.toStorytellerBook(), candidates)) {
+                is MatchOutcome.Confirmed -> outcome.links.forEach { match ->
+                    val slot = match.absServerUuid to match.absLibraryItemId
+                    val existing = readaloudLinkDao.findByAbsItem(match.absServerUuid, match.absLibraryItemId)
+                    if (existing?.userConfirmed == true) {
+                        // The user owns this ABS slot; never overwrite it. Only mark it fresh when
+                        // it already points at this book, so an unrelated user choice isn't swept.
+                        if (existing.storytellerServerId == book.serverId && existing.storytellerBookId == book.itemId) {
+                            freshAutoSlots += slot
+                        }
+                        return@forEach
                     }
-                    continue
-                }
-                readaloudLinkDao.upsert(
-                    ReadaloudLinkEntity(
-                        absServerId = match.absServerUuid,
-                        absLibraryItemId = match.absLibraryItemId,
-                        storytellerServerId = book.serverId,
-                        storytellerBookId = book.itemId,
-                        state = ReadaloudLinkEntity.STATE_CONFIRMED,
-                        userConfirmed = false,
-                        createdAt = existing?.createdAt ?: now,
-                        updatedAt = now,
+                    readaloudLinkDao.upsert(
+                        ReadaloudLinkEntity(
+                            absServerId = match.absServerUuid,
+                            absLibraryItemId = match.absLibraryItemId,
+                            storytellerServerId = book.serverId,
+                            storytellerBookId = book.itemId,
+                            state = ReadaloudLinkEntity.STATE_CONFIRMED,
+                            userConfirmed = false,
+                            createdAt = existing?.createdAt ?: now,
+                            updatedAt = now,
+                        )
                     )
-                )
-                freshAutoSlots += slot
+                    freshAutoSlots += slot
+                }
+
+                is MatchOutcome.PendingReview -> {
+                    val dismissedPairs = readaloudDismissalDao
+                        .findByStorytellerBook(book.serverId, book.itemId)
+                        .filter { it.scope == ReadaloudDismissalEntity.SCOPE_CANDIDATE }
+                        .map { it.absServerId to it.absLibraryItemId }
+                        .toSet()
+                    outcome.candidates
+                        .filter { (it.absServerUuid to it.absLibraryItemId) !in dismissedPairs }
+                        .forEach {
+                            freshCandidates += ReadaloudCandidateEntity(
+                                storytellerServerId = book.serverId,
+                                storytellerBookId = book.itemId,
+                                absServerId = it.absServerUuid,
+                                absLibraryItemId = it.absLibraryItemId,
+                                score = it.score,
+                            )
+                        }
+                }
+
+                MatchOutcome.Unmatched -> Unit
             }
         }
 
         sweepStaleAutoLinks(freshAutoSlots)
+        // The candidate table is fully regenerated each pass (reconcile sees every book/item).
+        readaloudCandidateDao.clearAll()
+        if (freshCandidates.isNotEmpty()) readaloudCandidateDao.upsertAll(freshCandidates)
         backfillReadaloudMetadata(storytellerBooks)
     }
 

--- a/core/data/src/main/kotlin/com/riffle/core/data/ReadaloudReviewRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/ReadaloudReviewRepositoryImpl.kt
@@ -1,0 +1,257 @@
+package com.riffle.core.data
+
+import com.riffle.core.database.LibraryDao
+import com.riffle.core.database.LibraryItemDao
+import com.riffle.core.database.LibraryItemEntity
+import com.riffle.core.database.ReadaloudCandidateDao
+import com.riffle.core.database.ReadaloudCandidateEntity
+import com.riffle.core.database.ReadaloudDismissalDao
+import com.riffle.core.database.ReadaloudDismissalEntity
+import com.riffle.core.database.ReadaloudLinkDao
+import com.riffle.core.database.ReadaloudLinkEntity
+import com.riffle.core.domain.AbsCandidate
+import com.riffle.core.domain.AbsPickerItem
+import com.riffle.core.domain.ConfirmedReadaloud
+import com.riffle.core.domain.PendingReadaloud
+import com.riffle.core.domain.ReadaloudReview
+import com.riffle.core.domain.ReadaloudReviewRepository
+import com.riffle.core.domain.ServerType
+import com.riffle.core.domain.UnmatchedReadaloud
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Reads the auto-matcher's persisted verdicts ([ReadaloudLinkDao], [ReadaloudCandidateDao]) and the
+ * user's sticky decisions ([ReadaloudDismissalDao]) to drive the review queue, and applies the
+ * per-candidate / per-book actions. ABS titles, authors, library names and covers are resolved
+ * lazily from [LibraryItemDao] / [LibraryDao].
+ */
+@Singleton
+class ReadaloudReviewRepositoryImpl(
+    private val libraryItemDao: LibraryItemDao,
+    private val libraryDao: LibraryDao,
+    private val linkDao: ReadaloudLinkDao,
+    private val candidateDao: ReadaloudCandidateDao,
+    private val dismissalDao: ReadaloudDismissalDao,
+    private val clock: () -> Long,
+) : ReadaloudReviewRepository {
+
+    @Inject constructor(
+        libraryItemDao: LibraryItemDao,
+        libraryDao: LibraryDao,
+        linkDao: ReadaloudLinkDao,
+        candidateDao: ReadaloudCandidateDao,
+        dismissalDao: ReadaloudDismissalDao,
+    ) : this(libraryItemDao, libraryDao, linkDao, candidateDao, dismissalDao, System::currentTimeMillis)
+
+    override fun observeReview(storytellerServerId: String): Flow<ReadaloudReview> =
+        combine(
+            linkDao.observeAll(),
+            candidateDao.observeForStorytellerServer(storytellerServerId),
+        ) { links, candidates ->
+            buildReview(storytellerServerId, links, candidates)
+        }
+
+    override suspend fun hasPendingCandidates(storytellerServerId: String, storytellerBookId: String): Boolean =
+        candidateDao.findByStorytellerBook(storytellerServerId, storytellerBookId).isNotEmpty()
+
+    private suspend fun buildReview(
+        storytellerServerId: String,
+        allLinks: List<ReadaloudLinkEntity>,
+        candidates: List<ReadaloudCandidateEntity>,
+    ): ReadaloudReview {
+        val books = libraryItemDao.listMatchableByServerType(ServerType.STORYTELLER.name)
+            .filter { it.serverId == storytellerServerId }
+
+        val linksForServer = allLinks.filter { it.storytellerServerId == storytellerServerId }
+        val confirmedBookIds = linksForServer.map { it.storytellerBookId }.toSet()
+        val candidatesByBook = candidates.groupBy { it.storytellerBookId }
+
+        val libraryNameCache = mutableMapOf<String, String>()
+        suspend fun libraryName(libraryId: String): String =
+            libraryNameCache.getOrPut(libraryId) { libraryDao.getById(libraryId)?.name ?: libraryId }
+
+        // Group per readaloud so Unlink detaches the whole match (ebook + audiobook stub) at once.
+        val confirmed = linksForServer
+            .groupBy { it.storytellerBookId }
+            .mapNotNull { (storytellerBookId, links) ->
+                val targets = links.mapNotNull { link ->
+                    val abs = libraryItemDao.getById(link.absLibraryItemId) ?: return@mapNotNull null
+                    ConfirmedReadaloud.ConfirmedTarget(
+                        absServerId = link.absServerId,
+                        absLibraryItemId = link.absLibraryItemId,
+                        absTitle = abs.title,
+                        absLibraryName = libraryName(abs.libraryId),
+                    )
+                }
+                if (targets.isEmpty()) return@mapNotNull null
+                val book = libraryItemDao.getById(storytellerBookId)
+                ConfirmedReadaloud(
+                    storytellerServerId = storytellerServerId,
+                    storytellerBookId = storytellerBookId,
+                    title = book?.title ?: storytellerBookId,
+                    targets = targets.sortedBy { it.absLibraryName.lowercase() },
+                )
+            }
+            .sortedBy { it.title.lowercase() }
+
+        val pending = books
+            .filter { it.itemId !in confirmedBookIds && candidatesByBook.containsKey(it.itemId) }
+            .map { book ->
+                val bookEntity = libraryItemDao.getById(book.itemId)
+                val cands = candidatesByBook.getValue(book.itemId)
+                    .sortedByDescending { it.score }
+                    .mapNotNull { cand ->
+                        val abs = libraryItemDao.getById(cand.absLibraryItemId) ?: return@mapNotNull null
+                        AbsCandidate(
+                            absServerId = cand.absServerId,
+                            absLibraryItemId = cand.absLibraryItemId,
+                            absTitle = abs.title,
+                            absAuthor = abs.author,
+                            absLibraryName = libraryName(abs.libraryId),
+                            coverUrl = abs.coverUrl,
+                            score = cand.score,
+                        )
+                    }
+                PendingReadaloud(
+                    storytellerServerId = storytellerServerId,
+                    storytellerBookId = book.itemId,
+                    title = book.title,
+                    author = book.author,
+                    coverUrl = bookEntity?.coverUrl,
+                    candidates = cands,
+                )
+            }
+            .filter { it.candidates.isNotEmpty() }
+            .sortedBy { it.title.lowercase() }
+
+        val pendingBookIds = pending.map { it.storytellerBookId }.toSet()
+
+        val unmatched = books
+            .filter { it.itemId !in confirmedBookIds && it.itemId !in pendingBookIds }
+            .map { book ->
+                val bookEntity = libraryItemDao.getById(book.itemId)
+                UnmatchedReadaloud(
+                    storytellerServerId = storytellerServerId,
+                    storytellerBookId = book.itemId,
+                    title = book.title,
+                    author = book.author,
+                    coverUrl = bookEntity?.coverUrl,
+                )
+            }
+            .sortedBy { it.title.lowercase() }
+
+        return ReadaloudReview(pending = pending, unmatched = unmatched, confirmed = confirmed)
+    }
+
+    override suspend fun confirmCandidate(
+        storytellerServerId: String,
+        storytellerBookId: String,
+        absServerId: String,
+        absLibraryItemId: String,
+    ) {
+        createUserConfirmedLink(storytellerServerId, storytellerBookId, absServerId, absLibraryItemId)
+        // The book is now Confirmed; drop all of its Pending-Review candidates.
+        candidateDao.deleteByStorytellerBook(storytellerServerId, storytellerBookId)
+    }
+
+    override suspend fun dismissCandidate(
+        storytellerServerId: String,
+        storytellerBookId: String,
+        absServerId: String,
+        absLibraryItemId: String,
+    ) {
+        dismissalDao.upsert(
+            ReadaloudDismissalEntity(
+                storytellerServerId = storytellerServerId,
+                storytellerBookId = storytellerBookId,
+                scope = ReadaloudDismissalEntity.SCOPE_CANDIDATE,
+                absServerId = absServerId,
+                absLibraryItemId = absLibraryItemId,
+            )
+        )
+        candidateDao.deleteCandidate(storytellerServerId, storytellerBookId, absServerId, absLibraryItemId)
+    }
+
+    override suspend fun dismissBook(storytellerServerId: String, storytellerBookId: String) {
+        dismissalDao.upsert(
+            ReadaloudDismissalEntity(
+                storytellerServerId = storytellerServerId,
+                storytellerBookId = storytellerBookId,
+                scope = ReadaloudDismissalEntity.SCOPE_BOOK,
+            )
+        )
+        candidateDao.deleteByStorytellerBook(storytellerServerId, storytellerBookId)
+    }
+
+    override suspend fun unlinkBook(storytellerServerId: String, storytellerBookId: String) {
+        linkDao.deleteByStorytellerBook(storytellerServerId, storytellerBookId)
+    }
+
+    override suspend fun unlinkAbsItem(absServerId: String, absLibraryItemId: String) {
+        linkDao.deleteByAbsItem(absServerId, absLibraryItemId)
+    }
+
+    override suspend fun pairManually(
+        storytellerServerId: String,
+        storytellerBookId: String,
+        absServerId: String,
+        absLibraryItemId: String,
+    ) {
+        createUserConfirmedLink(storytellerServerId, storytellerBookId, absServerId, absLibraryItemId)
+        // Manual pairing overrides any prior "don't ask again" and clears stale candidates.
+        dismissalDao.clearBookDismissal(storytellerServerId, storytellerBookId)
+        candidateDao.deleteByStorytellerBook(storytellerServerId, storytellerBookId)
+    }
+
+    override suspend fun searchAbsItems(query: String): List<AbsPickerItem> {
+        val trimmed = query.trim()
+        val all = libraryItemDao.listMatchableByServerType(ServerType.AUDIOBOOKSHELF.name)
+        val matched = if (trimmed.isEmpty()) {
+            all
+        } else {
+            all.filter { it.title.contains(trimmed, ignoreCase = true) || it.author.contains(trimmed, ignoreCase = true) }
+        }
+        val libraryNameCache = mutableMapOf<String, String>()
+        return matched
+            .sortedBy { it.title.lowercase() }
+            .mapNotNull { row ->
+                val abs: LibraryItemEntity = libraryItemDao.getById(row.itemId) ?: return@mapNotNull null
+                val name = libraryNameCache.getOrPut(abs.libraryId) {
+                    libraryDao.getById(abs.libraryId)?.name ?: abs.libraryId
+                }
+                AbsPickerItem(
+                    absServerId = row.serverId,
+                    absLibraryItemId = row.itemId,
+                    title = abs.title,
+                    author = abs.author,
+                    libraryName = name,
+                    coverUrl = abs.coverUrl,
+                )
+            }
+    }
+
+    private suspend fun createUserConfirmedLink(
+        storytellerServerId: String,
+        storytellerBookId: String,
+        absServerId: String,
+        absLibraryItemId: String,
+    ) {
+        val now = clock()
+        val existing = linkDao.findByAbsItem(absServerId, absLibraryItemId)
+        linkDao.upsert(
+            ReadaloudLinkEntity(
+                absServerId = absServerId,
+                absLibraryItemId = absLibraryItemId,
+                storytellerServerId = storytellerServerId,
+                storytellerBookId = storytellerBookId,
+                state = ReadaloudLinkEntity.STATE_CONFIRMED,
+                userConfirmed = true,
+                createdAt = existing?.createdAt ?: now,
+                updatedAt = now,
+            )
+        )
+    }
+}

--- a/core/data/src/main/kotlin/com/riffle/core/data/di/DataModule.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/di/DataModule.kt
@@ -16,6 +16,7 @@ import com.riffle.core.data.LibraryVisibilityPreferencesStoreImpl
 import com.riffle.core.data.LocalStoreImpl
 import com.riffle.core.data.PdfRepositoryImpl
 import com.riffle.core.data.ReadaloudLinkRepositoryImpl
+import com.riffle.core.data.ReadaloudReviewRepositoryImpl
 import com.riffle.core.data.ReadingPositionStoreImpl
 import com.riffle.core.data.ReadingSessionRepositoryImpl
 import com.riffle.core.data.ServerRepositoryImpl
@@ -35,6 +36,7 @@ import com.riffle.core.domain.LibraryVisibilityPreferencesStore
 import com.riffle.core.domain.LocalStore
 import com.riffle.core.domain.PdfRepository
 import com.riffle.core.domain.ReadaloudLinkRepository
+import com.riffle.core.domain.ReadaloudReviewRepository
 import com.riffle.core.domain.ReadingPositionStore
 import com.riffle.core.domain.ReadingSessionRepository
 import com.riffle.core.domain.ServerRepository
@@ -128,6 +130,10 @@ abstract class DataModule {
     @Binds
     @Singleton
     abstract fun bindReadaloudLinkRepository(impl: ReadaloudLinkRepositoryImpl): ReadaloudLinkRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindReadaloudReviewRepository(impl: ReadaloudReviewRepositoryImpl): ReadaloudReviewRepository
 
     @Binds
     @Singleton

--- a/core/data/src/main/kotlin/com/riffle/core/data/di/DatabaseModule.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/di/DatabaseModule.kt
@@ -6,6 +6,8 @@ import com.riffle.core.database.BookFormattingPreferencesDao
 import com.riffle.core.database.CollectionDao
 import com.riffle.core.database.LibraryDao
 import com.riffle.core.database.LibraryItemDao
+import com.riffle.core.database.ReadaloudCandidateDao
+import com.riffle.core.database.ReadaloudDismissalDao
 import com.riffle.core.database.ReadaloudLinkDao
 import com.riffle.core.database.ReadingPositionDao
 import com.riffle.core.database.RiffleDatabase
@@ -48,6 +50,7 @@ object DatabaseModule {
                 RiffleDatabase.MIGRATION_19_20,
                 RiffleDatabase.MIGRATION_20_21,
                 RiffleDatabase.MIGRATION_21_22,
+                RiffleDatabase.MIGRATION_22_23,
             )
             .build()
 
@@ -82,4 +85,12 @@ object DatabaseModule {
     @Provides
     @Singleton
     fun provideReadaloudLinkDao(db: RiffleDatabase): ReadaloudLinkDao = db.readaloudLinkDao()
+
+    @Provides
+    @Singleton
+    fun provideReadaloudCandidateDao(db: RiffleDatabase): ReadaloudCandidateDao = db.readaloudCandidateDao()
+
+    @Provides
+    @Singleton
+    fun provideReadaloudDismissalDao(db: RiffleDatabase): ReadaloudDismissalDao = db.readaloudDismissalDao()
 }

--- a/core/data/src/test/kotlin/com/riffle/core/data/LibraryRepositoryTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/LibraryRepositoryTest.kt
@@ -266,7 +266,7 @@ class LibraryRepositoryTest {
     )
 
     private fun noopMatchingService(itemDao: FakeLibraryItemDao): ReadaloudMatchingService =
-        ReadaloudMatchingService(itemDao, NoopReadaloudLinkDao)
+        ReadaloudMatchingService(itemDao, NoopReadaloudLinkDao, NoopReadaloudCandidateDao, NoopReadaloudDismissalDao)
 
     private val storytellerApiNotCalled = object : com.riffle.core.network.StorytellerLibraryApi {
         override suspend fun validateToken(baseUrl: String, token: String, insecureAllowed: Boolean) =

--- a/core/data/src/test/kotlin/com/riffle/core/data/NoopLibraryDaos.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/NoopLibraryDaos.kt
@@ -1,0 +1,47 @@
+package com.riffle.core.data
+
+import com.riffle.core.database.LastOpenedAtRow
+import com.riffle.core.database.LibraryDao
+import com.riffle.core.database.LibraryEntity
+import com.riffle.core.database.LibraryItemDao
+import com.riffle.core.database.LibraryItemEntity
+import com.riffle.core.database.MatchableItemRow
+import com.riffle.core.database.ReadingProgressRow
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+
+/** Empty [LibraryItemDao] for tests that never touch metadata resolution. */
+internal object ThrowingLibraryItemDao : LibraryItemDao {
+    override fun observeByLibraryId(libraryId: String): Flow<List<LibraryItemEntity>> = flowOf(emptyList())
+    override fun observeUngroupedByLibraryId(libraryId: String): Flow<List<LibraryItemEntity>> = flowOf(emptyList())
+    override fun observeInProgress(libraryId: String): Flow<List<LibraryItemEntity>> = flowOf(emptyList())
+    override fun observeFinished(libraryId: String): Flow<List<LibraryItemEntity>> = flowOf(emptyList())
+    override fun observeRecentlyAdded(libraryId: String): Flow<List<LibraryItemEntity>> = flowOf(emptyList())
+    override fun observeAllBooks(libraryId: String): Flow<List<LibraryItemEntity>> = flowOf(emptyList())
+    override suspend fun upsertAll(items: List<LibraryItemEntity>) = Unit
+    override suspend fun getById(itemId: String): LibraryItemEntity? = null
+    override suspend fun deleteByLibraryId(libraryId: String) = Unit
+    override suspend fun updateLastOpenedAt(itemId: String, timestamp: Long) = Unit
+    override suspend fun updateReadingProgress(itemId: String, progress: Float) = Unit
+    override suspend fun updateReadaloudMetadata(
+        itemId: String,
+        author: String?,
+        description: String?,
+        publishedYear: String?,
+        publisher: String?,
+        genres: String,
+    ) = Unit
+    override suspend fun getLastOpenedAtMap(libraryId: String): List<LastOpenedAtRow> = emptyList()
+    override suspend fun getReadingProgressMap(libraryId: String): List<ReadingProgressRow> = emptyList()
+    override suspend fun listMatchableByServerType(serverType: String): List<MatchableItemRow> = emptyList()
+}
+
+/** Empty [LibraryDao] for tests that never resolve library names. */
+internal object ThrowingLibraryDao : LibraryDao {
+    override fun observeByServerId(serverId: String): Flow<List<LibraryEntity>> = flowOf(emptyList())
+    override suspend fun libraryIdsForServer(serverId: String): List<String> = emptyList()
+    override suspend fun getById(libraryId: String): LibraryEntity? = null
+    override suspend fun upsertAll(libraries: List<LibraryEntity>) = Unit
+    override suspend fun deleteByServerId(serverId: String) = Unit
+    override suspend fun setUnsupported(libraryId: String, isUnsupported: Boolean) = Unit
+}

--- a/core/data/src/test/kotlin/com/riffle/core/data/NoopReadaloudLinkDao.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/NoopReadaloudLinkDao.kt
@@ -1,5 +1,9 @@
 package com.riffle.core.data
 
+import com.riffle.core.database.ReadaloudCandidateDao
+import com.riffle.core.database.ReadaloudCandidateEntity
+import com.riffle.core.database.ReadaloudDismissalDao
+import com.riffle.core.database.ReadaloudDismissalEntity
 import com.riffle.core.database.ReadaloudLinkDao
 import com.riffle.core.database.ReadaloudLinkEntity
 import kotlinx.coroutines.flow.Flow
@@ -16,4 +20,25 @@ internal object NoopReadaloudLinkDao : ReadaloudLinkDao {
     override suspend fun countForServer(serverId: String): Int = 0
     override suspend fun deleteByAbsItem(absServerId: String, absLibraryItemId: String) = Unit
     override suspend fun deleteByStorytellerBook(storytellerServerId: String, storytellerBookId: String) = Unit
+}
+
+internal object NoopReadaloudCandidateDao : ReadaloudCandidateDao {
+    override suspend fun upsert(entity: ReadaloudCandidateEntity) = Unit
+    override suspend fun upsertAll(entities: List<ReadaloudCandidateEntity>) = Unit
+    override suspend fun allRows(): List<ReadaloudCandidateEntity> = emptyList()
+    override suspend fun clearAll() = Unit
+    override fun observeAll(): Flow<List<ReadaloudCandidateEntity>> = flowOf(emptyList())
+    override fun observeForStorytellerServer(storytellerServerId: String): Flow<List<ReadaloudCandidateEntity>> = flowOf(emptyList())
+    override suspend fun findByStorytellerBook(storytellerServerId: String, storytellerBookId: String): List<ReadaloudCandidateEntity> = emptyList()
+    override suspend fun deleteByStorytellerBook(storytellerServerId: String, storytellerBookId: String) = Unit
+    override suspend fun deleteCandidate(storytellerServerId: String, storytellerBookId: String, absServerId: String, absLibraryItemId: String) = Unit
+}
+
+internal object NoopReadaloudDismissalDao : ReadaloudDismissalDao {
+    override suspend fun upsert(entity: ReadaloudDismissalEntity) = Unit
+    override suspend fun allRows(): List<ReadaloudDismissalEntity> = emptyList()
+    override fun observeAll(): Flow<List<ReadaloudDismissalEntity>> = flowOf(emptyList())
+    override suspend fun findByStorytellerBook(storytellerServerId: String, storytellerBookId: String): List<ReadaloudDismissalEntity> = emptyList()
+    override suspend fun isBookDismissed(storytellerServerId: String, storytellerBookId: String): Boolean = false
+    override suspend fun clearBookDismissal(storytellerServerId: String, storytellerBookId: String) = Unit
 }

--- a/core/data/src/test/kotlin/com/riffle/core/data/ReadaloudMatchingServiceTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/ReadaloudMatchingServiceTest.kt
@@ -4,6 +4,10 @@ import com.riffle.core.database.LastOpenedAtRow
 import com.riffle.core.database.LibraryItemDao
 import com.riffle.core.database.LibraryItemEntity
 import com.riffle.core.database.MatchableItemRow
+import com.riffle.core.database.ReadaloudCandidateDao
+import com.riffle.core.database.ReadaloudCandidateEntity
+import com.riffle.core.database.ReadaloudDismissalDao
+import com.riffle.core.database.ReadaloudDismissalEntity
 import com.riffle.core.database.ReadaloudLinkDao
 import com.riffle.core.database.ReadaloudLinkEntity
 import com.riffle.core.database.ReadingProgressRow
@@ -28,7 +32,7 @@ class ReadaloudMatchingServiceTest {
         )
         val links = RecordingReadaloudLinkDao()
 
-        ReadaloudMatchingService(items, links, clock = { 12345L }).reconcileLinks()
+        service(items, links, clock = { 12345L }).reconcileLinks()
 
         assertEquals(2, links.upserts.size)
         val keys = links.upserts.map { it.absServerId to it.absLibraryItemId }.toSet()
@@ -54,7 +58,7 @@ class ReadaloudMatchingServiceTest {
         )
         val links = RecordingReadaloudLinkDao()
 
-        ReadaloudMatchingService(items, links).reconcileLinks()
+        service(items, links).reconcileLinks()
 
         assertEquals(2, links.upserts.size)
         val keys = links.upserts.map { it.absServerId to it.absLibraryItemId }.toSet()
@@ -81,7 +85,7 @@ class ReadaloudMatchingServiceTest {
             )
         }
 
-        ReadaloudMatchingService(items, links).reconcileLinks()
+        service(items, links).reconcileLinks()
 
         assertTrue("userConfirmed row stays untouched", links.upserts.isEmpty())
         assertTrue("userConfirmed row not deleted", links.deletions.isEmpty())
@@ -107,7 +111,7 @@ class ReadaloudMatchingServiceTest {
             )
         }
 
-        ReadaloudMatchingService(items, links, clock = { 500L }).reconcileLinks()
+        service(items, links, clock = { 500L }).reconcileLinks()
 
         // The old auto row gets swept; the new ABS slot is upserted.
         assertEquals(1, links.upserts.size)
@@ -137,7 +141,7 @@ class ReadaloudMatchingServiceTest {
             )
         }
 
-        ReadaloudMatchingService(items, links).reconcileLinks()
+        service(items, links).reconcileLinks()
 
         assertTrue(links.upserts.isEmpty())
         assertEquals(listOf("abs-1" to "old"), links.deletions)
@@ -156,8 +160,8 @@ class ReadaloudMatchingServiceTest {
         val a = RecordingReadaloudLinkDao()
         val b = RecordingReadaloudLinkDao()
 
-        ReadaloudMatchingService(noSt, a).reconcileLinks()
-        ReadaloudMatchingService(noAbs, b).reconcileLinks()
+        service(noSt, a).reconcileLinks()
+        service(noAbs, b).reconcileLinks()
 
         assertTrue(a.upserts.isEmpty())
         assertTrue(b.upserts.isEmpty())
@@ -180,7 +184,7 @@ class ReadaloudMatchingServiceTest {
         )
         val links = RecordingReadaloudLinkDao()
 
-        ReadaloudMatchingService(items, links).reconcileLinks()
+        service(items, links).reconcileLinks()
 
         val update = items.metadataUpdates.single { it.itemId == "42" }
         assertEquals("An epic tale", update.description)
@@ -197,7 +201,7 @@ class ReadaloudMatchingServiceTest {
         )
         val links = RecordingReadaloudLinkDao()
 
-        ReadaloudMatchingService(items, links).reconcileLinks()
+        service(items, links).reconcileLinks()
 
         val update = items.metadataUpdates.single { it.itemId == "42" }
         assertEquals(null, update.description)
@@ -217,7 +221,7 @@ class ReadaloudMatchingServiceTest {
         )
         val links = RecordingReadaloudLinkDao()
 
-        ReadaloudMatchingService(items, links).reconcileLinks()
+        service(items, links).reconcileLinks()
 
         assertEquals("Andy Weir", items.metadataUpdates.single { it.itemId == "42" }.author)
     }
@@ -231,7 +235,7 @@ class ReadaloudMatchingServiceTest {
         )
         val links = RecordingReadaloudLinkDao()
 
-        ReadaloudMatchingService(items, links).reconcileLinks()
+        service(items, links).reconcileLinks()
 
         assertEquals(null, items.metadataUpdates.single { it.itemId == "42" }.author)
     }
@@ -254,13 +258,125 @@ class ReadaloudMatchingServiceTest {
         )
         val links = RecordingReadaloudLinkDao()
 
-        ReadaloudMatchingService(items, links).reconcileLinks()
+        service(items, links).reconcileLinks()
 
         val update = items.metadataUpdates.single { it.itemId == "42" }
         assertEquals("the real synopsis", update.description)
         assertEquals("Crown", update.publisher)
         assertEquals("Sci-Fi", update.genres)
     }
+
+    // ---- Tier 3 / Pending Review + sticky decisions ---------------------------------------
+
+    @Test
+    fun `Tier 3 fuzzy match writes Pending-Review candidates with scores and no link`() = runTest {
+        val items = StubLibraryItemDao(
+            storyteller = listOf(row("st-1", "42", title = "The Hitchhikers Guide to the Galaxy Part One", author = "Douglas Adams")),
+            abs = listOf(row("abs-1", "cand", title = "The Hitchhikers Guide to the Galaxy Part Two", author = "Douglas Adams")),
+        )
+        val links = RecordingReadaloudLinkDao()
+        val candidates = RecordingReadaloudCandidateDao()
+
+        service(items, links, candidates = candidates).reconcileLinks()
+
+        assertTrue("fuzzy match must not auto-confirm a link", links.upserts.isEmpty())
+        val c = candidates.rows.single()
+        assertEquals("st-1", c.storytellerServerId)
+        assertEquals("42", c.storytellerBookId)
+        assertEquals("abs-1", c.absServerId)
+        assertEquals("cand", c.absLibraryItemId)
+        assertTrue("score ${c.score} should be >= threshold", c.score >= 0.85)
+    }
+
+    @Test
+    fun `per-book don't-ask-again keeps the book Unmatched with no candidates`() = runTest {
+        val items = StubLibraryItemDao(
+            storyteller = listOf(row("st-1", "42", title = "The Hitchhikers Guide to the Galaxy Part One", author = "Douglas Adams")),
+            abs = listOf(row("abs-1", "cand", title = "The Hitchhikers Guide to the Galaxy Part Two", author = "Douglas Adams")),
+        )
+        val links = RecordingReadaloudLinkDao()
+        val candidates = RecordingReadaloudCandidateDao()
+        val dismissals = RecordingReadaloudDismissalDao().apply { seedBookDismissal("st-1", "42") }
+
+        service(items, links, candidates = candidates, dismissals = dismissals).reconcileLinks()
+
+        assertTrue(candidates.rows.isEmpty())
+        assertTrue(links.upserts.isEmpty())
+    }
+
+    @Test
+    fun `dismissed candidate is filtered out of Pending Review but others remain`() = runTest {
+        val items = StubLibraryItemDao(
+            storyteller = listOf(row("st-1", "42", title = "The Hitchhikers Guide to the Galaxy Part One", author = "Douglas Adams")),
+            abs = listOf(
+                row("abs-1", "cand-a", title = "The Hitchhikers Guide to the Galaxy Part Two", author = "Douglas Adams"),
+                row("abs-1", "cand-b", title = "The Hitchhikers Guide to the Galaxy Part Three", author = "Douglas Adams"),
+            ),
+        )
+        val links = RecordingReadaloudLinkDao()
+        val candidates = RecordingReadaloudCandidateDao()
+        val dismissals = RecordingReadaloudDismissalDao().apply {
+            seedCandidateDismissal("st-1", "42", "abs-1", "cand-a")
+        }
+
+        service(items, links, candidates = candidates, dismissals = dismissals).reconcileLinks()
+
+        assertEquals(setOf("cand-b"), candidates.rows.map { it.absLibraryItemId }.toSet())
+    }
+
+    @Test
+    fun `user-Confirmed book is not re-evaluated into Pending Review`() = runTest {
+        val items = StubLibraryItemDao(
+            storyteller = listOf(row("st-1", "42", title = "The Hitchhikers Guide to the Galaxy Part One", author = "Douglas Adams")),
+            abs = listOf(row("abs-1", "fuzzy", title = "The Hitchhikers Guide to the Galaxy Part Two", author = "Douglas Adams")),
+        )
+        val links = RecordingReadaloudLinkDao().apply {
+            seed(
+                ReadaloudLinkEntity(
+                    absServerId = "abs-1",
+                    absLibraryItemId = "user-pick",
+                    storytellerServerId = "st-1",
+                    storytellerBookId = "42",
+                    state = ReadaloudLinkEntity.STATE_CONFIRMED,
+                    userConfirmed = true,
+                    createdAt = 1L, updatedAt = 1L,
+                ),
+            )
+        }
+        val candidates = RecordingReadaloudCandidateDao()
+
+        service(items, links, candidates = candidates).reconcileLinks()
+
+        assertTrue("no candidates for an already user-confirmed book", candidates.rows.isEmpty())
+        assertTrue("user link untouched", links.upserts.isEmpty())
+        assertTrue("user link not swept", links.deletions.isEmpty())
+    }
+
+    @Test
+    fun `stale candidates are cleared every pass`() = runTest {
+        val items = StubLibraryItemDao(
+            storyteller = listOf(row("st-1", "42", title = "Dune", author = "Frank Herbert")),
+            abs = listOf(row("abs-9", "unrelated", title = "Atomic Habits", author = "James Clear")),
+        )
+        val links = RecordingReadaloudLinkDao()
+        val candidates = RecordingReadaloudCandidateDao().apply {
+            // A candidate left over from a previous pass that no longer fuzzy-matches.
+            seed(ReadaloudCandidateEntity("st-1", "42", "abs-9", "stale", 0.9))
+        }
+
+        service(items, links, candidates = candidates).reconcileLinks()
+
+        assertTrue("stale candidate must be cleared", candidates.rows.isEmpty())
+        assertTrue(candidates.clearAllCalled)
+    }
+
+    private fun service(
+        items: StubLibraryItemDao,
+        links: RecordingReadaloudLinkDao,
+        candidates: RecordingReadaloudCandidateDao = RecordingReadaloudCandidateDao(),
+        dismissals: RecordingReadaloudDismissalDao = RecordingReadaloudDismissalDao(),
+        clock: () -> Long = { 0L },
+    ) = ReadaloudMatchingService(items, links, candidates, dismissals, clock)
 
     private fun row(
         serverId: String,
@@ -371,6 +487,67 @@ class ReadaloudMatchingServiceTest {
             val toRemove = store.filterValues { it.storytellerServerId == storytellerServerId && it.storytellerBookId == storytellerBookId }.keys
             deletions += toRemove
             toRemove.forEach { store.remove(it) }
+        }
+    }
+
+    private class RecordingReadaloudCandidateDao : ReadaloudCandidateDao {
+        private val store = mutableListOf<ReadaloudCandidateEntity>()
+        var clearAllCalled = false
+            private set
+
+        /** Final persisted candidate state after a reconcile pass. */
+        val rows: List<ReadaloudCandidateEntity> get() = store.toList()
+
+        fun seed(entity: ReadaloudCandidateEntity) { store += entity }
+
+        override suspend fun upsert(entity: ReadaloudCandidateEntity) { store += entity }
+        override suspend fun upsertAll(entities: List<ReadaloudCandidateEntity>) { store += entities }
+        override suspend fun allRows(): List<ReadaloudCandidateEntity> = store.toList()
+        override suspend fun clearAll() { clearAllCalled = true; store.clear() }
+        override fun observeAll(): Flow<List<ReadaloudCandidateEntity>> = flowOf(store.toList())
+        override fun observeForStorytellerServer(storytellerServerId: String): Flow<List<ReadaloudCandidateEntity>> =
+            flowOf(store.filter { it.storytellerServerId == storytellerServerId })
+        override suspend fun findByStorytellerBook(storytellerServerId: String, storytellerBookId: String): List<ReadaloudCandidateEntity> =
+            store.filter { it.storytellerServerId == storytellerServerId && it.storytellerBookId == storytellerBookId }
+        override suspend fun deleteByStorytellerBook(storytellerServerId: String, storytellerBookId: String) {
+            store.removeAll { it.storytellerServerId == storytellerServerId && it.storytellerBookId == storytellerBookId }
+        }
+        override suspend fun deleteCandidate(storytellerServerId: String, storytellerBookId: String, absServerId: String, absLibraryItemId: String) {
+            store.removeAll {
+                it.storytellerServerId == storytellerServerId && it.storytellerBookId == storytellerBookId &&
+                    it.absServerId == absServerId && it.absLibraryItemId == absLibraryItemId
+            }
+        }
+    }
+
+    private class RecordingReadaloudDismissalDao : ReadaloudDismissalDao {
+        private val store = mutableListOf<ReadaloudDismissalEntity>()
+
+        fun seedBookDismissal(storytellerServerId: String, storytellerBookId: String) {
+            store += ReadaloudDismissalEntity(storytellerServerId, storytellerBookId, ReadaloudDismissalEntity.SCOPE_BOOK)
+        }
+
+        fun seedCandidateDismissal(storytellerServerId: String, storytellerBookId: String, absServerId: String, absLibraryItemId: String) {
+            store += ReadaloudDismissalEntity(
+                storytellerServerId, storytellerBookId, ReadaloudDismissalEntity.SCOPE_CANDIDATE, absServerId, absLibraryItemId,
+            )
+        }
+
+        override suspend fun upsert(entity: ReadaloudDismissalEntity) { store += entity }
+        override suspend fun allRows(): List<ReadaloudDismissalEntity> = store.toList()
+        override fun observeAll(): Flow<List<ReadaloudDismissalEntity>> = flowOf(store.toList())
+        override suspend fun findByStorytellerBook(storytellerServerId: String, storytellerBookId: String): List<ReadaloudDismissalEntity> =
+            store.filter { it.storytellerServerId == storytellerServerId && it.storytellerBookId == storytellerBookId }
+        override suspend fun isBookDismissed(storytellerServerId: String, storytellerBookId: String): Boolean =
+            store.any {
+                it.storytellerServerId == storytellerServerId && it.storytellerBookId == storytellerBookId &&
+                    it.scope == ReadaloudDismissalEntity.SCOPE_BOOK
+            }
+        override suspend fun clearBookDismissal(storytellerServerId: String, storytellerBookId: String) {
+            store.removeAll {
+                it.storytellerServerId == storytellerServerId && it.storytellerBookId == storytellerBookId &&
+                    it.scope == ReadaloudDismissalEntity.SCOPE_BOOK
+            }
         }
     }
 }

--- a/core/data/src/test/kotlin/com/riffle/core/data/ReadaloudReviewRepositoryTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/ReadaloudReviewRepositoryTest.kt
@@ -1,0 +1,215 @@
+package com.riffle.core.data
+
+import com.riffle.core.database.ReadaloudCandidateDao
+import com.riffle.core.database.ReadaloudCandidateEntity
+import com.riffle.core.database.ReadaloudDismissalDao
+import com.riffle.core.database.ReadaloudDismissalEntity
+import com.riffle.core.database.ReadaloudLinkDao
+import com.riffle.core.database.ReadaloudLinkEntity
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ReadaloudReviewRepositoryTest {
+
+    @Test
+    fun `confirmCandidate creates a userConfirmed link and clears the book's candidates`() = runTest {
+        val links = RecordingLinkDao()
+        val candidates = RecordingCandidateDao().apply {
+            seed(ReadaloudCandidateEntity("st-1", "42", "abs-1", "pick", 0.9))
+            seed(ReadaloudCandidateEntity("st-1", "42", "abs-1", "other", 0.86))
+        }
+        val repo = repo(links, candidates)
+
+        repo.confirmCandidate("st-1", "42", "abs-1", "pick")
+
+        val link = links.findByAbsItem("abs-1", "pick")!!
+        assertEquals("42", link.storytellerBookId)
+        assertTrue("confirmed link must be sticky", link.userConfirmed)
+        assertTrue("all of the book's candidates are cleared", candidates.rows.isEmpty())
+    }
+
+    @Test
+    fun `dismissCandidate persists a candidate-scope dismissal and removes only that candidate`() = runTest {
+        val candidates = RecordingCandidateDao().apply {
+            seed(ReadaloudCandidateEntity("st-1", "42", "abs-1", "a", 0.9))
+            seed(ReadaloudCandidateEntity("st-1", "42", "abs-1", "b", 0.86))
+        }
+        val dismissals = RecordingDismissalDao()
+        val repo = repo(RecordingLinkDao(), candidates, dismissals)
+
+        repo.dismissCandidate("st-1", "42", "abs-1", "a")
+
+        assertEquals(setOf("b"), candidates.rows.map { it.absLibraryItemId }.toSet())
+        val d = dismissals.rows.single()
+        assertEquals(ReadaloudDismissalEntity.SCOPE_CANDIDATE, d.scope)
+        assertEquals("a", d.absLibraryItemId)
+    }
+
+    @Test
+    fun `dismissBook persists a book-scope dismissal and clears all candidates`() = runTest {
+        val candidates = RecordingCandidateDao().apply {
+            seed(ReadaloudCandidateEntity("st-1", "42", "abs-1", "a", 0.9))
+        }
+        val dismissals = RecordingDismissalDao()
+        val repo = repo(RecordingLinkDao(), candidates, dismissals)
+
+        repo.dismissBook("st-1", "42")
+
+        assertTrue(candidates.rows.isEmpty())
+        assertEquals(ReadaloudDismissalEntity.SCOPE_BOOK, dismissals.rows.single().scope)
+        assertTrue(dismissals.isBookDismissed("st-1", "42"))
+    }
+
+    @Test
+    fun `unlinkBook removes every ABS row paired with the readaloud in one action`() = runTest {
+        // Regression: a readaloud links to both an ebook and an audiobook stub. Unlinking the
+        // match must detach BOTH so the book returns to Unmatched immediately — not require a
+        // second unlink for the audiobook before the "Match manually" button reappears.
+        val links = RecordingLinkDao().apply {
+            seed(link("abs-1", "ebook", "st-1", "42", userConfirmed = true))
+            seed(link("abs-1", "audiobook", "st-1", "42", userConfirmed = true))
+        }
+        val repo = repo(links, RecordingCandidateDao())
+
+        repo.unlinkBook("st-1", "42")
+
+        assertNull(links.findByAbsItem("abs-1", "ebook"))
+        assertNull(links.findByAbsItem("abs-1", "audiobook"))
+    }
+
+    @Test
+    fun `pairManually can attach several ABS items to one readaloud`() = runTest {
+        // A readaloud links to both an ebook and an audiobook. Picking the second must NOT
+        // remove the first — the picker stays open so the user can attach more than one.
+        val links = RecordingLinkDao()
+        val repo = repo(links, RecordingCandidateDao())
+
+        repo.pairManually("st-1", "42", "abs-1", "ebook")
+        repo.pairManually("st-1", "42", "abs-1", "audiobook")
+
+        assertEquals(
+            setOf("ebook", "audiobook"),
+            links.findByStorytellerBook("st-1", "42").map { it.absLibraryItemId }.toSet(),
+        )
+    }
+
+    @Test
+    fun `unlinkAbsItem detaches one ABS item and leaves siblings linked`() = runTest {
+        val links = RecordingLinkDao().apply {
+            seed(link("abs-1", "ebook", "st-1", "42", userConfirmed = true))
+            seed(link("abs-1", "audiobook", "st-1", "42", userConfirmed = true))
+        }
+        val repo = repo(links, RecordingCandidateDao())
+
+        repo.unlinkAbsItem("abs-1", "ebook")
+
+        assertNull(links.findByAbsItem("abs-1", "ebook"))
+        assertEquals(
+            setOf("audiobook"),
+            links.findByStorytellerBook("st-1", "42").map { it.absLibraryItemId }.toSet(),
+        )
+    }
+
+    @Test
+    fun `pairManually creates a sticky link and clears prior don't-ask-again`() = runTest {
+        val links = RecordingLinkDao()
+        val candidates = RecordingCandidateDao()
+        val dismissals = RecordingDismissalDao().apply {
+            store += ReadaloudDismissalEntity("st-1", "42", ReadaloudDismissalEntity.SCOPE_BOOK)
+        }
+        val repo = repo(links, candidates, dismissals)
+
+        repo.pairManually("st-1", "42", "abs-2", "chosen")
+
+        val link = links.findByAbsItem("abs-2", "chosen")!!
+        assertTrue(link.userConfirmed)
+        assertTrue("manual pairing overrides 'don't ask again'", !dismissals.isBookDismissed("st-1", "42"))
+    }
+
+    private fun repo(
+        links: RecordingLinkDao,
+        candidates: RecordingCandidateDao,
+        dismissals: RecordingDismissalDao = RecordingDismissalDao(),
+    ) = ReadaloudReviewRepositoryImpl(
+        libraryItemDao = ThrowingLibraryItemDao,
+        libraryDao = ThrowingLibraryDao,
+        linkDao = links,
+        candidateDao = candidates,
+        dismissalDao = dismissals,
+        clock = { 1000L },
+    )
+
+    private fun link(
+        absServerId: String,
+        absLibraryItemId: String,
+        storytellerServerId: String,
+        storytellerBookId: String,
+        userConfirmed: Boolean,
+    ) = ReadaloudLinkEntity(
+        absServerId, absLibraryItemId, storytellerServerId, storytellerBookId,
+        ReadaloudLinkEntity.STATE_CONFIRMED, userConfirmed, 1L, 1L,
+    )
+
+    private class RecordingLinkDao : ReadaloudLinkDao {
+        private val store = mutableMapOf<Pair<String, String>, ReadaloudLinkEntity>()
+        fun seed(e: ReadaloudLinkEntity) { store[e.absServerId to e.absLibraryItemId] = e }
+        override suspend fun upsert(entity: ReadaloudLinkEntity) { store[entity.absServerId to entity.absLibraryItemId] = entity }
+        override suspend fun findByAbsItem(absServerId: String, absLibraryItemId: String) = store[absServerId to absLibraryItemId]
+        override suspend fun findByStorytellerBook(storytellerServerId: String, storytellerBookId: String) =
+            store.values.filter { it.storytellerServerId == storytellerServerId && it.storytellerBookId == storytellerBookId }
+        override fun observeAll(): Flow<List<ReadaloudLinkEntity>> = flowOf(store.values.toList())
+        override suspend fun allRows() = store.values.toList()
+        override fun observeLinkedAbsItemIds(): Flow<List<String>> = flowOf(store.values.map { it.absLibraryItemId })
+        override fun observeLinkedStorytellerBookIds(): Flow<List<String>> = flowOf(store.values.map { it.storytellerBookId })
+        override suspend fun countForServer(serverId: String) = 0
+        override suspend fun deleteByAbsItem(absServerId: String, absLibraryItemId: String) { store.remove(absServerId to absLibraryItemId) }
+        override suspend fun deleteByStorytellerBook(storytellerServerId: String, storytellerBookId: String) {
+            store.values.filter { it.storytellerServerId == storytellerServerId && it.storytellerBookId == storytellerBookId }
+                .forEach { store.remove(it.absServerId to it.absLibraryItemId) }
+        }
+    }
+
+    private class RecordingCandidateDao : ReadaloudCandidateDao {
+        private val store = mutableListOf<ReadaloudCandidateEntity>()
+        val rows: List<ReadaloudCandidateEntity> get() = store.toList()
+        fun seed(e: ReadaloudCandidateEntity) { store += e }
+        override suspend fun upsert(entity: ReadaloudCandidateEntity) { store += entity }
+        override suspend fun upsertAll(entities: List<ReadaloudCandidateEntity>) { store += entities }
+        override suspend fun allRows() = store.toList()
+        override suspend fun clearAll() { store.clear() }
+        override fun observeAll(): Flow<List<ReadaloudCandidateEntity>> = flowOf(store.toList())
+        override fun observeForStorytellerServer(storytellerServerId: String): Flow<List<ReadaloudCandidateEntity>> =
+            flowOf(store.filter { it.storytellerServerId == storytellerServerId })
+        override suspend fun findByStorytellerBook(storytellerServerId: String, storytellerBookId: String) =
+            store.filter { it.storytellerServerId == storytellerServerId && it.storytellerBookId == storytellerBookId }
+        override suspend fun deleteByStorytellerBook(storytellerServerId: String, storytellerBookId: String) {
+            store.removeAll { it.storytellerServerId == storytellerServerId && it.storytellerBookId == storytellerBookId }
+        }
+        override suspend fun deleteCandidate(storytellerServerId: String, storytellerBookId: String, absServerId: String, absLibraryItemId: String) {
+            store.removeAll {
+                it.storytellerServerId == storytellerServerId && it.storytellerBookId == storytellerBookId &&
+                    it.absServerId == absServerId && it.absLibraryItemId == absLibraryItemId
+            }
+        }
+    }
+
+    private class RecordingDismissalDao : ReadaloudDismissalDao {
+        val store = mutableListOf<ReadaloudDismissalEntity>()
+        val rows: List<ReadaloudDismissalEntity> get() = store.toList()
+        override suspend fun upsert(entity: ReadaloudDismissalEntity) { store += entity }
+        override suspend fun allRows() = store.toList()
+        override fun observeAll(): Flow<List<ReadaloudDismissalEntity>> = flowOf(store.toList())
+        override suspend fun findByStorytellerBook(storytellerServerId: String, storytellerBookId: String) =
+            store.filter { it.storytellerServerId == storytellerServerId && it.storytellerBookId == storytellerBookId }
+        override suspend fun isBookDismissed(storytellerServerId: String, storytellerBookId: String) =
+            store.any { it.storytellerServerId == storytellerServerId && it.storytellerBookId == storytellerBookId && it.scope == ReadaloudDismissalEntity.SCOPE_BOOK }
+        override suspend fun clearBookDismissal(storytellerServerId: String, storytellerBookId: String) {
+            store.removeAll { it.storytellerServerId == storytellerServerId && it.storytellerBookId == storytellerBookId && it.scope == ReadaloudDismissalEntity.SCOPE_BOOK }
+        }
+    }
+}

--- a/core/data/src/test/kotlin/com/riffle/core/data/SeriesIntegrationTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/SeriesIntegrationTest.kt
@@ -141,7 +141,7 @@ class SeriesIntegrationTest {
         serverRepository = fakeServerRepository,
         tokenStorage = fakeTokenStorage,
         readingSessionRepository = NoopReadingSessionRepository,
-        readaloudMatchingService = ReadaloudMatchingService(FakeLibraryItemDao(), NoopReadaloudLinkDao),
+        readaloudMatchingService = ReadaloudMatchingService(FakeLibraryItemDao(), NoopReadaloudLinkDao, NoopReadaloudCandidateDao, NoopReadaloudDismissalDao),
     )
 
     private object NoopReadingSessionRepository : com.riffle.core.domain.ReadingSessionRepository {

--- a/core/database/schemas/com.riffle.core.database.RiffleDatabase/23.json
+++ b/core/database/schemas/com.riffle.core.database.RiffleDatabase/23.json
@@ -1,0 +1,718 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 23,
+    "identityHash": "758cd36ffb97bdf206ad1a07fb38a372",
+    "entities": [
+      {
+        "tableName": "servers",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `url` TEXT NOT NULL, `isActive` INTEGER NOT NULL, `insecureConnectionAllowed` INTEGER NOT NULL, `username` TEXT NOT NULL, `serverType` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "isActive",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "insecureConnectionAllowed",
+            "columnName": "insecureConnectionAllowed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "username",
+            "columnName": "username",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverType",
+            "columnName": "serverType",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "libraries",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `mediaType` TEXT NOT NULL, `serverId` TEXT NOT NULL, `isUnsupported` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaType",
+            "columnName": "mediaType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isUnsupported",
+            "columnName": "isUnsupported",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "library_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `title` TEXT NOT NULL, `author` TEXT NOT NULL, `coverUrl` TEXT, `readingProgress` REAL NOT NULL, `ebookFileIno` TEXT, `ebookFormat` TEXT NOT NULL, `description` TEXT, `seriesName` TEXT, `publishedYear` TEXT, `genres` TEXT NOT NULL, `publisher` TEXT, `lastOpenedAt` INTEGER, `addedAt` INTEGER, `isbn` TEXT, `asin` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "coverUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "readingProgress",
+            "columnName": "readingProgress",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ebookFileIno",
+            "columnName": "ebookFileIno",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "ebookFormat",
+            "columnName": "ebookFormat",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seriesName",
+            "columnName": "seriesName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "publishedYear",
+            "columnName": "publishedYear",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "genres",
+            "columnName": "genres",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "publisher",
+            "columnName": "publisher",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastOpenedAt",
+            "columnName": "lastOpenedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "isbn",
+            "columnName": "isbn",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "asin",
+            "columnName": "asin",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "series",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `name` TEXT NOT NULL, `coverUrl` TEXT, `bookCount` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "coverUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "bookCount",
+            "columnName": "bookCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "collections",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `name` TEXT NOT NULL, `bookCount` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookCount",
+            "columnName": "bookCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "series_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`seriesId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `sequenceOrder` REAL NOT NULL, PRIMARY KEY(`seriesId`, `itemId`))",
+        "fields": [
+          {
+            "fieldPath": "seriesId",
+            "columnName": "seriesId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sequenceOrder",
+            "columnName": "sequenceOrder",
+            "affinity": "REAL",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "seriesId",
+            "itemId"
+          ]
+        }
+      },
+      {
+        "tableName": "collection_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`collectionId` TEXT NOT NULL, `itemId` TEXT NOT NULL, PRIMARY KEY(`collectionId`, `itemId`))",
+        "fields": [
+          {
+            "fieldPath": "collectionId",
+            "columnName": "collectionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "collectionId",
+            "itemId"
+          ]
+        }
+      },
+      {
+        "tableName": "reading_positions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`serverId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `cfi` TEXT NOT NULL, `localUpdatedAt` INTEGER NOT NULL, PRIMARY KEY(`serverId`, `itemId`), FOREIGN KEY(`serverId`) REFERENCES `servers`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cfi",
+            "columnName": "cfi",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localUpdatedAt",
+            "columnName": "localUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "serverId",
+            "itemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_reading_positions_serverId",
+            "unique": false,
+            "columnNames": [
+              "serverId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_reading_positions_serverId` ON `${TABLE_NAME}` (`serverId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "servers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "serverId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "book_formatting_preferences",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`itemId` TEXT NOT NULL, `fontSize` REAL, `theme` TEXT, `fontFamily` TEXT, `lineSpacing` REAL, `margins` REAL, `orientation` TEXT, `showChapterMap` INTEGER, `showReadingProgressLabels` INTEGER, `showCurrentChapterLabel` INTEGER, `doublePageSpread` INTEGER, `justifyText` INTEGER, PRIMARY KEY(`itemId`))",
+        "fields": [
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fontSize",
+            "columnName": "fontSize",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "theme",
+            "columnName": "theme",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "fontFamily",
+            "columnName": "fontFamily",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lineSpacing",
+            "columnName": "lineSpacing",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "margins",
+            "columnName": "margins",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "orientation",
+            "columnName": "orientation",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "showChapterMap",
+            "columnName": "showChapterMap",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "showReadingProgressLabels",
+            "columnName": "showReadingProgressLabels",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "showCurrentChapterLabel",
+            "columnName": "showCurrentChapterLabel",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "doublePageSpread",
+            "columnName": "doublePageSpread",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "justifyText",
+            "columnName": "justifyText",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "itemId"
+          ]
+        }
+      },
+      {
+        "tableName": "readaloud_links",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`absServerId` TEXT NOT NULL, `absLibraryItemId` TEXT NOT NULL, `storytellerServerId` TEXT NOT NULL, `storytellerBookId` TEXT NOT NULL, `state` TEXT NOT NULL, `userConfirmed` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`absServerId`, `absLibraryItemId`), FOREIGN KEY(`storytellerServerId`) REFERENCES `servers`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`absServerId`) REFERENCES `servers`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "absServerId",
+            "columnName": "absServerId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absLibraryItemId",
+            "columnName": "absLibraryItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerServerId",
+            "columnName": "storytellerServerId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerBookId",
+            "columnName": "storytellerBookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userConfirmed",
+            "columnName": "userConfirmed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "absServerId",
+            "absLibraryItemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_readaloud_links_storytellerServerId_storytellerBookId",
+            "unique": false,
+            "columnNames": [
+              "storytellerServerId",
+              "storytellerBookId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_readaloud_links_storytellerServerId_storytellerBookId` ON `${TABLE_NAME}` (`storytellerServerId`, `storytellerBookId`)"
+          },
+          {
+            "name": "index_readaloud_links_storytellerServerId",
+            "unique": false,
+            "columnNames": [
+              "storytellerServerId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_readaloud_links_storytellerServerId` ON `${TABLE_NAME}` (`storytellerServerId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "servers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "storytellerServerId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "servers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "absServerId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "readaloud_candidates",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`storytellerServerId` TEXT NOT NULL, `storytellerBookId` TEXT NOT NULL, `absServerId` TEXT NOT NULL, `absLibraryItemId` TEXT NOT NULL, `score` REAL NOT NULL, PRIMARY KEY(`storytellerServerId`, `storytellerBookId`, `absServerId`, `absLibraryItemId`), FOREIGN KEY(`storytellerServerId`) REFERENCES `servers`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`absServerId`) REFERENCES `servers`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "storytellerServerId",
+            "columnName": "storytellerServerId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerBookId",
+            "columnName": "storytellerBookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absServerId",
+            "columnName": "absServerId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absLibraryItemId",
+            "columnName": "absLibraryItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "score",
+            "columnName": "score",
+            "affinity": "REAL",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "storytellerServerId",
+            "storytellerBookId",
+            "absServerId",
+            "absLibraryItemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_readaloud_candidates_absServerId",
+            "unique": false,
+            "columnNames": [
+              "absServerId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_readaloud_candidates_absServerId` ON `${TABLE_NAME}` (`absServerId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "servers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "storytellerServerId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "servers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "absServerId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "readaloud_dismissals",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`storytellerServerId` TEXT NOT NULL, `storytellerBookId` TEXT NOT NULL, `scope` TEXT NOT NULL, `absServerId` TEXT NOT NULL, `absLibraryItemId` TEXT NOT NULL, PRIMARY KEY(`storytellerServerId`, `storytellerBookId`, `absServerId`, `absLibraryItemId`), FOREIGN KEY(`storytellerServerId`) REFERENCES `servers`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "storytellerServerId",
+            "columnName": "storytellerServerId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerBookId",
+            "columnName": "storytellerBookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scope",
+            "columnName": "scope",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absServerId",
+            "columnName": "absServerId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absLibraryItemId",
+            "columnName": "absLibraryItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "storytellerServerId",
+            "storytellerBookId",
+            "absServerId",
+            "absLibraryItemId"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "servers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "storytellerServerId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '758cd36ffb97bdf206ad1a07fb38a372')"
+    ]
+  }
+}

--- a/core/database/src/androidTest/kotlin/com/riffle/core/database/MigrationTest.kt
+++ b/core/database/src/androidTest/kotlin/com/riffle/core/database/MigrationTest.kt
@@ -734,6 +734,96 @@ class MigrationTest {
     }
 
     @Test
+    fun migration22To23_addsReadaloudCandidatesAndDismissals() {
+        helper.createDatabase(TEST_DB, 22).use { db ->
+            db.execSQL(
+                "INSERT INTO servers (id, url, isActive, insecureConnectionAllowed, username, serverType) " +
+                    "VALUES ('st1', 'http://media-server:8001', 0, 0, 'plamen', 'STORYTELLER')"
+            )
+            db.execSQL(
+                "INSERT INTO servers (id, url, isActive, insecureConnectionAllowed, username, serverType) " +
+                    "VALUES ('abs1', 'http://media-server:13378', 1, 0, 'plamen', 'AUDIOBOOKSHELF')"
+            )
+            // A pre-existing readaloud_link must survive untouched.
+            db.execSQL(
+                "INSERT INTO readaloud_links " +
+                    "(absServerId, absLibraryItemId, storytellerServerId, storytellerBookId, state, userConfirmed, createdAt, updatedAt) " +
+                    "VALUES ('abs1', 'item-ebook', 'st1', 'book-42', 'CONFIRMED', 1, 1000, 1000)"
+            )
+        }
+
+        val db = helper.runMigrationsAndValidate(TEST_DB, 23, true, RiffleDatabase.MIGRATION_22_23)
+
+        // Both new tables start empty.
+        db.query("SELECT COUNT(*) FROM readaloud_candidates").use { cursor ->
+            cursor.moveToFirst()
+            assertEquals(0, cursor.getInt(0))
+        }
+        db.query("SELECT COUNT(*) FROM readaloud_dismissals").use { cursor ->
+            cursor.moveToFirst()
+            assertEquals(0, cursor.getInt(0))
+        }
+        // The pre-existing link is preserved across the migration.
+        db.query("SELECT userConfirmed FROM readaloud_links WHERE absServerId = 'abs1' AND absLibraryItemId = 'item-ebook'").use { cursor ->
+            assertEquals(1, cursor.count)
+            cursor.moveToFirst()
+            assertEquals(1, cursor.getInt(0))
+        }
+
+        // Candidates can be written with a score; PK is the full (readaloud, ABS item) pair.
+        db.execSQL(
+            "INSERT INTO readaloud_candidates " +
+                "(storytellerServerId, storytellerBookId, absServerId, absLibraryItemId, score) " +
+                "VALUES ('st1', 'book-7', 'abs1', 'cand-a', 0.91)"
+        )
+        db.execSQL(
+            "INSERT INTO readaloud_candidates " +
+                "(storytellerServerId, storytellerBookId, absServerId, absLibraryItemId, score) " +
+                "VALUES ('st1', 'book-7', 'abs1', 'cand-b', 0.88)"
+        )
+        db.query("SELECT score FROM readaloud_candidates WHERE storytellerBookId = 'book-7' AND absLibraryItemId = 'cand-a'").use { cursor ->
+            assertEquals(1, cursor.count)
+            cursor.moveToFirst()
+            assertEquals(0.91, cursor.getDouble(0), 0.0001)
+        }
+        db.query("SELECT COUNT(*) FROM readaloud_candidates WHERE storytellerBookId = 'book-7'").use { cursor ->
+            cursor.moveToFirst()
+            assertEquals(2, cursor.getInt(0))
+        }
+
+        // Dismissals: a per-book "don't ask again" (empty ABS ids) and a per-candidate dismissal
+        // coexist for the same book because the ABS ids are part of the key.
+        db.execSQL(
+            "INSERT INTO readaloud_dismissals " +
+                "(storytellerServerId, storytellerBookId, scope, absServerId, absLibraryItemId) " +
+                "VALUES ('st1', 'book-9', 'BOOK', '', '')"
+        )
+        db.execSQL(
+            "INSERT INTO readaloud_dismissals " +
+                "(storytellerServerId, storytellerBookId, scope, absServerId, absLibraryItemId) " +
+                "VALUES ('st1', 'book-9', 'CANDIDATE', 'abs1', 'cand-x')"
+        )
+        db.query("SELECT COUNT(*) FROM readaloud_dismissals WHERE storytellerBookId = 'book-9'").use { cursor ->
+            cursor.moveToFirst()
+            assertEquals(2, cursor.getInt(0))
+        }
+
+        // FK cascade clears candidates when the ABS server is removed.
+        db.execSQL("PRAGMA foreign_keys = ON")
+        db.execSQL("DELETE FROM servers WHERE id = 'abs1'")
+        db.query("SELECT COUNT(*) FROM readaloud_candidates").use { cursor ->
+            cursor.moveToFirst()
+            assertEquals(0, cursor.getInt(0))
+        }
+        // Removing the Storyteller server cascades candidates and dismissals away.
+        db.execSQL("DELETE FROM servers WHERE id = 'st1'")
+        db.query("SELECT COUNT(*) FROM readaloud_dismissals").use { cursor ->
+            cursor.moveToFirst()
+            assertEquals(0, cursor.getInt(0))
+        }
+    }
+
+    @Test
     fun migrateFullChain() {
         helper.createDatabase(TEST_DB, 1).use { db ->
             db.execSQL(
@@ -742,7 +832,7 @@ class MigrationTest {
         }
 
         val db = helper.runMigrationsAndValidate(
-            TEST_DB, 22, true,
+            TEST_DB, 23, true,
             RiffleDatabase.MIGRATION_1_2,
             RiffleDatabase.MIGRATION_2_3,
             RiffleDatabase.MIGRATION_3_4,
@@ -764,6 +854,7 @@ class MigrationTest {
             RiffleDatabase.MIGRATION_19_20,
             RiffleDatabase.MIGRATION_20_21,
             RiffleDatabase.MIGRATION_21_22,
+            RiffleDatabase.MIGRATION_22_23,
         )
 
         db.query("SELECT url, username, serverType FROM servers WHERE id = 's1'").use { cursor ->

--- a/core/database/src/main/kotlin/com/riffle/core/database/ReadaloudCandidateDao.kt
+++ b/core/database/src/main/kotlin/com/riffle/core/database/ReadaloudCandidateDao.kt
@@ -1,0 +1,58 @@
+package com.riffle.core.database
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface ReadaloudCandidateDao {
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsert(entity: ReadaloudCandidateEntity)
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsertAll(entities: List<ReadaloudCandidateEntity>)
+
+    @Query("SELECT * FROM readaloud_candidates")
+    suspend fun allRows(): List<ReadaloudCandidateEntity>
+
+    /** Wipe the whole table — the reconciler regenerates it from the current full pass. */
+    @Query("DELETE FROM readaloud_candidates")
+    suspend fun clearAll()
+
+    @Query("SELECT * FROM readaloud_candidates")
+    fun observeAll(): Flow<List<ReadaloudCandidateEntity>>
+
+    /** All Pending-Review candidates whose readaloud lives on the given Storyteller server. */
+    @Query("SELECT * FROM readaloud_candidates WHERE storytellerServerId = :storytellerServerId")
+    fun observeForStorytellerServer(storytellerServerId: String): Flow<List<ReadaloudCandidateEntity>>
+
+    @Query(
+        "SELECT * FROM readaloud_candidates " +
+            "WHERE storytellerServerId = :storytellerServerId AND storytellerBookId = :storytellerBookId"
+    )
+    suspend fun findByStorytellerBook(
+        storytellerServerId: String,
+        storytellerBookId: String,
+    ): List<ReadaloudCandidateEntity>
+
+    @Query(
+        "DELETE FROM readaloud_candidates " +
+            "WHERE storytellerServerId = :storytellerServerId AND storytellerBookId = :storytellerBookId"
+    )
+    suspend fun deleteByStorytellerBook(storytellerServerId: String, storytellerBookId: String)
+
+    @Query(
+        "DELETE FROM readaloud_candidates " +
+            "WHERE storytellerServerId = :storytellerServerId AND storytellerBookId = :storytellerBookId " +
+            "AND absServerId = :absServerId AND absLibraryItemId = :absLibraryItemId"
+    )
+    suspend fun deleteCandidate(
+        storytellerServerId: String,
+        storytellerBookId: String,
+        absServerId: String,
+        absLibraryItemId: String,
+    )
+}

--- a/core/database/src/main/kotlin/com/riffle/core/database/ReadaloudCandidateEntity.kt
+++ b/core/database/src/main/kotlin/com/riffle/core/database/ReadaloudCandidateEntity.kt
@@ -1,0 +1,45 @@
+package com.riffle.core.database
+
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+
+/**
+ * A Tier 3 (fuzzy) ABS candidate for a Storyteller readaloud, awaiting the user's review
+ * decision (ADR 0021). One row per (readaloud, ABS item) pair the auto-matcher surfaced;
+ * [score] is the matcher's combined title/author similarity.
+ *
+ * Keyed on the full (Storyteller, ABS) pair because a single readaloud can have several
+ * fuzzy candidates and a single ABS item could (in principle) be a candidate for more than
+ * one readaloud. Both server columns FK-cascade to `servers.id` so candidates vanish when
+ * either side's Server is removed.
+ */
+@Entity(
+    tableName = "readaloud_candidates",
+    primaryKeys = ["storytellerServerId", "storytellerBookId", "absServerId", "absLibraryItemId"],
+    foreignKeys = [
+        ForeignKey(
+            entity = ServerEntity::class,
+            parentColumns = ["id"],
+            childColumns = ["storytellerServerId"],
+            onDelete = ForeignKey.CASCADE,
+        ),
+        ForeignKey(
+            entity = ServerEntity::class,
+            parentColumns = ["id"],
+            childColumns = ["absServerId"],
+            onDelete = ForeignKey.CASCADE,
+        ),
+    ],
+    indices = [
+        // The storyteller FK is covered by the PK prefix; the ABS FK needs its own index.
+        Index(value = ["absServerId"]),
+    ],
+)
+data class ReadaloudCandidateEntity(
+    val storytellerServerId: String,
+    val storytellerBookId: String,
+    val absServerId: String,
+    val absLibraryItemId: String,
+    val score: Double,
+)

--- a/core/database/src/main/kotlin/com/riffle/core/database/ReadaloudDismissalDao.kt
+++ b/core/database/src/main/kotlin/com/riffle/core/database/ReadaloudDismissalDao.kt
@@ -1,0 +1,45 @@
+package com.riffle.core.database
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface ReadaloudDismissalDao {
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsert(entity: ReadaloudDismissalEntity)
+
+    @Query("SELECT * FROM readaloud_dismissals")
+    suspend fun allRows(): List<ReadaloudDismissalEntity>
+
+    @Query("SELECT * FROM readaloud_dismissals")
+    fun observeAll(): Flow<List<ReadaloudDismissalEntity>>
+
+    @Query(
+        "SELECT * FROM readaloud_dismissals " +
+            "WHERE storytellerServerId = :storytellerServerId AND storytellerBookId = :storytellerBookId"
+    )
+    suspend fun findByStorytellerBook(
+        storytellerServerId: String,
+        storytellerBookId: String,
+    ): List<ReadaloudDismissalEntity>
+
+    /** True when the user chose "No match — don't ask again" for this readaloud. */
+    @Query(
+        "SELECT COUNT(*) > 0 FROM readaloud_dismissals " +
+            "WHERE storytellerServerId = :storytellerServerId AND storytellerBookId = :storytellerBookId " +
+            "AND scope = '" + "BOOK" + "'"
+    )
+    suspend fun isBookDismissed(storytellerServerId: String, storytellerBookId: String): Boolean
+
+    /** Undo a per-book "don't ask again" so the matcher can re-evaluate it. */
+    @Query(
+        "DELETE FROM readaloud_dismissals " +
+            "WHERE storytellerServerId = :storytellerServerId AND storytellerBookId = :storytellerBookId " +
+            "AND scope = '" + "BOOK" + "'"
+    )
+    suspend fun clearBookDismissal(storytellerServerId: String, storytellerBookId: String)
+}

--- a/core/database/src/main/kotlin/com/riffle/core/database/ReadaloudDismissalEntity.kt
+++ b/core/database/src/main/kotlin/com/riffle/core/database/ReadaloudDismissalEntity.kt
@@ -1,0 +1,42 @@
+package com.riffle.core.database
+
+import androidx.room.Entity
+import androidx.room.ForeignKey
+
+/**
+ * A sticky user decision that suppresses an auto-match from re-surfacing (ADR 0021):
+ *
+ *  - [SCOPE_BOOK] — "No match — don't ask again" for a whole readaloud. The book moves to
+ *    Unmatched and the matcher never proposes candidates for it again. [absServerId] /
+ *    [absLibraryItemId] are empty.
+ *  - [SCOPE_CANDIDATE] — "Dismiss this candidate" for a single (readaloud, ABS item) pair.
+ *    That specific pair never reappears in Pending Review; other candidates are unaffected.
+ *
+ * Empty-string ABS ids for book-scope rows keep the four-column primary key unique without a
+ * nullable key column (a real ABS item id is never empty). Only the Storyteller server column
+ * FK-cascades — the ABS id is a sentinel for book scope, so it cannot carry a foreign key.
+ */
+@Entity(
+    tableName = "readaloud_dismissals",
+    primaryKeys = ["storytellerServerId", "storytellerBookId", "absServerId", "absLibraryItemId"],
+    foreignKeys = [
+        ForeignKey(
+            entity = ServerEntity::class,
+            parentColumns = ["id"],
+            childColumns = ["storytellerServerId"],
+            onDelete = ForeignKey.CASCADE,
+        ),
+    ],
+)
+data class ReadaloudDismissalEntity(
+    val storytellerServerId: String,
+    val storytellerBookId: String,
+    val scope: String,
+    val absServerId: String = "",
+    val absLibraryItemId: String = "",
+) {
+    companion object {
+        const val SCOPE_BOOK = "BOOK"
+        const val SCOPE_CANDIDATE = "CANDIDATE"
+    }
+}

--- a/core/database/src/main/kotlin/com/riffle/core/database/RiffleDatabase.kt
+++ b/core/database/src/main/kotlin/com/riffle/core/database/RiffleDatabase.kt
@@ -17,8 +17,10 @@ import androidx.sqlite.db.SupportSQLiteDatabase
         ReadingPositionEntity::class,
         BookFormattingPreferencesEntity::class,
         ReadaloudLinkEntity::class,
+        ReadaloudCandidateEntity::class,
+        ReadaloudDismissalEntity::class,
     ],
-    version = 22,
+    version = 23,
     exportSchema = true,
 )
 abstract class RiffleDatabase : RoomDatabase() {
@@ -30,6 +32,8 @@ abstract class RiffleDatabase : RoomDatabase() {
     abstract fun readingPositionDao(): ReadingPositionDao
     abstract fun bookFormattingPreferencesDao(): BookFormattingPreferencesDao
     abstract fun readaloudLinkDao(): ReadaloudLinkDao
+    abstract fun readaloudCandidateDao(): ReadaloudCandidateDao
+    abstract fun readaloudDismissalDao(): ReadaloudDismissalDao
 
     companion object {
         val MIGRATION_1_2 = object : Migration(1, 2) {
@@ -324,6 +328,47 @@ abstract class RiffleDatabase : RoomDatabase() {
                 db.execSQL(
                     "CREATE INDEX IF NOT EXISTS `index_readaloud_links_storytellerServerId` " +
                         "ON `readaloud_links` (`storytellerServerId`)"
+                )
+            }
+        }
+
+        // Completes the ADR 0021 match ladder (issue #39). Two new tables back the review queue:
+        //
+        // 1. `readaloud_candidates` records Tier 3 fuzzy candidates awaiting user review — one
+        //    row per (readaloud, ABS item) pair with the matcher's similarity score. Both
+        //    server columns FK-cascade so candidates clear when either Server is removed.
+        // 2. `readaloud_dismissals` records sticky user decisions: a per-book "don't ask again"
+        //    (BOOK scope, empty ABS ids) and per-candidate dismissals (CANDIDATE scope). Only
+        //    the Storyteller server FK-cascades; the ABS id is a sentinel for book scope.
+        val MIGRATION_22_23 = object : Migration(22, 23) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL(
+                    "CREATE TABLE IF NOT EXISTS `readaloud_candidates` (" +
+                        "`storytellerServerId` TEXT NOT NULL, " +
+                        "`storytellerBookId` TEXT NOT NULL, " +
+                        "`absServerId` TEXT NOT NULL, " +
+                        "`absLibraryItemId` TEXT NOT NULL, " +
+                        "`score` REAL NOT NULL, " +
+                        "PRIMARY KEY(`storytellerServerId`, `storytellerBookId`, `absServerId`, `absLibraryItemId`), " +
+                        "FOREIGN KEY(`storytellerServerId`) REFERENCES `servers`(`id`) " +
+                        "ON UPDATE NO ACTION ON DELETE CASCADE, " +
+                        "FOREIGN KEY(`absServerId`) REFERENCES `servers`(`id`) " +
+                        "ON UPDATE NO ACTION ON DELETE CASCADE)"
+                )
+                db.execSQL(
+                    "CREATE INDEX IF NOT EXISTS `index_readaloud_candidates_absServerId` " +
+                        "ON `readaloud_candidates` (`absServerId`)"
+                )
+                db.execSQL(
+                    "CREATE TABLE IF NOT EXISTS `readaloud_dismissals` (" +
+                        "`storytellerServerId` TEXT NOT NULL, " +
+                        "`storytellerBookId` TEXT NOT NULL, " +
+                        "`scope` TEXT NOT NULL, " +
+                        "`absServerId` TEXT NOT NULL, " +
+                        "`absLibraryItemId` TEXT NOT NULL, " +
+                        "PRIMARY KEY(`storytellerServerId`, `storytellerBookId`, `absServerId`, `absLibraryItemId`), " +
+                        "FOREIGN KEY(`storytellerServerId`) REFERENCES `servers`(`id`) " +
+                        "ON UPDATE NO ACTION ON DELETE CASCADE)"
                 )
             }
         }

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/ReadaloudMatcher.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/ReadaloudMatcher.kt
@@ -17,31 +17,83 @@ data class MatchableAbsItem(
     val asin: String? = null,
 )
 
+/** An ABS slot the readaloud is auto-linked to (Tier 1/2). */
 data class Confirmed(val absServerUuid: String, val absLibraryItemId: String)
+
+/** A Tier 3 fuzzy candidate surfaced for user review, with its combined similarity [score]. */
+data class ScoredCandidate(
+    val absServerUuid: String,
+    val absLibraryItemId: String,
+    val score: Double,
+)
+
+/**
+ * The match state of a single Storyteller readaloud against the configured ABS Library Items,
+ * per [ADR 0021]. Exactly one of these is produced for each readaloud per matcher run.
+ */
+sealed interface MatchOutcome {
+    /**
+     * Tier 1 (identifier) or Tier 2 (normalised title + author) produced one or more
+     * high-confidence ABS slots. Multiplicity is preserved: a readaloud legitimately links to
+     * every ABS item sharing its metadata (e.g. an ebook entry plus an audiobook stub).
+     */
+    data class Confirmed(val links: List<com.riffle.core.domain.Confirmed>) : MatchOutcome
+
+    /** Tier 3: fuzzy candidates above threshold the user must choose between (or reject). */
+    data class PendingReview(val candidates: List<ScoredCandidate>) : MatchOutcome
+
+    /** Tier 4: no plausible ABS candidate. Available for manual pairing. */
+    data object Unmatched : MatchOutcome
+}
 
 object ReadaloudMatcher {
 
+    /** Minimum token-set similarity (on both title and author) for a Tier 3 fuzzy candidate. */
+    const val FUZZY_THRESHOLD = 0.85
+
     /**
-     * Returns every ABS candidate the readaloud should link to. Tier 1 (identifier match)
-     * takes precedence: if any candidate matches by ISBN/ASIN, only those candidates are
-     * returned and Tier 2 is skipped. Tier 2 (normalised title + author with subset
-     * overlap on author tokens) is the fallback when no identifier matches.
+     * Classifies a readaloud against [candidates], evaluated strongest tier first:
      *
-     * Multiple matches are expected and valid — `readaloud_links` is keyed by ABS item,
-     * so a single readaloud legitimately links to both an ebook entry in a Books library
-     * and an audiobook stub in an Audiobooks library when they share the same metadata.
+     *  - **Tier 1 (identifier)** — any candidate matching by normalised ISBN/ASIN. If present,
+     *    only identifier hits are returned and weaker tiers are skipped.
+     *  - **Tier 2 (normalised title + author)** — exact normalised title with author token
+     *    subset overlap. Tiers 1 and 2 both produce [MatchOutcome.Confirmed] and preserve
+     *    multiplicity (`readaloud_links` is ABS-keyed, so one readaloud may link to several
+     *    ABS items that share its metadata).
+     *  - **Tier 3 (fuzzy)** — Sørensen–Dice token-set similarity ≥ [FUZZY_THRESHOLD] on both
+     *    title and author. Every above-threshold candidate is surfaced together as
+     *    [MatchOutcome.PendingReview] for the user to resolve.
+     *  - **Tier 4** — nothing plausible → [MatchOutcome.Unmatched].
      */
-    fun match(book: MatchableStorytellerBook, candidates: List<MatchableAbsItem>): List<Confirmed> {
+    fun match(book: MatchableStorytellerBook, candidates: List<MatchableAbsItem>): MatchOutcome {
         val identifierHits = candidates.filter { identifierMatches(book, it) }
-        if (identifierHits.isNotEmpty()) return identifierHits.map { it.confirmed() }
+        if (identifierHits.isNotEmpty()) {
+            return MatchOutcome.Confirmed(identifierHits.map { it.confirmed() })
+        }
 
         val bookTitle = normaliseTitle(book.title)
+        val bookTitleTokens = titleTokens(book.title)
         val bookAuthorTokens = authorTokens(book.author)
-        if (bookTitle.isEmpty() || bookAuthorTokens.isEmpty()) return emptyList()
+        if (bookTitle.isEmpty() || bookAuthorTokens.isEmpty()) return MatchOutcome.Unmatched
 
-        return candidates
-            .filter { normaliseTitle(it.title) == bookTitle && authorsOverlap(bookAuthorTokens, authorTokens(it.author)) }
-            .map { it.confirmed() }
+        val titleAuthorHits = candidates.filter {
+            normaliseTitle(it.title) == bookTitle &&
+                authorsOverlap(bookAuthorTokens, authorTokens(it.author))
+        }
+        if (titleAuthorHits.isNotEmpty()) {
+            return MatchOutcome.Confirmed(titleAuthorHits.map { it.confirmed() })
+        }
+
+        val fuzzy = candidates.mapNotNull { candidate ->
+            val titleSim = diceSimilarity(bookTitleTokens, titleTokens(candidate.title))
+            val authorSim = diceSimilarity(bookAuthorTokens, authorTokens(candidate.author))
+            if (titleSim >= FUZZY_THRESHOLD && authorSim >= FUZZY_THRESHOLD) {
+                ScoredCandidate(candidate.serverUuid, candidate.libraryItemId, (titleSim + authorSim) / 2.0)
+            } else {
+                null
+            }
+        }
+        return if (fuzzy.isNotEmpty()) MatchOutcome.PendingReview(fuzzy) else MatchOutcome.Unmatched
     }
 
     /**
@@ -54,6 +106,18 @@ object ReadaloudMatcher {
     private fun authorsOverlap(a: Set<String>, b: Set<String>): Boolean {
         if (a.isEmpty() || b.isEmpty()) return false
         return a.containsAll(b) || b.containsAll(a)
+    }
+
+    /**
+     * Sørensen–Dice coefficient over two token sets: `2·|A∩B| / (|A|+|B|)`. Chosen over Jaccard
+     * because it is more forgiving of a single differing token in a multi-token title/author,
+     * which is precisely the imperfect-metadata case Tier 3 exists to surface. Returns 0 when
+     * either side is empty so an empty title/author can never clear the threshold.
+     */
+    private fun diceSimilarity(a: Set<String>, b: Set<String>): Double {
+        if (a.isEmpty() || b.isEmpty()) return 0.0
+        val intersection = a.count { it in b }
+        return (2.0 * intersection) / (a.size + b.size)
     }
 
     private fun identifierMatches(book: MatchableStorytellerBook, abs: MatchableAbsItem): Boolean {
@@ -82,25 +146,26 @@ object ReadaloudMatcher {
         return stripped.ifEmpty { null }?.uppercase()
     }
 
-    private fun normaliseTitle(raw: String): String {
-        // Strip subtitle: anything after the first `:` or em-dash. Storyteller derives titles
-        // from the EPUB OPF and keeps the "A Novel"-style subtitle; ABS users curate it out.
-        // Comparing only the head pairs the empirical reality without sacrificing safety —
-        // when the head alone collides across distinct ABS items, the collision rule
-        // demotes to Unmatched.
+    /**
+     * Ordered, normalised title used for Tier 2 exact comparison. Strips the subtitle (anything
+     * after the first `:` or em-dash — Storyteller keeps the OPF "A Novel"-style subtitle that ABS
+     * users curate out), lowercases, strips punctuation, and drops a single leading article.
+     */
+    private fun normaliseTitle(raw: String): String = titleTokenList(raw).joinToString(" ")
+
+    /** Token set form of [normaliseTitle], used for Tier 3 token-set similarity. */
+    private fun titleTokens(raw: String): Set<String> = titleTokenList(raw).toSet()
+
+    private fun titleTokenList(raw: String): List<String> {
         val head = raw.split(':', '—').first()
         val tokens = head.lowercase()
             .map { if (it.isLetterOrDigit() || it.isWhitespace()) it else ' ' }
             .joinToString("")
             .split(Regex("\\s+"))
             .filter { it.isNotEmpty() }
-        // Drop a leading article ("the", "a", "an"). Library cataloguing convention drops
-        // it; OPF metadata usually keeps it. Only the very first token is touched so that
-        // "A Brief History of Time" doesn't become "Brief History of Time" by mistake when
-        // the indefinite article is title-internal — it isn't, here, but the token-level
-        // restriction guards against false trims like "The The" → "" pathologies.
-        val deArticled = if (tokens.firstOrNull() in LEADING_ARTICLES) tokens.drop(1) else tokens
-        return deArticled.joinToString(" ")
+        // Drop a leading article only from the very first token, so a title-internal article
+        // (or a "The The" pathology) is never trimmed by mistake.
+        return if (tokens.firstOrNull() in LEADING_ARTICLES) tokens.drop(1) else tokens
     }
 
     private val LEADING_ARTICLES = setOf("the", "a", "an")

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/ReadaloudReview.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/ReadaloudReview.kt
@@ -1,0 +1,70 @@
+package com.riffle.core.domain
+
+/**
+ * The full review surface for one Storyteller Server's readalouds (ADR 0021): the three sections
+ * shown under Settings → [Storyteller Server] → Readaloud matches.
+ */
+data class ReadaloudReview(
+    val pending: List<PendingReadaloud>,
+    val unmatched: List<UnmatchedReadaloud>,
+    val confirmed: List<ConfirmedReadaloud>,
+)
+
+/** A readaloud the auto-matcher couldn't auto-Confirm, with its above-threshold ABS candidates. */
+data class PendingReadaloud(
+    val storytellerServerId: String,
+    val storytellerBookId: String,
+    val title: String,
+    val author: String,
+    val coverUrl: String?,
+    val candidates: List<AbsCandidate>,
+)
+
+/** One scored ABS candidate for a [PendingReadaloud]. */
+data class AbsCandidate(
+    val absServerId: String,
+    val absLibraryItemId: String,
+    val absTitle: String,
+    val absAuthor: String,
+    val absLibraryName: String,
+    val coverUrl: String?,
+    val score: Double,
+)
+
+/** A readaloud with no Confirmed link and no surviving candidates — available for manual pairing. */
+data class UnmatchedReadaloud(
+    val storytellerServerId: String,
+    val storytellerBookId: String,
+    val title: String,
+    val author: String,
+    val coverUrl: String?,
+)
+
+/**
+ * A Confirmed readaloud, grouped per book. A readaloud legitimately links to more than one ABS
+ * item (e.g. an ebook entry and an audiobook stub of the same work), so all of them are listed
+ * here and Unlink detaches the whole match at once — un-matching the book in a single action.
+ */
+data class ConfirmedReadaloud(
+    val storytellerServerId: String,
+    val storytellerBookId: String,
+    val title: String,
+    val targets: List<ConfirmedTarget>,
+) {
+    data class ConfirmedTarget(
+        val absServerId: String,
+        val absLibraryItemId: String,
+        val absTitle: String,
+        val absLibraryName: String,
+    )
+}
+
+/** A searchable ABS Library Item shown in the "Match manually…" picker, across every ABS Server. */
+data class AbsPickerItem(
+    val absServerId: String,
+    val absLibraryItemId: String,
+    val title: String,
+    val author: String,
+    val libraryName: String,
+    val coverUrl: String?,
+)

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/ReadaloudReviewRepository.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/ReadaloudReviewRepository.kt
@@ -1,0 +1,58 @@
+package com.riffle.core.domain
+
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Backs the Readaloud-matches review queue (ADR 0021). Reads the auto-matcher's persisted
+ * verdicts and the user's sticky decisions, and applies the per-candidate / per-book actions.
+ */
+interface ReadaloudReviewRepository {
+
+    /** The live three-section review for one Storyteller Server. */
+    fun observeReview(storytellerServerId: String): Flow<ReadaloudReview>
+
+    /** True when a readaloud has at least one surviving Pending-Review candidate. */
+    suspend fun hasPendingCandidates(storytellerServerId: String, storytellerBookId: String): Boolean
+
+    /** Confirm a candidate: create a sticky `userConfirmed` link and clear the book's candidates. */
+    suspend fun confirmCandidate(
+        storytellerServerId: String,
+        storytellerBookId: String,
+        absServerId: String,
+        absLibraryItemId: String,
+    )
+
+    /** Dismiss one candidate so this exact pair never re-surfaces in Pending Review. */
+    suspend fun dismissCandidate(
+        storytellerServerId: String,
+        storytellerBookId: String,
+        absServerId: String,
+        absLibraryItemId: String,
+    )
+
+    /** "No match — don't ask again": the book moves to Unmatched and stays there. */
+    suspend fun dismissBook(storytellerServerId: String, storytellerBookId: String)
+
+    /**
+     * Unlink a Confirmed readaloud — removes **every** ABS row paired with it so the book returns
+     * to Unmatched in one action (a readaloud can be linked to several ABS items at once).
+     */
+    suspend fun unlinkBook(storytellerServerId: String, storytellerBookId: String)
+
+    /** Unlink a single ABS item from a readaloud, leaving any other links intact (used by the picker). */
+    suspend fun unlinkAbsItem(absServerId: String, absLibraryItemId: String)
+
+    /**
+     * Manually pair an Unmatched readaloud to an ABS item the user chose from the picker. Creates a
+     * sticky `userConfirmed` link and clears any prior "don't ask again" / candidate state.
+     */
+    suspend fun pairManually(
+        storytellerServerId: String,
+        storytellerBookId: String,
+        absServerId: String,
+        absLibraryItemId: String,
+    )
+
+    /** Search ABS Library Items across every configured ABS Server by title/author. */
+    suspend fun searchAbsItems(query: String): List<AbsPickerItem>
+}

--- a/core/domain/src/test/kotlin/com/riffle/core/domain/ReadaloudMatcherTest.kt
+++ b/core/domain/src/test/kotlin/com/riffle/core/domain/ReadaloudMatcherTest.kt
@@ -6,12 +6,14 @@ import org.junit.Test
 
 class ReadaloudMatcherTest {
 
+    // ---- Tier 1: identifier ----------------------------------------------------------------
+
     @Test
     fun `single ABS candidate with matching ISBN-13 confirms it`() {
         val book = storytellerBook(isbn = "9780261103573")
         val abs = absItem(serverUuid = "abs-1", libraryItemId = "item-1", isbn = "9780261103573")
 
-        assertEquals(listOf(Confirmed("abs-1", "item-1")), ReadaloudMatcher.match(book, listOf(abs)))
+        assertEquals(confirmed("abs-1" to "item-1"), ReadaloudMatcher.match(book, listOf(abs)))
     }
 
     @Test
@@ -19,7 +21,7 @@ class ReadaloudMatcherTest {
         val book = storytellerBook(isbn = " 978-0-261-10357-3 ")
         val abs = absItem(isbn = "9780261103573")
 
-        assertEquals(listOf(Confirmed("abs-1", "item-1")), ReadaloudMatcher.match(book, listOf(abs)))
+        assertEquals(confirmed("abs-1" to "item-1"), ReadaloudMatcher.match(book, listOf(abs)))
     }
 
     @Test
@@ -27,7 +29,7 @@ class ReadaloudMatcherTest {
         val book = storytellerBook(asin = "b000fc1pzc")
         val abs = absItem(asin = "B000FC1PZC")
 
-        assertEquals(listOf(Confirmed("abs-1", "item-1")), ReadaloudMatcher.match(book, listOf(abs)))
+        assertEquals(confirmed("abs-1" to "item-1"), ReadaloudMatcher.match(book, listOf(abs)))
     }
 
     @Test
@@ -40,133 +42,12 @@ class ReadaloudMatcherTest {
 
         val result = ReadaloudMatcher.match(book, listOf(a, b))
 
-        assertEquals(setOf(Confirmed("abs-1", "ebook"), Confirmed("abs-2", "audio")), result.toSet())
-    }
-
-    @Test
-    fun `multiple ABS candidates with matching title and author all match`() {
-        val book = storytellerBook(title = "The Martian", author = "Andy Weir")
-        val ebook = absItem(serverUuid = "abs-1", libraryItemId = "ebook", title = "The Martian", author = "Andy Weir")
-        val audio = absItem(serverUuid = "abs-1", libraryItemId = "audio", title = "The Martian", author = "Andy Weir")
-
-        val result = ReadaloudMatcher.match(book, listOf(ebook, audio))
-
-        assertEquals(setOf(Confirmed("abs-1", "ebook"), Confirmed("abs-1", "audio")), result.toSet())
-    }
-
-    @Test
-    fun `no candidates returns empty list`() {
-        val book = storytellerBook(isbn = "9780261103573")
-
-        assertTrue(ReadaloudMatcher.match(book, emptyList()).isEmpty())
-    }
-
-    @Test
-    fun `exact normalised title and author matches when no identifiers present`() {
-        val book = storytellerBook(title = "The Fellowship of the Ring", author = "J.R.R. Tolkien")
-        val abs = absItem(title = "The Fellowship of the Ring", author = "J.R.R. Tolkien")
-
-        assertEquals(listOf(Confirmed("abs-1", "item-1")), ReadaloudMatcher.match(book, listOf(abs)))
-    }
-
-    @Test
-    fun `title and author match is case-insensitive and whitespace-collapsed`() {
-        val book = storytellerBook(title = "the   fellowship of THE ring", author = "j.r.r.   tolkien")
-        val abs = absItem(title = "The Fellowship of the Ring", author = "J.R.R. Tolkien")
-
-        assertEquals(listOf(Confirmed("abs-1", "item-1")), ReadaloudMatcher.match(book, listOf(abs)))
-    }
-
-    @Test
-    fun `title and author match strips punctuation`() {
-        val book = storytellerBook(title = "The Fellowship of the Ring!", author = "J.R.R. Tolkien")
-        val abs = absItem(title = "The Fellowship of the Ring.", author = "J.R.R. Tolkien.")
-
-        assertEquals(listOf(Confirmed("abs-1", "item-1")), ReadaloudMatcher.match(book, listOf(abs)))
-    }
-
-    @Test
-    fun `author name order variant Smith John equals John Smith`() {
-        val book = storytellerBook(title = "Atomic Habits", author = "Clear, James")
-        val abs = absItem(title = "Atomic Habits", author = "James Clear")
-
-        assertEquals(listOf(Confirmed("abs-1", "item-1")), ReadaloudMatcher.match(book, listOf(abs)))
-    }
-
-    @Test
-    fun `subtitle after colon is stripped before title comparison`() {
-        val book = storytellerBook(title = "The Martian: A Novel", author = "Andy Weir")
-        val abs = absItem(title = "The Martian", author = "Andy Weir")
-
-        assertEquals(listOf(Confirmed("abs-1", "item-1")), ReadaloudMatcher.match(book, listOf(abs)))
-    }
-
-    @Test
-    fun `subtitle after em-dash is stripped before title comparison`() {
-        val book = storytellerBook(title = "Project Hail Mary — A Novel", author = "Andy Weir")
-        val abs = absItem(title = "Project Hail Mary", author = "Andy Weir")
-
-        assertEquals(listOf(Confirmed("abs-1", "item-1")), ReadaloudMatcher.match(book, listOf(abs)))
-    }
-
-    @Test
-    fun `leading article on one side does not block title match`() {
-        val book = storytellerBook(title = "The Dragons of Eden", author = "Carl Sagan")
-        val abs = absItem(title = "Dragons of Eden", author = "Carl Sagan")
-
-        assertEquals(listOf(Confirmed("abs-1", "item-1")), ReadaloudMatcher.match(book, listOf(abs)))
-    }
-
-    @Test
-    fun `Storyteller multi-author list still matches single-author ABS`() {
-        val book = storytellerBook(
-            title = "The Dragons of Eden",
-            author = "Carl Sagan, JD Jackson, Ann Druyan",
-        )
-        val abs = absItem(title = "The Dragons of Eden", author = "Carl Sagan")
-
-        assertEquals(listOf(Confirmed("abs-1", "item-1")), ReadaloudMatcher.match(book, listOf(abs)))
-    }
-
-    @Test
-    fun `Storyteller duplicated-author OPF still matches single-author ABS`() {
-        val book = storytellerBook(title = "Project Hail Mary", author = "Andy Weir, Andy Weir;")
-        val abs = absItem(title = "Project Hail Mary", author = "Andy Weir")
-
-        assertEquals(listOf(Confirmed("abs-1", "item-1")), ReadaloudMatcher.match(book, listOf(abs)))
-    }
-
-    @Test
-    fun `subset match still rejects when no author token overlaps`() {
-        val book = storytellerBook(title = "The Same Title", author = "Carl Sagan, JD Jackson")
-        val abs = absItem(title = "The Same Title", author = "Someone Else")
-
-        assertTrue(ReadaloudMatcher.match(book, listOf(abs)).isEmpty())
-    }
-
-    @Test
-    fun `empty author on one side cannot satisfy subset rule`() {
-        val book = storytellerBook(title = "X", author = "")
-        val abs = absItem(title = "X", author = "Anyone")
-
-        assertTrue(ReadaloudMatcher.match(book, listOf(abs)).isEmpty())
-    }
-
-    @Test
-    fun `differing author rules out title-only match`() {
-        val book = storytellerBook(title = "Atomic Habits", author = "James Clear")
-        val abs = absItem(title = "Atomic Habits", author = "Someone Else")
-
-        assertTrue(ReadaloudMatcher.match(book, listOf(abs)).isEmpty())
+        assertEquals(setOf(Confirmed("abs-1", "ebook"), Confirmed("abs-2", "audio")), confirmedLinks(result))
     }
 
     @Test
     fun `ISBN tier wins over title-author tier when identifier is decisive`() {
-        // Storyteller has ISBN that matches one candidate exactly. A second candidate matches
-        // only on title+author. Tier 1 takes precedence — only the identifier hit is returned.
-        val book = storytellerBook(
-            title = "Atomic Habits", author = "James Clear", isbn = "9780735211292",
-        )
+        val book = storytellerBook(title = "Atomic Habits", author = "James Clear", isbn = "9780735211292")
         val isbnHit = absItem(
             serverUuid = "abs-1", libraryItemId = "item-isbn",
             title = "Atomic Habits (Hardcover)", author = "Clear, James",
@@ -178,18 +59,14 @@ class ReadaloudMatcherTest {
         )
 
         assertEquals(
-            listOf(Confirmed("abs-1", "item-isbn")),
+            confirmed("abs-1" to "item-isbn"),
             ReadaloudMatcher.match(book, listOf(isbnHit, titleAuthorOnly)),
         )
     }
 
     @Test
     fun `Tier 1 hits suppress Tier 2 even when Tier 1 has multiple candidates`() {
-        // 1:many version of the asymmetric-cost rule: if any Tier 1 candidate matches,
-        // we use ONLY Tier 1 hits and never let weaker Tier 2 candidates leak in.
-        val book = storytellerBook(
-            title = "Atomic Habits", author = "James Clear", isbn = "9780735211292",
-        )
+        val book = storytellerBook(title = "Atomic Habits", author = "James Clear", isbn = "9780735211292")
         val isbnHit1 = absItem(serverUuid = "abs-1", libraryItemId = "item-1", isbn = "9780735211292")
         val isbnHit2 = absItem(serverUuid = "abs-2", libraryItemId = "item-2", isbn = "9780735211292")
         val titleAuthorElsewhere = absItem(
@@ -199,11 +76,250 @@ class ReadaloudMatcherTest {
 
         val result = ReadaloudMatcher.match(book, listOf(isbnHit1, isbnHit2, titleAuthorElsewhere))
 
+        assertEquals(setOf(Confirmed("abs-1", "item-1"), Confirmed("abs-2", "item-2")), confirmedLinks(result))
+    }
+
+    // ---- Tier 2: normalised title + author -------------------------------------------------
+
+    @Test
+    fun `multiple ABS candidates with matching title and author all match`() {
+        val book = storytellerBook(title = "The Martian", author = "Andy Weir")
+        val ebook = absItem(serverUuid = "abs-1", libraryItemId = "ebook", title = "The Martian", author = "Andy Weir")
+        val audio = absItem(serverUuid = "abs-1", libraryItemId = "audio", title = "The Martian", author = "Andy Weir")
+
+        val result = ReadaloudMatcher.match(book, listOf(ebook, audio))
+
+        assertEquals(setOf(Confirmed("abs-1", "ebook"), Confirmed("abs-1", "audio")), confirmedLinks(result))
+    }
+
+    @Test
+    fun `exact normalised title and author matches when no identifiers present`() {
+        val book = storytellerBook(title = "The Fellowship of the Ring", author = "J.R.R. Tolkien")
+        val abs = absItem(title = "The Fellowship of the Ring", author = "J.R.R. Tolkien")
+
+        assertEquals(confirmed("abs-1" to "item-1"), ReadaloudMatcher.match(book, listOf(abs)))
+    }
+
+    @Test
+    fun `title and author match is case-insensitive and whitespace-collapsed`() {
+        val book = storytellerBook(title = "the   fellowship of THE ring", author = "j.r.r.   tolkien")
+        val abs = absItem(title = "The Fellowship of the Ring", author = "J.R.R. Tolkien")
+
+        assertEquals(confirmed("abs-1" to "item-1"), ReadaloudMatcher.match(book, listOf(abs)))
+    }
+
+    @Test
+    fun `title and author match strips punctuation`() {
+        val book = storytellerBook(title = "The Fellowship of the Ring!", author = "J.R.R. Tolkien")
+        val abs = absItem(title = "The Fellowship of the Ring.", author = "J.R.R. Tolkien.")
+
+        assertEquals(confirmed("abs-1" to "item-1"), ReadaloudMatcher.match(book, listOf(abs)))
+    }
+
+    @Test
+    fun `author name order variant Smith John equals John Smith`() {
+        val book = storytellerBook(title = "Atomic Habits", author = "Clear, James")
+        val abs = absItem(title = "Atomic Habits", author = "James Clear")
+
+        assertEquals(confirmed("abs-1" to "item-1"), ReadaloudMatcher.match(book, listOf(abs)))
+    }
+
+    @Test
+    fun `subtitle after colon is stripped before title comparison`() {
+        val book = storytellerBook(title = "The Martian: A Novel", author = "Andy Weir")
+        val abs = absItem(title = "The Martian", author = "Andy Weir")
+
+        assertEquals(confirmed("abs-1" to "item-1"), ReadaloudMatcher.match(book, listOf(abs)))
+    }
+
+    @Test
+    fun `subtitle after em-dash is stripped before title comparison`() {
+        val book = storytellerBook(title = "Project Hail Mary — A Novel", author = "Andy Weir")
+        val abs = absItem(title = "Project Hail Mary", author = "Andy Weir")
+
+        assertEquals(confirmed("abs-1" to "item-1"), ReadaloudMatcher.match(book, listOf(abs)))
+    }
+
+    @Test
+    fun `leading article on one side does not block title match`() {
+        val book = storytellerBook(title = "The Dragons of Eden", author = "Carl Sagan")
+        val abs = absItem(title = "Dragons of Eden", author = "Carl Sagan")
+
+        assertEquals(confirmed("abs-1" to "item-1"), ReadaloudMatcher.match(book, listOf(abs)))
+    }
+
+    @Test
+    fun `Storyteller multi-author list still matches single-author ABS`() {
+        val book = storytellerBook(
+            title = "The Dragons of Eden",
+            author = "Carl Sagan, JD Jackson, Ann Druyan",
+        )
+        val abs = absItem(title = "The Dragons of Eden", author = "Carl Sagan")
+
+        assertEquals(confirmed("abs-1" to "item-1"), ReadaloudMatcher.match(book, listOf(abs)))
+    }
+
+    @Test
+    fun `Storyteller duplicated-author OPF still matches single-author ABS`() {
+        val book = storytellerBook(title = "Project Hail Mary", author = "Andy Weir, Andy Weir;")
+        val abs = absItem(title = "Project Hail Mary", author = "Andy Weir")
+
+        assertEquals(confirmed("abs-1" to "item-1"), ReadaloudMatcher.match(book, listOf(abs)))
+    }
+
+    // ---- Tier 3: fuzzy → Pending Review ----------------------------------------------------
+
+    @Test
+    fun `fuzzy title above threshold with matching author surfaces a Pending candidate`() {
+        // Titles differ by one token out of seven (Dice ≈ 0.857 ≥ 0.85); author identical.
+        val book = storytellerBook(
+            title = "The Hitchhikers Guide to the Galaxy Part One", author = "Douglas Adams",
+        )
+        val abs = absItem(
+            title = "The Hitchhikers Guide to the Galaxy Part Two", author = "Douglas Adams",
+        )
+
+        val result = ReadaloudMatcher.match(book, listOf(abs))
+
+        assertTrue(result is MatchOutcome.PendingReview)
+        val candidate = (result as MatchOutcome.PendingReview).candidates.single()
+        assertEquals("abs-1", candidate.absServerUuid)
+        assertEquals("item-1", candidate.absLibraryItemId)
+        assertTrue("score ${candidate.score} should be >= threshold", candidate.score >= ReadaloudMatcher.FUZZY_THRESHOLD)
+    }
+
+    @Test
+    fun `fuzzy ignores case punctuation and whitespace like the exact tiers`() {
+        val book = storytellerBook(
+            title = "the HITCHHIKERS  guide to the galaxy part one!!!", author = "douglas   adams",
+        )
+        val abs = absItem(
+            title = "The Hitchhikers Guide to the Galaxy Part Two", author = "Douglas Adams",
+        )
+
+        assertTrue(ReadaloudMatcher.match(book, listOf(abs)) is MatchOutcome.PendingReview)
+    }
+
+    @Test
+    fun `fuzzy tolerates author name-order variant`() {
+        val book = storytellerBook(
+            title = "The Hitchhikers Guide to the Galaxy Part One", author = "Adams, Douglas",
+        )
+        val abs = absItem(
+            title = "The Hitchhikers Guide to the Galaxy Part Two", author = "Douglas Adams",
+        )
+
+        assertTrue(ReadaloudMatcher.match(book, listOf(abs)) is MatchOutcome.PendingReview)
+    }
+
+    @Test
+    fun `multiple fuzzy candidates above threshold are surfaced together`() {
+        val book = storytellerBook(
+            title = "The Hitchhikers Guide to the Galaxy Part One", author = "Douglas Adams",
+        )
+        val abs2 = absItem(
+            serverUuid = "abs-1", libraryItemId = "two",
+            title = "The Hitchhikers Guide to the Galaxy Part Two", author = "Douglas Adams",
+        )
+        val abs3 = absItem(
+            serverUuid = "abs-2", libraryItemId = "three",
+            title = "The Hitchhikers Guide to the Galaxy Part Three", author = "Douglas Adams",
+        )
+
+        val result = ReadaloudMatcher.match(book, listOf(abs2, abs3))
+
+        assertTrue(result is MatchOutcome.PendingReview)
         assertEquals(
-            setOf(Confirmed("abs-1", "item-1"), Confirmed("abs-2", "item-2")),
-            result.toSet(),
+            setOf("abs-1" to "two", "abs-2" to "three"),
+            (result as MatchOutcome.PendingReview).candidates
+                .map { it.absServerUuid to it.absLibraryItemId }.toSet(),
         )
     }
+
+    @Test
+    fun `exact Tier 2 match wins over a fuzzy candidate`() {
+        val book = storytellerBook(
+            title = "The Hitchhikers Guide to the Galaxy Part One", author = "Douglas Adams",
+        )
+        val exact = absItem(
+            serverUuid = "abs-1", libraryItemId = "exact",
+            title = "The Hitchhikers Guide to the Galaxy Part One", author = "Douglas Adams",
+        )
+        val fuzzy = absItem(
+            serverUuid = "abs-2", libraryItemId = "fuzzy",
+            title = "The Hitchhikers Guide to the Galaxy Part Two", author = "Douglas Adams",
+        )
+
+        assertEquals(confirmed("abs-1" to "exact"), ReadaloudMatcher.match(book, listOf(exact, fuzzy)))
+    }
+
+    // ---- Tier 4 / rejection ----------------------------------------------------------------
+
+    @Test
+    fun `title too different falls below threshold and is Unmatched`() {
+        // Dice ≈ 0.667 on title (3 shared of 3 vs 6 tokens).
+        val book = storytellerBook(title = "The Way of Kings", author = "Brandon Sanderson")
+        val abs = absItem(
+            title = "The Way of Kings Prime Extended Reader Edition", author = "Brandon Sanderson",
+        )
+
+        assertEquals(MatchOutcome.Unmatched, ReadaloudMatcher.match(book, listOf(abs)))
+    }
+
+    @Test
+    fun `matching title but author below threshold is Unmatched`() {
+        val book = storytellerBook(title = "Atomic Habits", author = "Brandon Sanderson")
+        val abs = absItem(title = "Atomic Habits", author = "Brandon Saunders")
+
+        assertEquals(MatchOutcome.Unmatched, ReadaloudMatcher.match(book, listOf(abs)))
+    }
+
+    @Test
+    fun `no candidates is Unmatched`() {
+        val book = storytellerBook(isbn = "9780261103573")
+
+        assertEquals(MatchOutcome.Unmatched, ReadaloudMatcher.match(book, emptyList()))
+    }
+
+    @Test
+    fun `subset match still rejects when no author token overlaps`() {
+        val book = storytellerBook(title = "The Same Title", author = "Carl Sagan, JD Jackson")
+        val abs = absItem(title = "The Same Title", author = "Someone Else")
+
+        assertEquals(MatchOutcome.Unmatched, ReadaloudMatcher.match(book, listOf(abs)))
+    }
+
+    @Test
+    fun `empty author on one side cannot satisfy subset rule`() {
+        val book = storytellerBook(title = "X", author = "")
+        val abs = absItem(title = "X", author = "Anyone")
+
+        assertEquals(MatchOutcome.Unmatched, ReadaloudMatcher.match(book, listOf(abs)))
+    }
+
+    @Test
+    fun `empty title is Unmatched even with a candidate`() {
+        val book = storytellerBook(title = "", author = "Andy Weir")
+        val abs = absItem(title = "The Martian", author = "Andy Weir")
+
+        assertEquals(MatchOutcome.Unmatched, ReadaloudMatcher.match(book, listOf(abs)))
+    }
+
+    @Test
+    fun `differing author rules out title-only match`() {
+        val book = storytellerBook(title = "Atomic Habits", author = "James Clear")
+        val abs = absItem(title = "Atomic Habits", author = "Someone Else")
+
+        assertEquals(MatchOutcome.Unmatched, ReadaloudMatcher.match(book, listOf(abs)))
+    }
+
+    // ---- fixtures --------------------------------------------------------------------------
+
+    private fun confirmed(vararg slots: Pair<String, String>) =
+        MatchOutcome.Confirmed(slots.map { Confirmed(it.first, it.second) })
+
+    private fun confirmedLinks(outcome: MatchOutcome): Set<Confirmed> =
+        (outcome as MatchOutcome.Confirmed).links.toSet()
 
     private fun storytellerBook(
         uuid: String = "st-1",


### PR DESCRIPTION
Closes #39.

## What changed

Completes the ADR 0021 match ladder and adds the user-facing review surface.

**Matcher (`core:domain`)**
- `ReadaloudMatcher.match` now returns a `MatchOutcome` sealed type: `Confirmed` / `PendingReview` / `Unmatched`.
- Tier 1 (identifier) and Tier 2 (exact normalised title + author) keep #36's 1:many multiplicity → `Confirmed`.
- Tier 3 fuzzy (Sørensen–Dice token-set similarity ≥ 0.85 on **both** title and author) → `PendingReview` with scored candidates.
- Tier 4 → `Unmatched`.

**Data (`core:database` / `core:data`)**
- New Room tables `readaloud_candidates` and `readaloud_dismissals`; `MIGRATION_22_23` (v22→23) with migration test + full-chain coverage; schema `23.json` exported.
- `ReadaloudMatchingService` persists Tier-3 candidates and honours sticky user decisions (userConfirmed links, per-book "don't ask again", per-candidate dismissals); the candidate table is regenerated each reconcile.
- New `ReadaloudReviewRepository` driving the review queue and the Confirm / Dismiss / No-match / Unlink / Match-manually actions.

**UI (`app`)**
- Settings → *[Storyteller Server]* → **Readaloud matches** screen with Pending Review (N) / Unmatched (N) / Confirmed (N) sections and counts.
- Manual-pair picker searches Library Items across every configured ABS Server (covers + title/author). It stays open so a readaloud can be linked to several ABS items (e.g. ebook + audiobook), with per-row Link/Unlink.
- Confirmed section groups per readaloud; a single Unlink detaches the whole match.
- Readaloud detail-screen footer renders all three states (Confirmed / Pending Review / Unmatched) with tap-navigation into the review queue / picker.

**Drive-by fixes (separate commits)**
- `fix(images)`: an OkHttp `Cache` shared `cacheDir/image_cache` with Coil's own `DiskCache`, corrupting the DiskLruCache journal ("unexpected journal header") and wiping the cover cache on launch. Coil's `DiskCache` is now the sole writer; the revalidation interceptor is kept.
- `chore`: gitignore `.kotlin/` compiler session dir.

## Intentionally not implemented
- ADR's "Tier 1/2 collisions demote to Pending Review" — by product decision multiplicity stays `Confirmed`, so collisions are not demoted at the matcher level.
- The ADR's optional Confirm side-effect (EPUB prefetch / CrossEpubIndex build) — not in the issue's acceptance criteria.

## Tested
- `./gradlew test` — all unit/integration green (new: ReadaloudMatcherTest, ReadaloudMatchingServiceTest, ReadaloudReviewRepositoryTest, RiffleImageLoaderTest, MigrationTest.migration22To23 + full chain).
- `./gradlew lint` — clean.
- `make harness-test` — 129 tests, 0 failures.
- `make harness-test-tablet` — 5 tests, 0 failures.
- New `migration22To23` + `migrateFullChain` pass on the harness AVD. (7 pre-existing migration tests for old versions fail identically on `main` on the API-25 AVD — a known environment artifact, unrelated to this change.)