### PR TITLE
feat(playback): media-notification tap opens the active player view

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -21,6 +21,7 @@
         <activity
             android:name=".MainActivity"
             android:exported="true"
+            android:launchMode="singleTop"
             android:theme="@style/Theme.Riffle">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/kotlin/com/riffle/app/MainActivity.kt
+++ b/app/src/main/kotlin/com/riffle/app/MainActivity.kt
@@ -1,5 +1,6 @@
 package com.riffle.app
 
+import android.content.Intent
 import android.os.Build
 import android.os.Bundle
 import android.view.KeyEvent
@@ -23,6 +24,7 @@ import com.riffle.app.feature.reader.VolumeKeyEventHandler
 import com.riffle.app.feature.reader.VolumeNavEvent
 import com.riffle.app.feature.reader.VolumeNavigationController
 import com.riffle.app.navigation.MainScreen
+import com.riffle.app.playback.NowPlayingNavigator
 import com.riffle.app.ui.BottomNavBarScrim
 import com.riffle.app.ui.theme.RiffleTheme
 import com.riffle.core.domain.VolumeKeyPreferencesStore
@@ -39,6 +41,7 @@ class MainActivity : FragmentActivity() {
     @Inject lateinit var volumeNavigationController: VolumeNavigationController
     @Inject lateinit var readerStateHolder: ReaderStateHolder
     @Inject lateinit var volumeKeyPreferencesStore: VolumeKeyPreferencesStore
+    @Inject lateinit var nowPlayingNavigator: NowPlayingNavigator
 
     private lateinit var volumeNavEnabled: StateFlow<Boolean>
     private lateinit var invertVolumeKeys: StateFlow<Boolean>
@@ -74,6 +77,7 @@ class MainActivity : FragmentActivity() {
             window.isNavigationBarContrastEnforced = false
             window.isStatusBarContrastEnforced = false
         }
+        handleIntent(intent)
         setContent {
             RiffleTheme {
                 @OptIn(ExperimentalMaterial3WindowSizeClassApi::class)
@@ -123,6 +127,27 @@ class MainActivity : FragmentActivity() {
     override fun onKeyUp(keyCode: Int, event: KeyEvent): Boolean {
         if (consumedVolumeKeyCodes.remove(keyCode)) return true
         return super.onKeyUp(keyCode, event)
+    }
+
+    // Reused instance (singleTop) — the media-notification tap arrives here while the app is running.
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        setIntent(intent)
+        handleIntent(intent)
+    }
+
+    /** Routes a media-notification tap to the active player; [MainScreen] reads NowPlayingStore. */
+    private fun handleIntent(intent: Intent?) {
+        if (intent?.action == ACTION_OPEN_NOW_PLAYING) {
+            nowPlayingNavigator.requestOpen()
+            // The activity retains its launch intent, so consume the action — otherwise a later
+            // recreation (e.g. rotation) would re-fire this and yank the user back to the player.
+            intent.action = null
+        }
+    }
+
+    companion object {
+        const val ACTION_OPEN_NOW_PLAYING = "com.riffle.app.action.OPEN_NOW_PLAYING"
     }
 }
 

--- a/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModel.kt
@@ -60,6 +60,7 @@ class AudiobookPlayerViewModel @Inject constructor(
     private val readerSyncFactory: com.riffle.app.feature.reader.ReaderSyncFactory,
     private val readaloudLinkRepository: com.riffle.core.domain.ReadaloudLinkRepository,
     private val crossEpubIndexBuilder: com.riffle.core.data.CrossEpubIndexBuilderService,
+    private val nowPlayingStore: com.riffle.app.playback.NowPlayingStore,
 ) : ViewModel() {
 
     private val itemId: String = savedStateHandle.get<String>("itemId") ?: ""
@@ -165,6 +166,8 @@ class AudiobookPlayerViewModel @Inject constructor(
                 durationSec = session.timeline.durationSec,
                 startAtSec = session.serverCurrentTimeSec,
             )
+            // Record the active session so a media-notification tap reopens this audiobook player.
+            nowPlayingStore.set(com.riffle.app.playback.NowPlaying.Audiobook(itemId))
             // Apply the persisted per-book speed to the freshly-prepared (singleton) controller, which
             // would otherwise retain the previous book's speed. Set directly on the controller (not the
             // VM's setSpeed) so restoring the saved value doesn't re-save it.
@@ -352,6 +355,8 @@ class AudiobookPlayerViewModel @Inject constructor(
         flushPendingSpeed()
         pushProgressOnStop()
         controller.stop()
+        // Leaving the player stops playback (no mini-bar), so this session is no longer playing.
+        nowPlayingStore.clearIf { it is com.riffle.app.playback.NowPlaying.Audiobook && it.itemId == itemId }
         super.onCleared()
     }
 

--- a/app/src/main/kotlin/com/riffle/app/feature/navigation/NavigationDrawerViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/navigation/NavigationDrawerViewModel.kt
@@ -10,6 +10,9 @@ import com.riffle.core.domain.Server
 import com.riffle.core.domain.ServerRepository
 import com.riffle.core.domain.ServerType
 import com.riffle.core.domain.isReadaloud
+import com.riffle.app.playback.NowPlaying
+import com.riffle.app.playback.NowPlayingNavigator
+import com.riffle.app.playback.NowPlayingStore
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
@@ -33,7 +36,14 @@ class NavigationDrawerViewModel @Inject constructor(
     private val libraryRepository: LibraryRepository,
     private val visibilityStore: LibraryVisibilityPreferencesStore,
     private val connectivityObserver: ConnectivityObserver,
+    nowPlayingNavigator: NowPlayingNavigator,
+    private val nowPlayingStore: NowPlayingStore,
 ) : ViewModel() {
+
+    // A media-notification tap asks to open the active player; MainScreen reads [currentNowPlaying].
+    val openNowPlayingRequests: Flow<Unit> = nowPlayingNavigator.events
+
+    fun currentNowPlaying(): NowPlaying? = nowPlayingStore.current
 
     // Storyteller is a Settings-only readaloud backend (ADR 0026): it never appears in the Server
     // Switcher and can never become the active browsable Server.

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -127,6 +127,7 @@ class EpubReaderViewModel @Inject constructor(
     private val readingPositionStore: ReadingPositionStore,
     private val readaloudResumeStore: ReadaloudResumeStore,
     private val annotationStore: AnnotationStore,
+    private val nowPlayingStore: com.riffle.app.playback.NowPlayingStore,
 ) : AndroidViewModel(application) {
 
     private val itemId: String = checkNotNull(savedStateHandle["itemId"])
@@ -837,6 +838,8 @@ class EpubReaderViewModel @Inject constructor(
         epubZip = null
         // Tear down the audio session so it doesn't outlive the reader (clears the highlight too).
         playerCoordinator.close()
+        // Readaloud can't outlive the reader, so this session is no longer playing.
+        nowPlayingStore.clearIf { it is com.riffle.app.playback.NowPlaying.Readaloud && it.itemId == itemId }
         // Cancel the coordinator's state-collection scope so it isn't leaked past this ViewModel.
         playerCoordinator.dispose()
     }
@@ -1292,6 +1295,8 @@ class EpubReaderViewModel @Inject constructor(
 
     private suspend fun ensurePreparedAndPlay(bundle: File) {
         ensureOpened(bundle) ?: return
+        // Record the active readaloud so a media-notification tap reopens this book's reader.
+        nowPlayingStore.set(com.riffle.app.playback.NowPlaying.Readaloud(itemId))
         if (readaloudStarted) {
             // Resume after a pause: ExoPlayer kept its place, just play.
             playerCoordinator.play()

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/AudioPlayerService.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/AudioPlayerService.kt
@@ -1,6 +1,9 @@
 package com.riffle.app.feature.reader.readaloud
 
+import android.app.PendingIntent
+import android.content.Intent
 import android.net.Uri
+import com.riffle.app.MainActivity
 import androidx.annotation.OptIn
 import androidx.media3.common.AudioAttributes
 import androidx.media3.common.C
@@ -56,7 +59,27 @@ class AudioPlayerService : MediaSessionService() {
             .build()
         mediaSession = MediaSession.Builder(this, player)
             .setCallback(MediaItemUriRestoringCallback)
+            .setSessionActivity(openRiffleIntent())
             .build()
+    }
+
+    /**
+     * Tapping the media notification or lock-screen player reopens Riffle on the active player view.
+     * The intent carries no per-item data — a constant action — because the player is paged through a
+     * single Compose [MainActivity]: it consults [com.riffle.app.playback.NowPlayingStore] at tap time
+     * to route to the audiobook player or the reader's readaloud session. [Intent.FLAG_ACTIVITY_SINGLE_TOP]
+     * plus the activity's `singleTop` launch mode reuses the running instance via `onNewIntent`.
+     */
+    private fun openRiffleIntent(): PendingIntent {
+        val intent = Intent(this, MainActivity::class.java)
+            .setAction(MainActivity.ACTION_OPEN_NOW_PLAYING)
+            .addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP)
+        return PendingIntent.getActivity(
+            this,
+            0,
+            intent,
+            PendingIntent.FLAG_IMMUTABLE,
+        )
     }
 
     /**

--- a/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
@@ -40,6 +40,7 @@ import com.riffle.app.feature.server.SelectLibrariesScreen
 import com.riffle.app.feature.server.ServerSetupViewModel
 import com.riffle.app.feature.settings.SettingsScreen
 import com.riffle.app.feature.settings.readaloud.ReadaloudMatchesScreen
+import com.riffle.app.playback.NowPlaying
 import kotlinx.coroutines.launch
 import java.net.URLDecoder
 import java.net.URLEncoder
@@ -95,6 +96,21 @@ fun MainScreen(
     // (e.g. LibraryItemsScreen) don't override it.
     BackHandler(enabled = !usePermanentDrawer && drawerState.isOpen) {
         scope.launch { drawerState.close() }
+    }
+
+    // A media-notification tap jumps to whatever is playing. launchSingleTop makes this a no-op when
+    // that screen is already current (the common case, since audio only plays while its screen is) —
+    // so playback is never restarted; otherwise it opens the right player.
+    LaunchedEffect(Unit) {
+        viewModel.openNowPlayingRequests.collect {
+            val target = viewModel.currentNowPlaying() ?: return@collect
+            val encoded = URLEncoder.encode(target.itemId, "UTF-8")
+            val route = when (target) {
+                is NowPlaying.Audiobook -> "audiobook_player/$encoded"
+                is NowPlaying.Readaloud -> "epub_reader/$encoded"
+            }
+            navController.navigate(route) { launchSingleTop = true }
+        }
     }
 
     LaunchedEffect(Unit) {

--- a/app/src/main/kotlin/com/riffle/app/playback/NowPlaying.kt
+++ b/app/src/main/kotlin/com/riffle/app/playback/NowPlaying.kt
@@ -1,0 +1,45 @@
+package com.riffle.app.playback
+
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * The single playback session currently backed by [com.riffle.app.feature.reader.readaloud.AudioPlayerService].
+ * Only one can be active at a time (one shared player/session), so [NowPlayingStore] holds at most one.
+ */
+sealed interface NowPlaying {
+    val itemId: String
+
+    /** A full-screen ABS audiobook, opened at `audiobook_player/{itemId}`. */
+    data class Audiobook(override val itemId: String) : NowPlaying
+
+    /** A readaloud session, which lives inside the EPUB reader at `epub_reader/{itemId}`. */
+    data class Readaloud(override val itemId: String) : NowPlaying
+}
+
+/**
+ * App-scoped record of what is playing right now, so a media-notification tap can route to the
+ * matching player view. In-memory only: while a media notification exists to tap, the foreground
+ * [com.riffle.app.feature.reader.readaloud.AudioPlayerService] keeps the process alive, so this
+ * singleton outlives any [androidx.activity.ComponentActivity] recreation without needing to be
+ * persisted across process death (when there would be no notification to tap anyway).
+ */
+@Singleton
+class NowPlayingStore @Inject constructor() {
+
+    @Volatile
+    var current: NowPlaying? = null
+        private set
+
+    fun set(value: NowPlaying) {
+        current = value
+    }
+
+    /**
+     * Clears the current session only when it matches [predicate]. Each player screen clears its own
+     * session on teardown; the guard stops one screen's teardown from wiping another's entry.
+     */
+    fun clearIf(predicate: (NowPlaying) -> Boolean) {
+        if (current?.let(predicate) == true) current = null
+    }
+}

--- a/app/src/main/kotlin/com/riffle/app/playback/NowPlayingNavigator.kt
+++ b/app/src/main/kotlin/com/riffle/app/playback/NowPlayingNavigator.kt
@@ -1,0 +1,23 @@
+package com.riffle.app.playback
+
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * One-shot channel for "open whatever is playing now" requests, emitted by [com.riffle.app.MainActivity]
+ * when the media-notification intent arrives and collected by the Compose navigation host
+ * ([com.riffle.app.navigation.MainScreen]), which reads [NowPlayingStore] to pick the destination.
+ * Mirrors `VolumeNavigationController` — a singleton bridge from the activity to Compose nav.
+ */
+@Singleton
+class NowPlayingNavigator @Inject constructor() {
+    private val _events = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
+    val events: SharedFlow<Unit> = _events.asSharedFlow()
+
+    fun requestOpen() {
+        _events.tryEmit(Unit)
+    }
+}

--- a/app/src/test/kotlin/com/riffle/app/feature/navigation/NavigationDrawerViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/navigation/NavigationDrawerViewModelTest.kt
@@ -129,6 +129,8 @@ class NavigationDrawerViewModelTest {
         libraryRepository = fakeLibraryRepo(),
         visibilityStore = fakeVisibilityStore(),
         connectivityObserver = fakeConnectivity(),
+        nowPlayingNavigator = com.riffle.app.playback.NowPlayingNavigator(),
+        nowPlayingStore = com.riffle.app.playback.NowPlayingStore(),
     )
 
     @Test

--- a/app/src/test/kotlin/com/riffle/app/playback/NowPlayingStoreTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/playback/NowPlayingStoreTest.kt
@@ -1,0 +1,52 @@
+package com.riffle.app.playback
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class NowPlayingStoreTest {
+
+    @Test
+    fun `starts empty`() {
+        assertNull(NowPlayingStore().current)
+    }
+
+    @Test
+    fun `set records the active session`() {
+        val store = NowPlayingStore()
+        store.set(NowPlaying.Audiobook("item-1"))
+        assertEquals(NowPlaying.Audiobook("item-1"), store.current)
+    }
+
+    @Test
+    fun `set overwrites the previous session`() {
+        val store = NowPlayingStore()
+        store.set(NowPlaying.Audiobook("item-1"))
+        store.set(NowPlaying.Readaloud("item-2"))
+        assertEquals(NowPlaying.Readaloud("item-2"), store.current)
+    }
+
+    @Test
+    fun `clearIf clears when the predicate matches`() {
+        val store = NowPlayingStore()
+        store.set(NowPlaying.Audiobook("item-1"))
+        store.clearIf { it is NowPlaying.Audiobook && it.itemId == "item-1" }
+        assertNull(store.current)
+    }
+
+    @Test
+    fun `clearIf leaves a non-matching session intact`() {
+        val store = NowPlayingStore()
+        store.set(NowPlaying.Audiobook("item-1"))
+        // A readaloud teardown for a different item must not wipe the audiobook entry.
+        store.clearIf { it is NowPlaying.Readaloud && it.itemId == "item-1" }
+        assertEquals(NowPlaying.Audiobook("item-1"), store.current)
+    }
+
+    @Test
+    fun `clearIf on an empty store is a no-op`() {
+        val store = NowPlayingStore()
+        store.clearIf { true }
+        assertNull(store.current)
+    }
+}

--- a/docs/superpowers/specs/2026-06-11-notification-tap-opens-player-design.md
+++ b/docs/superpowers/specs/2026-06-11-notification-tap-opens-player-design.md
@@ -1,0 +1,135 @@
+# Notification tap opens the active player view
+
+## Problem
+
+While an audiobook or readaloud book is playing, tapping the Android media
+notification / lock-screen player brings Riffle to the foreground but does not
+reliably land on the player view. We want the tap to navigate to whichever
+player is currently active — the full-screen audiobook player, or the EPUB
+reader with the active readaloud session.
+
+## Relevant facts about the current code
+
+- One shared `AudioPlayerService` (a Media3 `MediaSessionService`) backs both
+  audiobook and readaloud playback. Its `MediaSession` now sets a session
+  activity, but it points at the bare launcher intent, so the tap only resumes
+  the task at whatever screen it was last on.
+- There is **no persistent now-playing mini-bar** (deferred in ADR 0029).
+  - `AudiobookPlayerViewModel.onCleared()` calls `controller.stop()`.
+  - `EpubReaderViewModel.onCleared()` calls `playerCoordinator.close()` →
+    `ReadaloudController.stop()`.
+  - Consequence: audio of either kind only plays while its own screen is the
+    current Compose destination and `MainActivity` is alive. Whenever a media
+    notification exists to tap, the process is alive (foreground service), so an
+    app-scoped in-memory store is sufficient — it need not survive process death.
+- Audiobook player route: `audiobook_player/{itemId}` (itemId URL-encoded).
+- Readaloud has no separate route; it lives inside `epub_reader/{itemId}`.
+- `MainActivity` hosts the Compose `NavHost` (`MainScreen`). It currently has no
+  `onNewIntent` override and uses default (`standard`) launch mode.
+- Existing pattern to drive navigation from `MainActivity` into Compose: the
+  injected `VolumeNavigationController` exposes a flow that `MainScreen` collects.
+
+## Design (Approach A)
+
+### 1. `NowPlayingStore` — Hilt `@Singleton`
+
+Single source of truth for the active session:
+
+```kotlin
+sealed interface NowPlaying {
+    val itemId: String
+    data class Audiobook(override val itemId: String) : NowPlaying
+    data class Readaloud(override val itemId: String) : NowPlaying
+}
+
+@Singleton
+class NowPlayingStore @Inject constructor() {
+    @Volatile var current: NowPlaying? = null
+        private set
+    fun set(value: NowPlaying) { current = value }
+    fun clearIf(predicate: (NowPlaying) -> Boolean) {
+        if (current?.let(predicate) == true) current = null
+    }
+}
+```
+
+- `AudiobookPlayerViewModel` calls `set(Audiobook(itemId))` when it prepares
+  playback; `onCleared()` calls `clearIf { it is Audiobook && it.itemId == itemId }`.
+- `EpubReaderViewModel` calls `set(Readaloud(itemId))` when readaloud starts;
+  `onCleared()` calls `clearIf { it is Readaloud && it.itemId == itemId }`.
+
+The `clearIf` guard keeps a plain reader close (or any non-matching teardown)
+from wiping an unrelated entry. App-scoped lifetime means the store survives
+`MainActivity` recreation.
+
+### 2. Session-activity `PendingIntent`
+
+In `AudioPlayerService`, replace the launcher intent with an explicit one:
+
+```kotlin
+private fun openRiffleIntent(): PendingIntent {
+    val intent = Intent(this, MainActivity::class.java)
+        .setAction(ACTION_OPEN_NOW_PLAYING)
+        .addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP)
+    return PendingIntent.getActivity(this, 0, intent, PendingIntent.FLAG_IMMUTABLE)
+}
+```
+
+`ACTION_OPEN_NOW_PLAYING` is a constant (e.g. `"com.riffle.app.action.OPEN_NOW_PLAYING"`).
+The intent carries no per-item data — the dynamic target is read from
+`NowPlayingStore` at tap time.
+
+`MainActivity` is declared `android:launchMode="singleTop"` so an existing
+instance receives `onNewIntent` rather than being recreated.
+
+### 3. Navigation bridge
+
+New injected `@Singleton NowPlayingNavigator`, mirroring
+`VolumeNavigationController`:
+
+```kotlin
+@Singleton
+class NowPlayingNavigator @Inject constructor() {
+    private val _events = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
+    val events: SharedFlow<Unit> = _events
+    fun requestOpen() { _events.tryEmit(Unit) }
+}
+```
+
+- `MainActivity` handles the intent in both `onCreate` (cold/recreated) and
+  `onNewIntent` (warm): if `intent.action == ACTION_OPEN_NOW_PLAYING`, call
+  `nowPlayingNavigator.requestOpen()`.
+- `MainScreen` collects `events`, reads `NowPlayingStore.current`, and navigates:
+  - `Audiobook(id)` → `audiobook_player/{encoded id}`
+  - `Readaloud(id)` → `epub_reader/{encoded id}`
+  - `null` → no-op.
+  - Use `launchSingleTop = true` so re-navigating to the screen you're already on
+    is a no-op (no playback restart).
+
+## Behaviour / tradeoffs
+
+- Warm case (player/reader still the current destination): the collected event
+  navigates to the same route with `launchSingleTop`, a no-op — audio is
+  untouched and you simply see the screen again.
+- If the nav state is somewhere else (e.g. activity was recreated to the start
+  destination), navigating fresh to the audiobook player re-prepares from the
+  server resume position — a brief reseek, not a restart. Acceptable.
+- Readaloud reopened fresh resumes from the saved sentence/position but does not
+  auto-start playback; in practice readaloud's screen is always the current
+  destination while it plays, so this path is the warm no-op.
+
+## Out of scope
+
+- Surviving process death (no notification exists to tap once the foreground
+  service is killed).
+- A persistent now-playing mini-bar (still deferred per ADR 0029).
+
+## Testing
+
+- Unit-test `NowPlayingStore` set/`clearIf` semantics (matching vs non-matching
+  clears).
+- Unit-test the route-selection mapping (NowPlaying → route string) if it is
+  extracted as a pure function.
+- Manual device verification: play audiobook → Home → tap notification → lands
+  on audiobook player; play readaloud → Home → tap notification → lands in reader
+  with readaloud active.


### PR DESCRIPTION
## What

While an audiobook or readaloud book is playing, tapping the Android media notification / lock-screen player now navigates to **whichever player is active** — the full-screen audiobook player, or the EPUB reader with the active readaloud session — instead of just resuming the app at its last screen.

## How

- **`NowPlayingStore`** (`@Singleton`, app-scoped) — the single source of truth for the active session (`Audiobook(itemId)` | `Readaloud(itemId)`). Set on play, cleared (guarded by type + itemId) on each player screen's `onCleared`. In-memory only: while a media notification exists to tap, the foreground service keeps the process alive, so it need not survive process death.
- **`NowPlayingNavigator`** — a `SharedFlow` bridge from `MainActivity` into Compose nav, mirroring the existing `VolumeNavigationController`.
- **`AudioPlayerService`** — the session-activity `PendingIntent` now targets `MainActivity` with a constant `OPEN_NOW_PLAYING` action (no per-item data; the target is read from the store at tap time).
- **`MainActivity`** — `launchMode="singleTop"`; handles the action in `onCreate`/`onNewIntent` and consumes it so a later recreation (rotation) can't re-fire the jump.
- **`MainScreen`** — collects the requests and navigates to `audiobook_player/{itemId}` or `epub_reader/{itemId}` with `launchSingleTop`, so when you're already on that screen it's a no-op and playback is never restarted.

Design rationale (incl. why an in-memory store suffices and the readaloud/audiobook lifecycle facts) is in `docs/superpowers/specs/2026-06-11-notification-tap-opens-player-design.md`.

## Tested

- `./gradlew test lint` — green (includes the new `NowPlayingStoreTest`).
- `make harness-test` — 184 tests, 0 failed.
- `make harness-test-tablet` — 5 tests, 0 failed.

Notification-tap behaviour itself isn't unit-testable; manual device verification of the tap → player navigation is still recommended before merge.
