### PR TITLE
feat(reader): scroll the TOC to the current chapter when opened

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/TocPanel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/TocPanel.kt
@@ -6,12 +6,14 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
@@ -24,11 +26,18 @@ fun TocPanel(
     onEntryClick: (TocEntry) -> Unit,
     onDismiss: () -> Unit,
 ) {
+    val listState = rememberLazyListState()
+    LaunchedEffect(entries, activeHref) {
+        val index = findActiveTopLevelIndex(entries, activeHref)
+        if (index != null) {
+            listState.scrollToItem(index)
+        }
+    }
     ModalBottomSheet(
         onDismissRequest = onDismiss,
         sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
     ) {
-        LazyColumn(modifier = Modifier.fillMaxWidth().testTag("toc_panel")) {
+        LazyColumn(state = listState, modifier = Modifier.fillMaxWidth().testTag("toc_panel")) {
             items(entries) { entry ->
                 TocEntryRow(entry = entry, depth = 0, activeHref = activeHref, onEntryClick = onEntryClick)
             }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/TocParser.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/TocParser.kt
@@ -18,3 +18,14 @@ fun findActiveEntry(entries: List<TocEntry>, currentHref: String): TocEntry? {
     }
     return null
 }
+
+/**
+ * Index into [entries] (the top-level list rendered by the TOC's `LazyColumn`) of the entry whose
+ * subtree contains [currentHref], or null if nothing matches. A nested child resolves to the index
+ * of its top-level ancestor, since children are rendered within their ancestor's list item.
+ */
+fun findActiveTopLevelIndex(entries: List<TocEntry>, currentHref: String?): Int? {
+    if (currentHref == null) return null
+    val index = entries.indexOfFirst { findActiveEntry(listOf(it), currentHref) != null }
+    return index.takeIf { it >= 0 }
+}

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/TocActiveEntryTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/TocActiveEntryTest.kt
@@ -42,4 +42,24 @@ class TocActiveEntryTest {
     fun `returns null for empty list`() {
         assertNull(findActiveEntry(emptyList(), "chapter1.xhtml"))
     }
+
+    @Test
+    fun `active top-level index matches the entry itself`() {
+        assertEquals(1, findActiveTopLevelIndex(toc, "chapter2.xhtml"))
+    }
+
+    @Test
+    fun `active top-level index resolves a nested child to its top-level ancestor`() {
+        assertEquals(0, findActiveTopLevelIndex(toc, "chapter1.xhtml#s2"))
+    }
+
+    @Test
+    fun `active top-level index is null when nothing matches`() {
+        assertNull(findActiveTopLevelIndex(toc, "chapter4.xhtml"))
+    }
+
+    @Test
+    fun `active top-level index is null for null href`() {
+        assertNull(findActiveTopLevelIndex(toc, null))
+    }
 }


### PR DESCRIPTION
## What

When the Table of Contents bottom sheet opens, it now scrolls so the entry for the current reading location is visible, instead of always starting at the top.

## How

- **`TocParser.kt`** — new `findActiveTopLevelIndex(entries, currentHref)`. The TOC's `LazyColumn` only lists *top-level* entries (children are rendered recursively inside their ancestor's item), so this resolves the active href — even a nested sub-section — to the index of its top-level ancestor row. Returns `null` when nothing matches or the href is null. Reuses the existing `findActiveEntry` for subtree containment.
- **`TocPanel.kt`** — added a `rememberLazyListState()` wired into the `LazyColumn`, plus a `LaunchedEffect(entries, activeHref)` that `scrollToItem`s to the active index. Re-runs if entries (async-loaded) or the current location change, so reopening on a different chapter lands correctly. Uses `scrollToItem` (immediate, no animation) so the chapter is already in view as the sheet expands.

## Known limitation

Scrolling targets the *top-level* entry containing the current location. Scrolling precisely to a deeply-nested sub-section row would require flattening the tree into the `LazyColumn` items (larger refactor); not done here.

## Tested

- `./gradlew test lint` — green (added 4 unit tests in `TocActiveEntryTest`)
- `make harness-test` (phone) — 184 tests, 0 failed
- `make harness-test-tablet` — 5 tests, 0 failed