### PR TITLE
fix(readaloud): Play-from-here resolves the selected sentence's own clip, not a same-id sentence in an earlier chapter

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -1165,7 +1165,14 @@ class EpubReaderViewModel @Inject constructor(
             readaloudStarted = true
             resumeFragmentRef = null
             closeLocator = null
-            playerCoordinator.playFromHere(fragmentRef)
+            // The selection ref is the displayed ABS "href#spanId". On a matched-ABS book the rendered
+            // ABS hrefs differ from the Storyteller bundle the clips come from, and span ids recur across
+            // chapters — so seeking by the bare id alone lands on the first book-wide occurrence (an
+            // earlier chapter), resetting reading progress. Re-key the ref onto the bundle chapter the
+            // selection sits in so the player resolves the selected sentence's own clip. Falls back to
+            // the original ref when there's no match (unmatched book, or the chapter can't be mapped).
+            val seekRef = threePeer?.bundleFragmentRefForSelection(fragmentRef) ?: fragmentRef
+            playerCoordinator.playFromHere(seekRef)
         }
     }
 

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderPositionBridge.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderPositionBridge.kt
@@ -136,6 +136,19 @@ class ReaderPositionBridge(
     fun canonicalToFragmentRef(locatorJson: String): String? =
         fromCanonical(locatorJson, Domain.ST)?.let { translator.fragmentAt(it) }
 
+    /**
+     * The Storyteller-bundle spine href for the displayed (ABS) chapter [displayedHref] — spine-aligned
+     * by index (ADR 0019). "Play from here" carries the rendered ABS href plus a Storyteller span id;
+     * since span ids recur across chapters, the player needs the bundle chapter the selection sits in to
+     * pick the right clip. Null when the href isn't a known ABS spine entry, so the caller keeps the
+     * original ref (the player then falls back to a bare-id match). The chapter index is shared between
+     * the two EPUBs; only the href scheme differs, which [ReadaloudTrack] reconciles.
+     */
+    fun displayedHrefToBundleHref(displayedHref: String): String? {
+        val idx = spineIndexOfHref(absSpineHrefs, displayedHref).takeIf { it >= 0 } ?: return null
+        return storytellerSpineHrefs.getOrNull(idx)
+    }
+
     private fun spineIndexOfHref(hrefs: List<String>, href: String): Int {
         val target = normalizeEpubHref(href)
         return hrefs.indexOfFirst { normalizeEpubHref(it) == target }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ThreePeerReaderSync.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ThreePeerReaderSync.kt
@@ -182,6 +182,19 @@ class ThreePeerReaderSyncCoordinator(
         bridge.canonicalToFragmentRef(canonicalLocatorJson)
 
     /**
+     * Re-keys a "Play from here" selection ref (the displayed ABS `href#spanId`) onto the Storyteller
+     * bundle chapter the selection sits in, so the player resolves the clip in THAT chapter rather than
+     * the first book-wide occurrence of the span id (ids recur across chapters — the "Play-from-here
+     * reset my progress" bug). Returns the bundle-href ref, or `null` when the chapter can't be mapped
+     * or the ref carries no span id; the caller then plays the original ref unchanged.
+     */
+    fun bundleFragmentRefForSelection(displayedRef: String): String? {
+        val spanId = displayedRef.substringAfter('#', "").takeIf { it.isNotEmpty() } ?: return null
+        val bundleHref = bridge.displayedHrefToBundleHref(displayedRef.substringBefore('#')) ?: return null
+        return "$bundleHref#$spanId"
+    }
+
+    /**
      * Responsive update of the matched ABS audiobook's `currentTime` from the current **reading
      * position**, translated through the bundle's SMIL ([ReaderPositionBridge.canonicalToAudioSeconds],
      * absolute over the concatenated audio files). Used by the audiobook-follow loop while readaloud

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ReaderPositionBridgeTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ReaderPositionBridgeTest.kt
@@ -96,4 +96,26 @@ class ReaderPositionBridgeTest {
         val remoteCanonical = bridge.audioSecondsToCanonical(2.0)!! // progression 0.125, no totalProgression
         assertEquals(0.125f, bridge.canonicalBookProgress(remoteCanonical), 1e-6f)
     }
+
+    // The two EPUBs are spine-aligned by index but carry different chapter hrefs (ADR 0026): a
+    // "Play from here" selection arrives as the rendered ABS href, but the player's clips are keyed
+    // by the Storyteller bundle href. This maps one to the other so the right chapter's clip is found.
+    private val splitHrefBridge = ReaderPositionBridge(
+        absSpineHrefs = listOf("xhtml/chapter1.xhtml", "xhtml/chapter2.xhtml"),
+        absChapterHtml = { null },
+        storytellerSpineHrefs = listOf("text/part0001.xhtml", "text/part0002.xhtml"),
+        storytellerChapterHtml = { null },
+        translator = translator,
+    )
+
+    @Test
+    fun `displayedHrefToBundleHref maps the ABS chapter href to the spine-aligned bundle href`() {
+        assertEquals("text/part0002.xhtml", splitHrefBridge.displayedHrefToBundleHref("xhtml/chapter2.xhtml"))
+        assertEquals("text/part0001.xhtml", splitHrefBridge.displayedHrefToBundleHref("/xhtml/chapter1.xhtml"))
+    }
+
+    @Test
+    fun `displayedHrefToBundleHref is null for an href outside the ABS spine`() {
+        assertNull(splitHrefBridge.displayedHrefToBundleHref("xhtml/nope.xhtml"))
+    }
 }

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/ReadaloudTrack.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/ReadaloudTrack.kt
@@ -43,16 +43,34 @@ class ReadaloudTrack(val clips: List<MediaOverlayClip>) {
         val target = href.trimStart('/')
         if (fragmentId != null) {
             clips.firstOrNull { it.textFragmentRef.trimStart('/') == "$target#$fragmentId" }?.let { return it }
-            // Fall back to the bare span id alone. The rendered publication (the ABS EPUB, ADR 0026) can
-            // carry different chapter hrefs than the Storyteller bundle the SMIL clips come from, so the
-            // href portions won't match even for the same sentence. Storyteller's sentence-span ids are
-            // unique within a book — the text-anchored highlight keys on them too (see ReadaloudTextQuotes)
-            // — so the id alone identifies the clip. Tried only after the exact match, so a book whose
-            // rendered hrefs DO line up is unaffected.
-            clips.firstOrNull { it.textFragmentRef.substringAfter('#', "") == fragmentId }?.let { return it }
+            // Fall back to the bare span id. The rendered publication (the ABS EPUB, ADR 0026) can carry
+            // different chapter hrefs than the Storyteller bundle the SMIL clips come from, so the href
+            // portions won't match even for the same sentence. But sentence-span ids are only unique
+            // WITHIN a document — they recur across chapters — so a plain bare-id match would return the
+            // earliest book-wide occurrence and jump narration to an identically-id'd sentence in an
+            // earlier chapter (the "Play-from-here reset my progress" bug). So among the clips sharing the
+            // id, prefer the one in the reader's chapter; only when the chapter can't be matched (the two
+            // EPUBs share nothing) do we fall back to the first occurrence, so a book whose hrefs don't
+            // line up still plays the right sentence when the id happens to be unique.
+            val sharingId = clips.filter { it.textFragmentRef.substringAfter('#', "") == fragmentId }
+            sharingId.firstOrNull { sameChapter(it, target) }?.let { return it }
+            sharingId.firstOrNull()?.let { return it }
         }
         fun chapterHref(clip: MediaOverlayClip) = clip.textFragmentRef.substringBefore('#').trimStart('/')
         clips.firstOrNull { chapterHref(it) == target }?.let { return it }
         return clips.firstOrNull { chapterHref(it) >= target }
+    }
+
+    /**
+     * Whether [clip]'s chapter is [targetHref], tolerant of the differing href schemes the same chapter
+     * carries across the pipeline: the player track's full zip path ("OEBPS/text/x.xhtml"), a bundle
+     * spine href ("text/x.xhtml"), and a raw SMIL ref ("../text/x.xhtml"). [resolveEpubHref] collapses
+     * `.`/`..`; the suffix test absorbs a leading directory (the OPF folder) one side carries and the
+     * other doesn't. Chapter hrefs are unique per book, so the suffix can't cross-match two chapters.
+     */
+    private fun sameChapter(clip: MediaOverlayClip, targetHref: String): Boolean {
+        val c = resolveEpubHref(clip.textFragmentRef.substringBefore('#')).trimStart('/')
+        val t = resolveEpubHref(targetHref).trimStart('/')
+        return c == t || c.endsWith("/$t") || t.endsWith("/$c")
     }
 }

--- a/core/domain/src/test/kotlin/com/riffle/core/domain/ReadaloudTrackTest.kt
+++ b/core/domain/src/test/kotlin/com/riffle/core/domain/ReadaloudTrackTest.kt
@@ -105,6 +105,34 @@ class ReadaloudTrackTest {
         assertEquals(chapterClips[1], chapterTrack.resolveStartClip("text/c1.html", "s2"))
     }
 
+    // Storyteller sentence-span ids are per-document and recur across chapters (the split fixture below
+    // reuses "s1" in four chapters). On a matched-ABS book the rendered ABS href never equals the bundle
+    // href, so resolveStartClip can't use the exact match — and a plain bare-id match returns the
+    // EARLIEST clip carrying that id, jumping "Play from here" to an identically-id'd sentence in an
+    // earlier chapter ("play-from-here reset my progress"). Given the reader's chapter (the caller maps
+    // the ABS href to the bundle href via ReaderPositionBridge), it must resolve to THAT chapter's clip.
+    private val collidingIdClips = listOf(
+        MediaOverlayClip("OEBPS/text/part0003.xhtml#s5", "a.mp3", 0.0, 2.0),    // earlier chapter (e.g. SOL 34)
+        MediaOverlayClip("OEBPS/text/part0050.xhtml#s5", "z.mp3", 900.0, 903.0), // the chapter the reader is on
+    )
+    private val collidingIdTrack = ReadaloudTrack(collidingIdClips)
+
+    @Test
+    fun `resolveStartClip with a span id shared across chapters resolves to the reader's chapter`() {
+        // The bundle href the bridge supplies is OPF-relative ("text/…"); the clips' hrefs are full
+        // zip paths ("OEBPS/text/…"). The chapter match must tolerate that scheme difference and still
+        // pick the reader's chapter rather than the first book-wide occurrence of the id.
+        assertEquals(collidingIdClips[1], collidingIdTrack.resolveStartClip("text/part0050.xhtml", "s5"))
+        assertEquals(collidingIdClips[0], collidingIdTrack.resolveStartClip("text/part0003.xhtml", "s5"))
+    }
+
+    @Test
+    fun `resolveStartClip falls back to a bare-id match when the chapter href cannot be matched`() {
+        // Degrade gracefully: when the target href shares nothing with the bundle, still resolve a
+        // uniquely-id'd sentence by its bare id so a book whose hrefs don't line up keeps working.
+        assertEquals(bundleHrefClips[2], bundleHrefTrack.resolveStartClip("xhtml/chapter2.xhtml", "c002-s0"))
+    }
+
     // Storyteller splits each chapter into an un-narrated heading page (…_split_000) plus narrated
     // body pages (…_split_001+). Navigating via the TOC lands the reader on the heading page, which
     // has no Media Overlay; starting narration must jump forward to the chapter's first narrated


### PR DESCRIPTION
## Problem

Starting **Play from here** on a matched-ABS readaloud book could reset the reader's progress: narration started in a *different, earlier* chapter and the reader's auto-follow then rewrote the saved reading position back to that chapter.

## Root cause

The selection ref is the displayed **ABS** EPUB `href#spanId`. On a matched-ABS book the rendered ABS EPUB and the Storyteller SMIL bundle carry different chapter hrefs (ADR 0026), so `ReadaloudTrack.resolveStartClip`'s exact `href#id` match always missed and fell back to matching the **bare span id**. Sentence-span ids are only unique *within a document* and recur across chapters, so `firstOrNull` returned the **earliest book-wide occurrence** — starting narration in an earlier chapter. The page-follow then dragged the reading position there ("Play-from-here reset my progress").

The selection resolver was *not* at fault — it only matches sentences in the current page's DOM, so it returns the correct span id; the mis-resolution was entirely in the clip lookup.

## Fix

- **`ReadaloudTrack.resolveStartClip`** — among clips sharing the span id, prefer the one in the **reader's chapter**; fall back to first-occurrence only when no chapter matches (so a book whose hrefs don't line up still plays the right uniquely-id'd sentence). Chapter matching is scheme-tolerant (`resolveEpubHref` + `/`-boundary suffix) because the same chapter appears as a full zip path, an OPF-relative href, and a raw SMIL ref across the pipeline.
- **`ReaderPositionBridge.displayedHrefToBundleHref`** — map the ABS chapter href → spine-aligned Storyteller bundle href.
- **`ThreePeerReaderSyncCoordinator.bundleFragmentRefForSelection`** + **`EpubReaderViewModel.playFromHere`** — re-key the selection ref onto the bundle chapter before seeking. Falls back to the original ref for unmatched books or unmappable chapters.

Playback still starts on the **exact selected sentence** — it just stops grabbing a same-id sentence in another chapter. The server-sync resume path benefits from the same chapter-anchoring.

## Tests

- New `ReadaloudTrackTest` cases: a span id shared across chapters resolves to the reader's chapter (red→green), and graceful bare-id fallback when the chapter href can't be matched.
- New `ReaderPositionBridgeTest` cases for the ABS→bundle spine-aligned href mapping.
- `./gradlew test` ✅ · `./gradlew lint` ✅ · `make harness-test` (172, 0 failed) ✅ · `make harness-test-tablet` (5, 0 failed) ✅

## Known limitation (pre-existing, out of scope)

A *free-text* selection that resolves to no span id still passes the bare ABS href into `resolveStartClip`'s lexical fallback — unchanged by this PR.
