### PR TITLE
fix(reader): keep side-edge page-turn swipes from exiting immersive mode

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -1410,10 +1410,21 @@ private fun EpubNavigatorView(
                     onPullProgress = { p -> pullProgress = p }
                     val fragmentContainer = FragmentContainerView(ctx).apply { id = containerId }
                     addView(fragmentContainer, FrameLayout.LayoutParams(FrameLayout.LayoutParams.MATCH_PARENT, FrameLayout.LayoutParams.MATCH_PARENT))
+                    // Claim the side edges from the system back gesture in paged mode so a
+                    // side-edge page-turn swipe doesn't trigger predictive-back, which would
+                    // reveal the system bars and exit immersive mode. Re-run on every layout so
+                    // size/rotation/inset changes recompute the strips. Scroll mode keeps the
+                    // back gesture (side swipes aren't page turns there).
+                    addOnLayoutChangeListener { _, _, _, _, _, _, _, _, _ ->
+                        applySideEdgeGestureExclusion(enabled = !isScrollMode)
+                    }
                 }.also { containerRef.value = it }
             },
             update = { container ->
                 container.isScrollMode = formattingPrefs.orientation == ReaderOrientation.Vertical
+                // Mode can flip without a relayout, so re-apply here too (the layout listener
+                // covers size/rotation changes).
+                container.applySideEdgeGestureExclusion(enabled = !container.isScrollMode)
 
                 val fragmentContainer = container.getChildAt(0) as? FragmentContainerView
                     ?: return@AndroidView

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/PdfReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/PdfReaderScreen.kt
@@ -256,6 +256,13 @@ private fun PdfNavigatorView(
                 ViewCompat.setOnApplyWindowInsetsListener(this) { _, _ ->
                     WindowInsetsCompat.CONSUMED
                 }
+                // Claim the side edges from the system back gesture so a side-edge page-turn
+                // swipe doesn't trigger predictive-back, which would reveal the system bars and
+                // exit immersive mode. The PDF reader is always paged. Re-run on every layout so
+                // size/rotation/inset changes recompute the strips.
+                addOnLayoutChangeListener { _, _, _, _, _, _, _, _, _ ->
+                    applySideEdgeGestureExclusion(enabled = true)
+                }
             }
         },
         update = { containerView ->

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/SideEdgeGestureExclusion.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/SideEdgeGestureExclusion.kt
@@ -1,0 +1,59 @@
+package com.riffle.app.feature.reader
+
+import android.graphics.Rect
+import android.os.Build
+import android.view.View
+import androidx.core.view.WindowInsetsCompat
+
+/**
+ * A left/right edge strip the app claims from the system back gesture, expressed independently of
+ * Android's [Rect] so the geometry can be unit-tested without a device.
+ */
+internal data class EdgeExclusion(val left: Int, val top: Int, val right: Int, val bottom: Int)
+
+/**
+ * Full-height strips over the left/right [systemGestures][WindowInsetsCompat.Type.systemGestures]
+ * insets. A side-edge swipe started inside one of these is delivered to the reader (page turn)
+ * instead of Android's predictive-back gesture — which, while the reader's system bars are hidden
+ * with `BEHAVIOR_DEFAULT`, would reveal the bars and kick the reader out of immersive mode.
+ *
+ * Only the *side* edges are excluded; top/bottom system gestures (status-bar / nav-bar reveal,
+ * home) are left to the system. Returns empty when the gesture insets are zero (3-button nav has
+ * no side back-gesture) or the view has no size yet.
+ */
+internal fun computeSideEdgeExclusions(
+    width: Int,
+    height: Int,
+    leftGestureInset: Int,
+    rightGestureInset: Int,
+): List<EdgeExclusion> {
+    if (width <= 0 || height <= 0) return emptyList()
+    return buildList {
+        if (leftGestureInset > 0) add(EdgeExclusion(0, 0, leftGestureInset, height))
+        if (rightGestureInset > 0) add(EdgeExclusion(width - rightGestureInset, 0, width, height))
+    }
+}
+
+/**
+ * Applies [computeSideEdgeExclusions] to this view's [View.setSystemGestureExclusionRects] when
+ * [enabled], otherwise clears it. No-op below API 29, where there is no side-edge system gesture.
+ * The OS's 200dp-per-edge exclusion cap does not apply while the reader is in immersive mode
+ * (system bars hidden), so the full-height strips take effect.
+ */
+internal fun View.applySideEdgeGestureExclusion(enabled: Boolean) {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) return
+    val gestures = if (enabled) {
+        rootWindowInsets
+            ?.let { WindowInsetsCompat.toWindowInsetsCompat(it) }
+            ?.getInsets(WindowInsetsCompat.Type.systemGestures())
+    } else {
+        null
+    }
+    val rects = computeSideEdgeExclusions(
+        width = width,
+        height = height,
+        leftGestureInset = gestures?.left ?: 0,
+        rightGestureInset = gestures?.right ?: 0,
+    ).map { Rect(it.left, it.top, it.right, it.bottom) }
+    if (systemGestureExclusionRects != rects) systemGestureExclusionRects = rects
+}

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/SideEdgeGestureExclusionTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/SideEdgeGestureExclusionTest.kt
@@ -1,0 +1,39 @@
+package com.riffle.app.feature.reader
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SideEdgeGestureExclusionTest {
+
+    @Test
+    fun `gesture insets produce full-height strips hugging each side edge`() {
+        val rects = computeSideEdgeExclusions(width = 1080, height = 1920, leftGestureInset = 40, rightGestureInset = 40)
+
+        assertEquals(
+            listOf(
+                EdgeExclusion(0, 0, 40, 1920),
+                EdgeExclusion(1040, 0, 1080, 1920),
+            ),
+            rects,
+        )
+    }
+
+    @Test
+    fun `zero gesture insets exclude nothing (3-button nav has no side back-gesture)`() {
+        assertTrue(computeSideEdgeExclusions(width = 1080, height = 1920, leftGestureInset = 0, rightGestureInset = 0).isEmpty())
+    }
+
+    @Test
+    fun `a single non-zero edge yields only that strip`() {
+        assertEquals(
+            listOf(EdgeExclusion(1040, 0, 1080, 1920)),
+            computeSideEdgeExclusions(width = 1080, height = 1920, leftGestureInset = 0, rightGestureInset = 40),
+        )
+    }
+
+    @Test
+    fun `unmeasured view excludes nothing`() {
+        assertTrue(computeSideEdgeExclusions(width = 0, height = 0, leftGestureInset = 40, rightGestureInset = 40).isEmpty())
+    }
+}


