### PR TITLE
fix(data): purge a removed server's downloaded/cached files from disk

### DIFF
--- a/core/data/src/main/kotlin/com/riffle/core/data/LocalStoreImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/LocalStoreImpl.kt
@@ -36,6 +36,10 @@ class LocalStoreImpl(private val dir: File, private val extension: String) : Loc
         fileFor(serverId, itemId).delete()
     }
 
+    override fun deleteServer(serverId: String) {
+        dir.resolve(serverId).deleteRecursively()
+    }
+
     override fun clear() {
         dir.listFiles()?.forEach { it.deleteRecursively() }
     }

--- a/core/data/src/main/kotlin/com/riffle/core/data/ServerFilesCleanerImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/ServerFilesCleanerImpl.kt
@@ -1,0 +1,25 @@
+package com.riffle.core.data
+
+import com.riffle.core.domain.LocalStore
+import com.riffle.core.domain.ServerFilesCleaner
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.io.File
+
+/**
+ * Purges a Server's files across all on-disk stores (ADR 0025). [stores] are the EPUB/PDF
+ * download+cache [LocalStore]s; [audiobookDownloadsDir] is the audiobook download root, which is a
+ * directory-per-item tree rather than a [LocalStore] (ADR 0029) but follows the same
+ * `<root>/<serverId>/…` layout, so it too is removed as a per-Server subtree.
+ */
+class ServerFilesCleanerImpl(
+    private val stores: List<LocalStore>,
+    private val audiobookDownloadsDir: File,
+) : ServerFilesCleaner {
+
+    override suspend fun deleteAllForServer(serverId: String) = withContext(Dispatchers.IO) {
+        stores.forEach { it.deleteServer(serverId) }
+        File(audiobookDownloadsDir, serverId).deleteRecursively()
+        Unit
+    }
+}

--- a/core/data/src/main/kotlin/com/riffle/core/data/ServerRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/ServerRepositoryImpl.kt
@@ -12,6 +12,7 @@ import com.riffle.core.domain.LibraryVisibilityPreferencesStore
 import com.riffle.core.domain.PendingServer
 import com.riffle.core.domain.READALOUD_MEDIA_TYPE
 import com.riffle.core.domain.Server
+import com.riffle.core.domain.ServerFilesCleaner
 import com.riffle.core.domain.ServerRepository
 import com.riffle.core.domain.ServerType
 import com.riffle.core.domain.ServerUrl
