### PR TITLE
fix(reader): preserve footnote marker number and make popup links clickable

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -90,7 +90,6 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.util.concurrent.ConcurrentHashMap
 import org.json.JSONObject
-import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import org.readium.r2.navigator.DecorableNavigator
 import org.readium.r2.navigator.Decoration
@@ -719,7 +718,7 @@ private fun EpubNavigatorView(
     volumeNavEvents: Flow<VolumeNavEvent>,
     onTap: () -> Unit,
     latestLocator: () -> Locator?,
-    onFootnoteTapped: (content: String) -> Unit,
+    onFootnoteTapped: (content: FootnoteContent) -> Unit,
     activeFragmentRef: String?,
     sentenceQuotes: Map<String, SentenceQuote>,
     pageTopProbeRequests: Flow<String>,
@@ -888,9 +887,8 @@ private fun EpubNavigatorView(
                 context: HyperlinkNavigator.LinkContext?,
             ): Boolean {
                 if (context !is HyperlinkNavigator.FootnoteContext) return true
-                val plainText = Jsoup.parse(context.noteContent).text().trim()
-                if (plainText.isEmpty()) return true
-                currentOnFootnoteTapped(plainText)
+                val content = FootnoteResolver.footnoteContent(context.noteContent) ?: return true
+                currentOnFootnoteTapped(content)
                 return false
             }
 
@@ -967,7 +965,7 @@ private fun EpubNavigatorView(
                 is FootnoteResolver.AnchorTarget.Footnote -> {
                     // Called from the JS binder thread; hop to main for Compose state.
                     coroutineScope.launch(Dispatchers.Main) {
-                        currentOnFootnoteTapped(target.text)
+                        currentOnFootnoteTapped(target.content)
                     }
                     true
                 }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -491,7 +491,7 @@ class EpubReaderViewModel @Inject constructor(
         }
     }
 
-    fun showFootnotePopup(content: String) {
+    fun showFootnotePopup(content: FootnoteContent) {
         _footnotePopup.value = FootnotePopupState(content)
     }
 

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/FootnotePopup.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/FootnotePopup.kt
@@ -25,6 +25,11 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.LinkAnnotation
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextLinkStyles
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 
@@ -65,8 +70,29 @@ fun FootnotePopup(
             shadowElevation = 8.dp,
         ) {
             Box {
+                val linkColor = MaterialTheme.colorScheme.primary
+                val annotated = remember(state.content, linkColor) {
+                    buildAnnotatedString {
+                        append(state.content.text)
+                        state.content.links.forEach { link ->
+                            addLink(
+                                LinkAnnotation.Url(
+                                    link.url,
+                                    TextLinkStyles(
+                                        SpanStyle(
+                                            color = linkColor,
+                                            textDecoration = TextDecoration.Underline,
+                                        ),
+                                    ),
+                                ),
+                                link.start,
+                                link.end,
+                            )
+                        }
+                    }
+                }
                 Text(
-                    text = state.content,
+                    text = annotated,
                     style = MaterialTheme.typography.bodyMedium.copy(lineHeight = 22.sp),
                     modifier = Modifier
                         .padding(start = 16.dp, top = 16.dp, end = 48.dp, bottom = 16.dp)

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/FootnoteResolver.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/FootnoteResolver.kt
@@ -3,6 +3,8 @@ package com.riffle.app.feature.reader
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
+import org.jsoup.nodes.Node
+import org.jsoup.nodes.TextNode
 
 // Detects footnote-style link targets so the reader can show a popup even when
 // Readium's strict EPUB3 noteref classification doesn't fire. Real-world EPUBs
@@ -27,8 +29,8 @@ internal object FootnoteResolver {
 
     // The outcome of classifying a tapped in-document anchor (href="#id").
     sealed interface AnchorTarget {
-        // Target is a footnote-style element: show the popup, [text] is its body.
-        data class Footnote(val text: String) : AnchorTarget
+        // Target is a footnote-style element: show the popup, [content] is its body.
+        data class Footnote(val content: FootnoteContent) : AnchorTarget
 
         // Target is a regular in-document element (e.g. a "Figure 4.1"
         // cross-reference). The caller must navigate via Readium's go() so the
@@ -48,6 +50,14 @@ internal object FootnoteResolver {
     // Anchors whose entire text is just a note marker — "7", "7.", "[7]",
     // "(7)", "7)" — are back-references into the body, not note content.
     private val MARKER_REGEX = Regex("""[\[(]?\d{1,4}[.)\]]?""")
+
+    // Bare-text URLs to linkify. Stops at whitespace, angle brackets, and parens
+    // so wrapping punctuation isn't swallowed into the link.
+    private val BARE_URL_REGEX = Regex("""https?://[^\s<>()]+""", RegexOption.IGNORE_CASE)
+
+    // Trailing characters trimmed off a detected bare URL — sentence punctuation
+    // that commonly abuts a URL in prose but isn't part of it.
+    private const val URL_TRAILING_PUNCTUATION = ".,;:!?\"')]}>"
 
     // "Return to text" glyphs an EPUB appends as a trailing back-link: upwards
     // arrow (↑), hooked/curved return arrows, carriage-return symbol.
@@ -75,7 +85,7 @@ internal object FootnoteResolver {
     // "id=ftn AND class=ch01fn01" and matches nothing — exactly the Readium
     // 3.0.0 bug this whole feature works around. Do not swap getElementById
     // for select here.
-    fun extractFootnoteText(doc: Document, targetId: String): String? {
+    fun extractFootnoteContent(doc: Document, targetId: String): FootnoteContent? {
         val target = doc.getElementById(targetId) ?: return null
         if (!looksLikeFootnote(target)) return null
         // Some EPUBs (e.g. "Influence Without Authority") point the in-text
@@ -84,8 +94,15 @@ internal object FootnoteResolver {
         // Landing there yields a popup that shows only the number, so climb to
         // the enclosing note entry before reading the body.
         val block = if (isBackReference(target)) noteEntryFor(target) else target
-        return noteText(block).takeIf { it.isNotEmpty() }
+        return noteContent(block).takeIf { it.text.isNotEmpty() }
     }
+
+    // Builds footnote content from a raw note HTML fragment, used by the Readium
+    // shouldFollowInternalLink fallback path (which hands us the note's markup
+    // directly rather than a cached document + id). Same marker/link processing
+    // as the getElementById path. Returns null when the body is empty.
+    fun footnoteContent(noteHtml: String): FootnoteContent? =
+        noteContent(Jsoup.parse(noteHtml).body()).takeIf { it.text.isNotEmpty() }
 
     // Classifies a tapped in-document anchor against the cached spine doc so the
     // reader can decide between showing a footnote popup, navigating via
@@ -100,7 +117,7 @@ internal object FootnoteResolver {
         // The id must exist in the current resource: the JS bridge only fires
         // for href="#id" links, which target the same document.
         doc.getElementById(fragmentId) ?: return AnchorTarget.Unresolved
-        val footnote = extractFootnoteText(doc, fragmentId)
+        val footnote = extractFootnoteContent(doc, fragmentId)
         return if (footnote != null) {
             AnchorTarget.Footnote(footnote)
         } else {
@@ -115,18 +132,116 @@ internal object FootnoteResolver {
         currentHref: String?,
         cache: Map<String, Document>,
         fragmentId: String,
-    ): String? =
-        (classifyAnchorTap(currentHref, cache, fragmentId) as? AnchorTarget.Footnote)?.text
+    ): FootnoteContent? =
+        (classifyAnchorTap(currentHref, cache, fragmentId) as? AnchorTarget.Footnote)?.content
 
-    // The visible note body for [block], with any back-reference marker anchors
-    // ("1.", "[7]" that link back into the text) removed — they're navigation
-    // chrome, not content. Cloning keeps the cached document untouched.
-    private fun noteText(block: Element): String {
+    // The visible note body for [block] with its links resolved. Cloning keeps
+    // the cached document untouched. See the helpers below for the transform:
+    // external links stay clickable, marker numbers are preserved as plain text,
+    // pure chrome (return arrows, non-numeric backlinks) is removed, and bare URLs
+    // are linkified.
+    private fun noteContent(block: Element): FootnoteContent {
         val clone = block.clone()
-        clone.select("a[href^=#]").forEach { anchor ->
-            if (isBackReference(anchor)) anchor.remove()
+        rewriteAnchors(clone)
+        val builder = InlineTextBuilder()
+        appendInline(clone, builder)
+        linkifyBareUrls(builder.text, builder.links)
+        return FootnoteContent(builder.text, builder.links.toList())
+    }
+
+    // Classifies every anchor and rewrites the tree in place: external links are
+    // left for appendInline to capture, pure chrome is removed, and everything
+    // else (numeric markers, in-document cross-references) is unwrapped to plain
+    // text since a popup can't navigate it.
+    private fun rewriteAnchors(root: Element) {
+        root.select("a").forEach { a ->
+            when {
+                isExternalLink(a) -> Unit
+                isBackReferenceChrome(a) -> a.remove()
+                else -> a.unwrap()
+            }
         }
-        return clone.text().trim()
+    }
+
+    private fun isExternalLink(a: Element): Boolean {
+        val href = a.attr("href").lowercase()
+        return href.startsWith("http://") ||
+            href.startsWith("https://") ||
+            href.startsWith("mailto:")
+    }
+
+    // A back-reference that carries no information: a return-to-text glyph or a
+    // typed backlink whose text isn't a number. Numeric markers are explicitly
+    // excluded so their digit survives as plain text.
+    private fun isBackReferenceChrome(a: Element): Boolean {
+        if (MARKER_REGEX.matches(a.text().trim())) return false
+        if (matchesAny(a.attr("epub:type"), BACKLINK_EPUB_TYPES)) return true
+        if (matchesAny(a.attr("role"), BACKLINK_ROLES)) return true
+        return a.text().trim() in BACKLINK_GLYPHS
+    }
+
+    // Walks the cleaned tree in document order, accumulating visible text and
+    // recording a link span for each surviving external anchor.
+    private fun appendInline(node: Node, builder: InlineTextBuilder) {
+        for (child in node.childNodes()) {
+            when (child) {
+                is TextNode -> builder.append(child.wholeText)
+                is Element -> if (isExternalLink(child)) {
+                    val range = builder.append(child.text())
+                    if (range != null) {
+                        builder.links.add(FootnoteLink(range.first, range.second, child.attr("href")))
+                    }
+                } else {
+                    appendInline(child, builder)
+                }
+                else -> Unit
+            }
+        }
+    }
+
+    // Bare-text URLs left in the assembled body become links too, unless they
+    // already sit inside an anchor span. Trailing sentence punctuation is trimmed
+    // so "see http://x." doesn't linkify the period.
+    private fun linkifyBareUrls(text: String, links: MutableList<FootnoteLink>) {
+        for (match in BARE_URL_REGEX.findAll(text)) {
+            val start = match.range.first
+            var end = match.range.last + 1
+            while (end > start && text[end - 1] in URL_TRAILING_PUNCTUATION) end--
+            if (end <= start) continue
+            if (links.any { it.start < end && start < it.end }) continue
+            links.add(FootnoteLink(start, end, text.substring(start, end)))
+        }
+    }
+
+    // Accumulates text with whitespace collapsed to single spaces, never leading
+    // or trailing, so recorded link offsets line up exactly with the final text.
+    private class InlineTextBuilder {
+        private val sb = StringBuilder()
+        val links = mutableListOf<FootnoteLink>()
+        private var pendingSpace = false
+
+        val text: String get() = sb.toString()
+
+        // Appends [raw], returning the [start, end) range (end exclusive) of the
+        // visible characters written, or null if [raw] was all whitespace.
+        fun append(raw: String): Pair<Int, Int>? {
+            var first = -1
+            var last = -1
+            for (c in raw) {
+                if (c.isWhitespace()) {
+                    if (sb.isNotEmpty()) pendingSpace = true
+                } else {
+                    if (pendingSpace) {
+                        sb.append(' ')
+                        pendingSpace = false
+                    }
+                    if (first < 0) first = sb.length
+                    sb.append(c)
+                    last = sb.length
+                }
+            }
+            return if (first < 0) null else first to last
+        }
     }
 
     // True when [element] is an in-document anchor that is navigation chrome

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/FootnoteResolver.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/FootnoteResolver.kt
@@ -59,6 +59,15 @@ internal object FootnoteResolver {
     // that commonly abuts a URL in prose but isn't part of it.
     private const val URL_TRAILING_PUNCTUATION = ".,;:!?\"')]}>"
 
+    // Block-level tags that imply a separating space between their content and
+    // adjacent content when flattened to plain text.
+    private val BLOCK_TAGS = setOf(
+        "p", "div", "section", "aside", "article", "blockquote", "pre",
+        "ul", "ol", "li", "dl", "dt", "dd",
+        "table", "thead", "tbody", "tr", "td", "th",
+        "figure", "figcaption", "h1", "h2", "h3", "h4", "h5", "h6", "hr",
+    )
+
     // "Return to text" glyphs an EPUB appends as a trailing back-link: upwards
     // arrow (↑), hooked/curved return arrows, carriage-return symbol.
     private val BACKLINK_GLYPHS = setOf(
@@ -175,26 +184,41 @@ internal object FootnoteResolver {
     // excluded so their digit survives as plain text.
     private fun isBackReferenceChrome(a: Element): Boolean {
         if (MARKER_REGEX.matches(a.text().trim())) return false
+        return isTypedOrGlyphBacklink(a)
+    }
+
+    // The signal-based backlink checks shared by [isBackReference] and
+    // [isBackReferenceChrome]: a DPUB-ARIA/EPUB3 backlink type/role, or a
+    // return-to-text glyph. A new backlink signal only needs adding here.
+    private fun isTypedOrGlyphBacklink(a: Element): Boolean {
         if (matchesAny(a.attr("epub:type"), BACKLINK_EPUB_TYPES)) return true
         if (matchesAny(a.attr("role"), BACKLINK_ROLES)) return true
         return a.text().trim() in BACKLINK_GLYPHS
     }
 
     // Walks the cleaned tree in document order, accumulating visible text and
-    // recording a link span for each surviving external anchor.
+    // recording a link span for each surviving external anchor. Block elements
+    // and <br> introduce a separating space (Jsoup's .text() did the same), so a
+    // multi-paragraph note doesn't jam its blocks together; inline elements add
+    // no spacing of their own.
     private fun appendInline(node: Node, builder: InlineTextBuilder) {
         for (child in node.childNodes()) {
-            when (child) {
-                is TextNode -> builder.append(child.wholeText)
-                is Element -> if (isExternalLink(child)) {
+            when {
+                child is TextNode -> builder.append(child.wholeText)
+                child is Element && isExternalLink(child) -> {
                     val range = builder.append(child.text())
                     if (range != null) {
                         builder.links.add(FootnoteLink(range.first, range.second, child.attr("href")))
                     }
-                } else {
-                    appendInline(child, builder)
                 }
-                else -> Unit
+                child is Element && child.tagName().equals("br", ignoreCase = true) ->
+                    builder.markBoundary()
+                child is Element && child.tagName().lowercase() in BLOCK_TAGS -> {
+                    builder.markBoundary()
+                    appendInline(child, builder)
+                    builder.markBoundary()
+                }
+                child is Element -> appendInline(child, builder)
             }
         }
     }
@@ -221,6 +245,12 @@ internal object FootnoteResolver {
         private var pendingSpace = false
 
         val text: String get() = sb.toString()
+
+        // Records a whitespace boundary (a single space before the next visible
+        // character), unless we're at the very start. Used at block-element edges.
+        fun markBoundary() {
+            if (sb.isNotEmpty()) pendingSpace = true
+        }
 
         // Appends [raw], returning the [start, end) range (end exclusive) of the
         // visible characters written, or null if [raw] was all whitespace.
@@ -251,10 +281,8 @@ internal object FootnoteResolver {
     private fun isBackReference(element: Element): Boolean {
         if (!element.tagName().equals("a", ignoreCase = true)) return false
         if (!element.attr("href").startsWith("#")) return false
-        if (matchesAny(element.attr("epub:type"), BACKLINK_EPUB_TYPES)) return true
-        if (matchesAny(element.attr("role"), BACKLINK_ROLES)) return true
-        val text = element.text().trim()
-        return MARKER_REGEX.matches(text) || text in BACKLINK_GLYPHS
+        if (isTypedOrGlyphBacklink(element)) return true
+        return MARKER_REGEX.matches(element.text().trim())
     }
 
     // Climbs from a marker anchor to the enclosing note entry: the nearest

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/FootnoteState.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/FootnoteState.kt
@@ -1,5 +1,19 @@
 package com.riffle.app.feature.reader
 
+// The resolved body of a footnote: the visible text plus the spans within it
+// that should render as tappable links. [links] is empty for plain-text notes.
+data class FootnoteContent(
+    val text: String,
+    val links: List<FootnoteLink> = emptyList(),
+)
+
+// A clickable span within a [FootnoteContent.text]. [end] is exclusive.
+data class FootnoteLink(
+    val start: Int,
+    val end: Int,
+    val url: String,
+)
+
 data class FootnotePopupState(
-    val content: String,
+    val content: FootnoteContent,
 )

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/EpubReaderViewModelFootnoteTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/EpubReaderViewModelFootnoteTest.kt
@@ -23,10 +23,10 @@ class EpubReaderViewModelFootnoteTest {
         val emissions = mutableListOf<FootnotePopupState?>()
         backgroundScope.launch { flow.collect { emissions.add(it) } }
 
-        flow.value = FootnotePopupState("Heraclitus of Ephesus (c. 535 BC)")
+        flow.value = FootnotePopupState(FootnoteContent("Heraclitus of Ephesus (c. 535 BC)"))
 
         assertEquals(2, emissions.size)
-        assertEquals("Heraclitus of Ephesus (c. 535 BC)", emissions[1]?.content)
+        assertEquals("Heraclitus of Ephesus (c. 535 BC)", emissions[1]?.content?.text)
     }
 
     @Test
@@ -35,12 +35,12 @@ class EpubReaderViewModelFootnoteTest {
         val emissions = mutableListOf<FootnotePopupState?>()
         backgroundScope.launch { flow.collect { emissions.add(it) } }
 
-        flow.value = FootnotePopupState("Some footnote")
+        flow.value = FootnotePopupState(FootnoteContent("Some footnote"))
         flow.value = null
 
         assertEquals(3, emissions.size)
         assertNull(emissions[0])
-        assertEquals("Some footnote", emissions[1]?.content)
+        assertEquals("Some footnote", emissions[1]?.content?.text)
         assertNull(emissions[2])
     }
 
@@ -50,12 +50,12 @@ class EpubReaderViewModelFootnoteTest {
         val emissions = mutableListOf<FootnotePopupState?>()
         backgroundScope.launch { flow.collect { emissions.add(it) } }
 
-        flow.value = FootnotePopupState("First footnote")
-        flow.value = FootnotePopupState("Second footnote")
+        flow.value = FootnotePopupState(FootnoteContent("First footnote"))
+        flow.value = FootnotePopupState(FootnoteContent("Second footnote"))
 
         assertEquals(3, emissions.size)
-        assertEquals("First footnote", emissions[1]?.content)
-        assertEquals("Second footnote", emissions[2]?.content)
+        assertEquals("First footnote", emissions[1]?.content?.text)
+        assertEquals("Second footnote", emissions[2]?.content?.text)
     }
 
     @Test
@@ -82,9 +82,9 @@ class EpubReaderViewModelFootnoteTest {
 
     @Test
     fun `FootnotePopupState equality is structural`() {
-        val a = FootnotePopupState("text")
-        val b = FootnotePopupState("text")
-        val c = FootnotePopupState("other")
+        val a = FootnotePopupState(FootnoteContent("text"))
+        val b = FootnotePopupState(FootnoteContent("text"))
+        val c = FootnotePopupState(FootnoteContent("other"))
         assertEquals(a, b)
         assert(a != c)
     }

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/FootnoteResolverTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/FootnoteResolverTest.kt
@@ -364,6 +364,51 @@ class FootnoteResolverTest {
         assertPlain("Note body.", FootnoteResolver.extractFootnoteContent(doc, "fn9"))
     }
 
+    // Multi-block notes must keep a separating space between blocks — the old
+    // Jsoup .text() inserted one, so dropping it would jam paragraphs together.
+    @Test
+    fun `adjacent block elements are separated by a space`() {
+        val html = """
+            <html><body>
+              <div class="footnote" id="fn1"><p>First paragraph.</p><p>Second paragraph.</p></div>
+            </body></html>
+        """.trimIndent()
+        val doc = FootnoteResolver.parse(html)
+        assertPlain(
+            "First paragraph. Second paragraph.",
+            FootnoteResolver.extractFootnoteContent(doc, "fn1"),
+        )
+    }
+
+    @Test
+    fun `line break is treated as a separating space`() {
+        val html = """
+            <html><body>
+              <div class="footnote" id="fn1"><p>Line one<br/>Line two</p></div>
+            </body></html>
+        """.trimIndent()
+        val doc = FootnoteResolver.parse(html)
+        assertPlain(
+            "Line one Line two",
+            FootnoteResolver.extractFootnoteContent(doc, "fn1"),
+        )
+    }
+
+    // An inline element (e.g. <i>) must NOT introduce spurious spaces — the only
+    // spacing comes from the surrounding text nodes.
+    @Test
+    fun `inline elements do not introduce spurious spaces`() {
+        val html = """
+            <html xmlns:epub="http://www.idpf.org/2007/ops"><body>
+              <aside id="en2" epub:type="rearnote">
+                <a id="m" href="#b">1.</a> Kanter, <i>Change Masters</i>.
+              </aside>
+            </body></html>
+        """.trimIndent()
+        val doc = FootnoteResolver.parse(html)
+        assertPlain("1. Kanter, Change Masters.", FootnoteResolver.extractFootnoteContent(doc, "en2"))
+    }
+
     @Test
     fun `class footnotes plural on container is detected`() {
         val html = """

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/FootnoteResolverTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/FootnoteResolverTest.kt
@@ -9,6 +9,13 @@ import org.junit.Test
 
 class FootnoteResolverTest {
 
+    // Convenience: assert a footnote resolves to plain text with no links.
+    private fun assertPlain(expected: String, content: FootnoteContent?) {
+        assertNotNull(content)
+        assertEquals(expected, content!!.text)
+        assertTrue("expected no links, got ${content.links}", content.links.isEmpty())
+    }
+
     @Test
     fun `target with epub-type footnote is detected`() {
         val html = """
@@ -17,7 +24,7 @@ class FootnoteResolverTest {
             </body></html>
         """.trimIndent()
         val doc = FootnoteResolver.parse(html)
-        assertEquals("Note one.", FootnoteResolver.extractFootnoteText(doc, "fn1"))
+        assertPlain("Note one.", FootnoteResolver.extractFootnoteContent(doc, "fn1"))
     }
 
     // The Lean Customer Development EPUB ships ch01fn02..ch01fn08 without
@@ -31,7 +38,7 @@ class FootnoteResolverTest {
             </body></html>
         """.trimIndent()
         val doc = FootnoteResolver.parse(html)
-        assertEquals("Body text.", FootnoteResolver.extractFootnoteText(doc, "ftn.ch01fn02"))
+        assertPlain("Body text.", FootnoteResolver.extractFootnoteContent(doc, "ftn.ch01fn02"))
     }
 
     @Test
@@ -44,7 +51,7 @@ class FootnoteResolverTest {
             </body></html>
         """.trimIndent()
         val doc = FootnoteResolver.parse(html)
-        assertEquals("Third note.", FootnoteResolver.extractFootnoteText(doc, "ftn.ch01fn03"))
+        assertPlain("Third note.", FootnoteResolver.extractFootnoteContent(doc, "ftn.ch01fn03"))
     }
 
     @Test
@@ -55,7 +62,7 @@ class FootnoteResolverTest {
             </body></html>
         """.trimIndent()
         val doc = FootnoteResolver.parse(html)
-        assertEquals("Aria note.", FootnoteResolver.extractFootnoteText(doc, "dfn1"))
+        assertPlain("Aria note.", FootnoteResolver.extractFootnoteContent(doc, "dfn1"))
     }
 
     @Test
@@ -67,26 +74,26 @@ class FootnoteResolverTest {
             </body></html>
         """.trimIndent()
         val doc = FootnoteResolver.parse(html)
-        assertNull(FootnoteResolver.extractFootnoteText(doc, "sec1"))
+        assertNull(FootnoteResolver.extractFootnoteContent(doc, "sec1"))
     }
 
     @Test
     fun `missing target id returns null`() {
         val doc = FootnoteResolver.parse("<html><body><p id=\"x\">Hi</p></body></html>")
-        assertNull(FootnoteResolver.extractFootnoteText(doc, "nope"))
+        assertNull(FootnoteResolver.extractFootnoteContent(doc, "nope"))
     }
 
     @Test
     fun `empty footnote body returns null`() {
         val html = """<html><body><div class="footnote" id="fn1"></div></body></html>"""
         val doc = FootnoteResolver.parse(html)
-        assertNull(FootnoteResolver.extractFootnoteText(doc, "fn1"))
+        assertNull(FootnoteResolver.extractFootnoteContent(doc, "fn1"))
     }
 
     // Regression for Readium 3.0.0's `select("#$id")` bug. Many EPUBs (O'Reilly
     // toolchain in particular) emit `id="ftn.ch01fn01"`, where Jsoup's CSS
     // selector parses the dot as a class separator and matches nothing.
-    // extractFootnoteText must use getElementById, not select.
+    // extractFootnoteContent must use getElementById, not select.
     @Test
     fun `dotted target id is still found`() {
         val html = """
@@ -97,11 +104,11 @@ class FootnoteResolverTest {
             </body></html>
         """.trimIndent()
         val doc = FootnoteResolver.parse(html)
-        assertEquals("Dotted body.", FootnoteResolver.extractFootnoteText(doc, "ftn.ch01fn01"))
+        assertPlain("Dotted body.", FootnoteResolver.extractFootnoteContent(doc, "ftn.ch01fn01"))
     }
 
     @Test
-    fun `resolveAnchorTap returns text on cache hit and footnote target`() {
+    fun `resolveAnchorTap returns content on cache hit and footnote target`() {
         val html = """
             <html><body>
               <div class="footnote" id="fn1"><p>Body.</p></div>
@@ -110,7 +117,7 @@ class FootnoteResolverTest {
         val cache = mapOf("OEBPS/ch01.html" to FootnoteResolver.parse(html))
         assertEquals(
             "Body.",
-            FootnoteResolver.resolveAnchorTap("OEBPS/ch01.html", cache, "fn1"),
+            FootnoteResolver.resolveAnchorTap("OEBPS/ch01.html", cache, "fn1")?.text,
         )
     }
 
@@ -174,7 +181,7 @@ class FootnoteResolverTest {
         """.trimIndent()
         val cache = mapOf("OEBPS/ch08.html" to FootnoteResolver.parse(html))
         assertEquals(
-            FootnoteResolver.AnchorTarget.Footnote("Note one."),
+            FootnoteResolver.AnchorTarget.Footnote(FootnoteContent("Note one.")),
             FootnoteResolver.classifyAnchorTap("OEBPS/ch08.html", cache, "fn1"),
         )
     }
@@ -251,10 +258,10 @@ class FootnoteResolverTest {
     //               <a id="c07-note-0002" href="#backTNT2">1.</a> Kanter…
     //             </aside>
     // getElementById("c07-note-0002") lands on the marker anchor whose text is
-    // just "1.", so the popup used to show only the number. The resolver must
-    // climb to the enclosing note entry and return the body, marker stripped.
+    // just "1.", so we climb to the enclosing note entry and return its body.
+    // The marker number is preserved (as plain text), only the dead link drops.
     @Test
-    fun `back-reference marker target resolves to the note body`() {
+    fun `back-reference marker target resolves to the note body with the number preserved`() {
         val html = """
             <html xmlns:epub="http://www.idpf.org/2007/ops"><body>
               <section epub:type="rearnotes">
@@ -265,16 +272,17 @@ class FootnoteResolverTest {
             </body></html>
         """.trimIndent()
         val doc = FootnoteResolver.parse(html)
-        assertEquals(
-            "Kanter, Change Masters.",
-            FootnoteResolver.extractFootnoteText(doc, "c07-note-0002"),
+        assertPlain(
+            "1. Kanter, Change Masters.",
+            FootnoteResolver.extractFootnoteContent(doc, "c07-note-0002"),
         )
     }
 
-    // Even when the id points straight at the note entry, the leading
-    // back-reference marker ("1.") is chrome, not content — strip it.
+    // Even when the id points straight at the note entry, the leading marker
+    // ("1.") is preserved as plain text — its number is useful context, only
+    // the back-link target is dropped.
     @Test
-    fun `note entry target strips the leading back-reference marker`() {
+    fun `note entry target preserves the leading marker number as plain text`() {
         val html = """
             <html xmlns:epub="http://www.idpf.org/2007/ops"><body>
               <aside id="en2" class="noteEntry" epub:type="rearnote">
@@ -283,14 +291,30 @@ class FootnoteResolverTest {
             </body></html>
         """.trimIndent()
         val doc = FootnoteResolver.parse(html)
-        assertEquals(
-            "Kanter, Change Masters.",
-            FootnoteResolver.extractFootnoteText(doc, "en2"),
+        assertPlain(
+            "1. Kanter, Change Masters.",
+            FootnoteResolver.extractFootnoteContent(doc, "en2"),
+        )
+    }
+
+    // The screenshot bug: brackets are plain text, the number is a back-reference
+    // anchor. Stripping the anchor left an orphaned "[]". The number must survive.
+    @Test
+    fun `numeric marker wrapped by text brackets is preserved`() {
+        val html = """
+            <html><body>
+              <div class="footnote" id="fn10">[<a href="#ref10">10</a>] KISSmetrics CEO talked.</div>
+            </body></html>
+        """.trimIndent()
+        val doc = FootnoteResolver.parse(html)
+        assertPlain(
+            "[10] KISSmetrics CEO talked.",
+            FootnoteResolver.extractFootnoteContent(doc, "fn10"),
         )
     }
 
     // A footnote whose body legitimately starts with a number must keep it;
-    // only the back-reference *anchor* is stripped, not arbitrary digits.
+    // only back-reference *anchors* are special-cased, not arbitrary digits.
     @Test
     fun `numeric body content is preserved when not a back-reference`() {
         val html = """
@@ -299,21 +323,17 @@ class FootnoteResolverTest {
             </body></html>
         """.trimIndent()
         val doc = FootnoteResolver.parse(html)
-        assertEquals(
+        assertPlain(
             "1984 was a pivotal year.",
-            FootnoteResolver.extractFootnoteText(doc, "en3"),
+            FootnoteResolver.extractFootnoteContent(doc, "en3"),
         )
     }
 
     // Many EPUBs append a "return to text" back-link at the END of the note —
-    // an up-arrow (↑) or hooked arrow that links back to the reference. Real
-    // sample from a Swedish-to-Bulgarian translation:
-    //   <div epub:type="footnote" id="note_3-1"><p>
-    //     <a href="#ref_3-1">[1]</a> Йостермалм … Б. пр. <a href="#ref_3-1">↑</a>
-    //   </p></div>
-    // Both the leading marker and the trailing arrow are chrome; strip both.
+    // an up-arrow (↑) or hooked arrow. The leading marker number is preserved
+    // as plain text; the trailing arrow is pure chrome and is removed.
     @Test
-    fun `trailing up-arrow back-link is stripped`() {
+    fun `leading marker kept, trailing up-arrow back-link stripped`() {
         val html = """
             <html xmlns:epub="http://www.idpf.org/2007/ops"><body>
               <div epub:type="footnote" id="note_3-1"><p>
@@ -323,14 +343,16 @@ class FootnoteResolverTest {
             </body></html>
         """.trimIndent()
         val doc = FootnoteResolver.parse(html)
-        assertEquals(
-            "Ostermalm is a district. Note.",
-            FootnoteResolver.extractFootnoteText(doc, "note_3-1"),
+        assertPlain(
+            "[1] Ostermalm is a district. Note.",
+            FootnoteResolver.extractFootnoteContent(doc, "note_3-1"),
         )
     }
 
+    // A non-numeric backlink (epub:type="backlink", text "Return") carries no
+    // information and is removed entirely.
     @Test
-    fun `standard epub-type backlink is stripped`() {
+    fun `non-numeric epub-type backlink is stripped`() {
         val html = """
             <html xmlns:epub="http://www.idpf.org/2007/ops"><body>
               <aside epub:type="footnote" id="fn9"><p>
@@ -339,7 +361,7 @@ class FootnoteResolverTest {
             </body></html>
         """.trimIndent()
         val doc = FootnoteResolver.parse(html)
-        assertEquals("Note body.", FootnoteResolver.extractFootnoteText(doc, "fn9"))
+        assertPlain("Note body.", FootnoteResolver.extractFootnoteContent(doc, "fn9"))
     }
 
     @Test
@@ -352,6 +374,95 @@ class FootnoteResolverTest {
             </body></html>
         """.trimIndent()
         val doc = FootnoteResolver.parse(html)
-        assertEquals("Container plural.", FootnoteResolver.extractFootnoteText(doc, "fnX"))
+        assertPlain("Container plural.", FootnoteResolver.extractFootnoteContent(doc, "fnX"))
+    }
+
+    // ── Clickable links ───────────────────────────────────────────────────────
+
+    // A real <a href="http…"> anchor whose visible text differs from the URL
+    // must survive as a link span covering its visible text, carrying the href.
+    @Test
+    fun `external anchor link is preserved with its href and visible-text offsets`() {
+        val html = """
+            <html><body>
+              <div class="footnote" id="fn1"><p>See <a href="https://example.com/study">the study</a> for details.</p></div>
+            </body></html>
+        """.trimIndent()
+        val doc = FootnoteResolver.parse(html)
+        val content = FootnoteResolver.extractFootnoteContent(doc, "fn1")
+        assertNotNull(content)
+        assertEquals("See the study for details.", content!!.text)
+        assertEquals(1, content.links.size)
+        val link = content.links.single()
+        assertEquals("https://example.com/study", link.url)
+        assertEquals("the study", content.text.substring(link.start, link.end))
+    }
+
+    // A bare-text URL (no anchor) — the screenshot's slideshare case — is
+    // linkified in place.
+    @Test
+    fun `bare text url is linkified`() {
+        val html = """
+            <html><body>
+              <div class="footnote" id="fn1"><p>Source: http://www.slideshare.net/hnshah/x</p></div>
+            </body></html>
+        """.trimIndent()
+        val doc = FootnoteResolver.parse(html)
+        val content = FootnoteResolver.extractFootnoteContent(doc, "fn1")
+        assertNotNull(content)
+        assertEquals("Source: http://www.slideshare.net/hnshah/x", content!!.text)
+        val link = content.links.single()
+        assertEquals("http://www.slideshare.net/hnshah/x", link.url)
+        assertEquals("http://www.slideshare.net/hnshah/x", content.text.substring(link.start, link.end))
+    }
+
+    // Trailing sentence punctuation must not be swallowed into the linkified URL.
+    @Test
+    fun `bare url trailing punctuation is trimmed from the link`() {
+        val html = """
+            <html><body>
+              <div class="footnote" id="fn1"><p>See http://example.com/a.</p></div>
+            </body></html>
+        """.trimIndent()
+        val doc = FootnoteResolver.parse(html)
+        val content = FootnoteResolver.extractFootnoteContent(doc, "fn1")
+        assertNotNull(content)
+        assertEquals("See http://example.com/a.", content!!.text)
+        val link = content.links.single()
+        assertEquals("http://example.com/a", link.url)
+        assertEquals("http://example.com/a", content.text.substring(link.start, link.end))
+    }
+
+    // A URL that is already an anchor must not be double-linkified by the
+    // bare-URL pass.
+    @Test
+    fun `url that is already an anchor is not double-linkified`() {
+        val html = """
+            <html><body>
+              <div class="footnote" id="fn1"><p><a href="http://example.com">http://example.com</a></p></div>
+            </body></html>
+        """.trimIndent()
+        val doc = FootnoteResolver.parse(html)
+        val content = FootnoteResolver.extractFootnoteContent(doc, "fn1")
+        assertNotNull(content)
+        assertEquals("http://example.com", content!!.text)
+        assertEquals(1, content.links.size)
+        assertEquals("http://example.com", content.links.single().url)
+    }
+
+    // footnoteContent(rawHtml) backs the Readium shouldFollowInternalLink path;
+    // it must apply the same marker/link processing as the getElementById path.
+    @Test
+    fun `footnoteContent parses raw note html with marker preserved and url linkified`() {
+        val noteHtml = "<aside>[<a href=\"#r\">2</a>] See http://example.com/x</aside>"
+        val content = FootnoteResolver.footnoteContent(noteHtml)
+        assertNotNull(content)
+        assertEquals("[2] See http://example.com/x", content!!.text)
+        assertEquals("http://example.com/x", content.links.single().url)
+    }
+
+    @Test
+    fun `footnoteContent returns null for empty note html`() {
+        assertNull(FootnoteResolver.footnoteContent("<aside></aside>"))
     }
 }

--- a/docs/superpowers/specs/2026-06-05-footnote-popup-number-and-links-design.md
+++ b/docs/superpowers/specs/2026-06-05-footnote-popup-number-and-links-design.md
@@ -1,0 +1,127 @@
+# Footnote popup: preserve the marker number and make links clickable
+
+## Problem
+
+The footnote popup mangles two things in the note body:
+
+1. **The marker number is destroyed.** Many EPUBs format a footnote entry as
+   `[<a href="#ref">10</a>] KISSmetrics CEO…` — the brackets are plain text and
+   the number is a back-reference anchor that links into the body. The resolver
+   strips *all* back-reference anchors (`FootnoteResolver.noteText`), so the
+   number disappears and the popup shows an orphaned `[] KISSmetrics CEO…`.
+
+2. **Links are dead.** The resolver flattens the body with Jsoup `.text()`,
+   which discards every `href`. Real `<a href="http…">` links lose their target,
+   and bare-text URLs (e.g. `http://www.slideshare.net/hnshah/…`) are never
+   linkified. The popup renders them as inert text.
+
+Why the stripping existed: a back-reference marker is a dead link inside a popup
+(it jumps to the body the popup already floats over), and some EPUBs point the
+in-text superscript at the marker anchor itself, which used to yield a popup
+showing *only* a number. Both concerns are real, but neither requires deleting
+the digit — they only require not rendering it as a tappable link and not
+landing on a bare-marker-only body.
+
+## Decisions
+
+- **Preserve the number in all footnotes**, rendered as plain (non-link) text.
+  Both footnote shapes show their marker: `[10] KISSmetrics…` and `[1]
+  Ostermalm…`. Trailing "return to text" glyphs (`↑`, `↩`, …) and non-numeric
+  backlinks (`epub:type="backlink"` / `role="doc-backlink"` with text like
+  "Return") are still removed — they carry no information.
+- **Make both link forms clickable**: preserve real `<a href="http…">` /
+  `mailto:` anchors (keeping their visible text), and linkify bare-text URLs.
+  In-document `#fragment` anchors stay plain text (not navigable from a popup).
+
+## Architecture
+
+The resolver currently returns `String`, throwing away `href`s. Introduce a
+plain-data model and thread it end-to-end; only the popup touches Compose.
+
+```kotlin
+data class FootnoteContent(val text: String, val links: List<FootnoteLink>)
+data class FootnoteLink(val start: Int, val end: Int, val url: String) // end exclusive
+```
+
+- `FootnoteResolver` returns `FootnoteContent` (empty `links` = plain text). All
+  marker/link/offset logic lives here — pure JVM, no Compose types.
+- `AnchorTarget.Footnote`, `FootnotePopupState`, `EpubReaderViewModel.showFootnotePopup`,
+  and the `onFootnoteTapped` callback carry `FootnoteContent` instead of `String`.
+- `FootnotePopup` builds an `AnnotatedString`, adding one `LinkAnnotation.Url`
+  span per `FootnoteLink`. `Text` renders them as styled, tappable links opened
+  via the default `UriHandler` — no click wiring.
+
+Rejected: building the `AnnotatedString` inside the resolver. Keeping the
+resolver a pure data transformer keeps the offset/link logic fully unit-testable
+with no Compose-runtime dependency; the popup conversion is ~8 lines.
+
+## Resolver processing (`noteContent(block): FootnoteContent`)
+
+On a clone of the note element:
+
+1. **Classify and rewrite every `<a>`:**
+   - External (`href` starts `http://`, `https://`, `mailto:`) → leave in place;
+     becomes a link span in step 2.
+   - In-document numeric marker (`href="#…"`, text matches the marker regex —
+     `10`, `[1]`, `1.`) → **unwrap** (number survives as plain text, dead link
+     gone). *Numeric check wins over the chrome check.*
+   - In-document chrome (`href="#…"`, non-numeric, and a backlink glyph or
+     `epub:type="backlink"` / `role="doc-backlink"`) → **remove**.
+   - Any other in-document / relative anchor → **unwrap** to plain text.
+2. **Build text + link spans via one in-order DOM walk** with whitespace
+   collapsing (single spaces, no leading/trailing) so offsets are exact — no
+   `.text()` + substring search. Each surviving external `<a>` records
+   `FootnoteLink(start, end, href)` around its visible text.
+3. **Linkify bare-text URLs** (`https?://…`) in the assembled string, trimming
+   trailing prose punctuation (`. , ; : ) ] } > " '`), skipping ranges already
+   covered by a step-2 anchor span.
+
+Empty resulting text → `null` (unchanged "no popup" behavior).
+
+### Entry points
+
+- `extractFootnoteContent(doc, targetId)` — JS-bridge path (renamed from
+  `extractFootnoteText`); still uses `getElementById` and climbs from a
+  marker-anchor target to the enclosing note entry as today.
+- `footnoteContent(noteHtml)` — Readium `shouldFollowInternalLink` fallback
+  (`EpubReaderScreen.kt:854`), replacing its ad-hoc `Jsoup.parse(...).text()`
+  so both paths behave identically.
+
+## Popup rendering
+
+```kotlin
+val linkColor = MaterialTheme.colorScheme.primary
+val annotated = buildAnnotatedString {
+    append(state.content.text)
+    state.content.links.forEach { l ->
+        addLink(
+            LinkAnnotation.Url(l.url, TextLinkStyles(SpanStyle(color = linkColor, textDecoration = TextDecoration.Underline))),
+            l.start, l.end,
+        )
+    }
+}
+Text(text = annotated, …)
+```
+
+## Testing
+
+Pure-JVM `FootnoteResolverTest`:
+
+- **Updated (intentional, per decision):** three cases that asserted the marker
+  was stripped now expect it preserved — e.g. trailing-up-arrow body becomes
+  `[1] Ostermalm is a district. Note.` (leading `[1]` kept, trailing `↑`
+  removed). The `epub:type="backlink"` / text "Return" case still removes the
+  anchor → unchanged.
+- **New:** bare-URL linkify (offset + url asserted); `<a href>` anchor
+  preservation with differing visible text; number-with-text-brackets
+  (`[<a>10</a>]` → `[10] …`); offset correctness against the produced `text`;
+  bare URL with trailing punctuation trimmed; URL range not double-linkified
+  when already an anchor.
+
+`EpubReaderViewModelFootnoteTest` and any other `FootnotePopupState("…")` /
+string-based call sites update to the `FootnoteContent` type.
+
+## Out of scope
+
+- Rendering other inline formatting (bold/italic) inside the popup.
+- Navigating in-document `#fragment` links from the popup.


### PR DESCRIPTION
## Problem

The footnote popup mangled two things in the note body:

1. **The marker number was destroyed.** Many EPUBs format an entry as `[<a href="#ref">10</a>] …` — brackets are plain text, the number is a back-reference link. The resolver stripped *all* back-reference anchors, leaving an orphaned `[]` (see screenshot in the issue).
2. **Links were dead.** The body was flattened with Jsoup `.text()`, discarding every `href`, so neither anchor-wrapped links nor bare-text URLs were tappable.

## Change

The resolver now returns a `FootnoteContent(text, links)` instead of a bare `String`, threaded through `AnchorTarget.Footnote` → `FootnotePopupState` → the popup:

- **Marker numbers preserved** as plain (non-link) text — both `[10] KISSmetrics…` and `[1] Ostermalm…`. Only the dead in-document link is dropped.
- **Pure chrome removed** — trailing return-to-text glyphs (`↑`) and non-numeric backlinks (`epub:type="backlink"` / `role="doc-backlink"`).
- **Links made clickable** — external `<a href="http…">`/`mailto:` anchors kept as spans (visible text preserved), and bare-text URLs linkified (with trailing-punctuation trimmed). In-document `#fragment` anchors stay plain text (a popup can't navigate them).
- **Block-boundary spacing preserved** — the DOM walk inserts a separating space at block edges and `<br>` (matching the old `.text()` behavior), while inline elements add no spurious spaces.

`FootnotePopup` builds an `AnnotatedString` with `LinkAnnotation.Url` spans; `Text` renders them styled and opens them via the default `UriHandler`. The Readium `shouldFollowInternalLink` fallback now routes through the same logic.

Design spec: `docs/superpowers/specs/2026-06-05-footnote-popup-number-and-links-design.md`.

## Testing

- **Unit (`FootnoteResolverTest`, `EpubReaderViewModelFootnoteTest`):** added cases for the screenshot shape (`[<a>10</a>]` → `[10]`), anchor-href preservation with offsets, bare-URL linkify, trailing-punctuation trim, no double-linkifying, multi-paragraph/`<br>` block spacing, and inline-element non-spacing. Three pre-existing cases that asserted the marker was *stripped* were updated to expect it *preserved* (intended behavior change).
- `./gradlew test lint` — ✅ green.
- `make harness-test` (phone) — green except the pre-existing `AutoFollowJsTest.paginatedSnapsToTheColumnContainingTheSentence` (fails on `main` too; unrelated to footnotes).
- `make harness-test-tablet` — ✅ 5/5.

Note: the popup's on-screen link-tap rendering isn't covered by an instrumentation test (`EpubFootnoteHarnessTest` is `@Ignore`'d due to a Compose `waitForIdle` hang with the Readium WebView); the link/marker logic is fully unit-tested.