### PR TITLE
fix(app): render summary HTML; stop nav root-switches blanking the screen

### DIFF
--- a/app/src/androidTest/kotlin/com/riffle/app/navigation/NavigateAsRootTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/navigation/NavigateAsRootTest.kt
@@ -1,0 +1,74 @@
+package com.riffle.app.navigation
+
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Regression: an intermittent blank white screen ("burger menu blank").
+ *
+ * The graph's start destination (HOME) is popped inclusively as soon as a library resolves at
+ * launch, so the old `popUpTo(HOME) { inclusive = true }` used by every root-switch navigation
+ * matched nothing afterwards. Each server/library switch then pushed a *duplicate* library_items
+ * root instead of replacing it, and backing out of the accumulated roots could empty the back
+ * stack entirely — leaving the NavHost with no destination (a blank screen).
+ *
+ * [navigateAsRoot] anchors the pop on the root graph id instead, so a single destination is always
+ * the sole root.
+ */
+@RunWith(AndroidJUnit4::class)
+class NavigateAsRootTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private fun libraryRoots(nav: NavHostController) =
+        nav.currentBackStack.value.count { it.destination.route?.startsWith("lib/") == true }
+
+    @Test
+    fun switchingRootsNeverAccumulatesOrEmptiesBackStack() {
+        lateinit var nav: NavHostController
+        composeTestRule.setContent {
+            nav = rememberNavController()
+            NavHost(navController = nav, startDestination = "home") {
+                composable("home") {}
+                composable("lib/{id}") {}
+                composable("detail/{id}") {}
+            }
+        }
+
+        // Launch router: resolve a library and pop HOME inclusively (mirrors HomeScreen).
+        composeTestRule.runOnUiThread { nav.navigateAsRoot("lib/a") }
+        composeTestRule.waitForIdle()
+        assertEquals("HOME should be gone after launch", null, currentRoute(nav, "home"))
+
+        // Switch libraries several times — each must REPLACE the root, never accumulate.
+        composeTestRule.runOnUiThread { nav.navigateAsRoot("lib/b") }
+        composeTestRule.runOnUiThread { nav.navigateAsRoot("lib/c") }
+        composeTestRule.waitForIdle()
+        assertEquals("library root must not accumulate on switch", 1, libraryRoots(nav))
+
+        // Drill into a detail, then back out: the stack must return to the single root, never empty.
+        composeTestRule.runOnUiThread { nav.navigate("detail/x") }
+        composeTestRule.waitForIdle()
+        composeTestRule.runOnUiThread { nav.popBackStack() }
+        composeTestRule.waitForIdle()
+
+        assertEquals("back from detail returns to the single library root", 1, libraryRoots(nav))
+        assertTrue(
+            "back stack must still have a current destination (not blank)",
+            nav.currentBackStackEntry?.destination?.route != null,
+        )
+    }
+
+    private fun currentRoute(nav: NavHostController, route: String): String? =
+        nav.currentBackStack.value.firstOrNull { it.destination.route == route }?.destination?.route
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemDetailScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemDetailScreen.kt
@@ -61,8 +61,10 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.fromHtml
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -225,12 +227,13 @@ fun LibraryItemDetailScreen(
 private fun CollapsibleDescription(description: String) {
     var expanded by remember { mutableStateOf(false) }
     var isOverflowing by remember { mutableStateOf(false) }
+    val formatted = remember(description) { AnnotatedString.fromHtml(description) }
 
     Column(modifier = Modifier.animateContentSize()) {
         Text(text = "Summary", style = MaterialTheme.typography.titleLarge)
         Spacer(modifier = Modifier.height(4.dp))
         Text(
-            text = description,
+            text = formatted,
             style = MaterialTheme.typography.bodyLarge,
             maxLines = if (expanded) Int.MAX_VALUE else 5,
             overflow = TextOverflow.Ellipsis,

--- a/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.navigation.NavController
 import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
@@ -99,9 +100,7 @@ fun MainScreen(
     LaunchedEffect(Unit) {
         viewModel.redirectToLibrary.collect { library ->
             val encoded = URLEncoder.encode(library.name, "UTF-8")
-            navController.navigate("library_items/${library.id}/$encoded") {
-                popUpTo(HOME) { inclusive = true }
-            }
+            navController.navigateAsRoot("library_items/${library.id}/$encoded")
             viewModel.setActiveLibrary(library.id)
         }
     }
@@ -119,15 +118,13 @@ fun MainScreen(
         onServerSelected = { server ->
             viewModel.setActiveServer(server.id)
             scope.launch { drawerState.close() }
-            navController.navigate(HOME) { popUpTo(HOME) { inclusive = true } }
+            navController.navigateAsRoot(HOME)
         },
         onLibrarySelected = { library ->
             viewModel.setActiveLibrary(library.id)
             scope.launch { drawerState.close() }
             val encoded = URLEncoder.encode(library.name, "UTF-8")
-            navController.navigate("library_items/${library.id}/$encoded") {
-                popUpTo(HOME) { inclusive = true }
-            }
+            navController.navigateAsRoot("library_items/${library.id}/$encoded")
         },
         onDownloadsSelected = {
             scope.launch { drawerState.close() }
@@ -142,16 +139,12 @@ fun MainScreen(
             composable(HOME) {
                 HomeScreen(
                     onNavigateToAddServer = {
-                        navController.navigate(ADD_SERVER) {
-                            popUpTo(HOME) { inclusive = true }
-                        }
+                        navController.navigateAsRoot(ADD_SERVER)
                     },
                     onNavigateToLibrary = { libraryId, libraryName ->
                         viewModel.setActiveLibrary(libraryId)
                         val encoded = URLEncoder.encode(libraryName, "UTF-8")
-                        navController.navigate("library_items/$libraryId/$encoded") {
-                            popUpTo(HOME) { inclusive = true }
-                        }
+                        navController.navigateAsRoot("library_items/$libraryId/$encoded")
                     },
                 )
             }
@@ -164,14 +157,14 @@ fun MainScreen(
                     AddServerScreen(
                         windowSizeClass = windowSizeClass,
                         onNavigateBack = {
-                            navController.navigate(HOME) { popUpTo(HOME) { inclusive = true } }
+                            navController.navigateAsRoot(HOME)
                         },
                         onAuthenticated = { pending ->
                             setupVm.pendingServer = pending
                             navController.navigate(SELECT_LIBRARIES)
                         },
                         onAutoCompleted = {
-                            navController.navigate(HOME) { popUpTo(HOME) { inclusive = true } }
+                            navController.navigateAsRoot(HOME)
                         },
                     )
                 }
@@ -189,7 +182,7 @@ fun MainScreen(
                             windowSizeClass = windowSizeClass,
                             onNavigateBack = { navController.popBackStack() },
                             onContinueComplete = {
-                                navController.navigate(HOME) { popUpTo(HOME) { inclusive = true } }
+                                navController.navigateAsRoot(HOME)
                             },
                         )
                     }
@@ -397,6 +390,22 @@ fun MainScreen(
                 AudiobookPlayerScreen(onNavigateBack = { navController.popBackStack() })
             }
         }
+    }
+}
+
+// Resets the back stack so [route] becomes the sole root. Used by every "switch the active
+// surface" navigation — launch router, server/library switch, redirect, server-setup completion.
+//
+// We deliberately do NOT anchor on popUpTo(HOME): HOME is the graph's start destination but it is
+// popped inclusively the moment a library resolves at launch, so popUpTo(HOME) afterwards matches
+// nothing ("Ignoring popBackStack to route home"), the inclusive pop is skipped, and each switch
+// pushes a duplicate root instead of replacing it. Backing out of those accumulated roots can empty
+// the stack entirely, leaving the NavHost with no destination — a blank white screen. Popping the
+// root graph id clears the whole stack regardless of whether HOME is still present.
+internal fun NavController.navigateAsRoot(route: String) {
+    navigate(route) {
+        popUpTo(graph.id) { inclusive = true }
+        launchSingleTop = true
     }
 }
 


### PR DESCRIPTION
## What

Two user-facing fixes:

### 1. Book summary renders raw HTML tags (`LibraryItemDetailScreen`)
ABS descriptions are HTML; the detail screen displayed them as plain text with visible markup. Parse once per description with `AnnotatedString.fromHtml` (Compose UI 1.7+) so bold/italic/links render properly.

### 2. Intermittent blank white screen while navigating (`MainScreen`)
**Root cause (captured live with back-stack instrumentation):** `HOME` is popped inclusively the moment a library resolves at launch, so every later `popUpTo(HOME) { inclusive = true }` matched nothing (`NavController: Ignoring popBackStack to route home`). Each server/library switch then **pushed a duplicate `library_items` root instead of replacing it**, and backing out of the accumulated roots could empty the back stack entirely — a `NavHost` with no destination renders as a blank white screen, and Back from there exits the app.

**Fix:** a `navigateAsRoot` helper anchoring the pop on the root graph id (always present) + `launchSingleTop`, used by all 8 root-switch sites (launch router, server/library switch, hidden-library redirect, server-setup completion).

## Testing

- Reproduced the empty back stack on an emulator pre-fix (logged `backstack=` going empty after library switches); post-fix the same flows keep exactly one root and the back stack never empties. User-verified on device.
- New instrumented regression test `NavigateAsRootTest` (passes via `make harness-test-class`).
- `./gradlew test` ✓, `./gradlew lint` ✓, `make harness-test` (180 tests) ✓, `make harness-test-tablet` (5 tests) ✓.