### PR TITLE
fix(readaloud): remember playback speed across in-session mini-player reopen

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -1146,6 +1146,10 @@ class EpubReaderViewModel @Inject constructor(
         // Apply to the live player immediately; persist debounced so a granular scrub/slide (which
         // fires many intermediate values) only writes the settled speed, not every 0.05 step.
         playerCoordinator.setSpeed(speed)
+        // Keep the value ensureOpened() reapplies on reopen in sync with the live speed. closeReadaloud
+        // resets readaloudPrepared, so an in-session reopen re-runs ensureOpened and would otherwise
+        // restore the stale book-open speed — losing the change the user just made.
+        initialSpeed = speed
         pendingSpeed = speed
         speedSaveJob?.cancel()
         speedSaveJob = viewModelScope.launch {

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/EpubReaderViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/EpubReaderViewModelTest.kt
@@ -944,3 +944,76 @@ class ReaderSyncOrchestrationTest {
         )
     }
 }
+
+/**
+ * Regression for "readaloud speed change is not remembered on mini player close."
+ *
+ * Speed has two homes: the DB row (persisted, debounced) and the in-memory `initialSpeed`, which
+ * `ensureOpened` reapplies to the freshly-prepared player on every (re)open. closeReadaloud()
+ * resets `readaloudPrepared = false`, so reopening within the same reading session re-runs
+ * ensureOpened. The bug: setSpeed persisted to the DB but never updated `initialSpeed`, so reopen
+ * clobbered the live player back to the speed loaded at book-open. Leaving and re-entering the book
+ * reloaded from the DB and looked correct, hiding the bug — it only bit on in-session reopen.
+ *
+ * EpubReaderViewModel can't be constructed in a JVM test (Readium needs android.net.Uri — see the
+ * file header), so this fake mirrors setSpeed / closeReadaloud / ensureOpened one-to-one; a
+ * regression here maps directly to the ViewModel.
+ */
+class ReadaloudSpeedPersistenceTest {
+
+    private class FakeSpeedStore(initial: Float) {
+        var persisted: Float = initial
+        fun load(): Float = persisted
+        fun save(speed: Float) { persisted = speed }
+    }
+
+    /** Mirrors PlayerCoordinator's speed: setSpeed sets it; close() tears the session down. */
+    private class FakePlayerCoordinator {
+        var currentSpeed: Float = 1.0f
+        fun setSpeed(s: Float) { currentSpeed = s }
+        fun close() { currentSpeed = 1.0f } // controller.stop() releases; speed is reapplied on reopen
+    }
+
+    // Mirrors EpubReaderViewModel's speed lifecycle.
+    private class SpeedSession(private val store: FakeSpeedStore, private val player: FakePlayerCoordinator) {
+        private var initialSpeed: Float = store.load() // set once at book open (line :395)
+        private var readaloudPrepared = false
+
+        fun ensureOpened() { // line :1374
+            if (!readaloudPrepared) {
+                player.setSpeed(initialSpeed) // line :1380 — reapply the persisted per-book speed
+                readaloudPrepared = true
+            }
+        }
+
+        fun setSpeed(speed: Float) { // line :1145
+            player.setSpeed(speed)
+            initialSpeed = speed // the fix: keep the value reopen reapplies in sync with the live one
+            store.save(speed)    // (production debounces this write; immaterial to the bug)
+        }
+
+        fun closeReadaloud() { // line :1072
+            readaloudPrepared = false
+            player.close()
+        }
+    }
+
+    @Test
+    fun `a speed picked before closing the mini player survives an in-session reopen`() {
+        val store = FakeSpeedStore(initial = 1.0f)
+        val player = FakePlayerCoordinator()
+        val session = SpeedSession(store, player)
+
+        session.ensureOpened()
+        assertEquals(1.0f, player.currentSpeed)
+
+        session.setSpeed(1.5f)
+        assertEquals(1.5f, player.currentSpeed)
+
+        session.closeReadaloud()
+        session.ensureOpened() // reopen within the same reading session
+
+        assertEquals("reopen must restore the chosen speed, not the book-open default", 1.5f, player.currentSpeed)
+        assertEquals(1.5f, store.persisted)
+    }
+}


### PR DESCRIPTION
## Problem

Changing the readaloud playback speed, then closing and reopening the mini-player **within the same reading session**, reverted the speed to its book-open value. The change was lost on mini-player close.

## Root cause

Speed lives in two places: the persisted DB row (debounced write) and an in-memory `initialSpeed` field that `ensureOpened()` reapplies to the freshly-prepared player on every (re)open.

`closeReadaloud()` resets `readaloudPrepared = false`, so an in-session reopen re-runs `ensureOpened()`, which calls `playerCoordinator.setSpeed(initialSpeed)`. But `setSpeed()` only wrote to the DB — it never updated `initialSpeed`, which was set once at book-open. So reopen restored the stale book-open speed and clobbered the live player.

The DB write itself was correct, which masked the bug: leaving and re-entering the book reloaded the right value from the DB. It only bit on in-session reopen — exactly "not remembered on mini player close."

## Fix

`setSpeed()` now also updates the in-memory `initialSpeed`, keeping the value `ensureOpened()` reapplies in sync with the live speed.

## Testing

- Added `ReadaloudSpeedPersistenceTest` mirroring the `setSpeed → closeReadaloud → ensureOpened` lifecycle (the ViewModel can't be JVM-constructed — Readium needs `android.net.Uri`, per the file's existing convention). Confirmed red before the fix, green after.
- `./gradlew test lint` — green
- `make harness-test` (phone) — 184 tests, 0 failed
- `make harness-test-tablet` — 5 tests, 0 failed