### PR TITLE
fix(reader): readaloud reader bugs on Android 7.1.1 (taps, play-from-here, reflow highlights)

### DIFF
--- a/app/src/androidTest/kotlin/com/riffle/app/feature/reader/ReaderWebViewScriptsTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/reader/ReaderWebViewScriptsTest.kt
@@ -1,24 +1,17 @@
 package com.riffle.app.feature.reader
 
 import android.webkit.WebView
-import android.webkit.WebViewClient
-import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import androidx.test.platform.app.InstrumentationRegistry
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.TimeUnit
 import org.json.JSONObject
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNotNull
-import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 
 /**
  * End-to-end verification of the two scripts EpubReaderScreen injects into every reflowable page,
- * run against a **real** WebView. The harness AVD is Android 7.1.1 (API 25), whose pre-Chromium-61
- * WebView is exactly the engine both fixes target — so these tests reproduce the original bugs and
- * prove the fix in the environment that actually broke.
+ * run against a **real** WebView via [withWebViewFixture]. The harness AVD is Android 7.1.1 (API 25),
+ * whose pre-Chromium-61 WebView is exactly the engine both fixes target — so these tests reproduce
+ * the original bugs and prove the fix in the environment that actually broke.
  *
  * Covers:
  *  - [RECT_TO_JSON_POLYFILL_JS]: on the old engine `getBoundingClientRect()` returns a ClientRect
@@ -40,13 +33,14 @@ class ReaderWebViewScriptsTest {
     """.trimIndent()
 
     // Sentence spans mirror the Storyteller bundle shape: each narrated sentence is a <span id="cNNN-sM">.
-    // s5 wraps an inner element with no id of its own to exercise the walk-up-to-nearest-id path.
+    // s5 wraps an inner element with no id of its own to exercise the walk-up-to-nearest-id path; the
+    // last paragraph has no id anywhere in its ancestry to exercise the "no sentence span" fallback.
     private val sentenceFixture = """
         <!DOCTYPE html>
         <html>
           <body>
             <p><span id="c007-s2">The quick brown fox.</span> <span id="c007-s5"><em>Jumps over it.</em></span></p>
-            <p id="no-sentence-id">Bare paragraph with no sentence span.</p>
+            <p>Bare paragraph with no id in its ancestry.</p>
           </body>
         </html>
     """.trimIndent()
@@ -55,7 +49,7 @@ class ReaderWebViewScriptsTest {
 
     @Test
     fun polyfillMakesGetBoundingClientRectToJsonReturnTheRect() {
-        withFixture(rectFixture) { webView ->
+        withWebViewFixture(rectFixture) { webView ->
             webView.evalSync(RECT_TO_JSON_POLYFILL_JS)
             // This is the exact call Readium's reflowable tap handler makes; on the un-polyfilled
             // API-25 engine it throws "toJSON is not a function" and swallows the tap.
@@ -78,7 +72,7 @@ class ReaderWebViewScriptsTest {
 
     @Test
     fun polyfillIsIdempotentAndKeepsToJsonWorking() {
-        withFixture(rectFixture) { webView ->
+        withWebViewFixture(rectFixture) { webView ->
             repeat(3) { webView.evalSync(RECT_TO_JSON_POLYFILL_JS) }
             val typeOfToJson = webView.evalSync(
                 "typeof document.getElementById('target').getBoundingClientRect().toJSON"
@@ -91,7 +85,7 @@ class ReaderWebViewScriptsTest {
 
     @Test
     fun selectionInsideSentenceSpanStashesItsId() {
-        withFixture(sentenceFixture) { webView ->
+        withWebViewFixture(sentenceFixture) { webView ->
             webView.evalSync(SELECTION_SPAN_TRACKER_JS)
             webView.selectWordIn("c007-s2")
             assertEquals("c007-s2", webView.awaitSelSpan())
@@ -100,7 +94,7 @@ class ReaderWebViewScriptsTest {
 
     @Test
     fun selectionWalksUpToNearestAncestorWithAnId() {
-        withFixture(sentenceFixture) { webView ->
+        withWebViewFixture(sentenceFixture) { webView ->
             webView.evalSync(SELECTION_SPAN_TRACKER_JS)
             // Selection lands inside the <em> (no id) → tracker must walk up to the enclosing span.
             webView.selectWordIn("c007-s5")
@@ -109,23 +103,39 @@ class ReaderWebViewScriptsTest {
     }
 
     @Test
-    fun collapsedSelectionDoesNotUpdateTheStashedId() {
-        withFixture(sentenceFixture) { webView ->
+    fun selectionWithoutASentenceSpanResetsTheStashedIdRatherThanLeavingItStale() {
+        withWebViewFixture(sentenceFixture) { webView ->
             webView.evalSync(SELECTION_SPAN_TRACKER_JS)
-            // First a real selection so __riffleSelSpan is set...
+            // Set a real span id first...
             webView.selectWordIn("c007-s2")
             assertEquals("c007-s2", webView.awaitSelSpan())
-            // ...then collapse it; the tracker ignores collapsed selections, so the value must hold.
+            // ...then select text whose ancestry has no id. The tracker must clear the stash to "" so
+            // "Play from here" falls back to the chapter position, NOT the previously-selected sentence.
+            webView.selectFirstWordOfBareParagraph()
+            assertEquals("", webView.awaitSelSpan(expectEmpty = true))
+        }
+    }
+
+    @Test
+    fun collapsedSelectionDoesNotUpdateTheStashedId() {
+        withWebViewFixture(sentenceFixture) { webView ->
+            webView.evalSync(SELECTION_SPAN_TRACKER_JS)
+            webView.selectWordIn("c007-s2")
+            assertEquals("c007-s2", webView.awaitSelSpan())
+            // Collapse it; the tracker ignores collapsed selections, so the value must hold.
             webView.evalSync("window.getSelection().collapseToEnd()")
-            // Give any (wrongly fired) update a chance to land, then re-read.
             Thread.sleep(150)
-            assertEquals("collapsed selection must not overwrite the stashed span", "c007-s2", webView.evalSync("window.__riffleSelSpan").trim('"'))
+            assertEquals(
+                "collapsed selection must not overwrite the stashed span",
+                "c007-s2",
+                webView.evalSync("window.__riffleSelSpan").trim('"'),
+            )
         }
     }
 
     @Test
     fun installIsIdempotent() {
-        withFixture(sentenceFixture) { webView ->
+        withWebViewFixture(sentenceFixture) { webView ->
             repeat(3) { webView.evalSync(SELECTION_SPAN_TRACKER_JS) }
             assertEquals("true", webView.evalSync("String(window.__riffleSelTrackerInstalled)").trim('"'))
             webView.selectWordIn("c007-s2")
@@ -135,8 +145,8 @@ class ReaderWebViewScriptsTest {
 
     // ---- helpers ----
 
-    // Selects a word inside the text node of [spanId] (or its first descendant text node), so the
-    // selection's startContainer is a text node — the realistic shape the tracker must handle.
+    // Selects a word inside the text node of [spanId], so the selection's startContainer is a text
+    // node — the realistic shape the tracker must handle.
     private fun WebView.selectWordIn(spanId: String) {
         evalSync(
             """
@@ -156,55 +166,36 @@ class ReaderWebViewScriptsTest {
         )
     }
 
-    // selectionchange is dispatched asynchronously; poll until the tracker has stashed a value.
-    private fun WebView.awaitSelSpan(timeoutMs: Long = 3_000): String {
+    // Selects inside the fixture's last <p>, which has no id anywhere in its ancestry.
+    private fun WebView.selectFirstWordOfBareParagraph() {
+        evalSync(
+            """
+            (function () {
+              var ps = document.getElementsByTagName('p');
+              var p = ps[ps.length - 1];
+              var textNode = p.firstChild;
+              var range = document.createRange();
+              range.setStart(textNode, 0);
+              range.setEnd(textNode, 4);
+              var sel = window.getSelection();
+              sel.removeAllRanges();
+              sel.addRange(range);
+              return 'ok';
+            })();
+            """.trimIndent(),
+        )
+    }
+
+    // selectionchange is dispatched asynchronously; poll until the tracker has written a value. When
+    // [expectEmpty], we instead wait for the stash to settle to "" (the reset case).
+    private fun WebView.awaitSelSpan(timeoutMs: Long = 3_000, expectEmpty: Boolean = false): String {
         val deadline = System.currentTimeMillis() + timeoutMs
         while (System.currentTimeMillis() < deadline) {
             val value = evalSync("window.__riffleSelSpan").trim('"')
-            if (value.isNotEmpty() && value != "null" && value != "undefined") return value
+            val settled = if (expectEmpty) value == "" else value.isNotEmpty() && value != "null" && value != "undefined"
+            if (settled) return value
             Thread.sleep(30)
         }
         return evalSync("window.__riffleSelSpan").trim('"')
-    }
-
-    private fun withFixture(html: String, block: (WebView) -> Unit) {
-        val instrumentation = InstrumentationRegistry.getInstrumentation()
-        val context = ApplicationProvider.getApplicationContext<android.content.Context>()
-        val ready = CountDownLatch(1)
-        val webViewHolder = arrayOfNulls<WebView>(1)
-        instrumentation.runOnMainSync {
-            val webView = WebView(context).also {
-                it.settings.javaScriptEnabled = true
-                it.webViewClient = object : WebViewClient() {
-                    override fun onPageFinished(view: WebView?, url: String?) {
-                        ready.countDown()
-                    }
-                }
-            }
-            webViewHolder[0] = webView
-            webView.loadDataWithBaseURL(null, html, "text/html", "utf-8", null)
-        }
-        assertTrue("Fixture page did not finish loading", ready.await(10, TimeUnit.SECONDS))
-        val webView = webViewHolder[0]!!
-        try {
-            block(webView)
-        } finally {
-            instrumentation.runOnMainSync { webView.destroy() }
-        }
-    }
-
-    private fun WebView.evalSync(script: String): String {
-        val latch = CountDownLatch(1)
-        val result = arrayOfNulls<String>(1)
-        InstrumentationRegistry.getInstrumentation().runOnMainSync {
-            evaluateJavascript(script) { value ->
-                result[0] = value
-                latch.countDown()
-            }
-        }
-        assertTrue("evaluateJavascript timed out for: $script", latch.await(5, TimeUnit.SECONDS))
-        val value = result[0]
-        assertNotNull("evaluateJavascript returned null for: $script", value)
-        return value!!
     }
 }

--- a/app/src/androidTest/kotlin/com/riffle/app/feature/reader/ReaderWebViewScriptsTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/reader/ReaderWebViewScriptsTest.kt
@@ -1,0 +1,210 @@
+package com.riffle.app.feature.reader
+
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * End-to-end verification of the two scripts EpubReaderScreen injects into every reflowable page,
+ * run against a **real** WebView. The harness AVD is Android 7.1.1 (API 25), whose pre-Chromium-61
+ * WebView is exactly the engine both fixes target — so these tests reproduce the original bugs and
+ * prove the fix in the environment that actually broke.
+ *
+ * Covers:
+ *  - [RECT_TO_JSON_POLYFILL_JS]: on the old engine `getBoundingClientRect()` returns a ClientRect
+ *    with no `toJSON()`, which made Readium's tap handler throw before delivering taps (the user
+ *    couldn't toggle immersive mode during readaloud). The polyfill restores a working `toJSON()`.
+ *  - [SELECTION_SPAN_TRACKER_JS]: stashes the narrated-sentence span id under the selection in
+ *    `window.__riffleSelSpan`, which "Play from here" reads to start at the selected sentence rather
+ *    than restarting the chapter.
+ */
+@RunWith(AndroidJUnit4::class)
+class ReaderWebViewScriptsTest {
+
+    private val rectFixture = """
+        <!DOCTYPE html>
+        <html>
+          <head><style>#target { position: absolute; left: 10px; top: 20px; width: 100px; height: 30px; }</style></head>
+          <body><div id="target">box</div></body>
+        </html>
+    """.trimIndent()
+
+    // Sentence spans mirror the Storyteller bundle shape: each narrated sentence is a <span id="cNNN-sM">.
+    // s5 wraps an inner element with no id of its own to exercise the walk-up-to-nearest-id path.
+    private val sentenceFixture = """
+        <!DOCTYPE html>
+        <html>
+          <body>
+            <p><span id="c007-s2">The quick brown fox.</span> <span id="c007-s5"><em>Jumps over it.</em></span></p>
+            <p id="no-sentence-id">Bare paragraph with no sentence span.</p>
+          </body>
+        </html>
+    """.trimIndent()
+
+    // ---- RECT_TO_JSON_POLYFILL_JS ----
+
+    @Test
+    fun polyfillMakesGetBoundingClientRectToJsonReturnTheRect() {
+        withFixture(rectFixture) { webView ->
+            webView.evalSync(RECT_TO_JSON_POLYFILL_JS)
+            // This is the exact call Readium's reflowable tap handler makes; on the un-polyfilled
+            // API-25 engine it throws "toJSON is not a function" and swallows the tap.
+            val typeOfToJson = webView.evalSync(
+                "typeof document.getElementById('target').getBoundingClientRect().toJSON"
+            ).trim('"')
+            assertEquals("polyfill must install a callable toJSON()", "function", typeOfToJson)
+
+            val json = webView.evalSync(
+                "JSON.stringify(document.getElementById('target').getBoundingClientRect().toJSON())"
+            )
+            // evaluateJavascript wraps strings in quotes and escapes inner quotes.
+            val obj = JSONObject(json.trim('"').replace("\\\"", "\""))
+            assertEquals("toJSON must carry the rect width", 100.0, obj.getDouble("width"), 0.5)
+            assertEquals("toJSON must carry the rect height", 30.0, obj.getDouble("height"), 0.5)
+            assertEquals("toJSON must carry the rect left", 10.0, obj.getDouble("left"), 0.5)
+            assertEquals("toJSON must carry the rect top", 20.0, obj.getDouble("top"), 0.5)
+        }
+    }
+
+    @Test
+    fun polyfillIsIdempotentAndKeepsToJsonWorking() {
+        withFixture(rectFixture) { webView ->
+            repeat(3) { webView.evalSync(RECT_TO_JSON_POLYFILL_JS) }
+            val typeOfToJson = webView.evalSync(
+                "typeof document.getElementById('target').getBoundingClientRect().toJSON"
+            ).trim('"')
+            assertEquals("repeat injection must leave a working toJSON()", "function", typeOfToJson)
+        }
+    }
+
+    // ---- SELECTION_SPAN_TRACKER_JS ----
+
+    @Test
+    fun selectionInsideSentenceSpanStashesItsId() {
+        withFixture(sentenceFixture) { webView ->
+            webView.evalSync(SELECTION_SPAN_TRACKER_JS)
+            webView.selectWordIn("c007-s2")
+            assertEquals("c007-s2", webView.awaitSelSpan())
+        }
+    }
+
+    @Test
+    fun selectionWalksUpToNearestAncestorWithAnId() {
+        withFixture(sentenceFixture) { webView ->
+            webView.evalSync(SELECTION_SPAN_TRACKER_JS)
+            // Selection lands inside the <em> (no id) → tracker must walk up to the enclosing span.
+            webView.selectWordIn("c007-s5")
+            assertEquals("c007-s5", webView.awaitSelSpan())
+        }
+    }
+
+    @Test
+    fun collapsedSelectionDoesNotUpdateTheStashedId() {
+        withFixture(sentenceFixture) { webView ->
+            webView.evalSync(SELECTION_SPAN_TRACKER_JS)
+            // First a real selection so __riffleSelSpan is set...
+            webView.selectWordIn("c007-s2")
+            assertEquals("c007-s2", webView.awaitSelSpan())
+            // ...then collapse it; the tracker ignores collapsed selections, so the value must hold.
+            webView.evalSync("window.getSelection().collapseToEnd()")
+            // Give any (wrongly fired) update a chance to land, then re-read.
+            Thread.sleep(150)
+            assertEquals("collapsed selection must not overwrite the stashed span", "c007-s2", webView.evalSync("window.__riffleSelSpan").trim('"'))
+        }
+    }
+
+    @Test
+    fun installIsIdempotent() {
+        withFixture(sentenceFixture) { webView ->
+            repeat(3) { webView.evalSync(SELECTION_SPAN_TRACKER_JS) }
+            assertEquals("true", webView.evalSync("String(window.__riffleSelTrackerInstalled)").trim('"'))
+            webView.selectWordIn("c007-s2")
+            assertEquals("c007-s2", webView.awaitSelSpan())
+        }
+    }
+
+    // ---- helpers ----
+
+    // Selects a word inside the text node of [spanId] (or its first descendant text node), so the
+    // selection's startContainer is a text node — the realistic shape the tracker must handle.
+    private fun WebView.selectWordIn(spanId: String) {
+        evalSync(
+            """
+            (function () {
+              var el = document.getElementById('$spanId');
+              var walker = document.createTreeWalker(el, NodeFilter.SHOW_TEXT, null, false);
+              var textNode = walker.nextNode();
+              var range = document.createRange();
+              range.setStart(textNode, 0);
+              range.setEnd(textNode, Math.min(3, textNode.length));
+              var sel = window.getSelection();
+              sel.removeAllRanges();
+              sel.addRange(range);
+              return 'ok';
+            })();
+            """.trimIndent(),
+        )
+    }
+
+    // selectionchange is dispatched asynchronously; poll until the tracker has stashed a value.
+    private fun WebView.awaitSelSpan(timeoutMs: Long = 3_000): String {
+        val deadline = System.currentTimeMillis() + timeoutMs
+        while (System.currentTimeMillis() < deadline) {
+            val value = evalSync("window.__riffleSelSpan").trim('"')
+            if (value.isNotEmpty() && value != "null" && value != "undefined") return value
+            Thread.sleep(30)
+        }
+        return evalSync("window.__riffleSelSpan").trim('"')
+    }
+
+    private fun withFixture(html: String, block: (WebView) -> Unit) {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+        val ready = CountDownLatch(1)
+        val webViewHolder = arrayOfNulls<WebView>(1)
+        instrumentation.runOnMainSync {
+            val webView = WebView(context).also {
+                it.settings.javaScriptEnabled = true
+                it.webViewClient = object : WebViewClient() {
+                    override fun onPageFinished(view: WebView?, url: String?) {
+                        ready.countDown()
+                    }
+                }
+            }
+            webViewHolder[0] = webView
+            webView.loadDataWithBaseURL(null, html, "text/html", "utf-8", null)
+        }
+        assertTrue("Fixture page did not finish loading", ready.await(10, TimeUnit.SECONDS))
+        val webView = webViewHolder[0]!!
+        try {
+            block(webView)
+        } finally {
+            instrumentation.runOnMainSync { webView.destroy() }
+        }
+    }
+
+    private fun WebView.evalSync(script: String): String {
+        val latch = CountDownLatch(1)
+        val result = arrayOfNulls<String>(1)
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            evaluateJavascript(script) { value ->
+                result[0] = value
+                latch.countDown()
+            }
+        }
+        assertTrue("evaluateJavascript timed out for: $script", latch.await(5, TimeUnit.SECONDS))
+        val value = result[0]
+        assertNotNull("evaluateJavascript returned null for: $script", value)
+        return value!!
+    }
+}

