### PR TITLE
feat(reader): volume keys control system volume while audio is playing

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/MainActivity.kt
+++ b/app/src/main/kotlin/com/riffle/app/MainActivity.kt
@@ -99,6 +99,7 @@ class MainActivity : FragmentActivity() {
             volumeNavEnabled = volumeNavEnabled.value,
             invertVolumeKeys = invertVolumeKeys.value,
             isPanelOpen = readerStateHolder.isPanelOpen,
+            isAudioPlaying = readerStateHolder.isAudioPlaying,
         )
         return when (action) {
             VolumeKeyAction.NavigateForward -> {

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -414,6 +414,8 @@ class EpubReaderViewModel @Inject constructor(
                 .map { it.isPlaying }
                 .distinctUntilChanged()
                 .collect { isPlaying ->
+                    // Hand the volume keys to system volume while audio plays; revert on pause/stop.
+                    readerStateHolder.isAudioPlaying = isPlaying
                     if (isPlaying) quoteBundle?.let { buildSentenceQuotes(it) }
                 }
         }
@@ -560,6 +562,7 @@ class EpubReaderViewModel @Inject constructor(
     fun onReaderClosed() {
         readerStateHolder.isReaderActive = false
         readerStateHolder.isPanelOpen = false
+        readerStateHolder.isAudioPlaying = false
         syncJob?.cancel()
         storytellerSyncJob?.cancel()
         if (closeSyncDone) return

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderStateHolder.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderStateHolder.kt
@@ -7,4 +7,8 @@ import javax.inject.Singleton
 class ReaderStateHolder @Inject constructor() {
     @Volatile var isReaderActive: Boolean = false
     @Volatile var isPanelOpen: Boolean = false
+
+    // True while in-app audio (Readaloud today; audiobook playback later) is actively
+    // playing. When set, the reader yields the volume keys to system volume control.
+    @Volatile var isAudioPlaying: Boolean = false
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/VolumeKeyEventHandler.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/VolumeKeyEventHandler.kt
@@ -7,8 +7,12 @@ object VolumeKeyEventHandler {
         volumeNavEnabled: Boolean,
         invertVolumeKeys: Boolean,
         isPanelOpen: Boolean,
+        isAudioPlaying: Boolean,
     ): VolumeKeyAction {
         if (!isReaderActive) return VolumeKeyAction.PassThrough
+        // While in-app audio is playing, the volume keys belong to system volume,
+        // overriding both page navigation and the panel swallow.
+        if (isAudioPlaying) return VolumeKeyAction.PassThrough
         if (!volumeNavEnabled) return VolumeKeyAction.PassThrough
         if (isPanelOpen) return VolumeKeyAction.Swallow
         val goForward = if (invertVolumeKeys) !isVolumeDown else isVolumeDown

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/VolumeKeyEventHandlerTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/VolumeKeyEventHandlerTest.kt
@@ -5,19 +5,21 @@ import org.junit.Test
 
 class VolumeKeyEventHandlerTest {
 
-    // Helper so tests read naturally: handle(volumeDown, readerActive, navEnabled, invert, panelOpen)
+    // Helper so tests read naturally: handle(volumeDown, readerActive, navEnabled, invert, panelOpen, audioPlaying)
     private fun handle(
         isVolumeDown: Boolean,
         isReaderActive: Boolean = true,
         volumeNavEnabled: Boolean = true,
         invertVolumeKeys: Boolean = false,
         isPanelOpen: Boolean = false,
+        isAudioPlaying: Boolean = false,
     ) = VolumeKeyEventHandler.handle(
         isVolumeDown = isVolumeDown,
         isReaderActive = isReaderActive,
         volumeNavEnabled = volumeNavEnabled,
         invertVolumeKeys = invertVolumeKeys,
         isPanelOpen = isPanelOpen,
+        isAudioPlaying = isAudioPlaying,
     )
 
     @Test
@@ -36,6 +38,28 @@ class VolumeKeyEventHandlerTest {
     fun `returns Swallow when a panel is open`() {
         assertEquals(VolumeKeyAction.Swallow, handle(isVolumeDown = true, isPanelOpen = true))
         assertEquals(VolumeKeyAction.Swallow, handle(isVolumeDown = false, isPanelOpen = true))
+    }
+
+    @Test
+    fun `returns PassThrough while audio is playing, even when nav is enabled`() {
+        assertEquals(VolumeKeyAction.PassThrough, handle(isVolumeDown = true, isAudioPlaying = true))
+        assertEquals(VolumeKeyAction.PassThrough, handle(isVolumeDown = false, isAudioPlaying = true))
+    }
+
+    @Test
+    fun `audio playback wins over an open panel`() {
+        assertEquals(
+            VolumeKeyAction.PassThrough,
+            handle(isVolumeDown = true, isPanelOpen = true, isAudioPlaying = true),
+        )
+    }
+
+    @Test
+    fun `audio playback wins regardless of invert setting`() {
+        assertEquals(
+            VolumeKeyAction.PassThrough,
+            handle(isVolumeDown = true, invertVolumeKeys = true, isAudioPlaying = true),
+        )
     }
 
     @Test

--- a/docs/superpowers/specs/2026-06-09-volume-keys-yield-to-audio-design.md
+++ b/docs/superpowers/specs/2026-06-09-volume-keys-yield-to-audio-design.md
@@ -1,0 +1,93 @@
+# Volume keys yield to active audio playback
+
+**Date:** 2026-06-09
+**Status:** Approved (design)
+
+## Problem
+
+Inside the reader, the hardware volume keys are repurposed for page navigation
+(when the user has that enabled). While audio is playing — today that's
+Readaloud — the user can no longer adjust playback volume with the volume keys,
+which is the natural expectation when sound is coming out of the device.
+
+## Goal
+
+While in-app audio is **actively playing**, the volume keys control the system
+(media) volume as Android normally would. The instant playback pauses or stops
+and the ebook is visible again, the keys revert to their existing reader
+behavior (page navigation / inverted / disabled, per the user's settings).
+
+No new user setting. This is a contextual default, not a preference fork: when
+audio is playing, everyone wants the volume keys to change volume. The two
+existing toggles (`volumeNavEnabled`, `invertVolumeKeys`) are genuine
+preferences and are left untouched.
+
+## Generic by design
+
+The signal is "**in-app audio is playing**", deliberately *not* tied to
+Readaloud. Readaloud is the first and currently only writer. Planned pure
+audiobook playback will write the same flag with **no further changes** to the
+key-handling code.
+
+## Behavior decisions
+
+- **Paused / stopped:** keys revert to normal reader behavior ("as long as no
+  sound is playing and the ebook is visible, revert to page navigation").
+- **Panel open while audio plays:** audio wins → **system volume**. If sound is
+  coming out, the volume keys should change its loudness regardless of whether
+  the Table-of-Contents drawer or formatting panel is open. (Today, with no
+  audio, an open panel `Swallow`s the keys; that is unchanged.)
+
+## Key-handling reference
+
+`VolumeKeyEventHandler.handle(...)` is a pure function returning a
+`VolumeKeyAction`:
+
+- `NavigateForward` / `NavigateBackward` — turn the page, consume the key.
+- `Swallow` — consume the key but do nothing (used so panel overlays don't
+  blind-page-turn).
+- `PassThrough` — Riffle declines the key; `MainActivity.onKeyDown` calls
+  `super.onKeyDown(...)`, letting Android adjust system/media volume and show
+  the OS volume slider. **"Audio playing → system volume" means returning
+  `PassThrough`.**
+
+## Changes
+
+1. **`ReaderStateHolder`** — add `@Volatile var isAudioPlaying: Boolean = false`,
+   alongside the existing `isReaderActive` / `isPanelOpen` flags (read on the
+   key-event thread).
+
+2. **`EpubReaderViewModel`** — extend the existing
+   `playbackState.map { it.isPlaying }.distinctUntilChanged().collect { ... }`
+   observer (around `EpubReaderViewModel.kt:412`) to also write
+   `readerStateHolder.isAudioPlaying = isPlaying`. Reset to `false` in
+   `onReaderClosed()` next to the existing `isReaderActive = false` /
+   `isPanelOpen = false`. (Future audiobook playback writes the same flag.)
+
+3. **`VolumeKeyEventHandler.handle(...)`** — add an `isAudioPlaying` parameter
+   and one early return, placed so active audio wins over both nav and panel:
+
+   ```kotlin
+   if (!isReaderActive)   return PassThrough
+   if (isAudioPlaying)    return PassThrough   // active audio → system volume
+   if (!volumeNavEnabled) return PassThrough
+   if (isPanelOpen)       return Swallow
+   // … invert + navigate
+   ```
+
+4. **`MainActivity.onKeyDown`** — pass `readerStateHolder.isAudioPlaying` into
+   `handle(...)`.
+
+## Testing
+
+Extend `VolumeKeyEventHandlerTest` (pure JVM, runs under `./gradlew test`):
+
+- `isAudioPlaying = true` → `PassThrough`, regardless of `volumeNavEnabled`,
+  `invertVolumeKeys`, or `isPanelOpen` (audio wins over the panel `Swallow`).
+- `isAudioPlaying = false` → all existing cases unchanged (regression guard via
+  the new default parameter in the test helper).
+
+## Out of scope
+
+- PDF reader has no audio; `isAudioPlaying` stays `false` there — no change.
+- No new setting, no UI, no changes to `volumeNavEnabled` / `invertVolumeKeys`.


### PR DESCRIPTION
## What & why

Inside the reader, the hardware volume keys are repurposed for page navigation (when the user has that enabled). While audio is playing, that left no way to adjust playback volume with the volume keys — the natural expectation when sound is coming out.

Now: **while in-app audio is actively playing, the volume keys pass through to system (media) volume.** The instant playback pauses or stops and the ebook is visible again, they revert to their existing reader behavior (page navigation / inverted / disabled, per the user's settings).

No new setting — this is a contextual default, not a preference fork. When audio plays, everyone wants the volume keys to change volume. The existing `volumeNavEnabled` / `invertVolumeKeys` toggles are untouched.

## Generic by design

The signal is "**in-app audio is playing**" (`ReaderStateHolder.isAudioPlaying`), deliberately not tied to Readaloud. Readaloud is the first writer; planned audiobook playback writes the same flag with no further changes to key handling.

## Changes

- `VolumeKeyEventHandler` — new `isAudioPlaying` param with an early `PassThrough`, placed above both the nav and panel checks so active audio wins over page-nav and over an open TOC/formatting panel.
- `ReaderStateHolder` — new generic `@Volatile isAudioPlaying` flag.
- `EpubReaderViewModel` — existing `playbackState.isPlaying` observer also writes the flag; reset to `false` in `onReaderClosed()`.
- `MainActivity` — passes the flag into the handler.

## Behavior decisions

- Paused/stopped → revert to page navigation.
- Panel open while audio plays → audio wins (system volume).

## Testing

- `./gradlew test` — green (includes new `VolumeKeyEventHandlerTest` cases: audio-playing → `PassThrough` regardless of nav-enabled / invert / panel-open).
- `./gradlew lint` — green.

Spec: `docs/superpowers/specs/2026-06-09-volume-keys-yield-to-audio-design.md`