### PR TITLE
fix(reader): keep TOC/search jumps pinned to the target through the post-load reflow

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -651,10 +651,18 @@ private val sharedEpubNavigatorConfig by lazy { EpubNavigatorFactory.Configurati
 
 private const val BOUNDARY_POLL_INTERVAL_MS = 120L
 
-// How long to keep the navigation cover up after go()+snap, so the WebView paints the snapped
-// target underneath before the cover lifts (otherwise the cover could reveal a pre-snap frame —
-// the exact jump it exists to hide). A couple of frames is enough.
-private const val NAV_COVER_SETTLE_MS = 100L
+// How long to keep the navigation cover up after go(), to hide the new chapter's opener/white-blank
+// flash while it loads and paints. Correctness of the landing no longer depends on this timing:
+// [snapToTargetColumnJs] keeps the target pinned to its column through the async typography reflow
+// (which can finish well after this), so the cover is purely cosmetic.
+private const val NAV_COVER_SETTLE_MS = 250L
+
+// The element id a TOC/search/resume locator points at (its href fragment), or null for a jump to a
+// resource start. Drives [snapToTargetColumnJs] so the landing snaps to the column the target itself
+// occupies — robust to where go() landed and to the post-load reflow.
+private fun navTargetFragmentId(href: String): String? =
+    href.substringAfter('#', "").ifEmpty { null }
+        ?.let { runCatching { java.net.URLDecoder.decode(it, "UTF-8") }.getOrDefault(it) }
 
 /**
  * Builds a Readium [Locator] from a readaloud fragment ref — "href#fragId", or a bare "href" when
@@ -993,10 +1001,10 @@ private fun EpubNavigatorView(
             navigating = cover
             try {
                 fragment.go(link)
-                // For a cross-resource jump, wait for the new chapter's typography reflow to settle
-                // (under the cover) BEFORE snapping, so we round the final position, not a transient.
+                // Snap to the target's column and keep it pinned through the new chapter's async
+                // typography reflow (see snapToTargetColumnJs). The cover is just cosmetic now.
+                fragment.evaluateJavascript(snapToTargetColumnJs(navTargetFragmentId(link.href.toString())))
                 if (cover) delay(NAV_COVER_SETTLE_MS)
-                fragment.evaluateJavascript(SNAP_NEAREST_COLUMN_JS)
             } finally {
                 navigating = false
             }
@@ -1005,15 +1013,12 @@ private fun EpubNavigatorView(
 
     LaunchedEffect(serverLocatorEvents) {
         serverLocatorEvents.collect { locator ->
-            // Background position sync (peer/resume): snap but never cover — a cover here would
-            // flash unexpectedly mid-reading. Still wait for the new chapter's reflow on a
-            // cross-resource jump so we round the settled position, not a pre-reflow transient.
+            // Background position sync (peer/resume): snap to the target's column and keep it pinned
+            // through the new chapter's reflow, but never cover — a cover here would flash
+            // unexpectedly mid-reading (see snapToTargetColumnJs).
             val fragment = fragmentRef.value ?: return@collect
-            val crossResource = locator.href.toString().substringBefore('#') !=
-                currentHrefHolder[0]?.substringBefore('#')
             fragment.go(locator)
-            if (crossResource) delay(NAV_COVER_SETTLE_MS)
-            fragment.evaluateJavascript(SNAP_NEAREST_COLUMN_JS)
+            fragment.evaluateJavascript(snapToTargetColumnJs(navTargetFragmentId(locator.href.toString())))
         }
     }
 
@@ -1025,8 +1030,8 @@ private fun EpubNavigatorView(
             navigating = cover
             try {
                 fragment.go(locator)
+                fragment.evaluateJavascript(snapToTargetColumnJs(navTargetFragmentId(locator.href.toString())))
                 if (cover) delay(NAV_COVER_SETTLE_MS)
-                fragment.evaluateJavascript(SNAP_NEAREST_COLUMN_JS)
             } finally {
                 navigating = false
             }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderWebViewScripts.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderWebViewScripts.kt
@@ -129,14 +129,43 @@ internal fun scrollToColumnJs(fragmentId: String): String =
         "var abs=el.getBoundingClientRect().left+se.scrollLeft;" +
         "se.scrollLeft=Math.floor(abs/iw)*iw;})()"
 
-// Snaps the CURRENT scroll position to the nearest column boundary. Run after a go()-based jump
-// (TOC/search/resume): Readium positions those flush to the target element, a gutter inside its
-// column, so the page lands off the grid (leading text clipped). Rounds rather than floors because
-// go() can leave the viewport just shy of the next column. A no-op for an already-aligned page, so
-// it never disturbs a normal page turn. Holds for the same reason as [scrollToColumnJs].
-internal val SNAP_NEAREST_COLUMN_JS: String =
-    "(function(){var se=document.scrollingElement;var iw=window.innerWidth;" +
-        "se.scrollLeft=Math.round(se.scrollLeft/iw)*iw;})()"
+// Lands a go()-based jump (TOC/search/resume) on the column grid, and KEEPS it there until the
+// freshly-loaded chapter's typography reflow settles. Run once after go().
+//
+// Why this isn't a one-shot round-to-nearest: on a cross-resource jump the new chapter loads, then
+// the injected typography override (see onPageLoaded) reflows it ASYNCHRONOUSLY — growing
+// scrollWidth and pushing the target into a different column a few hundred ms later. A fixed-delay
+// snap that rounds the current scroll position locks onto the PRE-reflow column and never corrects,
+// leaving the page a page or more before/after the target (the "TOC is hit-and-miss" bug). Instead
+// we drive a requestAnimationFrame loop that, every frame, re-locates the target by its [fragmentId]
+// and FLOORS scrollLeft to the column the target currently occupies — so it tracks the target as the
+// reflow moves it — and stops only once scrollWidth has held steady for a few frames (reflow done) or
+// a safety cap elapses. Anchoring to the element (not the current scroll) also makes it robust to
+// where exactly go() landed. Same floor-to-grid math and innerWidth==page-pitch assumption as
+// [scrollToColumnJs] (see [alignedReaderWidthDp]).
+//
+// [fragmentId] is the target's element id (a TOC/search locator fragment). When null/empty the jump
+// targets a resource start, so we floor to column 0. If the id can't be found (e.g. Readium stripped
+// the element) we fall back to rounding the current position — best-effort alignment without yanking
+// the page to the top.
+internal fun snapToTargetColumnJs(fragmentId: String?): String {
+    val idLiteral = if (fragmentId.isNullOrEmpty()) "null" else JSONObject.quote(fragmentId)
+    return "(function(){var id=$idLiteral;" +
+        "var se=document.scrollingElement;" +
+        "var gen=(window.__riffleSnapGen=(window.__riffleSnapGen||0)+1);" +
+        "var lastW=-1,stable=0,frames=0;" +
+        "function snap(){var iw=window.innerWidth;" +
+        "if(id){var el=document.getElementById(id);" +
+        "if(el){se.scrollLeft=Math.floor((el.getBoundingClientRect().left+se.scrollLeft)/iw)*iw;}" +
+        "else{se.scrollLeft=Math.round(se.scrollLeft/iw)*iw;}}" +
+        "else{se.scrollLeft=0;}}" +
+        "function tick(){if(gen!==window.__riffleSnapGen)return;" + // a newer jump superseded us
+        "var w=se.scrollWidth;if(w===lastW)stable++;else{stable=0;lastW=w;}" +
+        "snap();" +
+        "if((stable>=3&&frames>=2)||frames++>72){snap();return;}" + // settled, or ~1.2s safety cap
+        "requestAnimationFrame(tick);}" +
+        "tick();})()"
+}
 
 /**
  * Finds the first narrated sentence visible on the current page. [highlights] are the sentence texts

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ReaderWebViewScriptsTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ReaderWebViewScriptsTest.kt
@@ -1,6 +1,5 @@
 package com.riffle.app.feature.reader
 
-import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -24,14 +23,34 @@ class ReaderWebViewScriptsTest {
         assertTrue(scrollToColumnJs("ftn.ch01fn01").contains("getElementById(\"ftn.ch01fn01\")"))
     }
 
-    // SNAP_NEAREST_COLUMN_JS rounds the current scroll position to the nearest column — for after a
-    // go()-based TOC/search jump. It must NOT depend on a specific element.
+    // snapToTargetColumnJs anchors a go()-based TOC/search jump to the column the TARGET occupies,
+    // re-applying it across the async typography reflow until scrollWidth settles — the fix for the
+    // "TOC lands a page before/after" bug where a one-shot snap locked onto the pre-reflow column.
     @Test
-    fun `SNAP_NEAREST_COLUMN_JS rounds the current scroll to the nearest column`() {
-        val js = SNAP_NEAREST_COLUMN_JS
-        assertTrue("rounds to the nearest column", js.contains("Math.round(se.scrollLeft/iw)*iw"))
+    fun `snapToTargetColumnJs floors to the target's column and waits for reflow to settle`() {
+        val js = snapToTargetColumnJs("creating_a_summary")
+        assertTrue("captures the target id", js.contains("var id=\"creating_a_summary\""))
+        assertTrue("looks up the target by id", js.contains("getElementById(id)"))
+        assertTrue("FLOORS to the target's column", js.contains("Math.floor(("))
         assertTrue("reads the live column pitch", js.contains("window.innerWidth"))
-        assertTrue("operates on the scroll container", js.contains("document.scrollingElement"))
-        assertFalse("must not target a specific element", js.contains("getElementById"))
+        assertTrue("re-applies across frames", js.contains("requestAnimationFrame"))
+        assertTrue("waits for scrollWidth to hold steady", js.contains("scrollWidth"))
+        assertTrue("bounded by a safety cap", js.contains("frames++>72"))
+        assertTrue("a newer jump supersedes it", js.contains("__riffleSnapGen"))
+    }
+
+    // A bare-href jump (no fragment) targets the resource start, so it floors to column 0 rather than
+    // hunting for an element id.
+    @Test
+    fun `snapToTargetColumnJs targets the resource start when there is no fragment`() {
+        val js = snapToTargetColumnJs(null)
+        assertTrue("id is null", js.contains("var id=null"))
+        assertTrue("snaps to column 0", js.contains("se.scrollLeft=0"))
+    }
+
+    // Dotted ids (O'Reilly-style "ftn.ch01fn01") must survive verbatim so getElementById matches them.
+    @Test
+    fun `snapToTargetColumnJs preserves dotted ids verbatim`() {
+        assertTrue(snapToTargetColumnJs("ftn.ch01fn01").contains("var id=\"ftn.ch01fn01\""))
     }
 }


### PR DESCRIPTION
## Problem

TOC and in-book-search jumps into a chapter intermittently landed a page (or more) **before/after** the target section — "TOC navigation is hit and miss." Most visible on large chapters with mid-chapter section fragments (e.g. *Lean Customer Development*, `ch06.html#creating_a_summary`).

## Root cause (reproduced on-device via WebView DevTools)

1. `go()` jumps to the target, then `onPageLoaded` injects the typography override, which **reflows the fresh chapter asynchronously** — growing `scrollWidth` and pushing the target into a *different* column a few hundred ms later.
2. The previous fix (#103) snapped a fixed **100 ms** after `go()` using `SNAP_NEAREST_COLUMN_JS`, which only **rounds the current scroll position**. So it fires *before* the reflow finishes, locks onto the pre-reflow column, and never re-corrects.

Instrumented capture jumping to "Creating a Summary": at 585 ms the heading was on column 7; at 731 ms the reflow grew `scrollWidth` by one column and moved the heading to column 8, but the page stayed snapped on column 7. It's intermittent because it races the reflow — worse on larger chapters.

(Not a rounding bug — every heading sits exactly the body-margin into its column, so round==floor once settled.)

## Fix

Replace `SNAP_NEAREST_COLUMN_JS` with **`snapToTargetColumnJs(fragmentId)`**: a `requestAnimationFrame` loop that, every frame, re-locates the target by its href-fragment id and **floors `scrollLeft` to the column it currently occupies** — tracking it as the reflow moves it — and stops only once `scrollWidth` holds steady for a few frames (reflow done) or a ~1.2 s safety cap. It's element-anchored like the existing figure-tap `scrollToColumnJs`, so it's robust both to where `go()` landed and to reflow timing. Bare-href jumps floor to column 0; an unfound id falls back to rounding the current position. The three nav handlers (TOC/search, peer-resume sync, search) all use it; the nav cover is now purely cosmetic.

## Testing

- `./gradlew test lint` — green.
- `make harness-test` — 152 tests, green except the documented pre-existing `AutoFollowJsTest.paginatedSnapsToTheColumnContainingTheSentence` (fails on `main` too; unaffected by this change).
- `make harness-test-tablet` — 5/5 green.
- New unit tests for `snapToTargetColumnJs` (target-column floor + reflow-settle loop, bare-href column-0, dotted-id preservation).
- Verified on-device that the element-anchored floor lands on the target's real column where the old round-snap was stuck a column short.