@@ -38,6 +39,7 @@ class ServerRepositoryImpl @Inject constructor(
     private val libraryDao: LibraryDao,
     private val libraryItemDao: LibraryItemDao,
     private val visibilityStore: LibraryVisibilityPreferencesStore,
+    private val filesCleaner: ServerFilesCleaner,
 ) : ServerRepository {
 
     override fun observeAll(): Flow<List<Server>> =
@@ -184,6 +186,9 @@ class ServerRepositoryImpl @Inject constructor(
         libraryDao.deleteByServerId(serverId)
         dao.deleteById(serverId)
         tokenStorage.deleteToken(serverId)
+        // The file stores live outside Room, so the FK cascade above doesn't touch them — purge the
+        // Server's downloaded/cached files here so they don't leak on disk after removal.
+        filesCleaner.deleteAllForServer(serverId)
     }
 
     override suspend fun getServerVersion(serverId: String): String? {

--- a/core/data/src/main/kotlin/com/riffle/core/data/di/DataModule.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/di/DataModule.kt
@@ -27,6 +27,7 @@ import com.riffle.core.data.ReadaloudReviewRepositoryImpl
 import com.riffle.core.data.ReadaloudResumeStoreImpl
 import com.riffle.core.data.ReadingPositionStoreImpl
 import com.riffle.core.data.ReadingSessionRepositoryImpl
+import com.riffle.core.data.ServerFilesCleanerImpl
 import com.riffle.core.data.ServerRepositoryImpl
 import com.riffle.core.data.ToReadRepository
 import com.riffle.core.data.ToReadRepositoryImpl
@@ -40,6 +41,7 @@ import com.riffle.core.domain.ConnectivityObserver
 import com.riffle.core.domain.CrashReportRepository
 import com.riffle.core.domain.DeviceIdStore
 import com.riffle.core.domain.DownloadsRepository
+import com.riffle.core.domain.ServerFilesCleaner
 import com.riffle.core.domain.EpubRepository
 import com.riffle.core.domain.FormattingPreferencesStore
 import com.riffle.core.domain.AudiobookDownloadRepository
@@ -412,6 +414,19 @@ abstract class DataModule {
             @PdfCacheStore pdfCacheStore: LocalStore,
             @PdfDownloadsStore pdfDownloadsStore: LocalStore,
         ): DownloadsRepository = DownloadsRepositoryImpl(epubCacheStore, epubDownloadsStore, pdfCacheStore, pdfDownloadsStore)
+
+        @Provides
+        @Singleton
+        fun provideServerFilesCleaner(
+            @EpubCacheStore epubCacheStore: LocalStore,
+            @EpubDownloadsStore epubDownloadsStore: LocalStore,
+            @PdfCacheStore pdfCacheStore: LocalStore,
+            @PdfDownloadsStore pdfDownloadsStore: LocalStore,
+            @AudiobookDownloadsDir audiobookDownloadsDir: File,
+        ): ServerFilesCleaner = ServerFilesCleanerImpl(
+            stores = listOf(epubCacheStore, epubDownloadsStore, pdfCacheStore, pdfDownloadsStore),
+            audiobookDownloadsDir = audiobookDownloadsDir,
+        )
 
         @Provides
         @Singleton

--- a/core/data/src/test/kotlin/com/riffle/core/data/ServerFilesCleanerImplTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/ServerFilesCleanerImplTest.kt
@@ -1,0 +1,66 @@
+package com.riffle.core.data
+
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.ByteArrayInputStream
+import java.io.File
+
+class ServerFilesCleanerImplTest {
+
+    @get:Rule
+    val tmp = TemporaryFolder()
+
+    private fun bytes(n: Int) = ByteArrayInputStream(ByteArray(n))
+
+    @Test
+    fun `deletes every store's files for the removed server but keeps other servers`() = runTest {
+        val epubDir = tmp.newFolder("epubs")
+        val pdfDir = tmp.newFolder("pdfs")
+        val audiobookDir = tmp.newFolder("audiobooks")
+
+        val epubStore = LocalStoreImpl(epubDir, ".epub")
+        val pdfStore = LocalStoreImpl(pdfDir, ".pdf")
+
+        // Two servers, each with an EPUB, a PDF, and an audiobook download directory.
+        epubStore.save("srv-A", "book-1", bytes(10))
+        epubStore.save("srv-B", "book-1", bytes(10))
+        pdfStore.save("srv-A", "doc-1", bytes(10))
+        pdfStore.save("srv-B", "doc-1", bytes(10))
+        File(audiobookDir, "srv-A/audio-1").apply { mkdirs() }.let { File(it, "track-0").writeBytes(ByteArray(10)) }
+        File(audiobookDir, "srv-B/audio-1").apply { mkdirs() }.let { File(it, "track-0").writeBytes(ByteArray(10)) }
+
+        val cleaner = ServerFilesCleanerImpl(
+            stores = listOf(epubStore, pdfStore),
+            audiobookDownloadsDir = audiobookDir,
+        )
+
+        cleaner.deleteAllForServer("srv-A")
+
+        // srv-A is gone from every store...
+        assertFalse(File(epubDir, "srv-A").exists())
+        assertFalse(File(pdfDir, "srv-A").exists())
+        assertFalse(File(audiobookDir, "srv-A").exists())
+        // ...and srv-B is untouched.
+        assertTrue(File(epubDir, "srv-B/book-1.epub").exists())
+        assertTrue(File(pdfDir, "srv-B/doc-1.pdf").exists())
+        assertTrue(File(audiobookDir, "srv-B/audio-1/track-0").exists())
+    }
+
+    @Test
+    fun `is a no-op when the server has no files`() = runTest {
+        val epubDir = tmp.newFolder("epubs")
+        val audiobookDir = tmp.newFolder("audiobooks")
+        val cleaner = ServerFilesCleanerImpl(
+            stores = listOf(LocalStoreImpl(epubDir, ".epub")),
+            audiobookDownloadsDir = audiobookDir,
+        )
+
+        cleaner.deleteAllForServer("ghost")
+
+        assertFalse(File(epubDir, "ghost").exists())
+    }
+}

--- a/core/data/src/test/kotlin/com/riffle/core/data/ServerRepositoryTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/ServerRepositoryTest.kt
@@ -10,6 +10,7 @@ import com.riffle.core.domain.InsecureConnectionType
 import com.riffle.core.domain.Library
 import com.riffle.core.domain.LibraryVisibilityPreferencesStore
 import com.riffle.core.domain.PendingServer
+import com.riffle.core.domain.ServerFilesCleaner
 import com.riffle.core.domain.ServerType
 import com.riffle.core.domain.ServerUrl
 import com.riffle.core.domain.TokenStorage
@@ -103,6 +104,13 @@ class ServerRepositoryTest {
         }
     }
 
+    private class RecordingFilesCleaner : ServerFilesCleaner {
+        val cleanedServerIds = mutableListOf<String>()
+        override suspend fun deleteAllForServer(serverId: String) { cleanedServerIds += serverId }
+    }
+
+    private fun fakeFilesCleaner() = RecordingFilesCleaner()
+
     private fun fakeLibraryItemDao() = object : com.riffle.core.database.LibraryItemDao {
         val deletedLibraryIds = mutableListOf<String>()
         private val rows = mutableMapOf<String, MutableList<com.riffle.core.database.LibraryItemEntity>>()
@@ -177,7 +185,7 @@ class ServerRepositoryTest {
                 )
             )
         )
