### PR TITLE
feat(reader): enlarge paginated top margin to 0.8× the gutter

### DIFF
--- a/app/src/androidTest/kotlin/com/riffle/app/feature/reader/TypographyOverrideWebViewTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/reader/TypographyOverrideWebViewTest.kt
@@ -106,7 +106,7 @@ class TypographyOverrideWebViewTest {
     // Margins override targets :root (not body) so every column in paginated mode gets equal
     // top/bottom whitespace. Without --USER__pageMargins set the gate doesn't match and :root
     // padding stays at the fixture default. With it set, padding-top/bottom should resolve to
-    // calc(--RS__pageGutter * --USER__pageMargins * 0.5). We simulate Readium's gutter with
+    // calc(--RS__pageGutter * --USER__pageMargins * 0.8). We simulate Readium's gutter with
     // an explicit --RS__pageGutter on :root so the calc has a concrete value.
     @Test
     fun marginsOverrideAppliesVerticalPaddingToRootWhenUserVariableIsSet() {
@@ -120,11 +120,10 @@ class TypographyOverrideWebViewTest {
             val paddingBottom = webView.evalSync(
                 "window.getComputedStyle(document.documentElement).paddingBottom"
             ).toCssPx()
-            // Top is 0.5× the horizontal gutter (narrower than sides — conventional book
-            // typography); bottom is 1.0× so the chapter-rail overlay has breathing room above
-            // the running text. See TypographyOverride.kt "margins" entry.
-            // 20px gutter × 2 (pageMargins) × 0.5 = 20px top; × 1.0 = 40px bottom.
-            assertEquals("padding-top should reflect --USER__pageMargins × gutter × 0.5", 20.0, paddingTop, 0.5)
+            // Top is 0.8× the horizontal gutter — slightly narrower than the side margins and
+            // the bottom (both 1.0×). See TypographyOverride.kt "margins" entry.
+            // 20px gutter × 2 (pageMargins) × 0.8 = 32px top; × 1.0 = 40px bottom.
+            assertEquals("padding-top should reflect --USER__pageMargins × gutter × 0.8", 32.0, paddingTop, 0.5)
             assertEquals("padding-bottom should reflect --USER__pageMargins × gutter × 1.0", 40.0, paddingBottom, 0.5)
         }
     }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/TypographyOverride.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/TypographyOverride.kt
@@ -76,14 +76,14 @@ internal val TYPOGRAPHY_OVERRIDES: Map<String, TypographyOverride> = mapOf(
     // `:root` is `height: auto`, so this becomes whitespace at the start/end of each loaded
     // resource — still the desired "margin" semantics.
     //
-    // Top stays at 0.5× the horizontal gutter (narrower than sides — conventional book
-    // typography). Bottom is 1.0× so the chapter-rail overlay has clear breathing room above
-    // the running text. Both scale with --USER__pageMargins, so cranking up margins keeps the
-    // top/bottom ratio constant.
+    // Top is 0.8× the horizontal gutter — close to the left/right side margins (Readium's
+    // built-in body padding, 1.0×) and the bottom (1.0×), but slightly narrower per conventional
+    // book typography. Both scale with --USER__pageMargins, so cranking up margins keeps the
+    // ratio constant.
     "margins" to TypographyOverride(
         userPropertyName = "--USER__pageMargins",
         declarations = listOf(
-            "padding-top" to "calc(var(--RS__pageGutter) * var(--USER__pageMargins) * 0.5)",
+            "padding-top" to "calc(var(--RS__pageGutter) * var(--USER__pageMargins) * 0.8)",
             "padding-bottom" to "calc(var(--RS__pageGutter) * var(--USER__pageMargins) * 1.0)",
         ),
         elements = "",  // empty → rule targets `:root` itself, not a descendant


### PR DESCRIPTION
## What

In paginated reading mode the top margin was `0.5×` the page gutter — half the left/right side margins. This bumps it to `0.8×` so there's more breathing room above the running text while staying slightly narrower than the sides, per conventional book typography.

Bottom margin is unchanged at `1.0×` (kept wider for the chapter-rail overlay). The override still only applies in paginated mode when the user has customised margins, and continues to scale proportionally with `--USER__pageMargins`.

## Changes

- `TypographyOverride.kt` — `padding-top` calc `0.5` → `0.8` (+ comment).
- `TypographyOverrideWebViewTest.kt` — pinning test now expects 32px top (20px gutter × 2 × 0.8).

## Tested

- `./gradlew test lint` — green.
- `make harness-test` — 180 phone tests pass (incl. the WebView margin test).