### PR TITLE
fix(library): render book details instantly instead of blocking on To Read refresh

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModel.kt
@@ -97,8 +97,6 @@ class LibraryItemDetailViewModel @Inject constructor(
                 val item = repository.getItem(itemId)
                 if (item != null) {
                     _downloadState.value = deriveDownloadState(item)
-                    toReadRepository.refresh(item.libraryId)
-                    val isInToRead = toReadRepository.isInToRead(item.id, item.libraryId)
                     val link = if (server?.id != null) {
                         readaloudLinkRepository.findByAbsItem(server.id, item.id)
                     } else {
@@ -109,6 +107,10 @@ class LibraryItemDetailViewModel @Inject constructor(
                         readaloudDownloadStateFor(readaloudAudioRepository.isAudioAvailable(it.storytellerServerId, it.storytellerBookId))
                     }
                     val isCachedOrDownloaded = epubRepository.isCached(item.serverId, item.id) || epubRepository.isDownloaded(item.serverId, item.id)
+                    // Render from the locally-cached To Read state immediately. The server refresh
+                    // below runs off the critical path so a slow/unreachable ABS server can't keep
+                    // the detail screen stuck in Loading for the network timeout (~10s).
+                    val isInToRead = toReadRepository.isInToRead(item.id, item.libraryId)
                     LibraryItemDetailUiState.Ready(
                         item = item,
                         isInToRead = isInToRead,
@@ -120,6 +122,21 @@ class LibraryItemDetailViewModel @Inject constructor(
                 }
             } catch (_: Exception) {
                 LibraryItemDetailUiState.Error
+            }
+
+            // Refresh To Read from the server without blocking the initial render; patch the
+            // isInToRead badge once it returns.
+            val ready = _uiState.value
+            if (ready is LibraryItemDetailUiState.Ready) {
+                launch {
+                    if (toReadRepository.refresh(ready.item.libraryId)) {
+                        val refreshed = toReadRepository.isInToRead(ready.item.id, ready.item.libraryId)
+                        val latest = _uiState.value
+                        if (latest is LibraryItemDetailUiState.Ready) {
+                            _uiState.value = latest.copy(isInToRead = refreshed)
+                        }
+                    }
+                }
             }
         }
 

--- a/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModelTest.kt
@@ -211,6 +211,15 @@ class LibraryItemDetailViewModelTest {
         }
     }
 
+    /** refresh() suspends forever, modelling a slow/unreachable server. */
+    private class BlockingRefreshToReadRepository : ToReadRepository {
+        override fun observeToReadItemIds(libraryId: String): Flow<Set<String>> = flowOf(emptySet())
+        override suspend fun refresh(libraryId: String): Boolean = kotlinx.coroutines.awaitCancellation()
+        override suspend fun isInToRead(libraryItemId: String, libraryId: String): Boolean = false
+        override suspend fun addToToRead(libraryItemId: String, libraryId: String): Boolean = true
+        override suspend fun removeFromToRead(libraryItemId: String, libraryId: String): Boolean = true
+    }
+
     private fun makeVm(
         repo: LibraryRepository,
         itemId: String = "item-1",
@@ -340,15 +349,30 @@ class LibraryItemDetailViewModelTest {
     }
 
     @Test
-    fun `init refreshes To Read before reading isInToRead`() = runTest {
-        val toRead = FakeToReadRepository()
+    fun `init shows local To Read state immediately then refreshes from the server`() = runTest {
+        // Local cache says the book is in To Read; the server refresh will confirm it.
+        val toRead = FakeToReadRepository(initial = setOf(knownItem.id))
         val vm = makeVm(repo = fakeRepo(knownItem), toReadRepo = toRead)
         backgroundScope.launch { vm.uiState.collect {} }
         testDispatcher.scheduler.advanceUntilIdle()
 
+        // The first isInToRead read happens before the refresh — Ready is not gated on the network.
+        val firstIsIn = toRead.callLog.indexOf("isInToRead")
         val refreshIdx = toRead.callLog.indexOf("refresh")
-        val isInIdx = toRead.callLog.indexOf("isInToRead")
-        assertTrue("expected refresh before isInToRead, got ${toRead.callLog}", refreshIdx in 0 until isInIdx)
+        assertTrue("expected isInToRead before refresh, got ${toRead.callLog}", firstIsIn in 0 until refreshIdx)
+        assertTrue((vm.uiState.value as Ready).isInToRead)
+    }
+
+    @Test
+    fun `uiState reaches Ready without waiting for the To Read server refresh`() = runTest {
+        // refresh() never completes — simulates a slow/unreachable ABS server. The detail screen
+        // must still render from local data instead of sitting in Loading for the network timeout.
+        val toRead = BlockingRefreshToReadRepository()
+        val vm = makeVm(repo = fakeRepo(knownItem), toReadRepo = toRead)
+        backgroundScope.launch { vm.uiState.collect {} }
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertTrue("expected Ready while refresh is still in flight", vm.uiState.value is Ready)
     }
 
     // --- toggleToRead tests ---


### PR DESCRIPTION
## Problem

Opening a book's detail screen sometimes hung on the loading spinner for close to 10 seconds.

## Root cause

`LibraryItemDetailViewModel`'s init block only emitted the `Ready` state **after** `toReadRepository.refresh()` returned. That `refresh()` is a blocking Audiobookshelf `getPlaylists()` network call on the default OkHttp client, whose default connect/read timeout is **~10 s**. So whenever the ABS server was slow or unreachable, the entire detail screen sat in `Loading` for the full timeout — even though everything it renders (the item from the local DB, the cached/downloaded flag from the filesystem) was already available locally. Only the secondary "in To Read" badge depended on the network round-trip.

## Fix

Render `Ready` immediately from local data (including the locally-cached To Read state), then run the server refresh **off the critical path** in a child coroutine, patching the `isInToRead` badge reactively when it returns. The screen is now instantaneous regardless of server latency; the badge self-corrects a moment later if the server disagrees.

## Tests

Two regression tests in `LibraryItemDetailViewModelTest`:
- `uiState reaches Ready without waiting for the To Read server refresh` — a fake whose `refresh()` suspends forever (models a dead server); asserts `Ready` is still reached. Deterministic capture of the bug.
- `init shows local To Read state immediately then refreshes from the server` — asserts the local read happens before the network refresh and the badge reflects local state right away.

Both fail against the old code and pass against the fix. Full `:app` and `:core:data` unit suites are green.

## Behavior note

On the very first open of a book whose playlists have never been fetched, the To Read badge appears unset for a moment and then fills in once the background refresh completes — the same eventual-consistency the toggle already relied on, just no longer blocking the screen.