### PR TITLE
feat(readaloud): remove tap-to-expand large player

### DIFF
--- a/app/src/androidTest/kotlin/com/riffle/app/feature/reader/readaloud/ReadaloudMiniPlayerTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/reader/readaloud/ReadaloudMiniPlayerTest.kt
@@ -44,7 +44,6 @@ class ReadaloudMiniPlayerTest {
                 onPreviousChapter = onPreviousChapter,
                 onNextChapter = onNextChapter,
                 onClose = {},
-                onExpand = {},
             )
         }
     }
@@ -105,7 +104,6 @@ class ReadaloudMiniPlayerTest {
                 onPreviousChapter = {},
                 onNextChapter = {},
                 onClose = {},
-                onExpand = {},
             )
         }
         rule.onNodeWithTag("readaloud_rewind").assertDoesNotExist()

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -75,7 +75,6 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import com.riffle.app.feature.reader.readaloud.ReadaloudDownloadDialog
-import com.riffle.app.feature.reader.readaloud.ReadaloudExpandedSheet
 import com.riffle.app.feature.reader.readaloud.ReadaloudMiniPlayer
 import com.riffle.app.ui.theme.RiffleTheme
 import com.riffle.core.domain.FormattingPreferences
@@ -231,7 +230,6 @@ fun EpubReaderScreen(
     val readaloudAvailable by viewModel.readaloudAvailable.collectAsState()
     val readaloudVisible by viewModel.readaloudVisible.collectAsState()
     val readaloudOpen by viewModel.readaloudOpen.collectAsState()
-    val readaloudExpanded by viewModel.readaloudExpanded.collectAsState()
     val playbackState by viewModel.playbackState.collectAsState()
     val activeFragmentRef by viewModel.activeFragmentRef.collectAsState()
     val sentenceQuotes by viewModel.sentenceQuotes.collectAsState()
@@ -383,7 +381,6 @@ fun EpubReaderScreen(
                         onPreviousChapter = viewModel::previousChapter,
                         onNextChapter = viewModel::nextChapter,
                         onClose = viewModel::closeReadaloud,
-                        onExpand = viewModel::expandPlayer,
                     )
                 }
                 if (showRailOverlay) {
@@ -396,17 +393,6 @@ fun EpubReaderScreen(
                     )
                 }
             }