### PR DESCRIPTION
## Problem

In paged view, swiping a page from a **left/right screen edge** kicked the reader out of immersive mode.

Root cause: the reader hides the system bars with `BEHAVIOR_DEFAULT` (`ImmersiveModeState.kt:44/107`). A side-edge swipe triggers Android's **predictive-back gesture**, which reveals the system bars — and with `BEHAVIOR_DEFAULT` that reveal is permanent. The `topInset 0→positive` watcher in `rememberImmersiveModeState` (`ImmersiveModeState.kt:201-214`) then fires `onBarsRestoredExternally()`, setting `isImmersive = false`.

## Fix

Distinguish side edges from top/bottom and disable only the side ones: claim the left/right edge strips from the system back gesture via `View.setSystemGestureExclusionRects`, so side-edge swipes reach the WebView (page turn) instead of the OS. **Top/bottom system gestures (status-bar / nav-bar reveal, home) are left untouched.**

- `SideEdgeGestureExclusion.kt` — pure, unit-tested `computeSideEdgeExclusions(...)` + thin `View.applySideEdgeGestureExclusion(enabled)`. Guards API < 29; uses real `systemGestures` insets for strip width (3-button nav → zero insets → excludes nothing).
- `EpubReaderScreen.kt` — applied on layout + mode change, **scoped to paged mode** (scroll mode keeps the back gesture).
- `PdfReaderScreen.kt` — applied (always paged).
- `SideEdgeGestureExclusionTest.kt` — geometry tests (both edges / single edge / 3-button nav / unmeasured view). Passing.

The 200dp-per-edge exclusion cap doesn't apply while the reader is immersive, so the full-height strips take effect.

## Verification status

⚠️ **Not yet device-verified.** This is a system-gesture bug that can't be reproduced in an automated harness — it needs a real device with gesture navigation. The unit tests only lock down the rectangle geometry, not the immersive-exit behavior itself.

One unverified assumption underlies the fix: that the trigger is the predictive-back gesture and that it reveals the **status bar** (the top inset the watcher observes). Before merging, confirm on a device that (a) side-edge page turns no longer exit immersive, and (b) a top swipe-down still reveals the status bar + chrome. Adding a temporary log in `onBarsRestoredExternally()` is the cheapest way to confirm the handler fires on the side-swipe and stops firing after this change.