--- a/app/src/androidTest/kotlin/com/riffle/app/feature/reader/ReflowReapplyGenerationTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/reader/ReflowReapplyGenerationTest.kt
@@ -1,0 +1,72 @@
+package com.riffle.app.feature.reader
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.riffle.core.domain.ReaderOrientation
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Unit-tests the reflow re-apply trigger ([rememberReflowReapplyGeneration]) in isolation — no
+ * WebView, no Readium. Guards bug-3: a paused readaloud highlight that landed on the wrong sentence
+ * after switching orientation because nothing re-applied the decoration onto the reflowed layout.
+ *
+ * The generation must stay put on first composition (so merely opening a book triggers no re-apply
+ * storm) and must bump after an orientation change (so the decoration effects keyed on it recompute).
+ */
+@RunWith(AndroidJUnit4::class)
+class ReflowReapplyGenerationTest {
+
+    @get:Rule val rule = createComposeRule()
+
+    @Test
+    fun firstCompositionDoesNotBump() {
+        var generation = -1
+        rule.setContent {
+            generation = rememberReflowReapplyGeneration(ReaderOrientation.Vertical)
+        }
+        rule.waitForIdle()
+        assertEquals("opening at a fixed orientation must not bump the generation", 0, generation)
+    }
+
+    @Test
+    fun orientationChangeBumpsAcrossTheSettleWindow() {
+        var orientation by mutableStateOf(ReaderOrientation.Vertical)
+        var generation = -1
+        rule.setContent {
+            generation = rememberReflowReapplyGeneration(orientation)
+        }
+        rule.waitForIdle()
+        assertEquals("baseline: no bump before any orientation change", 0, generation)
+
+        orientation = ReaderOrientation.Horizontal
+
+        // The trigger re-applies a few times across the relayout settle window (150 + 350 + 700 ms);
+        // the auto-advancing test clock drives those delays. Three bumps in total.
+        rule.waitUntil(timeoutMillis = 5_000) { generation == 3 }
+        assertEquals(3, generation)
+    }
+
+    @Test
+    fun eachOrientationChangeRetriggersTheBumps() {
+        var orientation by mutableStateOf(ReaderOrientation.Vertical)
+        var generation = -1
+        rule.setContent {
+            generation = rememberReflowReapplyGeneration(orientation)
+        }
+        rule.waitForIdle()
+
+        orientation = ReaderOrientation.Horizontal
+        rule.waitUntil(timeoutMillis = 5_000) { generation == 3 }
+
+        // A second switch must schedule another round of re-applies, not stay latched at 3.
+        orientation = ReaderOrientation.Vertical
+        rule.waitUntil(timeoutMillis = 5_000) { generation == 6 }
+        assertEquals(6, generation)
+    }
+}

