### PR TITLE
feat(player): show the Riffle mark in the media notification

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/AudioPlayerService.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/AudioPlayerService.kt
@@ -10,10 +10,12 @@ import androidx.media3.datasource.DataSource
 import androidx.media3.datasource.DefaultHttpDataSource
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
+import androidx.media3.session.DefaultMediaNotificationProvider
 import androidx.media3.session.MediaSession
 import androidx.media3.session.MediaSessionService
 import com.google.common.util.concurrent.Futures
 import com.google.common.util.concurrent.ListenableFuture
+import com.riffle.app.R
 
 /**
  * Foreground [MediaSessionService] that plays Readaloud audio. Media3 supplies the media
@@ -34,6 +36,13 @@ class AudioPlayerService : MediaSessionService() {
 
     override fun onCreate() {
         super.onCreate()
+        // Show the Riffle mark in the status bar / system media player instead of Media3's default
+        // generic music-note small icon.
+        setMediaNotificationProvider(
+            DefaultMediaNotificationProvider.Builder(this)
+                .build()
+                .apply { setSmallIcon(R.drawable.ic_notification) },
+        )
         val player = ExoPlayer.Builder(this)
             .setAudioAttributes(
                 AudioAttributes.Builder()

--- a/app/src/main/res/drawable/ic_notification.xml
+++ b/app/src/main/res/drawable/ic_notification.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Status-bar / media-notification small icon. Android renders notification small icons as a
+  silhouette (only the alpha channel matters), so this is the Riffle launcher mark — the open
+  book — as a solid white glyph sized for the 24dp notification icon slot.
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M21,5c-1.11,-0.35 -2.33,-0.5 -3.5,-0.5 -1.95,0 -4.05,0.4 -5.5,1.5 -1.45,-1.1 -3.55,-1.5 -5.5,-1.5S2.45,4.9 1,6v14.65c0,0.25 0.25,0.5 0.5,0.5 0.1,0 0.15,-0.05 0.25,-0.05C3.1,20.45 5.05,20 6.5,20c1.95,0 4.05,0.4 5.5,1.5 1.35,-0.85 3.8,-1.5 5.5,-1.5 1.65,0 3.35,0.3 4.75,1.05 0.1,0.05 0.15,0.05 0.25,0.05 0.25,0 0.5,-0.25 0.5,-0.5V6c-0.6,-0.45 -1.25,-0.75 -2,-1zM12,18.5c-1.45,-0.85 -3.55,-1.5 -5.5,-1.5 -1.2,0 -2.4,0.15 -3.5,0.5V7c1.1,-0.35 2.3,-0.5 3.5,-0.5 1.95,0 4.05,0.4 5.5,1.5v10.5z" />
+</vector>


### PR DESCRIPTION
## What

Both the audiobook and readaloud players run through a single Media3 `AudioPlayerService`. Its media notification (status bar + system media player + lock screen) was using Media3's built-in **default small icon** — a generic music note — instead of anything Riffle-branded.

This registers a `DefaultMediaNotificationProvider` with a Riffle small icon, so both audiobook and readaloud playback show the Riffle book mark in the notification.

- `ic_notification.xml` — a white open-book glyph matching the launcher icon. Android renders notification small icons as monochrome silhouettes (only the alpha channel matters), so the full-color launcher icon can't be reused directly; this is the silhouette equivalent.
- `AudioPlayerService.onCreate()` — registers the provider with `setSmallIcon(R.drawable.ic_notification)`.

Cover art (the large icon on the right of the notification, and the in-app player artwork) is unaffected — it continues to come from artwork embedded in the audio stream, extracted by ExoPlayer.

## Testing

- `./gradlew test` — green
- `./gradlew lint` — green (the new `DefaultMediaNotificationProvider` usage is covered by the service's existing class-level `@OptIn(UnstableApi::class)`)
- `make harness-test` (phone) — 179 tests, 0 failed
- `make harness-test-tablet` — 5 tests, 0 failed
- Manually verified on an emulator: played an audiobook, confirmed the notification shows the Riffle book glyph as the small icon and the cover art still renders.