### PR TITLE
feat(sync): three-peer progress sync for matched readaloud books (#38)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -100,6 +100,8 @@ dependencies {
 
     implementation(project(":core:domain"))
     implementation(project(":core:data"))
+    // Three-peer reader sync constructs SyncRemotes over the position APIs directly (issue #38).
+    implementation(project(":core:network"))
 
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)

--- a/app/src/androidTest/kotlin/com/riffle/app/di/TestDatabaseModule.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/di/TestDatabaseModule.kt
@@ -5,6 +5,7 @@ import androidx.room.Room
 import com.riffle.core.data.di.DatabaseModule
 import com.riffle.core.database.BookFormattingPreferencesDao
 import com.riffle.core.database.CollectionDao
+import com.riffle.core.database.CrossEpubIndexDao
 import com.riffle.core.database.LibraryDao
 import com.riffle.core.database.LibraryItemDao
 import com.riffle.core.database.ReadaloudCandidateDao
@@ -82,4 +83,8 @@ object TestDatabaseModule {
     @Provides
     @Singleton
     fun provideReadaloudDismissalDao(db: RiffleDatabase): ReadaloudDismissalDao = db.readaloudDismissalDao()
+
+    @Provides
+    @Singleton
+    fun provideCrossEpubIndexDao(db: RiffleDatabase): CrossEpubIndexDao = db.crossEpubIndexDao()
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubCfiTranslator.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubCfiTranslator.kt
@@ -1,5 +1,6 @@
 package com.riffle.app.feature.reader
 
+import com.riffle.core.domain.EpubTextChars
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Element
 import org.jsoup.nodes.Node
@@ -115,13 +116,9 @@ internal fun walkCfiSteps(root: Element, steps: List<Int>): Node? {
 
 // ── Character counting ────────────────────────────────────────────────────────
 
-internal fun countBodyChars(body: Element): Long = countNodeChars(body)
-
-private fun countNodeChars(node: Node): Long = when (node) {
-    is TextNode -> if (node.wholeText.isNotBlank()) node.wholeText.length.toLong() else 0L
-    is Element -> node.childNodes().sumOf { countNodeChars(it) }
-    else -> 0L
-}
+// Single source of truth for the readable-character definition, shared with the
+// cross-EPUB index (ADR 0019) via core/domain.
+internal fun countBodyChars(body: Element): Long = EpubTextChars.countReadableChars(body)
 
 internal fun countCharsBefore(body: Element, target: TextNode, offsetInTarget: Int): Long {
     var count = 0L

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -27,6 +27,7 @@ import com.riffle.core.domain.ReadingSessionRepository
 import com.riffle.core.domain.ServerProgress
 import com.riffle.core.domain.ServerRepository
 import com.riffle.core.domain.ServerType
+import com.riffle.core.domain.ReadingPositionStore
 import com.riffle.core.domain.SessionPayload
 import com.riffle.core.domain.withResolvedTheme
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -101,6 +102,8 @@ class EpubReaderViewModel @Inject constructor(
     private val storytellerSyncController: StorytellerPositionSyncController,
     private val serverRepository: ServerRepository,
     private val connectivityObserver: ConnectivityObserver,
+    private val threePeerSyncFactory: ThreePeerReaderSyncFactory,
+    private val readingPositionStore: ReadingPositionStore,
 ) : AndroidViewModel(application) {
 
     private val itemId: String = checkNotNull(savedStateHandle["itemId"])
@@ -136,6 +139,11 @@ class EpubReaderViewModel @Inject constructor(
     private val chapterHtmlCache = mutableMapOf<Int, String>()
     private var syncJob: Job? = null
     private var closeSyncDone = false
+    // Non-null once a matched book's three-peer prerequisites are cached: the unified cycle then
+    // replaces the single-peer ABS/Storyteller paths. [threePeerServerId] is the active server
+    // (the displayed side) that keys the canonical localUpdatedAt.
+    private var threePeer: ThreePeerReaderSyncCoordinator? = null
+    private var threePeerServerId: String? = null
     // True after the navigator emits its first locator (the restored position on open).
     // The first emission is not new user progress — the position is already in DB — so we skip
     // the DB write to avoid stomping localUpdatedAt before the initial sync cycle runs.
@@ -342,9 +350,18 @@ class EpubReaderViewModel @Inject constructor(
                     title = item.title,
                     initialLocator = locator,
                 )
+                // A matched book with cached prerequisites runs the three-peer cycle instead of
+                // the single-peer ABS/Storyteller paths; otherwise this is null and nothing changes.
+                threePeer = runCatching { threePeerSyncFactory.createIfApplicable(itemId) }.getOrNull()
+                threePeerServerId = serverRepository.getActive()?.id
+
                 // Sync immediately while localUpdatedAt is still the genuine stored value —
                 // before the navigator restore emits and would stamp localUpdatedAt = now.
-                progressSyncController.sync(itemId, locator?.toPayload() ?: SessionPayload("", 0f))
+                if (threePeer != null) {
+                    runThreePeerCycle(locator)
+                } else {
+                    progressSyncController.sync(itemId, locator?.toPayload() ?: SessionPayload("", 0f))
+                }
 
                 startPeriodicSync()
             }
@@ -372,7 +389,30 @@ class EpubReaderViewModel @Inject constructor(
     private fun syncCurrentPosition() {
         val locator = lastLocator ?: return
         viewModelScope.launch {
-            progressSyncController.sync(itemId, locator.toPayload())
+            if (threePeer != null) runThreePeerCycle(locator)
+            else progressSyncController.sync(itemId, locator.toPayload())
+        }
+    }
+
+    /**
+     * One unified three-peer reconciliation cycle (ADR 0019). The canonical position is the
+     * displayed-EPUB Locator; a remote win jumps the reader via the same channel the Storyteller
+     * path uses, and the winning timestamp is persisted as the canonical localUpdatedAt so the
+     * next cycle doesn't re-pull. Any failure is isolated to this cycle.
+     */
+    private suspend fun runThreePeerCycle(locator: Locator?) {
+        val coordinator = threePeer ?: return
+        val serverId = threePeerServerId ?: return
+        val locJson = (locator ?: lastLocator)?.toJSON()?.toString() ?: return
+        val localUpdatedAt = readingPositionStore.loadLocalUpdatedAt(serverId, itemId)
+        val result = runCatching { coordinator.runCycle(locJson, localUpdatedAt) }.getOrNull() ?: return
+        result.jumpLocatorJson?.let { json ->
+            try {
+                Locator.fromJSON(JSONObject(json))?.let { _serverLocatorChannel.trySend(it) }
+            } catch (_: Exception) { /* malformed jump locator — skip */ }
+        }
+        if (result.canonicalLastUpdate > localUpdatedAt) {
+            readingPositionStore.updateLocalTimestamp(serverId, itemId, result.canonicalLastUpdate)
         }
     }
 
@@ -418,7 +458,8 @@ class EpubReaderViewModel @Inject constructor(
         viewModelScope.launch {
             val payload = locator.toPayload()
             positionSaveCoordinator.onClose(locator.toJSON().toString(), payload.ebookProgress)
-            progressSyncController.sync(itemId, payload)
+            if (threePeer != null) runThreePeerCycle(locator)
+            else progressSyncController.sync(itemId, payload)
         }
     }
 
@@ -849,6 +890,8 @@ class EpubReaderViewModel @Inject constructor(
 
     private fun startStorytellerSync() {
         if (!isStorytellerServer) return
+        // Three-peer reconciles Storyteller itself; don't also run the single-peer Storyteller loop.
+        if (threePeer != null) return
         if (storytellerSyncJob?.isActive == true) return
         storytellerSyncJob = viewModelScope.launch {
             while (true) {

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderPositionBridge.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderPositionBridge.kt
@@ -1,0 +1,124 @@
+package com.riffle.app.feature.reader
+
+import com.riffle.core.domain.CanonicalPositionTranslator
+import com.riffle.core.domain.ChapterProgression
+import com.riffle.core.domain.OpenedSide
+import org.json.JSONObject
+
+/**
+ * Converts the reader's canonical position (a Readium Locator JSON on the **displayed** EPUB)
+ * to and from each peer's native coordinate for a matched readaloud book (ADR 0019):
+ *
+ *  - ABS ebook → a CFI in the ABS EPUB,
+ *  - ABS audiobook → seconds (via the Storyteller SMIL),
+ *  - Storyteller → a Locator on the Storyteller EPUB.
+ *
+ * It owns the spine hrefs and chapter HTML of **both** EPUBs plus the
+ * [CanonicalPositionTranslator]; every conversion routes through a spine-aligned
+ * [ChapterProgression] and returns `null` when it can't be placed, so a missing mapping
+ * defers a PATCH rather than producing a wrong one. Pure (JSON + jsoup), unit-testable.
+ */
+class ReaderPositionBridge(
+    private val displayedSide: OpenedSide,
+    private val absSpineHrefs: List<String>,
+    private val absChapterHtml: (Int) -> String?,
+    private val storytellerSpineHrefs: List<String>,
+    private val storytellerChapterHtml: (Int) -> String?,
+    private val translator: CanonicalPositionTranslator,
+) {
+    private val displayedDomain = if (displayedSide == OpenedSide.ABS) Domain.ABS else Domain.ST
+
+    private enum class Domain { ABS, ST }
+
+    // ── Canonical (displayed-EPUB Locator JSON) ↔ displayed ChapterProgression ──────
+
+    private fun spineHrefs(domain: Domain) = if (domain == Domain.ABS) absSpineHrefs else storytellerSpineHrefs
+
+    private fun canonicalToDisplayedProgression(locatorJson: String): ChapterProgression? {
+        val obj = runCatching { JSONObject(locatorJson) }.getOrNull() ?: return null
+        val href = obj.optString("href").takeIf { it.isNotEmpty() } ?: return null
+        val idx = spineIndexOfHref(spineHrefs(displayedDomain), href).takeIf { it >= 0 } ?: return null
+        val progression = obj.optJSONObject("locations")?.optDouble("progression", 0.0) ?: 0.0
+        return ChapterProgression(idx, progression)
+    }
+
+    private fun displayedProgressionToCanonical(p: ChapterProgression, totalProgression: Double?): String? {
+        val href = spineHrefs(displayedDomain).getOrNull(p.chapterIndex) ?: return null
+        val locations = JSONObject().put("progression", p.progression)
+        if (totalProgression != null) locations.put("totalProgression", totalProgression)
+        return JSONObject()
+            .put("href", href)
+            .put("type", "application/xhtml+xml")
+            .put("locations", locations)
+            .toString()
+    }
+
+    /** Cross-domain progression conversion (chapter index is spine-aligned; only progression scales). */
+    private fun convert(p: ChapterProgression, from: Domain, to: Domain): ChapterProgression? = when {
+        from == to -> p
+        from == Domain.ABS -> translator.absToStorytellerProgression(p)
+        else -> translator.storytellerToAbsProgression(p)
+    }
+
+    private fun toCanonical(p: ChapterProgression, from: Domain): String? =
+        convert(p, from, displayedDomain)?.let { displayedProgressionToCanonical(it, null) }
+
+    private fun fromCanonical(locatorJson: String, to: Domain): ChapterProgression? =
+        canonicalToDisplayedProgression(locatorJson)?.let { convert(it, displayedDomain, to) }
+
+    // ── ABS ebook (CFI) ────────────────────────────────────────────────────────────
+
+    fun absCfiToCanonical(cfi: String): String? {
+        val idx = epubCfiToSpineIndex(cfi) ?: return null
+        val docPath = extractCfiDocPath(cfi) ?: return null
+        val html = absChapterHtml(idx) ?: return null
+        val progression = cfiDocPathToProgression(docPath, html) ?: return null
+        return toCanonical(ChapterProgression(idx, progression), Domain.ABS)
+    }
+
+    fun canonicalToAbsCfi(locatorJson: String): String? {
+        val p = fromCanonical(locatorJson, Domain.ABS) ?: return null
+        val html = absChapterHtml(p.chapterIndex) ?: return null
+        val docPath = progressionToCfiDocPath(p.progression, html) ?: return null
+        val spineStep = (p.chapterIndex + 1) * 2
+        return "epubcfi(/6/$spineStep!$docPath)"
+    }
+
+    /** Book-wide progress float for the ABS progress bar; best-effort from the canonical locator. */
+    fun canonicalBookProgress(locatorJson: String): Float =
+        runCatching { JSONObject(locatorJson).optJSONObject("locations")?.optDouble("totalProgression", 0.0) ?: 0.0 }
+            .getOrDefault(0.0).toFloat()
+
+    // ── Storyteller (Locator on the Storyteller EPUB) ───────────────────────────────
+
+    fun storytellerLocatorToCanonical(stLocatorJson: String): String? {
+        val obj = runCatching { JSONObject(stLocatorJson) }.getOrNull() ?: return null
+        val href = obj.optString("href").takeIf { it.isNotEmpty() } ?: return null
+        val idx = spineIndexOfHref(storytellerSpineHrefs, href).takeIf { it >= 0 } ?: return null
+        val progression = obj.optJSONObject("locations")?.optDouble("progression", 0.0) ?: 0.0
+        return toCanonical(ChapterProgression(idx, progression), Domain.ST)
+    }
+
+    fun canonicalToStorytellerLocator(locatorJson: String): String? {
+        val p = fromCanonical(locatorJson, Domain.ST) ?: return null
+        val href = storytellerSpineHrefs.getOrNull(p.chapterIndex) ?: return null
+        return JSONObject()
+            .put("href", href)
+            .put("type", "application/xhtml+xml")
+            .put("locations", JSONObject().put("progression", p.progression))
+            .toString()
+    }
+
+    // ── ABS audiobook (seconds, via SMIL on the Storyteller EPUB) ────────────────────
+
+    fun audioSecondsToCanonical(seconds: Double): String? =
+        translator.audioSecondsToStorytellerProgression(seconds)?.let { toCanonical(it, Domain.ST) }
+
+    fun canonicalToAudioSeconds(locatorJson: String): Double? =
+        fromCanonical(locatorJson, Domain.ST)?.let { translator.storytellerProgressionToAudioSeconds(it) }
+
+    private fun spineIndexOfHref(hrefs: List<String>, href: String): Int {
+        val target = normalizeEpubHref(href)
+        return hrefs.indexOfFirst { normalizeEpubHref(it) == target }
+    }
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ThreePeerReaderSync.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ThreePeerReaderSync.kt
@@ -1,0 +1,143 @@
+package com.riffle.app.feature.reader
+
+import com.riffle.core.domain.BookSyncState
+import com.riffle.core.domain.CanonicalReaderPosition
+import com.riffle.core.domain.LocalCanonical
+import com.riffle.core.domain.ProgressSyncStrategy
+import com.riffle.core.domain.RemoteKind
+import com.riffle.core.domain.RemoteRead
+import com.riffle.core.domain.SyncRemote
+import com.riffle.core.network.AbsSessionApi
+import com.riffle.core.network.NetworkAudiobookProgressPayload
+import com.riffle.core.network.NetworkEbookProgressPayload
+import com.riffle.core.network.NetworkGetProgressResult
+import com.riffle.core.network.NetworkStorytellerPositionResult
+import com.riffle.core.network.NetworkStorytellerPutResult
+import com.riffle.core.network.NetworkSyncSessionResult
+import com.riffle.core.network.StorytellerPositionApi
+
+/** Resolved ABS endpoint for the single matched ABS Library Item (its media-progress record). */
+data class AbsSyncEndpoint(val baseUrl: String, val token: String, val insecure: Boolean, val itemId: String)
+
+/** Resolved Storyteller endpoint for the matched readaloud book. */
+data class StorytellerSyncEndpoint(val baseUrl: String, val token: String, val insecure: Boolean, val bookId: String)
+
+// A reachable peer that has no position yet: it never wins (timestamp 0) but is stale relative
+// to any local progress, so the cycle still pushes the reader's first position to it.
+internal val EMPTY_REMOTE_READ = RemoteRead(CanonicalReaderPosition(""), 0L)
+
+/** ABS ebook progress as a sync remote: an ebookLocation CFI on the ABS EPUB. */
+internal class AbsEbookSyncRemote(
+    private val api: AbsSessionApi,
+    private val ep: AbsSyncEndpoint,
+    private val bridge: ReaderPositionBridge,
+) : SyncRemote {
+    override val id = RemoteKind.ABS_EBOOK.name
+
+    override suspend fun tryGet(): RemoteRead? {
+        // NetworkError → null (unreachable, excluded); 404/no-CFI → reachable-empty placeholder.
+        val p = (api.getProgress(ep.baseUrl, ep.itemId, ep.token, ep.insecure) as? NetworkGetProgressResult.Success)
+            ?.progress ?: return null
+        val cfi = p.ebookLocation.takeIf { it.startsWith("epubcfi(") }
+        if (p.lastUpdate <= 0L || cfi == null) return EMPTY_REMOTE_READ
+        val canonical = bridge.absCfiToCanonical(cfi) ?: return EMPTY_REMOTE_READ
+        return RemoteRead(CanonicalReaderPosition(canonical), p.lastUpdate)
+    }
+
+    override suspend fun tryPatch(canonical: CanonicalReaderPosition): Boolean {
+        val cfi = bridge.canonicalToAbsCfi(canonical.value) ?: return false
+        val payload = NetworkEbookProgressPayload(cfi, bridge.canonicalBookProgress(canonical.value))
+        return api.syncEbookProgress(ep.baseUrl, ep.itemId, payload, ep.token, ep.insecure) is NetworkSyncSessionResult.Success
+    }
+}
+
+/** ABS audiobook progress as a sync remote: a `currentTime` in seconds, bridged through the SMIL. */
+internal class AbsAudiobookSyncRemote(
+    private val api: AbsSessionApi,
+    private val ep: AbsSyncEndpoint,
+    private val bridge: ReaderPositionBridge,
+) : SyncRemote {
+    override val id = RemoteKind.ABS_AUDIO.name
+    private var lastDuration: Double = 0.0
+
+    override suspend fun tryGet(): RemoteRead? {
+        val p = (api.getProgress(ep.baseUrl, ep.itemId, ep.token, ep.insecure) as? NetworkGetProgressResult.Success)
+            ?.progress ?: return null
+        lastDuration = p.duration
+        if (p.lastUpdate <= 0L || p.currentTime <= 0.0) return EMPTY_REMOTE_READ // no audiobook position yet
+        val canonical = bridge.audioSecondsToCanonical(p.currentTime) ?: return EMPTY_REMOTE_READ
+        return RemoteRead(CanonicalReaderPosition(canonical), p.lastUpdate)
+    }
+
+    override suspend fun tryPatch(canonical: CanonicalReaderPosition): Boolean {
+        val seconds = bridge.canonicalToAudioSeconds(canonical.value) ?: return false
+        val payload = NetworkAudiobookProgressPayload(seconds, lastDuration)
+        return api.syncAudiobookProgress(ep.baseUrl, ep.itemId, payload, ep.token, ep.insecure) is NetworkSyncSessionResult.Success
+    }
+}
+
+/** Storyteller position as a sync remote: a Readium Locator on the Storyteller EPUB. */
+internal class StorytellerSyncRemote(
+    private val api: StorytellerPositionApi,
+    private val ep: StorytellerSyncEndpoint,
+    private val bridge: ReaderPositionBridge,
+    private val pushTimestamp: Long,
+) : SyncRemote {
+    override val id = RemoteKind.STORYTELLER.name
+
+    override suspend fun tryGet(): RemoteRead? {
+        val r = api.getPosition(ep.baseUrl, ep.bookId, ep.token, ep.insecure)
+        val (locatorJson, ts) = when (r) {
+            is NetworkStorytellerPositionResult.Success -> r.locatorJson to r.timestampMillis
+            is NetworkStorytellerPositionResult.NoPosition -> return EMPTY_REMOTE_READ
+            is NetworkStorytellerPositionResult.NetworkError -> return null
+        }
+        if (locatorJson == null || ts <= 0L) return EMPTY_REMOTE_READ // reachable, no position yet
+        val canonical = bridge.storytellerLocatorToCanonical(locatorJson) ?: return EMPTY_REMOTE_READ
+        return RemoteRead(CanonicalReaderPosition(canonical), ts)
+    }
+
+    override suspend fun tryPatch(canonical: CanonicalReaderPosition): Boolean {
+        val locator = bridge.canonicalToStorytellerLocator(canonical.value) ?: return false
+        return api.putPosition(ep.baseUrl, ep.bookId, locator, pushTimestamp, ep.token, ep.insecure) is NetworkStorytellerPutResult.Success
+    }
+}
+
+/**
+ * Drives one matched readaloud book's three-peer reconciliation (ADR 0019). Builds the live
+ * [SyncRemote]s for the applicable peer set and runs the unified [ProgressSyncStrategy] each
+ * cycle. The canonical position is the displayed-EPUB Locator JSON; [runCycle] returns the
+ * Locator JSON the reader should jump to, or `null` for no jump.
+ *
+ * Both ABS remotes target the same media-progress record (it carries ebookLocation and
+ * currentTime together); a peer that can't be built (missing endpoint) is simply skipped.
+ */
+/**
+ * @param jumpLocatorJson the displayed-EPUB Locator JSON to jump the reader to, or `null` for
+ *   no jump. @param canonicalLastUpdate the winning timestamp to persist as `localUpdatedAt`.
+ */
+data class ThreePeerReaderCycleResult(val jumpLocatorJson: String?, val canonicalLastUpdate: Long)
+
+class ThreePeerReaderSyncCoordinator(
+    private val state: BookSyncState,
+    private val bridge: ReaderPositionBridge,
+    private val absApi: AbsSessionApi,
+    private val storytellerApi: StorytellerPositionApi,
+    private val absEndpoint: AbsSyncEndpoint?,
+    private val storytellerEndpoint: StorytellerSyncEndpoint?,
+) {
+    suspend fun runCycle(displayedLocatorJson: String, localUpdatedAt: Long): ThreePeerReaderCycleResult {
+        val strategy = ProgressSyncStrategy { kind ->
+            when (kind) {
+                RemoteKind.ABS_EBOOK -> absEndpoint?.let { AbsEbookSyncRemote(absApi, it, bridge) }
+                RemoteKind.ABS_AUDIO -> absEndpoint?.let { AbsAudiobookSyncRemote(absApi, it, bridge) }
+                RemoteKind.STORYTELLER -> storytellerEndpoint?.let { StorytellerSyncRemote(storytellerApi, it, bridge, localUpdatedAt) }
+            }
+        }
+        val local = LocalCanonical(CanonicalReaderPosition(displayedLocatorJson), localUpdatedAt)
+        val result = strategy.runCycle(state, local)
+        // Guard the empty-remote placeholder: it never legitimately wins, but never jump to "".
+        val jump = result.jumpTo?.value?.takeIf { it.isNotEmpty() }
+        return ThreePeerReaderCycleResult(jump, result.canonicalLastUpdate)
+    }
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ThreePeerReaderSyncFactory.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ThreePeerReaderSyncFactory.kt
@@ -1,0 +1,106 @@
+package com.riffle.app.feature.reader
+
+import com.riffle.core.data.di.EpubCacheStore
+import com.riffle.core.data.di.EpubDownloadsStore
+import com.riffle.core.domain.BookSyncState
+import com.riffle.core.domain.CanonicalPositionTranslator
+import com.riffle.core.domain.CrossEpubIndexStore
+import com.riffle.core.domain.EpubChecksum
+import com.riffle.core.domain.EpubContentExtractor
+import com.riffle.core.domain.ExtractedEpub
+import com.riffle.core.domain.LocalStore
+import com.riffle.core.domain.OpenedSide
+import com.riffle.core.domain.ReadaloudLink
+import com.riffle.core.domain.ReadaloudLinkRepository
+import com.riffle.core.domain.Server
+import com.riffle.core.domain.ServerRepository
+import com.riffle.core.domain.ServerType
+import com.riffle.core.domain.StorytellerFragmentIndexBuilder
+import com.riffle.core.domain.TokenStorage
+import com.riffle.core.network.AbsSessionApi
+import com.riffle.core.network.StorytellerPositionApi
+import javax.inject.Inject
+
+/**
+ * Assembles a [ThreePeerReaderSyncCoordinator] for the open book when, and only when, all of
+ * ADR 0019's three-peer prerequisites are met: the book is a Confirmed match with **exactly
+ * one** ABS link, both EPUBs are cached, and the cross-EPUB index for their current checksums
+ * is built. Any miss returns `null`, leaving the reader on its existing single-peer path — so
+ * three-peer is strictly additive and never degrades the non-matched case.
+ */
+class ThreePeerReaderSyncFactory @Inject constructor(
+    private val linkRepository: ReadaloudLinkRepository,
+    private val serverRepository: ServerRepository,
+    private val tokenStorage: TokenStorage,
+    private val indexStore: CrossEpubIndexStore,
+    private val absSessionApi: AbsSessionApi,
+    private val storytellerPositionApi: StorytellerPositionApi,
+    @EpubCacheStore private val cacheStore: LocalStore,
+    @EpubDownloadsStore private val downloadsStore: LocalStore,
+) {
+    /**
+     * @param itemId the id the reader opened (an ABS Library Item id on the ABS side, a
+     *   Storyteller book id on the Readaloud side).
+     */
+    suspend fun createIfApplicable(itemId: String): ThreePeerReaderSyncCoordinator? {
+        val active = serverRepository.getActive() ?: return null
+        val side = if (active.serverType == ServerType.STORYTELLER) OpenedSide.READALOUD else OpenedSide.ABS
+
+        // Resolve the single Confirmed link; three-peer requires exactly one ABS link.
+        val link = when (side) {
+            OpenedSide.ABS -> linkRepository.findByAbsItem(active.id, itemId) ?: return null
+            OpenedSide.READALOUD -> linkRepository.findByStorytellerBook(active.id, itemId).singleOrNull() ?: return null
+        }
+        val absLinkCount = linkRepository.findByStorytellerBook(link.storytellerServerId, link.storytellerBookId).size
+        if (absLinkCount != 1) return null
+
+        val absServer = serverRepository.getById(link.absServerId) ?: return null
+        val absToken = tokenStorage.getToken(link.absServerId) ?: return null
+        val storytellerServer = serverRepository.getById(link.storytellerServerId) ?: return null
+        val storytellerToken = tokenStorage.getToken(link.storytellerServerId) ?: return null
+
+        val absBytes = cachedBytes(link.absLibraryItemId) ?: return null
+        val storytellerBytes = cachedBytes(link.storytellerBookId) ?: return null
+
+        // The index must already be built for these exact bytes (checksum-keyed); otherwise the
+        // background builder hasn't caught up — stay single-peer until it has.
+        val index = indexStore.load(EpubChecksum.of(absBytes), EpubChecksum.of(storytellerBytes)) ?: return null
+
+        val absExtract = EpubContentExtractor.extract(absBytes) ?: return null
+        val storytellerExtract = EpubContentExtractor.extract(storytellerBytes) ?: return null
+
+        val fragmentProgressions = StorytellerFragmentIndexBuilder.build(
+            storytellerExtract.chapters, storytellerExtract.smilClips,
+        )
+        val translator = CanonicalPositionTranslator(storytellerExtract.smilClips, index, fragmentProgressions)
+
+        val bridge = ReaderPositionBridge(
+            displayedSide = side,
+            absSpineHrefs = absExtract.hrefs(),
+            absChapterHtml = absExtract.htmlAt(),
+            storytellerSpineHrefs = storytellerExtract.hrefs(),
+            storytellerChapterHtml = storytellerExtract.htmlAt(),
+            translator = translator,
+        )
+
+        return ThreePeerReaderSyncCoordinator(
+            state = BookSyncState(isMatched = true, confirmedAbsLinkCount = 1, prerequisitesCached = true, openedSide = side),
+            bridge = bridge,
+            absApi = absSessionApi,
+            storytellerApi = storytellerPositionApi,
+            absEndpoint = endpoint(absServer, absToken, link.absLibraryItemId),
+            storytellerEndpoint = StorytellerSyncEndpoint(
+                storytellerServer.url.value, storytellerToken, storytellerServer.insecureConnectionAllowed, link.storytellerBookId,
+            ),
+        )
+    }
+
+    private fun endpoint(server: Server, token: String, itemId: String) =
+        AbsSyncEndpoint(server.url.value, token, server.insecureConnectionAllowed, itemId)
+
+    private fun cachedBytes(itemId: String): ByteArray? =
+        (downloadsStore.get(itemId) ?: cacheStore.get(itemId))?.readBytes()
+
+    private fun ExtractedEpub.hrefs() = chapters.map { it.href }
+    private fun ExtractedEpub.htmlAt(): (Int) -> String? = { chapters.getOrNull(it)?.html }
+}

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ReaderPositionBridgeTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ReaderPositionBridgeTest.kt
@@ -1,0 +1,83 @@
+package com.riffle.app.feature.reader
+
+import com.riffle.core.domain.CanonicalPositionTranslator
+import com.riffle.core.domain.ChapterCharMap
+import com.riffle.core.domain.ChapterProgression
+import com.riffle.core.domain.CrossEpubIndex
+import com.riffle.core.domain.MediaOverlayClip
+import com.riffle.core.domain.OpenedSide
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class ReaderPositionBridgeTest {
+
+    // ABS chapter 0 is twice as long (in readable chars) as the Storyteller chapter, so a
+    // character offset maps to half the progression on the ABS side.
+    private val index = CrossEpubIndex(listOf(ChapterCharMap(absChars = 200, storytellerChars = 100)))
+    private val clips = listOf(MediaOverlayClip("c1.xhtml#f1", "a.mp3", clipBeginSec = 0.0, clipEndSec = 5.0))
+    private val fragmentProgressions = mapOf("c1.xhtml#f1" to ChapterProgression(0, 0.25))
+    private val translator = CanonicalPositionTranslator(clips, index, fragmentProgressions)
+
+    private val absHtml = "<html><body><p>${"x".repeat(200)}</p></body></html>"
+
+    private fun bridge(side: OpenedSide) = ReaderPositionBridge(
+        displayedSide = side,
+        absSpineHrefs = listOf("c1.xhtml"),
+        absChapterHtml = { if (it == 0) absHtml else null },
+        storytellerSpineHrefs = listOf("c1.xhtml"),
+        storytellerChapterHtml = { null },
+        translator = translator,
+    )
+
+    private fun progressionOf(locatorJson: String): Double =
+        JSONObject(locatorJson).getJSONObject("locations").getDouble("progression")
+
+    @Test
+    fun `audio seconds convert to the canonical position of the narrated fragment`() {
+        // Readaloud side: canonical is the Storyteller EPUB, so the fragment progression passes through.
+        val canonical = bridge(OpenedSide.READALOUD).audioSecondsToCanonical(2.0)
+
+        assertNotNull(canonical)
+        assertEquals(0.25, progressionOf(canonical!!), 1e-9)
+    }
+
+    @Test
+    fun `a canonical Storyteller position round-trips to a Storyteller locator unchanged`() {
+        val bridge = bridge(OpenedSide.READALOUD)
+        val canonical = JSONObject()
+            .put("href", "c1.xhtml")
+            .put("locations", JSONObject().put("progression", 0.4))
+            .toString()
+
+        val stLocator = bridge.canonicalToStorytellerLocator(canonical)
+
+        assertNotNull(stLocator)
+        assertEquals(0.4, progressionOf(stLocator!!), 1e-9)
+    }
+
+    @Test
+    fun `a Storyteller-side canonical position converts to an ABS CFI and back, preserving the offset`() {
+        val bridge = bridge(OpenedSide.READALOUD)
+        // Storyteller progression 0.25 → char offset 25 → ABS progression 25/200 = 0.125.
+        val canonical = JSONObject()
+            .put("href", "c1.xhtml")
+            .put("locations", JSONObject().put("progression", 0.25))
+            .toString()
+
+        val cfi = bridge.canonicalToAbsCfi(canonical)
+        assertNotNull(cfi)
+
+        // Round-tripping the CFI back lands at the same Storyteller-domain progression (±1 char).
+        val back = bridge.absCfiToCanonical(cfi!!)
+        assertNotNull(back)
+        assertEquals(0.25, progressionOf(back!!), 0.02)
+    }
+
+    @Test
+    fun `an unmappable fragment yields no canonical position`() {
+        assertNull(bridge(OpenedSide.READALOUD).audioSecondsToCanonical(99.0))
+    }
+}

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ThreePeerReaderSyncCoordinatorTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ThreePeerReaderSyncCoordinatorTest.kt
@@ -1,0 +1,106 @@
+package com.riffle.app.feature.reader
+
+import com.riffle.core.domain.BookSyncState
+import com.riffle.core.domain.CanonicalPositionTranslator
+import com.riffle.core.domain.ChapterCharMap
+import com.riffle.core.domain.CrossEpubIndex
+import com.riffle.core.domain.OpenedSide
+import com.riffle.core.network.AbsSessionApi
+import com.riffle.core.network.NetworkAudiobookProgressPayload
+import com.riffle.core.network.NetworkEbookProgressPayload
+import com.riffle.core.network.NetworkGetProgressResult
+import com.riffle.core.network.NetworkServerProgress
+import com.riffle.core.network.NetworkStorytellerPositionResult
+import com.riffle.core.network.NetworkStorytellerPutResult
+import com.riffle.core.network.NetworkSyncSessionResult
+import com.riffle.core.network.StorytellerPositionApi
+import kotlinx.coroutines.test.runTest
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ThreePeerReaderSyncCoordinatorTest {
+
+    // Identity cross-EPUB index → Storyteller and ABS progressions coincide; keeps the assertions
+    // about routing/winner selection independent of the (separately-tested) translation math.
+    private val translator = CanonicalPositionTranslator(
+        smilClips = emptyList(),
+        index = CrossEpubIndex(listOf(ChapterCharMap(absChars = 100, storytellerChars = 100))),
+    )
+    private val absHtml = "<html><body><p>${"x".repeat(100)}</p></body></html>"
+    private val bridge = ReaderPositionBridge(
+        displayedSide = OpenedSide.READALOUD,
+        absSpineHrefs = listOf("c1.xhtml"),
+        absChapterHtml = { if (it == 0) absHtml else null },
+        storytellerSpineHrefs = listOf("c1.xhtml"),
+        storytellerChapterHtml = { null },
+        translator = translator,
+    )
+
+    private val state = BookSyncState(
+        isMatched = true, confirmedAbsLinkCount = 1, prerequisitesCached = true, openedSide = OpenedSide.READALOUD,
+    )
+    private val absEp = AbsSyncEndpoint("http://abs", "t", false, "abs-item")
+    private val stEp = StorytellerSyncEndpoint("http://st", "t", false, "st-book")
+
+    private fun locator(progression: Double) = JSONObject()
+        .put("href", "c1.xhtml")
+        .put("locations", JSONObject().put("progression", progression))
+        .toString()
+
+    private class FakeAbs(
+        var progress: NetworkServerProgress,
+    ) : AbsSessionApi {
+        var ebookPatch: NetworkEbookProgressPayload? = null
+        var audioPatch: NetworkAudiobookProgressPayload? = null
+        override suspend fun syncEbookProgress(baseUrl: String, libraryItemId: String, payload: NetworkEbookProgressPayload, token: String, insecureAllowed: Boolean): NetworkSyncSessionResult {
+            ebookPatch = payload; return NetworkSyncSessionResult.Success(0L)
+        }
+        override suspend fun syncAudiobookProgress(baseUrl: String, libraryItemId: String, payload: NetworkAudiobookProgressPayload, token: String, insecureAllowed: Boolean): NetworkSyncSessionResult {
+            audioPatch = payload; return NetworkSyncSessionResult.Success(0L)
+        }
+        override suspend fun getProgress(baseUrl: String, libraryItemId: String, token: String, insecureAllowed: Boolean) =
+            NetworkGetProgressResult.Success(progress)
+    }
+
+    private class FakeStoryteller(
+        private val get: NetworkStorytellerPositionResult,
+    ) : StorytellerPositionApi {
+        var put: String? = null
+        override suspend fun getPosition(baseUrl: String, bookId: String, token: String, insecureAllowed: Boolean) = get
+        override suspend fun putPosition(baseUrl: String, bookId: String, locatorJson: String, timestampMillis: Long, token: String, insecureAllowed: Boolean): NetworkStorytellerPutResult {
+            put = locatorJson; return NetworkStorytellerPutResult.Success
+        }
+    }
+
+    @Test
+    fun `a newer Storyteller position wins the cycle and the reader jumps to it`() = runTest {
+        val abs = FakeAbs(NetworkServerProgress(ebookLocation = "", lastUpdate = 0L)) // empty ABS record
+        val st = FakeStoryteller(NetworkStorytellerPositionResult.Success(locator(0.6), 5_000L))
+        val coordinator = ThreePeerReaderSyncCoordinator(state, bridge, abs, st, absEp, stEp)
+
+        val result = coordinator.runCycle(locator(0.2), localUpdatedAt = 1_000L)
+
+        assertNotNull(result.jumpLocatorJson)
+        assertEquals(0.6, JSONObject(result.jumpLocatorJson!!).getJSONObject("locations").getDouble("progression"), 1e-9)
+        assertEquals(5_000L, result.canonicalLastUpdate)
+        assertNull("the winner is not patched", st.put)
+    }
+
+    @Test
+    fun `when local is newest there is no jump and every peer is pushed the local position`() = runTest {
+        val abs = FakeAbs(NetworkServerProgress(ebookLocation = "", lastUpdate = 0L))
+        val st = FakeStoryteller(NetworkStorytellerPositionResult.NoPosition)
+        val coordinator = ThreePeerReaderSyncCoordinator(state, bridge, abs, st, absEp, stEp)
+
+        val result = coordinator.runCycle(locator(0.3), localUpdatedAt = 9_000L)
+
+        assertNull(result.jumpLocatorJson)
+        assertNotNull("ABS ebook received the first write", abs.ebookPatch)
+        assertTrue(abs.ebookPatch!!.ebookLocation.startsWith("epubcfi("))
+        assertNotNull("Storyteller received the first write", st.put)
+    }
+}

--- a/core/data/src/main/kotlin/com/riffle/core/data/CrossEpubIndexBuilderService.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/CrossEpubIndexBuilderService.kt
@@ -1,0 +1,131 @@
+package com.riffle.core.data
+
+import com.riffle.core.data.di.EpubCacheStore
+import com.riffle.core.data.di.EpubDownloadsStore
+import com.riffle.core.domain.CrossEpubBuildInputs
+import com.riffle.core.domain.CrossEpubIndexBuildOutcome
+import com.riffle.core.domain.CrossEpubIndexService
+import com.riffle.core.domain.CrossEpubIndexStore
+import com.riffle.core.domain.EpubContentExtractor
+import com.riffle.core.domain.LocalStore
+import com.riffle.core.domain.ReadaloudLink
+import com.riffle.core.domain.Server
+import com.riffle.core.domain.ServerRepository
+import com.riffle.core.domain.TokenStorage
+import com.riffle.core.network.AbsLibraryApi
+import com.riffle.core.network.NetworkEpubDownloadResult
+import com.riffle.core.network.NetworkItemEbookInoResult
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+import java.util.Collections
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Builds and persists the cross-EPUB index for Confirmed matched books (ADR 0019/0021).
+ *
+ * [enqueueBuild] is fire-and-forget on a background scope so a library refresh never blocks
+ * on EPUB downloads; the work is idempotent (it skips when the index for the current
+ * checksums already exists) and degrades to *deferred* — never a partial/wrong index — when
+ * a prerequisite EPUB can't be fetched. Both EPUBs are read cache-first and only downloaded
+ * (the few-MB EPUB bundle, never the audio bundle) on the first build, then cached so later
+ * refreshes just re-hash from disk.
+ */
+@Singleton
+class CrossEpubIndexBuilderService(
+    private val serverRepository: ServerRepository,
+    private val tokenStorage: TokenStorage,
+    private val absApi: AbsLibraryApi,
+    private val bundleFetcher: EpubBundleFetcher,
+    @EpubCacheStore private val cacheStore: LocalStore,
+    @EpubDownloadsStore private val downloadsStore: LocalStore,
+    private val store: CrossEpubIndexStore,
+    private val clock: () -> Long,
+) {
+    @Inject constructor(
+        serverRepository: ServerRepository,
+        tokenStorage: TokenStorage,
+        absApi: AbsLibraryApi,
+        bundleFetcher: EpubBundleFetcher,
+        @EpubCacheStore cacheStore: LocalStore,
+        @EpubDownloadsStore downloadsStore: LocalStore,
+        store: CrossEpubIndexStore,
+    ) : this(serverRepository, tokenStorage, absApi, bundleFetcher, cacheStore, downloadsStore, store, System::currentTimeMillis)
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val inFlight = Collections.synchronizedSet(mutableSetOf<Pair<String, String>>())
+
+    private val service = CrossEpubIndexService(
+        loadInputs = ::loadInputs,
+        store = store,
+        clock = clock,
+    )
+
+    /** Schedule an idempotent background build for [link]; returns immediately. */
+    fun enqueueBuild(link: ReadaloudLink) {
+        val key = link.absServerId to link.absLibraryItemId
+        if (!inFlight.add(key)) return
+        scope.launch {
+            try {
+                ensureBuilt(link)
+            } finally {
+                inFlight.remove(key)
+            }
+        }
+    }
+
+    suspend fun ensureBuilt(link: ReadaloudLink): CrossEpubIndexBuildOutcome = service.buildOnConfirm(link)
+
+    private suspend fun loadInputs(link: ReadaloudLink): CrossEpubBuildInputs? {
+        val absServer = serverRepository.getById(link.absServerId) ?: return null
+        val absToken = tokenStorage.getToken(link.absServerId) ?: return null
+        val storytellerServer = serverRepository.getById(link.storytellerServerId) ?: return null
+        val storytellerToken = tokenStorage.getToken(link.storytellerServerId) ?: return null
+
+        val absBytes = absEpubBytes(absServer, absToken, link.absLibraryItemId) ?: return null
+        val storytellerBytes = storytellerEpubBytes(storytellerServer, storytellerToken, link.storytellerBookId) ?: return null
+
+        val absExtract = EpubContentExtractor.extract(absBytes) ?: return null
+        val storytellerExtract = EpubContentExtractor.extract(storytellerBytes) ?: return null
+
+        return CrossEpubBuildInputs(
+            absEpubBytes = absBytes,
+            storytellerEpubBytes = storytellerBytes,
+            absChaptersHtml = absExtract.chapters.map { it.html },
+            storytellerChaptersHtml = storytellerExtract.chapters.map { it.html },
+        )
+    }
+
+    private fun cachedBytes(itemId: String): ByteArray? =
+        (downloadsStore.get(itemId) ?: cacheStore.get(itemId))?.readBytes()
+
+    private suspend fun absEpubBytes(server: Server, token: String, itemId: String): ByteArray? {
+        cachedBytes(itemId)?.let { return it }
+        val ino = when (val r = absApi.getItemEbookFileIno(server.url.value, itemId, token, server.insecureConnectionAllowed)) {
+            is NetworkItemEbookInoResult.Success -> r.ino
+            is NetworkItemEbookInoResult.NetworkError -> return null
+        }
+        val bytes = when (val r = absApi.downloadEpub(server.url.value, itemId, ino, token, server.insecureConnectionAllowed)) {
+            is NetworkEpubDownloadResult.Success -> r.body.use { it.byteStream().readBytes() }
+            is NetworkEpubDownloadResult.NetworkError -> return null
+        }
+        cacheStore.save(itemId, bytes.inputStream())
+        return bytes
+    }
+
+    private suspend fun storytellerEpubBytes(server: Server, token: String, bookId: String): ByteArray? {
+        cachedBytes(bookId)?.let { return it }
+        return when (val r = bundleFetcher.fetch(server.url.value, bookId, token, server.insecureConnectionAllowed)) {
+            is EpubBundleFetcher.Result.Success -> try {
+                val bytes = r.epubFile.readBytes()
+                cacheStore.save(bookId, bytes.inputStream())
+                bytes
+            } finally {
+                r.epubFile.delete()
+            }
+            is EpubBundleFetcher.Result.NetworkError -> null
+        }
+    }
+}

--- a/core/data/src/main/kotlin/com/riffle/core/data/CrossEpubIndexStoreImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/CrossEpubIndexStoreImpl.kt
@@ -1,0 +1,31 @@
+package com.riffle.core.data
+
+import com.riffle.core.database.CrossEpubIndexDao
+import com.riffle.core.database.CrossEpubIndexEntity
+import com.riffle.core.domain.CrossEpubIndex
+import com.riffle.core.domain.CrossEpubIndexSerializer
+import com.riffle.core.domain.CrossEpubIndexStore
+import javax.inject.Inject
+
+/** [CrossEpubIndexStore] backed by the `cross_epub_index` Room table. */
+class CrossEpubIndexStoreImpl @Inject constructor(
+    private val dao: CrossEpubIndexDao,
+) : CrossEpubIndexStore {
+
+    override suspend fun exists(absChecksum: String, storytellerChecksum: String): Boolean =
+        dao.find(absChecksum, storytellerChecksum) != null
+
+    override suspend fun load(absChecksum: String, storytellerChecksum: String): CrossEpubIndex? =
+        dao.find(absChecksum, storytellerChecksum)?.let { CrossEpubIndexSerializer.decode(it.perChapterMapsBlob) }
+
+    override suspend fun put(absChecksum: String, storytellerChecksum: String, blob: String, builtAt: Long) {
+        dao.upsert(
+            CrossEpubIndexEntity(
+                absEpubChecksum = absChecksum,
+                storytellerEpubChecksum = storytellerChecksum,
+                perChapterMapsBlob = blob,
+                builtAt = builtAt,
+            )
+        )
+    }
+}

--- a/core/data/src/main/kotlin/com/riffle/core/data/ReadaloudMatchingService.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/ReadaloudMatchingService.kt
@@ -11,6 +11,7 @@ import com.riffle.core.database.ReadaloudLinkEntity
 import com.riffle.core.domain.EbookFormat
 import com.riffle.core.domain.MatchOutcome
 import com.riffle.core.domain.MatchableAbsItem
+import com.riffle.core.domain.ReadaloudLink
 import com.riffle.core.domain.MatchableStorytellerBook
 import com.riffle.core.domain.ReadaloudMatcher
 import com.riffle.core.domain.ServerType
@@ -40,14 +41,18 @@ class ReadaloudMatchingService(
     private val readaloudLinkDao: ReadaloudLinkDao,
     private val readaloudCandidateDao: ReadaloudCandidateDao,
     private val readaloudDismissalDao: ReadaloudDismissalDao,
-    private val clock: () -> Long,
+    private val clock: () -> Long = System::currentTimeMillis,
+    // Eager cross-EPUB index build on Confirm (ADR 0019/0021). Optional so unit tests of the
+    // matcher run without the I/O-heavy builder; wired in production via DI.
+    private val indexBuilder: CrossEpubIndexBuilderService? = null,
 ) {
     @Inject constructor(
         libraryItemDao: LibraryItemDao,
         readaloudLinkDao: ReadaloudLinkDao,
         readaloudCandidateDao: ReadaloudCandidateDao,
         readaloudDismissalDao: ReadaloudDismissalDao,
-    ) : this(libraryItemDao, readaloudLinkDao, readaloudCandidateDao, readaloudDismissalDao, System::currentTimeMillis)
+        indexBuilder: CrossEpubIndexBuilderService,
+    ) : this(libraryItemDao, readaloudLinkDao, readaloudCandidateDao, readaloudDismissalDao, System::currentTimeMillis, indexBuilder)
 
     suspend fun reconcileLinks() {
         val storytellerBooks = libraryItemDao.listMatchableByServerType(ServerType.STORYTELLER.name)
@@ -127,6 +132,28 @@ class ReadaloudMatchingService(
         readaloudCandidateDao.clearAll()
         if (freshCandidates.isNotEmpty()) readaloudCandidateDao.upsertAll(freshCandidates)
         backfillReadaloudMetadata(storytellerBooks)
+        enqueueIndexBuilds()
+    }
+
+    /**
+     * Kick off a background cross-EPUB index build for every surviving Confirmed link. Each
+     * build is idempotent (skipped once the index for the current EPUB checksums exists), so
+     * re-running on every refresh just retries any link whose prerequisites weren't available
+     * at Confirm time — the opportunistic rebuild from ADR 0019.
+     */
+    private suspend fun enqueueIndexBuilds() {
+        val builder = indexBuilder ?: return
+        for (row in readaloudLinkDao.allRows()) {
+            builder.enqueueBuild(
+                ReadaloudLink(
+                    storytellerServerId = row.storytellerServerId,
+                    storytellerBookId = row.storytellerBookId,
+                    absServerId = row.absServerId,
+                    absLibraryItemId = row.absLibraryItemId,
+                    userConfirmed = row.userConfirmed,
+                )
+            )
+        }
     }
 
     /**

--- a/core/data/src/main/kotlin/com/riffle/core/data/ServerRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/ServerRepositoryImpl.kt
@@ -44,6 +44,8 @@ class ServerRepositoryImpl @Inject constructor(
 
     override suspend fun getActive(): Server? = dao.getActive()?.toDomain()
 
+    override suspend fun getById(serverId: String): Server? = dao.getById(serverId)?.toDomain()
+
     override suspend fun authenticate(
         url: ServerUrl,
         username: String,

--- a/core/data/src/main/kotlin/com/riffle/core/data/di/DataModule.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/di/DataModule.kt
@@ -15,6 +15,7 @@ import com.riffle.core.data.AudioCachePreferencesStoreImpl
 import com.riffle.core.data.LibraryVisibilityPreferencesStoreImpl
 import com.riffle.core.data.LocalStoreImpl
 import com.riffle.core.data.PdfRepositoryImpl
+import com.riffle.core.data.CrossEpubIndexStoreImpl
 import com.riffle.core.data.ReadaloudLinkRepositoryImpl
 import com.riffle.core.data.ReadaloudReviewRepositoryImpl
 import com.riffle.core.data.ReadingPositionStoreImpl
@@ -35,6 +36,7 @@ import com.riffle.core.domain.LibraryRepository
 import com.riffle.core.domain.LibraryVisibilityPreferencesStore
 import com.riffle.core.domain.LocalStore
 import com.riffle.core.domain.PdfRepository
+import com.riffle.core.domain.CrossEpubIndexStore
 import com.riffle.core.domain.ReadaloudLinkRepository
 import com.riffle.core.domain.ReadaloudReviewRepository
 import com.riffle.core.domain.ReadingPositionStore
@@ -166,6 +168,10 @@ abstract class DataModule {
     @Binds
     @Singleton
     abstract fun bindStorytellerLibraryApi(impl: StorytellerApiClient): StorytellerLibraryApi
+
+    @Binds
+    @Singleton
+    abstract fun bindCrossEpubIndexStore(impl: CrossEpubIndexStoreImpl): CrossEpubIndexStore
 
     @Binds
     @Singleton

--- a/core/data/src/main/kotlin/com/riffle/core/data/di/DatabaseModule.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/di/DatabaseModule.kt
@@ -6,6 +6,7 @@ import com.riffle.core.database.BookFormattingPreferencesDao
 import com.riffle.core.database.CollectionDao
 import com.riffle.core.database.LibraryDao
 import com.riffle.core.database.LibraryItemDao
+import com.riffle.core.database.CrossEpubIndexDao
 import com.riffle.core.database.ReadaloudCandidateDao
 import com.riffle.core.database.ReadaloudDismissalDao
 import com.riffle.core.database.ReadaloudLinkDao
@@ -51,6 +52,7 @@ object DatabaseModule {
                 RiffleDatabase.MIGRATION_20_21,
                 RiffleDatabase.MIGRATION_21_22,
                 RiffleDatabase.MIGRATION_22_23,
+                RiffleDatabase.MIGRATION_23_24,
             )
             .build()
 
@@ -93,4 +95,8 @@ object DatabaseModule {
     @Provides
     @Singleton
     fun provideReadaloudDismissalDao(db: RiffleDatabase): ReadaloudDismissalDao = db.readaloudDismissalDao()
+
+    @Provides
+    @Singleton
+    fun provideCrossEpubIndexDao(db: RiffleDatabase): CrossEpubIndexDao = db.crossEpubIndexDao()
 }

--- a/core/data/src/test/kotlin/com/riffle/core/data/ProgressSyncCycleTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/ProgressSyncCycleTest.kt
@@ -11,6 +11,7 @@ import com.riffle.core.domain.ServerUrl
 import com.riffle.core.domain.SessionPayload
 import com.riffle.core.domain.TokenStorage
 import com.riffle.core.network.AbsSessionApi
+import com.riffle.core.network.NetworkAudiobookProgressPayload
 import com.riffle.core.network.NetworkEbookProgressPayload
 import com.riffle.core.network.NetworkGetProgressResult
 import com.riffle.core.network.NetworkServerProgress
@@ -53,6 +54,10 @@ class ProgressSyncCycleTest {
             patchCallCount++
             return patchResult
         }
+        override suspend fun syncAudiobookProgress(
+            baseUrl: String, libraryItemId: String, payload: NetworkAudiobookProgressPayload,
+            token: String, insecureAllowed: Boolean,
+        ): NetworkSyncSessionResult = patchResult
         override suspend fun getProgress(
             baseUrl: String, libraryItemId: String, token: String, insecureAllowed: Boolean,
         ): NetworkGetProgressResult = getResult
@@ -289,6 +294,10 @@ class ProgressSyncCycleTest {
                 patchPayload = payload
                 return NetworkSyncSessionResult.Success(7_777L)
             }
+            override suspend fun syncAudiobookProgress(
+                baseUrl: String, libraryItemId: String, payload: NetworkAudiobookProgressPayload,
+                token: String, insecureAllowed: Boolean,
+            ) = NetworkSyncSessionResult.Success(0L)
             override suspend fun getProgress(baseUrl: String, libraryItemId: String, token: String, insecureAllowed: Boolean) =
                 NetworkGetProgressResult.Success(NetworkServerProgress("server-cfi", ebookProgress = 0.42f, lastUpdate = 3_000L))
         }

--- a/core/database/schemas/com.riffle.core.database.RiffleDatabase/24.json
+++ b/core/database/schemas/com.riffle.core.database.RiffleDatabase/24.json
@@ -1,0 +1,755 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 24,
+    "identityHash": "cb7d86bceb7ed5a4f94632a64c3a4c09",
+    "entities": [
+      {
+        "tableName": "servers",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `url` TEXT NOT NULL, `isActive` INTEGER NOT NULL, `insecureConnectionAllowed` INTEGER NOT NULL, `username` TEXT NOT NULL, `serverType` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "isActive",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "insecureConnectionAllowed",
+            "columnName": "insecureConnectionAllowed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "username",
+            "columnName": "username",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverType",
+            "columnName": "serverType",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "libraries",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `mediaType` TEXT NOT NULL, `serverId` TEXT NOT NULL, `isUnsupported` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaType",
+            "columnName": "mediaType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isUnsupported",
+            "columnName": "isUnsupported",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "library_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `title` TEXT NOT NULL, `author` TEXT NOT NULL, `coverUrl` TEXT, `readingProgress` REAL NOT NULL, `ebookFileIno` TEXT, `ebookFormat` TEXT NOT NULL, `description` TEXT, `seriesName` TEXT, `publishedYear` TEXT, `genres` TEXT NOT NULL, `publisher` TEXT, `lastOpenedAt` INTEGER, `addedAt` INTEGER, `isbn` TEXT, `asin` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "coverUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "readingProgress",
+            "columnName": "readingProgress",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ebookFileIno",
+            "columnName": "ebookFileIno",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "ebookFormat",
+            "columnName": "ebookFormat",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seriesName",
+            "columnName": "seriesName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "publishedYear",
+            "columnName": "publishedYear",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "genres",
+            "columnName": "genres",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "publisher",
+            "columnName": "publisher",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastOpenedAt",
+            "columnName": "lastOpenedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "isbn",
+            "columnName": "isbn",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "asin",
+            "columnName": "asin",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "series",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `name` TEXT NOT NULL, `coverUrl` TEXT, `bookCount` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "coverUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "bookCount",
+            "columnName": "bookCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "collections",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `name` TEXT NOT NULL, `bookCount` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookCount",
+            "columnName": "bookCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "series_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`seriesId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `sequenceOrder` REAL NOT NULL, PRIMARY KEY(`seriesId`, `itemId`))",
+        "fields": [
+          {
+            "fieldPath": "seriesId",
+            "columnName": "seriesId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sequenceOrder",
+            "columnName": "sequenceOrder",
+            "affinity": "REAL",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "seriesId",
+            "itemId"
+          ]
+        }
+      },
+      {
+        "tableName": "collection_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`collectionId` TEXT NOT NULL, `itemId` TEXT NOT NULL, PRIMARY KEY(`collectionId`, `itemId`))",
+        "fields": [
+          {
+            "fieldPath": "collectionId",
+            "columnName": "collectionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "collectionId",
+            "itemId"
+          ]
+        }
+      },
+      {
+        "tableName": "reading_positions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`serverId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `cfi` TEXT NOT NULL, `localUpdatedAt` INTEGER NOT NULL, PRIMARY KEY(`serverId`, `itemId`), FOREIGN KEY(`serverId`) REFERENCES `servers`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cfi",
+            "columnName": "cfi",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localUpdatedAt",
+            "columnName": "localUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "serverId",
+            "itemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_reading_positions_serverId",
+            "unique": false,
+            "columnNames": [
+              "serverId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_reading_positions_serverId` ON `${TABLE_NAME}` (`serverId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "servers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "serverId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "book_formatting_preferences",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`itemId` TEXT NOT NULL, `fontSize` REAL, `theme` TEXT, `fontFamily` TEXT, `lineSpacing` REAL, `margins` REAL, `orientation` TEXT, `showChapterMap` INTEGER, `showReadingProgressLabels` INTEGER, `showCurrentChapterLabel` INTEGER, `doublePageSpread` INTEGER, `justifyText` INTEGER, PRIMARY KEY(`itemId`))",
+        "fields": [
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fontSize",
+            "columnName": "fontSize",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "theme",
+            "columnName": "theme",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "fontFamily",
+            "columnName": "fontFamily",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lineSpacing",
+            "columnName": "lineSpacing",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "margins",
+            "columnName": "margins",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "orientation",
+            "columnName": "orientation",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "showChapterMap",
+            "columnName": "showChapterMap",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "showReadingProgressLabels",
+            "columnName": "showReadingProgressLabels",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "showCurrentChapterLabel",
+            "columnName": "showCurrentChapterLabel",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "doublePageSpread",
+            "columnName": "doublePageSpread",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "justifyText",
+            "columnName": "justifyText",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "itemId"
+          ]
+        }
+      },
+      {
+        "tableName": "readaloud_links",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`absServerId` TEXT NOT NULL, `absLibraryItemId` TEXT NOT NULL, `storytellerServerId` TEXT NOT NULL, `storytellerBookId` TEXT NOT NULL, `state` TEXT NOT NULL, `userConfirmed` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`absServerId`, `absLibraryItemId`), FOREIGN KEY(`storytellerServerId`) REFERENCES `servers`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`absServerId`) REFERENCES `servers`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "absServerId",
+            "columnName": "absServerId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absLibraryItemId",
+            "columnName": "absLibraryItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerServerId",
+            "columnName": "storytellerServerId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerBookId",
+            "columnName": "storytellerBookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userConfirmed",
+            "columnName": "userConfirmed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "absServerId",
+            "absLibraryItemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_readaloud_links_storytellerServerId_storytellerBookId",
+            "unique": false,
+            "columnNames": [
+              "storytellerServerId",
+              "storytellerBookId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_readaloud_links_storytellerServerId_storytellerBookId` ON `${TABLE_NAME}` (`storytellerServerId`, `storytellerBookId`)"
+          },
+          {
+            "name": "index_readaloud_links_storytellerServerId",
+            "unique": false,
+            "columnNames": [
+              "storytellerServerId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_readaloud_links_storytellerServerId` ON `${TABLE_NAME}` (`storytellerServerId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "servers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "storytellerServerId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "servers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "absServerId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "readaloud_candidates",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`storytellerServerId` TEXT NOT NULL, `storytellerBookId` TEXT NOT NULL, `absServerId` TEXT NOT NULL, `absLibraryItemId` TEXT NOT NULL, `score` REAL NOT NULL, PRIMARY KEY(`storytellerServerId`, `storytellerBookId`, `absServerId`, `absLibraryItemId`), FOREIGN KEY(`storytellerServerId`) REFERENCES `servers`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`absServerId`) REFERENCES `servers`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "storytellerServerId",
+            "columnName": "storytellerServerId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerBookId",
+            "columnName": "storytellerBookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absServerId",
+            "columnName": "absServerId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absLibraryItemId",
+            "columnName": "absLibraryItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "score",
+            "columnName": "score",
+            "affinity": "REAL",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "storytellerServerId",
+            "storytellerBookId",
+            "absServerId",
+            "absLibraryItemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_readaloud_candidates_absServerId",
+            "unique": false,
+            "columnNames": [
+              "absServerId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_readaloud_candidates_absServerId` ON `${TABLE_NAME}` (`absServerId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "servers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "storytellerServerId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "servers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "absServerId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "readaloud_dismissals",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`storytellerServerId` TEXT NOT NULL, `storytellerBookId` TEXT NOT NULL, `scope` TEXT NOT NULL, `absServerId` TEXT NOT NULL, `absLibraryItemId` TEXT NOT NULL, PRIMARY KEY(`storytellerServerId`, `storytellerBookId`, `absServerId`, `absLibraryItemId`), FOREIGN KEY(`storytellerServerId`) REFERENCES `servers`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "storytellerServerId",
+            "columnName": "storytellerServerId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerBookId",
+            "columnName": "storytellerBookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scope",
+            "columnName": "scope",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absServerId",
+            "columnName": "absServerId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absLibraryItemId",
+            "columnName": "absLibraryItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "storytellerServerId",
+            "storytellerBookId",
+            "absServerId",
+            "absLibraryItemId"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "servers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "storytellerServerId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "cross_epub_index",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`absEpubChecksum` TEXT NOT NULL, `storytellerEpubChecksum` TEXT NOT NULL, `perChapterMapsBlob` TEXT NOT NULL, `builtAt` INTEGER NOT NULL, PRIMARY KEY(`absEpubChecksum`, `storytellerEpubChecksum`))",
+        "fields": [
+          {
+            "fieldPath": "absEpubChecksum",
+            "columnName": "absEpubChecksum",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerEpubChecksum",
+            "columnName": "storytellerEpubChecksum",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "perChapterMapsBlob",
+            "columnName": "perChapterMapsBlob",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "builtAt",
+            "columnName": "builtAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "absEpubChecksum",
+            "storytellerEpubChecksum"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'cb7d86bceb7ed5a4f94632a64c3a4c09')"
+    ]
+  }
+}

--- a/core/database/src/androidTest/kotlin/com/riffle/core/database/MigrationTest.kt
+++ b/core/database/src/androidTest/kotlin/com/riffle/core/database/MigrationTest.kt
@@ -823,6 +823,74 @@ class MigrationTest {
         }
     }
 
+
+    @Test
+    fun migration23To24_addsCrossEpubIndexCacheTable() {
+        helper.createDatabase(TEST_DB, 23).use { db ->
+            // A pre-existing readaloud_links row that must survive the new table being added.
+            db.execSQL(
+                "INSERT INTO servers (id, url, isActive, insecureConnectionAllowed, username, serverType) " +
+                    "VALUES ('st1', 'http://media-server:8001', 0, 0, 'plamen', 'STORYTELLER')"
+            )
+            db.execSQL(
+                "INSERT INTO servers (id, url, isActive, insecureConnectionAllowed, username, serverType) " +
+                    "VALUES ('abs1', 'http://media-server:13378', 1, 0, 'plamen', 'AUDIOBOOKSHELF')"
+            )
+            db.execSQL(
+                "INSERT INTO readaloud_links " +
+                    "(absServerId, absLibraryItemId, storytellerServerId, storytellerBookId, state, userConfirmed, createdAt, updatedAt) " +
+                    "VALUES ('abs1', 'item1', 'st1', 'book-1', 'CONFIRMED', 0, 1000, 1000)"
+            )
+        }
+
+        val db = helper.runMigrationsAndValidate(TEST_DB, 24, true, RiffleDatabase.MIGRATION_23_24)
+
+        // Pre-existing data survives.
+        db.query("SELECT COUNT(*) FROM readaloud_links").use { cursor ->
+            cursor.moveToFirst()
+            assertEquals(1, cursor.getInt(0))
+        }
+
+        // New cache table exists and starts empty.
+        db.query("SELECT COUNT(*) FROM cross_epub_index").use { cursor ->
+            cursor.moveToFirst()
+            assertEquals(0, cursor.getInt(0))
+        }
+
+        // A row keyed by both checksums round-trips.
+        db.execSQL(
+            "INSERT INTO cross_epub_index (absEpubChecksum, storytellerEpubChecksum, perChapterMapsBlob, builtAt) " +
+                "VALUES ('absChk', 'stChk', '[{\"absChars\":12,\"storytellerChars\":12}]', 5000)"
+        )
+        db.query("SELECT perChapterMapsBlob, builtAt FROM cross_epub_index WHERE absEpubChecksum = 'absChk' AND storytellerEpubChecksum = 'stChk'").use { cursor ->
+            assertEquals(1, cursor.count)
+            cursor.moveToFirst()
+            assertEquals("[{\"absChars\":12,\"storytellerChars\":12}]", cursor.getString(0))
+            assertEquals(5000L, cursor.getLong(1))
+        }
+
+        // A different checksum on either side is a distinct row (invalidation = keyed miss).
+        db.execSQL(
+            "INSERT INTO cross_epub_index (absEpubChecksum, storytellerEpubChecksum, perChapterMapsBlob, builtAt) " +
+                "VALUES ('absChk2', 'stChk', '[]', 6000)"
+        )
+        db.query("SELECT COUNT(*) FROM cross_epub_index").use { cursor ->
+            cursor.moveToFirst()
+            assertEquals(2, cursor.getInt(0))
+        }
+
+        // Same composite key collides via REPLACE.
+        db.execSQL(
+            "INSERT OR REPLACE INTO cross_epub_index (absEpubChecksum, storytellerEpubChecksum, perChapterMapsBlob, builtAt) " +
+                "VALUES ('absChk', 'stChk', '[]', 9000)"
+        )
+        db.query("SELECT builtAt FROM cross_epub_index WHERE absEpubChecksum = 'absChk' AND storytellerEpubChecksum = 'stChk'").use { cursor ->
+            assertEquals(1, cursor.count)
+            cursor.moveToFirst()
+            assertEquals(9000L, cursor.getLong(0))
+        }
+    }
+
     @Test
     fun migrateFullChain() {
         helper.createDatabase(TEST_DB, 1).use { db ->
@@ -832,7 +900,7 @@ class MigrationTest {
         }
 
         val db = helper.runMigrationsAndValidate(
-            TEST_DB, 23, true,
+            TEST_DB, 24, true,
             RiffleDatabase.MIGRATION_1_2,
             RiffleDatabase.MIGRATION_2_3,
             RiffleDatabase.MIGRATION_3_4,
@@ -855,6 +923,7 @@ class MigrationTest {
             RiffleDatabase.MIGRATION_20_21,
             RiffleDatabase.MIGRATION_21_22,
             RiffleDatabase.MIGRATION_22_23,
+            RiffleDatabase.MIGRATION_23_24,
         )
 
         db.query("SELECT url, username, serverType FROM servers WHERE id = 's1'").use { cursor ->
@@ -866,3 +935,4 @@ class MigrationTest {
         }
     }
 }
+

--- a/core/database/src/main/kotlin/com/riffle/core/database/CrossEpubIndexDao.kt
+++ b/core/database/src/main/kotlin/com/riffle/core/database/CrossEpubIndexDao.kt
@@ -1,0 +1,24 @@
+package com.riffle.core.database
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+
+@Dao
+interface CrossEpubIndexDao {
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsert(entity: CrossEpubIndexEntity)
+
+    /** Hit only when both checksums match what the index was built from. */
+    @Query(
+        "SELECT * FROM cross_epub_index " +
+            "WHERE absEpubChecksum = :absEpubChecksum AND storytellerEpubChecksum = :storytellerEpubChecksum " +
+            "LIMIT 1"
+    )
+    suspend fun find(absEpubChecksum: String, storytellerEpubChecksum: String): CrossEpubIndexEntity?
+
+    @Query("DELETE FROM cross_epub_index")
+    suspend fun clear()
+}

--- a/core/database/src/main/kotlin/com/riffle/core/database/CrossEpubIndexEntity.kt
+++ b/core/database/src/main/kotlin/com/riffle/core/database/CrossEpubIndexEntity.kt
@@ -1,0 +1,25 @@
+package com.riffle.core.database
+
+import androidx.room.Entity
+
+/**
+ * Cached cross-EPUB character-position index for a matched readaloud book (ADR 0019).
+ *
+ * Keyed by the two source EPUBs' checksums: a row is a hit only while both the ABS EPUB
+ * and the Storyteller EPUB are byte-for-byte what the index was built from. If either
+ * server re-uploads its EPUB, its checksum changes, the keyed lookup misses, and the next
+ * sync cycle rebuilds — so the table needs no explicit invalidation.
+ *
+ * [perChapterMapsBlob] is the serialised per-chapter character maps (the domain
+ * `CrossEpubIndex`). This table is a pure local cache: no foreign keys, cleared freely.
+ */
+@Entity(
+    tableName = "cross_epub_index",
+    primaryKeys = ["absEpubChecksum", "storytellerEpubChecksum"],
+)
+data class CrossEpubIndexEntity(
+    val absEpubChecksum: String,
+    val storytellerEpubChecksum: String,
+    val perChapterMapsBlob: String,
+    val builtAt: Long,
+)

--- a/core/database/src/main/kotlin/com/riffle/core/database/RiffleDatabase.kt
+++ b/core/database/src/main/kotlin/com/riffle/core/database/RiffleDatabase.kt
@@ -19,8 +19,9 @@ import androidx.sqlite.db.SupportSQLiteDatabase
         ReadaloudLinkEntity::class,
         ReadaloudCandidateEntity::class,
         ReadaloudDismissalEntity::class,
+        CrossEpubIndexEntity::class,
     ],
-    version = 23,
+    version = 24,
     exportSchema = true,
 )
 abstract class RiffleDatabase : RoomDatabase() {
@@ -34,6 +35,7 @@ abstract class RiffleDatabase : RoomDatabase() {
     abstract fun readaloudLinkDao(): ReadaloudLinkDao
     abstract fun readaloudCandidateDao(): ReadaloudCandidateDao
     abstract fun readaloudDismissalDao(): ReadaloudDismissalDao
+    abstract fun crossEpubIndexDao(): CrossEpubIndexDao
 
     companion object {
         val MIGRATION_1_2 = object : Migration(1, 2) {
@@ -369,6 +371,23 @@ abstract class RiffleDatabase : RoomDatabase() {
                         "PRIMARY KEY(`storytellerServerId`, `storytellerBookId`, `absServerId`, `absLibraryItemId`), " +
                         "FOREIGN KEY(`storytellerServerId`) REFERENCES `servers`(`id`) " +
                         "ON UPDATE NO ACTION ON DELETE CASCADE)"
+                )
+            }
+        }
+
+        // Cross-EPUB character-position index cache (issue #38, ADR 0019). A standalone
+        // local cache table keyed by the two source EPUBs' checksums — no foreign keys,
+        // since a row is invalidated by a checksum change (keyed-lookup miss), not by any
+        // Server lifecycle event.
+        val MIGRATION_23_24 = object : Migration(23, 24) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL(
+                    "CREATE TABLE IF NOT EXISTS `cross_epub_index` (" +
+                        "`absEpubChecksum` TEXT NOT NULL, " +
+                        "`storytellerEpubChecksum` TEXT NOT NULL, " +
+                        "`perChapterMapsBlob` TEXT NOT NULL, " +
+                        "`builtAt` INTEGER NOT NULL, " +
+                        "PRIMARY KEY(`absEpubChecksum`, `storytellerEpubChecksum`))"
                 )
             }
         }

--- a/core/domain/build.gradle.kts
+++ b/core/domain/build.gradle.kts
@@ -1,9 +1,12 @@
 plugins {
     alias(libs.plugins.kotlin.jvm)
+    alias(libs.plugins.kotlin.serialization)
 }
 
 dependencies {
     implementation(libs.kotlinx.coroutines.core)
+    implementation(libs.jsoup)
+    implementation(libs.kotlinx.serialization.json)
 
     testImplementation(libs.junit)
     testImplementation(libs.kotlinx.coroutines.test)

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/ApplicableRemotes.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/ApplicableRemotes.kt
@@ -1,0 +1,52 @@
+package com.riffle.core.domain
+
+/** A reconcilable position holder for the open book. */
+enum class RemoteKind { ABS_EBOOK, ABS_AUDIO, STORYTELLER }
+
+/** Which entry point the book was opened from — determines single-peer fallback. */
+enum class OpenedSide { ABS, READALOUD }
+
+/**
+ * The match- and prerequisite-state that decides a book's applicable remote set (ADR 0019).
+ *
+ * @param isMatched a Confirmed [ReadaloudLink] exists for the open book.
+ * @param confirmedAbsLinkCount how many Confirmed ABS links the Storyteller readaloud holds;
+ *   the three-peer invariant requires exactly one (one readaloud ↔ one ABS Library Item).
+ * @param prerequisitesCached the Storyteller EPUB bundle and cross-EPUB index are available.
+ * @param openedSide the entry point, which selects the single-peer fallback set.
+ */
+data class BookSyncState(
+    val isMatched: Boolean,
+    val confirmedAbsLinkCount: Int,
+    val prerequisitesCached: Boolean,
+    val openedSide: OpenedSide,
+)
+
+/**
+ * The set of remotes a sync cycle reconciles for the open book.
+ *
+ * - Unmatched: single-peer, the open side's own remote (`{ABS ebook}` / `{Storyteller}`).
+ * - Matched, **exactly one** ABS link, prerequisites cached: three-peer from either side.
+ * - Matched, **more than one** ABS link: the multi-link guard — those are distinct users'
+ *   progress sharing one Storyteller position, so Storyteller is excluded and the book
+ *   degrades to a two-peer ABS-ebook ↔ ABS-audiobook cycle.
+ * - Matched, one ABS link, prerequisites not yet cached: single-peer side fallback until
+ *   the prerequisites land, then it upgrades on a later cycle.
+ */
+fun applicableRemotes(state: BookSyncState): Set<RemoteKind> {
+    val sidePeer = when (state.openedSide) {
+        OpenedSide.ABS -> setOf(RemoteKind.ABS_EBOOK)
+        OpenedSide.READALOUD -> setOf(RemoteKind.STORYTELLER)
+    }
+
+    if (!state.isMatched) return sidePeer
+
+    if (state.confirmedAbsLinkCount > 1) {
+        // Multi-link guard: never write the shared Storyteller position.
+        return setOf(RemoteKind.ABS_EBOOK, RemoteKind.ABS_AUDIO)
+    }
+
+    if (!state.prerequisitesCached) return sidePeer
+
+    return setOf(RemoteKind.ABS_EBOOK, RemoteKind.ABS_AUDIO, RemoteKind.STORYTELLER)
+}

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/CanonicalPositionTranslator.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/CanonicalPositionTranslator.kt
@@ -1,0 +1,85 @@
+package com.riffle.core.domain
+
+/**
+ * The single point of conversion between the three coordinate systems a matched
+ * readaloud book holds a position in (ADR 0019):
+ *
+ *  - **audio-seconds** — ABS audiobook progress, an offset into the audio file.
+ *  - **Storyteller-EPUB text position** — a text fragment reference (`href#id`) in
+ *    Storyteller's publication, the anchor of a Readium Locator.
+ *  - **ABS-EPUB CFI** — a CFI in the ABS-served EPUB (a different file for the same
+ *    logical book).
+ *
+ * Every conversion is best-effort: an input that cannot be placed in the target
+ * system returns `null` rather than guessing, so a missing mapping degrades a sync
+ * cycle to a deferred PATCH instead of a wrong one.
+ */
+class CanonicalPositionTranslator(
+    private val smilClips: List<MediaOverlayClip>,
+    private val index: CrossEpubIndex = CrossEpubIndex(emptyList()),
+    private val fragmentProgressions: Map<String, ChapterProgression> = emptyMap(),
+) {
+
+    /**
+     * Audio time → canonical (Storyteller-EPUB) progression: the narrated SMIL fragment
+     * resolved to its within-chapter progression. Returns `null` when no clip covers the
+     * time or the fragment has no resolved progression.
+     */
+    fun audioSecondsToStorytellerProgression(seconds: Double): ChapterProgression? =
+        audioSecondsToTextFragment(seconds)?.let { fragmentProgressions[it] }
+
+    /**
+     * Canonical (Storyteller-EPUB) progression → audio time: the start of the clip for
+     * the latest narrated fragment at or before [pos] within the same chapter. Returns
+     * `null` when no narrated fragment precedes [pos].
+     */
+    fun storytellerProgressionToAudioSeconds(pos: ChapterProgression): Double? {
+        val fragment = fragmentProgressions.entries
+            .filter { it.value.chapterIndex == pos.chapterIndex && it.value.progression <= pos.progression }
+            .maxByOrNull { it.value.progression }
+            ?.key
+            ?: return null
+        return textFragmentToAudioSeconds(fragment)
+    }
+
+    /**
+     * A within-chapter progression in the Storyteller EPUB → the same logical point as
+     * a within-chapter progression in the ABS EPUB, preserving the absolute readable-
+     * character offset (the chapters hold the same prose, marked up differently).
+     * Returns `null` when the chapter has no entry in the cross-EPUB index.
+     */
+    fun storytellerToAbsProgression(pos: ChapterProgression): ChapterProgression? =
+        remap(pos, fromChars = { it.storytellerChars }, toChars = { it.absChars })
+
+    /** Inverse of [storytellerToAbsProgression]. */
+    fun absToStorytellerProgression(pos: ChapterProgression): ChapterProgression? =
+        remap(pos, fromChars = { it.absChars }, toChars = { it.storytellerChars })
+
+    private inline fun remap(
+        pos: ChapterProgression,
+        fromChars: (ChapterCharMap) -> Long,
+        toChars: (ChapterCharMap) -> Long,
+    ): ChapterProgression? {
+        val map = index.perChapter.getOrNull(pos.chapterIndex) ?: return null
+        val to = toChars(map)
+        if (to == 0L) return null
+        val charOffset = pos.progression * fromChars(map)
+        return ChapterProgression(pos.chapterIndex, (charOffset / to).coerceIn(0.0, 1.0))
+    }
+
+    /**
+     * Audio time → the Storyteller text fragment the SMIL narrates at that instant.
+     * Returns `null` when no clip covers [seconds] (e.g. before the first or past the
+     * last clip).
+     */
+    fun audioSecondsToTextFragment(seconds: Double): String? =
+        smilClips.firstOrNull { seconds >= it.clipBeginSec && seconds < it.clipEndSec }
+            ?.textFragmentRef
+
+    /**
+     * Storyteller text fragment → the audio time where its narration begins. Returns
+     * `null` when no clip narrates [textFragmentRef].
+     */
+    fun textFragmentToAudioSeconds(textFragmentRef: String): Double? =
+        smilClips.firstOrNull { it.textFragmentRef == textFragmentRef }?.clipBeginSec
+}

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/CrossEpubIndex.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/CrossEpubIndex.kt
@@ -1,0 +1,36 @@
+package com.riffle.core.domain
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Readable-character counts for one logical chapter as it appears in each of the two
+ * EPUBs of a matched readaloud book. A position inside the chapter is bridged between
+ * the two CFI domains by scaling its character offset proportionally between
+ * [absChars] and [storytellerChars] — best-effort, per ADR 0019.
+ */
+@Serializable
+data class ChapterCharMap(
+    val absChars: Long,
+    val storytellerChars: Long,
+)
+
+/**
+ * The per-matched-book cross-EPUB character-position index (ADR 0019): one
+ * [ChapterCharMap] per chapter, aligned by spine order. Serialisable for Room
+ * persistence keyed by the two EPUBs' checksums.
+ */
+@Serializable
+data class CrossEpubIndex(
+    val perChapter: List<ChapterCharMap>,
+)
+
+/**
+ * A position within a logical book that is EPUB-file-agnostic: a spine-aligned chapter
+ * index plus a [progression] (0..1) through that chapter's readable characters. This is
+ * the canonical currency [CanonicalPositionTranslator] converts between coordinate
+ * systems; the reader translates it to/from the displayed EPUB's CFI at its boundary.
+ */
+data class ChapterProgression(
+    val chapterIndex: Int,
+    val progression: Double,
+)

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/CrossEpubIndexBuilder.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/CrossEpubIndexBuilder.kt
@@ -1,0 +1,24 @@
+package com.riffle.core.domain
+
+/**
+ * Builds a [CrossEpubIndex] from the two EPUBs of a matched readaloud book. Pure given
+ * the two chapter-HTML lists (the caller reads them out of the cached EPUB bundles);
+ * reuses [EpubTextChars] so the readable-character definition matches the CFI
+ * translator's exactly. Chapters are aligned by spine order.
+ */
+object CrossEpubIndexBuilder {
+
+    fun build(
+        absChaptersHtml: List<String>,
+        storytellerChaptersHtml: List<String>,
+    ): CrossEpubIndex {
+        val chapterCount = minOf(absChaptersHtml.size, storytellerChaptersHtml.size)
+        val maps = (0 until chapterCount).map { i ->
+            ChapterCharMap(
+                absChars = EpubTextChars.countReadableChars(absChaptersHtml[i]),
+                storytellerChars = EpubTextChars.countReadableChars(storytellerChaptersHtml[i]),
+            )
+        }
+        return CrossEpubIndex(perChapter = maps)
+    }
+}

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/CrossEpubIndexSerializer.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/CrossEpubIndexSerializer.kt
@@ -1,0 +1,23 @@
+package com.riffle.core.domain
+
+import kotlinx.serialization.json.Json
+
+/**
+ * Serialises a [CrossEpubIndex] to and from the `perChapterMapsBlob` string persisted in
+ * the `cross_epub_index` Room table. [decode] returns `null` for a malformed blob so a
+ * corrupt cache row degrades to a rebuild rather than crashing a sync cycle.
+ */
+object CrossEpubIndexSerializer {
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    fun encode(index: CrossEpubIndex): String =
+        json.encodeToString(CrossEpubIndex.serializer(), index)
+
+    fun decode(blob: String): CrossEpubIndex? =
+        try {
+            json.decodeFromString<CrossEpubIndex>(blob)
+        } catch (_: Exception) {
+            null
+        }
+}

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/CrossEpubIndexService.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/CrossEpubIndexService.kt
@@ -1,0 +1,53 @@
+package com.riffle.core.domain
+
+/** The locally-cached materials needed to build a cross-EPUB index for one matched book. */
+data class CrossEpubBuildInputs(
+    val absEpubBytes: ByteArray,
+    val storytellerEpubBytes: ByteArray,
+    val absChaptersHtml: List<String>,
+    val storytellerChaptersHtml: List<String>,
+)
+
+/** Persistence port for the cross-EPUB index cache (backed by the `cross_epub_index` table). */
+interface CrossEpubIndexStore {
+    suspend fun exists(absChecksum: String, storytellerChecksum: String): Boolean
+    suspend fun put(absChecksum: String, storytellerChecksum: String, blob: String, builtAt: Long)
+    /** Load the cached index for the current checksums, or `null` on a miss (rebuild needed). */
+    suspend fun load(absChecksum: String, storytellerChecksum: String): CrossEpubIndex? = null
+}
+
+sealed interface CrossEpubIndexBuildOutcome {
+    /** Both EPUBs were present and the index was built and persisted under their checksums. */
+    data class Built(val absChecksum: String, val storytellerChecksum: String) : CrossEpubIndexBuildOutcome
+    /** A row for the current checksums already existed — nothing rebuilt. */
+    data object AlreadyBuilt : CrossEpubIndexBuildOutcome
+    /** A prerequisite EPUB couldn't be obtained; the book degrades to single-peer until it lands. */
+    data object Deferred : CrossEpubIndexBuildOutcome
+}
+
+/**
+ * Builds and persists the cross-EPUB index for a Confirmed [ReadaloudLink] (ADR 0019/0021):
+ * eagerly on Confirm, and opportunistically on the first sync cycle that needs it if the
+ * eager build was deferred. [loadInputs] ensures both EPUBs are cached (fetching the
+ * Storyteller bundle and/or ABS EPUB as needed — never the audiobook bundle) and returns
+ * the build materials, or `null` when a prerequisite can't be obtained. A missing
+ * prerequisite defers rather than persisting a partial index, so a sync cycle never gets a
+ * wrong cross-domain mapping — only a deferred one.
+ */
+class CrossEpubIndexService(
+    private val loadInputs: suspend (ReadaloudLink) -> CrossEpubBuildInputs?,
+    private val store: CrossEpubIndexStore,
+    private val clock: () -> Long,
+) {
+    suspend fun buildOnConfirm(link: ReadaloudLink): CrossEpubIndexBuildOutcome {
+        val inputs = loadInputs(link) ?: return CrossEpubIndexBuildOutcome.Deferred
+
+        val absChecksum = EpubChecksum.of(inputs.absEpubBytes)
+        val storytellerChecksum = EpubChecksum.of(inputs.storytellerEpubBytes)
+        if (store.exists(absChecksum, storytellerChecksum)) return CrossEpubIndexBuildOutcome.AlreadyBuilt
+
+        val index = CrossEpubIndexBuilder.build(inputs.absChaptersHtml, inputs.storytellerChaptersHtml)
+        store.put(absChecksum, storytellerChecksum, CrossEpubIndexSerializer.encode(index), clock())
+        return CrossEpubIndexBuildOutcome.Built(absChecksum, storytellerChecksum)
+    }
+}

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/EpubChecksum.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/EpubChecksum.kt
@@ -1,0 +1,16 @@
+package com.riffle.core.domain
+
+import java.security.MessageDigest
+
+/**
+ * Content checksum of an EPUB file, used to key the cross-EPUB index cache (ADR 0019).
+ * A server re-uploading its EPUB changes the bytes and therefore the checksum, so the
+ * keyed cache lookup misses and the next sync cycle rebuilds — no explicit invalidation.
+ */
+object EpubChecksum {
+
+    fun of(bytes: ByteArray): String =
+        MessageDigest.getInstance("SHA-256")
+            .digest(bytes)
+            .joinToString("") { "%02x".format(it) }
+}

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/EpubContentExtractor.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/EpubContentExtractor.kt
@@ -1,0 +1,101 @@
+package com.riffle.core.domain
+
+import org.w3c.dom.Element
+import java.io.ByteArrayInputStream
+import java.util.zip.ZipInputStream
+import javax.xml.parsers.DocumentBuilderFactory
+
+/** The spine chapters and media-overlay clips extracted from one EPUB. */
+data class ExtractedEpub(
+    val chapters: List<EpubChapterHtml>,
+    val smilClips: List<MediaOverlayClip>,
+)
+
+/**
+ * Pure EPUB-bytes → spine chapters (in reading order) + media-overlay [MediaOverlayClip]s,
+ * used to build the cross-EPUB index and the Storyteller fragment map (ADR 0019). Walks
+ * `META-INF/container.xml` → OPF → spine, resolving hrefs relative to the OPF directory and
+ * following each spine item's `media-overlay` to its SMIL. Returns `null` for input that is
+ * not a readable EPUB, so a corrupt download degrades to a deferred build, never a wrong one.
+ */
+object EpubContentExtractor {
+
+    fun extract(epubBytes: ByteArray): ExtractedEpub? = try {
+        val entries = readAllEntries(epubBytes)
+
+        val opfPath = rootfilePath(entries["META-INF/container.xml"]) ?: return null
+        val opfDir = opfPath.substringBeforeLast('/', "")
+        val opf = parseXml(entries[opfPath] ?: return null) ?: return null
+
+        // manifest: id → (href, mediaOverlayId)
+        val manifest = opf.elementsByTag("item").associate { item ->
+            item.getAttribute("id") to (item.getAttribute("href") to item.getAttribute("media-overlay"))
+        }
+
+        val chapters = mutableListOf<EpubChapterHtml>()
+        val clips = mutableListOf<MediaOverlayClip>()
+        for (itemref in opf.elementsByTag("itemref")) {
+            val idref = itemref.getAttribute("idref")
+            val (href, overlayId) = manifest[idref] ?: continue
+            val html = entries[resolve(opfDir, href)]?.toString(Charsets.UTF_8) ?: continue
+            chapters += EpubChapterHtml(href = href, html = html)
+
+            val overlayHref = overlayId.takeIf { it.isNotEmpty() }?.let { manifest[it]?.first }
+            if (overlayHref != null) {
+                entries[resolve(opfDir, overlayHref)]?.toString(Charsets.UTF_8)?.let { smilXml ->
+                    clips += SmilOverlayParser.parse(smilXml)
+                }
+            }
+        }
+        if (chapters.isEmpty()) null else ExtractedEpub(chapters, clips)
+    } catch (_: Exception) {
+        null
+    }
+
+    private fun readAllEntries(bytes: ByteArray): Map<String, ByteArray> {
+        val out = LinkedHashMap<String, ByteArray>()
+        ZipInputStream(ByteArrayInputStream(bytes)).use { zip ->
+            var entry = zip.nextEntry
+            // A non-zip stream yields no entries; the OPF lookup below then fails to null.
+            while (entry != null) {
+                if (!entry.isDirectory) out[entry.name] = zip.readBytes()
+                entry = zip.nextEntry
+            }
+        }
+        return out
+    }
+
+    private fun rootfilePath(containerXml: ByteArray?): String? {
+        val doc = parseXml(containerXml ?: return null) ?: return null
+        return doc.elementsByTag("rootfile").firstOrNull()?.getAttribute("full-path")?.takeIf { it.isNotEmpty() }
+    }
+
+    /** Resolve [href] (relative to the OPF dir) to a zip entry path; handles `../` and `./`. */
+    private fun resolve(opfDir: String, href: String): String {
+        val base = if (opfDir.isEmpty()) emptyList() else opfDir.split('/').toMutableList()
+        val segments = base.toMutableList()
+        for (part in href.split('/')) {
+            when (part) {
+                "", "." -> {}
+                ".." -> if (segments.isNotEmpty()) segments.removeAt(segments.size - 1)
+                else -> segments += part
+            }
+        }
+        return segments.joinToString("/")
+    }
+
+    private fun parseXml(bytes: ByteArray): Element? = try {
+        DocumentBuilderFactory.newInstance()
+            .apply { isNamespaceAware = false }
+            .newDocumentBuilder()
+            .parse(ByteArrayInputStream(bytes))
+            .documentElement
+    } catch (_: Exception) {
+        null
+    }
+
+    private fun Element.elementsByTag(tag: String): List<Element> {
+        val nodes = getElementsByTagName(tag)
+        return (0 until nodes.length).mapNotNull { nodes.item(it) as? Element }
+    }
+}

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/EpubTextChars.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/EpubTextChars.kt
@@ -1,0 +1,60 @@
+package com.riffle.core.domain
+
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Element
+import org.jsoup.nodes.Node
+import org.jsoup.nodes.TextNode
+
+/**
+ * The readable-character counting primitive shared by the CFI translator (ADR 0013)
+ * and the cross-EPUB index (ADR 0019). "Readable" means non-blank text-node content:
+ * markup, whitespace-only nodes, and image elements contribute zero, so the same
+ * logical prose counts the same across two EPUBs that mark it up differently.
+ */
+object EpubTextChars {
+
+    /** Count readable characters in a parsed body (or any element subtree). */
+    fun countReadableChars(node: Node): Long = when (node) {
+        is TextNode -> if (node.wholeText.isNotBlank()) node.wholeText.length.toLong() else 0L
+        is Element -> node.childNodes().sumOf { countReadableChars(it) }
+        else -> 0L
+    }
+
+    /** Parse [html] and count the readable characters of its `<body>`. */
+    fun countReadableChars(html: String): Long {
+        val body = Jsoup.parse(html).body() ?: return 0L
+        return countReadableChars(body)
+    }
+
+    /**
+     * The within-chapter progression (0..1) of the start of the element with [elementId]
+     * in [html]: readable characters before that element divided by the chapter total.
+     * Returns `null` when the id is absent or the chapter has no readable characters.
+     */
+    fun progressionOfElementId(html: String, elementId: String): Double? {
+        val doc = Jsoup.parse(html)
+        val body = doc.body() ?: return null
+        val target = doc.getElementById(elementId) ?: return null
+        val total = countReadableChars(body)
+        if (total == 0L) return null
+        val before = countReadableCharsBefore(body, target)
+        if (before < 0L) return null
+        return (before.toDouble() / total).coerceIn(0.0, 1.0)
+    }
+
+    /** Readable characters before [target] in document order, or -1 if not found. */
+    private fun countReadableCharsBefore(body: Element, target: Element): Long {
+        var count = 0L
+        var found = false
+        fun visit(node: Node) {
+            if (found) return
+            when {
+                node === target -> found = true
+                node is TextNode -> if (node.wholeText.isNotBlank()) count += node.wholeText.length
+                node is Element -> node.childNodes().forEach { visit(it) }
+            }
+        }
+        body.childNodes().forEach { visit(it) }
+        return if (found) count else -1L
+    }
+}

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/ProgressSyncStrategy.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/ProgressSyncStrategy.kt
@@ -1,0 +1,21 @@
+package com.riffle.core.domain
+
+/**
+ * Selects the applicable remote set for the open book (ADR 0019) and runs the unified
+ * reconciliation [ThreePeerSyncCycle] over it — the same code path for single-peer
+ * (one remote), two-peer (the multi-link guard), and three-peer cases. This is the
+ * strategy [ProgressSyncController] delegates to once it knows the book's [BookSyncState];
+ * the open side feeds only into [applicableRemotes], never into the cycle itself.
+ *
+ * [remoteFor] constructs the live [SyncRemote] for a kind (wiring the network APIs and the
+ * [CanonicalPositionTranslator]); it may return `null` when a remote cannot be built this
+ * cycle (e.g. a prerequisite went missing), in which case that target is simply skipped.
+ */
+class ProgressSyncStrategy(
+    private val remoteFor: (RemoteKind) -> SyncRemote?,
+) {
+    suspend fun runCycle(state: BookSyncState, local: LocalCanonical): ThreePeerCycleResult {
+        val remotes = applicableRemotes(state).mapNotNull { remoteFor(it) }
+        return ThreePeerSyncCycle.run(local, remotes)
+    }
+}

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/ServerRepository.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/ServerRepository.kt
@@ -18,6 +18,8 @@ sealed class CommitServerResult {
 interface ServerRepository {
     fun observeAll(): Flow<List<Server>>
     suspend fun getActive(): Server?
+    /** Resolve a specific server by id (e.g. the ABS and Storyteller sides of a matched book). */
+    suspend fun getById(serverId: String): Server? = null
     suspend fun authenticate(
         url: ServerUrl,
         username: String,

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/StorytellerFragmentIndexBuilder.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/StorytellerFragmentIndexBuilder.kt
@@ -1,0 +1,37 @@
+package com.riffle.core.domain
+
+/** One spine chapter of an EPUB: its manifest href and its (already-extracted) HTML. */
+data class EpubChapterHtml(
+    val href: String,
+    val html: String,
+)
+
+/**
+ * Resolves the Storyteller EPUB's SMIL fragment references (`href#id`) to canonical
+ * [ChapterProgression]s, so [CanonicalPositionTranslator] can bridge audio time to a
+ * reader position. Pure given the spine HTML and the parsed SMIL clips; fragments whose
+ * chapter or element cannot be located are dropped (a missing anchor degrades a single
+ * conversion, never the whole map).
+ */
+object StorytellerFragmentIndexBuilder {
+
+    fun build(
+        chapters: List<EpubChapterHtml>,
+        clips: List<MediaOverlayClip>,
+    ): Map<String, ChapterProgression> {
+        val chapterIndexByHref = chapters.withIndex().associate { (i, c) -> c.href to i }
+        val result = LinkedHashMap<String, ChapterProgression>()
+        for (clip in clips) {
+            val ref = clip.textFragmentRef
+            val hash = ref.indexOf('#')
+            if (hash < 0) continue
+            val href = ref.substring(0, hash)
+            val elementId = ref.substring(hash + 1)
+            val chapterIndex = chapterIndexByHref[href] ?: continue
+            val progression = EpubTextChars.progressionOfElementId(chapters[chapterIndex].html, elementId)
+                ?: continue
+            result[ref] = ChapterProgression(chapterIndex, progression)
+        }
+        return result
+    }
+}

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/ThreePeerSyncCycle.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/ThreePeerSyncCycle.kt
@@ -1,0 +1,82 @@
+package com.riffle.core.domain
+
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+
+/**
+ * A reader position expressed in the canonical coordinate system of the cycle — the
+ * Readium Locator on the EPUB the reader currently displays (ADR 0019). Opaque to the
+ * cycle, which only compares update times and routes the value to remotes; remotes
+ * translate it to/from their native coordinates at their boundary.
+ */
+data class CanonicalReaderPosition(val value: String)
+
+/** The local reader position and the single `localUpdatedAt` it was last changed at. */
+data class LocalCanonical(val position: CanonicalReaderPosition, val lastUpdate: Long)
+
+/** A remote's position already translated to canonical, plus the time it last changed there. */
+data class RemoteRead(val canonical: CanonicalReaderPosition, val lastUpdate: Long)
+
+/**
+ * One reconcilable position holder (ABS ebook, ABS audiobook, or Storyteller). Both
+ * operations are per-target isolated: [tryGet] returns `null` when the remote is
+ * unreachable or its position cannot be translated to canonical (so it is left out of the
+ * inbound comparison and not patched), and [tryPatch] returns `false` on failure without
+ * affecting any other remote.
+ */
+interface SyncRemote {
+    val id: String
+    suspend fun tryGet(): RemoteRead?
+    suspend fun tryPatch(canonical: CanonicalReaderPosition): Boolean
+}
+
+/** Outcome of one reconciliation cycle. */
+data class ThreePeerCycleResult(
+    val jumpTo: CanonicalReaderPosition?,
+    val patched: Set<String>,
+    val canonicalLastUpdate: Long,
+)
+
+/**
+ * The unified-canonical reconciliation cycle of ADR 0019, run over whatever remote set is
+ * applicable to the open book. Invariant: one inbound winner, at most one reader jump, and
+ * every outbound PATCH derived from the same canonical position.
+ */
+object ThreePeerSyncCycle {
+
+    suspend fun run(local: LocalCanonical, remotes: List<SyncRemote>): ThreePeerCycleResult {
+        // GET each remote in parallel, isolating per-target failures (null = excluded).
+        val reads = coroutineScope {
+            remotes.map { remote -> remote to async { remote.tryGet() } }
+                .map { (remote, deferred) -> remote to deferred.await() }
+        }
+
+        // Inbound winner: the maximum lastUpdate among the local position and the
+        // successfully-read remotes. Local wins ties, so an in-sync remote never forces a jump.
+        var winnerCanonical = local.position
+        var canonicalLastUpdate = local.lastUpdate
+        for ((_, read) in reads) {
+            if (read != null && read.lastUpdate > canonicalLastUpdate) {
+                winnerCanonical = read.canonical
+                canonicalLastUpdate = read.lastUpdate
+            }
+        }
+
+        val jumpTo = if (winnerCanonical != local.position) winnerCanonical else null
+
+        // Outbound: patch every successfully-read remote that is now stale, all from the
+        // single canonical winner. Unreachable remotes (null read) are left untouched.
+        val patched = mutableSetOf<String>()
+        for ((remote, read) in reads) {
+            if (read != null && read.lastUpdate < canonicalLastUpdate) {
+                if (remote.tryPatch(winnerCanonical)) patched += remote.id
+            }
+        }
+
+        return ThreePeerCycleResult(
+            jumpTo = jumpTo,
+            patched = patched,
+            canonicalLastUpdate = canonicalLastUpdate,
+        )
+    }
+}

--- a/core/domain/src/test/kotlin/com/riffle/core/domain/ApplicableRemotesTest.kt
+++ b/core/domain/src/test/kotlin/com/riffle/core/domain/ApplicableRemotesTest.kt
@@ -1,0 +1,65 @@
+package com.riffle.core.domain
+
+import com.riffle.core.domain.RemoteKind.ABS_AUDIO
+import com.riffle.core.domain.RemoteKind.ABS_EBOOK
+import com.riffle.core.domain.RemoteKind.STORYTELLER
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ApplicableRemotesTest {
+
+    @Test
+    fun `an unmatched book opened from the ABS side syncs ABS ebook only`() {
+        val state = BookSyncState(
+            isMatched = false,
+            confirmedAbsLinkCount = 0,
+            prerequisitesCached = false,
+            openedSide = OpenedSide.ABS,
+        )
+
+        assertEquals(setOf(ABS_EBOOK), applicableRemotes(state))
+    }
+
+    @Test
+    fun `a Storyteller-only book opened from the Readaloud side syncs Storyteller only`() {
+        val state = BookSyncState(
+            isMatched = false,
+            confirmedAbsLinkCount = 0,
+            prerequisitesCached = false,
+            openedSide = OpenedSide.READALOUD,
+        )
+
+        assertEquals(setOf(STORYTELLER), applicableRemotes(state))
+    }
+
+    @Test
+    fun `a matched book with one ABS link and cached prerequisites runs three-peer from either side`() {
+        val absSide = BookSyncState(true, confirmedAbsLinkCount = 1, prerequisitesCached = true, openedSide = OpenedSide.ABS)
+        val readaloudSide = absSide.copy(openedSide = OpenedSide.READALOUD)
+
+        val expected = setOf(ABS_EBOOK, ABS_AUDIO, STORYTELLER)
+        assertEquals(expected, applicableRemotes(absSide))
+        assertEquals(expected, applicableRemotes(readaloudSide))
+    }
+
+    @Test
+    fun `the multi-link guard excludes Storyteller and degrades to a two-peer ABS cycle`() {
+        val state = BookSyncState(
+            isMatched = true,
+            confirmedAbsLinkCount = 2,
+            prerequisitesCached = true,
+            openedSide = OpenedSide.READALOUD,
+        )
+
+        assertEquals(setOf(ABS_EBOOK, ABS_AUDIO), applicableRemotes(state))
+    }
+
+    @Test
+    fun `a matched book without cached prerequisites falls back to its side's single peer`() {
+        val absSide = BookSyncState(true, confirmedAbsLinkCount = 1, prerequisitesCached = false, openedSide = OpenedSide.ABS)
+        val readaloudSide = absSide.copy(openedSide = OpenedSide.READALOUD)
+
+        assertEquals(setOf(ABS_EBOOK), applicableRemotes(absSide))
+        assertEquals(setOf(STORYTELLER), applicableRemotes(readaloudSide))
+    }
+}

--- a/core/domain/src/test/kotlin/com/riffle/core/domain/CanonicalPositionTranslatorTest.kt
+++ b/core/domain/src/test/kotlin/com/riffle/core/domain/CanonicalPositionTranslatorTest.kt
@@ -1,0 +1,141 @@
+package com.riffle.core.domain
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class CanonicalPositionTranslatorTest {
+
+    private val clips = listOf(
+        MediaOverlayClip("chapter1.xhtml#sent1", "audio/ch1.mp3", clipBeginSec = 0.0, clipEndSec = 3.5),
+        MediaOverlayClip("chapter1.xhtml#sent2", "audio/ch1.mp3", clipBeginSec = 3.5, clipEndSec = 7.0),
+        MediaOverlayClip("chapter2.xhtml#sent1", "audio/ch2.mp3", clipBeginSec = 7.0, clipEndSec = 10.0),
+    )
+
+    @Test
+    fun `audio seconds map to the text fragment whose clip covers that time`() {
+        val translator = CanonicalPositionTranslator(smilClips = clips)
+
+        assertEquals("chapter1.xhtml#sent2", translator.audioSecondsToTextFragment(4.0))
+    }
+
+    @Test
+    fun `audio seconds before any clip are unmappable`() {
+        val translator = CanonicalPositionTranslator(smilClips = clips)
+
+        assertNull(translator.audioSecondsToTextFragment(-1.0))
+    }
+
+    @Test
+    fun `audio seconds past the last clip are unmappable`() {
+        val translator = CanonicalPositionTranslator(smilClips = clips)
+
+        assertNull(translator.audioSecondsToTextFragment(100.0))
+    }
+
+    @Test
+    fun `a text fragment maps to the start of its narrating clip`() {
+        val translator = CanonicalPositionTranslator(smilClips = clips)
+
+        assertEquals(3.5, translator.textFragmentToAudioSeconds("chapter1.xhtml#sent2")!!, 0.0001)
+    }
+
+    @Test
+    fun `a text fragment with no narrating clip is unmappable`() {
+        val translator = CanonicalPositionTranslator(smilClips = clips)
+
+        assertNull(translator.textFragmentToAudioSeconds("chapter9.xhtml#nope"))
+    }
+
+    // ── Cross-EPUB progression mapping ─────────────────────────────────────────
+    // A within-chapter progression is a readable-character offset divided by the
+    // chapter's character count. Mapping across the two EPUBs preserves the absolute
+    // readable-character offset, so progression scales by the chapters' count ratio.
+
+    private val index = CrossEpubIndex(
+        perChapter = listOf(
+            ChapterCharMap(absChars = 200, storytellerChars = 100),
+        ),
+    )
+
+    @Test
+    fun `Storyteller progression maps to ABS progression preserving character offset`() {
+        val translator = CanonicalPositionTranslator(smilClips = clips, index = index)
+
+        // st progression 0.5 → offset 50 chars → abs progression 50/200 = 0.25
+        val abs = translator.storytellerToAbsProgression(ChapterProgression(0, 0.5))
+
+        assertEquals(ChapterProgression(0, 0.25), abs)
+    }
+
+    @Test
+    fun `ABS progression maps back to Storyteller progression`() {
+        val translator = CanonicalPositionTranslator(smilClips = clips, index = index)
+
+        // abs progression 0.25 → offset 50 chars → st progression 50/100 = 0.5
+        val st = translator.absToStorytellerProgression(ChapterProgression(0, 0.25))
+
+        assertEquals(ChapterProgression(0, 0.5), st)
+    }
+
+    @Test
+    fun `a chapter index with no entry in the cross-EPUB index is unmappable`() {
+        val translator = CanonicalPositionTranslator(smilClips = clips, index = index)
+
+        assertNull(translator.storytellerToAbsProgression(ChapterProgression(9, 0.5)))
+    }
+
+    // ── Audio-seconds ↔ canonical (Storyteller) progression ────────────────────
+    // Composes the SMIL clip lookup with each fragment's resolved within-chapter
+    // progression in the Storyteller EPUB.
+
+    private val fragmentProgressions = mapOf(
+        "chapter1.xhtml#sent1" to ChapterProgression(0, 0.0),
+        "chapter1.xhtml#sent2" to ChapterProgression(0, 0.4),
+        "chapter2.xhtml#sent1" to ChapterProgression(1, 0.0),
+    )
+
+    @Test
+    fun `audio seconds map to the canonical progression of the narrated fragment`() {
+        val translator = CanonicalPositionTranslator(
+            smilClips = clips,
+            fragmentProgressions = fragmentProgressions,
+        )
+
+        assertEquals(
+            ChapterProgression(0, 0.4),
+            translator.audioSecondsToStorytellerProgression(4.0),
+        )
+    }
+
+    @Test
+    fun `audio seconds are unmappable when the narrated fragment has no resolved progression`() {
+        val translator = CanonicalPositionTranslator(
+            smilClips = clips,
+            fragmentProgressions = emptyMap(),
+        )
+
+        assertNull(translator.audioSecondsToStorytellerProgression(4.0))
+    }
+
+    @Test
+    fun `a canonical progression maps to the audio time of the fragment it falls in`() {
+        val translator = CanonicalPositionTranslator(
+            smilClips = clips,
+            fragmentProgressions = fragmentProgressions,
+        )
+
+        // progression 0.5 in chapter 0 falls in sent2 (0.4), whose clip begins at 3.5s
+        assertEquals(3.5, translator.storytellerProgressionToAudioSeconds(ChapterProgression(0, 0.5))!!, 0.0001)
+    }
+
+    @Test
+    fun `a canonical progression before any narrated fragment is unmappable to audio`() {
+        val translator = CanonicalPositionTranslator(
+            smilClips = clips,
+            fragmentProgressions = fragmentProgressions,
+        )
+
+        assertNull(translator.storytellerProgressionToAudioSeconds(ChapterProgression(5, 0.5)))
+    }
+}

--- a/core/domain/src/test/kotlin/com/riffle/core/domain/CrossEpubIndexBuilderTest.kt
+++ b/core/domain/src/test/kotlin/com/riffle/core/domain/CrossEpubIndexBuilderTest.kt
@@ -1,0 +1,32 @@
+package com.riffle.core.domain
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class CrossEpubIndexBuilderTest {
+
+    @Test
+    fun `emits one char map per chapter with each side's readable-character count`() {
+        // Same logical text, but the two publications mark it up differently:
+        // the ABS EPUB wraps the second sentence in extra markup (no readable-text
+        // change), so readable-character counts per chapter match across the two.
+        val absChapters = listOf(
+            "<html><body><p>Hello there.</p></body></html>",
+            "<html><body><p>Chapter <b>two</b> begins.</p></body></html>",
+        )
+        val storytellerChapters = listOf(
+            "<html><body><span id=\"s1\">Hello there.</span></body></html>",
+            "<html><body><span id=\"s1\">Chapter two begins.</span></body></html>",
+        )
+
+        val index = CrossEpubIndexBuilder.build(absChapters, storytellerChapters)
+
+        assertEquals(
+            listOf(
+                ChapterCharMap(absChars = 12, storytellerChars = 12),
+                ChapterCharMap(absChars = 19, storytellerChars = 19),
+            ),
+            index.perChapter,
+        )
+    }
+}

--- a/core/domain/src/test/kotlin/com/riffle/core/domain/CrossEpubIndexSerializerTest.kt
+++ b/core/domain/src/test/kotlin/com/riffle/core/domain/CrossEpubIndexSerializerTest.kt
@@ -1,0 +1,34 @@
+package com.riffle.core.domain
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class CrossEpubIndexSerializerTest {
+
+    @Test
+    fun `an index round-trips through serialisation`() {
+        val index = CrossEpubIndex(
+            perChapter = listOf(
+                ChapterCharMap(absChars = 12, storytellerChars = 12),
+                ChapterCharMap(absChars = 200, storytellerChars = 100),
+            ),
+        )
+
+        val blob = CrossEpubIndexSerializer.encode(index)
+
+        assertEquals(index, CrossEpubIndexSerializer.decode(blob))
+    }
+
+    @Test
+    fun `an empty index round-trips`() {
+        val index = CrossEpubIndex(perChapter = emptyList())
+
+        assertEquals(index, CrossEpubIndexSerializer.decode(CrossEpubIndexSerializer.encode(index)))
+    }
+
+    @Test
+    fun `a malformed blob decodes to null rather than throwing`() {
+        assertNull(CrossEpubIndexSerializer.decode("not json at all"))
+    }
+}

--- a/core/domain/src/test/kotlin/com/riffle/core/domain/CrossEpubIndexServiceTest.kt
+++ b/core/domain/src/test/kotlin/com/riffle/core/domain/CrossEpubIndexServiceTest.kt
@@ -1,0 +1,92 @@
+package com.riffle.core.domain
+
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CrossEpubIndexServiceTest {
+
+    private val link = ReadaloudLink(
+        storytellerServerId = "st1",
+        storytellerBookId = "book-1",
+        absServerId = "abs1",
+        absLibraryItemId = "item-1",
+        userConfirmed = false,
+    )
+
+    private val inputs = CrossEpubBuildInputs(
+        absEpubBytes = "abs-v1".toByteArray(),
+        storytellerEpubBytes = "st-v1".toByteArray(),
+        absChaptersHtml = listOf("<html><body><p>Hello there.</p></body></html>"),
+        storytellerChaptersHtml = listOf("<html><body><p>Hello there.</p></body></html>"),
+    )
+
+    private class FakeStore : CrossEpubIndexStore {
+        val rows = mutableMapOf<Pair<String, String>, Pair<String, Long>>()
+        override suspend fun exists(absChecksum: String, storytellerChecksum: String) =
+            (absChecksum to storytellerChecksum) in rows
+        override suspend fun put(absChecksum: String, storytellerChecksum: String, blob: String, builtAt: Long) {
+            rows[absChecksum to storytellerChecksum] = blob to builtAt
+        }
+    }
+
+    @Test
+    fun `building on Confirm persists the index keyed by both EPUB checksums`() = runTest {
+        val store = FakeStore()
+        val service = CrossEpubIndexService(
+            loadInputs = { inputs },
+            store = store,
+            clock = { 5000L },
+        )
+
+        val outcome = service.buildOnConfirm(link)
+
+        val absChk = EpubChecksum.of(inputs.absEpubBytes)
+        val stChk = EpubChecksum.of(inputs.storytellerEpubBytes)
+        assertEquals(CrossEpubIndexBuildOutcome.Built(absChk, stChk), outcome)
+        val (blob, builtAt) = store.rows.getValue(absChk to stChk)
+        assertEquals(5000L, builtAt)
+        // The persisted blob deserialises back to the expected per-chapter char map.
+        assertEquals(
+            CrossEpubIndex(listOf(ChapterCharMap(absChars = 12, storytellerChars = 12))),
+            CrossEpubIndexSerializer.decode(blob),
+        )
+    }
+
+    @Test
+    fun `a missing prerequisite EPUB defers the build and persists nothing`() = runTest {
+        val store = FakeStore()
+        val service = CrossEpubIndexService(
+            loadInputs = { null }, // e.g. offline at Confirm time
+            store = store,
+            clock = { 5000L },
+        )
+
+        val outcome = service.buildOnConfirm(link)
+
+        assertEquals(CrossEpubIndexBuildOutcome.Deferred, outcome)
+        assertTrue(store.rows.isEmpty())
+    }
+
+    @Test
+    fun `an already-cached index for the same checksums is not rebuilt`() = runTest {
+        val store = FakeStore()
+        val absChk = EpubChecksum.of(inputs.absEpubBytes)
+        val stChk = EpubChecksum.of(inputs.storytellerEpubBytes)
+        store.put(absChk, stChk, "preexisting", 1L)
+        var loadCalls = 0
+        val service = CrossEpubIndexService(
+            loadInputs = { loadCalls++; inputs },
+            store = store,
+            clock = { 9999L },
+        )
+
+        val outcome = service.buildOnConfirm(link)
+
+        assertEquals(CrossEpubIndexBuildOutcome.AlreadyBuilt, outcome)
+        // The pre-existing row is untouched (no rebuild).
+        assertEquals("preexisting" to 1L, store.rows.getValue(absChk to stChk))
+    }
+}

--- a/core/domain/src/test/kotlin/com/riffle/core/domain/EpubChecksumTest.kt
+++ b/core/domain/src/test/kotlin/com/riffle/core/domain/EpubChecksumTest.kt
@@ -1,0 +1,32 @@
+package com.riffle.core.domain
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Test
+
+class EpubChecksumTest {
+
+    @Test
+    fun `the same bytes always produce the same checksum`() {
+        val bytes = "epub-contents".toByteArray()
+
+        assertEquals(EpubChecksum.of(bytes), EpubChecksum.of(bytes.copyOf()))
+    }
+
+    @Test
+    fun `different bytes produce different checksums, invalidating a stale index row`() {
+        assertNotEquals(
+            EpubChecksum.of("version-1".toByteArray()),
+            EpubChecksum.of("version-2".toByteArray()),
+        )
+    }
+
+    @Test
+    fun `the checksum is a stable hex SHA-256`() {
+        // SHA-256 of the empty input, well-known vector.
+        assertEquals(
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+            EpubChecksum.of(ByteArray(0)),
+        )
+    }
+}

--- a/core/domain/src/test/kotlin/com/riffle/core/domain/EpubContentExtractorTest.kt
+++ b/core/domain/src/test/kotlin/com/riffle/core/domain/EpubContentExtractorTest.kt
@@ -1,0 +1,79 @@
+package com.riffle.core.domain
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import java.io.ByteArrayOutputStream
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+
+class EpubContentExtractorTest {
+
+    /** Build a minimal but structurally-valid EPUB 3 (with a media overlay) in memory. */
+    private fun buildEpub(): ByteArray {
+        val container = """
+            <?xml version="1.0"?>
+            <container xmlns="urn:oasis:names:tc:opendocument:xmlns:container" version="1.0">
+              <rootfiles><rootfile full-path="OEBPS/content.opf" media-type="application/oebps-package+xml"/></rootfiles>
+            </container>
+        """.trimIndent()
+        val opf = """
+            <?xml version="1.0"?>
+            <package xmlns="http://www.idpf.org/2007/opf" version="3.0">
+              <manifest>
+                <item id="c1" href="chapter1.xhtml" media-type="application/xhtml+xml" media-overlay="c1smil"/>
+                <item id="c2" href="chapter2.xhtml" media-type="application/xhtml+xml"/>
+                <item id="c1smil" href="chapter1.smil" media-type="application/smil+xml"/>
+              </manifest>
+              <spine>
+                <itemref idref="c1"/>
+                <itemref idref="c2"/>
+              </spine>
+            </package>
+        """.trimIndent()
+        val chapter1 = "<html><body><p id=\"s1\">Hello there.</p></body></html>"
+        val chapter2 = "<html><body><p>Chapter two.</p></body></html>"
+        val smil = """
+            <?xml version="1.0"?>
+            <smil xmlns="http://www.w3.org/ns/SMIL" version="3.0">
+              <body><par><text src="chapter1.xhtml#s1"/><audio src="ch1.mp3" clipBegin="0s" clipEnd="2.5s"/></par></body>
+            </smil>
+        """.trimIndent()
+
+        val bos = ByteArrayOutputStream()
+        ZipOutputStream(bos).use { zip ->
+            fun put(name: String, content: String) {
+                zip.putNextEntry(ZipEntry(name)); zip.write(content.toByteArray()); zip.closeEntry()
+            }
+            put("META-INF/container.xml", container)
+            put("OEBPS/content.opf", opf)
+            put("OEBPS/chapter1.xhtml", chapter1)
+            put("OEBPS/chapter2.xhtml", chapter2)
+            put("OEBPS/chapter1.smil", smil)
+        }
+        return bos.toByteArray()
+    }
+
+    @Test
+    fun `extracts spine chapters in order with their hrefs and html`() {
+        val extracted = EpubContentExtractor.extract(buildEpub())!!
+
+        assertEquals(listOf("chapter1.xhtml", "chapter2.xhtml"), extracted.chapters.map { it.href })
+        assertEquals(12L, EpubTextChars.countReadableChars(extracted.chapters[0].html)) // "Hello there."
+    }
+
+    @Test
+    fun `extracts media-overlay SMIL clips referencing chapter fragments`() {
+        val extracted = EpubContentExtractor.extract(buildEpub())!!
+
+        assertEquals(
+            listOf(MediaOverlayClip("chapter1.xhtml#s1", "ch1.mp3", clipBeginSec = 0.0, clipEndSec = 2.5)),
+            extracted.smilClips,
+        )
+    }
+
+    @Test
+    fun `returns null for bytes that are not a valid EPUB`() {
+        assertNull(EpubContentExtractor.extract("not a zip".toByteArray()))
+    }
+}

--- a/core/domain/src/test/kotlin/com/riffle/core/domain/EpubTextCharsTest.kt
+++ b/core/domain/src/test/kotlin/com/riffle/core/domain/EpubTextCharsTest.kt
@@ -1,0 +1,31 @@
+package com.riffle.core.domain
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class EpubTextCharsTest {
+
+    @Test
+    fun `counts only non-blank text characters, ignoring markup and whitespace`() {
+        val html = "<html><body><p>Hello</p>\n  <p><b>there</b>.</p></body></html>"
+
+        // "Hello" = 5, "there" = 5, "." = 1 → 11
+        assertEquals(11L, EpubTextChars.countReadableChars(html))
+    }
+
+    @Test
+    fun `progression of an element id is its readable-character offset over the total`() {
+        val html = "<html><body><p>AAAA</p><p id=\"x\">BBBB</p></body></html>"
+
+        // "AAAA" before #x = 4 chars, total = 8 → 0.5
+        assertEquals(0.5, EpubTextChars.progressionOfElementId(html, "x")!!, 0.0001)
+    }
+
+    @Test
+    fun `progression is null for an id that is not present`() {
+        val html = "<html><body><p>AAAA</p></body></html>"
+
+        assertNull(EpubTextChars.progressionOfElementId(html, "missing"))
+    }
+}

--- a/core/domain/src/test/kotlin/com/riffle/core/domain/ProgressSyncStrategyTest.kt
+++ b/core/domain/src/test/kotlin/com/riffle/core/domain/ProgressSyncStrategyTest.kt
@@ -1,0 +1,82 @@
+package com.riffle.core.domain
+
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ProgressSyncStrategyTest {
+
+    private class FakeRemote(override val id: String) : SyncRemote {
+        var patchedWith: CanonicalReaderPosition? = null
+        override suspend fun tryGet(): RemoteRead? = null
+        override suspend fun tryPatch(canonical: CanonicalReaderPosition): Boolean {
+            patchedWith = canonical
+            return true
+        }
+    }
+
+    private val local = LocalCanonical(CanonicalReaderPosition("L"), lastUpdate = 100)
+
+    @Test
+    fun `a three-peer state reconciles over all three remotes`() = runTest {
+        val built = mutableListOf<RemoteKind>()
+        val strategy = ProgressSyncStrategy { kind -> built += kind; FakeRemote(kind.name) }
+
+        val state = BookSyncState(
+            isMatched = true,
+            confirmedAbsLinkCount = 1,
+            prerequisitesCached = true,
+            openedSide = OpenedSide.ABS,
+        )
+        strategy.runCycle(state, local)
+
+        assertEquals(
+            setOf(RemoteKind.ABS_EBOOK, RemoteKind.ABS_AUDIO, RemoteKind.STORYTELLER),
+            built.toSet(),
+        )
+    }
+
+    @Test
+    fun `the multi-link guard never constructs or reconciles the Storyteller remote`() = runTest {
+        val built = mutableListOf<RemoteKind>()
+        val strategy = ProgressSyncStrategy { kind -> built += kind; FakeRemote(kind.name) }
+
+        val state = BookSyncState(
+            isMatched = true,
+            confirmedAbsLinkCount = 2, // collision → Storyteller excluded
+            prerequisitesCached = true,
+            openedSide = OpenedSide.READALOUD,
+        )
+        strategy.runCycle(state, local)
+
+        assertTrue(RemoteKind.STORYTELLER !in built)
+        assertEquals(setOf(RemoteKind.ABS_EBOOK, RemoteKind.ABS_AUDIO), built.toSet())
+    }
+
+    @Test
+    fun `an unmatched ABS-side book runs single-peer over ABS ebook only`() = runTest {
+        val built = mutableListOf<RemoteKind>()
+        val strategy = ProgressSyncStrategy { kind -> built += kind; FakeRemote(kind.name) }
+
+        val state = BookSyncState(false, 0, prerequisitesCached = false, openedSide = OpenedSide.ABS)
+        strategy.runCycle(state, local)
+
+        assertEquals(listOf(RemoteKind.ABS_EBOOK), built)
+    }
+
+    @Test
+    fun `a remote the factory cannot build is skipped without poisoning the cycle`() = runTest {
+        // Prerequisites cached but the Storyteller remote can't be constructed (e.g. bundle gone).
+        val strategy = ProgressSyncStrategy { kind ->
+            if (kind == RemoteKind.STORYTELLER) null else FakeRemote(kind.name)
+        }
+
+        val state = BookSyncState(true, 1, prerequisitesCached = true, openedSide = OpenedSide.ABS)
+        val result = strategy.runCycle(state, local)
+
+        // No remote was newer than local and none can be read, so no jump; cycle still completes.
+        assertNull(result.jumpTo)
+    }
+}

--- a/core/domain/src/test/kotlin/com/riffle/core/domain/StorytellerFragmentIndexBuilderTest.kt
+++ b/core/domain/src/test/kotlin/com/riffle/core/domain/StorytellerFragmentIndexBuilderTest.kt
@@ -1,0 +1,53 @@
+package com.riffle.core.domain
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class StorytellerFragmentIndexBuilderTest {
+
+    @Test
+    fun `resolves each SMIL fragment to its chapter index and within-chapter progression`() {
+        val chapters = listOf(
+            EpubChapterHtml(
+                href = "chapter1.xhtml",
+                html = "<html><body><p id=\"sent1\">AAAA</p><p id=\"sent2\">BBBB</p></body></html>",
+            ),
+            EpubChapterHtml(
+                href = "chapter2.xhtml",
+                html = "<html><body><p id=\"sent1\">CCCC</p></body></html>",
+            ),
+        )
+        val clips = listOf(
+            MediaOverlayClip("chapter1.xhtml#sent1", "a.mp3", 0.0, 1.0),
+            MediaOverlayClip("chapter1.xhtml#sent2", "a.mp3", 1.0, 2.0),
+            MediaOverlayClip("chapter2.xhtml#sent1", "b.mp3", 2.0, 3.0),
+        )
+
+        val map = StorytellerFragmentIndexBuilder.build(chapters, clips)
+
+        assertEquals(
+            mapOf(
+                "chapter1.xhtml#sent1" to ChapterProgression(0, 0.0),
+                "chapter1.xhtml#sent2" to ChapterProgression(0, 0.5),
+                "chapter2.xhtml#sent1" to ChapterProgression(1, 0.0),
+            ),
+            map,
+        )
+    }
+
+    @Test
+    fun `skips fragments whose chapter or element cannot be resolved`() {
+        val chapters = listOf(
+            EpubChapterHtml("chapter1.xhtml", "<html><body><p id=\"sent1\">AAAA</p></body></html>"),
+        )
+        val clips = listOf(
+            MediaOverlayClip("chapter1.xhtml#sent1", "a.mp3", 0.0, 1.0),
+            MediaOverlayClip("chapter1.xhtml#ghost", "a.mp3", 1.0, 2.0), // id absent
+            MediaOverlayClip("nochapter.xhtml#sent1", "a.mp3", 2.0, 3.0), // href absent
+        )
+
+        val map = StorytellerFragmentIndexBuilder.build(chapters, clips)
+
+        assertEquals(mapOf("chapter1.xhtml#sent1" to ChapterProgression(0, 0.0)), map)
+    }
+}

--- a/core/domain/src/test/kotlin/com/riffle/core/domain/ThreePeerSyncCycleTest.kt
+++ b/core/domain/src/test/kotlin/com/riffle/core/domain/ThreePeerSyncCycleTest.kt
@@ -1,0 +1,95 @@
+package com.riffle.core.domain
+
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ThreePeerSyncCycleTest {
+
+    /** A fake remote with injectable GET result and a recorded PATCH. */
+    private class FakeRemote(
+        override val id: String,
+        private val getResult: RemoteRead?,
+    ) : SyncRemote {
+        var patchedWith: CanonicalReaderPosition? = null
+            private set
+        var patchFails: Boolean = false
+        var getCalls = 0
+            private set
+
+        override suspend fun tryGet(): RemoteRead? {
+            getCalls++
+            return getResult
+        }
+
+        override suspend fun tryPatch(canonical: CanonicalReaderPosition): Boolean {
+            if (patchFails) return false
+            patchedWith = canonical
+            return true
+        }
+    }
+
+    private fun pos(v: String) = CanonicalReaderPosition(v)
+
+    @Test
+    fun `the newest remote wins, the reader jumps to it, and stale remotes are patched to it`() = runTest {
+        val local = LocalCanonical(pos("L"), lastUpdate = 100)
+        val ebook = FakeRemote("ABS_EBOOK", RemoteRead(pos("A"), lastUpdate = 90))
+        val audio = FakeRemote("ABS_AUDIO", RemoteRead(pos("B"), lastUpdate = 80))
+        val storyteller = FakeRemote("STORYTELLER", RemoteRead(pos("S"), lastUpdate = 150))
+
+        val result = ThreePeerSyncCycle.run(local, listOf(ebook, audio, storyteller))
+
+        // One inbound winner, one jump, to the Storyteller position.
+        assertEquals(pos("S"), result.jumpTo)
+        assertEquals(150, result.canonicalLastUpdate)
+        // Stale remotes are patched to the single canonical winner; the winner is not.
+        assertEquals(pos("S"), ebook.patchedWith)
+        assertEquals(pos("S"), audio.patchedWith)
+        assertNull(storyteller.patchedWith)
+        assertEquals(setOf("ABS_EBOOK", "ABS_AUDIO"), result.patched)
+    }
+
+    @Test
+    fun `when local is newest there is no jump and every remote is patched to local`() = runTest {
+        val local = LocalCanonical(pos("L"), lastUpdate = 200)
+        val ebook = FakeRemote("ABS_EBOOK", RemoteRead(pos("A"), lastUpdate = 90))
+        val storyteller = FakeRemote("STORYTELLER", RemoteRead(pos("S"), lastUpdate = 150))
+
+        val result = ThreePeerSyncCycle.run(local, listOf(ebook, storyteller))
+
+        assertNull(result.jumpTo)
+        assertEquals(pos("L"), ebook.patchedWith)
+        assertEquals(pos("L"), storyteller.patchedWith)
+        assertEquals(setOf("ABS_EBOOK", "STORYTELLER"), result.patched)
+    }
+
+    @Test
+    fun `a failed GET excludes that remote from comparison and from patching`() = runTest {
+        val local = LocalCanonical(pos("L"), lastUpdate = 100)
+        val ebook = FakeRemote("ABS_EBOOK", RemoteRead(pos("A"), lastUpdate = 90))
+        val audio = FakeRemote("ABS_AUDIO", getResult = null) // unreachable
+        val storyteller = FakeRemote("STORYTELLER", RemoteRead(pos("S"), lastUpdate = 150))
+
+        val result = ThreePeerSyncCycle.run(local, listOf(ebook, audio, storyteller))
+
+        assertEquals(pos("S"), result.jumpTo)
+        // The unreachable remote is neither compared nor patched (we don't know its state).
+        assertNull(audio.patchedWith)
+        assertTrue("ABS_AUDIO" !in result.patched)
+    }
+
+    @Test
+    fun `a failed PATCH leaves that remote out of the patched set but does not poison others`() = runTest {
+        val local = LocalCanonical(pos("L"), lastUpdate = 200)
+        val ebook = FakeRemote("ABS_EBOOK", RemoteRead(pos("A"), lastUpdate = 90)).apply { patchFails = true }
+        val storyteller = FakeRemote("STORYTELLER", RemoteRead(pos("S"), lastUpdate = 150))
+
+        val result = ThreePeerSyncCycle.run(local, listOf(ebook, storyteller))
+
+        assertEquals(setOf("STORYTELLER"), result.patched)
+        assertEquals(pos("L"), storyteller.patchedWith)
+    }
+}

--- a/core/network/src/main/kotlin/com/riffle/core/network/AbsApiClient.kt
+++ b/core/network/src/main/kotlin/com/riffle/core/network/AbsApiClient.kt
@@ -6,6 +6,7 @@ import com.riffle.core.network.model.AbsCollectionBookRequest
 import com.riffle.core.network.model.AbsCollectionsResponse
 import com.riffle.core.network.model.AbsCreateCollectionRequest
 import com.riffle.core.network.model.AbsCreatePlaylistRequest
+import com.riffle.core.network.model.AbsAudiobookProgressRequest
 import com.riffle.core.network.model.AbsEbookProgressRequest
 import com.riffle.core.network.model.AbsItemResponse
 import com.riffle.core.network.model.AbsLibrariesResponse
@@ -527,6 +528,34 @@ class AbsApiClient(private val httpClient: OkHttpClient) : AbsApi, AbsLibraryApi
         }
     }
 
+    override suspend fun syncAudiobookProgress(
+        baseUrl: String,
+        libraryItemId: String,
+        payload: NetworkAudiobookProgressPayload,
+        token: String,
+        insecureAllowed: Boolean,
+    ): NetworkSyncSessionResult = withContext(Dispatchers.IO) {
+        val client = if (insecureAllowed) httpClient.trustAllCerts() else httpClient
+        val body = json.encodeToString(AbsAudiobookProgressRequest(payload.currentTime, payload.duration))
+            .toRequestBody(jsonMediaType)
+        val request = Request.Builder()
+            .url("$baseUrl/api/me/progress/$libraryItemId")
+            .addHeader("Authorization", "Bearer $token")
+            .patch(body)
+            .build()
+        try {
+            val response = client.newCall(request).execute()
+            if (response.isSuccessful) {
+                val lastUpdate = response.body?.string()
+                    ?.let { runCatching { json.decodeFromString<AbsProgressResponse>(it) }.getOrNull() }
+                    ?.lastUpdate ?: 0L
+                NetworkSyncSessionResult.Success(lastUpdate)
+            } else NetworkSyncSessionResult.NetworkError(IOException("HTTP ${response.code}"))
+        } catch (e: IOException) {
+            NetworkSyncSessionResult.NetworkError(e)
+        }
+    }
+
     override suspend fun getProgress(
         baseUrl: String,
         libraryItemId: String,
@@ -548,10 +577,16 @@ class AbsApiClient(private val httpClient: OkHttpClient) : AbsApi, AbsLibraryApi
                 )
                 val parsed = json.decodeFromString<AbsProgressResponse>(raw)
                 NetworkGetProgressResult.Success(
-                    NetworkServerProgress(parsed.ebookLocation, parsed.ebookProgress, parsed.lastUpdate)
+                    NetworkServerProgress(
+                        ebookLocation = parsed.ebookLocation,
+                        ebookProgress = parsed.ebookProgress,
+                        currentTime = parsed.currentTime,
+                        duration = parsed.duration,
+                        lastUpdate = parsed.lastUpdate,
+                    )
                 )
             } else if (response.code == 404) {
-                NetworkGetProgressResult.Success(NetworkServerProgress("", 0f, 0L))
+                NetworkGetProgressResult.Success(NetworkServerProgress(ebookLocation = "", lastUpdate = 0L))
             } else {
                 NetworkGetProgressResult.NetworkError(IOException("HTTP ${response.code}"))
             }

--- a/core/network/src/main/kotlin/com/riffle/core/network/AbsSessionApi.kt
+++ b/core/network/src/main/kotlin/com/riffle/core/network/AbsSessionApi.kt
@@ -5,9 +5,17 @@ data class NetworkEbookProgressPayload(
     val ebookProgress: Float,
 )
 
+data class NetworkAudiobookProgressPayload(
+    val currentTime: Double,
+    val duration: Double,
+)
+
 data class NetworkServerProgress(
     val ebookLocation: String,
     val ebookProgress: Float = 0f,
+    // Audiobook progress from the same ABS media-progress record.
+    val currentTime: Double = 0.0,
+    val duration: Double = 0.0,
     val lastUpdate: Long,
 )
 
@@ -26,6 +34,14 @@ interface AbsSessionApi {
         baseUrl: String,
         libraryItemId: String,
         payload: NetworkEbookProgressPayload,
+        token: String,
+        insecureAllowed: Boolean,
+    ): NetworkSyncSessionResult
+
+    suspend fun syncAudiobookProgress(
+        baseUrl: String,
+        libraryItemId: String,
+        payload: NetworkAudiobookProgressPayload,
         token: String,
         insecureAllowed: Boolean,
     ): NetworkSyncSessionResult

--- a/core/network/src/main/kotlin/com/riffle/core/network/model/AbsProgressResponse.kt
+++ b/core/network/src/main/kotlin/com/riffle/core/network/model/AbsProgressResponse.kt
@@ -6,5 +6,9 @@ import kotlinx.serialization.Serializable
 internal data class AbsProgressResponse(
     val ebookLocation: String = "",
     val ebookProgress: Float = 0f,
+    // Audiobook progress shares this media-progress record: an offset in seconds into the
+    // audio plus the audiobook's total duration (both 0 for ebook-only items).
+    val currentTime: Double = 0.0,
+    val duration: Double = 0.0,
     val lastUpdate: Long = 0L,
 )

--- a/core/network/src/main/kotlin/com/riffle/core/network/model/AbsSessionModels.kt
+++ b/core/network/src/main/kotlin/com/riffle/core/network/model/AbsSessionModels.kt
@@ -7,3 +7,9 @@ internal data class AbsEbookProgressRequest(
     val ebookLocation: String,
     val ebookProgress: Float,
 )
+
+@Serializable
+internal data class AbsAudiobookProgressRequest(
+    val currentTime: Double,
+    val duration: Double,
+)


### PR DESCRIPTION
## What this does

Implements three-peer Progress Sync (ADR 0019) for Confirmed-matched Storyteller readaloud books (#38). Reading or listening to a matched book in Riffle now reconciles **ABS ebook progress**, **ABS audiobook progress**, and **Storyteller position** with each other and with other clients — regardless of which side the book was opened from. Non-matched books are unchanged.

## How it's built

**Domain engine (pure, fully unit-tested):**
- `CanonicalPositionTranslator` — single conversion point between audio-seconds, Storyteller-EPUB position, and ABS-EPUB progression; unmappable inputs → `null`.
- `CrossEpubIndex` + `CrossEpubIndexBuilder` + `StorytellerFragmentIndexBuilder` + `CrossEpubIndexSerializer` + `EpubChecksum`; `EpubContentExtractor` (spine + SMIL from EPUB bytes). `EpubTextChars` is the shared readable-char primitive the app's `EpubCfiTranslator` now delegates to.
- `ThreePeerSyncCycle` — one inbound winner, ≤1 reader jump, all PATCHes from one canonical position, per-target GET/PATCH isolation.
- `applicableRemotes` + the **multi-link guard** (>1 Confirmed ABS link ⇒ Storyteller excluded, degrade to two-peer), `ProgressSyncStrategy`, `CrossEpubIndexService` (eager build-on-Confirm; defers — never partial — on a missing prerequisite).

**Persistence:** `cross_epub_index` Room table + `MIGRATION_23_24` (rebased above #39's v23). Built lazily in the background: the matcher enqueues an idempotent build per Confirmed link on each library refresh, fetching both EPUBs (cache-first, the few-MB bundle, never audio) from their respective servers.

**Network:** ABS audiobook progress (`currentTime`/`duration`) added to the existing `/api/me/progress/{id}` endpoint — verified against the live ABS server.

**Reader:** `ThreePeerReaderSyncFactory` assembles a `ThreePeerReaderSyncCoordinator` only when all prerequisites are cached (matched, exactly one ABS link, both EPUBs + index present); it drives live `SyncRemote` adapters via the cross-EPUB index + SMIL. Wired into `EpubReaderViewModel` with strict gating + single-peer fallback.

## Testing

- `./gradlew test` (all modules incl. pure-JVM) — green
- `./gradlew lint` — green
- `make harness-test` — 129 instrumented tests, 0 failed (installs on a real AVD; exercises the **v24 DB migration** and the new DI graph at runtime)
- `make harness-test-tablet` — 5 tests, 0 failed
- New unit tests: `CanonicalPositionTranslatorTest`, `CrossEpubIndexBuilderTest`, `StorytellerFragmentIndexBuilderTest`, `EpubTextCharsTest`, `EpubChecksumTest`, `EpubContentExtractorTest`, `CrossEpubIndexSerializerTest`, `ThreePeerSyncCycleTest`, `ApplicableRemotesTest`, `ProgressSyncStrategyTest`, `CrossEpubIndexServiceTest`, `ReaderPositionBridgeTest`, `ThreePeerReaderSyncCoordinatorTest`; `MigrationTest.migration23To24` added.

## Verify before relying on it

The reader-driver glue (live position conversion against two servers) is covered by unit tests but **not yet verified end-to-end on a device with a real matched book** (both EPUBs + SMIL + audio). Key item: `EpubContentExtractor` spine hrefs must line up with Readium locator hrefs for the bridge to map positions. The failure mode is "doesn't sync," not "corrupts," and is gated to fully-prereq'd matched books.

## Notes
- `app` now depends on `core:network` (the reader builds `SyncRemote`s over the position APIs directly).
- Rebased onto main after #39 merged: renumbered the migration to 23→24, merged the index-build hook into #39's matcher ladder, regenerated schema `24.json`.
