### PR TITLE
feat(annotations): sync-ready Room schema + create & render EPUB highlights

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,10 +4,6 @@
 
 Always run harness tests via `make harness-test` (phone-form-factor tests) or `make harness-test-tablet` (tests annotated with `@TabletLayout`). Never call `./gradlew :app:connectedDebugAndroidTest` directly — it targets all connected devices and will interfere with the developer's physical device. Each target boots its dedicated AVD ("Harness Medium Phone" or "Harness Medium Tablet"), runs its filtered test subset against it exclusively, then shuts it down. The two subsets are mutually exclusive, so tests never double-run across targets.
 
-## Feature progress
-
-When an issue is closed (a feature is implemented and merged), mark it as complete in the Features list in `README.md` by changing `- [ ]` to `- [x]` on the corresponding line, and include that change in the PR for that issue.
-
 ## Database migrations
 
 When adding a new Room migration:

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -112,14 +112,22 @@ An EPUB Canonical Fragment Identifier — a string of the form `epubcfi(/6/N!<do
 ### EPUB CFI Translator
 The layer (`EpubCfiTranslator`) responsible for converting between Readium's native position representation and the character-count-based EPUB CFI format used by ABS/epub.js. All `ebookLocation` values crossing the Riffle↔ABS API boundary — in both directions — must pass through this translator. Inbound: server CFI → within-chapter progression → Readium Locator. Outbound: Readium within-chapter progression → CFI doc path → full CFI string. `ebookProgress` (book-wide float) is a separate display field and does not go through the translator. See ADR 0013.
 
+### Annotation
+Umbrella term for the three user-authored marks attached to a Library Item: [Highlight], [Note], and [Bookmark]. All three share one storage model and one [Annotation Sync] format. Each carries a stable client-generated ID, creation and last-modified timestamps, and a device-origin tag, and anchors to an **EPUB CFI** (the same coordinate family ABS already stores in `mediaProgress.ebookLocation` and that the [EPUB CFI Translator] operates on). The CFI is the load-bearing, irreversible anchor choice; every Annotation additionally stores the surrounding text snippet and chapter href as a human-readable fallback and re-anchoring aid if the EPUB is re-uploaded.
+
+Annotations are an **ABS-book capability**, anchored in the **ABS EPUB's** coordinate system, and keyed by the ABS Library Item. A [Storyteller Server] is only a [Readaloud] provider, so a Storyteller-only (unmatched) book carries no Annotations, and — because the ABS and Storyteller editions are different EPUB files with different CFIs (see [ADR 0019](adr/0019-three-peer-unified-canonical-progress-sync.md)) — Annotations are created and displayed only while reading the **ABS side** in v1. Surfacing them on the Readaloud side (via ADR 0019's cross-EPUB index) is a deferred enhancement.
+
+### Annotation Sync
+The mechanism by which [Annotation]s roam between devices. The local Room store is always the primary, queryable store; Sync is an optional layer on top, reached through a single `AnnotationSyncTarget` abstraction (`list / read / write-own-file`) so the backing store is swappable without touching the format or the schema. The on-the-wire format is the **W3C Web Annotation Data Model** (JSON-LD), with a `riffle:` extension namespace carrying the merge-critical fields the standard omits (`device`, `updatedAt`, `deleted` tombstone). Two target *kinds* are anticipated: **blob-store** targets (a folder of one file per device per book, merged client-side by per-record last-write-wins — `deviceId` names the file, the annotation UUID is the identity) and **record-store** targets (per-record CRUD with server-side merge). **v1 ships local-only — no target implemented** — but the schema is sync-ready so enabling a target later is additive, never a migration. Abusing the ABS bookmark API as a record-store target was considered and **rejected**: it pollutes the audiobook-bookmark surface that Riffle itself will render once it becomes an audiobook player. A native ABS annotation endpoint is the eventual target the format is designed to slot into.
+
 ### Highlight
-A marked text range in an EPUB, stored with a colour and an optional Note. Anchored to an EPUB CFI position.
+A marked **text range** in an EPUB, stored with a colour and an optional [Note]. The colour is a token from a small fixed palette (yellow — the default — green, blue, pink), not a freeform value; the reader's theme system owns the light/dark RGB mapping so a Highlight stays legible in any theme. Anchored to a **CFI range** (start + end) over the selected text. An [Annotation].
 
 ### Note
-A user-written text annotation attached to a Highlight or a specific location in a Library Item.
+A user-written text comment on a [Highlight], annotating that range. In v1 a Note is **not a standalone entity** — it is an optional field on a Highlight, so a Highlight may exist with no Note, but a Note never exists without a Highlight. (A future standalone "margin note" at a bare location — a point anchor with a body — is deferred.) An [Annotation].
 
 ### Bookmark
-A saved position in a Library Item with no text selection — a pure location marker. Distinct from a Highlight.
+A saved reading location with no text selection — a pure location marker, distinct from a [Highlight]. Anchored to a **CFI point** at the top-of-viewport text of the current page (the reader's `currentLocator`, the same canonical position [Progress Sync] tracks); reflowable EPUBs have no fixed pages, so a Bookmark marks a text position, never a page number. An [Annotation].
 
 ### Table of Contents (TOC)
 The navigable chapter and subchapter structure of a Library Item, derived from the EPUB or PDF's own structure.

--- a/app/src/androidTest/kotlin/com/riffle/app/di/TestDatabaseModule.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/di/TestDatabaseModule.kt
@@ -3,6 +3,7 @@ package com.riffle.app.di
 import android.content.Context
 import androidx.room.Room
 import com.riffle.core.data.di.DatabaseModule
+import com.riffle.core.database.AnnotationDao
 import com.riffle.core.database.BookFormattingPreferencesDao
 import com.riffle.core.database.CollectionDao
 import com.riffle.core.database.CrossEpubIndexDao
@@ -87,4 +88,8 @@ object TestDatabaseModule {
     @Provides
     @Singleton
     fun provideCrossEpubIndexDao(db: RiffleDatabase): CrossEpubIndexDao = db.crossEpubIndexDao()
+
+    @Provides
+    @Singleton
+    fun provideAnnotationDao(db: RiffleDatabase): AnnotationDao = db.annotationDao()
 }

--- a/app/src/androidTest/kotlin/com/riffle/app/feature/reader/AnnotationReopenInstrumentedTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/reader/AnnotationReopenInstrumentedTest.kt
@@ -1,0 +1,147 @@
+package com.riffle.app.feature.reader
+
+import androidx.room.Room
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.riffle.core.data.AnnotationStoreImpl
+import com.riffle.core.database.RiffleDatabase
+import com.riffle.core.database.ServerEntity
+import com.riffle.core.domain.DeviceIdStore
+import dagger.hilt.android.testing.HiltAndroidRule
+import dagger.hilt.android.testing.HiltAndroidTest
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import org.junit.runner.RunWith
+import org.readium.r2.shared.util.AbsoluteUrl
+import org.readium.r2.shared.util.Try
+import org.readium.r2.shared.util.asset.AssetRetriever
+import org.readium.r2.streamer.PublicationOpener
+import java.io.File
+import java.util.zip.ZipFile
+import javax.inject.Inject
+
+/**
+ * End-to-end re-render-on-reopen for highlights against a real EPUB, without driving WebView text
+ * selection. Exercises the load-bearing path (ADR 0024): a selection's start progression + text →
+ * a persisted CFI **range**, then — as on reopen — that range re-anchored back to a within-chapter
+ * progression and spine index. The Readium decoration itself is rendered by the same
+ * DecorableNavigator mechanism the search/readaloud highlights already use.
+ */
+@HiltAndroidTest
+@RunWith(AndroidJUnit4::class)
+class AnnotationReopenInstrumentedTest {
+
+    @get:Rule(order = 0) val hiltRule = HiltAndroidRule(this)
+    @get:Rule(order = 1) val tmp = TemporaryFolder()
+
+    @Inject lateinit var assetRetriever: AssetRetriever
+    @Inject lateinit var publicationOpener: PublicationOpener
+
+    private lateinit var db: RiffleDatabase
+    private lateinit var store: AnnotationStoreImpl
+
+    private class FixedDeviceIdStore : DeviceIdStore {
+        override suspend fun getOrCreate(): String = "device-test"
+    }
+
+    @Before
+    fun setUp() {
+        hiltRule.inject()
+        db = Room.inMemoryDatabaseBuilder(
+            InstrumentationRegistry.getInstrumentation().targetContext,
+            RiffleDatabase::class.java,
+        ).allowMainThreadQueries().build()
+        store = AnnotationStoreImpl(
+            dao = db.annotationDao(),
+            deviceIdStore = FixedDeviceIdStore(),
+            clock = { 1_000L },
+            idGenerator = { "uuid-1" },
+        )
+    }
+
+    @After
+    fun tearDown() {
+        db.close()
+    }
+
+    @Test
+    fun highlightPersistsAsRangeAndReanchorsOnReopen() = runTest {
+        val epubFile = copyTestEpub()
+        val pub = openTestEpub(epubFile)
+        // annotations.serverId is a FK → seed the ABS server.
+        db.serverDao().upsert(
+            ServerEntity("abs1", "http://abs1", isActive = true, insecureConnectionAllowed = false, username = "u"),
+        )
+
+        // Chapter 0 of the test EPUB.
+        val spineIndex = 0
+        val link = pub.readingOrder[spineIndex]
+        val html = readChapterHtml(epubFile, normalizeEpubHref(link.href.toString()))
+        assertNotNull("test EPUB chapter 0 HTML should be readable", html)
+        val spineStep = (spineIndex + 1) * 2
+
+        // A selection a little way into the chapter.
+        val startProgression = 0.1
+        val selectedText = "the"
+        val cfiRange = buildHighlightCfiRangeForSelection(spineStep, html!!, startProgression, selectedText)
+        assertNotNull("a range CFI should be built from the selection", cfiRange)
+        assertTrue("a highlight CFI must be a range (comma-separated)", cfiRange!!.contains(','))
+
+        // Create (persist) the highlight, scoped to the ABS item.
+        store.createHighlight(
+            serverId = "abs1",
+            itemId = "item-1",
+            cfi = cfiRange,
+            textSnippet = selectedText,
+            chapterHref = link.href.toString(),
+        )
+
+        // Reopen: read back what's stored and re-anchor it, exactly as the ViewModel does.
+        val reopened = store.observeHighlights("abs1", "item-1").first()
+        assertEquals(1, reopened.size)
+        val stored = reopened[0]
+        assertEquals(cfiRange, stored.cfi)
+        assertEquals(selectedText, stored.textSnippet)
+
+        assertEquals(
+            "stored CFI must re-anchor to the original spine item on reopen",
+            spineIndex,
+            epubCfiToSpineIndex(stored.cfi),
+        )
+        val reanchored = highlightStartProgression(stored.cfi, html)
+        assertNotNull("stored CFI must re-anchor to a within-chapter progression", reanchored)
+        assertEquals(
+            "re-anchored start progression must recover the original selection start",
+            startProgression,
+            reanchored!!,
+            0.02,
+        )
+    }
+
+    private fun copyTestEpub(): File {
+        val context = InstrumentationRegistry.getInstrumentation().context
+        val epubBytes = context.assets.open("test.epub").use { it.readBytes() }
+        return File(tmp.newFolder("epub"), "test.epub").also { it.writeBytes(epubBytes) }
+    }
+
+    private suspend fun openTestEpub(epubFile: File) = run {
+        val url = AbsoluteUrl("file://${epubFile.absolutePath}")!!
+        val asset = (assetRetriever.retrieve(url) as Try.Success).value
+        (publicationOpener.open(asset, allowUserInteraction = false) as Try.Success).value
+    }
+
+    private fun readChapterHtml(epubFile: File, entryPath: String): String? =
+        ZipFile(epubFile).use { zip ->
+            zip.getEntry(entryPath)?.let { entry ->
+                zip.getInputStream(entry).bufferedReader().readText()
+            }
+        }
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubCfiRange.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubCfiRange.kt
@@ -1,0 +1,88 @@
+package com.riffle.app.feature.reader
+
+import org.jsoup.Jsoup
+
+// Builds an EPUB CFI *range* for a highlight (ADR 0024). Reuses the char-count positioning model
+// of EpubCfiTranslator so the range's endpoints are in the same coordinate family ABS stores.
+//
+// A range CFI factors the two endpoints to their nearest common ancestor:
+//   epubcfi(/6/<spineStep>!<commonParent>,<startRemainder>,<endRemainder>)
+// e.g. epubcfi(/6/4!/4/2,/1:0,/1:5) — both ends inside the same text node of the first paragraph.
+
+/**
+ * Build a range CFI spanning [startChar]..[endChar] (body character offsets, blank-text-node aware)
+ * within the chapter [html] at spine step [spineStep] (i.e. `/6/<spineStep>`). Returns null when
+ * either offset falls outside the document.
+ */
+internal fun buildHighlightCfiRange(spineStep: Int, html: String, startChar: Long, endChar: Long): String? {
+    val doc = Jsoup.parse(html)
+    val htmlEl = doc.child(0) ?: return null
+    val body = doc.body() ?: return null
+
+    val (startNode, startOffset) = findNodeAtChar(body, startChar) ?: return null
+    val (endNode, endOffset) = findNodeAtChar(body, endChar) ?: return null
+
+    val startPath = buildCfiDocPath(htmlEl, startNode, startOffset) ?: return null
+    val endPath = buildCfiDocPath(htmlEl, endNode, endOffset) ?: return null
+
+    val startTokens = startPath.trimStart('/').split('/')
+    val endTokens = endPath.trimStart('/').split('/')
+
+    var common = 0
+    while (common < startTokens.size && common < endTokens.size && startTokens[common] == endTokens[common]) {
+        common++
+    }
+
+    val parent = "/" + startTokens.take(common).joinToString("/")
+    val startRemainder = "/" + startTokens.drop(common).joinToString("/")
+    val endRemainder = "/" + endTokens.drop(common).joinToString("/")
+
+    return "epubcfi(/6/$spineStep!$parent,$startRemainder,$endRemainder)"
+}
+
+/**
+ * Build a range CFI from a Readium selection's start [startProgression] and its [selectedText].
+ * The end is the start advanced by the selected text's length in the char-count model — exact for
+ * single-node selections and a close best-effort across nodes (the end point is not load-bearing;
+ * the start point and text snippet re-anchor the highlight). Returns null for blank selections or
+ * when the start falls outside the document.
+ */
+internal fun buildHighlightCfiRangeForSelection(
+    spineStep: Int,
+    html: String,
+    startProgression: Double,
+    selectedText: String,
+): String? {
+    if (selectedText.isBlank()) return null
+    val doc = Jsoup.parse(html)
+    val body = doc.body() ?: return null
+    val totalChars = countBodyChars(body)
+    if (totalChars == 0L) return null
+
+    val startChar = (startProgression.coerceIn(0.0, 1.0) * totalChars).toLong().coerceIn(0L, totalChars - 1L)
+    val endChar = (startChar + selectedText.length).coerceAtMost(totalChars - 1L)
+    return buildHighlightCfiRange(spineStep, html, startChar, endChar)
+}
+
+/**
+ * The absolute doc path of a range CFI's start point — `<commonParent><startRemainder>` — suitable
+ * for [cfiDocPathToProgression]. Returns null if [rangeCfi] is not a well-formed range.
+ */
+internal fun rangeStartDocPath(rangeCfi: String): String? {
+    val docPath = extractCfiDocPath(rangeCfi) ?: return null
+    val parts = docPath.split(',')
+    if (parts.size != 3) return null
+    val parent = parts[0].trimEnd('/')
+    val startRemainder = parts[1]
+    return parent + startRemainder
+}
+
+/**
+ * The within-chapter progression of a stored highlight's start, used to re-anchor (re-render) the
+ * highlight on reopen. Returns null when [rangeCfi] is not a range or its start can't be located in
+ * [html].
+ */
+internal fun highlightStartProgression(rangeCfi: String, html: String): Double? {
+    val startDocPath = rangeStartDocPath(rangeCfi) ?: return null
+    return cfiDocPathToProgression(startDocPath, html)
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -183,6 +183,8 @@ fun EpubReaderScreen(
     val tocVisible by viewModel.tocVisible.collectAsState()
     val footnotePopup by viewModel.footnotePopup.collectAsState()
 
+    val annotationsAvailable by viewModel.annotationsAvailable.collectAsState()
+    val highlightRenders by viewModel.highlightRenders.collectAsState()
     val readaloudAvailable by viewModel.readaloudAvailable.collectAsState()
     val readaloudOpen by viewModel.readaloudOpen.collectAsState()
     val readaloudExpanded by viewModel.readaloudExpanded.collectAsState()
@@ -243,6 +245,9 @@ fun EpubReaderScreen(
                         advancePageEvents = viewModel.advancePageEvents,
                         onReportVisibleFragments = viewModel::reportVisibleFragments,
                         onPlayFromHere = viewModel::playFromHere,
+                        annotationsAvailable = annotationsAvailable,
+                        highlightRenders = highlightRenders,
+                        onHighlight = viewModel::createHighlight,
                         modifier = Modifier
                             .fillMaxSize()
                             .testTag("reader_ready")
@@ -586,6 +591,9 @@ private fun EpubNavigatorView(
     advancePageEvents: Flow<Unit>,
     onReportVisibleFragments: (Set<String>) -> Unit,
     onPlayFromHere: (fragmentRef: String) -> Unit,
+    annotationsAvailable: Boolean,
+    highlightRenders: List<EpubReaderViewModel.HighlightRender>,
+    onHighlight: (Locator) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val context = LocalContext.current
@@ -608,6 +616,8 @@ private fun EpubNavigatorView(
     val currentOnTap by rememberUpdatedState(onTap)
     val currentOnFootnoteTapped by rememberUpdatedState(onFootnoteTapped)
     val currentOnPlayFromHere by rememberUpdatedState(onPlayFromHere)
+    val currentOnHighlight by rememberUpdatedState(onHighlight)
+    val currentAnnotationsAvailable by rememberUpdatedState(annotationsAvailable)
     val currentPublication by rememberUpdatedState(state.publication)
 
     // "Play from here" is added to the WebView text-selection action bar via Readium's
@@ -617,9 +627,13 @@ private fun EpubNavigatorView(
     // we use the selection's first fragment id (locations.fragments) when present, falling back to
     // the bare href; ReadaloudTrack.clipForFragment then matches the nearest narrated clip it can.
     val playFromHereMenuId = remember { View.generateViewId() }
+    // "Highlight" is added to the same Readium selection action bar (ADR 0024). Gated on
+    // annotationsAvailable so it never shows on a Storyteller-only book / the Readaloud side.
+    val highlightMenuId = remember { View.generateViewId() }
     val playFromHereActionMode = remember {
         object : android.view.ActionMode.Callback {
             override fun onCreateActionMode(mode: android.view.ActionMode, menu: android.view.Menu): Boolean {
+                if (currentAnnotationsAvailable) menu.add(0, highlightMenuId, 0, "Highlight")
                 menu.add(0, playFromHereMenuId, 0, "Play from here")
                 return true
             }
@@ -627,18 +641,34 @@ private fun EpubNavigatorView(
             override fun onPrepareActionMode(mode: android.view.ActionMode, menu: android.view.Menu) = false
 
             override fun onActionItemClicked(mode: android.view.ActionMode, item: android.view.MenuItem): Boolean {
-                if (item.itemId != playFromHereMenuId) return false
-                val selectable = fragmentRef.value as? org.readium.r2.navigator.SelectableNavigator ?: return false
-                coroutineScope.launch {
-                    val selection = selectable.currentSelection() ?: return@launch
-                    val loc = selection.locator
-                    val fragId = loc.locations.fragments.firstOrNull()
-                    val ref = if (fragId != null) "${loc.href}#$fragId" else loc.href.toString()
-                    currentOnPlayFromHere(ref)
-                    selectable.clearSelection()
+                when (item.itemId) {
+                    highlightMenuId -> {
+                        val selectable = fragmentRef.value as? org.readium.r2.navigator.SelectableNavigator
+                            ?: return false
+                        coroutineScope.launch {
+                            val selection = selectable.currentSelection() ?: return@launch
+                            currentOnHighlight(selection.locator)
+                            selectable.clearSelection()
+                        }
+                        mode.finish()
+                        return true
+                    }
+                    playFromHereMenuId -> {
+                        val selectable = fragmentRef.value as? org.readium.r2.navigator.SelectableNavigator
+                            ?: return false
+                        coroutineScope.launch {
+                            val selection = selectable.currentSelection() ?: return@launch
+                            val loc = selection.locator
+                            val fragId = loc.locations.fragments.firstOrNull()
+                            val ref = if (fragId != null) "${loc.href}#$fragId" else loc.href.toString()
+                            currentOnPlayFromHere(ref)
+                            selectable.clearSelection()
+                        }
+                        mode.finish()
+                        return true
+                    }
+                    else -> return false
                 }
-                mode.finish()
-                return true
             }
 
             override fun onDestroyActionMode(mode: android.view.ActionMode) {}
@@ -806,6 +836,34 @@ private fun EpubNavigatorView(
             fragment.applyDecorations(listOf(decoration), group = "readaloud")
         }
         hasReadaloudDecoration.value = true
+    }
+
+    // ---- Persisted highlights (ADR 0024) ---------------------------------------------------
+    // Renders all of a book's stored highlights via the same DecorableNavigator mechanism, on its
+    // own "annotations" group. Re-applied whenever the set changes — including the re-render of
+    // every highlight when the book is reopened, and the immediate paint after a new highlight.
+    val hasHighlightDecorations = remember { mutableStateOf(false) }
+    LaunchedEffect(highlightRenders) {
+        val fragment = fragmentRef.value as? DecorableNavigator ?: return@LaunchedEffect
+        if (highlightRenders.isEmpty()) {
+            if (!hasHighlightDecorations.value) return@LaunchedEffect
+            withContext(Dispatchers.Main) {
+                fragment.applyDecorations(emptyList(), group = "annotations")
+            }
+            hasHighlightDecorations.value = false
+            return@LaunchedEffect
+        }
+        val decorations = highlightRenders.map { h ->
+            Decoration(
+                id = h.id,
+                locator = h.locator,
+                style = Decoration.Style.Highlight(tint = highlightTint(h.color)),
+            )
+        }
+        withContext(Dispatchers.Main) {
+            fragment.applyDecorations(decorations, group = "annotations")
+        }
+        hasHighlightDecorations.value = true
     }
 
     // ---- Auto-page-turn --------------------------------------------------------------------
@@ -1118,3 +1176,8 @@ private fun PullChip(forward: Boolean, progress: Float) {
     }
 }
 
+
+// Maps an annotation colour token to a Readium highlight tint. v1 has only yellow (ADR 0024); a
+// later colour-picker slice maps `color` to other tints.
+private fun highlightTint(color: String): Int =
+    android.graphics.Color.parseColor("#FFFDE68A")

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -10,6 +10,8 @@ import com.riffle.app.feature.reader.readaloud.PlayerCoordinator
 import com.riffle.app.feature.reader.readaloud.ReadaloudController
 import com.riffle.core.data.StorytellerPositionSyncController
 import com.riffle.core.data.StorytellerSyncOutcome
+import com.riffle.core.domain.Annotation
+import com.riffle.core.domain.AnnotationStore
 import com.riffle.core.domain.BookFormattingOverrides
 import com.riffle.core.domain.BookFormattingPreferencesStore
 import com.riffle.core.domain.ConnectivityObserver
@@ -104,6 +106,7 @@ class EpubReaderViewModel @Inject constructor(
     private val connectivityObserver: ConnectivityObserver,
     private val threePeerSyncFactory: ThreePeerReaderSyncFactory,
     private val readingPositionStore: ReadingPositionStore,
+    private val annotationStore: AnnotationStore,
 ) : AndroidViewModel(application) {
 
     private val itemId: String = checkNotNull(savedStateHandle["itemId"])
@@ -211,6 +214,24 @@ class EpubReaderViewModel @Inject constructor(
     // be downloaded on demand); ABS books qualify only when a synced bundle is already present.
     private var isStorytellerServer = false
 
+    // ---- Annotations (ADR 0024 / 0025) -------------------------------------------------------
+
+    // The ABS server hosting this item; annotations key on it together with itemId. Resolved once
+    // the active server is known. Null on the Storyteller-only / Readaloud side, where annotations
+    // are absent.
+    private var annotationServerId: String? = null
+
+    // Highlights exist only while reading the ABS side. False on a Storyteller-only book — the
+    // "Highlight" affordance must not appear there (ADR 0024).
+    private val _annotationsAvailable = MutableStateFlow(false)
+    val annotationsAvailable: StateFlow<Boolean> = _annotationsAvailable
+
+    /** A persisted highlight reconstructed into a renderable Readium locator + colour token. */
+    data class HighlightRender(val id: String, val locator: Locator, val color: String)
+
+    private val _highlightRenders = MutableStateFlow<List<HighlightRender>>(emptyList())
+    val highlightRenders: StateFlow<List<HighlightRender>> = _highlightRenders
+
     private val _readaloudAvailable = MutableStateFlow(false)
     val readaloudAvailable: StateFlow<Boolean> = _readaloudAvailable
 
@@ -297,9 +318,17 @@ class EpubReaderViewModel @Inject constructor(
         viewModelScope.launch {
             // Active-server type decides Readaloud availability: every Storyteller book qualifies,
             // while ABS books qualify only when a synced bundle has already been downloaded.
-            isStorytellerServer = serverRepository.getActive()?.serverType == ServerType.STORYTELLER
+            val activeServer = serverRepository.getActive()
+            isStorytellerServer = activeServer?.serverType == ServerType.STORYTELLER
             _readaloudAvailable.value =
                 isStorytellerServer || readaloudAudioRepository.isAudioAvailable(itemId)
+
+            // Annotations are ABS-side only (ADR 0024): available on a non-Storyteller server.
+            if (!isStorytellerServer && activeServer != null) {
+                annotationServerId = activeServer.id
+                _annotationsAvailable.value = true
+                observeHighlights(activeServer.id)
+            }
         }
         @OptIn(FlowPreview::class)
         viewModelScope.launch {
@@ -511,6 +540,73 @@ class EpubReaderViewModel @Inject constructor(
         // Fallback: no usable CFI — navigate via book-wide progress float
         val progress = serverProgress.ebookProgress.toDouble().coerceIn(0.0, 1.0)
         return if (progress > 0.0) pub.locateProgression(progress) else null
+    }
+
+    // ---- Annotations -------------------------------------------------------------------------
+
+    // Keeps highlightRenders in sync with the store. Re-runs when the book finishes opening
+    // (state → Ready) so persisted highlights re-render on reopen, and whenever the set changes.
+    private fun observeHighlights(serverId: String) {
+        viewModelScope.launch {
+            combine(
+                annotationStore.observeHighlights(serverId, itemId),
+                state,
+            ) { annotations, st -> annotations to (st is ReaderState.Ready) }
+                .collect { (annotations, ready) ->
+                    _highlightRenders.value =
+                        if (!ready) emptyList() else annotations.mapNotNull { annotationToRender(it) }
+                }
+        }
+    }
+
+    // Create a yellow highlight at the current text selection. Anchors on a CFI range built from
+    // the selection's start progression + selected text (ADR 0024), capturing the snippet + href.
+    fun createHighlight(selectionLocator: Locator) {
+        val serverId = annotationServerId ?: return
+        viewModelScope.launch {
+            val pub = publication ?: return@launch
+            val snippet = selectionLocator.text.highlight?.takeIf { it.isNotBlank() } ?: return@launch
+            val href = selectionLocator.href.toString()
+            val spineIndex = pub.readingOrder.indexOfFirst {
+                normalizeEpubHref(it.href.toString()) == normalizeEpubHref(href)
+            }
+            if (spineIndex < 0) return@launch
+            val spineStep = (spineIndex + 1) * 2
+            val html = readChapterHtml(spineIndex) ?: return@launch
+            val progression = selectionLocator.locations.progression ?: 0.0
+            val cfiRange = buildHighlightCfiRangeForSelection(spineStep, html, progression, snippet)
+                ?: return@launch
+            annotationStore.createHighlight(
+                serverId = serverId,
+                itemId = itemId,
+                cfi = cfiRange,
+                textSnippet = snippet,
+                chapterHref = href,
+            )
+            // observeHighlights re-emits → highlightRenders updates → the screen re-applies decorations.
+        }
+    }
+
+    // Reconstruct a persisted highlight into a renderable Readium locator. The CFI start re-anchors
+    // the within-chapter position; the text snippet lets Readium's decorator locate the range.
+    private suspend fun annotationToRender(a: Annotation): HighlightRender? {
+        val pub = publication ?: return null
+        val spineIndex = epubCfiToSpineIndex(a.cfi) ?: return null
+        val link = pub.readingOrder.getOrNull(spineIndex) ?: return null
+        val html = readChapterHtml(spineIndex) ?: return null
+        val progression = highlightStartProgression(a.cfi, html) ?: return null
+        val locator = try {
+            Locator.fromJSON(
+                JSONObject()
+                    .put("href", link.href.toString())
+                    .put("type", "application/xhtml+xml")
+                    .put("locations", JSONObject().put("progression", progression))
+                    .put("text", JSONObject().put("highlight", a.textSnippet)),
+            )
+        } catch (_: Exception) {
+            null
+        } ?: return null
+        return HighlightRender(a.id, locator, a.color)
     }
 
     private suspend fun readChapterHtml(spineIndex: Int): String? {

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/EpubCfiRangeTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/EpubCfiRangeTest.kt
@@ -1,0 +1,95 @@
+package com.riffle.app.feature.reader
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+// Shares the char-count model of EpubCfiTranslatorTest:
+// body = "Hello world"(11) + "Second paragraph"(16) = 27 chars; body=step4, p[0]=step2, p[1]=step4, text=step1.
+class EpubCfiRangeTest {
+
+    private val simpleHtml = """
+        <html>
+          <head><title>Test</title></head>
+          <body>
+            <p>Hello world</p>
+            <p>Second paragraph</p>
+          </body>
+        </html>
+    """.trimIndent()
+
+    // A selection wholly inside one text node factors to a shared parent with two char offsets.
+    @Test
+    fun `range within a single text node shares the element parent`() {
+        // "Hello" = chars 0..5 of the first paragraph.
+        assertEquals(
+            "epubcfi(/6/4!/4/2,/1:0,/1:5)",
+            buildHighlightCfiRange(spineStep = 4, html = simpleHtml, startChar = 0, endChar = 5),
+        )
+    }
+
+    // A selection crossing paragraph boundaries factors to the nearest common ancestor.
+    @Test
+    fun `range spanning two paragraphs factors to the common ancestor`() {
+        // start char 6 ('w' in "world", p[0]); end char 13 (offset 2 in "Second", p[1] starts at 11).
+        assertEquals(
+            "epubcfi(/6/4!/4,/2/1:6,/4/1:2)",
+            buildHighlightCfiRange(spineStep = 4, html = simpleHtml, startChar = 6, endChar = 13),
+        )
+    }
+
+    // The start point of the produced range round-trips back to a progression (load-bearing on reopen).
+    @Test
+    fun `range start round-trips through cfiDocPathToProgression`() {
+        val cfi = buildHighlightCfiRange(spineStep = 4, html = simpleHtml, startChar = 0, endChar = 5)!!
+        // Reconstruct the start point: take the parent + start remainder.
+        val startPoint = rangeStartDocPath(cfi)!!
+        assertEquals(0.0, cfiDocPathToProgression(startPoint, simpleHtml)!!, 0.0001)
+    }
+
+    @Test
+    fun `returns null when the char positions fall outside the document`() {
+        assertNull(buildHighlightCfiRange(spineStep = 4, html = simpleHtml, startChar = 999, endChar = 1000))
+    }
+
+    // The ViewModel-facing entry point: a selection's start progression + selected text → range CFI.
+    @Test
+    fun `selection at start of chapter highlighting Hello yields the same range`() {
+        // progression 0.0 = char 0; "Hello" is 5 chars → end char 5.
+        assertEquals(
+            "epubcfi(/6/4!/4/2,/1:0,/1:5)",
+            buildHighlightCfiRangeForSelection(
+                spineStep = 4,
+                html = simpleHtml,
+                startProgression = 0.0,
+                selectedText = "Hello",
+            ),
+        )
+    }
+
+    // On reopen a stored highlight is re-anchored from its CFI start → within-chapter progression.
+    @Test
+    fun `highlightStartProgression recovers the selection start from a stored range CFI`() {
+        val cfi = buildHighlightCfiRangeForSelection(
+            spineStep = 4, html = simpleHtml, startProgression = 0.0, selectedText = "Hello",
+        )!!
+        assertEquals(0.0, highlightStartProgression(cfi, simpleHtml)!!, 0.0001)
+    }
+
+    @Test
+    fun `highlightStartProgression returns null for a non-range CFI`() {
+        assertNull(highlightStartProgression("epubcfi(/6/4!/4/2/1:0)", simpleHtml))
+    }
+
+    @Test
+    fun `selection with blank selected text yields null`() {
+        assertNull(
+            buildHighlightCfiRangeForSelection(
+                spineStep = 4,
+                html = simpleHtml,
+                startProgression = 0.0,
+                selectedText = "",
+            ),
+        )
+    }
+}

--- a/core/data/src/main/kotlin/com/riffle/core/data/AnnotationStoreImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/AnnotationStoreImpl.kt
@@ -1,0 +1,78 @@
+package com.riffle.core.data
+
+import com.riffle.core.database.AnnotationDao
+import com.riffle.core.database.AnnotationEntity
+import com.riffle.core.domain.Annotation
+import com.riffle.core.domain.AnnotationStore
+import com.riffle.core.domain.DeviceIdStore
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import java.util.UUID
+import javax.inject.Inject
+
+class AnnotationStoreImpl(
+    private val dao: AnnotationDao,
+    private val deviceIdStore: DeviceIdStore,
+    private val clock: () -> Long,
+    private val idGenerator: () -> String,
+) : AnnotationStore {
+
+    @Inject
+    constructor(dao: AnnotationDao, deviceIdStore: DeviceIdStore) : this(
+        dao = dao,
+        deviceIdStore = deviceIdStore,
+        clock = { System.currentTimeMillis() },
+        idGenerator = { UUID.randomUUID().toString() },
+    )
+
+    override fun observeHighlights(serverId: String, itemId: String): Flow<List<Annotation>> =
+        dao.observeForItem(serverId, itemId).map { rows -> rows.map { it.toDomain() } }
+
+    override suspend fun createHighlight(
+        serverId: String,
+        itemId: String,
+        cfi: String,
+        textSnippet: String,
+        chapterHref: String,
+        color: String,
+    ): Annotation {
+        val deviceId = deviceIdStore.getOrCreate()
+        val now = clock()
+        val entity = AnnotationEntity(
+            id = idGenerator(),
+            serverId = serverId,
+            itemId = itemId,
+            type = AnnotationEntity.TYPE_HIGHLIGHT,
+            cfi = cfi,
+            color = color,
+            note = null,
+            textSnippet = textSnippet,
+            chapterHref = chapterHref,
+            createdAt = now,
+            updatedAt = now,
+            originDeviceId = deviceId,
+            lastModifiedByDeviceId = deviceId,
+            deleted = false,
+        )
+        dao.upsert(entity)
+        return entity.toDomain()
+    }
+
+    override suspend fun delete(id: String) {
+        dao.tombstone(id, updatedAt = clock(), deviceId = deviceIdStore.getOrCreate())
+    }
+}
+
+private fun AnnotationEntity.toDomain() = Annotation(
+    id = id,
+    serverId = serverId,
+    itemId = itemId,
+    type = type,
+    cfi = cfi,
+    color = color,
+    note = note,
+    textSnippet = textSnippet,
+    chapterHref = chapterHref,
+    createdAt = createdAt,
+    updatedAt = updatedAt,
+)

--- a/core/data/src/main/kotlin/com/riffle/core/data/DeviceIdStoreImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/DeviceIdStoreImpl.kt
@@ -1,0 +1,29 @@
+package com.riffle.core.data
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import com.riffle.core.data.di.DeviceIdDataStore
+import com.riffle.core.domain.DeviceIdStore
+import java.util.UUID
+import javax.inject.Inject
+
+class DeviceIdStoreImpl @Inject constructor(
+    @param:DeviceIdDataStore private val dataStore: DataStore<Preferences>,
+) : DeviceIdStore {
+
+    override suspend fun getOrCreate(): String {
+        // Mint inside the atomic edit so concurrent first-run callers agree on one value.
+        var result = ""
+        dataStore.edit { prefs ->
+            val id = prefs[KEY_DEVICE_ID] ?: UUID.randomUUID().toString().also { prefs[KEY_DEVICE_ID] = it }
+            result = id
+        }
+        return result
+    }
+
+    private companion object {
+        val KEY_DEVICE_ID = stringPreferencesKey("device_id")
+    }
+}

--- a/core/data/src/main/kotlin/com/riffle/core/data/di/DataModule.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/di/DataModule.kt
@@ -6,11 +6,13 @@ import androidx.datastore.preferences.core.Preferences
 import com.riffle.core.data.BookFormattingPreferencesStoreImpl
 import com.riffle.core.data.ConnectivityObserverImpl
 import com.riffle.core.data.CrashReportRepositoryImpl
+import com.riffle.core.data.DeviceIdStoreImpl
 import com.riffle.core.data.DownloadsRepositoryImpl
 import com.riffle.core.data.EpubRepositoryImpl
 import com.riffle.core.data.FormattingPreferencesStoreImpl
 import com.riffle.core.data.KeystoreTokenStorage
 import com.riffle.core.data.LibraryRepositoryImpl
+import com.riffle.core.data.AnnotationStoreImpl
 import com.riffle.core.data.AudioCachePreferencesStoreImpl
 import com.riffle.core.data.LibraryVisibilityPreferencesStoreImpl
 import com.riffle.core.data.LocalStoreImpl
@@ -25,10 +27,12 @@ import com.riffle.core.data.ToReadRepository
 import com.riffle.core.data.ToReadRepositoryImpl
 import com.riffle.core.data.VolumeKeyPreferencesStoreImpl
 import com.riffle.core.data.WakeLockPreferencesStoreImpl
+import com.riffle.core.domain.AnnotationStore
 import com.riffle.core.domain.AudioCachePreferencesStore
 import com.riffle.core.domain.BookFormattingPreferencesStore
 import com.riffle.core.domain.ConnectivityObserver
 import com.riffle.core.domain.CrashReportRepository
+import com.riffle.core.domain.DeviceIdStore
 import com.riffle.core.domain.DownloadsRepository
 import com.riffle.core.domain.EpubRepository
 import com.riffle.core.domain.FormattingPreferencesStore
@@ -96,6 +100,10 @@ annotation class WakeLockPreferencesDataStore
 @Qualifier
 @Retention(AnnotationRetention.BINARY)
 annotation class VolumeKeyPreferencesDataStore
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class DeviceIdDataStore
 
 @Qualifier
 @Retention(AnnotationRetention.BINARY)
@@ -208,6 +216,14 @@ abstract class DataModule {
     @Binds
     @Singleton
     abstract fun bindConnectivityObserver(impl: ConnectivityObserverImpl): ConnectivityObserver
+
+    @Binds
+    @Singleton
+    abstract fun bindDeviceIdStore(impl: DeviceIdStoreImpl): DeviceIdStore
+
+    @Binds
+    @Singleton
+    abstract fun bindAnnotationStore(impl: AnnotationStoreImpl): AnnotationStore
 
     companion object {
         @Provides
@@ -390,5 +406,12 @@ abstract class DataModule {
         fun provideVolumeKeyPreferencesDataStore(
             @ApplicationContext context: Context
         ): DataStore<Preferences> = context.volumeKeyPreferencesDataStore
+
+        @Provides
+        @Singleton
+        @DeviceIdDataStore
+        fun provideDeviceIdDataStore(
+            @ApplicationContext context: Context
+        ): DataStore<Preferences> = context.deviceIdDataStore
     }
 }

--- a/core/data/src/main/kotlin/com/riffle/core/data/di/DatabaseModule.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/di/DatabaseModule.kt
@@ -2,6 +2,7 @@ package com.riffle.core.data.di
 
 import android.content.Context
 import androidx.room.Room
+import com.riffle.core.database.AnnotationDao
 import com.riffle.core.database.BookFormattingPreferencesDao
 import com.riffle.core.database.CollectionDao
 import com.riffle.core.database.LibraryDao
@@ -53,6 +54,7 @@ object DatabaseModule {
                 RiffleDatabase.MIGRATION_21_22,
                 RiffleDatabase.MIGRATION_22_23,
                 RiffleDatabase.MIGRATION_23_24,
+                RiffleDatabase.MIGRATION_24_25,
             )
             .build()
 
@@ -99,4 +101,8 @@ object DatabaseModule {
     @Provides
     @Singleton
     fun provideCrossEpubIndexDao(db: RiffleDatabase): CrossEpubIndexDao = db.crossEpubIndexDao()
+
+    @Provides
+    @Singleton
+    fun provideAnnotationDao(db: RiffleDatabase): AnnotationDao = db.annotationDao()
 }

--- a/core/data/src/main/kotlin/com/riffle/core/data/di/DeviceIdDataStoreExt.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/di/DeviceIdDataStoreExt.kt
@@ -1,0 +1,9 @@
+package com.riffle.core.data.di
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.preferencesDataStore
+
+val Context.deviceIdDataStore: DataStore<Preferences>
+    by preferencesDataStore(name = "device_id")

--- a/core/data/src/test/kotlin/com/riffle/core/data/AnnotationStoreTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/AnnotationStoreTest.kt
@@ -1,0 +1,119 @@
+package com.riffle.core.data
+
+import com.riffle.core.database.AnnotationDao
+import com.riffle.core.database.AnnotationEntity
+import com.riffle.core.domain.DeviceIdStore
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AnnotationStoreTest {
+
+    private class FakeAnnotationDao : AnnotationDao {
+        val rows = MutableStateFlow<List<AnnotationEntity>>(emptyList())
+        override fun observeForItem(serverId: String, itemId: String): Flow<List<AnnotationEntity>> =
+            rows.map { list ->
+                list.filter { it.serverId == serverId && it.itemId == itemId && !it.deleted }
+                    .sortedBy { it.createdAt }
+            }
+        override suspend fun getForItem(serverId: String, itemId: String): List<AnnotationEntity> =
+            rows.value.filter { it.serverId == serverId && it.itemId == itemId && !it.deleted }
+                .sortedBy { it.createdAt }
+        override suspend fun getById(id: String): AnnotationEntity? = rows.value.firstOrNull { it.id == id }
+        override suspend fun upsert(entity: AnnotationEntity) {
+            rows.value = rows.value.filterNot { it.id == entity.id } + entity
+        }
+        override suspend fun tombstone(id: String, updatedAt: Long, deviceId: String) {
+            rows.value = rows.value.map {
+                if (it.id == id) it.copy(deleted = true, updatedAt = updatedAt, lastModifiedByDeviceId = deviceId) else it
+            }
+        }
+    }
+
+    private class FakeDeviceIdStore(private val id: String) : DeviceIdStore {
+        override suspend fun getOrCreate(): String = id
+    }
+
+    private fun buildStore(
+        dao: AnnotationDao = FakeAnnotationDao(),
+        deviceId: String = "device-A",
+        clock: () -> Long = { 1234L },
+        idGenerator: () -> String = { "uuid-fixed" },
+    ) = AnnotationStoreImpl(dao, FakeDeviceIdStore(deviceId), clock, idGenerator)
+
+    // Tracer bullet: createHighlight persists a yellow highlight carrying every sync-ready field.
+    @Test
+    fun `createHighlight persists a sync-ready yellow highlight`() = runTest {
+        val dao = FakeAnnotationDao()
+        val store = buildStore(dao = dao, deviceId = "device-A", clock = { 5000L }, idGenerator = { "uuid-1" })
+
+        store.createHighlight(
+            serverId = "abs1",
+            itemId = "item1",
+            cfi = "epubcfi(/6/4!/4/2,/1:0,/1:10)",
+            textSnippet = "selected words",
+            chapterHref = "chap01.xhtml",
+        )
+
+        val saved = dao.getById("uuid-1")!!
+        assertEquals("abs1", saved.serverId)
+        assertEquals("item1", saved.itemId)
+        assertEquals(AnnotationEntity.TYPE_HIGHLIGHT, saved.type)
+        assertEquals("epubcfi(/6/4!/4/2,/1:0,/1:10)", saved.cfi)
+        assertEquals(AnnotationEntity.COLOR_YELLOW, saved.color)
+        assertNull(saved.note)
+        assertEquals("selected words", saved.textSnippet)
+        assertEquals("chap01.xhtml", saved.chapterHref)
+        assertEquals(5000L, saved.createdAt)
+        assertEquals(5000L, saved.updatedAt)
+        assertEquals("device-A", saved.originDeviceId)
+        assertEquals("device-A", saved.lastModifiedByDeviceId)
+        assertFalse(saved.deleted)
+    }
+
+    @Test
+    fun `createHighlight returns the created annotation`() = runTest {
+        val store = buildStore(idGenerator = { "uuid-1" })
+
+        val created = store.createHighlight("abs1", "item1", "epubcfi(x)", "snip", "c.xhtml")
+
+        assertEquals("uuid-1", created.id)
+        assertEquals("epubcfi(x)", created.cfi)
+        assertEquals(AnnotationEntity.COLOR_YELLOW, created.color)
+    }
+
+    @Test
+    fun `observeHighlights emits non-deleted highlights for the item`() = runTest {
+        val dao = FakeAnnotationDao()
+        var n = 0
+        val store = buildStore(dao = dao, idGenerator = { "id-${n++}" })
+
+        store.createHighlight("abs1", "item1", "epubcfi(a)", "s", "c")
+        store.createHighlight("abs1", "item2", "epubcfi(b)", "s", "c")
+
+        val list = store.observeHighlights("abs1", "item1").first()
+        assertEquals(1, list.size)
+        assertEquals("item1", list[0].itemId)
+    }
+
+    @Test
+    fun `delete tombstones the annotation so it leaves the live query`() = runTest {
+        val dao = FakeAnnotationDao()
+        val store = buildStore(dao = dao, deviceId = "device-A", clock = { 7000L }, idGenerator = { "uuid-1" })
+        store.createHighlight("abs1", "item1", "epubcfi(a)", "s", "c")
+
+        store.delete("uuid-1")
+
+        assertTrue(store.observeHighlights("abs1", "item1").first().isEmpty())
+        val tomb = dao.getById("uuid-1")!!
+        assertTrue(tomb.deleted)
+        assertEquals(7000L, tomb.updatedAt)
+    }
+}

--- a/core/data/src/test/kotlin/com/riffle/core/data/DeviceIdStoreTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/DeviceIdStoreTest.kt
@@ -1,0 +1,70 @@
+package com.riffle.core.data
+
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class DeviceIdStoreTest {
+
+    @get:Rule
+    val tmp = TemporaryFolder()
+
+    private val dispatcher = UnconfinedTestDispatcher()
+    private val testScope = TestScope(dispatcher)
+
+    private fun buildStore() = DeviceIdStoreImpl(
+        PreferenceDataStoreFactory.create(
+            scope = testScope.backgroundScope,
+            produceFile = { tmp.newFile("device_id.preferences_pb") },
+        )
+    )
+
+    @Test
+    fun `getOrCreate returns a non-blank value when DataStore is empty`() = testScope.runTest {
+        val id = buildStore().getOrCreate()
+        assertTrue("expected a non-blank deviceId, got '$id'", id.isNotBlank())
+    }
+
+    @Test
+    fun `getOrCreate returns the same value on repeated calls`() = testScope.runTest {
+        val store = buildStore()
+        val first = store.getOrCreate()
+        val second = store.getOrCreate()
+        assertEquals(first, second)
+    }
+
+    @Test
+    fun `deviceId persists across store instances on the same file`() {
+        val file = tmp.newFile("device_id_round_trip.preferences_pb")
+
+        val writeScope = CoroutineScope(UnconfinedTestDispatcher() + Job())
+        val minted = runBlocking {
+            DeviceIdStoreImpl(
+                PreferenceDataStoreFactory.create(scope = writeScope, produceFile = { file })
+            ).getOrCreate()
+        }
+        writeScope.cancel()
+
+        val readScope = CoroutineScope(UnconfinedTestDispatcher() + Job())
+        val reread = runBlocking {
+            DeviceIdStoreImpl(
+                PreferenceDataStoreFactory.create(scope = readScope, produceFile = { file })
+            ).getOrCreate()
+        }
+        readScope.cancel()
+
+        assertEquals(minted, reread)
+    }
+}

--- a/core/database/schemas/com.riffle.core.database.RiffleDatabase/25.json
+++ b/core/database/schemas/com.riffle.core.database.RiffleDatabase/25.json
@@ -1,0 +1,875 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 25,
+    "identityHash": "b3945e081627ece72a7d9ef031f71b5a",
+    "entities": [
+      {
+        "tableName": "servers",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `url` TEXT NOT NULL, `isActive` INTEGER NOT NULL, `insecureConnectionAllowed` INTEGER NOT NULL, `username` TEXT NOT NULL, `serverType` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "isActive",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "insecureConnectionAllowed",
+            "columnName": "insecureConnectionAllowed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "username",
+            "columnName": "username",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverType",
+            "columnName": "serverType",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "libraries",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `mediaType` TEXT NOT NULL, `serverId` TEXT NOT NULL, `isUnsupported` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaType",
+            "columnName": "mediaType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isUnsupported",
+            "columnName": "isUnsupported",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "library_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `title` TEXT NOT NULL, `author` TEXT NOT NULL, `coverUrl` TEXT, `readingProgress` REAL NOT NULL, `ebookFileIno` TEXT, `ebookFormat` TEXT NOT NULL, `description` TEXT, `seriesName` TEXT, `publishedYear` TEXT, `genres` TEXT NOT NULL, `publisher` TEXT, `lastOpenedAt` INTEGER, `addedAt` INTEGER, `isbn` TEXT, `asin` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "coverUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "readingProgress",
+            "columnName": "readingProgress",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ebookFileIno",
+            "columnName": "ebookFileIno",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "ebookFormat",
+            "columnName": "ebookFormat",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seriesName",
+            "columnName": "seriesName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "publishedYear",
+            "columnName": "publishedYear",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "genres",
+            "columnName": "genres",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "publisher",
+            "columnName": "publisher",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastOpenedAt",
+            "columnName": "lastOpenedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "isbn",
+            "columnName": "isbn",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "asin",
+            "columnName": "asin",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "series",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `name` TEXT NOT NULL, `coverUrl` TEXT, `bookCount` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "coverUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "bookCount",
+            "columnName": "bookCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "collections",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `name` TEXT NOT NULL, `bookCount` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookCount",
+            "columnName": "bookCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "series_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`seriesId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `sequenceOrder` REAL NOT NULL, PRIMARY KEY(`seriesId`, `itemId`))",
+        "fields": [
+          {
+            "fieldPath": "seriesId",
+            "columnName": "seriesId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sequenceOrder",
+            "columnName": "sequenceOrder",
+            "affinity": "REAL",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "seriesId",
+            "itemId"
+          ]
+        }
+      },
+      {
+        "tableName": "collection_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`collectionId` TEXT NOT NULL, `itemId` TEXT NOT NULL, PRIMARY KEY(`collectionId`, `itemId`))",
+        "fields": [
+          {
+            "fieldPath": "collectionId",
+            "columnName": "collectionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "collectionId",
+            "itemId"
+          ]
+        }
+      },
+      {
+        "tableName": "reading_positions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`serverId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `cfi` TEXT NOT NULL, `localUpdatedAt` INTEGER NOT NULL, PRIMARY KEY(`serverId`, `itemId`), FOREIGN KEY(`serverId`) REFERENCES `servers`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cfi",
+            "columnName": "cfi",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localUpdatedAt",
+            "columnName": "localUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "serverId",
+            "itemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_reading_positions_serverId",
+            "unique": false,
+            "columnNames": [
+              "serverId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_reading_positions_serverId` ON `${TABLE_NAME}` (`serverId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "servers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "serverId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "book_formatting_preferences",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`itemId` TEXT NOT NULL, `fontSize` REAL, `theme` TEXT, `fontFamily` TEXT, `lineSpacing` REAL, `margins` REAL, `orientation` TEXT, `showChapterMap` INTEGER, `showReadingProgressLabels` INTEGER, `showCurrentChapterLabel` INTEGER, `doublePageSpread` INTEGER, `justifyText` INTEGER, PRIMARY KEY(`itemId`))",
+        "fields": [
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fontSize",
+            "columnName": "fontSize",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "theme",
+            "columnName": "theme",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "fontFamily",
+            "columnName": "fontFamily",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lineSpacing",
+            "columnName": "lineSpacing",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "margins",
+            "columnName": "margins",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "orientation",
+            "columnName": "orientation",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "showChapterMap",
+            "columnName": "showChapterMap",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "showReadingProgressLabels",
+            "columnName": "showReadingProgressLabels",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "showCurrentChapterLabel",
+            "columnName": "showCurrentChapterLabel",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "doublePageSpread",
+            "columnName": "doublePageSpread",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "justifyText",
+            "columnName": "justifyText",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "itemId"
+          ]
+        }
+      },
+      {
+        "tableName": "readaloud_links",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`absServerId` TEXT NOT NULL, `absLibraryItemId` TEXT NOT NULL, `storytellerServerId` TEXT NOT NULL, `storytellerBookId` TEXT NOT NULL, `state` TEXT NOT NULL, `userConfirmed` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`absServerId`, `absLibraryItemId`), FOREIGN KEY(`storytellerServerId`) REFERENCES `servers`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`absServerId`) REFERENCES `servers`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "absServerId",
+            "columnName": "absServerId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absLibraryItemId",
+            "columnName": "absLibraryItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerServerId",
+            "columnName": "storytellerServerId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerBookId",
+            "columnName": "storytellerBookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userConfirmed",
+            "columnName": "userConfirmed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "absServerId",
+            "absLibraryItemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_readaloud_links_storytellerServerId_storytellerBookId",
+            "unique": false,
+            "columnNames": [
+              "storytellerServerId",
+              "storytellerBookId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_readaloud_links_storytellerServerId_storytellerBookId` ON `${TABLE_NAME}` (`storytellerServerId`, `storytellerBookId`)"
+          },
+          {
+            "name": "index_readaloud_links_storytellerServerId",
+            "unique": false,
+            "columnNames": [
+              "storytellerServerId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_readaloud_links_storytellerServerId` ON `${TABLE_NAME}` (`storytellerServerId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "servers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "storytellerServerId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "servers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "absServerId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "readaloud_candidates",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`storytellerServerId` TEXT NOT NULL, `storytellerBookId` TEXT NOT NULL, `absServerId` TEXT NOT NULL, `absLibraryItemId` TEXT NOT NULL, `score` REAL NOT NULL, PRIMARY KEY(`storytellerServerId`, `storytellerBookId`, `absServerId`, `absLibraryItemId`), FOREIGN KEY(`storytellerServerId`) REFERENCES `servers`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`absServerId`) REFERENCES `servers`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "storytellerServerId",
+            "columnName": "storytellerServerId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerBookId",
+            "columnName": "storytellerBookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absServerId",
+            "columnName": "absServerId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absLibraryItemId",
+            "columnName": "absLibraryItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "score",
+            "columnName": "score",
+            "affinity": "REAL",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "storytellerServerId",
+            "storytellerBookId",
+            "absServerId",
+            "absLibraryItemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_readaloud_candidates_absServerId",
+            "unique": false,
+            "columnNames": [
+              "absServerId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_readaloud_candidates_absServerId` ON `${TABLE_NAME}` (`absServerId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "servers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "storytellerServerId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "servers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "absServerId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "readaloud_dismissals",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`storytellerServerId` TEXT NOT NULL, `storytellerBookId` TEXT NOT NULL, `scope` TEXT NOT NULL, `absServerId` TEXT NOT NULL, `absLibraryItemId` TEXT NOT NULL, PRIMARY KEY(`storytellerServerId`, `storytellerBookId`, `absServerId`, `absLibraryItemId`), FOREIGN KEY(`storytellerServerId`) REFERENCES `servers`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "storytellerServerId",
+            "columnName": "storytellerServerId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerBookId",
+            "columnName": "storytellerBookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scope",
+            "columnName": "scope",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absServerId",
+            "columnName": "absServerId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absLibraryItemId",
+            "columnName": "absLibraryItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "storytellerServerId",
+            "storytellerBookId",
+            "absServerId",
+            "absLibraryItemId"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "servers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "storytellerServerId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "cross_epub_index",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`absEpubChecksum` TEXT NOT NULL, `storytellerEpubChecksum` TEXT NOT NULL, `perChapterMapsBlob` TEXT NOT NULL, `builtAt` INTEGER NOT NULL, PRIMARY KEY(`absEpubChecksum`, `storytellerEpubChecksum`))",
+        "fields": [
+          {
+            "fieldPath": "absEpubChecksum",
+            "columnName": "absEpubChecksum",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerEpubChecksum",
+            "columnName": "storytellerEpubChecksum",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "perChapterMapsBlob",
+            "columnName": "perChapterMapsBlob",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "builtAt",
+            "columnName": "builtAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "absEpubChecksum",
+            "storytellerEpubChecksum"
+          ]
+        }
+      },
+      {
+        "tableName": "annotations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `serverId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `type` TEXT NOT NULL, `cfi` TEXT NOT NULL, `color` TEXT NOT NULL, `note` TEXT, `textSnippet` TEXT NOT NULL, `chapterHref` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `originDeviceId` TEXT NOT NULL, `lastModifiedByDeviceId` TEXT NOT NULL, `deleted` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`serverId`) REFERENCES `servers`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cfi",
+            "columnName": "cfi",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "color",
+            "columnName": "color",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "note",
+            "columnName": "note",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "textSnippet",
+            "columnName": "textSnippet",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chapterHref",
+            "columnName": "chapterHref",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "originDeviceId",
+            "columnName": "originDeviceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastModifiedByDeviceId",
+            "columnName": "lastModifiedByDeviceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deleted",
+            "columnName": "deleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_annotations_serverId_itemId",
+            "unique": false,
+            "columnNames": [
+              "serverId",
+              "itemId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_annotations_serverId_itemId` ON `${TABLE_NAME}` (`serverId`, `itemId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "servers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "serverId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'b3945e081627ece72a7d9ef031f71b5a')"
+    ]
+  }
+}

