### PR TITLE
fix(data): key Library Items by (serverId, itemId) end-to-end

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/RiffleApplication.kt
+++ b/app/src/main/kotlin/com/riffle/app/RiffleApplication.kt
@@ -5,7 +5,16 @@ import android.content.Context
 import coil.ImageLoader
 import coil.ImageLoaderFactory
 import coil.disk.DiskCache
+import com.riffle.core.data.LocalStoreMigrator
+import dagger.hilt.EntryPoint
+import dagger.hilt.InstallIn
+import dagger.hilt.android.EntryPointAccessors
 import dagger.hilt.android.HiltAndroidApp
+import dagger.hilt.components.SingletonComponent
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
 import okhttp3.Interceptor
 import okhttp3.OkHttpClient
 import org.acra.ReportField
@@ -13,6 +22,12 @@ import org.acra.ktx.initAcra
 
 @HiltAndroidApp
 class RiffleApplication : Application(), ImageLoaderFactory {
+
+    @EntryPoint
+    @InstallIn(SingletonComponent::class)
+    interface MigratorEntryPoint {
+        fun localStoreMigrator(): LocalStoreMigrator
+    }
 
     override fun attachBaseContext(base: Context) {
         super.attachBaseContext(base)
@@ -24,6 +39,16 @@ class RiffleApplication : Application(), ImageLoaderFactory {
                 ReportField.APP_VERSION_NAME,
                 ReportField.AVAILABLE_MEM_SIZE,
             )
+        }
+    }
+
+    override fun onCreate() {
+        super.onCreate()
+        // One-time relocation of legacy flat cache/download files into per-Server dirs (ADR 0025).
+        // Idempotent and best-effort; runs off the main thread and never blocks startup.
+        val migrator = EntryPointAccessors.fromApplication(this, MigratorEntryPoint::class.java).localStoreMigrator()
+        CoroutineScope(SupervisorJob() + Dispatchers.IO).launch {
+            runCatching { migrator.migrate() }
         }
     }
 

