### PR TITLE
fix(settings): configure libraries for every ABS server, not just the active one (#113)

### DIFF
--- a/core/data/src/main/kotlin/com/riffle/core/data/LibraryRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/LibraryRepositoryImpl.kt
@@ -100,8 +100,12 @@ class LibraryRepositoryImpl @Inject constructor(
     override suspend fun getItem(serverId: String, itemId: String): LibraryItem? =
         libraryItemDao.getById(serverId, itemId)?.toDomain()
 
-    override suspend fun getLibrary(libraryId: String): Library? =
-        libraryDao.getById(libraryId)?.toDomain()
+    // Library ids are only unique within a Server (issue #113); resolve against the active Server's
+    // copy, mirroring how [getItem] keys item reads. No active Server → nothing to resolve.
+    override suspend fun getLibrary(libraryId: String): Library? {
+        val serverId = serverRepository.getActive()?.id ?: return null
+        return libraryDao.getById(serverId, libraryId)?.toDomain()
+    }
 
     override suspend fun getSeriesIdForItem(serverId: String, itemId: String): String? =
         seriesDao.findSeriesIdForItem(serverId, itemId)
@@ -181,7 +185,7 @@ class LibraryRepositoryImpl @Inject constructor(
                     }
                 libraryItemDao.replaceAllForLibrary(libraryId, entities)
                 val isUnsupported = entities.isNotEmpty() && entities.none { it.ebookFormat != EbookFormat.Unsupported.toStorageString() }
-                libraryDao.setUnsupported(libraryId, isUnsupported)
+                libraryDao.setUnsupported(server.id, libraryId, isUnsupported)
                 storytellerReadaloudSyncer.syncStale()
                 readaloudMatchingService.reconcileLinks()
                 LibraryRefreshResult.Success

--- a/core/data/src/main/kotlin/com/riffle/core/data/ReadaloudReviewRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/ReadaloudReviewRepositoryImpl.kt
@@ -67,8 +67,12 @@ class ReadaloudReviewRepositoryImpl(
         val candidatesByBook = candidates.groupBy { it.storytellerBookId }
 
         val libraryNameCache = mutableMapOf<String, String>()
-        suspend fun libraryName(libraryId: String): String =
-            libraryNameCache.getOrPut(libraryId) { libraryDao.getById(libraryId)?.name ?: libraryId }
+        // Library ids are unique only within a Server (issue #113) — key the cache and the lookup
+        // by (serverId, libraryId) so two Servers' same-id libraries resolve to their own names.
+        suspend fun libraryName(serverId: String, libraryId: String): String =
+            libraryNameCache.getOrPut("$serverId|$libraryId") {
+                libraryDao.getById(serverId, libraryId)?.name ?: libraryId
+            }
 
         // Group per readaloud so Unlink detaches the whole match (ebook + audiobook stub) at once.
         val confirmed = linksForServer
@@ -80,7 +84,7 @@ class ReadaloudReviewRepositoryImpl(
                         absServerId = link.absServerId,
                         absLibraryItemId = link.absLibraryItemId,
                         absTitle = abs.title,
-                        absLibraryName = libraryName(abs.libraryId),
+                        absLibraryName = libraryName(abs.serverId, abs.libraryId),
                     )
                 }
                 if (targets.isEmpty()) return@mapNotNull null
@@ -107,7 +111,7 @@ class ReadaloudReviewRepositoryImpl(
                             absLibraryItemId = cand.absLibraryItemId,
                             absTitle = abs.title,
                             absAuthor = abs.author,
-                            absLibraryName = libraryName(abs.libraryId),
+                            absLibraryName = libraryName(abs.serverId, abs.libraryId),
                             coverUrl = abs.coverUrl,
                             score = cand.score,
                         )
@@ -216,8 +220,8 @@ class ReadaloudReviewRepositoryImpl(
             .sortedBy { it.title.lowercase() }
             .mapNotNull { row ->
                 val abs: LibraryItemEntity = libraryItemDao.getById(row.serverId, row.itemId) ?: return@mapNotNull null
-                val name = libraryNameCache.getOrPut(abs.libraryId) {
-                    libraryDao.getById(abs.libraryId)?.name ?: abs.libraryId
+                val name = libraryNameCache.getOrPut("${abs.serverId}|${abs.libraryId}") {
+                    libraryDao.getById(abs.serverId, abs.libraryId)?.name ?: abs.libraryId
                 }
                 AbsPickerItem(
                     absServerId = row.serverId,

--- a/core/data/src/main/kotlin/com/riffle/core/data/di/DatabaseModule.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/di/DatabaseModule.kt
@@ -61,6 +61,7 @@ object DatabaseModule {
                 RiffleDatabase.MIGRATION_27_28,
                 RiffleDatabase.MIGRATION_28_29,
                 RiffleDatabase.MIGRATION_29_30,
+                RiffleDatabase.MIGRATION_30_31,
             )
             .build()
 

--- a/core/data/src/test/kotlin/com/riffle/core/data/LibraryRepositoryTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/LibraryRepositoryTest.kt
@@ -79,8 +79,8 @@ class LibraryRepositoryTest {
         override suspend fun libraryIdsForServer(serverId: String): List<String> =
             roomData[serverId]?.value.orEmpty().map { it.id }
 
-        override suspend fun getById(libraryId: String): LibraryEntity? =
-            roomData.values.flatMap { it.value }.firstOrNull { it.id == libraryId }
+        override suspend fun getById(serverId: String, libraryId: String): LibraryEntity? =
+            roomData[serverId]?.value.orEmpty().firstOrNull { it.id == libraryId }
 
         override suspend fun upsertAll(libraries: List<LibraryEntity>) {
             upserted.addAll(libraries)
@@ -93,9 +93,9 @@ class LibraryRepositoryTest {
             roomData[serverId]?.value = emptyList()
         }
 
-        override suspend fun setUnsupported(libraryId: String, isUnsupported: Boolean) {
-            val current = roomData[libraryId]?.value ?: return
-            roomData[libraryId]?.value = current.map { it.copy(isUnsupported = isUnsupported) }
+        override suspend fun setUnsupported(serverId: String, libraryId: String, isUnsupported: Boolean) {
+            val flow = roomData[serverId] ?: return
+            flow.value = flow.value.map { if (it.id == libraryId) it.copy(isUnsupported = isUnsupported) else it }
         }
     }
 

--- a/core/data/src/test/kotlin/com/riffle/core/data/NoopLibraryDaos.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/NoopLibraryDaos.kt
@@ -33,8 +33,8 @@ internal object ThrowingLibraryItemDao : LibraryItemDao {
 internal object ThrowingLibraryDao : LibraryDao {
     override fun observeByServerId(serverId: String): Flow<List<LibraryEntity>> = flowOf(emptyList())
     override suspend fun libraryIdsForServer(serverId: String): List<String> = emptyList()
-    override suspend fun getById(libraryId: String): LibraryEntity? = null
+    override suspend fun getById(serverId: String, libraryId: String): LibraryEntity? = null
     override suspend fun upsertAll(libraries: List<LibraryEntity>) = Unit
     override suspend fun deleteByServerId(serverId: String) = Unit
-    override suspend fun setUnsupported(libraryId: String, isUnsupported: Boolean) = Unit
+    override suspend fun setUnsupported(serverId: String, libraryId: String, isUnsupported: Boolean) = Unit
 }

--- a/core/data/src/test/kotlin/com/riffle/core/data/SeriesIntegrationTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/SeriesIntegrationTest.kt
@@ -99,10 +99,10 @@ class SeriesIntegrationTest {
     private class FakeLibraryDao : LibraryDao {
         override fun observeByServerId(serverId: String): Flow<List<LibraryEntity>> = MutableStateFlow(emptyList())
         override suspend fun libraryIdsForServer(serverId: String): List<String> = emptyList()
-        override suspend fun getById(libraryId: String): LibraryEntity? = null
+        override suspend fun getById(serverId: String, libraryId: String): LibraryEntity? = null
         override suspend fun upsertAll(libraries: List<LibraryEntity>) {}
         override suspend fun deleteByServerId(serverId: String) {}
-        override suspend fun setUnsupported(libraryId: String, isUnsupported: Boolean) {}
+        override suspend fun setUnsupported(serverId: String, libraryId: String, isUnsupported: Boolean) {}
     }
 
     private class FakeLibraryItemDao : LibraryItemDao {

--- a/core/data/src/test/kotlin/com/riffle/core/data/ServerRepositoryTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/ServerRepositoryTest.kt
@@ -82,13 +82,11 @@ class ServerRepositoryTest {
             flowOf(rows[serverId].orEmpty().toList())
         override suspend fun libraryIdsForServer(serverId: String): List<String> =
             rows[serverId].orEmpty().map { it.id }
-        override suspend fun getById(libraryId: String): LibraryEntity? =
-            rows.values.flatten().firstOrNull { it.id == libraryId }
+        override suspend fun getById(serverId: String, libraryId: String): LibraryEntity? =
+            rows[serverId].orEmpty().firstOrNull { it.id == libraryId }
         override suspend fun deleteByServerId(serverId: String) { rows.remove(serverId) }
-        override suspend fun setUnsupported(libraryId: String, isUnsupported: Boolean) {
-            rows.values.forEach { list ->
-                list.replaceAll { if (it.id == libraryId) it.copy(isUnsupported = isUnsupported) else it }
-            }
+        override suspend fun setUnsupported(serverId: String, libraryId: String, isUnsupported: Boolean) {
+            rows[serverId]?.replaceAll { if (it.id == libraryId) it.copy(isUnsupported = isUnsupported) else it }
         }
         fun allEntities(): List<LibraryEntity> = rows.values.flatten()
     }

--- a/core/database/schemas/com.riffle.core.database.RiffleDatabase/31.json
+++ b/core/database/schemas/com.riffle.core.database.RiffleDatabase/31.json
@@ -1,0 +1,1064 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 31,
+    "identityHash": "c88f14dc9ccca5f13452fd238e8a4b8c",
+    "entities": [
+      {
+        "tableName": "servers",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `url` TEXT NOT NULL, `isActive` INTEGER NOT NULL, `insecureConnectionAllowed` INTEGER NOT NULL, `username` TEXT NOT NULL, `serverType` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "isActive",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "insecureConnectionAllowed",
+            "columnName": "insecureConnectionAllowed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "username",
+            "columnName": "username",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverType",
+            "columnName": "serverType",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "libraries",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `mediaType` TEXT NOT NULL, `serverId` TEXT NOT NULL, `isUnsupported` INTEGER NOT NULL, PRIMARY KEY(`serverId`, `id`), FOREIGN KEY(`serverId`) REFERENCES `servers`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaType",
+            "columnName": "mediaType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isUnsupported",
+            "columnName": "isUnsupported",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "serverId",
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_libraries_serverId",
+            "unique": false,
+            "columnNames": [
+              "serverId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_libraries_serverId` ON `${TABLE_NAME}` (`serverId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "servers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "serverId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "library_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`serverId` TEXT NOT NULL, `id` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `title` TEXT NOT NULL, `author` TEXT NOT NULL, `coverUrl` TEXT, `readingProgress` REAL NOT NULL, `ebookFileIno` TEXT, `ebookFormat` TEXT NOT NULL, `hasAudio` INTEGER NOT NULL, `audioDurationSec` REAL NOT NULL, `description` TEXT, `seriesName` TEXT, `publishedYear` TEXT, `genres` TEXT NOT NULL, `publisher` TEXT, `language` TEXT, `lastOpenedAt` INTEGER, `addedAt` INTEGER, `isbn` TEXT, `asin` TEXT, PRIMARY KEY(`serverId`, `id`), FOREIGN KEY(`serverId`) REFERENCES `servers`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "coverUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "readingProgress",
+            "columnName": "readingProgress",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ebookFileIno",
+            "columnName": "ebookFileIno",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "ebookFormat",
+            "columnName": "ebookFormat",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hasAudio",
+            "columnName": "hasAudio",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "audioDurationSec",
+            "columnName": "audioDurationSec",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seriesName",
+            "columnName": "seriesName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "publishedYear",
+            "columnName": "publishedYear",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "genres",
+            "columnName": "genres",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "publisher",
+            "columnName": "publisher",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "language",
+            "columnName": "language",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastOpenedAt",
+            "columnName": "lastOpenedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "isbn",
+            "columnName": "isbn",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "asin",
+            "columnName": "asin",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "serverId",
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_library_items_serverId",
+            "unique": false,
+            "columnNames": [
+              "serverId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_library_items_serverId` ON `${TABLE_NAME}` (`serverId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "servers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "serverId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "series",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `name` TEXT NOT NULL, `coverUrl` TEXT, `bookCount` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "coverUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "bookCount",
+            "columnName": "bookCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "collections",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `name` TEXT NOT NULL, `bookCount` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookCount",
+            "columnName": "bookCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "series_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`seriesId` TEXT NOT NULL, `serverId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `sequenceOrder` REAL NOT NULL, PRIMARY KEY(`seriesId`, `serverId`, `itemId`))",
+        "fields": [
+          {
+            "fieldPath": "seriesId",
+            "columnName": "seriesId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sequenceOrder",
+            "columnName": "sequenceOrder",
+            "affinity": "REAL",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "seriesId",
+            "serverId",
+            "itemId"
+          ]
+        }
+      },
+      {
+        "tableName": "collection_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`collectionId` TEXT NOT NULL, `serverId` TEXT NOT NULL, `itemId` TEXT NOT NULL, PRIMARY KEY(`collectionId`, `serverId`, `itemId`))",
+        "fields": [
+          {
+            "fieldPath": "collectionId",
+            "columnName": "collectionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "collectionId",
+            "serverId",
+            "itemId"
+          ]
+        }
+      },
+      {
+        "tableName": "reading_positions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`serverId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `cfi` TEXT NOT NULL, `localUpdatedAt` INTEGER NOT NULL, PRIMARY KEY(`serverId`, `itemId`), FOREIGN KEY(`serverId`) REFERENCES `servers`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cfi",
+            "columnName": "cfi",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localUpdatedAt",
+            "columnName": "localUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "serverId",
+            "itemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_reading_positions_serverId",
+            "unique": false,
+            "columnNames": [
+              "serverId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_reading_positions_serverId` ON `${TABLE_NAME}` (`serverId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "servers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "serverId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "book_formatting_preferences",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`serverId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `fontSize` REAL, `theme` TEXT, `fontFamily` TEXT, `lineSpacing` REAL, `margins` REAL, `orientation` TEXT, `showChapterMap` INTEGER, `showReadingProgressLabels` INTEGER, `showCurrentChapterLabel` INTEGER, `doublePageSpread` INTEGER, `justifyText` INTEGER, PRIMARY KEY(`serverId`, `itemId`), FOREIGN KEY(`serverId`) REFERENCES `servers`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fontSize",
+            "columnName": "fontSize",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "theme",
+            "columnName": "theme",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "fontFamily",
+            "columnName": "fontFamily",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lineSpacing",
+            "columnName": "lineSpacing",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "margins",
+            "columnName": "margins",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "orientation",
+            "columnName": "orientation",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "showChapterMap",
+            "columnName": "showChapterMap",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "showReadingProgressLabels",
+            "columnName": "showReadingProgressLabels",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "showCurrentChapterLabel",
+            "columnName": "showCurrentChapterLabel",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "doublePageSpread",
+            "columnName": "doublePageSpread",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "justifyText",
+            "columnName": "justifyText",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "serverId",
+            "itemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_book_formatting_preferences_serverId",
+            "unique": false,
+            "columnNames": [
+              "serverId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_book_formatting_preferences_serverId` ON `${TABLE_NAME}` (`serverId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "servers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "serverId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "readaloud_links",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`absServerId` TEXT NOT NULL, `absLibraryItemId` TEXT NOT NULL, `storytellerServerId` TEXT NOT NULL, `storytellerBookId` TEXT NOT NULL, `state` TEXT NOT NULL, `userConfirmed` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`absServerId`, `absLibraryItemId`), FOREIGN KEY(`storytellerServerId`) REFERENCES `servers`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`absServerId`) REFERENCES `servers`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "absServerId",
+            "columnName": "absServerId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absLibraryItemId",
+            "columnName": "absLibraryItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerServerId",
+            "columnName": "storytellerServerId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerBookId",
+            "columnName": "storytellerBookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userConfirmed",
+            "columnName": "userConfirmed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "absServerId",
+            "absLibraryItemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_readaloud_links_storytellerServerId_storytellerBookId",
+            "unique": false,
+            "columnNames": [
+              "storytellerServerId",
+              "storytellerBookId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_readaloud_links_storytellerServerId_storytellerBookId` ON `${TABLE_NAME}` (`storytellerServerId`, `storytellerBookId`)"
+          },
+          {
+            "name": "index_readaloud_links_storytellerServerId",
+            "unique": false,
+            "columnNames": [
+              "storytellerServerId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_readaloud_links_storytellerServerId` ON `${TABLE_NAME}` (`storytellerServerId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "servers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "storytellerServerId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "servers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "absServerId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "readaloud_candidates",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`storytellerServerId` TEXT NOT NULL, `storytellerBookId` TEXT NOT NULL, `absServerId` TEXT NOT NULL, `absLibraryItemId` TEXT NOT NULL, `score` REAL NOT NULL, PRIMARY KEY(`storytellerServerId`, `storytellerBookId`, `absServerId`, `absLibraryItemId`), FOREIGN KEY(`storytellerServerId`) REFERENCES `servers`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`absServerId`) REFERENCES `servers`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "storytellerServerId",
+            "columnName": "storytellerServerId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerBookId",
+            "columnName": "storytellerBookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absServerId",
+            "columnName": "absServerId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absLibraryItemId",
+            "columnName": "absLibraryItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "score",
+            "columnName": "score",
+            "affinity": "REAL",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "storytellerServerId",
+            "storytellerBookId",
+            "absServerId",
+            "absLibraryItemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_readaloud_candidates_absServerId",
+            "unique": false,
+            "columnNames": [
+              "absServerId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_readaloud_candidates_absServerId` ON `${TABLE_NAME}` (`absServerId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "servers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "storytellerServerId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "servers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "absServerId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "readaloud_dismissals",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`storytellerServerId` TEXT NOT NULL, `storytellerBookId` TEXT NOT NULL, `scope` TEXT NOT NULL, `absServerId` TEXT NOT NULL, `absLibraryItemId` TEXT NOT NULL, PRIMARY KEY(`storytellerServerId`, `storytellerBookId`, `absServerId`, `absLibraryItemId`), FOREIGN KEY(`storytellerServerId`) REFERENCES `servers`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "storytellerServerId",
+            "columnName": "storytellerServerId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerBookId",
+            "columnName": "storytellerBookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scope",
+            "columnName": "scope",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absServerId",
+            "columnName": "absServerId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absLibraryItemId",
+            "columnName": "absLibraryItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "storytellerServerId",
+            "storytellerBookId",
+            "absServerId",
+            "absLibraryItemId"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "servers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "storytellerServerId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "cross_epub_index",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`absEpubChecksum` TEXT NOT NULL, `storytellerEpubChecksum` TEXT NOT NULL, `perChapterMapsBlob` TEXT NOT NULL, `builtAt` INTEGER NOT NULL, PRIMARY KEY(`absEpubChecksum`, `storytellerEpubChecksum`))",
+        "fields": [
+          {
+            "fieldPath": "absEpubChecksum",
+            "columnName": "absEpubChecksum",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerEpubChecksum",
+            "columnName": "storytellerEpubChecksum",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "perChapterMapsBlob",
+            "columnName": "perChapterMapsBlob",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "builtAt",
+            "columnName": "builtAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "absEpubChecksum",
+            "storytellerEpubChecksum"
+          ]
+        }
+      },
+      {
+        "tableName": "annotations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `serverId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `type` TEXT NOT NULL, `cfi` TEXT NOT NULL, `color` TEXT NOT NULL, `note` TEXT, `textSnippet` TEXT NOT NULL, `chapterHref` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `originDeviceId` TEXT NOT NULL, `lastModifiedByDeviceId` TEXT NOT NULL, `deleted` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`serverId`) REFERENCES `servers`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cfi",
+            "columnName": "cfi",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "color",
+            "columnName": "color",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "note",
+            "columnName": "note",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "textSnippet",
+            "columnName": "textSnippet",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chapterHref",
+            "columnName": "chapterHref",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "originDeviceId",
+            "columnName": "originDeviceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastModifiedByDeviceId",
+            "columnName": "lastModifiedByDeviceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deleted",
+            "columnName": "deleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_annotations_serverId_itemId",
+            "unique": false,
+            "columnNames": [
+              "serverId",
+              "itemId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_annotations_serverId_itemId` ON `${TABLE_NAME}` (`serverId`, `itemId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "servers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "serverId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "readaloud_resume_positions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`serverId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `href` TEXT NOT NULL, `progression` REAL, `fragmentRef` TEXT, `localUpdatedAt` INTEGER NOT NULL, PRIMARY KEY(`serverId`, `itemId`), FOREIGN KEY(`serverId`) REFERENCES `servers`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "href",
+            "columnName": "href",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "progression",
+            "columnName": "progression",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "fragmentRef",
+            "columnName": "fragmentRef",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localUpdatedAt",
+            "columnName": "localUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "serverId",
+            "itemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_readaloud_resume_positions_serverId",
+            "unique": false,
+            "columnNames": [
+              "serverId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_readaloud_resume_positions_serverId` ON `${TABLE_NAME}` (`serverId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "servers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "serverId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'c88f14dc9ccca5f13452fd238e8a4b8c')"
+    ]
+  }
+}

--- a/core/database/src/androidTest/kotlin/com/riffle/core/database/LibraryDaoTest.kt
+++ b/core/database/src/androidTest/kotlin/com/riffle/core/database/LibraryDaoTest.kt
@@ -1,0 +1,73 @@
+package com.riffle.core.database
+
+import androidx.room.Room
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class LibraryDaoTest {
+
+    private lateinit var db: RiffleDatabase
+    private lateinit var dao: LibraryDao
+
+    @Before
+    fun setup() {
+        db = Room.inMemoryDatabaseBuilder(
+            InstrumentationRegistry.getInstrumentation().targetContext,
+            RiffleDatabase::class.java,
+        ).allowMainThreadQueries().build()
+        dao = db.libraryDao()
+        // libraries FK-references servers; seed the owning Servers first.
+        runBlocking {
+            db.serverDao().upsert(ServerEntity("s1", "http://s1", isActive = true, insecureConnectionAllowed = false, username = "u"))
+            db.serverDao().upsert(ServerEntity("s2", "http://s2", isActive = false, insecureConnectionAllowed = false, username = "u"))
+        }
+    }
+
+    @After
+    fun teardown() {
+        db.close()
+    }
+
+    private fun library(id: String, serverId: String, name: String = "Library $id", mediaType: String = "book") =
+        LibraryEntity(id = id, name = name, mediaType = mediaType, serverId = serverId)
+
+    // Two Servers pointing at the same Audiobookshelf instance (issue #113) emit identical
+    // library ids — they are unique only within an instance. Both rows must coexist, each owned
+    // by its own Server.
+    @Test
+    fun sameLibraryIdOnDifferentServersBothPersist() = runTest {
+        dao.replaceAllForServer("s1", listOf(library("lib", "s1", name = "From s1")))
+        dao.replaceAllForServer("s2", listOf(library("lib", "s2", name = "From s2")))
+
+        val s1Libs = dao.observeByServerId("s1").first()
+        val s2Libs = dao.observeByServerId("s2").first()
+
+        assertEquals(listOf("From s1"), s1Libs.map { it.name })
+        assertEquals(listOf("From s2"), s2Libs.map { it.name })
+    }
+
+    // replaceAllForServer must scope its delete+upsert to the target Server only — refreshing one
+    // Server's libraries must not steal a same-id library away from another Server.
+    @Test
+    fun replaceAllForServerLeavesOtherServersSameIdLibraryIntact() = runTest {
+        dao.replaceAllForServer("s1", listOf(library("lib", "s1")))
+        dao.replaceAllForServer("s2", listOf(library("lib", "s2")))
+
+        // Re-refresh s1 (as refreshLibraries does for the active Server).
+        dao.replaceAllForServer("s1", listOf(library("lib", "s1")))
+
+        assertEquals(1, dao.observeByServerId("s1").first().size)
+        assertEquals(1, dao.observeByServerId("s2").first().size)
+    }
+}

--- a/core/database/src/androidTest/kotlin/com/riffle/core/database/MigrationTest.kt
+++ b/core/database/src/androidTest/kotlin/com/riffle/core/database/MigrationTest.kt
@@ -1259,6 +1259,59 @@ class MigrationTest {
     }
 
     @Test
+    fun migration30To31_reKeysLibrariesByServerIdAndId() {
+        helper.createDatabase(TEST_DB, 30).use { db ->
+            // Two Servers on the same Audiobookshelf instance (issue #113).
+            db.execSQL(
+                "INSERT INTO servers (id, url, isActive, insecureConnectionAllowed, username, serverType) " +
+                    "VALUES ('s1', 'http://media-server', 1, 0, 'test', 'AUDIOBOOKSHELF')"
+            )
+            db.execSQL(
+                "INSERT INTO servers (id, url, isActive, insecureConnectionAllowed, username, serverType) " +
+                    "VALUES ('s2', 'http://media-server', 0, 0, 'plamen', 'AUDIOBOOKSHELF')"
+            )
+            // A pre-existing library owned by s1. Under the v30 bare-id PK only one row per id can
+            // exist, so the collision can't be pre-seeded here — the migration must enable it.
+            db.execSQL("INSERT INTO libraries (id, name, mediaType, serverId, isUnsupported) VALUES ('lib', 'Books', 'book', 's1', 1)")
+            // An orphan whose serverId references no Server — dropped so the new FK holds.
+            db.execSQL("INSERT INTO libraries (id, name, mediaType, serverId, isUnsupported) VALUES ('orphan', 'Ghost', 'book', 'ghost', 0)")
+        }
+
+        val db = helper.runMigrationsAndValidate(TEST_DB, 31, true, RiffleDatabase.MIGRATION_30_31)
+
+        // s1's library is preserved with all its column values.
+        db.query("SELECT name, mediaType, isUnsupported FROM libraries WHERE serverId = 's1' AND id = 'lib'").use { cursor ->
+            assertEquals(1, cursor.count)
+            cursor.moveToFirst()
+            assertEquals("Books", cursor.getString(0))
+            assertEquals("book", cursor.getString(1))
+            assertEquals(1, cursor.getInt(2))
+        }
+        // The orphan row was dropped.
+        db.query("SELECT COUNT(*) FROM libraries WHERE id = 'orphan'").use { cursor ->
+            cursor.moveToFirst()
+            assertEquals(0, cursor.getInt(0))
+        }
+        // The composite key now lets the other Server own a same-id library — the heart of #113.
+        db.execSQL("INSERT INTO libraries (id, name, mediaType, serverId, isUnsupported) VALUES ('lib', 'Audiobooks', 'book', 's2', 0)")
+        db.query("SELECT name FROM libraries WHERE id = 'lib' ORDER BY serverId").use { cursor ->
+            assertEquals(2, cursor.count)
+            cursor.moveToFirst()
+            assertEquals("Books", cursor.getString(0))
+            cursor.moveToNext()
+            assertEquals("Audiobooks", cursor.getString(0))
+        }
+        // FK cascade: removing a Server clears its libraries (and only its own).
+        db.execSQL("PRAGMA foreign_keys = ON")
+        db.execSQL("DELETE FROM servers WHERE id = 's1'")
+        db.query("SELECT serverId FROM libraries WHERE id = 'lib'").use { cursor ->
+            assertEquals(1, cursor.count)
+            cursor.moveToFirst()
+            assertEquals("s2", cursor.getString(0))
+        }
+    }
+
+    @Test
     fun migrateFullChain() {
         helper.createDatabase(TEST_DB, 1).use { db ->
             db.execSQL(
@@ -1267,7 +1320,7 @@ class MigrationTest {
         }
 
         val db = helper.runMigrationsAndValidate(
-            TEST_DB, 30, true,
+            TEST_DB, 31, true,
             RiffleDatabase.MIGRATION_1_2,
             RiffleDatabase.MIGRATION_2_3,
             RiffleDatabase.MIGRATION_3_4,
@@ -1297,6 +1350,7 @@ class MigrationTest {
             RiffleDatabase.MIGRATION_27_28,
             RiffleDatabase.MIGRATION_28_29,
             RiffleDatabase.MIGRATION_29_30,
+            RiffleDatabase.MIGRATION_30_31,
         )
 
         db.query("SELECT url, username, serverType FROM servers WHERE id = 's1'").use { cursor ->

--- a/core/database/src/main/kotlin/com/riffle/core/database/LibraryDao.kt
+++ b/core/database/src/main/kotlin/com/riffle/core/database/LibraryDao.kt
@@ -16,8 +16,8 @@ interface LibraryDao {
     @Query("SELECT id FROM libraries WHERE serverId = :serverId")
     suspend fun libraryIdsForServer(serverId: String): List<String>
 
-    @Query("SELECT * FROM libraries WHERE id = :libraryId LIMIT 1")
-    suspend fun getById(libraryId: String): LibraryEntity?
+    @Query("SELECT * FROM libraries WHERE serverId = :serverId AND id = :libraryId LIMIT 1")
+    suspend fun getById(serverId: String, libraryId: String): LibraryEntity?
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun upsertAll(libraries: List<LibraryEntity>)
@@ -31,6 +31,6 @@ interface LibraryDao {
         upsertAll(libraries)
     }
 
-    @Query("UPDATE libraries SET isUnsupported = :isUnsupported WHERE id = :libraryId")
-    suspend fun setUnsupported(libraryId: String, isUnsupported: Boolean)
+    @Query("UPDATE libraries SET isUnsupported = :isUnsupported WHERE serverId = :serverId AND id = :libraryId")
+    suspend fun setUnsupported(serverId: String, libraryId: String, isUnsupported: Boolean)
 }

--- a/core/database/src/main/kotlin/com/riffle/core/database/LibraryEntity.kt
+++ b/core/database/src/main/kotlin/com/riffle/core/database/LibraryEntity.kt
@@ -1,11 +1,27 @@
 package com.riffle.core.database
 
 import androidx.room.Entity
-import androidx.room.PrimaryKey
+import androidx.room.ForeignKey
+import androidx.room.Index
 
-@Entity(tableName = "libraries")
+// Keyed by (serverId, id): library ids are only unique within an Audiobookshelf instance, so two
+// Servers pointing at the same instance emit identical ids (issue #113). serverId FK-cascades so
+// removing a Server clears its libraries — mirroring [LibraryItemEntity] (ADR 0025).
+@Entity(
+    tableName = "libraries",
+    primaryKeys = ["serverId", "id"],
+    foreignKeys = [
+        ForeignKey(
+            entity = ServerEntity::class,
+            parentColumns = ["id"],
+            childColumns = ["serverId"],
+            onDelete = ForeignKey.CASCADE,
+        ),
+    ],
+    indices = [Index("serverId")],
+)
 data class LibraryEntity(
-    @PrimaryKey val id: String,
+    val id: String,
     val name: String,
     val mediaType: String,
     val serverId: String,

--- a/core/database/src/main/kotlin/com/riffle/core/database/RiffleDatabase.kt
+++ b/core/database/src/main/kotlin/com/riffle/core/database/RiffleDatabase.kt
@@ -23,7 +23,7 @@ import androidx.sqlite.db.SupportSQLiteDatabase
         AnnotationEntity::class,
         ReadaloudResumePositionEntity::class,
     ],
-    version = 30,
+    version = 31,
     exportSchema = true,
 )
 abstract class RiffleDatabase : RoomDatabase() {
@@ -599,6 +599,38 @@ abstract class RiffleDatabase : RoomDatabase() {
         val MIGRATION_29_30 = object : Migration(29, 30) {
             override fun migrate(db: SupportSQLiteDatabase) {
                 db.execSQL("ALTER TABLE `library_items` ADD COLUMN `audioDurationSec` REAL NOT NULL DEFAULT 0")
+            }
+        }
+
+        // Re-keys `libraries` from (id) to (serverId, id). Library ids are unique only within an
+        // Audiobookshelf instance, so two Servers pointing at the same instance emit identical ids
+        // (issue #113); the bare-id PK let one Server's libraries overwrite the other's. Adds the
+        // serverId FK-cascade (libraries previously relied on manual cleanup in ServerRepository)
+        // and a serverId index, matching `library_items`. Orphan rows whose serverId no longer
+        // references a Server are dropped so the new FK holds.
+        val MIGRATION_30_31 = object : Migration(30, 31) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL(
+                    "CREATE TABLE IF NOT EXISTS `libraries_new` (" +
+                        "`id` TEXT NOT NULL, " +
+                        "`name` TEXT NOT NULL, " +
+                        "`mediaType` TEXT NOT NULL, " +
+                        "`serverId` TEXT NOT NULL, " +
+                        "`isUnsupported` INTEGER NOT NULL, " +
+                        "PRIMARY KEY(`serverId`, `id`), " +
+                        "FOREIGN KEY(`serverId`) REFERENCES `servers`(`id`) " +
+                        "ON UPDATE NO ACTION ON DELETE CASCADE)"
+                )
+                db.execSQL(
+                    "INSERT INTO `libraries_new` (id, name, mediaType, serverId, isUnsupported) " +
+                        "SELECT id, name, mediaType, serverId, isUnsupported FROM `libraries` " +
+                        "WHERE serverId IN (SELECT id FROM `servers`)"
+                )
+                db.execSQL("DROP TABLE `libraries`")
+                db.execSQL("ALTER TABLE `libraries_new` RENAME TO `libraries`")
+                db.execSQL(
+                    "CREATE INDEX IF NOT EXISTS `index_libraries_serverId` ON `libraries` (`serverId`)"
+                )
             }
         }
     }


### PR DESCRIPTION
Closes #113.

## Problem

In global Settings, only the **active** Audiobookshelf server showed its libraries; a non-active server displayed "Enabled libraries: No libraries found." even when it had libraries.

## Root cause

`LibraryEntity` used the bare Audiobookshelf library id as its primary key, but **library ids are unique only within an instance**. Two servers pointing at the same instance (e.g. the same host with two user logins) share library ids, so `replaceAllForServer`'s `upsertAll(OnConflictStrategy.REPLACE)` stole rows from one server to the other, and `refreshLibraries()` (active server only) stole them back — leaving the non-active server with none. This is exactly the hazard `library_items` already avoids with its `(serverId, id)` key.

## Fix

- Re-key `libraries` by `(serverId, id)` with a `serverId` FK-cascade + index, mirroring `library_items` — via `MIGRATION_30_31` (DB version → 31, schema exported, registered in `DatabaseModule` + `MigrationTest`).
- Scope `LibraryDao.getById`/`setUnsupported` by `serverId` (ambiguous under the composite key); callers resolve the server id, so the `LibraryRepository` interface is unchanged.

## Tests (TDD)

- New `LibraryDaoTest` — two servers with the same library id both persist; `replaceAllForServer` no longer steals a same-id row. (Written first, confirmed red, then green.)
- `MigrationTest.migration30To31` — colliding-id libraries survive, orphans dropped, FK cascade holds; `migrateFullChain` extended to v31.
- JVM suite green; full `core:database` connected suite green on the emulator.

## Merge note

Best merged **after** #124 (which adds the connected-test CI job + repairs the pre-existing migration-schema drift). After #124 lands, rebasing this branch lets its connected tests run in CI too.