### PR TITLE
fix(reader): suppress chapter pill at the book's ends in scroll mode

### DIFF
--- a/app/src/androidTest/kotlin/com/riffle/app/feature/reader/ScrollBoundaryNavigationContainerTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/reader/ScrollBoundaryNavigationContainerTest.kt
@@ -23,6 +23,8 @@ class ScrollBoundaryNavigationContainerTest {
         isScrollMode: Boolean = true,
         atForwardBoundary: Boolean = false,
         atBackwardBoundary: Boolean = false,
+        canNavigateForward: Boolean = true,
+        canNavigateBackward: Boolean = true,
     ): ScrollBoundaryNavigationContainer {
         var c: ScrollBoundaryNavigationContainer? = null
         onMain {
@@ -30,6 +32,8 @@ class ScrollBoundaryNavigationContainerTest {
                 this.isScrollMode = isScrollMode
                 this.atForwardBoundary = atForwardBoundary
                 this.atBackwardBoundary = atBackwardBoundary
+                this.canNavigateForward = canNavigateForward
+                this.canNavigateBackward = canNavigateBackward
             }
         }
         return c!!
@@ -180,6 +184,32 @@ class ScrollBoundaryNavigationContainerTest {
         }
         onMain {}
         assertFalse(invoked)
+    }
+
+    @Test
+    fun forwardPullAtLastChapterDoesNotArmPullOrNavigate() {
+        // Pull-up on the very last chapter: nowhere forward to go, so no pill and no nav.
+        var navigated = false
+        var pillShown = false
+        val c = container(atForwardBoundary = true, canNavigateForward = false)
+        c.onNavigateForward = { navigated = true }
+        c.onPullStarted = { pillShown = true }
+        simulatePull(c, forward = true)
+        assertFalse(navigated)
+        assertFalse(pillShown)
+    }
+
+    @Test
+    fun backwardPullAtFirstChapterDoesNotArmPullOrNavigate() {
+        // Pull-down on the very first chapter: nowhere back to go, so no pill and no nav.
+        var navigated = false
+        var pillShown = false
+        val c = container(atBackwardBoundary = true, canNavigateBackward = false)
+        c.onNavigateBackward = { navigated = true }
+        c.onPullStarted = { pillShown = true }
+        simulatePull(c, forward = false)
+        assertFalse(navigated)
+        assertFalse(pillShown)
     }
 
     @Test

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -1037,6 +1037,14 @@ private fun EpubNavigatorView(
                     )?.trim('"') == "true"
                     container.atForwardBoundary = atBottom
                     container.atBackwardBoundary = atTop
+
+                    // No pill at the book's ends: a pull-down on the very first chapter or a
+                    // pull-up on the very last has nowhere to go, so don't arm the gesture.
+                    val idx = state.publication.readingOrder
+                        .indexOfFirst { it.href.toString() == currentHrefHolder[0] }
+                    container.canNavigateForward =
+                        idx in 0 until state.publication.readingOrder.size - 1
+                    container.canNavigateBackward = idx > 0
                 }
             }
             delay(BOUNDARY_POLL_INTERVAL_MS)

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ScrollBoundaryNavigationContainer.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ScrollBoundaryNavigationContainer.kt
@@ -19,6 +19,12 @@ class ScrollBoundaryNavigationContainer(context: Context) : FrameLayout(context)
     var atForwardBoundary: Boolean = false
     var atBackwardBoundary: Boolean = false
 
+    // Whether a chapter actually exists past the current one. Set by EpubReaderScreen from the
+    // reading-order position. At the very first/last chapter there is nowhere to navigate, so we
+    // never arm a pull there — no pill, no feedback for a gesture that could never complete.
+    var canNavigateForward: Boolean = true
+    var canNavigateBackward: Boolean = true
+
     var onNavigateForward: (() -> Unit)? = null
     var onNavigateBackward: (() -> Unit)? = null
     // Two-channel feedback API. Visibility binds to the started/ended pair; the circle's
@@ -156,14 +162,14 @@ class ScrollBoundaryNavigationContainer(context: Context) : FrameLayout(context)
         // Start a new pull only when finger moves in the correct direction at a boundary.
         if (pullDirection == 0) {
             when {
-                dy < -MOVEMENT_SLOP_PX && atForwardBoundary -> {
+                dy < -MOVEMENT_SLOP_PX && atForwardBoundary && canNavigateForward -> {
                     pullDirection = 1
                     pullDistancePx = 0f
                     lastMoveTimeMs = now
                     onPullStarted?.invoke(true)
                     onPullProgress?.invoke(0f)
                 }
-                dy > MOVEMENT_SLOP_PX && atBackwardBoundary -> {
+                dy > MOVEMENT_SLOP_PX && atBackwardBoundary && canNavigateBackward -> {
                     pullDirection = -1
                     pullDistancePx = 0f
                     lastMoveTimeMs = now


### PR DESCRIPTION
## What

In vertical scroll mode, the pull-to-navigate pill ("Previous chapter" / "Next chapter") armed at *any* scroll boundary. So pulling **down on the first chapter** or **up on the last chapter** showed a pill for a gesture that could never complete — there's no chapter to navigate to.

## Change

Gate pull-arming in `ScrollBoundaryNavigationContainer` on whether a chapter actually exists past the current one:

- Added `canNavigateForward` / `canNavigateBackward` flags (default `true`) to the container; a pull only arms when the matching flag is set, so at the book's ends there's no pill and no feedback.
- `EpubReaderScreen`'s existing boundary poll derives these flags from the reading-order index (`idx in 0 until size-1` / `idx > 0`), mirroring the guards already in the `onNavigate*` callbacks.

Mid-book chapter boundaries are unaffected.

## Tested

- `ScrollBoundaryNavigationContainerTest` — added two tests asserting that a pull at the first/last chapter fires neither navigation nor the pill (`onPullStarted`). All 25 tests in the class pass on the Harness Medium Phone AVD.
- `./gradlew test` — green.
- `./gradlew lint` — green.