### PR TITLE
feat(settings): expandable per-server settings

### DIFF
--- a/app/src/androidTest/kotlin/com/riffle/app/feature/settings/ServerSettingsExpansionTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/settings/ServerSettingsExpansionTest.kt
@@ -75,18 +75,19 @@ class ServerSettingsExpansionTest {
     }
 
     @Test
-    fun inactiveAbsServerShowsActivateNote() {
+    fun inactiveAbsServerStillShowsItsLibraries() {
         composeTestRule.setContent {
             ServerSettingsExpansion(
                 server = server(ServerType.AUDIOBOOKSHELF, active = false),
-                libraryItems = emptyList(),
+                libraryItems = listOf(libraryItem("Fiction")),
                 summary = null,
                 onSetLibraryVisible = { _, _ -> },
                 onOpenReadaloudMatches = {},
             )
         }
 
-        composeTestRule.onNodeWithText("Activate this server to manage its libraries.").assertIsDisplayed()
+        // No activation required — a non-active server manages its own libraries.
+        composeTestRule.onNodeWithText("Fiction").assertIsDisplayed()
     }
 
     @Test

--- a/app/src/androidTest/kotlin/com/riffle/app/feature/settings/ServerSettingsExpansionTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/settings/ServerSettingsExpansionTest.kt
@@ -1,0 +1,111 @@
+package com.riffle.app.feature.settings
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.isToggleable
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onFirst
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import com.riffle.core.domain.Library
+import com.riffle.core.domain.Server
+import com.riffle.core.domain.ServerType
+import com.riffle.core.domain.ServerUrl
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class ServerSettingsExpansionTest {
+
+    @get:Rule val composeTestRule = createComposeRule()
+
+    private fun server(type: ServerType, active: Boolean) = Server(
+        id = "srv-1",
+        url = ServerUrl.parse("https://example.com")!!,
+        isActive = active,
+        insecureConnectionAllowed = false,
+        username = "",
+        serverType = type,
+    )
+
+    private fun libraryItem(id: String, visible: Boolean = true) = LibraryUiItem(
+        library = Library(id = id, name = id, mediaType = "book", isUnsupported = false),
+        isVisible = visible,
+        switchEnabled = true,
+    )
+
+    @Test
+    fun activeAbsServerShowsLibrarySwitches() {
+        composeTestRule.setContent {
+            ServerSettingsExpansion(
+                server = server(ServerType.AUDIOBOOKSHELF, active = true),
+                libraryItems = listOf(libraryItem("Fiction"), libraryItem("Non-fiction")),
+                summary = null,
+                onSetLibraryVisible = { _, _ -> },
+                onOpenReadaloudMatches = {},
+            )
+        }
+
+        composeTestRule.onNodeWithText("Enabled libraries").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Fiction").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Non-fiction").assertIsDisplayed()
+    }
+
+    @Test
+    fun togglingALibrarySwitchInvokesCallback() {
+        var toggledLibrary: String? = null
+        var toggledVisible: Boolean? = null
+        composeTestRule.setContent {
+            ServerSettingsExpansion(
+                server = server(ServerType.AUDIOBOOKSHELF, active = true),
+                libraryItems = listOf(libraryItem("Fiction", visible = true)),
+                summary = null,
+                onSetLibraryVisible = { id, visible -> toggledLibrary = id; toggledVisible = visible },
+                onOpenReadaloudMatches = {},
+            )
+        }
+
+        composeTestRule.onAllNodes(isToggleable()).onFirst().performClick()
+
+        assertEquals("Fiction", toggledLibrary)
+        assertEquals(false, toggledVisible)
+    }
+
+    @Test
+    fun inactiveAbsServerShowsActivateNote() {
+        composeTestRule.setContent {
+            ServerSettingsExpansion(
+                server = server(ServerType.AUDIOBOOKSHELF, active = false),
+                libraryItems = emptyList(),
+                summary = null,
+                onSetLibraryVisible = { _, _ -> },
+                onOpenReadaloudMatches = {},
+            )
+        }
+
+        composeTestRule.onNodeWithText("Activate this server to manage its libraries.").assertIsDisplayed()
+    }
+
+    @Test
+    fun storytellerServerShowsMatchesSummaryAndNavigates() {
+        var opened = false
+        composeTestRule.setContent {
+            ServerSettingsExpansion(
+                server = server(ServerType.STORYTELLER, active = true),
+                libraryItems = emptyList(),
+                summary = ReadaloudMatchSummary(confirmedCount = 3, pendingCount = 1, unmatchedCount = 2),
+                onSetLibraryVisible = { _, _ -> },
+                onOpenReadaloudMatches = { opened = true },
+            )
+        }
+
+        composeTestRule.onNodeWithText("Readaloud matches").assertIsDisplayed()
+        composeTestRule.onNodeWithText("3 confirmed · 1 pending review · 2 unmatched").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Review & pair readalouds").performClick()
+
+        assertTrue(opened)
+    }
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsScreen.kt
@@ -78,7 +78,7 @@ fun SettingsScreen(
     val invertVolumeKeys by viewModel.invertVolumeKeys.collectAsState()
     val servers by viewModel.servers.collectAsState()
     val serverVersions by viewModel.serverVersions.collectAsState()
-    val libraryItems by viewModel.libraryUiItems.collectAsState()
+    val libraryItemsByServer by viewModel.libraryUiItemsByServer.collectAsState()
     val storytellerServers by viewModel.storytellerServers.collectAsState()
     val audioCacheCaps by viewModel.audioCacheCaps.collectAsState()
     val readaloudSummaries by viewModel.readaloudSummaries.collectAsState()
@@ -176,7 +176,7 @@ fun SettingsScreen(
                             AnimatedVisibility(visible = isExpanded) {
                                 ServerSettingsExpansion(
                                     server = server,
-                                    libraryItems = libraryItems,
+                                    libraryItems = libraryItemsByServer[server.id].orEmpty(),
                                     summary = readaloudSummaries[server.id],
                                     onSetLibraryVisible = { libraryId, visible ->
                                         viewModel.setLibraryVisible(server.id, libraryId, visible)
@@ -340,12 +340,10 @@ internal fun ServerSettingsExpansion(
         when (server.serverType) {
             ServerType.AUDIOBOOKSHELF -> {
                 ExpansionHeader("Enabled libraries")
-                when {
-                    !server.isActive ->
-                        ExpansionNote("Activate this server to manage its libraries.")
-                    libraryItems.isEmpty() ->
-                        ExpansionNote("No libraries found.")
-                    else -> libraryItems.forEach { item ->
+                if (libraryItems.isEmpty()) {
+                    ExpansionNote("No libraries found.")
+                } else {
+                    libraryItems.forEach { item ->
                         ListItem(
                             colors = transparentColors,
                             modifier = Modifier.padding(start = 24.dp),

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsScreen.kt
@@ -1,6 +1,9 @@
 package com.riffle.app.feature.settings
 
 import android.content.ClipData
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Box
@@ -22,6 +25,7 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.ListItem
+import androidx.compose.material3.ListItemDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SwipeToDismissBox
@@ -36,11 +40,14 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.ClipEntry
 import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.text.font.FontFamily
@@ -49,6 +56,8 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import com.riffle.app.feature.reader.FormattingPanel
 import com.riffle.app.ui.TabletContentWidthContainer
 import com.riffle.core.domain.AudioCachePreferencesStore
+import com.riffle.core.domain.Server
+import com.riffle.core.domain.ServerType
 import kotlinx.coroutines.launch
 import java.text.DateFormat
 import java.util.Date
@@ -72,8 +81,10 @@ fun SettingsScreen(
     val libraryItems by viewModel.libraryUiItems.collectAsState()
     val storytellerServers by viewModel.storytellerServers.collectAsState()
     val audioCacheCaps by viewModel.audioCacheCaps.collectAsState()
+    val readaloudSummaries by viewModel.readaloudSummaries.collectAsState()
     val clipboard = LocalClipboard.current
     val scope = rememberCoroutineScope()
+    val expandedServers = remember { mutableStateMapOf<String, Boolean>() }
     var expanded by remember { mutableStateOf(false) }
     var showFormattingPanel by remember { mutableStateOf(false) }
 
@@ -126,26 +137,54 @@ fun SettingsScreen(
                         state = dismissState,
                         backgroundContent = {},
                     ) {
-                        val username = server.username.takeIf { it.isNotEmpty() }
-                        val version = serverVersions[server.id]
-                        val subtitle = buildString {
-                            if (username != null) {
-                                append(username)
-                                append(" · ")
+                        Column {
+                            val isExpanded = expandedServers[server.id] == true
+                            val username = server.username.takeIf { it.isNotEmpty() }
+                            val version = serverVersions[server.id]
+                            val subtitle = buildString {
+                                if (username != null) {
+                                    append(username)
+                                    append(" · ")
+                                }
+                                append(server.url.value)
+                                if (version != null) {
+                                    append(" · v")
+                                    append(version)
+                                }
                             }
-                            append(server.url.value)
-                            if (version != null) {
-                                append(" · v")
-                                append(version)
+                            val chevronRotation by animateFloatAsState(
+                                targetValue = if (isExpanded) 90f else 0f,
+                                label = "chevron",
+                            )
+                            ListItem(
+                                modifier = Modifier.clickable {
+                                    expandedServers[server.id] = !isExpanded
+                                },
+                                leadingContent = {
+                                    Icon(
+                                        Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                                        contentDescription = if (isExpanded) "Collapse" else "Expand",
+                                        modifier = Modifier.rotate(chevronRotation),
+                                    )
+                                },
+                                headlineContent = { Text(server.serverType.label) },
+                                supportingContent = { Text(subtitle) },
+                                trailingContent = if (server.isActive) {
+                                    { Text("Active", style = MaterialTheme.typography.labelSmall) }
+                                } else null,
+                            )
+                            AnimatedVisibility(visible = isExpanded) {
+                                ServerSettingsExpansion(
+                                    server = server,
+                                    libraryItems = libraryItems,
+                                    summary = readaloudSummaries[server.id],
+                                    onSetLibraryVisible = { libraryId, visible ->
+                                        viewModel.setLibraryVisible(server.id, libraryId, visible)
+                                    },
+                                    onOpenReadaloudMatches = { viewModel.openReadaloudMatches(server.id) },
+                                )
                             }
                         }
-                        ListItem(
-                            headlineContent = { Text(server.serverType.label) },
-                            supportingContent = { Text(subtitle) },
-                            trailingContent = if (server.isActive) {
-                                { Text("Active", style = MaterialTheme.typography.labelSmall) }
-                            } else null,
-                        )
                     }
                 }
                 Button(
@@ -157,32 +196,6 @@ fun SettingsScreen(
                     Text("Add Server")
                 }
                 HorizontalDivider()
-
-                if (libraryItems.isNotEmpty()) {
-                    val activeServerName = servers.firstOrNull { it.isActive }?.serverType?.label ?: ""
-                    Text(
-                        text = "Libraries — $activeServerName",
-                        style = MaterialTheme.typography.titleSmall,
-                        modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
-                    )
-                    HorizontalDivider()
-                    libraryItems.forEach { item ->
-                        ListItem(
-                            headlineContent = { Text(item.library.name) },
-                            trailingContent = {
-                                Switch(
-                                    checked = item.isVisible,
-                                    onCheckedChange = { visible ->
-                                        val serverId = servers.firstOrNull { it.isActive }?.id ?: return@Switch
-                                        viewModel.setLibraryVisible(serverId, item.library.id, visible)
-                                    },
-                                    enabled = item.switchEnabled,
-                                )
-                            },
-                        )
-                    }
-                    HorizontalDivider()
-                }
 
                 if (storytellerServers.isNotEmpty()) {
                     Text(
@@ -218,29 +231,6 @@ fun SettingsScreen(
                                     }
                                 }
                             },
-                        )
-                    }
-                    HorizontalDivider()
-                }
-
-                if (storytellerServers.isNotEmpty()) {
-                    Text(
-                        text = "Readaloud matches",
-                        style = MaterialTheme.typography.titleSmall,
-                        modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
-                    )
-                    HorizontalDivider()
-                    storytellerServers.forEach { server ->
-                        ListItem(
-                            headlineContent = { Text(server.name) },
-                            supportingContent = { Text("Review and pair Storyteller readalouds with ABS books") },
-                            trailingContent = {
-                                Icon(
-                                    Icons.AutoMirrored.Filled.KeyboardArrowRight,
-                                    contentDescription = null,
-                                )
-                            },
-                            modifier = Modifier.clickable { viewModel.openReadaloudMatches(server.id) },
                         )
                     }
                     HorizontalDivider()
@@ -327,6 +317,93 @@ fun SettingsScreen(
             fullScreen = true,
         )
     }
+}
+
+/**
+ * The settings revealed when a server row is expanded: ABS servers show their library visibility
+ * switches; Storyteller servers show a readaloud-matches summary that opens the full matches screen.
+ */
+@Composable
+internal fun ServerSettingsExpansion(
+    server: Server,
+    libraryItems: List<LibraryUiItem>,
+    summary: ReadaloudMatchSummary?,
+    onSetLibraryVisible: (libraryId: String, visible: Boolean) -> Unit,
+    onOpenReadaloudMatches: () -> Unit,
+) {
+    val transparentColors = ListItemDefaults.colors(containerColor = Color.Transparent)
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f)),
+    ) {
+        when (server.serverType) {
+            ServerType.AUDIOBOOKSHELF -> {
+                ExpansionHeader("Enabled libraries")
+                when {
+                    !server.isActive ->
+                        ExpansionNote("Activate this server to manage its libraries.")
+                    libraryItems.isEmpty() ->
+                        ExpansionNote("No libraries found.")
+                    else -> libraryItems.forEach { item ->
+                        ListItem(
+                            colors = transparentColors,
+                            modifier = Modifier.padding(start = 24.dp),
+                            headlineContent = { Text(item.library.name) },
+                            trailingContent = {
+                                Switch(
+                                    checked = item.isVisible,
+                                    onCheckedChange = { visible -> onSetLibraryVisible(item.library.id, visible) },
+                                    enabled = item.switchEnabled,
+                                )
+                            },
+                        )
+                    }
+                }
+            }
+            ServerType.STORYTELLER -> {
+                ExpansionHeader("Readaloud matches")
+                val counts = summary ?: ReadaloudMatchSummary(0, 0, 0)
+                ListItem(
+                    colors = transparentColors,
+                    modifier = Modifier
+                        .padding(start = 24.dp)
+                        .clickable { onOpenReadaloudMatches() },
+                    headlineContent = { Text("Review & pair readalouds") },
+                    supportingContent = {
+                        Text(
+                            "${counts.confirmedCount} confirmed · " +
+                                "${counts.pendingCount} pending review · " +
+                                "${counts.unmatchedCount} unmatched",
+                        )
+                    },
+                    trailingContent = {
+                        Icon(Icons.AutoMirrored.Filled.KeyboardArrowRight, contentDescription = null)
+                    },
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun ExpansionHeader(text: String) {
+    Text(
+        text = text,
+        style = MaterialTheme.typography.labelMedium,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = Modifier.padding(start = 24.dp, end = 16.dp, top = 12.dp, bottom = 4.dp),
+    )
+}
+
+@Composable
+private fun ExpansionNote(text: String) {
+    Text(
+        text = text,
+        style = MaterialTheme.typography.bodySmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = Modifier.padding(start = 24.dp, end = 16.dp, top = 4.dp, bottom = 12.dp),
+    )
 }
 
 private const val GIB: Long = 1024L * 1024 * 1024

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsViewModel.kt
@@ -11,6 +11,7 @@ import com.riffle.core.domain.FormattingPreferencesStore
 import com.riffle.core.domain.LibraryRepository
 import com.riffle.core.domain.LibraryVisibilityPreferencesStore
 import com.riffle.core.domain.ReadaloudAudioRepository
+import com.riffle.core.domain.ReadaloudReviewRepository
 import com.riffle.core.domain.Server
 import com.riffle.core.domain.ServerType
 import com.riffle.core.domain.VolumeKeyPreferencesStore
@@ -44,6 +45,7 @@ class SettingsViewModel @Inject constructor(
     private val volumeKeyPreferencesStore: VolumeKeyPreferencesStore,
     private val audioCachePreferencesStore: AudioCachePreferencesStore,
     private val readaloudAudioRepository: ReadaloudAudioRepository,
+    private val readaloudReviewRepository: ReadaloudReviewRepository,
     private val connectivityObserver: ConnectivityObserver,
 ) : ViewModel() {
 
@@ -82,6 +84,27 @@ class SettingsViewModel @Inject constructor(
                 combine(
                     items.map { item ->
                         audioCachePreferencesStore.capBytes(item.id).map { item.id to it }
+                    }
+                ) { pairs -> pairs.toMap() }
+            }
+        }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyMap())
+
+    /** Readaloud-matches counts (confirmed / pending / unmatched) for each Storyteller server. */
+    val readaloudSummaries: StateFlow<Map<String, ReadaloudMatchSummary>> = storytellerServers
+        .flatMapLatest { items ->
+            if (items.isEmpty()) {
+                MutableStateFlow(emptyMap<String, ReadaloudMatchSummary>())
+            } else {
+                combine(
+                    items.map { item ->
+                        readaloudReviewRepository.observeReview(item.id).map { review ->
+                            item.id to ReadaloudMatchSummary(
+                                confirmedCount = review.confirmed.size,
+                                pendingCount = review.pending.size,
+                                unmatchedCount = review.unmatched.size,
+                            )
+                        }
                     }
                 ) { pairs -> pairs.toMap() }
             }
@@ -193,4 +216,11 @@ class SettingsViewModel @Inject constructor(
 data class StorytellerServerUiItem(
     val id: String,
     val name: String,
+)
+
+/** Counts shown in a Storyteller server's expanded "Readaloud matches" summary. */
+data class ReadaloudMatchSummary(
+    val confirmedCount: Int,
+    val pendingCount: Int,
+    val unmatchedCount: Int,
 )

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsViewModel.kt
@@ -26,7 +26,6 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
@@ -131,29 +130,40 @@ class SettingsViewModel @Inject constructor(
         }
     }
 
-    private val activeServer: StateFlow<Server?> = servers
-        .map { it.firstOrNull { s -> s.isActive } }
-        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), null)
+    private val absServers: StateFlow<List<Server>> = servers
+        .map { list -> list.filter { it.serverType == ServerType.AUDIOBOOKSHELF } }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
 
-    val libraryUiItems: StateFlow<List<LibraryUiItem>> = activeServer
-        .filterNotNull()
-        .flatMapLatest { server ->
-            combine(
-                libraryRepository.observeLibraries(),
-                visibilityStore.hiddenLibraryIds(server.id),
-            ) { libraries, hiddenIds ->
-                val visibleCount = libraries.count { it.id !in hiddenIds }
-                libraries.map { lib ->
-                    val isVisible = lib.id !in hiddenIds
-                    LibraryUiItem(
-                        library = lib,
-                        isVisible = isVisible,
-                        switchEnabled = !isVisible || visibleCount > 1,
-                    )
-                }
+    /**
+     * Library visibility items for each Audiobookshelf server, keyed by server id. Libraries are
+     * read from the local DB per server, so a server need not be active to manage its libraries.
+     */
+    val libraryUiItemsByServer: StateFlow<Map<String, List<LibraryUiItem>>> = absServers
+        .flatMapLatest { list ->
+            if (list.isEmpty()) {
+                MutableStateFlow(emptyMap<String, List<LibraryUiItem>>())
+            } else {
+                combine(
+                    list.map { server ->
+                        combine(
+                            libraryRepository.observeLibraries(server.id),
+                            visibilityStore.hiddenLibraryIds(server.id),
+                        ) { libraries, hiddenIds ->
+                            val visibleCount = libraries.count { it.id !in hiddenIds }
+                            server.id to libraries.map { lib ->
+                                val isVisible = lib.id !in hiddenIds
+                                LibraryUiItem(
+                                    library = lib,
+                                    isVisible = isVisible,
+                                    switchEnabled = !isVisible || visibleCount > 1,
+                                )
+                            }
+                        }
+                    }
+                ) { pairs -> pairs.toMap() }
             }
         }
-        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyMap())
 
     private val _navigationEvents = Channel<SettingsNavEvent>(Channel.CONFLATED)
     val navigationEvents = _navigationEvents.receiveAsFlow()

--- a/app/src/test/kotlin/com/riffle/app/feature/library/CollectionDetailViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/CollectionDetailViewModelTest.kt
@@ -49,6 +49,7 @@ class CollectionDetailViewModelTest {
         onRefreshCall: () -> Unit = {},
     ): LibraryRepository = object : LibraryRepository {
         override fun observeLibraries(): Flow<List<Library>> = MutableStateFlow(emptyList())
+        override fun observeLibraries(serverId: String): Flow<List<Library>> = observeLibraries()
         override fun observeLibraryItems(libraryId: String): Flow<List<LibraryItem>> = MutableStateFlow(emptyList())
         override fun observeUngroupedLibraryItems(libraryId: String): Flow<List<LibraryItem>> = MutableStateFlow(emptyList())
         override fun observeInProgressItems(libraryId: String): Flow<List<LibraryItem>> = MutableStateFlow(emptyList())
@@ -73,6 +74,7 @@ class CollectionDetailViewModelTest {
 
     private fun fakeRepo(): LibraryRepository = object : LibraryRepository {
         override fun observeLibraries(): Flow<List<Library>> = MutableStateFlow(emptyList())
+        override fun observeLibraries(serverId: String): Flow<List<Library>> = observeLibraries()
         override fun observeLibraryItems(libraryId: String): Flow<List<LibraryItem>> = MutableStateFlow(emptyList())
         override fun observeUngroupedLibraryItems(libraryId: String): Flow<List<LibraryItem>> = MutableStateFlow(emptyList())
         override fun observeInProgressItems(libraryId: String): Flow<List<LibraryItem>> = MutableStateFlow(emptyList())

--- a/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModelTest.kt
@@ -70,6 +70,7 @@ class LibraryItemDetailViewModelTest {
 
     private fun fakeRepo(item: LibraryItem? = null): LibraryRepository = object : LibraryRepository {
         override fun observeLibraries(): Flow<List<Library>> = MutableStateFlow(emptyList())
+        override fun observeLibraries(serverId: String): Flow<List<Library>> = observeLibraries()
         override fun observeLibraryItems(libraryId: String): Flow<List<LibraryItem>> = MutableStateFlow(emptyList())
         override fun observeUngroupedLibraryItems(libraryId: String): Flow<List<LibraryItem>> = MutableStateFlow(emptyList())
         override fun observeInProgressItems(libraryId: String): Flow<List<LibraryItem>> = MutableStateFlow(emptyList())
@@ -92,6 +93,7 @@ class LibraryItemDetailViewModelTest {
 
     private fun throwingRepo(): LibraryRepository = object : LibraryRepository {
         override fun observeLibraries(): Flow<List<Library>> = MutableStateFlow(emptyList())
+        override fun observeLibraries(serverId: String): Flow<List<Library>> = observeLibraries()
         override fun observeLibraryItems(libraryId: String): Flow<List<LibraryItem>> = MutableStateFlow(emptyList())
         override fun observeUngroupedLibraryItems(libraryId: String): Flow<List<LibraryItem>> = MutableStateFlow(emptyList())
         override fun observeInProgressItems(libraryId: String): Flow<List<LibraryItem>> = MutableStateFlow(emptyList())

--- a/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemsViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemsViewModelTest.kt
@@ -62,6 +62,7 @@ class LibraryItemsViewModelTest {
 
     private fun fakeRepo(): LibraryRepository = object : LibraryRepository {
         override fun observeLibraries(): Flow<List<Library>> = librariesFlow
+        override fun observeLibraries(serverId: String): Flow<List<Library>> = observeLibraries()
         override fun observeLibraryItems(libraryId: String): Flow<List<LibraryItem>> = allItemsFlow
         override fun observeUngroupedLibraryItems(libraryId: String): Flow<List<LibraryItem>> = itemsFlow
         override fun observeInProgressItems(libraryId: String): Flow<List<LibraryItem>> = inProgressFlow
@@ -694,6 +695,7 @@ class LibraryItemsViewModelTest {
         onRefreshCall: () -> Unit = {},
     ): LibraryRepository = object : LibraryRepository {
         override fun observeLibraries(): Flow<List<Library>> = MutableStateFlow(emptyList())
+        override fun observeLibraries(serverId: String): Flow<List<Library>> = observeLibraries()
         override fun observeLibraryItems(libraryId: String): Flow<List<LibraryItem>> = allItemsFlow
         override fun observeUngroupedLibraryItems(libraryId: String): Flow<List<LibraryItem>> = itemsFlow
         override fun observeInProgressItems(libraryId: String): Flow<List<LibraryItem>> = inProgressFlow

--- a/app/src/test/kotlin/com/riffle/app/feature/library/SeriesDetailViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/SeriesDetailViewModelTest.kt
@@ -49,6 +49,7 @@ class SeriesDetailViewModelTest {
         onRefreshCall: () -> Unit = {},
     ): LibraryRepository = object : LibraryRepository {
         override fun observeLibraries(): Flow<List<Library>> = MutableStateFlow(emptyList())
+        override fun observeLibraries(serverId: String): Flow<List<Library>> = observeLibraries()
         override fun observeLibraryItems(libraryId: String): Flow<List<LibraryItem>> = MutableStateFlow(emptyList())
         override fun observeUngroupedLibraryItems(libraryId: String): Flow<List<LibraryItem>> = MutableStateFlow(emptyList())
         override fun observeInProgressItems(libraryId: String): Flow<List<LibraryItem>> = MutableStateFlow(emptyList())

--- a/app/src/test/kotlin/com/riffle/app/feature/navigation/HomeViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/navigation/HomeViewModelTest.kt
@@ -61,6 +61,7 @@ class HomeViewModelTest {
         refreshResult: LibraryRefreshResult = LibraryRefreshResult.Success,
     ): LibraryRepository = object : LibraryRepository {
         override fun observeLibraries(): Flow<List<Library>> = librariesFlow
+        override fun observeLibraries(serverId: String): Flow<List<Library>> = observeLibraries()
         override fun observeLibraryItems(libraryId: String): Flow<List<LibraryItem>> = MutableStateFlow(emptyList())
         override fun observeUngroupedLibraryItems(libraryId: String): Flow<List<LibraryItem>> = MutableStateFlow(emptyList())
         override fun observeInProgressItems(libraryId: String): Flow<List<LibraryItem>> = MutableStateFlow(emptyList())

--- a/app/src/test/kotlin/com/riffle/app/feature/navigation/NavigationDrawerViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/navigation/NavigationDrawerViewModelTest.kt
@@ -75,6 +75,7 @@ class NavigationDrawerViewModelTest {
 
     private fun fakeLibraryRepo(): LibraryRepository = object : LibraryRepository {
         override fun observeLibraries(): Flow<List<Library>> = librariesFlow
+        override fun observeLibraries(serverId: String): Flow<List<Library>> = observeLibraries()
         override fun observeLibraryItems(libraryId: String): Flow<List<LibraryItem>> = MutableStateFlow(emptyList())
         override fun observeUngroupedLibraryItems(libraryId: String): Flow<List<LibraryItem>> = MutableStateFlow(emptyList())
         override fun observeInProgressItems(libraryId: String): Flow<List<LibraryItem>> = MutableStateFlow(emptyList())

--- a/app/src/test/kotlin/com/riffle/app/feature/settings/SettingsViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/settings/SettingsViewModelTest.kt
@@ -96,7 +96,6 @@ class SettingsViewModelTest {
     private val serversFlow = MutableStateFlow<List<Server>>(emptyList())
     private val librariesFlow = MutableStateFlow<List<Library>>(emptyList())
     private val hiddenFlow = MutableStateFlow<Map<String, Set<String>>>(emptyMap())
-    private val activeServerId get() = serversFlow.value.firstOrNull { it.isActive }?.id
 
     private fun fakeServerRepo(): ServerRepository = object : ServerRepository {
         override fun observeAll(): Flow<List<Server>> = serversFlow

--- a/app/src/test/kotlin/com/riffle/app/feature/settings/SettingsViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/settings/SettingsViewModelTest.kt
@@ -15,10 +15,17 @@ import com.riffle.core.domain.LibraryItem
 import com.riffle.core.domain.LibraryRefreshResult
 import com.riffle.core.domain.LibraryRepository
 import com.riffle.core.domain.LibraryVisibilityPreferencesStore
+import com.riffle.core.domain.AbsPickerItem
+import com.riffle.core.domain.ConfirmedReadaloud
+import com.riffle.core.domain.PendingReadaloud
+import com.riffle.core.domain.ReadaloudReview
+import com.riffle.core.domain.ReadaloudReviewRepository
 import com.riffle.core.domain.Series
 import com.riffle.core.domain.Server
 import com.riffle.core.domain.ServerRepository
+import com.riffle.core.domain.ServerType
 import com.riffle.core.domain.ServerUrl
+import com.riffle.core.domain.UnmatchedReadaloud
 import com.riffle.core.domain.VolumeKeyPreferencesStore
 import com.riffle.core.domain.WakeLockPreferencesStore
 import kotlinx.coroutines.Dispatchers
@@ -71,12 +78,17 @@ class SettingsViewModelTest {
         override suspend fun setInvertVolumeKeys(value: Boolean) { invertVolumeKeysFlow.value = value }
     }
 
-    private fun server(id: String, active: Boolean = false) = Server(
+    private fun server(
+        id: String,
+        active: Boolean = false,
+        serverType: ServerType = ServerType.AUDIOBOOKSHELF,
+    ) = Server(
         id = id,
         url = ServerUrl.parse("https://$id.example.com")!!,
         isActive = active,
         insecureConnectionAllowed = false,
         username = "",
+        serverType = serverType,
     )
 
     private fun library(id: String) = Library(id = id, name = id, mediaType = "book", isUnsupported = false)
@@ -140,6 +152,20 @@ class SettingsViewModelTest {
         override val isOnline: kotlinx.coroutines.flow.StateFlow<Boolean> = isOnlineFlow
     }
 
+    private val reviewsFlow = MutableStateFlow<Map<String, ReadaloudReview>>(emptyMap())
+    private val fakeReviewRepo = object : ReadaloudReviewRepository {
+        override fun observeReview(storytellerServerId: String): Flow<ReadaloudReview> =
+            reviewsFlow.map { it[storytellerServerId] ?: ReadaloudReview(emptyList(), emptyList(), emptyList()) }
+        override suspend fun hasPendingCandidates(storytellerServerId: String, storytellerBookId: String) = false
+        override suspend fun confirmCandidate(storytellerServerId: String, storytellerBookId: String, absServerId: String, absLibraryItemId: String) = Unit
+        override suspend fun dismissCandidate(storytellerServerId: String, storytellerBookId: String, absServerId: String, absLibraryItemId: String) = Unit
+        override suspend fun dismissBook(storytellerServerId: String, storytellerBookId: String) = Unit
+        override suspend fun unlinkBook(storytellerServerId: String, storytellerBookId: String) = Unit
+        override suspend fun unlinkAbsItem(absServerId: String, absLibraryItemId: String) = Unit
+        override suspend fun pairManually(storytellerServerId: String, storytellerBookId: String, absServerId: String, absLibraryItemId: String) = Unit
+        override suspend fun searchAbsItems(query: String): List<AbsPickerItem> = emptyList()
+    }
+
     private fun makeViewModel(report: CrashReport? = null) = SettingsViewModel(
         crashReportRepository = object : CrashReportRepository {
             override fun getLastCrashReport() = report
@@ -152,6 +178,7 @@ class SettingsViewModelTest {
         volumeKeyPreferencesStore = fakeVolumeKeyStore,
         audioCachePreferencesStore = fakeAudioCacheStore,
         readaloudAudioRepository = fakeReadaloudAudioRepo,
+        readaloudReviewRepository = fakeReviewRepo,
         connectivityObserver = fakeConnectivity,
     )
 
@@ -296,6 +323,51 @@ class SettingsViewModelTest {
         val items = vm.libraryUiItems.value
         assertTrue(items.all { it.switchEnabled })
     }
+
+    // --- readaloud matches summary ---
+
+    @Test
+    fun `readaloudSummaries reports per-server confirmed pending and unmatched counts`() = runTest {
+        serversFlow.value = listOf(server("st-1", active = true, serverType = ServerType.STORYTELLER))
+        reviewsFlow.value = mapOf(
+            "st-1" to ReadaloudReview(
+                pending = listOf(pending("b1")),
+                unmatched = listOf(unmatched("b2"), unmatched("b3")),
+                confirmed = listOf(confirmed("b4"), confirmed("b5"), confirmed("b6")),
+            )
+        )
+        val vm = makeViewModel()
+        backgroundScope.launch { vm.readaloudSummaries.collect {} }
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        val summary = vm.readaloudSummaries.value["st-1"]
+        assertEquals(ReadaloudMatchSummary(confirmedCount = 3, pendingCount = 1, unmatchedCount = 2), summary)
+    }
+
+    @Test
+    fun `readaloudSummaries is empty when there are no Storyteller servers`() = runTest {
+        serversFlow.value = listOf(server("abs-1", active = true))
+        val vm = makeViewModel()
+        backgroundScope.launch { vm.readaloudSummaries.collect {} }
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertTrue(vm.readaloudSummaries.value.isEmpty())
+    }
+
+    private fun pending(bookId: String) = PendingReadaloud(
+        storytellerServerId = "st-1", storytellerBookId = bookId,
+        title = bookId, author = "", coverUrl = null, candidates = emptyList(),
+    )
+
+    private fun unmatched(bookId: String) = UnmatchedReadaloud(
+        storytellerServerId = "st-1", storytellerBookId = bookId,
+        title = bookId, author = "", coverUrl = null,
+    )
+
+    private fun confirmed(bookId: String) = ConfirmedReadaloud(
+        storytellerServerId = "st-1", storytellerBookId = bookId,
+        title = bookId, targets = emptyList(),
+    )
 
     // --- volume key preferences ---
 

--- a/app/src/test/kotlin/com/riffle/app/feature/settings/SettingsViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/settings/SettingsViewModelTest.kt
@@ -116,6 +116,7 @@ class SettingsViewModelTest {
 
     private fun fakeLibraryRepo(): LibraryRepository = object : LibraryRepository {
         override fun observeLibraries(): Flow<List<Library>> = librariesFlow
+        override fun observeLibraries(serverId: String): Flow<List<Library>> = observeLibraries()
         override fun observeLibraryItems(libraryId: String): Flow<List<LibraryItem>> = MutableStateFlow(emptyList())
         override fun observeUngroupedLibraryItems(libraryId: String): Flow<List<LibraryItem>> = MutableStateFlow(emptyList())
         override fun observeInProgressItems(libraryId: String): Flow<List<LibraryItem>> = MutableStateFlow(emptyList())
@@ -269,7 +270,7 @@ class SettingsViewModelTest {
         serversFlow.value = listOf(server("srv-1", active = true))
         librariesFlow.value = listOf(library("lib-1"), library("lib-2"))
         val vm = makeViewModel()
-        backgroundScope.launch { vm.libraryUiItems.collect {} }
+        backgroundScope.launch { vm.libraryUiItemsByServer.collect {} }
         testDispatcher.scheduler.advanceUntilIdle()
 
         vm.setLibraryVisible(serverId = "srv-1", libraryId = "lib-1", visible = false)
@@ -285,7 +286,7 @@ class SettingsViewModelTest {
         librariesFlow.value = listOf(library("lib-1"), library("lib-2"))
         hiddenFlow.value = mapOf("srv-1" to setOf("lib-1"))
         val vm = makeViewModel()
-        backgroundScope.launch { vm.libraryUiItems.collect {} }
+        backgroundScope.launch { vm.libraryUiItemsByServer.collect {} }
         testDispatcher.scheduler.advanceUntilIdle()
 
         vm.setLibraryVisible(serverId = "srv-1", libraryId = "lib-1", visible = true)
@@ -301,10 +302,10 @@ class SettingsViewModelTest {
         librariesFlow.value = listOf(library("lib-1"), library("lib-2"))
         hiddenFlow.value = mapOf("srv-1" to setOf("lib-2"))  // only lib-1 is visible
         val vm = makeViewModel()
-        backgroundScope.launch { vm.libraryUiItems.collect {} }
+        backgroundScope.launch { vm.libraryUiItemsByServer.collect {} }
         testDispatcher.scheduler.advanceUntilIdle()
 
-        val items = vm.libraryUiItems.value
+        val items = vm.libraryUiItemsByServer.value["srv-1"].orEmpty()
         val lib1Item = items.first { it.library.id == "lib-1" }
         val lib2Item = items.first { it.library.id == "lib-2" }
         assertFalse("lib-1 is the sole visible library, its switch must be disabled", lib1Item.switchEnabled)
@@ -317,11 +318,27 @@ class SettingsViewModelTest {
         librariesFlow.value = listOf(library("lib-1"), library("lib-2"))
         // nothing hidden — both visible
         val vm = makeViewModel()
-        backgroundScope.launch { vm.libraryUiItems.collect {} }
+        backgroundScope.launch { vm.libraryUiItemsByServer.collect {} }
         testDispatcher.scheduler.advanceUntilIdle()
 
-        val items = vm.libraryUiItems.value
+        val items = vm.libraryUiItemsByServer.value["srv-1"].orEmpty()
         assertTrue(items.all { it.switchEnabled })
+    }
+
+    @Test
+    fun `libraryUiItemsByServer exposes libraries for a non-active ABS server`() = runTest {
+        serversFlow.value = listOf(
+            server("srv-active", active = true),
+            server("srv-other", active = false),
+        )
+        librariesFlow.value = listOf(library("lib-1"), library("lib-2"))
+        val vm = makeViewModel()
+        backgroundScope.launch { vm.libraryUiItemsByServer.collect {} }
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        // The non-active server still has manageable library items — no activation required.
+        val items = vm.libraryUiItemsByServer.value["srv-other"].orEmpty()
+        assertEquals(2, items.size)
     }
 
     // --- readaloud matches summary ---

--- a/core/data/src/main/kotlin/com/riffle/core/data/LibraryRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/LibraryRepositoryImpl.kt
@@ -60,6 +60,9 @@ class LibraryRepositoryImpl @Inject constructor(
                 else libraryDao.observeByServerId(serverId).map { list -> list.map { it.toDomain() } }
             }
 
+    override fun observeLibraries(serverId: String): Flow<List<Library>> =
+        libraryDao.observeByServerId(serverId).map { list -> list.map { it.toDomain() } }
+
     override fun observeLibraryItems(libraryId: String): Flow<List<LibraryItem>> =
         libraryItemDao.observeByLibraryId(libraryId).map { list -> list.map { it.toDomain() } }
 

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/LibraryRepository.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/LibraryRepository.kt
@@ -10,6 +10,10 @@ sealed class LibraryRefreshResult {
 
 interface LibraryRepository {
     fun observeLibraries(): Flow<List<Library>>
+
+    /** Libraries for a specific server (active or not). Reads the local DB; does not hit the network. */
+    fun observeLibraries(serverId: String): Flow<List<Library>>
+
     fun observeLibraryItems(libraryId: String): Flow<List<LibraryItem>>
     fun observeUngroupedLibraryItems(libraryId: String): Flow<List<LibraryItem>>
     fun observeInProgressItems(libraryId: String): Flow<List<LibraryItem>>

--- a/docs/superpowers/specs/2026-06-02-expandable-server-settings-design.md
+++ b/docs/superpowers/specs/2026-06-02-expandable-server-settings-design.md
@@ -33,18 +33,16 @@ It stays a **dedicated screen**. The Storyteller expansion shows a compact **sum
 row that navigates to the existing screen. The expansion only relocates the entry point under
 its server; it does not inline the matches UI.
 
-### Audio cache — make it genuinely global, not per-server (Option A + cleanup)
+### Audio cache — left untouched, out of scope
 
-Today the cache cap is *stored* per Storyteller server id, but the cache itself is a single
-shared on-disk store and `enforceCacheCap()` applies only the **active** server's cap to it.
-The per-server-ness is an implementation artifact, not real isolation, and would be a lie if
-surfaced under each server's expansion.
+The readaloud audio-cache cap is **not part of this task**. It only ever governs Storyteller
+readaloud audio (ABS EPUB/PDF books live in entirely separate cache/download stores with no
+app-level cap), and making it genuinely global — let alone unifying it with the book caches —
+is a separate piece of work.
 
-Resolution: treat the cap as **one global setting** and clean up the code to match.
-
-- It is **not** placed in any server's expansion. It remains its own section
-  ("Readaloud audio cache"), shown whenever at least one Storyteller server exists.
-- Storage collapses from per-`serverId` keys to a single global key.
+Resolution: the existing `Audio cache` section stays **exactly as it is today** (its own
+section, per-Storyteller-server dropdowns). It is **not** moved into any server expansion and
+no cache code is changed.
 
 ## Affected code
 
@@ -58,8 +56,7 @@ Resolution: treat the cap as **one global setting** and clean up the code to mat
 - Storyteller expansion renders the matches summary + navigate row (currently the standalone
   `Readaloud matches` section).
 - Remove the standalone `Libraries` and `Readaloud matches` sections.
-- `Audio cache` section becomes a single global "Readaloud audio cache" cap dropdown
-  (shown when any Storyteller server exists), no longer per-server.
+- Leave the `Audio cache` section exactly as-is (out of scope).
 
 ### ViewModel — `app/.../feature/settings/SettingsViewModel.kt`
 
@@ -69,27 +66,19 @@ Resolution: treat the cap as **one global setting** and clean up the code to mat
   server is out of scope for v1 — only the active ABS server shows its library switches.
   Non-active ABS expansions show a short note ("Activate this server to manage its
   libraries") rather than fetching. *(Confirm during planning — see Open questions.)*
-- `audioCacheCaps: StateFlow<Map<String, Long>>` → single `audioCacheCap: StateFlow<Long>`.
-- `setAudioCacheCap(serverId, cap)` → `setAudioCacheCap(cap)`.
+- `audioCacheCaps` / `setAudioCacheCap` are left unchanged (cache out of scope).
 - Add a matches **summary** stream per Storyteller server (counts of confirmed / pending /
   unmatched) to feed the expansion. Derive from the same source
   `ReadaloudMatchesViewModel` uses (`ReadaloudReview`).
 
-### Cache store — make global
+### Cache store — unchanged
 
-- `AudioCachePreferencesStore`: `capBytes(serverId)` / `setCapBytes(serverId, cap)` →
-  `capBytes()` / `setCapBytes(cap)`.
-- `AudioCachePreferencesStoreImpl`: single key `longPreferencesKey("audio_cache_cap")`
-  instead of `audio_cache_cap_$serverId`. No DataStore migration of old per-server values
-  is required (caps are a convenience setting that re-defaults to 2 GB); note this in the PR.
-- `ReadaloudAudioRepositoryImpl.enforceCacheCap()`: drop the `getActive()` lookup; read the
-  global cap directly.
-- Update the KDoc on the store (no longer "Per-Storyteller-Server").
+The audio-cache store, preferences, and `enforceCacheCap()` are **not touched** by this task.
 
 ## Testing
 
-- `SettingsViewModelTest`: update for the global `audioCacheCap` / `setAudioCacheCap(cap)`
-  signature; add a test for the new matches-summary stream.
+- `SettingsViewModelTest`: add a test for the new matches-summary stream. Audio-cache tests
+  stay as-is.
 - Harness UI test (phone form factor): expanding an ABS server reveals its library switches;
   expanding a Storyteller server reveals the matches summary + navigate row; collapsing hides
   them. Follow existing settings harness-test patterns.
@@ -98,12 +87,11 @@ Resolution: treat the cap as **one global setting** and clean up the code to mat
 ## Out of scope
 
 - Inlining the full matches UI (rejected — Option A chosen).
-- Genuinely partitioning the audio cache per server (Option B from discussion).
+- Any change to the readaloud audio-cache (global cap, per-server partitioning, or a unified
+  app-wide cap spanning the EPUB/PDF book caches) — all deferred as separate work.
 - Managing libraries for non-active ABS servers (deferred; see Open questions).
 
 ## Open questions (resolve in planning)
 
 1. Non-active ABS server expansion: show a "activate to manage" note vs. fetch libraries for
    any ABS server. Leaning toward the note for v1.
-2. Should the global audio-cache section move under a general "Storyteller" heading, or stay a
-   top-level "Readaloud audio cache" section? Leaning top-level.

--- a/docs/superpowers/specs/2026-06-02-expandable-server-settings-design.md
+++ b/docs/superpowers/specs/2026-06-02-expandable-server-settings-design.md
@@ -1,0 +1,109 @@
+# Expandable per-server settings — design
+
+**Date:** 2026-06-02
+**Branch:** `pkmetski/expandable-server-settings`
+
+## Problem
+
+In the Settings screen, server-specific settings are scattered as sibling sections
+(`Servers`, `Libraries`, `Readaloud matches`, `Audio cache`) rather than attached to the
+server they belong to. The user must infer which server each section governs, and
+`Libraries` only ever reflects the *active* server. This is confusing and doesn't scale as
+more servers are added.
+
+## Goal
+
+Make each server row in the `Servers` section an **expandable disclosure**. Tapping a row
+unfolds that server's own settings beneath it:
+
+- **Audiobookshelf** → **Enabled libraries** (visibility switches)
+- **Storyteller** → **Readaloud matches** (summary + entry point to the full matches screen)
+
+The standalone `Libraries`, `Readaloud matches` sibling sections go away — their content
+moves into the relevant server's expansion.
+
+## Scope decisions
+
+### Storyteller readaloud matches — stay a separate screen (Option A)
+
+The matches experience (`ReadaloudMatchesScreen`) is complex: Pending / Unmatched /
+Confirmed lists, per-item confirm/dismiss, cover images, and a manual-pairing search dialog.
+It stays a **dedicated screen**. The Storyteller expansion shows a compact **summary**
+(e.g. "3 confirmed · 1 pending review · 2 unmatched") plus a **"Review & pair readalouds →"**
+row that navigates to the existing screen. The expansion only relocates the entry point under
+its server; it does not inline the matches UI.
+
+### Audio cache — make it genuinely global, not per-server (Option A + cleanup)
+
+Today the cache cap is *stored* per Storyteller server id, but the cache itself is a single
+shared on-disk store and `enforceCacheCap()` applies only the **active** server's cap to it.
+The per-server-ness is an implementation artifact, not real isolation, and would be a lie if
+surfaced under each server's expansion.
+
+Resolution: treat the cap as **one global setting** and clean up the code to match.
+
+- It is **not** placed in any server's expansion. It remains its own section
+  ("Readaloud audio cache"), shown whenever at least one Storyteller server exists.
+- Storage collapses from per-`serverId` keys to a single global key.
+
+## Affected code
+
+### UI — `app/.../feature/settings/SettingsScreen.kt`
+
+- Servers section: each `ListItem` gains a leading chevron and click-to-expand behavior.
+  Keep the existing `SwipeToDismissBox` delete. Track expanded state per server id
+  (`remember { mutableStateMapOf<String, Boolean>() }` or similar). Animate with
+  `AnimatedVisibility` / `animateContentSize` (patterns already used elsewhere in the app).
+- ABS expansion renders the library switches (currently the standalone `Libraries` section).
+- Storyteller expansion renders the matches summary + navigate row (currently the standalone
+  `Readaloud matches` section).
+- Remove the standalone `Libraries` and `Readaloud matches` sections.
+- `Audio cache` section becomes a single global "Readaloud audio cache" cap dropdown
+  (shown when any Storyteller server exists), no longer per-server.
+
+### ViewModel — `app/.../feature/settings/SettingsViewModel.kt`
+
+- `libraryUiItems` currently keys off the **active** server only. For ABS expansions we need
+  libraries **per ABS server**. Decision: ABS libraries are still fetched for the active
+  server (the library list comes from the active connection); expanding a non-active ABS
+  server is out of scope for v1 — only the active ABS server shows its library switches.
+  Non-active ABS expansions show a short note ("Activate this server to manage its
+  libraries") rather than fetching. *(Confirm during planning — see Open questions.)*
+- `audioCacheCaps: StateFlow<Map<String, Long>>` → single `audioCacheCap: StateFlow<Long>`.
+- `setAudioCacheCap(serverId, cap)` → `setAudioCacheCap(cap)`.
+- Add a matches **summary** stream per Storyteller server (counts of confirmed / pending /
+  unmatched) to feed the expansion. Derive from the same source
+  `ReadaloudMatchesViewModel` uses (`ReadaloudReview`).
+
+### Cache store — make global
+
+- `AudioCachePreferencesStore`: `capBytes(serverId)` / `setCapBytes(serverId, cap)` →
+  `capBytes()` / `setCapBytes(cap)`.
+- `AudioCachePreferencesStoreImpl`: single key `longPreferencesKey("audio_cache_cap")`
+  instead of `audio_cache_cap_$serverId`. No DataStore migration of old per-server values
+  is required (caps are a convenience setting that re-defaults to 2 GB); note this in the PR.
+- `ReadaloudAudioRepositoryImpl.enforceCacheCap()`: drop the `getActive()` lookup; read the
+  global cap directly.
+- Update the KDoc on the store (no longer "Per-Storyteller-Server").
+
+## Testing
+
+- `SettingsViewModelTest`: update for the global `audioCacheCap` / `setAudioCacheCap(cap)`
+  signature; add a test for the new matches-summary stream.
+- Harness UI test (phone form factor): expanding an ABS server reveals its library switches;
+  expanding a Storyteller server reveals the matches summary + navigate row; collapsing hides
+  them. Follow existing settings harness-test patterns.
+- Existing `ReadaloudMatchesScreen` navigation continues to work from the new entry point.
+
+## Out of scope
+
+- Inlining the full matches UI (rejected — Option A chosen).
+- Genuinely partitioning the audio cache per server (Option B from discussion).
+- Managing libraries for non-active ABS servers (deferred; see Open questions).
+
+## Open questions (resolve in planning)
+
+1. Non-active ABS server expansion: show a "activate to manage" note vs. fetch libraries for
+   any ABS server. Leaning toward the note for v1.
+2. Should the global audio-cache section move under a general "Storyteller" heading, or stay a
+   top-level "Readaloud audio cache" section? Leaning top-level.


### PR DESCRIPTION
## What

Reorganizes Settings so each **server row expands** to reveal that server's own settings, instead of scattering them across sibling sections.

- **Audiobookshelf** → **Enabled libraries** (visibility switches), shown for **every** ABS server — not just the active one.
- **Storyteller** → **Readaloud matches** summary (`N confirmed · N pending review · N unmatched`) + a row that opens the existing full matches screen.
- Removed the standalone **Libraries** and **Readaloud matches** sections. The **Audio cache** section is left unchanged.

## Why "manage any server's libraries without activating it"

Library visibility was already stored per-server, and the `libraries` table keeps every server's rows simultaneously. Requiring a server to be *active* to edit its library list was purely an artifact of `LibraryRepository.observeLibraries()` being hardcoded to the active server. This adds `observeLibraries(serverId)` (reads the local DB per server) and builds `SettingsViewModel.libraryUiItemsByServer` for every ABS server, dropping the "Activate this server to manage its libraries" note.

## Scope notes

- Audio-cache work is intentionally out of scope (see design doc) — the readaloud cache is a single shared store; making it truly global / app-wide is separate work.
- The Storyteller linking/unlinking UI stays a dedicated screen (reached from the expansion).

## Tests

- `./gradlew test` — green
- `./gradlew lint` — green
- `make harness-test` — 133 tests, 0 failed (incl. new `ServerSettingsExpansionTest`)
- `make harness-test-tablet` — 5 tests, 0 failed
- New: `SettingsViewModelTest` coverage for `readaloudSummaries` and per-server libraries (incl. a non-active server); `ServerSettingsExpansionTest` isolated Compose UI tests for both server types.

Design doc: `docs/superpowers/specs/2026-06-02-expandable-server-settings-design.md`
