### PR TITLE
fix(reader): footnote-page back-marker navigates to the reference instead of an empty popup

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/FootnoteResolver.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/FootnoteResolver.kt
@@ -101,8 +101,13 @@ internal object FootnoteResolver {
         // reference at the note's inner back-reference anchor — an <a> whose
         // text is just the marker ("1.") — rather than the note entry itself.
         // Landing there yields a popup that shows only the number, so climb to
-        // the enclosing note entry before reading the body.
-        val block = if (isBackReference(target)) noteEntryFor(target) else target
+        // the enclosing note entry before reading the body. When the marker has
+        // no note-entry ancestor it isn't note content at all but an in-prose
+        // noteref (Lean Customer Development's <a class="footnote"> markers carry
+        // the signal themselves yet sit in body text): bail so the reader treats
+        // the tap as a backlink and navigates to the reference instead of
+        // showing a "[4]"-only popup.
+        val block = if (isBackReference(target)) noteEntryFor(target) ?: return null else target
         return noteContent(block).takeIf { it.text.isNotEmpty() }
     }
 
@@ -287,14 +292,17 @@ internal object FootnoteResolver {
 
     // Climbs from a marker anchor to the enclosing note entry: the nearest
     // ancestor that itself carries a footnote signal (so a single <aside>, not
-    // the plural <section epub:type="rearnotes"> that wraps every note).
-    private fun noteEntryFor(marker: Element): Element {
+    // the plural <section epub:type="rearnotes"> that wraps every note). Returns
+    // null when no ancestor carries a footnote signal — the marker is then an
+    // in-prose noteref/backlink, not the inner marker of a note entry, and has
+    // no body to show.
+    private fun noteEntryFor(marker: Element): Element? {
         var node: Element? = marker.parent()
         while (node != null) {
             if (carriesFootnoteSignal(node)) return node
             node = node.parent()
         }
-        return marker.parent() ?: marker
+        return null
     }
 
     private fun looksLikeFootnote(element: Element): Boolean {

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/FootnoteResolverTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/FootnoteResolverTest.kt
@@ -297,6 +297,76 @@ class FootnoteResolverTest {
         )
     }
 
+    // The "footnote page" bug (Lean Customer Development): the chapter renders its
+    // notes inline at the end of the same resource. Each entry begins with a
+    // back-marker that links to the in-text noteref:
+    //   in body:   <sup>[<a id="ch01fn02" href="#ftn.ch01fn02" class="footnote">4</a>]</sup>
+    //   note entry: <div class="footnote" id="ftn.ch01fn02">
+    //                 <p><sup>[<a href="#ch01fn02" class="para">4</a>] </sup> …url…</p>
+    //               </div>
+    // Tapping the note entry's back-marker fires the JS bridge with the body
+    // noteref id "ch01fn02". getElementById lands on that body <a>, which carries
+    // class="footnote" *itself* (so looksLikeFootnote is true) but sits in prose,
+    // not in a note container. We must NOT climb to its <sup> and return "[4]" —
+    // there is no note body there. Returning null lets the reader treat it as a
+    // backlink and navigate to the in-text reference instead.
+    @Test
+    fun `back-marker resolving to an in-prose noteref is not a footnote`() {
+        val html = """
+            <html xmlns:epub="http://www.idpf.org/2007/ops"><body>
+              <p>Market matters most.<sup>[<a id="ch01fn02" href="#ftn.ch01fn02" class="footnote">4</a>]</sup></p>
+              <div class="footnote" id="ftn.ch01fn02">
+                <p><sup>[<a href="#ch01fn02" class="para">4</a>] </sup>
+                  <a class="ulink" href="http://blog.pmarca.com/x">http://blog.pmarca.com/x</a></p>
+              </div>
+            </body></html>
+        """.trimIndent()
+        val doc = FootnoteResolver.parse(html)
+        // The body noteref id — what the back-marker's href points at.
+        assertNull(FootnoteResolver.extractFootnoteContent(doc, "ch01fn02"))
+    }
+
+    // The complement of the above: tapping the in-text noteref (whose href is the
+    // note entry's id) still resolves to the full note body with its url.
+    @Test
+    fun `in-text noteref still resolves to the note body`() {
+        val html = """
+            <html xmlns:epub="http://www.idpf.org/2007/ops"><body>
+              <p>Market matters most.<sup>[<a id="ch01fn02" href="#ftn.ch01fn02" class="footnote">4</a>]</sup></p>
+              <div class="footnote" id="ftn.ch01fn02">
+                <p><sup>[<a href="#ch01fn02" class="para">4</a>] </sup>
+                  <a class="ulink" href="http://blog.pmarca.com/x">http://blog.pmarca.com/x</a></p>
+              </div>
+            </body></html>
+        """.trimIndent()
+        val doc = FootnoteResolver.parse(html)
+        val content = FootnoteResolver.extractFootnoteContent(doc, "ftn.ch01fn02")
+        assertNotNull(content)
+        assertEquals("[4] http://blog.pmarca.com/x", content!!.text)
+        assertEquals("http://blog.pmarca.com/x", content.links.single().url)
+    }
+
+    // End-to-end: tapping the note entry's back-marker classifies as a
+    // CrossReference, so the reader snaps to the in-text noteref's column
+    // (navigating back to the reference) instead of opening a "[4]"-only popup.
+    @Test
+    fun `classifyAnchorTap treats a note back-marker as CrossReference`() {
+        val html = """
+            <html xmlns:epub="http://www.idpf.org/2007/ops"><body>
+              <p>Market matters most.<sup>[<a id="ch01fn02" href="#ftn.ch01fn02" class="footnote">4</a>]</sup></p>
+              <div class="footnote" id="ftn.ch01fn02">
+                <p><sup>[<a href="#ch01fn02" class="para">4</a>] </sup>
+                  <a class="ulink" href="http://blog.pmarca.com/x">http://blog.pmarca.com/x</a></p>
+              </div>
+            </body></html>
+        """.trimIndent()
+        val cache = mapOf("OEBPS/ch01.html" to FootnoteResolver.parse(html))
+        assertEquals(
+            FootnoteResolver.AnchorTarget.CrossReference,
+            FootnoteResolver.classifyAnchorTap("OEBPS/ch01.html", cache, "ch01fn02"),
+        )
+    }
+
     // The screenshot bug: brackets are plain text, the number is a back-reference
     // anchor. Stripping the anchor left an orphaned "[]". The number must survive.
     @Test


### PR DESCRIPTION
## Problem

On a page that lists notes inline (e.g. *Lean Customer Development*, whose chapters render their footnotes as a block at the end of the same resource), tapping a note's leading number opened a popup containing only the marker — `[18]` — with no note text.

## Cause

Each note entry begins with a back-marker that links to the in-text reference:

```html
<!-- in the body -->
…Andreessen said…<sup>[<a id="ch01fn02" href="#ftn.ch01fn02" class="footnote">4</a>]</sup>
<!-- the note entry, listed at the end of the chapter -->
<div class="footnote" id="ftn.ch01fn02">
  <p><sup>[<a href="#ch01fn02" class="para">4</a>]</sup> …url…</p>
</div>
```

Tapping the note entry's `4` fires the JS bridge with the body noteref id `ch01fn02`. `getElementById` lands on the body `<a class="footnote">` — which carries the footnote signal *on the anchor itself* yet sits in prose, not in a note container. `extractFootnoteContent` saw a back-reference, climbed via `noteEntryFor` for an enclosing note, found none, and fell back to the anchor's `<sup>`, yielding a marker-only `"[4]"` body.

## Fix

`noteEntryFor` now returns `null` when no ancestor carries a footnote signal (the marker is an in-prose noteref/backlink, not the inner marker of a note entry), and `extractFootnoteContent` bails. The tap then classifies as a `CrossReference`, so the reader snaps back to the in-text reference — the marker's own backlink target — instead of showing an empty popup. The forward direction (tapping the body reference to read the note) is unchanged.

## Tests

- Added 3 unit tests built from the real *Lean Customer Development* markup: back-marker → not a footnote, in-text noteref → still resolves to the full note body + URL, and `classifyAnchorTap` → `CrossReference`.
- `./gradlew test lint` — green (full JVM unit/integration suites + lint).
- Harness suite skipped: this is pure-JVM `FootnoteResolver` logic with full unit coverage, the only footnote harness test is `@Ignore`d, and a non-owned `Harness_Medium_Phone` emulator was running that the harness target would have force-killed.
