### PR TITLE
feat(readaloud): reserve player height so paginated page never reflows on open

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -237,9 +237,16 @@ fun EpubReaderScreen(
     val readaloudOfflineMessage by viewModel.readaloudOfflineMessage.collectAsState()
     val downloadProgress by viewModel.downloadProgress.collectAsState()
 
-    // The readaloud player floats over the bottom of the page: it does NOT reserve space or
-    // re-paginate, so the page stays static when the player opens. Its translucent backdrop lets the
-    // covered last line or two — and the narrated highlight — show through.
+    // Reserve a fixed bottom strip for the readaloud mini-player whenever readaloud is AVAILABLE
+    // (a downloaded/usable match) and the reader is paginated. The reserve is held for the whole
+    // session — NOT gated on the player being open — so toggling the player (Play-from-here, the play
+    // button, close) never re-paginates and the page can never jump. Non-readaloud books, and ABS
+    // matches whose bundle isn't downloaded yet, reserve nothing and render edge to edge. Scroll mode
+    // needs no reserve (the player floats over a freely-scrollable page). See ReadaloudReserve.kt.
+    val readaloudReservePx: Int = readaloudReserveDp(
+        readaloudAvailable = readaloudAvailable,
+        paginated = formattingPrefs.orientation != ReaderOrientation.Vertical,
+    )
 
     // TopAppBar floats as an overlay so its show/hide never resizes the content area —
     // eliminates the compound flicker that Scaffold's topBar slot caused by reflowing the
@@ -294,6 +301,7 @@ fun EpubReaderScreen(
                         onPageTopResolved = viewModel::onPageTopResolved,
                         onPlayFromHere = viewModel::playFromHere,
                         readaloudAvailable = readaloudAvailable,
+                        readaloudReservePx = readaloudReservePx,
                         annotationsAvailable = annotationsAvailable,
                         highlightRenders = highlightRenders,
                         onHighlight = viewModel::createHighlight,
@@ -354,10 +362,13 @@ fun EpubReaderScreen(
                     // overlay backdrop (which paints readerTheme.palette.background) and the two
                     // read as one continuous, theme-following strip.
                     //
-                    // The player floats over the page (it no longer reserves space / re-paginates), so
-                    // it can sit over the last line or two. Paint its backdrop semi-transparent so that
-                    // covered text — and the narrated highlight — stays visible through the bar. The
-                    // controls are Surface CONTENT, unaffected by this alpha, so they remain opaque.
+                    // In paginated mode the page reserves this bar's height at the bottom (see
+                    // readaloudReservePx / ReadaloudReserve.kt), so the player sits over an empty strip
+                    // rather than live text. The backdrop is kept slightly translucent so that in the
+                    // cases without a reserve — scroll mode, or when the chapter rail also shows and
+                    // lifts the bar above the reserved strip — the covered text and the narrated
+                    // highlight still read through. Controls are Surface CONTENT, unaffected by the
+                    // alpha, so they stay opaque.
                     val readerPalette = formattingPrefs.theme.palette
                     ReadaloudMiniPlayer(
                         isPlaying = playbackState.isPlaying,
@@ -719,6 +730,7 @@ private fun EpubNavigatorView(
     onPageTopResolved: (href: String, fragmentId: String?) -> Unit,
     onPlayFromHere: (fragmentRef: String) -> Unit,
     readaloudAvailable: Boolean,
+    readaloudReservePx: Int = 0,
     annotationsAvailable: Boolean,
     highlightRenders: List<EpubReaderViewModel.HighlightRender>,
     onHighlight: (Locator) -> Unit,
@@ -753,6 +765,9 @@ private fun EpubNavigatorView(
     val currentOnHighlight by rememberUpdatedState(onHighlight)
     val currentAnnotationsAvailable by rememberUpdatedState(annotationsAvailable)
     val currentReadaloudAvailable by rememberUpdatedState(readaloudAvailable)
+    // Latest readaloud bottom reserve, read inside the (remembered-once) pagination listener so each
+    // freshly loaded page re-applies the current value.
+    val currentReadaloudReservePx by rememberUpdatedState(readaloudReservePx)
     val currentPublication by rememberUpdatedState(state.publication)
 
     // The text-selection action bar is fully owned by this callback (Readium 3.0.0's
@@ -905,9 +920,10 @@ private fun EpubNavigatorView(
 
     // Bumps whenever a formatting change (font/margin/spacing/orientation) reflows the layout so the
     // decoration effects and the auto-follow probe below re-apply / re-centre onto the new pagination
-    // (see rememberReflowReapplyGeneration). The readaloud player floats over the page and no longer
-    // reflows it, so opening it is not a reflow trigger.
-    val reflowGeneration = rememberReflowReapplyGeneration(formattingPrefs)
+    // (see rememberReflowReapplyGeneration). Also keyed on the readaloud reserve: it's constant across
+    // the session in the common case (so opening the player is NOT a reflow trigger), but it flips once
+    // if an ABS bundle finishes downloading mid-session — that one re-paginates, so re-apply then too.
+    val reflowGeneration = rememberReflowReapplyGeneration(formattingPrefs to readaloudReservePx)
 
     // Bumps every time a page finishes loading. This is the precise "the layout is now settled" signal
     // that reflowGeneration's timer heuristic only approximates — and the only one available after a
@@ -935,6 +951,12 @@ private fun EpubNavigatorView(
                     fragment.evaluateJavascript(SELECTION_SPAN_TRACKER_JS)
                     fragment.evaluateJavascript(typographyOverrideInjectionJs())
                     fragment.evaluateJavascript(FootnoteAnchorBridge.INSTALL_SCRIPT)
+                    // Reserve the bottom strip for the readaloud player on this freshly loaded page
+                    // (paginated + readaloud-available only; see ReadaloudReserve.kt). Inject the rule,
+                    // then apply the current value so the page lands already paginated above the strip —
+                    // no reflow when the player is later opened.
+                    fragment.evaluateJavascript(readaloudReserveInjectionJs())
+                    fragment.evaluateJavascript(readaloudReserveApplyJs(currentReadaloudReservePx))
                     // Install the at-rest column-snap backstop: once scrolling settles off-grid in
                     // paginated mode it rounds to the nearest column, so the page can never REST between
                     // two pages no matter what moved it. Idempotent; defers to the rAF trackers.
@@ -948,6 +970,18 @@ private fun EpubNavigatorView(
         }
     }
 
+    // Push the reserve to the live page if it changes without a page reload — readaloud becoming
+    // available mid-session (an ABS bundle finishes downloading) or the reader switching to/from scroll
+    // mode. In the common case the value is set at the first page load and never changes here, so this
+    // is a no-op. Unlike the earlier open-gated reserve, there is no top-of-page anchor to capture: the
+    // reserve isn't tied to the player opening, so this transition isn't one the user is staring at.
+    LaunchedEffect(readaloudReservePx) {
+        val fragment = fragmentRef.value ?: return@LaunchedEffect
+        withContext(Dispatchers.Main) {
+            fragment.evaluateJavascript(readaloudReserveInjectionJs())
+            fragment.evaluateJavascript(readaloudReserveApplyJs(readaloudReservePx))
+        }
+    }
 
     // Tap on an in-document anchor inside the WebView → look up the target in
     // the cached spine doc. A footnote shows the popup; a regular cross-

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ReadaloudReserve.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ReadaloudReserve.kt
@@ -45,9 +45,10 @@ internal fun readaloudReserveDp(readaloudAvailable: Boolean, paginated: Boolean)
 
 /**
  * The reserve rule. Active only while `<html>` carries [RESERVE_ACTIVE_CLASS]. The bottom padding is
- * the page's own bottom margin (the SAME calc as the margins override — `--RS__pageGutter *
- * --USER__pageMargins` — so the gap above the player tracks the margins slider exactly, staying
- * symmetric with the top margin) PLUS the strip height carried in [RESERVE_VAR] (the player bar). The
+ * the page's own bottom margin — the SAME `--RS__pageGutter * --USER__pageMargins` calc the margins
+ * override uses for its `padding-bottom` (the 1.0× bottom factor; the override's top is 0.5×, so this
+ * is NOT symmetric with the top), so the gap above the player tracks the margins slider exactly —
+ * PLUS the strip height carried in [RESERVE_VAR] (the player bar). The
  * doubled `:root` raises specificity to (0,3,0) so it beats both Readium's `:root{padding:0}` (0,1,0)
  * and the margins override (0,2,0) regardless of source order. `--USER__pageMargins` defaults to 1 so
  * the `calc()` stays valid on books left at the default margin (an unset var with no fallback would

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ReadaloudReserve.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ReadaloudReserve.kt
@@ -1,0 +1,110 @@
+package com.riffle.app.feature.reader
+
+// Reserves a bottom strip in the paginated reader for the readaloud mini-player. Unlike the earlier
+// (reverted) version, the reserve is NOT tied to the player being open — it is held for the whole
+// session whenever readaloud is AVAILABLE (a downloaded/usable match) for the book. Because the
+// reserve is constant, opening or closing the player never changes the layout, so the page can never
+// jump when Play-from-here (or the play button) shows the player. That sidesteps the entire
+// reflow-pin problem the open-gated reserve had: there is no reflow to pin across.
+//
+// HOW: the reserve is injected as extra `padding-bottom` on `:root` — the same lever the page-margin
+// override uses (see TypographyOverride.kt's "margins" entry). Padding on the multicol container
+// shrinks every column's height, so the text is paginated above the strip the player will occupy. A
+// native WebView resize (Compose padding or View.setPadding) is ignored once the page is laid out,
+// but a CSS change paginates correctly from the start, exactly like the formatting panel's margin
+// slider.
+//
+// PAGINATED ONLY: scroll/vertical mode needs no reserve — text there isn't pinned to a page, so the
+// player floats over the bottom and anything under it is one small scroll away. Scoping to paginated
+// also keeps the inset path disabled (shouldApplyInsetsPadding = false), avoiding the scroll-mode
+// cutout band.
+
+/** Stable element id for the injected `<style>` so repeated injections don't accumulate. */
+private const val RESERVE_STYLE_ID = "riffle-readaloud-reserve"
+
+/** Class toggled on `<html>` to activate the reserve rule, and the CSS var carrying its height. */
+private const val RESERVE_ACTIVE_CLASS = "riffle-ra-on"
+private const val RESERVE_VAR = "--riffle-ra-reserve"
+
+/**
+ * Height (CSS px ≈ dp; a WebView CSS-px equals a dp because both divide device-px by the same
+ * density/devicePixelRatio) of the strip held for the floating mini-player. Matches the player bar's
+ * rendered height (a single row of 48dp icon buttons + 2×4dp row padding ≈ 56dp), so the player
+ * exactly fills the reserve and the gap above it is the page's own bottom margin.
+ */
+internal const val READALOUD_RESERVE_DP = 56
+
+/**
+ * CSS-px bottom reserve to hold the floating player clear of the text — [READALOUD_RESERVE_DP] when
+ * readaloud is available AND the reader is paginated, else 0 (no reserve; the page renders edge to
+ * edge). Gated on availability, NOT on the player being open, so the value is stable across the
+ * session and toggling the player never re-paginates.
+ */
+internal fun readaloudReserveDp(readaloudAvailable: Boolean, paginated: Boolean): Int =
+    if (readaloudAvailable && paginated) READALOUD_RESERVE_DP else 0
+
+/**
+ * The reserve rule. Active only while `<html>` carries [RESERVE_ACTIVE_CLASS]. The bottom padding is
+ * the page's own bottom margin (the SAME calc as the margins override — `--RS__pageGutter *
+ * --USER__pageMargins` — so the gap above the player tracks the margins slider exactly, staying
+ * symmetric with the top margin) PLUS the strip height carried in [RESERVE_VAR] (the player bar). The
+ * doubled `:root` raises specificity to (0,3,0) so it beats both Readium's `:root{padding:0}` (0,1,0)
+ * and the margins override (0,2,0) regardless of source order. `--USER__pageMargins` defaults to 1 so
+ * the `calc()` stays valid on books left at the default margin (an unset var with no fallback would
+ * void the whole declaration and drop the reserve).
+ */
+internal fun readaloudReserveCss(): String =
+    """
+    :root.$RESERVE_ACTIVE_CLASS:root {
+      padding-bottom: calc(
+        var(--RS__pageGutter, 8px) * var(--USER__pageMargins, 1) + var($RESERVE_VAR, 0px)
+      ) !important;
+    }
+    """.trimIndent()
+
+/**
+ * Idempotently injects [readaloudReserveCss] as a `<style>` in `document.head`. Re-run on every page
+ * load (each resource is a fresh document); the stable id prevents duplicates.
+ */
+internal fun readaloudReserveInjectionJs(): String {
+    val css = readaloudReserveCss()
+        .replace("\\", "\\\\")
+        .replace("`", "\\`")
+        .replace("\$", "\\\$")
+    return """
+        (function() {
+          var id = '$RESERVE_STYLE_ID';
+          if (document.getElementById(id)) return;
+          var style = document.createElement('style');
+          style.id = id;
+          style.textContent = `$css`;
+          document.head.appendChild(style);
+        })();
+    """.trimIndent()
+}
+
+/**
+ * Toggles the reserve on the live document: sets the height var and activates the rule when
+ * [reserveCssPx] > 0, or clears both when it's 0. Setting/removing the var re-paginates the page
+ * immediately — no fragment recreation. Re-run on page load (to re-apply to the new document) and
+ * whenever the reserve changes (readaloud becomes available mid-session via a download, or the reader
+ * switches to/from scroll mode).
+ */
+internal fun readaloudReserveApplyJs(reserveCssPx: Int): String =
+    if (reserveCssPx > 0) {
+        """
+        (function() {
+          var d = document.documentElement;
+          d.style.setProperty('$RESERVE_VAR', '${reserveCssPx}px');
+          d.classList.add('$RESERVE_ACTIVE_CLASS');
+        })();
+        """.trimIndent()
+    } else {
+        """
+        (function() {
+          var d = document.documentElement;
+          d.classList.remove('$RESERVE_ACTIVE_CLASS');
+          d.style.removeProperty('$RESERVE_VAR');
+        })();
+        """.trimIndent()
+    }

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ReadaloudReserveTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ReadaloudReserveTest.kt
@@ -1,0 +1,61 @@
+package com.riffle.app.feature.reader
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ReadaloudReserveTest {
+
+    @Test
+    fun `no reserve when readaloud unavailable`() {
+        assertEquals(0, readaloudReserveDp(readaloudAvailable = false, paginated = true))
+    }
+
+    @Test
+    fun `no reserve in scroll mode even when readaloud available`() {
+        // Scroll/vertical mode: text isn't pinned to a page, so the player floating over the bottom
+        // sliver is a non-issue (one small scroll reveals it). Deliberately reserves nothing.
+        assertEquals(0, readaloudReserveDp(readaloudAvailable = true, paginated = false))
+    }
+
+    @Test
+    fun `reserves the bar height when readaloud available and paginated`() {
+        // Gated on availability, NOT on the player being open — so the value is stable across the
+        // session and toggling the player never re-paginates.
+        assertEquals(READALOUD_RESERVE_DP, readaloudReserveDp(readaloudAvailable = true, paginated = true))
+    }
+
+    @Test
+    fun `apply js activates rule and sets var when reserve positive`() {
+        val js = readaloudReserveApplyJs(140)
+        assertTrue(js.contains("classList.add('riffle-ra-on')"))
+        assertTrue(js.contains("setProperty('--riffle-ra-reserve', '140px')"))
+    }
+
+    @Test
+    fun `apply js clears rule and var when reserve is zero`() {
+        val js = readaloudReserveApplyJs(0)
+        assertTrue(js.contains("classList.remove('riffle-ra-on')"))
+        assertTrue(js.contains("removeProperty('--riffle-ra-reserve')"))
+    }
+
+    @Test
+    fun `reserve css honors the page bottom margin plus the bar height`() {
+        val css = readaloudReserveCss()
+        // gap above the player == the page's own bottom margin (tracks the margins slider via
+        // --USER__pageMargins, symmetric with the top), plus the bar height carried in the var.
+        assertTrue(css.contains("var(--RS__pageGutter"))
+        assertTrue(css.contains("var(--USER__pageMargins, 1)"))
+        assertTrue(css.contains("var(--riffle-ra-reserve, 0px)"))
+        assertTrue(css.contains("padding-bottom"))
+        // gated on the active class, doubled :root to win specificity over the margins override
+        assertTrue(css.contains(":root.riffle-ra-on:root"))
+    }
+
+    @Test
+    fun `injection js is idempotent by stable id`() {
+        val js = readaloudReserveInjectionJs()
+        assertTrue(js.contains("'riffle-readaloud-reserve'"))
+        assertTrue(js.contains("if (document.getElementById(id)) return"))
+    }
+}


### PR DESCRIPTION
## Draft — ships with a known regression (see below)

Reserve a fixed bottom strip (the mini-player's height) in **paginated** mode whenever read-aloud is **available** for the book — *not* while the player is open. Because the reserve is constant for the session, opening/closing the player (Play-from-here, the play button, close) never re-paginates, so **the page can never jump**. This sidesteps the reflow-pin problem the earlier open-gated reserve had (PR #128 reverted it): there's no reflow to pin across.

This is the outcome we converged on after prototyping the alternatives (exact-split anchor, etc.): a constant reserve is the only jump-free approach that doesn't fight Readium's post-reflow scroll restoration.

### What changed
- **`ReadaloudReserve.kt`** (new) — injects `padding-bottom` on `:root` (the same lever the margins override uses). The gap above the bar tracks the page's **bottom** margin (margins-slider controlled); the bar height is reserved on top.
- Gated on `readaloudAvailable` (`control.enabled`): Storyteller always; matched ABS **only when the bundle is downloaded**; plain EPUBs never (full page, zero cost).
- **Scroll mode** reserves nothing — the player floats over a freely-scrollable page (no per-chapter gaps).
- Unit tests for the gating + JS emission.

### ⚠️ Known regression (fix in follow-up)
The read-aloud **highlight does not appear**. Root cause: the reserve reflows the page in `onPageLoaded` *after* the decoration's rects are fixed, displacing it (off-screen). The proper fix is to apply the reserve at **load time** (before first layout) instead of post-load — an architectural change that also eliminates the per-page-turn reflow. Tracked as the next step; this PR is intentionally a **draft**.

### Review items deferred to that follow-up (not blockers, same root area)
- **Chapter-rail combo**: when the chapter rail/progress overlay is also enabled, the player stacks above it and floats above the reserved strip over live text (unchanged vs. current `main`'s floating behavior; translucent backdrop mitigates).
- **Altitude**: post-load injection vs. a load-time CSS/preferences hook — the load-time move fixes both the highlight regression and an extra per-page reflow.
- **Duplication**: the bottom-margin calc is replicated from `TYPOGRAPHY_OVERRIDES["margins"]`; no test links them.
- **`LaunchedEffect(readaloudReservePx)`**: partially redundant with the page-load injection (only the rare mid-session availability flip needs it).

Review item **addressed**: corrected a KDoc that wrongly claimed the gap is "symmetric with the top margin" (top is 0.5×, bottom 1.0×).

### Tested
- `./gradlew test` ✅
- `./gradlew lint` ✅
- `make harness-test` (phone) ✅ 0 failed
- `make harness-test-tablet` ✅