### PR TITLE
fix(audiobook): resume without a brief play-from-start blip

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookController.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookController.kt
@@ -58,10 +58,13 @@ class AudiobookController @Inject constructor(
     private var spans: List<AudiobookTrackSpan> = emptyList()
     private var durationSec: Double = 0.0
     private var prepared = false
-    private var playWhenPrepared = false
+    private var wantsToPlay = false
 
     private val listener = object : Player.Listener {
-        override fun onEvents(player: Player, events: Player.Events) = pushState()
+        override fun onEvents(player: Player, events: Player.Events) {
+            maybeStart(player)
+            pushState()
+        }
         override fun onPlayerError(error: PlaybackException) {
             Log.e(LOG, "playback error code=${error.errorCodeName} src=${controller?.currentMediaItem?.mediaId}", error)
         }
@@ -83,32 +86,37 @@ class AudiobookController @Inject constructor(
         val items = trackUrls.map { url ->
             MediaItem.Builder().setMediaId(url).setUri(url).build()
         }
-        c.setMediaItems(items)
+        // Seed the start position *into* setMediaItems rather than seeking after prepare(): a seek
+        // after prepare() lets ExoPlayer briefly buffer/play the first track from 0 before the seek
+        // lands. Passing the resolved track index + offset makes it buffer from the resume point.
+        val start = AudiobookTracks.startPositionFor(startAtSec, durationSec, spans)
+        c.setMediaItems(items, start.trackIndex, start.offsetMs)
         c.prepare()
-        seekTo(startAtSec)
         prepared = true
-        // If the user pressed play before preparation finished, honour it now so playback starts as
-        // soon as it's pressed rather than being silently dropped.
-        if (playWhenPrepared) {
-            playWhenPrepared = false
-            c.play()
-            startPolling()
-        }
+        // If the user pressed play before preparation finished, honour it now — but only once the
+        // player is ready (see [ResumePlaybackGate]); otherwise the listener starts it on STATE_READY.
+        maybeStart(c)
         pushState()
     }
 
     fun play() {
-        val c = controller
-        if (!prepared || c == null) {
-            // Not connected/prepared yet — latch the intent; prepare() starts playback when ready.
-            playWhenPrepared = true
-            return
+        // Latch the intent; [maybeStart] / the STATE_READY gate starts playback once the player is
+        // buffered at the resume position (see [ResumePlaybackGate]).
+        wantsToPlay = true
+        controller?.let { if (prepared) maybeStart(it) }
+    }
+
+    /** Starts playback iff a play intent is latched and the player has buffered to its position. */
+    private fun maybeStart(player: Player) {
+        if (ResumePlaybackGate.shouldStart(wantsToPlay, player.playbackState == Player.STATE_READY)) {
+            wantsToPlay = false
+            player.play()
+            startPolling()
         }
-        c.play()
-        startPolling()
     }
 
     fun pause() {
+        wantsToPlay = false
         controller?.pause()
         pollJob?.cancel()
         pollJob = null
@@ -150,7 +158,7 @@ class AudiobookController @Inject constructor(
         controller = null
         spans = emptyList()
         prepared = false
-        playWhenPrepared = false
+        wantsToPlay = false
         _state.value = PlaybackState()
     }
 

--- a/app/src/main/kotlin/com/riffle/app/feature/audiobook/ResumePlaybackGate.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audiobook/ResumePlaybackGate.kt
@@ -1,0 +1,16 @@
+package com.riffle.app.feature.audiobook
+
+/**
+ * Decides when a latched "play" intent may actually start the audiobook player.
+ *
+ * A resume-at-position open buffers from the saved point, but starting before the player reaches
+ * `STATE_READY` lets the decoder emit a brief blip from the track's *start* before the in-track seek
+ * settles — the audible "plays from the beginning for a moment" symptom. Buffering happens regardless
+ * of whether playback is started, so deferring the start until ready costs nothing but the blip.
+ *
+ * Pure so the gate is unit-testable without a real [androidx.media3.session.MediaController].
+ */
+internal object ResumePlaybackGate {
+    /** Whether a latched play intent may start now: only once the player has buffered to its position. */
+    fun shouldStart(wantsToPlay: Boolean, ready: Boolean): Boolean = wantsToPlay && ready
+}

--- a/app/src/test/kotlin/com/riffle/app/feature/audiobook/ResumePlaybackGateTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/audiobook/ResumePlaybackGateTest.kt
@@ -1,0 +1,26 @@
+package com.riffle.app.feature.audiobook
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ResumePlaybackGateTest {
+
+    @Test
+    fun `does not start before the player is ready`() {
+        // The regression: starting a resume-at-position open before STATE_READY blips from the
+        // track's start. A latched intent must wait for the player to buffer to its position.
+        assertFalse(ResumePlaybackGate.shouldStart(wantsToPlay = true, ready = false))
+    }
+
+    @Test
+    fun `starts once ready when a play intent is latched`() {
+        assertTrue(ResumePlaybackGate.shouldStart(wantsToPlay = true, ready = true))
+    }
+
+    @Test
+    fun `never starts without a play intent, ready or not`() {
+        assertFalse(ResumePlaybackGate.shouldStart(wantsToPlay = false, ready = true))
+        assertFalse(ResumePlaybackGate.shouldStart(wantsToPlay = false, ready = false))
+    }
+}

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/AudiobookTracks.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/AudiobookTracks.kt
@@ -34,4 +34,22 @@ object AudiobookTracks {
         val track = tracks.getOrNull(index) ?: return offsetInTrackSec.coerceAtLeast(0.0)
         return track.startOffsetSec + offsetInTrackSec.coerceAtLeast(0.0)
     }
+
+    /**
+     * Resolves a book-absolute resume position to the (track index, in-track offset) start point to
+     * seed into the player's *initial* media-item list, so playback buffers from the resume point
+     * rather than starting at track 0 / offset 0 and audibly snapping forward (ADR 0029). [absoluteSec]
+     * is clamped into `[0, durationSec]` (or `[0, absoluteSec]` when the duration is unknown).
+     */
+    fun startPositionFor(
+        absoluteSec: Double,
+        durationSec: Double,
+        tracks: List<AudiobookTrackSpan>,
+    ): StartPosition {
+        val clamped = absoluteSec.coerceIn(0.0, if (durationSec > 0) durationSec else absoluteSec)
+        return StartPosition(trackIndexAt(clamped, tracks), (offsetInTrackSec(clamped, tracks) * 1000).toLong())
+    }
 }
+
+/** A resolved player start point: which track and the offset within it (ms), for `setMediaItems`. */
+data class StartPosition(val trackIndex: Int, val offsetMs: Long)

--- a/core/domain/src/test/kotlin/com/riffle/core/domain/AudiobookTracksTest.kt
+++ b/core/domain/src/test/kotlin/com/riffle/core/domain/AudiobookTracksTest.kt
@@ -43,4 +43,41 @@ class AudiobookTracksTest {
         assertEquals(42.0, AudiobookTracks.offsetInTrackSec(42.0, emptyList()), 0.0)
         assertEquals(42.0, AudiobookTracks.absoluteSec(0, 42.0, emptyList()), 0.0)
     }
+
+    @Test
+    fun `startPositionFor resumes mid-track at the right track and offset, not track 0`() {
+        // The bug: opening at a saved mid-book position briefly played from track 0 / offset 0. The
+        // resolved start must land on the containing track with the in-track offset in millis.
+        val start = AudiobookTracks.startPositionFor(absoluteSec = 325.0, durationSec = 600.0, tracks = tracks)
+        assertEquals(2, start.trackIndex)
+        assertEquals(25_000L, start.offsetMs)
+    }
+
+    @Test
+    fun `startPositionFor at a track boundary starts that track at offset 0`() {
+        val start = AudiobookTracks.startPositionFor(absoluteSec = 100.0, durationSec = 600.0, tracks = tracks)
+        assertEquals(1, start.trackIndex)
+        assertEquals(0L, start.offsetMs)
+    }
+
+    @Test
+    fun `startPositionFor from the very beginning is track 0 offset 0`() {
+        val start = AudiobookTracks.startPositionFor(absoluteSec = 0.0, durationSec = 600.0, tracks = tracks)
+        assertEquals(0, start.trackIndex)
+        assertEquals(0L, start.offsetMs)
+    }
+
+    @Test
+    fun `startPositionFor clamps a beyond-duration position to the last track`() {
+        val start = AudiobookTracks.startPositionFor(absoluteSec = 10_000.0, durationSec = 600.0, tracks = tracks)
+        assertEquals(2, start.trackIndex)
+        assertEquals(300_000L, start.offsetMs) // clamped to 600s -> 300s into track 2
+    }
+
+    @Test
+    fun `startPositionFor clamps a negative position to the start`() {
+        val start = AudiobookTracks.startPositionFor(absoluteSec = -5.0, durationSec = 600.0, tracks = tracks)
+        assertEquals(0, start.trackIndex)
+        assertEquals(0L, start.offsetMs)
+    }
 }


### PR DESCRIPTION
## Problem

Opening an audiobook with saved progress audibly played from the **very beginning** for a moment before snapping to the resume position.

## Root cause (two compounding causes)

1. **Seek-after-prepare.** `AudiobookController.prepare()` called `seekTo()` *after* `setMediaItems()` + `prepare()`, so ExoPlayer began buffering/playing the first track from position 0 before the seek landed. Over HTTP-streamed ABS tracks this window was ~0.5s.
2. **Start-before-ready.** Even with the start position seeded into `setMediaItems(...)`, playback was started before the player had buffered *to* that point, so the decoder briefly emitted samples from the **track's start** before the in-track seek settled (a shorter, but still audible, blip).

## Fix

1. Seed the resolved `(track index, in-track offset)` straight into `setMediaItems(items, startIndex, startOffsetMs)` so the player buffers from the resume point and never touches position 0. Resolution extracted as the pure `AudiobookTracks.startPositionFor(...)`.
2. Gate the latched play intent on `STATE_READY` (`ResumePlaybackGate`): playback begins only once the player has buffered to its position. Buffering happens regardless of `playWhenReady`, so this costs nothing but the blip. The three start-sites (`prepare`, `play`, the player listener) now funnel through a single `maybeStart()`.

## Testing

- Verified on device: opening an audiobook with progress now starts cleanly at the resume position with no play-from-start blip.
- `AudiobookTracksTest` — `startPositionFor` resolves mid-track / boundary / start / beyond-duration / negative positions correctly (the original "starts at track 0" regression).
- `ResumePlaybackGateTest` — never starts before ready, never without a latched intent, starts once both hold.
- `./gradlew test` green.