### PR TITLE
feat(readaloud): turn the page mid-sentence when a sentence spans columns

### DIFF
--- a/app/src/androidTest/kotlin/com/riffle/app/feature/reader/NarratedColumnsJsTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/reader/NarratedColumnsJsTest.kt
@@ -1,0 +1,157 @@
+package com.riffle.app.feature.reader
+
+import android.webkit.WebView
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.json.JSONArray
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Verifies the intra-sentence column geometry ([ColumnSnap.measureNarratedColumnsJs] /
+ * [ColumnSnap.snapNarratedColumnJs]) against a real, sized WebView — the device half of the
+ * sentence-spanning-page follow whose decision half is unit-tested in NarratedColumnProgressionTest.
+ *
+ * Assertions are deliberately STRUCTURAL (column count, monotonicity, last≈1.0, snap ordering) rather
+ * than exact fractions: on the fractional-density test AVD getClientRects() reports coordinates in a
+ * space inflated relative to scroll space (~1.25×, see AutoFollowJsTest), which skews the per-column
+ * width split but never the invariants that matter — a spanning sentence still measures ≥2 columns,
+ * and snapping to a later column still moves the page right onto the grid.
+ */
+@RunWith(AndroidJUnit4::class)
+class NarratedColumnsJsTest {
+
+    // A short sentence that fits on one line → one column.
+    private val singleColText = "Short single column line"
+
+    // A long sentence forced to straddle the column-0/column-1 boundary: an 82vh spacer fills most of
+    // the first viewport-wide column, so this sentence starts near its bottom and wraps into the next
+    // column. Distinctive in its first 12 chars so the text probe resolves it.
+    private val spanningText =
+        "Spanning narrated sentence that is deliberately long enough to overflow the bottom of the " +
+            "first column and continue wrapping onto the following column so its rendered rectangles " +
+            "fall into two distinct paginated columns of the document under test here today now."
+
+    // Viewport-wide CSS columns with a fixed height, so overflow flows into horizontal columns
+    // (paginated mode, not scroll mode). The spacer deterministically pushes the spanning sentence
+    // across the first column boundary.
+    private val spanningFixture = """
+        <!DOCTYPE html>
+        <html><head><meta name="viewport" content="width=device-width, initial-scale=1"></head>
+          <body style="margin:0">
+            <div style="height:100vh; columns:100vw; column-gap:0; column-fill:auto; font-size:18px; line-height:26px">
+              <div style="height:82vh"></div>
+              <span>$spanningText</span>
+            </div>
+          </body>
+        </html>
+    """.trimIndent()
+
+    // One viewport-wide column, a single short sentence near the top → exactly one column.
+    private val singleColumnFixture = """
+        <!DOCTYPE html>
+        <html><head><meta name="viewport" content="width=device-width, initial-scale=1"></head>
+          <body style="margin:0">
+            <div style="height:100vh; columns:100vw; column-gap:0; column-fill:auto; font-size:18px; line-height:26px">
+              <span>$singleColText</span>
+            </div>
+          </body>
+        </html>
+    """.trimIndent()
+
+    // A document much taller than the viewport → scroll (vertical) mode, where intra-sentence column
+    // following does not apply.
+    private val tallFixture = """
+        <!DOCTYPE html>
+        <html><head><meta name="viewport" content="width=device-width, initial-scale=1"></head>
+          <body style="margin:0; height:6000px; position:relative">
+            <div style="position:absolute; top:3000px">$singleColText</div>
+          </body>
+        </html>
+    """.trimIndent()
+
+    @Test
+    fun measuresASpanningSentenceAsAtLeastTwoColumns() {
+        withSizedWebViewFixture(spanningFixture, widthPx = 1080, heightPx = 1600) { webView ->
+            webView.awaitInnerHeight()
+            val fr = webView.evalSync(ColumnSnap.measureNarratedColumnsJs(spanningText)).asFractions()
+
+            assertTrue("a sentence wrapping across the column boundary must measure ≥2 columns (got $fr)", fr.size >= 2)
+            // Cumulative width fractions: strictly increasing, ending at the whole sentence (1.0).
+            for (i in 1 until fr.size) {
+                assertTrue("fractions must strictly increase (got $fr)", fr[i] > fr[i - 1])
+            }
+            assertEquals("the last cumulative fraction is the whole sentence", 1.0, fr.last(), 0.0001)
+            assertTrue("every fraction is in (0,1]", fr.all { it > 0.0 && it <= 1.0001 })
+        }
+    }
+
+    @Test
+    fun measuresASingleLineSentenceAsOneColumn() {
+        withSizedWebViewFixture(singleColumnFixture, widthPx = 1080, heightPx = 1600) { webView ->
+            webView.awaitInnerHeight()
+            val fr = webView.evalSync(ColumnSnap.measureNarratedColumnsJs(singleColText)).asFractions()
+            assertEquals("a one-line sentence occupies a single column (got $fr)", 1, fr.size)
+            assertEquals(1.0, fr[0], 0.0001)
+        }
+    }
+
+    @Test
+    fun snappingToALaterColumnMovesThePageRightOntoTheGrid() {
+        withSizedWebViewFixture(spanningFixture, widthPx = 1080, heightPx = 1600) { webView ->
+            val iw = webView.evalSync("window.innerWidth").trim('"').toDouble().toInt()
+            assertTrue("viewport must have a real width", iw > 100)
+            val lastColumn = webView.evalSync(ColumnSnap.measureNarratedColumnsJs(spanningText)).asFractions().size - 1
+
+            assertEquals("snapping returns on", "on", webView.evalSync(ColumnSnap.snapNarratedColumnJs(spanningText, 0)).trim('"'))
+            val x0 = webView.scrollX()
+            assertEquals("column 0 lands flush on the grid", 0, x0 % iw)
+
+            webView.evalSync(ColumnSnap.snapNarratedColumnJs(spanningText, lastColumn))
+            val xLast = webView.scrollX()
+            assertTrue("a later column is to the right of column 0 (x0=$x0 xLast=$xLast)", xLast > x0)
+            assertEquals("the later column also lands flush on the grid (xLast=$xLast iw=$iw)", 0, xLast % iw)
+        }
+    }
+
+    @Test
+    fun snapClampsAnOutOfRangeColumnIndex() {
+        withSizedWebViewFixture(spanningFixture, widthPx = 1080, heightPx = 1600) { webView ->
+            val iw = webView.evalSync("window.innerWidth").trim('"').toDouble().toInt()
+            // Far past the last column — clamps to the last rather than scrolling into empty space.
+            assertEquals("on", webView.evalSync(ColumnSnap.snapNarratedColumnJs(spanningText, 99)).trim('"'))
+            val clamped = webView.scrollX()
+            val lastColumn = webView.evalSync(ColumnSnap.measureNarratedColumnsJs(spanningText)).asFractions().size - 1
+            webView.evalSync(ColumnSnap.snapNarratedColumnJs(spanningText, lastColumn))
+            assertEquals("an out-of-range index clamps to the last column", webView.scrollX(), clamped)
+        }
+    }
+
+    @Test
+    fun returnsScrollForAVerticallyOverflowingDocument() {
+        withSizedWebViewFixture(tallFixture, widthPx = 1080, heightPx = 1600) { webView ->
+            webView.awaitInnerHeight()
+            assertEquals("scroll", webView.evalSync(ColumnSnap.measureNarratedColumnsJs(singleColText)).trim('"'))
+        }
+    }
+
+    @Test
+    fun returnsOffForTextNotOnThePage() {
+        withSizedWebViewFixture(singleColumnFixture, widthPx = 1080, heightPx = 1600) { webView ->
+            webView.awaitInnerHeight()
+            assertEquals("off", webView.evalSync(ColumnSnap.measureNarratedColumnsJs("Zzz nonexistent text")).trim('"'))
+            assertEquals("off", webView.evalSync(ColumnSnap.measureNarratedColumnsJs("")).trim('"'))
+        }
+    }
+
+    // evaluateJavascript wraps a returned JSON string in quotes (the inner numeric array has no quotes
+    // to escape); strip them and parse the array.
+    private fun String.asFractions(): List<Double> {
+        val json = trim('"')
+        val arr = JSONArray(json)
+        return List(arr.length()) { arr.getDouble(it) }
+    }
+
+    private fun WebView.scrollX(): Int = evalSync("window.scrollX").trim('"').toDouble().toInt()
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ColumnSnap.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ColumnSnap.kt
@@ -79,6 +79,35 @@ internal object ColumnSnap {
     suspend fun followNarratedSentence(fragment: EpubNavigatorFragment, text: String): String? =
         fragment.evaluateJavascript(autoFollowSnapJs(text))?.trim('"')
 
+    /**
+     * Measures how the narrated sentence [text] is laid out across paginated columns: the CUMULATIVE
+     * fraction of its rendered width that falls in each column it spans, in reading order (e.g.
+     * `[0.62, 1.0]` for a sentence whose first 62% of width is on the current page and the rest on the
+     * next). Drives [NarratedColumnProgression] so intra-sentence page turns track the narration.
+     *
+     * Empty when the sentence fits a single column, isn't on this resource, or the reader is in scroll
+     * mode (vertical follow handles that) — all of which mean "don't turn within the sentence".
+     */
+    suspend fun measureNarratedColumns(fragment: EpubNavigatorFragment, text: String): List<Double> {
+        val raw = fragment.evaluateJavascript(measureNarratedColumnsJs(text))?.trim('"')?.trim() ?: return emptyList()
+        if (raw == "off" || raw == "scroll" || !raw.startsWith("[")) return emptyList()
+        // The JS returns a JSON number array; it was double-encoded as a JS string, so unescape \" → ".
+        return runCatching {
+            val arr = org.json.JSONArray(raw.replace("\\\"", "\""))
+            List(arr.length()) { arr.getDouble(it) }
+        }.getOrDefault(emptyList())
+    }
+
+    /**
+     * Snaps the page to the [columnIndex]-th column the narrated sentence [text] spans (clamped to the
+     * range it actually occupies), landing flush on the column grid. The companion to
+     * [measureNarratedColumns]: the progression decides the index, this performs the turn. Re-locates
+     * the sentence each call so it is robust to a reflow having moved the columns since measurement.
+     */
+    suspend fun snapNarratedColumn(fragment: EpubNavigatorFragment, text: String, columnIndex: Int) {
+        fragment.evaluateJavascript(snapNarratedColumnJs(text, columnIndex))
+    }
+
     // ── Snapping primitives (JS builders) — implementation, internal for the script tests ────
 
     // The element id a TOC/search/resume locator points at (its href fragment), or null for a jump to a
@@ -143,6 +172,82 @@ internal object ColumnSnap {
         })()
         """.trimIndent()
     }
+
+    // Locate-and-group prelude shared by [measureNarratedColumnsJs] and [snapNarratedColumnJs]. Runs
+    // inside an IIFE and leaves in scope, on success: `se` (scrolling element), `order` (the ascending
+    // list of column-boundary scrollLeft values the sentence spans, each a multiple of innerWidth),
+    // `wmap` (boundary → summed rect width), and `total` (their sum). It locates the sentence by a
+    // 12-char prefix of [text] (Readium strips the media-overlay span ids, so getElementById misses),
+    // extends a Range across the sentence's characters — walking forward through text nodes so inline
+    // children (italics, etc.) don't truncate it — and buckets the Range's client rects into columns by
+    // the SAME floor(x / innerWidth) math the rest of ColumnSnap trusts. Early-returns "off" (sentence
+    // not on this resource) or "scroll" (vertical mode → no column grid; the caller centres instead).
+    private fun narratedColumnsPreludeJs(text: String): String {
+        val full = JSONObject.quote(text.trim())
+        return """
+          var full=$full; if(!full) return "off";
+          var key=full.slice(0,12);
+          var w=document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT, null, false), n, sn=null, so=0;
+          while(n=w.nextNode()){ var i=n.nodeValue.indexOf(key); if(i>=0){ sn=n; so=i; break; } }
+          if(!sn) return "off";
+          var se=document.scrollingElement||document.documentElement;
+          if(se && se.scrollHeight > window.innerHeight + 4) return "scroll";
+          var iw=window.innerWidth; if(!(iw>0)) return "off";
+          var rng=document.createRange(); rng.setStart(sn, so);
+          var endNode=sn, endOff=Math.min(sn.nodeValue.length, so + full.length), remaining=full.length - (endOff - so);
+          if(remaining > 0){
+            var w2=document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT, null, false), m;
+            while(m=w2.nextNode()){ if(m===sn) break; }
+            var node;
+            while(remaining > 0 && (node=w2.nextNode())){
+              var len=node.nodeValue.length;
+              if(len >= remaining){ endNode=node; endOff=remaining; remaining=0; }
+              else { remaining-=len; endNode=node; endOff=len; }
+            }
+          }
+          rng.setEnd(endNode, endOff);
+          var rects=rng.getClientRects(), order=[], wmap={};
+          for(var k=0;k<rects.length;k++){
+            var rc=rects[k]; if(rc.width<=0 || rc.height<=0) continue;
+            var b=Math.floor((rc.left + se.scrollLeft) / iw) * iw;
+            if(!(b in wmap)){ wmap[b]=0; order.push(b); }
+            wmap[b]+=rc.width;
+          }
+          if(order.length===0) return "off";
+          order.sort(function(a,b){return a-b;});
+          var total=0; for(var j=0;j<order.length;j++) total+=wmap[order[j]];
+          if(!(total>0)) return "off";
+        """.trimIndent()
+    }
+
+    /**
+     * Returns a JSON array of the narrated sentence's cumulative per-column width fractions (last ≈ 1.0),
+     * or the bare strings "off"/"scroll". See [measureNarratedColumns] for the Kotlin-side contract.
+     */
+    internal fun measureNarratedColumnsJs(text: String): String =
+        """
+        (function(){
+        ${narratedColumnsPreludeJs(text)}
+          var cum=0, fr=[];
+          for(var j=0;j<order.length;j++){ cum+=wmap[order[j]]; fr.push(cum/total); }
+          return JSON.stringify(fr);
+        })()
+        """.trimIndent()
+
+    /**
+     * Snaps scrollLeft to the [columnIndex]-th column the narrated sentence occupies (clamped), landing
+     * flush on the grid. Returns "on", or "off"/"scroll" when there's nothing to snap. See
+     * [snapNarratedColumn].
+     */
+    internal fun snapNarratedColumnJs(text: String, columnIndex: Int): String =
+        """
+        (function(){
+        ${narratedColumnsPreludeJs(text)}
+          var idx=$columnIndex; if(idx<0) idx=0; if(idx>order.length-1) idx=order.length-1;
+          se.scrollLeft=order[idx];
+          return "on";
+        })()
+        """.trimIndent()
 
     // Scrolls the current resource so the column CONTAINING [fragmentId] sits flush at the viewport's
     // left edge — for an in-document cross-reference tap ("Figure 4.1"). go(cssSelector) lands flush to

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ColumnSnap.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ColumnSnap.kt
@@ -91,9 +91,9 @@ internal object ColumnSnap {
     suspend fun measureNarratedColumns(fragment: EpubNavigatorFragment, text: String): List<Double> {
         val raw = fragment.evaluateJavascript(measureNarratedColumnsJs(text))?.trim('"')?.trim() ?: return emptyList()
         if (raw == "off" || raw == "scroll" || !raw.startsWith("[")) return emptyList()
-        // The JS returns a JSON number array; it was double-encoded as a JS string, so unescape \" → ".
+        // The JS returns a JSON number array (no quote chars to unescape).
         return runCatching {
-            val arr = org.json.JSONArray(raw.replace("\\\"", "\""))
+            val arr = org.json.JSONArray(raw)
             List(arr.length()) { arr.getDouble(it) }
         }.getOrDefault(emptyList())
     }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -74,6 +74,8 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
+import com.riffle.app.feature.reader.readaloud.NarratedColumnProgression
+import com.riffle.app.feature.reader.readaloud.PlayerCoordinator
 import com.riffle.app.feature.reader.readaloud.ReadaloudDownloadDialog
 import com.riffle.app.feature.reader.readaloud.ReadaloudMiniPlayer
 import com.riffle.app.ui.theme.RiffleTheme
@@ -305,6 +307,7 @@ fun EpubReaderScreen(
                         onFootnoteTapped = viewModel::showFootnotePopup,
                         activeFragmentRef = activeFragmentRef,
                         sentenceQuotes = sentenceQuotes,
+                        narrationProgress = viewModel.narrationProgress,
                         pageTopProbeRequests = viewModel.pageTopProbeRequests,
                         onPageTopResolved = viewModel::onPageTopResolved,
                         onPlayFromHere = viewModel::playFromHere,
@@ -729,6 +732,7 @@ private fun EpubNavigatorView(
     onFootnoteTapped: (content: FootnoteContent) -> Unit,
     activeFragmentRef: String?,
     sentenceQuotes: Map<String, SentenceQuote>,
+    narrationProgress: Flow<PlayerCoordinator.NarrationProgress?>,
     pageTopProbeRequests: Flow<String>,
     onPageTopResolved: (href: String, fragmentId: String?) -> Unit,
     onPlayFromHere: (fragmentRef: String) -> Unit,
@@ -1270,6 +1274,37 @@ private fun EpubNavigatorView(
         val where = ColumnSnap.followNarratedSentence(fragment, quote.highlight)
         if (where != "off") return@LaunchedEffect
         fragmentLocator(ref, quote)?.let { fragment.go(it, animated = false) }
+    }
+
+    // INTRA-sentence page follow (paginated): the effect above snaps to the column holding the
+    // sentence's START on each sentence change, but a sentence whose text wraps across the column
+    // boundary leaves its tail on the next page while the voice keeps reading it. Read-aloud timing is
+    // per-sentence, so we estimate the crossing from the elapsed fraction of the sentence's clip:
+    // [NarratedColumnProgression] maps that fraction onto the sentence's measured column layout and
+    // tells us when to turn — only ON A CHANGE, so position polls between break points (and a manual
+    // page-turn) are left alone, and a backward seek turns back.
+    //
+    // The sentence is re-measured whenever it changes OR a relayout moves the columns (reflow /
+    // rotation / chapter load), so re-keying on those generations also re-asserts the right column
+    // after the start-snap above has yanked back to column 0.
+    val columnProgression = remember { NarratedColumnProgression() }
+    LaunchedEffect(sentenceQuotes, reflowGeneration, pageLoadGeneration.value) {
+        var measuredRef: String? = null
+        narrationProgress.collect { progress ->
+            val fragment = fragmentRef.value ?: return@collect
+            if (progress == null) { columnProgression.reset(); measuredRef = null; return@collect }
+            val ref = progress.fragmentRef
+            if (ref.indexOf('#') < 0) return@collect
+            val quote = sentenceQuotes[ref.substringAfter('#', "")] ?: return@collect
+            if (ref != measuredRef) {
+                // New sentence (or a relayout restarted this effect): measure how it spans columns.
+                columnProgression.onSentence(ColumnSnap.measureNarratedColumns(fragment, quote.highlight))
+                measuredRef = ref
+            }
+            columnProgression.advance(progress.fraction)?.let { column ->
+                ColumnSnap.snapNarratedColumn(fragment, quote.highlight, column)
+            }
+        }
     }
 
     LaunchedEffect(volumeNavEvents) {

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -299,6 +299,10 @@ class EpubReaderViewModel @Inject constructor(
     // The text fragment currently narrated — drives the synced highlight. Null clears it.
     val activeFragmentRef: StateFlow<String?> = playerCoordinator.activeFragmentRef
 
+    // How far the live position has advanced through the narrated sentence — drives intra-sentence
+    // page turns when a sentence spans more than one paginated column.
+    val narrationProgress: StateFlow<PlayerCoordinator.NarrationProgress?> = playerCoordinator.narrationProgress
+
     // The track is parsed once on first play and reused.
     private var readaloudTrack: com.riffle.core.domain.ReadaloudTrack? = null
 

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/NarratedColumnProgression.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/NarratedColumnProgression.kt
@@ -51,9 +51,16 @@ class NarratedColumnProgression(private val lead: Double = DEFAULT_LEAD) {
     fun columnAt(fraction: Double): Int {
         val n = boundaries.size
         if (n <= 1) return 0
-        val f = fraction + lead
+        var prev = 0.0
         for (i in 0 until n - 1) {
-            if (f < boundaries[i]) return i
+            // Turn into column i+1 slightly before narration reaches the break, to absorb estimate
+            // drift. The lead is capped at half the column we're leaving so a column narrower than the
+            // lead can't turn at its very start — otherwise a sentence beginning in the last sliver of
+            // a page (a tiny first column) would jump off column 0 at fraction 0, fighting the
+            // sentence-start snap.
+            val effectiveLead = minOf(lead, (boundaries[i] - prev) / 2)
+            if (fraction < boundaries[i] - effectiveLead) return i
+            prev = boundaries[i]
         }
         return n - 1
     }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/NarratedColumnProgression.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/NarratedColumnProgression.kt
@@ -1,0 +1,83 @@
+package com.riffle.app.feature.reader.readaloud
+
+/**
+ * Decides, as narration advances WITHIN a single sentence, which of the columns that sentence spans
+ * should be on screen — and signals a page turn ONLY when that column changes.
+ *
+ * Read-aloud timing is per-sentence, not per-word: the audio clip maps to a whole sentence, so all we
+ * know inside a sentence is the elapsed fraction of its clip. A sentence whose text wraps across a
+ * paginated column boundary therefore has its tail stranded on the next page while the voice keeps
+ * reading it. This maps that elapsed fraction onto the sentence's measured column layout and turns the
+ * page at the estimated moment narration crosses each break.
+ *
+ * The columns are described by [onSentence] as a list of CUMULATIVE width fractions — `[0.6, 1.0]`
+ * means 60% of the sentence's rendered width is in column 0 and the rest in column 1. Width is a
+ * better proxy for narration time than character count (wider text takes longer to read), and it is
+ * what the DOM hands us directly via `getClientRects()` (see ColumnSnap.measureNarratedColumns).
+ *
+ * Why "signal only on change" ([advance] returns null until the target column moves):
+ *  - **Manual override** — between break points the target is constant, so a user who paged away
+ *    mid-column is never yanked back on the next position poll; only a genuine break crossing re-asserts.
+ *  - **Backward seek** — the target is recomputed from the live fraction every tick, so scrubbing back
+ *    into an earlier column naturally turns back, with no special case.
+ *
+ * [lead] biases a drifting estimate slightly early (turn before the tail is spoken rather than strand
+ * it briefly) — narration speed isn't perfectly uniform, and being a touch early is the lesser evil.
+ *
+ * Pure and synchronous so the page-turn decision is unit-testable in isolation; the geometry
+ * (measuring the columns, performing the snap) lives in ColumnSnap.
+ */
+class NarratedColumnProgression(private val lead: Double = DEFAULT_LEAD) {
+
+    // Cumulative width fractions, strictly increasing with last ≈ 1.0; size == number of columns the
+    // current sentence spans. Empty or single-element ⇒ the sentence fits one column and never turns.
+    private var boundaries: List<Double> = emptyList()
+
+    // The column we last drove the page to, so [advance] can fire only on a change.
+    private var lastColumn: Int = 0
+
+    /**
+     * Begin following a new sentence whose columns have cumulative width [fractions] (ascending, last
+     * ≈ 1.0). An empty list (scroll mode, or a sentence not on this page) or a single column means the
+     * sentence never turns. Resets the change-tracking — the caller's auto-follow has already placed
+     * the page on the sentence's first column, so we start from column 0 and only turn from there.
+     */
+    fun onSentence(fractions: List<Double>) {
+        boundaries = fractions
+        lastColumn = 0
+    }
+
+    /** The column index that progress [fraction] (0..1 within the sentence) should display. */
+    fun columnAt(fraction: Double): Int {
+        val n = boundaries.size
+        if (n <= 1) return 0
+        val f = fraction + lead
+        for (i in 0 until n - 1) {
+            if (f < boundaries[i]) return i
+        }
+        return n - 1
+    }
+
+    /**
+     * Feed a progress tick (elapsed [fraction] of the current sentence's clip). Returns the column to
+     * snap to ONLY when it differs from the column we last drove to, else null — so ticks between
+     * break points, and a manual page-turn, are left alone; a backward seek returns an earlier column.
+     */
+    fun advance(fraction: Double): Int? {
+        val target = columnAt(fraction)
+        if (target == lastColumn) return null
+        lastColumn = target
+        return target
+    }
+
+    /** Forget the current sentence (nothing measured) — e.g. when playback stops. */
+    fun reset() {
+        boundaries = emptyList()
+        lastColumn = 0
+    }
+
+    companion object {
+        /** Turn this fraction of the sentence early to absorb estimate drift, biasing toward "slightly early". */
+        const val DEFAULT_LEAD = 0.06
+    }
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/PlayerCoordinator.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/PlayerCoordinator.kt
@@ -37,14 +37,27 @@ class PlayerCoordinator @Inject constructor(
     /** The text fragment currently narrated, or null when nothing is playing/prepared. */
     val activeFragmentRef: StateFlow<String?> = _activeFragmentRef.asStateFlow()
 
+    private val _narrationProgress = MutableStateFlow<NarrationProgress?>(null)
+    /**
+     * How far the live position has advanced THROUGH the currently-narrated sentence's clip, or null
+     * when nothing is playing. Read-aloud timing is per-sentence, so this elapsed fraction is the only
+     * within-sentence signal available — the reader uses it to turn the page when a sentence spans more
+     * than one paginated column (see NarratedColumnProgression).
+     */
+    val narrationProgress: StateFlow<NarrationProgress?> = _narrationProgress.asStateFlow()
+
     init {
         scope.launch {
             controller.state.collect { s ->
                 val t = track
-                _activeFragmentRef.value = if (t != null && s.currentAudioSrc != null) {
-                    t.activeClipAt(s.currentAudioSrc, s.positionSec)?.textFragmentRef
+                val clip = if (t != null && s.currentAudioSrc != null) {
+                    t.activeClipAt(s.currentAudioSrc, s.positionSec)
                 } else {
                     null
+                }
+                _activeFragmentRef.value = clip?.textFragmentRef
+                _narrationProgress.value = clip?.let {
+                    NarrationProgress(it.textFragmentRef, it.progressAt(s.positionSec))
                 }
             }
         }
@@ -102,6 +115,7 @@ class PlayerCoordinator @Inject constructor(
         track = null
         controller.stop()
         _activeFragmentRef.value = null
+        _narrationProgress.value = null
     }
 
     /** Cancels the state-collection scope. Call when the owning ViewModel is cleared (not on a
@@ -109,4 +123,10 @@ class PlayerCoordinator @Inject constructor(
     fun dispose() {
         scope.cancel()
     }
+
+    /**
+     * How far narration has advanced through [fragmentRef]'s sentence clip, in `[0, 1]`. The reader
+     * follows this to turn the page mid-sentence when the sentence spans multiple paginated columns.
+     */
+    data class NarrationProgress(val fragmentRef: String, val fraction: Double)
 }

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/readaloud/NarratedColumnProgressionTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/readaloud/NarratedColumnProgressionTest.kt
@@ -91,6 +91,17 @@ class NarratedColumnProgressionTest {
         assertEquals(1, lead.advance(0.56)) // 0.56 + 0.06 ≥ 0.60 → turns early
     }
 
+    @Test fun leadNeverTurnsOffTheFirstColumnAtTheVeryStart() {
+        // A sentence beginning in the last sliver of a page: its first column holds <lead of the width.
+        // The lead must not yank the page off column 0 at fraction 0 (it would fight the start-snap and
+        // flicker); the lead is capped to half the (tiny) column, so the turn still happens — just not
+        // before narration has actually entered the sentence.
+        val p = NarratedColumnProgression(lead = NarratedColumnProgression.DEFAULT_LEAD)
+        p.onSentence(listOf(0.04, 1.0)) // 4% of the width on column 0, 96% on column 1
+        assertNull("must start on column 0, not jump to column 1 at the sentence's first tick", p.advance(0.0))
+        assertEquals(1, p.advance(0.05)) // turns once narration is genuinely into the sentence
+    }
+
     // ── clamping ────────────────────────────────────────────────────────────────────────────────
 
     @Test fun fractionPastTheEndClampsToTheLastColumn() {

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/readaloud/NarratedColumnProgressionTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/readaloud/NarratedColumnProgressionTest.kt
@@ -1,0 +1,120 @@
+package com.riffle.app.feature.reader.readaloud
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * The decision core of intra-sentence page following: as a single narrated sentence plays, decide
+ * which of the columns it spans should be on screen, and signal a page turn ONLY when that column
+ * changes. These tests pin the behaviours that make the follow robust — drift lead, snap-on-change
+ * (so it never fights a manual turn between break points), backward-seek reversal, 3+ column
+ * sentences, and the no-timing fallback.
+ */
+class NarratedColumnProgressionTest {
+
+    // ── single column: never turns ─────────────────────────────────────────────────────────────
+
+    @Test fun singleColumnSentenceNeverTurns() {
+        val p = NarratedColumnProgression(lead = 0.0)
+        p.onSentence(listOf(1.0))
+        assertNull(p.advance(0.0))
+        assertNull(p.advance(0.5))
+        assertNull(p.advance(1.0))
+    }
+
+    @Test fun unmeasuredSentenceNeverTurns() {
+        val p = NarratedColumnProgression(lead = 0.0)
+        p.onSentence(emptyList()) // measurement was "off"/"scroll" → no columns
+        assertNull(p.advance(0.0))
+        assertNull(p.advance(0.9))
+    }
+
+    // ── two columns: snap-on-change ─────────────────────────────────────────────────────────────
+
+    @Test fun twoColumnTurnsOnceWhenCrossingTheBreak() {
+        val p = NarratedColumnProgression(lead = 0.0)
+        p.onSentence(listOf(0.6, 1.0)) // 60% of the sentence's width is in column 0
+        assertNull(p.advance(0.0))      // starts on column 0 (no turn — auto-follow already put us there)
+        assertNull(p.advance(0.3))      // still column 0
+        assertNull(p.advance(0.59))     // still column 0
+        assertEquals(1, p.advance(0.60)) // crosses the break → turn to column 1
+        assertNull(p.advance(0.7))      // already column 1 → no repeat turn
+        assertNull(p.advance(0.99))
+    }
+
+    // ── manual override: ticks within a column never re-snap ────────────────────────────────────
+
+    @Test fun ticksWithinAColumnDoNotReSnap() {
+        // Many position polls land inside one column; only the boundary crossing should snap, so a
+        // user who manually paged away mid-column is not yanked back on every tick.
+        val p = NarratedColumnProgression(lead = 0.0)
+        p.onSentence(listOf(0.6, 1.0))
+        for (f in listOf(0.61, 0.65, 0.7, 0.8, 0.9, 0.95)) {
+            val turn = p.advance(f)
+            if (f == 0.61) assertEquals(1, turn) else assertNull(turn)
+        }
+    }
+
+    // ── backward seek reverses ──────────────────────────────────────────────────────────────────
+
+    @Test fun backwardSeekReturnsToTheEarlierColumn() {
+        val p = NarratedColumnProgression(lead = 0.0)
+        p.onSentence(listOf(0.6, 1.0))
+        assertEquals(1, p.advance(0.8)) // played into column 1
+        assertEquals(0, p.advance(0.2)) // scrubbed back into column 0 → snap back
+        assertEquals(1, p.advance(0.7)) // forward again
+    }
+
+    // ── three+ columns ──────────────────────────────────────────────────────────────────────────
+
+    @Test fun threeColumnSentenceTurnsAtEachBreak() {
+        val p = NarratedColumnProgression(lead = 0.0)
+        p.onSentence(listOf(0.4, 0.75, 1.0))
+        assertNull(p.advance(0.1))
+        assertEquals(1, p.advance(0.5))
+        assertNull(p.advance(0.6))
+        assertEquals(2, p.advance(0.8))
+        assertNull(p.advance(0.95))
+        assertEquals(0, p.advance(0.05)) // big seek back to the first column
+    }
+
+    // ── drift lead: bias slightly early ─────────────────────────────────────────────────────────
+
+    @Test fun leadTurnsTheePageSlightlyEarly() {
+        val noLead = NarratedColumnProgression(lead = 0.0)
+        noLead.onSentence(listOf(0.6, 1.0))
+        assertNull(noLead.advance(0.56)) // 0.56 < 0.60 → still column 0
+
+        val lead = NarratedColumnProgression(lead = 0.06)
+        lead.onSentence(listOf(0.6, 1.0))
+        assertEquals(1, lead.advance(0.56)) // 0.56 + 0.06 ≥ 0.60 → turns early
+    }
+
+    // ── clamping ────────────────────────────────────────────────────────────────────────────────
+
+    @Test fun fractionPastTheEndClampsToTheLastColumn() {
+        val p = NarratedColumnProgression(lead = 0.0)
+        p.onSentence(listOf(0.4, 0.75, 1.0))
+        assertEquals(2, p.advance(1.5)) // overshoot (lead/rounding) never indexes past the last column
+    }
+
+    // ── reset / new sentence ────────────────────────────────────────────────────────────────────
+
+    @Test fun onSentenceResetsToTheFirstColumn() {
+        val p = NarratedColumnProgression(lead = 0.0)
+        p.onSentence(listOf(0.6, 1.0))
+        assertEquals(1, p.advance(0.9)) // end of sentence A on column 1
+        p.onSentence(listOf(0.5, 1.0)) // sentence B begins — auto-follow has snapped to its column 0
+        assertNull(p.advance(0.1))      // no spurious turn just because the previous one ended on column 1
+        assertEquals(1, p.advance(0.6))
+    }
+
+    @Test fun resetForgetsTheCurrentSentence() {
+        val p = NarratedColumnProgression(lead = 0.0)
+        p.onSentence(listOf(0.6, 1.0))
+        p.advance(0.9)
+        p.reset()
+        assertNull(p.advance(0.9)) // nothing measured → no turn
+    }
+}

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/SmilOverlayParser.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/SmilOverlayParser.kt
@@ -15,7 +15,19 @@ data class MediaOverlayClip(
     val audioSrc: String,
     val clipBeginSec: Double,
     val clipEndSec: Double,
-)
+) {
+    /**
+     * How far this clip's audio has elapsed at [positionSec], as a fraction in `[0, 1]`. Since
+     * read-aloud timing is per-sentence (one clip per sentence), this is the only within-sentence
+     * progress signal available — the reader uses it to turn the page when a sentence spans more than
+     * one paginated column. A zero-or-negative-duration clip (a degenerate SMIL `par`) reports 0.
+     */
+    fun progressAt(positionSec: Double): Double {
+        val duration = clipEndSec - clipBeginSec
+        if (duration <= 0.0) return 0.0
+        return ((positionSec - clipBeginSec) / duration).coerceIn(0.0, 1.0)
+    }
+}
 
 /**
  * Pure SMIL → [MediaOverlayClip] parser. No I/O — callers read the `.smil` entries out

--- a/core/domain/src/test/kotlin/com/riffle/core/domain/MediaOverlayClipProgressTest.kt
+++ b/core/domain/src/test/kotlin/com/riffle/core/domain/MediaOverlayClipProgressTest.kt
@@ -1,0 +1,40 @@
+package com.riffle.core.domain
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * [MediaOverlayClip.progressAt] — the within-sentence elapsed fraction the reader follows to turn the
+ * page when a sentence spans more than one paginated column.
+ */
+class MediaOverlayClipProgressTest {
+
+    private fun clip(begin: Double, end: Double) =
+        MediaOverlayClip(textFragmentRef = "c1.xhtml#s0", audioSrc = "c1.mp3", clipBeginSec = begin, clipEndSec = end)
+
+    @Test fun `reports the fraction elapsed within the clip`() {
+        val c = clip(begin = 10.0, end = 14.0) // 4s clip
+        assertEquals(0.0, c.progressAt(10.0), 1e-9)
+        assertEquals(0.25, c.progressAt(11.0), 1e-9)
+        assertEquals(0.5, c.progressAt(12.0), 1e-9)
+        assertEquals(1.0, c.progressAt(14.0), 1e-9)
+    }
+
+    @Test fun `clamps a position before the clip to 0`() {
+        assertEquals(0.0, clip(10.0, 14.0).progressAt(5.0), 1e-9)
+    }
+
+    @Test fun `clamps a position past the clip to 1`() {
+        // The boundary instant belongs to the next clip, but a poll can land just past clipEnd while
+        // this is still the active clip — clamp rather than overshoot past the last column.
+        assertEquals(1.0, clip(10.0, 14.0).progressAt(99.0), 1e-9)
+    }
+
+    @Test fun `a zero-duration clip reports 0`() {
+        assertEquals(0.0, clip(10.0, 10.0).progressAt(10.0), 1e-9)
+    }
+
+    @Test fun `a negative-duration clip reports 0`() {
+        assertEquals(0.0, clip(14.0, 10.0).progressAt(12.0), 1e-9)
+    }
+}


### PR DESCRIPTION
## Problem

In paginated read-aloud, auto-follow snaps to the column containing the **start** of the narrated sentence. A sentence whose text wraps across the column boundary has its tail stranded on the next page while the voice keeps reading it — the reader sits still and the user never sees the words being spoken.

## Approach

Read-aloud timing is per-sentence (one audio clip per sentence), so there are no word-level timestamps inside a sentence. We estimate the column crossing from the **elapsed fraction of the sentence's clip** and turn the page at each break.

Three layers, each tested where it's testable:

- **`NarratedColumnProgression`** — pure decision core. Maps the elapsed fraction onto the sentence's measured column layout (cumulative width fractions) and signals a turn **only on a column change**. That single rule handles the failure modes:
  - *manual page-turn* — between breaks it returns null, so polls never yank the user back;
  - *backward seek* — target is recomputed from the live fraction, so scrubbing back turns back;
  - *drift* — a small lead biases turns slightly early, capped at half the column being left so a tiny first column can't jump at fraction 0;
  - *3+ columns* and *no-timing/scroll-mode fallback*.
- **`ColumnSnap.measureNarratedColumns` / `snapNarratedColumn`** — the WebView geometry: locate the sentence by text (Readium strips the media-overlay spans), span a Range across it, bucket its client rects into columns by the existing floor-by-`innerWidth` grid math.
- **`MediaOverlayClip.progressAt` + `PlayerCoordinator.narrationProgress`** — the within-sentence elapsed-fraction signal, wired into `EpubReaderScreen`'s paginated follow as a new effect alongside the existing sentence-change follow.

## Testing

- `NarratedColumnProgressionTest` — 12 unit tests (snap-on-change, backward seek, N-column, drift lead, tiny-first-column regression).
- `MediaOverlayClipProgressTest` — 5 unit tests (fraction, clamping, zero/negative duration).
- `NarratedColumnsJsTest` — 6 instrumented WebView tests (spanning ⇒ ≥2 columns, single-line ⇒ 1, snap ordering + grid-flush, clamp, scroll/off).
- Full suites green locally: `./gradlew :app:testDebugUnitTest :core:domain:test`, `./gradlew lint`, `make harness-test` (190 tests, 0 failed).
- Manually verified working end-to-end in the reader.