### PR TITLE
fix(readaloud): match titles where a colon is part of the work name

### DIFF
--- a/core/domain/src/main/kotlin/com/riffle/core/domain/ReadaloudMatcher.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/ReadaloudMatcher.kt
@@ -71,13 +71,12 @@ object ReadaloudMatcher {
             return MatchOutcome.Confirmed(identifierHits.map { it.confirmed() })
         }
 
-        val bookTitle = normaliseTitle(book.title)
-        val bookTitleTokens = titleTokens(book.title)
+        val bookTitleForms = titleForms(book.title)
         val bookAuthorTokens = authorTokens(book.author)
-        if (bookTitle.isEmpty() || bookAuthorTokens.isEmpty()) return MatchOutcome.Unmatched
+        if (bookTitleForms.all { it.isEmpty() } || bookAuthorTokens.isEmpty()) return MatchOutcome.Unmatched
 
         val titleAuthorHits = candidates.filter {
-            normaliseTitle(it.title) == bookTitle &&
+            titlesMatchExactly(bookTitleForms, titleForms(it.title)) &&
                 authorsOverlap(bookAuthorTokens, authorTokens(it.author))
         }
         if (titleAuthorHits.isNotEmpty()) {
@@ -85,7 +84,7 @@ object ReadaloudMatcher {
         }
 
         val fuzzy = candidates.mapNotNull { candidate ->
-            val titleSim = diceSimilarity(bookTitleTokens, titleTokens(candidate.title))
+            val titleSim = bestTitleSimilarity(bookTitleForms, titleForms(candidate.title))
             val authorSim = diceSimilarity(bookAuthorTokens, authorTokens(candidate.author))
             if (titleSim >= FUZZY_THRESHOLD && authorSim >= FUZZY_THRESHOLD) {
                 ScoredCandidate(candidate.serverUuid, candidate.libraryItemId, (titleSim + authorSim) / 2.0)
@@ -146,19 +145,31 @@ object ReadaloudMatcher {
         return stripped.ifEmpty { null }?.uppercase()
     }
 
+    /** Tier 2: titles match iff any normalised form on one side equals a form on the other. */
+    private fun titlesMatchExactly(a: Set<List<String>>, b: Set<List<String>>): Boolean =
+        a.any { it.isNotEmpty() && it in b }
+
+    /** Tier 3: best token-set similarity across every pairing of the two sides' title forms. */
+    private fun bestTitleSimilarity(a: Set<List<String>>, b: Set<List<String>>): Double =
+        a.maxOf { x -> b.maxOf { y -> diceSimilarity(x.toSet(), y.toSet()) } }
+
     /**
-     * Ordered, normalised title used for Tier 2 exact comparison. Strips the subtitle (anything
-     * after the first `:` or em-dash — Storyteller keeps the OPF "A Novel"-style subtitle that ABS
-     * users curate out), lowercases, strips punctuation, and drops a single leading article.
+     * The normalised, ordered token forms of a title to compare against. Two are produced: the
+     * **full** title and the **subtitle-stripped head** (text before the first `:` or em-dash).
+     *
+     * Stripping the head rescues "The Martian: A Novel" ↔ "The Martian" — Storyteller keeps the
+     * OPF "A Novel"-style subtitle that ABS users curate out. But a colon is not always a subtitle
+     * separator: in "2001: A Space Odyssey" it is part of the work's name, and the head form
+     * collapses to "2001", which matches nothing. Keeping both forms — and matching if *any* form
+     * on one side aligns with *any* on the other — handles both cases without having to guess which
+     * interpretation of the colon is correct. Each form lowercases, strips punctuation, and drops a
+     * single leading article.
      */
-    private fun normaliseTitle(raw: String): String = titleTokenList(raw).joinToString(" ")
+    private fun titleForms(raw: String): Set<List<String>> =
+        setOf(normaliseTokens(raw), normaliseTokens(raw.split(':', '—').first()))
 
-    /** Token set form of [normaliseTitle], used for Tier 3 token-set similarity. */
-    private fun titleTokens(raw: String): Set<String> = titleTokenList(raw).toSet()
-
-    private fun titleTokenList(raw: String): List<String> {
-        val head = raw.split(':', '—').first()
-        val tokens = head.lowercase()
+    private fun normaliseTokens(raw: String): List<String> {
+        val tokens = raw.lowercase()
             .map { if (it.isLetterOrDigit() || it.isWhitespace()) it else ' ' }
             .joinToString("")
             .split(Regex("\\s+"))

--- a/core/domain/src/test/kotlin/com/riffle/core/domain/ReadaloudMatcherTest.kt
+++ b/core/domain/src/test/kotlin/com/riffle/core/domain/ReadaloudMatcherTest.kt
@@ -141,6 +141,30 @@ class ReadaloudMatcherTest {
     }
 
     @Test
+    fun `colon that is part of the work name still matches the full title`() {
+        // Real data: ABS "2001: A Space Odyssey" vs Storyteller "2001. A Space Odyssey". The
+        // colon here is part of the title, not a "A Novel"-style subtitle, so stripping it to
+        // "2001" loses everything that discriminates the book. The full forms align exactly.
+        val book = storytellerBook(title = "2001. A Space Odyssey", author = "Arthur C. Clarke")
+        val abs = absItem(title = "2001: A Space Odyssey", author = "Arthur C. Clarke")
+
+        assertEquals(confirmed("abs-1" to "item-1"), ReadaloudMatcher.match(book, listOf(abs)))
+    }
+
+    @Test
+    fun `colon subtitle still matches when both sides carry it`() {
+        // Stripping must remain available: "A Dance with Dragons: A Song of Ice and Fire: Book
+        // Five" on the Storyteller side vs the bare ABS title still pairs via the head form.
+        val book = storytellerBook(
+            title = "A Dance with Dragons: A Song of Ice and Fire: Book Five",
+            author = "George R.R. Martin",
+        )
+        val abs = absItem(title = "A Dance with Dragons", author = "George R.R. Martin")
+
+        assertEquals(confirmed("abs-1" to "item-1"), ReadaloudMatcher.match(book, listOf(abs)))
+    }
+
+    @Test
     fun `leading article on one side does not block title match`() {
         val book = storytellerBook(title = "The Dragons of Eden", author = "Carl Sagan")
         val abs = absItem(title = "Dragons of Eden", author = "Carl Sagan")


### PR DESCRIPTION
## Problem

\"2001: A Space Odyssey\" never matched its readaloud — it landed in **Unmatched** instead of auto-confirming against its Audiobookshelf counterpart.

Ground-truth metadata from the test servers:

| Side | Raw title | Old normalised title |
|------|-----------|----------------------|
| ABS | `2001: A Space Odyssey` | `2001` ← colon stripped, all content lost |
| Storyteller | `2001. A Space Odyssey` | `2001 a space odyssey` |

The title normaliser stripped everything after the first `:`/`—` as a disposable \"A Novel\"-style subtitle. For `2001: A Space Odyssey` the colon is part of the work's name, so stripping collapsed the title to `2001` and discarded every discriminating token. Tier 2 (exact) failed; Tier 3 (fuzzy) scored Dice `2·1/(1+4) = 0.40`, far below the 0.85 threshold → **Unmatched**.

## Fix

Stop guessing whether a colon introduces a subtitle. `titleForms()` now produces **both** the full title and the subtitle-stripped head, and a title matches if **any** form on one side aligns with any on the other (`titlesMatchExactly` for Tier 2, `bestTitleSimilarity` taking the max across pairings for Tier 3).

- Keeps the `The Martian: A Novel` ↔ `The Martian` rescue working (head form).
- Also pairs `2001: A Space Odyssey`, where both sides normalise identically to `2001 a space odyssey` (full form).
- Strictly **additive**: can only introduce matches where the full forms genuinely agree, never remove existing ones. Verified no new false positives and no empty-set exceptions.

## Tests

- Added a regression test from the real 2001 data (red → green) plus a guard test ensuring subtitle stripping still works when both sides carry the colon.
- `./gradlew test` — ✅ BUILD SUCCESSFUL
- `./gradlew lint` — ✅ BUILD SUCCESSFUL
- Harness tests skipped (per request).