### PR TITLE
feat(readaloud): mini-player skip controls (rewind 15s / forward 30s, prev/next chapter)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,7 +135,7 @@ jobs:
   # Instrumented Room tests (migrations + DAOs) need an emulator, so they run here on a
   # hardware-accelerated AVD rather than in the JVM jobs above.
   connected-test:
-    name: Connected Tests (core:database)
+    name: Database tests (core:database)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/app/src/androidTest/kotlin/com/riffle/app/feature/reader/readaloud/ReadaloudMiniPlayerTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/reader/readaloud/ReadaloudMiniPlayerTest.kt
@@ -1,0 +1,114 @@
+package com.riffle.app.feature.reader.readaloud
+
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class ReadaloudMiniPlayerTest {
+
+    @get:Rule
+    val rule = createAndroidComposeRule<ComponentActivity>()
+
+    private fun setPlayer(
+        canPreviousChapter: Boolean = true,
+        canNextChapter: Boolean = true,
+        onRewind: () -> Unit = {},
+        onForward: () -> Unit = {},
+        onPreviousChapter: () -> Unit = {},
+        onNextChapter: () -> Unit = {},
+    ) {
+        rule.setContent {
+            ReadaloudMiniPlayer(
+                isPlaying = false,
+                speed = 1f,
+                offlineMessage = false,
+                downloadProgress = null,
+                canPreviousChapter = canPreviousChapter,
+                canNextChapter = canNextChapter,
+                containerColor = Color.LightGray,
+                contentColor = Color.Black,
+                onPlayPause = {},
+                onCycleSpeed = {},
+                onRewind = onRewind,
+                onForward = onForward,
+                onPreviousChapter = onPreviousChapter,
+                onNextChapter = onNextChapter,
+                onClose = {},
+                onExpand = {},
+            )
+        }
+    }
+
+    @Test
+    fun skipButtons_areDisplayedInThePlayableState() {
+        setPlayer()
+        rule.onNodeWithTag("readaloud_rewind").assertIsDisplayed()
+        rule.onNodeWithTag("readaloud_prev_chapter").assertIsDisplayed()
+        rule.onNodeWithTag("readaloud_next_chapter").assertIsDisplayed()
+        rule.onNodeWithTag("readaloud_forward").assertIsDisplayed()
+    }
+
+    @Test
+    fun skipButtons_invokeTheirCallbacks() {
+        var rewinds = 0
+        var forwards = 0
+        var prevs = 0
+        var nexts = 0
+        setPlayer(
+            onRewind = { rewinds++ },
+            onForward = { forwards++ },
+            onPreviousChapter = { prevs++ },
+            onNextChapter = { nexts++ },
+        )
+        rule.onNodeWithTag("readaloud_rewind").performClick()
+        rule.onNodeWithTag("readaloud_forward").performClick()
+        rule.onNodeWithTag("readaloud_prev_chapter").performClick()
+        rule.onNodeWithTag("readaloud_next_chapter").performClick()
+        assertEquals(1, rewinds)
+        assertEquals(1, forwards)
+        assertEquals(1, prevs)
+        assertEquals(1, nexts)
+    }
+
+    @Test
+    fun nextChapter_isDisabledAtTheLastChapter() {
+        setPlayer(canNextChapter = false)
+        rule.onNodeWithTag("readaloud_next_chapter").assertIsNotEnabled()
+    }
+
+    @Test
+    fun skipButtons_areAbsentWhileOffline() {
+        rule.setContent {
+            ReadaloudMiniPlayer(
+                isPlaying = false,
+                speed = 1f,
+                offlineMessage = true,
+                downloadProgress = null,
+                canPreviousChapter = true,
+                canNextChapter = true,
+                containerColor = Color.LightGray,
+                contentColor = Color.Black,
+                onPlayPause = {},
+                onCycleSpeed = {},
+                onRewind = {},
+                onForward = {},
+                onPreviousChapter = {},
+                onNextChapter = {},
+                onClose = {},
+                onExpand = {},
+            )
+        }
+        rule.onNodeWithTag("readaloud_rewind").assertDoesNotExist()
+        rule.onNodeWithTag("readaloud_next_chapter").assertDoesNotExist()
+    }
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -366,6 +366,9 @@ fun EpubReaderScreen(
                         speed = playbackState.speed,
                         offlineMessage = readaloudOfflineMessage,
                         downloadProgress = downloadProgress,
+                        canPreviousChapter = playbackState.currentChapterIndex > 0,
+                        canNextChapter = playbackState.currentChapterIndex >= 0 &&
+                            playbackState.currentChapterIndex < playbackState.chapterCount - 1,
                         containerColor = readerPalette.background.copy(alpha = 0.65f),
                         contentColor = readerPalette.foreground,
                         onPlayPause = viewModel::togglePlayPause,
@@ -375,6 +378,10 @@ fun EpubReaderScreen(
                             val idx = speeds.indexOfFirst { kotlin.math.abs(it - playbackState.speed) < 0.001f }
                             viewModel.setSpeed(if (idx < 0) 1f else speeds[(idx + 1) % speeds.size])
                         },
+                        onRewind = viewModel::rewind,
+                        onForward = viewModel::forward,
+                        onPreviousChapter = viewModel::previousChapter,
+                        onNextChapter = viewModel::nextChapter,
                         onClose = viewModel::closeReadaloud,
                         onExpand = viewModel::expandPlayer,
                     )

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -238,6 +238,8 @@ fun EpubReaderScreen(
     val downloadPromptBytes by viewModel.downloadPromptBytes.collectAsState()
     val readaloudOfflineMessage by viewModel.readaloudOfflineMessage.collectAsState()
     val downloadProgress by viewModel.downloadProgress.collectAsState()
+    val railSegments by viewModel.railSegments.collectAsState()
+    val activeRailSegmentIndex by viewModel.activeRailSegmentIndex.collectAsState()
 
     // The readaloud player floats over the bottom of the page: it does NOT reserve space or
     // re-paginate, so the page stays static when the player opens. Its translucent backdrop lets the
@@ -295,7 +297,7 @@ fun EpubReaderScreen(
                         pageTopProbeRequests = viewModel.pageTopProbeRequests,
                         onPageTopResolved = viewModel::onPageTopResolved,
                         onPlayFromHere = viewModel::playFromHere,
-                        onNarratedSentenceFollowed = viewModel::onNarratedSentenceFollowed,
+                        chapterPlayRequests = viewModel.chapterPlayRequests,
                         readaloudAvailable = readaloudAvailable,
                         annotationsAvailable = annotationsAvailable,
                         highlightRenders = highlightRenders,
@@ -367,9 +369,8 @@ fun EpubReaderScreen(
                         speed = playbackState.speed,
                         offlineMessage = readaloudOfflineMessage,
                         downloadProgress = downloadProgress,
-                        canPreviousChapter = playbackState.currentChapterIndex > 0,
-                        canNextChapter = playbackState.currentChapterIndex >= 0 &&
-                            playbackState.currentChapterIndex < playbackState.chapterCount - 1,
+                        canPreviousChapter = activeRailSegmentIndex > 0,
+                        canNextChapter = activeRailSegmentIndex < railSegments.size - 1,
                         containerColor = readerPalette.background.copy(alpha = 0.65f),
                         contentColor = readerPalette.foreground,
                         onPlayPause = viewModel::togglePlayPause,
@@ -733,7 +734,7 @@ private fun EpubNavigatorView(
     pageTopProbeRequests: Flow<String>,
     onPageTopResolved: (href: String, fragmentId: String?) -> Unit,
     onPlayFromHere: (fragmentRef: String) -> Unit,
-    onNarratedSentenceFollowed: () -> Unit,
+    chapterPlayRequests: Flow<Link>,
     readaloudAvailable: Boolean,
     annotationsAvailable: Boolean,
     highlightRenders: List<EpubReaderViewModel.HighlightRender>,
@@ -755,6 +756,10 @@ private fun EpubNavigatorView(
     // Non-State holder for current href — written by the locator coroutine, read inside
     // navigation callbacks. Using a plain array avoids triggering recomposition on scroll.
     val currentHrefHolder = remember { arrayOf<String?>(null) }
+    // While a readaloud chapter jump navigates the reader, the outgoing (paused) narration's
+    // auto-follow must not yank the page back to the old sentence on the new chapter's page-load.
+    // Held true across the jump's navigate→probe→play, then cleared. Plain array to avoid recomposition.
+    val suppressAutoFollowHolder = remember { arrayOf(false) }
     // Tracks the isDoublePage value the current fragment was created with; null = no fragment.
     // Plain array (not MutableState) to avoid triggering recomposition.
     val fragmentDoublePageHolder = remember { arrayOf<Boolean?>(null) }
@@ -1073,6 +1078,62 @@ private fun EpubNavigatorView(
         }
     }
 
+    // Readaloud chapter jump (prev/next chapter buttons): navigate the reader to the destination
+    // chapter, wait for it to settle, then resolve that chapter's first narrated sentence and start
+    // narration there — the same page-top probe the reopen path uses. Driven by the reader's real TOC
+    // chapters (not the Storyteller bundle's clip hrefs, which are misaligned with the rendered EPUB).
+    LaunchedEffect(chapterPlayRequests) {
+        chapterPlayRequests.collect { link ->
+            val fragment = fragmentRef.value ?: return@collect
+            // Suppress auto-follow so the outgoing (paused) sentence doesn't yank the page back when the
+            // new chapter loads.
+            suppressAutoFollowHolder[0] = true
+            try {
+                val preHref = currentHrefHolder[0]
+                ColumnSnap.goAndSnap(fragment, link)
+                // Wait for the new resource to actually load (currentHrefHolder is set by onPositionChanged)
+                // before probing — go() returns before the new DOM is ready.
+                var waited = 0
+                while (currentHrefHolder[0] == preHref && waited < 2000) { delay(50); waited += 50 }
+                delay(150)
+                // Resolve the chapter's first narrated sentence against the resource the reader LANDED on
+                // (the rendered ABS href — NOT the TOC link href, which the SMIL clips can't be matched to,
+                // ADR 0026). The TOC chapter often lands on an un-narrated heading page (…_split_000) with
+                // no sentence; in that case page forward to the chapter's body and probe again.
+                var fragmentId: String? = null
+                var href = currentHrefHolder[0] ?: link.href.toString()
+                val ordered = currentSentenceQuotes.entries.toList()
+                for (attempt in 0 until 3) {
+                    href = currentHrefHolder[0] ?: href
+                    // Poll until this just-loaded resource actually has a narrated sentence in its text
+                    // (the DOM lags the navigation), so an empty too-early probe can't trigger a spurious
+                    // goForward that overshoots the chapter's real first sentence.
+                    var probe = ""
+                    var w = 0
+                    while (w < 1500 && ordered.isNotEmpty()) {
+                        probe = fragment.evaluateJavascript(
+                            firstSentenceInDocumentJs(ordered.map { it.value.highlight }),
+                        )?.trim('"').orEmpty()
+                        if (probe.isNotEmpty()) break
+                        delay(100); w += 100
+                    }
+                    fragmentId = probe.toIntOrNull()?.let { ordered.getOrNull(it)?.key }
+                    // Found the chapter's first narrated sentence — stop. Otherwise this resource is a
+                    // pure heading page (no narration); advance to the chapter body and probe again.
+                    if (fragmentId != null) break
+                    fragment.goForward(animated = false)
+                    delay(300)
+                }
+                onPageTopResolved(href, fragmentId)
+                // Let the seek land and activeFragmentRef settle on the new chapter before re-enabling
+                // follow, so it resumes tracking the NEW sentence rather than the stale outgoing one.
+                delay(400)
+            } finally {
+                suppressAutoFollowHolder[0] = false
+            }
+        }
+    }
+
     // Tracks whether we have live search decorations painted in the WebView.
     // Prevents calling applyDecorations on initial composition (before WebView content loads),
     // which crashes the WebView renderer via a premature JS evaluation. See ADR 0015.
@@ -1235,6 +1296,7 @@ private fun EpubNavigatorView(
     // so the narrated sentence is re-centred after those relayouts. The player floats over the page and
     // no longer reflows it, so opening it doesn't move the narrated sentence's column.
     LaunchedEffect(activeFragmentRef, sentenceQuotes, reflowGeneration, pageLoadGeneration.value) {
+        if (suppressAutoFollowHolder[0]) return@LaunchedEffect
         val ref = activeFragmentRef ?: return@LaunchedEffect
         val fragment = fragmentRef.value ?: return@LaunchedEffect
         if (ref.indexOf('#') < 0) return@LaunchedEffect
@@ -1247,13 +1309,7 @@ private fun EpubNavigatorView(
         // column itself in paginated mode; "off" comes back only when the text isn't on this resource
         // (another chapter), where we fall back to a text-anchored go() to load it.
         val where = ColumnSnap.followNarratedSentence(fragment, quote.highlight)
-        if (where != "off") {
-            // The narrated sentence is on screen now. If a chapter jump paused playback to wait for
-            // this chapter's (slow) load, resume here — so playback resumes on the chapter's first
-            // sentence instead of having run on past it during the load.
-            onNarratedSentenceFollowed()
-            return@LaunchedEffect
-        }
+        if (where != "off") return@LaunchedEffect
         fragmentLocator(ref, quote)?.let { fragment.go(it, animated = false) }
     }
 

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -295,6 +295,7 @@ fun EpubReaderScreen(
                         pageTopProbeRequests = viewModel.pageTopProbeRequests,
                         onPageTopResolved = viewModel::onPageTopResolved,
                         onPlayFromHere = viewModel::playFromHere,
+                        onNarratedSentenceFollowed = viewModel::onNarratedSentenceFollowed,
                         readaloudAvailable = readaloudAvailable,
                         annotationsAvailable = annotationsAvailable,
                         highlightRenders = highlightRenders,
@@ -732,6 +733,7 @@ private fun EpubNavigatorView(
     pageTopProbeRequests: Flow<String>,
     onPageTopResolved: (href: String, fragmentId: String?) -> Unit,
     onPlayFromHere: (fragmentRef: String) -> Unit,
+    onNarratedSentenceFollowed: () -> Unit,
     readaloudAvailable: Boolean,
     annotationsAvailable: Boolean,
     highlightRenders: List<EpubReaderViewModel.HighlightRender>,
@@ -1245,7 +1247,13 @@ private fun EpubNavigatorView(
         // column itself in paginated mode; "off" comes back only when the text isn't on this resource
         // (another chapter), where we fall back to a text-anchored go() to load it.
         val where = ColumnSnap.followNarratedSentence(fragment, quote.highlight)
-        if (where != "off") return@LaunchedEffect
+        if (where != "off") {
+            // The narrated sentence is on screen now. If a chapter jump paused playback to wait for
+            // this chapter's (slow) load, resume here — so playback resumes on the chapter's first
+            // sentence instead of having run on past it during the load.
+            onNarratedSentenceFollowed()
+            return@LaunchedEffect
+        }
         fragmentLocator(ref, quote)?.let { fragment.go(it, animated = false) }
     }
 

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -238,8 +238,6 @@ fun EpubReaderScreen(
     val downloadPromptBytes by viewModel.downloadPromptBytes.collectAsState()
     val readaloudOfflineMessage by viewModel.readaloudOfflineMessage.collectAsState()
     val downloadProgress by viewModel.downloadProgress.collectAsState()
-    val railSegments by viewModel.railSegments.collectAsState()
-    val activeRailSegmentIndex by viewModel.activeRailSegmentIndex.collectAsState()
 
     // The readaloud player floats over the bottom of the page: it does NOT reserve space or
     // re-paginate, so the page stays static when the player opens. Its translucent backdrop lets the
@@ -297,7 +295,6 @@ fun EpubReaderScreen(
                         pageTopProbeRequests = viewModel.pageTopProbeRequests,
                         onPageTopResolved = viewModel::onPageTopResolved,
                         onPlayFromHere = viewModel::playFromHere,
-                        chapterPlayRequests = viewModel.chapterPlayRequests,
                         readaloudAvailable = readaloudAvailable,
                         annotationsAvailable = annotationsAvailable,
                         highlightRenders = highlightRenders,
@@ -369,8 +366,9 @@ fun EpubReaderScreen(
                         speed = playbackState.speed,
                         offlineMessage = readaloudOfflineMessage,
                         downloadProgress = downloadProgress,
-                        canPreviousChapter = activeRailSegmentIndex > 0,
-                        canNextChapter = activeRailSegmentIndex < railSegments.size - 1,
+                        canPreviousChapter = playbackState.currentChapterIndex > 0,
+                        canNextChapter = playbackState.currentChapterIndex >= 0 &&
+                            playbackState.currentChapterIndex < playbackState.chapterCount - 1,
                         containerColor = readerPalette.background.copy(alpha = 0.65f),
                         contentColor = readerPalette.foreground,
                         onPlayPause = viewModel::togglePlayPause,
@@ -734,7 +732,6 @@ private fun EpubNavigatorView(
     pageTopProbeRequests: Flow<String>,
     onPageTopResolved: (href: String, fragmentId: String?) -> Unit,
     onPlayFromHere: (fragmentRef: String) -> Unit,
-    chapterPlayRequests: Flow<Link>,
     readaloudAvailable: Boolean,
     annotationsAvailable: Boolean,
     highlightRenders: List<EpubReaderViewModel.HighlightRender>,
@@ -756,10 +753,6 @@ private fun EpubNavigatorView(
     // Non-State holder for current href — written by the locator coroutine, read inside
     // navigation callbacks. Using a plain array avoids triggering recomposition on scroll.
     val currentHrefHolder = remember { arrayOf<String?>(null) }
-    // While a readaloud chapter jump navigates the reader, the outgoing (paused) narration's
-    // auto-follow must not yank the page back to the old sentence on the new chapter's page-load.
-    // Held true across the jump's navigate→probe→play, then cleared. Plain array to avoid recomposition.
-    val suppressAutoFollowHolder = remember { arrayOf(false) }
     // Tracks the isDoublePage value the current fragment was created with; null = no fragment.
     // Plain array (not MutableState) to avoid triggering recomposition.
     val fragmentDoublePageHolder = remember { arrayOf<Boolean?>(null) }
@@ -1078,62 +1071,6 @@ private fun EpubNavigatorView(
         }
     }
 
-    // Readaloud chapter jump (prev/next chapter buttons): navigate the reader to the destination
-    // chapter, wait for it to settle, then resolve that chapter's first narrated sentence and start
-    // narration there — the same page-top probe the reopen path uses. Driven by the reader's real TOC
-    // chapters (not the Storyteller bundle's clip hrefs, which are misaligned with the rendered EPUB).
-    LaunchedEffect(chapterPlayRequests) {
-        chapterPlayRequests.collect { link ->
-            val fragment = fragmentRef.value ?: return@collect
-            // Suppress auto-follow so the outgoing (paused) sentence doesn't yank the page back when the
-            // new chapter loads.
-            suppressAutoFollowHolder[0] = true
-            try {
-                val preHref = currentHrefHolder[0]
-                ColumnSnap.goAndSnap(fragment, link)
-                // Wait for the new resource to actually load (currentHrefHolder is set by onPositionChanged)
-                // before probing — go() returns before the new DOM is ready.
-                var waited = 0
-                while (currentHrefHolder[0] == preHref && waited < 2000) { delay(50); waited += 50 }
-                delay(150)
-                // Resolve the chapter's first narrated sentence against the resource the reader LANDED on
-                // (the rendered ABS href — NOT the TOC link href, which the SMIL clips can't be matched to,
-                // ADR 0026). The TOC chapter often lands on an un-narrated heading page (…_split_000) with
-                // no sentence; in that case page forward to the chapter's body and probe again.
-                var fragmentId: String? = null
-                var href = currentHrefHolder[0] ?: link.href.toString()
-                val ordered = currentSentenceQuotes.entries.toList()
-                for (attempt in 0 until 3) {
-                    href = currentHrefHolder[0] ?: href
-                    // Poll until this just-loaded resource actually has a narrated sentence in its text
-                    // (the DOM lags the navigation), so an empty too-early probe can't trigger a spurious
-                    // goForward that overshoots the chapter's real first sentence.
-                    var probe = ""
-                    var w = 0
-                    while (w < 1500 && ordered.isNotEmpty()) {
-                        probe = fragment.evaluateJavascript(
-                            firstSentenceInDocumentJs(ordered.map { it.value.highlight }),
-                        )?.trim('"').orEmpty()
-                        if (probe.isNotEmpty()) break
-                        delay(100); w += 100
-                    }
-                    fragmentId = probe.toIntOrNull()?.let { ordered.getOrNull(it)?.key }
-                    // Found the chapter's first narrated sentence — stop. Otherwise this resource is a
-                    // pure heading page (no narration); advance to the chapter body and probe again.
-                    if (fragmentId != null) break
-                    fragment.goForward(animated = false)
-                    delay(300)
-                }
-                onPageTopResolved(href, fragmentId)
-                // Let the seek land and activeFragmentRef settle on the new chapter before re-enabling
-                // follow, so it resumes tracking the NEW sentence rather than the stale outgoing one.
-                delay(400)
-            } finally {
-                suppressAutoFollowHolder[0] = false
-            }
-        }
-    }
-
     // Tracks whether we have live search decorations painted in the WebView.
     // Prevents calling applyDecorations on initial composition (before WebView content loads),
     // which crashes the WebView renderer via a premature JS evaluation. See ADR 0015.
@@ -1296,7 +1233,6 @@ private fun EpubNavigatorView(
     // so the narrated sentence is re-centred after those relayouts. The player floats over the page and
     // no longer reflows it, so opening it doesn't move the narrated sentence's column.
     LaunchedEffect(activeFragmentRef, sentenceQuotes, reflowGeneration, pageLoadGeneration.value) {
-        if (suppressAutoFollowHolder[0]) return@LaunchedEffect
         val ref = activeFragmentRef ?: return@LaunchedEffect
         val fragment = fragmentRef.value ?: return@LaunchedEffect
         if (ref.indexOf('#') < 0) return@LaunchedEffect

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -1125,34 +1125,9 @@ class EpubReaderViewModel @Inject constructor(
 
     fun forward() = playerCoordinator.forward()
 
-    fun previousChapter() = jumpChapter(-1)
+    fun previousChapter() = playerCoordinator.previousChapter()
 
-    fun nextChapter() = jumpChapter(+1)
-
-    private val _chapterPlayChannel = Channel<Link>(Channel.CONFLATED)
-    /**
-     * A readaloud chapter jump: the screen navigates the reader to this chapter's link, then resolves
-     * the chapter's first narrated sentence on the freshly-loaded page and starts narration there via
-     * [onPageTopResolved]. Chapters are the reader's real TOC chapters ([railSegments]) — NOT the
-     * Storyteller bundle's per-fragment clip hrefs, which are misaligned with the rendered ABS EPUB
-     * and would land the jump a sentence or two into the chapter.
-     */
-    val chapterPlayRequests: Flow<Link> = _chapterPlayChannel.receiveAsFlow()
-
-    /**
-     * Jumps [delta] chapters from the active rail segment and starts narration at the destination
-     * chapter's first sentence. Pauses first so the outgoing audio (and the highlight auto-follow it
-     * drives) can't fight the reader navigation; the screen resumes playback once the new chapter's
-     * first sentence is located (see [chapterPlayRequests] → [onPageTopResolved]).
-     */
-    private fun jumpChapter(delta: Int) {
-        val segments = railSegments.value
-        val target = segments.getOrNull(activeRailSegmentIndex.value + delta) ?: return
-        val pub = (state.value as? ReaderState.Ready)?.publication ?: return
-        val link = pub.tableOfContents.findLinkByHref(target.href) ?: return
-        playerCoordinator.pause()
-        _chapterPlayChannel.trySend(link)
-    }
+    fun nextChapter() = playerCoordinator.nextChapter()
 
     /**
      * Play tapped. If a local bundle is present we prepare (if needed) and play. Otherwise: when

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -1121,6 +1121,14 @@ class EpubReaderViewModel @Inject constructor(
 
     fun setSpeed(speed: Float) = playerCoordinator.setSpeed(speed)
 
+    fun rewind() = playerCoordinator.rewind()
+
+    fun forward() = playerCoordinator.forward()
+
+    fun previousChapter() = playerCoordinator.previousChapter()
+
+    fun nextChapter() = playerCoordinator.nextChapter()
+
     /**
      * Play tapped. If a local bundle is present we prepare (if needed) and play. Otherwise: when
      * online, probe the download size and surface the confirm dialog; when offline, surface the

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -1125,9 +1125,39 @@ class EpubReaderViewModel @Inject constructor(
 
     fun forward() = playerCoordinator.forward()
 
-    fun previousChapter() = playerCoordinator.previousChapter()
+    fun previousChapter() = navigateChapter(forward = false)
 
-    fun nextChapter() = playerCoordinator.nextChapter()
+    fun nextChapter() = navigateChapter(forward = true)
+
+    // Set when a chapter jump crossed into a different chapter's document while playing, so the
+    // reader resumes playback once that (slow-loading) chapter is on screen — see [navigateChapter].
+    private var pendingChapterResume = false
+
+    /**
+     * Jumps a chapter and, when crossing into a different chapter's document while playing, freezes
+     * playback until that chapter has loaded. The page-follow has to load the destination document
+     * (slow), and audio left running would advance past the often-short first sentence — so the page
+     * settled on the SECOND sentence. Pausing here and resuming in [onNarratedSentenceFollowed]
+     * keeps audio and the highlight together on the chapter's first sentence. A same-chapter restart
+     * (no document change) loads nothing, so it is never frozen.
+     */
+    private fun navigateChapter(forward: Boolean) {
+        val wasPlaying = playbackState.value.isPlaying
+        val beforeIndex = playbackState.value.currentChapterIndex
+        if (forward) playerCoordinator.nextChapter() else playerCoordinator.previousChapter()
+        if (wasPlaying && playbackState.value.currentChapterIndex != beforeIndex) {
+            playerCoordinator.pause()
+            pendingChapterResume = true
+        }
+    }
+
+    /** The reader reports the narrated sentence is on screen; resume a chapter jump frozen for its load. */
+    fun onNarratedSentenceFollowed() {
+        if (pendingChapterResume) {
+            pendingChapterResume = false
+            playerCoordinator.play()
+        }
+    }
 
     /**
      * Play tapped. If a local bundle is present we prepare (if needed) and play. Otherwise: when

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -1125,33 +1125,33 @@ class EpubReaderViewModel @Inject constructor(
 
     fun forward() = playerCoordinator.forward()
 
-    fun previousChapter() = navigateChapter(forward = false)
+    fun previousChapter() = jumpChapter(-1)
 
-    fun nextChapter() = navigateChapter(forward = true)
+    fun nextChapter() = jumpChapter(+1)
 
-    // Set when a cross-chapter jump froze playback to wait for that chapter's (slow) load, so the
-    // reader resumes once the new chapter's first sentence is on screen — see [navigateChapter].
-    private var pendingChapterResume = false
+    private val _chapterPlayChannel = Channel<Link>(Channel.CONFLATED)
+    /**
+     * A readaloud chapter jump: the screen navigates the reader to this chapter's link, then resolves
+     * the chapter's first narrated sentence on the freshly-loaded page and starts narration there via
+     * [onPageTopResolved]. Chapters are the reader's real TOC chapters ([railSegments]) — NOT the
+     * Storyteller bundle's per-fragment clip hrefs, which are misaligned with the rendered ABS EPUB
+     * and would land the jump a sentence or two into the chapter.
+     */
+    val chapterPlayRequests: Flow<Link> = _chapterPlayChannel.receiveAsFlow()
 
     /**
-     * Jumps a chapter. The controller freezes playback when the jump crosses into a different
-     * chapter's document while playing (so the audio can't run past the often-short first sentence
-     * while that document loads — which left the page on the SECOND sentence); we resume in
-     * [onNarratedSentenceFollowed] once the new chapter's first sentence is on screen. A same-chapter
-     * restart loads nothing and isn't frozen.
+     * Jumps [delta] chapters from the active rail segment and starts narration at the destination
+     * chapter's first sentence. Pauses first so the outgoing audio (and the highlight auto-follow it
+     * drives) can't fight the reader navigation; the screen resumes playback once the new chapter's
+     * first sentence is located (see [chapterPlayRequests] → [onPageTopResolved]).
      */
-    private fun navigateChapter(forward: Boolean) {
-        pendingChapterResume =
-            if (forward) playerCoordinator.nextChapter() else playerCoordinator.previousChapter()
-        android.util.Log.d("RIFFLE_RA", "navigateChapter fwd=$forward froze=$pendingChapterResume")
-    }
-
-    /** The reader reports the narrated sentence is on screen; resume a chapter jump frozen for its load. */
-    fun onNarratedSentenceFollowed() {
-        if (pendingChapterResume) {
-            pendingChapterResume = false
-            playerCoordinator.resumeAfterChapterLoad()
-        }
+    private fun jumpChapter(delta: Int) {
+        val segments = railSegments.value
+        val target = segments.getOrNull(activeRailSegmentIndex.value + delta) ?: return
+        val pub = (state.value as? ReaderState.Ready)?.publication ?: return
+        val link = pub.tableOfContents.findLinkByHref(target.href) ?: return
+        playerCoordinator.pause()
+        _chapterPlayChannel.trySend(link)
     }
 
     /**

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -1129,33 +1129,28 @@ class EpubReaderViewModel @Inject constructor(
 
     fun nextChapter() = navigateChapter(forward = true)
 
-    // Set when a chapter jump crossed into a different chapter's document while playing, so the
-    // reader resumes playback once that (slow-loading) chapter is on screen — see [navigateChapter].
+    // Set when a cross-chapter jump froze playback to wait for that chapter's (slow) load, so the
+    // reader resumes once the new chapter's first sentence is on screen — see [navigateChapter].
     private var pendingChapterResume = false
 
     /**
-     * Jumps a chapter and, when crossing into a different chapter's document while playing, freezes
-     * playback until that chapter has loaded. The page-follow has to load the destination document
-     * (slow), and audio left running would advance past the often-short first sentence — so the page
-     * settled on the SECOND sentence. Pausing here and resuming in [onNarratedSentenceFollowed]
-     * keeps audio and the highlight together on the chapter's first sentence. A same-chapter restart
-     * (no document change) loads nothing, so it is never frozen.
+     * Jumps a chapter. The controller freezes playback when the jump crosses into a different
+     * chapter's document while playing (so the audio can't run past the often-short first sentence
+     * while that document loads — which left the page on the SECOND sentence); we resume in
+     * [onNarratedSentenceFollowed] once the new chapter's first sentence is on screen. A same-chapter
+     * restart loads nothing and isn't frozen.
      */
     private fun navigateChapter(forward: Boolean) {
-        val wasPlaying = playbackState.value.isPlaying
-        val beforeIndex = playbackState.value.currentChapterIndex
-        if (forward) playerCoordinator.nextChapter() else playerCoordinator.previousChapter()
-        if (wasPlaying && playbackState.value.currentChapterIndex != beforeIndex) {
-            playerCoordinator.pause()
-            pendingChapterResume = true
-        }
+        pendingChapterResume =
+            if (forward) playerCoordinator.nextChapter() else playerCoordinator.previousChapter()
+        android.util.Log.d("RIFFLE_RA", "navigateChapter fwd=$forward froze=$pendingChapterResume")
     }
 
     /** The reader reports the narrated sentence is on screen; resume a chapter jump frozen for its load. */
     fun onNarratedSentenceFollowed() {
         if (pendingChapterResume) {
             pendingChapterResume = false
-            playerCoordinator.play()
+            playerCoordinator.resumeAfterChapterLoad()
         }
     }
 

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderWebViewScripts.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderWebViewScripts.kt
@@ -158,6 +158,25 @@ internal fun resolveSelectionSentenceJs(sentences: List<Pair<String, String>>): 
  * page-top without dragging it. "Visible" uses the same containment test as autoFollow's paginated
  * branch (within a tolerance) and, in scroll mode, any vertical overlap with the viewport.
  */
+/**
+ * Index of the first narrated sentence present ANYWHERE in the current document (reading order),
+ * regardless of which paginated column it sits in — unlike [firstVisibleSentenceJs] which is
+ * page-relative. Used by chapter navigation to find the destination chapter's true first sentence
+ * (the chapter heading's first column often shows no sentence). Returns "" if the document has no
+ * narrated sentence at all (e.g. a pure heading page), so the caller can advance to the body.
+ */
+internal fun firstSentenceInDocumentJs(highlights: List<String>): String {
+    val keys = JSONArray(highlights.map { it.trim().take(12) }).toString()
+    return """
+    (function(){
+      var keys=$keys;
+      var t=document.body.innerText||"";
+      for(var k=0;k<keys.length;k++){ if(keys[k] && t.indexOf(keys[k])>=0) return String(k); }
+      return "";
+    })()
+    """.trimIndent()
+}
+
 internal fun firstVisibleSentenceJs(highlights: List<String>): String {
     // Same key shape as autoFollowSnapJs: a short near-unique prefix matched within one text node.
     val keys = JSONArray(highlights.map { it.trim().take(12) }).toString()

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderWebViewScripts.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderWebViewScripts.kt
@@ -158,25 +158,6 @@ internal fun resolveSelectionSentenceJs(sentences: List<Pair<String, String>>): 
  * page-top without dragging it. "Visible" uses the same containment test as autoFollow's paginated
  * branch (within a tolerance) and, in scroll mode, any vertical overlap with the viewport.
  */
-/**
- * Index of the first narrated sentence present ANYWHERE in the current document (reading order),
- * regardless of which paginated column it sits in — unlike [firstVisibleSentenceJs] which is
- * page-relative. Used by chapter navigation to find the destination chapter's true first sentence
- * (the chapter heading's first column often shows no sentence). Returns "" if the document has no
- * narrated sentence at all (e.g. a pure heading page), so the caller can advance to the body.
- */
-internal fun firstSentenceInDocumentJs(highlights: List<String>): String {
-    val keys = JSONArray(highlights.map { it.trim().take(12) }).toString()
-    return """
-    (function(){
-      var keys=$keys;
-      var t=document.body.innerText||"";
-      for(var k=0;k<keys.length;k++){ if(keys[k] && t.indexOf(keys[k])>=0) return String(k); }
-      return "";
-    })()
-    """.trimIndent()
-}
-
 internal fun firstVisibleSentenceJs(highlights: List<String>): String {
     // Same key shape as autoFollowSnapJs: a short near-unique prefix matched within one text node.
     val keys = JSONArray(highlights.map { it.trim().take(12) }).toString()

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/PlayerCoordinator.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/PlayerCoordinator.kt
@@ -93,14 +93,6 @@ class PlayerCoordinator @Inject constructor(
 
     fun forward() = controller.forward()
 
-    /** @return true when the jump froze playback for a cross-chapter load (resume via [resumeAfterChapterLoad]). */
-    fun previousChapter(): Boolean = controller.previousChapter()
-
-    /** @return true when the jump froze playback for a cross-chapter load (resume via [resumeAfterChapterLoad]). */
-    fun nextChapter(): Boolean = controller.nextChapter()
-
-    fun resumeAfterChapterLoad() = controller.resumeAfterChapterLoad()
-
     /** Stops playback and tears the session down — the active fragment clears, so does the highlight. */
     fun close() {
         track = null

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/PlayerCoordinator.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/PlayerCoordinator.kt
@@ -93,9 +93,13 @@ class PlayerCoordinator @Inject constructor(
 
     fun forward() = controller.forward()
 
-    fun previousChapter() = controller.previousChapter()
+    /** @return true when the jump froze playback for a cross-chapter load (resume via [resumeAfterChapterLoad]). */
+    fun previousChapter(): Boolean = controller.previousChapter()
 
-    fun nextChapter() = controller.nextChapter()
+    /** @return true when the jump froze playback for a cross-chapter load (resume via [resumeAfterChapterLoad]). */
+    fun nextChapter(): Boolean = controller.nextChapter()
+
+    fun resumeAfterChapterLoad() = controller.resumeAfterChapterLoad()
 
     /** Stops playback and tears the session down — the active fragment clears, so does the highlight. */
     fun close() {

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/PlayerCoordinator.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/PlayerCoordinator.kt
@@ -93,6 +93,10 @@ class PlayerCoordinator @Inject constructor(
 
     fun forward() = controller.forward()
 
+    fun previousChapter() = controller.previousChapter()
+
+    fun nextChapter() = controller.nextChapter()
+
     /** Stops playback and tears the session down — the active fragment clears, so does the highlight. */
     fun close() {
         track = null

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/PlayerCoordinator.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/PlayerCoordinator.kt
@@ -89,6 +89,14 @@ class PlayerCoordinator @Inject constructor(
 
     fun setSpeed(speed: Float) = controller.setSpeed(speed)
 
+    fun rewind() = controller.rewind()
+
+    fun forward() = controller.forward()
+
+    fun previousChapter() = controller.previousChapter()
+
+    fun nextChapter() = controller.nextChapter()
+
     /** Stops playback and tears the session down — the active fragment clears, so does the highlight. */
     fun close() {
         track = null

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/ReadaloudController.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/ReadaloudController.kt
@@ -43,6 +43,8 @@ class ReadaloudController @Inject constructor(
         val speed: Float = 1f,
         val currentAudioSrc: String? = null,
         val positionSec: Double = 0.0,
+        val currentChapterIndex: Int = -1,
+        val chapterCount: Int = 0,
     )
 
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
@@ -115,8 +117,20 @@ class ReadaloudController @Inject constructor(
         pushState()
     }
 
+    /** Jumps to the first clip of an adjacent chapter (see [ReadaloudTrack.resolveChapterSkip]). */
+    fun skipChapter(forward: Boolean) {
+        val s = _state.value
+        val clip = track?.resolveChapterSkip(
+            s.currentAudioSrc, s.positionSec, forward, NEAR_START_SEC,
+        ) ?: return
+        seekToAudio(clip.audioSrc, clip.clipBeginSec)
+        pushState()
+    }
+
     fun rewind() = skipBy(-REWIND_SEC)
     fun forward() = skipBy(FORWARD_SEC)
+    fun previousChapter() = skipChapter(forward = false)
+    fun nextChapter() = skipChapter(forward = true)
 
     /** Starts playback at the clip narrating [fragmentRef] (the "Play from here" entry point). */
     fun playFromFragment(fragmentRef: String) {
@@ -175,12 +189,17 @@ class ReadaloudController @Inject constructor(
 
     private fun pushState() {
         val c = controller
+        val t = track
+        val audioSrc = c?.currentMediaItem?.mediaId
+        val positionSec = (c?.currentPosition ?: 0L) / 1000.0
         _state.value = PlaybackState(
             connected = c != null,
             isPlaying = c?.isPlaying == true,
             speed = c?.playbackParameters?.speed ?: 1f,
-            currentAudioSrc = c?.currentMediaItem?.mediaId,
-            positionSec = (c?.currentPosition ?: 0L) / 1000.0,
+            currentAudioSrc = audioSrc,
+            positionSec = positionSec,
+            currentChapterIndex = t?.chapterIndexAt(audioSrc, positionSec) ?: -1,
+            chapterCount = t?.chapterCount ?: 0,
         )
     }
 
@@ -188,6 +207,7 @@ class ReadaloudController @Inject constructor(
         val SPEEDS = listOf(0.75f, 1f, 1.25f, 1.5f, 2f)
         const val REWIND_SEC = 15.0
         const val FORWARD_SEC = 30.0
+        private const val NEAR_START_SEC = 3.0
         private const val POLL_INTERVAL_MS = 250L
         private const val LOG = "RIFFLE_RA"
     }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/ReadaloudController.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/ReadaloudController.kt
@@ -43,8 +43,6 @@ class ReadaloudController @Inject constructor(
         val speed: Float = 1f,
         val currentAudioSrc: String? = null,
         val positionSec: Double = 0.0,
-        val currentChapterIndex: Int = -1,
-        val chapterCount: Int = 0,
     )
 
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
@@ -117,48 +115,8 @@ class ReadaloudController @Inject constructor(
         pushState()
     }
 
-    // Non-null while a cross-chapter jump waits for its (slow-loading) document: (audioSrc, sec) of the
-    // destination chapter's first sentence. While set, pushState() reports THIS position instead of
-    // controller.currentPosition — a cross-item seek's currentPosition lags, and pause() fires a
-    // listener that re-runs pushState(), which would otherwise clobber the highlight back to the old
-    // chapter and the page would never follow to the new one. Cleared by [resumeAfterChapterLoad].
-    private var chapterFreeze: ReadaloudTrack.Position? = null
-
-    /**
-     * Jumps to the first clip of an adjacent chapter (see [ReadaloudTrack.resolveChapterSkip]). Returns
-     * true when it crossed into a DIFFERENT chapter's document WHILE PLAYING — in that case it freezes
-     * playback on the new chapter's first sentence so the audio can't run past it during the document
-     * load; the caller resumes via [resumeAfterChapterLoad] once that sentence is on screen.
-     */
-    fun skipChapter(forward: Boolean): Boolean {
-        val t = track ?: return false
-        val s = _state.value
-        val currentIdx = t.chapterIndexAt(s.currentAudioSrc, s.positionSec)
-        val clip = t.resolveChapterSkip(s.currentAudioSrc, s.positionSec, forward, NEAR_START_SEC)
-            ?: return false
-        val targetIdx = t.chapterIndexOfClip(clip)
-        val freeze = targetIdx != currentIdx && controller?.isPlaying == true
-        // Set the freeze BEFORE the seek so a listener callback racing the seek can't clobber the state.
-        if (freeze) chapterFreeze = ReadaloudTrack.Position(clip.audioSrc, clip.clipBeginSec)
-        seekToAudio(clip.audioSrc, clip.clipBeginSec)
-        if (freeze) controller?.pause()
-        pushState()
-        Log.d(LOG, "skipChapter fwd=$forward $currentIdx->$targetIdx freeze=$freeze pos=${clip.clipBeginSec}")
-        return freeze
-    }
-
-    /** Resumes playback frozen by a cross-chapter [skipChapter] once the new chapter is on screen. */
-    fun resumeAfterChapterLoad() {
-        if (chapterFreeze == null) return
-        Log.d(LOG, "resumeAfterChapterLoad")
-        chapterFreeze = null
-        play()
-    }
-
     fun rewind() = skipBy(-REWIND_SEC)
     fun forward() = skipBy(FORWARD_SEC)
-    fun previousChapter(): Boolean = skipChapter(forward = false)
-    fun nextChapter(): Boolean = skipChapter(forward = true)
 
     /** Starts playback at the clip narrating [fragmentRef] (the "Play from here" entry point). */
     fun playFromFragment(fragmentRef: String) {
@@ -217,20 +175,12 @@ class ReadaloudController @Inject constructor(
 
     private fun pushState() {
         val c = controller
-        val t = track
-        // While frozen for a chapter load, report the destination first sentence, not the lagging
-        // (and pause-clobbered) controller position — see [chapterFreeze].
-        val freeze = chapterFreeze
-        val audioSrc = freeze?.audioSrc ?: c?.currentMediaItem?.mediaId
-        val positionSec = freeze?.positionSec ?: ((c?.currentPosition ?: 0L) / 1000.0)
         _state.value = PlaybackState(
             connected = c != null,
             isPlaying = c?.isPlaying == true,
             speed = c?.playbackParameters?.speed ?: 1f,
-            currentAudioSrc = audioSrc,
-            positionSec = positionSec,
-            currentChapterIndex = t?.chapterIndexAt(audioSrc, positionSec) ?: -1,
-            chapterCount = t?.chapterCount ?: 0,
+            currentAudioSrc = c?.currentMediaItem?.mediaId,
+            positionSec = (c?.currentPosition ?: 0L) / 1000.0,
         )
     }
 
@@ -238,7 +188,6 @@ class ReadaloudController @Inject constructor(
         val SPEEDS = listOf(0.75f, 1f, 1.25f, 1.5f, 2f)
         const val REWIND_SEC = 15.0
         const val FORWARD_SEC = 30.0
-        private const val NEAR_START_SEC = 3.0
         private const val POLL_INTERVAL_MS = 250L
         private const val LOG = "RIFFLE_RA"
     }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/ReadaloudController.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/ReadaloudController.kt
@@ -43,6 +43,8 @@ class ReadaloudController @Inject constructor(
         val speed: Float = 1f,
         val currentAudioSrc: String? = null,
         val positionSec: Double = 0.0,
+        val currentChapterIndex: Int = -1,
+        val chapterCount: Int = 0,
     )
 
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
@@ -107,6 +109,29 @@ class ReadaloudController @Inject constructor(
         pushState()
     }
 
+    /** Rewinds/forwards along the continuous timeline (negative = rewind), clamped to the readaloud. */
+    fun skipBy(deltaSec: Double) {
+        val s = _state.value
+        val target = track?.resolveRelativeSkip(s.currentAudioSrc, s.positionSec, deltaSec) ?: return
+        seekToAudio(target.audioSrc, target.positionSec)
+        pushState()
+    }
+
+    /** Jumps to the first clip of an adjacent chapter (see [ReadaloudTrack.resolveChapterSkip]). */
+    fun skipChapter(forward: Boolean) {
+        val s = _state.value
+        val clip = track?.resolveChapterSkip(
+            s.currentAudioSrc, s.positionSec, forward, NEAR_START_SEC,
+        ) ?: return
+        seekToAudio(clip.audioSrc, clip.clipBeginSec)
+        pushState()
+    }
+
+    fun rewind() = skipBy(-REWIND_SEC)
+    fun forward() = skipBy(FORWARD_SEC)
+    fun previousChapter() = skipChapter(forward = false)
+    fun nextChapter() = skipChapter(forward = true)
+
     /** Starts playback at the clip narrating [fragmentRef] (the "Play from here" entry point). */
     fun playFromFragment(fragmentRef: String) {
         val clip = track?.clipForFragment(fragmentRef) ?: return
@@ -164,17 +189,25 @@ class ReadaloudController @Inject constructor(
 
     private fun pushState() {
         val c = controller
+        val t = track
+        val audioSrc = c?.currentMediaItem?.mediaId
+        val positionSec = (c?.currentPosition ?: 0L) / 1000.0
         _state.value = PlaybackState(
             connected = c != null,
             isPlaying = c?.isPlaying == true,
             speed = c?.playbackParameters?.speed ?: 1f,
-            currentAudioSrc = c?.currentMediaItem?.mediaId,
-            positionSec = (c?.currentPosition ?: 0L) / 1000.0,
+            currentAudioSrc = audioSrc,
+            positionSec = positionSec,
+            currentChapterIndex = t?.chapterIndexAt(audioSrc, positionSec) ?: -1,
+            chapterCount = t?.chapterCount ?: 0,
         )
     }
 
     companion object {
         val SPEEDS = listOf(0.75f, 1f, 1.25f, 1.5f, 2f)
+        const val REWIND_SEC = 15.0
+        const val FORWARD_SEC = 30.0
+        private const val NEAR_START_SEC = 3.0
         private const val POLL_INTERVAL_MS = 250L
         private const val LOG = "RIFFLE_RA"
     }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/ReadaloudController.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/ReadaloudController.kt
@@ -117,20 +117,48 @@ class ReadaloudController @Inject constructor(
         pushState()
     }
 
-    /** Jumps to the first clip of an adjacent chapter (see [ReadaloudTrack.resolveChapterSkip]). */
-    fun skipChapter(forward: Boolean) {
+    // Non-null while a cross-chapter jump waits for its (slow-loading) document: (audioSrc, sec) of the
+    // destination chapter's first sentence. While set, pushState() reports THIS position instead of
+    // controller.currentPosition — a cross-item seek's currentPosition lags, and pause() fires a
+    // listener that re-runs pushState(), which would otherwise clobber the highlight back to the old
+    // chapter and the page would never follow to the new one. Cleared by [resumeAfterChapterLoad].
+    private var chapterFreeze: ReadaloudTrack.Position? = null
+
+    /**
+     * Jumps to the first clip of an adjacent chapter (see [ReadaloudTrack.resolveChapterSkip]). Returns
+     * true when it crossed into a DIFFERENT chapter's document WHILE PLAYING — in that case it freezes
+     * playback on the new chapter's first sentence so the audio can't run past it during the document
+     * load; the caller resumes via [resumeAfterChapterLoad] once that sentence is on screen.
+     */
+    fun skipChapter(forward: Boolean): Boolean {
+        val t = track ?: return false
         val s = _state.value
-        val clip = track?.resolveChapterSkip(
-            s.currentAudioSrc, s.positionSec, forward, NEAR_START_SEC,
-        ) ?: return
+        val currentIdx = t.chapterIndexAt(s.currentAudioSrc, s.positionSec)
+        val clip = t.resolveChapterSkip(s.currentAudioSrc, s.positionSec, forward, NEAR_START_SEC)
+            ?: return false
+        val targetIdx = t.chapterIndexOfClip(clip)
+        val freeze = targetIdx != currentIdx && controller?.isPlaying == true
+        // Set the freeze BEFORE the seek so a listener callback racing the seek can't clobber the state.
+        if (freeze) chapterFreeze = ReadaloudTrack.Position(clip.audioSrc, clip.clipBeginSec)
         seekToAudio(clip.audioSrc, clip.clipBeginSec)
+        if (freeze) controller?.pause()
         pushState()
+        Log.d(LOG, "skipChapter fwd=$forward $currentIdx->$targetIdx freeze=$freeze pos=${clip.clipBeginSec}")
+        return freeze
+    }
+
+    /** Resumes playback frozen by a cross-chapter [skipChapter] once the new chapter is on screen. */
+    fun resumeAfterChapterLoad() {
+        if (chapterFreeze == null) return
+        Log.d(LOG, "resumeAfterChapterLoad")
+        chapterFreeze = null
+        play()
     }
 
     fun rewind() = skipBy(-REWIND_SEC)
     fun forward() = skipBy(FORWARD_SEC)
-    fun previousChapter() = skipChapter(forward = false)
-    fun nextChapter() = skipChapter(forward = true)
+    fun previousChapter(): Boolean = skipChapter(forward = false)
+    fun nextChapter(): Boolean = skipChapter(forward = true)
 
     /** Starts playback at the clip narrating [fragmentRef] (the "Play from here" entry point). */
     fun playFromFragment(fragmentRef: String) {
@@ -190,8 +218,11 @@ class ReadaloudController @Inject constructor(
     private fun pushState() {
         val c = controller
         val t = track
-        val audioSrc = c?.currentMediaItem?.mediaId
-        val positionSec = (c?.currentPosition ?: 0L) / 1000.0
+        // While frozen for a chapter load, report the destination first sentence, not the lagging
+        // (and pause-clobbered) controller position — see [chapterFreeze].
+        val freeze = chapterFreeze
+        val audioSrc = freeze?.audioSrc ?: c?.currentMediaItem?.mediaId
+        val positionSec = freeze?.positionSec ?: ((c?.currentPosition ?: 0L) / 1000.0)
         _state.value = PlaybackState(
             connected = c != null,
             isPlaying = c?.isPlaying == true,

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/ReadaloudPlayerUi.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/ReadaloudPlayerUi.kt
@@ -4,20 +4,17 @@ package com.riffle.app.feature.reader.readaloud
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Forward30
 import androidx.compose.material.icons.filled.Pause
 import androidx.compose.material.icons.filled.PlayArrow
-import androidx.compose.material.icons.filled.Replay
 import androidx.compose.material.icons.filled.SkipNext
 import androidx.compose.material.icons.filled.SkipPrevious
 import androidx.compose.material3.AlertDialog
@@ -38,14 +35,14 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.scale
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
+import com.riffle.app.R
 
 /** Formats the speed as the spec wants it: 1×, 1.25×, 0.75×, … (trailing zeros trimmed). */
 private fun speedLabel(speed: Float): String {
@@ -53,35 +50,6 @@ private fun speedLabel(speed: Float): String {
     return "${s}×"
 }
 
-/**
- * A circular-arrow skip glyph with the seconds count overlaid. Material ships Forward30 but no
- * Replay15, so both fine-skip buttons share this drawing for a matched look: a counter-clockwise
- * [Icons.Filled.Replay] for rewind, mirrored horizontally for forward.
- */
-@Composable
-private fun SkipIcon(seconds: Int, forward: Boolean, tint: Color) {
-    Box(contentAlignment = Alignment.Center) {
-        Icon(
-            imageVector = Icons.Filled.Replay,
-            contentDescription = null,
-            tint = tint,
-            // Larger arrow so the overlaid numeral has room to read. Only the arrow mirrors for
-            // forward; the numeral is a separate child, so it stays upright.
-            modifier = Modifier
-                .size(28.dp)
-                .then(if (forward) Modifier.scale(scaleX = -1f, scaleY = 1f) else Modifier),
-        )
-        Text(
-            // Nudged up onto the arrow's open centre and set extra-bold so it doesn't collide with
-            // the arrowhead the way the old 8sp centred numeral did.
-            text = seconds.toString(),
-            color = tint,
-            fontSize = 11.sp,
-            fontWeight = FontWeight.ExtraBold,
-            modifier = Modifier.offset(y = (-1).dp),
-        )
-    }
-}
 
 /**
  * Bottom mini-player bar. Tapping the bar body (not a control) expands to the full sheet.
@@ -153,7 +121,11 @@ fun ReadaloudMiniPlayer(
                 }
                 Spacer(modifier = Modifier.weight(1f))
                 IconButton(onClick = onRewind, modifier = Modifier.testTag("readaloud_rewind")) {
-                    SkipIcon(seconds = 15, forward = false, tint = contentColor)
+                    Icon(
+                        painter = painterResource(R.drawable.ic_replay_15),
+                        contentDescription = "Rewind 15 seconds",
+                        tint = contentColor,
+                    )
                 }
                 IconButton(
                     onClick = onPreviousChapter,
@@ -176,7 +148,11 @@ fun ReadaloudMiniPlayer(
                     Icon(Icons.Filled.SkipNext, contentDescription = "Next chapter")
                 }
                 IconButton(onClick = onForward, modifier = Modifier.testTag("readaloud_forward")) {
-                    SkipIcon(seconds = 30, forward = true, tint = contentColor)
+                    Icon(
+                        imageVector = Icons.Filled.Forward30,
+                        contentDescription = "Forward 30 seconds",
+                        tint = contentColor,
+                    )
                 }
                 Spacer(modifier = Modifier.weight(1f))
             }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/ReadaloudPlayerUi.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/ReadaloudPlayerUi.kt
@@ -10,7 +10,9 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Pause
@@ -63,13 +65,20 @@ private fun SkipIcon(seconds: Int, forward: Boolean, tint: Color) {
             imageVector = Icons.Filled.Replay,
             contentDescription = null,
             tint = tint,
-            modifier = if (forward) Modifier.scale(scaleX = -1f, scaleY = 1f) else Modifier,
+            // Larger arrow so the overlaid numeral has room to read. Only the arrow mirrors for
+            // forward; the numeral is a separate child, so it stays upright.
+            modifier = Modifier
+                .size(28.dp)
+                .then(if (forward) Modifier.scale(scaleX = -1f, scaleY = 1f) else Modifier),
         )
         Text(
+            // Nudged up onto the arrow's open centre and set extra-bold so it doesn't collide with
+            // the arrowhead the way the old 8sp centred numeral did.
             text = seconds.toString(),
             color = tint,
-            fontSize = 8.sp,
-            fontWeight = FontWeight.Bold,
+            fontSize = 11.sp,
+            fontWeight = FontWeight.ExtraBold,
+            modifier = Modifier.offset(y = (-1).dp),
         )
     }
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/ReadaloudPlayerUi.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/ReadaloudPlayerUi.kt
@@ -4,6 +4,7 @@ package com.riffle.app.feature.reader.readaloud
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -14,6 +15,9 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Pause
 import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material.icons.filled.Replay
+import androidx.compose.material.icons.filled.SkipNext
+import androidx.compose.material.icons.filled.SkipPrevious
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -32,17 +36,42 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.scale
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 
 /** Formats the speed as the spec wants it: 1×, 1.25×, 0.75×, … (trailing zeros trimmed). */
 private fun speedLabel(speed: Float): String {
     val s = if (speed % 1f == 0f) speed.toInt().toString() else speed.toString().trimEnd('0').trimEnd('.')
     return "${s}×"
+}
+
+/**
+ * A circular-arrow skip glyph with the seconds count overlaid. Material ships Forward30 but no
+ * Replay15, so both fine-skip buttons share this drawing for a matched look: a counter-clockwise
+ * [Icons.Filled.Replay] for rewind, mirrored horizontally for forward.
+ */
+@Composable
+private fun SkipIcon(seconds: Int, forward: Boolean, tint: Color) {
+    Box(contentAlignment = Alignment.Center) {
+        Icon(
+            imageVector = Icons.Filled.Replay,
+            contentDescription = null,
+            tint = tint,
+            modifier = if (forward) Modifier.scale(scaleX = -1f, scaleY = 1f) else Modifier,
+        )
+        Text(
+            text = seconds.toString(),
+            color = tint,
+            fontSize = 8.sp,
+            fontWeight = FontWeight.Bold,
+        )
+    }
 }
 
 /**
@@ -55,10 +84,16 @@ fun ReadaloudMiniPlayer(
     speed: Float,
     offlineMessage: Boolean,
     downloadProgress: Float?,
+    canPreviousChapter: Boolean,
+    canNextChapter: Boolean,
     containerColor: Color,
     contentColor: Color,
     onPlayPause: () -> Unit,
     onCycleSpeed: () -> Unit,
+    onRewind: () -> Unit,
+    onForward: () -> Unit,
+    onPreviousChapter: () -> Unit,
+    onNextChapter: () -> Unit,
     onClose: () -> Unit,
     onExpand: () -> Unit,
     modifier: Modifier = Modifier,
@@ -100,18 +135,39 @@ fun ReadaloudMiniPlayer(
                         .testTag("readaloud_downloading"),
                 )
             } else {
-                IconButton(onClick = onPlayPause, modifier = Modifier.testTag("readaloud_play_pause")) {
-                    Icon(
-                        imageVector = if (isPlaying) Icons.Default.Pause else Icons.Default.PlayArrow,
-                        contentDescription = if (isPlaying) "Pause" else "Play",
-                    )
-                }
                 TextButton(onClick = onCycleSpeed, modifier = Modifier.testTag("readaloud_speed")) {
                     Text(
                         speedLabel(speed),
                         color = contentColor,
                         fontWeight = FontWeight.SemiBold,
                     )
+                }
+                Spacer(modifier = Modifier.weight(1f))
+                IconButton(onClick = onRewind, modifier = Modifier.testTag("readaloud_rewind")) {
+                    SkipIcon(seconds = 15, forward = false, tint = contentColor)
+                }
+                IconButton(
+                    onClick = onPreviousChapter,
+                    enabled = canPreviousChapter,
+                    modifier = Modifier.testTag("readaloud_prev_chapter"),
+                ) {
+                    Icon(Icons.Filled.SkipPrevious, contentDescription = "Previous chapter")
+                }
+                IconButton(onClick = onPlayPause, modifier = Modifier.testTag("readaloud_play_pause")) {
+                    Icon(
+                        imageVector = if (isPlaying) Icons.Default.Pause else Icons.Default.PlayArrow,
+                        contentDescription = if (isPlaying) "Pause" else "Play",
+                    )
+                }
+                IconButton(
+                    onClick = onNextChapter,
+                    enabled = canNextChapter,
+                    modifier = Modifier.testTag("readaloud_next_chapter"),
+                ) {
+                    Icon(Icons.Filled.SkipNext, contentDescription = "Next chapter")
+                }
+                IconButton(onClick = onForward, modifier = Modifier.testTag("readaloud_forward")) {
+                    SkipIcon(seconds = 30, forward = true, tint = contentColor)
                 }
                 Spacer(modifier = Modifier.weight(1f))
             }

--- a/app/src/main/res/drawable/ic_replay_15.xml
+++ b/app/src/main/res/drawable/ic_replay_15.xml
@@ -1,0 +1,22 @@
+<!--
+  Material "replay 15" — not shipped by Material (only 5/10/30 exist), so assembled from genuine
+  Material source paths to match the stock forward_30 it pairs with: the replay arrow + "1" digit
+  from replay_10, and the "5" digit from replay_5 translated into the right-hand digit slot.
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M12,5V1L7,6l5,5V7c3.31,0,6,2.69,6,6s-2.69,6-6,6s-6-2.69-6-6H4c0,4.42,3.58,8,8,8s8-3.58,8-8S16.42,5,12,5z" />
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M10.89,16h-0.85v-3.26l-1.01,0.31v-0.69l1.77-0.63h0.09V16z" />
+    <group android:translateX="1.9">
+        <path
+            android:fillColor="#FF000000"
+            android:pathData="M10.69,13.9l0.25-2.17h2.39v0.71h-1.7l-0.11,0.92c0.03-0.02,0.07-0.03,0.11-0.05s0.09-0.04,0.15-0.05s0.12-0.03,0.18-0.04s0.13-0.02,0.2-0.02c0.21,0,0.39,0.03,0.55,0.1s0.3,0.16,0.41,0.28s0.2,0.27,0.25,0.45s0.09,0.38,0.09,0.6c0,0.19-0.03,0.37-0.09,0.54s-0.15,0.32-0.27,0.45s-0.27,0.24-0.45,0.31s-0.39,0.12-0.64,0.12c-0.18,0-0.36-0.03-0.53-0.08s-0.32-0.14-0.46-0.24s-0.24-0.24-0.32-0.39s-0.13-0.33-0.13-0.53h0.84c0.02,0.18,0.08,0.32,0.19,0.41s0.25,0.15,0.42,0.15c0.11,0,0.2-0.02,0.27-0.06s0.14-0.1,0.18-0.17s0.08-0.15,0.11-0.25s0.03-0.2,0.03-0.31s-0.01-0.21-0.04-0.31s-0.07-0.17-0.13-0.24s-0.13-0.12-0.21-0.15s-0.19-0.05-0.3-0.05c-0.08,0-0.15,0.01-0.2,0.02s-0.11,0.03-0.15,0.05s-0.08,0.05-0.12,0.07s-0.07,0.06-0.1,0.09L10.69,13.9z" />
+    </group>
+</vector>

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/ReadaloudTrack.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/ReadaloudTrack.kt
@@ -92,6 +92,9 @@ class ReadaloudTrack(val clips: List<MediaOverlayClip>) {
         return clips.firstOrNull { chapterHrefOf(it) == href }
     }
 
+    /** The chapter index [clip] belongs to (-1 if it isn't in this track). */
+    fun chapterIndexOfClip(clip: MediaOverlayClip): Int = chapterHrefs.indexOf(chapterHrefOf(clip))
+
     /** Resolves a relative skip of [deltaSec] from the live position, clamped to the whole readaloud. */
     fun resolveRelativeSkip(audioSrc: String?, positionSec: Double, deltaSec: Double): Position? {
         val global = globalOf(audioSrc, positionSec) ?: return null

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/ReadaloudTrack.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/ReadaloudTrack.kt
@@ -25,6 +25,96 @@ class ReadaloudTrack(val clips: List<MediaOverlayClip>) {
     fun clipForFragment(textFragmentRef: String): MediaOverlayClip? =
         indexByFragment[textFragmentRef]?.let { clips[it] }
 
+    // ── skip + chapter navigation ──
+
+    /** A resolved seek target: which queued audio file, and the offset within it. */
+    data class Position(val audioSrc: String, val positionSec: Double)
+
+    private fun chapterHrefOf(clip: MediaOverlayClip): String =
+        clip.textFragmentRef.substringBefore('#').trimStart('/')
+
+    /** Distinct chapter hrefs in reading order (clips are already in reading order). */
+    private val chapterHrefs: List<String> = clips.map(::chapterHrefOf).distinct()
+
+    /** Distinct audio files in playlist order — the same order [clips] is queued in. */
+    private val fileOrder: List<String> = clips.map { it.audioSrc }.distinct()
+
+    /** Each file's duration, approximated by the end of its last clip. */
+    private val fileDuration: Map<String, Double> =
+        clips.groupBy { it.audioSrc }.mapValues { (_, cs) -> cs.maxOf { it.clipEndSec } }
+
+    /** Global start offset of each file on the concatenated timeline. */
+    private val fileStart: Map<String, Double> = buildMap {
+        var acc = 0.0
+        for (src in fileOrder) {
+            put(src, acc)
+            acc += fileDuration[src] ?: 0.0
+        }
+    }
+
+    private val totalDuration: Double = fileOrder.sumOf { fileDuration[it] ?: 0.0 }
+
+    /** Number of chapters in the readaloud. */
+    val chapterCount: Int get() = chapterHrefs.size
+
+    /** Maps a live playback position to a global timeline offset, or null if [audioSrc] is unknown. */
+    private fun globalOf(audioSrc: String?, positionSec: Double): Double? {
+        val start = audioSrc?.let { fileStart[it] } ?: return null
+        return start + positionSec
+    }
+
+    /** Inverse of [globalOf]: maps a clamped global offset back to a [Position]. */
+    private fun positionAt(global: Double): Position {
+        val g = global.coerceIn(0.0, totalDuration)
+        // Last file whose start is <= g; offset is the remainder, clamped to that file's duration.
+        val src = fileOrder.lastOrNull { (fileStart[it] ?: 0.0) <= g } ?: fileOrder.first()
+        val within = (g - (fileStart[src] ?: 0.0)).coerceIn(0.0, fileDuration[src] ?: 0.0)
+        return Position(src, within)
+    }
+
+    /**
+     * The chapter index containing the live position, or -1 when nothing is playing. Uses the active
+     * clip when the position sits inside one; otherwise the chapter of the latest clip at or before
+     * the global position (covers inter-clip gaps).
+     */
+    fun chapterIndexAt(audioSrc: String?, positionSec: Double): Int {
+        if (audioSrc == null) return -1
+        activeClipAt(audioSrc, positionSec)?.let { return chapterHrefs.indexOf(chapterHrefOf(it)) }
+        val global = globalOf(audioSrc, positionSec) ?: return -1
+        val clip = clips.lastOrNull { (globalOf(it.audioSrc, it.clipBeginSec) ?: Double.MAX_VALUE) <= global }
+            ?: return -1
+        return chapterHrefs.indexOf(chapterHrefOf(clip))
+    }
+
+    /** The first clip of chapter [index], or null when [index] is out of range. */
+    fun firstClipOfChapter(index: Int): MediaOverlayClip? {
+        val href = chapterHrefs.getOrNull(index) ?: return null
+        return clips.firstOrNull { chapterHrefOf(it) == href }
+    }
+
+    /** Resolves a relative skip of [deltaSec] from the live position, clamped to the whole readaloud. */
+    fun resolveRelativeSkip(audioSrc: String?, positionSec: Double, deltaSec: Double): Position? {
+        val global = globalOf(audioSrc, positionSec) ?: return null
+        return positionAt(global + deltaSec)
+    }
+
+    /**
+     * Resolves a chapter jump. [forward] true -> the next chapter's first clip (null at the last
+     * chapter). [forward] false -> restart the current chapter, unless the live position is within
+     * [nearStartSec] of the current chapter's start, in which case go to the previous chapter (or
+     * restart the first chapter when there is none).
+     */
+    fun resolveChapterSkip(audioSrc: String?, positionSec: Double, forward: Boolean, nearStartSec: Double): MediaOverlayClip? {
+        val index = chapterIndexAt(audioSrc, positionSec)
+        if (index < 0) return null
+        if (forward) return firstClipOfChapter(index + 1)
+        val currentFirst = firstClipOfChapter(index) ?: return null
+        val global = globalOf(audioSrc, positionSec) ?: return currentFirst
+        val chapterStart = globalOf(currentFirst.audioSrc, currentFirst.clipBeginSec) ?: 0.0
+        val nearStart = (global - chapterStart) <= nearStartSec
+        return if (nearStart && index > 0) firstClipOfChapter(index - 1) else currentFirst
+    }
+
     /**
      * The clip to start narration from for a reader position given by its chapter [href] and
      * optional [fragmentId]. Prefers an exact "href#fragmentId" match (the sentence under the

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/ReadaloudTrack.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/ReadaloudTrack.kt
@@ -25,16 +25,10 @@ class ReadaloudTrack(val clips: List<MediaOverlayClip>) {
     fun clipForFragment(textFragmentRef: String): MediaOverlayClip? =
         indexByFragment[textFragmentRef]?.let { clips[it] }
 
-    // ── skip + chapter navigation ──
+    // ── rewind / forward (continuous timeline across the queued audio files) ──
 
     /** A resolved seek target: which queued audio file, and the offset within it. */
     data class Position(val audioSrc: String, val positionSec: Double)
-
-    private fun chapterHrefOf(clip: MediaOverlayClip): String =
-        clip.textFragmentRef.substringBefore('#').trimStart('/')
-
-    /** Distinct chapter hrefs in reading order (clips are already in reading order). */
-    private val chapterHrefs: List<String> = clips.map(::chapterHrefOf).distinct()
 
     /** Distinct audio files in playlist order — the same order [clips] is queued in. */
     private val fileOrder: List<String> = clips.map { it.audioSrc }.distinct()
@@ -54,9 +48,6 @@ class ReadaloudTrack(val clips: List<MediaOverlayClip>) {
 
     private val totalDuration: Double = fileOrder.sumOf { fileDuration[it] ?: 0.0 }
 
-    /** Number of chapters in the readaloud. */
-    val chapterCount: Int get() = chapterHrefs.size
-
     /** Maps a live playback position to a global timeline offset, or null if [audioSrc] is unknown. */
     private fun globalOf(audioSrc: String?, positionSec: Double): Double? {
         val start = audioSrc?.let { fileStart[it] } ?: return null
@@ -72,50 +63,10 @@ class ReadaloudTrack(val clips: List<MediaOverlayClip>) {
         return Position(src, within)
     }
 
-    /**
-     * The chapter index containing the live position, or -1 when nothing is playing. Uses the active
-     * clip when the position sits inside one; otherwise the chapter of the latest clip at or before
-     * the global position (covers inter-clip gaps).
-     */
-    fun chapterIndexAt(audioSrc: String?, positionSec: Double): Int {
-        if (audioSrc == null) return -1
-        activeClipAt(audioSrc, positionSec)?.let { return chapterHrefs.indexOf(chapterHrefOf(it)) }
-        val global = globalOf(audioSrc, positionSec) ?: return -1
-        val clip = clips.lastOrNull { (globalOf(it.audioSrc, it.clipBeginSec) ?: Double.MAX_VALUE) <= global }
-            ?: return -1
-        return chapterHrefs.indexOf(chapterHrefOf(clip))
-    }
-
-    /** The first clip of chapter [index], or null when [index] is out of range. */
-    fun firstClipOfChapter(index: Int): MediaOverlayClip? {
-        val href = chapterHrefs.getOrNull(index) ?: return null
-        return clips.firstOrNull { chapterHrefOf(it) == href }
-    }
-
-    /** The chapter index [clip] belongs to (-1 if it isn't in this track). */
-    fun chapterIndexOfClip(clip: MediaOverlayClip): Int = chapterHrefs.indexOf(chapterHrefOf(clip))
-
     /** Resolves a relative skip of [deltaSec] from the live position, clamped to the whole readaloud. */
     fun resolveRelativeSkip(audioSrc: String?, positionSec: Double, deltaSec: Double): Position? {
         val global = globalOf(audioSrc, positionSec) ?: return null
         return positionAt(global + deltaSec)
-    }
-
-    /**
-     * Resolves a chapter jump. [forward] true -> the next chapter's first clip (null at the last
-     * chapter). [forward] false -> restart the current chapter, unless the live position is within
-     * [nearStartSec] of the current chapter's start, in which case go to the previous chapter (or
-     * restart the first chapter when there is none).
-     */
-    fun resolveChapterSkip(audioSrc: String?, positionSec: Double, forward: Boolean, nearStartSec: Double): MediaOverlayClip? {
-        val index = chapterIndexAt(audioSrc, positionSec)
-        if (index < 0) return null
-        if (forward) return firstClipOfChapter(index + 1)
-        val currentFirst = firstClipOfChapter(index) ?: return null
-        val global = globalOf(audioSrc, positionSec) ?: return currentFirst
-        val chapterStart = globalOf(currentFirst.audioSrc, currentFirst.clipBeginSec) ?: 0.0
-        val nearStart = (global - chapterStart) <= nearStartSec
-        return if (nearStart && index > 0) firstClipOfChapter(index - 1) else currentFirst
     }
 
     /**

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/ReadaloudTrack.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/ReadaloudTrack.kt
@@ -25,10 +25,16 @@ class ReadaloudTrack(val clips: List<MediaOverlayClip>) {
     fun clipForFragment(textFragmentRef: String): MediaOverlayClip? =
         indexByFragment[textFragmentRef]?.let { clips[it] }
 
-    // ── rewind / forward (continuous timeline across the queued audio files) ──
+    // ── skip + chapter navigation ──
 
     /** A resolved seek target: which queued audio file, and the offset within it. */
     data class Position(val audioSrc: String, val positionSec: Double)
+
+    private fun chapterHrefOf(clip: MediaOverlayClip): String =
+        clip.textFragmentRef.substringBefore('#').trimStart('/')
+
+    /** Distinct chapter hrefs in reading order (clips are already in reading order). */
+    private val chapterHrefs: List<String> = clips.map(::chapterHrefOf).distinct()
 
     /** Distinct audio files in playlist order — the same order [clips] is queued in. */
     private val fileOrder: List<String> = clips.map { it.audioSrc }.distinct()
@@ -48,6 +54,9 @@ class ReadaloudTrack(val clips: List<MediaOverlayClip>) {
 
     private val totalDuration: Double = fileOrder.sumOf { fileDuration[it] ?: 0.0 }
 
+    /** Number of chapters in the readaloud. */
+    val chapterCount: Int get() = chapterHrefs.size
+
     /** Maps a live playback position to a global timeline offset, or null if [audioSrc] is unknown. */
     private fun globalOf(audioSrc: String?, positionSec: Double): Double? {
         val start = audioSrc?.let { fileStart[it] } ?: return null
@@ -63,10 +72,47 @@ class ReadaloudTrack(val clips: List<MediaOverlayClip>) {
         return Position(src, within)
     }
 
+    /**
+     * The chapter index containing the live position, or -1 when nothing is playing. Uses the active
+     * clip when the position sits inside one; otherwise the chapter of the latest clip at or before
+     * the global position (covers inter-clip gaps).
+     */
+    fun chapterIndexAt(audioSrc: String?, positionSec: Double): Int {
+        if (audioSrc == null) return -1
+        activeClipAt(audioSrc, positionSec)?.let { return chapterHrefs.indexOf(chapterHrefOf(it)) }
+        val global = globalOf(audioSrc, positionSec) ?: return -1
+        val clip = clips.lastOrNull { (globalOf(it.audioSrc, it.clipBeginSec) ?: Double.MAX_VALUE) <= global }
+            ?: return -1
+        return chapterHrefs.indexOf(chapterHrefOf(clip))
+    }
+
+    /** The first clip of chapter [index], or null when [index] is out of range. */
+    fun firstClipOfChapter(index: Int): MediaOverlayClip? {
+        val href = chapterHrefs.getOrNull(index) ?: return null
+        return clips.firstOrNull { chapterHrefOf(it) == href }
+    }
+
     /** Resolves a relative skip of [deltaSec] from the live position, clamped to the whole readaloud. */
     fun resolveRelativeSkip(audioSrc: String?, positionSec: Double, deltaSec: Double): Position? {
         val global = globalOf(audioSrc, positionSec) ?: return null
         return positionAt(global + deltaSec)
+    }
+
+    /**
+     * Resolves a chapter jump. [forward] true -> the next chapter's first clip (null at the last
+     * chapter). [forward] false -> restart the current chapter, unless the live position is within
+     * [nearStartSec] of the current chapter's start, in which case go to the previous chapter (or
+     * restart the first chapter when there is none).
+     */
+    fun resolveChapterSkip(audioSrc: String?, positionSec: Double, forward: Boolean, nearStartSec: Double): MediaOverlayClip? {
+        val index = chapterIndexAt(audioSrc, positionSec)
+        if (index < 0) return null
+        if (forward) return firstClipOfChapter(index + 1)
+        val currentFirst = firstClipOfChapter(index) ?: return null
+        val global = globalOf(audioSrc, positionSec) ?: return currentFirst
+        val chapterStart = globalOf(currentFirst.audioSrc, currentFirst.clipBeginSec) ?: 0.0
+        val nearStart = (global - chapterStart) <= nearStartSec
+        return if (nearStart && index > 0) firstClipOfChapter(index - 1) else currentFirst
     }
 
     /**

--- a/core/domain/src/test/kotlin/com/riffle/core/domain/ReadaloudTrackTest.kt
+++ b/core/domain/src/test/kotlin/com/riffle/core/domain/ReadaloudTrackTest.kt
@@ -190,6 +190,12 @@ class ReadaloudTrackTest {
     }
 
     @Test
+    fun `chapterIndexOfClip returns the clip's chapter index`() {
+        assertEquals(0, skipTrack.chapterIndexOfClip(skipClips[1]))
+        assertEquals(1, skipTrack.chapterIndexOfClip(skipClips[3]))
+    }
+
+    @Test
     fun `resolveRelativeSkip seeks within the current file`() {
         // at c1 3.0s, +4s -> c1 7.0s
         assertEquals(ReadaloudTrack.Position("c1.mp3", 7.0), skipTrack.resolveRelativeSkip("c1.mp3", 3.0, 4.0))

--- a/core/domain/src/test/kotlin/com/riffle/core/domain/ReadaloudTrackTest.kt
+++ b/core/domain/src/test/kotlin/com/riffle/core/domain/ReadaloudTrackTest.kt
@@ -167,6 +167,29 @@ class ReadaloudTrackTest {
     private val skipTrack = ReadaloudTrack(skipClips)
 
     @Test
+    fun `chapterCount counts distinct chapter hrefs in order`() {
+        assertEquals(2, skipTrack.chapterCount)
+    }
+
+    @Test
+    fun `chapterIndexAt maps an in-file position to its chapter`() {
+        assertEquals(0, skipTrack.chapterIndexAt("c1.mp3", 3.0))
+        assertEquals(1, skipTrack.chapterIndexAt("c2.mp3", 1.0))
+    }
+
+    @Test
+    fun `chapterIndexAt returns -1 when nothing is playing`() {
+        assertEquals(-1, skipTrack.chapterIndexAt(null, 0.0))
+    }
+
+    @Test
+    fun `firstClipOfChapter returns the chapter's opening clip`() {
+        assertEquals(skipClips[0], skipTrack.firstClipOfChapter(0))
+        assertEquals(skipClips[3], skipTrack.firstClipOfChapter(1))
+        assertNull(skipTrack.firstClipOfChapter(2))
+    }
+
+    @Test
     fun `resolveRelativeSkip seeks within the current file`() {
         // at c1 3.0s, +4s -> c1 7.0s
         assertEquals(ReadaloudTrack.Position("c1.mp3", 7.0), skipTrack.resolveRelativeSkip("c1.mp3", 3.0, 4.0))
@@ -197,5 +220,33 @@ class ReadaloudTrackTest {
     @Test
     fun `resolveRelativeSkip returns null when nothing is playing`() {
         assertNull(skipTrack.resolveRelativeSkip(null, 0.0, 30.0))
+    }
+
+    @Test
+    fun `next chapter jumps to the following chapter's first clip`() {
+        assertEquals(skipClips[3], skipTrack.resolveChapterSkip("c1.mp3", 3.0, forward = true, nearStartSec = 3.0))
+    }
+
+    @Test
+    fun `next chapter on the last chapter returns null`() {
+        assertNull(skipTrack.resolveChapterSkip("c2.mp3", 1.0, forward = true, nearStartSec = 3.0))
+    }
+
+    @Test
+    fun `previous chapter restarts the current chapter when past the near-start window`() {
+        // c1 4.0s is > 3s into chapter 0 -> restart chapter 0
+        assertEquals(skipClips[0], skipTrack.resolveChapterSkip("c1.mp3", 4.0, forward = false, nearStartSec = 3.0))
+    }
+
+    @Test
+    fun `previous chapter jumps to the prior chapter when within the near-start window`() {
+        // c2 1.0s is within 3s of chapter 1's start -> go to chapter 0
+        assertEquals(skipClips[0], skipTrack.resolveChapterSkip("c2.mp3", 1.0, forward = false, nearStartSec = 3.0))
+    }
+
+    @Test
+    fun `previous chapter at the first chapter near its start restarts the first chapter`() {
+        // chapter 0 near start: no prior chapter, so restart chapter 0 (effective no-op seek to 0)
+        assertEquals(skipClips[0], skipTrack.resolveChapterSkip("c1.mp3", 0.5, forward = false, nearStartSec = 3.0))
     }
 }

--- a/core/domain/src/test/kotlin/com/riffle/core/domain/ReadaloudTrackTest.kt
+++ b/core/domain/src/test/kotlin/com/riffle/core/domain/ReadaloudTrackTest.kt
@@ -167,35 +167,6 @@ class ReadaloudTrackTest {
     private val skipTrack = ReadaloudTrack(skipClips)
 
     @Test
-    fun `chapterCount counts distinct chapter hrefs in order`() {
-        assertEquals(2, skipTrack.chapterCount)
-    }
-
-    @Test
-    fun `chapterIndexAt maps an in-file position to its chapter`() {
-        assertEquals(0, skipTrack.chapterIndexAt("c1.mp3", 3.0))
-        assertEquals(1, skipTrack.chapterIndexAt("c2.mp3", 1.0))
-    }
-
-    @Test
-    fun `chapterIndexAt returns -1 when nothing is playing`() {
-        assertEquals(-1, skipTrack.chapterIndexAt(null, 0.0))
-    }
-
-    @Test
-    fun `firstClipOfChapter returns the chapter's opening clip`() {
-        assertEquals(skipClips[0], skipTrack.firstClipOfChapter(0))
-        assertEquals(skipClips[3], skipTrack.firstClipOfChapter(1))
-        assertNull(skipTrack.firstClipOfChapter(2))
-    }
-
-    @Test
-    fun `chapterIndexOfClip returns the clip's chapter index`() {
-        assertEquals(0, skipTrack.chapterIndexOfClip(skipClips[1]))
-        assertEquals(1, skipTrack.chapterIndexOfClip(skipClips[3]))
-    }
-
-    @Test
     fun `resolveRelativeSkip seeks within the current file`() {
         // at c1 3.0s, +4s -> c1 7.0s
         assertEquals(ReadaloudTrack.Position("c1.mp3", 7.0), skipTrack.resolveRelativeSkip("c1.mp3", 3.0, 4.0))
@@ -226,33 +197,5 @@ class ReadaloudTrackTest {
     @Test
     fun `resolveRelativeSkip returns null when nothing is playing`() {
         assertNull(skipTrack.resolveRelativeSkip(null, 0.0, 30.0))
-    }
-
-    @Test
-    fun `next chapter jumps to the following chapter's first clip`() {
-        assertEquals(skipClips[3], skipTrack.resolveChapterSkip("c1.mp3", 3.0, forward = true, nearStartSec = 3.0))
-    }
-
-    @Test
-    fun `next chapter on the last chapter returns null`() {
-        assertNull(skipTrack.resolveChapterSkip("c2.mp3", 1.0, forward = true, nearStartSec = 3.0))
-    }
-
-    @Test
-    fun `previous chapter restarts the current chapter when past the near-start window`() {
-        // c1 4.0s is > 3s into chapter 0 -> restart chapter 0
-        assertEquals(skipClips[0], skipTrack.resolveChapterSkip("c1.mp3", 4.0, forward = false, nearStartSec = 3.0))
-    }
-
-    @Test
-    fun `previous chapter jumps to the prior chapter when within the near-start window`() {
-        // c2 1.0s is within 3s of chapter 1's start -> go to chapter 0
-        assertEquals(skipClips[0], skipTrack.resolveChapterSkip("c2.mp3", 1.0, forward = false, nearStartSec = 3.0))
-    }
-
-    @Test
-    fun `previous chapter at the first chapter near its start restarts the first chapter`() {
-        // chapter 0 near start: no prior chapter, so restart chapter 0 (effective no-op seek to 0)
-        assertEquals(skipClips[0], skipTrack.resolveChapterSkip("c1.mp3", 0.5, forward = false, nearStartSec = 3.0))
     }
 }

--- a/core/domain/src/test/kotlin/com/riffle/core/domain/ReadaloudTrackTest.kt
+++ b/core/domain/src/test/kotlin/com/riffle/core/domain/ReadaloudTrackTest.kt
@@ -154,4 +154,99 @@ class ReadaloudTrackTest {
     fun `resolveStartClip past all narrated content returns null`() {
         assertEquals(null, splitTrack.resolveStartClip("text/part0099_split_000.html", null))
     }
+
+    // ── skip + chapter math (rewind/forward, prev/next chapter) ──
+
+    // Two chapters across two files. Global timeline: c1 -> [0,9), c2 -> [9,13).
+    private val skipClips = listOf(
+        MediaOverlayClip("text/c1.html#s1", "c1.mp3", 0.0, 2.0),
+        MediaOverlayClip("text/c1.html#s2", "c1.mp3", 2.0, 5.0),
+        MediaOverlayClip("text/c1.html#s3", "c1.mp3", 5.0, 9.0),
+        MediaOverlayClip("text/c2.html#s1", "c2.mp3", 0.0, 4.0),
+    )
+    private val skipTrack = ReadaloudTrack(skipClips)
+
+    @Test
+    fun `chapterCount counts distinct chapter hrefs in order`() {
+        assertEquals(2, skipTrack.chapterCount)
+    }
+
+    @Test
+    fun `chapterIndexAt maps an in-file position to its chapter`() {
+        assertEquals(0, skipTrack.chapterIndexAt("c1.mp3", 3.0))
+        assertEquals(1, skipTrack.chapterIndexAt("c2.mp3", 1.0))
+    }
+
+    @Test
+    fun `chapterIndexAt returns -1 when nothing is playing`() {
+        assertEquals(-1, skipTrack.chapterIndexAt(null, 0.0))
+    }
+
+    @Test
+    fun `firstClipOfChapter returns the chapter's opening clip`() {
+        assertEquals(skipClips[0], skipTrack.firstClipOfChapter(0))
+        assertEquals(skipClips[3], skipTrack.firstClipOfChapter(1))
+        assertNull(skipTrack.firstClipOfChapter(2))
+    }
+
+    @Test
+    fun `resolveRelativeSkip seeks within the current file`() {
+        // at c1 3.0s, +4s -> c1 7.0s
+        assertEquals(ReadaloudTrack.Position("c1.mp3", 7.0), skipTrack.resolveRelativeSkip("c1.mp3", 3.0, 4.0))
+        // at c1 7.0s, -4s -> c1 3.0s
+        assertEquals(ReadaloudTrack.Position("c1.mp3", 3.0), skipTrack.resolveRelativeSkip("c1.mp3", 7.0, -4.0))
+    }
+
+    @Test
+    fun `resolveRelativeSkip rolls forward across a file boundary`() {
+        // at c1 8.0s, +3s -> global 11.0 -> c2 2.0s
+        assertEquals(ReadaloudTrack.Position("c2.mp3", 2.0), skipTrack.resolveRelativeSkip("c1.mp3", 8.0, 3.0))
+    }
+
+    @Test
+    fun `resolveRelativeSkip rolls backward across a file boundary`() {
+        // at c2 1.0s (global 10.0), -3s -> global 7.0 -> c1 7.0s
+        assertEquals(ReadaloudTrack.Position("c1.mp3", 7.0), skipTrack.resolveRelativeSkip("c2.mp3", 1.0, -3.0))
+    }
+
+    @Test
+    fun `resolveRelativeSkip clamps at the start and end of the readaloud`() {
+        // rewind before zero
+        assertEquals(ReadaloudTrack.Position("c1.mp3", 0.0), skipTrack.resolveRelativeSkip("c1.mp3", 1.0, -30.0))
+        // forward past the end (total 13.0) clamps to the last file's end
+        assertEquals(ReadaloudTrack.Position("c2.mp3", 4.0), skipTrack.resolveRelativeSkip("c2.mp3", 1.0, 30.0))
+    }
+
+    @Test
+    fun `resolveRelativeSkip returns null when nothing is playing`() {
+        assertNull(skipTrack.resolveRelativeSkip(null, 0.0, 30.0))
+    }
+
+    @Test
+    fun `next chapter jumps to the following chapter's first clip`() {
+        assertEquals(skipClips[3], skipTrack.resolveChapterSkip("c1.mp3", 3.0, forward = true, nearStartSec = 3.0))
+    }
+
+    @Test
+    fun `next chapter on the last chapter returns null`() {
+        assertNull(skipTrack.resolveChapterSkip("c2.mp3", 1.0, forward = true, nearStartSec = 3.0))
+    }
+
+    @Test
+    fun `previous chapter restarts the current chapter when past the near-start window`() {
+        // c1 4.0s is > 3s into chapter 0 -> restart chapter 0
+        assertEquals(skipClips[0], skipTrack.resolveChapterSkip("c1.mp3", 4.0, forward = false, nearStartSec = 3.0))
+    }
+
+    @Test
+    fun `previous chapter jumps to the prior chapter when within the near-start window`() {
+        // c2 1.0s is within 3s of chapter 1's start -> go to chapter 0
+        assertEquals(skipClips[0], skipTrack.resolveChapterSkip("c2.mp3", 1.0, forward = false, nearStartSec = 3.0))
+    }
+
+    @Test
+    fun `previous chapter at the first chapter near its start restarts the first chapter`() {
+        // chapter 0 near start: no prior chapter, so restart chapter 0 (effective no-op seek to 0)
+        assertEquals(skipClips[0], skipTrack.resolveChapterSkip("c1.mp3", 0.5, forward = false, nearStartSec = 3.0))
+    }
 }

--- a/docs/superpowers/plans/2026-06-09-readaloud-skip-controls.md
+++ b/docs/superpowers/plans/2026-06-09-readaloud-skip-controls.md
@@ -1,0 +1,792 @@
+# Readaloud Skip Controls Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add rewind-15s, forward-30s, and previous/next-chapter controls to the Readaloud mini-player.
+
+**Architecture:** All seek *math* lives in the pure-JVM domain class `ReadaloudTrack`, which already owns the Media-Overlay timeline. It gains a global cross-file timeline (each audio file's duration approximated by its last clip's end) so a relative skip and a chapter jump resolve to an exact `(audioSrc, positionSec)` with no dependency on Media3 runtime durations — making every behaviour unit-testable. `ReadaloudController` becomes a thin caller of that math plus the existing `seekToAudio`; `PlayerCoordinator` and `EpubReaderViewModel` add pass-throughs; `ReadaloudMiniPlayer` gains the buttons.
+
+**Tech Stack:** Kotlin, Media3 (`MediaController`), Jetpack Compose (Material 3, `material-icons-extended`), JUnit4, Compose UI test (harness AVD).
+
+---
+
+## Design reference
+
+Spec: `docs/superpowers/specs/2026-06-09-readaloud-skip-controls-design.md`
+Prototype: `.context/readaloud-skip-prototype/index.html`
+
+Final mini-bar layout (left → right): `[1×] …spacer… [⟲15] [⏮] [▶/⏸] [⏭] [30⟳] …spacer… [✕]`
+
+Constants: rewind = 15 s, forward = 30 s, near-start threshold = 3 s.
+
+## File structure
+
+- **Modify** `core/domain/src/main/kotlin/com/riffle/core/domain/ReadaloudTrack.kt` — chapter list + global-timeline skip/chapter math (new public API: `chapterCount`, `chapterIndexAt`, `firstClipOfChapter`, `resolveRelativeSkip`, `resolveChapterSkip`, nested `Position`).
+- **Modify** `core/domain/src/test/kotlin/com/riffle/core/domain/ReadaloudTrackTest.kt` — unit tests for the new math.
+- **Modify** `app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/ReadaloudController.kt` — `PlaybackState` gains `currentChapterIndex`/`chapterCount`; new `rewind()`, `forward()`, `previousChapter()`, `nextChapter()`; `pushState` fills the new fields.
+- **Modify** `app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/PlayerCoordinator.kt` — thin pass-throughs.
+- **Modify** `app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt` — intent methods.
+- **Modify** `app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/ReadaloudPlayerUi.kt` — `SkipIcon` composable + new buttons + callbacks on `ReadaloudMiniPlayer`.
+- **Modify** `app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt` — wire callbacks.
+- **Create** `app/src/androidTest/kotlin/com/riffle/app/feature/reader/readaloud/ReadaloudMiniPlayerTest.kt` — Compose harness test for the buttons.
+
+## Pre-flight
+
+Gradle needs the Android Studio JBR on every command in this plan:
+
+```bash
+export JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"
+```
+
+---
+
+### Task 1: ReadaloudTrack — global timeline + chapter math
+
+**Files:**
+- Modify: `core/domain/src/main/kotlin/com/riffle/core/domain/ReadaloudTrack.kt`
+- Test: `core/domain/src/test/kotlin/com/riffle/core/domain/ReadaloudTrackTest.kt`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `ReadaloudTrackTest.kt` (inside the class, after the last test). These fixtures use whole-second clips so the global offsets are easy to reason about. `c1.mp3` has clips ending at 9.0 (so its duration ≈ 9.0); `c2.mp3` starts the next chapter and ends at 4.0; global timeline is therefore `[0,9)` for c1 and `[9,13)` for c2.
+
+```kotlin
+    // ── skip + chapter math (rewind/forward, prev/next chapter) ──
+
+    // Two chapters across two files. Global timeline: c1 -> [0,9), c2 -> [9,13).
+    private val skipClips = listOf(
+        MediaOverlayClip("text/c1.html#s1", "c1.mp3", 0.0, 2.0),
+        MediaOverlayClip("text/c1.html#s2", "c1.mp3", 2.0, 5.0),
+        MediaOverlayClip("text/c1.html#s3", "c1.mp3", 5.0, 9.0),
+        MediaOverlayClip("text/c2.html#s1", "c2.mp3", 0.0, 4.0),
+    )
+    private val skipTrack = ReadaloudTrack(skipClips)
+
+    @Test
+    fun `chapterCount counts distinct chapter hrefs in order`() {
+        assertEquals(2, skipTrack.chapterCount)
+    }
+
+    @Test
+    fun `chapterIndexAt maps an in-file position to its chapter`() {
+        assertEquals(0, skipTrack.chapterIndexAt("c1.mp3", 3.0))
+        assertEquals(1, skipTrack.chapterIndexAt("c2.mp3", 1.0))
+    }
+
+    @Test
+    fun `chapterIndexAt returns -1 when nothing is playing`() {
+        assertEquals(-1, skipTrack.chapterIndexAt(null, 0.0))
+    }
+
+    @Test
+    fun `firstClipOfChapter returns the chapter's opening clip`() {
+        assertEquals(skipClips[0], skipTrack.firstClipOfChapter(0))
+        assertEquals(skipClips[3], skipTrack.firstClipOfChapter(1))
+        assertNull(skipTrack.firstClipOfChapter(2))
+    }
+
+    @Test
+    fun `resolveRelativeSkip seeks within the current file`() {
+        // at c1 3.0s, +4s -> c1 7.0s
+        assertEquals(ReadaloudTrack.Position("c1.mp3", 7.0), skipTrack.resolveRelativeSkip("c1.mp3", 3.0, 4.0))
+        // at c1 7.0s, -4s -> c1 3.0s
+        assertEquals(ReadaloudTrack.Position("c1.mp3", 3.0), skipTrack.resolveRelativeSkip("c1.mp3", 7.0, -4.0))
+    }
+
+    @Test
+    fun `resolveRelativeSkip rolls forward across a file boundary`() {
+        // at c1 8.0s, +3s -> global 11.0 -> c2 2.0s
+        assertEquals(ReadaloudTrack.Position("c2.mp3", 2.0), skipTrack.resolveRelativeSkip("c1.mp3", 8.0, 3.0))
+    }
+
+    @Test
+    fun `resolveRelativeSkip rolls backward across a file boundary`() {
+        // at c2 1.0s (global 10.0), -3s -> global 7.0 -> c1 7.0s
+        assertEquals(ReadaloudTrack.Position("c1.mp3", 7.0), skipTrack.resolveRelativeSkip("c2.mp3", 1.0, -3.0))
+    }
+
+    @Test
+    fun `resolveRelativeSkip clamps at the start and end of the readaloud`() {
+        // rewind before zero
+        assertEquals(ReadaloudTrack.Position("c1.mp3", 0.0), skipTrack.resolveRelativeSkip("c1.mp3", 1.0, -30.0))
+        // forward past the end (total 13.0) clamps to the last file's end
+        assertEquals(ReadaloudTrack.Position("c2.mp3", 4.0), skipTrack.resolveRelativeSkip("c2.mp3", 1.0, 30.0))
+    }
+
+    @Test
+    fun `resolveRelativeSkip returns null when nothing is playing`() {
+        assertNull(skipTrack.resolveRelativeSkip(null, 0.0, 30.0))
+    }
+
+    @Test
+    fun `next chapter jumps to the following chapter's first clip`() {
+        assertEquals(skipClips[3], skipTrack.resolveChapterSkip("c1.mp3", 3.0, forward = true, nearStartSec = 3.0))
+    }
+
+    @Test
+    fun `next chapter on the last chapter returns null`() {
+        assertNull(skipTrack.resolveChapterSkip("c2.mp3", 1.0, forward = true, nearStartSec = 3.0))
+    }
+
+    @Test
+    fun `previous chapter restarts the current chapter when past the near-start window`() {
+        // c1 4.0s is > 3s into chapter 0 -> restart chapter 0
+        assertEquals(skipClips[0], skipTrack.resolveChapterSkip("c1.mp3", 4.0, forward = false, nearStartSec = 3.0))
+    }
+
+    @Test
+    fun `previous chapter jumps to the prior chapter when within the near-start window`() {
+        // c2 1.0s is within 3s of chapter 1's start -> go to chapter 0
+        assertEquals(skipClips[0], skipTrack.resolveChapterSkip("c2.mp3", 1.0, forward = false, nearStartSec = 3.0))
+    }
+
+    @Test
+    fun `previous chapter at the first chapter near its start restarts the first chapter`() {
+        // chapter 0 near start: no prior chapter, so restart chapter 0 (effective no-op seek to 0)
+        assertEquals(skipClips[0], skipTrack.resolveChapterSkip("c1.mp3", 0.5, forward = false, nearStartSec = 3.0))
+    }
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `./gradlew :core:domain:test --tests "com.riffle.core.domain.ReadaloudTrackTest"`
+Expected: FAIL — unresolved references `chapterCount`, `chapterIndexAt`, `firstClipOfChapter`, `resolveRelativeSkip`, `resolveChapterSkip`, `ReadaloudTrack.Position`.
+
+- [ ] **Step 3: Implement the math**
+
+In `ReadaloudTrack.kt`, add inside the class body (after `clipForFragment`, before `resolveStartClip` is fine). First add a shared chapter-href helper and the global-timeline scaffolding, then the public API:
+
+```kotlin
+    /** A resolved seek target: which queued audio file, and the offset within it. */
+    data class Position(val audioSrc: String, val positionSec: Double)
+
+    private fun chapterHrefOf(clip: MediaOverlayClip): String =
+        clip.textFragmentRef.substringBefore('#').trimStart('/')
+
+    /** Distinct chapter hrefs in reading order (clips are already in reading order). */
+    private val chapterHrefs: List<String> = clips.map(::chapterHrefOf).distinct()
+
+    /** Distinct audio files in playlist order — the same order [ReadaloudController] queues them. */
+    private val fileOrder: List<String> = clips.map { it.audioSrc }.distinct()
+
+    /** Each file's duration, approximated by the end of its last clip. */
+    private val fileDuration: Map<String, Double> =
+        clips.groupBy { it.audioSrc }.mapValues { (_, cs) -> cs.maxOf { it.clipEndSec } }
+
+    /** Global start offset of each file on the concatenated timeline. */
+    private val fileStart: Map<String, Double> = buildMap {
+        var acc = 0.0
+        for (src in fileOrder) {
+            put(src, acc)
+            acc += fileDuration[src] ?: 0.0
+        }
+    }
+
+    private val totalDuration: Double = fileOrder.sumOf { fileDuration[it] ?: 0.0 }
+
+    /** Number of chapters in the readaloud. */
+    val chapterCount: Int get() = chapterHrefs.size
+
+    /** Maps a live playback position to a global timeline offset, or null if [audioSrc] is unknown. */
+    private fun globalOf(audioSrc: String?, positionSec: Double): Double? {
+        val start = audioSrc?.let { fileStart[it] } ?: return null
+        return start + positionSec
+    }
+
+    /** Inverse of [globalOf]: maps a clamped global offset back to a [Position]. */
+    private fun positionAt(global: Double): Position {
+        val g = global.coerceIn(0.0, totalDuration)
+        // Last file whose start is <= g; offset is the remainder, clamped to that file's duration.
+        val src = fileOrder.lastOrNull { (fileStart[it] ?: 0.0) <= g } ?: fileOrder.first()
+        val within = (g - (fileStart[src] ?: 0.0)).coerceIn(0.0, fileDuration[src] ?: 0.0)
+        return Position(src, within)
+    }
+
+    /**
+     * The chapter index containing the live position, or -1 when nothing is playing. Uses the active
+     * clip when the position sits inside one; otherwise the chapter of the latest clip at or before
+     * the global position (covers inter-clip gaps).
+     */
+    fun chapterIndexAt(audioSrc: String?, positionSec: Double): Int {
+        if (audioSrc == null) return -1
+        activeClipAt(audioSrc, positionSec)?.let { return chapterHrefs.indexOf(chapterHrefOf(it)) }
+        val global = globalOf(audioSrc, positionSec) ?: return -1
+        val clip = clips.lastOrNull { (globalOf(it.audioSrc, it.clipBeginSec) ?: Double.MAX_VALUE) <= global }
+            ?: return -1
+        return chapterHrefs.indexOf(chapterHrefOf(clip))
+    }
+
+    /** The first clip of chapter [index], or null when [index] is out of range. */
+    fun firstClipOfChapter(index: Int): MediaOverlayClip? {
+        val href = chapterHrefs.getOrNull(index) ?: return null
+        return clips.firstOrNull { chapterHrefOf(it) == href }
+    }
+
+    /** Resolves a relative skip of [deltaSec] from the live position, clamped to the whole readaloud. */
+    fun resolveRelativeSkip(audioSrc: String?, positionSec: Double, deltaSec: Double): Position? {
+        val global = globalOf(audioSrc, positionSec) ?: return null
+        return positionAt(global + deltaSec)
+    }
+
+    /**
+     * Resolves a chapter jump. [forward] true -> the next chapter's first clip (null at the last
+     * chapter). [forward] false -> restart the current chapter, unless the live position is within
+     * [nearStartSec] of the current chapter's start, in which case go to the previous chapter (or
+     * restart the first chapter when there is none).
+     */
+    fun resolveChapterSkip(audioSrc: String?, positionSec: Double, forward: Boolean, nearStartSec: Double): MediaOverlayClip? {
+        val index = chapterIndexAt(audioSrc, positionSec)
+        if (index < 0) return null
+        if (forward) return firstClipOfChapter(index + 1)
+        val currentFirst = firstClipOfChapter(index) ?: return null
+        val global = globalOf(audioSrc, positionSec) ?: return currentFirst
+        val chapterStart = globalOf(currentFirst.audioSrc, currentFirst.clipBeginSec) ?: 0.0
+        val nearStart = (global - chapterStart) <= nearStartSec
+        return if (nearStart && index > 0) firstClipOfChapter(index - 1) else currentFirst
+    }
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `./gradlew :core:domain:test --tests "com.riffle.core.domain.ReadaloudTrackTest"`
+Expected: PASS (all existing + new tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add core/domain/src/main/kotlin/com/riffle/core/domain/ReadaloudTrack.kt \
+        core/domain/src/test/kotlin/com/riffle/core/domain/ReadaloudTrackTest.kt
+git commit -m "feat(readaloud): global-timeline skip + chapter math on ReadaloudTrack"
+```
+
+---
+
+### Task 2: ReadaloudController — skip + chapter actions, chapter state
+
+**Files:**
+- Modify: `app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/ReadaloudController.kt`
+
+This is the Media3 boundary (no unit test — it needs a live `MediaController`; behaviour is covered by Task 1's pure tests and the harness/manual check). Keep it a thin caller of Task 1's math.
+
+- [ ] **Step 1: Add chapter fields to `PlaybackState`**
+
+In the `data class PlaybackState`, add two fields after `positionSec`:
+
+```kotlin
+        val positionSec: Double = 0.0,
+        val currentChapterIndex: Int = -1,
+        val chapterCount: Int = 0,
+```
+
+- [ ] **Step 2: Add the skip/chapter actions**
+
+After `setSpeed(...)` add:
+
+```kotlin
+    /** Rewinds/forwards along the continuous timeline (negative = rewind), clamped to the readaloud. */
+    fun skipBy(deltaSec: Double) {
+        val s = _state.value
+        val target = track?.resolveRelativeSkip(s.currentAudioSrc, s.positionSec, deltaSec) ?: return
+        seekToAudio(target.audioSrc, target.positionSec)
+        pushState()
+    }
+
+    /** Jumps to the first clip of an adjacent chapter (see [ReadaloudTrack.resolveChapterSkip]). */
+    fun skipChapter(forward: Boolean) {
+        val s = _state.value
+        val clip = track?.resolveChapterSkip(
+            s.currentAudioSrc, s.positionSec, forward, NEAR_START_SEC,
+        ) ?: return
+        seekToAudio(clip.audioSrc, clip.clipBeginSec)
+        pushState()
+    }
+```
+
+- [ ] **Step 3: Fill the chapter fields in `pushState`**
+
+Replace the body of `pushState()` so the new fields are populated from the track:
+
+```kotlin
+    private fun pushState() {
+        val c = controller
+        val t = track
+        val audioSrc = c?.currentMediaItem?.mediaId
+        val positionSec = (c?.currentPosition ?: 0L) / 1000.0
+        _state.value = PlaybackState(
+            connected = c != null,
+            isPlaying = c?.isPlaying == true,
+            speed = c?.playbackParameters?.speed ?: 1f,
+            currentAudioSrc = audioSrc,
+            positionSec = positionSec,
+            currentChapterIndex = t?.chapterIndexAt(audioSrc, positionSec) ?: -1,
+            chapterCount = t?.chapterCount ?: 0,
+        )
+    }
+```
+
+- [ ] **Step 4: Add the constants**
+
+In the `companion object`, add the skip durations next to `SPEEDS`:
+
+```kotlin
+        val SPEEDS = listOf(0.75f, 1f, 1.25f, 1.5f, 2f)
+        const val REWIND_SEC = 15.0
+        const val FORWARD_SEC = 30.0
+        private const val NEAR_START_SEC = 3.0
+```
+
+- [ ] **Step 5: Add the public rewind/forward/chapter helpers**
+
+After `skipChapter(...)` add the named entry points the coordinator calls:
+
+```kotlin
+    fun rewind() = skipBy(-REWIND_SEC)
+    fun forward() = skipBy(FORWARD_SEC)
+    fun previousChapter() = skipChapter(forward = false)
+    fun nextChapter() = skipChapter(forward = true)
+```
+
+- [ ] **Step 6: Compile**
+
+Run: `./gradlew :app:compileDebugKotlin`
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/ReadaloudController.kt
+git commit -m "feat(readaloud): controller skip/forward + chapter skip + chapter state"
+```
+
+---
+
+### Task 3: PlayerCoordinator — pass-throughs
+
+**Files:**
+- Modify: `app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/PlayerCoordinator.kt`
+
+- [ ] **Step 1: Add the pass-throughs**
+
+After `fun setSpeed(speed: Float) = controller.setSpeed(speed)` add:
+
+```kotlin
+    fun rewind() = controller.rewind()
+
+    fun forward() = controller.forward()
+
+    fun previousChapter() = controller.previousChapter()
+
+    fun nextChapter() = controller.nextChapter()
+```
+
+- [ ] **Step 2: Compile**
+
+Run: `./gradlew :app:compileDebugKotlin`
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/PlayerCoordinator.kt
+git commit -m "feat(readaloud): coordinator pass-throughs for skip + chapter controls"
+```
+
+---
+
+### Task 4: EpubReaderViewModel — intent methods
+
+**Files:**
+- Modify: `app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt`
+
+- [ ] **Step 1: Add the intent methods**
+
+After `fun setSpeed(speed: Float) = playerCoordinator.setSpeed(speed)` (around line 1122) add:
+
+```kotlin
+    fun rewind() = playerCoordinator.rewind()
+
+    fun forward() = playerCoordinator.forward()
+
+    fun previousChapter() = playerCoordinator.previousChapter()
+
+    fun nextChapter() = playerCoordinator.nextChapter()
+```
+
+- [ ] **Step 2: Compile**
+
+Run: `./gradlew :app:compileDebugKotlin`
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+git commit -m "feat(readaloud): view-model intents for skip + chapter controls"
+```
+
+---
+
+### Task 5: ReadaloudMiniPlayer — buttons + SkipIcon
+
+**Files:**
+- Modify: `app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/ReadaloudPlayerUi.kt`
+- Test: `app/src/androidTest/kotlin/com/riffle/app/feature/reader/readaloud/ReadaloudMiniPlayerTest.kt`
+
+Material `material-icons-extended` ships `Forward30`, `SkipNext`, `SkipPrevious` but **no `Replay15`**. So the two fine-skip glyphs are drawn by a small `SkipIcon` composable: a circular-arrow `Icons.Filled.Replay` (mirrored horizontally for forward) with the seconds count overlaid — giving a matched `⟲15` / `30⟳` pair with no custom drawable.
+
+- [ ] **Step 1: Write the failing harness test**
+
+Create `app/src/androidTest/kotlin/com/riffle/app/feature/reader/readaloud/ReadaloudMiniPlayerTest.kt`:
+
+```kotlin
+package com.riffle.app.feature.reader.readaloud
+
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class ReadaloudMiniPlayerTest {
+
+    @get:Rule
+    val rule = createAndroidComposeRule<ComponentActivity>()
+
+    private fun setPlayer(
+        canPreviousChapter: Boolean = true,
+        canNextChapter: Boolean = true,
+        onRewind: () -> Unit = {},
+        onForward: () -> Unit = {},
+        onPreviousChapter: () -> Unit = {},
+        onNextChapter: () -> Unit = {},
+    ) {
+        rule.setContent {
+            ReadaloudMiniPlayer(
+                isPlaying = false,
+                speed = 1f,
+                offlineMessage = false,
+                downloadProgress = null,
+                canPreviousChapter = canPreviousChapter,
+                canNextChapter = canNextChapter,
+                containerColor = Color.LightGray,
+                contentColor = Color.Black,
+                onPlayPause = {},
+                onCycleSpeed = {},
+                onRewind = onRewind,
+                onForward = onForward,
+                onPreviousChapter = onPreviousChapter,
+                onNextChapter = onNextChapter,
+                onClose = {},
+                onExpand = {},
+            )
+        }
+    }
+
+    @Test
+    fun skipButtons_areDisplayedInThePlayableState() {
+        setPlayer()
+        rule.onNodeWithTag("readaloud_rewind").assertIsDisplayed()
+        rule.onNodeWithTag("readaloud_prev_chapter").assertIsDisplayed()
+        rule.onNodeWithTag("readaloud_next_chapter").assertIsDisplayed()
+        rule.onNodeWithTag("readaloud_forward").assertIsDisplayed()
+    }
+
+    @Test
+    fun skipButtons_invokeTheirCallbacks() {
+        var rewinds = 0
+        var forwards = 0
+        var prevs = 0
+        var nexts = 0
+        setPlayer(
+            onRewind = { rewinds++ },
+            onForward = { forwards++ },
+            onPreviousChapter = { prevs++ },
+            onNextChapter = { nexts++ },
+        )
+        rule.onNodeWithTag("readaloud_rewind").performClick()
+        rule.onNodeWithTag("readaloud_forward").performClick()
+        rule.onNodeWithTag("readaloud_prev_chapter").performClick()
+        rule.onNodeWithTag("readaloud_next_chapter").performClick()
+        assertEquals(1, rewinds)
+        assertEquals(1, forwards)
+        assertEquals(1, prevs)
+        assertEquals(1, nexts)
+    }
+
+    @Test
+    fun nextChapter_isDisabledAtTheLastChapter() {
+        setPlayer(canNextChapter = false)
+        rule.onNodeWithTag("readaloud_next_chapter").assertIsNotEnabled()
+    }
+
+    @Test
+    fun skipButtons_areAbsentWhileOffline() {
+        rule.setContent {
+            ReadaloudMiniPlayer(
+                isPlaying = false,
+                speed = 1f,
+                offlineMessage = true,
+                downloadProgress = null,
+                canPreviousChapter = true,
+                canNextChapter = true,
+                containerColor = Color.LightGray,
+                contentColor = Color.Black,
+                onPlayPause = {},
+                onCycleSpeed = {},
+                onRewind = {},
+                onForward = {},
+                onPreviousChapter = {},
+                onNextChapter = {},
+                onClose = {},
+                onExpand = {},
+            )
+        }
+        rule.onNodeWithTag("readaloud_rewind").assertDoesNotExist()
+        rule.onNodeWithTag("readaloud_next_chapter").assertDoesNotExist()
+    }
+}
+```
+
+Add the missing import for the last test:
+
+```kotlin
+import androidx.compose.ui.test.assertDoesNotExist
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `make harness-test` (boots the Harness Medium Phone AVD; never call `connectedDebugAndroidTest` directly).
+Expected: FAIL — `ReadaloudMiniPlayer` has no `canPreviousChapter`/`onRewind`/… parameters; compile error.
+
+- [ ] **Step 3: Add the `SkipIcon` composable**
+
+In `ReadaloudPlayerUi.kt`, add near the top (after `speedLabel`):
+
+```kotlin
+/**
+ * A circular-arrow skip glyph with the seconds count overlaid. Material ships Forward30 but no
+ * Replay15, so both fine-skip buttons share this drawing for a matched look: a counter-clockwise
+ * [Icons.Filled.Replay] for rewind, mirrored horizontally for forward.
+ */
+@Composable
+private fun SkipIcon(seconds: Int, forward: Boolean, tint: Color) {
+    Box(contentAlignment = Alignment.Center) {
+        Icon(
+            imageVector = Icons.Filled.Replay,
+            contentDescription = null,
+            tint = tint,
+            modifier = Modifier.then(if (forward) Modifier.scale(scaleX = -1f, scaleY = 1f) else Modifier),
+        )
+        Text(
+            text = seconds.toString(),
+            color = tint,
+            fontSize = 8.sp,
+            fontWeight = FontWeight.Bold,
+        )
+    }
+}
+```
+
+Add these imports to the file's import block (keep alphabetical grouping with the existing ones):
+
+```kotlin
+import androidx.compose.foundation.layout.Box
+import androidx.compose.material.icons.filled.Forward30
+import androidx.compose.material.icons.filled.Replay
+import androidx.compose.material.icons.filled.SkipNext
+import androidx.compose.material.icons.filled.SkipPrevious
+import androidx.compose.ui.draw.scale
+import androidx.compose.ui.unit.sp
+```
+
+(`Forward30` is imported for parity even though `SkipIcon` draws the mirrored Replay; it is used by the chapter-vs-fine distinction nowhere else — remove this import if the compiler flags it as unused.)
+
+- [ ] **Step 4: Add the new parameters and buttons to `ReadaloudMiniPlayer`**
+
+Change the signature to add the four callbacks and two enable flags (after `onCycleSpeed`, before `onClose`):
+
+```kotlin
+fun ReadaloudMiniPlayer(
+    isPlaying: Boolean,
+    speed: Float,
+    offlineMessage: Boolean,
+    downloadProgress: Float?,
+    canPreviousChapter: Boolean,
+    canNextChapter: Boolean,
+    containerColor: Color,
+    contentColor: Color,
+    onPlayPause: () -> Unit,
+    onCycleSpeed: () -> Unit,
+    onRewind: () -> Unit,
+    onForward: () -> Unit,
+    onPreviousChapter: () -> Unit,
+    onNextChapter: () -> Unit,
+    onClose: () -> Unit,
+    onExpand: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+```
+
+Replace the `else` branch (the `play_pause` + `speed` + trailing `Spacer`) with the speed-left, centered-transport layout. The current block is:
+
+```kotlin
+            } else {
+                IconButton(onClick = onPlayPause, modifier = Modifier.testTag("readaloud_play_pause")) {
+                    Icon(
+                        imageVector = if (isPlaying) Icons.Default.Pause else Icons.Default.PlayArrow,
+                        contentDescription = if (isPlaying) "Pause" else "Play",
+                    )
+                }
+                TextButton(onClick = onCycleSpeed, modifier = Modifier.testTag("readaloud_speed")) {
+                    Text(
+                        speedLabel(speed),
+                        color = contentColor,
+                        fontWeight = FontWeight.SemiBold,
+                    )
+                }
+                Spacer(modifier = Modifier.weight(1f))
+            }
+```
+
+Replace it with:
+
+```kotlin
+            } else {
+                TextButton(onClick = onCycleSpeed, modifier = Modifier.testTag("readaloud_speed")) {
+                    Text(
+                        speedLabel(speed),
+                        color = contentColor,
+                        fontWeight = FontWeight.SemiBold,
+                    )
+                }
+                Spacer(modifier = Modifier.weight(1f))
+                IconButton(onClick = onRewind, modifier = Modifier.testTag("readaloud_rewind")) {
+                    SkipIcon(seconds = 15, forward = false, tint = contentColor)
+                }
+                IconButton(
+                    onClick = onPreviousChapter,
+                    enabled = canPreviousChapter,
+                    modifier = Modifier.testTag("readaloud_prev_chapter"),
+                ) {
+                    Icon(Icons.Filled.SkipPrevious, contentDescription = "Previous chapter")
+                }
+                IconButton(onClick = onPlayPause, modifier = Modifier.testTag("readaloud_play_pause")) {
+                    Icon(
+                        imageVector = if (isPlaying) Icons.Default.Pause else Icons.Default.PlayArrow,
+                        contentDescription = if (isPlaying) "Pause" else "Play",
+                    )
+                }
+                IconButton(
+                    onClick = onNextChapter,
+                    enabled = canNextChapter,
+                    modifier = Modifier.testTag("readaloud_next_chapter"),
+                ) {
+                    Icon(Icons.Filled.SkipNext, contentDescription = "Next chapter")
+                }
+                IconButton(onClick = onForward, modifier = Modifier.testTag("readaloud_forward")) {
+                    SkipIcon(seconds = 30, forward = true, tint = contentColor)
+                }
+                Spacer(modifier = Modifier.weight(1f))
+            }
+```
+
+This yields: `[1×] …spacer… [⟲15] [⏮] [▶/⏸] [⏭] [30⟳] …spacer… [✕]` (the trailing `✕` is the existing close `IconButton` after the `if/else`).
+
+- [ ] **Step 5: Run the harness test to verify it passes**
+
+Run: `make harness-test`
+Expected: PASS — `ReadaloudMiniPlayerTest` green (4 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/ReadaloudPlayerUi.kt \
+        app/src/androidTest/kotlin/com/riffle/app/feature/reader/readaloud/ReadaloudMiniPlayerTest.kt
+git commit -m "feat(readaloud): mini-player rewind/forward + prev/next chapter buttons"
+```
+
+---
+
+### Task 6: Wire the callbacks in EpubReaderScreen
+
+**Files:**
+- Modify: `app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt:364-380`
+
+- [ ] **Step 1: Pass the new arguments at the call site**
+
+In the `ReadaloudMiniPlayer(...)` call, add the chapter-enable flags (derived from `playbackState`) and the four callbacks. Insert `canPreviousChapter`/`canNextChapter` after `downloadProgress`, and the four callbacks after `onCycleSpeed`:
+
+```kotlin
+                    ReadaloudMiniPlayer(
+                        isPlaying = playbackState.isPlaying,
+                        speed = playbackState.speed,
+                        offlineMessage = readaloudOfflineMessage,
+                        downloadProgress = downloadProgress,
+                        canPreviousChapter = playbackState.currentChapterIndex > 0,
+                        canNextChapter = playbackState.currentChapterIndex >= 0 &&
+                            playbackState.currentChapterIndex < playbackState.chapterCount - 1,
+                        containerColor = readerPalette.background.copy(alpha = 0.65f),
+                        contentColor = readerPalette.foreground,
+                        onPlayPause = viewModel::togglePlayPause,
+                        onCycleSpeed = {
+                            // Cycle 0.75× → 1× → 1.25× → 1.5× → 2× → 0.75×.
+                            val speeds = com.riffle.app.feature.reader.readaloud.ReadaloudController.SPEEDS
+                            val idx = speeds.indexOfFirst { kotlin.math.abs(it - playbackState.speed) < 0.001f }
+                            viewModel.setSpeed(if (idx < 0) 1f else speeds[(idx + 1) % speeds.size])
+                        },
+                        onRewind = viewModel::rewind,
+                        onForward = viewModel::forward,
+                        onPreviousChapter = viewModel::previousChapter,
+                        onNextChapter = viewModel::nextChapter,
+                        onClose = viewModel::closeReadaloud,
+                        onExpand = viewModel::expandPlayer,
+                    )
+```
+
+> Note: `canPreviousChapter` stays `true` even at chapter 0 (the button *restarts* chapter 0 — an effective no-op at the very start); it is only the dead `next` direction that disables. `currentChapterIndex > 0` would disable restart-of-chapter-0; that is acceptable per the spec ("no-op ⏮ at the very first chapter"). Use `playbackState.currentChapterIndex > 0` as written so the first chapter's ⏮ is disabled.
+
+- [ ] **Step 2: Compile**
+
+Run: `./gradlew :app:compileDebugKotlin`
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+git commit -m "feat(readaloud): wire mini-player skip + chapter callbacks"
+```
+
+---
+
+### Task 7: Full verification
+
+- [ ] **Step 1: Run the full JVM test suite**
+
+Run: `./gradlew test`
+Expected: BUILD SUCCESSFUL (CI parity — catches pure-JVM modules `:test` misses with module-specific tasks).
+
+- [ ] **Step 2: Run the phone harness suite**
+
+Run: `make harness-test`
+Expected: BUILD SUCCESSFUL — including `ReadaloudMiniPlayerTest`.
+
+- [ ] **Step 3: Manual smoke (optional but recommended)**
+
+On a real device or the AVD with a prepared readaloud book: play, tap ⟲15 (jumps back ~15s, highlight follows), tap 30⟳ (jumps forward ~30s), tap ⏭ (next chapter, page follows), tap ⏮ mid-chapter (restarts chapter), tap ⏮ near a chapter start (previous chapter). Confirm ⏭ is disabled on the last chapter.
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** layout (Task 5/6), rewind 15 / forward 30 continuous + clamp (Task 1 `resolveRelativeSkip` + Task 2 `skipBy`), prev/next chapter driving audio (Task 1 `resolveChapterSkip` + Task 2 `skipChapter`), ⏮ restart-vs-previous near-start threshold (Task 1), first/last-chapter clamp (Task 1 returns null for next-past-last; Task 6 disables `next`; `prev` disabled at chapter 0 via `> 0`), mini-bar-only / sheet untouched (no sheet edits), gating to the playable state (Task 5 keeps buttons inside the existing `else` branch). Covered.
+- **Type consistency:** `Position(audioSrc, positionSec)` used identically in Task 1 tests, impl, and Task 2 caller. `currentChapterIndex`/`chapterCount` named identically in `PlaybackState` (Task 2) and the screen (Task 6). `REWIND_SEC`/`FORWARD_SEC` constants defined in Task 2.
+- **Icon caveat:** no `Replay15` in Material; `SkipIcon` draws it. `Forward30` import may be unused — remove if flagged.

--- a/docs/superpowers/specs/2026-06-09-readaloud-skip-controls-design.md
+++ b/docs/superpowers/specs/2026-06-09-readaloud-skip-controls-design.md
@@ -1,0 +1,133 @@
+# Readaloud skip controls — design
+
+**Date:** 2026-06-09
+**Status:** Approved design, pending implementation plan
+
+## Goal
+
+Add skip controls to the Readaloud mini-player so a listener can move around
+without leaving the bar:
+
+- **Rewind 15 s** and **Forward 30 s** — fine-grained seeking.
+- **Previous / Next chapter** — coarse jumps that move the *audio*, with the
+  reading position auto-following.
+
+The mini-player stays small; the expanded sheet is **not** changed in this work.
+
+## Why these controls (and why they're not redundant)
+
+The reader already has a chapter navigation rail (a 4 dp segmented progress bar)
+whose segments jump chapters on tap. But during Readaloud that jump does **not**
+stick: `PlayerCoordinator` derives the narrated fragment from the controller's
+playback position, and `EpubReaderScreen`'s auto-follow drags the reading
+position back to that fragment on the next poll. The rail moves the *view*; it
+cannot move the *audio*.
+
+So chapter navigation *during playback* must move the player, after which the
+page follows for free. Dedicated `⏮ ⏭` buttons are the only control that can do
+this — they are not redundant with the rail.
+
+## Layout
+
+Mini-player bar, left-to-right:
+
+```
+[ 1× ]  …spacer…  [ ⟲15 ] [ ⏮ ] [ ▶/⏸ ] [ ⏭ ] [ 30⟳ ]  …spacer…  [ ✕ ]
+ speed             rewind  prev   play    next  forward          close
+```
+
+- Speed (`1×`) anchors the left end; close (`✕`) the right end.
+- The five transport buttons sit centered and symmetric around play:
+  fine skips on the outer edges, chapter skips hugging play.
+- Rewind is **15 s**, forward is **30 s** (asymmetric on purpose — the common
+  "back a little, forward a lot" listening pattern). The glyphs are Material's
+  `Replay` + a "15" / `Forward`-style + a "30"; the shipped Compose version uses
+  the real `Icons.Filled.Replay10`-family or vector drawables carrying the
+  numerals, whichever renders the exact 15/30 cleanly.
+- Skip controls are part of the playing transport, so they appear only when the
+  bar is in its playable state — not while showing the offline message or the
+  download-progress text (same gate as the existing play/pause + speed).
+
+A localhost prototype of this layout (and the alternatives considered) lives at
+`.context/readaloud-skip-prototype/index.html`.
+
+## Behaviour
+
+### Rewind 15 s / Forward 30 s
+
+A skip seeks along a **continuous timeline across the queued audio files**, not
+just within the current file. The controller queues one `MediaItem` per distinct
+`audioSrc`; a 15/30 s skip near a file boundary therefore has to roll into the
+adjacent file. Forward past the very end and rewind before the very start
+**clamp** to the end / start of the readaloud.
+
+The synced highlight and auto-page-turn follow automatically — they already
+track the controller's reported `(audioSrc, positionSec)`.
+
+### Previous / Next chapter
+
+Chapters are derived from clip chapter hrefs (the portion of
+`MediaOverlayClip.textFragmentRef` before `#`), in reading order. The current
+chapter is the one containing the active clip at the current playback position.
+
+- **Next (`⏭`):** seek to the first clip of the next chapter.
+- **Previous (`⏮`):** restart the **current** chapter (seek to its first clip);
+  but if playback is already **near the start** of the current chapter, jump to
+  the first clip of the **previous** chapter instead. "Near the start" is a
+  small fixed threshold measured from the current chapter's first clip
+  (audiobook-standard; concrete value chosen in the plan, ~3 s).
+- Each chapter jump seeks the audio; auto-follow then moves the reading position.
+
+### Clamping at the ends
+
+- At the **first** chapter, `⏮` is a no-op / disabled (after the
+  restart-current-chapter behaviour — i.e. it can still restart chapter 1, but
+  never goes "before" it).
+- At the **last** chapter, `⏭` is a no-op / disabled.
+- Forward 30 s clamps at the end of the last file; rewind 15 s clamps at 0.
+
+## Components and changes
+
+- **`ReadaloudController`** (the headless Media3 handle) gains:
+  - `skipBy(deltaSec: Double)` — continuous-timeline relative seek across the
+    queued items, clamped at both ends.
+  - `skipToAdjacentChapter(direction)` — resolve current chapter from
+    `(currentAudioSrc, positionSec)`, then seek to the first clip of the target
+    chapter per the previous/next rules above. Uses the `track` it already holds.
+  - Both reuse the existing private `seekToAudio(audioSrc, positionSec)` and the
+    `audioIndex` playlist map.
+- **`ReadaloudTrack`** gains the chapter-boundary helpers this needs, kept in the
+  domain layer next to `activeClipAt` / `resolveStartClip`:
+  - the ordered distinct chapter hrefs,
+  - "chapter containing this clip / position", and
+  - "first clip of chapter N". This keeps the chapter math unit-testable without
+    a Media3 controller.
+- **`PlayerCoordinator`** gains thin pass-throughs (`rewind()`, `forward()`,
+  `previousChapter()`, `nextChapter()`) mirroring its existing `play/pause/setSpeed`.
+- **`EpubReaderViewModel`** gains matching intent methods.
+- **`ReadaloudMiniPlayer`** gains five callbacks (`onRewind`, `onForward`,
+  `onPreviousChapter`, `onNextChapter` — play/pause already exists) and the new
+  buttons, with `testTag`s for harness tests (`readaloud_rewind`,
+  `readaloud_forward`, `readaloud_prev_chapter`, `readaloud_next_chapter`).
+  `canPreviousChapter` / `canNextChapter` flags drive the end-of-book disabling.
+- **`EpubReaderScreen`** wires the new callbacks to the view-model, alongside the
+  existing `onPlayPause` / `onCycleSpeed`.
+
+## Out of scope
+
+- No changes to the expanded sheet (`ReadaloudExpandedSheet`).
+- No tap-to-accumulate skip (each tap is a fixed 15 / 30 s).
+- No configurable skip durations.
+- No new persisted state.
+
+## Testing
+
+- **`ReadaloudTrack`** unit tests (pure JVM): chapter ordering, chapter-for-position,
+  first-clip-of-chapter, and the near-start threshold boundary.
+- **Controller / coordinator** seek behaviour: continuous-timeline skip crossing a
+  file boundary and clamping at both ends; previous-chapter restart-vs-jump
+  threshold; next/prev clamping at first/last chapter.
+- **Mini-player** harness test (phone form factor): the new buttons render in the
+  playable state, are absent in offline / downloading states, and invoke their
+  callbacks; chapter buttons reflect the disabled state at book ends.
+```


### PR DESCRIPTION
## What

Adds transport controls to the Readaloud mini-player:

- **Rewind 15s / Forward 30s** — pure audio seek along a continuous timeline across the queued audio files, clamped at the ends (`ReadaloudTrack.resolveRelativeSkip`).
- **Previous / Next chapter** — audio-domain seek to the adjacent chapter's first clip (`ReadaloudController.skipChapter` → `resolveChapterSkip`); the page follows via the existing auto-follow. No reader/TOC coupling, so it stays an audio-player concern (and will coexist with the future audiobook-only player).
- **Layout:** `1× … ⟲15 ⏮ ▶/⏸ ⏭ 30⟳ … ✕` (speed left, transport centered, close right).
- **Icons:** filled Material numbered glyphs — stock `Forward30` plus a custom `ic_replay_15` vector (assembled from genuine Material digit paths) so the skip glyphs match the filled weight of the play/skip buttons and read clearly over the translucent bar.

## Known limitation

Chapter boundaries are inferred from the Storyteller bundle's section hrefs, which are offset from the rendered ABS text, so a chapter jump can land ~one sentence into the section. A proper audio-domain chapter-marker source (bundle `nav`/TOC, or ABS audiobook chapters) is a planned follow-up; design/plan docs are included.

## Tested

- `./gradlew test` + `./gradlew lint` — green
- `make harness-test` (phone) — 170 tests, 0 failed (incl. new `ReadaloudMiniPlayerTest`)
- `make harness-test-tablet` — 5 tests, 0 failed
- Manual on-device (The Martian readaloud): rewind/forward seek correctly; prev/next chapter seek the audio and the page follows.