### PR TITLE
feat(reader): persist readaloud resume position across book sessions

### DIFF
--- a/app/src/androidTest/kotlin/com/riffle/app/di/TestDatabaseModule.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/di/TestDatabaseModule.kt
@@ -12,6 +12,7 @@ import com.riffle.core.database.LibraryItemDao
 import com.riffle.core.database.ReadaloudCandidateDao
 import com.riffle.core.database.ReadaloudDismissalDao
 import com.riffle.core.database.ReadaloudLinkDao
+import com.riffle.core.database.ReadaloudResumePositionDao
 import com.riffle.core.database.ReadingPositionDao
 import com.riffle.core.database.RiffleDatabase
 import com.riffle.core.database.SeriesDao
@@ -68,6 +69,10 @@ object TestDatabaseModule {
     @Provides
     @Singleton
     fun provideReadingPositionDao(db: RiffleDatabase): ReadingPositionDao = db.readingPositionDao()
+
+    @Provides
+    @Singleton
+    fun provideReadaloudResumePositionDao(db: RiffleDatabase): ReadaloudResumePositionDao = db.readaloudResumePositionDao()
 
     @Provides
     @Singleton

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -33,6 +33,8 @@ import com.riffle.core.domain.ReadingSessionRepository
 import com.riffle.core.domain.ServerProgress
 import com.riffle.core.domain.ServerRepository
 import com.riffle.core.domain.ServerType
+import com.riffle.core.domain.ReadaloudResumePosition
+import com.riffle.core.domain.ReadaloudResumeStore
 import com.riffle.core.domain.ReadingPositionStore
 import com.riffle.core.domain.SessionPayload
 import com.riffle.core.domain.withResolvedTheme
@@ -111,6 +113,7 @@ class EpubReaderViewModel @Inject constructor(
     private val connectivityObserver: ConnectivityObserver,
     private val threePeerSyncFactory: ThreePeerReaderSyncFactory,
     private val readingPositionStore: ReadingPositionStore,
+    private val readaloudResumeStore: ReadaloudResumeStore,
     private val annotationStore: AnnotationStore,
 ) : AndroidViewModel(application) {
 
@@ -356,6 +359,18 @@ class EpubReaderViewModel @Inject constructor(
             audioBookId = link?.storytellerBookId ?: itemId
             audioServerId = link?.storytellerServerId ?: activeServer?.id ?: ""
 
+            // Restore the readaloud resume position persisted when the book was last left, so the
+            // first Play this session continues where narration stopped (same page) or starts at the
+            // top of the current page (different page) — the same decision an in-session reopen makes.
+            // Keyed by the reader's (serverId, itemId); seeding closeLocator makes the planner treat
+            // this as a reopen rather than a first-ever play.
+            if (activeServer != null) {
+                readaloudResumeStore.load(activeServer.id, itemId)?.let { saved ->
+                    closeLocator = saved.toCloseLocator()
+                    resumeFragmentRef = saved.fragmentRef
+                }
+            }
+
             val control = readaloudControlState(
                 isStoryteller = isStorytellerServer,
                 isMatchedAbs = link != null,
@@ -527,6 +542,11 @@ class EpubReaderViewModel @Inject constructor(
         readerStateHolder.isPanelOpen = false
         syncJob?.cancel()
         storytellerSyncJob?.cancel()
+        // Leaving the book without first pressing X: persist the sentence narrating now so re-entry
+        // resumes there. (Pressing X already persisted via closeReadaloud, which closes the player.)
+        if (_readaloudOpen.value) {
+            persistReadaloudResumePosition(lastLocator, playerCoordinator.activeFragmentRef.value)
+        }
         if (closeSyncDone) return
         closeSyncDone = true
         val locator = lastLocator ?: return
@@ -908,9 +928,39 @@ class EpubReaderViewModel @Inject constructor(
         // before close() — it nulls the active fragment.
         resumeFragmentRef = playerCoordinator.activeFragmentRef.value
         closeLocator = lastLocator
+        // Persist the same stopped position so it survives leaving the book / process death, not just
+        // an in-session reopen. Capture before close() nulls the active fragment.
+        persistReadaloudResumePosition(closeLocator, resumeFragmentRef)
         readaloudPrepared = false
         readaloudStarted = false
         playerCoordinator.close()
+    }
+
+    /**
+     * Saves where narration stopped for this book, keyed by the reader's (serverId, itemId). Skips
+     * when there is no reader page to resume to. Overwrites any previous row so the position persists
+     * indefinitely until the next stop — it is not cleared when consumed on resume.
+     */
+    private fun persistReadaloudResumePosition(locator: Locator?, fragmentRef: String?) {
+        val href = locator?.href?.toString() ?: return
+        val progression = locator.locations.progression
+        viewModelScope.launch {
+            val serverId = serverRepository.getActive()?.id ?: return@launch
+            readaloudResumeStore.save(serverId, itemId, ReadaloudResumePosition(href, progression, fragmentRef))
+        }
+    }
+
+    /** Rebuilds the minimal reader [Locator] the resume planner reads — href + column progression. */
+    private fun ReadaloudResumePosition.toCloseLocator(): Locator? = try {
+        val locations = JSONObject().also { obj -> progression?.let { obj.put("progression", it) } }
+        Locator.fromJSON(
+            JSONObject()
+                .put("href", href)
+                .put("type", "application/xhtml+xml")
+                .put("locations", locations)
+        )
+    } catch (_: Exception) {
+        null
     }
 
     fun expandPlayer() { _readaloudExpanded.value = true }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -260,6 +260,11 @@ class EpubReaderViewModel @Inject constructor(
     // For a matched ABS book this is the linked Storyteller Server; otherwise the active Server.
     private var audioServerId: String = ""
 
+    // The reader's active Server id, resolved once on open. Keys the readaloud resume position (reader
+    // space, like the reading position) for both the seed-on-open load and the save-on-close — using
+    // one captured id keeps the two symmetric and avoids a per-close getActive() DB read.
+    private var readerServerId: String? = null
+
     // Whether the bottom mini-player / sheet is showing.
     private val _readaloudOpen = MutableStateFlow(false)
     val readaloudOpen: StateFlow<Boolean> = _readaloudOpen
@@ -358,14 +363,15 @@ class EpubReaderViewModel @Inject constructor(
             }
             audioBookId = link?.storytellerBookId ?: itemId
             audioServerId = link?.storytellerServerId ?: activeServer?.id ?: ""
+            readerServerId = activeServer?.id
 
             // Restore the readaloud resume position persisted when the book was last left, so the
             // first Play this session continues where narration stopped (same page) or starts at the
             // top of the current page (different page) — the same decision an in-session reopen makes.
             // Keyed by the reader's (serverId, itemId); seeding closeLocator makes the planner treat
             // this as a reopen rather than a first-ever play.
-            if (activeServer != null) {
-                readaloudResumeStore.load(activeServer.id, itemId)?.let { saved ->
+            readerServerId?.let { serverId ->
+                readaloudResumeStore.load(serverId, itemId)?.let { saved ->
                     closeLocator = saved.toCloseLocator()
                     resumeFragmentRef = saved.fragmentRef
                 }
@@ -542,13 +548,14 @@ class EpubReaderViewModel @Inject constructor(
         readerStateHolder.isPanelOpen = false
         syncJob?.cancel()
         storytellerSyncJob?.cancel()
+        if (closeSyncDone) return
+        closeSyncDone = true
         // Leaving the book without first pressing X: persist the sentence narrating now so re-entry
         // resumes there. (Pressing X already persisted via closeReadaloud, which closes the player.)
+        // Below the closeSyncDone guard so the ON_STOP + onDispose pair doesn't double-write.
         if (_readaloudOpen.value) {
             persistReadaloudResumePosition(lastLocator, playerCoordinator.activeFragmentRef.value)
         }
-        if (closeSyncDone) return
-        closeSyncDone = true
         val locator = lastLocator ?: return
         viewModelScope.launch {
             val payload = locator.toPayload()
@@ -943,9 +950,9 @@ class EpubReaderViewModel @Inject constructor(
      */
     private fun persistReadaloudResumePosition(locator: Locator?, fragmentRef: String?) {
         val href = locator?.href?.toString() ?: return
+        val serverId = readerServerId ?: return
         val progression = locator.locations.progression
         viewModelScope.launch {
-            val serverId = serverRepository.getActive()?.id ?: return@launch
             readaloudResumeStore.save(serverId, itemId, ReadaloudResumePosition(href, progression, fragmentRef))
         }
     }

--- a/core/data/src/main/kotlin/com/riffle/core/data/ReadaloudResumeStoreImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/ReadaloudResumeStoreImpl.kt
@@ -1,0 +1,30 @@
+package com.riffle.core.data
+
+import com.riffle.core.database.ReadaloudResumePositionDao
+import com.riffle.core.database.ReadaloudResumePositionEntity
+import com.riffle.core.domain.ReadaloudResumePosition
+import com.riffle.core.domain.ReadaloudResumeStore
+import javax.inject.Inject
+
+class ReadaloudResumeStoreImpl @Inject constructor(
+    private val dao: ReadaloudResumePositionDao,
+) : ReadaloudResumeStore {
+
+    override suspend fun save(serverId: String, itemId: String, position: ReadaloudResumePosition) {
+        dao.upsert(
+            ReadaloudResumePositionEntity(
+                serverId = serverId,
+                itemId = itemId,
+                href = position.href,
+                progression = position.progression,
+                fragmentRef = position.fragmentRef,
+                localUpdatedAt = System.currentTimeMillis(),
+            )
+        )
+    }
+
+    override suspend fun load(serverId: String, itemId: String): ReadaloudResumePosition? =
+        dao.getByItemId(serverId, itemId)?.let {
+            ReadaloudResumePosition(href = it.href, progression = it.progression, fragmentRef = it.fragmentRef)
+        }
+}

--- a/core/data/src/main/kotlin/com/riffle/core/data/di/DataModule.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/di/DataModule.kt
@@ -20,6 +20,7 @@ import com.riffle.core.data.PdfRepositoryImpl
 import com.riffle.core.data.CrossEpubIndexStoreImpl
 import com.riffle.core.data.ReadaloudLinkRepositoryImpl
 import com.riffle.core.data.ReadaloudReviewRepositoryImpl
+import com.riffle.core.data.ReadaloudResumeStoreImpl
 import com.riffle.core.data.ReadingPositionStoreImpl
 import com.riffle.core.data.ReadingSessionRepositoryImpl
 import com.riffle.core.data.ServerRepositoryImpl
@@ -42,6 +43,7 @@ import com.riffle.core.domain.PdfRepository
 import com.riffle.core.domain.CrossEpubIndexStore
 import com.riffle.core.domain.ReadaloudLinkRepository
 import com.riffle.core.domain.ReadaloudReviewRepository
+import com.riffle.core.domain.ReadaloudResumeStore
 import com.riffle.core.domain.ReadingPositionStore
 import com.riffle.core.domain.ReadingSessionRepository
 import com.riffle.core.domain.ServerRepository
@@ -180,6 +182,10 @@ abstract class DataModule {
     @Binds
     @Singleton
     abstract fun bindReadingPositionStore(impl: ReadingPositionStoreImpl): ReadingPositionStore
+
+    @Binds
+    @Singleton
+    abstract fun bindReadaloudResumeStore(impl: ReadaloudResumeStoreImpl): ReadaloudResumeStore
 
     @Binds
     @Singleton

--- a/core/data/src/main/kotlin/com/riffle/core/data/di/DatabaseModule.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/di/DatabaseModule.kt
@@ -11,6 +11,7 @@ import com.riffle.core.database.CrossEpubIndexDao
 import com.riffle.core.database.ReadaloudCandidateDao
 import com.riffle.core.database.ReadaloudDismissalDao
 import com.riffle.core.database.ReadaloudLinkDao
+import com.riffle.core.database.ReadaloudResumePositionDao
 import com.riffle.core.database.ReadingPositionDao
 import com.riffle.core.database.RiffleDatabase
 import com.riffle.core.database.SeriesDao
@@ -56,6 +57,7 @@ object DatabaseModule {
                 RiffleDatabase.MIGRATION_23_24,
                 RiffleDatabase.MIGRATION_24_25,
                 RiffleDatabase.MIGRATION_25_26,
+                RiffleDatabase.MIGRATION_26_27,
             )
             .build()
 
@@ -82,6 +84,10 @@ object DatabaseModule {
     @Provides
     @Singleton
     fun provideReadingPositionDao(db: RiffleDatabase): ReadingPositionDao = db.readingPositionDao()
+
+    @Provides
+    @Singleton
+    fun provideReadaloudResumePositionDao(db: RiffleDatabase): ReadaloudResumePositionDao = db.readaloudResumePositionDao()
 
     @Provides
     @Singleton

--- a/core/data/src/test/kotlin/com/riffle/core/data/ReadaloudResumeStoreTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/ReadaloudResumeStoreTest.kt
@@ -1,0 +1,87 @@
+package com.riffle.core.data
+
+import com.riffle.core.database.ReadaloudResumePositionDao
+import com.riffle.core.database.ReadaloudResumePositionEntity
+import com.riffle.core.domain.ReadaloudResumePosition
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class ReadaloudResumeStoreTest {
+
+    private class FakeReadaloudResumePositionDao : ReadaloudResumePositionDao {
+        private val entities: MutableMap<Pair<String, String>, ReadaloudResumePositionEntity> = mutableMapOf()
+        val store: Map<Pair<String, String>, ReadaloudResumePositionEntity> get() = entities
+        fun seed(entity: ReadaloudResumePositionEntity) { entities[entity.serverId to entity.itemId] = entity }
+        override suspend fun upsert(entity: ReadaloudResumePositionEntity) {
+            entities[entity.serverId to entity.itemId] = entity
+        }
+        override suspend fun getByItemId(serverId: String, itemId: String): ReadaloudResumePositionEntity? =
+            entities[serverId to itemId]
+    }
+
+    @Test
+    fun `save persists the resume position for the given item`() = runTest {
+        val dao = FakeReadaloudResumePositionDao()
+        val store = ReadaloudResumeStoreImpl(dao)
+        store.save("server-A", "item-1", ReadaloudResumePosition("ch1.xhtml", 0.25, "ch1.xhtml#s5"))
+        val saved = dao.store["server-A" to "item-1"]
+        assertEquals("ch1.xhtml", saved?.href)
+        assertEquals(0.25, saved?.progression!!, 1e-9)
+        assertEquals("ch1.xhtml#s5", saved.fragmentRef)
+    }
+
+    @Test
+    fun `load returns the saved resume position`() = runTest {
+        val dao = FakeReadaloudResumePositionDao().also {
+            it.seed(ReadaloudResumePositionEntity("server-A", "item-1", "ch2.xhtml", 0.5, "ch2.xhtml#s9"))
+        }
+        val store = ReadaloudResumeStoreImpl(dao)
+        assertEquals(ReadaloudResumePosition("ch2.xhtml", 0.5, "ch2.xhtml#s9"), store.load("server-A", "item-1"))
+    }
+
+    @Test
+    fun `load returns null for an item with no saved position`() = runTest {
+        val store = ReadaloudResumeStoreImpl(FakeReadaloudResumePositionDao())
+        assertNull(store.load("server-A", "item-new"))
+    }
+
+    @Test
+    fun `save overwrites the previous position for the same server-item`() = runTest {
+        val dao = FakeReadaloudResumePositionDao()
+        val store = ReadaloudResumeStoreImpl(dao)
+        store.save("server-A", "item-1", ReadaloudResumePosition("ch1.xhtml", 0.1, "ch1.xhtml#s1"))
+        store.save("server-A", "item-1", ReadaloudResumePosition("ch3.xhtml", 0.9, "ch3.xhtml#s9"))
+        assertEquals(ReadaloudResumePosition("ch3.xhtml", 0.9, "ch3.xhtml#s9"), store.load("server-A", "item-1"))
+    }
+
+    @Test
+    fun `null progression and fragmentRef round-trip`() = runTest {
+        val dao = FakeReadaloudResumePositionDao()
+        val store = ReadaloudResumeStoreImpl(dao)
+        store.save("server-A", "item-1", ReadaloudResumePosition("ch1.xhtml", null, null))
+        assertEquals(ReadaloudResumePosition("ch1.xhtml", null, null), store.load("server-A", "item-1"))
+    }
+
+    @Test
+    fun `save stamps localUpdatedAt with current time`() = runTest {
+        val dao = FakeReadaloudResumePositionDao()
+        val store = ReadaloudResumeStoreImpl(dao)
+        val before = System.currentTimeMillis()
+        store.save("server-A", "item-1", ReadaloudResumePosition("ch1.xhtml", 0.0, "ch1.xhtml#s1"))
+        val after = System.currentTimeMillis()
+        val ts = dao.store["server-A" to "item-1"]?.localUpdatedAt ?: 0L
+        assert(ts in before..after) { "Expected timestamp in [$before..$after] but was $ts" }
+    }
+
+    @Test
+    fun `positions for the same itemId on different servers are isolated`() = runTest {
+        val dao = FakeReadaloudResumePositionDao()
+        val store = ReadaloudResumeStoreImpl(dao)
+        store.save("server-A", "item-1", ReadaloudResumePosition("a.xhtml", 0.1, "a.xhtml#s1"))
+        store.save("server-B", "item-1", ReadaloudResumePosition("b.xhtml", 0.9, "b.xhtml#s9"))
+        assertEquals("a.xhtml", store.load("server-A", "item-1")?.href)
+        assertEquals("b.xhtml", store.load("server-B", "item-1")?.href)
+    }
+}

--- a/core/database/schemas/com.riffle.core.database.RiffleDatabase/27.json
+++ b/core/database/schemas/com.riffle.core.database.RiffleDatabase/27.json
@@ -1,0 +1,1022 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 27,
+    "identityHash": "11474a9cc666f7a1835cc4b5c10ed0e6",
+    "entities": [
+      {
+        "tableName": "servers",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `url` TEXT NOT NULL, `isActive` INTEGER NOT NULL, `insecureConnectionAllowed` INTEGER NOT NULL, `username` TEXT NOT NULL, `serverType` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "isActive",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "insecureConnectionAllowed",
+            "columnName": "insecureConnectionAllowed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "username",
+            "columnName": "username",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverType",
+            "columnName": "serverType",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "libraries",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `mediaType` TEXT NOT NULL, `serverId` TEXT NOT NULL, `isUnsupported` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaType",
+            "columnName": "mediaType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isUnsupported",
+            "columnName": "isUnsupported",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "library_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`serverId` TEXT NOT NULL, `id` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `title` TEXT NOT NULL, `author` TEXT NOT NULL, `coverUrl` TEXT, `readingProgress` REAL NOT NULL, `ebookFileIno` TEXT, `ebookFormat` TEXT NOT NULL, `description` TEXT, `seriesName` TEXT, `publishedYear` TEXT, `genres` TEXT NOT NULL, `publisher` TEXT, `lastOpenedAt` INTEGER, `addedAt` INTEGER, `isbn` TEXT, `asin` TEXT, PRIMARY KEY(`serverId`, `id`), FOREIGN KEY(`serverId`) REFERENCES `servers`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "coverUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "readingProgress",
+            "columnName": "readingProgress",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ebookFileIno",
+            "columnName": "ebookFileIno",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "ebookFormat",
+            "columnName": "ebookFormat",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seriesName",
+            "columnName": "seriesName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "publishedYear",
+            "columnName": "publishedYear",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "genres",
+            "columnName": "genres",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "publisher",
+            "columnName": "publisher",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastOpenedAt",
+            "columnName": "lastOpenedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "isbn",
+            "columnName": "isbn",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "asin",
+            "columnName": "asin",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "serverId",
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_library_items_serverId",
+            "unique": false,
+            "columnNames": [
+              "serverId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_library_items_serverId` ON `${TABLE_NAME}` (`serverId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "servers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "serverId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "series",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `name` TEXT NOT NULL, `coverUrl` TEXT, `bookCount` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "coverUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "bookCount",
+            "columnName": "bookCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "collections",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `name` TEXT NOT NULL, `bookCount` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookCount",
+            "columnName": "bookCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "series_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`seriesId` TEXT NOT NULL, `serverId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `sequenceOrder` REAL NOT NULL, PRIMARY KEY(`seriesId`, `serverId`, `itemId`))",
+        "fields": [
+          {
+            "fieldPath": "seriesId",
+            "columnName": "seriesId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sequenceOrder",
+            "columnName": "sequenceOrder",
+            "affinity": "REAL",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "seriesId",
+            "serverId",
+            "itemId"
+          ]
+        }
+      },
+      {
+        "tableName": "collection_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`collectionId` TEXT NOT NULL, `serverId` TEXT NOT NULL, `itemId` TEXT NOT NULL, PRIMARY KEY(`collectionId`, `serverId`, `itemId`))",
+        "fields": [
+          {
+            "fieldPath": "collectionId",
+            "columnName": "collectionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "collectionId",
+            "serverId",
+            "itemId"
+          ]
+        }
+      },
+      {
+        "tableName": "reading_positions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`serverId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `cfi` TEXT NOT NULL, `localUpdatedAt` INTEGER NOT NULL, PRIMARY KEY(`serverId`, `itemId`), FOREIGN KEY(`serverId`) REFERENCES `servers`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cfi",
+            "columnName": "cfi",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localUpdatedAt",
+            "columnName": "localUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "serverId",
+            "itemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_reading_positions_serverId",
+            "unique": false,
+            "columnNames": [
+              "serverId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_reading_positions_serverId` ON `${TABLE_NAME}` (`serverId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "servers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "serverId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "book_formatting_preferences",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`serverId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `fontSize` REAL, `theme` TEXT, `fontFamily` TEXT, `lineSpacing` REAL, `margins` REAL, `orientation` TEXT, `showChapterMap` INTEGER, `showReadingProgressLabels` INTEGER, `showCurrentChapterLabel` INTEGER, `doublePageSpread` INTEGER, `justifyText` INTEGER, PRIMARY KEY(`serverId`, `itemId`), FOREIGN KEY(`serverId`) REFERENCES `servers`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fontSize",
+            "columnName": "fontSize",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "theme",
+            "columnName": "theme",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "fontFamily",
+            "columnName": "fontFamily",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lineSpacing",
+            "columnName": "lineSpacing",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "margins",
+            "columnName": "margins",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "orientation",
+            "columnName": "orientation",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "showChapterMap",
+            "columnName": "showChapterMap",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "showReadingProgressLabels",
+            "columnName": "showReadingProgressLabels",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "showCurrentChapterLabel",
+            "columnName": "showCurrentChapterLabel",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "doublePageSpread",
+            "columnName": "doublePageSpread",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "justifyText",
+            "columnName": "justifyText",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "serverId",
+            "itemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_book_formatting_preferences_serverId",
+            "unique": false,
+            "columnNames": [
+              "serverId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_book_formatting_preferences_serverId` ON `${TABLE_NAME}` (`serverId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "servers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "serverId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "readaloud_links",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`absServerId` TEXT NOT NULL, `absLibraryItemId` TEXT NOT NULL, `storytellerServerId` TEXT NOT NULL, `storytellerBookId` TEXT NOT NULL, `state` TEXT NOT NULL, `userConfirmed` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`absServerId`, `absLibraryItemId`), FOREIGN KEY(`storytellerServerId`) REFERENCES `servers`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`absServerId`) REFERENCES `servers`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "absServerId",
+            "columnName": "absServerId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absLibraryItemId",
+            "columnName": "absLibraryItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerServerId",
+            "columnName": "storytellerServerId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerBookId",
+            "columnName": "storytellerBookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userConfirmed",
+            "columnName": "userConfirmed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "absServerId",
+            "absLibraryItemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_readaloud_links_storytellerServerId_storytellerBookId",
+            "unique": false,
+            "columnNames": [
+              "storytellerServerId",
+              "storytellerBookId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_readaloud_links_storytellerServerId_storytellerBookId` ON `${TABLE_NAME}` (`storytellerServerId`, `storytellerBookId`)"
+          },
+          {
+            "name": "index_readaloud_links_storytellerServerId",
+            "unique": false,
+            "columnNames": [
+              "storytellerServerId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_readaloud_links_storytellerServerId` ON `${TABLE_NAME}` (`storytellerServerId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "servers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "storytellerServerId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "servers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "absServerId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "readaloud_candidates",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`storytellerServerId` TEXT NOT NULL, `storytellerBookId` TEXT NOT NULL, `absServerId` TEXT NOT NULL, `absLibraryItemId` TEXT NOT NULL, `score` REAL NOT NULL, PRIMARY KEY(`storytellerServerId`, `storytellerBookId`, `absServerId`, `absLibraryItemId`), FOREIGN KEY(`storytellerServerId`) REFERENCES `servers`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`absServerId`) REFERENCES `servers`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "storytellerServerId",
+            "columnName": "storytellerServerId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerBookId",
+            "columnName": "storytellerBookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absServerId",
+            "columnName": "absServerId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absLibraryItemId",
+            "columnName": "absLibraryItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "score",
+            "columnName": "score",
+            "affinity": "REAL",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "storytellerServerId",
+            "storytellerBookId",
+            "absServerId",
+            "absLibraryItemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_readaloud_candidates_absServerId",
+            "unique": false,
+            "columnNames": [
+              "absServerId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_readaloud_candidates_absServerId` ON `${TABLE_NAME}` (`absServerId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "servers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "storytellerServerId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "servers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "absServerId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "readaloud_dismissals",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`storytellerServerId` TEXT NOT NULL, `storytellerBookId` TEXT NOT NULL, `scope` TEXT NOT NULL, `absServerId` TEXT NOT NULL, `absLibraryItemId` TEXT NOT NULL, PRIMARY KEY(`storytellerServerId`, `storytellerBookId`, `absServerId`, `absLibraryItemId`), FOREIGN KEY(`storytellerServerId`) REFERENCES `servers`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "storytellerServerId",
+            "columnName": "storytellerServerId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerBookId",
+            "columnName": "storytellerBookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scope",
+            "columnName": "scope",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absServerId",
+            "columnName": "absServerId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absLibraryItemId",
+            "columnName": "absLibraryItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "storytellerServerId",
+            "storytellerBookId",
+            "absServerId",
+            "absLibraryItemId"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "servers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "storytellerServerId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "cross_epub_index",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`absEpubChecksum` TEXT NOT NULL, `storytellerEpubChecksum` TEXT NOT NULL, `perChapterMapsBlob` TEXT NOT NULL, `builtAt` INTEGER NOT NULL, PRIMARY KEY(`absEpubChecksum`, `storytellerEpubChecksum`))",
+        "fields": [
+          {
+            "fieldPath": "absEpubChecksum",
+            "columnName": "absEpubChecksum",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerEpubChecksum",
+            "columnName": "storytellerEpubChecksum",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "perChapterMapsBlob",
+            "columnName": "perChapterMapsBlob",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "builtAt",
+            "columnName": "builtAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "absEpubChecksum",
+            "storytellerEpubChecksum"
+          ]
+        }
+      },
+      {
+        "tableName": "annotations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `serverId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `type` TEXT NOT NULL, `cfi` TEXT NOT NULL, `color` TEXT NOT NULL, `note` TEXT, `textSnippet` TEXT NOT NULL, `chapterHref` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `originDeviceId` TEXT NOT NULL, `lastModifiedByDeviceId` TEXT NOT NULL, `deleted` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`serverId`) REFERENCES `servers`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cfi",
+            "columnName": "cfi",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "color",
+            "columnName": "color",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "note",
+            "columnName": "note",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "textSnippet",
+            "columnName": "textSnippet",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chapterHref",
+            "columnName": "chapterHref",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "originDeviceId",
+            "columnName": "originDeviceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastModifiedByDeviceId",
+            "columnName": "lastModifiedByDeviceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deleted",
+            "columnName": "deleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_annotations_serverId_itemId",
+            "unique": false,
+            "columnNames": [
+              "serverId",
+              "itemId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_annotations_serverId_itemId` ON `${TABLE_NAME}` (`serverId`, `itemId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "servers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "serverId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "readaloud_resume_positions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`serverId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `href` TEXT NOT NULL, `progression` REAL, `fragmentRef` TEXT, `localUpdatedAt` INTEGER NOT NULL, PRIMARY KEY(`serverId`, `itemId`), FOREIGN KEY(`serverId`) REFERENCES `servers`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "href",
+            "columnName": "href",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "progression",
+            "columnName": "progression",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "fragmentRef",
+            "columnName": "fragmentRef",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localUpdatedAt",
+            "columnName": "localUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "serverId",
+            "itemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_readaloud_resume_positions_serverId",
+            "unique": false,
+            "columnNames": [
+              "serverId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_readaloud_resume_positions_serverId` ON `${TABLE_NAME}` (`serverId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "servers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "serverId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '11474a9cc666f7a1835cc4b5c10ed0e6')"
+    ]
+  }
+}

--- a/core/database/src/androidTest/kotlin/com/riffle/core/database/MigrationTest.kt
+++ b/core/database/src/androidTest/kotlin/com/riffle/core/database/MigrationTest.kt
@@ -1086,6 +1086,73 @@ class MigrationTest {
     }
 
     @Test
+    fun migration26To27_addsReadaloudResumePositionsKeyedByServerAndItem() {
+        helper.createDatabase(TEST_DB, 26).use { db ->
+            // A server the resume position will reference (FK target), plus a pre-existing reading
+            // position that must survive the new table being added.
+            db.execSQL(
+                "INSERT INTO servers (id, url, isActive, insecureConnectionAllowed, username, serverType) " +
+                    "VALUES ('s1', 'http://media-server:8001', 1, 0, 'plamen', 'STORYTELLER')"
+            )
+            db.execSQL(
+                "INSERT INTO reading_positions (serverId, itemId, cfi, localUpdatedAt) " +
+                    "VALUES ('s1', 'item-1', 'epubcfi(/6/2!/4/1:0)', 1000)"
+            )
+        }
+
+        val db = helper.runMigrationsAndValidate(TEST_DB, 27, true, RiffleDatabase.MIGRATION_26_27)
+
+        // Pre-existing data survives.
+        db.query("SELECT cfi FROM reading_positions WHERE serverId = 's1' AND itemId = 'item-1'").use { cursor ->
+            assertEquals(1, cursor.count)
+            cursor.moveToFirst()
+            assertEquals("epubcfi(/6/2!/4/1:0)", cursor.getString(0))
+        }
+
+        // New table exists and starts empty.
+        db.query("SELECT COUNT(*) FROM readaloud_resume_positions").use { cursor ->
+            cursor.moveToFirst()
+            assertEquals(0, cursor.getInt(0))
+        }
+
+        // A full resume row round-trips, including nullable progression/fragmentRef populated.
+        db.execSQL(
+            "INSERT INTO readaloud_resume_positions (serverId, itemId, href, progression, fragmentRef, localUpdatedAt) " +
+                "VALUES ('s1', 'item-1', 'chap03.xhtml', 0.42, 'chap03.xhtml#sent12', 5000)"
+        )
+        db.query(
+            "SELECT href, progression, fragmentRef, localUpdatedAt FROM readaloud_resume_positions " +
+                "WHERE serverId = 's1' AND itemId = 'item-1'"
+        ).use { cursor ->
+            assertEquals(1, cursor.count)
+            cursor.moveToFirst()
+            assertEquals("chap03.xhtml", cursor.getString(0))
+            assertEquals(0.42, cursor.getDouble(1), 1e-9)
+            assertEquals("chap03.xhtml#sent12", cursor.getString(2))
+            assertEquals(5000L, cursor.getLong(3))
+        }
+
+        // Nullable columns accept NULL (close with no resolvable column/sentence).
+        db.execSQL(
+            "INSERT INTO readaloud_resume_positions (serverId, itemId, href, progression, fragmentRef, localUpdatedAt) " +
+                "VALUES ('s1', 'item-2', 'chap01.xhtml', NULL, NULL, 6000)"
+        )
+        db.query("SELECT progression, fragmentRef FROM readaloud_resume_positions WHERE serverId = 's1' AND itemId = 'item-2'").use { cursor ->
+            cursor.moveToFirst()
+            assertTrue(cursor.isNull(0))
+            assertTrue(cursor.isNull(1))
+        }
+
+        // FK cascade: removing the server clears its resume positions.
+        db.execSQL("PRAGMA foreign_keys = ON")
+        db.execSQL("DELETE FROM servers WHERE id = 's1'")
+        db.query("SELECT COUNT(*) FROM readaloud_resume_positions").use { cursor ->
+            cursor.moveToFirst()
+            assertEquals(0, cursor.getInt(0))
+        }
+    }
+
+    @Test
     fun migrateFullChain() {
         helper.createDatabase(TEST_DB, 1).use { db ->
             db.execSQL(
@@ -1094,7 +1161,7 @@ class MigrationTest {
         }
 
         val db = helper.runMigrationsAndValidate(
-            TEST_DB, 26, true,
+            TEST_DB, 27, true,
             RiffleDatabase.MIGRATION_1_2,
             RiffleDatabase.MIGRATION_2_3,
             RiffleDatabase.MIGRATION_3_4,
@@ -1120,6 +1187,7 @@ class MigrationTest {
             RiffleDatabase.MIGRATION_23_24,
             RiffleDatabase.MIGRATION_24_25,
             RiffleDatabase.MIGRATION_25_26,
+            RiffleDatabase.MIGRATION_26_27,
         )
 
         db.query("SELECT url, username, serverType FROM servers WHERE id = 's1'").use { cursor ->

--- a/core/database/src/main/kotlin/com/riffle/core/database/ReadaloudResumePositionDao.kt
+++ b/core/database/src/main/kotlin/com/riffle/core/database/ReadaloudResumePositionDao.kt
@@ -1,0 +1,16 @@
+package com.riffle.core.database
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+
+@Dao
+interface ReadaloudResumePositionDao {
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsert(entity: ReadaloudResumePositionEntity)
+
+    @Query("SELECT * FROM readaloud_resume_positions WHERE serverId = :serverId AND itemId = :itemId LIMIT 1")
+    suspend fun getByItemId(serverId: String, itemId: String): ReadaloudResumePositionEntity?
+}

--- a/core/database/src/main/kotlin/com/riffle/core/database/ReadaloudResumePositionEntity.kt
+++ b/core/database/src/main/kotlin/com/riffle/core/database/ReadaloudResumePositionEntity.kt
@@ -1,0 +1,31 @@
+package com.riffle.core.database
+
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+
+/**
+ * Per-device readaloud resume position, keyed by the reader's (serverId, itemId). Mirrors
+ * [ReadingPositionEntity]'s keying and CASCADE so deleting a server cleans up its rows. Never synced.
+ */
+@Entity(
+    tableName = "readaloud_resume_positions",
+    primaryKeys = ["serverId", "itemId"],
+    foreignKeys = [
+        ForeignKey(
+            entity = ServerEntity::class,
+            parentColumns = ["id"],
+            childColumns = ["serverId"],
+            onDelete = ForeignKey.CASCADE,
+        ),
+    ],
+    indices = [Index("serverId")],
+)
+data class ReadaloudResumePositionEntity(
+    val serverId: String,
+    val itemId: String,
+    val href: String,
+    val progression: Double?,
+    val fragmentRef: String?,
+    val localUpdatedAt: Long = 0,
+)

--- a/core/database/src/main/kotlin/com/riffle/core/database/RiffleDatabase.kt
+++ b/core/database/src/main/kotlin/com/riffle/core/database/RiffleDatabase.kt
@@ -21,8 +21,9 @@ import androidx.sqlite.db.SupportSQLiteDatabase
         ReadaloudDismissalEntity::class,
         CrossEpubIndexEntity::class,
         AnnotationEntity::class,
+        ReadaloudResumePositionEntity::class,
     ],
-    version = 26,
+    version = 27,
     exportSchema = true,
 )
 abstract class RiffleDatabase : RoomDatabase() {
@@ -38,6 +39,7 @@ abstract class RiffleDatabase : RoomDatabase() {
     abstract fun readaloudDismissalDao(): ReadaloudDismissalDao
     abstract fun crossEpubIndexDao(): CrossEpubIndexDao
     abstract fun annotationDao(): AnnotationDao
+    abstract fun readaloudResumePositionDao(): ReadaloudResumePositionDao
 
     companion object {
         val MIGRATION_1_2 = object : Migration(1, 2) {
@@ -545,6 +547,28 @@ abstract class RiffleDatabase : RoomDatabase() {
                 db.execSQL(
                     "CREATE INDEX IF NOT EXISTS `index_book_formatting_preferences_serverId` " +
                         "ON `book_formatting_preferences` (`serverId`)"
+                )
+            }
+        }
+
+        // Per-device readaloud resume position so narration resumes where it stopped after leaving
+        // and re-entering a book. Keyed like reading_positions; never synced.
+        val MIGRATION_26_27 = object : Migration(26, 27) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL(
+                    "CREATE TABLE IF NOT EXISTS `readaloud_resume_positions` (" +
+                        "`serverId` TEXT NOT NULL, " +
+                        "`itemId` TEXT NOT NULL, " +
+                        "`href` TEXT NOT NULL, " +
+                        "`progression` REAL, " +
+                        "`fragmentRef` TEXT, " +
+                        "`localUpdatedAt` INTEGER NOT NULL, " +
+                        "PRIMARY KEY(`serverId`, `itemId`), " +
+                        "FOREIGN KEY(`serverId`) REFERENCES `servers`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE)"
+                )
+                db.execSQL(
+                    "CREATE INDEX IF NOT EXISTS `index_readaloud_resume_positions_serverId` " +
+                        "ON `readaloud_resume_positions` (`serverId`)"
                 )
             }
         }

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/ReadaloudResumeStore.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/ReadaloudResumeStore.kt
@@ -1,0 +1,23 @@
+package com.riffle.core.domain
+
+/**
+ * Where readaloud narration should resume, captured when the player was last closed: the reader page
+ * ([href] + [progression]) and the sentence narrating at that moment ([fragmentRef], "href#fragmentId").
+ * [progression] and [fragmentRef] are null when the close happened with no resolvable sentence/column.
+ */
+data class ReadaloudResumePosition(
+    val href: String,
+    val progression: Double?,
+    val fragmentRef: String?,
+)
+
+/**
+ * Persists the readaloud resume position per book so it survives leaving and re-entering the book (and
+ * process death). Keyed by the reader's (serverId, itemId) — the same identity as the reading position —
+ * because [ReadaloudResumePosition.href]/[ReadaloudResumePosition.fragmentRef] live in reader-locator
+ * space. Device-local: unlike the reading position it is never synced to a server.
+ */
+interface ReadaloudResumeStore {
+    suspend fun save(serverId: String, itemId: String, position: ReadaloudResumePosition)
+    suspend fun load(serverId: String, itemId: String): ReadaloudResumePosition?
+}

--- a/docs/superpowers/specs/2026-06-05-readaloud-resume-across-sessions-design.md
+++ b/docs/superpowers/specs/2026-06-05-readaloud-resume-across-sessions-design.md
@@ -122,8 +122,40 @@ into the unchanged planner on first Play.
   `Resume` when the current page matches the close page, and `PageTop` when it differs
   (the page-8 scenario). Phone-form-factor harness test via `make harness-test`.
 
+## Composition with `readaloud-progress-sync`
+
+The `pkmetski/readaloud-progress-sync` branch routes readaloud progress to the matched
+ABS items (ebook CFI → ebook item, audiobook `currentTime` → audiobook item) and, via
+three-peer sync, restores a **canonical reading position** that now folds in audiobook
+listening. The two features are orthogonal and compose at **different granularities**:
+
+- progress-sync restores the canonical position resolved to a CFI → a **page**;
+- this feature refines that to the **exact narrated sentence** only when the first Play
+  lands back on that same page.
+
+They compose through the planner's existing **"current page wins"** rule: the seeded
+local close-state is compared against the *live* restored locator. If the canonical
+position (e.g. audiobook listened ahead on another device) restored the reader to a
+different page, `PageTop` wins and the stale local sentence is ignored — no special
+casing. The audiobook clock cannot provide sentence precision regardless: the ABS
+audiobook is a different recording than the Storyteller readaloud bundle, so its
+`currentTime` maps to a page (via CFI), never to a Storyteller SMIL clip. No
+timestamp-recency guard is added — a millisecond-level `localUpdatedAt` comparison
+against the reading position would be fragile and break the base case; the page-level
+tiebreaker is the robust integration point. The same-page residual (audiobook advanced
+*within* the restored page since the local stop → resume rewinds a few seconds) is
+accepted as negligible.
+
+**Migration version coordination.** Both branches independently introduced a
+`MIGRATION_26_27` / `@Database(version = 27)` / `27.json`. This branch (implemented and
+merged first) **owns 26 → 27** (creates `readaloud_resume_positions`).
+`readaloud-progress-sync` must renumber its `hasAudio` change to **27 → 28** when it
+lands. The two are independent schema changes (new table vs new column), so sequential
+migrations suffice; no merge of the migrations themselves.
+
 ## Out of scope
 
 - Server-side sync of readaloud position (intentionally device-local).
 - Changing the planner's same-page/different-page logic.
 - Autoplay on re-entry.
+- A timestamp-recency guard against the canonical position (see Composition above).

--- a/docs/superpowers/specs/2026-06-05-readaloud-resume-across-sessions-design.md
+++ b/docs/superpowers/specs/2026-06-05-readaloud-resume-across-sessions-design.md
@@ -1,0 +1,129 @@
+# Persist Readaloud resume position across book sessions
+
+**Date:** 2026-06-05
+**Status:** Approved (design)
+
+## Problem
+
+When the user stops Readaloud with the player's **X** (close) button and then taps
+**Play** again *within the same reading session*, narration correctly resumes from the
+last narrated sentence (same page) or from the top of the current page (different
+page). But if the user **leaves the book and re-enters it**, that resume position is
+lost — the next Play starts as a brand-new "first play from the reader's position"
+instead of honoring where audio last stopped.
+
+### Root cause
+
+The resume state lives in `EpubReaderViewModel` instance fields:
+
+- `closeLocator: Locator?` — the reader page when the player was last closed
+- `resumeFragmentRef: String?` — the sentence narrating at that moment
+
+(`EpubReaderViewModel.kt:1018-1019`, captured in `closeReadaloud()` at lines 909-910.)
+
+These survive an in-session X→Play only because the ViewModel object survives. Leaving
+the book destroys the ViewModel (`onCleared`, line 678); re-entering constructs a fresh
+one with both fields `null`. `ReadaloudResumePlanner.plan(...)` then sees
+`closeHref == null`, interprets it as "never closed this session," and returns
+`FromReaderPosition` — restarting from the reader's current position rather than
+resuming.
+
+## Desired behavior
+
+Re-entering the book should behave **identically to an in-session reopen**:
+
+- **Same page** as where audio stopped → resume the exact last narrated sentence.
+- **Different page** (e.g. audio stopped on page 1, user is now on page 8) → start
+  from the **top of the current page** (page 8). The current reader page overrides the
+  stale audio position.
+
+No autoplay — resume happens on the next **Play** tap (mirrors in-session behavior).
+Durable across leaving/re-entering **and** app process death.
+
+This maps **exactly** onto the existing `ReadaloudResumePlanner` logic. The only thing
+missing is that the close-state must survive ViewModel destruction. **The planner is
+not changed.**
+
+## Design
+
+Persist the close-state to disk, keyed by book; load it when the book opens; feed it
+into the unchanged planner on first Play.
+
+### Storage — new Room table
+
+`readaloud_resume_positions`:
+
+| column           | type    | notes                                            |
+|------------------|---------|--------------------------------------------------|
+| `serverId`       | TEXT    | PK part 1; FK → `servers(id)` ON DELETE CASCADE  |
+| `itemId`         | TEXT    | PK part 2                                         |
+| `href`           | TEXT    | reader-locator href of the close page            |
+| `progression`    | REAL    | within-chapter progression of the close page     |
+| `fragmentRef`    | TEXT    | `"href#fragmentId"` of the last narrated sentence|
+| `localUpdatedAt` | INTEGER | `System.currentTimeMillis()` at write            |
+
+- **Per-device, NOT server-synced.** Readaloud position has no server counterpart, so
+  unlike `reading_positions` it is never pushed to ABS/Storyteller. This is also why a
+  *separate* table is used rather than adding columns to the server-synced
+  `reading_positions` entity (mixing device-local data into a synced entity invites
+  sync bugs).
+- **Keyed by the reader's `(serverId, itemId)`** — same identity as `reading_positions`.
+  `href` and `fragmentRef` are in the reader's EPUB-locator space, so the reader
+  identity is the correct key even for a matched-ABS book whose *audio* bundle lives
+  under a different Storyteller `(audioServerId, audioBookId)`.
+- FK `CASCADE` matches `reading_positions`, so deleting a server cleans up its rows.
+
+### Flow
+
+1. **Write on close.** In `closeReadaloud()` — and in `onReaderClosed()` when the
+   player was open — persist `{href, progression, fragmentRef}` for the current
+   `(serverId, itemId)`. Overwrite any existing row (upsert). The position **persists
+   indefinitely** until the next close overwrites it; it is **not** cleared when
+   consumed, so any number of re-entries keep resuming correctly.
+2. **Load on open.** When the book opens, load the row for `(serverId, itemId)` and
+   seed `closeLocator` / `resumeFragmentRef` before the first Play can occur.
+3. **First Play.** `ensurePreparedAndPlay` passes the seeded values into
+   `ReadaloudResumePlanner.plan(...)` exactly as today:
+   - same page → `Resume(fragmentRef)`
+   - different page → `PageTop(currentHref)` (the page-8 case)
+   - genuinely no saved row (never readaloud'd) → `closeHref == null` →
+     `FromReaderPosition`, unchanged.
+4. **Navigation.** Auto-follow already moves the reader to the narrated sentence when
+   `Resume` starts, so no new navigation code is required.
+
+### Layers touched
+
+- **core/database**
+  - New `ReadaloudResumePositionEntity` + `ReadaloudResumePositionDao`.
+  - Bump `@Database version` `26 → 27`; add `MIGRATION_26_27` creating the table.
+  - Export schema JSON `27.json` (KSP, via a build).
+  - Register `MIGRATION_26_27` in `DataModule`/`addMigrations(...)`.
+  - Add `MigrationTest.migration26To27()` + extend `migrateFullChain` (per CLAUDE.md
+    migration checklist).
+- **core/domain**
+  - `ReadaloudResumeStore` interface (mirrors `ReadingPositionStore`): `save(...)`,
+    `load(serverId, itemId): ReadaloudResumePosition?`. A small `ReadaloudResumePosition`
+    domain value (`href`, `progression`, `fragmentRef`).
+- **core/data**
+  - `ReadaloudResumeStoreImpl` backed by the DAO; DI wiring for the new DAO + store.
+- **app**
+  - `EpubReaderViewModel`: write on close, load on open, seed the existing fields.
+    Resolve `serverId` the same way the reading-position path does.
+
+## Testing
+
+- **Planner** — already unit-tested; unchanged, so existing tests stand.
+- **Store round-trip** — save then load returns the same `{href, progression,
+  fragmentRef}`; overwrite replaces.
+- **Migration** — `MigrationTest.migration26To27()` creates the table at v26→27 and
+  asserts a pre-seeded row survives and the new table is present with correct columns;
+  add to `migrateFullChain`.
+- **ViewModel** — a fresh ViewModel seeded from a persisted close-state produces
+  `Resume` when the current page matches the close page, and `PageTop` when it differs
+  (the page-8 scenario). Phone-form-factor harness test via `make harness-test`.
+
+## Out of scope
+
+- Server-side sync of readaloud position (intentionally device-local).
+- Changing the planner's same-page/different-page logic.
+- Autoplay on re-entry.


### PR DESCRIPTION
## What

Readaloud resumed from its last sentence after an in-session **X → Play**, but not after **leaving and re-entering** the book. The resume state (`closeLocator` + `resumeFragmentRef`) lived only in `EpubReaderViewModel` fields, which die when the ViewModel is recreated — so on re-entry the planner fell back to a first-play.

This persists the close-state to a new **per-device** Room table `readaloud_resume_positions`, keyed by the reader's `(serverId, itemId)` (never synced), loads it on book open, and feeds it into the **unchanged** `ReadaloudResumePlanner`:

- **same page** as where audio stopped → resume the exact sentence;
- **different page** (stopped on p.1, now on p.8) → start at the **top of the current page** (current page wins);
- durable across re-entry **and** process death; no autoplay (resume happens on the next Play tap).

Persisted on X (`closeReadaloud`) and on leaving while the player is open (`onReaderClosed`).

## Layers

- `core/database`: `ReadaloudResumePositionEntity` + DAO, `MIGRATION_26_27`, `@Database(version = 27)`, exported `27.json`, registered in `DatabaseModule`.
- `core/domain`: `ReadaloudResumeStore` + `ReadaloudResumePosition`.
- `core/data`: `ReadaloudResumeStoreImpl` + DI.
- `app`: `EpubReaderViewModel` write-on-close / load-on-open; `TestDatabaseModule` provides the new DAO.

## Integration with `readaloud-progress-sync`

The two compose at different granularities: progress-sync restores the canonical position → a **page**; this refines it to the exact **sentence** only when you land on that same page, via the planner's "current page wins" tiebreaker. The audiobook clock can't give sentence precision (different recording than the Storyteller bundle). See the spec's "Composition" section.

⚠️ **Migration coordination:** this branch owns **26 → 27**. `readaloud-progress-sync`'s `hasAudio` change (also drafted as 26 → 27) must renumber to **27 → 28** when it lands. Independent schema changes; sequential migrations.

## Tested

- `./gradlew test` ✅ and `./gradlew lint` ✅
- `ReadaloudResumeStoreTest` (JVM, written test-first) ✅
- `MigrationTest.migration26To27` + `migrateFullChain` on the Harness phone AVD ✅
- `make harness-test` → 151/152 pass; the one failure is the documented pre-existing `AutoFollowJsTest.paginatedSnapsToTheColumnContainingTheSentence` flake (fails on `main` on local Harness AVDs; unrelated — this PR touches no auto-follow/snap code).
- `make harness-test-tablet` → 5/5 ✅

Code review run on the branch; addressed: deduped a double resume-save (ON_STOP + onDispose) and keyed the save by the open-time server id (removing a per-close `getActive()` read and a seed/save key asymmetry).