### PR TITLE
fix(readaloud): reduce mini-player translucency

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -378,7 +378,7 @@ fun EpubReaderScreen(
                         canPreviousChapter = playbackState.currentChapterIndex > 0,
                         canNextChapter = playbackState.currentChapterIndex >= 0 &&
                             playbackState.currentChapterIndex < playbackState.chapterCount - 1,
-                        containerColor = readerPalette.background.copy(alpha = 0.65f),
+                        containerColor = readerPalette.background.copy(alpha = 0.85f),
                         contentColor = readerPalette.foreground,
                         onPlayPause = viewModel::togglePlayPause,
                         onSpeedChange = viewModel::setSpeed,


### PR DESCRIPTION
Reduces the read-aloud mini-player's translucency so it's easier to read against the page behind it.

Bumps the container background alpha from `0.65f` → `0.85f` in `EpubReaderScreen.kt`. The player stays slightly translucent (a faint hint of the page still shows through) but is now far more opaque.