### PR TITLE
fix(reader): reliable search-highlight navigation & alignment; debug build SHA in drawer

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -44,7 +44,7 @@ android {
         minSdk = 24
         targetSdk = 36
         versionCode = (findProperty("versionCode") as String?)?.toInt() ?: 1
-        versionName = findProperty("versionName") as String? ?: "0.1.0"
+        versionName = findProperty("versionName") as String? ?: "0.0.0-dev"
 
         testInstrumentationRunner = "com.riffle.app.HiltTestRunner"
         vectorDrawables {
@@ -59,8 +59,9 @@ android {
         // (Readium 3.2.0+ regresses the readaloud highlight — see that test).
         buildConfigField("String", "READIUM_VERSION", "\"${libs.versions.readium.get()}\"")
 
-        // Build commit SHA shown in the nav drawer (see gitSha above).
-        buildConfigField("String", "GIT_SHA", "\"$gitSha\"")
+        // Build commit SHA shown in the nav drawer (see gitSha above). Empty by default so
+        // published (release) builds carry no SHA; the debug build type fills in the real value.
+        buildConfigField("String", "GIT_SHA", "\"\"")
     }
 
     val keystorePath = System.getenv("KEYSTORE_PATH")
@@ -80,6 +81,8 @@ android {
             buildConfigField("String", "DEV_SERVER_URL", "\"${localProps.getProperty("dev.serverUrl", "")}\"")
             buildConfigField("String", "DEV_USERNAME",   "\"${localProps.getProperty("dev.username", "")}\"")
             buildConfigField("String", "DEV_PASSWORD",   "\"${localProps.getProperty("dev.password", "")}\"")
+            // SHA is debug-only — release builds keep the empty default from defaultConfig.
+            buildConfigField("String", "GIT_SHA", "\"$gitSha\"")
         }
         release {
             if (keystorePath != null) {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -24,6 +24,17 @@ val localProps = Properties().apply {
     rootProject.file("local.properties").takeIf { it.exists() }?.inputStream()?.use { load(it) }
 }
 
+// Short git SHA of the build, surfaced in the nav drawer so a tester can confirm exactly which commit
+// an installed APK was built from. Appends "-dirty" when the working tree had uncommitted changes.
+// Uses providers.exec (configuration-cache friendly); falls back to "unknown" outside a git checkout.
+val gitSha: String = runCatching {
+    val sha = providers.exec { commandLine("git", "rev-parse", "--short", "HEAD") }
+        .standardOutput.asText.get().trim()
+    val dirty = providers.exec { commandLine("git", "status", "--porcelain") }
+        .standardOutput.asText.get().isNotBlank()
+    if (sha.isBlank()) "unknown" else if (dirty) "$sha-dirty" else sha
+}.getOrDefault("unknown")
+
 android {
     namespace = "com.riffle.app"
     compileSdk = 36
@@ -47,6 +58,9 @@ android {
         // Resolved Readium version, surfaced so ReadiumVersionPinTest can flag any future bump
         // (Readium 3.2.0+ regresses the readaloud highlight — see that test).
         buildConfigField("String", "READIUM_VERSION", "\"${libs.versions.readium.get()}\"")
+
+        // Build commit SHA shown in the nav drawer (see gitSha above).
+        buildConfigField("String", "GIT_SHA", "\"$gitSha\"")
     }
 
     val keystorePath = System.getenv("KEYSTORE_PATH")

--- a/app/src/main/kotlin/com/riffle/app/feature/navigation/NavigationDrawerComposable.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/navigation/NavigationDrawerComposable.kt
@@ -162,7 +162,7 @@ private fun DrawerSheetContent(
             textAlign = TextAlign.Center,
         )
         Text(
-            text = "Riffle v${BuildConfig.VERSION_NAME}",
+            text = "Riffle v${BuildConfig.VERSION_NAME} (${BuildConfig.GIT_SHA})",
             style = MaterialTheme.typography.labelSmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f),
             modifier = Modifier

--- a/app/src/main/kotlin/com/riffle/app/feature/navigation/NavigationDrawerComposable.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/navigation/NavigationDrawerComposable.kt
@@ -161,8 +161,9 @@ private fun DrawerSheetContent(
                 .padding(top = 8.dp, bottom = 2.dp),
             textAlign = TextAlign.Center,
         )
+        val sha = BuildConfig.GIT_SHA.takeIf { it.isNotEmpty() }
         Text(
-            text = "Riffle v${BuildConfig.VERSION_NAME} (${BuildConfig.GIT_SHA})",
+            text = "Riffle v${BuildConfig.VERSION_NAME}" + (sha?.let { " ($it)" } ?: ""),
             style = MaterialTheme.typography.labelSmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f),
             modifier = Modifier

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -1069,7 +1069,13 @@ private fun EpubNavigatorView(
     // which crashes the WebView renderer via a premature JS evaluation. See ADR 0015.
     val hasActiveDecorations = remember { mutableStateOf(false) }
 
-    LaunchedEffect(searchResults, currentSearchIndex) {
+    // Re-keys on reflowGeneration + pageLoadGeneration for the SAME reason the readaloud and annotations
+    // decoration effects do: Readium fixes a decoration's rects at applyDecorations time. Applied once
+    // (before the chapter's typography reflow settles, or before a freshly navigated chapter has loaded),
+    // the search highlight is positioned against the compact default layout; the text then reflows larger
+    // and shifts DOWN, but the rect stays put — so the highlight lands several lines too high (on the
+    // wrong word). Re-applying after the layout settles re-resolves the rects against the real pagination.
+    LaunchedEffect(searchResults, currentSearchIndex, reflowGeneration, pageLoadGeneration.value) {
         if (searchResults.isEmpty()) {
             if (!hasActiveDecorations.value) return@LaunchedEffect
             val fragment = fragmentRef.value as? DecorableNavigator ?: return@LaunchedEffect

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -1033,7 +1033,11 @@ private fun EpubNavigatorView(
                 currentHrefHolder[0]?.substringBefore('#')
             navigating = cover
             try {
-                ColumnSnap.goAndSnap(fragment, locator)
+                // Search locators carry an occurrence-specific progression but no #fragment, so go()
+                // lands on the right hit and we must round THAT page to the grid — not snap to column 0
+                // (the default), which would yank to the chapter top and lose the hit. Same route as the
+                // resume/peer background sync above.
+                ColumnSnap.goAndSnap(fragment, locator, landAtStartWhenNoTarget = false)
                 if (cover) delay(NAV_COVER_SETTLE_MS)
             } finally {
                 navigating = false

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -1069,12 +1069,16 @@ private fun EpubNavigatorView(
     // which crashes the WebView renderer via a premature JS evaluation. See ADR 0015.
     val hasActiveDecorations = remember { mutableStateOf(false) }
 
-    // Re-keys on reflowGeneration + pageLoadGeneration for the SAME reason the readaloud and annotations
-    // decoration effects do: Readium fixes a decoration's rects at applyDecorations time. Applied once
-    // (before the chapter's typography reflow settles, or before a freshly navigated chapter has loaded),
-    // the search highlight is positioned against the compact default layout; the text then reflows larger
-    // and shifts DOWN, but the rect stays put — so the highlight lands several lines too high (on the
-    // wrong word). Re-applying after the layout settles re-resolves the rects against the real pagination.
+    // Readium fixes a decoration's rects at applyDecorations time and never re-positions them. When a
+    // search result is navigated to, the landing page's layout is still settling as the decoration is
+    // applied (the page snaps to the column grid and the search top bar's inset resolves AFTER the first
+    // apply), so the box is placed against the pre-settle layout and the text then shifts out from under
+    // it — verified on device as a constant ~152px vertical offset onto the wrong word (same column, same
+    // width: a placement-timing bug, not a fuzzy mis-resolution). readaloud never shows this because it
+    // re-applies its decoration on every audio tick; search applies once per navigation. We therefore
+    // re-apply across a short settle window after each (re)apply so the boxes track the final layout. The
+    // re-applies are idempotent (same id + locator). Re-keys on reflow/pageLoad as well for rotation and
+    // formatting reflows, matching the readaloud and annotations decoration effects.
     LaunchedEffect(searchResults, currentSearchIndex, reflowGeneration, pageLoadGeneration.value) {
         if (searchResults.isEmpty()) {
             if (!hasActiveDecorations.value) return@LaunchedEffect
@@ -1099,10 +1103,19 @@ private fun EpubNavigatorView(
                     Decoration.Style.Highlight(tint = android.graphics.Color.parseColor("#FFFDE68A")),
             )
         }
+        // Apply immediately, then re-apply across the post-navigation settle window so Readium re-resolves
+        // the box positions against the final layout (the column snap + search-bar inset land after the
+        // first apply). Without this the active result's box stays where the page was mid-settle.
         withContext(Dispatchers.Main) {
             fragment.applyDecorations(decorations, group = "search")
         }
         hasActiveDecorations.value = true
+        for (settleDelayMs in longArrayOf(200L, 300L, 350L)) {
+            delay(settleDelayMs)
+            withContext(Dispatchers.Main) {
+                fragment.applyDecorations(decorations, group = "search")
+            }
+        }
     }
 
     // ---- Readaloud synced highlight --------------------------------------------------------

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -1092,7 +1092,8 @@ private fun EpubNavigatorView(
             hasActiveDecorations.value = false
             return@LaunchedEffect
         }
-        val fragment = fragmentRef.value as? DecorableNavigator ?: return@LaunchedEffect
+        val navFragment = fragmentRef.value ?: return@LaunchedEffect
+        val fragment = navFragment as? DecorableNavigator ?: return@LaunchedEffect
         val decorations = searchResults.mapIndexed { index, locator ->
             Decoration(
                 id = "search_$index",
@@ -1103,16 +1104,33 @@ private fun EpubNavigatorView(
                     Decoration.Style.Highlight(tint = android.graphics.Color.parseColor("#FFFDE68A")),
             )
         }
-        // Apply immediately, then re-apply across the post-navigation settle window so Readium re-resolves
-        // the box positions against the final layout (the column snap + search-bar inset land after the
-        // first apply). Without this the active result's box stays where the page was mid-settle.
+        // Apply immediately for the first paint, then re-apply ONCE the navigated page's layout has
+        // stopped moving. Readium fixes a decoration box's position at applyDecorations time and never
+        // re-positions it; after navigating to a result the page keeps shifting for up to ~1.5s (go() +
+        // the column-snap rAF loop + the async typography reflow), so the first apply lands the box against
+        // a pre-settle layout and the text then slides out from under it — the reported "the first result
+        // is highlighted, the next ones aren't" (a fixed re-apply window was too short for cross-page
+        // jumps). Poll scrollWidth+scrollLeft until they hold steady (a few reads) or a safety cap, then
+        // re-resolve positions with a final re-apply. readaloud avoids this by re-applying every audio tick.
         withContext(Dispatchers.Main) {
             fragment.applyDecorations(decorations, group = "search")
         }
         hasActiveDecorations.value = true
-        for (settleDelayMs in longArrayOf(200L, 300L, 350L)) {
+        // Re-resolve the box positions across the post-navigation settle window. Two things matter here:
+        //  1) Readium re-positions a decoration only when its set CHANGES — re-applying the identical list
+        //     is a no-op diff, so the box keeps its first (pre-settle) position. We therefore CLEAR then
+        //     re-apply (back to back on the main thread, no visible gap — the same trick the readaloud
+        //     group uses), which forces Readium to re-run its locator→range resolver against the current,
+        //     settled DOM.
+        //  2) The layout keeps moving after the first apply (go() + the column-snap rAF loop ~1.2s + the
+        //     async typography reflow), so we repeat the clear+re-apply on a SPACED schedule out to ~2.6s.
+        //     Spaced (not a tight poll): a 100ms loop floods the still-navigating WebView and can blank the
+        //     page (ADR 0015); a handful of spaced re-applies is as safe as the first one.
+        for (settleDelayMs in longArrayOf(400L, 600L, 700L, 900L)) {
             delay(settleDelayMs)
+            if (fragmentRef.value !== navFragment) break // navigated away / fragment recreated — newer effect owns it
             withContext(Dispatchers.Main) {
+                fragment.applyDecorations(emptyList(), group = "search")
                 fragment.applyDecorations(decorations, group = "search")
             }
         }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -1104,14 +1104,9 @@ private fun EpubNavigatorView(
                     Decoration.Style.Highlight(tint = android.graphics.Color.parseColor("#FFFDE68A")),
             )
         }
-        // Apply immediately for the first paint, then re-apply ONCE the navigated page's layout has
-        // stopped moving. Readium fixes a decoration box's position at applyDecorations time and never
-        // re-positions it; after navigating to a result the page keeps shifting for up to ~1.5s (go() +
-        // the column-snap rAF loop + the async typography reflow), so the first apply lands the box against
-        // a pre-settle layout and the text then slides out from under it — the reported "the first result
-        // is highlighted, the next ones aren't" (a fixed re-apply window was too short for cross-page
-        // jumps). Poll scrollWidth+scrollLeft until they hold steady (a few reads) or a safety cap, then
-        // re-resolve positions with a final re-apply. readaloud avoids this by re-applying every audio tick.
+        // Apply immediately for the first paint; the re-resolve loop below then tracks the page as it
+        // settles (see its comment for the why). "The first result is highlighted, the next ones aren't"
+        // was this exact bug on navigated results — the landing page is still moving when the box lands.
         withContext(Dispatchers.Main) {
             fragment.applyDecorations(decorations, group = "search")
         }

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ReaderWebViewScriptsTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ReaderWebViewScriptsTest.kt
@@ -53,4 +53,17 @@ class ReaderWebViewScriptsTest {
     fun `snapToTargetColumnJs preserves dotted ids verbatim`() {
         assertTrue(ColumnSnap.snapToTargetColumnJs("ftn.ch01fn01").contains("var id=\"ftn.ch01fn01\""))
     }
+
+    // A no-fragment jump that must PRESERVE where go() landed (search hits, resume/peer sync) passes
+    // landAtStartWhenNoTarget=false: with no DOM target it ROUNDS the current scroll to the column grid
+    // instead of snapping to column 0. This is the contract search navigation relies on so a search hit
+    // (located by its occurrence-specific progression via go()) lands flush on its own page rather than
+    // being yanked to the chapter top.
+    @Test
+    fun `snapToTargetColumnJs rounds the current scroll to the grid when no target and not landing at start`() {
+        val js = ColumnSnap.snapToTargetColumnJs(null, landAtStartWhenNoTarget = false)
+        assertTrue("id is null", js.contains("var id=null"))
+        assertTrue("rounds the current scroll to the grid", js.contains("se.scrollLeft=Math.round(se.scrollLeft/iw)*iw"))
+        assertTrue("does NOT yank to column 0", !js.contains("se.scrollLeft=0;"))
+    }
 }

--- a/docs/superpowers/specs/2026-06-09-search-highlight-into-view-design.md
+++ b/docs/superpowers/specs/2026-06-09-search-highlight-into-view-design.md
@@ -39,78 +39,77 @@ column.
   another read-along format may appear later.
 - Search must work fully on books with no readaloud.
 
-## Design
+## Why NOT text-anchoring (a flaw caught during implementation)
 
-### Dependency shape
+The first design draft proposed bringing the hit into view by **text-anchoring
+on `locator.text.highlight`**, the way readaloud follows a narrated sentence.
+This is wrong for search:
 
-Three independent highlight clients, one shared **format-neutral** primitive.
-No client imports another.
+- Readaloud's follow primitive (`autoFollowSnapJs`) locates text by walking the
+  DOM and matching the **first** occurrence of a 12-char prefix in document
+  order. That is unambiguous for a long, near-unique sentence.
+- A search term is short and **repeats** — the reporting screenshot shows
+  "watney", result **4 of 224**. Text-anchoring on "watney" would always snap to
+  the *first* "watney" in the chapter, never the 4th hit the user navigated to.
+- Readaloud is *forced* to text-anchor because Readium strips its sentence spans.
+  **Search is not**: Readium's `SearchService` gives each result locator an
+  **occurrence-specific `progression`** (position within the resource). Text-
+  anchoring would throw that precision away and regress to the wrong occurrence.
+
+So search must use its locator's precise position, not a text search.
+
+## Design (Option X — minimal, occurrence-correct)
+
+`go(locator)` already scrolls to the **correct occurrence** via the locator's
+progression. The only bug is the snap that runs afterwards.
+
+Search currently calls `ColumnSnap.goAndSnap(fragment, locator)` with the default
+`landAtStartWhenNoTarget = true`. Because search locators have no `#fragment`,
+the post-`go()` snap runs `scrollLeft = 0` and yanks to the chapter top, undoing
+`go()`'s correct within-chapter scroll.
+
+**The fix:** pass `landAtStartWhenNoTarget = false` — the *exact route* the
+resume/peer background-sync already uses (`EpubReaderScreen.kt:1070`). With no
+DOM target it rounds the page `go()` landed on to the column grid (flush — fixes
+the misalignment) instead of yanking to the chapter top (fixes the navigation).
+It is occurrence-correct because `go()` used the progression.
 
 ```
-        ┌─────────────────────────────────────────┐
-        │  ColumnSnap (existing, format-neutral)    │
-        │  • applyDecorations on an isolated group  │
-        │  • bringTextIntoView(text): keep-visible  │  ← the shared rule
-        └─────────────────────────────────────────┘
+        ┌──────────────────────────────────────────────┐
+        │  ColumnSnap.goAndSnap(locator, landAtStart…)   │  ← the shared nav route
+        └──────────────────────────────────────────────┘
               ▲              ▲                 ▲
-       readaloud         search          persisted highlights
-   (text from           (text from       (paint only, no follow)
-    Storyteller         Readium
-    bundle)             SearchService)
+            TOC          resume / peer       search
+        (=true,         (=false, round    (NOW =false, round
+         chapter top)    to grid)          to grid)
 ```
 
-The into-view primitive already lives in `ColumnSnap` and already takes a plain
-`String` — it knows nothing about Storyteller, media overlays, or the readaloud
-bundle. `ColumnSnap`'s own doc names it the single owner of column-snapping for
-"TOC / search / resume / read-aloud follow". Search becomes a **peer** of
-readaloud, sourcing its text from Readium's own search result
-(`locator.text.highlight`, which already carries before/highlight/after context).
-
-If a third read-along format appears, it is simply a third client of the same
-neutral primitive.
+This is the real consolidation: search joins the **existing shared `goAndSnap`
+nav route** alongside TOC/resume/peer. It introduces **no coupling to readaloud**
+and **no new primitive** — the opposite of the discarded text-anchor draft.
 
 ### Into-view behavior: keep-visible (Option B / "Option 1")
 
-It is enough that the matched word is **visible** on the page; it does not need
-to be centered.
-
-Reuse the existing readaloud follow primitive **unchanged**:
-
-- Match already on the current page → no movement, **except** the existing
-  drift-correction nudge that floors a visibly-off-grid page flush (a fix, not a
-  jump).
-- Match off the current page → floor `scrollLeft` to the matched word's column
-  so it lands visible.
-
-No new branch is added; multiple hits sharing a page do not produce disruptive
-jumps because the primitive already no-ops when the matched column is the current
-page.
+It is enough that the matched word is **visible** on the page; it need not be
+centered. `go(progression)` lands on the occurrence's page (Readium snaps to its
+own page boundary); the no-target round-to-grid then floors that to the column
+grid — a no-op when already flush, the Option-1 drift-correction when resting a
+few px off-grid. Hits already on the current page do not produce a disruptive
+jump.
 
 ### Changes
 
-1. **`ColumnSnap`** — neutralize the readaloud-specific naming (pure rename, no
-   behavior change):
-   - `followNarratedSentence(fragment, text)` → `bringTextIntoView(fragment, text)`
-   - internal `autoFollowSnapJs(text)` → `snapTextColumnJs(text)`
-   - Readaloud's call site (`EpubReaderScreen.kt:1251`) updates to the new name.
-   This makes "search calls a readaloud-named function" structurally impossible —
-   it is now a neutral primitive both call.
+1. **Search navigation** (`EpubReaderScreen` `searchNavigationEvents`,
+   `:1074–1087`): change the single call
+   `ColumnSnap.goAndSnap(fragment, locator)` →
+   `ColumnSnap.goAndSnap(fragment, locator, landAtStartWhenNoTarget = false)`.
+   Nothing else in the effect changes (cover detection, cover delay unchanged).
 
-2. **Search navigation** (`EpubReaderScreen` `searchNavigationEvents`, currently
-   `:1074–1087`) becomes the structural twin of readaloud's auto-follow effect:
-   - **Same chapter** (hit is in the loaded resource): skip `go()` entirely; call
-     `ColumnSnap.bringTextIntoView(fragment, locator.text.highlight)`. Avoids
-     `go(cssSelector)`'s flush-to-element sliver.
-   - **Different chapter** (cover jump): `go(locator)` to load the chapter, then a
-     follow effect keyed on `pageLoadGeneration` (and the current result) re-runs
-     `bringTextIntoView` once the new chapter paints — exactly how readaloud
-     re-snaps after a chapter load. The `scrollLeft = 0` chapter-top yank is gone.
-   - `bringTextIntoView` returning `"off"` (text not yet painted) is not an error:
-     the `pageLoadGeneration` re-key re-runs it after load, mirroring readaloud.
-
-3. **Decoration painting is unchanged.** `searchResults` →
+2. **Decoration painting is unchanged.** `searchResults` →
    `applyDecorations(group = "search")` (`EpubReaderScreen.kt:1113–1141`) already
    works; only the *into-view* step was broken.
+
+No rename, no new `ColumnSnap` primitive, no readaloud changes.
 
 ## Caveat (verify, don't assume)
 
@@ -120,16 +119,28 @@ the word even when the page is snapped flush — this change will not fix it. Th
 is treated as a separate follow-up. We will **not** claim the misalignment is
 fixed without observing it on a device.
 
+Cross-chapter reflow tracking is whatever resume/peer already get from this route
+(the no-target branch rounds the current scroll to the grid through the reflow-
+settle loop, not anchored to the occurrence). If cross-chapter hits drift after
+the new chapter's typography reflow, escalate to **Option Y**: a new `ColumnSnap`
+primitive that snaps to the hit's progression and tracks it through reflow.
+
 ## Testing
 
-- **JS unit tests** (harness script tests) for `snapTextColumnJs` already exist
-  from the readaloud follow; they now cover the shared primitive directly. Add a
-  search-flavored case: multiple hits on one page → no page move; a hit off-page
-  → snaps flush to the matched word's column.
-- **Device verification** (harness, paginated mode): search a frequent word, step
-  Next across pages and across a chapter boundary; confirm each hit lands visible
-  and the highlight sits on the word. This is where the rect-offset caveat above
-  is checked.
+- **Characterization unit test** (`ReaderWebViewScriptsTest`, pure JVM): the
+  existing test covers `snapToTargetColumnJs(null)` (default `true` → `scrollLeft
+  = 0`). Add the `landAtStartWhenNoTarget = false` no-target case search now
+  depends on: it rounds the current scroll to the grid
+  (`Math.round(se.scrollLeft/iw)*iw`) rather than snapping to column 0. (This
+  passes against existing production code — the `false` branch already exists; it
+  locks the contract search now relies on, it is not red-green TDD, because
+  Option X adds no new production logic, only routes search through an existing
+  tested path.)
+- **Device verification** (harness, paginated mode): search a frequent word
+  ("watney"), step Next across pages and across a chapter boundary; confirm each
+  hit lands on its own page (not the first occurrence, not the chapter top),
+  visible, with the highlight on the word. This is where the rect-offset caveat
+  above is checked.
 
 ## Out of scope
 

--- a/docs/superpowers/specs/2026-06-09-search-highlight-into-view-design.md
+++ b/docs/superpowers/specs/2026-06-09-search-highlight-into-view-design.md
@@ -1,0 +1,140 @@
+# Search highlight: reliable navigation & alignment
+
+**Date:** 2026-06-09
+**Status:** Approved — ready for implementation plan
+
+## Problem
+
+In-book search highlights are unreliable in two ways:
+
+1. **Navigation doesn't land on the match.** Stepping Next/Prev (or the initial
+   jump to result 1) often does not bring the reader to the page that holds the
+   highlight.
+2. **Misalignment.** When a hit is shown, the highlighted word frequently sits
+   at a ragged page offset rather than cleanly on the page.
+
+Readaloud highlights never have these problems: they always bring the narrated
+sentence into view and land it flush on the column grid.
+
+## Root cause
+
+Search navigation calls `ColumnSnap.goAndSnap(fragment, locator)` with the
+default `landAtStartWhenNoTarget = true` (`EpubReaderScreen.kt:1081`). Readium's
+`SearchService` locators carry a `cssSelector` + text quote but **no href
+`#fragment`**, so `navTargetFragmentId` returns null and the post-`go()` snap
+runs `scrollLeft = 0` — yanking the reader to the **chapter top** and undoing
+the within-chapter scroll `go()` had performed. The background position-sync
+path already works around this by passing `landAtStartWhenNoTarget = false`
+(`EpubReaderScreen.kt:1070`); search was never given the equivalent treatment.
+
+The misalignment is the same defect seen visually: with the page resting at the
+chapter top (or otherwise off the column grid) the highlighted word lands at an
+arbitrary offset — half-clipped at a ragged page edge — instead of flush in a
+column.
+
+## Constraints (from the requester)
+
+- **No dependency from search to readaloud.** They must not be coupled. Not
+  every book has readaloud; readaloud is a proprietary (Storyteller) format, and
+  another read-along format may appear later.
+- Search must work fully on books with no readaloud.
+
+## Design
+
+### Dependency shape
+
+Three independent highlight clients, one shared **format-neutral** primitive.
+No client imports another.
+
+```
+        ┌─────────────────────────────────────────┐
+        │  ColumnSnap (existing, format-neutral)    │
+        │  • applyDecorations on an isolated group  │
+        │  • bringTextIntoView(text): keep-visible  │  ← the shared rule
+        └─────────────────────────────────────────┘
+              ▲              ▲                 ▲
+       readaloud         search          persisted highlights
+   (text from           (text from       (paint only, no follow)
+    Storyteller         Readium
+    bundle)             SearchService)
+```
+
+The into-view primitive already lives in `ColumnSnap` and already takes a plain
+`String` — it knows nothing about Storyteller, media overlays, or the readaloud
+bundle. `ColumnSnap`'s own doc names it the single owner of column-snapping for
+"TOC / search / resume / read-aloud follow". Search becomes a **peer** of
+readaloud, sourcing its text from Readium's own search result
+(`locator.text.highlight`, which already carries before/highlight/after context).
+
+If a third read-along format appears, it is simply a third client of the same
+neutral primitive.
+
+### Into-view behavior: keep-visible (Option B / "Option 1")
+
+It is enough that the matched word is **visible** on the page; it does not need
+to be centered.
+
+Reuse the existing readaloud follow primitive **unchanged**:
+
+- Match already on the current page → no movement, **except** the existing
+  drift-correction nudge that floors a visibly-off-grid page flush (a fix, not a
+  jump).
+- Match off the current page → floor `scrollLeft` to the matched word's column
+  so it lands visible.
+
+No new branch is added; multiple hits sharing a page do not produce disruptive
+jumps because the primitive already no-ops when the matched column is the current
+page.
+
+### Changes
+
+1. **`ColumnSnap`** — neutralize the readaloud-specific naming (pure rename, no
+   behavior change):
+   - `followNarratedSentence(fragment, text)` → `bringTextIntoView(fragment, text)`
+   - internal `autoFollowSnapJs(text)` → `snapTextColumnJs(text)`
+   - Readaloud's call site (`EpubReaderScreen.kt:1251`) updates to the new name.
+   This makes "search calls a readaloud-named function" structurally impossible —
+   it is now a neutral primitive both call.
+
+2. **Search navigation** (`EpubReaderScreen` `searchNavigationEvents`, currently
+   `:1074–1087`) becomes the structural twin of readaloud's auto-follow effect:
+   - **Same chapter** (hit is in the loaded resource): skip `go()` entirely; call
+     `ColumnSnap.bringTextIntoView(fragment, locator.text.highlight)`. Avoids
+     `go(cssSelector)`'s flush-to-element sliver.
+   - **Different chapter** (cover jump): `go(locator)` to load the chapter, then a
+     follow effect keyed on `pageLoadGeneration` (and the current result) re-runs
+     `bringTextIntoView` once the new chapter paints — exactly how readaloud
+     re-snaps after a chapter load. The `scrollLeft = 0` chapter-top yank is gone.
+   - `bringTextIntoView` returning `"off"` (text not yet painted) is not an error:
+     the `pageLoadGeneration` re-key re-runs it after load, mirroring readaloud.
+
+3. **Decoration painting is unchanged.** `searchResults` →
+   `applyDecorations(group = "search")` (`EpubReaderScreen.kt:1113–1141`) already
+   works; only the *into-view* step was broken.
+
+## Caveat (verify, don't assume)
+
+The expected drift is the **page**, not the decoration rect. If a residual
+Readium decoration-positioning bug remains — the highlight box drawn offset from
+the word even when the page is snapped flush — this change will not fix it. That
+is treated as a separate follow-up. We will **not** claim the misalignment is
+fixed without observing it on a device.
+
+## Testing
+
+- **JS unit tests** (harness script tests) for `snapTextColumnJs` already exist
+  from the readaloud follow; they now cover the shared primitive directly. Add a
+  search-flavored case: multiple hits on one page → no page move; a hit off-page
+  → snaps flush to the matched word's column.
+- **Device verification** (harness, paginated mode): search a frequent word, step
+  Next across pages and across a chapter boundary; confirm each hit lands visible
+  and the highlight sits on the word. This is where the rect-offset caveat above
+  is checked.
+
+## Out of scope
+
+- Any change to readaloud's text source, the Storyteller bundle, or media-overlay
+  handling.
+- Persisted-highlight (annotations) rendering.
+- Scroll/vertical-mode behavior beyond what the shared primitive already does
+  (it centers in scroll mode; search inherits that unchanged).


### PR DESCRIPTION
## What

Makes in-book **search highlights reliably land on the matched word** and navigate to the right page, and adds a debug-only build-SHA marker to the nav drawer.

### Search highlight nav + alignment
- **Navigation lands on the hit's page, flush to the column grid.** Search locators carry an occurrence-specific `progression` but no `#fragment`, so `go()` lands on the correct hit; the snap must round *that* page to the grid (`landAtStartWhenNoTarget = false`) instead of snapping to column 0, which previously yanked to the chapter top and lost the hit.
- **Highlight aligns to the word, not a stale pre-reflow position.** Readium fixes a decoration's rects at `applyDecorations` time and never re-positions them. On a *navigated* result the landing page is still settling (`go()` + the column-snap rAF loop ~1.2s + async typography reflow), so the box was placed against a pre-settle layout and the text slid out from under it — a constant ~152px vertical offset onto the wrong word (verified on device). This is the reported "the first result is highlighted, the next ones aren't" (the first result is usually on the already-loaded page, so it was never broken).
- **Fix:** clear-then-re-apply the decoration set on a spaced settle schedule (~400/600/700/900ms). Re-applying the *identical* list is a no-op in Readium's diff, so we `applyDecorations(emptyList())` then re-apply back-to-back (no visible gap — the same trick the readaloud group uses), forcing Readium to re-resolve the locator→range against the settled DOM. Spaced, not a tight poll: a 100ms loop floods the still-navigating WebView and can blank the page (ADR 0015).

### Build SHA in nav drawer (debug-only)
- Surfaces the short git SHA (`-dirty` when the tree is dirty) in the drawer version line so a tester can confirm exactly which commit an installed APK was built from.
- Gated to **debug builds only** — `GIT_SHA` defaults to empty in `defaultConfig` and is filled in only by the `debug` build type, so release/published builds carry no SHA. The drawer guards the parenthetical so an empty SHA renders nothing.
- Local `versionName` fallback changed `0.1.0` → `0.0.0-dev` to read clearly as a non-release build.

## Testing
- `./gradlew test lint` — green.
- `make harness-test` (phone) — 171 tests, 0 failed.
- `make harness-test-tablet` — 5 tests, green.
- Search highlight fix verified on a windowed AVD against the real Martian EPUB over ABS: deep navigated results (11/224, 23/224) measured via WebView DevTools land pixel-exact on the word (box-to-word vertical delta = 0px, vs ~152px before).

## Notes
- Adds a JVM characterization test for `snapToTargetColumnJs(null, landAtStartWhenNoTarget=false)` (rounds the current scroll to the grid rather than snapping to column 0).
- The headless instrumented harness cannot reproduce the navigated-result case (Readium page-navigation animation stalls headless), so the fix was verified on a real windowed AVD; a design spec is included under `docs/`.
