### PR TITLE
feat(library): show download progress percentage in download buttons

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/library/DownloadButton.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/DownloadButton.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 
@@ -49,32 +50,12 @@ fun DownloadButton(
             }
         }
         is DownloadState.InProgress -> {
-            Box(
-                modifier = modifier.size(size),
-                contentAlignment = Alignment.Center,
-            ) {
-                val percent = state.percent
-                if (percent == null) {
-                    // No advertised size — fall back to the indeterminate spinner.
-                    CircularProgressIndicator(modifier = Modifier.size(size))
-                } else {
-                    // Animate between reported steps so the ring sweeps smoothly rather than jumping.
-                    val animated by animateFloatAsState(
-                        targetValue = percent / 100f,
-                        label = "downloadProgress",
-                    )
-                    CircularProgressIndicator(
-                        progress = { animated },
-                        modifier = Modifier.size(size),
-                    )
-                    Text(
-                        text = "$percent%",
-                        color = MaterialTheme.colorScheme.primary,
-                        fontSize = 11.sp,
-                        fontWeight = FontWeight.SemiBold,
-                    )
-                }
-            }
+            DownloadProgressIndicator(
+                percent = state.percent,
+                size = size,
+                label = "downloadProgress",
+                modifier = modifier,
+            )
         }
         DownloadState.Downloaded -> {
             Box(
@@ -92,6 +73,36 @@ fun DownloadButton(
                     modifier = Modifier.size(20.dp),
                 )
             }
+        }
+    }
+}
+
+/**
+ * The in-progress affordance shared by [DownloadButton] and [ReadaloudDownloadButton]: a determinate
+ * ring with the live percent centered inside, or an indeterminate spinner when [percent] is null
+ * (the download advertised no size). [label] names the animation for tooling.
+ */
+@Composable
+internal fun DownloadProgressIndicator(
+    percent: Int?,
+    size: Dp,
+    label: String,
+    modifier: Modifier = Modifier,
+) {
+    Box(modifier = modifier.size(size), contentAlignment = Alignment.Center) {
+        if (percent == null) {
+            CircularProgressIndicator(modifier = Modifier.size(size))
+        } else {
+            // animateFloatAsState remembers its Animatable across recompositions, so the ring sweeps
+            // smoothly from the current value toward each reported step rather than jumping.
+            val animated by animateFloatAsState(targetValue = percent / 100f, label = label)
+            CircularProgressIndicator(progress = { animated }, modifier = Modifier.size(size))
+            Text(
+                text = "$percent%",
+                color = MaterialTheme.colorScheme.primary,
+                fontSize = 11.sp,
+                fontWeight = FontWeight.SemiBold,
+            )
         }
     }
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/library/DownloadButton.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/DownloadButton.kt
@@ -1,5 +1,6 @@
 package com.riffle.app.feature.library
 
+import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -11,11 +12,15 @@ import androidx.compose.material.icons.filled.ArrowDownward
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 
 @Composable
 fun DownloadButton(
@@ -43,12 +48,32 @@ fun DownloadButton(
                 )
             }
         }