--- a/app/src/main/kotlin/com/riffle/app/feature/downloads/DownloadsScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/downloads/DownloadsScreen.kt
@@ -102,12 +102,12 @@ fun DownloadsScreen(
                         EmptySection("No downloaded books")
                     }
                 } else {
-                    items(uiState.downloadedItems, key = { it.item.id }) { entry ->
+                    items(uiState.downloadedItems, key = { it.serverId + "/" + it.item.id }) { entry ->
                         LocalItemRow(
                             entry = entry,
                             pillColor = PillColor.Downloaded,
                             onClick = { onItemSelected(entry.item) },
-                            onRemove = { viewModel.removeDownloadedItem(entry.item.id) },
+                            onRemove = { viewModel.removeDownloadedItem(entry.serverId, entry.item.id) },
                         )
                     }
                 }
@@ -125,12 +125,12 @@ fun DownloadsScreen(
                         EmptySection("No cached books")
                     }
                 } else {
-                    items(uiState.cachedItems, key = { it.item.id }) { entry ->
+                    items(uiState.cachedItems, key = { it.serverId + "/" + it.item.id }) { entry ->
                         LocalItemRow(
                             entry = entry,
                             pillColor = PillColor.Cached,
                             onClick = { onItemSelected(entry.item) },
-                            onRemove = { viewModel.removeCachedItem(entry.item.id) },
+                            onRemove = { viewModel.removeCachedItem(entry.serverId, entry.item.id) },
                         )
                     }
                 }

--- a/app/src/main/kotlin/com/riffle/app/feature/downloads/DownloadsViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/downloads/DownloadsViewModel.kt
@@ -13,6 +13,7 @@ import javax.inject.Inject
 
 /** A locally-available item paired with the on-disk size of its file. */
 data class LocalItemUi(
+    val serverId: String,
     val item: LibraryItem,
     val sizeBytes: Long,
 )
@@ -40,30 +41,34 @@ class DownloadsViewModel @Inject constructor(
 
     private fun load() {
         viewModelScope.launch {
-            val downloadedIds = downloadsRepository.getDownloadedItemIds()
-            val cachedIds = downloadsRepository.getCachedItemIds()
+            val downloaded = downloadsRepository.getDownloadedItems()
+            val cached = downloadsRepository.getCachedItems()
 
-            val downloadedItems = downloadedIds.mapNotNull { id ->
-                libraryRepository.getItem(id)?.let { LocalItemUi(it, downloadsRepository.sizeOf(id)) }
+            val downloadedItems = downloaded.mapNotNull { ref ->
+                libraryRepository.getItem(ref.serverId, ref.itemId)?.let {
+                    LocalItemUi(ref.serverId, it, downloadsRepository.sizeOf(ref.serverId, ref.itemId))
+                }
             }
-            val cachedItems = cachedIds.mapNotNull { id ->
-                libraryRepository.getItem(id)?.let { LocalItemUi(it, downloadsRepository.sizeOf(id)) }
+            val cachedItems = cached.mapNotNull { ref ->
+                libraryRepository.getItem(ref.serverId, ref.itemId)?.let {
+                    LocalItemUi(ref.serverId, it, downloadsRepository.sizeOf(ref.serverId, ref.itemId))
+                }
             }
 
             _uiState.value = DownloadsUiState(downloadedItems = downloadedItems, cachedItems = cachedItems)
         }
     }
 
-    fun removeDownloadedItem(itemId: String) {
+    fun removeDownloadedItem(serverId: String, itemId: String) {
         viewModelScope.launch {
-            downloadsRepository.removeDownload(itemId)
+            downloadsRepository.removeDownload(serverId, itemId)
             load()
         }
     }
 
-    fun removeCachedItem(itemId: String) {
+    fun removeCachedItem(serverId: String, itemId: String) {
         viewModelScope.launch {
-            downloadsRepository.removeCached(itemId)
+            downloadsRepository.removeCached(serverId, itemId)
             load()
         }
     }

--- a/app/src/main/kotlin/com/riffle/app/feature/library/CollectionDetailViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/CollectionDetailViewModel.kt
@@ -100,8 +100,8 @@ class CollectionDetailViewModel @Inject constructor(
     }
 
     private fun isAvailableOffline(item: LibraryItem): Boolean = when (item.ebookFormat) {
-        EbookFormat.Epub -> epubRepository.isDownloaded(item.id) || epubRepository.isCached(item.id)
-        EbookFormat.Pdf -> pdfRepository.isDownloaded(item.id) || pdfRepository.isCached(item.id)
+        EbookFormat.Epub -> epubRepository.isDownloaded(item.serverId, item.id) || epubRepository.isCached(item.serverId, item.id)
+        EbookFormat.Pdf -> pdfRepository.isDownloaded(item.serverId, item.id) || pdfRepository.isCached(item.serverId, item.id)
         else -> false
     }
 

--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModel.kt
@@ -141,10 +141,10 @@ class LibraryItemDetailViewModel @Inject constructor(
                     }
                     readaloudLink = link
                     _readaloudDownloadState.value = link?.let {
-                        readaloudDownloadStateFor(readaloudAudioRepository.isAudioAvailable(it.storytellerBookId))
+                        readaloudDownloadStateFor(readaloudAudioRepository.isAudioAvailable(it.storytellerServerId, it.storytellerBookId))
                     }
                     val footer = resolveReadaloudFooter(item, isReadaloud, server?.id)
-                    val isCachedOrDownloaded = epubRepository.isCached(item.id) || epubRepository.isDownloaded(item.id)
+                    val isCachedOrDownloaded = epubRepository.isCached(item.serverId, item.id) || epubRepository.isDownloaded(item.serverId, item.id)
                     LibraryItemDetailUiState.Ready(
                         item = item,
                         isInToRead = isInToRead,
@@ -250,9 +250,10 @@ class LibraryItemDetailViewModel @Inject constructor(
 
     fun removeDownload() {
         viewModelScope.launch {
-            when ((uiState.value as? LibraryItemDetailUiState.Ready)?.item?.ebookFormat) {
-                EbookFormat.Epub -> epubRepository.removeDownload(itemId)
-                EbookFormat.Pdf -> pdfRepository.removeDownload(itemId)
+            val item = (uiState.value as? LibraryItemDetailUiState.Ready)?.item
+            when (item?.ebookFormat) {
+                EbookFormat.Epub -> epubRepository.removeDownload(item.serverId, item.id)
+                EbookFormat.Pdf -> pdfRepository.removeDownload(item.serverId, item.id)
                 else -> {}
             }
             _downloadState.value = DownloadState.NotDownloaded
@@ -285,7 +286,7 @@ class LibraryItemDetailViewModel @Inject constructor(
         _readaloudDownloadState.value = DownloadState.InProgress
         viewModelScope.launch {
             val result = readaloudAudioRepository.downloadAudio(
-                link.storytellerBookId, link.storytellerServerId,
+                link.storytellerServerId, link.storytellerBookId,
             ) { _, _ -> }
             _readaloudDownloadState.value = readaloudDownloadStateFor(
                 result is com.riffle.core.domain.AudioDownloadResult.Success,
@@ -299,7 +300,7 @@ class LibraryItemDetailViewModel @Inject constructor(
     fun onRemoveReadaloud() {
         val link = readaloudLink ?: return
         viewModelScope.launch {
-            readaloudAudioRepository.removeAudio(link.storytellerBookId)
+            readaloudAudioRepository.removeAudio(link.storytellerServerId, link.storytellerBookId)
             _readaloudDownloadState.value = DownloadState.NotDownloaded
         }
     }
@@ -352,7 +353,7 @@ class LibraryItemDetailViewModel @Inject constructor(
 
     private fun refreshCacheState() {
         val current = _uiState.value as? LibraryItemDetailUiState.Ready ?: return
-        val refreshed = epubRepository.isCached(itemId) || epubRepository.isDownloaded(itemId)
+        val refreshed = epubRepository.isCached(current.item.serverId, itemId) || epubRepository.isDownloaded(current.item.serverId, itemId)
         _uiState.value = current.copy(isCachedOrDownloaded = refreshed)
     }
 
@@ -364,8 +365,8 @@ class LibraryItemDetailViewModel @Inject constructor(
     }
 
     private fun isDownloadedForFormat(item: LibraryItem): Boolean = when (item.ebookFormat) {
-        EbookFormat.Epub -> epubRepository.isDownloaded(item.id)
-        EbookFormat.Pdf -> pdfRepository.isDownloaded(item.id)
+        EbookFormat.Epub -> epubRepository.isDownloaded(item.serverId, item.id)
+        EbookFormat.Pdf -> pdfRepository.isDownloaded(item.serverId, item.id)
         else -> false
     }
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsViewModel.kt
@@ -284,8 +284,8 @@ class LibraryItemsViewModel @Inject constructor(
     }
 
     private fun isAvailableOffline(item: LibraryItem): Boolean = when (item.ebookFormat) {
-        EbookFormat.Epub -> epubRepository.isDownloaded(item.id) || epubRepository.isCached(item.id)
-        EbookFormat.Pdf -> pdfRepository.isDownloaded(item.id) || pdfRepository.isCached(item.id)
+        EbookFormat.Epub -> epubRepository.isDownloaded(item.serverId, item.id) || epubRepository.isCached(item.serverId, item.id)
+        EbookFormat.Pdf -> pdfRepository.isDownloaded(item.serverId, item.id) || pdfRepository.isCached(item.serverId, item.id)
         else -> false
     }
 

--- a/app/src/main/kotlin/com/riffle/app/feature/library/SeriesDetailViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/SeriesDetailViewModel.kt
@@ -100,8 +100,8 @@ class SeriesDetailViewModel @Inject constructor(
     }
 
     private fun isAvailableOffline(item: LibraryItem): Boolean = when (item.ebookFormat) {
-        EbookFormat.Epub -> epubRepository.isDownloaded(item.id) || epubRepository.isCached(item.id)
-        EbookFormat.Pdf -> pdfRepository.isDownloaded(item.id) || pdfRepository.isCached(item.id)
+        EbookFormat.Epub -> epubRepository.isDownloaded(item.serverId, item.id) || epubRepository.isCached(item.serverId, item.id)
+        EbookFormat.Pdf -> pdfRepository.isDownloaded(item.serverId, item.id) || pdfRepository.isCached(item.serverId, item.id)
         else -> false
     }
 

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -243,6 +243,9 @@ class EpubReaderViewModel @Inject constructor(
     // The id under which the synced bundle is stored. For a matched ABS book this is the linked
     // Storyteller book id; for a Storyteller book (or unmatched ABS) it is the opened itemId.
     private var audioBookId: String = itemId
+    // The Server the bundle lives on, paired with [audioBookId] to key the file store (ADR 0025).
+    // For a matched ABS book this is the linked Storyteller Server; otherwise the active Server.
+    private var audioServerId: String = ""
 
     // Whether the bottom mini-player / sheet is showing.
     private val _readaloudOpen = MutableStateFlow(false)
@@ -335,11 +338,12 @@ class EpubReaderViewModel @Inject constructor(
                 null
             }
             audioBookId = link?.storytellerBookId ?: itemId
+            audioServerId = link?.storytellerServerId ?: activeServer?.id ?: ""
 
             val control = readaloudControlState(
                 isStoryteller = isStorytellerServer,
                 isMatchedAbs = link != null,
-                bundlePresent = readaloudAudioRepository.isAudioAvailable(audioBookId),
+                bundlePresent = readaloudAudioRepository.isAudioAvailable(audioServerId, audioBookId),
             )
             _readaloudVisible.value = control.visible
             _readaloudAvailable.value = control.enabled
@@ -898,7 +902,7 @@ class EpubReaderViewModel @Inject constructor(
      */
     fun onPlayTapped() {
         _readaloudOfflineMessage.value = false
-        val bundle = readaloudAudioRepository.bundleFile(audioBookId)
+        val bundle = readaloudAudioRepository.bundleFile(audioServerId, audioBookId)
         if (bundle != null) {
             viewModelScope.launch { ensurePreparedAndPlay(bundle) }
             return
@@ -919,14 +923,14 @@ class EpubReaderViewModel @Inject constructor(
             // Storyteller) reach this path, and audioBookId resolves correctly.
             // probeSizeBytes may return null (can't probe) — fall back to a zero-sized prompt so
             // the user can still choose to download.
-            _downloadPromptBytes.value = readaloudAudioRepository.probeSizeBytes(audioBookId) ?: 0L
+            _downloadPromptBytes.value = readaloudAudioRepository.probeSizeBytes(audioServerId, audioBookId) ?: 0L
         }
     }
 
     /** "Play from here" from the text-selection menu — seek to the clip narrating [fragmentRef]. */
     fun playFromHere(fragmentRef: String) {
         if (!_readaloudOpen.value) openReadaloud()
-        val bundle = readaloudAudioRepository.bundleFile(audioBookId)
+        val bundle = readaloudAudioRepository.bundleFile(audioServerId, audioBookId)
         if (bundle == null) {
             // No bundle yet — fall through to the normal play path (prompt/notify) so the user is
             // told to download first.
@@ -952,7 +956,7 @@ class EpubReaderViewModel @Inject constructor(
         }
         viewModelScope.launch {
             _downloadProgress.value = 0f
-            val result = readaloudAudioRepository.downloadAudio(audioBookId) { downloaded, total ->
+            val result = readaloudAudioRepository.downloadAudio(audioServerId, audioBookId) { downloaded, total ->
                 if (total > 0) _downloadProgress.value = downloaded.toFloat() / total.toFloat()
             }
             _downloadProgress.value = null
@@ -961,7 +965,7 @@ class EpubReaderViewModel @Inject constructor(
                     // Bundle now present: keep the control visible and enable it.
                     _readaloudVisible.value = true
                     _readaloudAvailable.value = true
-                    readaloudAudioRepository.bundleFile(audioBookId)?.let { ensurePreparedAndPlay(it) }
+                    readaloudAudioRepository.bundleFile(audioServerId, audioBookId)?.let { ensurePreparedAndPlay(it) }
                 }
                 com.riffle.core.domain.AudioDownloadResult.NoBundle -> Unit
                 is com.riffle.core.domain.AudioDownloadResult.NetworkError ->
@@ -1014,7 +1018,7 @@ class EpubReaderViewModel @Inject constructor(
 
     private suspend fun ensureTrack(bundle: File): com.riffle.core.domain.ReadaloudTrack? {
         readaloudTrack?.let { return it }
-        val track = readaloudAudioRepository.readTrack(audioBookId) ?: return null
+        val track = readaloudAudioRepository.readTrack(audioServerId, audioBookId) ?: return null
         readaloudTrack = track
         return track
     }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ThreePeerReaderSyncFactory.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ThreePeerReaderSyncFactory.kt
@@ -59,8 +59,8 @@ class ThreePeerReaderSyncFactory @Inject constructor(
         val storytellerServer = serverRepository.getById(link.storytellerServerId) ?: return null
         val storytellerToken = tokenStorage.getToken(link.storytellerServerId) ?: return null
 
-        val absFile = cachedFile(link.absLibraryItemId) ?: return null
-        val storytellerFile = cachedFile(link.storytellerBookId) ?: return null
+        val absFile = cachedFile(link.absServerId, link.absLibraryItemId) ?: return null
+        val storytellerFile = cachedFile(link.storytellerServerId, link.storytellerBookId) ?: return null
 
         // The index must already be built for these exact bytes (checksum-keyed); otherwise the
         // background builder hasn't caught up — stay single-peer until it has. Checksums stream the
@@ -99,8 +99,8 @@ class ThreePeerReaderSyncFactory @Inject constructor(
     private fun endpoint(server: Server, token: String, itemId: String) =
         AbsSyncEndpoint(server.url.value, token, server.insecureConnectionAllowed, itemId)
 
-    private fun cachedFile(itemId: String): java.io.File? =
-        downloadsStore.get(itemId) ?: cacheStore.get(itemId)
+    private fun cachedFile(serverId: String, itemId: String): java.io.File? =
+        downloadsStore.get(serverId, itemId) ?: cacheStore.get(serverId, itemId)
 
     private fun ExtractedEpub.hrefs() = chapters.map { it.href }
     private fun ExtractedEpub.htmlAt(): (Int) -> String? = { chapters.getOrNull(it)?.html }

--- a/app/src/test/kotlin/com/riffle/app/feature/library/CollectionDetailViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/CollectionDetailViewModelTest.kt
@@ -61,6 +61,7 @@ class CollectionDetailViewModelTest {
         override fun observeSeriesItems(seriesId: String): Flow<List<LibraryItem>> = MutableStateFlow(emptyList())
         override fun observeCollectionItems(collectionId: String): Flow<List<LibraryItem>> = collectionItemsFlow
         override suspend fun getItem(itemId: String): LibraryItem? = null
+        override suspend fun getItem(serverId: String, itemId: String): LibraryItem? = getItem(itemId)
         override suspend fun getLibrary(libraryId: String): com.riffle.core.domain.Library? = null
         override suspend fun markItemOpened(itemId: String) {}
         override suspend fun updateReadingProgress(itemId: String, progress: Float) {}
@@ -86,6 +87,7 @@ class CollectionDetailViewModelTest {
         override fun observeSeriesItems(seriesId: String): Flow<List<LibraryItem>> = MutableStateFlow(emptyList())
         override fun observeCollectionItems(collectionId: String): Flow<List<LibraryItem>> = collectionItemsFlow
         override suspend fun getItem(itemId: String): LibraryItem? = null
+        override suspend fun getItem(serverId: String, itemId: String): LibraryItem? = getItem(itemId)
         override suspend fun getLibrary(libraryId: String): com.riffle.core.domain.Library? = null
         override suspend fun markItemOpened(itemId: String) {}
         override suspend fun updateReadingProgress(itemId: String, progress: Float) {}
@@ -116,18 +118,18 @@ class CollectionDetailViewModelTest {
     private class FakeEpubRepository(private val downloadedIds: Set<String> = emptySet()) : EpubRepository {
         override suspend fun openEpub(item: LibraryItem) = EpubOpenResult.Offline
         override suspend fun downloadEpub(item: LibraryItem) = EpubDownloadResult.Success
-        override suspend fun removeDownload(itemId: String) {}
-        override fun isDownloaded(itemId: String): Boolean = itemId in downloadedIds
-        override fun isCached(itemId: String): Boolean = false
+        override suspend fun removeDownload(serverId: String, itemId: String) {}
+        override fun isDownloaded(serverId: String, itemId: String): Boolean = itemId in downloadedIds
+        override fun isCached(serverId: String, itemId: String): Boolean = false
         override suspend fun saveReadingPosition(itemId: String, cfi: String) {}
     }
 
     private class FakePdfRepository : PdfRepository {
         override suspend fun openPdf(item: LibraryItem) = PdfOpenResult.Offline
         override suspend fun downloadPdf(item: LibraryItem) = PdfDownloadResult.Success
-        override suspend fun removeDownload(itemId: String) {}
-        override fun isDownloaded(itemId: String): Boolean = false
-        override fun isCached(itemId: String): Boolean = false
+        override suspend fun removeDownload(serverId: String, itemId: String) {}
+        override fun isDownloaded(serverId: String, itemId: String): Boolean = false
+        override fun isCached(serverId: String, itemId: String): Boolean = false
         override suspend fun saveReadingPosition(itemId: String, locatorJson: String) {}
     }
 

--- a/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemDetailReadaloudDownloadTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemDetailReadaloudDownloadTest.kt
@@ -14,17 +14,15 @@ class LibraryItemDetailReadaloudDownloadTest {
         var lastDownloadBookId: String? = null
         var lastDownloadServerId: String? = null
         var lastRemoveBookId: String? = null
-        override fun isAudioAvailable(itemId: String) = present
-        override fun bundleFile(itemId: String): File? = if (present) File("x") else null
-        override suspend fun readTrack(itemId: String): ReadaloudTrack? = null
-        override suspend fun probeSizeBytes(itemId: String): Long? = null
-        override suspend fun downloadAudio(itemId: String, onProgress: (Long, Long) -> Unit) =
-            downloadAudio(itemId, "active", onProgress)
-        override suspend fun downloadAudio(bookId: String, serverId: String, onProgress: (Long, Long) -> Unit): AudioDownloadResult {
+        override fun isAudioAvailable(serverId: String, itemId: String) = present
+        override fun bundleFile(serverId: String, itemId: String): File? = if (present) File("x") else null
+        override suspend fun readTrack(serverId: String, itemId: String): ReadaloudTrack? = null
+        override suspend fun probeSizeBytes(serverId: String, itemId: String): Long? = null
+        override suspend fun downloadAudio(serverId: String, bookId: String, onProgress: (Long, Long) -> Unit): AudioDownloadResult {
             lastDownloadBookId = bookId; lastDownloadServerId = serverId; present = true
             return AudioDownloadResult.Success
         }
-        override suspend fun removeAudio(itemId: String): Long { lastRemoveBookId = itemId; present = false; return 0L }
+        override suspend fun removeAudio(serverId: String, itemId: String): Long { lastRemoveBookId = itemId; present = false; return 0L }
     }
 
     @Test fun download_state_maps_from_bundle_presence() {

--- a/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModelTest.kt
@@ -82,6 +82,7 @@ class LibraryItemDetailViewModelTest {
         override fun observeSeriesItems(seriesId: String): Flow<List<LibraryItem>> = MutableStateFlow(emptyList())
         override fun observeCollectionItems(collectionId: String): Flow<List<LibraryItem>> = MutableStateFlow(emptyList())
         override suspend fun getItem(itemId: String): LibraryItem? = item
+        override suspend fun getItem(serverId: String, itemId: String): LibraryItem? = getItem(itemId)
         override suspend fun getLibrary(libraryId: String): com.riffle.core.domain.Library? = null
         override suspend fun markItemOpened(itemId: String) {}
         override suspend fun updateReadingProgress(itemId: String, progress: Float) {}
@@ -105,6 +106,7 @@ class LibraryItemDetailViewModelTest {
         override fun observeSeriesItems(seriesId: String): Flow<List<LibraryItem>> = MutableStateFlow(emptyList())
         override fun observeCollectionItems(collectionId: String): Flow<List<LibraryItem>> = MutableStateFlow(emptyList())
         override suspend fun getItem(itemId: String): LibraryItem? = throw RuntimeException("DB unavailable")
+        override suspend fun getItem(serverId: String, itemId: String): LibraryItem? = getItem(itemId)
         override suspend fun getLibrary(libraryId: String): com.riffle.core.domain.Library? = null
         override suspend fun markItemOpened(itemId: String) {}
         override suspend fun updateReadingProgress(itemId: String, progress: Float) {}
@@ -143,9 +145,9 @@ class LibraryItemDetailViewModelTest {
             if (downloadResult is EpubDownloadResult.Success) downloaded = true
             return downloadResult
         }
-        override suspend fun removeDownload(itemId: String) { downloaded = false }
-        override fun isDownloaded(itemId: String): Boolean = downloaded
-        override fun isCached(itemId: String): Boolean = itemId in cachedIds
+        override suspend fun removeDownload(serverId: String, itemId: String) { downloaded = false }
+        override fun isDownloaded(serverId: String, itemId: String): Boolean = downloaded
+        override fun isCached(serverId: String, itemId: String): Boolean = itemId in cachedIds
         override suspend fun saveReadingPosition(itemId: String, cfi: String) {}
     }
 
@@ -161,9 +163,9 @@ class LibraryItemDetailViewModelTest {
             downloaded = true
             return PdfDownloadResult.Success
         }
-        override suspend fun removeDownload(itemId: String) { downloaded = false }
-        override fun isDownloaded(itemId: String): Boolean = downloaded
-        override fun isCached(itemId: String): Boolean = false
+        override suspend fun removeDownload(serverId: String, itemId: String) { downloaded = false }
+        override fun isDownloaded(serverId: String, itemId: String): Boolean = downloaded
+        override fun isCached(serverId: String, itemId: String): Boolean = false
         override suspend fun saveReadingPosition(itemId: String, locatorJson: String) {}
     }
 

--- a/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemsViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemsViewModelTest.kt
@@ -76,6 +76,7 @@ class LibraryItemsViewModelTest {
         override fun observeCollectionItems(collectionId: String): Flow<List<LibraryItem>> =
             collectionItemsByCollectionId.getOrPut(collectionId) { MutableStateFlow(emptyList()) }
         override suspend fun getItem(itemId: String): LibraryItem? = null
+        override suspend fun getItem(serverId: String, itemId: String): LibraryItem? = getItem(itemId)
         override suspend fun getLibrary(libraryId: String): com.riffle.core.domain.Library? = null
         override suspend fun markItemOpened(itemId: String) {}
         override suspend fun updateReadingProgress(itemId: String, progress: Float) {}
@@ -106,18 +107,18 @@ class LibraryItemsViewModelTest {
     private fun fakeEpubRepo(): EpubRepository = object : EpubRepository {
         override suspend fun openEpub(item: LibraryItem): EpubOpenResult = EpubOpenResult.Offline
         override suspend fun downloadEpub(item: LibraryItem): EpubDownloadResult = EpubDownloadResult.Success
-        override suspend fun removeDownload(itemId: String) {}
-        override fun isDownloaded(itemId: String): Boolean = false
-        override fun isCached(itemId: String): Boolean = false
+        override suspend fun removeDownload(serverId: String, itemId: String) {}
+        override fun isDownloaded(serverId: String, itemId: String): Boolean = false
+        override fun isCached(serverId: String, itemId: String): Boolean = false
         override suspend fun saveReadingPosition(itemId: String, cfi: String) {}
     }
 
     private fun fakePdfRepo(): PdfRepository = object : PdfRepository {
         override suspend fun openPdf(item: LibraryItem): PdfOpenResult = PdfOpenResult.Offline
         override suspend fun downloadPdf(item: LibraryItem): PdfDownloadResult = PdfDownloadResult.Success
-        override suspend fun removeDownload(itemId: String) {}
-        override fun isDownloaded(itemId: String): Boolean = false
-        override fun isCached(itemId: String): Boolean = false
+        override suspend fun removeDownload(serverId: String, itemId: String) {}
+        override fun isDownloaded(serverId: String, itemId: String): Boolean = false
+        override fun isCached(serverId: String, itemId: String): Boolean = false
         override suspend fun saveReadingPosition(itemId: String, locatorJson: String) {}
     }
 
@@ -427,9 +428,9 @@ class LibraryItemsViewModelTest {
     private fun fakeEpubRepoWithDownloads(downloadedIds: Set<String>): EpubRepository = object : EpubRepository {
         override suspend fun openEpub(item: LibraryItem) = EpubOpenResult.Offline
         override suspend fun downloadEpub(item: LibraryItem) = EpubDownloadResult.Success
-        override suspend fun removeDownload(itemId: String) {}
-        override fun isDownloaded(itemId: String): Boolean = itemId in downloadedIds
-        override fun isCached(itemId: String): Boolean = false
+        override suspend fun removeDownload(serverId: String, itemId: String) {}
+        override fun isDownloaded(serverId: String, itemId: String): Boolean = itemId in downloadedIds
+        override fun isCached(serverId: String, itemId: String): Boolean = false
         override suspend fun saveReadingPosition(itemId: String, cfi: String) {}
     }
 
@@ -709,6 +710,7 @@ class LibraryItemsViewModelTest {
         override fun observeCollectionItems(collectionId: String): Flow<List<LibraryItem>> =
             collectionItemsByCollectionId.getOrPut(collectionId) { MutableStateFlow(emptyList()) }
         override suspend fun getItem(itemId: String): LibraryItem? = null
+        override suspend fun getItem(serverId: String, itemId: String): LibraryItem? = getItem(itemId)
         override suspend fun getLibrary(libraryId: String): com.riffle.core.domain.Library? = null
         override suspend fun markItemOpened(itemId: String) {}
         override suspend fun updateReadingProgress(itemId: String, progress: Float) {}

--- a/app/src/test/kotlin/com/riffle/app/feature/library/NoopReadaloudAudioRepository.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/NoopReadaloudAudioRepository.kt
@@ -6,13 +6,11 @@ import com.riffle.core.domain.ReadaloudTrack
 import java.io.File
 
 internal object NoopReadaloudAudioRepository : ReadaloudAudioRepository {
-    override fun isAudioAvailable(itemId: String): Boolean = false
-    override fun bundleFile(itemId: String): File? = null
-    override suspend fun readTrack(itemId: String): ReadaloudTrack? = null
-    override suspend fun probeSizeBytes(itemId: String): Long? = null
-    override suspend fun downloadAudio(itemId: String, onProgress: (Long, Long) -> Unit): AudioDownloadResult =
+    override fun isAudioAvailable(serverId: String, itemId: String): Boolean = false
+    override fun bundleFile(serverId: String, itemId: String): File? = null
+    override suspend fun readTrack(serverId: String, itemId: String): ReadaloudTrack? = null
+    override suspend fun probeSizeBytes(serverId: String, itemId: String): Long? = null
+    override suspend fun downloadAudio(serverId: String, bookId: String, onProgress: (Long, Long) -> Unit): AudioDownloadResult =
         AudioDownloadResult.Success
-    override suspend fun downloadAudio(bookId: String, serverId: String, onProgress: (Long, Long) -> Unit): AudioDownloadResult =
-        AudioDownloadResult.Success
-    override suspend fun removeAudio(itemId: String): Long = 0L
+    override suspend fun removeAudio(serverId: String, itemId: String): Long = 0L
 }

--- a/app/src/test/kotlin/com/riffle/app/feature/library/SeriesDetailViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/SeriesDetailViewModelTest.kt
@@ -61,6 +61,7 @@ class SeriesDetailViewModelTest {
         override fun observeSeriesItems(seriesId: String): Flow<List<LibraryItem>> = seriesItemsFlow
         override fun observeCollectionItems(collectionId: String): Flow<List<LibraryItem>> = MutableStateFlow(emptyList())
         override suspend fun getItem(itemId: String): LibraryItem? = null
+        override suspend fun getItem(serverId: String, itemId: String): LibraryItem? = getItem(itemId)
         override suspend fun getLibrary(libraryId: String): com.riffle.core.domain.Library? = null
         override suspend fun markItemOpened(itemId: String) {}
         override suspend fun updateReadingProgress(itemId: String, progress: Float) {}
@@ -93,18 +94,18 @@ class SeriesDetailViewModelTest {
     private class FakeEpubRepository : EpubRepository {
         override suspend fun openEpub(item: LibraryItem) = EpubOpenResult.Offline
         override suspend fun downloadEpub(item: LibraryItem) = EpubDownloadResult.Success
-        override suspend fun removeDownload(itemId: String) {}
-        override fun isDownloaded(itemId: String): Boolean = false
-        override fun isCached(itemId: String): Boolean = false
+        override suspend fun removeDownload(serverId: String, itemId: String) {}
+        override fun isDownloaded(serverId: String, itemId: String): Boolean = false
+        override fun isCached(serverId: String, itemId: String): Boolean = false
         override suspend fun saveReadingPosition(itemId: String, cfi: String) {}
     }
 
     private class FakePdfRepository : PdfRepository {
         override suspend fun openPdf(item: LibraryItem) = PdfOpenResult.Offline
         override suspend fun downloadPdf(item: LibraryItem) = PdfDownloadResult.Success
-        override suspend fun removeDownload(itemId: String) {}
-        override fun isDownloaded(itemId: String): Boolean = false
-        override fun isCached(itemId: String): Boolean = false
+        override suspend fun removeDownload(serverId: String, itemId: String) {}
+        override fun isDownloaded(serverId: String, itemId: String): Boolean = false
+        override fun isCached(serverId: String, itemId: String): Boolean = false
         override suspend fun saveReadingPosition(itemId: String, locatorJson: String) {}
     }
 

--- a/app/src/test/kotlin/com/riffle/app/feature/navigation/HomeViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/navigation/HomeViewModelTest.kt
@@ -73,6 +73,7 @@ class HomeViewModelTest {
         override fun observeSeriesItems(seriesId: String): Flow<List<LibraryItem>> = MutableStateFlow(emptyList())
         override fun observeCollectionItems(collectionId: String): Flow<List<LibraryItem>> = MutableStateFlow(emptyList())
         override suspend fun getItem(itemId: String): LibraryItem? = null
+        override suspend fun getItem(serverId: String, itemId: String): LibraryItem? = getItem(itemId)
         override suspend fun getLibrary(libraryId: String): com.riffle.core.domain.Library? = null
         override suspend fun markItemOpened(itemId: String) {}
         override suspend fun updateReadingProgress(itemId: String, progress: Float) {}

--- a/app/src/test/kotlin/com/riffle/app/feature/navigation/NavigationDrawerViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/navigation/NavigationDrawerViewModelTest.kt
@@ -87,6 +87,7 @@ class NavigationDrawerViewModelTest {
         override fun observeSeriesItems(seriesId: String): Flow<List<LibraryItem>> = MutableStateFlow(emptyList())
         override fun observeCollectionItems(collectionId: String): Flow<List<LibraryItem>> = MutableStateFlow(emptyList())
         override suspend fun getItem(itemId: String): LibraryItem? = null
+        override suspend fun getItem(serverId: String, itemId: String): LibraryItem? = getItem(itemId)
         override suspend fun getLibrary(libraryId: String): com.riffle.core.domain.Library? = null
         override suspend fun markItemOpened(itemId: String) {}
         override suspend fun updateReadingProgress(itemId: String, progress: Float) {}

--- a/app/src/test/kotlin/com/riffle/app/feature/settings/SettingsViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/settings/SettingsViewModelTest.kt
@@ -127,6 +127,7 @@ class SettingsViewModelTest {
         override fun observeSeriesItems(seriesId: String): Flow<List<LibraryItem>> = MutableStateFlow(emptyList())
         override fun observeCollectionItems(collectionId: String): Flow<List<LibraryItem>> = MutableStateFlow(emptyList())
         override suspend fun getItem(itemId: String): LibraryItem? = null
+        override suspend fun getItem(serverId: String, itemId: String): LibraryItem? = getItem(itemId)
         override suspend fun getLibrary(libraryId: String): com.riffle.core.domain.Library? = null
         override suspend fun markItemOpened(itemId: String) {}
         override suspend fun updateReadingProgress(itemId: String, progress: Float) {}

--- a/core/data/src/main/kotlin/com/riffle/core/data/AudiobookBundleDownloader.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/AudiobookBundleDownloader.kt
@@ -18,8 +18,10 @@ class AudiobookBundleDownloader(
     private val api: AudiobookBundleApi,
     // Resolves the final on-disk destination for a book's bundle. The reader and the player share
     // this single file (the synced bundle is both the EPUB and the audio source — ADR 0023), so the
-    // caller points this at the Downloads EPUB store location.
-    private val targetFileProvider: (bookId: String) -> File,
+    // caller points this at the Downloads EPUB store location. Keyed by (serverId, bookId) since
+    // bundle ids are only unique within a Server (ADR 0025) — it must land where the Downloads store
+    // looks it up, i.e. under the serverId subdirectory.
+    private val targetFileProvider: (serverId: String, bookId: String) -> File,
 ) {
 
     sealed interface Result {
@@ -28,13 +30,14 @@ class AudiobookBundleDownloader(
     }
 
     suspend fun download(
+        serverId: String,
         baseUrl: String,
         bookId: String,
         token: String,
         insecureAllowed: Boolean,
         onProgress: (downloaded: Long, total: Long) -> Unit,
     ): Result = withContext(Dispatchers.IO) {
-        val finalFile = targetFileProvider(bookId)
+        val finalFile = targetFileProvider(serverId, bookId)
         finalFile.parentFile?.let { if (!it.exists()) it.mkdirs() }
         if (finalFile.exists()) return@withContext Result.Success(finalFile)
 

--- a/core/data/src/main/kotlin/com/riffle/core/data/BookFormattingPreferencesStoreImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/BookFormattingPreferencesStoreImpl.kt
@@ -7,14 +7,20 @@ import com.riffle.core.domain.BookFormattingPreferencesStore
 import com.riffle.core.domain.ReaderFontFamily
 import com.riffle.core.domain.ReaderOrientation
 import com.riffle.core.domain.ReaderTheme
+import com.riffle.core.domain.ServerRepository
 import javax.inject.Inject
 
+// Formatting is per-device but keyed by (serverId, itemId) so two Servers' colliding item ids
+// don't share one row (ADR 0025). Like LibraryRepositoryImpl, the active Server is resolved here
+// — you format the book you're actively reading — keeping the domain interface itemId-only.
 class BookFormattingPreferencesStoreImpl @Inject constructor(
     private val dao: BookFormattingPreferencesDao,
+    private val serverRepository: ServerRepository,
 ) : BookFormattingPreferencesStore {
 
     override suspend fun load(itemId: String): BookFormattingOverrides {
-        val entity = dao.getByItemId(itemId) ?: return BookFormattingOverrides()
+        val serverId = serverRepository.getActive()?.id ?: return BookFormattingOverrides()
+        val entity = dao.getByItemId(serverId, itemId) ?: return BookFormattingOverrides()
         return BookFormattingOverrides(
             fontSize = entity.fontSize,
             theme = entity.theme?.let { runCatching { ReaderTheme.valueOf(it) }.getOrNull() },
@@ -31,12 +37,14 @@ class BookFormattingPreferencesStoreImpl @Inject constructor(
     }
 
     override suspend fun save(itemId: String, overrides: BookFormattingOverrides) {
+        val serverId = serverRepository.getActive()?.id ?: return
         if (overrides.isEmpty) {
-            dao.deleteByItemId(itemId)
+            dao.deleteByItemId(serverId, itemId)
             return
         }
         dao.upsert(
             BookFormattingPreferencesEntity(
+                serverId = serverId,
                 itemId = itemId,
                 fontSize = overrides.fontSize,
                 theme = overrides.theme?.name,
@@ -54,6 +62,7 @@ class BookFormattingPreferencesStoreImpl @Inject constructor(
     }
 
     override suspend fun clear(itemId: String) {
-        dao.deleteByItemId(itemId)
+        val serverId = serverRepository.getActive()?.id ?: return
+        dao.deleteByItemId(serverId, itemId)
     }
 }

--- a/core/data/src/main/kotlin/com/riffle/core/data/CrossEpubIndexBuilderService.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/CrossEpubIndexBuilderService.kt
@@ -102,26 +102,26 @@ class CrossEpubIndexBuilderService(
         )
     }
 
-    private fun cachedFile(itemId: String): File? =
-        downloadsStore.get(itemId) ?: cacheStore.get(itemId)
+    private fun cachedFile(serverId: String, itemId: String): File? =
+        downloadsStore.get(serverId, itemId) ?: cacheStore.get(serverId, itemId)
 
     private suspend fun absEpubFile(server: Server, token: String, itemId: String): File? {
-        cachedFile(itemId)?.let { return it }
+        cachedFile(server.id, itemId)?.let { return it }
         val ino = when (val r = absApi.getItemEbookFileIno(server.url.value, itemId, token, server.insecureConnectionAllowed)) {
             is NetworkItemEbookInoResult.Success -> r.ino
             is NetworkItemEbookInoResult.NetworkError -> return null
         }
         return when (val r = absApi.downloadEpub(server.url.value, itemId, ino, token, server.insecureConnectionAllowed)) {
-            is NetworkEpubDownloadResult.Success -> r.body.use { cacheStore.save(itemId, it.byteStream()) }
+            is NetworkEpubDownloadResult.Success -> r.body.use { cacheStore.save(server.id, itemId, it.byteStream()) }
             is NetworkEpubDownloadResult.NetworkError -> null
         }
     }
 
     private suspend fun storytellerEpubFile(server: Server, token: String, bookId: String): File? {
-        cachedFile(bookId)?.let { return it }
+        cachedFile(server.id, bookId)?.let { return it }
         return when (val r = bundleFetcher.fetch(server.url.value, bookId, token, server.insecureConnectionAllowed)) {
             is EpubBundleFetcher.Result.Success -> try {
-                r.epubFile.inputStream().use { cacheStore.save(bookId, it) }
+                r.epubFile.inputStream().use { cacheStore.save(server.id, bookId, it) }
             } finally {
                 r.epubFile.delete()
             }

--- a/core/data/src/main/kotlin/com/riffle/core/data/DownloadsRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/DownloadsRepositoryImpl.kt
@@ -2,6 +2,7 @@ package com.riffle.core.data
 
 import com.riffle.core.domain.DownloadsRepository
 import com.riffle.core.domain.LocalStore
+import com.riffle.core.domain.StoredItemRef
 
 class DownloadsRepositoryImpl(
     private val epubCacheStore: LocalStore,
@@ -10,28 +11,28 @@ class DownloadsRepositoryImpl(
     private val pdfDownloadsStore: LocalStore,
 ) : DownloadsRepository {
 
-    override fun getDownloadedItemIds(): List<String> =
-        (epubDownloadsStore.listItemIds() + pdfDownloadsStore.listItemIds()).distinct()
+    override fun getDownloadedItems(): List<StoredItemRef> =
+        (epubDownloadsStore.listItems() + pdfDownloadsStore.listItems()).distinct()
 
-    override fun getCachedItemIds(): List<String> {
-        val downloadedIds = getDownloadedItemIds().toHashSet()
-        return (epubCacheStore.listItemIds() + pdfCacheStore.listItemIds())
+    override fun getCachedItems(): List<StoredItemRef> {
+        val downloaded = getDownloadedItems().toHashSet()
+        return (epubCacheStore.listItems() + pdfCacheStore.listItems())
             .distinct()
-            .filter { it !in downloadedIds }
+            .filter { it !in downloaded }
     }
 
-    override fun sizeOf(itemId: String): Long =
+    override fun sizeOf(serverId: String, itemId: String): Long =
         listOf(epubDownloadsStore, pdfDownloadsStore, epubCacheStore, pdfCacheStore)
-            .sumOf { it.get(itemId)?.length() ?: 0L }
+            .sumOf { it.get(serverId, itemId)?.length() ?: 0L }
 
-    override suspend fun removeDownload(itemId: String) {
-        epubDownloadsStore.delete(itemId)
-        pdfDownloadsStore.delete(itemId)
+    override suspend fun removeDownload(serverId: String, itemId: String) {
+        epubDownloadsStore.delete(serverId, itemId)
+        pdfDownloadsStore.delete(serverId, itemId)
     }
 
-    override suspend fun removeCached(itemId: String) {
-        epubCacheStore.delete(itemId)
-        pdfCacheStore.delete(itemId)
+    override suspend fun removeCached(serverId: String, itemId: String) {
+        epubCacheStore.delete(serverId, itemId)
+        pdfCacheStore.delete(serverId, itemId)
     }
 
     override suspend fun removeAllDownloads() {

--- a/core/data/src/main/kotlin/com/riffle/core/data/EpubRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/EpubRepositoryImpl.kt
@@ -29,7 +29,7 @@ class EpubRepositoryImpl(
     override suspend fun openEpub(item: LibraryItem): EpubOpenResult {
         val activeServer = serverRepository.getActive()
             ?: return EpubOpenResult.NetworkError(IllegalStateException("No active server"))
-        val local = downloadsStore.get(item.id) ?: cacheStore.get(item.id)
+        val local = downloadsStore.get(activeServer.id, item.id) ?: cacheStore.get(activeServer.id, item.id)
         val epubFile = if (local != null) {
             local
         } else {
@@ -45,7 +45,7 @@ class EpubRepositoryImpl(
                     }
                     when (val result = api.downloadEpub(activeServer.url.value, item.id, ino, token, activeServer.insecureConnectionAllowed)) {
                         is NetworkEpubDownloadResult.Success -> result.body.use { body ->
-                            cacheStore.save(item.id, body.byteStream())
+                            cacheStore.save(activeServer.id, item.id, body.byteStream())
                         }
                         is NetworkEpubDownloadResult.NetworkError -> return EpubOpenResult.NetworkError(result.cause)
                     }
@@ -66,7 +66,7 @@ class EpubRepositoryImpl(
                     when (val r = bundleFetcher.fetch(activeServer.url.value, item.id, token, activeServer.insecureConnectionAllowed)) {
                         is EpubBundleFetcher.Result.Success -> {
                             try {
-                                r.epubFile.inputStream().use { cacheStore.save(item.id, it) }
+                                r.epubFile.inputStream().use { cacheStore.save(activeServer.id, item.id, it) }
                             } finally {
                                 r.epubFile.delete()
                             }
@@ -88,11 +88,11 @@ class EpubRepositoryImpl(
     }
 
     override suspend fun downloadEpub(item: LibraryItem): EpubDownloadResult {
-        if (downloadsStore.get(item.id) != null) return EpubDownloadResult.AlreadyDownloaded
-        val cached = cacheStore.get(item.id)
+        if (downloadsStore.get(item.serverId, item.id) != null) return EpubDownloadResult.AlreadyDownloaded
+        val cached = cacheStore.get(item.serverId, item.id)
         if (cached != null) {
-            cached.inputStream().use { downloadsStore.save(item.id, it) }
-            cacheStore.delete(item.id)
+            cached.inputStream().use { downloadsStore.save(item.serverId, item.id, it) }
+            cacheStore.delete(item.serverId, item.id)
             return EpubDownloadResult.Success
         }
         val server = serverRepository.getActive()
@@ -104,7 +104,7 @@ class EpubRepositoryImpl(
                 when (val r = bundleFetcher.fetch(server.url.value, item.id, token, server.insecureConnectionAllowed)) {
                     is EpubBundleFetcher.Result.Success -> {
                         try {
-                            r.epubFile.inputStream().use { downloadsStore.save(item.id, it) }
+                            r.epubFile.inputStream().use { downloadsStore.save(item.serverId, item.id, it) }
                         } finally {
                             r.epubFile.delete()
                         }
@@ -122,7 +122,7 @@ class EpubRepositoryImpl(
                 }
                 when (val result = api.downloadEpub(server.url.value, item.id, ino, token, server.insecureConnectionAllowed)) {
                     is NetworkEpubDownloadResult.Success -> {
-                        result.body.use { body -> downloadsStore.save(item.id, body.byteStream()) }
+                        result.body.use { body -> downloadsStore.save(item.serverId, item.id, body.byteStream()) }
                         EpubDownloadResult.Success
                     }
                     is NetworkEpubDownloadResult.NetworkError -> EpubDownloadResult.NetworkError(result.cause)
@@ -131,13 +131,13 @@ class EpubRepositoryImpl(
         }
     }
 
-    override suspend fun removeDownload(itemId: String) {
-        downloadsStore.delete(itemId)
+    override suspend fun removeDownload(serverId: String, itemId: String) {
+        downloadsStore.delete(serverId, itemId)
     }
 
-    override fun isDownloaded(itemId: String): Boolean = downloadsStore.get(itemId) != null
+    override fun isDownloaded(serverId: String, itemId: String): Boolean = downloadsStore.get(serverId, itemId) != null
 
-    override fun isCached(itemId: String): Boolean = cacheStore.get(itemId) != null
+    override fun isCached(serverId: String, itemId: String): Boolean = cacheStore.get(serverId, itemId) != null
 
     override suspend fun saveReadingPosition(itemId: String, cfi: String) {
         val serverId = serverRepository.getActive()?.id ?: return

--- a/core/data/src/main/kotlin/com/riffle/core/data/LibraryRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/LibraryRepositoryImpl.kt
@@ -94,14 +94,22 @@ class LibraryRepositoryImpl @Inject constructor(
     override fun observeCollectionItems(collectionId: String): Flow<List<LibraryItem>> =
         collectionDao.observeItemsByCollectionId(collectionId).map { list -> list.map { it.toDomain() } }
 
-    override suspend fun getItem(itemId: String): LibraryItem? =
-        libraryItemDao.getById(itemId)?.toDomain()
+    // Item ids are only unique within a Server (ADR 0025); reads/writes here target the active
+    // Server's copy, mirroring how reading positions are keyed. No active Server → nothing to do.
+    override suspend fun getItem(itemId: String): LibraryItem? {
+        val serverId = serverRepository.getActive()?.id ?: return null
+        return libraryItemDao.getById(serverId, itemId)?.toDomain()
+    }
+
+    override suspend fun getItem(serverId: String, itemId: String): LibraryItem? =
+        libraryItemDao.getById(serverId, itemId)?.toDomain()
 
     override suspend fun getLibrary(libraryId: String): Library? =
         libraryDao.getById(libraryId)?.toDomain()
 
     override suspend fun markItemOpened(itemId: String) {
-        libraryItemDao.updateLastOpenedAt(itemId, System.currentTimeMillis())
+        val serverId = serverRepository.getActive()?.id ?: return
+        libraryItemDao.updateLastOpenedAt(serverId, itemId, System.currentTimeMillis())
         // Best-effort push so other devices see this open via mediaProgress.lastUpdate. Offline
         // failures are intentionally swallowed — the local stamp lifts the server timestamp via
         // max() on the next successful library refresh.
@@ -109,7 +117,8 @@ class LibraryRepositoryImpl @Inject constructor(
     }
 
     override suspend fun updateReadingProgress(itemId: String, progress: Float) {
-        libraryItemDao.updateReadingProgress(itemId, progress)
+        val serverId = serverRepository.getActive()?.id ?: return
+        libraryItemDao.updateReadingProgress(serverId, itemId, progress)
     }
 
     override suspend fun refreshLibraries(): LibraryRefreshResult {
@@ -147,6 +156,7 @@ class LibraryRepositoryImpl @Inject constructor(
                     .map { item ->
                         val serverProgress = serverProgressMap[item.id]
                         LibraryItemEntity(
+                            serverId = server.id,
                             id = item.id,
                             libraryId = item.libraryId,
                             title = item.title,
@@ -202,6 +212,7 @@ class LibraryRepositoryImpl @Inject constructor(
                     s.items.mapIndexed { index, item ->
                         SeriesItemEntity(
                             seriesId = s.id,
+                            serverId = server.id,
                             itemId = item.id,
                             sequenceOrder = item.sequence?.toFloatOrNull() ?: (index + 1).toFloat(),
                         )
@@ -231,7 +242,7 @@ class LibraryRepositoryImpl @Inject constructor(
                 }
                 val collectionItemEntities = result.collections.flatMap { c ->
                     c.items.map { item ->
-                        CollectionItemEntity(collectionId = c.id, itemId = item.id)
+                        CollectionItemEntity(collectionId = c.id, serverId = server.id, itemId = item.id)
                     }
                 }
                 collectionDao.replaceAllForLibrary(libraryId, collectionEntities, collectionItemEntities)
@@ -253,6 +264,7 @@ class LibraryRepositoryImpl @Inject constructor(
             val localProgressMap = libraryItemDao.getReadingProgressMap(libraryId).associate { it.id to it.readingProgress }
             val entities = storytellerBooksToEntities(
                 books = result.books,
+                serverId = server.id,
                 libraryId = libraryId,
                 coverUrlOf = { bookId -> storytellerApi.coverUrl(server.url.value, bookId) },
                 lastOpenedAtMap = lastOpenedAtMap,
@@ -277,6 +289,7 @@ class LibraryRepositoryImpl @Inject constructor(
 
     private fun LibraryItemEntity.toDomain() = LibraryItem(
         id = id,
+        serverId = serverId,
         libraryId = libraryId,
         title = title,
         author = author,

--- a/core/data/src/main/kotlin/com/riffle/core/data/LocalStoreImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/LocalStoreImpl.kt
@@ -1,20 +1,27 @@
 package com.riffle.core.data
 
 import com.riffle.core.domain.LocalStore
+import com.riffle.core.domain.StoredItemRef
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.io.File
 import java.io.InputStream
 
+// Files live under dir/<serverId>/<itemId><ext> so item ids that collide across Servers
+// (e.g. two Storyteller Servers each emitting "1") never overwrite each other (ADR 0025).
 class LocalStoreImpl(private val dir: File, private val extension: String) : LocalStore {
 
-    override fun get(itemId: String): File? =
-        dir.resolve("$itemId$extension").takeIf { it.exists() }
+    private fun fileFor(serverId: String, itemId: String): File =
+        dir.resolve(serverId).resolve("$itemId$extension")
 
-    override suspend fun save(itemId: String, stream: InputStream): File =
+    override fun get(serverId: String, itemId: String): File? =
+        fileFor(serverId, itemId).takeIf { it.exists() }
+
+    override suspend fun save(serverId: String, itemId: String, stream: InputStream): File =
         withContext(Dispatchers.IO) {
-            val dest = dir.resolve("$itemId$extension")
-            val tmp = dir.resolve("$itemId$extension.tmp")
+            val serverDir = dir.resolve(serverId).also { it.mkdirs() }
+            val dest = serverDir.resolve("$itemId$extension")
+            val tmp = serverDir.resolve("$itemId$extension.tmp")
             try {
                 tmp.outputStream().use { out -> stream.copyTo(out) }
                 tmp.renameTo(dest)
@@ -25,17 +32,22 @@ class LocalStoreImpl(private val dir: File, private val extension: String) : Loc
             }
         }
 
-    override fun delete(itemId: String) {
-        dir.resolve("$itemId$extension").delete()
+    override fun delete(serverId: String, itemId: String) {
+        fileFor(serverId, itemId).delete()
     }
 
     override fun clear() {
-        dir.listFiles()?.forEach { it.delete() }
+        dir.listFiles()?.forEach { it.deleteRecursively() }
     }
 
-    override fun listItemIds(): List<String> =
+    override fun listItems(): List<StoredItemRef> =
         dir.listFiles()
-            ?.filter { it.name.endsWith(extension) }
-            ?.map { it.name.removeSuffix(extension) }
+            ?.filter { it.isDirectory }
+            ?.flatMap { serverDir ->
+                serverDir.listFiles()
+                    ?.filter { it.name.endsWith(extension) }
+                    ?.map { StoredItemRef(serverId = serverDir.name, itemId = it.name.removeSuffix(extension)) }
+                    ?: emptyList()
+            }
             ?: emptyList()
 }

--- a/core/data/src/main/kotlin/com/riffle/core/data/LocalStoreMigrator.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/LocalStoreMigrator.kt
@@ -1,0 +1,45 @@
+package com.riffle.core.data
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.io.File
+
+/**
+ * One-time on-disk relocation for the (serverId, itemId) file keying introduced by ADR 0025.
+ *
+ * Before this change `LocalStore` kept files flat as `dir/<itemId><ext>`; now they live under
+ * `dir/<serverId>/<itemId><ext>`. This migrator finds any legacy flat files left at the top level
+ * of each store dir, resolves each one's owning Server from the (already-migrated) DB, and moves it
+ * into the per-Server subdirectory. Files whose item id no longer resolves to any row are orphans
+ * (the book was removed) and are deleted.
+ *
+ * It is idempotent: once relocation has run there are no top-level files left, so subsequent calls
+ * are no-ops — no run-once flag is needed. Resolution depends on the Room 25→26 migration having
+ * already backfilled `library_items.serverId`, which it has by the time any DAO query returns.
+ */
+class LocalStoreMigrator(
+    // (store directory, file extension) for each of the four EPUB/PDF cache & downloads stores.
+    private val stores: List<Pair<File, String>>,
+    private val resolveServerId: suspend (itemId: String) -> String?,
+) {
+    suspend fun migrate() = withContext(Dispatchers.IO) {
+        for ((dir, extension) in stores) {
+            val flatFiles = dir.listFiles()?.filter { it.isFile && it.name.endsWith(extension) } ?: continue
+            for (file in flatFiles) {
+                val itemId = file.name.removeSuffix(extension)
+                val serverId = resolveServerId(itemId)
+                if (serverId == null) {
+                    // Orphan: no library item owns this id anymore.
+                    file.delete()
+                    continue
+                }
+                val destDir = dir.resolve(serverId).also { it.mkdirs() }
+                val dest = destDir.resolve(file.name)
+                if (!file.renameTo(dest)) {
+                    // Rename can fail across links; fall back to copy+delete, then drop the source.
+                    runCatching { file.copyTo(dest, overwrite = true) }.onSuccess { file.delete() }
+                }
+            }
+        }
+    }
+}

--- a/core/data/src/main/kotlin/com/riffle/core/data/PdfRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/PdfRepositoryImpl.kt
@@ -25,9 +25,9 @@ class PdfRepositoryImpl(
     override suspend fun openPdf(item: LibraryItem): PdfOpenResult {
         val activeServer = serverRepository.getActive()
             ?: return PdfOpenResult.NetworkError(IllegalStateException("No active server"))
-        val local = (downloadsStore.get(item.id) ?: cacheStore.get(item.id))?.takeIf { it.isValidPdf() }
+        val local = (downloadsStore.get(activeServer.id, item.id) ?: cacheStore.get(activeServer.id, item.id))?.takeIf { it.isValidPdf() }
         if (local == null) {
-            cacheStore.delete(item.id)
+            cacheStore.delete(activeServer.id, item.id)
         }
         val pdfFile = if (local != null) {
             local
@@ -42,7 +42,7 @@ class PdfRepositoryImpl(
             }
             when (val result = api.downloadEpub(activeServer.url.value, item.id, ino, token, activeServer.insecureConnectionAllowed)) {
                 is NetworkEpubDownloadResult.Success -> result.body.use { body ->
-                    cacheStore.save(item.id, body.byteStream())
+                    cacheStore.save(activeServer.id, item.id, body.byteStream())
                 }
                 is NetworkEpubDownloadResult.NetworkError -> return PdfOpenResult.NetworkError(result.cause)
             }
@@ -52,11 +52,11 @@ class PdfRepositoryImpl(
     }
 
     override suspend fun downloadPdf(item: LibraryItem): PdfDownloadResult {
-        if (downloadsStore.get(item.id) != null) return PdfDownloadResult.AlreadyDownloaded
-        val cached = cacheStore.get(item.id)
+        if (downloadsStore.get(item.serverId, item.id) != null) return PdfDownloadResult.AlreadyDownloaded
+        val cached = cacheStore.get(item.serverId, item.id)
         if (cached != null) {
-            cached.inputStream().use { downloadsStore.save(item.id, it) }
-            cacheStore.delete(item.id)
+            cached.inputStream().use { downloadsStore.save(item.serverId, item.id, it) }
+            cacheStore.delete(item.serverId, item.id)
             return PdfDownloadResult.Success
         }
         val server = serverRepository.getActive()
@@ -71,20 +71,20 @@ class PdfRepositoryImpl(
         }
         return when (val result = api.downloadEpub(server.url.value, item.id, ino, token, server.insecureConnectionAllowed)) {
             is NetworkEpubDownloadResult.Success -> {
-                result.body.use { body -> downloadsStore.save(item.id, body.byteStream()) }
+                result.body.use { body -> downloadsStore.save(item.serverId, item.id, body.byteStream()) }
                 PdfDownloadResult.Success
             }
             is NetworkEpubDownloadResult.NetworkError -> PdfDownloadResult.NetworkError(result.cause)
         }
     }
 
-    override suspend fun removeDownload(itemId: String) {
-        downloadsStore.delete(itemId)
+    override suspend fun removeDownload(serverId: String, itemId: String) {
+        downloadsStore.delete(serverId, itemId)
     }
 
-    override fun isDownloaded(itemId: String): Boolean = downloadsStore.get(itemId) != null
+    override fun isDownloaded(serverId: String, itemId: String): Boolean = downloadsStore.get(serverId, itemId) != null
 
-    override fun isCached(itemId: String): Boolean = cacheStore.get(itemId) != null
+    override fun isCached(serverId: String, itemId: String): Boolean = cacheStore.get(serverId, itemId) != null
 
     override suspend fun saveReadingPosition(itemId: String, locatorJson: String) {
         val serverId = serverRepository.getActive()?.id ?: return

--- a/core/data/src/main/kotlin/com/riffle/core/data/ReadaloudAudioRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/ReadaloudAudioRepositoryImpl.kt
@@ -52,7 +52,7 @@ class ReadaloudAudioRepositoryImpl(
             ?: return AudioDownloadResult.NetworkError(IllegalStateException("No server $serverId"))
         val token = tokenStorage.getToken(serverId)
             ?: return AudioDownloadResult.NetworkError(IllegalStateException("No token for $serverId"))
-        return when (val r = downloader.download(server.url.value, bookId, token, server.insecureConnectionAllowed, onProgress)) {
+        return when (val r = downloader.download(serverId, server.url.value, bookId, token, server.insecureConnectionAllowed, onProgress)) {
             is AudiobookBundleDownloader.Result.Success -> AudioDownloadResult.Success
             is AudiobookBundleDownloader.Result.NetworkError -> AudioDownloadResult.NetworkError(r.cause)
         }

--- a/core/data/src/main/kotlin/com/riffle/core/data/ReadaloudAudioRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/ReadaloudAudioRepositoryImpl.kt
@@ -21,20 +21,20 @@ class ReadaloudAudioRepositoryImpl(
     private val tokenStorage: TokenStorage,
 ) : ReadaloudAudioRepository {
 
-    override fun isAudioAvailable(itemId: String): Boolean = bundleFile(itemId) != null
+    override fun isAudioAvailable(serverId: String, itemId: String): Boolean = bundleFile(serverId, itemId) != null
 
-    override fun bundleFile(itemId: String): File? =
-        downloadsStore.get(itemId) ?: cacheStore.get(itemId)
+    override fun bundleFile(serverId: String, itemId: String): File? =
+        downloadsStore.get(serverId, itemId) ?: cacheStore.get(serverId, itemId)
 
-    override suspend fun readTrack(itemId: String): ReadaloudTrack? = withContext(Dispatchers.IO) {
-        val file = bundleFile(itemId) ?: return@withContext null
+    override suspend fun readTrack(serverId: String, itemId: String): ReadaloudTrack? = withContext(Dispatchers.IO) {
+        val file = bundleFile(serverId, itemId) ?: return@withContext null
         runCatching { MediaOverlayReader.readTrack(file) }
             .getOrNull()
             ?.takeIf { it.clips.isNotEmpty() }
     }
 
-    override suspend fun probeSizeBytes(itemId: String): Long? {
-        val server = serverRepository.getActive() ?: return null
+    override suspend fun probeSizeBytes(serverId: String, itemId: String): Long? {
+        val server = serverRepository.getById(serverId) ?: return null
         val token = tokenStorage.getToken(server.id) ?: return null
         return when (val r = bundleProbe.probeBundleSize(server.url.value, itemId, token, server.insecureConnectionAllowed)) {
             is NetworkStorytellerBundleSizeResult.Success -> r.sizeBytes
@@ -43,20 +43,11 @@ class ReadaloudAudioRepositoryImpl(
     }
 
     override suspend fun downloadAudio(
-        itemId: String,
-        onProgress: (downloaded: Long, total: Long) -> Unit,
-    ): AudioDownloadResult {
-        val activeId = serverRepository.getActive()?.id
-            ?: return AudioDownloadResult.NetworkError(IllegalStateException("No active server"))
-        return downloadAudio(itemId, activeId, onProgress)
-    }
-
-    override suspend fun downloadAudio(
-        bookId: String,
         serverId: String,
+        bookId: String,
         onProgress: (downloaded: Long, total: Long) -> Unit,
     ): AudioDownloadResult {
-        if (downloadsStore.get(bookId) != null) return AudioDownloadResult.Success
+        if (downloadsStore.get(serverId, bookId) != null) return AudioDownloadResult.Success
         val server = serverRepository.getById(serverId)
             ?: return AudioDownloadResult.NetworkError(IllegalStateException("No server $serverId"))
         val token = tokenStorage.getToken(serverId)
@@ -67,10 +58,10 @@ class ReadaloudAudioRepositoryImpl(
         }
     }
 
-    override suspend fun removeAudio(itemId: String): Long = withContext(Dispatchers.IO) {
-        val freed = (downloadsStore.get(itemId)?.length() ?: 0L) + (cacheStore.get(itemId)?.length() ?: 0L)
-        downloadsStore.delete(itemId)
-        cacheStore.delete(itemId)
+    override suspend fun removeAudio(serverId: String, itemId: String): Long = withContext(Dispatchers.IO) {
+        val freed = (downloadsStore.get(serverId, itemId)?.length() ?: 0L) + (cacheStore.get(serverId, itemId)?.length() ?: 0L)
+        downloadsStore.delete(serverId, itemId)
+        cacheStore.delete(serverId, itemId)
         freed
     }
 }

--- a/core/data/src/main/kotlin/com/riffle/core/data/ReadaloudMatchingService.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/ReadaloudMatchingService.kt
@@ -168,7 +168,7 @@ class ReadaloudMatchingService(
             // same work). Borrow from the ebook — the supported format with the richer metadata —
             // before any unsupported stub, then settle ties by libraryId for a stable choice.
             val abs = readaloudLinkDao.findByStorytellerBook(book.serverId, book.itemId)
-                .mapNotNull { libraryItemDao.getById(it.absLibraryItemId) }
+                .mapNotNull { libraryItemDao.getById(it.absServerId, it.absLibraryItemId) }
                 .sortedWith(
                     compareBy(
                         { if (it.ebookFormat == EbookFormat.Unsupported.toStorageString()) 1 else 0 },
@@ -177,6 +177,7 @@ class ReadaloudMatchingService(
                 )
                 .firstOrNull()
             libraryItemDao.updateReadaloudMetadata(
+                serverId = book.serverId,
                 itemId = book.itemId,
                 // Overwrite the (possibly duplicated/malformed) Storyteller author when linked;
                 // null leaves it untouched so an unlinked readaloud keeps its own author.

--- a/core/data/src/main/kotlin/com/riffle/core/data/ReadaloudReviewRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/ReadaloudReviewRepositoryImpl.kt
@@ -78,7 +78,7 @@ class ReadaloudReviewRepositoryImpl(
             .groupBy { it.storytellerBookId }
             .mapNotNull { (storytellerBookId, links) ->
                 val targets = links.mapNotNull { link ->
-                    val abs = libraryItemDao.getById(link.absLibraryItemId) ?: return@mapNotNull null
+                    val abs = libraryItemDao.getById(link.absServerId, link.absLibraryItemId) ?: return@mapNotNull null
                     ConfirmedReadaloud.ConfirmedTarget(
                         absServerId = link.absServerId,
                         absLibraryItemId = link.absLibraryItemId,
@@ -87,7 +87,7 @@ class ReadaloudReviewRepositoryImpl(
                     )
                 }
                 if (targets.isEmpty()) return@mapNotNull null
-                val book = libraryItemDao.getById(storytellerBookId)
+                val book = libraryItemDao.getById(storytellerServerId, storytellerBookId)
                 ConfirmedReadaloud(
                     storytellerServerId = storytellerServerId,
                     storytellerBookId = storytellerBookId,
@@ -100,11 +100,11 @@ class ReadaloudReviewRepositoryImpl(
         val pending = books
             .filter { it.itemId !in confirmedBookIds && candidatesByBook.containsKey(it.itemId) }
             .map { book ->
-                val bookEntity = libraryItemDao.getById(book.itemId)
+                val bookEntity = libraryItemDao.getById(storytellerServerId, book.itemId)
                 val cands = candidatesByBook.getValue(book.itemId)
                     .sortedByDescending { it.score }
                     .mapNotNull { cand ->
-                        val abs = libraryItemDao.getById(cand.absLibraryItemId) ?: return@mapNotNull null
+                        val abs = libraryItemDao.getById(cand.absServerId, cand.absLibraryItemId) ?: return@mapNotNull null
                         AbsCandidate(
                             absServerId = cand.absServerId,
                             absLibraryItemId = cand.absLibraryItemId,
@@ -132,7 +132,7 @@ class ReadaloudReviewRepositoryImpl(
         val unmatched = books
             .filter { it.itemId !in confirmedBookIds && it.itemId !in pendingBookIds }
             .map { book ->
-                val bookEntity = libraryItemDao.getById(book.itemId)
+                val bookEntity = libraryItemDao.getById(storytellerServerId, book.itemId)
                 UnmatchedReadaloud(
                     storytellerServerId = storytellerServerId,
                     storytellerBookId = book.itemId,
@@ -218,7 +218,7 @@ class ReadaloudReviewRepositoryImpl(
         return matched
             .sortedBy { it.title.lowercase() }
             .mapNotNull { row ->
-                val abs: LibraryItemEntity = libraryItemDao.getById(row.itemId) ?: return@mapNotNull null
+                val abs: LibraryItemEntity = libraryItemDao.getById(row.serverId, row.itemId) ?: return@mapNotNull null
                 val name = libraryNameCache.getOrPut(abs.libraryId) {
                     libraryDao.getById(abs.libraryId)?.name ?: abs.libraryId
                 }

--- a/core/data/src/main/kotlin/com/riffle/core/data/StorytellerReadaloudSyncer.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/StorytellerReadaloudSyncer.kt
@@ -21,6 +21,7 @@ import kotlinx.coroutines.flow.first
  */
 internal fun storytellerBooksToEntities(
     books: List<NetworkStorytellerBook>,
+    serverId: String,
     libraryId: String,
     coverUrlOf: (Long) -> String,
     lastOpenedAtMap: Map<String, Long?>,
@@ -28,6 +29,7 @@ internal fun storytellerBooksToEntities(
 ): List<LibraryItemEntity> = books.map { book ->
     val id = book.id.toString()
     LibraryItemEntity(
+        serverId = serverId,
         id = id,
         libraryId = libraryId,
         title = book.title,
@@ -90,6 +92,7 @@ open class StorytellerReadaloudSyncer(
                 val progressMap = libraryItemDao.getReadingProgressMap(libraryId).associate { it.id to it.readingProgress }
                 val entities = storytellerBooksToEntities(
                     books = r.books,
+                    serverId = server.id,
                     libraryId = libraryId,
                     coverUrlOf = { bookId -> storytellerApi.coverUrl(server.url.value, bookId) },
                     lastOpenedAtMap = lastOpenedAtMap,

--- a/core/data/src/main/kotlin/com/riffle/core/data/di/DataModule.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/di/DataModule.kt
@@ -15,6 +15,7 @@ import com.riffle.core.data.LibraryRepositoryImpl
 import com.riffle.core.data.AnnotationStoreImpl
 import com.riffle.core.data.LibraryVisibilityPreferencesStoreImpl
 import com.riffle.core.data.LocalStoreImpl
+import com.riffle.core.data.LocalStoreMigrator
 import com.riffle.core.data.PdfRepositoryImpl
 import com.riffle.core.data.CrossEpubIndexStoreImpl
 import com.riffle.core.data.ReadaloudLinkRepositoryImpl
@@ -261,6 +262,23 @@ abstract class DataModule {
         @PdfDownloadsStore
         fun providePdfDownloadsStore(@ApplicationContext context: Context): LocalStore =
             LocalStoreImpl(context.filesDir.resolve("downloads/pdfs").also { it.mkdirs() }, ".pdf")
+
+        // One-time relocation of legacy flat files into per-Server subdirectories (ADR 0025).
+        @Provides
+        @Singleton
+        fun provideLocalStoreMigrator(
+            @ApplicationContext context: Context,
+            libraryItemDao: LibraryItemDao,
+        ): LocalStoreMigrator =
+            LocalStoreMigrator(
+                stores = listOf(
+                    context.cacheDir.resolve("epubs") to ".epub",
+                    context.filesDir.resolve("downloads/epubs") to ".epub",
+                    context.cacheDir.resolve("pdfs") to ".pdf",
+                    context.filesDir.resolve("downloads/pdfs") to ".pdf",
+                ),
+                resolveServerId = { itemId -> libraryItemDao.findServerIdForItem(itemId) },
+            )
 
         @Provides
         @Singleton

--- a/core/data/src/main/kotlin/com/riffle/core/data/di/DataModule.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/di/DataModule.kt
@@ -308,9 +308,10 @@ abstract class DataModule {
         ): AudiobookBundleDownloader = AudiobookBundleDownloader(
             api = api,
             // Write into the same Downloads EPUB store the reader reads from — the synced bundle is
-            // both the EPUB and the audio source (ADR 0023), so they share one file.
-            targetFileProvider = { id ->
-                context.filesDir.resolve("downloads/epubs").also { it.mkdirs() }.resolve("$id.epub")
+            // both the EPUB and the audio source (ADR 0023), so they share one file. Must mirror
+            // LocalStoreImpl's dir/<serverId>/<id> layout so downloadsStore.get(serverId, id) finds it.
+            targetFileProvider = { serverId, id ->
+                context.filesDir.resolve("downloads/epubs").resolve(serverId).also { it.mkdirs() }.resolve("$id.epub")
             },
         )
 

--- a/core/data/src/main/kotlin/com/riffle/core/data/di/DatabaseModule.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/di/DatabaseModule.kt
@@ -55,6 +55,7 @@ object DatabaseModule {
                 RiffleDatabase.MIGRATION_22_23,
                 RiffleDatabase.MIGRATION_23_24,
                 RiffleDatabase.MIGRATION_24_25,
+                RiffleDatabase.MIGRATION_25_26,
             )
             .build()
 

--- a/core/data/src/test/kotlin/com/riffle/core/data/AudiobookBundleDownloaderTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/AudiobookBundleDownloaderTest.kt
@@ -55,14 +55,14 @@ class AudiobookBundleDownloaderTest {
     }
 
     private fun downloader(api: AudiobookBundleApi, dir: File) =
-        AudiobookBundleDownloader(api = api, targetFileProvider = { File(dir, "$it.epub") })
+        AudiobookBundleDownloader(api = api, targetFileProvider = { _, id -> File(dir, "$id.epub") })
 
     @Test fun freshDownload_writesFullBundle_andReportsProgressToCompletion() = runTest {
         val dir = tmp.newFolder()
         var lastDownloaded = 0L
         var lastTotal = 0L
 
-        val result = downloader(FakeApi(), dir).download("u", "42", "t", false) { d, total ->
+        val result = downloader(FakeApi(), dir).download("s1", "u", "42", "t", false) { d, total ->
             lastDownloaded = d; lastTotal = total
         }
 
@@ -81,7 +81,7 @@ class AudiobookBundleDownloaderTest {
         val part = File(dir, "42.epub.part")
         part.writeBytes(full.copyOfRange(0, 80))
 
-        val result = downloader(api, dir).download("u", "42", "t", false) { _, _ -> }
+        val result = downloader(api, dir).download("s1", "u", "42", "t", false) { _, _ -> }
 
         assertEquals(80L, api.requestedFromByte)
         assertTrue(result is AudiobookBundleDownloader.Result.Success)
@@ -93,7 +93,7 @@ class AudiobookBundleDownloaderTest {
         val part = File(dir, "42.epub.part")
         part.writeBytes(full.copyOfRange(0, 80))
 
-        val result = downloader(FakeApi(honorRange = false), dir).download("u", "42", "t", false) { _, _ -> }
+        val result = downloader(FakeApi(honorRange = false), dir).download("s1", "u", "42", "t", false) { _, _ -> }
 
         assertTrue(result is AudiobookBundleDownloader.Result.Success)
         assertArrayEquals(full, (result as AudiobookBundleDownloader.Result.Success).file.readBytes())
@@ -104,7 +104,7 @@ class AudiobookBundleDownloaderTest {
         val existing = File(dir, "42.epub").apply { writeBytes(full) }
         val api = FakeApi()
 
-        val result = downloader(api, dir).download("u", "42", "t", false) { _, _ -> }
+        val result = downloader(api, dir).download("s1", "u", "42", "t", false) { _, _ -> }
 
         assertEquals(-1L, api.requestedFromByte) // never called
         assertTrue(result is AudiobookBundleDownloader.Result.Success)
@@ -116,7 +116,7 @@ class AudiobookBundleDownloaderTest {
         val part = File(dir, "42.epub.part").apply { writeBytes(full.copyOfRange(0, 40)) }
 
         val result = downloader(FakeApi(failWith = IOException("boom")), dir)
-            .download("u", "42", "t", false) { _, _ -> }
+            .download("s1", "u", "42", "t", false) { _, _ -> }
 
         assertTrue(result is AudiobookBundleDownloader.Result.NetworkError)
         assertTrue("partial kept for resume", part.exists())

--- a/core/data/src/test/kotlin/com/riffle/core/data/EpubRepositoryTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/EpubRepositoryTest.kt
@@ -121,7 +121,7 @@ class EpubRepositoryTest {
         override suspend fun updateLocalTimestamp(serverId: String, itemId: String, millis: Long) = Unit
     }
 
-    private fun item(id: String = "item-1", ino: String? = "ino-42") = LibraryItem(
+    private fun item(id: String = "item-1", ino: String? = "ino-42", serverId: String = "server-1") = LibraryItem(
         id = id,
         libraryId = "lib-1",
         title = "Test Book",
@@ -132,6 +132,7 @@ class EpubRepositoryTest {
         isDownloaded = false,
         ebookFormat = EbookFormat.Epub,
         ebookFileIno = ino,
+        serverId = serverId,
     )
 
     // --- openEpub ---
@@ -147,12 +148,12 @@ class EpubRepositoryTest {
     fun `openEpub with cache miss writes file to cache for subsequent opens`() = runTest {
         server.enqueue(MockResponse().setResponseCode(200).setBody(Buffer().write(epubBytes)))
         repo.openEpub(item())
-        assertTrue(cacheStore.get("item-1") != null)
+        assertTrue(cacheStore.get("server-1", "item-1") != null)
     }
 
     @Test
     fun `openEpub with cache hit makes no network request`() = runTest {
-        cacheStore.save("item-1", epubBytes.inputStream())
+        cacheStore.save("server-1", "item-1", epubBytes.inputStream())
         val result = repo.openEpub(item())
         assertEquals(0, server.requestCount)
         assertTrue(result is EpubOpenResult.Success)
@@ -160,7 +161,7 @@ class EpubRepositoryTest {
 
     @Test
     fun `openEpub with downloads hit makes no network request`() = runTest {
-        downloadsStore.save("item-1", epubBytes.inputStream())
+        downloadsStore.save("server-1", "item-1", epubBytes.inputStream())
         val result = repo.openEpub(item())
         assertEquals(0, server.requestCount)
         assertTrue(result is EpubOpenResult.Success)
@@ -168,7 +169,7 @@ class EpubRepositoryTest {
 
     @Test
     fun `openEpub returns last saved reading position`() = runTest {
-        cacheStore.save("item-1", epubBytes.inputStream())
+        cacheStore.save("server-1", "item-1", epubBytes.inputStream())
         positionStore.save("server-1", "item-1", "epubcfi(/6/4!/4/1:0)")
         val result = repo.openEpub(item()) as EpubOpenResult.Success
         assertEquals("epubcfi(/6/4!/4/1:0)", result.lastPosition)
@@ -176,7 +177,7 @@ class EpubRepositoryTest {
 
     @Test
     fun `openEpub returns null lastPosition for fresh book`() = runTest {
-        cacheStore.save("item-1", epubBytes.inputStream())
+        cacheStore.save("server-1", "item-1", epubBytes.inputStream())
         val result = repo.openEpub(item()) as EpubOpenResult.Success
         assertNull(result.lastPosition)
     }
@@ -214,12 +215,12 @@ class EpubRepositoryTest {
         server.enqueue(MockResponse().setResponseCode(200).setBody(Buffer().write(epubBytes)))
         val result = repo.downloadEpub(item())
         assertTrue(result is EpubDownloadResult.Success)
-        assertTrue(downloadsStore.get("item-1") != null)
+        assertTrue(downloadsStore.get("server-1", "item-1") != null)
     }
 
     @Test
     fun `downloadEpub returns AlreadyDownloaded when file already in downloads store`() = runTest {
-        downloadsStore.save("item-1", epubBytes.inputStream())
+        downloadsStore.save("server-1", "item-1", epubBytes.inputStream())
         val result = repo.downloadEpub(item())
         assertEquals(0, server.requestCount)
         assertTrue(result is EpubDownloadResult.AlreadyDownloaded)
@@ -229,38 +230,38 @@ class EpubRepositoryTest {
     fun `downloadEpub does not write to cache store`() = runTest {
         server.enqueue(MockResponse().setResponseCode(200).setBody(Buffer().write(epubBytes)))
         repo.downloadEpub(item())
-        assertNull(cacheStore.get("item-1"))
+        assertNull(cacheStore.get("server-1", "item-1"))
     }
 
     @Test
     fun `isDownloaded returns true after downloadEpub succeeds`() = runTest {
         server.enqueue(MockResponse().setResponseCode(200).setBody(Buffer().write(epubBytes)))
         repo.downloadEpub(item())
-        assertTrue(repo.isDownloaded("item-1"))
+        assertTrue(repo.isDownloaded("server-1", "item-1"))
     }
 
     @Test
     fun `isCached returns true after openEpub populates cache`() = runTest {
         server.enqueue(MockResponse().setResponseCode(200).setBody(Buffer().write(epubBytes)))
         repo.openEpub(item())
-        assertTrue(repo.isCached("item-1"))
+        assertTrue(repo.isCached("server-1", "item-1"))
     }
 
     @Test
     fun `removeDownload deletes file from downloads store`() = runTest {
-        downloadsStore.save("item-1", epubBytes.inputStream())
-        repo.removeDownload("item-1")
-        assertTrue(!repo.isDownloaded("item-1"))
+        downloadsStore.save("server-1", "item-1", epubBytes.inputStream())
+        repo.removeDownload("server-1", "item-1")
+        assertTrue(!repo.isDownloaded("server-1", "item-1"))
     }
 
     @Test
     fun `downloadEpub promotes cached file to downloads without network request`() = runTest {
-        cacheStore.save("item-1", epubBytes.inputStream())
+        cacheStore.save("server-1", "item-1", epubBytes.inputStream())
         val result = repo.downloadEpub(item())
         assertEquals(0, server.requestCount)
         assertTrue(result is EpubDownloadResult.Success)
-        assertTrue(downloadsStore.get("item-1") != null)
-        assertNull(cacheStore.get("item-1"))
+        assertTrue(downloadsStore.get("server-1", "item-1") != null)
+        assertNull(cacheStore.get("server-1", "item-1"))
     }
 
     // --- Storyteller ---
@@ -294,16 +295,16 @@ class EpubRepositoryTest {
             tokenStorage = fakeTokenStorage("st-token"),
         )
 
-        val result = storytellerRepo.downloadEpub(item(id = "77", ino = null))
+        val result = storytellerRepo.downloadEpub(item(id = "77", ino = null, serverId = "st-srv"))
 
         assertEquals(EpubDownloadResult.Success, result)
-        assertEquals(epubBytes.toList(), downloads.get("77")!!.readBytes().toList())
+        assertEquals(epubBytes.toList(), downloads.get("st-srv", "77")!!.readBytes().toList())
     }
 
     @Test
     fun `downloadEpub for Storyteller server promotes cache without calling fetcher`() = runTest {
         val cache = LocalStoreImpl(tmp.newFolder("st-cache-promote"), ".epub")
-        cache.save("77", "CACHED".byteInputStream())
+        cache.save("st-srv", "77", "CACHED".byteInputStream())
         val downloads = LocalStoreImpl(tmp.newFolder("st-dl-promote"), ".epub")
 
         val bundleApi = StorytellerBundleApi { _, _, _, _ ->
@@ -328,11 +329,11 @@ class EpubRepositoryTest {
             tokenStorage = fakeTokenStorage("st-token"),
         )
 
-        val result = storytellerRepo.downloadEpub(item(id = "77", ino = null))
+        val result = storytellerRepo.downloadEpub(item(id = "77", ino = null, serverId = "st-srv"))
 
         assertEquals(EpubDownloadResult.Success, result)
-        assertEquals("CACHED", downloads.get("77")!!.readText())
-        assertEquals(null, cache.get("77"))
+        assertEquals("CACHED", downloads.get("st-srv", "77")!!.readText())
+        assertEquals(null, cache.get("st-srv", "77"))
     }
 
     @Test
@@ -370,10 +371,10 @@ class EpubRepositoryTest {
             tokenStorage = fakeTokenStorage("st-token"),
         )
 
-        val result = storytellerRepo.openEpub(item(id = "42", ino = null))
+        val result = storytellerRepo.openEpub(item(id = "42", ino = null, serverId = "st-srv"))
 
         assertTrue("Expected Success but got $result", result is EpubOpenResult.Success)
-        val cached = storytellerCache.get("42")
+        val cached = storytellerCache.get("st-srv", "42")
         assertEquals(epubContent.toList(), cached!!.readBytes().toList())
     }
 
@@ -404,10 +405,10 @@ class EpubRepositoryTest {
             tokenStorage = fakeTokenStorage("st-token"),
         )
 
-        val result = storytellerRepo.openEpub(item(id = "99", ino = null))
+        val result = storytellerRepo.openEpub(item(id = "99", ino = null, serverId = "st-srv"))
 
         assertTrue("Expected BundleTooLarge but got $result", result is EpubOpenResult.BundleTooLarge)
         assertEquals(tooBig, (result as EpubOpenResult.BundleTooLarge).sizeBytes)
-        assertEquals(null, cache.get("99"))
+        assertEquals(null, cache.get("st-srv", "99"))
     }
 }

--- a/core/data/src/test/kotlin/com/riffle/core/data/FakeLibraryItemDao.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/FakeLibraryItemDao.kt
@@ -44,14 +44,17 @@ internal class FakeLibraryItemDao : LibraryItemDao {
 
     // replaceAllForLibrary is intentionally inherited (deleteByLibraryId + upsertAll @Transaction default).
 
-    override suspend fun getById(itemId: String): LibraryItemEntity? =
-        roomData.values.flatMap { it.value }.firstOrNull { it.id == itemId }
+    override suspend fun getById(serverId: String, itemId: String): LibraryItemEntity? =
+        roomData.values.flatMap { it.value }.firstOrNull { it.serverId == serverId && it.id == itemId }
+
+    override suspend fun findServerIdForItem(itemId: String): String? =
+        roomData.values.flatMap { it.value }.firstOrNull { it.id == itemId }?.serverId
 
     override suspend fun deleteByLibraryId(libraryId: String) {
         roomData[libraryId]?.value = emptyList()
     }
 
-    override suspend fun updateLastOpenedAt(itemId: String, timestamp: Long) {}
+    override suspend fun updateLastOpenedAt(serverId: String, itemId: String, timestamp: Long) {}
 
     override suspend fun getLastOpenedAtMap(libraryId: String): List<LastOpenedAtRow> =
         roomData[libraryId]?.value
@@ -65,9 +68,10 @@ internal class FakeLibraryItemDao : LibraryItemDao {
             ?.map { ReadingProgressRow(it.id, it.readingProgress) }
             ?: emptyList()
 
-    override suspend fun updateReadingProgress(itemId: String, progress: Float) {}
+    override suspend fun updateReadingProgress(serverId: String, itemId: String, progress: Float) {}
 
     override suspend fun updateReadaloudMetadata(
+        serverId: String,
         itemId: String,
         author: String?,
         description: String?,

--- a/core/data/src/test/kotlin/com/riffle/core/data/LibraryRepositoryTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/LibraryRepositoryTest.kt
@@ -377,7 +377,7 @@ class LibraryRepositoryTest {
         fakeTokenStorage.tokens["s1"] = "tok"
         val dao = FakeLibraryItemDao()
         dao.upsertAll(listOf(
-            LibraryItemEntity("item-1", "lib-1", "My Book", "Author A", null, 0.4f, lastOpenedAt = 1_000L),
+            LibraryItemEntity("s1", "item-1", "lib-1", "My Book", "Author A", null, 0.4f, lastOpenedAt = 1_000L),
         ))
         val api = object : AbsLibraryApi {
             override suspend fun getUserProgress(baseUrl: String, token: String, insecureAllowed: Boolean) =
@@ -405,7 +405,7 @@ class LibraryRepositoryTest {
         fakeTokenStorage.tokens["s1"] = "tok"
         val dao = FakeLibraryItemDao()
         dao.upsertAll(listOf(
-            LibraryItemEntity("item-1", "lib-1", "My Book", "Author A", null, 0.4f, lastOpenedAt = 9_000L),
+            LibraryItemEntity("s1", "item-1", "lib-1", "My Book", "Author A", null, 0.4f, lastOpenedAt = 9_000L),
         ))
         val api = object : AbsLibraryApi {
             override suspend fun getUserProgress(baseUrl: String, token: String, insecureAllowed: Boolean) =
@@ -443,7 +443,7 @@ class LibraryRepositoryTest {
         val dao = FakeLibraryItemDao()
         // Seed an existing item with a known lastOpenedAt
         dao.upsertAll(listOf(
-            LibraryItemEntity("item-1", "lib-1", "My Book", "Author A", null, 0.4f, lastOpenedAt = 99_000L),
+            LibraryItemEntity("s1", "item-1", "lib-1", "My Book", "Author A", null, 0.4f, lastOpenedAt = 99_000L),
         ))
         val api = object : AbsLibraryApi {
             override suspend fun getLibraries(baseUrl: String, token: String, insecureAllowed: Boolean) =
@@ -486,8 +486,8 @@ class LibraryRepositoryTest {
     fun `observeRecentlyAddedItems emits items from DAO ordered by addedAt`() = runTest {
         val dao = FakeLibraryItemDao()
         dao.upsertAll(listOf(
-            LibraryItemEntity("item-1", "lib-1", "Older Book", "Author", null, 0f, addedAt = 1_000L),
-            LibraryItemEntity("item-2", "lib-1", "Newer Book", "Author", null, 0f, addedAt = 2_000L),
+            LibraryItemEntity("s1", "item-1", "lib-1", "Older Book", "Author", null, 0f, addedAt = 1_000L),
+            LibraryItemEntity("s1", "item-2", "lib-1", "Newer Book", "Author", null, 0f, addedAt = 2_000L),
         ))
         val result = makeRepo(libraryItemDao = dao).observeRecentlyAddedItems("lib-1").first()
         assertEquals(2, result.size)
@@ -518,7 +518,7 @@ class LibraryRepositoryTest {
     @Test
     fun `observeLibraryItems emits from Room`() = runTest {
         val dao = FakeLibraryItemDao()
-        dao.upsertAll(listOf(LibraryItemEntity("item-1", "lib-1", "My Book", "Author A", null, 0.5f)))
+        dao.upsertAll(listOf(LibraryItemEntity("s1", "item-1", "lib-1", "My Book", "Author A", null, 0.5f)))
         val result = makeRepo(libraryItemDao = dao).observeLibraryItems("lib-1").first()
         assertEquals(1, result.size)
         assertEquals("item-1", result[0].id)
@@ -530,7 +530,7 @@ class LibraryRepositoryTest {
     @Test
     fun `epub ebookFormat maps to isSupported true`() = runTest {
         val dao = FakeLibraryItemDao()
-        dao.upsertAll(listOf(LibraryItemEntity("item-1", "lib-1", "Dune", "Herbert", null, 0f, ebookFormat = "epub")))
+        dao.upsertAll(listOf(LibraryItemEntity("s1", "item-1", "lib-1", "Dune", "Herbert", null, 0f, ebookFormat = "epub")))
         val item = makeRepo(libraryItemDao = dao).observeLibraryItems("lib-1").first()[0]
         assertEquals(EbookFormat.Epub, item.ebookFormat)
         assertTrue(item.isSupported)
@@ -539,7 +539,7 @@ class LibraryRepositoryTest {
     @Test
     fun `pdf ebookFormat maps to isSupported true`() = runTest {
         val dao = FakeLibraryItemDao()
-        dao.upsertAll(listOf(LibraryItemEntity("item-1", "lib-1", "Dune", "Herbert", null, 0f, ebookFormat = "pdf")))
+        dao.upsertAll(listOf(LibraryItemEntity("s1", "item-1", "lib-1", "Dune", "Herbert", null, 0f, ebookFormat = "pdf")))
         val item = makeRepo(libraryItemDao = dao).observeLibraryItems("lib-1").first()[0]
         assertEquals(EbookFormat.Pdf, item.ebookFormat)
         assertTrue(item.isSupported)
@@ -548,7 +548,7 @@ class LibraryRepositoryTest {
     @Test
     fun `unsupported ebookFormat maps to isSupported false`() = runTest {
         val dao = FakeLibraryItemDao()
-        dao.upsertAll(listOf(LibraryItemEntity("item-1", "lib-1", "Dune", "Herbert", null, 0f, ebookFormat = "unsupported")))
+        dao.upsertAll(listOf(LibraryItemEntity("s1", "item-1", "lib-1", "Dune", "Herbert", null, 0f, ebookFormat = "unsupported")))
         val item = makeRepo(libraryItemDao = dao).observeLibraryItems("lib-1").first()[0]
         assertEquals(EbookFormat.Unsupported, item.ebookFormat)
         assertFalse(item.isSupported)
@@ -557,7 +557,7 @@ class LibraryRepositoryTest {
     @Test
     fun `unknown ebookFormat string maps to isSupported false`() = runTest {
         val dao = FakeLibraryItemDao()
-        dao.upsertAll(listOf(LibraryItemEntity("item-1", "lib-1", "Comic", "Author", null, 0f, ebookFormat = "cbz")))
+        dao.upsertAll(listOf(LibraryItemEntity("s1", "item-1", "lib-1", "Comic", "Author", null, 0f, ebookFormat = "cbz")))
         val item = makeRepo(libraryItemDao = dao).observeLibraryItems("lib-1").first()[0]
         assertEquals(EbookFormat.Unsupported, item.ebookFormat)
         assertFalse(item.isSupported)
@@ -738,8 +738,8 @@ class LibraryRepositoryTest {
     @Test
     fun `observeSeriesItems emits items from Room in series order`() = runTest {
         val dao = FakeSeriesDao()
-        val item1 = LibraryItemEntity("item-1", "lib-1", "WoK", "Sanderson", null, 0.5f)
-        val item2 = LibraryItemEntity("item-2", "lib-1", "WoR", "Sanderson", null, 0f)
+        val item1 = LibraryItemEntity("s1", "item-1", "lib-1", "WoK", "Sanderson", null, 0.5f)
+        val item2 = LibraryItemEntity("s1", "item-2", "lib-1", "WoR", "Sanderson", null, 0f)
         dao.seedItems("ser-1", listOf(item1, item2))
         val result = makeRepo(seriesDao = dao).observeSeriesItems("ser-1").first()
         assertEquals(2, result.size)
@@ -752,7 +752,7 @@ class LibraryRepositoryTest {
     @Test
     fun `observeCollectionItems emits items from Room`() = runTest {
         val dao = FakeCollectionDao()
-        val item1 = LibraryItemEntity("item-1", "lib-1", "Book A", "Author", null, 0f)
+        val item1 = LibraryItemEntity("s1", "item-1", "lib-1", "Book A", "Author", null, 0f)
         dao.seedItems("col-1", listOf(item1))
         val result = makeRepo(collectionDao = dao).observeCollectionItems("col-1").first()
         assertEquals(1, result.size)

--- a/core/data/src/test/kotlin/com/riffle/core/data/LocalStoreMigratorTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/LocalStoreMigratorTest.kt
@@ -1,0 +1,89 @@
+package com.riffle.core.data
+
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+class LocalStoreMigratorTest {
+
+    @get:Rule
+    val tmp = TemporaryFolder()
+
+    private fun writeFlat(dir: File, name: String, content: String): File =
+        dir.resolve(name).apply { parentFile?.mkdirs(); writeText(content) }
+
+    @Test
+    fun migrate_relocatesFlatFilesUnderOwningServer() = runTest {
+        val epubDir = tmp.newFolder("epubs")
+        writeFlat(epubDir, "1.epub", "A's book one")
+        writeFlat(epubDir, "2.epub", "A's book two")
+
+        // itemId "1" belongs to server A, "2" to server B.
+        val owners = mapOf("1" to "serverA", "2" to "serverB")
+        val migrator = LocalStoreMigrator(
+            stores = listOf(epubDir to ".epub"),
+            resolveServerId = { owners[it] },
+        )
+
+        migrator.migrate()
+
+        assertFalse("flat file should be gone", epubDir.resolve("1.epub").exists())
+        assertEquals("A's book one", epubDir.resolve("serverA").resolve("1.epub").readText())
+        assertEquals("A's book two", epubDir.resolve("serverB").resolve("2.epub").readText())
+    }
+
+    @Test
+    fun migrate_deletesOrphansWithNoOwningServer() = runTest {
+        val epubDir = tmp.newFolder("epubs")
+        writeFlat(epubDir, "ghost.epub", "no owner")
+
+        val migrator = LocalStoreMigrator(
+            stores = listOf(epubDir to ".epub"),
+            resolveServerId = { null },
+        )
+
+        migrator.migrate()
+
+        assertFalse("orphan should be deleted", epubDir.resolve("ghost.epub").exists())
+        assertTrue("no server subdir created", epubDir.listFiles()?.none { it.isDirectory } ?: true)
+    }
+
+    @Test
+    fun migrate_isIdempotent_leavesRelocatedFilesUntouched() = runTest {
+        val epubDir = tmp.newFolder("epubs")
+        writeFlat(epubDir, "1.epub", "content")
+        val migrator = LocalStoreMigrator(
+            stores = listOf(epubDir to ".epub"),
+            resolveServerId = { "serverA" },
+        )
+
+        migrator.migrate()
+        // Second run: nothing flat remains, so the already-relocated file is left in place.
+        migrator.migrate()
+
+        assertEquals("content", epubDir.resolve("serverA").resolve("1.epub").readText())
+    }
+
+    @Test
+    fun migrate_ignoresFilesAlreadyInServerSubdirs() = runTest {
+        val epubDir = tmp.newFolder("epubs")
+        // A file already correctly placed under a server dir must not be touched / re-resolved.
+        writeFlat(epubDir.resolve("serverA"), "1.epub", "already placed")
+
+        var resolverCalls = 0
+        val migrator = LocalStoreMigrator(
+            stores = listOf(epubDir to ".epub"),
+            resolveServerId = { resolverCalls++; "serverB" },
+        )
+
+        migrator.migrate()
+
+        assertEquals("resolver should not run for subdir files", 0, resolverCalls)
+        assertEquals("already placed", epubDir.resolve("serverA").resolve("1.epub").readText())
+    }
+}

--- a/core/data/src/test/kotlin/com/riffle/core/data/LocalStoreTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/LocalStoreTest.kt
@@ -1,5 +1,6 @@
 package com.riffle.core.data
 
+import com.riffle.core.domain.StoredItemRef
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertNotNull
@@ -29,13 +30,13 @@ class LocalStoreTest {
 
     @Test
     fun `get returns null when item is absent`() {
-        assertNull(store.get("item-missing"))
+        assertNull(store.get("server-1", "item-missing"))
     }
 
     @Test
     fun `save writes file to store directory`() = runTest {
         val bytes = "epub-content".toByteArray()
-        val file = store.save("item-1", bytes.inputStream())
+        val file = store.save("server-1", "item-1", bytes.inputStream())
         assertTrue(file.exists())
         assertTrue(file.absolutePath.startsWith(storeDir.absolutePath))
     }
@@ -43,8 +44,8 @@ class LocalStoreTest {
     @Test
     fun `get returns saved file with correct content`() = runTest {
         val bytes = "epub-content".toByteArray()
-        store.save("item-1", bytes.inputStream())
-        val result = store.get("item-1")
+        store.save("server-1", "item-1", bytes.inputStream())
+        val result = store.get("server-1", "item-1")
         assertNotNull(result)
         assertArrayEquals(bytes, result!!.readBytes())
     }
@@ -59,43 +60,43 @@ class LocalStoreTest {
             }
         }
         try {
-            store.save("item-broken", failingStream)
+            store.save("server-1", "item-broken", failingStream)
         } catch (_: IOException) {}
-        assertNull(store.get("item-broken"))
-        assertTrue(storeDir.listFiles()?.none { it.name.contains("item-broken") } ?: true)
+        assertNull(store.get("server-1", "item-broken"))
+        assertTrue(storeDir.walkTopDown().none { it.name.contains("item-broken") })
     }
 
     @Test
     fun `delete removes a previously saved file`() = runTest {
-        store.save("item-1", "content".toByteArray().inputStream())
-        store.delete("item-1")
-        assertNull(store.get("item-1"))
+        store.save("server-1", "item-1", "content".toByteArray().inputStream())
+        store.delete("server-1", "item-1")
+        assertNull(store.get("server-1", "item-1"))
     }
 
     @Test
     fun `clear removes all files in store dir without touching other directories`() = runTest {
-        store.save("item-1", "a".toByteArray().inputStream())
-        store.save("item-2", "b".toByteArray().inputStream())
+        store.save("server-1", "item-1", "a".toByteArray().inputStream())
+        store.save("server-1", "item-2", "b".toByteArray().inputStream())
         val sentinel = otherDir.resolve("sentinel.epub").also { it.writeBytes("x".toByteArray()) }
 
         store.clear()
 
-        assertNull(store.get("item-1"))
-        assertNull(store.get("item-2"))
+        assertNull(store.get("server-1", "item-1"))
+        assertNull(store.get("server-1", "item-2"))
         assertTrue(sentinel.exists())
     }
 
     @Test
-    fun `listItemIds returns ids of all saved items`() = runTest {
-        store.save("item-a", "a".toByteArray().inputStream())
-        store.save("item-b", "b".toByteArray().inputStream())
-        val ids = store.listItemIds()
-        assertTrue(ids.containsAll(listOf("item-a", "item-b")))
-        assertTrue(ids.size == 2)
+    fun `listItems returns refs of all saved items`() = runTest {
+        store.save("server-1", "item-a", "a".toByteArray().inputStream())
+        store.save("server-1", "item-b", "b".toByteArray().inputStream())
+        val refs = store.listItems()
+        assertTrue(refs.containsAll(listOf(StoredItemRef("server-1", "item-a"), StoredItemRef("server-1", "item-b"))))
+        assertTrue(refs.size == 2)
     }
 
     @Test
-    fun `listItemIds returns empty list when store is empty`() {
-        assertTrue(store.listItemIds().isEmpty())
+    fun `listItems returns empty list when store is empty`() {
+        assertTrue(store.listItems().isEmpty())
     }
 }

--- a/core/data/src/test/kotlin/com/riffle/core/data/NoopLibraryDaos.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/NoopLibraryDaos.kt
@@ -19,11 +19,13 @@ internal object ThrowingLibraryItemDao : LibraryItemDao {
     override fun observeRecentlyAdded(libraryId: String): Flow<List<LibraryItemEntity>> = flowOf(emptyList())
     override fun observeAllBooks(libraryId: String): Flow<List<LibraryItemEntity>> = flowOf(emptyList())
     override suspend fun upsertAll(items: List<LibraryItemEntity>) = Unit
-    override suspend fun getById(itemId: String): LibraryItemEntity? = null
+    override suspend fun getById(serverId: String, itemId: String): LibraryItemEntity? = null
+    override suspend fun findServerIdForItem(itemId: String): String? = null
     override suspend fun deleteByLibraryId(libraryId: String) = Unit
-    override suspend fun updateLastOpenedAt(itemId: String, timestamp: Long) = Unit
-    override suspend fun updateReadingProgress(itemId: String, progress: Float) = Unit
+    override suspend fun updateLastOpenedAt(serverId: String, itemId: String, timestamp: Long) = Unit
+    override suspend fun updateReadingProgress(serverId: String, itemId: String, progress: Float) = Unit
     override suspend fun updateReadaloudMetadata(
+        serverId: String,
         itemId: String,
         author: String?,
         description: String?,

--- a/core/data/src/test/kotlin/com/riffle/core/data/PdfRepositoryTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/PdfRepositoryTest.kt
@@ -107,6 +107,7 @@ class PdfRepositoryTest {
         isDownloaded = false,
         ebookFormat = EbookFormat.Pdf,
         ebookFileIno = ino,
+        serverId = "server-1",
     )
 
     // --- openPdf ---
@@ -122,12 +123,12 @@ class PdfRepositoryTest {
     fun `openPdf with cache miss writes file to cache for subsequent opens`() = runTest {
         server.enqueue(MockResponse().setResponseCode(200).setBody(Buffer().write(pdfBytes)))
         repo.openPdf(item())
-        assertTrue(cacheStore.get("item-1") != null)
+        assertTrue(cacheStore.get("server-1", "item-1") != null)
     }
 
     @Test
     fun `openPdf with cache hit makes no network request`() = runTest {
-        cacheStore.save("item-1", pdfBytes.inputStream())
+        cacheStore.save("server-1", "item-1", pdfBytes.inputStream())
         val result = repo.openPdf(item())
         assertEquals(0, server.requestCount)
         assertTrue(result is PdfOpenResult.Success)
@@ -135,7 +136,7 @@ class PdfRepositoryTest {
 
     @Test
     fun `openPdf with downloads hit makes no network request`() = runTest {
-        downloadsStore.save("item-1", pdfBytes.inputStream())
+        downloadsStore.save("server-1", "item-1", pdfBytes.inputStream())
         val result = repo.openPdf(item())
         assertEquals(0, server.requestCount)
         assertTrue(result is PdfOpenResult.Success)
@@ -143,7 +144,7 @@ class PdfRepositoryTest {
 
     @Test
     fun `openPdf returns last saved reading position`() = runTest {
-        cacheStore.save("item-1", pdfBytes.inputStream())
+        cacheStore.save("server-1", "item-1", pdfBytes.inputStream())
         positionStore.save("server-1", "item-1", """{"href":"publication.pdf","type":"application/pdf","locations":{"position":5}}""")
         val result = repo.openPdf(item()) as PdfOpenResult.Success
         assertEquals("""{"href":"publication.pdf","type":"application/pdf","locations":{"position":5}}""", result.lastPosition)
@@ -151,7 +152,7 @@ class PdfRepositoryTest {
 
     @Test
     fun `openPdf returns null lastPosition for fresh pdf`() = runTest {
-        cacheStore.save("item-1", pdfBytes.inputStream())
+        cacheStore.save("server-1", "item-1", pdfBytes.inputStream())
         val result = repo.openPdf(item()) as PdfOpenResult.Success
         assertNull(result.lastPosition)
     }
@@ -183,12 +184,12 @@ class PdfRepositoryTest {
         server.enqueue(MockResponse().setResponseCode(200).setBody(Buffer().write(pdfBytes)))
         val result = repo.downloadPdf(item())
         assertTrue(result is PdfDownloadResult.Success)
-        assertTrue(downloadsStore.get("item-1") != null)
+        assertTrue(downloadsStore.get("server-1", "item-1") != null)
     }
 
     @Test
     fun `downloadPdf returns AlreadyDownloaded when file already in downloads store`() = runTest {
-        downloadsStore.save("item-1", pdfBytes.inputStream())
+        downloadsStore.save("server-1", "item-1", pdfBytes.inputStream())
         val result = repo.downloadPdf(item())
         assertEquals(0, server.requestCount)
         assertTrue(result is PdfDownloadResult.AlreadyDownloaded)
@@ -198,37 +199,37 @@ class PdfRepositoryTest {
     fun `downloadPdf does not write to cache store`() = runTest {
         server.enqueue(MockResponse().setResponseCode(200).setBody(Buffer().write(pdfBytes)))
         repo.downloadPdf(item())
-        assertNull(cacheStore.get("item-1"))
+        assertNull(cacheStore.get("server-1", "item-1"))
     }
 
     @Test
     fun `isDownloaded returns true after downloadPdf succeeds`() = runTest {
         server.enqueue(MockResponse().setResponseCode(200).setBody(Buffer().write(pdfBytes)))
         repo.downloadPdf(item())
-        assertTrue(repo.isDownloaded("item-1"))
+        assertTrue(repo.isDownloaded("server-1", "item-1"))
     }
 
     @Test
     fun `isCached returns true after openPdf populates cache`() = runTest {
         server.enqueue(MockResponse().setResponseCode(200).setBody(Buffer().write(pdfBytes)))
         repo.openPdf(item())
-        assertTrue(repo.isCached("item-1"))
+        assertTrue(repo.isCached("server-1", "item-1"))
     }
 
     @Test
     fun `removeDownload deletes file from downloads store`() = runTest {
-        downloadsStore.save("item-1", pdfBytes.inputStream())
-        repo.removeDownload("item-1")
-        assertTrue(!repo.isDownloaded("item-1"))
+        downloadsStore.save("server-1", "item-1", pdfBytes.inputStream())
+        repo.removeDownload("server-1", "item-1")
+        assertTrue(!repo.isDownloaded("server-1", "item-1"))
     }
 
     @Test
     fun `downloadPdf promotes cached file to downloads without network request`() = runTest {
-        cacheStore.save("item-1", pdfBytes.inputStream())
+        cacheStore.save("server-1", "item-1", pdfBytes.inputStream())
         val result = repo.downloadPdf(item())
         assertEquals(0, server.requestCount)
         assertTrue(result is PdfDownloadResult.Success)
-        assertTrue(downloadsStore.get("item-1") != null)
-        assertNull(cacheStore.get("item-1"))
+        assertTrue(downloadsStore.get("server-1", "item-1") != null)
+        assertNull(cacheStore.get("server-1", "item-1"))
     }
 }

--- a/core/data/src/test/kotlin/com/riffle/core/data/ReadaloudMatchingServiceTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/ReadaloudMatchingServiceTest.kt
@@ -396,6 +396,7 @@ class ReadaloudMatchingServiceTest {
         genres: String = "",
         ebookFormat: String = "epub",
     ) = LibraryItemEntity(
+        serverId = "srv",
         id = itemId,
         libraryId = "$itemId-lib",
         title = "Title",
@@ -438,11 +439,13 @@ class ReadaloudMatchingServiceTest {
         override fun observeRecentlyAdded(libraryId: String): Flow<List<LibraryItemEntity>> = flowOf(emptyList())
         override fun observeAllBooks(libraryId: String): Flow<List<LibraryItemEntity>> = flowOf(emptyList())
         override suspend fun upsertAll(items: List<LibraryItemEntity>) = Unit
-        override suspend fun getById(itemId: String): LibraryItemEntity? = byId[itemId]
+        override suspend fun getById(serverId: String, itemId: String): LibraryItemEntity? = byId[itemId]
+        override suspend fun findServerIdForItem(itemId: String): String? = byId[itemId]?.serverId
         override suspend fun deleteByLibraryId(libraryId: String) = Unit
-        override suspend fun updateLastOpenedAt(itemId: String, timestamp: Long) = Unit
-        override suspend fun updateReadingProgress(itemId: String, progress: Float) = Unit
+        override suspend fun updateLastOpenedAt(serverId: String, itemId: String, timestamp: Long) = Unit
+        override suspend fun updateReadingProgress(serverId: String, itemId: String, progress: Float) = Unit
         override suspend fun updateReadaloudMetadata(
+            serverId: String,
             itemId: String,
             author: String?,
             description: String?,

--- a/core/data/src/test/kotlin/com/riffle/core/data/SeriesIntegrationTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/SeriesIntegrationTest.kt
@@ -111,14 +111,15 @@ class SeriesIntegrationTest {
         override fun observeFinished(libraryId: String): Flow<List<LibraryItemEntity>> = MutableStateFlow(emptyList())
         override fun observeRecentlyAdded(libraryId: String): Flow<List<LibraryItemEntity>> = MutableStateFlow(emptyList())
         override fun observeAllBooks(libraryId: String): Flow<List<LibraryItemEntity>> = MutableStateFlow(emptyList())
-        override suspend fun getById(itemId: String): LibraryItemEntity? = null
+        override suspend fun getById(serverId: String, itemId: String): LibraryItemEntity? = null
+        override suspend fun findServerIdForItem(itemId: String): String? = null
         override suspend fun upsertAll(items: List<LibraryItemEntity>) {}
         override suspend fun deleteByLibraryId(libraryId: String) {}
-        override suspend fun updateLastOpenedAt(itemId: String, timestamp: Long) {}
+        override suspend fun updateLastOpenedAt(serverId: String, itemId: String, timestamp: Long) {}
         override suspend fun getLastOpenedAtMap(libraryId: String): List<LastOpenedAtRow> = emptyList()
         override suspend fun getReadingProgressMap(libraryId: String): List<ReadingProgressRow> = emptyList()
-        override suspend fun updateReadingProgress(itemId: String, progress: Float) {}
-        override suspend fun updateReadaloudMetadata(itemId: String, author: String?, description: String?, publishedYear: String?, publisher: String?, genres: String) {}
+        override suspend fun updateReadingProgress(serverId: String, itemId: String, progress: Float) {}
+        override suspend fun updateReadaloudMetadata(serverId: String, itemId: String, author: String?, description: String?, publishedYear: String?, publisher: String?, genres: String) {}
         override suspend fun listMatchableByServerType(serverType: String): List<com.riffle.core.database.MatchableItemRow> = emptyList()
     }
 

--- a/core/data/src/test/kotlin/com/riffle/core/data/ServerRepositoryTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/ServerRepositoryTest.kt
@@ -119,7 +119,8 @@ class ServerRepositoryTest {
         override fun observeFinished(libraryId: String) = flowOf(emptyList<com.riffle.core.database.LibraryItemEntity>())
         override fun observeRecentlyAdded(libraryId: String) = flowOf(emptyList<com.riffle.core.database.LibraryItemEntity>())
         override fun observeAllBooks(libraryId: String) = flowOf(emptyList<com.riffle.core.database.LibraryItemEntity>())
-        override suspend fun getById(itemId: String) = rows.values.flatten().firstOrNull { it.id == itemId }
+        override suspend fun getById(serverId: String, itemId: String) = rows.values.flatten().firstOrNull { it.id == itemId }
+        override suspend fun findServerIdForItem(itemId: String): String? = rows.values.flatten().firstOrNull { it.id == itemId }?.serverId
         override suspend fun upsertAll(items: List<com.riffle.core.database.LibraryItemEntity>) {
             items.groupBy { it.libraryId }.forEach { (libraryId, entities) ->
                 rows.getOrPut(libraryId) { mutableListOf() }.addAll(entities)
@@ -129,11 +130,11 @@ class ServerRepositoryTest {
             deletedLibraryIds += libraryId
             rows.remove(libraryId)
         }
-        override suspend fun updateLastOpenedAt(itemId: String, timestamp: Long) {}
+        override suspend fun updateLastOpenedAt(serverId: String, itemId: String, timestamp: Long) {}
         override suspend fun getLastOpenedAtMap(libraryId: String) = emptyList<com.riffle.core.database.LastOpenedAtRow>()
         override suspend fun getReadingProgressMap(libraryId: String) = emptyList<com.riffle.core.database.ReadingProgressRow>()
-        override suspend fun updateReadingProgress(itemId: String, progress: Float) {}
-        override suspend fun updateReadaloudMetadata(itemId: String, author: String?, description: String?, publishedYear: String?, publisher: String?, genres: String) {}
+        override suspend fun updateReadingProgress(serverId: String, itemId: String, progress: Float) {}
+        override suspend fun updateReadaloudMetadata(serverId: String, itemId: String, author: String?, description: String?, publishedYear: String?, publisher: String?, genres: String) {}
         override suspend fun listMatchableByServerType(serverType: String) = emptyList<com.riffle.core.database.MatchableItemRow>()
     }
 
@@ -448,8 +449,8 @@ class ServerRepositoryTest {
         libDao.rows["st-1"] = mutableListOf(LibraryEntity(libraryId, "Readalouds", "readaloud", "st-1"))
         val itemDao = fakeLibraryItemDao()
         itemDao.seed(libraryId, listOf(
-            com.riffle.core.database.LibraryItemEntity("1385738337074647", libraryId, "The Martian", "Andy Weir", null, 0f),
-            com.riffle.core.database.LibraryItemEntity("99", libraryId, "Dune", "Frank Herbert", null, 0f),
+            com.riffle.core.database.LibraryItemEntity("st-1", "1385738337074647", libraryId, "The Martian", "Andy Weir", null, 0f),
+            com.riffle.core.database.LibraryItemEntity("st-1", "99", libraryId, "Dune", "Frank Herbert", null, 0f),
         ))
         val absApi = AbsApi { _, _, _, _ -> error("not called") }
         val repo = ServerRepositoryImpl(
@@ -477,8 +478,8 @@ class ServerRepositoryTest {
             LibraryEntity("lib-2", "Audiobooks", "book", "abs-1"),
         )
         val itemDao = fakeLibraryItemDao()
-        itemDao.seed("lib-1", listOf(com.riffle.core.database.LibraryItemEntity("i-1", "lib-1", "Dune", "Herbert", null, 0f)))
-        itemDao.seed("lib-2", listOf(com.riffle.core.database.LibraryItemEntity("i-2", "lib-2", "Foundation", "Asimov", null, 0f)))
+        itemDao.seed("lib-1", listOf(com.riffle.core.database.LibraryItemEntity("s1", "i-1", "lib-1", "Dune", "Herbert", null, 0f)))
+        itemDao.seed("lib-2", listOf(com.riffle.core.database.LibraryItemEntity("s1", "i-2", "lib-2", "Foundation", "Asimov", null, 0f)))
         val absApi = AbsApi { _, _, _, _ -> error("not called") }
         val repo = ServerRepositoryImpl(
             dao, tokens, absApi, storytellerApiNotCalled, fakeServerInfoApi, libsApiNotCalled, libDao, itemDao, fakeVisibilityStore()

--- a/core/data/src/test/kotlin/com/riffle/core/data/StorytellerReadaloudSyncerTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/StorytellerReadaloudSyncerTest.kt
@@ -96,6 +96,7 @@ class StorytellerReadaloudSyncerTest {
         )
         val entities = storytellerBooksToEntities(
             books = books,
+            serverId = "st-1",
             libraryId = "readaloud:st-1",
             coverUrlOf = { id -> "http://s/api/books/$id/cover" },
             lastOpenedAtMap = mapOf("42" to 1234L),

--- a/core/database/schemas/com.riffle.core.database.RiffleDatabase/26.json
+++ b/core/database/schemas/com.riffle.core.database.RiffleDatabase/26.json
@@ -1,0 +1,951 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 26,
+    "identityHash": "db59c6a5a7da74b4a638436095c1cf36",
+    "entities": [
+      {
+        "tableName": "servers",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `url` TEXT NOT NULL, `isActive` INTEGER NOT NULL, `insecureConnectionAllowed` INTEGER NOT NULL, `username` TEXT NOT NULL, `serverType` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "isActive",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "insecureConnectionAllowed",
+            "columnName": "insecureConnectionAllowed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "username",
+            "columnName": "username",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverType",
+            "columnName": "serverType",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "libraries",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `mediaType` TEXT NOT NULL, `serverId` TEXT NOT NULL, `isUnsupported` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaType",
+            "columnName": "mediaType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isUnsupported",
+            "columnName": "isUnsupported",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "library_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`serverId` TEXT NOT NULL, `id` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `title` TEXT NOT NULL, `author` TEXT NOT NULL, `coverUrl` TEXT, `readingProgress` REAL NOT NULL, `ebookFileIno` TEXT, `ebookFormat` TEXT NOT NULL, `description` TEXT, `seriesName` TEXT, `publishedYear` TEXT, `genres` TEXT NOT NULL, `publisher` TEXT, `lastOpenedAt` INTEGER, `addedAt` INTEGER, `isbn` TEXT, `asin` TEXT, PRIMARY KEY(`serverId`, `id`), FOREIGN KEY(`serverId`) REFERENCES `servers`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "coverUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "readingProgress",
+            "columnName": "readingProgress",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ebookFileIno",
+            "columnName": "ebookFileIno",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "ebookFormat",
+            "columnName": "ebookFormat",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seriesName",
+            "columnName": "seriesName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "publishedYear",
+            "columnName": "publishedYear",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "genres",
+            "columnName": "genres",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "publisher",
+            "columnName": "publisher",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastOpenedAt",
+            "columnName": "lastOpenedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "isbn",
+            "columnName": "isbn",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "asin",
+            "columnName": "asin",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "serverId",
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_library_items_serverId",
+            "unique": false,
+            "columnNames": [
+              "serverId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_library_items_serverId` ON `${TABLE_NAME}` (`serverId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "servers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "serverId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "series",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `name` TEXT NOT NULL, `coverUrl` TEXT, `bookCount` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "coverUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "bookCount",
+            "columnName": "bookCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "collections",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `name` TEXT NOT NULL, `bookCount` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookCount",
+            "columnName": "bookCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "series_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`seriesId` TEXT NOT NULL, `serverId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `sequenceOrder` REAL NOT NULL, PRIMARY KEY(`seriesId`, `serverId`, `itemId`))",
+        "fields": [
+          {
+            "fieldPath": "seriesId",
+            "columnName": "seriesId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sequenceOrder",
+            "columnName": "sequenceOrder",
+            "affinity": "REAL",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "seriesId",
+            "serverId",
+            "itemId"
+          ]
+        }
+      },
+      {
+        "tableName": "collection_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`collectionId` TEXT NOT NULL, `serverId` TEXT NOT NULL, `itemId` TEXT NOT NULL, PRIMARY KEY(`collectionId`, `serverId`, `itemId`))",
+        "fields": [
+          {
+            "fieldPath": "collectionId",
+            "columnName": "collectionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "collectionId",
+            "serverId",
+            "itemId"
+          ]
+        }
+      },
+      {
+        "tableName": "reading_positions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`serverId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `cfi` TEXT NOT NULL, `localUpdatedAt` INTEGER NOT NULL, PRIMARY KEY(`serverId`, `itemId`), FOREIGN KEY(`serverId`) REFERENCES `servers`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cfi",
+            "columnName": "cfi",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localUpdatedAt",
+            "columnName": "localUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "serverId",
+            "itemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_reading_positions_serverId",
+            "unique": false,
+            "columnNames": [
+              "serverId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_reading_positions_serverId` ON `${TABLE_NAME}` (`serverId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "servers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "serverId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "book_formatting_preferences",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`serverId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `fontSize` REAL, `theme` TEXT, `fontFamily` TEXT, `lineSpacing` REAL, `margins` REAL, `orientation` TEXT, `showChapterMap` INTEGER, `showReadingProgressLabels` INTEGER, `showCurrentChapterLabel` INTEGER, `doublePageSpread` INTEGER, `justifyText` INTEGER, PRIMARY KEY(`serverId`, `itemId`), FOREIGN KEY(`serverId`) REFERENCES `servers`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fontSize",
+            "columnName": "fontSize",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "theme",
+            "columnName": "theme",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "fontFamily",
+            "columnName": "fontFamily",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lineSpacing",
+            "columnName": "lineSpacing",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "margins",
+            "columnName": "margins",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "orientation",
+            "columnName": "orientation",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "showChapterMap",
+            "columnName": "showChapterMap",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "showReadingProgressLabels",
+            "columnName": "showReadingProgressLabels",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "showCurrentChapterLabel",
+            "columnName": "showCurrentChapterLabel",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "doublePageSpread",
+            "columnName": "doublePageSpread",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "justifyText",
+            "columnName": "justifyText",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "serverId",
+            "itemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_book_formatting_preferences_serverId",
+            "unique": false,
+            "columnNames": [
+              "serverId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_book_formatting_preferences_serverId` ON `${TABLE_NAME}` (`serverId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "servers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "serverId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "readaloud_links",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`absServerId` TEXT NOT NULL, `absLibraryItemId` TEXT NOT NULL, `storytellerServerId` TEXT NOT NULL, `storytellerBookId` TEXT NOT NULL, `state` TEXT NOT NULL, `userConfirmed` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`absServerId`, `absLibraryItemId`), FOREIGN KEY(`storytellerServerId`) REFERENCES `servers`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`absServerId`) REFERENCES `servers`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "absServerId",
+            "columnName": "absServerId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absLibraryItemId",
+            "columnName": "absLibraryItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerServerId",
+            "columnName": "storytellerServerId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerBookId",
+            "columnName": "storytellerBookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userConfirmed",
+            "columnName": "userConfirmed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "absServerId",
+            "absLibraryItemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_readaloud_links_storytellerServerId_storytellerBookId",
+            "unique": false,
+            "columnNames": [
+              "storytellerServerId",
+              "storytellerBookId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_readaloud_links_storytellerServerId_storytellerBookId` ON `${TABLE_NAME}` (`storytellerServerId`, `storytellerBookId`)"
+          },
+          {
+            "name": "index_readaloud_links_storytellerServerId",
+            "unique": false,
+            "columnNames": [
+              "storytellerServerId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_readaloud_links_storytellerServerId` ON `${TABLE_NAME}` (`storytellerServerId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "servers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "storytellerServerId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "servers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "absServerId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "readaloud_candidates",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`storytellerServerId` TEXT NOT NULL, `storytellerBookId` TEXT NOT NULL, `absServerId` TEXT NOT NULL, `absLibraryItemId` TEXT NOT NULL, `score` REAL NOT NULL, PRIMARY KEY(`storytellerServerId`, `storytellerBookId`, `absServerId`, `absLibraryItemId`), FOREIGN KEY(`storytellerServerId`) REFERENCES `servers`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`absServerId`) REFERENCES `servers`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "storytellerServerId",
+            "columnName": "storytellerServerId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerBookId",
+            "columnName": "storytellerBookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absServerId",
+            "columnName": "absServerId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absLibraryItemId",
+            "columnName": "absLibraryItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "score",
+            "columnName": "score",
+            "affinity": "REAL",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "storytellerServerId",
+            "storytellerBookId",
+            "absServerId",
+            "absLibraryItemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_readaloud_candidates_absServerId",
+            "unique": false,
+            "columnNames": [
+              "absServerId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_readaloud_candidates_absServerId` ON `${TABLE_NAME}` (`absServerId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "servers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "storytellerServerId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "servers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "absServerId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "readaloud_dismissals",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`storytellerServerId` TEXT NOT NULL, `storytellerBookId` TEXT NOT NULL, `scope` TEXT NOT NULL, `absServerId` TEXT NOT NULL, `absLibraryItemId` TEXT NOT NULL, PRIMARY KEY(`storytellerServerId`, `storytellerBookId`, `absServerId`, `absLibraryItemId`), FOREIGN KEY(`storytellerServerId`) REFERENCES `servers`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "storytellerServerId",
+            "columnName": "storytellerServerId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerBookId",
+            "columnName": "storytellerBookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scope",
+            "columnName": "scope",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absServerId",
+            "columnName": "absServerId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absLibraryItemId",
+            "columnName": "absLibraryItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "storytellerServerId",
+            "storytellerBookId",
+            "absServerId",
+            "absLibraryItemId"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "servers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "storytellerServerId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "cross_epub_index",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`absEpubChecksum` TEXT NOT NULL, `storytellerEpubChecksum` TEXT NOT NULL, `perChapterMapsBlob` TEXT NOT NULL, `builtAt` INTEGER NOT NULL, PRIMARY KEY(`absEpubChecksum`, `storytellerEpubChecksum`))",
+        "fields": [
+          {
+            "fieldPath": "absEpubChecksum",
+            "columnName": "absEpubChecksum",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerEpubChecksum",
+            "columnName": "storytellerEpubChecksum",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "perChapterMapsBlob",
+            "columnName": "perChapterMapsBlob",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "builtAt",
+            "columnName": "builtAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "absEpubChecksum",
+            "storytellerEpubChecksum"
+          ]
+        }
+      },
+      {
+        "tableName": "annotations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `serverId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `type` TEXT NOT NULL, `cfi` TEXT NOT NULL, `color` TEXT NOT NULL, `note` TEXT, `textSnippet` TEXT NOT NULL, `chapterHref` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `originDeviceId` TEXT NOT NULL, `lastModifiedByDeviceId` TEXT NOT NULL, `deleted` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`serverId`) REFERENCES `servers`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cfi",
+            "columnName": "cfi",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "color",
+            "columnName": "color",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "note",
+            "columnName": "note",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "textSnippet",
+            "columnName": "textSnippet",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chapterHref",
+            "columnName": "chapterHref",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "originDeviceId",
+            "columnName": "originDeviceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastModifiedByDeviceId",
+            "columnName": "lastModifiedByDeviceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deleted",
+            "columnName": "deleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_annotations_serverId_itemId",
+            "unique": false,
+            "columnNames": [
+              "serverId",
+              "itemId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_annotations_serverId_itemId` ON `${TABLE_NAME}` (`serverId`, `itemId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "servers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "serverId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'db59c6a5a7da74b4a638436095c1cf36')"
+    ]
+  }
+}

--- a/core/database/src/androidTest/kotlin/com/riffle/core/database/CollectionDaoTest.kt
+++ b/core/database/src/androidTest/kotlin/com/riffle/core/database/CollectionDaoTest.kt
@@ -5,6 +5,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.yield
 import org.junit.After
@@ -26,6 +27,10 @@ class CollectionDaoTest {
             RiffleDatabase::class.java,
         ).allowMainThreadQueries().build()
         dao = db.collectionDao()
+        // library_items FK-references servers; seed the owning Server first.
+        runBlocking {
+            db.serverDao().upsert(ServerEntity("s1", "http://s1", isActive = true, insecureConnectionAllowed = false, username = "u"))
+        }
     }
 
     @After
@@ -61,16 +66,16 @@ class CollectionDaoTest {
     @Test
     fun observeItemsByCollectionId_returnsItemsInTitleOrder() = runTest {
         val items = listOf(
-            LibraryItemEntity("item-z", "lib1", "Zorro", "Author", null, 0f),
-            LibraryItemEntity("item-a", "lib1", "Asimov", "Author", null, 0f),
-            LibraryItemEntity("item-m", "lib1", "Middle", "Author", null, 0f),
+            LibraryItemEntity(serverId = "s1", id = "item-z", libraryId = "lib1", title = "Zorro", author = "Author", coverUrl = null, readingProgress = 0f),
+            LibraryItemEntity(serverId = "s1", id = "item-a", libraryId = "lib1", title = "Asimov", author = "Author", coverUrl = null, readingProgress = 0f),
+            LibraryItemEntity(serverId = "s1", id = "item-m", libraryId = "lib1", title = "Middle", author = "Author", coverUrl = null, readingProgress = 0f),
         )
         db.libraryItemDao().upsertAll(items)
         dao.upsertAll(listOf(collection("c1")))
         dao.upsertAllItems(listOf(
-            CollectionItemEntity("c1", "item-z"),
-            CollectionItemEntity("c1", "item-a"),
-            CollectionItemEntity("c1", "item-m"),
+            CollectionItemEntity("c1", serverId = "s1", itemId = "item-z"),
+            CollectionItemEntity("c1", serverId = "s1", itemId = "item-a"),
+            CollectionItemEntity("c1", serverId = "s1", itemId = "item-m"),
         ))
 
         val result = dao.observeItemsByCollectionId("c1").first()

--- a/core/database/src/androidTest/kotlin/com/riffle/core/database/LibraryItemDaoTest.kt
+++ b/core/database/src/androidTest/kotlin/com/riffle/core/database/LibraryItemDaoTest.kt
@@ -5,6 +5,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.yield
 import org.junit.After
@@ -26,6 +27,11 @@ class LibraryItemDaoTest {
             RiffleDatabase::class.java,
         ).allowMainThreadQueries().build()
         dao = db.libraryItemDao()
+        // library_items FK-references servers; seed the owning Servers first.
+        runBlocking {
+            db.serverDao().upsert(ServerEntity("s1", "http://s1", isActive = true, insecureConnectionAllowed = false, username = "u"))
+            db.serverDao().upsert(ServerEntity("s2", "http://s2", isActive = false, insecureConnectionAllowed = false, username = "u"))
+        }
     }
 
     @After
@@ -37,7 +43,9 @@ class LibraryItemDaoTest {
         id: String,
         readingProgress: Float,
         lastOpenedAt: Long? = null,
+        serverId: String = "s1",
     ) = LibraryItemEntity(
+        serverId = serverId,
         id = id,
         libraryId = "lib1",
         title = "Title $id",
@@ -118,6 +126,19 @@ class LibraryItemDaoTest {
         assertEquals(0, inProgress.size)
         assertEquals(0, finished.size)
         assertEquals(1, allBooks.size)
+    }
+
+    // A0 — two Servers can hold a book with the same itemId without colliding; getById resolves
+    // the right one by (serverId, itemId). This is the core fix for issue #81.
+    @Test
+    fun getById_distinguishesSameItemIdAcrossServers() = runTest {
+        dao.upsertAll(listOf(
+            item("1", readingProgress = 0.25f, serverId = "s1").copy(title = "War and Peace"),
+            item("1", readingProgress = 0.5f, serverId = "s2").copy(title = "A Different Book"),
+        ))
+
+        assertEquals("War and Peace", dao.getById("s1", "1")?.title)
+        assertEquals("A Different Book", dao.getById("s2", "1")?.title)
     }
 
     // A6 — replaceAllForLibrary must never expose an empty intermediate state to observers.

--- a/core/database/src/androidTest/kotlin/com/riffle/core/database/MigrationTest.kt
+++ b/core/database/src/androidTest/kotlin/com/riffle/core/database/MigrationTest.kt
@@ -955,6 +955,136 @@ class MigrationTest {
         }
     }
 
+    // 25 → 26: key Library Items by (serverId, itemId) end-to-end (issue #81, ADR 0025).
+    // `library_items` gains a `serverId` column + composite PK (serverId, id), backfilled from
+    // each item's owning library (libraryId → libraries.serverId). The series_items /
+    // collection_items join tables and book_formatting_preferences gain `serverId` in their PKs,
+    // backfilled by resolving itemId → library_items → libraries.serverId. This lets two
+    // Storyteller Servers each hold a book "1" without collision. Orphan rows whose item/library
+    // no longer resolves to a Server are dropped.
+    @Test
+    fun migration25To26_keysLibraryItemsByServerAndItem() {
+        helper.createDatabase(TEST_DB, 25).use { db ->
+            // Two Storyteller servers, each with one library.
+            db.execSQL(
+                "INSERT INTO servers (id, url, isActive, insecureConnectionAllowed, username, serverType) " +
+                    "VALUES ('s1', 'http://story-a', 1, 0, 'plamen', 'STORYTELLER')"
+            )
+            db.execSQL(
+                "INSERT INTO servers (id, url, isActive, insecureConnectionAllowed, username, serverType) " +
+                    "VALUES ('s2', 'http://story-b', 0, 0, 'plamen', 'STORYTELLER')"
+            )
+            db.execSQL("INSERT INTO libraries (id, name, mediaType, serverId, isUnsupported) VALUES ('libA', 'Books A', 'book', 's1', 0)")
+            db.execSQL("INSERT INTO libraries (id, name, mediaType, serverId, isUnsupported) VALUES ('libB', 'Books B', 'book', 's2', 0)")
+
+            // Pre-migration the PK is itemId alone, so the two servers' book "1" can't both exist
+            // yet; seed item "1" on s1 and item "2" on s2.
+            db.execSQL(
+                "INSERT INTO library_items (id, libraryId, title, author, coverUrl, readingProgress, ebookFormat, genres) " +
+                    "VALUES ('1', 'libA', 'War and Peace', 'Tolstoy', NULL, 0.25, 'epub', '')"
+            )
+            db.execSQL(
+                "INSERT INTO library_items (id, libraryId, title, author, coverUrl, readingProgress, ebookFormat, genres) " +
+                    "VALUES ('2', 'libB', 'Picture Book', 'Anon', NULL, 0.5, 'epub', '')"
+            )
+
+            // Series / collection groupings and formatting prefs for s1's book "1".
+            db.execSQL("INSERT INTO series (id, libraryId, name, coverUrl, bookCount) VALUES ('ser1', 'libA', 'Classics', NULL, 1)")
+            db.execSQL("INSERT INTO collections (id, libraryId, name, bookCount) VALUES ('col1', 'libA', 'Favourites', 1)")
+            db.execSQL("INSERT INTO series_items (seriesId, itemId, sequenceOrder) VALUES ('ser1', '1', 1.0)")
+            db.execSQL("INSERT INTO collection_items (collectionId, itemId) VALUES ('col1', '1')")
+            db.execSQL(
+                "INSERT INTO book_formatting_preferences (itemId, fontSize, theme) VALUES ('1', 18.0, 'sepia')"
+            )
+
+            // An orphan formatting-pref row whose item no longer exists — must be dropped.
+            db.execSQL(
+                "INSERT INTO book_formatting_preferences (itemId, fontSize, theme) VALUES ('ghost', 99.0, 'dark')"
+            )
+        }
+
+        val db = helper.runMigrationsAndValidate(TEST_DB, 26, true, RiffleDatabase.MIGRATION_25_26)
+
+        // library_items: serverId backfilled from the owning library, data preserved.
+        db.query("SELECT serverId, libraryId, title, readingProgress FROM library_items WHERE id = '1'").use { cursor ->
+            assertEquals(1, cursor.count)
+            cursor.moveToFirst()
+            assertEquals("s1", cursor.getString(0))
+            assertEquals("libA", cursor.getString(1))
+            assertEquals("War and Peace", cursor.getString(2))
+            assertEquals(0.25f, cursor.getFloat(3), 0.0001f)
+        }
+        db.query("SELECT serverId FROM library_items WHERE id = '2'").use { cursor ->
+            cursor.moveToFirst()
+            assertEquals("s2", cursor.getString(0))
+        }
+
+        // Composite PK now lets the two servers' book "1" coexist as distinct rows.
+        db.execSQL(
+            "INSERT INTO library_items (serverId, id, libraryId, title, author, coverUrl, readingProgress, ebookFormat, genres) " +
+                "VALUES ('s2', '1', 'libB', 'A Different Book', 'Someone', NULL, 0.0, 'epub', '')"
+        )
+        db.query("SELECT title FROM library_items WHERE serverId = 's1' AND id = '1'").use { cursor ->
+            cursor.moveToFirst()
+            assertEquals("War and Peace", cursor.getString(0))
+        }
+        db.query("SELECT title FROM library_items WHERE serverId = 's2' AND id = '1'").use { cursor ->
+            cursor.moveToFirst()
+            assertEquals("A Different Book", cursor.getString(0))
+        }
+
+        // Join tables carry serverId, backfilled from the item's owning server.
+        db.query("SELECT serverId, sequenceOrder FROM series_items WHERE seriesId = 'ser1' AND itemId = '1'").use { cursor ->
+            assertEquals(1, cursor.count)
+            cursor.moveToFirst()
+            assertEquals("s1", cursor.getString(0))
+            assertEquals(1.0f, cursor.getFloat(1), 0.0001f)
+        }
+        db.query("SELECT serverId FROM collection_items WHERE collectionId = 'col1' AND itemId = '1'").use { cursor ->
+            assertEquals(1, cursor.count)
+            cursor.moveToFirst()
+            assertEquals("s1", cursor.getString(0))
+        }
+
+        // Formatting prefs: serverId backfilled, value preserved; orphan dropped.
+        db.query("SELECT serverId, fontSize, theme FROM book_formatting_preferences WHERE itemId = '1'").use { cursor ->
+            assertEquals(1, cursor.count)
+            cursor.moveToFirst()
+            assertEquals("s1", cursor.getString(0))
+            assertEquals(18.0f, cursor.getFloat(1), 0.0001f)
+            assertEquals("sepia", cursor.getString(2))
+        }
+        db.query("SELECT COUNT(*) FROM book_formatting_preferences WHERE itemId = 'ghost'").use { cursor ->
+            cursor.moveToFirst()
+            assertEquals(0, cursor.getInt(0))
+        }
+
+        // Two servers' formatting for book "1" no longer collide.
+        db.execSQL(
+            "INSERT INTO book_formatting_preferences (serverId, itemId, fontSize, theme) VALUES ('s2', '1', 32.0, 'dark')"
+        )
+        db.query("SELECT fontSize FROM book_formatting_preferences WHERE serverId = 's1' AND itemId = '1'").use { cursor ->
+            cursor.moveToFirst()
+            assertEquals(18.0f, cursor.getFloat(0), 0.0001f)
+        }
+        db.query("SELECT fontSize FROM book_formatting_preferences WHERE serverId = 's2' AND itemId = '1'").use { cursor ->
+            cursor.moveToFirst()
+            assertEquals(32.0f, cursor.getFloat(0), 0.0001f)
+        }
+
+        // FK cascade: removing a server clears its library items.
+        db.execSQL("PRAGMA foreign_keys = ON")
+        db.execSQL("DELETE FROM servers WHERE id = 's2'")
+        db.query("SELECT COUNT(*) FROM library_items WHERE serverId = 's2'").use { cursor ->
+            cursor.moveToFirst()
+            assertEquals(0, cursor.getInt(0))
+        }
+        db.query("SELECT COUNT(*) FROM library_items WHERE serverId = 's1'").use { cursor ->
+            cursor.moveToFirst()
+            assertEquals(1, cursor.getInt(0))
+        }
+    }
+
     @Test
     fun migrateFullChain() {
         helper.createDatabase(TEST_DB, 1).use { db ->
@@ -964,7 +1094,7 @@ class MigrationTest {
         }
 
         val db = helper.runMigrationsAndValidate(
-            TEST_DB, 25, true,
+            TEST_DB, 26, true,
             RiffleDatabase.MIGRATION_1_2,
             RiffleDatabase.MIGRATION_2_3,
             RiffleDatabase.MIGRATION_3_4,
@@ -989,6 +1119,7 @@ class MigrationTest {
             RiffleDatabase.MIGRATION_22_23,
             RiffleDatabase.MIGRATION_23_24,
             RiffleDatabase.MIGRATION_24_25,
+            RiffleDatabase.MIGRATION_25_26,
         )
 
         db.query("SELECT url, username, serverType FROM servers WHERE id = 's1'").use { cursor ->

--- a/core/database/src/androidTest/kotlin/com/riffle/core/database/SeriesDaoTest.kt
+++ b/core/database/src/androidTest/kotlin/com/riffle/core/database/SeriesDaoTest.kt
@@ -5,6 +5,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.yield
 import org.junit.After
@@ -26,6 +27,10 @@ class SeriesDaoTest {
             RiffleDatabase::class.java,
         ).allowMainThreadQueries().build()
         dao = db.seriesDao()
+        // library_items FK-references servers; seed the owning Server first.
+        runBlocking {
+            db.serverDao().upsert(ServerEntity("s1", "http://s1", isActive = true, insecureConnectionAllowed = false, username = "u"))
+        }
     }
 
     @After
@@ -34,7 +39,7 @@ class SeriesDaoTest {
     }
 
     private fun series(id: String) = SeriesEntity(id = id, libraryId = "lib1", name = "Series $id", coverUrl = null, bookCount = 1)
-    private fun seriesItem(seriesId: String, itemId: String) = SeriesItemEntity(seriesId = seriesId, itemId = itemId, sequenceOrder = 1f)
+    private fun seriesItem(seriesId: String, itemId: String) = SeriesItemEntity(seriesId = seriesId, serverId = "s1", itemId = itemId, sequenceOrder = 1f)
 
     // B1 — replaceAllForLibrary must never expose an empty intermediate state to series observers.
     @Test
@@ -62,16 +67,16 @@ class SeriesDaoTest {
     @Test
     fun observeItemsBySeriesId_returnsItemsInSequenceOrder() = runTest {
         val items = listOf(
-            LibraryItemEntity("item-1", "lib1", "Title 1", "Author", null, 0f),
-            LibraryItemEntity("item-2", "lib1", "Title 2", "Author", null, 0f),
-            LibraryItemEntity("item-3", "lib1", "Title 3", "Author", null, 0f),
+            LibraryItemEntity(serverId = "s1", id = "item-1", libraryId = "lib1", title = "Title 1", author = "Author", coverUrl = null, readingProgress = 0f),
+            LibraryItemEntity(serverId = "s1", id = "item-2", libraryId = "lib1", title = "Title 2", author = "Author", coverUrl = null, readingProgress = 0f),
+            LibraryItemEntity(serverId = "s1", id = "item-3", libraryId = "lib1", title = "Title 3", author = "Author", coverUrl = null, readingProgress = 0f),
         )
         db.libraryItemDao().upsertAll(items)
         dao.upsertAll(listOf(series("s1")))
         dao.upsertAllItems(listOf(
-            SeriesItemEntity("s1", "item-3", sequenceOrder = 1f),
-            SeriesItemEntity("s1", "item-1", sequenceOrder = 2f),
-            SeriesItemEntity("s1", "item-2", sequenceOrder = 3f),
+            SeriesItemEntity("s1", serverId = "s1", itemId = "item-3", sequenceOrder = 1f),
+            SeriesItemEntity("s1", serverId = "s1", itemId = "item-1", sequenceOrder = 2f),
+            SeriesItemEntity("s1", serverId = "s1", itemId = "item-2", sequenceOrder = 3f),
         ))
 
         val result = dao.observeItemsBySeriesId("s1").first()

--- a/core/database/src/main/kotlin/com/riffle/core/database/BookFormattingPreferencesDao.kt
+++ b/core/database/src/main/kotlin/com/riffle/core/database/BookFormattingPreferencesDao.kt
@@ -11,9 +11,9 @@ interface BookFormattingPreferencesDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun upsert(entity: BookFormattingPreferencesEntity)
 
-    @Query("SELECT * FROM book_formatting_preferences WHERE itemId = :itemId LIMIT 1")
-    suspend fun getByItemId(itemId: String): BookFormattingPreferencesEntity?
+    @Query("SELECT * FROM book_formatting_preferences WHERE serverId = :serverId AND itemId = :itemId LIMIT 1")
+    suspend fun getByItemId(serverId: String, itemId: String): BookFormattingPreferencesEntity?
 
-    @Query("DELETE FROM book_formatting_preferences WHERE itemId = :itemId")
-    suspend fun deleteByItemId(itemId: String)
+    @Query("DELETE FROM book_formatting_preferences WHERE serverId = :serverId AND itemId = :itemId")
+    suspend fun deleteByItemId(serverId: String, itemId: String)
 }

--- a/core/database/src/main/kotlin/com/riffle/core/database/BookFormattingPreferencesEntity.kt
+++ b/core/database/src/main/kotlin/com/riffle/core/database/BookFormattingPreferencesEntity.kt
@@ -1,11 +1,29 @@
 package com.riffle.core.database
 
 import androidx.room.Entity
-import androidx.room.PrimaryKey
+import androidx.room.ForeignKey
+import androidx.room.Index
 
-@Entity(tableName = "book_formatting_preferences")
+// Formatting stays per-device (never synced, never per-user), but the row must point at the *right*
+// book: once item ids collide across Servers, itemId alone would let two different books share one
+// formatting row (ADR 0025). serverId is added for *identity*, not as a per-server feature; it
+// FK-cascades so a removed Server's formatting is cleared.
+@Entity(
+    tableName = "book_formatting_preferences",
+    primaryKeys = ["serverId", "itemId"],
+    foreignKeys = [
+        ForeignKey(
+            entity = ServerEntity::class,
+            parentColumns = ["id"],
+            childColumns = ["serverId"],
+            onDelete = ForeignKey.CASCADE,
+        ),
+    ],
+    indices = [Index("serverId")],
+)
 data class BookFormattingPreferencesEntity(
-    @PrimaryKey val itemId: String,
+    val serverId: String,
+    val itemId: String,
     val fontSize: Float? = null,
     val theme: String? = null,
     val fontFamily: String? = null,

--- a/core/database/src/main/kotlin/com/riffle/core/database/CollectionDao.kt
+++ b/core/database/src/main/kotlin/com/riffle/core/database/CollectionDao.kt
@@ -15,7 +15,7 @@ interface CollectionDao {
 
     @Query("""
         SELECT li.* FROM library_items li
-        INNER JOIN collection_items ci ON li.id = ci.itemId
+        INNER JOIN collection_items ci ON li.serverId = ci.serverId AND li.id = ci.itemId
         WHERE ci.collectionId = :collectionId
         ORDER BY li.title ASC
     """)

--- a/core/database/src/main/kotlin/com/riffle/core/database/CollectionItemEntity.kt
+++ b/core/database/src/main/kotlin/com/riffle/core/database/CollectionItemEntity.kt
@@ -2,8 +2,11 @@ package com.riffle.core.database
 
 import androidx.room.Entity
 
-@Entity(tableName = "collection_items", primaryKeys = ["collectionId", "itemId"])
+// serverId disambiguates colliding item ids across Servers (ADR 0025); a collection is library-
+// (hence server-) scoped, so serverId is the owning library's server.
+@Entity(tableName = "collection_items", primaryKeys = ["collectionId", "serverId", "itemId"])
 data class CollectionItemEntity(
     val collectionId: String,
+    val serverId: String,
     val itemId: String,
 )

--- a/core/database/src/main/kotlin/com/riffle/core/database/LibraryItemDao.kt
+++ b/core/database/src/main/kotlin/com/riffle/core/database/LibraryItemDao.kt
@@ -31,8 +31,16 @@ interface LibraryItemDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun upsertAll(items: List<LibraryItemEntity>)
 
-    @Query("SELECT * FROM library_items WHERE id = :itemId LIMIT 1")
-    suspend fun getById(itemId: String): LibraryItemEntity?
+    @Query("SELECT * FROM library_items WHERE serverId = :serverId AND id = :itemId LIMIT 1")
+    suspend fun getById(serverId: String, itemId: String): LibraryItemEntity?
+
+    /**
+     * The Server that owns an item id. Used by the one-time on-disk file migration (ADR 0025) to
+     * relocate legacy flat `<itemId>` files under their owning Server. Pre-migration item ids were
+     * globally unique (DB PK was itemId), so at most one row matches.
+     */
+    @Query("SELECT serverId FROM library_items WHERE id = :itemId LIMIT 1")
+    suspend fun findServerIdForItem(itemId: String): String?
 
     @Query("DELETE FROM library_items WHERE libraryId = :libraryId")
     suspend fun deleteByLibraryId(libraryId: String)
@@ -61,11 +69,11 @@ interface LibraryItemDao {
     @Query("SELECT * FROM library_items WHERE libraryId = :libraryId ORDER BY title ASC")
     fun observeAllBooks(libraryId: String): Flow<List<LibraryItemEntity>>
 
-    @Query("UPDATE library_items SET lastOpenedAt = :timestamp WHERE id = :itemId")
-    suspend fun updateLastOpenedAt(itemId: String, timestamp: Long)
+    @Query("UPDATE library_items SET lastOpenedAt = :timestamp WHERE serverId = :serverId AND id = :itemId")
+    suspend fun updateLastOpenedAt(serverId: String, itemId: String, timestamp: Long)
 
-    @Query("UPDATE library_items SET readingProgress = :progress WHERE id = :itemId")
-    suspend fun updateReadingProgress(itemId: String, progress: Float)
+    @Query("UPDATE library_items SET readingProgress = :progress WHERE serverId = :serverId AND id = :itemId")
+    suspend fun updateReadingProgress(serverId: String, itemId: String, progress: Float)
 
     /**
      * Borrow ABS metadata onto a single item. Used by the Storyteller↔ABS matcher to backfill a
@@ -79,9 +87,11 @@ interface LibraryItemDao {
      */
     @Query(
         "UPDATE library_items SET author = COALESCE(:author, author), description = :description, " +
-            "publishedYear = :publishedYear, publisher = :publisher, genres = :genres WHERE id = :itemId"
+            "publishedYear = :publishedYear, publisher = :publisher, genres = :genres " +
+            "WHERE serverId = :serverId AND id = :itemId"
     )
     suspend fun updateReadaloudMetadata(
+        serverId: String,
         itemId: String,
         author: String?,
         description: String?,

--- a/core/database/src/main/kotlin/com/riffle/core/database/LibraryItemEntity.kt
+++ b/core/database/src/main/kotlin/com/riffle/core/database/LibraryItemEntity.kt
@@ -1,11 +1,27 @@
 package com.riffle.core.database
 
 import androidx.room.Entity
-import androidx.room.PrimaryKey
+import androidx.room.ForeignKey
+import androidx.room.Index
 
-@Entity(tableName = "library_items")
+// Keyed by (serverId, id): item ids are only unique within a Server — two Storyteller Servers
+// each emit "1", "2", … (ADR 0025). serverId FK-cascades so removing a Server clears its items.
+@Entity(
+    tableName = "library_items",
+    primaryKeys = ["serverId", "id"],
+    foreignKeys = [
+        ForeignKey(
+            entity = ServerEntity::class,
+            parentColumns = ["id"],
+            childColumns = ["serverId"],
+            onDelete = ForeignKey.CASCADE,
+        ),
+    ],
+    indices = [Index("serverId")],
+)
 data class LibraryItemEntity(
-    @PrimaryKey val id: String,
+    val serverId: String,
+    val id: String,
     val libraryId: String,
     val title: String,
     val author: String,

--- a/core/database/src/main/kotlin/com/riffle/core/database/RiffleDatabase.kt
+++ b/core/database/src/main/kotlin/com/riffle/core/database/RiffleDatabase.kt
@@ -22,7 +22,7 @@ import androidx.sqlite.db.SupportSQLiteDatabase
         CrossEpubIndexEntity::class,
         AnnotationEntity::class,
     ],
-    version = 25,
+    version = 26,
     exportSchema = true,
 )
 abstract class RiffleDatabase : RoomDatabase() {
@@ -425,6 +425,126 @@ abstract class RiffleDatabase : RoomDatabase() {
                 db.execSQL(
                     "CREATE INDEX IF NOT EXISTS `index_annotations_serverId_itemId` " +
                         "ON `annotations` (`serverId`, `itemId`)"
+                )
+            }
+        }
+
+        // 25 → 26: key Library Items by (serverId, itemId) end-to-end (issue #81, ADR 0025).
+        // Item ids are unique only within a Server — two Storyteller Servers each emit "1", "2", …
+        // — so itemId-alone keying collides. Recreate `library_items` with a `serverId` column and
+        // a composite PK (serverId, id), backfilling serverId from each item's owning library
+        // (libraryId → libraries.serverId); an FK to servers cascade-deletes a Server's items.
+        // The series_items / collection_items join tables and book_formatting_preferences gain
+        // `serverId` in their PKs, backfilled by resolving itemId → the recreated library_items.
+        // Rows whose itemId no longer resolves to a surviving item (hence Server) are dropped as
+        // orphans. `reading_positions`, `readaloud_*`, and `annotations` are already (serverId,
+        // itemId)-keyed and untouched.
+        val MIGRATION_25_26 = object : Migration(25, 26) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                // library_items: add serverId + composite PK, backfilled from the owning library.
+                db.execSQL(
+                    "CREATE TABLE IF NOT EXISTS `library_items_new` (" +
+                        "`serverId` TEXT NOT NULL, " +
+                        "`id` TEXT NOT NULL, " +
+                        "`libraryId` TEXT NOT NULL, " +
+                        "`title` TEXT NOT NULL, " +
+                        "`author` TEXT NOT NULL, " +
+                        "`coverUrl` TEXT, " +
+                        "`readingProgress` REAL NOT NULL, " +
+                        "`ebookFileIno` TEXT, " +
+                        "`ebookFormat` TEXT NOT NULL, " +
+                        "`description` TEXT, " +
+                        "`seriesName` TEXT, " +
+                        "`publishedYear` TEXT, " +
+                        "`genres` TEXT NOT NULL, " +
+                        "`publisher` TEXT, " +
+                        "`lastOpenedAt` INTEGER, " +
+                        "`addedAt` INTEGER, " +
+                        "`isbn` TEXT, " +
+                        "`asin` TEXT, " +
+                        "PRIMARY KEY(`serverId`, `id`), " +
+                        "FOREIGN KEY(`serverId`) REFERENCES `servers`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE)"
+                )
+                db.execSQL(
+                    "INSERT INTO `library_items_new` " +
+                        "(serverId, id, libraryId, title, author, coverUrl, readingProgress, ebookFileIno, " +
+                        "ebookFormat, description, seriesName, publishedYear, genres, publisher, lastOpenedAt, addedAt, isbn, asin) " +
+                        "SELECT lib.serverId, li.id, li.libraryId, li.title, li.author, li.coverUrl, li.readingProgress, " +
+                        "li.ebookFileIno, li.ebookFormat, li.description, li.seriesName, li.publishedYear, li.genres, " +
+                        "li.publisher, li.lastOpenedAt, li.addedAt, li.isbn, li.asin " +
+                        "FROM `library_items` li JOIN `libraries` lib ON li.libraryId = lib.id"
+                )
+                db.execSQL("DROP TABLE `library_items`")
+                db.execSQL("ALTER TABLE `library_items_new` RENAME TO `library_items`")
+                db.execSQL("CREATE INDEX IF NOT EXISTS `index_library_items_serverId` ON `library_items` (`serverId`)")
+
+                // series_items: add serverId to the PK, resolved via the item's owning server.
+                db.execSQL(
+                    "CREATE TABLE IF NOT EXISTS `series_items_new` (" +
+                        "`seriesId` TEXT NOT NULL, " +
+                        "`serverId` TEXT NOT NULL, " +
+                        "`itemId` TEXT NOT NULL, " +
+                        "`sequenceOrder` REAL NOT NULL, " +
+                        "PRIMARY KEY(`seriesId`, `serverId`, `itemId`))"
+                )
+                db.execSQL(
+                    "INSERT INTO `series_items_new` (seriesId, serverId, itemId, sequenceOrder) " +
+                        "SELECT si.seriesId, li.serverId, si.itemId, si.sequenceOrder " +
+                        "FROM `series_items` si JOIN `library_items` li ON si.itemId = li.id"
+                )
+                db.execSQL("DROP TABLE `series_items`")
+                db.execSQL("ALTER TABLE `series_items_new` RENAME TO `series_items`")
+
+                // collection_items: same treatment.
+                db.execSQL(
+                    "CREATE TABLE IF NOT EXISTS `collection_items_new` (" +
+                        "`collectionId` TEXT NOT NULL, " +
+                        "`serverId` TEXT NOT NULL, " +
+                        "`itemId` TEXT NOT NULL, " +
+                        "PRIMARY KEY(`collectionId`, `serverId`, `itemId`))"
+                )
+                db.execSQL(
+                    "INSERT INTO `collection_items_new` (collectionId, serverId, itemId) " +
+                        "SELECT ci.collectionId, li.serverId, ci.itemId " +
+                        "FROM `collection_items` ci JOIN `library_items` li ON ci.itemId = li.id"
+                )
+                db.execSQL("DROP TABLE `collection_items`")
+                db.execSQL("ALTER TABLE `collection_items_new` RENAME TO `collection_items`")
+
+                // book_formatting_preferences: add serverId + composite PK for identity (still
+                // per-device, never synced). Backfill via the item's owning server; orphans drop.
+                db.execSQL(
+                    "CREATE TABLE IF NOT EXISTS `book_formatting_preferences_new` (" +
+                        "`serverId` TEXT NOT NULL, " +
+                        "`itemId` TEXT NOT NULL, " +
+                        "`fontSize` REAL, " +
+                        "`theme` TEXT, " +
+                        "`fontFamily` TEXT, " +
+                        "`lineSpacing` REAL, " +
+                        "`margins` REAL, " +
+                        "`orientation` TEXT, " +
+                        "`showChapterMap` INTEGER, " +
+                        "`showReadingProgressLabels` INTEGER, " +
+                        "`showCurrentChapterLabel` INTEGER, " +
+                        "`doublePageSpread` INTEGER, " +
+                        "`justifyText` INTEGER, " +
+                        "PRIMARY KEY(`serverId`, `itemId`), " +
+                        "FOREIGN KEY(`serverId`) REFERENCES `servers`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE)"
+                )
+                db.execSQL(
+                    "INSERT INTO `book_formatting_preferences_new` " +
+                        "(serverId, itemId, fontSize, theme, fontFamily, lineSpacing, margins, orientation, " +
+                        "showChapterMap, showReadingProgressLabels, showCurrentChapterLabel, doublePageSpread, justifyText) " +
+                        "SELECT li.serverId, bfp.itemId, bfp.fontSize, bfp.theme, bfp.fontFamily, bfp.lineSpacing, " +
+                        "bfp.margins, bfp.orientation, bfp.showChapterMap, bfp.showReadingProgressLabels, " +
+                        "bfp.showCurrentChapterLabel, bfp.doublePageSpread, bfp.justifyText " +
+                        "FROM `book_formatting_preferences` bfp JOIN `library_items` li ON bfp.itemId = li.id"
+                )
+                db.execSQL("DROP TABLE `book_formatting_preferences`")
+                db.execSQL("ALTER TABLE `book_formatting_preferences_new` RENAME TO `book_formatting_preferences`")
+                db.execSQL(
+                    "CREATE INDEX IF NOT EXISTS `index_book_formatting_preferences_serverId` " +
+                        "ON `book_formatting_preferences` (`serverId`)"
                 )
             }
         }

--- a/core/database/src/main/kotlin/com/riffle/core/database/SeriesDao.kt
+++ b/core/database/src/main/kotlin/com/riffle/core/database/SeriesDao.kt
@@ -15,7 +15,7 @@ interface SeriesDao {
 
     @Query("""
         SELECT li.* FROM library_items li
-        INNER JOIN series_items si ON li.id = si.itemId
+        INNER JOIN series_items si ON li.serverId = si.serverId AND li.id = si.itemId
         WHERE si.seriesId = :seriesId
         ORDER BY si.sequenceOrder ASC
     """)

--- a/core/database/src/main/kotlin/com/riffle/core/database/SeriesItemEntity.kt
+++ b/core/database/src/main/kotlin/com/riffle/core/database/SeriesItemEntity.kt
@@ -2,9 +2,12 @@ package com.riffle.core.database
 
 import androidx.room.Entity
 
-@Entity(tableName = "series_items", primaryKeys = ["seriesId", "itemId"])
+// serverId disambiguates colliding item ids across Servers (ADR 0025); a series is library-
+// (hence server-) scoped, so serverId is the owning library's server.
+@Entity(tableName = "series_items", primaryKeys = ["seriesId", "serverId", "itemId"])
 data class SeriesItemEntity(
     val seriesId: String,
+    val serverId: String,
     val itemId: String,
     val sequenceOrder: Float,
 )

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/DownloadsRepository.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/DownloadsRepository.kt
@@ -1,17 +1,19 @@
 package com.riffle.core.domain
 
+// The Downloads screen is inherently cross-Server (it lists every file on disk), so it keys by
+// (serverId, itemId) rather than itemId alone (ADR 0025).
 interface DownloadsRepository {
-    fun getDownloadedItemIds(): List<String>
-    fun getCachedItemIds(): List<String>
+    fun getDownloadedItems(): List<StoredItemRef>
+    fun getCachedItems(): List<StoredItemRef>
 
     /** Total bytes of the item's local file(s), across the EPUB and PDF stores. */
-    fun sizeOf(itemId: String): Long
+    fun sizeOf(serverId: String, itemId: String): Long
 
     /** Removes the permanent download for a single item. Immediate; no Undo. */
-    suspend fun removeDownload(itemId: String)
+    suspend fun removeDownload(serverId: String, itemId: String)
 
     /** Removes the cached copy for a single item. Immediate; no Undo. */
-    suspend fun removeCached(itemId: String)
+    suspend fun removeCached(serverId: String, itemId: String)
 
     suspend fun removeAllDownloads()
     suspend fun clearAllCached()

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/EpubRepository.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/EpubRepository.kt
@@ -18,8 +18,8 @@ sealed class EpubDownloadResult {
 interface EpubRepository {
     suspend fun openEpub(item: LibraryItem): EpubOpenResult
     suspend fun downloadEpub(item: LibraryItem): EpubDownloadResult
-    suspend fun removeDownload(itemId: String)
-    fun isDownloaded(itemId: String): Boolean
-    fun isCached(itemId: String): Boolean
+    suspend fun removeDownload(serverId: String, itemId: String)
+    fun isDownloaded(serverId: String, itemId: String): Boolean
+    fun isCached(serverId: String, itemId: String): Boolean
     suspend fun saveReadingPosition(itemId: String, cfi: String)
 }

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/LibraryItem.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/LibraryItem.kt
@@ -20,6 +20,10 @@ data class LibraryItem(
     val addedAt: Long? = null,
     val isbn: String? = null,
     val asin: String? = null,
+    // The owning Server. Item ids are only unique within a Server (ADR 0025), so callers that key
+    // local files / DB rows must pair id with serverId. Defaulted for construction sites (e.g.
+    // tests) that don't care; the real value is set when mapping from the DB entity.
+    val serverId: String = "",
 ) {
     val isSupported: Boolean get() = ebookFormat != EbookFormat.Unsupported
 }

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/LibraryRepository.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/LibraryRepository.kt
@@ -24,7 +24,11 @@ interface LibraryRepository {
     fun observeCollections(libraryId: String): Flow<List<Collection>>
     fun observeSeriesItems(seriesId: String): Flow<List<LibraryItem>>
     fun observeCollectionItems(collectionId: String): Flow<List<LibraryItem>>
+    /** The active Server's copy of an item (item ids are only unique within a Server, ADR 0025). */
     suspend fun getItem(itemId: String): LibraryItem?
+
+    /** A specific Server's copy of an item — for cross-Server callers like the Downloads screen. */
+    suspend fun getItem(serverId: String, itemId: String): LibraryItem?
     suspend fun getLibrary(libraryId: String): Library?
     suspend fun markItemOpened(itemId: String)
     suspend fun updateReadingProgress(itemId: String, progress: Float)

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/LocalStore.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/LocalStore.kt
@@ -3,10 +3,16 @@ package com.riffle.core.domain
 import java.io.File
 import java.io.InputStream
 
+/** A locally-stored item, identified by its owning Server and item id (ADR 0025). */
+data class StoredItemRef(val serverId: String, val itemId: String)
+
+// Files are keyed by (serverId, itemId) — item ids are only unique within a Server (ADR 0025).
+// On disk they live under dir/<serverId>/<itemId><ext> so two Servers' colliding ids never
+// overwrite each other.
 interface LocalStore {
-    fun get(itemId: String): File?
-    suspend fun save(itemId: String, stream: InputStream): File
-    fun delete(itemId: String)
+    fun get(serverId: String, itemId: String): File?
+    suspend fun save(serverId: String, itemId: String, stream: InputStream): File
+    fun delete(serverId: String, itemId: String)
     fun clear()
-    fun listItemIds(): List<String>
+    fun listItems(): List<StoredItemRef>
 }

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/PdfRepository.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/PdfRepository.kt
@@ -17,8 +17,8 @@ sealed class PdfDownloadResult {
 interface PdfRepository {
     suspend fun openPdf(item: LibraryItem): PdfOpenResult
     suspend fun downloadPdf(item: LibraryItem): PdfDownloadResult
-    suspend fun removeDownload(itemId: String)
-    fun isDownloaded(itemId: String): Boolean
-    fun isCached(itemId: String): Boolean
+    suspend fun removeDownload(serverId: String, itemId: String)
+    fun isDownloaded(serverId: String, itemId: String): Boolean
+    fun isCached(serverId: String, itemId: String): Boolean
     suspend fun saveReadingPosition(itemId: String, locatorJson: String)
 }

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/ReadaloudAudioRepository.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/ReadaloudAudioRepository.kt
@@ -15,32 +15,31 @@ sealed interface AudioDownloadResult {
  * cache-size cap (ADR 0024).
  */
 interface ReadaloudAudioRepository {
+    // The bundle lives on the Storyteller Server; [serverId] is that Server (ADR 0025) — which on
+    // the ABS item-detail screen is NOT the active Server.
+
     /** True when the synced bundle is present locally (Downloads or Cache). */
-    fun isAudioAvailable(itemId: String): Boolean
+    fun isAudioAvailable(serverId: String, itemId: String): Boolean
 
     /** The local synced-bundle file, or null if not present. */
-    fun bundleFile(itemId: String): File?
+    fun bundleFile(serverId: String, itemId: String): File?
 
     /** Parses the Media Overlay timeline out of the local bundle, or null if no bundle / no overlays. */
-    suspend fun readTrack(itemId: String): ReadaloudTrack?
+    suspend fun readTrack(serverId: String, itemId: String): ReadaloudTrack?
 
     /** The download size in bytes (server Content-Length), or null if it can't be probed. */
-    suspend fun probeSizeBytes(itemId: String): Long?
-
-    /** Downloads the synced bundle into permanent Downloads with resume + progress. */
-    suspend fun downloadAudio(itemId: String, onProgress: (downloaded: Long, total: Long) -> Unit): AudioDownloadResult
+    suspend fun probeSizeBytes(serverId: String, itemId: String): Long?
 
     /**
-     * Downloads the synced bundle from a specific server (by id) rather than the active one.
-     * Used by the ABS item-detail screen, where the active server is ABS but the bundle lives
-     * on the linked Storyteller server. Keyed by [bookId] (the Storyteller book id).
+     * Downloads the synced bundle into permanent Downloads with resume + progress, from the
+     * Storyteller [serverId] the bundle lives on. Keyed by [bookId] (the Storyteller book id).
      */
     suspend fun downloadAudio(
-        bookId: String,
         serverId: String,
+        bookId: String,
         onProgress: (downloaded: Long, total: Long) -> Unit,
     ): AudioDownloadResult
 
     /** Removes the downloaded bundle; returns the number of bytes freed. */
-    suspend fun removeAudio(itemId: String): Long
+    suspend fun removeAudio(serverId: String, itemId: String): Long
 }

--- a/docs/adr/0025-key-local-stores-by-server-and-item.md
+++ b/docs/adr/0025-key-local-stores-by-server-and-item.md
@@ -1,6 +1,6 @@
 # ADR 0025 — Key Library Items by (serverId, itemId) end-to-end
 
-**Status:** Proposed (not yet implemented — scoped out of the downloads/caching consolidation once the collision was found to be systemic). Tracked in [issue #81](https://github.com/pkmetski/riffle/issues/81), which also weighs design **A** (composite PK) vs **B** (namespaced id).
+**Status:** Accepted — **design A** (composite `(serverId, itemId)` PK across the schema). Tracked in [issue #81](https://github.com/pkmetski/riffle/issues/81), which weighed design **A** against design **B** (namespaced id at ingestion).
 
 ## Context
 
@@ -21,17 +21,21 @@ This is why a file-store-only re-key is a **half-measure**: separating files by 
 Key Library Items by **(serverId, itemId)** consistently across **both** the file stores and the database — not the file stores alone.
 
 - **File stores:** `LocalStore` methods take `serverId`; files live under `dir/<serverId>/<itemId><ext>`. A one-time on-disk migration relocates legacy flat files using each item's owning Server (resolved itemId → libraryId → `libraries.serverId`), deleting orphans.
-- **Database:** `library_items` gains a `serverId` column and a composite key (`serverId`, `id`); `getItem`, item queries, and every table that references item ids (series_items, collection_items, readaloud links/candidates) are updated accordingly, with a Room schema migration.
+- **Database:** `library_items` gains a `serverId` column and a composite key (`serverId`, `id`); `getItem`, item queries, and every table that references item ids are updated accordingly, with a Room schema migration. `readaloud_links` / `readaloud_candidates` / `reading_positions` / `annotations` are **already** `(serverId, itemId)`-keyed, so the change touches `library_items`, the `series_items` / `collection_items` join tables, and `book_formatting_preferences` (see below).
+- **`book_formatting_preferences` is in scope, keyed by `(serverId, itemId)` — for *identity*, not sync.** Formatting (font size, theme, margins, …) stays per-device: never synced, never per-user. But the row must point at the *right* book, and once `itemId` alone no longer identifies a book on-device, two colliding Storyteller books would otherwise share one formatting row and stomp each other. Adding `serverId` to its key disambiguates which book; it does **not** make formatting a per-server feature and adds no `userId`. (Reverses the earlier "never add serverId to formatting prefs" stance, which conflated the *sync* axis with the *identity* axis.)
 - `serverId` — not Server *type* and not username — is the disambiguator. Type is too coarse (does not separate two Servers of the same type); username is the wrong axis (cached bytes are book content, not user data).
+- **Why A over B:** the codebase already keys four tables by `(serverId, itemId)`, so A makes `library_items` consistent with its neighbours instead of introducing a second, opposite convention; `MIGRATION_18_19` (reading_positions itemId → composite) is a proven template. B's "strip the `serverId:` prefix at every network boundary" is a stringly-typed footgun — every missed call site is a silently wrong-server request that still compiles. A's costs are concentrated and compiler-checked; B's are diffuse and runtime-checked.
+- **Migration is 25 → 26.** The DB is already at v25 (the `annotations` store, `MIGRATION_24_25`, landed after this ADR was first drafted); the issue text's "v24→25" is stale.
 
 ## Alternatives considered
 
 - **Re-key the file stores only.** Rejected: does not fix the collision because the DB primary key is still itemId; produces an inconsistent file-vs-metadata state. This was the original (too-narrow) framing of this ADR.
 - **Leave keying as itemId-only, document the risk.** Tenable while no user runs two Storyteller Servers; rejected as the long-term answer because it is a real correctness bug.
 - **Key by (serverType, itemId) / (serverId, username, itemId).** Rejected — see Decision.
+- **Design B — namespace the id at ingestion** (`LibraryItem.id = "${serverId}:${rawId}"`, single-column PK kept, strip the prefix before every server call). Rejected — see "Why A over B" above. Smaller DB footprint, but the cost moves to the network boundary as runtime-checked prefix-stripping at every call site, against the grain of the four tables already keyed by `(serverId, itemId)`.
 
 ## Consequences
 
-- This is a cross-cutting change (Room migration + DAO/query updates + file-store interface + on-disk migration + their tests), independent of and larger than the downloads/caching-settings consolidation. It is therefore deferred to its own change rather than bundled in.
-- Until done, the two-Storyteller-Server collision remains a known limitation (documented in CONTEXT.md and ADR 0023's keying notes).
-- When implemented, file stores and `library_items` become consistent with `ReadingPositionStore`'s `(serverId, itemId)` keying.
+- This is a cross-cutting change (Room migration + DAO/query updates + file-store interface + on-disk migration + their tests), independent of and larger than the downloads/caching-settings consolidation. It is therefore its own change rather than bundled in.
+- File stores, `library_items`, `series_items` / `collection_items`, and `book_formatting_preferences` become consistent with the `(serverId, itemId)` keying already used by `reading_positions`, `readaloud_links`, `readaloud_candidates`, and `annotations`.
+- DAO queries and file-store calls that previously took `itemId` alone now also require `serverId`; callers thread it through (they already hold `activeServer.id`). Because `itemId` stays raw (design A, not B), calls *to* servers are unaffected — no prefix-stripping.


### PR DESCRIPTION
## What & why

Riffle keyed local Library-Item data by **item id alone**, assuming ids are globally unique. They are not: **Storyteller** item ids are sequential integers that restart per Server, so two Storyteller Servers both emit `"1"`, `"2"`, … and collided in two places — the file stores (`1.epub` returned the wrong server's bytes) and the DB (`library_items` PK was `id`, `REPLACE` overwrote rows). Fixes #81.

**Design A** (composite `(serverId, itemId)` key), per ADR 0025 (now Accepted). Chosen over the namespaced-id alternative because the codebase already keys four tables this way (`reading_positions`, `readaloud_links`/`candidates`, `annotations`), and `MIGRATION_18_19` is a proven template — A's costs are concentrated and compiler-checked, B's were diffuse runtime-checked prefix-stripping.

## Changes

- **DB (migration 25→26):** `library_items` gains `serverId` + composite PK `(serverId, id)` + FK-cascade to `servers`; `series_items` / `collection_items` / `book_formatting_preferences` gain `serverId` in their PKs. `MIGRATION_25_26` backfills `serverId` from each item's owning library and drops orphans. Schema re-exported.
- **`book_formatting_preferences`:** kept **per-device** (never synced, never per-user) but keyed by `(serverId, itemId)` for *identity* — otherwise two colliding books would share one formatting row.
- **DAOs/repos:** `LibraryItemDao`, Series/Collection joins (`serverId AND itemId`), `BookFormattingPreferencesDao`, and all callers re-keyed. Domain interfaces resolve the active Server internally where possible to avoid ViewModel churn.
- **File stores:** `LocalStore` keyed by `dir/<serverId>/<itemId>`; `DownloadsRepository` made Server-aware (the Downloads screen is inherently cross-Server); `ReadaloudAudioRepository` now targets the **Storyteller** Server, not the active one (fixes a latent bug); `AudiobookBundleDownloader` writes under the `serverId` subdir.
- **Migration:** one-time `LocalStoreMigrator` relocates legacy flat files into per-Server dirs at startup (orphans deleted).

## Testing

- `./gradlew test` (full JVM unit suite, all modules) — green
- `./gradlew lint` — green
- `make harness-test` (phone) — ~132 instrumented tests, 0 failed
- `make harness-test-tablet` — 5 `@TabletLayout` tests, 0 failed
- `core:database` migration/DAO instrumented tests on the AVD — `migration25To26`, `migrateFullChain`, the two-Storyteller-server collision test, and the serverId-qualified joins all pass
- New unit test: `LocalStoreMigratorTest` (relocate / orphan / idempotent / skip-subdir)