### PR TITLE
fix(reader): reflow paginated text above the readaloud player via live CSS re-pagination

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -54,6 +54,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
@@ -234,6 +235,20 @@ fun EpubReaderScreen(
     val readaloudOfflineMessage by viewModel.readaloudOfflineMessage.collectAsState()
     val downloadProgress by viewModel.downloadProgress.collectAsState()
 
+    // Measured height (px) of the floating bottom overlay stack (readaloud player + chapter rail).
+    // While the player is open AND the reader is paginated, that height is reserved as bottom padding
+    // inside the page so Readium re-paginates the text above the player — the bug where, in landscape
+    // especially, the player covered the last lines. The reserve is injected as CSS (live re-pagination,
+    // see ReadaloudReserve.kt); a native resize would be ignored once the page is laid out. Scroll mode
+    // and a closed player reserve nothing — the page renders edge to edge.
+    var bottomOverlayHeightPx by remember { mutableStateOf(0) }
+    val density = LocalDensity.current
+    val readaloudReservePx: Int = readaloudReserveCssPx(
+        playerOpen = readaloudOpen,
+        paginated = formattingPrefs.orientation != ReaderOrientation.Vertical,
+        overlayHeightDp = bottomOverlayHeightPx / density.density,
+    )
+
     // TopAppBar floats as an overlay so its show/hide never resizes the content area —
     // eliminates the compound flicker that Scaffold's topBar slot caused by reflowing the
     // WebView simultaneously with the system-bar animation.
@@ -289,6 +304,7 @@ fun EpubReaderScreen(
                         annotationsAvailable = annotationsAvailable,
                         highlightRenders = highlightRenders,
                         onHighlight = viewModel::createHighlight,
+                        readaloudReservePx = readaloudReservePx,
                         modifier = Modifier
                             .fillMaxSize()
                             .testTag("reader_ready")
@@ -338,7 +354,11 @@ fun EpubReaderScreen(
                     formattingPrefs.showCurrentChapterLabel
                 )
         if (state is ReaderState.Ready && (readaloudOpen || showRailOverlay)) {
-            Column(modifier = Modifier.align(Alignment.BottomCenter)) {
+            Column(
+                modifier = Modifier
+                    .align(Alignment.BottomCenter)
+                    .onSizeChanged { bottomOverlayHeightPx = it.height },
+            ) {
                 if (readaloudOpen) {
                     // Reference the reader-theme palette so the player matches the chapter-rail
                     // overlay backdrop (which paints readerTheme.palette.background) and the two
@@ -701,6 +721,7 @@ private fun EpubNavigatorView(
     annotationsAvailable: Boolean,
     highlightRenders: List<EpubReaderViewModel.HighlightRender>,
     onHighlight: (Locator) -> Unit,
+    readaloudReservePx: Int = 0,
     modifier: Modifier = Modifier,
 ) {
     val context = LocalContext.current
@@ -732,6 +753,9 @@ private fun EpubNavigatorView(
     val currentOnHighlight by rememberUpdatedState(onHighlight)
     val currentAnnotationsAvailable by rememberUpdatedState(annotationsAvailable)
     val currentPublication by rememberUpdatedState(state.publication)
+    // Latest readaloud bottom reserve, read inside the (remembered-once) pagination listener so each
+    // freshly loaded page re-applies the current value.
+    val currentReadaloudReservePx by rememberUpdatedState(readaloudReservePx)
 
     // The text-selection action bar is fully owned by this callback (Readium 3.0.0's
     // selectionActionModeCallback is the only supported hook, and it replaces the WebView's default
@@ -861,9 +885,11 @@ private fun EpubNavigatorView(
         }
     }
 
-    // Bumps whenever a formatting change reflows the layout so the decoration effects below re-apply
-    // onto the new layout (see rememberReflowReapplyGeneration for why).
-    val reflowGeneration = rememberReflowReapplyGeneration(formattingPrefs)
+    // Bumps whenever a formatting change OR a readaloud reserve change reflows the layout so the
+    // decoration effects below re-apply onto the new pagination (see rememberReflowReapplyGeneration).
+    // Opening/closing the player re-paginates, which moves the narrated sentence's column — the
+    // highlight and auto-follow must re-run against the new layout.
+    val reflowGeneration = rememberReflowReapplyGeneration(formattingPrefs to readaloudReservePx)
 
     // Injects, into each newly loaded reflowable page: the ClientRect.toJSON polyfill (see
     // RECT_TO_JSON_POLYFILL_JS), the selection-span tracker (SELECTION_SPAN_TRACKER_JS), the targeted
@@ -884,8 +910,24 @@ private fun EpubNavigatorView(
                     // reflows the page asynchronously, so a snap at this point rounds a pre-reflow
                     // position and lands close-but-not-exact. The post-go() snap in the navigation
                     // handlers runs after the reflow has settled and is the authoritative one.
+                    // Reserve the bottom strip for the readaloud player on this freshly loaded page
+                    // (paginated only; see ReadaloudReserve.kt). Inject the rule, then apply the
+                    // current value so the page lands already paginated above the player.
+                    fragment.evaluateJavascript(readaloudReserveInjectionJs())
+                    fragment.evaluateJavascript(readaloudReserveApplyJs(currentReadaloudReservePx))
                 }
             }
+        }
+    }
+
+    // Push the readaloud reserve to the live page the moment it changes (player opens/closes, rail
+    // toggles, rotation) so the text re-paginates above the player without waiting for a page reload.
+    // The decoration/auto-follow effects re-run via reflowGeneration, which also keys on the reserve.
+    LaunchedEffect(readaloudReservePx) {
+        val fragment = fragmentRef.value ?: return@LaunchedEffect
+        withContext(Dispatchers.Main) {
+            fragment.evaluateJavascript(readaloudReserveInjectionJs())
+            fragment.evaluateJavascript(readaloudReserveApplyJs(readaloudReservePx))
         }
     }
 
@@ -1114,7 +1156,10 @@ private fun EpubNavigatorView(
     //
     // A missing element (sentence in another chapter's document) reads as "off" → go(locator) jumps
     // chapters, so cross-chapter follow falls out for free in both modes.
-    LaunchedEffect(activeFragmentRef, sentenceQuotes) {
+    //
+    // Re-keys on reflowGeneration so that when opening the player re-paginates the page, the snap
+    // re-runs and re-centres the narrated sentence's (now moved) column.
+    LaunchedEffect(activeFragmentRef, sentenceQuotes, reflowGeneration) {
         val ref = activeFragmentRef ?: return@LaunchedEffect
         val fragment = fragmentRef.value ?: return@LaunchedEffect
         if (ref.indexOf('#') < 0) return@LaunchedEffect

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ReadaloudReserve.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ReadaloudReserve.kt
@@ -1,0 +1,105 @@
+package com.riffle.app.feature.reader
+
+import kotlin.math.roundToInt
+
+// Reserves a bottom strip in the paginated reader while the readaloud mini-player is open, so the
+// player (and the chapter rail beneath it) no longer float over live text — the bug where the
+// player covered the last lines, worst in landscape.
+//
+// HOW: the reserve is injected as extra `padding-bottom` on `:root` — the same lever the page-margin
+// override uses (see TypographyOverride.kt's "margins" entry). Padding on the multicol container
+// shrinks every column's height, so Readium re-paginates *live* with the last lines lifted above the
+// player. This is the only thing that reflows post-creation: a native WebView resize (Compose padding
+// or View.setPadding) is ignored once the page is laid out, but a CSS change reflows immediately,
+// exactly like the formatting panel's margin slider (submitPreferences).
+//
+// PAGINATED ONLY: scroll/vertical mode needs no reserve — text there isn't pinned to a page, so
+// anything under the player is one small scroll away. Scoping to paginated also avoids re-enabling
+// the inset path that caused the scroll-mode cutout band (shouldApplyInsetsPadding = false).
+
+/** Stable element id for the injected `<style>` so repeated injections don't accumulate. */
+private const val RESERVE_STYLE_ID = "riffle-readaloud-reserve"
+
+/** Class toggled on `<html>` to activate the reserve rule, and the CSS var carrying its height. */
+private const val RESERVE_ACTIVE_CLASS = "riffle-ra-on"
+private const val RESERVE_VAR = "--riffle-ra-reserve"
+
+/**
+ * CSS-px bottom reserve (≈ dp; WebView CSS-px == dp since both divide device-px by the same
+ * density/devicePixelRatio) to hold the floating player+rail clear of the text. Zero — i.e. no
+ * reserve — unless the player is open AND the reader is paginated. The visible *gap* above the
+ * player is added by the CSS itself (the page's own bottom margin), so this is just the height of
+ * the floating stack that must be cleared.
+ */
+internal fun readaloudReserveCssPx(
+    playerOpen: Boolean,
+    paginated: Boolean,
+    overlayHeightDp: Float,
+): Int {
+    if (!playerOpen || !paginated) return 0
+    return overlayHeightDp.coerceAtLeast(0f).roundToInt()
+}
+
+/**
+ * The reserve rule. Active only while `<html>` carries [RESERVE_ACTIVE_CLASS]. The bottom padding is
+ * the page's own bottom margin (same calc as the margins override, so the gap above the player tracks
+ * the user's margin setting) PLUS the floating-stack height carried in [RESERVE_VAR]. The doubled
+ * `:root` raises specificity to (0,3,0) so it beats both Readium's `:root{padding:0}` (0,1,0) and the
+ * margins override (0,2,0) regardless of source order. `--USER__pageMargins` defaults to 1 so the
+ * `calc()` stays valid on books left at the default margin (an unset var with no fallback would void
+ * the whole declaration and drop the reserve).
+ */
+internal fun readaloudReserveCss(): String =
+    """
+    :root.$RESERVE_ACTIVE_CLASS:root {
+      padding-bottom: calc(
+        var(--RS__pageGutter, 8px) * var(--USER__pageMargins, 1) + var($RESERVE_VAR, 0px)
+      ) !important;
+    }
+    """.trimIndent()
+
+/**
+ * Idempotently injects [readaloudReserveCss] as a `<style>` in `document.head`. Re-run on every page
+ * load (each resource is a fresh document); the stable id prevents duplicates.
+ */
+internal fun readaloudReserveInjectionJs(): String {
+    val css = readaloudReserveCss()
+        .replace("\\", "\\\\")
+        .replace("`", "\\`")
+        .replace("\$", "\\\$")
+    return """
+        (function() {
+          var id = '$RESERVE_STYLE_ID';
+          if (document.getElementById(id)) return;
+          var style = document.createElement('style');
+          style.id = id;
+          style.textContent = `$css`;
+          document.head.appendChild(style);
+        })();
+    """.trimIndent()
+}
+
+/**
+ * Toggles the reserve on the live document: sets the height var and activates the rule when
+ * [reserveCssPx] > 0, or clears both when it's 0. Setting/removing the var reflows the page
+ * immediately — no fragment recreation. Re-run on page load (to re-apply to the new document) and
+ * whenever the reserve changes (player opens/closes, rotation, rail visibility).
+ */
+internal fun readaloudReserveApplyJs(reserveCssPx: Int): String =
+    if (reserveCssPx > 0) {
+        """
+        (function() {
+          var d = document.documentElement;
+          d.style.setProperty('$RESERVE_VAR', '${reserveCssPx}px');
+          d.classList.add('$RESERVE_ACTIVE_CLASS');
+        })();
+        """.trimIndent()
+    } else {
+        """
+        (function() {
+          var d = document.documentElement;
+          d.classList.remove('$RESERVE_ACTIVE_CLASS');
+          d.style.removeProperty('$RESERVE_VAR');
+        })();
+        """.trimIndent()
+    }

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ReadaloudReserveTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ReadaloudReserveTest.kt
@@ -1,0 +1,70 @@
+package com.riffle.app.feature.reader
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ReadaloudReserveTest {
+
+    @Test
+    fun `no reserve when player closed`() {
+        assertEquals(0, readaloudReserveCssPx(playerOpen = false, paginated = true, overlayHeightDp = 120f))
+    }
+
+    @Test
+    fun `no reserve in scroll mode even with player open`() {
+        // Scroll/vertical mode: text isn't pinned to a page, so the player covering the bottom
+        // sliver is a non-issue (one small scroll reveals it). Deliberately reserves nothing.
+        assertEquals(0, readaloudReserveCssPx(playerOpen = true, paginated = false, overlayHeightDp = 120f))
+    }
+
+    @Test
+    fun `reserves the overlay height when player open and paginated`() {
+        assertEquals(120, readaloudReserveCssPx(playerOpen = true, paginated = true, overlayHeightDp = 120f))
+    }
+
+    @Test
+    fun `rounds fractional dp to nearest css px`() {
+        assertEquals(117, readaloudReserveCssPx(playerOpen = true, paginated = true, overlayHeightDp = 116.6f))
+        assertEquals(116, readaloudReserveCssPx(playerOpen = true, paginated = true, overlayHeightDp = 116.4f))
+    }
+
+    @Test
+    fun `negative measured height clamps to zero`() {
+        assertEquals(0, readaloudReserveCssPx(playerOpen = true, paginated = true, overlayHeightDp = -5f))
+    }
+
+    @Test
+    fun `apply js activates rule and sets var when reserve positive`() {
+        val js = readaloudReserveApplyJs(140)
+        assertTrue(js.contains("classList.add('riffle-ra-on')"))
+        assertTrue(js.contains("setProperty('--riffle-ra-reserve', '140px')"))
+    }
+
+    @Test
+    fun `apply js clears rule and var when reserve is zero`() {
+        val js = readaloudReserveApplyJs(0)
+        assertTrue(js.contains("classList.remove('riffle-ra-on')"))
+        assertTrue(js.contains("removeProperty('--riffle-ra-reserve')"))
+    }
+
+    @Test
+    fun `reserve css composes the page margin with the floating-stack height`() {
+        val css = readaloudReserveCss()
+        // gap above the player == the page's own bottom margin (scales with --USER__pageMargins),
+        // plus the floating stack height carried in the var.
+        assertTrue(css.contains("var(--RS__pageGutter"))
+        assertTrue(css.contains("var(--USER__pageMargins, 1)"))
+        assertTrue(css.contains("var(--riffle-ra-reserve, 0px)"))
+        assertTrue(css.contains("padding-bottom"))
+        // gated on the active class, doubled :root to win specificity over the margins override
+        assertTrue(css.contains(":root.riffle-ra-on:root"))
+    }
+
+    @Test
+    fun `injection js is idempotent by stable id`() {
+        val js = readaloudReserveInjectionJs()
+        assertTrue(js.contains("'riffle-readaloud-reserve'"))
+        assertTrue(js.contains("if (document.getElementById(id)) return"))
+    }
+}


### PR DESCRIPTION
## Problem

The readaloud mini-player floats over the bottom of the reader and covered the last lines of prose — worst in landscape, where the reduced height left only a few lines visible under the player.

## Fix

Reserve a bottom strip **only while the player is open and the reader is paginated**, so the page reflows above it. When the player is closed, or in scroll/vertical mode, the page stays edge-to-edge (scroll mode needs no reserve — text isn't pinned to a page, so anything under the player is one small scroll away).

The reserve is injected as extra `padding-bottom` on `:root` via `evaluateJavascript` — the same idempotent `<style>` pattern as `TypographyOverride`, and the same lever the page-margin override uses. Padding the multicol container shrinks each column's height, so Readium **re-paginates live**.

### Why CSS and not a native resize

Readium's paginated WebView ignores a post-creation native resize — Compose modifier padding and `View.setPadding` both leave `window.innerHeight` at full screen (the player opens *after* the reader is built, so resize approaches don't reflow). A CSS change reflows immediately, exactly like the formatting panel's margin slider (`submitPreferences`). This replaces the earlier non-working Compose-padding attempt.

### Details

- Gap above the player tracks the user's page-margin setting (`--RS__pageGutter * --USER__pageMargins`) plus the floating-stack height carried in a CSS var.
- Doubled `:root.riffle-ra-on:root` (specificity 0,3,0) beats Readium's `:root{padding:0}` and the margins override.
- Folded into `reflowGeneration` so the readaloud highlight re-applies after reflow, and added to the auto-follow key so the narrated sentence re-snaps to its column.

## Testing

- `ReadaloudReserveTest` — 9/9 (closed/scroll → 0, height when open+paginated, rounding, negative clamp, apply-JS toggle, CSS composition, idempotent injection).
- Full JVM `test` + `lint` green.
- Harness suite 151/152 — lone failure is the documented pre-existing `AutoFollowJsTest.paginatedSnapsToTheColumnContainingTheSentence` (fails on `main` too).
- **Device-verified core mechanism** (real Readium WebView, paginated): the exact production CSS+class+var set `padding-bottom` 0→320px and the text reflowed above the strip; removing the class reverted to 0px / full height — live and reversible, no fragment recreation, no flash.

### Not yet exercised

The full in-app trigger (tap readaloud → player opens → reflow) was not driven on-device — the test emulator had ABS but no Storyteller-matched readaloud book. That last link (Compose state → `evaluateJavascript`) is unit-tested and wired identically to the proven typography injection.
