### PR TITLE
fix(reader): align reading-progress % with book details (whole-book progression + reactive details)

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModel.kt
@@ -155,6 +155,21 @@ class LibraryItemDetailViewModel @Inject constructor(
             }
         }
 
+        // Keep the rendered progress current: the reader persists new readingProgress to the DB on
+        // close, but this screen — retained on the back stack while the user reads — would otherwise
+        // keep showing the one-shot snapshot taken in init. Observing the item patches the live row
+        // (e.g. readingProgress) into the existing Ready state so book details matches where the
+        // reader left off. Only patches once Ready, so it never pre-empts the Error/enrichment path.
+        repository.observeItem(itemId)
+            .onEach { latest ->
+                if (latest == null) return@onEach
+                val current = _uiState.value
+                if (current is LibraryItemDetailUiState.Ready && current.item != latest) {
+                    _uiState.value = current.copy(item = latest)
+                }
+            }
+            .launchIn(viewModelScope)
+
         // Reactively update isOffline in Ready state when connectivity changes.
         connectivityObserver.isOnline
             .onEach { online ->

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -526,6 +526,9 @@ private fun EpubChapterRailOverlay(
     val railSegments by viewModel.railSegments.collectAsState()
     val activeRailSegmentIndex by viewModel.activeRailSegmentIndex.collectAsState()
     val cursorPosition by viewModel.railCursorPosition.collectAsState()
+    // Whole-book progress for the "% read" label — matches book details. Kept separate from
+    // cursorPosition, which places the cursor inside the active (chapter-weighted) rail segment.
+    val totalProgress by viewModel.currentLocatorTotalProgression.collectAsState()
     val darkTheme = readerTheme == ReaderTheme.Dark || readerTheme == ReaderTheme.DarkDim
     RiffleTheme(darkTheme = darkTheme) {
         // Backdrop is the exact reader-theme page colour so the strip reads as page margin,
@@ -541,7 +544,7 @@ private fun EpubChapterRailOverlay(
                     activeChapterIndex = activeRailSegmentIndex,
                     chapterCount = railSegments.size,
                     activeChapterTitle = railSegments.getOrNull(activeRailSegmentIndex)?.title.orEmpty(),
-                    totalProgress = cursorPosition,
+                    totalProgress = totalProgress,
                     readerTheme = readerTheme,
                     showCountAndPercent = showProgressLabels,
                     showChapterName = showChapterNameLabel,

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -529,6 +529,12 @@ private fun EpubChapterRailOverlay(
     // Whole-book progress for the "% read" label — matches book details. Kept separate from
     // cursorPosition, which places the cursor inside the active (chapter-weighted) rail segment.
     val totalProgress by viewModel.currentLocatorTotalProgression.collectAsState()
+    // totalProgression is absent until Readium computes positions, and stays absent for the whole
+    // session if a publication's positions never compute. Fall back to the chapter-weighted rail
+    // cursor then so the label shows a sensible estimate instead of sticking at 0%. Once a real
+    // whole-book value arrives it wins (and matches book details). At genuine 0% the rail cursor is
+    // also ~0, so the fallback is indistinguishable there.
+    val labelProgress = if (totalProgress > 0f) totalProgress else cursorPosition
     val darkTheme = readerTheme == ReaderTheme.Dark || readerTheme == ReaderTheme.DarkDim
     RiffleTheme(darkTheme = darkTheme) {
         // Backdrop is the exact reader-theme page colour so the strip reads as page margin,
@@ -544,7 +550,7 @@ private fun EpubChapterRailOverlay(
                     activeChapterIndex = activeRailSegmentIndex,
                     chapterCount = railSegments.size,
                     activeChapterTitle = railSegments.getOrNull(activeRailSegmentIndex)?.title.orEmpty(),
-                    totalProgress = totalProgress,
+                    totalProgress = labelProgress,
                     readerTheme = readerTheme,
                     showCountAndPercent = showProgressLabels,
                     showChapterName = showChapterNameLabel,

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -623,6 +623,7 @@ class EpubReaderViewModel @Inject constructor(
         lastLocator = locator
         _currentLocatorHref.value = locator.href.toString()
         _currentLocatorProgression.value = locator.locations.progression?.toFloat() ?: 0f
+        locator.locations.totalProgression?.toFloat()?.let { _currentLocatorTotalProgression.value = it }
         if (!initialLocatorSeen) {
             initialLocatorSeen = true
             return
@@ -825,6 +826,14 @@ class EpubReaderViewModel @Inject constructor(
 
     private val _currentLocatorProgression = MutableStateFlow(0f)
     val currentLocatorProgression: StateFlow<Float> = _currentLocatorProgression
+
+    // Whole-book progress (0..1) for the reading "% read" label — the same coordinate persisted as
+    // ebookProgress and shown in book details. Distinct from railCursorPosition, which is a
+    // chapter-weighted fraction over TOC segments only and so diverges from the stored progress.
+    // Updated only when the navigator emits a non-null totalProgression: a null (positions not yet
+    // computed) holds the last real value rather than falling back to the within-chapter progression.
+    private val _currentLocatorTotalProgression = MutableStateFlow(0f)
+    val currentLocatorTotalProgression: StateFlow<Float> = _currentLocatorTotalProgression
 
     private val _tocVisible = MutableStateFlow(false)
     val tocVisible: StateFlow<Boolean> = _tocVisible

--- a/app/src/test/kotlin/com/riffle/app/feature/library/CollectionDetailViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/CollectionDetailViewModelTest.kt
@@ -61,6 +61,7 @@ class CollectionDetailViewModelTest {
         override fun observeSeriesItems(seriesId: String): Flow<List<LibraryItem>> = MutableStateFlow(emptyList())
         override fun observeCollectionItems(collectionId: String): Flow<List<LibraryItem>> = collectionItemsFlow
         override suspend fun getItem(itemId: String): LibraryItem? = null
+        override fun observeItem(itemId: String): Flow<LibraryItem?> = MutableStateFlow<LibraryItem?>(null)
         override suspend fun getItem(serverId: String, itemId: String): LibraryItem? = getItem(itemId)
         override suspend fun getLibrary(libraryId: String): com.riffle.core.domain.Library? = null
         override suspend fun getSeriesIdForItem(serverId: String, itemId: String): String? = null
@@ -88,6 +89,7 @@ class CollectionDetailViewModelTest {
         override fun observeSeriesItems(seriesId: String): Flow<List<LibraryItem>> = MutableStateFlow(emptyList())
         override fun observeCollectionItems(collectionId: String): Flow<List<LibraryItem>> = collectionItemsFlow
         override suspend fun getItem(itemId: String): LibraryItem? = null
+        override fun observeItem(itemId: String): Flow<LibraryItem?> = MutableStateFlow<LibraryItem?>(null)
         override suspend fun getItem(serverId: String, itemId: String): LibraryItem? = getItem(itemId)
         override suspend fun getLibrary(libraryId: String): com.riffle.core.domain.Library? = null
         override suspend fun getSeriesIdForItem(serverId: String, itemId: String): String? = null

--- a/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModelTest.kt
@@ -68,7 +68,10 @@ class LibraryItemDetailViewModelTest {
         ebookFormat = EbookFormat.Epub,
     )
 
-    private fun fakeRepo(item: LibraryItem? = null): LibraryRepository = object : LibraryRepository {
+    private fun fakeRepo(
+        item: LibraryItem? = null,
+        itemFlow: MutableStateFlow<LibraryItem?> = MutableStateFlow(item),
+    ): LibraryRepository = object : LibraryRepository {
         override fun observeLibraries(): Flow<List<Library>> = MutableStateFlow(emptyList())
         override fun observeLibraries(serverId: String): Flow<List<Library>> = observeLibraries()
         override fun observeLibraryItems(libraryId: String): Flow<List<LibraryItem>> = MutableStateFlow(emptyList())
@@ -82,6 +85,7 @@ class LibraryItemDetailViewModelTest {
         override fun observeSeriesItems(seriesId: String): Flow<List<LibraryItem>> = MutableStateFlow(emptyList())
         override fun observeCollectionItems(collectionId: String): Flow<List<LibraryItem>> = MutableStateFlow(emptyList())
         override suspend fun getItem(itemId: String): LibraryItem? = item
+        override fun observeItem(itemId: String): Flow<LibraryItem?> = itemFlow
         override suspend fun getItem(serverId: String, itemId: String): LibraryItem? = getItem(itemId)
         override suspend fun getLibrary(libraryId: String): com.riffle.core.domain.Library? = null
         override suspend fun getSeriesIdForItem(serverId: String, itemId: String): String? = null
@@ -107,6 +111,7 @@ class LibraryItemDetailViewModelTest {
         override fun observeSeriesItems(seriesId: String): Flow<List<LibraryItem>> = MutableStateFlow(emptyList())
         override fun observeCollectionItems(collectionId: String): Flow<List<LibraryItem>> = MutableStateFlow(emptyList())
         override suspend fun getItem(itemId: String): LibraryItem? = throw RuntimeException("DB unavailable")
+        override fun observeItem(itemId: String): Flow<LibraryItem?> = MutableStateFlow(null)
         override suspend fun getItem(serverId: String, itemId: String): LibraryItem? = getItem(itemId)
         override suspend fun getLibrary(libraryId: String): com.riffle.core.domain.Library? = null
         override suspend fun getSeriesIdForItem(serverId: String, itemId: String): String? = null
@@ -289,6 +294,25 @@ class LibraryItemDetailViewModelTest {
         testDispatcher.scheduler.advanceUntilIdle()
 
         assertEquals(LibraryItemDetailUiState.Error, vm.uiState.value)
+    }
+
+    // Regression for "book details shows a different (stale) progress than the reader." The screen
+    // is retained on the back stack while the user reads; the reader persists new readingProgress to
+    // the DB on close. A one-shot getItem snapshot would keep showing the pre-reading value, so the
+    // VM observes the item row and patches the live progress into the Ready state.
+    @Test
+    fun `readingProgress updates reactively when the item row changes after reading`() = runTest {
+        val itemFlow = MutableStateFlow<LibraryItem?>(knownItem) // starts at 0.5
+        val vm = makeVm(fakeRepo(knownItem, itemFlow))
+        backgroundScope.launch { vm.uiState.collect {} }
+        testDispatcher.scheduler.advanceUntilIdle()
+        assertEquals(0.5f, (vm.uiState.value as Ready).item.readingProgress)
+
+        // Reader closes and writes 0.8 to the DB; the observed row re-emits.
+        itemFlow.value = knownItem.copy(readingProgress = 0.8f)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(0.8f, (vm.uiState.value as Ready).item.readingProgress)
     }
 
     // --- downloadState tests ---

--- a/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemsViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemsViewModelTest.kt
@@ -76,6 +76,7 @@ class LibraryItemsViewModelTest {
         override fun observeCollectionItems(collectionId: String): Flow<List<LibraryItem>> =
             collectionItemsByCollectionId.getOrPut(collectionId) { MutableStateFlow(emptyList()) }
         override suspend fun getItem(itemId: String): LibraryItem? = null
+        override fun observeItem(itemId: String): Flow<LibraryItem?> = MutableStateFlow<LibraryItem?>(null)
         override suspend fun getItem(serverId: String, itemId: String): LibraryItem? = getItem(itemId)
         override suspend fun getLibrary(libraryId: String): com.riffle.core.domain.Library? = null
         override suspend fun getSeriesIdForItem(serverId: String, itemId: String): String? = null
@@ -711,6 +712,7 @@ class LibraryItemsViewModelTest {
         override fun observeCollectionItems(collectionId: String): Flow<List<LibraryItem>> =
             collectionItemsByCollectionId.getOrPut(collectionId) { MutableStateFlow(emptyList()) }
         override suspend fun getItem(itemId: String): LibraryItem? = null
+        override fun observeItem(itemId: String): Flow<LibraryItem?> = MutableStateFlow<LibraryItem?>(null)
         override suspend fun getItem(serverId: String, itemId: String): LibraryItem? = getItem(itemId)
         override suspend fun getLibrary(libraryId: String): com.riffle.core.domain.Library? = null
         override suspend fun getSeriesIdForItem(serverId: String, itemId: String): String? = null

--- a/app/src/test/kotlin/com/riffle/app/feature/library/SeriesDetailViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/SeriesDetailViewModelTest.kt
@@ -61,6 +61,7 @@ class SeriesDetailViewModelTest {
         override fun observeSeriesItems(seriesId: String): Flow<List<LibraryItem>> = seriesItemsFlow
         override fun observeCollectionItems(collectionId: String): Flow<List<LibraryItem>> = MutableStateFlow(emptyList())
         override suspend fun getItem(itemId: String): LibraryItem? = null
+        override fun observeItem(itemId: String): Flow<LibraryItem?> = MutableStateFlow<LibraryItem?>(null)
         override suspend fun getItem(serverId: String, itemId: String): LibraryItem? = getItem(itemId)
         override suspend fun getLibrary(libraryId: String): com.riffle.core.domain.Library? = null
         override suspend fun getSeriesIdForItem(serverId: String, itemId: String): String? = null

--- a/app/src/test/kotlin/com/riffle/app/feature/navigation/HomeViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/navigation/HomeViewModelTest.kt
@@ -73,6 +73,7 @@ class HomeViewModelTest {
         override fun observeSeriesItems(seriesId: String): Flow<List<LibraryItem>> = MutableStateFlow(emptyList())
         override fun observeCollectionItems(collectionId: String): Flow<List<LibraryItem>> = MutableStateFlow(emptyList())
         override suspend fun getItem(itemId: String): LibraryItem? = null
+        override fun observeItem(itemId: String): Flow<LibraryItem?> = MutableStateFlow<LibraryItem?>(null)
         override suspend fun getItem(serverId: String, itemId: String): LibraryItem? = getItem(itemId)
         override suspend fun getLibrary(libraryId: String): com.riffle.core.domain.Library? = null
         override suspend fun getSeriesIdForItem(serverId: String, itemId: String): String? = null

--- a/app/src/test/kotlin/com/riffle/app/feature/navigation/NavigationDrawerViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/navigation/NavigationDrawerViewModelTest.kt
@@ -94,6 +94,7 @@ class NavigationDrawerViewModelTest {
         override fun observeSeriesItems(seriesId: String): Flow<List<LibraryItem>> = MutableStateFlow(emptyList())
         override fun observeCollectionItems(collectionId: String): Flow<List<LibraryItem>> = MutableStateFlow(emptyList())
         override suspend fun getItem(itemId: String): LibraryItem? = null
+        override fun observeItem(itemId: String): Flow<LibraryItem?> = MutableStateFlow<LibraryItem?>(null)
         override suspend fun getItem(serverId: String, itemId: String): LibraryItem? = getItem(itemId)
         override suspend fun getLibrary(libraryId: String): com.riffle.core.domain.Library? = null
         override suspend fun getSeriesIdForItem(serverId: String, itemId: String): String? = null

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/EpubReaderViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/EpubReaderViewModelTest.kt
@@ -702,6 +702,56 @@ class SearchPipelineTest {
 }
 
 /**
+ * Regression for "book progress in book details differs from the % shown above the chapter map."
+ *
+ * Book details shows the persisted `ebookProgress`, which is the locator's whole-book
+ * `totalProgression`. The reading label used to show `railCursorPosition` — a *chapter-weighted*
+ * fraction over TOC segments only — so the two numbers measured different things and diverged.
+ *
+ * The fix drives the label from a dedicated flow fed by `locator.locations.totalProgression` (the
+ * same coordinate book details stores), updated ONLY when present so a null never falls back to the
+ * within-chapter `progression`. EpubReaderViewModel can't be constructed in a JVM test (Readium needs
+ * android.net.Uri — see the file header), so this fake mirrors onPositionChanged's two progression
+ * flows one-to-one; a regression here maps directly to the ViewModel.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class ReadingProgressLabelSourceTest {
+
+    // Mirrors EpubReaderViewModel.onPositionChanged:
+    //   _currentLocatorProgression      = locations.progression       → rail cursor within-segment placement
+    //   _currentLocatorTotalProgression = locations.totalProgression  → "% read" label (updated only when present)
+    private class LabelSource {
+        val withinChapterProgression = MutableStateFlow(0f)
+        val totalProgression = MutableStateFlow(0f)
+        fun onPositionChanged(progression: Float?, total: Float?) {
+            withinChapterProgression.value = progression ?: 0f
+            total?.let { totalProgression.value = it } // never substitute the within-chapter number
+        }
+    }
+
+    @Test
+    fun `label reads whole-book totalProgression, not the within-chapter progression`() {
+        val s = LabelSource()
+        // Halfway through chapter 1, but only 3% through the whole book.
+        s.onPositionChanged(progression = 0.5f, total = 0.03f)
+
+        assertEquals(0.03f, s.totalProgression.value)
+        assertNotEquals(s.withinChapterProgression.value, s.totalProgression.value)
+    }
+
+    @Test
+    fun `a null totalProgression holds the last whole-book value rather than falling back to progression`() {
+        val s = LabelSource()
+        s.onPositionChanged(progression = 0.2f, total = 0.1f)
+
+        // Positions not yet computed: total is null while the within-chapter number jumps to 0.9.
+        s.onPositionChanged(progression = 0.9f, total = null)
+
+        assertEquals("must hold the last real total, never show the chapter-local 0.9", 0.1f, s.totalProgression.value)
+    }
+}
+
+/**
  * Unit tests for the three-peer sync invariants that live in EpubReaderViewModel's
  * onPositionChanged / push / readaloud-start control flow. The ViewModel itself can't be constructed
  * in a JVM test (Readium needs android.net.Uri — see the file header), so each fake mirrors the exact

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/EpubReaderViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/EpubReaderViewModelTest.kt
@@ -749,6 +749,23 @@ class ReadingProgressLabelSourceTest {
 
         assertEquals("must hold the last real total, never show the chapter-local 0.9", 0.1f, s.totalProgression.value)
     }
+
+    // Mirrors EpubChapterRailOverlay's display selection:
+    //   labelProgress = if (totalProgress > 0f) totalProgress else cursorPosition
+    // Guards against the label sticking at 0% when a publication's positions never compute (so
+    // totalProgression stays absent) — fall back to the chapter-weighted rail cursor there.
+    private fun labelProgress(total: Float, cursor: Float): Float = if (total > 0f) total else cursor
+
+    @Test
+    fun `label falls back to the rail cursor when no whole-book total has been observed`() {
+        // Positions never computed → total stays 0; show the chapter-weighted estimate, not 0%.
+        assertEquals(0.42f, labelProgress(total = 0f, cursor = 0.42f))
+    }
+
+    @Test
+    fun `a real whole-book total wins over the rail cursor once it arrives`() {
+        assertEquals(0.11f, labelProgress(total = 0.11f, cursor = 0.42f))
+    }
 }
 
 /**

--- a/app/src/test/kotlin/com/riffle/app/feature/settings/SettingsViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/settings/SettingsViewModelTest.kt
@@ -127,6 +127,7 @@ class SettingsViewModelTest {
         override fun observeSeriesItems(seriesId: String): Flow<List<LibraryItem>> = MutableStateFlow(emptyList())
         override fun observeCollectionItems(collectionId: String): Flow<List<LibraryItem>> = MutableStateFlow(emptyList())
         override suspend fun getItem(itemId: String): LibraryItem? = null
+        override fun observeItem(itemId: String): Flow<LibraryItem?> = MutableStateFlow<LibraryItem?>(null)
         override suspend fun getItem(serverId: String, itemId: String): LibraryItem? = getItem(itemId)
         override suspend fun getLibrary(libraryId: String): com.riffle.core.domain.Library? = null
         override suspend fun getSeriesIdForItem(serverId: String, itemId: String): String? = null

--- a/core/data/src/main/kotlin/com/riffle/core/data/LibraryRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/LibraryRepositoryImpl.kt
@@ -97,6 +97,16 @@ class LibraryRepositoryImpl @Inject constructor(
         return libraryItemDao.getById(serverId, itemId)?.toDomain()
     }
 
+    @OptIn(ExperimentalCoroutinesApi::class)
+    override fun observeItem(itemId: String): Flow<LibraryItem?> =
+        serverRepository.observeAll()
+            .map { servers -> servers.firstOrNull { it.isActive }?.id }
+            .distinctUntilChanged()
+            .flatMapLatest { serverId ->
+                if (serverId == null) flowOf(null)
+                else libraryItemDao.observeById(serverId, itemId).map { it?.toDomain() }
+            }
+
     override suspend fun getItem(serverId: String, itemId: String): LibraryItem? =
         libraryItemDao.getById(serverId, itemId)?.toDomain()
 

--- a/core/data/src/test/kotlin/com/riffle/core/data/FakeLibraryItemDao.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/FakeLibraryItemDao.kt
@@ -47,6 +47,9 @@ internal class FakeLibraryItemDao : LibraryItemDao {
     override suspend fun getById(serverId: String, itemId: String): LibraryItemEntity? =
         roomData.values.flatMap { it.value }.firstOrNull { it.serverId == serverId && it.id == itemId }
 
+    override fun observeById(serverId: String, itemId: String): Flow<LibraryItemEntity?> =
+        MutableStateFlow(roomData.values.flatMap { it.value }.firstOrNull { it.serverId == serverId && it.id == itemId })
+
     override suspend fun findServerIdForItem(itemId: String): String? =
         roomData.values.flatMap { it.value }.firstOrNull { it.id == itemId }?.serverId
 

--- a/core/data/src/test/kotlin/com/riffle/core/data/NoopLibraryDaos.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/NoopLibraryDaos.kt
@@ -20,6 +20,7 @@ internal object ThrowingLibraryItemDao : LibraryItemDao {
     override fun observeAllBooks(libraryId: String): Flow<List<LibraryItemEntity>> = flowOf(emptyList())
     override suspend fun upsertAll(items: List<LibraryItemEntity>) = Unit
     override suspend fun getById(serverId: String, itemId: String): LibraryItemEntity? = null
+    override fun observeById(serverId: String, itemId: String): Flow<LibraryItemEntity?> = flowOf(null)
     override suspend fun findServerIdForItem(itemId: String): String? = null
     override suspend fun deleteByLibraryId(libraryId: String) = Unit
     override suspend fun updateLastOpenedAt(serverId: String, itemId: String, timestamp: Long) = Unit

--- a/core/data/src/test/kotlin/com/riffle/core/data/ReadaloudMatchingServiceTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/ReadaloudMatchingServiceTest.kt
@@ -331,6 +331,7 @@ class ReadaloudMatchingServiceTest {
         override fun observeAllBooks(libraryId: String): Flow<List<LibraryItemEntity>> = flowOf(emptyList())
         override suspend fun upsertAll(items: List<LibraryItemEntity>) = Unit
         override suspend fun getById(serverId: String, itemId: String): LibraryItemEntity? = byId[itemId]
+        override fun observeById(serverId: String, itemId: String): Flow<LibraryItemEntity?> = flowOf(byId[itemId])
         override suspend fun findServerIdForItem(itemId: String): String? = byId[itemId]?.serverId
         override suspend fun deleteByLibraryId(libraryId: String) = Unit
         override suspend fun updateLastOpenedAt(serverId: String, itemId: String, timestamp: Long) = Unit

--- a/core/data/src/test/kotlin/com/riffle/core/data/SeriesIntegrationTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/SeriesIntegrationTest.kt
@@ -113,6 +113,7 @@ class SeriesIntegrationTest {
         override fun observeRecentlyAdded(libraryId: String): Flow<List<LibraryItemEntity>> = MutableStateFlow(emptyList())
         override fun observeAllBooks(libraryId: String): Flow<List<LibraryItemEntity>> = MutableStateFlow(emptyList())
         override suspend fun getById(serverId: String, itemId: String): LibraryItemEntity? = null
+        override fun observeById(serverId: String, itemId: String): Flow<LibraryItemEntity?> = MutableStateFlow(null)
         override suspend fun findServerIdForItem(itemId: String): String? = null
         override suspend fun upsertAll(items: List<LibraryItemEntity>) {}
         override suspend fun deleteByLibraryId(libraryId: String) {}

--- a/core/data/src/test/kotlin/com/riffle/core/data/ServerRepositoryTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/ServerRepositoryTest.kt
@@ -119,6 +119,7 @@ class ServerRepositoryTest {
         override fun observeRecentlyAdded(libraryId: String) = flowOf(emptyList<com.riffle.core.database.LibraryItemEntity>())
         override fun observeAllBooks(libraryId: String) = flowOf(emptyList<com.riffle.core.database.LibraryItemEntity>())
         override suspend fun getById(serverId: String, itemId: String) = rows.values.flatten().firstOrNull { it.id == itemId }
+        override fun observeById(serverId: String, itemId: String) = flowOf(rows.values.flatten().firstOrNull { it.id == itemId })
         override suspend fun findServerIdForItem(itemId: String): String? = rows.values.flatten().firstOrNull { it.id == itemId }?.serverId
         override suspend fun upsertAll(items: List<com.riffle.core.database.LibraryItemEntity>) {
             items.groupBy { it.libraryId }.forEach { (libraryId, entities) ->

--- a/core/database/src/main/kotlin/com/riffle/core/database/LibraryItemDao.kt
+++ b/core/database/src/main/kotlin/com/riffle/core/database/LibraryItemDao.kt
@@ -34,6 +34,10 @@ interface LibraryItemDao {
     @Query("SELECT * FROM library_items WHERE serverId = :serverId AND id = :itemId LIMIT 1")
     suspend fun getById(serverId: String, itemId: String): LibraryItemEntity?
 
+    /** Reactive single-item read — re-emits when the row changes (e.g. readingProgress on reader close). */
+    @Query("SELECT * FROM library_items WHERE serverId = :serverId AND id = :itemId LIMIT 1")
+    fun observeById(serverId: String, itemId: String): Flow<LibraryItemEntity?>
+
     /**
      * The Server that owns an item id. Used by the one-time on-disk file migration (ADR 0025) to
      * relocate legacy flat `<itemId>` files under their owning Server. Pre-migration item ids were

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/LibraryRepository.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/LibraryRepository.kt
@@ -27,6 +27,13 @@ interface LibraryRepository {
     /** The active Server's copy of an item (item ids are only unique within a Server, ADR 0025). */
     suspend fun getItem(itemId: String): LibraryItem?
 
+    /**
+     * Reactive view of the active Server's copy of an item. Re-emits when the row changes — notably
+     * when the reader persists new readingProgress on close — so screens stay current instead of
+     * showing a one-shot snapshot taken before the user read.
+     */
+    fun observeItem(itemId: String): Flow<LibraryItem?>
+
     /** A specific Server's copy of an item — for cross-Server callers like the Downloads screen. */
     suspend fun getItem(serverId: String, itemId: String): LibraryItem?
     suspend fun getLibrary(libraryId: String): Library?


### PR DESCRIPTION
## Problem

Book progress shown in the **book details** screen differed from the **% read** label above the chapter map while reading the same book. Two distinct causes:

1. **Different computations.** The reading label read `railCursorPosition` — a fraction weighted only across TOC chapter segments — while book details shows the persisted `ebookProgress` (Readium's whole-book `totalProgression`). They measured different things and diverged (worst near the front of books with non-TOC front matter).
2. **Stale snapshot.** Even after aligning both to `totalProgression`, the detail screen read `repository.getItem()` once in `init` and never re-read it. Retained on the back stack while the user read, it kept showing the pre-reading value even though the reader persists new `readingProgress` to the DB on close.

## Changes

- **Reader % label → whole-book progress.** New `currentLocatorTotalProgression` flow fed from `locator.locations.totalProgression`, updated only when non-null (a null never falls back to the within-chapter `progression`). The rail cursor keeps `railCursorPosition` for its visual placement inside the active segment.
- **Fallback for missing positions.** If a publication's positions never compute (so `totalProgression` stays absent), the label falls back to the chapter-weighted rail cursor instead of sticking at 0%. A real whole-book value wins once it arrives. *(From review.)*
- **Reactive book details.** Added `LibraryItemDao.observeById` + `LibraryRepository.observeItem` (reactive single-item read) and collect it in `LibraryItemDetailViewModel` to patch the live row into the `Ready` state. Now details reflects where the reader left off once the book is closed.

## Tests

- `ReadingProgressLabelSourceTest` — label reads whole-book total (not within-chapter); a null total holds the last real value; fallback-to-rail-cursor selection.
- `LibraryItemDetailViewModelTest` — `readingProgress` updates reactively when the item row changes after reading.
- Updated all `LibraryRepository` / `LibraryItemDao` test fakes for the new methods.
- `./gradlew test` ✅ and `./gradlew lint` ✅ both green.
- **Harness tests not run** — the shared `Harness_Medium_Phone` AVD was contended by other parallel workspaces; CI does not run connected tests, so these still need a local run before merge.
