### PR TITLE
test(database): repair drifted migration schemas, deflake DAO tests, run connected tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,3 +131,42 @@ jobs:
           name: integration-test-reports
           path: core/data/build/reports/tests/
           if-no-files-found: ignore
+
+  # Instrumented Room tests (migrations + DAOs) need an emulator, so they run here on a
+  # hardware-accelerated AVD rather than in the JVM jobs above.
+  connected-test:
+    name: Connected Tests (core:database)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 17
+      - uses: gradle/actions/setup-gradle@v6
+        with:
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+          cache-read-only: true
+      - name: Download Gradle wrapper jar
+        run: |
+          curl -fsSL -o gradle/wrapper/gradle-wrapper.jar \
+            "https://raw.githubusercontent.com/gradle/gradle/v9.4.1/gradle/wrapper/gradle-wrapper.jar"
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+      - name: Run core:database connected tests
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 30
+          target: google_apis
+          arch: x86_64
+          script: ./gradlew :core:database:connectedDebugAndroidTest
+      - name: Upload connected-test reports
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: connected-test-reports
+          path: core/database/build/reports/androidTests/
+          if-no-files-found: ignore

--- a/core/database/schemas/com.riffle.core.database.RiffleDatabase/10.json
+++ b/core/database/schemas/com.riffle.core.database.RiffleDatabase/10.json
@@ -318,7 +318,7 @@
       },
       {
         "tableName": "reading_positions",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`itemId` TEXT NOT NULL, `cfi` TEXT NOT NULL, PRIMARY KEY(`itemId`))",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`itemId` TEXT NOT NULL, `cfi` TEXT NOT NULL, `localUpdatedAt` INTEGER NOT NULL, PRIMARY KEY(`itemId`))",
         "fields": [
           {
             "fieldPath": "itemId",
@@ -330,6 +330,12 @@
             "fieldPath": "cfi",
             "columnName": "cfi",
             "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localUpdatedAt",
+            "columnName": "localUpdatedAt",
+            "affinity": "INTEGER",
             "notNull": true
           }
         ],

--- a/core/database/schemas/com.riffle.core.database.RiffleDatabase/12.json
+++ b/core/database/schemas/com.riffle.core.database.RiffleDatabase/12.json
@@ -6,7 +6,7 @@
     "entities": [
       {
         "tableName": "servers",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `url` TEXT NOT NULL, `displayName` TEXT NOT NULL, `isActive` INTEGER NOT NULL, `insecureConnectionAllowed` INTEGER NOT NULL, `username` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `url` TEXT NOT NULL, `displayName` TEXT NOT NULL, `isActive` INTEGER NOT NULL, `insecureConnectionAllowed` INTEGER NOT NULL, PRIMARY KEY(`id`))",
         "fields": [
           {
             "fieldPath": "id",
@@ -36,12 +36,6 @@
             "fieldPath": "insecureConnectionAllowed",
             "columnName": "insecureConnectionAllowed",
             "affinity": "INTEGER",
-            "notNull": true
-          },
-          {
-            "fieldPath": "username",
-            "columnName": "username",
-            "affinity": "TEXT",
             "notNull": true
           }
         ],
@@ -96,7 +90,7 @@
       },
       {
         "tableName": "library_items",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `title` TEXT NOT NULL, `author` TEXT NOT NULL, `coverUrl` TEXT, `readingProgress` REAL NOT NULL, `ebookFileIno` TEXT, `ebookFormat` TEXT NOT NULL, `description` TEXT, `seriesName` TEXT, `publishedYear` TEXT, `genres` TEXT NOT NULL, `publisher` TEXT, `lastOpenedAt` INTEGER, PRIMARY KEY(`id`))",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `title` TEXT NOT NULL, `author` TEXT NOT NULL, `coverUrl` TEXT, `readingProgress` REAL NOT NULL, `ebookFileIno` TEXT, `ebookFormat` TEXT NOT NULL, `description` TEXT, `seriesName` TEXT, `publishedYear` TEXT, `genres` TEXT NOT NULL, `publisher` TEXT, `lastOpenedAt` INTEGER, `addedAt` INTEGER, PRIMARY KEY(`id`))",
         "fields": [
           {
             "fieldPath": "id",
@@ -173,6 +167,11 @@
           {
             "fieldPath": "lastOpenedAt",
             "columnName": "lastOpenedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
             "affinity": "INTEGER"
           }
         ],

--- a/core/database/schemas/com.riffle.core.database.RiffleDatabase/7.json
+++ b/core/database/schemas/com.riffle.core.database.RiffleDatabase/7.json
@@ -293,7 +293,7 @@
       },
       {
         "tableName": "reading_positions",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`itemId` TEXT NOT NULL, `cfi` TEXT NOT NULL, `localUpdatedAt` INTEGER NOT NULL, PRIMARY KEY(`itemId`))",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`itemId` TEXT NOT NULL, `cfi` TEXT NOT NULL, PRIMARY KEY(`itemId`))",
         "fields": [
           {
             "fieldPath": "itemId",
@@ -305,12 +305,6 @@
             "fieldPath": "cfi",
             "columnName": "cfi",
             "affinity": "TEXT",
-            "notNull": true
-          },
-          {
-            "fieldPath": "localUpdatedAt",
-            "columnName": "localUpdatedAt",
-            "affinity": "INTEGER",
             "notNull": true
           }
         ],

