### PR TITLE
fix(reader): Play-from-here starts at the selected sentence, no page jump on player open

### DIFF
--- a/app/src/androidTest/kotlin/com/riffle/app/feature/reader/AutoFollowJsTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/reader/AutoFollowJsTest.kt
@@ -82,6 +82,35 @@ class AutoFollowJsTest {
     }
 
     @Test
+    fun paginatedKeepsAVisibleSentenceInPlaceWithoutReSnapping() {
+        withSizedWebViewFixture(shortFixture, widthPx = 1080, heightPx = 1600) { webView ->
+            webView.awaitInnerHeight()
+            // Drift the page a few px off the column grid, with the on-page sentence still visible. The
+            // keep-visible follow must leave the page exactly where it is (the old always-snap behaviour
+            // would have pulled scrollLeft back to the grid at 0 — the "jump" when playback starts).
+            webView.evalSync("document.scrollingElement.scrollLeft=10")
+            val result = webView.evalSync(autoFollowSnapJs(onPageText)).trim('"')
+            assertEquals("a visible sentence keeps the page 'on'", "on", result)
+            assertEquals("a visible sentence must be left in place, not re-snapped to the grid", 10, webView.scrollX())
+        }
+    }
+
+    @Test
+    fun paginatedDoesNotSnapBackForASentenceWrappingInFromThePreviousColumn() {
+        withSizedWebViewFixture(shortFixture, widthPx = 1080, heightPx = 1600) { webView ->
+            webView.awaitInnerHeight()
+            // Drift the page forward so the on-page sentence's START sits just off the left edge while its
+            // body stays visible on this page — the column-spanning case (a narrated sentence wrapped in
+            // from the previous column). Keep-visible must leave the page put; the old probe snapped
+            // scrollLeft back to the start's column — the page "jump" when playback starts on such a line.
+            webView.evalSync("document.scrollingElement.scrollLeft=40")
+            val result = webView.evalSync(autoFollowSnapJs(onPageText)).trim('"')
+            assertEquals("a sentence wrapping in from the previous column stays on the page", "on", result)
+            assertEquals("a wrapped-in sentence must not snap the page back a column", 40, webView.scrollX())
+        }
+    }
+
+    @Test
     fun paginatedSnapsToTheColumnContainingTheSentence() {
         withSizedWebViewFixture(shortFixture, widthPx = 1080, heightPx = 1600) { webView ->
             webView.awaitInnerHeight()

--- a/app/src/androidTest/kotlin/com/riffle/app/feature/reader/AutoFollowJsTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/reader/AutoFollowJsTest.kt
@@ -111,6 +111,18 @@ class AutoFollowJsTest {
     }
 
     @Test
+    fun reflowAnchorCaptureReturnsTheTopOfPageLine() {
+        withSizedWebViewFixture(shortFixture, widthPx = 1080, heightPx = 1600) { webView ->
+            webView.awaitInnerHeight()
+            // The capture returns a prefix of the line at the top of the current page — the anchor the
+            // reserve reflow pins back. It must be the on-page line, never the off-page (next-column) one.
+            val anchor = webView.evalSync(reflowAnchorCaptureJs()).trim('"')
+            assertTrue("a non-empty anchor is captured", anchor.isNotEmpty())
+            assertTrue("anchor is the on-page line (got '$anchor')", onPageText.startsWith(anchor))
+        }
+    }
+
+    @Test
     fun paginatedSnapsToTheColumnContainingTheSentence() {
         withSizedWebViewFixture(shortFixture, widthPx = 1080, heightPx = 1600) { webView ->
             webView.awaitInnerHeight()

--- a/app/src/androidTest/kotlin/com/riffle/app/feature/reader/ReaderWebViewScriptsTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/reader/ReaderWebViewScriptsTest.kt
@@ -4,6 +4,7 @@ import android.webkit.WebView
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.json.JSONObject
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 
@@ -143,7 +144,166 @@ class ReaderWebViewScriptsTest {
         }
     }
 
+    // ---- resolveSelectionSentenceJs ----
+    //
+    // These exercise the GEOMETRY-based resolver against a real, sized WebView: we drive a real text
+    // selection (which fires selectionchange so the tracker stashes window.__riffleSelRect), then ask the
+    // resolver which narrated sentence the selection landed in. The fixtures mirror the DOM Readium serves
+    // for a readaloud (ABS) EPUB — the per-sentence span ids are stripped, leaving only prose — and the
+    // [resolveSentences] carry the bundle's flattened sentence text keyed by span id.
+
+    // "cat" recurs across sentences AND paragraphs, so resolving by the bare word would be ambiguous —
+    // the resolver must use the selection's POSITION.
+    private val strippedFixture = """
+        <!DOCTYPE html>
+        <html><head><meta name="viewport" content="width=device-width, initial-scale=1"></head>
+          <body style="margin:0">
+            <p>The cat sat on the mat. The cat ran away quickly.</p>
+            <p>Later the cat returned home. The dog barked twice.</p>
+          </body>
+        </html>
+    """.trimIndent()
+
+    private val strippedSentences = listOf(
+        "c1-s0" to "The cat sat on the mat.",
+        "c1-s1" to "The cat ran away quickly.",
+        "c1-s2" to "Later the cat returned home.",
+        "c1-s3" to "The dog barked twice.",
+    )
+
+    // Mirrors the real Project Hail Mary failure: the served page italicises the recurring ship name
+    // ("<em>Hermes</em>"), splitting each such sentence into multiple text nodes, and the bundle's
+    // sentence text ("…to Hermes." / "Once we got to Hermes, …") differs from the rendered run. Geometry
+    // sidesteps all of that. A selection on the LAST Hermes sentence must resolve to THAT sentence — not
+    // the earlier markup-free one (the bug: selected "Once we got to Hermes…", got "I guess I should…").
+    private val italicFixture = """
+        <!DOCTYPE html>
+        <html><head><meta name="viewport" content="width=device-width, initial-scale=1"></head>
+          <body style="margin:0">
+            <p>I guess I should explain how Mars missions work, for any layman who may be reading this.</p>
+            <p>We got to Earth orbit the normal way, through an ordinary ship to <em>Hermes</em>.</p>
+            <p>Once we got to <em>Hermes</em>, four additional unmanned missions brought us fuel.</p>
+          </body>
+        </html>
+    """.trimIndent()
+
+    private val italicSentences = listOf(
+        "s0" to "I guess I should explain how Mars missions work, for any layman who may be reading this.",
+        "s1" to "We got to Earth orbit the normal way, through an ordinary ship to Hermes.",
+        "s2" to "Once we got to Hermes, four additional unmanned missions brought us fuel.",
+    )
+
+    @Test
+    fun resolveSelectionResolvesTheSentenceContainingTheSelection() {
+        withSizedWebViewFixture(strippedFixture, widthPx = 1080, heightPx = 1600) { webView ->
+            webView.awaitInnerHeight()
+            webView.evalSync(SELECTION_SPAN_TRACKER_JS)
+            webView.selectNthOccurrence("sat", 1) // first sentence
+            assertTrue("tracker must stash a selection rect", webView.awaitSelRect())
+            assertEquals("c1-s0", webView.evalSync(resolveSelectionSentenceJs(strippedSentences)).trim('"'))
+        }
+    }
+
+    @Test
+    fun resolveSelectionPicksTheRightOccurrenceOfARecurringWord() {
+        withSizedWebViewFixture(strippedFixture, widthPx = 1080, heightPx = 1600) { webView ->
+            webView.awaitInnerHeight()
+            webView.evalSync(SELECTION_SPAN_TRACKER_JS)
+            // "cat" occurs in s0, s1, s2 (in reading order). The 3rd lands in s2 — bare word-matching
+            // would pick the 1st; geometry picks the sentence the tap is actually in.
+            webView.selectNthOccurrence("cat", 3)
+            assertTrue(webView.awaitSelRect())
+            assertEquals("c1-s2", webView.evalSync(resolveSelectionSentenceJs(strippedSentences)).trim('"'))
+        }
+    }
+
+    @Test
+    fun resolveSelectionPicksTheSecondSentenceForAWordOnlyItContains() {
+        withSizedWebViewFixture(strippedFixture, widthPx = 1080, heightPx = 1600) { webView ->
+            webView.awaitInnerHeight()
+            webView.evalSync(SELECTION_SPAN_TRACKER_JS)
+            webView.selectNthOccurrence("ran", 1) // only in s1
+            assertTrue(webView.awaitSelRect())
+            assertEquals("c1-s1", webView.evalSync(resolveSelectionSentenceJs(strippedSentences)).trim('"'))
+        }
+    }
+
+    @Test
+    fun resolveSelectionResolvesASentenceContainingInlineMarkup() {
+        withSizedWebViewFixture(italicFixture, widthPx = 1080, heightPx = 1600) { webView ->
+            webView.awaitInnerHeight()
+            webView.evalSync(SELECTION_SPAN_TRACKER_JS)
+            webView.selectNthOccurrence("Hermes", 2) // 2nd Hermes is in s2
+            assertTrue(webView.awaitSelRect())
+            assertEquals(
+                "the sentence with the italic ship name must resolve to itself, not the earlier sentence",
+                "s2",
+                webView.evalSync(resolveSelectionSentenceJs(italicSentences)).trim('"'),
+            )
+        }
+    }
+
+    @Test
+    fun resolveSelectionResolvesTheMiddleSentenceWithInlineMarkup() {
+        withSizedWebViewFixture(italicFixture, widthPx = 1080, heightPx = 1600) { webView ->
+            webView.awaitInnerHeight()
+            webView.evalSync(SELECTION_SPAN_TRACKER_JS)
+            webView.selectNthOccurrence("Hermes", 1) // 1st Hermes is in s1
+            assertTrue(webView.awaitSelRect())
+            assertEquals("s1", webView.evalSync(resolveSelectionSentenceJs(italicSentences)).trim('"'))
+        }
+    }
+
+    @Test
+    fun resolveSelectionReturnsEmptyWhenNoSelectionRectIsStashed() {
+        withSizedWebViewFixture(strippedFixture, widthPx = 1080, heightPx = 1600) { webView ->
+            webView.awaitInnerHeight()
+            // No selection has been made, so __riffleSelRect is unset → resolver yields "" (caller falls back).
+            assertEquals("", webView.evalSync(resolveSelectionSentenceJs(strippedSentences)).trim('"'))
+        }
+    }
+
     // ---- helpers ----
+
+    // Selects the [n]-th occurrence (1-based, document order) of [word], driving a real selection so the
+    // tracker's selectionchange listener fires and stashes window.__riffleSelRect — the realistic path.
+    private fun WebView.selectNthOccurrence(word: String, n: Int) {
+        evalSync(
+            """
+            (function () {
+              var word = ${org.json.JSONObject.quote(word)}, n = $n, count = 0;
+              var w = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT, null, false), node;
+              while (node = w.nextNode()) {
+                var from = 0, i;
+                while ((i = node.nodeValue.indexOf(word, from)) >= 0) {
+                  count++;
+                  if (count === n) {
+                    var range = document.createRange();
+                    range.setStart(node, i);
+                    range.setEnd(node, i + word.length);
+                    var sel = window.getSelection();
+                    sel.removeAllRanges();
+                    sel.addRange(range);
+                    return 'ok';
+                  }
+                  from = i + word.length;
+                }
+              }
+              return 'notfound';
+            })();
+            """.trimIndent(),
+        )
+    }
+
+    // Polls until the tracker has stashed a selection rect (selectionchange is dispatched asynchronously).
+    private fun WebView.awaitSelRect(timeoutMs: Long = 3_000): Boolean {
+        val deadline = System.currentTimeMillis() + timeoutMs
+        while (System.currentTimeMillis() < deadline) {
+            if (evalSync("window.__riffleSelRect ? 'y' : 'n'").trim('"') == "y") return true
+            Thread.sleep(30)
+        }
+        return false
+    }
 
     // Selects a word inside the text node of [spanId], so the selection's startContainer is a text
     // node — the realistic shape the tracker must handle.

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -848,17 +848,34 @@ private fun EpubNavigatorView(
                         coroutineScope.launch {
                             val selection = selectable.currentSelection() ?: return@launch
                             val loc = selection.locator
-                            // Storyteller wraps each narrated sentence in <span id="cNNN-sM"> — exactly the
-                            // SMIL clip target the player keys on. Readium's selection locator carries only
-                            // text + rect (no fragment id), so without that span id the player can't map the
-                            // selection to a clip and restarts the chapter from its first clip. The
-                            // selectionchange tracker (SELECTION_SPAN_TRACKER_JS, injected per page) stashes
-                            // the enclosing span id in window.__riffleSelSpan as the user selects; we read
-                            // that stash rather than the live DOM selection so the value is robust to the
-                            // action-mode teardown. Empty when the selection had no sentence-span ancestor →
-                            // falls back to the locator fragment, then the bare href (chapter start).
-                            val spanId = nav?.evaluateJavascript("window.__riffleSelSpan || ''")
-                                ?.trim('"')?.takeIf { it.isNotEmpty() }
+                            // We need the narrated-sentence span id (<span id="cNNN-sM">) the SMIL clips key
+                            // on; Readium's selection locator carries only text + rect (no fragment id), so
+                            // without that id the player can't map the selection to a clip and restarts the
+                            // chapter from its first clip.
+                            //
+                            // Preferred path — resolveSelectionSentenceJs: resolve the span id by POSITION
+                            // from the captured locator's text context. This survives Readium stripping the
+                            // sentence spans from the served HTML (the common case — the ABS EPUB; see
+                            // ReadaloudTextQuotes) because it locates the selection within the rendered prose
+                            // by text offset rather than reading a DOM id that isn't there. Needs the
+                            // sentence-text map, which is built off-thread after the track loads.
+                            //
+                            // Fallback — window.__riffleSelSpan: the selectionchange tracker
+                            // (SELECTION_SPAN_TRACKER_JS) stashes the enclosing span id, which only exists on
+                            // pages whose spans survived (pure-Storyteller rendering) or before the quotes
+                            // map is ready. Empty → falls back to the locator fragment, then the bare href
+                            // (chapter start).
+                            val sentences = currentSentenceQuotes.entries
+                                .map { it.key to it.value.highlight }
+                            val byText = if (sentences.isNotEmpty() && nav != null) {
+                                nav.evaluateJavascript(resolveSelectionSentenceJs(sentences))
+                                    ?.trim('"')?.takeIf { it.isNotEmpty() }
+                            } else {
+                                null
+                            }
+                            val spanId = byText
+                                ?: nav?.evaluateJavascript("window.__riffleSelSpan || ''")
+                                    ?.trim('"')?.takeIf { it.isNotEmpty() }
                             val fragId = spanId ?: loc.locations.fragments.firstOrNull()
                             val ref = if (fragId != null) "${loc.href}#$fragId" else loc.href.toString()
                             currentOnPlayFromHere(ref)
@@ -1181,19 +1198,19 @@ private fun EpubNavigatorView(
     //
     //  - Scroll (Vertical) mode — the document overflows the viewport, so we scroll it to KEEP THE
     //    SENTENCE CENTERED, the natural karaoke-follow.
-    //  - Paginated (Horizontal) mode — each page is exactly viewport-sized (nothing to scroll), so the
-    //    probe SNAPS scrollLeft to the column boundary that contains the sentence's start (landing on
-    //    the page grid) and returns "on". It does this every sentence rather than gating on rough
-    //    visibility: a go()-based snap lands flush to the element's box (a sliver of the next column
-    //    shows), and a tolerance gate never re-aligns a page that's already drifted between columns.
-    //    The snap holds because the reader is sized so innerWidth == Readium's page-snap pitch
+    //  - Paginated (Horizontal) mode — each page is exactly viewport-sized, KEEP-VISIBLE follow: while
+    //    the narrated sentence's start is on the current page the probe leaves the page in place, and
+    //    only flips (snaps scrollLeft onto the column grid) once the sentence's start moves off the
+    //    current page. This is what stops starting playback — and the player-open reflow that re-runs
+    //    this probe — from yanking the line the user pressed onto a fresh column boundary. The snap
+    //    holds because the reader is sized so innerWidth == Readium's page-snap pitch
     //    ([alignedReaderWidthDp]), so floor(x / innerWidth) * innerWidth is exactly a column boundary.
     //
     // A missing element (sentence in another chapter's document) reads as "off" → go(locator) jumps
     // chapters, so cross-chapter follow falls out for free in both modes.
     //
-    // Re-keys on reflowGeneration so that when opening the player re-paginates the page, the snap
-    // re-runs and re-centres the narrated sentence's (now moved) column.
+    // Re-keys on reflowGeneration so that when opening the player re-paginates the page, the probe
+    // re-runs — flipping only if the reflow pushed the narrated sentence off the current page.
     LaunchedEffect(activeFragmentRef, sentenceQuotes, reflowGeneration) {
         val ref = activeFragmentRef ?: return@LaunchedEffect
         val fragment = fragmentRef.value ?: return@LaunchedEffect

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -969,12 +969,32 @@ private fun EpubNavigatorView(
 
     // Push the readaloud reserve to the live page the moment it changes (player opens/closes, rail
     // toggles, rotation) so the text re-paginates above the player without waiting for a page reload.
-    // The decoration/auto-follow effects re-run via reflowGeneration, which also keys on the reserve.
+    // The decoration effect re-runs via reflowGeneration to re-render the highlight onto the reflowed
+    // layout. The page POSITION through the reflow is handled here, not by the auto-follow probe: the
+    // reserve shrinks/grows every column, re-wrapping the whole text chain, so the page would otherwise
+    // land on different content (the "line jumps when the player opens" bug). We pin the line that was
+    // at the top of the page across the reflow: capture it before, re-anchor to it after as the layout
+    // settles. Only on a real live change (player opens/closes, rail toggles) — not the initial
+    // composition or a page-load re-apply, which have nothing to preserve.
+    var prevReservePx by remember { mutableStateOf<Int?>(null) }
     LaunchedEffect(readaloudReservePx) {
         val fragment = fragmentRef.value ?: return@LaunchedEffect
+        val prev = prevReservePx
+        prevReservePx = readaloudReservePx
         withContext(Dispatchers.Main) {
+            val anchor = if (prev != null && prev != readaloudReservePx) {
+                fragment.evaluateJavascript(reflowAnchorCaptureJs())?.trim('"').orEmpty()
+            } else {
+                ""
+            }
+            // Injecting the <style> doesn't reflow (the rule is inert until the class is added). Apply
+            // the reserve AND start the re-anchor in ONE evaluation so no frame paints between the
+            // re-pagination and the first snap — the re-anchor's first pass forces a synchronous layout
+            // and corrects scrollLeft before paint, so there's no flash of the reflowed-but-unscrolled page.
             fragment.evaluateJavascript(readaloudReserveInjectionJs())
-            fragment.evaluateJavascript(readaloudReserveApplyJs(readaloudReservePx))
+            val applyAndReAnchor = readaloudReserveApplyJs(readaloudReservePx) +
+                if (anchor.isNotEmpty()) "\n;" + reflowAnchorSnapJs(anchor) else ""
+            fragment.evaluateJavascript(applyAndReAnchor)
         }
     }
 
@@ -1209,9 +1229,12 @@ private fun EpubNavigatorView(
     // A missing element (sentence in another chapter's document) reads as "off" → go(locator) jumps
     // chapters, so cross-chapter follow falls out for free in both modes.
     //
-    // Re-keys on reflowGeneration so that when opening the player re-paginates the page, the probe
-    // re-runs — flipping only if the reflow pushed the narrated sentence off the current page.
-    LaunchedEffect(activeFragmentRef, sentenceQuotes, reflowGeneration) {
+    // Deliberately NOT keyed on reflowGeneration: the readaloud-reserve reflow re-paginates the whole
+    // chapter, and re-snapping to the narrated sentence's column here would land the page on whatever
+    // text now precedes it (the "line jumps when the player opens" bug). The reserve effect above
+    // instead pins the line that was at the top of the page across the reflow; this probe only follows
+    // genuine narration advances (activeFragmentRef) and quote arrival.
+    LaunchedEffect(activeFragmentRef, sentenceQuotes) {
         val ref = activeFragmentRef ?: return@LaunchedEffect
         val fragment = fragmentRef.value ?: return@LaunchedEffect
         if (ref.indexOf('#') < 0) return@LaunchedEffect

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -926,6 +926,12 @@ private fun EpubNavigatorView(
     // Opening/closing the player re-paginates, which moves the narrated sentence's column — the
     // highlight and auto-follow must re-run against the new layout.
     val reflowGeneration = rememberReflowReapplyGeneration(formattingPrefs to readaloudReservePx)
+    // Same settle-window generation but keyed ONLY on the formatting prefs, not the readaloud reserve.
+    // The auto-follow probe re-runs on this (plus page loads) to re-centre the narrated sentence after a
+    // font/margin/spacing/orientation reflow — but NOT after the player-open/close reserve reflow, which
+    // the reserve effect pins to the top-of-page line instead (re-following the narrated column there
+    // would re-introduce the "line jumps when the player opens" bug).
+    val followReflowGeneration = rememberReflowReapplyGeneration(formattingPrefs)
 
     // Bumps every time a page finishes loading. This is the precise "the layout is now settled" signal
     // that reflowGeneration's timer heuristic only approximates — and the only one available after a
@@ -1229,12 +1235,12 @@ private fun EpubNavigatorView(
     // A missing element (sentence in another chapter's document) reads as "off" → go(locator) jumps
     // chapters, so cross-chapter follow falls out for free in both modes.
     //
-    // Deliberately NOT keyed on reflowGeneration: the readaloud-reserve reflow re-paginates the whole
-    // chapter, and re-snapping to the narrated sentence's column here would land the page on whatever
-    // text now precedes it (the "line jumps when the player opens" bug). The reserve effect above
-    // instead pins the line that was at the top of the page across the reflow; this probe only follows
-    // genuine narration advances (activeFragmentRef) and quote arrival.
-    LaunchedEffect(activeFragmentRef, sentenceQuotes) {
+    // Re-keys on followReflowGeneration (formatting reflows) and pageLoadGeneration (rotation / chapter
+    // load) so the narrated sentence is re-centred after those relayouts — but deliberately NOT on the
+    // readaloud-reserve reflow: re-snapping to the narrated sentence's column when the player opens would
+    // land the page on whatever text now precedes it (the "line jumps when the player opens" bug). The
+    // reserve effect above instead pins the line that was at the top of the page across that reflow.
+    LaunchedEffect(activeFragmentRef, sentenceQuotes, followReflowGeneration, pageLoadGeneration.value) {
         val ref = activeFragmentRef ?: return@LaunchedEffect
         val fragment = fragmentRef.value ?: return@LaunchedEffect
         if (ref.indexOf('#') < 0) return@LaunchedEffect

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -385,6 +385,20 @@ class EpubReaderViewModel @Inject constructor(
             _readaloudVisible.value = control.visible
             _readaloudAvailable.value = control.enabled
 
+            // Build the sentence-quote map eagerly once the readaloud bundle is known to be on disk, so
+            // the selection→sentence resolution ("Play from here") and the page-top start probe have it
+            // ready before the user can act. It was previously deferred until isPlaying to avoid starving
+            // ExoPlayer's audio-start I/O — but at book-open no audio is playing yet, so there's no
+            // contention, and a first "Play from here" (before any playback) would otherwise see an empty
+            // map and fall back to the chapter start. The isPlaying trigger stays as a backstop for the
+            // matched-ABS case where the bundle is downloaded later in the session.
+            if (control.enabled) {
+                readaloudAudioRepository.bundleFile(audioServerId, audioBookId)?.let { bundle ->
+                    quoteBundle = bundle
+                    buildSentenceQuotes(bundle)
+                }
+            }
+
             // Annotations are ABS-side only (ADR 0024): available on a non-Storyteller server.
             if (!isStorytellerServer && activeServer != null) {
                 annotationServerId = activeServer.id
@@ -914,12 +928,22 @@ class EpubReaderViewModel @Inject constructor(
 
     fun openReadaloud() {
         if (!_readaloudAvailable.value) return
-        _readaloudOpen.value = true
-        startStorytellerSync()
+        openReadaloudSession()
         // Pressing the reader's readaloud control plays immediately — no separate Play tap.
         // A matched ABS book only enables the control once the bundle is present, so this reaches
         // the bundle-present play path; a Storyteller book matches today's Play-tap behavior.
         onPlayTapped()
+    }
+
+    // Opens the readaloud session (shows the player, starts the sync loop) WITHOUT auto-playing.
+    // "Play from here" uses this instead of openReadaloud(): it drives its own seek to the selected
+    // sentence, and routing through onPlayTapped()'s resume planner would fire a SECOND, competing
+    // seek — to the saved resume position or the page-top fallback — that races the selection seek.
+    // Whichever landed last won nondeterministically, so "Play from here" sometimes started at the
+    // chapter top, sometimes at a stale resume point, sometimes at the selection (the unreliable bug).
+    private fun openReadaloudSession() {
+        _readaloudOpen.value = true
+        startStorytellerSync()
     }
 
     fun closeReadaloud() {
@@ -1013,19 +1037,25 @@ class EpubReaderViewModel @Inject constructor(
 
     /** "Play from here" from the text-selection menu — seek to the clip narrating [fragmentRef]. */
     fun playFromHere(fragmentRef: String) {
-        if (!_readaloudOpen.value) openReadaloud()
         val bundle = readaloudAudioRepository.bundleFile(audioServerId, audioBookId)
         if (bundle == null) {
-            // No bundle yet — fall through to the normal play path (prompt/notify) so the user is
+            // No bundle yet — route through the normal play path (prompt/notify) so the user is
             // told to download first.
-            onPlayTapped()
+            if (!_readaloudOpen.value) openReadaloud() else onPlayTapped()
             return
         }
+        // Open the session WITHOUT onPlayTapped()'s resume autoplay: the only seek this session must
+        // make is the one below, to the selected sentence. Going through openReadaloud() would race a
+        // resume/page-top seek against it (see openReadaloudSession).
+        if (!_readaloudOpen.value) openReadaloudSession()
         viewModelScope.launch {
             ensureOpened(bundle) ?: return@launch
             // Starting here counts as the session's first play, so a later pause/resume stays put
-            // rather than re-seeking to the reader position.
+            // rather than re-seeking. Consume any pending resume/close position so the resume planner
+            // can never re-seek away from the selection.
             readaloudStarted = true
+            resumeFragmentRef = null
+            closeLocator = null
             playerCoordinator.playFromHere(fragmentRef)
         }
     }
@@ -1100,14 +1130,14 @@ class EpubReaderViewModel @Inject constructor(
         )
         when (plan) {
             ReadaloudStartPlan.FromReaderPosition ->
-                // First play of this session: start narration from the reader's current position (the
-                // spec requires this), not the beginning of the book. Resolves to chapter granularity
-                // because the reader locator carries no sentence fragment.
+                // First play of this session: start at the first FULL sentence visible on the reader's
+                // current page — not the chapter top, and not the book start. The reader locator carries
+                // no sentence fragment, so we route through the same page-top probe the reopen path uses:
+                // it asks the WebView for the first narrated sentence whose start is on the page and
+                // replies via onPageTopResolved(), which starts playback there. Falls back to plain play
+                // only when there is no reader page at all.
                 if (loc != null) {
-                    playerCoordinator.playFromReaderPosition(
-                        href = loc.href.toString(),
-                        fragmentId = loc.locations.fragments.firstOrNull(),
-                    )
+                    _pageTopProbeChannel.trySend(loc.href.toString())
                 } else {
                     playerCoordinator.play()
                 }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderWebViewScripts.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderWebViewScripts.kt
@@ -46,6 +46,18 @@ internal val RECT_TO_JSON_POLYFILL_JS = """
 // overwrite on a fresh selection — never leave a previous selection's id behind — so a selection with
 // no sentence-span ancestor cleanly falls back to the chapter position rather than reusing a stale id.
 // Idempotent via the installed flag.
+//
+// NOTE: this DOM-id path only works on pages whose sentence spans survive into the served HTML
+// (pure-Storyteller rendering). When the reader renders the ABS EPUB, Readium STRIPS those id-only
+// spans (see [autoFollowSnapJs] / [ReadaloudTextQuotes]), so the walk never finds a sentence id and
+// "Play from here" would fall back to the chapter's first clip — i.e. restart the chapter. The menu
+// handler therefore prefers [resolveSelectionSentenceJs] (position based, span-stripping proof) and
+// only uses this stash as a fallback.
+//
+// The tracker also stashes the selection START's viewport rect in window.__riffleSelRect, which
+// [resolveSelectionSentenceJs] reads to resolve the narrated sentence by POSITION. We capture it here,
+// on selectionchange, because the live DOM selection is gone by the time the action-mode menu handler
+// runs. getClientRects()[0] is the rect of the selection's first glyph (its start).
 internal val SELECTION_SPAN_TRACKER_JS = """
     (function () {
       if (window.__riffleSelTrackerInstalled) return;
@@ -53,7 +65,8 @@ internal val SELECTION_SPAN_TRACKER_JS = """
       document.addEventListener('selectionchange', function () {
         var s = window.getSelection();
         if (!s || s.rangeCount === 0 || s.isCollapsed) return;
-        var n = s.getRangeAt(0).startContainer;
+        var rng = s.getRangeAt(0);
+        var n = rng.startContainer;
         if (n && n.nodeType === 3) n = n.parentElement;
         var id = '';
         while (n && n !== document.body) {
@@ -61,9 +74,80 @@ internal val SELECTION_SPAN_TRACKER_JS = """
           n = n.parentElement;
         }
         window.__riffleSelSpan = id;
+        try {
+          var rects = rng.getClientRects();
+          var rr = (rects && rects.length) ? rects[0] : rng.getBoundingClientRect();
+          window.__riffleSelRect = { top: rr.top, left: rr.left, bottom: rr.bottom };
+        } catch (e) { window.__riffleSelRect = null; }
       });
     })();
 """.trimIndent()
+
+/**
+ * Resolves a text selection to the narrated-sentence span id the user tapped into — by GEOMETRY, not by
+ * matching sentence text. This is what "Play from here" uses to start narration at the selected sentence.
+ *
+ * Why not by a DOM id: Readium strips Storyteller's `<span id="cNNN-sM">` wrappers from the ABS EPUB it
+ * serves (see [autoFollowSnapJs] / [ReadaloudTextQuotes]), so there is no sentence id under the selection
+ * to read — that path falls back to the chapter's first clip (the "restarts the chapter" bug).
+ *
+ * Why not by matching whole sentence text: the served (ABS) prose and the bundle's sentence text diverge
+ * just enough — smart quotes, dashes, inline markup, edition differences — that whole-sentence matching
+ * misses unpredictably, so the resolver either mis-seats to an earlier sentence or finds nothing at all.
+ *
+ * Geometry is robust. We reuse the exact primitive the production highlight-follow relies on
+ * ([autoFollowSnapJs] / [firstVisibleSentenceJs]): match each sentence's SHORT start prefix WITHIN A
+ * SINGLE text node. The prefix is 12 chars — the same length [autoFollowSnapJs] uses — short enough to
+ * sit before any inline markup the sentence's opening words run into (e.g. "Once we got " precedes the
+ * italic "<em>Hermes</em>"); a longer prefix would straddle that node boundary and never match. We only
+ * need to *locate* the start, not match the whole sentence, so the text-fidelity gaps don't matter. For each
+ * located start we take its on-screen rect and keep the one that is latest in reading order
+ * (top-to-bottom; left within a line) AT OR BEFORE the selection's start rect — i.e. the sentence the tap
+ * landed in. Only starts on the current page/column are considered, so off-page columns can't interfere.
+ * The selection rect is read from window.__riffleSelRect (stashed by [SELECTION_SPAN_TRACKER_JS] while the
+ * selection was live). Returns "" when nothing resolves; the caller then falls back to the span-id stash,
+ * then the chapter position.
+ *
+ * [sentences] is the book's narrated sentences as (span id → text), in reading order; sentences from other
+ * chapters aren't in this document's DOM, so their prefixes simply aren't found.
+ */
+internal fun resolveSelectionSentenceJs(sentences: List<Pair<String, String>>): String {
+    val sents = JSONArray(
+        sentences.map { (id, text) -> JSONArray(listOf(id, text.trim().take(12))) },
+    ).toString()
+    return """
+    (function(){
+      var sel=window.__riffleSelRect;
+      if(!sel) return "";
+      var sents=$sents;
+      var iw=window.innerWidth, ih=window.innerHeight;
+      var LH=Math.max(8, sel.bottom - sel.top);
+      var w=document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT, null, false), n;
+      var bestId="", bestTop=-1e9, bestLeft=-1e9;
+      while(n=w.nextNode()){
+        var nv=n.nodeValue;
+        for(var k=0;k<sents.length;k++){
+          var key=sents[k][1];
+          if(!key) continue;
+          var i=nv.indexOf(key);
+          if(i<0) continue;
+          var g=document.createRange(); g.setStart(n,i); g.setEnd(n, Math.min(nv.length, i+1));
+          var r=g.getBoundingClientRect();
+          // Only sentence-starts on the current page/column.
+          if(!(r.left>=0 && r.left<iw && r.bottom>0 && r.top<ih)) continue;
+          // At or before the selection start in reading order (above it, or earlier on the same line).
+          var before=(r.top < sel.top - LH*0.5) || (Math.abs(r.top - sel.top) <= LH*0.5 && r.left <= sel.left + 1);
+          if(!before) continue;
+          // Keep the latest such start (greatest top, then greatest left) = the sentence the tap is in.
+          if(r.top > bestTop + LH*0.5 || (Math.abs(r.top - bestTop) <= LH*0.5 && r.left > bestLeft)){
+            bestTop=r.top; bestLeft=r.left; bestId=sents[k][0];
+          }
+        }
+      }
+      return bestId;
+    })()
+    """.trimIndent()
+}
 
 /**
  * The page-follow probe run on each narrated-sentence change (auto-follow). It locates the narrated
@@ -74,16 +158,15 @@ internal val SELECTION_SPAN_TRACKER_JS = """
  *
  *  - Scroll mode (document overflows the viewport): scrolls *vertically* to centre the sentence —
  *    the karaoke follow — and returns "on".
- *  - Paginated mode (page is exactly viewport-sized): snaps scrollLeft to the COLUMN BOUNDARY that
- *    contains the sentence's start, then returns "on". We snap here rather than report "off" and let
- *    the Kotlin side go(): go() resolves the locator by text/cssSelector and lands flush to the
- *    element's box — a little inside its column — so the page rests between two columns; and a binary
- *    "is it roughly visible?" gate (the old ±tolerance check) never re-aligns a page that's already
- *    drifted between two columns, nor follows promptly when a sentence starts just past the edge.
- *    Snapping scrollLeft to floor(x / innerWidth) * innerWidth lands on the clean page grid every
- *    sentence. This holds because the reader is sized so innerWidth == Readium's page-snap pitch (see
- *    [alignedReaderWidthDp]), so the boundary we pick is exactly where Readium would rest anyway —
- *    here we locate the sentence by text (the span id is stripped) rather than by element.
+ *  - Paginated mode (page is exactly viewport-sized): KEEP-VISIBLE follow. While the sentence's start
+ *    is on the current page it returns "on" and leaves the page untouched, so starting playback — and
+ *    the player-open reflow that re-runs this probe — never yanks a visible line onto a fresh column
+ *    boundary. Only once the sentence's start is off the current page does it snap scrollLeft to the
+ *    COLUMN BOUNDARY containing that start (floor(x / innerWidth) * innerWidth) and return "on". We snap
+ *    (rather than report "off" and let the Kotlin side go()) because go() lands flush to the element's
+ *    box — a little inside its column — so the page would rest between two columns. The floor snap lands
+ *    on the clean page grid; this holds because the reader is sized so innerWidth == Readium's page-snap
+ *    pitch (see [alignedReaderWidthDp]). The sentence is located by text (the span id is stripped).
  *
  * Returns "off" only when the text isn't on the current resource (sentence in another chapter) → the
  * Kotlin side's go() jumps chapters, as before.
@@ -110,6 +193,14 @@ internal fun autoFollowSnapJs(text: String): String {
         return "on";
       }
       var iw=window.innerWidth;
+      // Paged keep-visible follow: while the narrated sentence is visible on the current page, leave the
+      // page exactly where it is — starting playback (and the player-open reflow that re-runs this probe)
+      // must not yank a visible line onto a fresh column boundary. The sentence's START may have wrapped
+      // in from the PREVIOUS column (r.left < 0) while its body shows on this page — the column-spanning
+      // case — so a start anywhere from the previous column up to the current page's right edge counts as
+      // on-page. Only once narration moves FORWARD to a later column (start at/after the next column's
+      // left edge, r.left >= iw) do we flip to (snap onto) that column. Scroll mode keeps centring.
+      if(r.left >= -iw && r.left < iw) return "on";
       var absX=r.left + se.scrollLeft;
       se.scrollLeft=Math.floor(absX / iw) * iw;
       return "on";

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderWebViewScripts.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderWebViewScripts.kt
@@ -258,6 +258,52 @@ internal fun snapToTargetColumnJs(fragmentId: String?): String {
         "tick();})()"
 }
 
+// Captures a short text prefix of the line at the TOP of the current paginated page — the first text
+// node in reading order whose first character sits on the current page. Read before the readaloud
+// reserve re-paginates the columns, so [reflowAnchorSnapJs] can pin that same line back afterwards:
+// the reserve shrinks/grows every column's height, which re-wraps the whole text chain from column 1,
+// so without re-anchoring the page lands on different content (the "line jumps when the player opens"
+// bug). Returns "" when nothing on-page is found.
+internal fun reflowAnchorCaptureJs(): String =
+    """
+    (function(){
+      var iw=window.innerWidth, ih=window.innerHeight;
+      var w=document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT, null, false), n;
+      while(n=w.nextNode()){
+        var t=n.nodeValue; if(t.replace(/\s/g,'').length < 4) continue;
+        var g=document.createRange(); g.setStart(n,0); g.setEnd(n, Math.min(t.length,1));
+        var r=g.getBoundingClientRect();
+        if(r.left >= 0 && r.left < iw && r.bottom > 0 && r.top < ih) return t.replace(/^\s+/, '').slice(0,24);
+      }
+      return "";
+    })()
+    """.trimIndent()
+
+// Re-pins the page to [anchorPrefix] (captured by [reflowAnchorCaptureJs]) while the readaloud reserve
+// re-paginates: a requestAnimationFrame loop that re-locates the prefix each frame and floors
+// scrollLeft to the column holding it, until scrollWidth holds steady (reflow done) or a safety cap.
+// Same floor-to-grid math and generation guard as [snapToTargetColumnJs] — and it shares
+// window.__riffleSnapGen, so a TOC/search jump and this re-anchor supersede each other instead of
+// fighting. No-op for an empty prefix.
+internal fun reflowAnchorSnapJs(anchorPrefix: String): String {
+    if (anchorPrefix.isEmpty()) return "(function(){})()"
+    val needle = JSONObject.quote(anchorPrefix)
+    return "(function(){var needle=$needle;" +
+        "var se=document.scrollingElement;" +
+        "var gen=(window.__riffleSnapGen=(window.__riffleSnapGen||0)+1);" +
+        "var lastW=-1,stable=0,frames=0;" +
+        "function locate(){var w=document.createTreeWalker(document.body,NodeFilter.SHOW_TEXT,null,false),n;" +
+        "while(n=w.nextNode()){var i=n.nodeValue.indexOf(needle);" +
+        "if(i>=0){var g=document.createRange();g.setStart(n,i);g.setEnd(n,Math.min(n.nodeValue.length,i+1));return g.getBoundingClientRect();}}return null;}" +
+        "function snap(){var iw=window.innerWidth;var r=locate();if(r)se.scrollLeft=Math.floor((r.left+se.scrollLeft)/iw)*iw;}" +
+        "function tick(){if(gen!==window.__riffleSnapGen)return;" +
+        "var w=se.scrollWidth;if(w===lastW)stable++;else{stable=0;lastW=w;}" +
+        "snap();" +
+        "if((stable>=3&&frames>=2)||frames++>72){snap();return;}" +
+        "requestAnimationFrame(tick);}" +
+        "tick();})()"
+}
+
 /**
  * Finds the first narrated sentence visible on the current page. [highlights] are the sentence texts
  * in reading order (whole book); only the current chapter's sentences exist in this document's DOM,

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/EpubReaderViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/EpubReaderViewModelTest.kt
@@ -638,4 +638,65 @@ class SearchPipelineTest {
         advanceTimeBy(400)
         assertEquals(2, searchCallCount)
     }
+
+    // --- "Play from here" must not race a resume seek ---------------------------------------------
+    //
+    // Regression for "Play from here lands in the wrong place / is unreliable — sometimes the chapter
+    // top, sometimes a few sentences off, sometimes the selected sentence." Root cause: the FIRST
+    // playFromHere() of a session opened the player via openReadaloud(), which auto-plays through the
+    // resume planner — firing a SECOND seek (to the saved resume position, or the page-top fallback)
+    // that raced the selection seek. Whichever landed last won, nondeterministically. The fix opens
+    // the session WITHOUT autoplay (openReadaloudSession), so the only seek is to the selection.
+    //
+    // EpubReaderViewModel itself can't be constructed in a JVM test (Readium needs android.net.Uri —
+    // see the file header), so, as the sibling race tests above do, these model the two control flows
+    // against a fake player that records seeks. They pin the invariant: opening a closed session for
+    // "Play from here" issues exactly one seek, to the selection — never the resume position.
+
+    private class FakePlayer { val seeks = mutableListOf<String>(); fun seek(ref: String) { seeks.add(ref) } }
+
+    // The OLD flow: openReadaloud() (resume autoplay) THEN the selection seek — two seeks, so the
+    // resume position can win. This documents the bug the fix removes.
+    @Test
+    fun `old play-from-here flow fires a competing resume seek`() {
+        val player = FakePlayer()
+        val savedResumeRef = "text/part0006_split_001.html#id191-s168"
+        val selectionRef = "text/part0006_split_001.html#id191-s178"
+        var sessionOpen = false
+
+        fun openReadaloudOldFlow() { sessionOpen = true; player.seek(savedResumeRef) } // onPlayTapped → resume
+        fun playFromHereOldFlow(ref: String) {
+            if (!sessionOpen) openReadaloudOldFlow()
+            player.seek(ref)
+        }
+
+        playFromHereOldFlow(selectionRef)
+
+        // Two seeks were issued; the resume position is among them — the race that misplaces playback.
+        assertEquals(listOf(savedResumeRef, selectionRef), player.seeks)
+        assertTrue(player.seeks.contains(savedResumeRef))
+    }
+
+    // The NEW flow: open the session without autoplay, seek only to the selection.
+    @Test
+    fun `play-from-here on a closed session seeks only to the selection, not the resume position`() {
+        val player = FakePlayer()
+        val savedResumeRef = "text/part0006_split_001.html#id191-s168"
+        val selectionRef = "text/part0006_split_001.html#id191-s178"
+        var sessionOpen = false
+        var resumeRef: String? = savedResumeRef
+
+        fun openReadaloudSession() { sessionOpen = true } // no onPlayTapped(): no resume autoplay
+        fun playFromHereNewFlow(ref: String) {
+            if (!sessionOpen) openReadaloudSession()
+            resumeRef = null // consumed so a later pause/resume can't re-seek away from the selection
+            player.seek(ref)
+        }
+
+        playFromHereNewFlow(selectionRef)
+
+        assertEquals(listOf(selectionRef), player.seeks)
+        assertFalse(player.seeks.contains(savedResumeRef))
+        assertNull(resumeRef)
+    }
 }

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/ReadaloudTrack.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/ReadaloudTrack.kt
@@ -43,6 +43,13 @@ class ReadaloudTrack(val clips: List<MediaOverlayClip>) {
         val target = href.trimStart('/')
         if (fragmentId != null) {
             clips.firstOrNull { it.textFragmentRef.trimStart('/') == "$target#$fragmentId" }?.let { return it }
+            // Fall back to the bare span id alone. The rendered publication (the ABS EPUB, ADR 0026) can
+            // carry different chapter hrefs than the Storyteller bundle the SMIL clips come from, so the
+            // href portions won't match even for the same sentence. Storyteller's sentence-span ids are
+            // unique within a book — the text-anchored highlight keys on them too (see ReadaloudTextQuotes)
+            // — so the id alone identifies the clip. Tried only after the exact match, so a book whose
+            // rendered hrefs DO line up is unaffected.
+            clips.firstOrNull { it.textFragmentRef.substringAfter('#', "") == fragmentId }?.let { return it }
         }
         fun chapterHref(clip: MediaOverlayClip) = clip.textFragmentRef.substringBefore('#').trimStart('/')
         clips.firstOrNull { chapterHref(it) == target }?.let { return it }

--- a/core/domain/src/test/kotlin/com/riffle/core/domain/ReadaloudTrackTest.kt
+++ b/core/domain/src/test/kotlin/com/riffle/core/domain/ReadaloudTrackTest.kt
@@ -78,6 +78,33 @@ class ReadaloudTrackTest {
         assertEquals(null, chapterTrack.resolveStartClip("text/c9.html", null))
     }
 
+    // A matched-ABS book renders the publisher's ABS EPUB (ADR 0026), whose chapter hrefs differ from
+    // the Storyteller bundle the SMIL clips come from — here the rendered href ("xhtml/chapter1.xhtml")
+    // shares nothing with the clips' "OEBPS/text/part0001.xhtml". But Storyteller's sentence-span ids
+    // are unique within a book, and that span id is exactly what "Play from here" / the page-top probe
+    // resolves. So resolveStartClip must find the clip by the bare span id when the href portion can't
+    // match. Regression for "Play from here / session start jumps to the chapter start on matched-ABS
+    // books".
+    private val bundleHrefClips = listOf(
+        MediaOverlayClip("OEBPS/text/part0001.xhtml#c001-s0", "a.mp3", 0.0, 2.0),
+        MediaOverlayClip("OEBPS/text/part0001.xhtml#c001-s1", "a.mp3", 2.0, 5.0),
+        MediaOverlayClip("OEBPS/text/part0002.xhtml#c002-s0", "b.mp3", 5.0, 9.0),
+    )
+    private val bundleHrefTrack = ReadaloudTrack(bundleHrefClips)
+
+    @Test
+    fun `resolveStartClip matches by bare span id when the rendered href differs from the bundle href`() {
+        assertEquals(bundleHrefClips[1], bundleHrefTrack.resolveStartClip("xhtml/chapter1.xhtml", "c001-s1"))
+        assertEquals(bundleHrefClips[2], bundleHrefTrack.resolveStartClip("xhtml/chapter2.xhtml", "c002-s0"))
+    }
+
+    @Test
+    fun `resolveStartClip still prefers the exact href#id match over a bare-id match`() {
+        // Two clips could share a span id across chapters only by collision; the exact href#id match
+        // must win when the rendered href DOES line up with the bundle, so a matching book is unaffected.
+        assertEquals(chapterClips[1], chapterTrack.resolveStartClip("text/c1.html", "s2"))
+    }
+
     // Storyteller splits each chapter into an un-narrated heading page (…_split_000) plus narrated
     // body pages (…_split_001+). Navigating via the TOC lands the reader on the heading page, which
     // has no Media Overlay; starting narration must jump forward to the chapter's first narrated


### PR DESCRIPTION
## What

Three reader fixes for readaloud "Play from here", surfaced while end-to-end testing the feature on a real ABS + Storyteller book.

### 1. Play-from-here starts at the *selected* sentence
- **Resume-autoplay race:** `playFromHere()` opened the player via `openReadaloud() → onPlayTapped() → the resume planner`, which fired a *second* seek (to the saved resume / page-top) that raced the selection seek — landing nondeterministically on the chapter top, a stale resume point, or the selection. Split a no-autoplay `openReadaloudSession()` out of `openReadaloud()`; `playFromHere()` uses it and clears the pending resume/close position, so the only seek is to the selection.
- **Selection→sentence resolution:** resolve the narrated span by **position** (`resolveSelectionSentenceJs` reading the stashed selection rect) so it survives Readium stripping the media-overlay spans and disambiguates a repeated word by where the tap landed.
- **`resolveStartClip`** falls back to a bare span-id match when the rendered href differs from the bundle href.

### 2. Page no longer jumps (or flashes) when the player opens
Opening the player reserves a bottom strip in paginated mode, which shrinks every column and re-wraps the whole chapter from column 1 — so the page landed on different content and the tapped line jumped. Pin the line that was at the top of the page across the reflow: capture it before applying the reserve, then re-anchor to it (rAF loop, same mechanism as `snapToTargetColumnJs`). Apply-reserve and re-anchor run in one JS evaluation so the synchronous first snap corrects scroll before any paint — no flash. Also: paged auto-follow keep-visible now holds when the narrated sentence wraps in from the previous column.

### 3. Auto-follow still re-centers after formatting / rotation reflows
Code-review follow-up: the reserve re-anchor required de-keying the auto-follow probe from the reserve reflow; re-key it on a formatting-only generation + `pageLoadGeneration` so it still re-centers the narrated sentence after a font/margin/spacing change or a rotation, without re-firing on (and fighting) the player-open reflow.

## Tests
- New JVM test: `playFromHere` opens the session without the resume autoplay (`EpubReaderViewModelTest`).
- New WebView harness tests: geometric selection resolver cases (`ReaderWebViewScriptsTest`); column-spanning keep-visible and top-of-view anchor capture (`AutoFollowJsTest`).
- Domain tests for the bare span-id fallback (`ReadaloudTrackTest`).
- `./gradlew test` + `./gradlew lint` green. Phone harness suite green except the pre-existing `AutoFollowJsTest.paginatedSnapsToTheColumnContainingTheSentence` flake (clamp edge at the unaligned 1080px fixture; fails on main too).
- Verified end-to-end on Medium Phone with The Martian + the Storyteller bundle: Play-from-here starts at the selection and the page holds still when the player opens.