### PR TITLE
fix(readaloud): match full sentence in auto-follow so chapter crossings don't flash the old chapter

### DIFF
--- a/app/src/androidTest/kotlin/com/riffle/app/feature/reader/AutoFollowJsTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/reader/AutoFollowJsTest.kt
@@ -24,10 +24,38 @@ class AutoFollowJsTest {
     private val offRightText = "Offright next page sentence here"
     private val targetText = "Narrated target sentence deep in the page"
 
-    // Distinct in their first 12 chars (the probe keys on a 12-char prefix), so each resolves to its
-    // own element rather than colliding on a shared "Adjacent sen…" prefix.
+    // Distinct sentences (the probe matches the WHOLE sentence text), so each resolves to its own
+    // element rather than colliding.
     private val adjacentA = "Alpha narrated line on screen"
     private val adjacentB = "Bravo narrated line on screen"
+
+    // A chapter-opening dateline of the kind The Martian uses on nearly every chapter ("LOG ENTRY: SOL
+    // N"). Two of them share the first 12 chars "LOG ENTRY: S" — the prefix the probe used to key on —
+    // so following the NEW chapter's dateline while the OLD chapter's is still on screen must NOT match
+    // the old one (the "shows the old chapter, corrects on the 2nd sentence" bug).
+    private val oldDateline = "LOG ENTRY: SOL 37"
+    private val newDateline = "LOG ENTRY: SOL 38"
+    private val datelineFixture = """
+        <!DOCTYPE html>
+        <html><head><meta name="viewport" content="width=device-width, initial-scale=1"></head>
+          <body style="margin:0; height:6000px; position:relative">
+            <div id="dateline" style="position:absolute; left:20px; top:60px; width:300px; height:40px">$oldDateline</div>
+            <div id="prose"    style="position:absolute; left:20px; top:120px; width:300px; height:40px">The Hab is now a bomb.</div>
+          </body>
+        </html>
+    """.trimIndent()
+
+    // A sentence broken across text nodes by inline markup (an <em>), the case the old short-prefix probe
+    // was built to tolerate. Whole-sentence matching must still find it across the node boundary.
+    private val splitSentence = "Once we got Hermes moving we coasted"
+    private val splitNodeFixture = """
+        <!DOCTYPE html>
+        <html><head><meta name="viewport" content="width=device-width, initial-scale=1"></head>
+          <body style="margin:0; height:6000px; position:relative">
+            <div id="split" style="position:absolute; left:20px; top:3000px; width:320px; height:40px">Once we got <em>Hermes</em> moving we coasted, burning fuel.</div>
+          </body>
+        </html>
+    """.trimIndent()
 
     // A tall (scroll-mode) document with two sentences one line apart, deep in the page. Used to prove
     // that following flaps back and forth between two ALREADY-VISIBLE adjacent sentences (what a small
@@ -199,6 +227,40 @@ class AutoFollowJsTest {
         withSizedWebViewFixture(shortFixture, widthPx = 1080, heightPx = 1600) { webView ->
             webView.awaitInnerHeight()
             assertEquals("empty/unknown text → off (caller falls back to go())", "off", webView.evalSync(ColumnSnap.autoFollowSnapJs("")).trim('"'))
+        }
+    }
+
+    @Test
+    fun datelineCollisionDoesNotFalseMatchThePreviousChaptersDateline() {
+        withSizedWebViewFixture(datelineFixture, widthPx = 1080, heightPx = 1600) { webView ->
+            webView.awaitInnerHeight()
+            // The new chapter's first narrated sentence is "LOG ENTRY: SOL 38" but the OUTGOING resource
+            // still shows "LOG ENTRY: SOL 37". A 12-char-prefix probe matched "LOG ENTRY: S" here and
+            // wrongly returned "on", suppressing the caller's cross-resource go() — the bug. Whole-sentence
+            // matching must report the SOL 38 sentence as NOT on this page → "off" → caller go()s.
+            val result = webView.evalSync(ColumnSnap.autoFollowSnapJs(newDateline)).trim('"')
+            assertEquals("a different chapter's dateline must NOT match this page → off", "off", result)
+        }
+    }
+
+    @Test
+    fun datelinePresentOnItsOwnPageStillFollows() {
+        withSizedWebViewFixture(datelineFixture, widthPx = 1080, heightPx = 1600) { webView ->
+            webView.awaitInnerHeight()
+            // The matching dateline IS on this page → followed normally.
+            val result = webView.evalSync(ColumnSnap.autoFollowSnapJs(oldDateline)).trim('"')
+            assertEquals("the dateline that IS on the page is followed → on", "on", result)
+        }
+    }
+
+    @Test
+    fun followsASentenceSplitAcrossInlineMarkupNodes() {
+        withSizedWebViewFixture(splitNodeFixture, widthPx = 1080, heightPx = 1600) { webView ->
+            webView.awaitInnerHeight()
+            // The sentence's text is broken into "Once we got " / "Hermes" / " moving we coasted…" by an
+            // <em>; whole-sentence matching over the canonical node concatenation must still locate it.
+            val result = webView.evalSync(ColumnSnap.autoFollowSnapJs(splitSentence)).trim('"')
+            assertEquals("a sentence split across inline-markup text nodes is still found → on", "on", result)
         }
     }
 

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ColumnSnap.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ColumnSnap.kt
@@ -98,19 +98,53 @@ internal object ColumnSnap {
      * only when the text isn't on the current resource (another chapter) → the caller go()s to load it.
      */
     internal fun autoFollowSnapJs(text: String): String {
-        // A short, near-unique prefix of the sentence; matched within a single text node (sentence starts
-        // almost never split across nodes). Empty text disables the lookup → "off" (caller's go() fallback).
-        val probe = text.trim().take(24)
+        // Locate the narrated sentence by its TEXT (Readium strips the media-overlay span ids, so
+        // getElementById can't find it). We match the WHOLE sentence, not a short prefix: chapter-opening
+        // sentences in some books are recurring datelines — "LOG ENTRY: SOL 38", "LOG ENTRY: SOL 37", … —
+        // whose first 12 chars are identical, so a prefix match finds the PREVIOUS chapter's dateline still
+        // on the outgoing resource, reports the sentence as already on-page, and SUPPRESSES the caller's
+        // cross-resource go(). The reader then hangs on the old chapter until a later, distinctive sentence
+        // plays — the "shows the old chapter, corrects on the 2nd sentence" bug.
+        //
+        // Whole-sentence matching is robust only if it survives the two reasons a short prefix was used
+        // before: (a) inline markup splits a sentence across text nodes ("Once we got " then an italic
+        // "<em>Hermes</em>"), and (b) the served ABS prose diverges slightly from the bundle's sentence text
+        // — smart vs straight quotes, en/em dashes, runs of whitespace. So we match over a CANONICAL
+        // concatenation of the body's text nodes (whitespace collapsed to single spaces; curly quotes and
+        // dashes folded to ASCII), keeping an index map from each canonical char back to its (node, offset)
+        // so the hit still yields a real DOM range for the column/scroll math. Not found on this resource →
+        // "off", and the caller go()s to the chapter that holds the sentence. This is the same text-fidelity
+        // contract the decoration highlight's TextQuoteAnchor already relies on. Empty text → "off".
         return """
         (function(){
-          var needle=${JSONObject.quote(probe)};
-          if(!needle) return "off";
-          var key=needle.slice(0,12);
-          var w=document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT, null, false), n, r=null;
-          while(n=w.nextNode()){
-            var i=n.nodeValue.indexOf(key);
-            if(i>=0){ var g=document.createRange(); g.setStart(n,i); g.setEnd(n, Math.min(n.nodeValue.length, i+1)); r=g.getBoundingClientRect(); break; }
+          function isWs(c){return c===32||c===9||c===10||c===13||c===12||c===160;}
+          function canon(ch){var c=ch.charCodeAt(0);
+            if(c===0x2018||c===0x2019||c===0x201A||c===0x2032||c===0x60||c===0xB4) return "'";
+            if(c===0x201C||c===0x201D||c===0x201E||c===0x2033) return '"';
+            if(c===0x2013||c===0x2014||c===0x2212) return '-';
+            return ch;}
+          var raw=${JSONObject.quote(text)};
+          var needle="", sp=false;
+          for(var a=0;a<raw.length;a++){
+            if(isWs(raw.charCodeAt(a))){ if(!sp && needle.length){ needle+=" "; sp=true; } continue; }
+            sp=false; needle+=canon(raw[a]);
           }
+          needle=needle.replace(/ ${'$'}/,"");
+          if(!needle) return "off";
+          var w=document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT, null, false), n;
+          var buf="", bn=[], bo=[], bsp=false;
+          while(n=w.nextNode()){
+            var v=n.nodeValue;
+            for(var j=0;j<v.length;j++){
+              if(isWs(v.charCodeAt(j))){ if(bsp) continue; buf+=" "; bsp=true; bn.push(n); bo.push(j); continue; }
+              bsp=false; buf+=canon(v[j]); bn.push(n); bo.push(j);
+            }
+          }
+          var pos=buf.indexOf(needle);
+          if(pos<0) return "off";
+          var node=bn[pos], off=bo[pos];
+          var g=document.createRange(); g.setStart(node,off); g.setEnd(node, Math.min(node.nodeValue.length, off+1));
+          var r=g.getBoundingClientRect();
           if(!r) return "off";
           var se=document.scrollingElement||document.documentElement;
           if(se && se.scrollHeight > window.innerHeight + 4){


### PR DESCRIPTION
## Problem

Reading aloud across a chapter boundary briefly showed the **outgoing** chapter and only corrected once the **second** sentence of the new chapter played.

## Root cause

The page-follow probe `ColumnSnap.autoFollowSnapJs` located the narrated sentence by a **12-char prefix** matched within a single text node. Many books (e.g. The Martian) open nearly every chapter on a recurring dateline — `"LOG ENTRY: SOL 38"`, `"LOG ENTRY: SOL 37"`, … — whose first 12 chars are all identically `"LOG ENTRY: S"`.

So when the new chapter's first sentence (`"LOG ENTRY: SOL 38"`) became active, the probe ran against the still-visible **outgoing** resource, found the *previous* chapter's `"LOG ENTRY: SOL 37"` via the shared 12-char prefix, reported the sentence as already on-page, and **suppressed the caller's cross-resource `go()`**. The reader stayed on the old chapter until the second sentence (unique prose) failed to match → `go()` finally fired.

Diagnosed on The Martian: the rendered resource (`part0009_split_005`) contained `"LOG ENTRY: SOL 37"` while the new chapter's first narrated sentence was `"LOG ENTRY: SOL 38"`; ~11 of the book's chapters open with a `"LOG ENTRY: SOL N"` dateline.

## Fix

Match the **whole sentence** instead of a 12-char prefix. The prefix was short on purpose — to tolerate (a) inline markup splitting a sentence across text nodes and (b) the small char-level divergence between the served ABS prose and the bundle's sentence text (smart vs straight quotes, en/em dashes, whitespace runs). To keep that tolerance while matching the full sentence, the probe now matches over a **canonical concatenation of the body's text nodes** — whitespace collapsed to single spaces, curly quotes and dashes folded to ASCII — keeping an index map from each canonical char back to its `(node, offset)` so the hit still yields a real DOM range for the column/scroll math. Not found on the current resource → `"off"`, so the caller `go()`s to the chapter that holds the sentence on sentence 1.

This is the same text-fidelity contract the decoration highlight's Readium `TextQuoteAnchor` already relies on. Sibling probes (`firstVisibleSentenceJs`, `resolveSelectionSentenceJs`) only ever search the current resource — where datelines don't recur — so they were left unchanged.

## Tests

`AutoFollowJsTest` gains:
- `datelineCollisionDoesNotFalseMatchThePreviousChaptersDateline` → asserts `"off"` (the bug)
- `datelinePresentOnItsOwnPageStillFollows` → `"on"`
- `followsASentenceSplitAcrossInlineMarkupNodes` → `"on"`

**12/12 pass on `Harness_Medium_Phone` (API 25 / Chrome 55)** — the WebView engine that exhibits the bug. `./gradlew test` (JVM units) green.