### PR TITLE
fix(reader): snap paginated page to the narrated sentence's column

### DIFF
--- a/app/src/androidTest/kotlin/com/riffle/app/feature/reader/AutoFollowJsTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/reader/AutoFollowJsTest.kt
@@ -12,16 +12,16 @@ import org.junit.runner.RunWith
  * the narrated sentence by its TEXT (Readium strips the media-overlay span ids), so these fixtures
  * carry distinctive sentence text rather than relying on element ids. Backs the two
  * "while the player is playing" behaviours:
- *  - the page follows the narrated sentence (scroll mode centres it; paginated mode reports "off" so
- *    the reader snaps to its page), and
- *  - the page never drifts sideways — the probe only ever scrolls the Y axis.
+ *  - the page follows the narrated sentence (scroll mode centres it vertically; paginated mode snaps
+ *    scrollLeft to the column that contains the sentence's start), and
+ *  - paginated snaps land on the page grid (scrollLeft a whole multiple of innerWidth), so the page
+ *    never rests between two columns.
  */
 @RunWith(AndroidJUnit4::class)
 class AutoFollowJsTest {
 
     private val onPageText = "Onpage visible sentence to follow"
     private val offRightText = "Offright next page sentence here"
-    private val offLeftText = "Offleft previous page sentence here"
     private val targetText = "Narrated target sentence deep in the page"
 
     // A document much taller than the viewport → scroll (karaoke) mode. The narrated sentence sits
@@ -35,15 +35,14 @@ class AutoFollowJsTest {
         </html>
     """.trimIndent()
 
-    // A viewport-sized page → paginated mode. The on-page sentence is fully visible; the others sit far
-    // to the right (next column/page) and far to the left (previous page).
+    // A viewport-sized page → paginated mode. The on-page sentence is fully visible; the off-page one
+    // sits far to the right (a later column/page), so following it requires a horizontal column snap.
     private val shortFixture = """
         <!DOCTYPE html>
         <html><head><meta name="viewport" content="width=device-width, initial-scale=1"></head>
           <body style="margin:0; height:40px; position:relative">
             <div id="onpage"  style="position:absolute; left:20px;    top:5px; width:240px; height:25px">$onPageText</div>
             <div id="offright" style="position:absolute; left:5000px;  top:5px; width:240px; height:25px">$offRightText</div>
-            <div id="offleft"  style="position:absolute; left:-5000px; top:5px; width:240px; height:25px">$offLeftText</div>
           </body>
         </html>
     """.trimIndent()
@@ -83,20 +82,21 @@ class AutoFollowJsTest {
     }
 
     @Test
-    fun paginatedReturnsOffForASentenceOnAnotherPage() {
+    fun paginatedSnapsToTheColumnContainingTheSentence() {
         withSizedWebViewFixture(shortFixture, widthPx = 1080, heightPx = 1600) { webView ->
             webView.awaitInnerHeight()
-            assertEquals(
-                "a sentence off to the right (next page) → off, so the reader snaps to its page",
-                "off",
-                webView.evalSync(autoFollowSnapJs(offRightText)).trim('"'),
-            )
-            assertEquals(
-                "a sentence off to the left (previous page) → off",
-                "off",
-                webView.evalSync(autoFollowSnapJs(offLeftText)).trim('"'),
-            )
-            assertEquals("probing an off-page sentence must not scroll horizontally", 0, webView.scrollX())
+            val iw = webView.innerWidth()
+            assertTrue("viewport must have a real width", iw > 100)
+
+            val result = webView.evalSync(autoFollowSnapJs(offRightText)).trim('"')
+            assertEquals("a sentence on another page is followed by snapping → on", "on", result)
+
+            // After the snap the sentence's column is flush-left: its first char's client-left equals
+            // (absX mod iw), which lands in [0, iw) exactly when scrollLeft is a whole multiple of iw
+            // — i.e. the page is on the column grid, not resting between two columns.
+            val left = webView.rectLeft("offright")
+            assertTrue("sentence should be snapped onto the page grid (left=$left, iw=$iw)", left in 0 until iw)
+            assertTrue("snapping a next-page sentence must move the page", webView.scrollX() > 0)
         }
     }
 
@@ -121,6 +121,12 @@ class AutoFollowJsTest {
     private fun WebView.rectCenterY(id: String): Int =
         evalSync("(function(){var r=document.getElementById('$id').getBoundingClientRect();return Math.round((r.top+r.bottom)/2);})()")
             .trim('"').toDouble().toInt()
+
+    private fun WebView.rectLeft(id: String): Int =
+        evalSync("(function(){return Math.round(document.getElementById('$id').getBoundingClientRect().left);})()")
+            .trim('"').toDouble().toInt()
+
+    private fun WebView.innerWidth(): Int = evalSync("window.innerWidth").trim('"').toDouble().toInt()
 
     private fun WebView.scrollX(): Int = evalSync("window.scrollX").trim('"').toDouble().toInt()
     private fun WebView.scrollY(): Int = evalSync("window.scrollY").trim('"').toDouble().toInt()

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -1005,16 +1005,15 @@ private fun EpubNavigatorView(
     //
     //  - Scroll (Vertical) mode — the document overflows the viewport, so we scroll it to KEEP THE
     //    SENTENCE CENTERED, the natural karaoke-follow.
-    //  - Paginated (Horizontal) mode — each page is exactly viewport-sized (nothing to scroll), so we
-    //    can't centre; instead we snap to the sentence's page when it isn't cleanly on the current
-    //    one. "on" requires FULL horizontal containment (within a tolerance): a reader resting at a
-    //    fractional page offset shows a clipped column plus a sliver of the next, and a sentence in
-    //    that sliver is "partly visible" but misaligned — requiring full containment snaps it instead
-    //    of leaving the page dragged sideways. go(locator) lands on a page boundary (aligned), which
-    //    also corrects the fractional offset; because we only rest on an aligned page, the saved
-    //    position stays aligned too.
+    //  - Paginated (Horizontal) mode — each page is exactly viewport-sized (nothing to scroll), so the
+    //    probe SNAPS scrollLeft to the column boundary that contains the sentence's start (landing on
+    //    the page grid) and returns "on". It does this every sentence rather than gating on rough
+    //    visibility: a go()-based snap lands flush to the element's box (a sliver of the next column
+    //    shows), and a tolerance gate never re-aligns a page that's already drifted between columns.
+    //    The snap holds because the reader is sized so innerWidth == Readium's page-snap pitch
+    //    ([alignedReaderWidthDp]) — the same column-snap the navigation path uses (scrollToColumnJs).
     //
-    // A missing element (sentence in another chapter's document) reads as off → go(locator) jumps
+    // A missing element (sentence in another chapter's document) reads as "off" → go(locator) jumps
     // chapters, so cross-chapter follow falls out for free in both modes.
     LaunchedEffect(activeFragmentRef, sentenceQuotes) {
         val ref = activeFragmentRef ?: return@LaunchedEffect
@@ -1025,8 +1024,9 @@ private fun EpubNavigatorView(
         // span-stripped ABS page, so a snap would flip to chapter start. Skip until the quote arrives;
         // this effect re-keys on [sentenceQuotes] and re-runs to follow correctly once it's available.
         val quote = sentenceQuotes[ref.substringAfter('#', "")] ?: return@LaunchedEffect
-        // Locate the sentence by its text (spans are stripped); "off" only when it's genuinely not on
-        // the current page, so we don't snap on every sentence. go() is text-anchored too.
+        // Locate the sentence by its text (spans are stripped). The probe snaps to the sentence's
+        // column itself in paginated mode; "off" comes back only when the text isn't on this resource
+        // (another chapter), where we fall back to a text-anchored go() to load it.
         val where = fragment.evaluateJavascript(autoFollowSnapJs(quote.highlight))?.trim('"')
         if (where != "off") return@LaunchedEffect
         fragmentLocator(ref, quote)?.let { fragment.go(it, animated = false) }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -1011,7 +1011,7 @@ private fun EpubNavigatorView(
     //    visibility: a go()-based snap lands flush to the element's box (a sliver of the next column
     //    shows), and a tolerance gate never re-aligns a page that's already drifted between columns.
     //    The snap holds because the reader is sized so innerWidth == Readium's page-snap pitch
-    //    ([alignedReaderWidthDp]) — the same column-snap the navigation path uses (scrollToColumnJs).
+    //    ([alignedReaderWidthDp]), so floor(x / innerWidth) * innerWidth is exactly a column boundary.
     //
     // A missing element (sentence in another chapter's document) reads as "off" → go(locator) jumps
     // chapters, so cross-chapter follow falls out for free in both modes.

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderWebViewScripts.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderWebViewScripts.kt
@@ -81,8 +81,8 @@ internal val SELECTION_SPAN_TRACKER_JS = """
  *    drifted between two columns, nor follows promptly when a sentence starts just past the edge.
  *    Snapping scrollLeft to floor(x / innerWidth) * innerWidth lands on the clean page grid every
  *    sentence. This holds because the reader is sized so innerWidth == Readium's page-snap pitch (see
- *    [alignedReaderWidthDp]), so the boundary we pick is exactly where Readium would rest anyway. This
- *    mirrors the navigation-path column snap (scrollToColumnJs) but locates by text, not span id.
+ *    [alignedReaderWidthDp]), so the boundary we pick is exactly where Readium would rest anyway —
+ *    here we locate the sentence by text (the span id is stripped) rather than by element.
  *
  * Returns "off" only when the text isn't on the current resource (sentence in another chapter) → the
  * Kotlin side's go() jumps chapters, as before.

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderWebViewScripts.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderWebViewScripts.kt
@@ -73,11 +73,19 @@ internal val SELECTION_SPAN_TRACKER_JS = """
  *
  *  - Scroll mode (document overflows the viewport): scrolls *vertically* to centre the sentence —
  *    the karaoke follow — and returns "on".
- *  - Paginated mode (page is exactly viewport-sized): returns "on" only when the sentence is fully
- *    horizontally contained (within a tolerance), else "off" so the Kotlin side snaps via go().
+ *  - Paginated mode (page is exactly viewport-sized): snaps scrollLeft to the COLUMN BOUNDARY that
+ *    contains the sentence's start, then returns "on". We snap here rather than report "off" and let
+ *    the Kotlin side go(): go() resolves the locator by text/cssSelector and lands flush to the
+ *    element's box — a little inside its column — so the page rests between two columns; and a binary
+ *    "is it roughly visible?" gate (the old ±tolerance check) never re-aligns a page that's already
+ *    drifted between two columns, nor follows promptly when a sentence starts just past the edge.
+ *    Snapping scrollLeft to floor(x / innerWidth) * innerWidth lands on the clean page grid every
+ *    sentence. This holds because the reader is sized so innerWidth == Readium's page-snap pitch (see
+ *    [alignedReaderWidthDp]), so the boundary we pick is exactly where Readium would rest anyway. This
+ *    mirrors the navigation-path column snap (scrollToColumnJs) but locates by text, not span id.
  *
- * Returns "off" when the text isn't on the current resource (sentence in another chapter) → go()
- * jumps chapters, as before. Only ever scrolls the Y axis — never X — so the page can't drift sideways.
+ * Returns "off" only when the text isn't on the current resource (sentence in another chapter) → the
+ * Kotlin side's go() jumps chapters, as before.
  */
 internal fun autoFollowSnapJs(text: String): String {
     // A short, near-unique prefix of the sentence; matched within a single text node (sentence starts
@@ -100,8 +108,10 @@ internal fun autoFollowSnapJs(text: String): String {
         if(Math.abs(delta) > 8) window.scrollBy(0, delta);
         return "on";
       }
-      var TOL=24;
-      return (r.left >= -TOL && r.right <= window.innerWidth+TOL && r.top < window.innerHeight && r.bottom > 0) ? "on" : "off";
+      var iw=window.innerWidth;
+      var absX=r.left + se.scrollLeft;
+      se.scrollLeft=Math.floor(absX / iw) * iw;
+      return "on";
     })()
     """.trimIndent()
 }