--- a/core/database/src/androidTest/kotlin/com/riffle/core/database/AnnotationDaoTest.kt
+++ b/core/database/src/androidTest/kotlin/com/riffle/core/database/AnnotationDaoTest.kt
@@ -1,0 +1,123 @@
+package com.riffle.core.database
+
+import androidx.room.Room
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class AnnotationDaoTest {
+
+    private lateinit var db: RiffleDatabase
+    private lateinit var dao: AnnotationDao
+
+    @Before
+    fun setup() = runBlocking {
+        db = Room.inMemoryDatabaseBuilder(
+            InstrumentationRegistry.getInstrumentation().targetContext,
+            RiffleDatabase::class.java,
+        ).allowMainThreadQueries().build()
+        dao = db.annotationDao()
+        // annotations.serverId is a FK to servers(id); seed the ABS servers the tests anchor to.
+        val servers = db.serverDao()
+        servers.upsert(ServerEntity("abs1", "http://abs1", isActive = true, insecureConnectionAllowed = false, username = "u"))
+        servers.upsert(ServerEntity("abs2", "http://abs2", isActive = false, insecureConnectionAllowed = false, username = "u"))
+    }
+
+    @After
+    fun teardown() {
+        db.close()
+    }
+
+    private fun highlight(
+        id: String,
+        serverId: String = "abs1",
+        itemId: String = "item1",
+        cfi: String = "epubcfi(/6/4!/4/2,/1:0,/1:10)",
+        createdAt: Long = 1000L,
+        deleted: Boolean = false,
+    ) = AnnotationEntity(
+        id = id,
+        serverId = serverId,
+        itemId = itemId,
+        cfi = cfi,
+        textSnippet = "the selected text",
+        chapterHref = "chapter1.xhtml",
+        createdAt = createdAt,
+        updatedAt = createdAt,
+        originDeviceId = "device-A",
+        lastModifiedByDeviceId = "device-A",
+        deleted = deleted,
+    )
+
+    // Tracer bullet: an inserted highlight round-trips back through observeForItem.
+    @Test
+    fun upsertedHighlight_roundTripsThroughObserveForItem() = runTest {
+        dao.upsert(highlight("h1"))
+
+        val result = dao.observeForItem("abs1", "item1").first()
+
+        assertEquals(1, result.size)
+        val a = result[0]
+        assertEquals("h1", a.id)
+        assertEquals(AnnotationEntity.TYPE_HIGHLIGHT, a.type)
+        assertEquals(AnnotationEntity.COLOR_YELLOW, a.color)
+        assertEquals("chapter1.xhtml", a.chapterHref)
+        assertEquals("the selected text", a.textSnippet)
+    }
+
+    // A CFI *range* string must survive storage byte-for-byte — it is the load-bearing anchor.
+    @Test
+    fun cfiRange_persistsIntact() = runTest {
+        val range = "epubcfi(/6/14!/4/2/2[c01]/1:7,/4/2/2[c01]/1:42)"
+        dao.upsert(highlight("h1", cfi = range))
+
+        assertEquals(range, dao.getById("h1")?.cfi)
+    }
+
+    // Annotations are scoped to a single ABS Library Item (serverId + itemId).
+    @Test
+    fun observeForItem_isScopedToServerAndItem() = runTest {
+        dao.upsert(highlight("h1", serverId = "abs1", itemId = "item1"))
+        dao.upsert(highlight("h2", serverId = "abs1", itemId = "item2"))
+        dao.upsert(highlight("h3", serverId = "abs2", itemId = "item1"))
+
+        val result = dao.observeForItem("abs1", "item1").first()
+
+        assertEquals(listOf("h1"), result.map { it.id })
+    }
+
+    // Tombstoned rows must drop out of the live queries but remain in the table for sync.
+    @Test
+    fun tombstonedHighlight_isExcludedFromLiveQueriesButRetained() = runTest {
+        dao.upsert(highlight("h1"))
+
+        dao.tombstone("h1", updatedAt = 2000L, deviceId = "device-B")
+
+        assertTrue(dao.observeForItem("abs1", "item1").first().isEmpty())
+        assertTrue(dao.getForItem("abs1", "item1").isEmpty())
+        val tomb = dao.getById("h1")
+        assertEquals(true, tomb?.deleted)
+        assertEquals(2000L, tomb?.updatedAt)
+        assertEquals("device-B", tomb?.lastModifiedByDeviceId)
+    }
+
+    @Test
+    fun observeForItem_ordersByCreatedAtAscending() = runTest {
+        dao.upsert(highlight("late", createdAt = 3000L))
+        dao.upsert(highlight("early", createdAt = 1000L))
+        dao.upsert(highlight("mid", createdAt = 2000L))
+
+        val ids = dao.observeForItem("abs1", "item1").first().map { it.id }
+
+        assertEquals(listOf("early", "mid", "late"), ids)
+    }
+}

