### PR TITLE
fix(readaloud): match the ebook when a middle initial + ABS-only co-author break author overlap

### DIFF
--- a/core/domain/src/main/kotlin/com/riffle/core/domain/ReadaloudMatcher.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/ReadaloudMatcher.kt
@@ -198,12 +198,19 @@ object ReadaloudMatcher {
      * produce the same set, which is how the spec's name-order equivalence is satisfied. Any
      * non-alphanumeric character is treated as a separator so OPF-junk like "Andy Weir;"
      * collapses to {andy, weir}.
+     *
+     * Single-character tokens (middle initials) are dropped: a side that spells out a middle
+     * initial ("Stephen W. Hawking") would otherwise carry a "w" token the other side lacks,
+     * breaking [authorsOverlap]'s subset rule. When that is combined with a genuine co-author
+     * present on only one side, neither set is a subset of the other and a real match is lost.
+     * Dropping the initial leaves the substantive name tokens, which the subset/Dice rules
+     * already handle. Two-letter initialisms ("JD Jackson") are kept.
      */
     private fun authorTokens(raw: String): Set<String> =
         raw.lowercase()
             .map { if (it.isLetterOrDigit() || it.isWhitespace()) it else ' ' }
             .joinToString("")
             .split(Regex("\\s+"))
-            .filter { it.isNotEmpty() }
+            .filter { it.length > 1 }
             .toSet()
 }

--- a/core/domain/src/test/kotlin/com/riffle/core/domain/ReadaloudMatcherTest.kt
+++ b/core/domain/src/test/kotlin/com/riffle/core/domain/ReadaloudMatcherTest.kt
@@ -228,6 +228,22 @@ class ReadaloudMatcherTest {
         assertEquals(confirmed("abs-1" to "item-1"), ReadaloudMatcher.match(book, listOf(abs)))
     }
 
+    @Test
+    fun `middle initial plus an ABS-only co-author still matches the ebook`() {
+        // Real data — "The Grand Design": the Storyteller readaloud lists the author both ways
+        // ("Stephen Hawking" + "Stephen W. Hawking"), contributing a middle-initial "w" the ABS
+        // ebook lacks, while the ABS ebook adds the curated co-author "Leonard Mlodinow" the
+        // readaloud omits. Flatten-and-subset breaks both directions, so the ebook was dropped
+        // and only the bare-{stephen,hawking} audiobook matched.
+        val book = storytellerBook(title = "The Grand Design", author = "Stephen Hawking, Stephen W. Hawking")
+        val ebook = absItem(serverUuid = "abs-1", libraryItemId = "ebook", title = "The Grand Design", author = "Stephen Hawking, Leonard Mlodinow")
+        val audio = absItem(serverUuid = "abs-2", libraryItemId = "audio", title = "The Grand Design", author = "Stephen Hawking")
+
+        val result = ReadaloudMatcher.match(book, listOf(ebook, audio))
+
+        assertEquals(setOf(Confirmed("abs-1", "ebook"), Confirmed("abs-2", "audio")), confirmedLinks(result))
+    }
+
     // ---- Tier 3: fuzzy → Pending Review ----------------------------------------------------
 
     @Test


### PR DESCRIPTION
## Problem

"The Grand Design" readaloud auto-matched only the ABS audiobook, never the ebook — so the ebook stayed unlinked.

Confirmed against the live test servers, the three items carry these authors:

| Source | Author(s) | Tokens |
|---|---|---|
| Storyteller readaloud | Stephen Hawking + Stephen **W.** Hawking | `{stephen, hawking, w}` |
| ABS **ebook** | Stephen Hawking + **Leonard Mlodinow** | `{stephen, hawking, leonard, mlodinow}` |
| ABS **audiobook** | Stephen Hawking | `{stephen, hawking}` |

`ReadaloudMatcher.authorsOverlap` flattens all authors into one token bag and requires one bag to be a subset of the other. Two metadata quirks combine to break that for the ebook: the readaloud spells out a **middle initial** (`w`) the ebook lacks, *and* the ebook lists a **co-author** (`Mlodinow`) the readaloud omits → neither set is a subset of the other. Tier 3 fuzzy didn't rescue it either (Dice 0.57 < 0.85). The audiobook's `{stephen,hawking}` *is* a subset, so only it matched.

## Fix

Drop single-character initial tokens during author tokenization (`authorTokens`). That collapses the readaloud side to the bare `{stephen,hawking}`, which the existing either-direction subset rule already matches against the ebook's co-author superset. Two-letter initialisms ("JD Jackson") are preserved. The change is gated by the exact-title (Tier 2) / Dice-threshold (Tier 3) checks, so it can't manufacture spurious matches.

## Tests

- Added `ReadaloudMatcherTest."middle initial plus an ABS-only co-author still matches the ebook"` using the exact real-world metadata — fails before the fix (audiobook only), passes after.
- `./gradlew test` — green (full JVM unit/integration suite).
- `./gradlew lint` — green.
- Harness tests N/A: change is pure-JVM domain logic with no UI/instrumented surface.