### PR DESCRIPTION
## Problem

During ReadAloud playback in paginated (horizontal) mode the page failed to follow the highlighted sentence cleanly: it would snap late (or not at all) and occasionally rest **stuck between two columns**.

## Root cause

The paginated auto-follow returned a coarse `on`/`off` probe and delegated the actual page move to Readium's `go()`. Two issues:

- `go()` resolves the readaloud locator by text/cssSelector and lands **flush to the element's box** — a little inside its column — so the viewport rests between two pages. (Confirmed against the Readium 3.3.0 reflowable JS: `scrollToLocator → S → scrollLeft = R(rect.left)`.)
- The `±24px` tolerance gate never re-aligned a page that had already drifted between columns, and classified a sentence starting just past the page edge as "on", so the page lagged a page behind.

## Fix

In paginated mode the probe now **snaps `scrollLeft` to the column boundary containing the sentence's start** (`floor(x / innerWidth) * innerWidth`) every sentence, locating the sentence by text (the media-overlay span is stripped on ABS books). This lands on the page grid because the reader is already sized so `innerWidth == Readium's page-snap pitch` (`alignedReaderWidthDp`). `go()` remains the cross-chapter fallback, returned only when the sentence text isn't on the current resource. Scroll (vertical) mode is unchanged.

This mirrors the deterministic column-snap approach used for navigation.

## Testing

- `./gradlew test lint` — green.
- `AutoFollowJsTest` updated: the old "off for another page" expectation is replaced by `paginatedSnapsToTheColumnContainingTheSentence`, asserting the off-page sentence snaps onto the page grid (first char lands in `[0, innerWidth)`) and the page moves.
- Harness/instrumented suite not run in this pass (requires a device); the `AutoFollowJsTest` change still needs an on-device run to confirm Readium doesn't re-assert its own `scrollLeft` during paginated playback.