-        }
-
-        if (readaloudOpen && readaloudExpanded) {
-            ReadaloudExpandedSheet(
-                isPlaying = playbackState.isPlaying,
-                speed = playbackState.speed,
-                positionSec = playbackState.positionSec,
-                onPlayPause = viewModel::togglePlayPause,
-                onSpeedSelected = viewModel::setSpeed,
-                onDismiss = viewModel::collapsePlayer,
-            )
         }
 
         downloadPromptBytes?.let { bytes ->

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -290,10 +290,6 @@ class EpubReaderViewModel @Inject constructor(
     private val _readaloudOpen = MutableStateFlow(false)
     val readaloudOpen: StateFlow<Boolean> = _readaloudOpen
 
-    // Mini-player (false) vs full-height bottom sheet (true).
-    private val _readaloudExpanded = MutableStateFlow(false)
-    val readaloudExpanded: StateFlow<Boolean> = _readaloudExpanded
-
     // Mirrors the controller's playback state for the bar/sheet controls.
     val playbackState: StateFlow<ReadaloudController.PlaybackState> = playerCoordinator.state
 
@@ -1072,7 +1068,6 @@ class EpubReaderViewModel @Inject constructor(
 
     fun closeReadaloud() {
         _readaloudOpen.value = false
-        _readaloudExpanded.value = false
         _downloadPromptBytes.value = null
         _readaloudOfflineMessage.value = false
         storytellerSyncJob?.cancel()
@@ -1124,9 +1119,6 @@ class EpubReaderViewModel @Inject constructor(
     } catch (_: Exception) {
         null
     }
-
-    fun expandPlayer() { _readaloudExpanded.value = true }
-    fun collapsePlayer() { _readaloudExpanded.value = false }
 
     fun togglePlayPause() {
         if (playbackState.value.isPlaying) {

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/ReadaloudPlayerUi.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/ReadaloudPlayerUi.kt
@@ -2,13 +2,9 @@
 
 package com.riffle.app.feature.reader.readaloud
 
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
@@ -21,13 +17,10 @@ import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.ModalBottomSheet
-import androidx.compose.material3.Slider
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
-import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -52,8 +45,7 @@ private fun speedLabel(speed: Float): String {
 
 
 /**
- * Bottom mini-player bar. Tapping the bar body (not a control) expands to the full sheet.
- * Sits above the chapter rail in the screen layout.
+ * Bottom mini-player bar. Sits above the chapter rail in the screen layout.
  */
 @Composable
 fun ReadaloudMiniPlayer(
@@ -72,7 +64,6 @@ fun ReadaloudMiniPlayer(
     onPreviousChapter: () -> Unit,
     onNextChapter: () -> Unit,
     onClose: () -> Unit,
-    onExpand: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     // Colours come from the reader-theme palette (the same page colour the chapter-rail overlay
@@ -89,7 +80,6 @@ fun ReadaloudMiniPlayer(
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .clickable(enabled = !offlineMessage) { onExpand() }
                 .padding(horizontal = 8.dp, vertical = 4.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
@@ -158,66 +148,6 @@ fun ReadaloudMiniPlayer(
             }
             IconButton(onClick = onClose, modifier = Modifier.testTag("readaloud_close")) {
                 Icon(Icons.Default.Close, contentDescription = "Close readaloud")
-            }
-        }
-    }
-}
-
-/**
- * Full-height expanded player. A scrubbable position slider plus the same play/pause and a
- * row of selectable speeds.
- */
-@Composable
-fun ReadaloudExpandedSheet(
-    isPlaying: Boolean,
-    speed: Float,
-    positionSec: Double,
-    onPlayPause: () -> Unit,
-    onSpeedSelected: (Float) -> Unit,
-    onDismiss: () -> Unit,
-) {
-    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
-    // Local scrub state: while the user drags, show the dragged value; commit visually only.
-    // We can't seek a position the controller doesn't expose, so the slider reflects the live
-    // position and dragging is best-effort visual (see limitation note in EpubReaderScreen).
-    ModalBottomSheet(onDismissRequest = onDismiss, sheetState = sheetState) {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(24.dp)
-                .testTag("readaloud_expanded_sheet"),
-            horizontalAlignment = Alignment.CenterHorizontally,
-        ) {
-            Text("Readaloud", style = MaterialTheme.typography.titleMedium)
-            Spacer(modifier = Modifier.height(16.dp))
-            Slider(
-                value = positionSec.toFloat(),
-                onValueChange = { /* live position is driven by playback; scrub is visual-only */ },
-                valueRange = 0f..(positionSec.toFloat().coerceAtLeast(1f)),
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .testTag("readaloud_position_slider"),
-            )
-            Spacer(modifier = Modifier.height(8.dp))
-            IconButton(onClick = onPlayPause, modifier = Modifier.testTag("readaloud_sheet_play_pause")) {
-                Icon(
-                    imageVector = if (isPlaying) Icons.Default.Pause else Icons.Default.PlayArrow,
-                    contentDescription = if (isPlaying) "Pause" else "Play",
-                )
-            }
-            Spacer(modifier = Modifier.height(16.dp))
-            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                ReadaloudController.SPEEDS.forEach { s ->
-                    val selected = kotlin.math.abs(s - speed) < 0.001f
-                    TextButton(onClick = { onSpeedSelected(s) }) {
-                        Text(
-                            speedLabel(s),
-                            fontWeight = if (selected) FontWeight.Bold else FontWeight.Normal,
-                            color = if (selected) MaterialTheme.colorScheme.primary
-                            else MaterialTheme.colorScheme.onSurfaceVariant,
-                        )
-                    }
-                }
             }
         }
     }


### PR DESCRIPTION
## What

Tapping the readaloud mini-player bar used to open a full-height `ModalBottomSheet` "large" player. This removes that expand-on-tap behavior entirely. The bar body is now inert; all controls (play/pause, speed, rewind/forward, chapter skip, close) stay on the mini-player.

## Why

The expanded sheet offered nothing the bar didn't already:
- its position slider could not actually seek (visual-only, per its own code comment),
- its speed row and play/pause duplicated the mini-player controls.

So the large player was redundant chrome that popped up on an easy-to-trigger tap.

## Changes

- `ReadaloudPlayerUi.kt` — drop the `onExpand` param and the bar's `clickable`; delete the `ReadaloudExpandedSheet` composable and now-unused imports.
- `EpubReaderScreen.kt` — remove the `onExpand` wiring, the expanded-sheet render block, and the `readaloudExpanded` state collection.
- `EpubReaderViewModel.kt` — remove `readaloudExpanded` state plus `expandPlayer()`/`collapsePlayer()`.
- `ReadaloudMiniPlayerTest.kt` — drop the `onExpand` test stubs.

Purely subtractive; no functional behavior lost.

## Tested

- `./gradlew test` — green
- `./gradlew lint` — green
- `make harness-test` — 175 tests, 0 failed
- `make harness-test-tablet` — 5 tests, 0 failed