### PR TITLE
feat(readaloud): granular playback speed control

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,3 +144,7 @@ harness-test: wrapper fonts ## Boot "Harness Medium Phone" AVD, run non-tablet h
 .PHONY: harness-test-tablet
 harness-test-tablet: wrapper fonts ## Boot "Harness Medium Tablet" AVD, run @TabletLayout tests only, then shut it down
 	@$(call run_harness_tests,$(TABLET_AVD),-Pandroid.testInstrumentationRunnerArguments.annotation=$(TABLET_ANNOTATION))
+
+.PHONY: harness-test-class
+harness-test-class: wrapper fonts ## Boot the phone AVD and run a single test CLASS=<fqcn> (or pkg.Class#method), then shut it down
+	@$(call run_harness_tests,$(PHONE_AVD),-Pandroid.testInstrumentationRunnerArguments.class=$(CLASS))

--- a/app/src/androidTest/kotlin/com/riffle/app/feature/reader/AutoFollowJsTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/reader/AutoFollowJsTest.kt
@@ -24,6 +24,24 @@ class AutoFollowJsTest {
     private val offRightText = "Offright next page sentence here"
     private val targetText = "Narrated target sentence deep in the page"
 
+    // Distinct in their first 12 chars (the probe keys on a 12-char prefix), so each resolves to its
+    // own element rather than colliding on a shared "Adjacent sen…" prefix.
+    private val adjacentA = "Alpha narrated line on screen"
+    private val adjacentB = "Bravo narrated line on screen"
+
+    // A tall (scroll-mode) document with two sentences one line apart, deep in the page. Used to prove
+    // that following flaps back and forth between two ALREADY-VISIBLE adjacent sentences (what a small
+    // audio-position jitter across a clip boundary produces) does not bounce the page up and down.
+    private val twoAdjacentFixture = """
+        <!DOCTYPE html>
+        <html><head><meta name="viewport" content="width=device-width, initial-scale=1"></head>
+          <body style="margin:0; height:6000px; position:relative">
+            <div id="adjA" style="position:absolute; left:20px; top:2980px; width:320px; height:40px">$adjacentA</div>
+            <div id="adjB" style="position:absolute; left:20px; top:3040px; width:320px; height:40px">$adjacentB</div>
+          </body>
+        </html>
+    """.trimIndent()
+
     // A document much taller than the viewport → scroll (karaoke) mode. The narrated sentence sits
     // far down the page so following it requires a real vertical scroll.
     private val tallFixture = """
@@ -66,6 +84,34 @@ class AutoFollowJsTest {
 
             val center = webView.rectCenterY("target")
             assertTrue("sentence should be vertically centred (center=$center, half=${h / 2})", Math.abs(center - h / 2) <= 12)
+        }
+    }
+
+    @Test
+    fun scrollModeDoesNotBounceBetweenAdjacentVisibleSentences() {
+        withSizedWebViewFixture(twoAdjacentFixture, widthPx = 1080, heightPx = 1600) { webView ->
+            webView.awaitInnerHeight()
+            // Centre sentence A first (so A is at mid-viewport and B is one line below it — both well
+            // inside the central comfort band, whatever the device's CSS innerHeight works out to).
+            val ih = webView.evalSync("window.innerHeight").trim('"').toDouble()
+            webView.evalSync("document.scrollingElement.scrollTop=${(2980 + 20 - ih / 2).toInt()}")
+            val y0 = webView.scrollY()
+
+            // Simulate the active sentence flapping A → B → A (a backward position blip across the clip
+            // boundary). Each follow must leave the page where it is — no re-centre, no up/down bounce.
+            webView.evalSync(ColumnSnap.autoFollowSnapJs(adjacentA))
+            val ya = webView.scrollY()
+            webView.evalSync(ColumnSnap.autoFollowSnapJs(adjacentB))
+            val yb = webView.scrollY()
+            webView.evalSync(ColumnSnap.autoFollowSnapJs(adjacentA))
+            val yc = webView.scrollY()
+
+            val maxDev = maxOf(Math.abs(ya - y0), Math.abs(yb - y0), Math.abs(yc - y0))
+            assertTrue(
+                "auto-follow must not bounce the page when the active sentence flaps between two " +
+                    "already-visible adjacent sentences (y0=$y0 ya=$ya yb=$yb yc=$yc maxDev=$maxDev)",
+                maxDev <= 8,
+            )
         }
     }
 

--- a/app/src/androidTest/kotlin/com/riffle/app/feature/reader/readaloud/ReadaloudMiniPlayerTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/reader/readaloud/ReadaloudMiniPlayerTest.kt
@@ -6,6 +6,7 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.Assert.assertEquals
@@ -20,8 +21,10 @@ class ReadaloudMiniPlayerTest {
     val rule = createAndroidComposeRule<ComponentActivity>()
 
     private fun setPlayer(
+        speed: Float = 1f,
         canPreviousChapter: Boolean = true,
         canNextChapter: Boolean = true,
+        onSpeedChange: (Float) -> Unit = {},
         onRewind: () -> Unit = {},
         onForward: () -> Unit = {},
         onPreviousChapter: () -> Unit = {},
@@ -30,7 +33,7 @@ class ReadaloudMiniPlayerTest {
         rule.setContent {
             ReadaloudMiniPlayer(
                 isPlaying = false,
-                speed = 1f,
+                speed = speed,
                 offlineMessage = false,
                 downloadProgress = null,
                 canPreviousChapter = canPreviousChapter,
@@ -38,7 +41,7 @@ class ReadaloudMiniPlayerTest {
                 containerColor = Color.LightGray,
                 contentColor = Color.Black,
                 onPlayPause = {},
-                onCycleSpeed = {},
+                onSpeedChange = onSpeedChange,
                 onRewind = onRewind,
                 onForward = onForward,
                 onPreviousChapter = onPreviousChapter,
@@ -80,6 +83,29 @@ class ReadaloudMiniPlayerTest {
     }
 
     @Test
+    fun tappingTheValue_opensTheSpeedSheet() {
+        setPlayer(speed = 1.4f)
+        rule.onNodeWithTag("readaloud_speed_slider_card").assertDoesNotExist()
+        rule.onNodeWithTag("readaloud_speed").performClick()
+        rule.onNodeWithTag("readaloud_speed_slider").assertIsDisplayed()
+    }
+
+    @Test
+    fun presetChip_setsThatSpeed() {
+        var requested = -1f
+        setPlayer(speed = 1.4f, onSpeedChange = { requested = it })
+        rule.onNodeWithTag("readaloud_speed").performClick()
+        rule.onNodeWithTag("readaloud_speed_preset_1.25×").performClick()
+        assertEquals(1.25f, requested, 0.0001f)
+    }
+
+    @Test
+    fun speedLabel_showsGranularValues() {
+        setPlayer(speed = 1.4f)
+        rule.onNodeWithText("1.4×").assertIsDisplayed()
+    }
+
+    @Test
     fun nextChapter_isDisabledAtTheLastChapter() {
         setPlayer(canNextChapter = false)
         rule.onNodeWithTag("readaloud_next_chapter").assertIsNotEnabled()
@@ -98,7 +124,7 @@ class ReadaloudMiniPlayerTest {
                 containerColor = Color.LightGray,
                 contentColor = Color.Black,
                 onPlayPause = {},
-                onCycleSpeed = {},
+                onSpeedChange = {},
                 onRewind = {},
                 onForward = {},
                 onPreviousChapter = {},

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ColumnSnap.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ColumnSnap.kt
@@ -114,8 +114,16 @@ internal object ColumnSnap {
           if(!r) return "off";
           var se=document.scrollingElement||document.documentElement;
           if(se && se.scrollHeight > window.innerHeight + 4){
-            var delta=Math.round((r.top+r.bottom)/2 - window.innerHeight/2);
-            if(Math.abs(delta) > 8) window.scrollBy(0, delta);
+            // KEEP-VISIBLE follow, not re-centre-every-sentence. Only scroll when the narrated sentence
+            // has drifted OUT of a central comfort band (the middle half of the viewport), then recentre
+            // it. Two adjacent sentences both inside the band — which is what a small audio-position
+            // jitter that flaps the active sentence back and forth across a clip boundary produces —
+            // move the page by nothing, so it no longer jiggles a line up-and-down on each change. This
+            // mirrors the deliberate keep-visible policy paginated mode already uses to avoid the same
+            // jitter. Forward reading still scrolls (in calm half-viewport steps) as the sentence nears
+            // an edge, and an off-screen sentence (e.g. after a seek) still recentres.
+            var h=window.innerHeight, mid=(r.top+r.bottom)/2, band=h*0.25;
+            if(mid < band || mid > h - band) window.scrollBy(0, Math.round(mid - h/2));
             return "on";
           }
           var iw=window.innerWidth;

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -381,12 +381,7 @@ fun EpubReaderScreen(
                         containerColor = readerPalette.background.copy(alpha = 0.65f),
                         contentColor = readerPalette.foreground,
                         onPlayPause = viewModel::togglePlayPause,
-                        onCycleSpeed = {
-                            // Cycle 0.75× → 1× → 1.25× → 1.5× → 2× → 0.75×.
-                            val speeds = com.riffle.app.feature.reader.readaloud.ReadaloudController.SPEEDS
-                            val idx = speeds.indexOfFirst { kotlin.math.abs(it - playbackState.speed) < 0.001f }
-                            viewModel.setSpeed(if (idx < 0) 1f else speeds[(idx + 1) % speeds.size])
-                        },
+                        onSpeedChange = viewModel::setSpeed,
                         onRewind = viewModel::rewind,
                         onForward = viewModel::forward,
                         onPreviousChapter = viewModel::previousChapter,

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -85,6 +85,9 @@ private const val SYNC_INTERVAL_MS = 30_000L
 // The audiobook follows the live audio on a tighter cadence than the 30s ebook reconcile, so a
 // listen reaches the server within seconds rather than only on the next ebook tick.
 private const val AUDIO_PUSH_INTERVAL_MS = 10_000L
+// Debounce window for persisting a playback-speed change, so a granular scrub/slide settles to a
+// single write rather than one per intermediate 0.05× value.
+private const val SPEED_SAVE_DEBOUNCE_MS = 400L
 
 sealed class ReaderState {
     data object Loading : ReaderState()
@@ -1132,9 +1135,17 @@ class EpubReaderViewModel @Inject constructor(
         }
     }
 
+    private var speedSaveJob: Job? = null
+
     fun setSpeed(speed: Float) {
+        // Apply to the live player immediately; persist debounced so a granular scrub/slide (which
+        // fires many intermediate values) only writes the settled speed, not every 0.05 step.
         playerCoordinator.setSpeed(speed)
-        viewModelScope.launch { audioPlaybackPreferencesStore.save(audioSettingsIdentity, speed) }
+        speedSaveJob?.cancel()
+        speedSaveJob = viewModelScope.launch {
+            delay(SPEED_SAVE_DEBOUNCE_MS)
+            audioPlaybackPreferencesStore.save(audioSettingsIdentity, speed)
+        }
     }
 
     fun rewind() = playerCoordinator.rewind()

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -1073,6 +1073,8 @@ class EpubReaderViewModel @Inject constructor(
         _readaloudOpen.value = false
         _downloadPromptBytes.value = null
         _readaloudOfflineMessage.value = false
+        // Persist any speed change still sitting in the debounce window before the session goes away.
+        flushPendingSpeed()
         storytellerSyncJob?.cancel()
         storytellerSyncJob = null
         // Remember where we stopped before tearing the session down: the sentence narrating now and
@@ -1136,16 +1138,30 @@ class EpubReaderViewModel @Inject constructor(
     }
 
     private var speedSaveJob: Job? = null
+    // The speed whose persistence is still pending behind the debounce, so close can flush it
+    // (null once written).
+    private var pendingSpeed: Float? = null
 
     fun setSpeed(speed: Float) {
         // Apply to the live player immediately; persist debounced so a granular scrub/slide (which
         // fires many intermediate values) only writes the settled speed, not every 0.05 step.
         playerCoordinator.setSpeed(speed)
+        pendingSpeed = speed
         speedSaveJob?.cancel()
         speedSaveJob = viewModelScope.launch {
             delay(SPEED_SAVE_DEBOUNCE_MS)
             audioPlaybackPreferencesStore.save(audioSettingsIdentity, speed)
+            pendingSpeed = null
         }
+    }
+
+    /** Persist a debounced-but-not-yet-written speed immediately, so the value a user picks just
+     * before dismissing the player isn't lost inside the debounce window. */
+    private fun flushPendingSpeed() {
+        val speed = pendingSpeed ?: return
+        speedSaveJob?.cancel()
+        pendingSpeed = null
+        viewModelScope.launch { audioPlaybackPreferencesStore.save(audioSettingsIdentity, speed) }
     }
 
     fun rewind() = playerCoordinator.rewind()

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/ReadaloudController.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/ReadaloudController.kt
@@ -31,7 +31,8 @@ import kotlin.coroutines.resume
  * queues one [MediaItem] per distinct audio file in the [ReadaloudTrack], and surfaces a polled
  * [PlaybackState] the reader observes to drive the synced highlight and auto-page-turn.
  *
- * The available playback speeds are exactly those in the spec: 0.75× / 1× / 1.25× / 1.5× / 2×.
+ * Playback speed is granular: any [SPEED_STEP] multiple in [[SPEED_MIN], [SPEED_MAX]] (so 1.4× is
+ * reachable), set from the mini-player's stepper / hold-to-slide control.
  */
 @Singleton
 class ReadaloudController @Inject constructor(
@@ -204,7 +205,18 @@ class ReadaloudController @Inject constructor(
     }
 
     companion object {
-        val SPEEDS = listOf(0.75f, 1f, 1.25f, 1.5f, 2f)
+        // Granular speed range for the fine stepper / scrub slider. Steps land on 0.05× multiples
+        // (so 1.4× is reachable), bounded to what stays intelligible at the extremes.
+        const val SPEED_MIN = 0.5f
+        const val SPEED_MAX = 3.0f
+        const val SPEED_STEP = 0.05f
+
+        /** Clamps to [[SPEED_MIN], [SPEED_MAX]] and snaps to the nearest [SPEED_STEP], free of float drift. */
+        fun snapSpeed(raw: Float): Float {
+            val stepped = Math.round(raw / SPEED_STEP) * SPEED_STEP
+            return stepped.coerceIn(SPEED_MIN, SPEED_MAX)
+        }
+
         const val REWIND_SEC = 15.0
         const val FORWARD_SEC = 30.0
         private const val NEAR_START_SEC = 3.0

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/ReadaloudPlayerUi.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/ReadaloudPlayerUi.kt
@@ -2,10 +2,16 @@
 
 package com.riffle.app.feature.reader.readaloud
 
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Forward30
@@ -17,6 +23,7 @@ import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Slider
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
@@ -29,18 +36,198 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.semantics.contentDescription
-import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntRect
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Popup
+import androidx.compose.ui.window.PopupPositionProvider
 import com.riffle.app.R
 
-/** Formats the speed as the spec wants it: 1×, 1.25×, 0.75×, … (trailing zeros trimmed). */
+/** Formats the speed as the spec wants it: 1×, 1.25×, 1.4×, 0.75×, … (rounded to 0.05, zeros trimmed). */
 private fun speedLabel(speed: Float): String {
-    val s = if (speed % 1f == 0f) speed.toInt().toString() else speed.toString().trimEnd('0').trimEnd('.')
+    // Round to 2 decimals first so 0.05-step floats (e.g. 1.35000002) print cleanly.
+    val rounded = Math.round(speed * 100.0) / 100.0
+    val s = if (rounded % 1.0 == 0.0) rounded.toInt().toString()
+    else rounded.toString().trimEnd('0').trimEnd('.')
     return "${s}×"
+}
+
+// Quick-jump presets surfaced as chips in the speed sheet (the familiar tap-cycle set), so common
+// speeds are one tap while the slider still reaches any 0.05-step value in between.
+private val SPEED_PRESETS = listOf(0.75f, 1f, 1.25f, 1.5f, 2f)
+
+// Detent labels printed under the slider track, spaced to read as a rough scale (not pixel-aligned
+// to the track — purely a legend, matching the prototype).
+private val SPEED_DETENTS = listOf("0.5×", "1×", "2×", "3×")
+
+/**
+ * The mini-player speed control: a single compact label on the bar. A **tap** (not a hold) opens a
+ * [SpeedSliderSheet] floating **above** the bar — a big live readout over a 0.05-step slider with a
+ * detent legend and quick-preset chips. The sheet is an overlay (a [Popup]), so the page text
+ * underneath never reflows, consistent with the floating player.
+ */
+@Composable
+private fun SpeedControl(
+    speed: Float,
+    contentColor: Color,
+    onSpeedChange: (Float) -> Unit,
+) {
+    val density = LocalDensity.current
+    var sheetOpen by remember { mutableStateOf(false) }
+
+    Box {
+        // Compact chip-style label. One tap toggles the sheet; there are no inline steppers and no
+        // press-and-hold gesture — all adjustment happens in the sheet.
+        Surface(
+            onClick = { sheetOpen = !sheetOpen },
+            shape = RoundedCornerShape(10.dp),
+            color = contentColor.copy(alpha = 0.08f),
+            contentColor = contentColor,
+            modifier = Modifier.testTag("readaloud_speed"),
+        ) {
+            Text(
+                speedLabel(speed),
+                fontWeight = FontWeight.SemiBold,
+                textAlign = TextAlign.Center,
+                maxLines = 1,
+                // Fixed width so the chip doesn't grow/shrink as the label changes (1× ↔ 0.75× ↔
+                // 1.45×) and shove the rest of the bar sideways while scrubbing.
+                modifier = Modifier
+                    .padding(horizontal = 12.dp, vertical = 7.dp)
+                    .width(48.dp),
+            )
+        }
+
+        if (sheetOpen) {
+            val gapPx = with(density) { 8.dp.roundToPx() }
+            Popup(
+                popupPositionProvider = remember(gapPx) { AboveAnchorPositionProvider(gapPx) },
+                onDismissRequest = { sheetOpen = false },
+            ) {
+                SpeedSliderSheet(speed = speed, onSpeedChange = onSpeedChange)
+            }
+        }
+    }
+}
+
+/**
+ * The card that floats above the bar while adjusting speed: a big readout, a 0.05-step slider with a
+ * detent legend, and quick-preset chips (prototype option B).
+ */
+@Composable
+private fun SpeedSliderSheet(
+    speed: Float,
+    onSpeedChange: (Float) -> Unit,
+) {
+    // One discrete stop per SPEED_STEP between the endpoints (Slider snaps onValueChange to them).
+    val stepCount = Math.round((ReadaloudController.SPEED_MAX - ReadaloudController.SPEED_MIN) /
+        ReadaloudController.SPEED_STEP) - 1
+    Surface(
+        shape = MaterialTheme.shapes.large,
+        tonalElevation = 3.dp,
+        shadowElevation = 6.dp,
+        modifier = Modifier
+            .width(320.dp)
+            .testTag("readaloud_speed_slider_card"),
+    ) {
+        Column(
+            modifier = Modifier.padding(horizontal = 16.dp, vertical = 14.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Text(
+                speedLabel(speed),
+                style = MaterialTheme.typography.headlineMedium,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.primary,
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            Slider(
+                value = speed.coerceIn(ReadaloudController.SPEED_MIN, ReadaloudController.SPEED_MAX),
+                onValueChange = { onSpeedChange(ReadaloudController.snapSpeed(it)) },
+                valueRange = ReadaloudController.SPEED_MIN..ReadaloudController.SPEED_MAX,
+                steps = stepCount,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .testTag("readaloud_speed_slider"),
+            )
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+            ) {
+                SPEED_DETENTS.forEach { detent ->
+                    Text(
+                        detent,
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+            Spacer(modifier = Modifier.height(12.dp))
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(6.dp, Alignment.CenterHorizontally),
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                SPEED_PRESETS.forEach { preset ->
+                    SpeedPresetChip(
+                        label = speedLabel(preset),
+                        selected = Math.abs(preset - speed) < 0.001f,
+                        onClick = { onSpeedChange(preset) },
+                    )
+                }
+            }
+        }
+    }
+}
+
+/** A compact pill preset (lighter than a Material [FilterChip] so all five fit one row). */
+@Composable
+private fun SpeedPresetChip(
+    label: String,
+    selected: Boolean,
+    onClick: () -> Unit,
+) {
+    Surface(
+        onClick = onClick,
+        shape = RoundedCornerShape(percent = 50),
+        color = if (selected) MaterialTheme.colorScheme.secondaryContainer
+        else MaterialTheme.colorScheme.surfaceVariant,
+        contentColor = if (selected) MaterialTheme.colorScheme.onSecondaryContainer
+        else MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = Modifier.testTag("readaloud_speed_preset_$label"),
+    ) {
+        Text(
+            label,
+            style = MaterialTheme.typography.labelLarge,
+            fontWeight = if (selected) FontWeight.SemiBold else FontWeight.Medium,
+            modifier = Modifier.padding(horizontal = 10.dp, vertical = 6.dp),
+        )
+    }
+}
+
+/**
+ * Positions the speed sheet centred horizontally in the WINDOW (not over its anchor — the speed label
+ * sits at the far left of the bar, so anchoring there would shove the sheet against the screen edge),
+ * floating just above the anchor row.
+ */
+private class AboveAnchorPositionProvider(private val gapPx: Int) : PopupPositionProvider {
+    override fun calculatePosition(
+        anchorBounds: IntRect,
+        windowSize: IntSize,
+        layoutDirection: LayoutDirection,
+        popupContentSize: IntSize,
+    ): IntOffset {
+        val x = ((windowSize.width - popupContentSize.width) / 2)
+            .coerceIn(0, (windowSize.width - popupContentSize.width).coerceAtLeast(0))
+        val y = anchorBounds.top - popupContentSize.height - gapPx
+        return IntOffset(x, y)
+    }
 }
 
 
@@ -58,7 +245,7 @@ fun ReadaloudMiniPlayer(
     containerColor: Color,
     contentColor: Color,
     onPlayPause: () -> Unit,
-    onCycleSpeed: () -> Unit,
+    onSpeedChange: (Float) -> Unit,
     onRewind: () -> Unit,
     onForward: () -> Unit,
     onPreviousChapter: () -> Unit,
@@ -102,13 +289,7 @@ fun ReadaloudMiniPlayer(
                         .testTag("readaloud_downloading"),
                 )
             } else {
-                TextButton(onClick = onCycleSpeed, modifier = Modifier.testTag("readaloud_speed")) {
-                    Text(
-                        speedLabel(speed),
-                        color = contentColor,
-                        fontWeight = FontWeight.SemiBold,
-                    )
-                }
+                SpeedControl(speed = speed, contentColor = contentColor, onSpeedChange = onSpeedChange)
                 Spacer(modifier = Modifier.weight(1f))
                 IconButton(onClick = onRewind, modifier = Modifier.testTag("readaloud_rewind")) {
                     Icon(

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/ReadaloudPlayerUi.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/ReadaloudPlayerUi.kt
@@ -225,7 +225,8 @@ private class AboveAnchorPositionProvider(private val gapPx: Int) : PopupPositio
     ): IntOffset {
         val x = ((windowSize.width - popupContentSize.width) / 2)
             .coerceIn(0, (windowSize.width - popupContentSize.width).coerceAtLeast(0))
-        val y = anchorBounds.top - popupContentSize.height - gapPx
+        // Float above the anchor, but never let the top clip off-screen on a short viewport.
+        val y = (anchorBounds.top - popupContentSize.height - gapPx).coerceAtLeast(0)
         return IntOffset(x, y)
     }
 }


### PR DESCRIPTION
## What & why

Readaloud speed was a fixed tap-cycle through `0.75 · 1 · 1.25 · 1.5 · 2×`, so values like **1.4×** were unreachable. This replaces it with a granular control.

### Speed control (mini-player)
- The speed chip on the bar now **opens a slider sheet that floats above the bar** — an overlay `Popup`, so the page text underneath never reflows (consistent with the floating player from #128/#133).
- The sheet has a big live readout, a **0.05-step slider** over **0.5–3.0×**, a detent legend, and quick-preset chips for the common speeds.
- `ReadaloudController` gains `SPEED_MIN/MAX/STEP` and `snapSpeed()` (clamp + snap, float-drift-free); the old `SPEEDS` preset list is gone.
- The bar's speed label is fixed-width/centered so it doesn't resize and shove the transport controls as the value changes.
- `setSpeed` applies to the live player immediately but **debounces persistence (400ms)** so a drag writes once rather than per 0.05 step; the pending value is flushed on close so a last-second change isn't lost in the debounce window.
- The expanded-player bottom sheet (whose position slider was visual-only / non-seeking) was removed as part of the redesign — speed now lives solely on the always-visible bar.

### Auto-follow jiggle fix (bundled, reader)
- Scroll-mode auto-follow recentered the narrated sentence on every change, so audio-position jitter across a clip boundary bounced the page a line up/down. Switched to a **keep-visible comfort band** (only scroll when the sentence leaves the middle half of the viewport), mirroring paginated mode.

## Testing
- `./gradlew test lint` — green
- `make harness-test` (phone) — 179 tests, 0 failed
- `make harness-test-tablet` — 5 tests, 0 failed
- New instrumented coverage: `ReadaloudMiniPlayerTest` (tap opens sheet, preset sets speed, granular label) and `AutoFollowJsTest.scrollModeDoesNotBounceBetweenAdjacentVisibleSentences`.

## Tooling
- `Makefile`: added `harness-test-class CLASS=<fqcn>` to run a single instrumented class through the managed phone AVD.