-        val repo = ServerRepositoryImpl(dao, tokens, absApi, storytellerApiNotCalled, fakeServerInfoApi, libsApi, libDao, fakeLibraryItemDao(), visibility)
+        val repo = ServerRepositoryImpl(dao, tokens, absApi, storytellerApiNotCalled, fakeServerInfoApi, libsApi, libDao, fakeLibraryItemDao(), visibility, fakeFilesCleaner())
         val url = ServerUrl.parse("https://abs.example.com")!!
 
         val result = repo.authenticate(url, "admin", "pass", insecureAllowed = false)
@@ -196,7 +204,7 @@ class ServerRepositoryTest {
         val dao = fakeDao(); val tokens = fakeTokenStorage()
         val libDao = fakeLibraryDao(); val visibility = fakeVisibilityStore()
         val absApi = AbsApi { _, _, _, _ -> NetworkLoginResult.WrongCredentials("nope") }
-        val repo = ServerRepositoryImpl(dao, tokens, absApi, storytellerApiNotCalled, fakeServerInfoApi, libsApiNotCalled, libDao, fakeLibraryItemDao(), visibility)
+        val repo = ServerRepositoryImpl(dao, tokens, absApi, storytellerApiNotCalled, fakeServerInfoApi, libsApiNotCalled, libDao, fakeLibraryItemDao(), visibility, fakeFilesCleaner())
 
         val result = repo.authenticate(ServerUrl.parse("https://x")!!, "u", "p", false)
 
@@ -212,7 +220,7 @@ class ServerRepositoryTest {
         val absApi = AbsApi { _, _, _, _ -> NetworkLoginResult.Success("uid", "tok", "u") }
         val cause = RuntimeException("boom")
         val libsApi = libsApiReturning(NetworkLibrariesResult.NetworkError(cause))
-        val repo = ServerRepositoryImpl(dao, tokens, absApi, storytellerApiNotCalled, fakeServerInfoApi, libsApi, libDao, fakeLibraryItemDao(), visibility)
+        val repo = ServerRepositoryImpl(dao, tokens, absApi, storytellerApiNotCalled, fakeServerInfoApi, libsApi, libDao, fakeLibraryItemDao(), visibility, fakeFilesCleaner())
 
         val result = repo.authenticate(ServerUrl.parse("https://x")!!, "u", "p", false)
 
@@ -226,7 +234,7 @@ class ServerRepositoryTest {
         val dao = fakeDao(); val tokens = fakeTokenStorage()
         val libDao = fakeLibraryDao(); val visibility = fakeVisibilityStore()
         val absApi = AbsApi { _, _, _, _ -> NetworkLoginResult.InsecureConnection(InsecureConnectionType.SELF_SIGNED) }
-        val repo = ServerRepositoryImpl(dao, tokens, absApi, storytellerApiNotCalled, fakeServerInfoApi, libsApiNotCalled, libDao, fakeLibraryItemDao(), visibility)
+        val repo = ServerRepositoryImpl(dao, tokens, absApi, storytellerApiNotCalled, fakeServerInfoApi, libsApiNotCalled, libDao, fakeLibraryItemDao(), visibility, fakeFilesCleaner())
 
         val result = repo.authenticate(ServerUrl.parse("https://abs.example.com")!!, "admin", "pass", insecureAllowed = false)
 
@@ -238,7 +246,7 @@ class ServerRepositoryTest {
         val dao = fakeDao(); val tokens = fakeTokenStorage()
         val libDao = fakeLibraryDao(); val visibility = fakeVisibilityStore()
         val absApi = AbsApi { _, _, _, _ -> error("not called") }
-        val repo = ServerRepositoryImpl(dao, tokens, absApi, storytellerApiNotCalled, fakeServerInfoApi, libsApiNotCalled, libDao, fakeLibraryItemDao(), visibility)
+        val repo = ServerRepositoryImpl(dao, tokens, absApi, storytellerApiNotCalled, fakeServerInfoApi, libsApiNotCalled, libDao, fakeLibraryItemDao(), visibility, fakeFilesCleaner())
 
         val url = ServerUrl.parse("https://abs.example.com")!!
         val pending = PendingServer(
@@ -268,7 +276,7 @@ class ServerRepositoryTest {
         val libDao = fakeLibraryDao(); val visibility = fakeVisibilityStore()
         val absApi = AbsApi { _, _, _, _ -> error("ABS auth must not be called for Storyteller") }
         val storyteller = storytellerApiReturning(NetworkStorytellerLoginResult.Success("tok-st"))
-        val repo = ServerRepositoryImpl(dao, tokens, absApi, storyteller, fakeServerInfoApi, libsApiNotCalled, libDao, fakeLibraryItemDao(), visibility)
+        val repo = ServerRepositoryImpl(dao, tokens, absApi, storyteller, fakeServerInfoApi, libsApiNotCalled, libDao, fakeLibraryItemDao(), visibility, fakeFilesCleaner())
 
         val result = repo.authenticate(
             ServerUrl.parse("http://media-server:8001")!!, "plamen", "pw", insecureAllowed = false,
@@ -291,7 +299,7 @@ class ServerRepositoryTest {
         val libDao = fakeLibraryDao(); val visibility = fakeVisibilityStore()
         val absApi = AbsApi { _, _, _, _ -> error("ABS auth must not be called for Storyteller") }
         val storyteller = storytellerApiReturning(NetworkStorytellerLoginResult.WrongCredentials("Incorrect username or password"))
-        val repo = ServerRepositoryImpl(dao, tokens, absApi, storyteller, fakeServerInfoApi, libsApiNotCalled, libDao, fakeLibraryItemDao(), visibility)
+        val repo = ServerRepositoryImpl(dao, tokens, absApi, storyteller, fakeServerInfoApi, libsApiNotCalled, libDao, fakeLibraryItemDao(), visibility, fakeFilesCleaner())
 
         val result = repo.authenticate(
             ServerUrl.parse("http://media-server:8001")!!, "plamen", "wrong", insecureAllowed = false,
@@ -307,7 +315,7 @@ class ServerRepositoryTest {
         val libDao = fakeLibraryDao(); val visibility = fakeVisibilityStore()
         val absApi = AbsApi { _, _, _, _ -> error("not called") }
         val storyteller = storytellerApiReturning(NetworkStorytellerLoginResult.Success("tok-st"))
-        val repo = ServerRepositoryImpl(dao, tokens, absApi, storyteller, fakeServerInfoApi, libsApiNotCalled, libDao, fakeLibraryItemDao(), visibility)
+        val repo = ServerRepositoryImpl(dao, tokens, absApi, storyteller, fakeServerInfoApi, libsApiNotCalled, libDao, fakeLibraryItemDao(), visibility, fakeFilesCleaner())
 
         val pendingA = PendingServer(
             url = ServerUrl.parse("http://media-server:8001")!!,
@@ -355,7 +363,7 @@ class ServerRepositoryTest {
         val dao = fakeDao(); val tokens = fakeTokenStorage()
         val libDao = fakeLibraryDao(); val visibility = fakeVisibilityStore()
         val absApi = AbsApi { _, _, _, _ -> error("not called") }
-        val repo = ServerRepositoryImpl(dao, tokens, absApi, storytellerApiNotCalled, fakeServerInfoApi, libsApiNotCalled, libDao, fakeLibraryItemDao(), visibility)
+        val repo = ServerRepositoryImpl(dao, tokens, absApi, storytellerApiNotCalled, fakeServerInfoApi, libsApiNotCalled, libDao, fakeLibraryItemDao(), visibility, fakeFilesCleaner())
 
         val pending = PendingServer(
             url = ServerUrl.parse("http://media-server:8001")!!,
@@ -380,7 +388,7 @@ class ServerRepositoryTest {
         val dao = fakeDao(); val tokens = fakeTokenStorage()
         val libDao = fakeLibraryDao(); val visibility = fakeVisibilityStore()
         val absApi = AbsApi { _, _, _, _ -> error("not called") }
-        val repo = ServerRepositoryImpl(dao, tokens, absApi, storytellerApiNotCalled, fakeServerInfoApi, libsApiNotCalled, libDao, fakeLibraryItemDao(), visibility)
+        val repo = ServerRepositoryImpl(dao, tokens, absApi, storytellerApiNotCalled, fakeServerInfoApi, libsApiNotCalled, libDao, fakeLibraryItemDao(), visibility, fakeFilesCleaner())
 
         val pending = PendingServer(
             url = ServerUrl.parse("http://media-server:8001")!!,
@@ -404,7 +412,7 @@ class ServerRepositoryTest {
         val dao = fakeDao(); val tokens = fakeTokenStorage()
         val libDao = fakeLibraryDao(); val visibility = fakeVisibilityStore()
         val absApi = AbsApi { _, _, _, _ -> error("not called") }
-        val repo = ServerRepositoryImpl(dao, tokens, absApi, storytellerApiNotCalled, fakeServerInfoApi, libsApiNotCalled, libDao, fakeLibraryItemDao(), visibility)
+        val repo = ServerRepositoryImpl(dao, tokens, absApi, storytellerApiNotCalled, fakeServerInfoApi, libsApiNotCalled, libDao, fakeLibraryItemDao(), visibility, fakeFilesCleaner())
 
         val pending = PendingServer(
             url = ServerUrl.parse("http://media-server:8001")!!,
@@ -429,11 +437,28 @@ class ServerRepositoryTest {
         tokens.tokens["srv-1"] = "tok"
         val absApi = AbsApi { _, _, _, _ -> NetworkLoginResult.WrongCredentials("") }
         val repo = ServerRepositoryImpl(
-            dao, tokens, absApi, storytellerApiNotCalled, fakeServerInfoApi, libsApiNotCalled, fakeLibraryDao(), fakeLibraryItemDao(), fakeVisibilityStore()
+            dao, tokens, absApi, storytellerApiNotCalled, fakeServerInfoApi, libsApiNotCalled, fakeLibraryDao(), fakeLibraryItemDao(), fakeVisibilityStore(), fakeFilesCleaner()
         )
         repo.remove("srv-1")
         assertTrue("token not deleted", tokens.tokens.isEmpty())
         assertNull("entity not deleted from store", dao.getActive())
+    }
+
+    @Test
+    fun `remove deletes the server's downloaded and cached files on disk`() = runTest {
+        val entity = ServerEntity("srv-1", "https://abs.example.com", true, false, username = "")
+        val dao = fakeDao(entity)
+        val tokens = fakeTokenStorage()
+        tokens.tokens["srv-1"] = "tok"
+        val cleaner = fakeFilesCleaner()
+        val absApi = AbsApi { _, _, _, _ -> NetworkLoginResult.WrongCredentials("") }
+        val repo = ServerRepositoryImpl(
+            dao, tokens, absApi, storytellerApiNotCalled, fakeServerInfoApi, libsApiNotCalled, fakeLibraryDao(), fakeLibraryItemDao(), fakeVisibilityStore(), cleaner
+        )
+
+        repo.remove("srv-1")
+
+        assertEquals("on-disk files not cleaned for the removed server", listOf("srv-1"), cleaner.cleanedServerIds)
     }
 
     @Test
@@ -452,7 +477,7 @@ class ServerRepositoryTest {
         ))
         val absApi = AbsApi { _, _, _, _ -> error("not called") }
         val repo = ServerRepositoryImpl(
-            dao, tokens, absApi, storytellerApiNotCalled, fakeServerInfoApi, libsApiNotCalled, libDao, itemDao, fakeVisibilityStore()
+            dao, tokens, absApi, storytellerApiNotCalled, fakeServerInfoApi, libsApiNotCalled, libDao, itemDao, fakeVisibilityStore(), fakeFilesCleaner()
         )
 
         repo.remove("st-1")
@@ -480,7 +505,7 @@ class ServerRepositoryTest {
         itemDao.seed("lib-2", listOf(com.riffle.core.database.LibraryItemEntity("s1", "i-2", "lib-2", "Foundation", "Asimov", null, 0f)))
         val absApi = AbsApi { _, _, _, _ -> error("not called") }
         val repo = ServerRepositoryImpl(
-            dao, tokens, absApi, storytellerApiNotCalled, fakeServerInfoApi, libsApiNotCalled, libDao, itemDao, fakeVisibilityStore()
+            dao, tokens, absApi, storytellerApiNotCalled, fakeServerInfoApi, libsApiNotCalled, libDao, itemDao, fakeVisibilityStore(), fakeFilesCleaner()
         )
 
         repo.remove("abs-1")
@@ -497,7 +522,7 @@ class ServerRepositoryTest {
         val dao = fakeDao(e1, e2)
         val absApi = AbsApi { _, _, _, _ -> NetworkLoginResult.WrongCredentials("") }
         val repo = ServerRepositoryImpl(
-            dao, fakeTokenStorage(), absApi, storytellerApiNotCalled, fakeServerInfoApi, libsApiNotCalled, fakeLibraryDao(), fakeLibraryItemDao(), fakeVisibilityStore()
+            dao, fakeTokenStorage(), absApi, storytellerApiNotCalled, fakeServerInfoApi, libsApiNotCalled, fakeLibraryDao(), fakeLibraryItemDao(), fakeVisibilityStore(), fakeFilesCleaner()
         )
         repo.setActive("s2")
         assertEquals("s2", dao.getActive()?.id)
@@ -510,7 +535,7 @@ class ServerRepositoryTest {
         val dao = fakeDao(abs, st)
         val absApi = AbsApi { _, _, _, _ -> NetworkLoginResult.WrongCredentials("") }
         val repo = ServerRepositoryImpl(
-            dao, fakeTokenStorage(), absApi, storytellerApiNotCalled, fakeServerInfoApi, libsApiNotCalled, fakeLibraryDao(), fakeLibraryItemDao(), fakeVisibilityStore()
+            dao, fakeTokenStorage(), absApi, storytellerApiNotCalled, fakeServerInfoApi, libsApiNotCalled, fakeLibraryDao(), fakeLibraryItemDao(), fakeVisibilityStore(), fakeFilesCleaner()
         )
 
         repo.setActive("st")

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/LocalStore.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/LocalStore.kt
@@ -13,6 +13,10 @@ interface LocalStore {
     fun get(serverId: String, itemId: String): File?
     suspend fun save(serverId: String, itemId: String, stream: InputStream): File
     fun delete(serverId: String, itemId: String)
+
+    /** Deletes every file owned by [serverId] (its whole `dir/<serverId>/` subtree). */
+    fun deleteServer(serverId: String)
+
     fun clear()
     fun listItems(): List<StoredItemRef>
 }

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/ServerFilesCleaner.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/ServerFilesCleaner.kt
@@ -1,0 +1,12 @@
+package com.riffle.core.domain
+
+/**
+ * Deletes every on-disk file a Server owns — downloaded and cached EPUBs/PDFs and downloaded
+ * audiobooks. The DB cascade ([ServerRepository.remove]) clears a removed Server's metadata, but the
+ * file stores live outside Room and would otherwise leak their bytes until OS cache reclaim or an
+ * app-data clear. All stores key files under `<dir>/<serverId>/…` (ADR 0025), so removal is a
+ * per-Server subtree delete.
+ */
+interface ServerFilesCleaner {
+    suspend fun deleteAllForServer(serverId: String)
+}


### PR DESCRIPTION
## Problem
Removing a server cleaned up DB metadata (server row, libraries, library_items, auth token, and Room `ON DELETE CASCADE` for reading positions / annotations / prefs / readaloud links) but **left every downloaded and cached file on disk**. The file stores live outside Room, so nothing purged them — orphaned EPUBs, PDFs, and downloaded audiobooks leaked under `<dir>/<serverId>/…` until OS cache reclaim or an app-data clear.

## Fix
Wire per-server file cleanup into `ServerRepositoryImpl.remove()`.

- **`LocalStore.deleteServer(serverId)`** — encapsulates the per-server subtree delete (`dir/<serverId>/`), implemented in `LocalStoreImpl`.
- **`ServerFilesCleaner`** (new domain interface) + **`ServerFilesCleanerImpl`** — purges all five on-disk stores: the four EPUB/PDF download+cache `LocalStore`s plus the audiobook download tree (a directory-per-item tree, not a `LocalStore`, but same `<root>/<serverId>/` layout per ADR 0025/0029). The EPUB downloads store also holds synced readaloud/audiobook bundles, so those are covered too.
- **`ServerRepositoryImpl.remove()`** calls `filesCleaner.deleteAllForServer(serverId)` after the DB cascade. Cleanup is keyed by `serverId` subtree, so it needs no item list and doesn't depend on DB state.

### Why a dedicated cleaner
Routing audiobook cleanup through `AudiobookDownloadRepository` would create a DI cycle (`AudiobookDownloadRepository → AudiobookRepository → ServerRepository`). `ServerFilesCleanerImpl` depends only on the stores + a `File`, keeping the graph acyclic.

### Out of scope
The cross-EPUB index is a Room table keyed by content checksums (not per-server, not on disk), so it's unaffected by this disk-files fix.

## Tests
- New `ServerFilesCleanerImplTest` — real `LocalStoreImpl`s + temp dirs: deletes the removed server across every store and the audiobook dir while leaving another server's files intact; no-op when nothing exists.
- New `ServerRepositoryTest` case `remove deletes the server's downloaded and cached files on disk` (closes the gap where the existing remove tests only asserted DB cleanup); all constructor sites updated with a recording fake cleaner.
- `./gradlew test` and `./gradlew lint` green across all modules.

Harness suites were not run: this is a pure data-layer change with no reader/library UI surface for them to exercise, and CI does not run connected tests.