### PR TITLE
fix(readaloud): resume in place / page-top instead of chapter top on reopen

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -283,6 +283,8 @@ fun EpubReaderScreen(
                         onFootnoteTapped = viewModel::showFootnotePopup,
                         activeFragmentRef = activeFragmentRef,
                         sentenceQuotes = sentenceQuotes,
+                        pageTopProbeRequests = viewModel.pageTopProbeRequests,
+                        onPageTopResolved = viewModel::onPageTopResolved,
                         onPlayFromHere = viewModel::playFromHere,
                         annotationsAvailable = annotationsAvailable,
                         highlightRenders = highlightRenders,
@@ -681,6 +683,8 @@ private fun EpubNavigatorView(
     onFootnoteTapped: (content: String) -> Unit,
     activeFragmentRef: String?,
     sentenceQuotes: Map<String, SentenceQuote>,
+    pageTopProbeRequests: Flow<String>,
+    onPageTopResolved: (href: String, fragmentId: String?) -> Unit,
     onPlayFromHere: (fragmentRef: String) -> Unit,
     annotationsAvailable: Boolean,
     highlightRenders: List<EpubReaderViewModel.HighlightRender>,
@@ -707,6 +711,7 @@ private fun EpubNavigatorView(
     val currentOnTap by rememberUpdatedState(onTap)
     val currentOnFootnoteTapped by rememberUpdatedState(onFootnoteTapped)
     val currentOnPlayFromHere by rememberUpdatedState(onPlayFromHere)
+    val currentSentenceQuotes by rememberUpdatedState(sentenceQuotes)
     val currentOnHighlight by rememberUpdatedState(onHighlight)
     val currentAnnotationsAvailable by rememberUpdatedState(annotationsAvailable)
     val currentPublication by rememberUpdatedState(state.publication)
@@ -895,6 +900,25 @@ private fun EpubNavigatorView(
     LaunchedEffect(searchNavigationEvents) {
         searchNavigationEvents.collect { locator ->
             fragmentRef.value?.go(locator)
+        }
+    }
+
+    // Resolve "top of the current page" when readaloud reopens on a different page: ask the WebView
+    // for the first narrated sentence visible on the page (spans are stripped, so we search by the
+    // sentence's text — quotes are in reading order and only this chapter's sentences are in the DOM).
+    LaunchedEffect(pageTopProbeRequests) {
+        pageTopProbeRequests.collect { href ->
+            val fragment = fragmentRef.value
+            val ordered = currentSentenceQuotes.entries.toList()
+            val fragmentId = if (fragment != null && ordered.isNotEmpty()) {
+                val idx = fragment.evaluateJavascript(
+                    firstVisibleSentenceJs(ordered.map { it.value.highlight }),
+                )?.trim('"')?.toIntOrNull()
+                idx?.let { ordered.getOrNull(it)?.key }
+            } else {
+                null
+            }
+            onPageTopResolved(href, fragmentId)
         }
     }
 

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -126,9 +126,11 @@ class EpubReaderViewModel @Inject constructor(
     val syncErrorEvents: SharedFlow<Unit> = _syncErrorEvents.asSharedFlow()
 
     // Carries the chapter href whose current-page top sentence the screen should resolve against the
-    // WebView (only the screen owns it). The screen replies via [onPageTopResolved].
-    private val _pageTopProbeRequests = MutableSharedFlow<String>(extraBufferCapacity = 1)
-    val pageTopProbeRequests: SharedFlow<String> = _pageTopProbeRequests.asSharedFlow()
+    // WebView (only the screen owns it). The screen replies via [onPageTopResolved]. A conflated
+    // channel (not a replay-less SharedFlow) so the request survives until the screen's collector
+    // receives it — a reopen can emit before the collector re-subscribes after a config change.
+    private val _pageTopProbeChannel = Channel<String>(Channel.CONFLATED)
+    val pageTopProbeRequests: Flow<String> = _pageTopProbeChannel.receiveAsFlow()
 
     private val progressSyncController = ProgressSyncController(
         repository = readingSessionRepository,
@@ -1055,15 +1057,17 @@ class EpubReaderViewModel @Inject constructor(
             is ReadaloudStartPlan.Resume -> playerCoordinator.playFromHere(plan.fragmentRef)
             // Reopened on a different page: the screen resolves the page's first sentence against the
             // WebView and replies via onPageTopResolved(); play starts there.
-            is ReadaloudStartPlan.PageTop -> _pageTopProbeRequests.tryEmit(plan.href)
+            is ReadaloudStartPlan.PageTop -> _pageTopProbeChannel.trySend(plan.href)
         }
     }
 
     /**
      * The screen resolved the first sentence visible on [href]'s current page ([fragmentId]), or null
-     * when none could be located. Starts narration there — chapter top when the id is null.
+     * when none could be located. Starts narration there — chapter top when the id is null. Ignored if
+     * the player was closed during the (async) probe round-trip, so a late reply can't revive it.
      */
     fun onPageTopResolved(href: String, fragmentId: String?) {
+        if (!_readaloudOpen.value) return
         playerCoordinator.playFromReaderPosition(href, fragmentId)
     }
 

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -26,6 +26,9 @@ import com.riffle.core.domain.ProgressSyncController
 import com.riffle.core.domain.ReaderTheme
 import com.riffle.core.domain.ReadaloudAudioRepository
 import com.riffle.core.domain.ReadaloudLinkRepository
+import com.riffle.core.domain.ReadaloudResumePlanner
+import com.riffle.core.domain.ReadaloudStartPlan
+import com.riffle.core.domain.ReaderOrientation
 import com.riffle.core.domain.ReadingSessionRepository
 import com.riffle.core.domain.ServerProgress
 import com.riffle.core.domain.ServerRepository
@@ -121,6 +124,11 @@ class EpubReaderViewModel @Inject constructor(
 
     private val _syncErrorEvents = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
     val syncErrorEvents: SharedFlow<Unit> = _syncErrorEvents.asSharedFlow()
+
+    // Carries the chapter href whose current-page top sentence the screen should resolve against the
+    // WebView (only the screen owns it). The screen replies via [onPageTopResolved].
+    private val _pageTopProbeRequests = MutableSharedFlow<String>(extraBufferCapacity = 1)
+    val pageTopProbeRequests: SharedFlow<String> = _pageTopProbeRequests.asSharedFlow()
 
     private val progressSyncController = ProgressSyncController(
         repository = readingSessionRepository,
@@ -892,6 +900,12 @@ class EpubReaderViewModel @Inject constructor(
         _readaloudOfflineMessage.value = false
         storytellerSyncJob?.cancel()
         storytellerSyncJob = null
+        // Remember where we stopped before tearing the session down: the sentence narrating now and
+        // the reader page it sits on. Reopening uses these to resume in place (same page) or start at
+        // the top of the current page (different page) instead of restarting the chapter. Capture
+        // before close() — it nulls the active fragment.
+        resumeFragmentRef = playerCoordinator.activeFragmentRef.value
+        closeLocator = lastLocator
         readaloudPrepared = false
         readaloudStarted = false
         playerCoordinator.close()
@@ -997,25 +1011,60 @@ class EpubReaderViewModel @Inject constructor(
     // position while a later resume-after-pause stays where it was.
     private var readaloudStarted = false
 
+    // The reader position when the player was last closed, and the sentence narrating at that moment.
+    // Non-null only after a close (not a pause): they drive the resume-vs-page-top decision on reopen.
+    private var closeLocator: Locator? = null
+    private var resumeFragmentRef: String? = null
+
     private suspend fun ensurePreparedAndPlay(bundle: File) {
         ensureOpened(bundle) ?: return
-        if (!readaloudStarted) {
-            // First play of this session: start narration from the reader's current position (the
-            // spec requires this), not the beginning of the book. Resuming after a pause keeps its
-            // place via the plain play() branch below.
-            readaloudStarted = true
-            val loc = lastLocator
-            if (loc != null) {
-                playerCoordinator.playFromReaderPosition(
-                    href = loc.href.toString(),
-                    fragmentId = loc.locations.fragments.firstOrNull(),
-                )
-            } else {
-                playerCoordinator.play()
-            }
-        } else {
+        if (readaloudStarted) {
+            // Resume after a pause: ExoPlayer kept its place, just play.
             playerCoordinator.play()
+            return
         }
+        readaloudStarted = true
+        // Consume the remembered close position so a later first-of-session play (after dispose) or a
+        // mid-chapter pause doesn't reuse a stale page.
+        val closed = closeLocator
+        val resume = resumeFragmentRef
+        closeLocator = null
+        resumeFragmentRef = null
+        val loc = lastLocator
+        val plan = ReadaloudResumePlanner.plan(
+            isScroll = effectiveFormattingPreferences.value.orientation == ReaderOrientation.Vertical,
+            closeHref = closed?.href?.toString(),
+            closeProgression = closed?.locations?.progression,
+            resumeFragmentRef = resume,
+            currentHref = loc?.href?.toString(),
+            currentProgression = loc?.locations?.progression,
+        )
+        when (plan) {
+            ReadaloudStartPlan.FromReaderPosition ->
+                // First play of this session: start narration from the reader's current position (the
+                // spec requires this), not the beginning of the book. Resolves to chapter granularity
+                // because the reader locator carries no sentence fragment.
+                if (loc != null) {
+                    playerCoordinator.playFromReaderPosition(
+                        href = loc.href.toString(),
+                        fragmentId = loc.locations.fragments.firstOrNull(),
+                    )
+                } else {
+                    playerCoordinator.play()
+                }
+            is ReadaloudStartPlan.Resume -> playerCoordinator.playFromHere(plan.fragmentRef)
+            // Reopened on a different page: the screen resolves the page's first sentence against the
+            // WebView and replies via onPageTopResolved(); play starts there.
+            is ReadaloudStartPlan.PageTop -> _pageTopProbeRequests.tryEmit(plan.href)
+        }
+    }
+
+    /**
+     * The screen resolved the first sentence visible on [href]'s current page ([fragmentId]), or null
+     * when none could be located. Starts narration there — chapter top when the id is null.
+     */
+    fun onPageTopResolved(href: String, fragmentId: String?) {
+        playerCoordinator.playFromReaderPosition(href, fragmentId)
     }
 
     private suspend fun ensureOpened(bundle: File): com.riffle.core.domain.ReadaloudTrack? {

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderWebViewScripts.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderWebViewScripts.kt
@@ -1,5 +1,6 @@
 package com.riffle.app.feature.reader
 
+import org.json.JSONArray
 import org.json.JSONObject
 
 /**
@@ -102,6 +103,43 @@ internal fun autoFollowSnapJs(text: String): String {
       }
       var TOL=24;
       return (r.left >= -TOL && r.right <= window.innerWidth+TOL && r.top < window.innerHeight && r.bottom > 0) ? "on" : "off";
+    })()
+    """.trimIndent()
+}
+
+/**
+ * Finds the first narrated sentence visible on the current page. [highlights] are the sentence texts
+ * in reading order (whole book); only the current chapter's sentences exist in this document's DOM,
+ * so the walk naturally ignores the rest. Returns the index into [highlights] of the first sentence
+ * whose start is on the current page, or "" when none is found.
+ *
+ * Unlike [autoFollowSnapJs] this never scrolls — it only reports visibility — so it can probe the
+ * page-top without dragging it. "Visible" uses the same containment test as autoFollow's paginated
+ * branch (within a tolerance) and, in scroll mode, any vertical overlap with the viewport.
+ */
+internal fun firstVisibleSentenceJs(highlights: List<String>): String {
+    // Same key shape as autoFollowSnapJs: a short near-unique prefix matched within one text node.
+    val keys = JSONArray(highlights.map { it.trim().take(12) }).toString()
+    return """
+    (function(){
+      var keys=$keys;
+      var seen={};
+      var w=document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT, null, false), n;
+      var TOL=24;
+      while(n=w.nextNode()){
+        for(var k=0;k<keys.length;k++){
+          if(seen[k]) continue;
+          var key=keys[k];
+          if(!key){ seen[k]=1; continue; }
+          var i=n.nodeValue.indexOf(key);
+          if(i<0) continue;
+          seen[k]=1;
+          var g=document.createRange(); g.setStart(n,i); g.setEnd(n, Math.min(n.nodeValue.length, i+1));
+          var r=g.getBoundingClientRect();
+          if(r.left >= -TOL && r.right <= window.innerWidth+TOL && r.top < window.innerHeight && r.bottom > 0) return String(k);
+        }
+      }
+      return "";
     })()
     """.trimIndent()
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderWebViewScripts.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderWebViewScripts.kt
@@ -120,20 +120,20 @@ internal fun autoFollowSnapJs(text: String): String {
 internal fun firstVisibleSentenceJs(highlights: List<String>): String {
     // Same key shape as autoFollowSnapJs: a short near-unique prefix matched within one text node.
     val keys = JSONArray(highlights.map { it.trim().take(12) }).toString()
+    // Walk text nodes in document order (== reading order) and return the first key whose start is on
+    // the current page. No "already-matched" short-circuit: a key's prefix can coincidentally appear
+    // in an earlier off-page node, and skipping it there would lose its real on-page occurrence.
     return """
     (function(){
       var keys=$keys;
-      var seen={};
       var w=document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT, null, false), n;
       var TOL=24;
       while(n=w.nextNode()){
         for(var k=0;k<keys.length;k++){
-          if(seen[k]) continue;
           var key=keys[k];
-          if(!key){ seen[k]=1; continue; }
+          if(!key) continue;
           var i=n.nodeValue.indexOf(key);
           if(i<0) continue;
-          seen[k]=1;
           var g=document.createRange(); g.setStart(n,i); g.setEnd(n, Math.min(n.nodeValue.length, i+1));
           var r=g.getBoundingClientRect();
           if(r.left >= -TOL && r.right <= window.innerWidth+TOL && r.top < window.innerHeight && r.bottom > 0) return String(k);

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/ReadaloudResumePlanner.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/ReadaloudResumePlanner.kt
@@ -1,0 +1,72 @@
+package com.riffle.core.domain
+
+import kotlin.math.abs
+
+/** How narration should be positioned when the readaloud player is (re)opened and play begins. */
+sealed interface ReadaloudStartPlan {
+    /**
+     * First play of the session (the player was never closed): start from the reader's current
+     * position, as the spec requires. Resolves to chapter granularity because the reader locator
+     * carries no sentence fragment.
+     */
+    object FromReaderPosition : ReadaloudStartPlan
+
+    /** Reopened in place: continue from the sentence narrating when the player was closed. */
+    data class Resume(val fragmentRef: String) : ReadaloudStartPlan
+
+    /**
+     * Reopened on a different page: start from the top of the current page. The chapter href is the
+     * page's resource; the first visible sentence is resolved against the WebView by the caller.
+     */
+    data class PageTop(val href: String) : ReadaloudStartPlan
+}
+
+/**
+ * Decides where narration starts when the readaloud player is reopened, from the position remembered
+ * at close versus the reader's position now:
+ *
+ *  - Never closed (first play) → [ReadaloudStartPlan.FromReaderPosition].
+ *  - Reopened on the same page → [ReadaloudStartPlan.Resume] the stopped sentence.
+ *  - Reopened on a different page → [ReadaloudStartPlan.PageTop].
+ *
+ * "Same page" is chapter href + column (progression) in paginated mode. Scroll mode has no clean page
+ * boundary, so it always resumes in place (the simplest behaviour for now).
+ */
+object ReadaloudResumePlanner {
+
+    /**
+     * Two reads of the same paginated column report the same progression; this guards float
+     * round-trips through the locator JSON without colliding adjacent pages on any realistic chapter.
+     */
+    const val PAGE_PROGRESSION_EPSILON = 1e-4
+
+    fun plan(
+        isScroll: Boolean,
+        closeHref: String?,
+        closeProgression: Double?,
+        resumeFragmentRef: String?,
+        currentHref: String?,
+        currentProgression: Double?,
+    ): ReadaloudStartPlan {
+        // null close href == the player was never closed this session: first play.
+        if (closeHref == null) return ReadaloudStartPlan.FromReaderPosition
+        if (resumeFragmentRef != null &&
+            resumesInPlace(isScroll, closeHref, closeProgression, currentHref, currentProgression)
+        ) {
+            return ReadaloudStartPlan.Resume(resumeFragmentRef)
+        }
+        return ReadaloudStartPlan.PageTop(currentHref ?: closeHref)
+    }
+
+    private fun resumesInPlace(
+        isScroll: Boolean,
+        closeHref: String,
+        closeProgression: Double?,
+        currentHref: String?,
+        currentProgression: Double?,
+    ): Boolean {
+        if (isScroll) return true
+        if (currentHref == null || closeHref != currentHref) return false
+        return abs((closeProgression ?: 0.0) - (currentProgression ?: 0.0)) < PAGE_PROGRESSION_EPSILON
+    }
+}

--- a/core/domain/src/test/kotlin/com/riffle/core/domain/ReadaloudResumePlannerTest.kt
+++ b/core/domain/src/test/kotlin/com/riffle/core/domain/ReadaloudResumePlannerTest.kt
@@ -1,0 +1,72 @@
+package com.riffle.core.domain
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ReadaloudResumePlannerTest {
+
+    private fun plan(
+        isScroll: Boolean = false,
+        closeHref: String? = "text/c5.html",
+        closeProgression: Double? = 0.40,
+        resumeFragmentRef: String? = "text/c5.html#c5-s12",
+        currentHref: String? = "text/c5.html",
+        currentProgression: Double? = 0.40,
+    ) = ReadaloudResumePlanner.plan(
+        isScroll, closeHref, closeProgression, resumeFragmentRef, currentHref, currentProgression,
+    )
+
+    @Test
+    fun `first play of the session starts from the reader position`() {
+        // closeHref null == never closed.
+        assertEquals(ReadaloudStartPlan.FromReaderPosition, plan(closeHref = null, closeProgression = null))
+    }
+
+    @Test
+    fun `reopened on the same page resumes the stopped sentence`() {
+        assertEquals(
+            ReadaloudStartPlan.Resume("text/c5.html#c5-s12"),
+            plan(closeProgression = 0.40, currentProgression = 0.40),
+        )
+    }
+
+    @Test
+    fun `tiny float drift on the same column still resumes`() {
+        assertEquals(
+            ReadaloudStartPlan.Resume("text/c5.html#c5-s12"),
+            plan(closeProgression = 0.40, currentProgression = 0.40 + 1e-6),
+        )
+    }
+
+    @Test
+    fun `reopened on a different page in the same chapter starts at the page top`() {
+        assertEquals(
+            ReadaloudStartPlan.PageTop("text/c5.html"),
+            plan(closeProgression = 0.40, currentProgression = 0.55),
+        )
+    }
+
+    @Test
+    fun `reopened in a different chapter starts at the page top of the new chapter`() {
+        assertEquals(
+            ReadaloudStartPlan.PageTop("text/c6.html"),
+            plan(currentHref = "text/c6.html"),
+        )
+    }
+
+    @Test
+    fun `scroll mode always resumes in place regardless of position`() {
+        assertEquals(
+            ReadaloudStartPlan.Resume("text/c5.html#c5-s12"),
+            plan(isScroll = true, currentHref = "text/c9.html", currentProgression = 0.99),
+        )
+    }
+
+    @Test
+    fun `no remembered sentence falls through to page top`() {
+        assertEquals(
+            ReadaloudStartPlan.PageTop("text/c5.html"),
+            plan(resumeFragmentRef = null),
+        )
+    }
+}


### PR DESCRIPTION
## Problem

Stopping a readaloud (the **Close (X)** in the player bar) and reopening it restarted narration from the **beginning of the chapter** of the current page. On close, the playback position was discarded and the session reset, so reopening took the first-play path and `resolveStartClip` fell back to the chapter's first clip.

## Behaviour now

On close we remember the sentence narrating at that moment and the reader locator. On reopen, `ReadaloudResumePlanner` decides:

- **Same page** → resume the stopped sentence.
- **Different page** (paginated) → start from the **top of the current page** — the first narrated sentence visible on the page, resolved against the WebView by text (Readium strips the sentence spans, so we search by the quote text, reusing the existing highlight machinery).
- **Scroll mode** → resume in place (simplest for now; can be refined).
- **First-ever play of a session** → unchanged (start from the reader's current position).

## Changes

- `core/domain/ReadaloudResumePlanner.kt` — pure, unit-tested decision (`FromReaderPosition` / `Resume` / `PageTop`).
- `EpubReaderViewModel` — capture stop position on close; run the planner in `ensurePreparedAndPlay`; new conflated-channel probe request + `onPageTopResolved` reply.
- `EpubReaderScreen` — collector that runs the page-top probe against the WebView and replies.
- `ReaderWebViewScripts.firstVisibleSentenceJs` — new (non-scrolling) probe for the first visible sentence on the page.

## Review fixes folded in (2nd commit)

- Page-top probe no longer skips a sentence whose 12-char prefix coincidentally appears in an earlier off-page node.
- Probe request uses a `CONFLATED Channel` (like `serverLocatorEvents`) so it survives until the collector subscribes.
- `onPageTopResolved` ignores a late reply if the player was closed mid-probe.

## Testing

- `./gradlew test` — green (incl. new `ReadaloudResumePlannerTest`, 7 cases).
- `./gradlew lint` — green.
- Harness tests skipped for this run.

## Note / follow-up

The paginated **page-snap drift** seen when resuming on a different page in the same chapter is a pre-existing auto-follow snap issue, addressed by the in-progress `pkmetski/page-snap-follow-highlight` work (snaps `scrollLeft` to the column grid every sentence). That fix and this one should land together for the page-top case to look clean on paginated layouts.