--- a/core/database/src/androidTest/kotlin/com/riffle/core/database/CollectionDaoTest.kt
+++ b/core/database/src/androidTest/kotlin/com/riffle/core/database/CollectionDaoTest.kt
@@ -3,11 +3,14 @@ package com.riffle.core.database
 import androidx.room.Room
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.yield
+import kotlinx.coroutines.withTimeout
+import java.util.concurrent.CopyOnWriteArrayList
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Before
@@ -42,17 +45,21 @@ class CollectionDaoTest {
 
     // C1 — replaceAllForLibrary must never expose an empty intermediate state to collection observers.
     @Test
-    fun replaceAllForLibrary_neverEmitsEmptyIntermediateState() = runTest {
+    fun replaceAllForLibrary_neverEmitsEmptyIntermediateState() = runBlocking {
         dao.upsertAll(listOf(collection("c1"), collection("c2")))
 
-        val emittedStates = mutableListOf<List<CollectionEntity>>()
-        val collectJob = launch {
+        // Room emits on its own query executor, not this coroutine's scheduler, so we wait for
+        // emissions deterministically (with a timeout) rather than racing them with yield().
+        val emittedStates = CopyOnWriteArrayList<List<CollectionEntity>>()
+        val collectJob = launch(Dispatchers.IO) {
             dao.observeByLibraryId("lib1").collect { emittedStates.add(it.toList()) }
         }
-        yield()
+        withTimeout(5_000) { while (emittedStates.isEmpty()) delay(10) }
 
         dao.replaceAllForLibrary("lib1", listOf(collection("c3"), collection("c4")), emptyList())
-        yield()
+        withTimeout(5_000) {
+            while (emittedStates.last().map { it.id }.toSet() != setOf("c3", "c4")) delay(10)
+        }
 
         collectJob.cancel()
 

--- a/core/database/src/androidTest/kotlin/com/riffle/core/database/LibraryItemDaoTest.kt
+++ b/core/database/src/androidTest/kotlin/com/riffle/core/database/LibraryItemDaoTest.kt
@@ -3,11 +3,15 @@ package com.riffle.core.database
 import androidx.room.Room
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeout
 import kotlinx.coroutines.yield
+import java.util.concurrent.CopyOnWriteArrayList
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Before
@@ -144,17 +148,21 @@ class LibraryItemDaoTest {
     // A6 — replaceAllForLibrary must never expose an empty intermediate state to observers.
     // If @Transaction is removed the delete emits before the insert, causing a visible flicker.
     @Test
-    fun replaceAllForLibrary_neverEmitsEmptyIntermediateState() = runTest {
+    fun replaceAllForLibrary_neverEmitsEmptyIntermediateState() = runBlocking {
         dao.upsertAll(listOf(item("a", 0.3f), item("b", 0.6f)))
 
-        val emittedStates = mutableListOf<List<LibraryItemEntity>>()
-        val collectJob = launch {
+        // Room emits on its own query executor, not this coroutine's scheduler, so we wait for
+        // emissions deterministically (with a timeout) rather than racing them with yield().
+        val emittedStates = CopyOnWriteArrayList<List<LibraryItemEntity>>()
+        val collectJob = launch(Dispatchers.IO) {
             dao.observeAllBooks("lib1").collect { emittedStates.add(it.toList()) }
         }
-        yield() // let the initial emission land before we replace
+        withTimeout(5_000) { while (emittedStates.isEmpty()) delay(10) }
 
         dao.replaceAllForLibrary("lib1", listOf(item("c", 0f), item("d", 0.5f), item("e", 1f)))
-        yield()
+        withTimeout(5_000) {
+            while (emittedStates.last().map { it.id }.toSet() != setOf("c", "d", "e")) delay(10)
+        }
 
         collectJob.cancel()
 

--- a/core/database/src/androidTest/kotlin/com/riffle/core/database/MigrationTest.kt
+++ b/core/database/src/androidTest/kotlin/com/riffle/core/database/MigrationTest.kt
@@ -201,7 +201,9 @@ class MigrationTest {
     fun migration8To9() {
         helper.createDatabase(TEST_DB, 8).use { db ->
             db.execSQL(
-                "INSERT INTO library_items (id, libraryId, title, author, coverUrl, readingProgress, isDownloaded, isSupported, ebookFileIno, ebookFormat) VALUES ('item1', 'lib1', 'Dune', 'Herbert', NULL, 0.5, 0, 1, NULL, 'epub')"
+                // genres (added at 7→8, NOT NULL) has only a Kotlin default, not a SQL one, so it
+                // isn't in the generated CREATE — the seed must supply it.
+                "INSERT INTO library_items (id, libraryId, title, author, coverUrl, readingProgress, isDownloaded, isSupported, ebookFileIno, ebookFormat, genres) VALUES ('item1', 'lib1', 'Dune', 'Herbert', NULL, 0.5, 0, 1, NULL, 'epub', '')"
             )
             db.execSQL(
                 "INSERT INTO reading_positions (itemId, cfi) VALUES ('item-1', 'epubcfi(/6/4!/4/1:0)')"

--- a/core/database/src/androidTest/kotlin/com/riffle/core/database/SeriesDaoTest.kt
+++ b/core/database/src/androidTest/kotlin/com/riffle/core/database/SeriesDaoTest.kt
@@ -3,11 +3,14 @@ package com.riffle.core.database
 import androidx.room.Room
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.yield
+import kotlinx.coroutines.withTimeout
+import java.util.concurrent.CopyOnWriteArrayList
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Before
@@ -43,17 +46,21 @@ class SeriesDaoTest {
 
     // B1 — replaceAllForLibrary must never expose an empty intermediate state to series observers.
     @Test
-    fun replaceAllForLibrary_neverEmitsEmptyIntermediateState() = runTest {
+    fun replaceAllForLibrary_neverEmitsEmptyIntermediateState() = runBlocking {
         dao.upsertAll(listOf(series("s1"), series("s2")))
 
-        val emittedStates = mutableListOf<List<SeriesEntity>>()
-        val collectJob = launch {
+        // Room emits on its own query executor, not this coroutine's scheduler, so we wait for
+        // emissions deterministically (with a timeout) rather than racing them with yield().
+        val emittedStates = CopyOnWriteArrayList<List<SeriesEntity>>()
+        val collectJob = launch(Dispatchers.IO) {
             dao.observeByLibraryId("lib1").collect { emittedStates.add(it.toList()) }
         }
-        yield()
+        withTimeout(5_000) { while (emittedStates.isEmpty()) delay(10) }
 
         dao.replaceAllForLibrary("lib1", listOf(series("s3"), series("s4")), emptyList())
-        yield()
+        withTimeout(5_000) {
+            while (emittedStates.last().map { it.id }.toSet() != setOf("s3", "s4")) delay(10)
+        }
 
         collectJob.cancel()
 


### PR DESCRIPTION
## Why

The `core:database` instrumented suite (`MigrationTest`, DAO tests) was never run in CI — `ci.yml` only runs `assembleDebug`, `lint`, `./gradlew test` (JVM), and the `core:data` integration job. None invoke `connectedDebugAndroidTest`. As a result the suite had silently rotted: **7 `MigrationTest` step-cases and 3 flaky DAO tests fail when run locally**, while CI stayed green.

## What

**Repair drifted intermediate schema JSONs** (they disagreed with the migrations; `migrateFullChain` already proves the chain produces the correct final schema):
- `7.json` — drop `reading_positions.localUpdatedAt` (added at 8→9, must be absent at v7)
- `10.json` — add `localUpdatedAt` (present from v9)
- `12.json` — drop `servers.username` (added at 13→14) and add `library_items.addedAt` (added at 11→12)
- `migration8To9` seed — supply the `NOT NULL genres` column it omitted (it has only a Kotlin default, not a SQL one)

**Deflake** the three `replaceAllForLibrary_neverEmitsEmptyIntermediateState` tests: they raced Room's query-executor emissions with `runTest`/`yield()`. Rewritten to `runBlocking` + `Dispatchers.IO` collection with `withTimeout` poll-waits for the initial and terminal emissions.

**Add a `connected-test` CI job** (`android-emulator-runner`, API 30) running `:core:database:connectedDebugAndroidTest`, so the suite can't rot again.

## Verification

- Full `core:database` connected suite: **47 tests, 0 failures** (green on repeated runs).
- The previously-flaky 3: stress-ran **4× clean** (was failing 3/2/3 before).
- No migration code changed — the migrations were already correct; only the generated schema snapshots and the tests were wrong.

## Notes

- The `:app` instrumented suite (run locally via `make harness-test`) is still outside CI — a sensible follow-up job once this lighter one proves stable on the runner.