### PR TITLE
fix(readaloud): match audiobook editions tagged with a trailing format qualifier

### DIFF
--- a/core/domain/src/main/kotlin/com/riffle/core/domain/ReadaloudMatcher.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/ReadaloudMatcher.kt
@@ -154,19 +154,31 @@ object ReadaloudMatcher {
         a.maxOf { x -> b.maxOf { y -> diceSimilarity(x.toSet(), y.toSet()) } }
 
     /**
-     * The normalised, ordered token forms of a title to compare against. Two are produced: the
-     * **full** title and the **subtitle-stripped head** (text before the first `:` or em-dash).
+     * The normalised, ordered token forms of a title to compare against. For each of two raw
+     * variants — the title as given and the title with any **trailing parenthetical qualifier**
+     * removed — two forms are produced: the **full** title and the **subtitle-stripped head**
+     * (text before the first `:` or em-dash).
      *
      * Stripping the head rescues "The Martian: A Novel" ↔ "The Martian" — Storyteller keeps the
      * OPF "A Novel"-style subtitle that ABS users curate out. But a colon is not always a subtitle
      * separator: in "2001: A Space Odyssey" it is part of the work's name, and the head form
      * collapses to "2001", which matches nothing. Keeping both forms — and matching if *any* form
      * on one side aligns with *any* on the other — handles both cases without having to guess which
-     * interpretation of the colon is correct. Each form lowercases, strips punctuation, and drops a
-     * single leading article.
+     * interpretation of the colon is correct.
+     *
+     * Dropping a trailing "(Dramatized)"/"(Unabridged)"-style qualifier is the audiobook analogue:
+     * ABS tags an audiobook edition "The Hobbit (Dramatized)" while the Storyteller readaloud is
+     * plain "The Hobbit". The qualifier is always trailing, so it is removed before the rest of the
+     * normalisation rather than being treated as a subtitle. Each form lowercases, strips
+     * punctuation, and drops a single leading article.
      */
     private fun titleForms(raw: String): Set<List<String>> =
-        setOf(normaliseTokens(raw), normaliseTokens(raw.split(':', '—').first()))
+        setOf(raw, raw.replace(TRAILING_PARENTHETICAL, "")).flatMap { variant ->
+            listOf(normaliseTokens(variant), normaliseTokens(variant.split(':', '—').first()))
+        }.toSet()
+
+    /** One or more trailing parenthesised groups, e.g. the " (Dramatized)" in "The Hobbit (Dramatized)". */
+    private val TRAILING_PARENTHETICAL = Regex("(\\s*\\([^)]*\\))+\\s*$")
 
     private fun normaliseTokens(raw: String): List<String> {
         val tokens = raw.lowercase()

--- a/core/domain/src/test/kotlin/com/riffle/core/domain/ReadaloudMatcherTest.kt
+++ b/core/domain/src/test/kotlin/com/riffle/core/domain/ReadaloudMatcherTest.kt
@@ -165,6 +165,43 @@ class ReadaloudMatcherTest {
     }
 
     @Test
+    fun `trailing format parenthetical on the ABS audiobook still matches`() {
+        // Real data: Storyteller readaloud "The Hobbit" must link to its ABS audiobook entry
+        // "The Hobbit (Dramatized)" as well as the bare-titled ebook. ABS tags audiobook
+        // editions with a trailing "(Dramatized)"/"(Unabridged)"-style qualifier the Storyteller
+        // side never carries; it is the audiobook analogue of a stripped "A Novel" subtitle.
+        val book = storytellerBook(title = "The Hobbit", author = "J. R. R. Tolkien")
+        val abs = absItem(title = "The Hobbit (Dramatized)", author = "J. R. R. Tolkien")
+
+        assertEquals(confirmed("abs-1" to "item-1"), ReadaloudMatcher.match(book, listOf(abs)))
+    }
+
+    @Test
+    fun `ebook and parenthetical audiobook both match the same readaloud`() {
+        // The whole point of the multiplicity model: one readaloud links to its ebook *and* its
+        // audiobook, even though only the audiobook carries the format qualifier.
+        val book = storytellerBook(title = "The Hobbit", author = "J. R. R. Tolkien")
+        val ebook = absItem(serverUuid = "abs-1", libraryItemId = "ebook", title = "The Hobbit", author = "J. R. R. Tolkien")
+        val audio = absItem(serverUuid = "abs-1", libraryItemId = "audio", title = "The Hobbit (Dramatized)", author = "J. R. R. Tolkien")
+
+        val result = ReadaloudMatcher.match(book, listOf(ebook, audio))
+
+        assertEquals(setOf(Confirmed("abs-1", "ebook"), Confirmed("abs-1", "audio")), confirmedLinks(result))
+    }
+
+    @Test
+    fun `trailing parenthetical strips while a title-internal colon is preserved`() {
+        // The qualifier must come off without the colon-head form swallowing the work name:
+        // "2001: A Space Odyssey (Unabridged)" must still align with the full "2001: A Space
+        // Odyssey", which only the parenthetical-stripped *full* form provides (the colon-head
+        // collapses to "2001").
+        val book = storytellerBook(title = "2001: A Space Odyssey", author = "Arthur C. Clarke")
+        val abs = absItem(title = "2001: A Space Odyssey (Unabridged)", author = "Arthur C. Clarke")
+
+        assertEquals(confirmed("abs-1" to "item-1"), ReadaloudMatcher.match(book, listOf(abs)))
+    }
+
+    @Test
     fun `leading article on one side does not block title match`() {
         val book = storytellerBook(title = "The Dragons of Eden", author = "Carl Sagan")
         val abs = absItem(title = "Dragons of Eden", author = "Carl Sagan")


### PR DESCRIPTION
## Problem

Some Storyteller readalouds matched their **ebook** in ABS but not the **audiobook**, leaving the audiobook slot unlinked. The matcher is meant to link a readaloud to *every* ABS item sharing its metadata (ebook + audiobook), but ABS tags audiobook editions with a trailing format qualifier the Storyteller side never carries — e.g. `The Hobbit (Dramatized)` vs the readaloud's plain `The Hobbit`. The extra `(Dramatized)` token blocked both the Tier-2 exact match and the Tier-3 fuzzy match (dice ≈ 0.67 < 0.85), so the audiobook fell through to Unmatched.

## Fix

`ReadaloudMatcher.titleForms` now also emits a variant with any **trailing parenthetical group** removed (`(Dramatized)`, `(Unabridged)`, `(Hardcover)`, …) — the audiobook analogue of the existing colon-head subtitle strip. The original forms are kept, so this can only *add* candidate forms, never drop an existing match. Author overlap is still required, preserving the ADR-0021 "avoid wrong matches" guard.

## Tests

- `core/domain` `ReadaloudMatcherTest`: bare Hobbit case, ebook+audiobook multiplicity case, and a composition test (`2001: A Space Odyssey (Unabridged)`) proving the qualifier strips while a title-internal colon survives. Verified red → green.
- `./gradlew test` ✅ · `./gradlew lint` ✅ · harness skipped for this domain-only change.

## Not covered

`The Fellowship of the Ring`'s audiobook is titled `The Lord of the Rings` with the real name only in the ABS `subtitle` field, which Riffle does not fetch or store. Matching it needs a separate subtitle pipeline + Room migration — left out of scope here.