### PR TITLE
fix(reader): align paginated viewport width to kill right-margin drift

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -65,9 +65,6 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import kotlin.math.abs
-import kotlin.math.floor
-import kotlin.math.roundToInt
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
@@ -1050,18 +1047,23 @@ private fun EpubNavigatorView(
     }
 
     // Single-page paginated reflowable is the only mode with horizontal column snapping, so it's
-    // the only one exposed to the column-grid drift bug. Scroll / fixed-layout / double-page keep
-    // fillMaxSize untouched. See reference_reader_right_margin_is_column_snap_bug.
+    // the only one exposed to the column-grid drift bug — and the only one we narrow (and paint a
+    // page-coloured gutter behind). Scroll / fixed-layout / double-page keep fillMaxSize and the
+    // bare modifier, untouched. See reference_reader_right_margin_is_column_snap_bug.
     val density = LocalDensity.current.density
     val isPaginated = !isFixedLayout && formattingPrefs.orientation != ReaderOrientation.Vertical
     val isDoublePage = isPaginated && formattingPrefs.doublePageSpread && isLandscape
     val alignViewport = isPaginated && !isDoublePage
-    BoxWithConstraints(
-        modifier = modifier.background(formattingPrefs.theme.palette.background),
-    ) {
+    val containerModifier = if (alignViewport) {
+        modifier.background(formattingPrefs.theme.palette.background)
+    } else {
+        modifier
+    }
+    BoxWithConstraints(modifier = containerModifier) {
+        val alignedWidth = remember(maxWidth, density) { alignedReaderWidthDp(maxWidth.value, density) }
         val readerModifier = if (alignViewport) {
             Modifier
-                .width(alignedReaderWidthDp(maxWidth.value, density).dp)
+                .width(alignedWidth.dp)
                 .fillMaxHeight()
                 .align(Alignment.Center)
         } else {
@@ -1238,22 +1240,6 @@ private fun PullChip(forward: Boolean, progress: Float) {
     }
 }
 
-
-// Largest reader width (dp) <= availDp whose physical pixel width (width * density) is a whole
-// number — so Readium's paginated column-snap pitch b = physicalWidth/dpr equals CSS innerWidth
-// and the column grid stops drifting (the right-margin-vanishes bug; see
-// reference_reader_right_margin_is_column_snap_bug). On integer densities (e.g. dpr 3.0) every
-// integer dp already maps to whole pixels, so this returns floor(availDp) — no gutter cost.
-internal fun alignedReaderWidthDp(availDp: Float, density: Float): Float {
-    if (availDp <= 0f || density <= 0f) return availDp
-    var c = floor(availDp).toInt()
-    while (c > 0) {
-        val px = c * density
-        if (abs(px - px.roundToInt()) < 0.001f) return c.toFloat()
-        c--
-    }
-    return availDp
-}
 
 // Maps an annotation colour token to a Readium highlight tint. v1 has only yellow (ADR 0024); a
 // later colour-picker slice maps `color` to other tints.

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -14,10 +14,12 @@ import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.ui.graphics.Color
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -54,6 +56,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
@@ -62,6 +65,9 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import kotlin.math.abs
+import kotlin.math.floor
+import kotlin.math.roundToInt
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
@@ -1043,7 +1049,24 @@ private fun EpubNavigatorView(
         }
     }
 
-    Box(modifier = modifier) {
+    // Single-page paginated reflowable is the only mode with horizontal column snapping, so it's
+    // the only one exposed to the column-grid drift bug. Scroll / fixed-layout / double-page keep
+    // fillMaxSize untouched. See reference_reader_right_margin_is_column_snap_bug.
+    val density = LocalDensity.current.density
+    val isPaginated = !isFixedLayout && formattingPrefs.orientation != ReaderOrientation.Vertical
+    val isDoublePage = isPaginated && formattingPrefs.doublePageSpread && isLandscape
+    val alignViewport = isPaginated && !isDoublePage
+    BoxWithConstraints(
+        modifier = modifier.background(formattingPrefs.theme.palette.background),
+    ) {
+        val readerModifier = if (alignViewport) {
+            Modifier
+                .width(alignedReaderWidthDp(maxWidth.value, density).dp)
+                .fillMaxHeight()
+                .align(Alignment.Center)
+        } else {
+            Modifier.fillMaxSize()
+        }
         AndroidView(
             factory = { ctx ->
                 ScrollBoundaryNavigationContainer(ctx).apply {
@@ -1164,7 +1187,7 @@ private fun EpubNavigatorView(
                     }
                 }
             },
-            modifier = Modifier.fillMaxSize(),
+            modifier = readerModifier,
         )
         AnimatedVisibility(
             visible = pullActive,
@@ -1215,6 +1238,22 @@ private fun PullChip(forward: Boolean, progress: Float) {
     }
 }
 
+
+// Largest reader width (dp) <= availDp whose physical pixel width (width * density) is a whole
+// number — so Readium's paginated column-snap pitch b = physicalWidth/dpr equals CSS innerWidth
+// and the column grid stops drifting (the right-margin-vanishes bug; see
+// reference_reader_right_margin_is_column_snap_bug). On integer densities (e.g. dpr 3.0) every
+// integer dp already maps to whole pixels, so this returns floor(availDp) — no gutter cost.
+internal fun alignedReaderWidthDp(availDp: Float, density: Float): Float {
+    if (availDp <= 0f || density <= 0f) return availDp
+    var c = floor(availDp).toInt()
+    while (c > 0) {
+        val px = c * density
+        if (abs(px - px.roundToInt()) < 0.001f) return c.toFloat()
+        c--
+    }
+    return availDp
+}
 
 // Maps an annotation colour token to a Readium highlight tint. v1 has only yellow (ADR 0024); a
 // later colour-picker slice maps `color` to other tints.

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderViewportAlignment.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderViewportAlignment.kt
@@ -1,0 +1,27 @@
+package com.riffle.app.feature.reader
+
+import kotlin.math.abs
+import kotlin.math.floor
+import kotlin.math.roundToInt
+
+// Largest reader width (dp) <= availDp whose physical pixel width (width * density) is a whole
+// number — so Readium's paginated column-snap pitch b = physicalWidth/dpr equals CSS innerWidth
+// and the column grid stops drifting (the right-margin-vanishes bug; see
+// reference_reader_right_margin_is_column_snap_bug). On integer densities (e.g. dpr 3.0) every
+// integer dp already maps to whole pixels, so this returns floor(availDp) — no gutter cost.
+//
+// The loop is bounded by the density's denominator: for a density p/q in lowest terms, c*density
+// is whole at every multiple of q, so a hit is found within q steps (Android densities are
+// small-denominator rationals, e.g. 2.625 = 21/8). If none is found the floored width is returned
+// — never the raw fractional availDp, which would reintroduce the drift this function exists to
+// kill.
+internal fun alignedReaderWidthDp(availDp: Float, density: Float): Float {
+    if (!availDp.isFinite() || availDp <= 0f || density <= 0f) return availDp
+    var c = floor(availDp).toInt()
+    while (c > 0) {
+        val px = c * density
+        if (abs(px - px.roundToInt()) < 0.001f) return c.toFloat()
+        c--
+    }
+    return floor(availDp)
+}

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/AlignedReaderWidthTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/AlignedReaderWidthTest.kt
@@ -1,0 +1,57 @@
+package com.riffle.app.feature.reader
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import kotlin.math.abs
+import kotlin.math.roundToInt
+
+/**
+ * [alignedReaderWidthDp] sizes the paginated reflowable reader so Readium's column-snap pitch
+ * b = physicalWidth/dpr lands on a whole number equal to CSS innerWidth, killing the right-margin
+ * drift (reference_reader_right_margin_is_column_snap_bug). The chosen width must therefore map to a
+ * whole number of physical pixels, never exceed the available width, and cost nothing on the
+ * integer densities most phones use.
+ */
+class AlignedReaderWidthTest {
+
+    /** Medium-Phone API-25: 1080px / density 2.625 = 411.43dp available. */
+    @Test
+    fun `picks largest whole-pixel width on density 2_625`() {
+        // 408 * 2.625 = 1071.0 (whole); 409..411 * 2.625 are fractional.
+        assertEquals(408f, alignedReaderWidthDp(availDp = 1080f / 2.625f, density = 2.625f))
+    }
+
+    @Test
+    fun `chosen width maps to a whole number of physical pixels`() {
+        val density = 2.625f
+        val px = alignedReaderWidthDp(availDp = 1080f / density, density = density) * density
+        assertTrue("expected whole px, got $px", abs(px - px.roundToInt()) < 0.001f)
+    }
+
+    @Test
+    fun `never exceeds the available width`() {
+        val avail = 1080f / 2.625f
+        assertTrue(alignedReaderWidthDp(avail, 2.625f) <= avail)
+    }
+
+    @Test
+    fun `costs nothing on integer densities`() {
+        // density 3.0: every integer dp is already a whole pixel, so the full floor(avail) is kept.
+        assertEquals(411f, alignedReaderWidthDp(availDp = 411.4f, density = 3f))
+        assertEquals(411f, alignedReaderWidthDp(availDp = 411.4f, density = 2f))
+        assertEquals(411f, alignedReaderWidthDp(availDp = 411.4f, density = 1f))
+    }
+
+    @Test
+    fun `aligns to the density denominator on quarter densities`() {
+        // density 2.75 = 11/4 -> only multiples of 4 dp are whole pixels; 408 is the largest <= 411.
+        assertEquals(408f, alignedReaderWidthDp(availDp = 411.4f, density = 2.75f))
+    }
+
+    @Test
+    fun `returns input unchanged for non-positive arguments`() {
+        assertEquals(0f, alignedReaderWidthDp(availDp = 0f, density = 2.625f))
+        assertEquals(411.4f, alignedReaderWidthDp(availDp = 411.4f, density = 0f))
+    }
+}


### PR DESCRIPTION
## Problem

Reflowable EPUB pages lost their right margin deep into long chapters: the whole justified column drifted right (left margin grew, right margin → 0, text clipping at the right edge under justify). Reproduced on "Influence without authority" (Medium-Phone API-25, dpr 2.625).

## Root cause

Readium snaps horizontal scroll to multiples of `b = getViewportWidth()/dpr`, while the CSS column pitch is `innerWidth`. On a non-integer dpr (e.g. 2.625) these differ — `1080/2.625 = 411.43` vs `innerWidth = 412` — so each page sits ~0.57px off-grid and the error **accumulates** within a chapter (resets at each chapter's first page, which is why short-chapter books look fine).

## Fix

In **single-page paginated reflowable mode only**, constrain the reader `AndroidView` to the largest dp width whose physical pixel size is whole (dpr 2.625 → `408dp = 1071px`), centered, so `b == innerWidth = 408` and the column grid never drifts. Unlike a post-hoc scroll re-snap, page turns land on-grid **in the first place** — no visible page-turn jump. Cost is a sub-perceptible symmetric gutter (~1.7 CSS px/side), painted with the page background so it's invisible.

- `alignedReaderWidthDp(availDp, density)` — pure helper in its own file (`ReaderViewportAlignment.kt`), unit-tested.
- Scroll, fixed-layout, and double-page modes keep `fillMaxSize` and the bare modifier — untouched.
- `ScrollBoundaryNavigationContainer` logic is not modified (layout-only change around it).

## Testing

- **Unit** (`AlignedReaderWidthTest`, 6 cases): largest whole-pixel width, maps to whole px, never exceeds available, zero cost on integer densities, quarter-density alignment, non-positive-arg guard.
- `./gradlew test` + `./gradlew lint`: green.
- `make harness-test` (135 tests) + `make harness-test-tablet` (5 tests): green.
- **On-device** (Medium-Phone API-25): paginated → `androidViewportWidth 1071`, `innerWidth = b = 408`; deep pages 0px off-grid, symmetric 20/20; real swipe page-turn lands on-grid with no jump. Scroll mode verified full-width / unaffected.