-        DownloadState.InProgress -> {
+        is DownloadState.InProgress -> {
             Box(
                 modifier = modifier.size(size),
                 contentAlignment = Alignment.Center,
             ) {
-                CircularProgressIndicator(modifier = Modifier.size(size))
+                val percent = state.percent
+                if (percent == null) {
+                    // No advertised size — fall back to the indeterminate spinner.
+                    CircularProgressIndicator(modifier = Modifier.size(size))
+                } else {
+                    // Animate between reported steps so the ring sweeps smoothly rather than jumping.
+                    val animated by animateFloatAsState(
+                        targetValue = percent / 100f,
+                        label = "downloadProgress",
+                    )
+                    CircularProgressIndicator(
+                        progress = { animated },
+                        modifier = Modifier.size(size),
+                    )
+                    Text(
+                        text = "$percent%",
+                        color = MaterialTheme.colorScheme.primary,
+                        fontSize = 11.sp,
+                        fontWeight = FontWeight.SemiBold,
+                    )
+                }
             }
         }
         DownloadState.Downloaded -> {
@@ -56,14 +81,14 @@ fun DownloadButton(
                 modifier = modifier
                     .size(size)
                     .clip(CircleShape)
-                    .background(MaterialTheme.colorScheme.primaryContainer)
+                    .background(MaterialTheme.colorScheme.primary)
                     .clickable(onClick = onRemove),
                 contentAlignment = Alignment.Center,
             ) {
                 Icon(
                     imageVector = Icons.Default.ArrowDownward,
                     contentDescription = "Remove download",
-                    tint = MaterialTheme.colorScheme.onPrimaryContainer,
+                    tint = MaterialTheme.colorScheme.onPrimary,
                     modifier = Modifier.size(20.dp),
                 )
             }

--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModel.kt
@@ -47,12 +47,21 @@ sealed interface LibraryItemDetailUiState {
 
 sealed interface DownloadState {
     data object NotDownloaded : DownloadState
-    data object InProgress : DownloadState
+    /** [percent] is 0..100 when the download advertises a size; null means indeterminate (spinner). */
+    data class InProgress(val percent: Int? = null) : DownloadState
     data object Downloaded : DownloadState
 }
 
 internal fun readaloudDownloadStateFor(bundlePresent: Boolean): DownloadState =
     if (bundlePresent) DownloadState.Downloaded else DownloadState.NotDownloaded
+
+/**
+ * Maps raw byte counts from a download into a 0..100 percentage for the progress ring, or null when
+ * the total size is unknown (the server sent no content length) so the UI shows an indeterminate
+ * spinner instead of a misleading number.
+ */
+internal fun downloadPercent(downloaded: Long, total: Long): Int? =
+    if (total > 0L) ((downloaded * 100L) / total).toInt().coerceIn(0, 100) else null
 
 @HiltViewModel
 class LibraryItemDetailViewModel @Inject constructor(
@@ -205,16 +214,19 @@ class LibraryItemDetailViewModel @Inject constructor(
     }
 
     fun startDownload() {
-        if (_downloadState.value == DownloadState.InProgress) return
+        if (_downloadState.value is DownloadState.InProgress) return
         val item = (uiState.value as? LibraryItemDetailUiState.Ready)?.item ?: return
-        _downloadState.value = DownloadState.InProgress
+        _downloadState.value = DownloadState.InProgress()
         viewModelScope.launch {
+            val onProgress: (Long, Long) -> Unit = { downloaded, total ->
+                _downloadState.value = DownloadState.InProgress(downloadPercent(downloaded, total))
+            }
             val newDownloadState = when (item.ebookFormat) {
-                EbookFormat.Epub -> when (epubRepository.downloadEpub(item)) {
+                EbookFormat.Epub -> when (epubRepository.downloadEpub(item, onProgress)) {
                     EpubDownloadResult.Success, EpubDownloadResult.AlreadyDownloaded -> DownloadState.Downloaded
                     is EpubDownloadResult.NetworkError -> DownloadState.NotDownloaded
                 }
-                EbookFormat.Pdf -> when (pdfRepository.downloadPdf(item)) {
+                EbookFormat.Pdf -> when (pdfRepository.downloadPdf(item, onProgress)) {
                     PdfDownloadResult.Success, PdfDownloadResult.AlreadyDownloaded -> DownloadState.Downloaded
                     is PdfDownloadResult.NetworkError -> DownloadState.NotDownloaded
                 }
@@ -242,12 +254,14 @@ class LibraryItemDetailViewModel @Inject constructor(
 
     fun onDownloadReadaloud() {
         val link = readaloudLink ?: return
-        if (_readaloudDownloadState.value == DownloadState.InProgress) return
-        _readaloudDownloadState.value = DownloadState.InProgress
+        if (_readaloudDownloadState.value is DownloadState.InProgress) return
+        _readaloudDownloadState.value = DownloadState.InProgress()
         viewModelScope.launch {
             val result = readaloudAudioRepository.downloadAudio(
                 link.storytellerServerId, link.storytellerBookId,
-            ) { _, _ -> }
+            ) { downloaded, total ->
+                _readaloudDownloadState.value = DownloadState.InProgress(downloadPercent(downloaded, total))
+            }
             _readaloudDownloadState.value = readaloudDownloadStateFor(
                 result is com.riffle.core.domain.AudioDownloadResult.Success,
             )

--- a/app/src/main/kotlin/com/riffle/app/feature/library/ReadaloudDownloadButton.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/ReadaloudDownloadButton.kt
@@ -1,6 +1,5 @@
 package com.riffle.app.feature.library
 
-import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -9,20 +8,15 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowDownward
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import com.riffle.app.R
 
 private val CircleSize = 40.dp
@@ -49,25 +43,11 @@ fun ReadaloudDownloadButton(
     when (state) {
         is DownloadState.InProgress -> {
             Box(modifier = modifier.size(OuterSize), contentAlignment = Alignment.Center) {
-                val percent = state.percent
-                if (percent == null) {
-                    CircularProgressIndicator(modifier = Modifier.size(CircleSize))
-                } else {
-                    val animated by animateFloatAsState(
-                        targetValue = percent / 100f,
-                        label = "readaloudDownloadProgress",
-                    )
-                    CircularProgressIndicator(
-                        progress = { animated },
-                        modifier = Modifier.size(CircleSize),
-                    )
-                    Text(
-                        text = "$percent%",
-                        color = MaterialTheme.colorScheme.primary,
-                        fontSize = 11.sp,
-                        fontWeight = FontWeight.SemiBold,
-                    )
-                }
+                DownloadProgressIndicator(
+                    percent = state.percent,
+                    size = CircleSize,
+                    label = "readaloudDownloadProgress",
+                )
             }
         }
         DownloadState.NotDownloaded -> {

--- a/app/src/main/kotlin/com/riffle/app/feature/library/ReadaloudDownloadButton.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/ReadaloudDownloadButton.kt
@@ -1,5 +1,6 @@
 package com.riffle.app.feature.library
 
+import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -11,13 +12,17 @@ import androidx.compose.material.icons.filled.ArrowDownward
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import com.riffle.app.R
 
 private val CircleSize = 40.dp
@@ -42,9 +47,27 @@ fun ReadaloudDownloadButton(
     modifier: Modifier = Modifier,
 ) {
     when (state) {
-        DownloadState.InProgress -> {
+        is DownloadState.InProgress -> {
             Box(modifier = modifier.size(OuterSize), contentAlignment = Alignment.Center) {
-                CircularProgressIndicator(modifier = Modifier.size(CircleSize))
+                val percent = state.percent
+                if (percent == null) {
+                    CircularProgressIndicator(modifier = Modifier.size(CircleSize))
+                } else {
+                    val animated by animateFloatAsState(
+                        targetValue = percent / 100f,
+                        label = "readaloudDownloadProgress",
+                    )
+                    CircularProgressIndicator(
+                        progress = { animated },
+                        modifier = Modifier.size(CircleSize),
+                    )
+                    Text(
+                        text = "$percent%",
+                        color = MaterialTheme.colorScheme.primary,
+                        fontSize = 11.sp,
+                        fontWeight = FontWeight.SemiBold,
+                    )
+                }
             }
         }
         DownloadState.NotDownloaded -> {

--- a/app/src/test/kotlin/com/riffle/app/feature/library/CollectionDetailViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/CollectionDetailViewModelTest.kt
@@ -117,7 +117,7 @@ class CollectionDetailViewModelTest {
 
     private class FakeEpubRepository(private val downloadedIds: Set<String> = emptySet()) : EpubRepository {
         override suspend fun openEpub(item: LibraryItem) = EpubOpenResult.Offline
-        override suspend fun downloadEpub(item: LibraryItem) = EpubDownloadResult.Success
+        override suspend fun downloadEpub(item: LibraryItem, onProgress: (Long, Long) -> Unit) = EpubDownloadResult.Success
         override suspend fun removeDownload(serverId: String, itemId: String) {}
         override fun isDownloaded(serverId: String, itemId: String): Boolean = itemId in downloadedIds
         override fun isCached(serverId: String, itemId: String): Boolean = false
@@ -126,7 +126,7 @@ class CollectionDetailViewModelTest {
 
     private class FakePdfRepository : PdfRepository {
         override suspend fun openPdf(item: LibraryItem) = PdfOpenResult.Offline
-        override suspend fun downloadPdf(item: LibraryItem) = PdfDownloadResult.Success
+        override suspend fun downloadPdf(item: LibraryItem, onProgress: (Long, Long) -> Unit) = PdfDownloadResult.Success
         override suspend fun removeDownload(serverId: String, itemId: String) {}
         override fun isDownloaded(serverId: String, itemId: String): Boolean = false
         override fun isCached(serverId: String, itemId: String): Boolean = false

--- a/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModelTest.kt
@@ -141,7 +141,7 @@ class LibraryItemDetailViewModelTest {
     ) : EpubRepository {
         private var downloaded = initialDownloaded
         override suspend fun openEpub(item: LibraryItem): EpubOpenResult = throw UnsupportedOperationException()
-        override suspend fun downloadEpub(item: LibraryItem): EpubDownloadResult {
+        override suspend fun downloadEpub(item: LibraryItem, onProgress: (Long, Long) -> Unit): EpubDownloadResult {
             if (downloadResult is EpubDownloadResult.Success) downloaded = true
             return downloadResult
         }
@@ -159,7 +159,7 @@ class LibraryItemDetailViewModelTest {
     private class FakePdfRepository : PdfRepository {
         private var downloaded = false
         override suspend fun openPdf(item: LibraryItem): PdfOpenResult = throw UnsupportedOperationException()
-        override suspend fun downloadPdf(item: LibraryItem): PdfDownloadResult {
+        override suspend fun downloadPdf(item: LibraryItem, onProgress: (Long, Long) -> Unit): PdfDownloadResult {
             downloaded = true
             return PdfDownloadResult.Success
         }

--- a/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemsViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemsViewModelTest.kt
@@ -106,7 +106,7 @@ class LibraryItemsViewModelTest {
 
     private fun fakeEpubRepo(): EpubRepository = object : EpubRepository {
         override suspend fun openEpub(item: LibraryItem): EpubOpenResult = EpubOpenResult.Offline
-        override suspend fun downloadEpub(item: LibraryItem): EpubDownloadResult = EpubDownloadResult.Success
+        override suspend fun downloadEpub(item: LibraryItem, onProgress: (Long, Long) -> Unit): EpubDownloadResult = EpubDownloadResult.Success
         override suspend fun removeDownload(serverId: String, itemId: String) {}
         override fun isDownloaded(serverId: String, itemId: String): Boolean = false
         override fun isCached(serverId: String, itemId: String): Boolean = false
@@ -115,7 +115,7 @@ class LibraryItemsViewModelTest {
 
     private fun fakePdfRepo(): PdfRepository = object : PdfRepository {
         override suspend fun openPdf(item: LibraryItem): PdfOpenResult = PdfOpenResult.Offline
-        override suspend fun downloadPdf(item: LibraryItem): PdfDownloadResult = PdfDownloadResult.Success
+        override suspend fun downloadPdf(item: LibraryItem, onProgress: (Long, Long) -> Unit): PdfDownloadResult = PdfDownloadResult.Success
         override suspend fun removeDownload(serverId: String, itemId: String) {}
         override fun isDownloaded(serverId: String, itemId: String): Boolean = false
         override fun isCached(serverId: String, itemId: String): Boolean = false
@@ -427,7 +427,7 @@ class LibraryItemsViewModelTest {
 
     private fun fakeEpubRepoWithDownloads(downloadedIds: Set<String>): EpubRepository = object : EpubRepository {
         override suspend fun openEpub(item: LibraryItem) = EpubOpenResult.Offline
-        override suspend fun downloadEpub(item: LibraryItem) = EpubDownloadResult.Success
+        override suspend fun downloadEpub(item: LibraryItem, onProgress: (Long, Long) -> Unit) = EpubDownloadResult.Success
         override suspend fun removeDownload(serverId: String, itemId: String) {}
         override fun isDownloaded(serverId: String, itemId: String): Boolean = itemId in downloadedIds
         override fun isCached(serverId: String, itemId: String): Boolean = false

--- a/app/src/test/kotlin/com/riffle/app/feature/library/SeriesDetailViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/SeriesDetailViewModelTest.kt
@@ -93,7 +93,7 @@ class SeriesDetailViewModelTest {
 
     private class FakeEpubRepository : EpubRepository {
         override suspend fun openEpub(item: LibraryItem) = EpubOpenResult.Offline
-        override suspend fun downloadEpub(item: LibraryItem) = EpubDownloadResult.Success
+        override suspend fun downloadEpub(item: LibraryItem, onProgress: (Long, Long) -> Unit) = EpubDownloadResult.Success
         override suspend fun removeDownload(serverId: String, itemId: String) {}
         override fun isDownloaded(serverId: String, itemId: String): Boolean = false
         override fun isCached(serverId: String, itemId: String): Boolean = false
@@ -102,7 +102,7 @@ class SeriesDetailViewModelTest {
 
     private class FakePdfRepository : PdfRepository {
         override suspend fun openPdf(item: LibraryItem) = PdfOpenResult.Offline
-        override suspend fun downloadPdf(item: LibraryItem) = PdfDownloadResult.Success
+        override suspend fun downloadPdf(item: LibraryItem, onProgress: (Long, Long) -> Unit) = PdfDownloadResult.Success
         override suspend fun removeDownload(serverId: String, itemId: String) {}
         override fun isDownloaded(serverId: String, itemId: String): Boolean = false
         override fun isCached(serverId: String, itemId: String): Boolean = false

--- a/core/data/src/main/kotlin/com/riffle/core/data/AudiobookBundleDownloader.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/AudiobookBundleDownloader.kt
@@ -63,7 +63,9 @@ class AudiobookBundleDownloader(
                                     if (n == -1) break
                                     sink.write(buffer, 0, n)
                                     written += n
-                                    onProgress(written, if (total > 0) total else written)
+                                    // Pass total verbatim — -1 when the server sent no length, so the
+                                    // UI shows an indeterminate spinner rather than a misleading 100%.
+                                    onProgress(written, total)
                                 }
                             }
                         }

--- a/core/data/src/main/kotlin/com/riffle/core/data/EpubRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/EpubRepositoryImpl.kt
@@ -47,11 +47,17 @@ class EpubRepositoryImpl(
         return EpubOpenResult.Success(epubFile = epubFile, lastPosition = lastPosition)
     }
 
-    override suspend fun downloadEpub(item: LibraryItem): EpubDownloadResult {
+    override suspend fun downloadEpub(
+        item: LibraryItem,
+        onProgress: (downloaded: Long, total: Long) -> Unit,
+    ): EpubDownloadResult {
         if (downloadsStore.get(item.serverId, item.id) != null) return EpubDownloadResult.AlreadyDownloaded
         val cached = cacheStore.get(item.serverId, item.id)
         if (cached != null) {
-            cached.inputStream().use { downloadsStore.save(item.serverId, item.id, it) }
+            val size = cached.length()
+            cached.inputStream().use {
+                downloadsStore.save(item.serverId, item.id, ProgressReportingInputStream(it, size, onProgress))
+            }
             cacheStore.delete(item.serverId, item.id)
             return EpubDownloadResult.Success
         }
@@ -67,7 +73,10 @@ class EpubRepositoryImpl(
         }
         return when (val result = api.downloadEpub(server.url.value, item.id, ino, token, server.insecureConnectionAllowed)) {
             is NetworkEpubDownloadResult.Success -> {
-                result.body.use { body -> downloadsStore.save(item.serverId, item.id, body.byteStream()) }
+                result.body.use { body ->
+                    val stream = ProgressReportingInputStream(body.byteStream(), body.contentLength(), onProgress)
+                    downloadsStore.save(item.serverId, item.id, stream)
+                }
                 EpubDownloadResult.Success
             }
             is NetworkEpubDownloadResult.NetworkError -> EpubDownloadResult.NetworkError(result.cause)

--- a/core/data/src/main/kotlin/com/riffle/core/data/PdfRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/PdfRepositoryImpl.kt
@@ -51,11 +51,17 @@ class PdfRepositoryImpl(
         return PdfOpenResult.Success(pdfFile = pdfFile, lastPosition = lastPosition)
     }
 
-    override suspend fun downloadPdf(item: LibraryItem): PdfDownloadResult {
+    override suspend fun downloadPdf(
+        item: LibraryItem,
+        onProgress: (downloaded: Long, total: Long) -> Unit,
+    ): PdfDownloadResult {
         if (downloadsStore.get(item.serverId, item.id) != null) return PdfDownloadResult.AlreadyDownloaded
         val cached = cacheStore.get(item.serverId, item.id)
         if (cached != null) {
-            cached.inputStream().use { downloadsStore.save(item.serverId, item.id, it) }
+            val size = cached.length()
+            cached.inputStream().use {
+                downloadsStore.save(item.serverId, item.id, ProgressReportingInputStream(it, size, onProgress))
+            }
             cacheStore.delete(item.serverId, item.id)
             return PdfDownloadResult.Success
         }
@@ -71,7 +77,10 @@ class PdfRepositoryImpl(
         }
         return when (val result = api.downloadEpub(server.url.value, item.id, ino, token, server.insecureConnectionAllowed)) {
             is NetworkEpubDownloadResult.Success -> {
-                result.body.use { body -> downloadsStore.save(item.serverId, item.id, body.byteStream()) }
+                result.body.use { body ->
+                    val stream = ProgressReportingInputStream(body.byteStream(), body.contentLength(), onProgress)
+                    downloadsStore.save(item.serverId, item.id, stream)
+                }
                 PdfDownloadResult.Success
             }
             is NetworkEpubDownloadResult.NetworkError -> PdfDownloadResult.NetworkError(result.cause)

--- a/core/data/src/main/kotlin/com/riffle/core/data/ProgressReportingInputStream.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/ProgressReportingInputStream.kt
@@ -1,0 +1,36 @@
+package com.riffle.core.data
+
+import java.io.FilterInputStream
+import java.io.InputStream
+
+/**
+ * Wraps a download body's stream and reports how many bytes have been read so far as the consumer
+ * (the [com.riffle.core.domain.LocalStore]) drains it. [total] is the advertised content length, or
+ * -1 when the server didn't send one — callers treat a non-positive total as "indeterminate" and
+ * fall back to a spinner instead of a percentage.
+ */
+internal class ProgressReportingInputStream(
+    delegate: InputStream,
+    private val total: Long,
+    private val onProgress: (downloaded: Long, total: Long) -> Unit,
+) : FilterInputStream(delegate) {
+
+    private var read = 0L
+
+    override fun read(): Int {
+        val b = super.read()
+        if (b != -1) report(1)
+        return b
+    }
+
+    override fun read(b: ByteArray, off: Int, len: Int): Int {
+        val n = super.read(b, off, len)
+        if (n > 0) report(n.toLong())
+        return n
+    }
+
+    private fun report(delta: Long) {
+        read += delta
+        onProgress(read, total)
+    }
+}

--- a/core/data/src/test/kotlin/com/riffle/core/data/EpubRepositoryTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/EpubRepositoryTest.kt
@@ -3,6 +3,7 @@ package com.riffle.core.data
 import com.riffle.core.domain.EbookFormat
 import com.riffle.core.domain.EpubDownloadResult
 import com.riffle.core.domain.EpubOpenResult
+import com.riffle.core.domain.EpubRepository
 import com.riffle.core.domain.LibraryItem
 import com.riffle.core.domain.ReadingPositionStore
 import com.riffle.core.domain.Server
@@ -42,7 +43,7 @@ class EpubRepositoryTest {
     private lateinit var cacheStore: LocalStoreImpl
     private lateinit var downloadsStore: LocalStoreImpl
     private lateinit var positionStore: FakePositionStore
-    private lateinit var repo: EpubRepositoryImpl
+    private lateinit var repo: EpubRepository
 
     private val epubBytes = "PK fake epub content".toByteArray()
 

--- a/core/data/src/test/kotlin/com/riffle/core/data/PdfRepositoryTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/PdfRepositoryTest.kt
@@ -4,6 +4,7 @@ import com.riffle.core.domain.EbookFormat
 import com.riffle.core.domain.LibraryItem
 import com.riffle.core.domain.PdfDownloadResult
 import com.riffle.core.domain.PdfOpenResult
+import com.riffle.core.domain.PdfRepository
 import com.riffle.core.domain.ReadingPositionStore
 import com.riffle.core.domain.Server
 import com.riffle.core.domain.ServerRepository
@@ -35,7 +36,7 @@ class PdfRepositoryTest {
     private lateinit var cacheStore: LocalStoreImpl
     private lateinit var downloadsStore: LocalStoreImpl
     private lateinit var positionStore: FakePdfPositionStore
-    private lateinit var repo: PdfRepositoryImpl
+    private lateinit var repo: PdfRepository
 
     private val pdfBytes = "%PDF-1.4 fake pdf content\n%%EOF".toByteArray()
 

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/EpubRepository.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/EpubRepository.kt
@@ -16,7 +16,10 @@ sealed class EpubDownloadResult {
 
 interface EpubRepository {
     suspend fun openEpub(item: LibraryItem): EpubOpenResult
-    suspend fun downloadEpub(item: LibraryItem): EpubDownloadResult
+    suspend fun downloadEpub(
+        item: LibraryItem,
+        onProgress: (downloaded: Long, total: Long) -> Unit = { _, _ -> },
+    ): EpubDownloadResult
     suspend fun removeDownload(serverId: String, itemId: String)
     fun isDownloaded(serverId: String, itemId: String): Boolean
     fun isCached(serverId: String, itemId: String): Boolean

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/PdfRepository.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/PdfRepository.kt
@@ -16,7 +16,10 @@ sealed class PdfDownloadResult {
 
 interface PdfRepository {
     suspend fun openPdf(item: LibraryItem): PdfOpenResult
-    suspend fun downloadPdf(item: LibraryItem): PdfDownloadResult
+    suspend fun downloadPdf(
+        item: LibraryItem,
+        onProgress: (downloaded: Long, total: Long) -> Unit = { _, _ -> },
+    ): PdfDownloadResult
     suspend fun removeDownload(serverId: String, itemId: String)
     fun isDownloaded(serverId: String, itemId: String): Boolean
     fun isCached(serverId: String, itemId: String): Boolean


### PR DESCRIPTION
## What

Download buttons now show the live progress percentage inside the in-progress ring instead of a bare indeterminate spinner. Applies to both the main ebook download button and the **readaloud** download button (the originally-requested target).

- `DownloadState.InProgress` now carries `percent: Int?` (null = indeterminate → spinner fallback).
- New `ProgressReportingInputStream` (core/data) counts bytes as the `LocalStore` drains the download stream and reports `(downloaded, total)`.
- `EpubRepository.downloadEpub` / `PdfRepository.downloadPdf` gained an optional `onProgress` callback (defaulted, so existing callers are untouched); both impls wrap the body stream (and the cache→downloads promotion stream) with the reporter.
- `LibraryItemDetailViewModel` computes the percent via `downloadPercent(downloaded, total)` and pushes `InProgress(percent)` for both ebook and readaloud downloads (the readaloud path previously discarded its progress callback).
- `AudiobookBundleDownloader` now passes the real total verbatim (`-1` when the server sends no length) instead of echoing `written` — so an unknown size shows a spinner rather than locking at a misleading 100%.
- Shared `DownloadProgressIndicator` composable renders the determinate ring + `NN%` (or spinner), used by both buttons.
- The main download button's **Downloaded** state is now a solid `primary` disc with a white arrow (was the paler `primaryContainer`).

## Testing

- `./gradlew test` — green
- `./gradlew lint` — green
- `make harness-test-tablet` — 5/5 pass
- `make harness-test` — all pass except `AutoFollowJsTest.paginatedSnapsToTheColumnContainingTheSentence`, a pre-existing failure on the local Harness AVD (reader column-snap fixture at 1080px; fails on `main` too), unrelated to this change.

## Note

The percentage relies on the download response carrying `Content-Length` (or `Content-Range` for resumed readaloud bundles). When absent, the button falls back to the indeterminate spinner by design.