--- a/app/src/androidTest/kotlin/com/riffle/app/feature/reader/TypographyOverrideWebViewTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/reader/TypographyOverrideWebViewTest.kt
@@ -1,15 +1,7 @@
 package com.riffle.app.feature.reader
 
-import android.webkit.WebView
-import android.webkit.WebViewClient
-import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import androidx.test.platform.app.InstrumentationRegistry
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.TimeUnit
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNotNull
-import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 
@@ -49,7 +41,7 @@ class TypographyOverrideWebViewTest {
 
     @Test
     fun overrideIsInertWhenUserVariableIsNotSetOnRoot() {
-        withFixture(hostileSboFixture) { webView ->
+        withWebViewFixture(hostileSboFixture) { webView ->
             // No --USER__lineHeight on :root → gate doesn't match → override inert →
             // publisher's 125% must win.
             webView.evalSync(typographyOverrideInjectionJs())
@@ -66,7 +58,7 @@ class TypographyOverrideWebViewTest {
 
     @Test
     fun overrideWinsWhenUserVariableIsSetOnRoot() {
-        withFixture(hostileSboFixture) { webView ->
+        withWebViewFixture(hostileSboFixture) { webView ->
             // User customised line-spacing → Readium would write --USER__lineHeight on :root.
             // We simulate that here, then inject our override. Without the override the
             // publisher's #sbo-rt-content p { line-height: 125% } would still win because
@@ -89,7 +81,7 @@ class TypographyOverrideWebViewTest {
 
     @Test
     fun overrideWinsForJustifyText() {
-        withFixture(hostileSboFixture) { webView ->
+        withWebViewFixture(hostileSboFixture) { webView ->
             webView.evalSync("document.documentElement.style.setProperty('--USER__textAlign', 'justify')")
             webView.evalSync(typographyOverrideInjectionJs())
             val textAlign = webView.evalSync(
@@ -101,7 +93,7 @@ class TypographyOverrideWebViewTest {
 
     @Test
     fun overrideIsInertForTextAlignWhenUserVariableIsNotSet() {
-        withFixture(hostileSboFixture) { webView ->
+        withWebViewFixture(hostileSboFixture) { webView ->
             webView.evalSync(typographyOverrideInjectionJs())
             val textAlign = webView.evalSync(
                 "window.getComputedStyle(document.getElementById('target')).textAlign"
@@ -118,7 +110,7 @@ class TypographyOverrideWebViewTest {
     // an explicit --RS__pageGutter on :root so the calc has a concrete value.
     @Test
     fun marginsOverrideAppliesVerticalPaddingToRootWhenUserVariableIsSet() {
-        withFixture(hostileSboFixture) { webView ->
+        withWebViewFixture(hostileSboFixture) { webView ->
             webView.evalSync("document.documentElement.style.setProperty('--RS__pageGutter', '20px')")
             webView.evalSync("document.documentElement.style.setProperty('--USER__pageMargins', '2')")
             webView.evalSync(typographyOverrideInjectionJs())
@@ -139,7 +131,7 @@ class TypographyOverrideWebViewTest {
 
     @Test
     fun marginsOverrideIsInertWhenUserVariableIsNotSet() {
-        withFixture(hostileSboFixture) { webView ->
+        withWebViewFixture(hostileSboFixture) { webView ->
             webView.evalSync("document.documentElement.style.setProperty('--RS__pageGutter', '20px')")
             webView.evalSync(typographyOverrideInjectionJs())
             // No --USER__pageMargins → gate doesn't match → :root padding stays at fixture default (0).
@@ -152,7 +144,7 @@ class TypographyOverrideWebViewTest {
 
     @Test
     fun repeatedInjectionDoesNotAccumulateStyleElements() {
-        withFixture(hostileSboFixture) { webView ->
+        withWebViewFixture(hostileSboFixture) { webView ->
             repeat(5) { webView.evalSync(typographyOverrideInjectionJs()) }
             val count = webView.evalSync(
                 "document.querySelectorAll('#riffle-typography-override').length.toString()"
@@ -162,47 +154,6 @@ class TypographyOverrideWebViewTest {
     }
 
     // ---- helpers ----
-
-    private fun withFixture(html: String, block: (WebView) -> Unit) {
-        val instrumentation = InstrumentationRegistry.getInstrumentation()
-        val context = ApplicationProvider.getApplicationContext<android.content.Context>()
-        val ready = CountDownLatch(1)
-        val webViewHolder = arrayOfNulls<WebView>(1)
-        instrumentation.runOnMainSync {
-            val webView = WebView(context).also {
-                it.settings.javaScriptEnabled = true
-                it.webViewClient = object : WebViewClient() {
-                    override fun onPageFinished(view: WebView?, url: String?) {
-                        ready.countDown()
-                    }
-                }
-            }
-            webViewHolder[0] = webView
-            webView.loadDataWithBaseURL(null, html, "text/html", "utf-8", null)
-        }
-        assertTrue("Fixture page did not finish loading", ready.await(10, TimeUnit.SECONDS))
-        val webView = webViewHolder[0]!!
-        try {
-            block(webView)
-        } finally {
-            instrumentation.runOnMainSync { webView.destroy() }
-        }
-    }
-
-    private fun WebView.evalSync(script: String): String {
-        val latch = CountDownLatch(1)
-        val result = arrayOfNulls<String>(1)
-        InstrumentationRegistry.getInstrumentation().runOnMainSync {
-            evaluateJavascript(script) { value ->
-                result[0] = value
-                latch.countDown()
-            }
-        }
-        assertTrue("evaluateJavascript timed out for: $script", latch.await(5, TimeUnit.SECONDS))
-        val value = result[0]
-        assertNotNull("evaluateJavascript returned null for: $script", value)
-        return value!!
-    }
 
     // `getComputedStyle().lineHeight` returns either a px string or "normal" — we never want
     // "normal" in these tests (the fixture sets explicit values), so parse the px number.

--- a/app/src/androidTest/kotlin/com/riffle/app/feature/reader/WebViewScriptFixture.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/reader/WebViewScriptFixture.kt
@@ -1,0 +1,57 @@
+package com.riffle.app.feature.reader
+
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.platform.app.InstrumentationRegistry
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+
+/**
+ * Shared real-WebView harness for the injected-reader-script tests (see [ReaderWebViewScriptsTest]
+ * and [TypographyOverrideWebViewTest]): load a fixed HTML fixture, run synchronous evaluateJavascript
+ * against it, then tear the WebView down. Kept in one place so timeout/setting tweaks don't drift.
+ */
+internal fun withWebViewFixture(html: String, block: (WebView) -> Unit) {
+    val instrumentation = InstrumentationRegistry.getInstrumentation()
+    val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+    val ready = CountDownLatch(1)
+    val webViewHolder = arrayOfNulls<WebView>(1)
+    instrumentation.runOnMainSync {
+        val webView = WebView(context).also {
+            it.settings.javaScriptEnabled = true
+            it.webViewClient = object : WebViewClient() {
+                override fun onPageFinished(view: WebView?, url: String?) {
+                    ready.countDown()
+                }
+            }
+        }
+        webViewHolder[0] = webView
+        webView.loadDataWithBaseURL(null, html, "text/html", "utf-8", null)
+    }
+    assertTrue("Fixture page did not finish loading", ready.await(10, TimeUnit.SECONDS))
+    val webView = webViewHolder[0]!!
+    try {
+        block(webView)
+    } finally {
+        instrumentation.runOnMainSync { webView.destroy() }
+    }
+}
+
+/** Runs [script] on the WebView's main thread and blocks until its result is available. */
+internal fun WebView.evalSync(script: String): String {
+    val latch = CountDownLatch(1)
+    val result = arrayOfNulls<String>(1)
+    InstrumentationRegistry.getInstrumentation().runOnMainSync {
+        evaluateJavascript(script) { value ->
+            result[0] = value
+            latch.countDown()
+        }
+    }
+    assertTrue("evaluateJavascript timed out for: $script", latch.await(5, TimeUnit.SECONDS))
+    val value = result[0]
+    assertNotNull("evaluateJavascript returned null for: $script", value)
+    return value!!
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -100,6 +100,89 @@ import org.readium.r2.shared.publication.Link
 import org.readium.r2.shared.publication.Locator
 import org.readium.r2.shared.util.AbsoluteUrl
 
+// Readium 3.0.0's reflowable tap handler (`ut` in readium-reflowable.js) hit-tests decorations
+// by calling `element.getBoundingClientRect().toJSON()`. On Android's pre-Chromium-61 WebView
+// (API ≤ 27, e.g. Android 7.1.1) getBoundingClientRect() returns a ClientRect with no toJSON(),
+// so that call throws *before* Readium forwards the gesture to Android.onTap — silently
+// swallowing every tap whenever an activable decoration is present. In practice that's the
+// readaloud sentence highlight: while (or after) readaloud runs, the user can no longer tap to
+// enter/exit immersive mode. Adding the missing toJSON() restores tap delivery. Injected per
+// page (see paginationListener) and guarded so it's a no-op where the engine already has it.
+internal val RECT_TO_JSON_POLYFILL_JS = """
+    (function () {
+      try {
+        var protos = [];
+        if (window.DOMRect && DOMRect.prototype) protos.push(DOMRect.prototype);
+        if (window.ClientRect && ClientRect.prototype) protos.push(ClientRect.prototype);
+        try { protos.push(Object.getPrototypeOf(document.documentElement.getBoundingClientRect())); } catch (e) {}
+        protos.forEach(function (p) {
+          if (p && typeof p.toJSON !== 'function') {
+            p.toJSON = function () {
+              return {
+                x: this.x, y: this.y, width: this.width, height: this.height,
+                top: this.top, right: this.right, bottom: this.bottom, left: this.left
+              };
+            };
+          }
+        });
+      } catch (e) {}
+    })();
+""".trimIndent()
+
+// Tracks the narrated-sentence span under the user's text selection so "Play from here" can resolve
+// the right SMIL clip. Storyteller wraps each sentence in <span id="cNNN-sM">; on every non-collapsed
+// selectionchange we walk up from the selection start to the nearest element with an id and stash it
+// in window.__riffleSelSpan. The stashed value survives the action-mode teardown that collapses the
+// DOM selection, so the menu handler can still read it. Idempotent via the installed flag.
+internal val SELECTION_SPAN_TRACKER_JS = """
+    (function () {
+      if (window.__riffleSelTrackerInstalled) return;
+      window.__riffleSelTrackerInstalled = true;
+      document.addEventListener('selectionchange', function () {
+        var s = window.getSelection();
+        if (!s || s.rangeCount === 0 || s.isCollapsed) return;
+        var n = s.getRangeAt(0).startContainer;
+        if (n && n.nodeType === 3) n = n.parentElement;
+        while (n && n !== document.body) {
+          if (n.id) { window.__riffleSelSpan = n.id; return; }
+          n = n.parentElement;
+        }
+      });
+    })();
+""".trimIndent()
+
+/**
+ * A generation counter that increments a few times shortly after [orientation] changes — so
+ * decoration effects keyed on it re-apply against the reflowed layout.
+ *
+ * Switching orientation/scroll mode reflows the WebView in place (submitPreferences). Readium does
+ * not re-render existing decorations onto the new layout, so a stable highlight — e.g. a paused
+ * readaloud sentence, whose activeFragmentRef isn't changing to re-trigger its own effect — ends up
+ * painted on the wrong sentence. The relayout settles asynchronously and emits no reliable "done"
+ * signal (onPageLoaded does not fire for an in-place reflow), so we bump a few times across a short
+ * settle window: the bump that lands once the relayout has completed is the one that makes the
+ * re-apply stick, and the earlier/duplicate re-applies are idempotent. The first composition is
+ * skipped so opening a book doesn't trigger a needless re-apply storm.
+ *
+ * Extracted (rather than inlined) so the trigger schedule is unit-testable independent of the reader.
+ */
+@Composable
+internal fun rememberReflowReapplyGeneration(orientation: ReaderOrientation): Int {
+    val generation = remember { mutableStateOf(0) }
+    var settled by remember { mutableStateOf(false) }
+    LaunchedEffect(orientation) {
+        if (!settled) {
+            settled = true
+            return@LaunchedEffect
+        }
+        for (settleMs in longArrayOf(150L, 350L, 700L)) {
+            delay(settleMs)
+            generation.value += 1
+        }
+    }
+    return generation.value
+}
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun EpubReaderScreen(
@@ -713,10 +796,21 @@ private fun EpubNavigatorView(
                     playFromHereMenuId -> {
                         val selectable = fragmentRef.value as? org.readium.r2.navigator.SelectableNavigator
                             ?: return false
+                        val nav = fragmentRef.value
                         coroutineScope.launch {
                             val selection = selectable.currentSelection() ?: return@launch
                             val loc = selection.locator
-                            val fragId = loc.locations.fragments.firstOrNull()
+                            // Storyteller wraps each narrated sentence in <span id="cNNN-sM"> — exactly the
+                            // SMIL clip target the player keys on. Readium's selection locator carries only
+                            // text + rect (no fragment id), so without that span id the player can't map the
+                            // selection to a clip and restarts the chapter from its first clip. The
+                            // selectionchange tracker (SELECTION_SPAN_TRACKER_JS, injected per page) stashes
+                            // the enclosing span id in window.__riffleSelSpan as the user selects, so it's
+                            // still readable here even though the action-mode teardown has collapsed the DOM
+                            // selection by the time this coroutine runs.
+                            val spanId = nav?.evaluateJavascript("window.__riffleSelSpan || ''")
+                                ?.trim('"')?.takeIf { it.isNotEmpty() }
+                            val fragId = spanId ?: loc.locations.fragments.firstOrNull()
                             val ref = if (fragId != null) "${loc.href}#$fragId" else loc.href.toString()
                             currentOnPlayFromHere(ref)
                             selectable.clearSelection()
@@ -762,15 +856,23 @@ private fun EpubNavigatorView(
         }
     }
 
-    // Injects the targeted typography overrides (see TypographyOverride.kt) into each newly
-    // loaded reflowable page, plus the footnote-anchor install script. Both are idempotent
-    // (typography deduplicates by <style> tag, footnote by window.__riffleFootnoteInstalled),
-    // so repeated firings during reflow are harmless.
+    // Bumps whenever the layout reflows so the decoration effects below re-apply onto the new layout
+    // (see rememberReflowReapplyGeneration for why).
+    val reflowGeneration = rememberReflowReapplyGeneration(formattingPrefs.orientation)
+
+    // Injects, into each newly loaded reflowable page: the ClientRect.toJSON polyfill (see
+    // RECT_TO_JSON_POLYFILL_JS), the selection-span tracker (SELECTION_SPAN_TRACKER_JS), the targeted
+    // typography overrides (see TypographyOverride.kt), and the footnote-anchor install script. All are
+    // idempotent (typography deduplicates by <style> tag, footnote by window.__riffleFootnoteInstalled,
+    // tracker by window.__riffleSelTrackerInstalled, the polyfill by a typeof guard), so repeated
+    // firings during reflow are harmless.
     val paginationListener = remember {
         object : EpubNavigatorFragment.PaginationListener {
             override fun onPageLoaded() {
                 val fragment = fragmentRef.value ?: return
                 coroutineScope.launch {
+                    fragment.evaluateJavascript(RECT_TO_JSON_POLYFILL_JS)
+                    fragment.evaluateJavascript(SELECTION_SPAN_TRACKER_JS)
                     fragment.evaluateJavascript(typographyOverrideInjectionJs())
                     fragment.evaluateJavascript(FootnoteAnchorBridge.INSTALL_SCRIPT)
                 }
@@ -854,7 +956,7 @@ private fun EpubNavigatorView(
     // a Locator with that href and a cssSelector targeting the fragment id, which is how Readium's
     // EPUB decorator resolves the DOM range for a highlight. Null clears the decoration.
     val hasReadaloudDecoration = remember { mutableStateOf(false) }
-    LaunchedEffect(activeFragmentRef) {
+    LaunchedEffect(activeFragmentRef, reflowGeneration) {
         val fragment = fragmentRef.value as? DecorableNavigator ?: return@LaunchedEffect
         val ref = activeFragmentRef
         if (ref == null) {
@@ -885,7 +987,7 @@ private fun EpubNavigatorView(
     // own "annotations" group. Re-applied whenever the set changes — including the re-render of
     // every highlight when the book is reopened, and the immediate paint after a new highlight.
     val hasHighlightDecorations = remember { mutableStateOf(false) }
-    LaunchedEffect(highlightRenders) {
+    LaunchedEffect(highlightRenders, reflowGeneration) {
         val fragment = fragmentRef.value as? DecorableNavigator ?: return@LaunchedEffect
         if (highlightRenders.isEmpty()) {
             if (!hasHighlightDecorations.value) return@LaunchedEffect

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -100,77 +100,28 @@ import org.readium.r2.shared.publication.Link
 import org.readium.r2.shared.publication.Locator
 import org.readium.r2.shared.util.AbsoluteUrl
 
-// Readium 3.0.0's reflowable tap handler (`ut` in readium-reflowable.js) hit-tests decorations
-// by calling `element.getBoundingClientRect().toJSON()`. On Android's pre-Chromium-61 WebView
-// (API ≤ 27, e.g. Android 7.1.1) getBoundingClientRect() returns a ClientRect with no toJSON(),
-// so that call throws *before* Readium forwards the gesture to Android.onTap — silently
-// swallowing every tap whenever an activable decoration is present. In practice that's the
-// readaloud sentence highlight: while (or after) readaloud runs, the user can no longer tap to
-// enter/exit immersive mode. Adding the missing toJSON() restores tap delivery. Injected per
-// page (see paginationListener) and guarded so it's a no-op where the engine already has it.
-internal val RECT_TO_JSON_POLYFILL_JS = """
-    (function () {
-      try {
-        var protos = [];
-        if (window.DOMRect && DOMRect.prototype) protos.push(DOMRect.prototype);
-        if (window.ClientRect && ClientRect.prototype) protos.push(ClientRect.prototype);
-        try { protos.push(Object.getPrototypeOf(document.documentElement.getBoundingClientRect())); } catch (e) {}
-        protos.forEach(function (p) {
-          if (p && typeof p.toJSON !== 'function') {
-            p.toJSON = function () {
-              return {
-                x: this.x, y: this.y, width: this.width, height: this.height,
-                top: this.top, right: this.right, bottom: this.bottom, left: this.left
-              };
-            };
-          }
-        });
-      } catch (e) {}
-    })();
-""".trimIndent()
-
-// Tracks the narrated-sentence span under the user's text selection so "Play from here" can resolve
-// the right SMIL clip. Storyteller wraps each sentence in <span id="cNNN-sM">; on every non-collapsed
-// selectionchange we walk up from the selection start to the nearest element with an id and stash it
-// in window.__riffleSelSpan. The stashed value survives the action-mode teardown that collapses the
-// DOM selection, so the menu handler can still read it. Idempotent via the installed flag.
-internal val SELECTION_SPAN_TRACKER_JS = """
-    (function () {
-      if (window.__riffleSelTrackerInstalled) return;
-      window.__riffleSelTrackerInstalled = true;
-      document.addEventListener('selectionchange', function () {
-        var s = window.getSelection();
-        if (!s || s.rangeCount === 0 || s.isCollapsed) return;
-        var n = s.getRangeAt(0).startContainer;
-        if (n && n.nodeType === 3) n = n.parentElement;
-        while (n && n !== document.body) {
-          if (n.id) { window.__riffleSelSpan = n.id; return; }
-          n = n.parentElement;
-        }
-      });
-    })();
-""".trimIndent()
-
 /**
- * A generation counter that increments a few times shortly after [orientation] changes — so
- * decoration effects keyed on it re-apply against the reflowed layout.
+ * A generation counter that increments a few times shortly after [reflowTrigger] changes — so
+ * decoration effects keyed on it re-apply against the reflowed layout. Pass a value that changes
+ * whenever the layout reflows; in practice the formatting preferences (orientation/scroll mode, font
+ * size, margins, line spacing, font family all reflow the page via submitPreferences).
  *
- * Switching orientation/scroll mode reflows the WebView in place (submitPreferences). Readium does
- * not re-render existing decorations onto the new layout, so a stable highlight — e.g. a paused
- * readaloud sentence, whose activeFragmentRef isn't changing to re-trigger its own effect — ends up
- * painted on the wrong sentence. The relayout settles asynchronously and emits no reliable "done"
- * signal (onPageLoaded does not fire for an in-place reflow), so we bump a few times across a short
- * settle window: the bump that lands once the relayout has completed is the one that makes the
- * re-apply stick, and the earlier/duplicate re-applies are idempotent. The first composition is
- * skipped so opening a book doesn't trigger a needless re-apply storm.
+ * Readium does not re-render existing decorations onto a reflowed layout, so a stable highlight —
+ * e.g. a paused readaloud sentence, whose activeFragmentRef isn't changing to re-trigger its own
+ * effect — ends up painted on the wrong sentence. The relayout settles asynchronously; for an
+ * in-place reflow there's no onPageLoaded to hang the re-apply on, so we bump a few times across a
+ * short settle window: the bump that lands once the relayout has completed is the one that makes the
+ * re-apply stick, and the earlier/duplicate re-applies are idempotent. The settle delays are a
+ * heuristic (no engine signal exists for "reflow done"); they're sized for the low-end API-25 devices
+ * the feature targets. The first composition is skipped so opening a book triggers no re-apply storm.
  *
  * Extracted (rather than inlined) so the trigger schedule is unit-testable independent of the reader.
  */
 @Composable
-internal fun rememberReflowReapplyGeneration(orientation: ReaderOrientation): Int {
+internal fun rememberReflowReapplyGeneration(reflowTrigger: Any?): Int {
     val generation = remember { mutableStateOf(0) }
     var settled by remember { mutableStateOf(false) }
-    LaunchedEffect(orientation) {
+    LaunchedEffect(reflowTrigger) {
         if (!settled) {
             settled = true
             return@LaunchedEffect
@@ -805,9 +756,10 @@ private fun EpubNavigatorView(
                             // text + rect (no fragment id), so without that span id the player can't map the
                             // selection to a clip and restarts the chapter from its first clip. The
                             // selectionchange tracker (SELECTION_SPAN_TRACKER_JS, injected per page) stashes
-                            // the enclosing span id in window.__riffleSelSpan as the user selects, so it's
-                            // still readable here even though the action-mode teardown has collapsed the DOM
-                            // selection by the time this coroutine runs.
+                            // the enclosing span id in window.__riffleSelSpan as the user selects; we read
+                            // that stash rather than the live DOM selection so the value is robust to the
+                            // action-mode teardown. Empty when the selection had no sentence-span ancestor →
+                            // falls back to the locator fragment, then the bare href (chapter start).
                             val spanId = nav?.evaluateJavascript("window.__riffleSelSpan || ''")
                                 ?.trim('"')?.takeIf { it.isNotEmpty() }
                             val fragId = spanId ?: loc.locations.fragments.firstOrNull()
@@ -856,9 +808,9 @@ private fun EpubNavigatorView(
         }
     }
 
-    // Bumps whenever the layout reflows so the decoration effects below re-apply onto the new layout
-    // (see rememberReflowReapplyGeneration for why).
-    val reflowGeneration = rememberReflowReapplyGeneration(formattingPrefs.orientation)
+    // Bumps whenever a formatting change reflows the layout so the decoration effects below re-apply
+    // onto the new layout (see rememberReflowReapplyGeneration for why).
+    val reflowGeneration = rememberReflowReapplyGeneration(formattingPrefs)
 
     // Injects, into each newly loaded reflowable page: the ClientRect.toJSON polyfill (see
     // RECT_TO_JSON_POLYFILL_JS), the selection-span tracker (SELECTION_SPAN_TRACKER_JS), the targeted

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderWebViewScripts.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderWebViewScripts.kt
@@ -1,0 +1,63 @@
+package com.riffle.app.feature.reader
+
+/**
+ * JavaScript snippets EpubReaderScreen injects into every reflowable page (see the
+ * paginationListener's onPageLoaded). Kept together — and out of the screen file — alongside the
+ * other injected-script homes ([TypographyOverride], [FootnoteAnchorBridge]). All are idempotent so
+ * repeated firing during reflow is harmless.
+ */
+
+// Readium 3.0.0's reflowable tap handler (`ut` in readium-reflowable.js) hit-tests decorations by
+// calling `element.getBoundingClientRect().toJSON()`. On Android's pre-Chromium-61 WebView (API ≤ 27,
+// e.g. Android 7.1.1) getBoundingClientRect() returns a ClientRect with no toJSON(), so that call
+// throws *before* Readium forwards the gesture to Android.onTap — silently swallowing every tap
+// whenever an activable decoration is present. In practice that's the readaloud sentence highlight:
+// while (or after) readaloud runs, the user can no longer tap to enter/exit immersive mode. Adding
+// the missing toJSON() restores tap delivery. Guarded so it's a no-op where the engine already has it.
+internal val RECT_TO_JSON_POLYFILL_JS = """
+    (function () {
+      try {
+        var protos = [];
+        if (window.DOMRect && DOMRect.prototype) protos.push(DOMRect.prototype);
+        if (window.ClientRect && ClientRect.prototype) protos.push(ClientRect.prototype);
+        try { protos.push(Object.getPrototypeOf(document.documentElement.getBoundingClientRect())); } catch (e) {}
+        protos.forEach(function (p) {
+          if (p && typeof p.toJSON !== 'function') {
+            p.toJSON = function () {
+              return {
+                x: this.x, y: this.y, width: this.width, height: this.height,
+                top: this.top, right: this.right, bottom: this.bottom, left: this.left
+              };
+            };
+          }
+        });
+      } catch (e) {}
+    })();
+""".trimIndent()
+
+// Tracks the narrated-sentence span under the user's text selection so "Play from here" can resolve
+// the right SMIL clip. Storyteller wraps each sentence in <span id="cNNN-sM">; on every non-collapsed
+// selectionchange we walk up from the selection start to the nearest element with an id and stash it
+// in window.__riffleSelSpan (or "" when nothing in the ancestry has one). The stashed value survives
+// the action-mode teardown, so the menu handler can read it after the DOM selection is gone. We always
+// overwrite on a fresh selection — never leave a previous selection's id behind — so a selection with
+// no sentence-span ancestor cleanly falls back to the chapter position rather than reusing a stale id.
+// Idempotent via the installed flag.
+internal val SELECTION_SPAN_TRACKER_JS = """
+    (function () {
+      if (window.__riffleSelTrackerInstalled) return;
+      window.__riffleSelTrackerInstalled = true;
+      document.addEventListener('selectionchange', function () {
+        var s = window.getSelection();
+        if (!s || s.rangeCount === 0 || s.isCollapsed) return;
+        var n = s.getRangeAt(0).startContainer;
+        if (n && n.nodeType === 3) n = n.parentElement;
+        var id = '';
+        while (n && n !== document.body) {
+          if (n.id) { id = n.id; break; }
+          n = n.parentElement;
+        }
+        window.__riffleSelSpan = id;
+      });
+    })();
+""".trimIndent()

--- a/core/domain/src/test/kotlin/com/riffle/core/domain/ReadaloudTrackTest.kt
+++ b/core/domain/src/test/kotlin/com/riffle/core/domain/ReadaloudTrackTest.kt
@@ -1,6 +1,7 @@
 package com.riffle.core.domain
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNull
 import org.junit.Test
 
@@ -53,6 +54,17 @@ class ReadaloudTrackTest {
     @Test
     fun `resolveStartClip ignores leading slash differences`() {
         assertEquals(chapterClips[1], chapterTrack.resolveStartClip("/text/c1.html", "s2"))
+    }
+
+    // Regression for "Play from here started at the beginning of the chapter": when the selection's
+    // sentence-span id is supplied, narration must begin at THAT sentence's clip — not silently fall
+    // back to the chapter's first clip. (The fix that surfaces the span id lives in EpubReaderScreen;
+    // this locks the resolver contract that fix depends on.)
+    @Test
+    fun `resolveStartClip on a mid-chapter sentence starts there, not at the chapter's first clip`() {
+        val resolved = chapterTrack.resolveStartClip("text/c1.html", "s2")
+        assertEquals(chapterClips[1], resolved)
+        assertNotEquals(chapterClips[0], resolved)
     }
 
     @Test


### PR DESCRIPTION
Fixes three readaloud reader bugs, all surfacing on Android 7.1.1 (API 25) and rooted in its pre-Chromium-61 WebView. Found and verified on-device on the API-25 harness emulator.

## Bugs & fixes

**1. Immersive mode can't be toggled during/after readaloud.**
Readium's reflowable tap handler hit-tests decorations via `getBoundingClientRect().toJSON()`, which throws on API 25 (`ClientRect` has no `toJSON()`) *before* the tap reaches `Android.onTap` — so every tap is swallowed while the sentence-highlight decoration is present. Fix: inject a `ClientRect.toJSON` polyfill into each reflowable page.

**2. "Play from here" restarts the chapter instead of starting at the selected sentence.**
Readium's selection locator carries no fragment id (only text + rect), so the player fell back to the chapter's first clip. Fix: a `selectionchange` tracker stashes the enclosing narrated-sentence span id (`window.__riffleSelSpan`); the menu handler reads it and passes it to the clip resolver. It always overwrites on a fresh selection (empty when there's no sentence-span ancestor), so a selection outside narrated text falls back cleanly to the chapter position rather than reusing a stale id.

**3. Switching orientation / formatting during playback leaves a paused highlight on the wrong sentence.**
Readium doesn't re-render existing decorations onto an in-place reflow. Fix: `rememberReflowReapplyGeneration` bumps a generation key across the relayout settle window so the decoration effects re-apply onto the new layout. Keyed on `formattingPrefs` so it covers all reflow-inducing changes (orientation, font size, margins, line spacing), not just orientation.

The injected WebView scripts live in a new `ReaderWebViewScripts.kt` (matching the `TypographyOverride` / `FootnoteAnchorBridge` convention).

## Tests
- `ReaderWebViewScriptsTest` (real WebView, runs on the API-25 harness — the engine that exhibited the bugs): the `toJSON` polyfill and the selection-span tracker, including the stale-id reset.
- `ReflowReapplyGenerationTest` (pure Compose): the reflow re-apply trigger schedule.
- `ReadaloudTrackTest`: locks the `resolveStartClip` contract play-from-here depends on.
- Shared `withWebViewFixture`/`evalSync` harness extracted (deduped with `TypographyOverrideWebViewTest`).

## Verification
- `./gradlew test lint` — green.
- Touched reader harness classes + `EpubHarnessTest`/`EpubFootnoteHarnessTest` — green on `Harness_Medium_Phone` (API 25).
- All three fixes also manually verified end-to-end on the API-25 emulator.

Note: readaloud *audio* can't be exercised on the headless API-25 emulator (its audio HAL wedges — no sound, frozen position, play/pause sawtooth); use a physical device or an audio-enabled emulator window for that.