### PR TITLE
feat(readaloud): enter immersive mode when readaloud starts playing

### DIFF
--- a/app/src/androidTest/kotlin/com/riffle/app/feature/reader/ImmersiveOnReadaloudPlayTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/reader/ImmersiveOnReadaloudPlayTest.kt
@@ -1,0 +1,105 @@
+package com.riffle.app.feature.reader
+
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Verifies the wiring that drops the reader into immersive mode when readaloud starts.
+ * Drives a real [ImmersiveModeState] (backed by a fake [SystemBarsController]) through the
+ * composable, asserting both the immersive flag and the actual hide()/show() calls.
+ */
+@RunWith(AndroidJUnit4::class)
+class ImmersiveOnReadaloudPlayTest {
+
+    @get:Rule
+    val rule = createComposeRule()
+
+    private class FakeController : SystemBarsController {
+        var hideCount = 0
+        var showCount = 0
+        override fun hide() { hideCount++ }
+        override fun show() { showCount++ }
+        override fun setBehaviorDefault() {}
+    }
+
+    private fun setContent(
+        controller: FakeController,
+        initialPlaying: Boolean,
+    ): Pair<ImmersiveModeState, (Boolean) -> Unit> {
+        val state = ImmersiveModeState(controller, clock = { 0L })
+        // Hoisted above setContent so it survives recomposition (a bare mutableStateOf inside
+        // the composable would reset to initialPlaying on every recompose).
+        val playing = mutableStateOf(initialPlaying)
+        rule.setContent {
+            ImmersiveOnReadaloudPlay(isReadaloudPlaying = playing.value, immersiveState = state)
+        }
+        return state to { value: Boolean -> playing.value = value }
+    }
+
+    @Test
+    fun startingPlayback_entersImmersive() {
+        val controller = FakeController()
+        val (state, setPlaying) = setContent(controller, initialPlaying = false)
+        rule.waitForIdle()
+        assertFalse(state.isImmersive)
+        assertEquals(0, controller.hideCount)
+
+        setPlaying(true)
+        rule.waitForIdle()
+
+        assertTrue(state.isImmersive)
+        assertEquals(1, controller.hideCount)
+    }
+
+    @Test
+    fun startingPlaybackInitially_entersImmersive() {
+        val controller = FakeController()
+        val (state, _) = setContent(controller, initialPlaying = true)
+        rule.waitForIdle()
+
+        assertTrue(state.isImmersive)
+        assertEquals(1, controller.hideCount)
+    }
+
+    @Test
+    fun pausing_doesNotRestoreChrome() {
+        val controller = FakeController()
+        val (state, setPlaying) = setContent(controller, initialPlaying = true)
+        rule.waitForIdle()
+        assertTrue(state.isImmersive)
+
+        setPlaying(false) // pause
+        rule.waitForIdle()
+
+        // One-way: pausing leaves immersive untouched and never calls show().
+        assertTrue(state.isImmersive)
+        assertEquals(0, controller.showCount)
+    }
+
+    @Test
+    fun resumingAfterManualReveal_reHidesChrome() {
+        val controller = FakeController()
+        val (state, setPlaying) = setContent(controller, initialPlaying = true)
+        rule.waitForIdle()
+        assertEquals(1, controller.hideCount)
+
+        setPlaying(false)       // pause
+        rule.waitForIdle()
+        state.toggle()          // user taps to reveal the bars while paused
+        rule.waitForIdle()
+        assertFalse(state.isImmersive)
+
+        setPlaying(true)        // resume
+        rule.waitForIdle()
+
+        // Every transition into playing re-hides, even after a manual reveal.
+        assertTrue(state.isImmersive)
+    }
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -237,6 +237,14 @@ fun EpubReaderScreen(
     val readaloudOfflineMessage by viewModel.readaloudOfflineMessage.collectAsState()
     val downloadProgress by viewModel.downloadProgress.collectAsState()
 
+    // Starting (or resuming) readaloud is a "lean back and listen" intent, so drop into
+    // immersive mode. See ImmersiveOnReadaloudPlay for the why (hides system bars + TopAppBar
+    // together, one-way, plays nicely with rotation/sleep-resume restore).
+    ImmersiveOnReadaloudPlay(
+        isReadaloudPlaying = playbackState.isPlaying,
+        immersiveState = immersiveState,
+    )
+
     // Reserve a fixed bottom strip for the readaloud mini-player whenever readaloud is AVAILABLE
     // (a downloaded/usable match) and the reader is paginated. The reserve is held for the whole
     // session — NOT gated on the player being open — so toggling the player (Play-from-here, the play

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ImmersiveOnReadaloudPlay.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ImmersiveOnReadaloudPlay.kt
@@ -1,0 +1,26 @@
+package com.riffle.app.feature.reader
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+
+/**
+ * Drops the reader into immersive mode whenever readaloud transitions into playing.
+ *
+ * [ImmersiveModeState.hide] collapses BOTH the OS system bars AND the reader TopAppBar (the bar's
+ * visibility is bound to `!isImmersive`), so a single call hides all chrome together.
+ *
+ * One-way by design: pausing does NOT restore the chrome, and a manual tap to reveal it still
+ * works — the next play re-hides. [ImmersiveModeState.hide] is idempotent and does not touch the
+ * persisted `savedIsImmersive` flag, so re-entering on every play never fights the rotation /
+ * sleep-resume restore logic. The readaloud mini-player stays visible (it is gated on the player
+ * being open, not on immersive state), so only the top bar and system bars go away.
+ */
+@Composable
+internal fun ImmersiveOnReadaloudPlay(
+    isReadaloudPlaying: Boolean,
+    immersiveState: ImmersiveModeState,
+) {
+    LaunchedEffect(isReadaloudPlaying) {
+        if (isReadaloudPlaying) immersiveState.hide()
+    }
+}


### PR DESCRIPTION
## What

Starting or resuming readaloud now drops the reader into immersive mode. A single call to `ImmersiveModeState.hide()` collapses **both** the OS system bars and the reader `TopAppBar` together (the bar's `AnimatedVisibility` is bound to `!isImmersive`), giving a clean lean-back-and-listen view.

Behavior:
- **Every** transition into playing — first play *and* resume-after-pause — hides system bars + top bar.
- **One-way:** pausing/stopping leaves the chrome hidden; a manual tap to reveal it still works, and the next play re-hides.
- `hide()` is idempotent and doesn't touch the persisted `savedIsImmersive` flag, so re-entering on every play never fights the existing rotation / sleep-resume restore logic.
- The readaloud mini-player stays visible (it's gated on the player being open, not on immersive state) — only the top bar and system bars go away.

## How

- New `ImmersiveOnReadaloudPlay` composable holds the wiring (`LaunchedEffect(isPlaying) { if (playing) hide() }`), extracted so it's an isolated, testable unit rather than logic buried in `EpubReaderScreen`.
- `EpubReaderScreen` delegates to it, passing `playbackState.isPlaying`.

## Testing

- New `ImmersiveOnReadaloudPlayTest` (4 tests) drives a real `ImmersiveModeState` with a fake `SystemBarsController`: enters immersive on play, enters when already-playing on first composition, pause is one-way (no `show()`), resume re-hides after a manual reveal.
- `./gradlew test lint` — green.
- `make harness-test` (184 tests, 0 failed) and `make harness-test-tablet` (5 tests) — green.