### PR TITLE
feat(readaloud): show ebook/audiobook completeness in Storyteller matches

### DIFF
--- a/app/src/androidTest/kotlin/com/riffle/app/feature/settings/ServerSettingsExpansionTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/settings/ServerSettingsExpansionTest.kt
@@ -97,15 +97,15 @@ class ServerSettingsExpansionTest {
             ServerSettingsExpansion(
                 server = server(ServerType.STORYTELLER, active = true),
                 libraryItems = emptyList(),
-                summary = ReadaloudMatchSummary(confirmedCount = 3, pendingCount = 1, unmatchedCount = 2),
+                summary = ReadaloudMatchSummary(unmatchedCount = 2, suggestedCount = 1, partiallyMatchedCount = 1, matchedCount = 3),
                 onSetLibraryVisible = { _, _ -> },
                 onOpenReadaloudMatches = { opened = true },
             )
         }
 
         composeTestRule.onNodeWithText("Readaloud matches").assertIsDisplayed()
-        composeTestRule.onNodeWithText("3 confirmed · 1 pending review · 2 unmatched").assertIsDisplayed()
-        composeTestRule.onNodeWithText("Review & pair readalouds").performClick()
+        composeTestRule.onNodeWithText("2 unmatched · 1 suggested · 1 partially matched · 3 matched").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Review & match readalouds").performClick()
 
         assertTrue(opened)
     }

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsScreen.kt
@@ -316,18 +316,19 @@ internal fun ServerSettingsExpansion(
             }
             ServerType.STORYTELLER -> {
                 ExpansionHeader("Readaloud matches")
-                val counts = summary ?: ReadaloudMatchSummary(0, 0, 0)
+                val counts = summary ?: ReadaloudMatchSummary(0, 0, 0, 0)
                 ListItem(
                     colors = transparentColors,
                     modifier = Modifier
                         .padding(start = 24.dp)
                         .clickable { onOpenReadaloudMatches() },
-                    headlineContent = { Text("Review & pair readalouds") },
+                    headlineContent = { Text("Review & match readalouds") },
                     supportingContent = {
                         Text(
-                            "${counts.confirmedCount} confirmed · " +
-                                "${counts.pendingCount} pending review · " +
-                                "${counts.unmatchedCount} unmatched",
+                            "${counts.unmatchedCount} unmatched · " +
+                                "${counts.suggestedCount} suggested · " +
+                                "${counts.partiallyMatchedCount} partially matched · " +
+                                "${counts.matchedCount} matched",
                         )
                     },
                     trailingContent = {

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsViewModel.kt
@@ -67,7 +67,7 @@ class SettingsViewModel @Inject constructor(
         .map { list -> list.filter { it.serverType == ServerType.STORYTELLER }.map { it.id } }
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
 
-    /** Readaloud-matches counts (confirmed / pending / unmatched) for each Storyteller server. */
+    /** Readaloud-matches counts (unmatched / suggested / partially matched / matched) per server. */
     val readaloudSummaries: StateFlow<Map<String, ReadaloudMatchSummary>> = storytellerServerIds
         .flatMapLatest { ids ->
             if (ids.isEmpty()) {
@@ -76,10 +76,12 @@ class SettingsViewModel @Inject constructor(
                 combine(
                     ids.map { id ->
                         readaloudReviewRepository.observeReview(id).map { review ->
+                            val partiallyMatched = review.confirmed.count { it.isIncomplete }
                             id to ReadaloudMatchSummary(
-                                confirmedCount = review.confirmed.size,
-                                pendingCount = review.pending.size,
                                 unmatchedCount = review.unmatched.size,
+                                suggestedCount = review.pending.size,
+                                partiallyMatchedCount = partiallyMatched,
+                                matchedCount = review.confirmed.size - partiallyMatched,
                             )
                         }
                     }
@@ -194,9 +196,10 @@ class SettingsViewModel @Inject constructor(
     }
 }
 
-/** Counts shown in a Storyteller server's expanded "Readaloud matches" summary. */
+/** Counts shown in a Storyteller server's expanded "Readaloud matches" summary (gradient order). */
 data class ReadaloudMatchSummary(
-    val confirmedCount: Int,
-    val pendingCount: Int,
     val unmatchedCount: Int,
+    val suggestedCount: Int,
+    val partiallyMatchedCount: Int,
+    val matchedCount: Int,
 )

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/readaloud/ReadaloudMatchesScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/readaloud/ReadaloudMatchesScreen.kt
@@ -1,5 +1,9 @@
 package com.riffle.app.feature.settings.readaloud
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -37,6 +41,11 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.PathEffect
+import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.painter.ColorPainter
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.draw.clip
@@ -48,6 +57,7 @@ import coil.compose.AsyncImage
 import coil.request.ImageRequest
 import androidx.compose.ui.platform.LocalContext
 import com.riffle.core.domain.AbsCandidate
+import com.riffle.core.domain.AbsFormatFilter
 import com.riffle.core.domain.AbsPickerItem
 import com.riffle.core.domain.ConfirmedReadaloud
 import com.riffle.core.domain.PendingReadaloud
@@ -82,9 +92,30 @@ fun ReadaloudMatchesScreen(
                 .fillMaxSize()
                 .padding(padding),
         ) {
-            sectionHeader("Pending Review (${review.pending.size})")
+            // A confirmed readaloud is "Matched" only when both an ebook and an audiobook are linked;
+            // otherwise it's "Partially matched" (one side still missing).
+            val (partiallyMatched, matched) = review.confirmed.partition { it.isIncomplete }
+
+            sectionHeader("Unmatched (${review.unmatched.size})")
+            if (review.unmatched.isEmpty()) {
+                emptyRow("Every readaloud is matched or suggested.")
+            } else {
+                items(review.unmatched, key = { it.storytellerBookId }) { book ->
+                    UnmatchedReadaloudRow(
+                        book = book,
+                        tokens = tokens,
+                        onMatchManually = {
+                            viewModel.setPickerFilter(AbsFormatFilter.ANY)
+                            pairingBookId = book.storytellerBookId
+                        },
+                    )
+                    HorizontalDivider()
+                }
+            }
+
+            sectionHeader("Suggested (${review.pending.size})")
             if (review.pending.isEmpty()) {
-                emptyRow("Nothing waiting for review.")
+                emptyRow("No suggested matches right now.")
             } else {
                 items(review.pending, key = { it.storytellerBookId }) { book ->
                     PendingReadaloudCard(
@@ -98,28 +129,35 @@ fun ReadaloudMatchesScreen(
                 }
             }
 
-            sectionHeader("Unmatched (${review.unmatched.size})")
-            if (review.unmatched.isEmpty()) {
-                emptyRow("Every readaloud is matched or under review.")
+            sectionHeader("Partially matched (${partiallyMatched.size})")
+            if (partiallyMatched.isEmpty()) {
+                emptyRow("Every match has both an ebook and an audiobook.")
             } else {
-                items(review.unmatched, key = { it.storytellerBookId }) { book ->
-                    UnmatchedReadaloudRow(
-                        book = book,
-                        tokens = tokens,
-                        onMatchManually = { pairingBookId = book.storytellerBookId },
+                items(partiallyMatched, key = { it.storytellerBookId }) { link ->
+                    ConfirmedReadaloudRow(
+                        link = link,
+                        onUnlink = { viewModel.unlinkBook(link) },
+                        onAddMissing = { filter ->
+                            viewModel.setPickerFilter(filter)
+                            pairingBookId = link.storytellerBookId
+                        },
                     )
                     HorizontalDivider()
                 }
             }
 
-            sectionHeader("Confirmed (${review.confirmed.size})")
-            if (review.confirmed.isEmpty()) {
-                emptyRow("No confirmed links yet.")
+            sectionHeader("Matched (${matched.size})")
+            if (matched.isEmpty()) {
+                emptyRow("No fully matched readalouds yet.")
             } else {
-                items(review.confirmed, key = { it.storytellerBookId }) { link ->
+                items(matched, key = { it.storytellerBookId }) { link ->
                     ConfirmedReadaloudRow(
                         link = link,
                         onUnlink = { viewModel.unlinkBook(link) },
+                        onAddMissing = { filter ->
+                            viewModel.setPickerFilter(filter)
+                            pairingBookId = link.storytellerBookId
+                        },
                     )
                     HorizontalDivider()
                 }
@@ -257,24 +295,103 @@ private fun UnmatchedReadaloudRow(
 private fun ConfirmedReadaloudRow(
     link: ConfirmedReadaloud,
     onUnlink: () -> Unit,
+    onAddMissing: (AbsFormatFilter) -> Unit,
 ) {
-    Row(
-        modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 12.dp),
-        verticalAlignment = Alignment.CenterVertically,
+    Column(modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 12.dp)) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Text(
+                link.title,
+                style = MaterialTheme.typography.titleMedium,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.weight(1f),
+            )
+            TextButton(onClick = onUnlink) { Text("Unlink") }
+        }
+        Spacer(Modifier.height(8.dp))
+        // Two fixed slots — a combined ABS item fills both; a one-sided match leaves the other
+        // slot empty and tappable so the missing side can be linked in place.
+        Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(10.dp)) {
+            FormatSlot(
+                label = "📖 Ebook",
+                targets = link.targets.filter { it.hasEbook },
+                onAdd = { onAddMissing(AbsFormatFilter.EBOOK) },
+                modifier = Modifier.weight(1f),
+            )
+            FormatSlot(
+                label = "🎧 Audiobook",
+                targets = link.targets.filter { it.hasAudio },
+                onAdd = { onAddMissing(AbsFormatFilter.AUDIO) },
+                modifier = Modifier.weight(1f),
+            )
+        }
+    }
+}
+
+@Composable
+private fun FormatSlot(
+    label: String,
+    targets: List<ConfirmedReadaloud.ConfirmedTarget>,
+    onAdd: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val shape = RoundedCornerShape(12.dp)
+    val isEmpty = targets.isEmpty()
+    // A missing slot is flagged with a warning amber (Material3 has no warning role). Tinted fill +
+    // amber dashed border + amber label so the gap reads as "needs attention", not a normal item.
+    val amber = if (isSystemInDarkTheme()) Color(0xFFE6B450) else Color(0xFF9A6700)
+    val amberFill = Color(0xFFFFC107).copy(alpha = if (isSystemInDarkTheme()) 0.10f else 0.16f)
+    Column(
+        modifier = modifier
+            .clip(shape)
+            .then(
+                if (isEmpty) {
+                    Modifier
+                        .background(amberFill, shape)
+                        .dashedBorder(amber)
+                        .clickable(onClick = onAdd)
+                } else {
+                    Modifier.border(1.dp, MaterialTheme.colorScheme.outline, shape)
+                }
+            )
+            .padding(horizontal = 10.dp, vertical = 9.dp),
     ) {
-        Column(Modifier.weight(1f)) {
-            Text(link.title, style = MaterialTheme.typography.titleMedium, maxLines = 2, overflow = TextOverflow.Ellipsis)
-            link.targets.forEach { target ->
+        Text(
+            label,
+            style = MaterialTheme.typography.labelSmall,
+            color = if (isEmpty) amber else MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Spacer(Modifier.height(3.dp))
+        if (isEmpty) {
+            Text(
+                "＋ Not linked",
+                style = MaterialTheme.typography.bodyMedium,
+                color = amber,
+            )
+        } else {
+            targets.forEach { target ->
                 Text(
-                    "Linked to: ${target.absTitle} · ${target.absLibraryName}",
+                    "${target.absTitle} · ${target.absLibraryName}",
                     style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
             }
         }
-        TextButton(onClick = onUnlink) { Text("Unlink") }
     }
 }
+
+/** A rounded dashed outline, used to render an empty (missing) format slot as a fill-me affordance. */
+private fun Modifier.dashedBorder(color: Color): Modifier =
+    drawBehind {
+        val stroke = Stroke(
+            width = 1.dp.toPx(),
+            pathEffect = PathEffect.dashPathEffect(floatArrayOf(10f, 8f), 0f),
+        )
+        drawRoundRect(
+            color = color,
+            style = stroke,
+            cornerRadius = CornerRadius(12.dp.toPx(), 12.dp.toPx()),
+        )
+    }
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/readaloud/ReadaloudMatchesScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/readaloud/ReadaloudMatchesScreen.kt
@@ -87,15 +87,21 @@ fun ReadaloudMatchesScreen(
             )
         },
     ) { padding ->
+        // A confirmed readaloud is "Matched" only when both an ebook and an audiobook are linked;
+        // otherwise it's "Partially matched" (one side still missing).
+        val (partiallyMatched, matched) = remember(review.confirmed) {
+            review.confirmed.partition { it.isIncomplete }
+        }
+        // Opens the manual picker for a readaloud, scoped to the slot that was tapped.
+        val openPicker = { bookId: String, filter: AbsFormatFilter ->
+            viewModel.setPickerFilter(filter)
+            pairingBookId = bookId
+        }
         LazyColumn(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(padding),
         ) {
-            // A confirmed readaloud is "Matched" only when both an ebook and an audiobook are linked;
-            // otherwise it's "Partially matched" (one side still missing).
-            val (partiallyMatched, matched) = review.confirmed.partition { it.isIncomplete }
-
             sectionHeader("Unmatched (${review.unmatched.size})")
             if (review.unmatched.isEmpty()) {
                 emptyRow("Every readaloud is matched or suggested.")
@@ -104,10 +110,7 @@ fun ReadaloudMatchesScreen(
                     UnmatchedReadaloudRow(
                         book = book,
                         tokens = tokens,
-                        onMatchManually = {
-                            viewModel.setPickerFilter(AbsFormatFilter.ANY)
-                            pairingBookId = book.storytellerBookId
-                        },
+                        onMatchManually = { openPicker(book.storytellerBookId, AbsFormatFilter.ANY) },
                     )
                     HorizontalDivider()
                 }
@@ -129,45 +132,28 @@ fun ReadaloudMatchesScreen(
                 }
             }
 
-            sectionHeader("Partially matched (${partiallyMatched.size})")
-            if (partiallyMatched.isEmpty()) {
-                emptyRow("Every match has both an ebook and an audiobook.")
-            } else {
-                items(partiallyMatched, key = { it.storytellerBookId }) { link ->
-                    ConfirmedReadaloudRow(
-                        link = link,
-                        onUnlink = { viewModel.unlinkBook(link) },
-                        onAddMissing = { filter ->
-                            viewModel.setPickerFilter(filter)
-                            pairingBookId = link.storytellerBookId
-                        },
-                    )
-                    HorizontalDivider()
-                }
-            }
+            confirmedSection(
+                title = "Partially matched",
+                links = partiallyMatched,
+                emptyText = "Every match has both an ebook and an audiobook.",
+                onUnlink = { viewModel.unlinkBook(it) },
+                onAddMissing = { link, filter -> openPicker(link.storytellerBookId, filter) },
+            )
 
-            sectionHeader("Matched (${matched.size})")
-            if (matched.isEmpty()) {
-                emptyRow("No fully matched readalouds yet.")
-            } else {
-                items(matched, key = { it.storytellerBookId }) { link ->
-                    ConfirmedReadaloudRow(
-                        link = link,
-                        onUnlink = { viewModel.unlinkBook(link) },
-                        onAddMissing = { filter ->
-                            viewModel.setPickerFilter(filter)
-                            pairingBookId = link.storytellerBookId
-                        },
-                    )
-                    HorizontalDivider()
-                }
-            }
+            confirmedSection(
+                title = "Matched",
+                links = matched,
+                emptyText = "No fully matched readalouds yet.",
+                onUnlink = { viewModel.unlinkBook(it) },
+                onAddMissing = { link, filter -> openPicker(link.storytellerBookId, filter) },
+            )
         }
     }
 
     pairingBookId?.let { bookId ->
         val query by viewModel.pickerQuery.collectAsState()
         val results by viewModel.pickerResults.collectAsState()
+        val filter by viewModel.pickerFilter.collectAsState()
         // Reactively reflects links as they're added/removed so the picker can stay open and let
         // the user attach several ABS items (e.g. ebook + audiobook) to one readaloud.
         val linkedItemIds = review.confirmed
@@ -177,12 +163,16 @@ fun ReadaloudMatchesScreen(
         AbsPickerDialog(
             query = query,
             results = results,
+            filter = filter,
             tokens = tokens,
             linkedItemIds = linkedItemIds,
             onQueryChange = viewModel::onPickerQueryChange,
             onLink = { item -> viewModel.pairManually(bookId, item) },
             onUnlink = { item -> viewModel.unlinkAbsItem(item) },
-            onDismiss = { pairingBookId = null },
+            onDismiss = {
+                pairingBookId = null
+                viewModel.closePicker()
+            },
         )
     }
 }
@@ -206,6 +196,29 @@ private fun LazyListScope.emptyRow(text: String) {
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 12.dp),
         )
+    }
+}
+
+/** A "Partially matched" / "Matched" section: a header plus one two-slot row per confirmed match. */
+private fun LazyListScope.confirmedSection(
+    title: String,
+    links: List<ConfirmedReadaloud>,
+    emptyText: String,
+    onUnlink: (ConfirmedReadaloud) -> Unit,
+    onAddMissing: (ConfirmedReadaloud, AbsFormatFilter) -> Unit,
+) {
+    sectionHeader("$title (${links.size})")
+    if (links.isEmpty()) {
+        emptyRow(emptyText)
+    } else {
+        items(links, key = { it.storytellerBookId }) { link ->
+            ConfirmedReadaloudRow(
+                link = link,
+                onUnlink = { onUnlink(link) },
+                onAddMissing = { filter -> onAddMissing(link, filter) },
+            )
+            HorizontalDivider()
+        }
     }
 }
 
@@ -398,6 +411,7 @@ private fun Modifier.dashedBorder(color: Color): Modifier =
 private fun AbsPickerDialog(
     query: String,
     results: List<AbsPickerItem>,
+    filter: AbsFormatFilter,
     tokens: Map<String, String>,
     linkedItemIds: Set<String>,
     onQueryChange: (String) -> Unit,
@@ -405,12 +419,24 @@ private fun AbsPickerDialog(
     onUnlink: (AbsPickerItem) -> Unit,
     onDismiss: () -> Unit,
 ) {
+    // When opened from an empty slot the list is filtered to that format — say so, otherwise an
+    // empty result reads as "nothing found" rather than "filtered to ebooks/audiobooks".
+    val title = when (filter) {
+        AbsFormatFilter.EBOOK -> "Link an ebook"
+        AbsFormatFilter.AUDIO -> "Link an audiobook"
+        AbsFormatFilter.ANY -> "Match manually"
+    }
+    val subtitle = when (filter) {
+        AbsFormatFilter.EBOOK -> "Showing ABS items that have an ebook."
+        AbsFormatFilter.AUDIO -> "Showing ABS items that have an audiobook."
+        AbsFormatFilter.ANY -> "A readaloud can link to more than one book (e.g. an ebook and an audiobook)."
+    }
     Dialog(onDismissRequest = onDismiss) {
         Surface(shape = RoundedCornerShape(12.dp), tonalElevation = 2.dp) {
             Column(modifier = Modifier.fillMaxWidth().padding(16.dp)) {
-                Text("Match manually", style = MaterialTheme.typography.titleMedium)
+                Text(title, style = MaterialTheme.typography.titleMedium)
                 Text(
-                    "A readaloud can link to more than one book (e.g. an ebook and an audiobook).",
+                    subtitle,
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/readaloud/ReadaloudMatchesViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/readaloud/ReadaloudMatchesViewModel.kt
@@ -56,6 +56,7 @@ class ReadaloudMatchesViewModel @Inject constructor(
     // Scopes the picker to the slot it was opened for: EBOOK / AUDIO from a Confirmed match's empty
     // slot, ANY from an Unmatched row's "Match manually…".
     private val _pickerFilter = MutableStateFlow(AbsFormatFilter.ANY)
+    val pickerFilter: StateFlow<AbsFormatFilter> = _pickerFilter.asStateFlow()
 
     private val _pickerResults = MutableStateFlow<List<AbsPickerItem>>(emptyList())
     val pickerResults: StateFlow<List<AbsPickerItem>> = _pickerResults.asStateFlow()
@@ -84,6 +85,12 @@ class ReadaloudMatchesViewModel @Inject constructor(
     fun setPickerFilter(filter: AbsFormatFilter) {
         _pickerQuery.value = ""
         _pickerFilter.value = filter
+    }
+
+    /** Clears picker state when the dialog is dismissed so the next open starts unfiltered. */
+    fun closePicker() {
+        _pickerQuery.value = ""
+        _pickerFilter.value = AbsFormatFilter.ANY
     }
 
     fun confirm(book: PendingReadaloud, candidate: AbsCandidate) {

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/readaloud/ReadaloudMatchesViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/readaloud/ReadaloudMatchesViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.riffle.core.domain.AbsCandidate
+import com.riffle.core.domain.AbsFormatFilter
 import com.riffle.core.domain.AbsPickerItem
 import com.riffle.core.domain.ConfirmedReadaloud
 import com.riffle.core.domain.PendingReadaloud
@@ -17,6 +18,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.stateIn
@@ -51,6 +53,10 @@ class ReadaloudMatchesViewModel @Inject constructor(
     private val _pickerQuery = MutableStateFlow("")
     val pickerQuery: StateFlow<String> = _pickerQuery.asStateFlow()
 
+    // Scopes the picker to the slot it was opened for: EBOOK / AUDIO from a Confirmed match's empty
+    // slot, ANY from an Unmatched row's "Match manually…".
+    private val _pickerFilter = MutableStateFlow(AbsFormatFilter.ANY)
+
     private val _pickerResults = MutableStateFlow<List<AbsPickerItem>>(emptyList())
     val pickerResults: StateFlow<List<AbsPickerItem>> = _pickerResults.asStateFlow()
 
@@ -64,10 +70,20 @@ class ReadaloudMatchesViewModel @Inject constructor(
             _tokensByServer.value = map
         }
         viewModelScope.launch {
-            _pickerQuery
-                .debounce(200)
-                .collect { query -> _pickerResults.value = reviewRepository.searchAbsItems(query) }
+            combine(_pickerQuery.debounce(200), _pickerFilter) { query, filter -> query to filter }
+                .collect { (query, filter) ->
+                    _pickerResults.value = reviewRepository.searchAbsItems(query, filter)
+                }
         }
+    }
+
+    /**
+     * Opens the picker scoped to [filter] (called from a Confirmed match's empty slot or an
+     * Unmatched row). Resets the query so stale results don't flash with a different filter.
+     */
+    fun setPickerFilter(filter: AbsFormatFilter) {
+        _pickerQuery.value = ""
+        _pickerFilter.value = filter
     }
 
     fun confirm(book: PendingReadaloud, candidate: AbsCandidate) {

--- a/app/src/test/kotlin/com/riffle/app/feature/library/NoopReadaloudReviewRepository.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/NoopReadaloudReviewRepository.kt
@@ -1,5 +1,6 @@
 package com.riffle.app.feature.library
 
+import com.riffle.core.domain.AbsFormatFilter
 import com.riffle.core.domain.AbsPickerItem
 import com.riffle.core.domain.ReadaloudReview
 import com.riffle.core.domain.ReadaloudReviewRepository
@@ -15,5 +16,5 @@ internal object NoopReadaloudReviewRepository : ReadaloudReviewRepository {
     override suspend fun unlinkBook(storytellerServerId: String, storytellerBookId: String) = Unit
     override suspend fun unlinkAbsItem(absServerId: String, absLibraryItemId: String) = Unit
     override suspend fun pairManually(storytellerServerId: String, storytellerBookId: String, absServerId: String, absLibraryItemId: String) = Unit
-    override suspend fun searchAbsItems(query: String): List<AbsPickerItem> = emptyList()
+    override suspend fun searchAbsItems(query: String, filter: AbsFormatFilter): List<AbsPickerItem> = emptyList()
 }

--- a/app/src/test/kotlin/com/riffle/app/feature/settings/SettingsViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/settings/SettingsViewModelTest.kt
@@ -165,7 +165,7 @@ class SettingsViewModelTest {
         override suspend fun unlinkBook(storytellerServerId: String, storytellerBookId: String) = Unit
         override suspend fun unlinkAbsItem(absServerId: String, absLibraryItemId: String) = Unit
         override suspend fun pairManually(storytellerServerId: String, storytellerBookId: String, absServerId: String, absLibraryItemId: String) = Unit
-        override suspend fun searchAbsItems(query: String): List<AbsPickerItem> = emptyList()
+        override suspend fun searchAbsItems(query: String, filter: com.riffle.core.domain.AbsFormatFilter): List<AbsPickerItem> = emptyList()
     }
 
     private fun makeViewModel(report: CrashReport? = null) = SettingsViewModel(
@@ -342,13 +342,14 @@ class SettingsViewModelTest {
     // --- readaloud matches summary ---
 
     @Test
-    fun `readaloudSummaries reports per-server confirmed pending and unmatched counts`() = runTest {
+    fun `readaloudSummaries reports per-server unmatched suggested partially-matched and matched counts`() = runTest {
         serversFlow.value = listOf(server("st-1", active = true, serverType = ServerType.STORYTELLER))
         reviewsFlow.value = mapOf(
             "st-1" to ReadaloudReview(
                 pending = listOf(pending("b1")),
                 unmatched = listOf(unmatched("b2"), unmatched("b3")),
-                confirmed = listOf(confirmed("b4"), confirmed("b5"), confirmed("b6")),
+                // b4/b5 fully matched; b6 missing its ebook → partially matched.
+                confirmed = listOf(confirmed("b4"), confirmed("b5"), confirmed("b6", hasEbook = false)),
             )
         )
         val vm = makeViewModel()
@@ -356,7 +357,10 @@ class SettingsViewModelTest {
         testDispatcher.scheduler.advanceUntilIdle()
 
         val summary = vm.readaloudSummaries.value["st-1"]
-        assertEquals(ReadaloudMatchSummary(confirmedCount = 3, pendingCount = 1, unmatchedCount = 2), summary)
+        assertEquals(
+            ReadaloudMatchSummary(unmatchedCount = 2, suggestedCount = 1, partiallyMatchedCount = 1, matchedCount = 2),
+            summary,
+        )
     }
 
     @Test
@@ -379,9 +383,14 @@ class SettingsViewModelTest {
         title = bookId, author = "", coverUrl = null,
     )
 
-    private fun confirmed(bookId: String) = ConfirmedReadaloud(
-        storytellerServerId = "st-1", storytellerBookId = bookId,
-        title = bookId, targets = emptyList(),
+    private fun confirmed(bookId: String, hasEbook: Boolean = true, hasAudio: Boolean = true) = ConfirmedReadaloud(
+        storytellerServerId = "st-1", storytellerBookId = bookId, title = bookId,
+        targets = listOf(
+            ConfirmedReadaloud.ConfirmedTarget(
+                absServerId = "abs", absLibraryItemId = bookId, absTitle = bookId,
+                absLibraryName = "lib", hasEbook = hasEbook, hasAudio = hasAudio,
+            )
+        ),
     )
 
     // --- volume key preferences ---

--- a/core/data/src/main/kotlin/com/riffle/core/data/ReadaloudReviewRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/ReadaloudReviewRepositoryImpl.kt
@@ -264,11 +264,12 @@ class ReadaloudReviewRepositoryImpl(
             .sortedBy { it.title.lowercase() }
             .mapNotNull { row ->
                 val abs: LibraryItemEntity = libraryItemDao.getById(row.serverId, row.itemId) ?: return@mapNotNull null
+                val hasEbook = abs.hasEbook()
                 // Strict filter: tapping the ebook slot only offers items with an ebook, and the
                 // audio slot only items with audio (a combined item satisfies both).
                 val keep = when (filter) {
                     AbsFormatFilter.ANY -> true
-                    AbsFormatFilter.EBOOK -> abs.hasEbook()
+                    AbsFormatFilter.EBOOK -> hasEbook
                     AbsFormatFilter.AUDIO -> abs.hasAudio
                 }
                 if (!keep) return@mapNotNull null
@@ -282,7 +283,7 @@ class ReadaloudReviewRepositoryImpl(
                     author = abs.author,
                     libraryName = name,
                     coverUrl = abs.coverUrl,
-                    hasEbook = abs.hasEbook(),
+                    hasEbook = hasEbook,
                     hasAudio = abs.hasAudio,
                 )
             }

--- a/core/data/src/main/kotlin/com/riffle/core/data/ReadaloudReviewRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/ReadaloudReviewRepositoryImpl.kt
@@ -10,8 +10,10 @@ import com.riffle.core.database.ReadaloudDismissalEntity
 import com.riffle.core.database.ReadaloudLinkDao
 import com.riffle.core.database.ReadaloudLinkEntity
 import com.riffle.core.domain.AbsCandidate
+import com.riffle.core.domain.AbsFormatFilter
 import com.riffle.core.domain.AbsPickerItem
 import com.riffle.core.domain.AudioIdentityResolver
+import com.riffle.core.domain.EbookFormat
 import com.riffle.core.domain.AudioPlaybackPreferencesStore
 import com.riffle.core.domain.ConfirmedReadaloud
 import com.riffle.core.domain.PendingReadaloud
@@ -94,6 +96,8 @@ class ReadaloudReviewRepositoryImpl(
                         absLibraryItemId = link.absLibraryItemId,
                         absTitle = abs.title,
                         absLibraryName = libraryName(abs.serverId, abs.libraryId),
+                        hasEbook = abs.hasEbook(),
+                        hasAudio = abs.hasAudio,
                     )
                 }
                 if (targets.isEmpty()) return@mapNotNull null
@@ -105,6 +109,8 @@ class ReadaloudReviewRepositoryImpl(
                     targets = targets.sortedBy { it.absLibraryName.lowercase() },
                 )
             }
+            // Alphabetical by title; the screen splits these into "Partially matched" vs "Matched"
+            // sections via ConfirmedReadaloud.isIncomplete, so each section stays in name order.
             .sortedBy { it.title.lowercase() }
 
         val pending = books
@@ -245,7 +251,7 @@ class ReadaloudReviewRepositoryImpl(
         if (before != after) audioPlaybackPreferencesStore.rekey(before, after)
     }
 
-    override suspend fun searchAbsItems(query: String): List<AbsPickerItem> {
+    override suspend fun searchAbsItems(query: String, filter: AbsFormatFilter): List<AbsPickerItem> {
         val trimmed = query.trim()
         val all = libraryItemDao.listMatchableByServerType(ServerType.AUDIOBOOKSHELF.name)
         val matched = if (trimmed.isEmpty()) {
@@ -258,6 +264,14 @@ class ReadaloudReviewRepositoryImpl(
             .sortedBy { it.title.lowercase() }
             .mapNotNull { row ->
                 val abs: LibraryItemEntity = libraryItemDao.getById(row.serverId, row.itemId) ?: return@mapNotNull null
+                // Strict filter: tapping the ebook slot only offers items with an ebook, and the
+                // audio slot only items with audio (a combined item satisfies both).
+                val keep = when (filter) {
+                    AbsFormatFilter.ANY -> true
+                    AbsFormatFilter.EBOOK -> abs.hasEbook()
+                    AbsFormatFilter.AUDIO -> abs.hasAudio
+                }
+                if (!keep) return@mapNotNull null
                 val name = libraryNameCache.getOrPut("${abs.serverId}|${abs.libraryId}") {
                     libraryDao.getById(abs.serverId, abs.libraryId)?.name ?: abs.libraryId
                 }
@@ -268,9 +282,15 @@ class ReadaloudReviewRepositoryImpl(
                     author = abs.author,
                     libraryName = name,
                     coverUrl = abs.coverUrl,
+                    hasEbook = abs.hasEbook(),
+                    hasAudio = abs.hasAudio,
                 )
             }
     }
+
+    /** True when this ABS item carries a readable ebook (epub/pdf), i.e. not an audio-only stub. */
+    private fun LibraryItemEntity.hasEbook(): Boolean =
+        EbookFormat.from(ebookFormat) != EbookFormat.Unsupported
 
     private suspend fun createUserConfirmedLink(
         storytellerServerId: String,

--- a/core/data/src/test/kotlin/com/riffle/core/data/ReadaloudReviewRepositoryTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/ReadaloudReviewRepositoryTest.kt
@@ -2,15 +2,19 @@ package com.riffle.core.data
 
 import com.riffle.core.database.LibraryItemDao
 import com.riffle.core.database.LibraryItemEntity
+import com.riffle.core.database.MatchableItemRow
 import com.riffle.core.database.ReadaloudCandidateDao
 import com.riffle.core.database.ReadaloudCandidateEntity
 import com.riffle.core.database.ReadaloudDismissalDao
 import com.riffle.core.database.ReadaloudDismissalEntity
 import com.riffle.core.database.ReadaloudLinkDao
 import com.riffle.core.database.ReadaloudLinkEntity
+import com.riffle.core.domain.AbsFormatFilter
 import com.riffle.core.domain.AudioIdentity
 import com.riffle.core.domain.AudioPlaybackPreferencesStore
+import com.riffle.core.domain.ServerType
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
@@ -178,6 +182,146 @@ class ReadaloudReviewRepositoryTest {
         repo.confirmCandidate("st-1", "42", "abs-1", "ebook")
 
         assertEquals(1.25f, audio.store[AudioIdentity("st-1", "42")])
+    }
+
+    // ── format slots: missing-side detection (Confirmed two-slot UI) ─────────
+
+    @Test
+    fun `confirmed targets carry ebook and audio flags so a missing side is detectable`() = runTest {
+        // An ebook entry + an audiobook stub linked to the same readaloud. Each target must report
+        // which slot it fills so the UI can leave the other slot empty when one is absent.
+        val items = MatchableLibraryItemDao(
+            listOf(absEbook("ebook"), absAudiobook("audio"), storytellerBook("42")),
+            absServerIds = setOf("abs"),
+            storytellerServerIds = setOf("st"),
+        )
+        val links = RecordingLinkDao().apply {
+            seed(link("abs", "ebook", "st", "42", userConfirmed = true))
+            seed(link("abs", "audio", "st", "42", userConfirmed = true))
+        }
+        val repo = repo(links, RecordingCandidateDao(), libraryItemDao = items)
+
+        val match = repo.observeReview("st").first().confirmed.single { it.storytellerBookId == "42" }
+
+        val ebookTarget = match.targets.single { it.absLibraryItemId == "ebook" }
+        assertTrue("ebook entry fills the ebook slot", ebookTarget.hasEbook)
+        assertTrue("ebook entry is not audio", !ebookTarget.hasAudio)
+        val audioTarget = match.targets.single { it.absLibraryItemId == "audio" }
+        assertTrue("audiobook stub fills the audio slot", audioTarget.hasAudio)
+        assertTrue("audiobook stub is not an ebook", !audioTarget.hasEbook)
+    }
+
+    @Test
+    fun `a combined item reports both slots filled`() = runTest {
+        val items = MatchableLibraryItemDao(
+            listOf(absCombined("both"), storytellerBook("7")),
+            absServerIds = setOf("abs"),
+            storytellerServerIds = setOf("st"),
+        )
+        val links = RecordingLinkDao().apply { seed(link("abs", "both", "st", "7", userConfirmed = true)) }
+        val repo = repo(links, RecordingCandidateDao(), libraryItemDao = items)
+
+        val target = repo.observeReview("st").first().confirmed.single().targets.single()
+
+        assertTrue(target.hasEbook)
+        assertTrue(target.hasAudio)
+    }
+
+    @Test
+    fun `confirmed matches are alphabetical and isIncomplete partitions them for the UI sections`() = runTest {
+        // The screen splits confirmed into "Partially matched" (isIncomplete) and "Matched". The repo
+        // returns one alphabetical list; partitioning by isIncomplete must keep each section in order.
+        val items = MatchableLibraryItemDao(
+            listOf(
+                absCombined("alpha"), storytellerBook("a").copy(title = "Alpha"),
+                absCombined("mango"), storytellerBook("m").copy(title = "Mango"),
+                absAudiobook("zebra"), storytellerBook("z").copy(title = "Zebra"),
+            ),
+            absServerIds = setOf("abs"),
+            storytellerServerIds = setOf("st"),
+        )
+        val links = RecordingLinkDao().apply {
+            seed(link("abs", "alpha", "st", "a", userConfirmed = true))
+            seed(link("abs", "mango", "st", "m", userConfirmed = true))
+            seed(link("abs", "zebra", "st", "z", userConfirmed = true))
+        }
+        val repo = repo(links, RecordingCandidateDao(), libraryItemDao = items)
+
+        val confirmed = repo.observeReview("st").first().confirmed
+
+        assertEquals(listOf("Alpha", "Mango", "Zebra"), confirmed.map { it.title })
+        val (incomplete, complete) = confirmed.partition { it.isIncomplete }
+        assertEquals(listOf("Zebra"), incomplete.map { it.title })
+        assertEquals(listOf("Alpha", "Mango"), complete.map { it.title })
+    }
+
+    @Test
+    fun `searchAbsItems EBOOK filter keeps ebook and combined, drops audio-only`() = runTest {
+        val repo = repo(RecordingLinkDao(), RecordingCandidateDao(), libraryItemDao = absSearchDao())
+
+        val result = repo.searchAbsItems("", AbsFormatFilter.EBOOK)
+
+        assertEquals(setOf("ebook", "both"), result.map { it.absLibraryItemId }.toSet())
+        assertTrue("every offered item can supply an ebook", result.all { it.hasEbook })
+    }
+
+    @Test
+    fun `searchAbsItems AUDIO filter keeps audiobook and combined, drops ebook-only`() = runTest {
+        val repo = repo(RecordingLinkDao(), RecordingCandidateDao(), libraryItemDao = absSearchDao())
+
+        val result = repo.searchAbsItems("", AbsFormatFilter.AUDIO)
+
+        assertEquals(setOf("audio", "both"), result.map { it.absLibraryItemId }.toSet())
+        assertTrue("every offered item can supply audio", result.all { it.hasAudio })
+    }
+
+    @Test
+    fun `searchAbsItems ANY returns all with correct format flags`() = runTest {
+        val repo = repo(RecordingLinkDao(), RecordingCandidateDao(), libraryItemDao = absSearchDao())
+
+        val byId = repo.searchAbsItems("").associateBy { it.absLibraryItemId }
+
+        assertEquals(setOf("ebook", "audio", "both"), byId.keys)
+        assertEquals(true to false, byId.getValue("ebook").let { it.hasEbook to it.hasAudio })
+        assertEquals(false to true, byId.getValue("audio").let { it.hasEbook to it.hasAudio })
+        assertEquals(true to true, byId.getValue("both").let { it.hasEbook to it.hasAudio })
+    }
+
+    private fun absSearchDao() = MatchableLibraryItemDao(
+        listOf(absEbook("ebook"), absAudiobook("audio"), absCombined("both")),
+        absServerIds = setOf("abs"),
+        storytellerServerIds = emptySet(),
+    )
+
+    private fun absEbook(id: String) =
+        LibraryItemEntity("abs", id, "lib", id, "Author", null, 0f, ebookFormat = "epub", hasAudio = false)
+
+    private fun absAudiobook(id: String) =
+        LibraryItemEntity("abs", id, "lib", id, "Author", null, 0f, ebookFormat = "unsupported", hasAudio = true)
+
+    private fun absCombined(id: String) =
+        LibraryItemEntity("abs", id, "lib", id, "Author", null, 0f, ebookFormat = "epub", hasAudio = true)
+
+    private fun storytellerBook(id: String) =
+        LibraryItemEntity("st", id, "lib", "Book $id", "Author", null, 0f)
+
+    /** A [LibraryItemDao] backing both `getById` lookups and `listMatchableByServerType` scans. */
+    private class MatchableLibraryItemDao(
+        private val items: List<LibraryItemEntity>,
+        private val absServerIds: Set<String>,
+        private val storytellerServerIds: Set<String>,
+    ) : LibraryItemDao by ThrowingLibraryItemDao {
+        override suspend fun getById(serverId: String, itemId: String) =
+            items.firstOrNull { it.serverId == serverId && it.id == itemId }
+        override suspend fun listMatchableByServerType(serverType: String): List<MatchableItemRow> {
+            val serverIds = when (serverType) {
+                ServerType.AUDIOBOOKSHELF.name -> absServerIds
+                ServerType.STORYTELLER.name -> storytellerServerIds
+                else -> emptySet()
+            }
+            return items.filter { it.serverId in serverIds }
+                .map { MatchableItemRow(it.id, it.serverId, it.title, it.author, null, null) }
+        }
     }
 
     private fun repo(

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/ReadaloudReview.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/ReadaloudReview.kt
@@ -51,11 +51,24 @@ data class ConfirmedReadaloud(
     val title: String,
     val targets: List<ConfirmedTarget>,
 ) {
+    /** True when at least one linked item supplies an ebook (a combined item counts). */
+    val hasEbook: Boolean get() = targets.any { it.hasEbook }
+
+    /** True when at least one linked item supplies audio (a combined item counts). */
+    val hasAudio: Boolean get() = targets.any { it.hasAudio }
+
+    /** Missing one of the two sides — surfaced above complete matches so the gap is easy to spot. */
+    val isIncomplete: Boolean get() = !hasEbook || !hasAudio
+
     data class ConfirmedTarget(
         val absServerId: String,
         val absLibraryItemId: String,
         val absTitle: String,
         val absLibraryName: String,
+        // Which side(s) of the readaloud this ABS item supplies. A "combined" item carries both,
+        // so it fills both slots; a one-sided match leaves the other slot empty (the missing side).
+        val hasEbook: Boolean,
+        val hasAudio: Boolean,
     )
 }
 
@@ -67,4 +80,13 @@ data class AbsPickerItem(
     val author: String,
     val libraryName: String,
     val coverUrl: String?,
+    val hasEbook: Boolean,
+    val hasAudio: Boolean,
 )
+
+/**
+ * Restricts the manual picker to items that can fill a specific missing slot of a Confirmed match:
+ * [EBOOK] / [AUDIO] keep only items supplying that side; [ANY] is the unfiltered "Match manually…"
+ * flow used from Unmatched rows.
+ */
+enum class AbsFormatFilter { ANY, EBOOK, AUDIO }

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/ReadaloudReviewRepository.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/ReadaloudReviewRepository.kt
@@ -50,6 +50,13 @@ interface ReadaloudReviewRepository {
         absLibraryItemId: String,
     )
 
-    /** Search ABS Library Items across every configured ABS Server by title/author. */
-    suspend fun searchAbsItems(query: String): List<AbsPickerItem>
+    /**
+     * Search ABS Library Items across every configured ABS Server by title/author. [filter] narrows
+     * results to items that can fill a specific missing slot (ebook / audio) of a Confirmed match;
+     * [AbsFormatFilter.ANY] is the unfiltered manual-pairing search.
+     */
+    suspend fun searchAbsItems(
+        query: String,
+        filter: AbsFormatFilter = AbsFormatFilter.ANY,
+    ): List<AbsPickerItem>
 }


### PR DESCRIPTION
## What

Storyteller **Readaloud matches** (global Settings → Storyteller server) now make the ebook/audiobook *completeness* of each match visible and fixable.

- **Two-slot confirmed rows.** Each confirmed match renders an **Ebook** slot and an **Audiobook** slot. A combined ABS item fills both. A missing side shows an amber, dashed, tappable **"＋ Not linked"** placeholder.
- **Fill the gap in place.** Tapping an empty slot opens the manual picker **filtered to that format** (`AbsFormatFilter` ANY/EBOOK/AUDIO); the dialog now says e.g. *"Link an audiobook · Showing ABS items that have an audiobook"* so an empty result reads as filtered, not "nothing found". Linking drops straight into the slot.
- **One vocabulary, completeness gradient.** Sections renamed onto a single "matched" axis and reordered: **Unmatched → Suggested → Partially matched → Matched** (was Pending Review / Unmatched / Confirmed).
- **Global-settings summary** updated to match: `Review & match readalouds` with `N unmatched · N suggested · N partially matched · N matched`.

Derivation uses data already on `LibraryItemEntity` (`hasAudio`, `ebookFormat`); new computed `hasEbook`/`hasAudio`/`isIncomplete` on `ConfirmedReadaloud` is the single source of truth for the UI partition and the settings counts.

## Why

A confirmed readaloud links 0–1 ebook and 0–1 audiobook. A one-sided match silently has nowhere to sync the other side's progress (the split-library audiobook case). This surfaces those matches instead of burying them.

## Tested

- `./gradlew test lint` — green
- `make harness-test` on `Harness_Medium_Phone_2` — 175 tests, 0 failed
- `make harness-test-tablet` — 5 tests, 0 failed
- New unit tests: confirmed-target format flags, combined-item-fills-both, `searchAbsItems` EBOOK/AUDIO/ANY filtering, confirmed partition order, four-count settings summary.