--- a/core/database/src/androidTest/kotlin/com/riffle/core/database/MigrationTest.kt
+++ b/core/database/src/androidTest/kotlin/com/riffle/core/database/MigrationTest.kt
@@ -892,6 +892,70 @@ class MigrationTest {
     }
 
     @Test
+    fun migration24To25_addsSyncReadyAnnotationsStoreKeyedByAbsItem() {
+        helper.createDatabase(TEST_DB, 24).use { db ->
+            // An ABS server the annotation will reference (FK target).
+            db.execSQL(
+                "INSERT INTO servers (id, url, isActive, insecureConnectionAllowed, username, serverType) " +
+                    "VALUES ('abs1', 'http://media-server:13378', 1, 0, 'plamen', 'AUDIOBOOKSHELF')"
+            )
+        }
+
+        val db = helper.runMigrationsAndValidate(TEST_DB, 25, true, RiffleDatabase.MIGRATION_24_25)
+
+        // The new table starts empty.
+        db.query("SELECT COUNT(*) FROM annotations").use { cursor ->
+            cursor.moveToFirst()
+            assertEquals(0, cursor.getInt(0))
+        }
+
+        // A full sync-ready highlight row — CFI *range*, snippet, chapter href, provenance,
+        // tombstone flag — writes and reads back intact.
+        db.execSQL(
+            "INSERT INTO annotations " +
+                "(id, serverId, itemId, type, cfi, color, note, textSnippet, chapterHref, createdAt, updatedAt, originDeviceId, lastModifiedByDeviceId, deleted) " +
+                "VALUES ('uuid-1', 'abs1', 'item-1', 'HIGHLIGHT', 'epubcfi(/6/4!/4/2,/1:0,/1:10)', 'yellow', NULL, 'hello world', 'chap01.xhtml', 1000, 1000, 'device-A', 'device-A', 0)"
+        )
+        db.query(
+            "SELECT serverId, itemId, type, cfi, color, note, textSnippet, chapterHref, originDeviceId, lastModifiedByDeviceId, deleted " +
+                "FROM annotations WHERE id = 'uuid-1'"
+        ).use { cursor ->
+            assertEquals(1, cursor.count)
+            cursor.moveToFirst()
+            assertEquals("abs1", cursor.getString(0))
+            assertEquals("item-1", cursor.getString(1))
+            assertEquals("HIGHLIGHT", cursor.getString(2))
+            assertEquals("epubcfi(/6/4!/4/2,/1:0,/1:10)", cursor.getString(3))
+            assertEquals("yellow", cursor.getString(4))
+            assertNull(cursor.getString(5))
+            assertEquals("hello world", cursor.getString(6))
+            assertEquals("chap01.xhtml", cursor.getString(7))
+            assertEquals("device-A", cursor.getString(8))
+            assertEquals("device-A", cursor.getString(9))
+            assertEquals(0, cursor.getInt(10))
+        }
+
+        // A note (nullable column populated) coexists with the highlight.
+        db.execSQL(
+            "INSERT INTO annotations " +
+                "(id, serverId, itemId, type, cfi, color, note, textSnippet, chapterHref, createdAt, updatedAt, originDeviceId, lastModifiedByDeviceId, deleted) " +
+                "VALUES ('uuid-2', 'abs1', 'item-1', 'HIGHLIGHT', 'epubcfi(/6/4!/6/2,/1:0,/1:4)', 'yellow', 'my thought', 'word', 'chap01.xhtml', 1100, 1100, 'device-A', 'device-A', 0)"
+        )
+        db.query("SELECT note FROM annotations WHERE id = 'uuid-2'").use { cursor ->
+            cursor.moveToFirst()
+            assertEquals("my thought", cursor.getString(0))
+        }
+
+        // FK cascade: removing the ABS server clears its annotations.
+        db.execSQL("PRAGMA foreign_keys = ON")
+        db.execSQL("DELETE FROM servers WHERE id = 'abs1'")
+        db.query("SELECT COUNT(*) FROM annotations").use { cursor ->
+            cursor.moveToFirst()
+            assertEquals(0, cursor.getInt(0))
+        }
+    }
+
+    @Test
     fun migrateFullChain() {
         helper.createDatabase(TEST_DB, 1).use { db ->
             db.execSQL(
@@ -900,7 +964,7 @@ class MigrationTest {
         }
 
         val db = helper.runMigrationsAndValidate(
-            TEST_DB, 24, true,
+            TEST_DB, 25, true,
             RiffleDatabase.MIGRATION_1_2,
             RiffleDatabase.MIGRATION_2_3,
             RiffleDatabase.MIGRATION_3_4,
@@ -924,6 +988,7 @@ class MigrationTest {
             RiffleDatabase.MIGRATION_21_22,
             RiffleDatabase.MIGRATION_22_23,
             RiffleDatabase.MIGRATION_23_24,
+            RiffleDatabase.MIGRATION_24_25,
         )
 
         db.query("SELECT url, username, serverType FROM servers WHERE id = 's1'").use { cursor ->

--- a/core/database/src/main/kotlin/com/riffle/core/database/AnnotationDao.kt
+++ b/core/database/src/main/kotlin/com/riffle/core/database/AnnotationDao.kt
@@ -1,0 +1,35 @@
+package com.riffle.core.database
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface AnnotationDao {
+
+    /** Live, non-deleted annotations for an ABS Library Item, oldest first. */
+    @Query(
+        "SELECT * FROM annotations WHERE serverId = :serverId AND itemId = :itemId AND deleted = 0 " +
+            "ORDER BY createdAt ASC"
+    )
+    fun observeForItem(serverId: String, itemId: String): Flow<List<AnnotationEntity>>
+
+    /** One-shot read of non-deleted annotations for an ABS Library Item, oldest first. */
+    @Query(
+        "SELECT * FROM annotations WHERE serverId = :serverId AND itemId = :itemId AND deleted = 0 " +
+            "ORDER BY createdAt ASC"
+    )
+    suspend fun getForItem(serverId: String, itemId: String): List<AnnotationEntity>
+
+    @Query("SELECT * FROM annotations WHERE id = :id LIMIT 1")
+    suspend fun getById(id: String): AnnotationEntity?
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsert(entity: AnnotationEntity)
+
+    /** Tombstone an annotation so the delete can later propagate to other devices. */
+    @Query("UPDATE annotations SET deleted = 1, updatedAt = :updatedAt, lastModifiedByDeviceId = :deviceId WHERE id = :id")
+    suspend fun tombstone(id: String, updatedAt: Long, deviceId: String)
+}

--- a/core/database/src/main/kotlin/com/riffle/core/database/AnnotationEntity.kt
+++ b/core/database/src/main/kotlin/com/riffle/core/database/AnnotationEntity.kt
@@ -1,0 +1,56 @@
+package com.riffle.core.database
+
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+/**
+ * A reader Annotation (Highlight in v1; Notes/Bookmarks land in later slices).
+ *
+ * The primary, always-queryable store (ADR 0025). Every field the future W3C Web Annotation
+ * format + per-device-file merge needs is carried now even though v1 has no sync:
+ *
+ * - [id] — stable client-generated UUID; the annotation's identity across devices.
+ * - [originDeviceId] / [lastModifiedByDeviceId] — provenance for last-write-wins merge.
+ * - [deleted] — tombstone so deletes propagate instead of vanishing.
+ * - [cfi] — the load-bearing anchor in the ABS-EPUB coordinate system; a CFI *range* for
+ *   highlights/notes, a CFI *point* for bookmarks (ADR 0024).
+ * - [textSnippet] + [chapterHref] — human-readable fallback / re-anchoring aid.
+ *
+ * Annotations are scoped to the ABS Library Item ([serverId] + [itemId]) and exist only on the
+ * ABS side; Storyteller-only books and the Readaloud reading side carry none (ADR 0024).
+ */
+@Entity(
+    tableName = "annotations",
+    foreignKeys = [
+        ForeignKey(
+            entity = ServerEntity::class,
+            parentColumns = ["id"],
+            childColumns = ["serverId"],
+            onDelete = ForeignKey.CASCADE,
+        ),
+    ],
+    indices = [Index(value = ["serverId", "itemId"])],
+)
+data class AnnotationEntity(
+    @PrimaryKey val id: String,
+    val serverId: String,
+    val itemId: String,
+    val type: String = TYPE_HIGHLIGHT,
+    val cfi: String,
+    val color: String = COLOR_YELLOW,
+    val note: String? = null,
+    val textSnippet: String,
+    val chapterHref: String,
+    val createdAt: Long,
+    val updatedAt: Long,
+    val originDeviceId: String,
+    val lastModifiedByDeviceId: String,
+    val deleted: Boolean = false,
+) {
+    companion object {
+        const val TYPE_HIGHLIGHT = "HIGHLIGHT"
+        const val COLOR_YELLOW = "yellow"
+    }
+}

--- a/core/database/src/main/kotlin/com/riffle/core/database/RiffleDatabase.kt
+++ b/core/database/src/main/kotlin/com/riffle/core/database/RiffleDatabase.kt
@@ -20,8 +20,9 @@ import androidx.sqlite.db.SupportSQLiteDatabase
         ReadaloudCandidateEntity::class,
         ReadaloudDismissalEntity::class,
         CrossEpubIndexEntity::class,
+        AnnotationEntity::class,
     ],
-    version = 24,
+    version = 25,
     exportSchema = true,
 )
 abstract class RiffleDatabase : RoomDatabase() {
@@ -36,6 +37,7 @@ abstract class RiffleDatabase : RoomDatabase() {
     abstract fun readaloudCandidateDao(): ReadaloudCandidateDao
     abstract fun readaloudDismissalDao(): ReadaloudDismissalDao
     abstract fun crossEpubIndexDao(): CrossEpubIndexDao
+    abstract fun annotationDao(): AnnotationDao
 
     companion object {
         val MIGRATION_1_2 = object : Migration(1, 2) {
@@ -388,6 +390,41 @@ abstract class RiffleDatabase : RoomDatabase() {
                         "`perChapterMapsBlob` TEXT NOT NULL, " +
                         "`builtAt` INTEGER NOT NULL, " +
                         "PRIMARY KEY(`absEpubChecksum`, `storytellerEpubChecksum`))"
+                )
+            }
+        }
+
+        // 24 → 25: the sync-ready Annotations store (ADR 0024 / 0025). One table carries every
+        // field the future W3C format + per-device-file merge needs — stable UUID identity,
+        // origin/last-modified device ids, a `deleted` tombstone, the CFI range anchor, colour
+        // token, nullable note, and the snippet + chapter href fallback. Scoped to the ABS
+        // Library Item (serverId + itemId); FK-cascade on serverId clears rows when the server
+        // is removed. v1 writes locally only — no sync target reads any of it yet.
+        val MIGRATION_24_25 = object : Migration(24, 25) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL(
+                    "CREATE TABLE IF NOT EXISTS `annotations` (" +
+                        "`id` TEXT NOT NULL, " +
+                        "`serverId` TEXT NOT NULL, " +
+                        "`itemId` TEXT NOT NULL, " +
+                        "`type` TEXT NOT NULL, " +
+                        "`cfi` TEXT NOT NULL, " +
+                        "`color` TEXT NOT NULL, " +
+                        "`note` TEXT, " +
+                        "`textSnippet` TEXT NOT NULL, " +
+                        "`chapterHref` TEXT NOT NULL, " +
+                        "`createdAt` INTEGER NOT NULL, " +
+                        "`updatedAt` INTEGER NOT NULL, " +
+                        "`originDeviceId` TEXT NOT NULL, " +
+                        "`lastModifiedByDeviceId` TEXT NOT NULL, " +
+                        "`deleted` INTEGER NOT NULL, " +
+                        "PRIMARY KEY(`id`), " +
+                        "FOREIGN KEY(`serverId`) REFERENCES `servers`(`id`) " +
+                        "ON UPDATE NO ACTION ON DELETE CASCADE)"
+                )
+                db.execSQL(
+                    "CREATE INDEX IF NOT EXISTS `index_annotations_serverId_itemId` " +
+                        "ON `annotations` (`serverId`, `itemId`)"
                 )
             }
         }

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/Annotation.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/Annotation.kt
@@ -1,0 +1,19 @@
+package com.riffle.core.domain
+
+/**
+ * A reader Annotation (Highlight in v1). Anchored on an ABS-EPUB CFI — a *range* for highlights —
+ * and scoped to an ABS Library Item ([serverId] + [itemId]). See ADR 0024 / 0025.
+ */
+data class Annotation(
+    val id: String,
+    val serverId: String,
+    val itemId: String,
+    val type: String,
+    val cfi: String,
+    val color: String,
+    val note: String?,
+    val textSnippet: String,
+    val chapterHref: String,
+    val createdAt: Long,
+    val updatedAt: Long,
+)

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/AnnotationStore.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/AnnotationStore.kt
@@ -1,0 +1,33 @@
+package com.riffle.core.domain
+
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * The primary, always-queryable Annotations store (ADR 0025). Local Room is the source of truth;
+ * sync is a later, additive layer. v1 creates and reads Highlights only, on the ABS side.
+ */
+interface AnnotationStore {
+
+    /** Live, non-deleted highlights for an ABS Library Item, oldest first. */
+    fun observeHighlights(serverId: String, itemId: String): Flow<List<Annotation>>
+
+    /**
+     * Create a Highlight at [cfi] (a CFI range) with the default colour, capturing the selected
+     * [textSnippet] and its [chapterHref]. Mints a fresh UUID and stamps the current device + time.
+     */
+    suspend fun createHighlight(
+        serverId: String,
+        itemId: String,
+        cfi: String,
+        textSnippet: String,
+        chapterHref: String,
+        color: String = DEFAULT_COLOR,
+    ): Annotation
+
+    /** Tombstone an annotation so the delete can later propagate to other devices. */
+    suspend fun delete(id: String)
+
+    companion object {
+        const val DEFAULT_COLOR = "yellow"
+    }
+}

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/DeviceIdStore.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/DeviceIdStore.kt
@@ -1,0 +1,13 @@
+package com.riffle.core.domain
+
+/**
+ * A stable per-install identifier, minted once on first run and reused across launches.
+ *
+ * Per ADR 0025 the `deviceId` only *names* an annotation sync file (`annotations-<deviceId>.jsonld`);
+ * annotation identity is the record UUID. v1 mints and persists it but no sync code reads it yet —
+ * it exists so the future per-device-file model works without a migration.
+ */
+interface DeviceIdStore {
+    /** Returns the persisted deviceId, generating and storing one on first call. */
+    suspend fun getOrCreate(): String
+}

--- a/docs/adr/0024-annotations-anchor-on-abs-epub-cfi.md
+++ b/docs/adr/0024-annotations-anchor-on-abs-epub-cfi.md
@@ -1,0 +1,30 @@
+# ADR 0024 — Annotations anchor on ABS-EPUB CFI, ABS-side only
+
+**Status:** Accepted
+
+## Context
+
+Highlights, Notes, and Bookmarks (collectively [Annotation]s) need a position anchor that is stable across font/screen changes, survives EPUB re-uploads as best it can, and round-trips losslessly for future sync. Reflowable EPUBs have no fixed pages, so a page number is not a usable anchor. A complication is that a Confirmed-matched Readaloud exists as **two different EPUB files** — the ABS EPUB and the Storyteller EPUB — with different internal structure and therefore different CFIs (see [ADR 0019](0019-three-peer-unified-canonical-progress-sync.md), [ADR 0023](0023-storyteller-synced-bundle-is-the-readaloud-audio-source.md)). The translation between them is best-effort.
+
+## Decision
+
+Every Annotation anchors on an **EPUB CFI** — a CFI *range* for Highlights/Notes, a CFI *point* (the reader's top-of-viewport `currentLocator`) for Bookmarks — plus a stored text snippet and chapter href as a human-readable fallback and re-anchoring aid. The CFI is the load-bearing, irreversible anchor.
+
+The **ABS EPUB is the canonical coordinate system** and the ABS Library Item is the key. Storyteller is only a [Readaloud] provider, so:
+
+- A Storyteller-only (unmatched) book carries **no** Annotations.
+- Annotations are created and displayed **only while reading the ABS side** in v1. The Readaloud (Storyteller) side stays pure playback.
+
+CFI is the same coordinate family ABS already stores in `mediaProgress.ebookLocation` and that [ADR 0013](0013-epub-cfi-translator-for-progress-sync.md)'s `EpubCfiTranslator` operates on — so a future native ABS annotation API maps mechanically.
+
+## Considered options
+
+- **Per-logical-book, crossing the ABS↔Storyteller match via ADR 0019's cross-EPUB index.** Rejected as the *storage* model: the index is best-effort, and anchoring synced data (which must round-trip exactly, forever) on a lossy translation would permanently misplace highlights. Crossing the match to *display* ABS-anchored annotations on the Readaloud side is left as a deferred enhancement, where the lossiness is ephemeral and confined to a second-class surface.
+- **Per-EPUB keying** (annotations scoped to whichever publication they were made in, never crossing). Rejected because, with ABS as the canonical home, keying by the ABS item gives the same exactness while letting annotations belong to the logical book.
+- **Page-number anchors.** Rejected for EPUB — pages aren't stable under reflow. (Page anchors remain the natural choice if/when PDF annotations are added.)
+
+## Consequences
+
+- Annotations require an ABS EPUB; the affordance is absent on Storyteller-only books and on the Readaloud reading side in v1.
+- Synced annotation data is always exact ABS-EPUB CFI; no best-effort translation ever enters the stored/synced record.
+- EPUB only in v1. PDF (page + rect anchors, a different anchor type the W3C format can also carry) is out of scope.

--- a/docs/adr/0025-annotation-sync-pluggable-target-w3c-format.md
+++ b/docs/adr/0025-annotation-sync-pluggable-target-w3c-format.md
@@ -1,0 +1,37 @@
+# ADR 0025 — Annotation sync: pluggable target, W3C Web Annotation format, per-device-file merge
+
+**Status:** Accepted
+**Extends:** [ADR 0003](0003-local-first-annotations.md) (local-first annotations) — keeps its local-first core, supersedes its "defer sync until ABS adds native support / push bookmarks to the ABS bookmark API" stance.
+
+## Context
+
+[Annotation]s need to roam between devices eventually, with no central merge server and no obligation to a single cloud provider. ABS cannot natively store EPUB highlights/notes: its `bookmarks` API is `{ time, title }` built for audiobook timestamps, and `mediaProgress` holds one position per book — confirmed against the live server. The durable artifact is therefore the **format**, not the transport; the transport must be swappable, including a swap to a native ABS endpoint if one ever ships.
+
+## Decision
+
+- **Local Room store is always primary and queryable.** Sync is an optional layer on top, reached through a single `AnnotationSyncTarget` abstraction (`list / read / write-own-file`) so the backing store swaps without touching the format or schema.
+- **Wire format = W3C Web Annotation Data Model** (JSON-LD): EPUB CFI as a `FragmentSelector` plus a `TextQuoteSelector` snippet, with a `riffle:` extension namespace for the merge-critical fields the standard omits — `device`, `updatedAt`, and a `deleted` tombstone.
+- **Merge model = per-device files, last-write-wins per record.** One file per device per book (`<serverId>/<itemId>/annotations-<deviceId>.jsonld`). The annotation **UUID is identity**; **`deviceId` only names a file** (a device writes only its own file, reads everyone's, merges into Room by `(uuid, updatedAt)`). Deletes propagate as tombstones. This is what "collaborative, no server" reduces to once real-time OT is excluded; annotations are independent records, so set-union with last-write-wins is sufficient (no OT needed).
+- **v1 ships local-only** — no target implemented — but the Room schema carries every field the format and merge need (stable UUID, `createdAt`, `updatedAt`, `originDeviceId`/`lastModifiedByDeviceId`, `deleted`, CFI anchor, snippet+chapter fallback), and a `deviceId` is minted on first run. Enabling a target later is additive, never a migration.
+
+## Considered options
+
+- **Abuse the ABS bookmark API as a record-store target** (encode the annotation JSON into the bookmark `title`, synthetic `time` key). Empirically works — `time` is unvalidated, `title` stores 20 KB+, multiple records per book coexist, and ABS would act as the server-side merge authority. **Rejected:** it floods the audiobook-bookmark surface that **Riffle itself will render once it becomes an audiobook player** (self-pollution, not just other-client pollution), and rides undocumented behaviour a future ABS release could break silently. Every other writable ABS surface (playlists, collections, item metadata, file upload) is either a surface Riffle will also render or the wrong scope (admin/shared, triggers scans).
+- **Single shared document** (`annotations.json` all devices write). Rejected: dumb stores resolve concurrent writes as file-level last-write-wins, silently destroying a device's edits. Making one shared document merge correctly requires an OT/CRDT server — the excluded new service. Per-device files are the serverless equivalent.
+- **Custom lean JSON format.** Rejected in favour of W3C: the standard's selector model is exactly the dual CFI+snippet anchor wanted, it is portable to other tooling, and "support an existing W3C standard" is a far easier eventual ask of ABS than "support Riffle's private dialect." The standard's silence on tombstones/merge is covered by the small `riffle:` extension.
+- **Cloud transports first** — SAF folder (Drive/Dropbox do **not** expose writable SAF trees; only local/Nextcloud/sync-app folders do), WebDAV (off-the-shelf, fits self-hosting), consumer-cloud OAuth (no infra, heavy client code). All deferred behind the interface; v1 is local-only by choice.
+
+## Consequences
+
+- Two target *kinds* are anticipated behind one interface: **blob-store** (folder of per-device files, client-side merge) and **record-store** (per-record CRUD, server-side merge — e.g. a future native ABS annotation API).
+- `deviceId` churn (reinstall, new device) costs only inert orphan *files*, never orphan *entries* — identity is the UUID, and any device can supersede or tombstone any record from its own file. The only true loss case is annotations created offline and never synced before an uninstall.
+- The format and schema are frozen-compatible with sync from day one, so local-only v1 cannot paint the design into a corner.
+
+## Planned first cloud transport (sync milestone — issues #75–78)
+
+When sync is built, the first concrete target is a **WebDAV** blob-store, hosted by the developer's **Synology NAS WebDAV Server** package and reached **over Tailscale** (the NAS joins the same tailnet the ABS server already uses; QuickConnect is deliberately *not* used — it brokers DSM/Synology-app traffic, not arbitrary WebDAV from a third-party HTTP client). These are reversible config/operational choices, not part of the irreversible format/merge core above:
+
+- **One global Annotation Sync config** (single WebDAV URL + user + password, credentials in Keystore-encrypted storage); per-Server scoping is preserved by the `<serverId>/<itemId>/` path, not by duplicate config.
+- **Per-book sync on the reader lifecycle** (open + close/pause) plus a debounced push on edit; **lazy per-book bootstrap** (no library-wide background sweep, no eager full pull) — add a sweep later only if a cross-library annotations view appears.
+- **No automatic GC:** tombstones and orphaned per-device files are kept indefinitely (tiny); only manual "forget device" / guarded tombstone-compaction actions, because purging a tombstone risks resurrection by a long-offline device.
+- **Privacy by construction:** Tailscale (WireGuard) encrypts transit and the data lives on the user's own NAS, so E2E payload encryption is deferred — revisit only if a third-party-cloud target (e.g. Google Drive `appDataFolder`, the strong second target for non-self-hosters) is added.


### PR DESCRIPTION
Closes #69.

## What changed

The tracer-bullet slice for EPUB Annotations: select text → coloured Highlight that persists and re-renders on reopen. Stands up the full sync-ready storage and the create→store→render path per [ADR 0024](docs/adr/0024-annotations-anchor-on-abs-epub-cfi.md) and [ADR 0025](docs/adr/0025-annotation-sync-pluggable-target-w3c-format.md).

- **`AnnotationEntity` + `AnnotationDao`** (`core/database`) carrying every sync-ready field now (stable UUID identity, `createdAt`/`updatedAt`, `originDeviceId`/`lastModifiedByDeviceId`, `deleted` tombstone, CFI **range** anchor, `color` token, nullable `note`, snippet + chapter href fallback) plus a `type` discriminator for future Notes/Bookmarks. DB **v24→v25**, schema `25.json` exported, `MIGRATION_24_25` registered, `MigrationTest` + `migrateFullChain` updated.
- **`DeviceIdStore`** (`core/domain` + `core/data`): a stable per-install UUID minted once via an atomic DataStore edit, reused across launches.
- **`AnnotationStore`**: `createHighlight` stamps a fresh UUID, yellow default, device-id provenance and timestamps; `delete` tombstones; `observeHighlights` returns the live, non-deleted set.
- **Pure CFI-range helpers** (`EpubCfiRange.kt`) reusing the character-count model of `EpubCfiTranslator`: build a range CFI from a selection, and re-anchor a stored highlight's start on reopen.
- **Reader wiring**: a "Highlight" action in the text-selection `ActionMode` (ABS-side only — absent on Storyteller-only / Readaloud), rendered via Readium's `DecorationService` on its own `annotations` group; all highlights re-render on reopen.

ABS-side reading only; EPUB only; no colour picker / notes UI / bookmarks / list view / sync (all later slices).

## Tested

- `./gradlew test` — all module unit/integration suites green.
- `./gradlew lint` — green.
- `make harness-test` (phone) — 134 tests, 0 failed (incl. `AnnotationReopenInstrumentedTest`, a real-EPUB persist→reopen re-anchor round-trip).
- `make harness-test-tablet` — 5 tests green.
- `core:database` instrumented — `AnnotationDaoTest` (5), `MigrationTest#migration24To25`, `migrateFullChain`→25 green.
- New unit tests: `DeviceIdStoreTest`, `AnnotationStoreTest`, `EpubCfiRangeTest`.