### PR TITLE
fix(reader): show full footnote body, strip marker and back-link chrome

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/FootnoteResolver.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/FootnoteResolver.kt
@@ -27,6 +27,27 @@ internal object FootnoteResolver {
 
     fun parse(html: String): Document = Jsoup.parse(html)
 
+    // Anchors whose entire text is just a note marker — "7", "7.", "[7]",
+    // "(7)", "7)" — are back-references into the body, not note content.
+    private val MARKER_REGEX = Regex("""[\[(]?\d{1,4}[.)\]]?""")
+
+    // "Return to text" glyphs an EPUB appends as a trailing back-link: upwards
+    // arrow (↑), hooked/curved return arrows, carriage-return symbol.
+    private val BACKLINK_GLYPHS = setOf(
+        "↑", // ↑ upwards arrow
+        "⤴", // ⤴ arrow pointing up then right
+        "↩", // ↩ leftwards arrow with hook
+        "↪", // ↪ rightwards arrow with hook
+        "↰", // ↰ upwards arrow with tip leftwards
+        "↵", // ↵ downwards arrow with corner leftwards
+        "⏎", // ⏎ return symbol
+        "⬆", // ⬆ heavy upwards arrow
+    )
+
+    // EPUB3 / DPUB-ARIA standard markers for the link that returns to the text.
+    private val BACKLINK_EPUB_TYPES = setOf("backlink")
+    private val BACKLINK_ROLES = setOf("doc-backlink")
+
     // Returns the footnote body text for [targetId] within [doc], or null if
     // the element with that id does not look like a footnote.
     //
@@ -37,9 +58,15 @@ internal object FootnoteResolver {
     // 3.0.0 bug this whole feature works around. Do not swap getElementById
     // for select here.
     fun extractFootnoteText(doc: Document, targetId: String): String? {
-        val element = doc.getElementById(targetId) ?: return null
-        if (!looksLikeFootnote(element)) return null
-        return element.text().trim().takeIf { it.isNotEmpty() }
+        val target = doc.getElementById(targetId) ?: return null
+        if (!looksLikeFootnote(target)) return null
+        // Some EPUBs (e.g. "Influence Without Authority") point the in-text
+        // reference at the note's inner back-reference anchor — an <a> whose
+        // text is just the marker ("1.") — rather than the note entry itself.
+        // Landing there yields a popup that shows only the number, so climb to
+        // the enclosing note entry before reading the body.
+        val block = if (isBackReference(target)) noteEntryFor(target) else target
+        return noteText(block).takeIf { it.isNotEmpty() }
     }
 
     // Resolves an anchor tap from the WebView to footnote popup text. Returns
@@ -56,14 +83,55 @@ internal object FootnoteResolver {
         return extractFootnoteText(doc, fragmentId)
     }
 
+    // The visible note body for [block], with any back-reference marker anchors
+    // ("1.", "[7]" that link back into the text) removed — they're navigation
+    // chrome, not content. Cloning keeps the cached document untouched.
+    private fun noteText(block: Element): String {
+        val clone = block.clone()
+        clone.select("a[href^=#]").forEach { anchor ->
+            if (isBackReference(anchor)) anchor.remove()
+        }
+        return clone.text().trim()
+    }
+
+    // True when [element] is an in-document anchor that is navigation chrome
+    // rather than note content: the marker that pairs with the in-text
+    // superscript ("7."/"[7]"), a "return to text" arrow (↑), or an anchor
+    // carrying the EPUB3/DPUB-ARIA backlink type/role.
+    private fun isBackReference(element: Element): Boolean {
+        if (!element.tagName().equals("a", ignoreCase = true)) return false
+        if (!element.attr("href").startsWith("#")) return false
+        if (matchesAny(element.attr("epub:type"), BACKLINK_EPUB_TYPES)) return true
+        if (matchesAny(element.attr("role"), BACKLINK_ROLES)) return true
+        val text = element.text().trim()
+        return MARKER_REGEX.matches(text) || text in BACKLINK_GLYPHS
+    }
+
+    // Climbs from a marker anchor to the enclosing note entry: the nearest
+    // ancestor that itself carries a footnote signal (so a single <aside>, not
+    // the plural <section epub:type="rearnotes"> that wraps every note).
+    private fun noteEntryFor(marker: Element): Element {
+        var node: Element? = marker.parent()
+        while (node != null) {
+            if (carriesFootnoteSignal(node)) return node
+            node = node.parent()
+        }
+        return marker.parent() ?: marker
+    }
+
     private fun looksLikeFootnote(element: Element): Boolean {
         var node: Element? = element
         while (node != null) {
-            if (matchesAny(node.attr("epub:type"), FOOTNOTE_EPUB_TYPES)) return true
-            if (matchesAny(node.attr("role"), FOOTNOTE_ROLES)) return true
-            if (node.classNames().any { it.lowercase() in FOOTNOTE_CLASSES }) return true
+            if (carriesFootnoteSignal(node)) return true
             node = node.parent()
         }
+        return false
+    }
+
+    private fun carriesFootnoteSignal(node: Element): Boolean {
+        if (matchesAny(node.attr("epub:type"), FOOTNOTE_EPUB_TYPES)) return true
+        if (matchesAny(node.attr("role"), FOOTNOTE_ROLES)) return true
+        if (node.classNames().any { it.lowercase() in FOOTNOTE_CLASSES }) return true
         return false
     }
 

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/FootnoteResolverTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/FootnoteResolverTest.kt
@@ -171,6 +171,104 @@ class FootnoteResolverTest {
         )
     }
 
+    // The real-world bug from "Influence Without Authority": the in-text
+    // reference links to the inner back-reference anchor, not the <aside>:
+    //   in body:  <a id="backTNT2" href="#c07-note-0002">1</a>
+    //   target:   <aside id="en2" epub:type="rearnote">
+    //               <a id="c07-note-0002" href="#backTNT2">1.</a> Kanter…
+    //             </aside>
+    // getElementById("c07-note-0002") lands on the marker anchor whose text is
+    // just "1.", so the popup used to show only the number. The resolver must
+    // climb to the enclosing note entry and return the body, marker stripped.
+    @Test
+    fun `back-reference marker target resolves to the note body`() {
+        val html = """
+            <html xmlns:epub="http://www.idpf.org/2007/ops"><body>
+              <section epub:type="rearnotes">
+                <aside id="en2" class="noteEntry" epub:type="rearnote">
+                  <a id="c07-note-0002" href="#backTNT2">1.</a> Kanter, <i>Change Masters</i>.
+                </aside>
+              </section>
+            </body></html>
+        """.trimIndent()
+        val doc = FootnoteResolver.parse(html)
+        assertEquals(
+            "Kanter, Change Masters.",
+            FootnoteResolver.extractFootnoteText(doc, "c07-note-0002"),
+        )
+    }
+
+    // Even when the id points straight at the note entry, the leading
+    // back-reference marker ("1.") is chrome, not content — strip it.
+    @Test
+    fun `note entry target strips the leading back-reference marker`() {
+        val html = """
+            <html xmlns:epub="http://www.idpf.org/2007/ops"><body>
+              <aside id="en2" class="noteEntry" epub:type="rearnote">
+                <a id="c07-note-0002" href="#backTNT2">1.</a> Kanter, <i>Change Masters</i>.
+              </aside>
+            </body></html>
+        """.trimIndent()
+        val doc = FootnoteResolver.parse(html)
+        assertEquals(
+            "Kanter, Change Masters.",
+            FootnoteResolver.extractFootnoteText(doc, "en2"),
+        )
+    }
+
+    // A footnote whose body legitimately starts with a number must keep it;
+    // only the back-reference *anchor* is stripped, not arbitrary digits.
+    @Test
+    fun `numeric body content is preserved when not a back-reference`() {
+        val html = """
+            <html xmlns:epub="http://www.idpf.org/2007/ops"><body>
+              <aside id="en3" epub:type="rearnote"><p>1984 was a pivotal year.</p></aside>
+            </body></html>
+        """.trimIndent()
+        val doc = FootnoteResolver.parse(html)
+        assertEquals(
+            "1984 was a pivotal year.",
+            FootnoteResolver.extractFootnoteText(doc, "en3"),
+        )
+    }
+
+    // Many EPUBs append a "return to text" back-link at the END of the note —
+    // an up-arrow (↑) or hooked arrow that links back to the reference. Real
+    // sample from a Swedish-to-Bulgarian translation:
+    //   <div epub:type="footnote" id="note_3-1"><p>
+    //     <a href="#ref_3-1">[1]</a> Йостермалм … Б. пр. <a href="#ref_3-1">↑</a>
+    //   </p></div>
+    // Both the leading marker and the trailing arrow are chrome; strip both.
+    @Test
+    fun `trailing up-arrow back-link is stripped`() {
+        val html = """
+            <html xmlns:epub="http://www.idpf.org/2007/ops"><body>
+              <div epub:type="footnote" id="note_3-1"><p>
+                <a href="#ref_3-1" title="Back to text">[1]</a>
+                Ostermalm is a district. Note. <a href="#ref_3-1" title="Back to text">↑</a>
+              </p></div>
+            </body></html>
+        """.trimIndent()
+        val doc = FootnoteResolver.parse(html)
+        assertEquals(
+            "Ostermalm is a district. Note.",
+            FootnoteResolver.extractFootnoteText(doc, "note_3-1"),
+        )
+    }
+
+    @Test
+    fun `standard epub-type backlink is stripped`() {
+        val html = """
+            <html xmlns:epub="http://www.idpf.org/2007/ops"><body>
+              <aside epub:type="footnote" id="fn9"><p>
+                Note body. <a epub:type="backlink" href="#ref9">Return</a>
+              </p></aside>
+            </body></html>
+        """.trimIndent()
+        val doc = FootnoteResolver.parse(html)
+        assertEquals("Note body.", FootnoteResolver.extractFootnoteText(doc, "fn9"))
+    }
+
     @Test
     fun `class footnotes plural on container is detected`() {
         val html = """


### PR DESCRIPTION
## Problem

Some footnote popups showed only the marker number (e.g. just "7.") instead of the note text, and others trailed a stray "↑" back-link glyph.

## Root cause

Two real-world EPUB structures (verified against books on the test server):

1. **Number-only popup** — *Influence Without Authority* (`e0bfbef0…`) points the in-text reference at the note's **inner back-reference anchor**, not the `<aside>`:
   ```html
   <!-- body -->     <a id="backTNT2" href="#c07-note-0002">1</a>
   <!-- note entry --><aside id="en2" epub:type="rearnote">
                        <a id="c07-note-0002" href="#backTNT2">1.</a> Kanter, <i>Change Masters</i>.
                      </aside>
   ```
   `getElementById("c07-note-0002")` landed on the marker anchor whose text is just `1.`.

2. **Trailing back-link** — a Bulgarian translation (`0807f241…`) appends a `↑` (U+2191) "return to text" anchor at the end of every note.

## Fix (`FootnoteResolver.kt`)

- When the tapped target is a back-reference anchor, climb to the enclosing note entry (nearest single ancestor carrying a footnote signal) before reading the body.
- Strip back-reference chrome from the displayed text: numeric markers (`7`, `7.`, `[7]`, `(7)`), "return to text" arrow glyphs (↑ ⤴ ↩ ↪ ↰ ↵ ⏎ ⬆), and anchors carrying the EPUB3 `epub:type="backlink"` / DPUB-ARIA `role="doc-backlink"`.
- Detection stays conservative: only in-document `<a href="#…">` anchors whose **entire** text is the glyph/marker qualify, so footnote bodies that merely contain a number or arrow are untouched.

## Tests

5 new `FootnoteResolverTest` cases against the real-world structures (back-reference target resolves to body, leading marker stripped, numeric body content preserved, trailing ↑ stripped, standard backlink type stripped). Full suite: 21 tests, 0 failures.

- `./gradlew test` — green
- `./gradlew lint` — green
- Harness tests skipped per request (resolver covered by JVM unit tests)