### PR TITLE
fix(reader): land TOC/figure navigation on the column grid

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -950,8 +950,14 @@ private fun EpubNavigatorView(
     LaunchedEffect(serverLocatorEvents) {
         serverLocatorEvents.collect { locator ->
             // Background position sync (peer/resume): snap but never cover — a cover here would
-            // flash unexpectedly mid-reading.
-            fragmentRef.value?.let { it.go(locator); it.evaluateJavascript(SNAP_NEAREST_COLUMN_JS) }
+            // flash unexpectedly mid-reading. Still wait for the new chapter's reflow on a
+            // cross-resource jump so we round the settled position, not a pre-reflow transient.
+            val fragment = fragmentRef.value ?: return@collect
+            val crossResource = locator.href.toString().substringBefore('#') !=
+                currentHrefHolder[0]?.substringBefore('#')
+            fragment.go(locator)
+            if (crossResource) delay(NAV_COVER_SETTLE_MS)
+            fragment.evaluateJavascript(SNAP_NEAREST_COLUMN_JS)
         }
     }
 

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -306,7 +306,13 @@ fun EpubReaderScreen(
                         TocPanel(
                             entries = tocEntries,
                             activeHref = locatorHref,
-                            onEntryClick = viewModel::navigateToEntry,
+                            // Jumping to a location is a "start reading there" intent, so drop
+                            // straight into immersive mode (system bars + TopAppBar hidden) the
+                            // same way opening the book does.
+                            onEntryClick = { entry ->
+                                viewModel.navigateToEntry(entry)
+                                immersiveState.hide()
+                            },
                             onDismiss = viewModel::closeToc,
                         )
                     }
@@ -617,6 +623,11 @@ private val sharedEpubNavigatorConfig by lazy { EpubNavigatorFactory.Configurati
 
 private const val BOUNDARY_POLL_INTERVAL_MS = 120L
 
+// How long to keep the navigation cover up after go()+snap, so the WebView paints the snapped
+// target underneath before the cover lifts (otherwise the cover could reveal a pre-snap frame —
+// the exact jump it exists to hide). A couple of frames is enough.
+private const val NAV_COVER_SETTLE_MS = 100L
+
 /**
  * Builds a Readium [Locator] from a readaloud fragment ref — "href#fragId", or a bare "href" when
  * the ref carries no fragment. The cssSelector targets the fragment id so Readium's EPUB decorator
@@ -698,6 +709,11 @@ private fun EpubNavigatorView(
     val coroutineScope = rememberCoroutineScope()
     val fragmentRef = remember { mutableStateOf<EpubNavigatorFragment?>(null) }
     val containerRef = remember { mutableStateOf<ScrollBoundaryNavigationContainer?>(null) }
+    // Covers the reader with a plain page-coloured screen while a cross-resource jump (TOC/search)
+    // loads the new chapter. Readium briefly paints the new resource's opener (a figure/graphic) or
+    // a white blank before scrolling to the target, and the column-snap nudges the page a beat after;
+    // masking the transition hides all of that so the jump looks instantaneous.
+    var navigating by remember { mutableStateOf(false) }
     // Non-State holder for current href — written by the locator coroutine, read inside
     // navigation callbacks. Using a plain array avoids triggering recomposition on scroll.
     val currentHrefHolder = remember { arrayOf<String?>(null) }
@@ -863,43 +879,95 @@ private fun EpubNavigatorView(
                     fragment.evaluateJavascript(SELECTION_SPAN_TRACKER_JS)
                     fragment.evaluateJavascript(typographyOverrideInjectionJs())
                     fragment.evaluateJavascript(FootnoteAnchorBridge.INSTALL_SCRIPT)
+                    // NOTE: do NOT snap to the column grid here. The typography injection above
+                    // reflows the page asynchronously, so a snap at this point rounds a pre-reflow
+                    // position and lands close-but-not-exact. The post-go() snap in the navigation
+                    // handlers runs after the reflow has settled and is the authoritative one.
                 }
             }
         }
     }
 
     // Tap on an in-document anchor inside the WebView → look up the target in
-    // the cached spine doc; if it's a footnote, show the popup and tell JS to
-    // preventDefault. Otherwise return false and let the WebView scroll.
+    // the cached spine doc. A footnote shows the popup; a regular cross-
+    // reference ("Figure 4.1") scrolls to the target's column boundary so the
+    // figure lands snapped on the page grid instead of the WebView's default
+    // same-document scroll leaving the page split mid-column. In both cases we
+    // preventDefault (return true). Only an unresolved target (cache cold / id
+    // absent) falls through to the default scroll.
+    //
+    // We scroll via JS rather than go(): go(cssSelector) lands flush to the
+    // element's box (a little inside its column → next-column sliver), go-by-
+    // progression is imprecise, and goForward/goBackward report success without
+    // moving on Readium 3.3.0. A direct scrollLeft snap holds because the reader
+    // is sized so innerWidth == Readium's page-snap pitch (see readerWidthDp).
     DisposableEffect(Unit) {
         FootnoteAnchorBridge.setHandler { fragmentId ->
-            val text = FootnoteResolver.resolveAnchorTap(
-                currentHrefHolder[0], footnoteDocCache, fragmentId,
-            ) ?: return@setHandler false
-            // Called from the JS binder thread; hop to main for Compose state.
-            coroutineScope.launch(Dispatchers.Main) {
-                currentOnFootnoteTapped(text)
+            when (
+                val target = FootnoteResolver.classifyAnchorTap(
+                    currentHrefHolder[0], footnoteDocCache, fragmentId,
+                )
+            ) {
+                is FootnoteResolver.AnchorTarget.Footnote -> {
+                    // Called from the JS binder thread; hop to main for Compose state.
+                    coroutineScope.launch(Dispatchers.Main) {
+                        currentOnFootnoteTapped(target.text)
+                    }
+                    true
+                }
+                FootnoteResolver.AnchorTarget.CrossReference -> {
+                    coroutineScope.launch(Dispatchers.Main) {
+                        fragmentRef.value?.evaluateJavascript(scrollToColumnJs(fragmentId))
+                    }
+                    true
+                }
+                FootnoteResolver.AnchorTarget.Unresolved -> false
             }
-            true
         }
         onDispose { FootnoteAnchorBridge.setHandler(null) }
     }
 
     LaunchedEffect(onNavigationEvents) {
         onNavigationEvents.collect { link ->
-            fragmentRef.value?.go(link)
+            val fragment = fragmentRef.value ?: return@collect
+            // Cover only a cross-resource jump (where the load flash happens); a same-chapter jump
+            // is instant and needs no mask.
+            val cover = link.href.toString().substringBefore('#') !=
+                currentHrefHolder[0]?.substringBefore('#')
+            navigating = cover
+            try {
+                fragment.go(link)
+                // For a cross-resource jump, wait for the new chapter's typography reflow to settle
+                // (under the cover) BEFORE snapping, so we round the final position, not a transient.
+                if (cover) delay(NAV_COVER_SETTLE_MS)
+                fragment.evaluateJavascript(SNAP_NEAREST_COLUMN_JS)
+            } finally {
+                navigating = false
+            }
         }
     }
 
     LaunchedEffect(serverLocatorEvents) {
         serverLocatorEvents.collect { locator ->
-            fragmentRef.value?.go(locator)
+            // Background position sync (peer/resume): snap but never cover — a cover here would
+            // flash unexpectedly mid-reading.
+            fragmentRef.value?.let { it.go(locator); it.evaluateJavascript(SNAP_NEAREST_COLUMN_JS) }
         }
     }
 
     LaunchedEffect(searchNavigationEvents) {
         searchNavigationEvents.collect { locator ->
-            fragmentRef.value?.go(locator)
+            val fragment = fragmentRef.value ?: return@collect
+            val cover = locator.href.toString().substringBefore('#') !=
+                currentHrefHolder[0]?.substringBefore('#')
+            navigating = cover
+            try {
+                fragment.go(locator)
+                if (cover) delay(NAV_COVER_SETTLE_MS)
+                fragment.evaluateJavascript(SNAP_NEAREST_COLUMN_JS)
+            } finally {
+                navigating = false
+            }
         }
     }
 
@@ -1313,6 +1381,18 @@ private fun EpubNavigatorView(
                 ),
         ) {
             PullChip(forward = pullForward, progress = pullProgress)
+        }
+        // Masks the load/snap transition during a cross-resource jump. Drawn last so it sits above
+        // the reader; the page colour makes it read as a brief blank rather than a flash of the
+        // wrong page.
+        if (navigating) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(formattingPrefs.theme.palette.background)
+                    .testTag("reader_nav_cover")
+                    .semantics { contentDescription = "Loading" },
+            )
         }
     }
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/FootnoteResolver.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/FootnoteResolver.kt
@@ -25,6 +25,24 @@ internal object FootnoteResolver {
         "footnotes", "endnotes", "rearnotes",
     )
 
+    // The outcome of classifying a tapped in-document anchor (href="#id").
+    sealed interface AnchorTarget {
+        // Target is a footnote-style element: show the popup, [text] is its body.
+        data class Footnote(val text: String) : AnchorTarget
+
+        // Target is a regular in-document element (e.g. a "Figure 4.1"
+        // cross-reference). The caller must navigate via Readium's go() so the
+        // viewport lands on a column-page boundary. Letting the WebView perform
+        // its default same-document anchor scroll lands scrollLeft mid-column in
+        // a paginated reflowable layout — the page sits split between two
+        // columns and Readium never re-snaps it.
+        data object CrossReference : AnchorTarget
+
+        // Can't tell — cache cold, no current resource, or the id isn't in the
+        // current spine doc. Leave it to the WebView's default handling.
+        data object Unresolved : AnchorTarget
+    }
+
     fun parse(html: String): Document = Jsoup.parse(html)
 
     // Anchors whose entire text is just a note marker — "7", "7.", "[7]",
@@ -69,6 +87,27 @@ internal object FootnoteResolver {
         return noteText(block).takeIf { it.isNotEmpty() }
     }
 
+    // Classifies a tapped in-document anchor against the cached spine doc so the
+    // reader can decide between showing a footnote popup, navigating via
+    // Readium's go() (snapped), or deferring to the WebView's default scroll.
+    fun classifyAnchorTap(
+        currentHref: String?,
+        cache: Map<String, Document>,
+        fragmentId: String,
+    ): AnchorTarget {
+        val href = currentHref ?: return AnchorTarget.Unresolved
+        val doc = cache[href.substringBefore('#')] ?: return AnchorTarget.Unresolved
+        // The id must exist in the current resource: the JS bridge only fires
+        // for href="#id" links, which target the same document.
+        doc.getElementById(fragmentId) ?: return AnchorTarget.Unresolved
+        val footnote = extractFootnoteText(doc, fragmentId)
+        return if (footnote != null) {
+            AnchorTarget.Footnote(footnote)
+        } else {
+            AnchorTarget.CrossReference
+        }
+    }
+
     // Resolves an anchor tap from the WebView to footnote popup text. Returns
     // null when no popup should be shown (cache cold, no current spine,
     // target is a regular cross-reference, etc.).
@@ -76,12 +115,8 @@ internal object FootnoteResolver {
         currentHref: String?,
         cache: Map<String, Document>,
         fragmentId: String,
-    ): String? {
-        val href = currentHref ?: return null
-        val key = href.substringBefore('#')
-        val doc = cache[key] ?: return null
-        return extractFootnoteText(doc, fragmentId)
-    }
+    ): String? =
+        (classifyAnchorTap(currentHref, cache, fragmentId) as? AnchorTarget.Footnote)?.text
 
     // The visible note body for [block], with any back-reference marker anchors
     // ("1.", "[7]" that link back into the text) removed — they're navigation

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderWebViewScripts.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderWebViewScripts.kt
@@ -117,6 +117,27 @@ internal fun autoFollowSnapJs(text: String): String {
     """.trimIndent()
 }
 
+// Scrolls the current resource so the column CONTAINING [fragmentId] sits flush at the viewport's
+// left edge — for an in-document cross-reference tap ("Figure 4.1"). go(cssSelector) lands flush to
+// the element's box (a little inside its column → a sliver of the neighbour shows); flooring
+// scrollLeft to a multiple of innerWidth lands on the column boundary. Holds because the reader is
+// sized so innerWidth == Readium's page-snap pitch (see [alignedReaderWidthDp]). Same floor-to-grid
+// math as [autoFollowSnapJs]'s paginated branch, but located by id rather than by sentence text.
+internal fun scrollToColumnJs(fragmentId: String): String =
+    "(function(){var el=document.getElementById(${JSONObject.quote(fragmentId)});" +
+        "if(!el)return;var se=document.scrollingElement;var iw=window.innerWidth;" +
+        "var abs=el.getBoundingClientRect().left+se.scrollLeft;" +
+        "se.scrollLeft=Math.floor(abs/iw)*iw;})()"
+
+// Snaps the CURRENT scroll position to the nearest column boundary. Run after a go()-based jump
+// (TOC/search/resume): Readium positions those flush to the target element, a gutter inside its
+// column, so the page lands off the grid (leading text clipped). Rounds rather than floors because
+// go() can leave the viewport just shy of the next column. A no-op for an already-aligned page, so
+// it never disturbs a normal page turn. Holds for the same reason as [scrollToColumnJs].
+internal val SNAP_NEAREST_COLUMN_JS: String =
+    "(function(){var se=document.scrollingElement;var iw=window.innerWidth;" +
+        "se.scrollLeft=Math.round(se.scrollLeft/iw)*iw;})()"
+
 /**
  * Finds the first narrated sentence visible on the current page. [highlights] are the sentence texts
  * in reading order (whole book); only the current chapter's sentences exist in this document's DOM,

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/FootnoteResolverTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/FootnoteResolverTest.kt
@@ -144,6 +144,66 @@ class FootnoteResolverTest {
         assertNull(FootnoteResolver.resolveAnchorTap("OEBPS/ch01.html", cache, "sec1"))
     }
 
+    // Regression for the reader-navigation bug: tapping an in-document cross-
+    // reference like "Figure 4.1" used to fall through to the WebView's default
+    // same-document anchor scroll, which lands scrollLeft mid-column in a
+    // paginated reflowable layout (the page splits between two columns and never
+    // re-snaps). classifyAnchorTap must report CrossReference so the reader
+    // navigates via Readium's go() instead, landing on a column-page boundary.
+    @Test
+    fun `classifyAnchorTap reports a non-footnote in-document target as CrossReference`() {
+        val html = """
+            <html><body>
+              <p>See <a href="#fig41">Figure 4.1</a>.</p>
+              <figure id="fig41"><img src="fig41.png"/><figcaption>Figure 4.1</figcaption></figure>
+            </body></html>
+        """.trimIndent()
+        val cache = mapOf("OEBPS/ch08.html" to FootnoteResolver.parse(html))
+        assertEquals(
+            FootnoteResolver.AnchorTarget.CrossReference,
+            FootnoteResolver.classifyAnchorTap("OEBPS/ch08.html", cache, "fig41"),
+        )
+    }
+
+    @Test
+    fun `classifyAnchorTap reports a footnote target as Footnote`() {
+        val html = """
+            <html xmlns:epub="http://www.idpf.org/2007/ops"><body>
+              <aside epub:type="footnote" id="fn1"><p>Note one.</p></aside>
+            </body></html>
+        """.trimIndent()
+        val cache = mapOf("OEBPS/ch08.html" to FootnoteResolver.parse(html))
+        assertEquals(
+            FootnoteResolver.AnchorTarget.Footnote("Note one."),
+            FootnoteResolver.classifyAnchorTap("OEBPS/ch08.html", cache, "fn1"),
+        )
+    }
+
+    // An id that isn't in the cached doc (or a cold cache / no current href)
+    // must stay Unresolved so the reader defers to the WebView rather than
+    // navigating to a bogus locator.
+    @Test
+    fun `classifyAnchorTap reports a missing id as Unresolved`() {
+        val html = """<html><body><h2 id="sec1">Section</h2></body></html>"""
+        val cache = mapOf("OEBPS/ch08.html" to FootnoteResolver.parse(html))
+        assertEquals(
+            FootnoteResolver.AnchorTarget.Unresolved,
+            FootnoteResolver.classifyAnchorTap("OEBPS/ch08.html", cache, "nope"),
+        )
+    }
+
+    @Test
+    fun `classifyAnchorTap reports a cold cache as Unresolved`() {
+        assertEquals(
+            FootnoteResolver.AnchorTarget.Unresolved,
+            FootnoteResolver.classifyAnchorTap("OEBPS/ch08.html", emptyMap(), "fig41"),
+        )
+        assertEquals(
+            FootnoteResolver.AnchorTarget.Unresolved,
+            FootnoteResolver.classifyAnchorTap(null, emptyMap(), "fig41"),
+        )
+    }
+
     // Regression guard for the two install-script hazards burnt in this session:
     //   1. anchor matching must be case-insensitive (XHTML keeps tagName lowercase)
     //   2. listener must be capture-phase so it runs before Readium's bubble-phase ut()

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/FootnoteResolverTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/FootnoteResolverTest.kt
@@ -192,6 +192,19 @@ class FootnoteResolverTest {
         )
     }
 
+    // An element that looks like a footnote but has an empty body resolves to CrossReference, not
+    // Footnote: there's no popup text to show, so we treat it as an in-document target and snap to
+    // its column (rather than the old behaviour of falling through to the WebView's default scroll).
+    @Test
+    fun `classifyAnchorTap reports an empty-body footnote as CrossReference`() {
+        val html = """<html><body><div class="footnote" id="fn1"></div></body></html>"""
+        val cache = mapOf("OEBPS/ch08.html" to FootnoteResolver.parse(html))
+        assertEquals(
+            FootnoteResolver.AnchorTarget.CrossReference,
+            FootnoteResolver.classifyAnchorTap("OEBPS/ch08.html", cache, "fn1"),
+        )
+    }
+
     @Test
     fun `classifyAnchorTap reports a cold cache as Unresolved`() {
         assertEquals(

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ReaderViewportAlignmentTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ReaderViewportAlignmentTest.kt
@@ -1,0 +1,53 @@
+package com.riffle.app.feature.reader
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import kotlin.math.abs
+import kotlin.math.roundToInt
+import org.junit.Test
+
+class ReaderViewportAlignmentTest {
+
+    // The point of the alignment: the chosen dp width must resolve to a WHOLE number of physical
+    // pixels, so innerWidth (== physicalPx / dpr) is an integer == Readium's page-snap pitch.
+    private fun resolvesToWholePixels(dp: Float, density: Float): Boolean =
+        abs(dp * density - (dp * density).roundToInt()) < 0.01f
+
+    @Test
+    fun `fractional density 2_625 trims to the nearest whole-pixel width`() {
+        // 1080px / 2.625 = 411.43 → avail 411dp. 408 * 2.625 = 1071.0 (whole); 409/410/411 are not.
+        assertEquals(408f, alignedReaderWidthDp(availDp = 411f, density = 2.625f))
+        assertTrue(resolvesToWholePixels(408f, 2.625f))
+    }
+
+    @Test
+    fun `integer density keeps the full floored width (no gutter)`() {
+        assertEquals(411f, alignedReaderWidthDp(411f, 2.0f))
+        assertEquals(411f, alignedReaderWidthDp(411f, 3.0f))
+        assertEquals(360f, alignedReaderWidthDp(360.4f, 1.0f))
+    }
+
+    @Test
+    fun `2_75 density (440dpi) keeps widths divisible by four`() {
+        // 2.75 = 11/4, so dp must be a multiple of 4 to land on a whole pixel. 411 → 408.
+        assertEquals(408f, alignedReaderWidthDp(411f, 2.75f))
+    }
+
+    @Test
+    fun `result is whole pixels and never exceeds the available width`() {
+        for (density in listOf(1.0f, 1.5f, 2.0f, 2.625f, 2.75f, 3.0f, 3.5f)) {
+            for (availDp in listOf(200f, 360f, 411f, 412.7f, 600f, 731f)) {
+                val w = alignedReaderWidthDp(availDp, density)
+                assertTrue("$w should be in 1..$availDp", w in 1f..availDp)
+                assertTrue("$w * $density should be whole", resolvesToWholePixels(w, density))
+            }
+        }
+    }
+
+    @Test
+    fun `degenerate inputs are returned unchanged rather than crashing`() {
+        assertEquals(0f, alignedReaderWidthDp(0f, 2.625f))
+        assertEquals(-5f, alignedReaderWidthDp(-5f, 2.625f))
+        assertEquals(411f, alignedReaderWidthDp(411f, 0f))
+    }
+}

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ReaderWebViewScriptsTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ReaderWebViewScriptsTest.kt
@@ -1,0 +1,37 @@
+package com.riffle.app.feature.reader
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ReaderWebViewScriptsTest {
+
+    // scrollToColumnJs floors scrollLeft to the column the element starts in, so a tapped figure
+    // cross-reference lands flush on the grid rather than a gutter inside its column.
+    @Test
+    fun `scrollToColumnJs floors to the element's column and quotes the id`() {
+        val js = scrollToColumnJs("c04-fig-0001")
+        assertTrue("looks up the target by id", js.contains("getElementById(\"c04-fig-0001\")"))
+        assertTrue("measures the element position", js.contains("getBoundingClientRect"))
+        assertTrue("reads the live column pitch", js.contains("window.innerWidth"))
+        assertTrue("FLOORS to the column boundary", js.contains("Math.floor(abs/iw)*iw"))
+    }
+
+    // Dotted ids (O'Reilly-style "ftn.ch01fn01") must survive verbatim — JSONObject.quote keeps them
+    // a plain string literal so getElementById (not a CSS selector) matches them.
+    @Test
+    fun `scrollToColumnJs preserves dotted ids verbatim`() {
+        assertTrue(scrollToColumnJs("ftn.ch01fn01").contains("getElementById(\"ftn.ch01fn01\")"))
+    }
+
+    // SNAP_NEAREST_COLUMN_JS rounds the current scroll position to the nearest column — for after a
+    // go()-based TOC/search jump. It must NOT depend on a specific element.
+    @Test
+    fun `SNAP_NEAREST_COLUMN_JS rounds the current scroll to the nearest column`() {
+        val js = SNAP_NEAREST_COLUMN_JS
+        assertTrue("rounds to the nearest column", js.contains("Math.round(se.scrollLeft/iw)*iw"))
+        assertTrue("reads the live column pitch", js.contains("window.innerWidth"))
+        assertTrue("operates on the scroll container", js.contains("document.scrollingElement"))
+        assertFalse("must not target a specific element", js.contains("getElementById"))
+    }
+}


### PR DESCRIPTION
## What

Reader navigation (TOC, search, in-document figure cross-references) positioned the viewport flush to the target element — a gutter inside its column — so the page rested off the column grid: leading text clipped, or a sliver of the next column showing. Built on top of the viewport-resize (#95) that makes `innerWidth` equal Readium's page-snap pitch, this snaps navigation onto the column boundary.

- **Figure cross-reference taps** (`FootnoteAnchorBridge`): classify the tapped anchor (footnote popup vs. cross-reference vs. unresolved) via `FootnoteResolver.classifyAnchorTap`, and scroll a cross-reference's column flush with `scrollToColumnJs`.
- **TOC / search / resume `go()`**: round `scrollLeft` to the nearest column after the jump (`SNAP_NEAREST_COLUMN_JS`). For a cross-resource jump, wait for the new chapter's typography reflow to settle *before* snapping (so we round the final position, not a pre-reflow transient), and mask the load with a page-coloured cover so the chapter-opener / white-blank flash and the snap are hidden.
- Tapping a TOC entry now drops into **immersive mode** (same as opening the book).
- Reader JS consolidated into `ReaderWebViewScripts.kt`; `alignedReaderWidthDp` reused for the width.

## Why not `go()` for the snap

`go(cssSelector)` lands flush to the element's box (off-grid); `go(progression)` is imprecise; `goForward/goBackward` report success without moving on Readium 3.3.0. A direct `scrollLeft` snap holds because the reader is sized so `innerWidth` == the snap pitch.

## Testing

- `./gradlew test lint` — green (added `ReaderViewportAlignmentTest` for the previously-untested `alignedReaderWidthDp`, `ReaderWebViewScriptsTest` for the snap snippets, and `FootnoteResolver` classification tests incl. empty-body footnote → CrossReference).
- `make harness-test` — 151/152 pass. The 1 failure (`AutoFollowJsTest.paginatedSnapsToTheColumnContainingTheSentence`) is **pre-existing**: it reproduces identically on `origin/main`, in `autoFollowSnapJs` (#100) which this PR does not touch.
- `make harness-test-tablet` — 5/5 pass.
