### PR TITLE
feat(audiobook): persist listen position locally as a last-update-wins peer

### DIFF
--- a/app/src/androidTest/kotlin/com/riffle/app/di/TestDatabaseModule.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/di/TestDatabaseModule.kt
@@ -5,6 +5,7 @@ import androidx.room.Room
 import com.riffle.core.data.di.DatabaseModule
 import com.riffle.core.database.AnnotationDao
 import com.riffle.core.database.AudioPlaybackPreferencesDao
+import com.riffle.core.database.AudiobookPositionDao
 import com.riffle.core.database.BookFormattingPreferencesDao
 import com.riffle.core.database.CollectionDao
 import com.riffle.core.database.CrossEpubIndexDao
@@ -82,6 +83,10 @@ object TestDatabaseModule {
     @Provides
     @Singleton
     fun provideAudioPlaybackPreferencesDao(db: RiffleDatabase): AudioPlaybackPreferencesDao = db.audioPlaybackPreferencesDao()
+
+    @Provides
+    @Singleton
+    fun provideAudiobookPositionDao(db: RiffleDatabase): AudiobookPositionDao = db.audiobookPositionDao()
 
     @Provides
     @Singleton

--- a/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModel.kt
@@ -61,6 +61,7 @@ class AudiobookPlayerViewModel @Inject constructor(
     private val readaloudLinkRepository: com.riffle.core.domain.ReadaloudLinkRepository,
     private val crossEpubIndexBuilder: com.riffle.core.data.CrossEpubIndexBuilderService,
     private val nowPlayingStore: com.riffle.app.playback.NowPlayingStore,
+    private val audiobookPositionStore: com.riffle.core.domain.AudiobookPositionStore,
 ) : ViewModel() {
 
     private val itemId: String = savedStateHandle.get<String>("itemId") ?: ""
@@ -97,13 +98,14 @@ class AudiobookPlayerViewModel @Inject constructor(
     // inbound-only so a newer remote (e.g. an ABS-web read) still pulls in. ADR 0029.
     private var reconciledResumeSec: Double = 0.0
 
-    // Same cold-path local-persistence policy as the ebook reader: the `readingProgress` float is
-    // written to `library_items` only on pause/close (never on the hot follow-loop tick), so the
-    // detail/library screens reflect listening without invalidating the library Room flow per tick.
-    // No `savePosition` — the audiobook resumes from ABS, so there is no local position to store;
-    // its backend sync (audio-led cycle / single-peer push) runs outside the coordinator (ADR 0029).
+    // Shared local-persistence policy with the ebook reader. Hot path (follow-loop tick): persist the
+    // listen position to the durable audiobook store so it survives process death and can win the
+    // last-update-wins resume. Cold path (pause/close): also write the `readingProgress` float to
+    // `library_items` so the detail/library screens reflect listening, without invalidating the library
+    // Room flow per tick. Backend (ABS) sync runs outside this coordinator (ADR 0029).
     private val positionSaveCoordinator = com.riffle.app.feature.reader.PositionSaveCoordinator<Double>(
         updateProgress = { progress -> libraryRepository.updateReadingProgress(itemId, progress) },
+        savePosition = { pos -> if (serverId.isNotEmpty()) audiobookPositionStore.save(serverId, itemId, pos) },
     )
 
     val uiState: StateFlow<AudiobookPlayerUiState> =
@@ -137,6 +139,37 @@ class AudiobookPlayerViewModel @Inject constructor(
                 return@launch
             }
             timeline = session.timeline
+            // Last-update-wins resume against the durable local store (mirrors the ebook reader): if
+            // our last listen position is newer than ABS's record — e.g. a final flush was dropped at
+            // teardown — resume from it; otherwise adopt the server position and stamp the local row so
+            // it does not re-push (ADR 0029).
+            val localSec = audiobookPositionStore.load(serverId, itemId)
+            val localTs = audiobookPositionStore.loadLocalUpdatedAt(serverId, itemId)
+            val resumeSec: Double
+            val resumeUpdatedAt: Long
+            when (
+                val decision = com.riffle.core.domain.AudiobookPositionReconciler.reconcile(
+                    localSec = localSec,
+                    localUpdatedAt = localTs,
+                    remoteSec = session.serverCurrentTimeSec,
+                    remoteUpdatedAt = session.serverLastUpdate,
+                )
+            ) {
+                is com.riffle.core.domain.AudiobookPositionReconciler.Decision.PullRemote -> {
+                    audiobookPositionStore.save(serverId, itemId, decision.positionSec)
+                    audiobookPositionStore.updateLocalTimestamp(serverId, itemId, decision.timestampMillis)
+                    resumeSec = decision.positionSec
+                    resumeUpdatedAt = decision.timestampMillis
+                }
+                is com.riffle.core.domain.AudiobookPositionReconciler.Decision.PushLocal -> {
+                    resumeSec = decision.positionSec
+                    resumeUpdatedAt = decision.timestampMillis
+                }
+                com.riffle.core.domain.AudiobookPositionReconciler.Decision.InSync -> {
+                    resumeSec = session.serverCurrentTimeSec
+                    resumeUpdatedAt = session.serverLastUpdate
+                }
+            }
             // Per-book speed (ADR 0028), shared with the linked Readaloud. Resolve the audio-settings
             // key the *same* way the reader does — via the resolver on this audiobook's link — so both
             // land on the identical key regardless of the `hasAudio` flag or sort order. With no link,
@@ -164,7 +197,7 @@ class AudiobookPlayerViewModel @Inject constructor(
                 trackUrls = session.trackUrls,
                 spans = session.tracks,
                 durationSec = session.timeline.durationSec,
-                startAtSec = session.serverCurrentTimeSec,
+                startAtSec = resumeSec,
             )
             // Record the active session so a media-notification tap reopens this audiobook player.
             nowPlayingStore.set(com.riffle.app.playback.NowPlaying.Audiobook(itemId))
@@ -172,7 +205,8 @@ class AudiobookPlayerViewModel @Inject constructor(
             // would otherwise retain the previous book's speed. Set directly on the controller (not the
             // VM's setSpeed) so restoring the saved value doesn't re-save it.
             controller.setSpeed(initialSpeed)
-            reconciledResumeSec = session.serverCurrentTimeSec
+            reconciledResumeSec = resumeSec
+            localUpdatedAt = resumeUpdatedAt
             // Opening the player is itself a "play" intent (the user tapped Listen), so start playback
             // immediately rather than landing on a paused player. A genuinely-newer remote resume is
             // still honoured: attachReaderSync's inbound-only reconcile seeks the already-playing
@@ -186,8 +220,9 @@ class AudiobookPlayerViewModel @Inject constructor(
             link?.let { crossEpubIndexBuilder.enqueueBuild(it) }
 
             // Attach the matched 2-peer cycle if its prerequisites are already cached (the follow loop
-            // re-attaches later if the index is still building).
-            attachReaderSync()
+            // re-attaches later if the index is still building). Seed it with the reconciled resume so
+            // a genuinely-newer local listen can lead the first cycle.
+            attachReaderSync(resumeSec, resumeUpdatedAt)
             // Always run the follow loop so the listen position reaches ABS while playing — in the
             // matched case it drives both ABS peers (audio-led), otherwise it pushes the single ABS
             // audiobook record (ADR 0029). Without this a plain audiobook only synced on pause/close.
@@ -201,14 +236,16 @@ class AudiobookPlayerViewModel @Inject constructor(
      * called on open and re-tried each follow-loop tick so the ebook starts syncing as soon as the
      * background index build finishes (ADR 0029).
      */
-    private suspend fun attachReaderSync(): Boolean {
+    private suspend fun attachReaderSync(atSec: Double, atUpdatedAt: Long): Boolean {
         if (readerSync != null || serverId.isEmpty()) return readerSync != null
         val rs = readerSyncFactory.createIfApplicable(itemId) ?: return false
         readerSync = rs
-        // Inbound-only reconcile (local time 0 → local can never win): the freshest remote wins this
-        // first cycle and the player seeks to the reconciled position before any playback leads — the
-        // resume-at-reconciled guard. A book-start local position can never drive the ebook here.
-        val r = rs.runAudioLedCycle(controller.currentAbsoluteSec(), localUpdatedAt = 0L)
+        // Seed the first cycle with the reconciled resume (not the live clock, which may not have
+        // settled) and its timestamp: a genuinely-newer local listen leads and propagates to the ebook
+        // CFI + audiobook record, while a newer remote (e.g. an ABS-web read) still wins and seeks.
+        // The self-heal mid-session attach passes 0 here, keeping it inbound-only so a not-yet-advanced
+        // position can never lead (the resume-at-reconciled guard).
+        val r = rs.runAudioLedCycle(atSec, atUpdatedAt)
         r.jumpToAudioSec?.let { controller.seekTo(it); reconciledResumeSec = it }
         localUpdatedAt = maxOf(localUpdatedAt, r.canonicalLastUpdate)
         return true
@@ -227,7 +264,7 @@ class AudiobookPlayerViewModel @Inject constructor(
                 kotlinx.coroutines.delay(FOLLOW_INTERVAL_MS)
                 // Self-heal: a matched book's index may finish building after open — attach then and
                 // skip this tick so the reconcile's resume seek settles before anything drives.
-                if (readerSync == null && attachReaderSync()) continue
+                if (readerSync == null && attachReaderSync(controller.currentAbsoluteSec(), 0L)) continue
 
                 val rs = readerSync
                 val pos = controller.currentAbsoluteSec()
@@ -244,6 +281,7 @@ class AudiobookPlayerViewModel @Inject constructor(
                         reconciledResumeSec = maxOf(reconciledResumeSec, pos)
                         val r = rs.runAudioLedCycle(pos, localUpdatedAt)
                         localUpdatedAt = maxOf(localUpdatedAt, r.canonicalLastUpdate)
+                        positionSaveCoordinator.onChanged(pos)
                     } else {
                         val r = rs.runAudioLedCycle(pos, localUpdatedAt = 0L)
                         r.jumpToAudioSec?.let { controller.seekTo(it); reconciledResumeSec = it }
@@ -254,6 +292,7 @@ class AudiobookPlayerViewModel @Inject constructor(
                     // below the resume (which would regress the record).
                     reconciledResumeSec = maxOf(reconciledResumeSec, pos)
                     saveProgress()
+                    positionSaveCoordinator.onChanged(pos)
                 }
             }
         }

--- a/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModel.kt
@@ -366,6 +366,11 @@ class AudiobookPlayerViewModel @Inject constructor(
     private fun pushProgressOnStop() {
         if (serverId.isEmpty()) return
         val pos = controller.currentAbsoluteSec()
+        // Only persist/push a genuine, settled position. A pause/teardown before the resume seek has
+        // settled leaves currentAbsoluteSec() at a transient book-start value; now that the position is
+        // durably stored locally AND pushed to ABS, writing that transient would regress the resume to
+        // 0 on the next open — the same fresh-stamped-0 erase the follow loop already guards against.
+        if (pos < reconciledResumeSec - SETTLE_EPS_SEC) return
         val fraction = audiobookProgressFraction(pos, timeline.durationSec)
         viewModelScope.launch {
             // Backend (ABS) sync — outside the coordinator, like the reader's progress-sync cycle.

--- a/core/data/src/main/kotlin/com/riffle/core/data/AudiobookPositionStoreImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/AudiobookPositionStoreImpl.kt
@@ -1,0 +1,27 @@
+package com.riffle.core.data
+
+import com.riffle.core.database.AudiobookPositionDao
+import com.riffle.core.database.AudiobookPositionEntity
+import com.riffle.core.domain.AudiobookPositionStore
+import javax.inject.Inject
+
+class AudiobookPositionStoreImpl @Inject constructor(
+    private val dao: AudiobookPositionDao,
+) : TimestampedPositionStore<Double>(), AudiobookPositionStore {
+
+    override suspend fun writePayload(serverId: String, itemId: String, payload: Double, updatedAt: Long) {
+        dao.upsert(AudiobookPositionEntity(serverId, itemId, payload, updatedAt))
+    }
+
+    override suspend fun readPayload(serverId: String, itemId: String): Double? =
+        dao.getByItemId(serverId, itemId)?.positionSec
+
+    override suspend fun readUpdatedAt(serverId: String, itemId: String): Long? =
+        dao.getByItemId(serverId, itemId)?.localUpdatedAt
+
+    override suspend fun writeUpdatedAt(serverId: String, itemId: String, updatedAt: Long) {
+        // upsert so a stamp before the first save still creates a row (see ReadingPositionStoreImpl).
+        val existing = dao.getByItemId(serverId, itemId)
+        dao.upsert(AudiobookPositionEntity(serverId, itemId, existing?.positionSec ?: 0.0, updatedAt))
+    }
+}

--- a/core/data/src/main/kotlin/com/riffle/core/data/AudiobookRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/AudiobookRepositoryImpl.kt
@@ -54,11 +54,23 @@ class AudiobookRepositoryImpl @Inject constructor(
                 AudiobookChapter(index = i, startSec = c.startSec, endSec = c.endSec, title = c.title)
             },
         )
+        // Read ABS's server-side lastUpdate so the player can last-update-wins resume against the
+        // durable local store. A failed read leaves it 0 (the play-session currentTime still resumes).
+        val serverLastUpdate = (
+            sessionApi.getProgress(
+                baseUrl = server.url.value,
+                libraryItemId = itemId,
+                token = token,
+                insecureAllowed = server.insecureConnectionAllowed,
+            ) as? com.riffle.core.network.NetworkGetProgressResult.Success
+        )?.progress?.lastUpdate ?: 0L
+
         return AudiobookSession(
             trackUrls = trackUrls,
             tracks = spans,
             timeline = timeline,
             serverCurrentTimeSec = session.currentTimeSec,
+            serverLastUpdate = serverLastUpdate,
         )
     }
 

--- a/core/data/src/main/kotlin/com/riffle/core/data/ReadingPositionStoreImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/ReadingPositionStoreImpl.kt
@@ -7,37 +7,23 @@ import javax.inject.Inject
 
 class ReadingPositionStoreImpl @Inject constructor(
     private val dao: ReadingPositionDao,
-) : ReadingPositionStore {
+) : TimestampedPositionStore<String>(), ReadingPositionStore {
 
-    override suspend fun save(serverId: String, itemId: String, cfi: String) {
-        dao.upsert(
-            ReadingPositionEntity(
-                serverId = serverId,
-                itemId = itemId,
-                cfi = cfi,
-                localUpdatedAt = System.currentTimeMillis(),
-            )
-        )
+    override suspend fun writePayload(serverId: String, itemId: String, payload: String, updatedAt: Long) {
+        dao.upsert(ReadingPositionEntity(serverId, itemId, payload, updatedAt))
     }
 
-    override suspend fun load(serverId: String, itemId: String): String? =
+    override suspend fun readPayload(serverId: String, itemId: String): String? =
         dao.getByItemId(serverId, itemId)?.cfi
 
-    override suspend fun loadLocalUpdatedAt(serverId: String, itemId: String): Long =
-        dao.getByItemId(serverId, itemId)?.localUpdatedAt ?: 0L
+    override suspend fun readUpdatedAt(serverId: String, itemId: String): Long? =
+        dao.getByItemId(serverId, itemId)?.localUpdatedAt
 
-    override suspend fun updateLocalTimestamp(serverId: String, itemId: String, millis: Long) {
-        // Use upsert so that a row is always created — the UPDATE-only query silently does nothing
-        // when no row exists yet, leaving localUpdatedAt = 0 and causing the server to win every
-        // subsequent sync cycle until the user has moved enough to trigger a position save.
+    override suspend fun writeUpdatedAt(serverId: String, itemId: String, updatedAt: Long) {
+        // upsert (not the UPDATE-only DAO query) so a row is always created — otherwise a stamp before
+        // the first position save silently no-ops, leaving localUpdatedAt = 0 and letting the server
+        // win every subsequent cycle.
         val existing = dao.getByItemId(serverId, itemId)
-        dao.upsert(
-            ReadingPositionEntity(
-                serverId = serverId,
-                itemId = itemId,
-                cfi = existing?.cfi ?: "",
-                localUpdatedAt = millis,
-            )
-        )
+        dao.upsert(ReadingPositionEntity(serverId, itemId, existing?.cfi ?: "", updatedAt))
     }
 }

--- a/core/data/src/main/kotlin/com/riffle/core/data/TimestampedPositionStore.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/TimestampedPositionStore.kt
@@ -1,0 +1,30 @@
+package com.riffle.core.data
+
+import com.riffle.core.domain.PositionStore
+
+/**
+ * Shared policy for the per-medium position stores: [save] stamps the current wall clock;
+ * [loadLocalUpdatedAt] defaults a missing row to 0L. Subclasses supply the per-table storage via the
+ * four template methods (Room forbids a shared generic entity/DAO). [now] is overridable for tests.
+ */
+abstract class TimestampedPositionStore<P> : PositionStore<P> {
+
+    protected open fun now(): Long = System.currentTimeMillis()
+
+    protected abstract suspend fun writePayload(serverId: String, itemId: String, payload: P, updatedAt: Long)
+    protected abstract suspend fun readPayload(serverId: String, itemId: String): P?
+    protected abstract suspend fun readUpdatedAt(serverId: String, itemId: String): Long?
+    protected abstract suspend fun writeUpdatedAt(serverId: String, itemId: String, updatedAt: Long)
+
+    final override suspend fun save(serverId: String, itemId: String, payload: P) =
+        writePayload(serverId, itemId, payload, now())
+
+    final override suspend fun load(serverId: String, itemId: String): P? =
+        readPayload(serverId, itemId)
+
+    final override suspend fun loadLocalUpdatedAt(serverId: String, itemId: String): Long =
+        readUpdatedAt(serverId, itemId) ?: 0L
+
+    final override suspend fun updateLocalTimestamp(serverId: String, itemId: String, millis: Long) =
+        writeUpdatedAt(serverId, itemId, millis)
+}

--- a/core/data/src/main/kotlin/com/riffle/core/data/di/DataModule.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/di/DataModule.kt
@@ -25,6 +25,7 @@ import com.riffle.core.data.CrossEpubIndexStoreImpl
 import com.riffle.core.data.ReadaloudLinkRepositoryImpl
 import com.riffle.core.data.ReadaloudReviewRepositoryImpl
 import com.riffle.core.data.ReadaloudResumeStoreImpl
+import com.riffle.core.data.AudiobookPositionStoreImpl
 import com.riffle.core.data.ReadingPositionStoreImpl
 import com.riffle.core.data.ReadingSessionRepositoryImpl
 import com.riffle.core.data.ServerFilesCleanerImpl
@@ -54,6 +55,7 @@ import com.riffle.core.domain.CrossEpubIndexStore
 import com.riffle.core.domain.ReadaloudLinkRepository
 import com.riffle.core.domain.ReadaloudReviewRepository
 import com.riffle.core.domain.ReadaloudResumeStore
+import com.riffle.core.domain.AudiobookPositionStore
 import com.riffle.core.domain.ReadingPositionStore
 import com.riffle.core.domain.ReadingSessionRepository
 import com.riffle.core.domain.ServerRepository
@@ -209,6 +211,10 @@ abstract class DataModule {
     @Binds
     @Singleton
     abstract fun bindReadingPositionStore(impl: ReadingPositionStoreImpl): ReadingPositionStore
+
+    @Binds
+    @Singleton
+    abstract fun bindAudiobookPositionStore(impl: AudiobookPositionStoreImpl): AudiobookPositionStore
 
     @Binds
     @Singleton

--- a/core/data/src/main/kotlin/com/riffle/core/data/di/DatabaseModule.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/di/DatabaseModule.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.room.Room
 import com.riffle.core.database.AnnotationDao
 import com.riffle.core.database.AudioPlaybackPreferencesDao
+import com.riffle.core.database.AudiobookPositionDao
 import com.riffle.core.database.BookFormattingPreferencesDao
 import com.riffle.core.database.CollectionDao
 import com.riffle.core.database.LibraryDao
@@ -64,6 +65,7 @@ object DatabaseModule {
                 RiffleDatabase.MIGRATION_29_30,
                 RiffleDatabase.MIGRATION_30_31,
                 RiffleDatabase.MIGRATION_31_32,
+                RiffleDatabase.MIGRATION_32_33,
             )
             .build()
 
@@ -102,6 +104,10 @@ object DatabaseModule {
     @Provides
     @Singleton
     fun provideAudioPlaybackPreferencesDao(db: RiffleDatabase): AudioPlaybackPreferencesDao = db.audioPlaybackPreferencesDao()
+
+    @Provides
+    @Singleton
+    fun provideAudiobookPositionDao(db: RiffleDatabase): AudiobookPositionDao = db.audiobookPositionDao()
 
     @Provides
     @Singleton

--- a/core/data/src/test/kotlin/com/riffle/core/data/AudiobookPositionStoreTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/AudiobookPositionStoreTest.kt
@@ -1,0 +1,89 @@
+package com.riffle.core.data
+
+import com.riffle.core.database.AudiobookPositionDao
+import com.riffle.core.database.AudiobookPositionEntity
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class AudiobookPositionStoreTest {
+
+    private class FakeAudiobookPositionDao : AudiobookPositionDao {
+        private val entities: MutableMap<Pair<String, String>, AudiobookPositionEntity> = mutableMapOf()
+        val store: Map<Pair<String, String>, AudiobookPositionEntity> get() = entities
+        fun seed(entity: AudiobookPositionEntity) { entities[entity.serverId to entity.itemId] = entity }
+        override suspend fun upsert(entity: AudiobookPositionEntity) {
+            entities[entity.serverId to entity.itemId] = entity
+        }
+        override suspend fun getByItemId(serverId: String, itemId: String): AudiobookPositionEntity? =
+            entities[serverId to itemId]
+    }
+
+    @Test
+    fun `save persists the seconds for the given item`() = runTest {
+        val dao = FakeAudiobookPositionDao()
+        val store = AudiobookPositionStoreImpl(dao)
+        store.save("server-A", "item-1", 123.5)
+        assertEquals(123.5, dao.store["server-A" to "item-1"]?.positionSec ?: 0.0, 0.0001)
+    }
+
+    @Test
+    fun `load returns the saved seconds`() = runTest {
+        val dao = FakeAudiobookPositionDao().also {
+            it.seed(AudiobookPositionEntity("server-A", "item-1", 42.0, 1L))
+        }
+        val store = AudiobookPositionStoreImpl(dao)
+        assertEquals(42.0, store.load("server-A", "item-1")!!, 0.0001)
+    }
+
+    @Test
+    fun `load returns null for an item with no saved position`() = runTest {
+        val store = AudiobookPositionStoreImpl(FakeAudiobookPositionDao())
+        assertNull(store.load("server-A", "item-new"))
+    }
+
+    @Test
+    fun `save overwrites the previous position for the same server-item`() = runTest {
+        val dao = FakeAudiobookPositionDao()
+        val store = AudiobookPositionStoreImpl(dao)
+        store.save("server-A", "item-1", 10.0)
+        store.save("server-A", "item-1", 99.0)
+        assertEquals(99.0, store.load("server-A", "item-1")!!, 0.0001)
+    }
+
+    @Test
+    fun `save stamps localUpdatedAt with current time`() = runTest {
+        val dao = FakeAudiobookPositionDao()
+        val store = AudiobookPositionStoreImpl(dao)
+        val before = System.currentTimeMillis()
+        store.save("server-A", "item-1", 1.0)
+        val after = System.currentTimeMillis()
+        val ts = dao.store["server-A" to "item-1"]?.localUpdatedAt ?: 0L
+        assert(ts in before..after) { "Expected timestamp in [$before..$after] but was $ts" }
+    }
+
+    @Test
+    fun `loadLocalUpdatedAt defaults to zero for a missing row`() = runTest {
+        val store = AudiobookPositionStoreImpl(FakeAudiobookPositionDao())
+        assertEquals(0L, store.loadLocalUpdatedAt("server-A", "item-new"))
+    }
+
+    @Test
+    fun `updateLocalTimestamp creates a row when none exists so it is not silently dropped`() = runTest {
+        val dao = FakeAudiobookPositionDao()
+        val store = AudiobookPositionStoreImpl(dao)
+        store.updateLocalTimestamp("server-A", "item-1", 555L)
+        assertEquals(555L, store.loadLocalUpdatedAt("server-A", "item-1"))
+    }
+
+    @Test
+    fun `positions for the same itemId on different servers are isolated`() = runTest {
+        val dao = FakeAudiobookPositionDao()
+        val store = AudiobookPositionStoreImpl(dao)
+        store.save("server-A", "item-1", 10.0)
+        store.save("server-B", "item-1", 99.0)
+        assertEquals(10.0, store.load("server-A", "item-1")!!, 0.0001)
+        assertEquals(99.0, store.load("server-B", "item-1")!!, 0.0001)
+    }
+}

--- a/core/data/src/test/kotlin/com/riffle/core/data/AudiobookRepositoryImplTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/AudiobookRepositoryImplTest.kt
@@ -77,6 +77,53 @@ class AudiobookRepositoryImplTest {
     }
 
     @Test
+    fun `openSession carries the server lastUpdate from the progress record`() = runTest {
+        val playback = FakePlaybackApi(
+            NetworkPlaybackSessionResult.Success(
+                NetworkPlaybackSession(
+                    sessionId = "ps",
+                    tracks = listOf(NetworkAudioTrack(0, 0.0, 100.0, "/api/items/it/file/1", "audio/mpeg")),
+                    chapters = emptyList(),
+                    currentTimeSec = 42.0,
+                    durationSec = 100.0,
+                ),
+            ),
+        )
+        val session = object : AbsSessionApi by NoopSessionApi {
+            override suspend fun getProgress(
+                baseUrl: String, libraryItemId: String, token: String, insecureAllowed: Boolean,
+            ) = NetworkGetProgressResult.Success(
+                com.riffle.core.network.NetworkServerProgress(
+                    ebookLocation = "", ebookProgress = 0f, currentTime = 42.0, duration = 100.0,
+                    lastUpdate = 1700000000000L,
+                ),
+            )
+        }
+
+        val s = repo(playback, session).openSession("srv", "it")!!
+
+        assertEquals(1700000000000L, s.serverLastUpdate)
+    }
+
+    @Test
+    fun `openSession defaults serverLastUpdate to zero when the progress read fails`() = runTest {
+        val playback = FakePlaybackApi(
+            NetworkPlaybackSessionResult.Success(
+                NetworkPlaybackSession(
+                    sessionId = "ps",
+                    tracks = listOf(NetworkAudioTrack(0, 0.0, 100.0, "/api/items/it/file/1", "audio/mpeg")),
+                    chapters = emptyList(),
+                    currentTimeSec = 42.0,
+                    durationSec = 100.0,
+                ),
+            ),
+        )
+        // NoopSessionApi.getProgress returns NetworkError → no stamp available.
+        val s = repo(playback).openSession("srv", "it")!!
+        assertEquals(0L, s.serverLastUpdate)
+    }
+
+    @Test
     fun `openSession returns null when the play session has no tracks`() = runTest {
         val playback = FakePlaybackApi(
             NetworkPlaybackSessionResult.Success(

--- a/core/data/src/test/kotlin/com/riffle/core/data/EpubRepositoryTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/EpubRepositoryTest.kt
@@ -109,8 +109,8 @@ class EpubRepositoryTest {
 
     private class FakePositionStore : ReadingPositionStore {
         val store = mutableMapOf<Pair<String, String>, String>()
-        override suspend fun save(serverId: String, itemId: String, cfi: String) {
-            store[serverId to itemId] = cfi
+        override suspend fun save(serverId: String, itemId: String, payload: String) {
+            store[serverId to itemId] = payload
         }
         override suspend fun load(serverId: String, itemId: String): String? = store[serverId to itemId]
         override suspend fun loadLocalUpdatedAt(serverId: String, itemId: String): Long = 0L

--- a/core/data/src/test/kotlin/com/riffle/core/data/PdfRepositoryTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/PdfRepositoryTest.kt
@@ -89,8 +89,8 @@ class PdfRepositoryTest {
 
     private class FakePdfPositionStore : ReadingPositionStore {
         val store = mutableMapOf<Pair<String, String>, String>()
-        override suspend fun save(serverId: String, itemId: String, cfi: String) {
-            store[serverId to itemId] = cfi
+        override suspend fun save(serverId: String, itemId: String, payload: String) {
+            store[serverId to itemId] = payload
         }
         override suspend fun load(serverId: String, itemId: String): String? = store[serverId to itemId]
         override suspend fun loadLocalUpdatedAt(serverId: String, itemId: String): Long = 0L

--- a/core/data/src/test/kotlin/com/riffle/core/data/ProgressSyncCycleTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/ProgressSyncCycleTest.kt
@@ -32,7 +32,7 @@ class ProgressSyncCycleTest {
     private class FakePositionStore(var localUpdatedAt: Long = 0L) : ReadingPositionStore {
         var updatedTimestamp: Long? = null
         var updatedServerId: String? = null
-        override suspend fun save(serverId: String, itemId: String, cfi: String) = Unit
+        override suspend fun save(serverId: String, itemId: String, payload: String) = Unit
         override suspend fun load(serverId: String, itemId: String): String? = null
         override suspend fun loadLocalUpdatedAt(serverId: String, itemId: String): Long = localUpdatedAt
         override suspend fun updateLocalTimestamp(serverId: String, itemId: String, millis: Long) {

--- a/core/data/src/test/kotlin/com/riffle/core/data/ProgressSyncIntegrationTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/ProgressSyncIntegrationTest.kt
@@ -40,7 +40,7 @@ class ProgressSyncIntegrationTest {
 
     private class RecordingPositionStore(var localUpdatedAt: Long = 0L) : ReadingPositionStore {
         var updatedTimestamp: Long? = null
-        override suspend fun save(serverId: String, itemId: String, cfi: String) = Unit
+        override suspend fun save(serverId: String, itemId: String, payload: String) = Unit
         override suspend fun load(serverId: String, itemId: String): String? = null
         override suspend fun loadLocalUpdatedAt(serverId: String, itemId: String): Long = localUpdatedAt
         override suspend fun updateLocalTimestamp(serverId: String, itemId: String, millis: Long) { updatedTimestamp = millis }

--- a/core/data/src/test/kotlin/com/riffle/core/data/ReadingSessionIntegrationTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/ReadingSessionIntegrationTest.kt
@@ -61,7 +61,7 @@ class ReadingSessionIntegrationTest {
             override suspend fun deleteToken(serverId: String) = Unit
         },
         positionStore = object : ReadingPositionStore {
-            override suspend fun save(serverId: String, itemId: String, cfi: String) = Unit
+            override suspend fun save(serverId: String, itemId: String, payload: String) = Unit
             override suspend fun load(serverId: String, itemId: String): String? = null
             override suspend fun loadLocalUpdatedAt(serverId: String, itemId: String): Long = 0L
             override suspend fun updateLocalTimestamp(serverId: String, itemId: String, millis: Long) = Unit

--- a/core/data/src/test/kotlin/com/riffle/core/data/StorytellerPositionSyncControllerTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/StorytellerPositionSyncControllerTest.kt
@@ -25,7 +25,7 @@ class StorytellerPositionSyncControllerTest {
     private class FakePositionStore(var ts: Long) : ReadingPositionStore {
         var saved: String? = null
         var savedTs: Long? = null
-        override suspend fun save(serverId: String, itemId: String, cfi: String) { saved = cfi }
+        override suspend fun save(serverId: String, itemId: String, payload: String) { saved = payload }
         override suspend fun load(serverId: String, itemId: String): String? = saved
         override suspend fun loadLocalUpdatedAt(serverId: String, itemId: String): Long = ts
         override suspend fun updateLocalTimestamp(serverId: String, itemId: String, millis: Long) { savedTs = millis; ts = millis }

--- a/core/database/schemas/com.riffle.core.database.RiffleDatabase/33.json
+++ b/core/database/schemas/com.riffle.core.database.RiffleDatabase/33.json
@@ -1,0 +1,1179 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 33,
+    "identityHash": "bb45e246343d980a97f4e00617516dac",
+    "entities": [
+      {
+        "tableName": "servers",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `url` TEXT NOT NULL, `isActive` INTEGER NOT NULL, `insecureConnectionAllowed` INTEGER NOT NULL, `username` TEXT NOT NULL, `serverType` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "isActive",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "insecureConnectionAllowed",
+            "columnName": "insecureConnectionAllowed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "username",
+            "columnName": "username",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverType",
+            "columnName": "serverType",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "libraries",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `mediaType` TEXT NOT NULL, `serverId` TEXT NOT NULL, `isUnsupported` INTEGER NOT NULL, PRIMARY KEY(`serverId`, `id`), FOREIGN KEY(`serverId`) REFERENCES `servers`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaType",
+            "columnName": "mediaType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isUnsupported",
+            "columnName": "isUnsupported",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "serverId",
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_libraries_serverId",
+            "unique": false,
+            "columnNames": [
+              "serverId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_libraries_serverId` ON `${TABLE_NAME}` (`serverId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "servers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "serverId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "library_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`serverId` TEXT NOT NULL, `id` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `title` TEXT NOT NULL, `author` TEXT NOT NULL, `coverUrl` TEXT, `readingProgress` REAL NOT NULL, `ebookFileIno` TEXT, `ebookFormat` TEXT NOT NULL, `hasAudio` INTEGER NOT NULL, `audioDurationSec` REAL NOT NULL, `description` TEXT, `seriesName` TEXT, `publishedYear` TEXT, `genres` TEXT NOT NULL, `publisher` TEXT, `language` TEXT, `lastOpenedAt` INTEGER, `addedAt` INTEGER, `isbn` TEXT, `asin` TEXT, PRIMARY KEY(`serverId`, `id`), FOREIGN KEY(`serverId`) REFERENCES `servers`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "coverUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "readingProgress",
+            "columnName": "readingProgress",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ebookFileIno",
+            "columnName": "ebookFileIno",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "ebookFormat",
+            "columnName": "ebookFormat",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hasAudio",
+            "columnName": "hasAudio",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "audioDurationSec",
+            "columnName": "audioDurationSec",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seriesName",
+            "columnName": "seriesName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "publishedYear",
+            "columnName": "publishedYear",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "genres",
+            "columnName": "genres",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "publisher",
+            "columnName": "publisher",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "language",
+            "columnName": "language",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastOpenedAt",
+            "columnName": "lastOpenedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "isbn",
+            "columnName": "isbn",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "asin",
+            "columnName": "asin",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "serverId",
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_library_items_serverId",
+            "unique": false,
+            "columnNames": [
+              "serverId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_library_items_serverId` ON `${TABLE_NAME}` (`serverId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "servers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "serverId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "series",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `name` TEXT NOT NULL, `coverUrl` TEXT, `bookCount` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "coverUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "bookCount",
+            "columnName": "bookCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "collections",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `name` TEXT NOT NULL, `bookCount` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookCount",
+            "columnName": "bookCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "series_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`seriesId` TEXT NOT NULL, `serverId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `sequenceOrder` REAL NOT NULL, PRIMARY KEY(`seriesId`, `serverId`, `itemId`))",
+        "fields": [
+          {
+            "fieldPath": "seriesId",
+            "columnName": "seriesId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sequenceOrder",
+            "columnName": "sequenceOrder",
+            "affinity": "REAL",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "seriesId",
+            "serverId",
+            "itemId"
+          ]
+        }
+      },
+      {
+        "tableName": "collection_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`collectionId` TEXT NOT NULL, `serverId` TEXT NOT NULL, `itemId` TEXT NOT NULL, PRIMARY KEY(`collectionId`, `serverId`, `itemId`))",
+        "fields": [
+          {
+            "fieldPath": "collectionId",
+            "columnName": "collectionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "collectionId",
+            "serverId",
+            "itemId"
+          ]
+        }
+      },
+      {
+        "tableName": "reading_positions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`serverId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `cfi` TEXT NOT NULL, `localUpdatedAt` INTEGER NOT NULL, PRIMARY KEY(`serverId`, `itemId`), FOREIGN KEY(`serverId`) REFERENCES `servers`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cfi",
+            "columnName": "cfi",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localUpdatedAt",
+            "columnName": "localUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "serverId",
+            "itemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_reading_positions_serverId",
+            "unique": false,
+            "columnNames": [
+              "serverId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_reading_positions_serverId` ON `${TABLE_NAME}` (`serverId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "servers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "serverId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "book_formatting_preferences",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`serverId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `fontSize` REAL, `theme` TEXT, `fontFamily` TEXT, `lineSpacing` REAL, `margins` REAL, `orientation` TEXT, `showChapterMap` INTEGER, `showReadingProgressLabels` INTEGER, `showCurrentChapterLabel` INTEGER, `doublePageSpread` INTEGER, `justifyText` INTEGER, PRIMARY KEY(`serverId`, `itemId`), FOREIGN KEY(`serverId`) REFERENCES `servers`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fontSize",
+            "columnName": "fontSize",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "theme",
+            "columnName": "theme",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "fontFamily",
+            "columnName": "fontFamily",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lineSpacing",
+            "columnName": "lineSpacing",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "margins",
+            "columnName": "margins",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "orientation",
+            "columnName": "orientation",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "showChapterMap",
+            "columnName": "showChapterMap",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "showReadingProgressLabels",
+            "columnName": "showReadingProgressLabels",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "showCurrentChapterLabel",
+            "columnName": "showCurrentChapterLabel",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "doublePageSpread",
+            "columnName": "doublePageSpread",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "justifyText",
+            "columnName": "justifyText",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "serverId",
+            "itemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_book_formatting_preferences_serverId",
+            "unique": false,
+            "columnNames": [
+              "serverId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_book_formatting_preferences_serverId` ON `${TABLE_NAME}` (`serverId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "servers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "serverId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "readaloud_links",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`absServerId` TEXT NOT NULL, `absLibraryItemId` TEXT NOT NULL, `storytellerServerId` TEXT NOT NULL, `storytellerBookId` TEXT NOT NULL, `state` TEXT NOT NULL, `userConfirmed` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`absServerId`, `absLibraryItemId`), FOREIGN KEY(`storytellerServerId`) REFERENCES `servers`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`absServerId`) REFERENCES `servers`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "absServerId",
+            "columnName": "absServerId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absLibraryItemId",
+            "columnName": "absLibraryItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerServerId",
+            "columnName": "storytellerServerId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerBookId",
+            "columnName": "storytellerBookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userConfirmed",
+            "columnName": "userConfirmed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "absServerId",
+            "absLibraryItemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_readaloud_links_storytellerServerId_storytellerBookId",
+            "unique": false,
+            "columnNames": [
+              "storytellerServerId",
+              "storytellerBookId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_readaloud_links_storytellerServerId_storytellerBookId` ON `${TABLE_NAME}` (`storytellerServerId`, `storytellerBookId`)"
+          },
+          {
+            "name": "index_readaloud_links_storytellerServerId",
+            "unique": false,
+            "columnNames": [
+              "storytellerServerId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_readaloud_links_storytellerServerId` ON `${TABLE_NAME}` (`storytellerServerId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "servers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "storytellerServerId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "servers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "absServerId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "readaloud_candidates",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`storytellerServerId` TEXT NOT NULL, `storytellerBookId` TEXT NOT NULL, `absServerId` TEXT NOT NULL, `absLibraryItemId` TEXT NOT NULL, `score` REAL NOT NULL, PRIMARY KEY(`storytellerServerId`, `storytellerBookId`, `absServerId`, `absLibraryItemId`), FOREIGN KEY(`storytellerServerId`) REFERENCES `servers`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`absServerId`) REFERENCES `servers`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "storytellerServerId",
+            "columnName": "storytellerServerId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerBookId",
+            "columnName": "storytellerBookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absServerId",
+            "columnName": "absServerId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absLibraryItemId",
+            "columnName": "absLibraryItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "score",
+            "columnName": "score",
+            "affinity": "REAL",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "storytellerServerId",
+            "storytellerBookId",
+            "absServerId",
+            "absLibraryItemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_readaloud_candidates_absServerId",
+            "unique": false,
+            "columnNames": [
+              "absServerId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_readaloud_candidates_absServerId` ON `${TABLE_NAME}` (`absServerId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "servers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "storytellerServerId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "servers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "absServerId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "readaloud_dismissals",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`storytellerServerId` TEXT NOT NULL, `storytellerBookId` TEXT NOT NULL, `scope` TEXT NOT NULL, `absServerId` TEXT NOT NULL, `absLibraryItemId` TEXT NOT NULL, PRIMARY KEY(`storytellerServerId`, `storytellerBookId`, `absServerId`, `absLibraryItemId`), FOREIGN KEY(`storytellerServerId`) REFERENCES `servers`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "storytellerServerId",
+            "columnName": "storytellerServerId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerBookId",
+            "columnName": "storytellerBookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scope",
+            "columnName": "scope",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absServerId",
+            "columnName": "absServerId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absLibraryItemId",
+            "columnName": "absLibraryItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "storytellerServerId",
+            "storytellerBookId",
+            "absServerId",
+            "absLibraryItemId"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "servers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "storytellerServerId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "cross_epub_index",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`absEpubChecksum` TEXT NOT NULL, `storytellerEpubChecksum` TEXT NOT NULL, `perChapterMapsBlob` TEXT NOT NULL, `builtAt` INTEGER NOT NULL, PRIMARY KEY(`absEpubChecksum`, `storytellerEpubChecksum`))",
+        "fields": [
+          {
+            "fieldPath": "absEpubChecksum",
+            "columnName": "absEpubChecksum",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerEpubChecksum",
+            "columnName": "storytellerEpubChecksum",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "perChapterMapsBlob",
+            "columnName": "perChapterMapsBlob",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "builtAt",
+            "columnName": "builtAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "absEpubChecksum",
+            "storytellerEpubChecksum"
+          ]
+        }
+      },
+      {
+        "tableName": "annotations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `serverId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `type` TEXT NOT NULL, `cfi` TEXT NOT NULL, `color` TEXT NOT NULL, `note` TEXT, `textSnippet` TEXT NOT NULL, `chapterHref` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `originDeviceId` TEXT NOT NULL, `lastModifiedByDeviceId` TEXT NOT NULL, `deleted` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`serverId`) REFERENCES `servers`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cfi",
+            "columnName": "cfi",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "color",
+            "columnName": "color",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "note",
+            "columnName": "note",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "textSnippet",
+            "columnName": "textSnippet",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chapterHref",
+            "columnName": "chapterHref",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "originDeviceId",
+            "columnName": "originDeviceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastModifiedByDeviceId",
+            "columnName": "lastModifiedByDeviceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deleted",
+            "columnName": "deleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_annotations_serverId_itemId",
+            "unique": false,
+            "columnNames": [
+              "serverId",
+              "itemId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_annotations_serverId_itemId` ON `${TABLE_NAME}` (`serverId`, `itemId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "servers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "serverId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "readaloud_resume_positions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`serverId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `href` TEXT NOT NULL, `progression` REAL, `fragmentRef` TEXT, `localUpdatedAt` INTEGER NOT NULL, PRIMARY KEY(`serverId`, `itemId`), FOREIGN KEY(`serverId`) REFERENCES `servers`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "href",
+            "columnName": "href",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "progression",
+            "columnName": "progression",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "fragmentRef",
+            "columnName": "fragmentRef",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localUpdatedAt",
+            "columnName": "localUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "serverId",
+            "itemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_readaloud_resume_positions_serverId",
+            "unique": false,
+            "columnNames": [
+              "serverId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_readaloud_resume_positions_serverId` ON `${TABLE_NAME}` (`serverId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "servers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "serverId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "audio_playback_preferences",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`serverId` TEXT NOT NULL, `bookId` TEXT NOT NULL, `speed` REAL, PRIMARY KEY(`serverId`, `bookId`), FOREIGN KEY(`serverId`) REFERENCES `servers`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "speed",
+            "columnName": "speed",
+            "affinity": "REAL"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "serverId",
+            "bookId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_audio_playback_preferences_serverId",
+            "unique": false,
+            "columnNames": [
+              "serverId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_audio_playback_preferences_serverId` ON `${TABLE_NAME}` (`serverId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "servers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "serverId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "audiobook_positions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`serverId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `positionSec` REAL NOT NULL, `localUpdatedAt` INTEGER NOT NULL, PRIMARY KEY(`serverId`, `itemId`), FOREIGN KEY(`serverId`) REFERENCES `servers`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "positionSec",
+            "columnName": "positionSec",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localUpdatedAt",
+            "columnName": "localUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "serverId",
+            "itemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_audiobook_positions_serverId",
+            "unique": false,
+            "columnNames": [
+              "serverId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_audiobook_positions_serverId` ON `${TABLE_NAME}` (`serverId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "servers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "serverId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'bb45e246343d980a97f4e00617516dac')"
+    ]
+  }
+}

--- a/core/database/src/androidTest/kotlin/com/riffle/core/database/MigrationTest.kt
+++ b/core/database/src/androidTest/kotlin/com/riffle/core/database/MigrationTest.kt
@@ -1350,6 +1350,46 @@ class MigrationTest {
     }
 
     @Test
+    fun migration32To33_addsAudiobookPositionsTable() {
+        helper.createDatabase(TEST_DB, 32).use { db ->
+            db.execSQL(
+                "INSERT INTO servers (id, url, isActive, insecureConnectionAllowed, username, serverType) " +
+                    "VALUES ('s1', 'http://media-server', 1, 0, 'test', 'AUDIOBOOKSHELF')"
+            )
+        }
+
+        val db = helper.runMigrationsAndValidate(TEST_DB, 33, true, RiffleDatabase.MIGRATION_32_33)
+
+        // The new table exists and is empty (no rows are backfilled).
+        db.query("SELECT COUNT(*) FROM audiobook_positions").use { cursor ->
+            cursor.moveToFirst()
+            assertEquals(0, cursor.getInt(0))
+        }
+
+        // A position row is writable and reads back with its seconds + timestamp intact.
+        db.execSQL(
+            "INSERT INTO audiobook_positions (serverId, itemId, positionSec, localUpdatedAt) " +
+                "VALUES ('s1', '42', 123.5, 1700000000000)"
+        )
+        db.query(
+            "SELECT positionSec, localUpdatedAt FROM audiobook_positions WHERE serverId = 's1' AND itemId = '42'"
+        ).use { cursor ->
+            assertEquals(1, cursor.count)
+            cursor.moveToFirst()
+            assertEquals(123.5, cursor.getDouble(0), 0.0001)
+            assertEquals(1700000000000L, cursor.getLong(1))
+        }
+
+        // FK cascade: removing the Server clears its audiobook positions.
+        db.execSQL("PRAGMA foreign_keys = ON")
+        db.execSQL("DELETE FROM servers WHERE id = 's1'")
+        db.query("SELECT COUNT(*) FROM audiobook_positions").use { cursor ->
+            cursor.moveToFirst()
+            assertEquals(0, cursor.getInt(0))
+        }
+    }
+
+    @Test
     fun migrateFullChain() {
         helper.createDatabase(TEST_DB, 1).use { db ->
             db.execSQL(
@@ -1358,7 +1398,7 @@ class MigrationTest {
         }
 
         val db = helper.runMigrationsAndValidate(
-            TEST_DB, 32, true,
+            TEST_DB, 33, true,
             RiffleDatabase.MIGRATION_1_2,
             RiffleDatabase.MIGRATION_2_3,
             RiffleDatabase.MIGRATION_3_4,
@@ -1390,6 +1430,7 @@ class MigrationTest {
             RiffleDatabase.MIGRATION_29_30,
             RiffleDatabase.MIGRATION_30_31,
             RiffleDatabase.MIGRATION_31_32,
+            RiffleDatabase.MIGRATION_32_33,
         )
 
         db.query("SELECT url, username, serverType FROM servers WHERE id = 's1'").use { cursor ->

--- a/core/database/src/main/kotlin/com/riffle/core/database/AudiobookPositionDao.kt
+++ b/core/database/src/main/kotlin/com/riffle/core/database/AudiobookPositionDao.kt
@@ -1,0 +1,16 @@
+package com.riffle.core.database
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+
+@Dao
+interface AudiobookPositionDao {
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsert(entity: AudiobookPositionEntity)
+
+    @Query("SELECT * FROM audiobook_positions WHERE serverId = :serverId AND itemId = :itemId LIMIT 1")
+    suspend fun getByItemId(serverId: String, itemId: String): AudiobookPositionEntity?
+}

--- a/core/database/src/main/kotlin/com/riffle/core/database/AudiobookPositionEntity.kt
+++ b/core/database/src/main/kotlin/com/riffle/core/database/AudiobookPositionEntity.kt
@@ -1,0 +1,29 @@
+package com.riffle.core.database
+
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+
+// The audiobook listen position (book-absolute seconds) + the wall-clock it was last set at, stored
+// per (serverId, itemId) — the same identity and FK-cascade as `reading_positions`. Server-synced
+// (unlike the device-local `readaloud_resume_positions`): it is a durable last-update-wins peer
+// against ABS's media-progress record (ADR 0029).
+@Entity(
+    tableName = "audiobook_positions",
+    primaryKeys = ["serverId", "itemId"],
+    foreignKeys = [
+        ForeignKey(
+            entity = ServerEntity::class,
+            parentColumns = ["id"],
+            childColumns = ["serverId"],
+            onDelete = ForeignKey.CASCADE,
+        ),
+    ],
+    indices = [Index("serverId")],
+)
+data class AudiobookPositionEntity(
+    val serverId: String,
+    val itemId: String,
+    val positionSec: Double,
+    val localUpdatedAt: Long = 0,
+)

--- a/core/database/src/main/kotlin/com/riffle/core/database/RiffleDatabase.kt
+++ b/core/database/src/main/kotlin/com/riffle/core/database/RiffleDatabase.kt
@@ -23,8 +23,9 @@ import androidx.sqlite.db.SupportSQLiteDatabase
         AnnotationEntity::class,
         ReadaloudResumePositionEntity::class,
         AudioPlaybackPreferencesEntity::class,
+        AudiobookPositionEntity::class,
     ],
-    version = 32,
+    version = 33,
     exportSchema = true,
 )
 abstract class RiffleDatabase : RoomDatabase() {
@@ -42,6 +43,7 @@ abstract class RiffleDatabase : RoomDatabase() {
     abstract fun annotationDao(): AnnotationDao
     abstract fun readaloudResumePositionDao(): ReadaloudResumePositionDao
     abstract fun audioPlaybackPreferencesDao(): AudioPlaybackPreferencesDao
+    abstract fun audiobookPositionDao(): AudiobookPositionDao
 
     companion object {
         val MIGRATION_1_2 = object : Migration(1, 2) {
@@ -653,6 +655,28 @@ abstract class RiffleDatabase : RoomDatabase() {
                 db.execSQL(
                     "CREATE INDEX IF NOT EXISTS `index_audio_playback_preferences_serverId` " +
                         "ON `audio_playback_preferences` (`serverId`)"
+                )
+            }
+        }
+
+        // Durable local audiobook listen position (ADR 0029): book-absolute seconds + the wall-clock
+        // it was last set at, keyed by (serverId, itemId) with serverId FK-cascade — mirrors
+        // `reading_positions`. Server-synced (a last-update-wins peer against ABS), unlike the
+        // device-local readaloud resume table.
+        val MIGRATION_32_33 = object : Migration(32, 33) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL(
+                    "CREATE TABLE IF NOT EXISTS `audiobook_positions` (" +
+                        "`serverId` TEXT NOT NULL, " +
+                        "`itemId` TEXT NOT NULL, " +
+                        "`positionSec` REAL NOT NULL, " +
+                        "`localUpdatedAt` INTEGER NOT NULL, " +
+                        "PRIMARY KEY(`serverId`, `itemId`), " +
+                        "FOREIGN KEY(`serverId`) REFERENCES `servers`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE)"
+                )
+                db.execSQL(
+                    "CREATE INDEX IF NOT EXISTS `index_audiobook_positions_serverId` " +
+                        "ON `audiobook_positions` (`serverId`)"
                 )
             }
         }

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/AudiobookPositionReconciler.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/AudiobookPositionReconciler.kt
@@ -1,0 +1,31 @@
+package com.riffle.core.domain
+
+/**
+ * Pure last-update-wins reconciliation for the audiobook's single durable local position against
+ * ABS's media-progress record (ADR 0029). Mirrors [StorytellerPositionReconciler] but over absolute
+ * seconds: whichever side has the newer timestamp wins; ties stay in sync (local-favoured). The
+ * caller resolves the offline case (a missing local row → [localSec] null, [localUpdatedAt] 0).
+ */
+object AudiobookPositionReconciler {
+
+    sealed interface Decision {
+        /** Remote is newer — resume at it and adopt its timestamp into the local row. */
+        data class PullRemote(val positionSec: Double, val timestampMillis: Long) : Decision
+        /** Local is newer — resume at it (the follow loop / push converges ABS). */
+        data class PushLocal(val positionSec: Double, val timestampMillis: Long) : Decision
+        data object InSync : Decision
+    }
+
+    fun reconcile(
+        localSec: Double?,
+        localUpdatedAt: Long,
+        remoteSec: Double,
+        remoteUpdatedAt: Long,
+    ): Decision = when {
+        remoteUpdatedAt > localUpdatedAt ->
+            Decision.PullRemote(remoteSec, remoteUpdatedAt)
+        localSec != null && localUpdatedAt > remoteUpdatedAt && localUpdatedAt > 0 ->
+            Decision.PushLocal(localSec, localUpdatedAt)
+        else -> Decision.InSync
+    }
+}

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/AudiobookPositionStore.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/AudiobookPositionStore.kt
@@ -1,0 +1,4 @@
+package com.riffle.core.domain
+
+/** The audiobook listen position (book-absolute seconds), stored per (serverId, itemId). */
+interface AudiobookPositionStore : PositionStore<Double>

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/AudiobookRepository.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/AudiobookRepository.kt
@@ -10,6 +10,9 @@ data class AudiobookSession(
     val tracks: List<AudiobookTrackSpan>,
     val timeline: AudiobookTimeline,
     val serverCurrentTimeSec: Double,
+    // ABS's server-side `lastUpdate` (ms) for this item's media-progress record, for last-update-wins
+    // resume against the durable local store. 0 when unknown (offline / downloaded session).
+    val serverLastUpdate: Long = 0,
 )
 
 interface AudiobookRepository {

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/PositionStore.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/PositionStore.kt
@@ -1,0 +1,14 @@
+package com.riffle.core.domain
+
+/**
+ * Durable, per-(serverId, itemId) store of a reading/listening position [payload] plus the wall-clock
+ * timestamp it was last set at. The timestamp drives last-update-wins reconciliation against the
+ * server. Room cannot share generic entities/DAOs, so each medium keeps its own table; this contract
+ * and the [TimestampedPositionStore] base are the shared layer.
+ */
+interface PositionStore<P> {
+    suspend fun save(serverId: String, itemId: String, payload: P)
+    suspend fun load(serverId: String, itemId: String): P?
+    suspend fun loadLocalUpdatedAt(serverId: String, itemId: String): Long
+    suspend fun updateLocalTimestamp(serverId: String, itemId: String, millis: Long)
+}

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/ReadingPositionStore.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/ReadingPositionStore.kt
@@ -1,8 +1,4 @@
 package com.riffle.core.domain
 
-interface ReadingPositionStore {
-    suspend fun save(serverId: String, itemId: String, cfi: String)
-    suspend fun load(serverId: String, itemId: String): String?
-    suspend fun loadLocalUpdatedAt(serverId: String, itemId: String): Long
-    suspend fun updateLocalTimestamp(serverId: String, itemId: String, millis: Long)
-}
+/** The ebook reading position (an EPUB/PDF locator string), stored per (serverId, itemId). */
+interface ReadingPositionStore : PositionStore<String>

--- a/core/domain/src/test/kotlin/com/riffle/core/domain/AudiobookPositionReconcilerTest.kt
+++ b/core/domain/src/test/kotlin/com/riffle/core/domain/AudiobookPositionReconcilerTest.kt
@@ -1,0 +1,56 @@
+package com.riffle.core.domain
+
+import com.riffle.core.domain.AudiobookPositionReconciler.Decision
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class AudiobookPositionReconcilerTest {
+
+    @Test
+    fun `remote newer than local pulls the remote position`() {
+        val d = AudiobookPositionReconciler.reconcile(
+            localSec = 10.0, localUpdatedAt = 100L, remoteSec = 50.0, remoteUpdatedAt = 200L,
+        )
+        assertEquals(Decision.PullRemote(50.0, 200L), d)
+    }
+
+    @Test
+    fun `local newer than remote pushes the local position`() {
+        val d = AudiobookPositionReconciler.reconcile(
+            localSec = 80.0, localUpdatedAt = 300L, remoteSec = 50.0, remoteUpdatedAt = 200L,
+        )
+        assertEquals(Decision.PushLocal(80.0, 300L), d)
+    }
+
+    @Test
+    fun `equal timestamps are in sync`() {
+        val d = AudiobookPositionReconciler.reconcile(
+            localSec = 80.0, localUpdatedAt = 200L, remoteSec = 50.0, remoteUpdatedAt = 200L,
+        )
+        assertEquals(Decision.InSync, d)
+    }
+
+    @Test
+    fun `no local row with a server stamp pulls the remote`() {
+        val d = AudiobookPositionReconciler.reconcile(
+            localSec = null, localUpdatedAt = 0L, remoteSec = 50.0, remoteUpdatedAt = 200L,
+        )
+        assertEquals(Decision.PullRemote(50.0, 200L), d)
+    }
+
+    @Test
+    fun `no local row and no server stamp is in sync`() {
+        val d = AudiobookPositionReconciler.reconcile(
+            localSec = null, localUpdatedAt = 0L, remoteSec = 0.0, remoteUpdatedAt = 0L,
+        )
+        assertEquals(Decision.InSync, d)
+    }
+
+    @Test
+    fun `a local stamp of zero never pushes even if remote is also zero`() {
+        val d = AudiobookPositionReconciler.reconcile(
+            localSec = 80.0, localUpdatedAt = 0L, remoteSec = 0.0, remoteUpdatedAt = 0L,
+        )
+        assertEquals(Decision.InSync, d)
+    }
+}

--- a/docs/superpowers/plans/2026-06-12-audiobook-position-persistence.md
+++ b/docs/superpowers/plans/2026-06-12-audiobook-position-persistence.md
@@ -1,0 +1,1068 @@
+# Audiobook Position Persistence Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give the audiobook player a durable local position store that mirrors the ebook reader — a full, durable last-update-wins peer on both the single-peer and matched paths — reusing a shared store base.
+
+**Architecture:** Extract the store contract + timestamp policy currently baked into `ReadingPositionStoreImpl` into a generic `PositionStore<P>` interface and `TimestampedPositionStore<P>` base (Room forbids generic entities/DAOs, so the table layer is mirrored per type). Build a new `audiobook_positions` table + `AudiobookPositionStore` on that base, plus a pure `AudiobookPositionReconciler`. Wire writes into the player's existing `PositionSaveCoordinator` + follow loop, and last-update-wins resume into the open path (and the matched audio-led attach).
+
+**Tech Stack:** Kotlin, Room, Hilt, Media3 (audiobook player), JUnit + kotlinx-coroutines-test.
+
+**Reference spec:** `docs/superpowers/specs/2026-06-12-audiobook-position-persistence-design.md`
+
+**Environment note:** `./gradlew` needs `JAVA_HOME` exported first:
+```bash
+export JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"
+```
+
+---
+
+## File structure
+
+- **Shared core (new):** `core/domain/.../PositionStore.kt`, `core/data/.../TimestampedPositionStore.kt`
+- **Refactor onto base:** `core/domain/.../ReadingPositionStore.kt`, `core/data/.../ReadingPositionStoreImpl.kt`
+- **Audiobook table (new):** `core/database/.../AudiobookPositionEntity.kt`, `core/database/.../AudiobookPositionDao.kt`; edits to `RiffleDatabase.kt`, `DatabaseModule.kt`, exported `33.json`, `MigrationTest.kt`
+- **Audiobook store (new):** `core/domain/.../AudiobookPositionStore.kt`, `core/data/.../AudiobookPositionStoreImpl.kt`; bind in `DataModule.kt`; test `AudiobookPositionStoreTest.kt`
+- **Reconciler (new):** `core/domain/.../AudiobookPositionReconciler.kt`; test `AudiobookPositionReconcilerTest.kt`
+- **Plumbing:** `core/domain/.../AudiobookRepository.kt` (field), `core/data/.../AudiobookRepositoryImpl.kt` (populate); test `AudiobookRepositoryImplTest.kt`
+- **Player:** `app/.../audiobook/AudiobookPlayerViewModel.kt`
+
+---
+
+## Task 1: Shared store core + refactor the ebook store onto it
+
+**Files:**
+- Create: `core/domain/src/main/kotlin/com/riffle/core/domain/PositionStore.kt`
+- Create: `core/data/src/main/kotlin/com/riffle/core/data/TimestampedPositionStore.kt`
+- Modify: `core/domain/src/main/kotlin/com/riffle/core/domain/ReadingPositionStore.kt`
+- Modify: `core/data/src/main/kotlin/com/riffle/core/data/ReadingPositionStoreImpl.kt`
+- Regression test: `core/data/src/test/kotlin/com/riffle/core/data/ReadingPositionStoreTest.kt` (unchanged — must stay green)
+
+- [ ] **Step 1: Create the generic `PositionStore<P>` interface**
+
+`core/domain/src/main/kotlin/com/riffle/core/domain/PositionStore.kt`:
+```kotlin
+package com.riffle.core.domain
+
+/**
+ * Durable, per-(serverId, itemId) store of a reading/listening position [payload] plus the wall-clock
+ * timestamp it was last set at. The timestamp drives last-update-wins reconciliation against the
+ * server. Room cannot share generic entities/DAOs, so each medium keeps its own table; this contract
+ * and the [TimestampedPositionStore] base are the shared layer.
+ */
+interface PositionStore<P> {
+    suspend fun save(serverId: String, itemId: String, payload: P)
+    suspend fun load(serverId: String, itemId: String): P?
+    suspend fun loadLocalUpdatedAt(serverId: String, itemId: String): Long
+    suspend fun updateLocalTimestamp(serverId: String, itemId: String, millis: Long)
+}
+```
+
+- [ ] **Step 2: Create the `TimestampedPositionStore<P>` base**
+
+`core/data/src/main/kotlin/com/riffle/core/data/TimestampedPositionStore.kt`:
+```kotlin
+package com.riffle.core.data
+
+import com.riffle.core.domain.PositionStore
+
+/**
+ * Shared policy for the per-medium position stores: [save] stamps the current wall clock;
+ * [loadLocalUpdatedAt] defaults a missing row to 0L. Subclasses supply the per-table storage via the
+ * four template methods (Room forbids a shared generic entity/DAO). [now] is overridable for tests.
+ */
+abstract class TimestampedPositionStore<P> : PositionStore<P> {
+
+    protected open fun now(): Long = System.currentTimeMillis()
+
+    protected abstract suspend fun writePayload(serverId: String, itemId: String, payload: P, updatedAt: Long)
+    protected abstract suspend fun readPayload(serverId: String, itemId: String): P?
+    protected abstract suspend fun readUpdatedAt(serverId: String, itemId: String): Long?
+    protected abstract suspend fun writeUpdatedAt(serverId: String, itemId: String, updatedAt: Long)
+
+    final override suspend fun save(serverId: String, itemId: String, payload: P) =
+        writePayload(serverId, itemId, payload, now())
+
+    final override suspend fun load(serverId: String, itemId: String): P? =
+        readPayload(serverId, itemId)
+
+    final override suspend fun loadLocalUpdatedAt(serverId: String, itemId: String): Long =
+        readUpdatedAt(serverId, itemId) ?: 0L
+
+    final override suspend fun updateLocalTimestamp(serverId: String, itemId: String, millis: Long) =
+        writeUpdatedAt(serverId, itemId, millis)
+}
+```
+
+- [ ] **Step 3: Make `ReadingPositionStore` extend the generic contract**
+
+Replace the whole body of `core/domain/src/main/kotlin/com/riffle/core/domain/ReadingPositionStore.kt`:
+```kotlin
+package com.riffle.core.domain
+
+/** The ebook reading position (an EPUB/PDF locator string), stored per (serverId, itemId). */
+interface ReadingPositionStore : PositionStore<String>
+```
+
+- [ ] **Step 4: Refactor `ReadingPositionStoreImpl` onto the base**
+
+Replace the whole body of `core/data/src/main/kotlin/com/riffle/core/data/ReadingPositionStoreImpl.kt`:
+```kotlin
+package com.riffle.core.data
+
+import com.riffle.core.database.ReadingPositionDao
+import com.riffle.core.database.ReadingPositionEntity
+import com.riffle.core.domain.ReadingPositionStore
+import javax.inject.Inject
+
+class ReadingPositionStoreImpl @Inject constructor(
+    private val dao: ReadingPositionDao,
+) : TimestampedPositionStore<String>(), ReadingPositionStore {
+
+    override suspend fun writePayload(serverId: String, itemId: String, payload: String, updatedAt: Long) {
+        dao.upsert(ReadingPositionEntity(serverId, itemId, payload, updatedAt))
+    }
+
+    override suspend fun readPayload(serverId: String, itemId: String): String? =
+        dao.getByItemId(serverId, itemId)?.cfi
+
+    override suspend fun readUpdatedAt(serverId: String, itemId: String): Long? =
+        dao.getByItemId(serverId, itemId)?.localUpdatedAt
+
+    override suspend fun writeUpdatedAt(serverId: String, itemId: String, updatedAt: Long) {
+        // upsert (not the UPDATE-only DAO query) so a row is always created — otherwise a stamp before
+        // the first position save silently no-ops, leaving localUpdatedAt = 0 and letting the server
+        // win every subsequent cycle.
+        val existing = dao.getByItemId(serverId, itemId)
+        dao.upsert(ReadingPositionEntity(serverId, itemId, existing?.cfi ?: "", updatedAt))
+    }
+}
+```
+
+- [ ] **Step 5: Run the ebook store regression test (must stay green)**
+
+```bash
+export JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"
+./gradlew :core:data:testDebugUnitTest --tests "com.riffle.core.data.ReadingPositionStoreTest"
+```
+Expected: BUILD SUCCESSFUL, all 7 tests pass (proves the refactor preserved behavior).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add core/domain/src/main/kotlin/com/riffle/core/domain/PositionStore.kt \
+        core/domain/src/main/kotlin/com/riffle/core/domain/ReadingPositionStore.kt \
+        core/data/src/main/kotlin/com/riffle/core/data/TimestampedPositionStore.kt \
+        core/data/src/main/kotlin/com/riffle/core/data/ReadingPositionStoreImpl.kt
+git commit -m "refactor(position): extract shared PositionStore base from the ebook store"
+```
+
+---
+
+## Task 2: Audiobook Room table — entity, DAO, migration, schema, DI
+
+**Files:**
+- Create: `core/database/src/main/kotlin/com/riffle/core/database/AudiobookPositionEntity.kt`
+- Create: `core/database/src/main/kotlin/com/riffle/core/database/AudiobookPositionDao.kt`
+- Modify: `core/database/src/main/kotlin/com/riffle/core/database/RiffleDatabase.kt` (entities list, version, DAO getter, `MIGRATION_32_33`)
+- Modify: `core/data/src/main/kotlin/com/riffle/core/data/di/DatabaseModule.kt` (DAO provider + `addMigrations`)
+- Generated: `core/database/schemas/com.riffle.core.database.RiffleDatabase/33.json`
+
+- [ ] **Step 1: Create the entity**
+
+`core/database/src/main/kotlin/com/riffle/core/database/AudiobookPositionEntity.kt`:
+```kotlin
+package com.riffle.core.database
+
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+
+// The audiobook listen position (book-absolute seconds) + the wall-clock it was last set at, stored
+// per (serverId, itemId) — the same identity and FK-cascade as `reading_positions`. Server-synced
+// (unlike the device-local `readaloud_resume_positions`): it is a durable last-update-wins peer
+// against ABS's media-progress record (ADR 0029).
+@Entity(
+    tableName = "audiobook_positions",
+    primaryKeys = ["serverId", "itemId"],
+    foreignKeys = [
+        ForeignKey(
+            entity = ServerEntity::class,
+            parentColumns = ["id"],
+            childColumns = ["serverId"],
+            onDelete = ForeignKey.CASCADE,
+        ),
+    ],
+    indices = [Index("serverId")],
+)
+data class AudiobookPositionEntity(
+    val serverId: String,
+    val itemId: String,
+    val positionSec: Double,
+    val localUpdatedAt: Long = 0,
+)
+```
+
+- [ ] **Step 2: Create the DAO**
+
+`core/database/src/main/kotlin/com/riffle/core/database/AudiobookPositionDao.kt`:
+```kotlin
+package com.riffle.core.database
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+
+@Dao
+interface AudiobookPositionDao {
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsert(entity: AudiobookPositionEntity)
+
+    @Query("SELECT * FROM audiobook_positions WHERE serverId = :serverId AND itemId = :itemId LIMIT 1")
+    suspend fun getByItemId(serverId: String, itemId: String): AudiobookPositionEntity?
+}
+```
+
+- [ ] **Step 3: Register the entity + DAO and bump the version in `RiffleDatabase.kt`**
+
+In the `@Database` `entities = [...]` list, add after `AudioPlaybackPreferencesEntity::class,` (currently line 25):
+```kotlin
+        AudioPlaybackPreferencesEntity::class,
+        AudiobookPositionEntity::class,
+```
+Change the version (currently line 27):
+```kotlin
+    version = 33,
+```
+Add the DAO getter after `audioPlaybackPreferencesDao()` (currently line 44):
+```kotlin
+    abstract fun audioPlaybackPreferencesDao(): AudioPlaybackPreferencesDao
+    abstract fun audiobookPositionDao(): AudiobookPositionDao
+```
+
+- [ ] **Step 4: Add `MIGRATION_32_33` in the `companion object`**
+
+In `RiffleDatabase.kt`, immediately after the `MIGRATION_31_32` object (currently ends line 658), inside the `companion object`:
+```kotlin
+        // Durable local audiobook listen position (ADR 0029): book-absolute seconds + the wall-clock
+        // it was last set at, keyed by (serverId, itemId) with serverId FK-cascade — mirrors
+        // `reading_positions`. Server-synced (a last-update-wins peer against ABS), unlike the
+        // device-local readaloud resume table.
+        val MIGRATION_32_33 = object : Migration(32, 33) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL(
+                    "CREATE TABLE IF NOT EXISTS `audiobook_positions` (" +
+                        "`serverId` TEXT NOT NULL, " +
+                        "`itemId` TEXT NOT NULL, " +
+                        "`positionSec` REAL NOT NULL, " +
+                        "`localUpdatedAt` INTEGER NOT NULL, " +
+                        "PRIMARY KEY(`serverId`, `itemId`), " +
+                        "FOREIGN KEY(`serverId`) REFERENCES `servers`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE)"
+                )
+                db.execSQL(
+                    "CREATE INDEX IF NOT EXISTS `index_audiobook_positions_serverId` " +
+                        "ON `audiobook_positions` (`serverId`)"
+                )
+            }
+        }
+```
+
+- [ ] **Step 5: Provide the DAO and register the migration in `DatabaseModule.kt`**
+
+Add the migration to the `addMigrations(...)` call after `RiffleDatabase.MIGRATION_31_32,` (currently line 66):
+```kotlin
+                RiffleDatabase.MIGRATION_31_32,
+                RiffleDatabase.MIGRATION_32_33,
+```
+Add a DAO provider after `provideAudioPlaybackPreferencesDao` (currently lines 102-104):
+```kotlin
+    @Provides
+    @Singleton
+    fun provideAudiobookPositionDao(db: RiffleDatabase): AudiobookPositionDao = db.audiobookPositionDao()
+```
+Add the import near the other DAO imports at the top of the file:
+```kotlin
+import com.riffle.core.database.AudiobookPositionDao
+```
+
+- [ ] **Step 6: Build to export schema `33.json`**
+
+```bash
+export JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"
+./gradlew :core:database:compileDebugKotlin
+```
+Expected: BUILD SUCCESSFUL and a new file `core/database/schemas/com.riffle.core.database.RiffleDatabase/33.json` exists. Verify:
+```bash
+ls core/database/schemas/com.riffle.core.database.RiffleDatabase/33.json
+grep -c "audiobook_positions" core/database/schemas/com.riffle.core.database.RiffleDatabase/33.json
+```
+Expected: the file exists and the grep count is ≥ 1.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add core/database/src/main/kotlin/com/riffle/core/database/AudiobookPositionEntity.kt \
+        core/database/src/main/kotlin/com/riffle/core/database/AudiobookPositionDao.kt \
+        core/database/src/main/kotlin/com/riffle/core/database/RiffleDatabase.kt \
+        core/data/src/main/kotlin/com/riffle/core/data/di/DatabaseModule.kt \
+        core/database/schemas/com.riffle.core.database.RiffleDatabase/33.json
+git commit -m "feat(database): add audiobook_positions table (migration 32→33)"
+```
+
+---
+
+## Task 3: Migration test for 32→33
+
+**Files:**
+- Modify: `core/database/src/androidTest/kotlin/com/riffle/core/database/MigrationTest.kt`
+
+- [ ] **Step 1: Add `migration32To33_addsAudiobookPositionsTable`**
+
+Insert this `@Test` immediately before `fun migrateFullChain()` (currently line 1352-1353, the `@Test` line above it):
+```kotlin
+    @Test
+    fun migration32To33_addsAudiobookPositionsTable() {
+        helper.createDatabase(TEST_DB, 32).use { db ->
+            db.execSQL(
+                "INSERT INTO servers (id, url, isActive, insecureConnectionAllowed, username, serverType) " +
+                    "VALUES ('s1', 'http://media-server', 1, 0, 'test', 'AUDIOBOOKSHELF')"
+            )
+        }
+
+        val db = helper.runMigrationsAndValidate(TEST_DB, 33, true, RiffleDatabase.MIGRATION_32_33)
+
+        // The new table exists and is empty (no rows are backfilled).
+        db.query("SELECT COUNT(*) FROM audiobook_positions").use { cursor ->
+            cursor.moveToFirst()
+            assertEquals(0, cursor.getInt(0))
+        }
+
+        // A position row is writable and reads back with its seconds + timestamp intact.
+        db.execSQL(
+            "INSERT INTO audiobook_positions (serverId, itemId, positionSec, localUpdatedAt) " +
+                "VALUES ('s1', '42', 123.5, 1700000000000)"
+        )
+        db.query(
+            "SELECT positionSec, localUpdatedAt FROM audiobook_positions WHERE serverId = 's1' AND itemId = '42'"
+        ).use { cursor ->
+            assertEquals(1, cursor.count)
+            cursor.moveToFirst()
+            assertEquals(123.5, cursor.getDouble(0), 0.0001)
+            assertEquals(1700000000000L, cursor.getLong(1))
+        }
+
+        // FK cascade: removing the Server clears its audiobook positions.
+        db.execSQL("PRAGMA foreign_keys = ON")
+        db.execSQL("DELETE FROM servers WHERE id = 's1'")
+        db.query("SELECT COUNT(*) FROM audiobook_positions").use { cursor ->
+            cursor.moveToFirst()
+            assertEquals(0, cursor.getInt(0))
+        }
+    }
+```
+
+- [ ] **Step 2: Extend `migrateFullChain` to 33**
+
+In `migrateFullChain()`, change the target version in the `runMigrationsAndValidate` call from `32` to `33` (currently line 1361) and add `MIGRATION_32_33` after `MIGRATION_31_32` in that call's argument list (currently line 1392):
+```kotlin
+        val db = helper.runMigrationsAndValidate(
+            TEST_DB, 33, true,
+```
+```kotlin
+            RiffleDatabase.MIGRATION_31_32,
+            RiffleDatabase.MIGRATION_32_33,
+        )
+```
+
+- [ ] **Step 3: Run the migration tests**
+
+```bash
+make harness-test
+```
+(Migration tests are phone-form-factor androidTest; `make harness-test` boots the Harness AVD and runs them.) Expected: `migration32To33_addsAudiobookPositionsTable` and `migrateFullChain` pass.
+
+> Note (from project memory): a handful of *pre-existing* `MigrationTest` steps fail on `main` due to schema-JSON drift unrelated to this change. Confirm the two tests above pass and that you have not introduced any *new* failures; do not chase the known-failing ones here.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add core/database/src/androidTest/kotlin/com/riffle/core/database/MigrationTest.kt
+git commit -m "test(database): migration 32→33 creates audiobook_positions"
+```
+
+---
+
+## Task 4: `AudiobookPositionStore` + impl + DI + unit test
+
+**Files:**
+- Create: `core/domain/src/main/kotlin/com/riffle/core/domain/AudiobookPositionStore.kt`
+- Create: `core/data/src/main/kotlin/com/riffle/core/data/AudiobookPositionStoreImpl.kt`
+- Modify: `core/data/src/main/kotlin/com/riffle/core/data/di/DataModule.kt` (bind + imports)
+- Test: `core/data/src/test/kotlin/com/riffle/core/data/AudiobookPositionStoreTest.kt`
+
+- [ ] **Step 1: Write the failing store test**
+
+`core/data/src/test/kotlin/com/riffle/core/data/AudiobookPositionStoreTest.kt`:
+```kotlin
+package com.riffle.core.data
+
+import com.riffle.core.database.AudiobookPositionDao
+import com.riffle.core.database.AudiobookPositionEntity
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class AudiobookPositionStoreTest {
+
+    private class FakeAudiobookPositionDao : AudiobookPositionDao {
+        private val entities: MutableMap<Pair<String, String>, AudiobookPositionEntity> = mutableMapOf()
+        val store: Map<Pair<String, String>, AudiobookPositionEntity> get() = entities
+        fun seed(entity: AudiobookPositionEntity) { entities[entity.serverId to entity.itemId] = entity }
+        override suspend fun upsert(entity: AudiobookPositionEntity) {
+            entities[entity.serverId to entity.itemId] = entity
+        }
+        override suspend fun getByItemId(serverId: String, itemId: String): AudiobookPositionEntity? =
+            entities[serverId to itemId]
+    }
+
+    @Test
+    fun `save persists the seconds for the given item`() = runTest {
+        val dao = FakeAudiobookPositionDao()
+        val store = AudiobookPositionStoreImpl(dao)
+        store.save("server-A", "item-1", 123.5)
+        assertEquals(123.5, dao.store["server-A" to "item-1"]?.positionSec ?: 0.0, 0.0001)
+    }
+
+    @Test
+    fun `load returns the saved seconds`() = runTest {
+        val dao = FakeAudiobookPositionDao().also {
+            it.seed(AudiobookPositionEntity("server-A", "item-1", 42.0, 1L))
+        }
+        val store = AudiobookPositionStoreImpl(dao)
+        assertEquals(42.0, store.load("server-A", "item-1")!!, 0.0001)
+    }
+
+    @Test
+    fun `load returns null for an item with no saved position`() = runTest {
+        val store = AudiobookPositionStoreImpl(FakeAudiobookPositionDao())
+        assertNull(store.load("server-A", "item-new"))
+    }
+
+    @Test
+    fun `save overwrites the previous position for the same server-item`() = runTest {
+        val dao = FakeAudiobookPositionDao()
+        val store = AudiobookPositionStoreImpl(dao)
+        store.save("server-A", "item-1", 10.0)
+        store.save("server-A", "item-1", 99.0)
+        assertEquals(99.0, store.load("server-A", "item-1")!!, 0.0001)
+    }
+
+    @Test
+    fun `save stamps localUpdatedAt with current time`() = runTest {
+        val dao = FakeAudiobookPositionDao()
+        val store = AudiobookPositionStoreImpl(dao)
+        val before = System.currentTimeMillis()
+        store.save("server-A", "item-1", 1.0)
+        val after = System.currentTimeMillis()
+        val ts = dao.store["server-A" to "item-1"]?.localUpdatedAt ?: 0L
+        assert(ts in before..after) { "Expected timestamp in [$before..$after] but was $ts" }
+    }
+
+    @Test
+    fun `loadLocalUpdatedAt defaults to zero for a missing row`() = runTest {
+        val store = AudiobookPositionStoreImpl(FakeAudiobookPositionDao())
+        assertEquals(0L, store.loadLocalUpdatedAt("server-A", "item-new"))
+    }
+
+    @Test
+    fun `updateLocalTimestamp creates a row when none exists so it is not silently dropped`() = runTest {
+        val dao = FakeAudiobookPositionDao()
+        val store = AudiobookPositionStoreImpl(dao)
+        store.updateLocalTimestamp("server-A", "item-1", 555L)
+        assertEquals(555L, store.loadLocalUpdatedAt("server-A", "item-1"))
+    }
+
+    @Test
+    fun `positions for the same itemId on different servers are isolated`() = runTest {
+        val dao = FakeAudiobookPositionDao()
+        val store = AudiobookPositionStoreImpl(dao)
+        store.save("server-A", "item-1", 10.0)
+        store.save("server-B", "item-1", 99.0)
+        assertEquals(10.0, store.load("server-A", "item-1")!!, 0.0001)
+        assertEquals(99.0, store.load("server-B", "item-1")!!, 0.0001)
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+export JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"
+./gradlew :core:data:testDebugUnitTest --tests "com.riffle.core.data.AudiobookPositionStoreTest"
+```
+Expected: FAIL — unresolved reference `AudiobookPositionStoreImpl` (and `AudiobookPositionStore`).
+
+- [ ] **Step 3: Create the domain interface**
+
+`core/domain/src/main/kotlin/com/riffle/core/domain/AudiobookPositionStore.kt`:
+```kotlin
+package com.riffle.core.domain
+
+/** The audiobook listen position (book-absolute seconds), stored per (serverId, itemId). */
+interface AudiobookPositionStore : PositionStore<Double>
+```
+
+- [ ] **Step 4: Create the impl on the shared base**
+
+`core/data/src/main/kotlin/com/riffle/core/data/AudiobookPositionStoreImpl.kt`:
+```kotlin
+package com.riffle.core.data
+
+import com.riffle.core.database.AudiobookPositionDao
+import com.riffle.core.database.AudiobookPositionEntity
+import com.riffle.core.domain.AudiobookPositionStore
+import javax.inject.Inject
+
+class AudiobookPositionStoreImpl @Inject constructor(
+    private val dao: AudiobookPositionDao,
+) : TimestampedPositionStore<Double>(), AudiobookPositionStore {
+
+    override suspend fun writePayload(serverId: String, itemId: String, payload: Double, updatedAt: Long) {
+        dao.upsert(AudiobookPositionEntity(serverId, itemId, payload, updatedAt))
+    }
+
+    override suspend fun readPayload(serverId: String, itemId: String): Double? =
+        dao.getByItemId(serverId, itemId)?.positionSec
+
+    override suspend fun readUpdatedAt(serverId: String, itemId: String): Long? =
+        dao.getByItemId(serverId, itemId)?.localUpdatedAt
+
+    override suspend fun writeUpdatedAt(serverId: String, itemId: String, updatedAt: Long) {
+        // upsert so a stamp before the first save still creates a row (see ReadingPositionStoreImpl).
+        val existing = dao.getByItemId(serverId, itemId)
+        dao.upsert(AudiobookPositionEntity(serverId, itemId, existing?.positionSec ?: 0.0, updatedAt))
+    }
+}
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+```bash
+./gradlew :core:data:testDebugUnitTest --tests "com.riffle.core.data.AudiobookPositionStoreTest"
+```
+Expected: PASS (all 8 tests).
+
+- [ ] **Step 6: Bind the store in `DataModule.kt`**
+
+Add the `@Binds` after `bindReadingPositionStore` (currently lines 209-211):
+```kotlin
+    @Binds
+    @Singleton
+    abstract fun bindAudiobookPositionStore(impl: AudiobookPositionStoreImpl): AudiobookPositionStore
+```
+Add imports near the existing ones (`ReadingPositionStoreImpl` import is at line 28; `ReadingPositionStore` at line 57):
+```kotlin
+import com.riffle.core.data.AudiobookPositionStoreImpl
+```
+```kotlin
+import com.riffle.core.domain.AudiobookPositionStore
+```
+
+- [ ] **Step 7: Verify the module compiles (Hilt graph)**
+
+```bash
+./gradlew :core:data:compileDebugKotlin
+```
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add core/domain/src/main/kotlin/com/riffle/core/domain/AudiobookPositionStore.kt \
+        core/data/src/main/kotlin/com/riffle/core/data/AudiobookPositionStoreImpl.kt \
+        core/data/src/main/kotlin/com/riffle/core/data/di/DataModule.kt \
+        core/data/src/test/kotlin/com/riffle/core/data/AudiobookPositionStoreTest.kt
+git commit -m "feat(audiobook): AudiobookPositionStore backed by the shared position base"
+```
+
+---
+
+## Task 5: `AudiobookPositionReconciler` (pure last-update-wins) + test
+
+**Files:**
+- Create: `core/domain/src/main/kotlin/com/riffle/core/domain/AudiobookPositionReconciler.kt`
+- Test: `core/domain/src/test/kotlin/com/riffle/core/domain/AudiobookPositionReconcilerTest.kt`
+
+- [ ] **Step 1: Write the failing reconciler test**
+
+`core/domain/src/test/kotlin/com/riffle/core/domain/AudiobookPositionReconcilerTest.kt`:
+```kotlin
+package com.riffle.core.domain
+
+import com.riffle.core.domain.AudiobookPositionReconciler.Decision
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class AudiobookPositionReconcilerTest {
+
+    @Test
+    fun `remote newer than local pulls the remote position`() {
+        val d = AudiobookPositionReconciler.reconcile(
+            localSec = 10.0, localUpdatedAt = 100L, remoteSec = 50.0, remoteUpdatedAt = 200L,
+        )
+        assertEquals(Decision.PullRemote(50.0, 200L), d)
+    }
+
+    @Test
+    fun `local newer than remote pushes the local position`() {
+        val d = AudiobookPositionReconciler.reconcile(
+            localSec = 80.0, localUpdatedAt = 300L, remoteSec = 50.0, remoteUpdatedAt = 200L,
+        )
+        assertEquals(Decision.PushLocal(80.0, 300L), d)
+    }
+
+    @Test
+    fun `equal timestamps are in sync`() {
+        val d = AudiobookPositionReconciler.reconcile(
+            localSec = 80.0, localUpdatedAt = 200L, remoteSec = 50.0, remoteUpdatedAt = 200L,
+        )
+        assertEquals(Decision.InSync, d)
+    }
+
+    @Test
+    fun `no local row with a server stamp pulls the remote`() {
+        val d = AudiobookPositionReconciler.reconcile(
+            localSec = null, localUpdatedAt = 0L, remoteSec = 50.0, remoteUpdatedAt = 200L,
+        )
+        assertEquals(Decision.PullRemote(50.0, 200L), d)
+    }
+
+    @Test
+    fun `no local row and no server stamp is in sync`() {
+        val d = AudiobookPositionReconciler.reconcile(
+            localSec = null, localUpdatedAt = 0L, remoteSec = 0.0, remoteUpdatedAt = 0L,
+        )
+        assertEquals(Decision.InSync, d)
+    }
+
+    @Test
+    fun `a local stamp of zero never pushes even if remote is also zero`() {
+        val d = AudiobookPositionReconciler.reconcile(
+            localSec = 80.0, localUpdatedAt = 0L, remoteSec = 0.0, remoteUpdatedAt = 0L,
+        )
+        assertEquals(Decision.InSync, d)
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+export JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"
+./gradlew :core:domain:test --tests "com.riffle.core.domain.AudiobookPositionReconcilerTest"
+```
+Expected: FAIL — unresolved reference `AudiobookPositionReconciler`.
+
+- [ ] **Step 3: Create the reconciler**
+
+`core/domain/src/main/kotlin/com/riffle/core/domain/AudiobookPositionReconciler.kt`:
+```kotlin
+package com.riffle.core.domain
+
+/**
+ * Pure last-update-wins reconciliation for the audiobook's single durable local position against
+ * ABS's media-progress record (ADR 0029). Mirrors [StorytellerPositionReconciler] but over absolute
+ * seconds: whichever side has the newer timestamp wins; ties stay in sync (local-favoured). The
+ * caller resolves the offline case (a missing local row → [localSec] null, [localUpdatedAt] 0).
+ */
+object AudiobookPositionReconciler {
+
+    sealed interface Decision {
+        /** Remote is newer — resume at it and adopt its timestamp into the local row. */
+        data class PullRemote(val positionSec: Double, val timestampMillis: Long) : Decision
+        /** Local is newer — resume at it (the follow loop / push converges ABS). */
+        data class PushLocal(val positionSec: Double, val timestampMillis: Long) : Decision
+        data object InSync : Decision
+    }
+
+    fun reconcile(
+        localSec: Double?,
+        localUpdatedAt: Long,
+        remoteSec: Double,
+        remoteUpdatedAt: Long,
+    ): Decision = when {
+        remoteUpdatedAt > localUpdatedAt ->
+            Decision.PullRemote(remoteSec, remoteUpdatedAt)
+        localSec != null && localUpdatedAt > remoteUpdatedAt && localUpdatedAt > 0 ->
+            Decision.PushLocal(localSec, localUpdatedAt)
+        else -> Decision.InSync
+    }
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+./gradlew :core:domain:test --tests "com.riffle.core.domain.AudiobookPositionReconcilerTest"
+```
+Expected: PASS (all 6 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add core/domain/src/main/kotlin/com/riffle/core/domain/AudiobookPositionReconciler.kt \
+        core/domain/src/test/kotlin/com/riffle/core/domain/AudiobookPositionReconcilerTest.kt
+git commit -m "feat(audiobook): pure last-update-wins position reconciler"
+```
+
+---
+
+## Task 6: Carry ABS `serverLastUpdate` on the session
+
+**Files:**
+- Modify: `core/domain/src/main/kotlin/com/riffle/core/domain/AudiobookRepository.kt` (add field)
+- Modify: `core/data/src/main/kotlin/com/riffle/core/data/AudiobookRepositoryImpl.kt` (populate it)
+- Test: `core/data/src/test/kotlin/com/riffle/core/data/AudiobookRepositoryImplTest.kt`
+
+- [ ] **Step 1: Add the field to `AudiobookSession`**
+
+In `core/domain/src/main/kotlin/com/riffle/core/domain/AudiobookRepository.kt`, change the data class (lines 8-13) to add `serverLastUpdate` with a default so the downloaded-session builder compiles unchanged:
+```kotlin
+data class AudiobookSession(
+    val trackUrls: List<String>,
+    val tracks: List<AudiobookTrackSpan>,
+    val timeline: AudiobookTimeline,
+    val serverCurrentTimeSec: Double,
+    // ABS's server-side `lastUpdate` (ms) for this item's media-progress record, for last-update-wins
+    // resume against the durable local store. 0 when unknown (offline / downloaded session).
+    val serverLastUpdate: Long = 0,
+)
+```
+
+- [ ] **Step 2: Write the failing repository test**
+
+Add this `@Test` to `core/data/src/test/kotlin/com/riffle/core/data/AudiobookRepositoryImplTest.kt` (after the existing `openSession builds...` test, around line 77). It uses a session API stub that returns a progress record with a `lastUpdate`:
+```kotlin
+    @Test
+    fun `openSession carries the server lastUpdate from the progress record`() = runTest {
+        val playback = FakePlaybackApi(
+            NetworkPlaybackSessionResult.Success(
+                NetworkPlaybackSession(
+                    sessionId = "ps",
+                    tracks = listOf(NetworkAudioTrack(0, 0.0, 100.0, "/api/items/it/file/1", "audio/mpeg")),
+                    chapters = emptyList(),
+                    currentTimeSec = 42.0,
+                    durationSec = 100.0,
+                ),
+            ),
+        )
+        val session = object : AbsSessionApi by NoopSessionApi {
+            override suspend fun getProgress(
+                baseUrl: String, libraryItemId: String, token: String, insecureAllowed: Boolean,
+            ) = NetworkGetProgressResult.Success(
+                com.riffle.core.network.NetworkServerProgress(
+                    ebookLocation = "", ebookProgress = 0f, currentTime = 42.0, duration = 100.0,
+                    lastUpdate = 1700000000000L,
+                ),
+            )
+        }
+
+        val s = repo(playback, session).openSession("srv", "it")!!
+
+        assertEquals(1700000000000L, s.serverLastUpdate)
+    }
+
+    @Test
+    fun `openSession defaults serverLastUpdate to zero when the progress read fails`() = runTest {
+        val playback = FakePlaybackApi(
+            NetworkPlaybackSessionResult.Success(
+                NetworkPlaybackSession(
+                    sessionId = "ps",
+                    tracks = listOf(NetworkAudioTrack(0, 0.0, 100.0, "/api/items/it/file/1", "audio/mpeg")),
+                    chapters = emptyList(),
+                    currentTimeSec = 42.0,
+                    durationSec = 100.0,
+                ),
+            ),
+        )
+        // NoopSessionApi.getProgress returns NetworkError → no stamp available.
+        val s = repo(playback).openSession("srv", "it")!!
+        assertEquals(0L, s.serverLastUpdate)
+    }
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+```bash
+export JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"
+./gradlew :core:data:testDebugUnitTest --tests "com.riffle.core.data.AudiobookRepositoryImplTest"
+```
+Expected: FAIL — `serverLastUpdate` is always 0 (the field isn't populated yet), so the first new test fails on `assertEquals(1700000000000L, ...)`.
+
+- [ ] **Step 4: Populate `serverLastUpdate` in `openSession`**
+
+In `core/data/src/main/kotlin/com/riffle/core/data/AudiobookRepositoryImpl.kt`, add a progress read just before the `return AudiobookSession(...)` (currently line 57), and pass it through. Replace the return block (lines 57-62):
+```kotlin
+        // Read ABS's server-side lastUpdate so the player can last-update-wins resume against the
+        // durable local store. A failed read leaves it 0 (the play-session currentTime still resumes).
+        val serverLastUpdate = (
+            sessionApi.getProgress(
+                baseUrl = server.url.value,
+                libraryItemId = itemId,
+                token = token,
+                insecureAllowed = server.insecureConnectionAllowed,
+            ) as? com.riffle.core.network.NetworkGetProgressResult.Success
+        )?.progress?.lastUpdate ?: 0L
+
+        return AudiobookSession(
+            trackUrls = trackUrls,
+            tracks = spans,
+            timeline = timeline,
+            serverCurrentTimeSec = session.currentTimeSec,
+            serverLastUpdate = serverLastUpdate,
+        )
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+```bash
+./gradlew :core:data:testDebugUnitTest --tests "com.riffle.core.data.AudiobookRepositoryImplTest"
+```
+Expected: PASS — all existing tests plus the two new ones (the existing `openSession builds...` test still passes because `NoopSessionApi.getProgress` returns an error → `serverLastUpdate = 0`, and that test doesn't assert on it).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add core/domain/src/main/kotlin/com/riffle/core/domain/AudiobookRepository.kt \
+        core/data/src/main/kotlin/com/riffle/core/data/AudiobookRepositoryImpl.kt \
+        core/data/src/test/kotlin/com/riffle/core/data/AudiobookRepositoryImplTest.kt
+git commit -m "feat(audiobook): carry ABS server lastUpdate on the opened session"
+```
+
+---
+
+## Task 7: Wire the store into the player — write paths
+
+**Files:**
+- Modify: `app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModel.kt`
+
+This task makes the player *persist* the position (hot path on the follow loop + cold path on close). Resume reconciliation is Task 8.
+
+- [ ] **Step 1: Inject `AudiobookPositionStore` into the ViewModel**
+
+In the constructor of `AudiobookPlayerViewModel` (currently ends with `nowPlayingStore` at line 63), add a parameter:
+```kotlin
+    private val nowPlayingStore: com.riffle.app.playback.NowPlayingStore,
+    private val audiobookPositionStore: com.riffle.core.domain.AudiobookPositionStore,
+) : ViewModel() {
+```
+
+- [ ] **Step 2: Make the coordinator actually persist the position**
+
+Replace the `positionSaveCoordinator` declaration (currently lines 100-107) with one that supplies `savePosition`:
+```kotlin
+    // Shared local-persistence policy with the ebook reader. Hot path (follow-loop tick): persist the
+    // listen position to the durable audiobook store so it survives process death and can win the
+    // last-update-wins resume. Cold path (pause/close): also write the `readingProgress` float for the
+    // library/detail screens. Backend (ABS) sync runs outside this coordinator (ADR 0029).
+    private val positionSaveCoordinator = com.riffle.app.feature.reader.PositionSaveCoordinator(
+        updateProgress = { progress -> libraryRepository.updateReadingProgress(itemId, progress) },
+        savePosition = { pos -> if (serverId.isNotEmpty()) audiobookPositionStore.save(serverId, itemId, pos) },
+    )
+```
+(The generic type `<Double>` is now inferred from the `savePosition` lambda; keep `PositionSaveCoordinator<Double>(...)` explicit if the compiler complains.)
+
+- [ ] **Step 3: Persist on the follow-loop advancing ticks**
+
+In `startFollowLoop()`, add a hot-path `onChanged(pos)` on the two branches where a genuine forward listen occurs. In the matched advancing branch (currently lines 242-246), after `localUpdatedAt = maxOf(localUpdatedAt, r.canonicalLastUpdate)`:
+```kotlin
+                    if (playing && pos >= reconciledResumeSec - SETTLE_EPS_SEC) {
+                        localUpdatedAt = System.currentTimeMillis()
+                        reconciledResumeSec = maxOf(reconciledResumeSec, pos)
+                        val r = rs.runAudioLedCycle(pos, localUpdatedAt)
+                        localUpdatedAt = maxOf(localUpdatedAt, r.canonicalLastUpdate)
+                        positionSaveCoordinator.onChanged(pos)
+                    } else {
+```
+And in the single-peer advancing branch (currently lines 252-257), alongside `saveProgress()`:
+```kotlin
+                } else if (playing && pos >= reconciledResumeSec - SETTLE_EPS_SEC) {
+                    // single-peer: push the ABS audiobook currentTime, but never a transient position
+                    // below the resume (which would regress the record).
+                    reconciledResumeSec = maxOf(reconciledResumeSec, pos)
+                    saveProgress()
+                    positionSaveCoordinator.onChanged(pos)
+                }
+```
+(The cold-path `positionSaveCoordinator.onClose(pos, fraction)` in `pushProgressOnStop()` at line 342 is already present and now persists the position too — no change needed there.)
+
+- [ ] **Step 4: Compile the app module**
+
+```bash
+export JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"
+./gradlew :app:compileDebugKotlin
+```
+Expected: BUILD SUCCESSFUL (Hilt resolves `AudiobookPositionStore` from the `@Binds` in Task 4).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModel.kt
+git commit -m "feat(audiobook): persist listen position on the follow loop and close"
+```
+
+---
+
+## Task 8: Wire last-update-wins resume + matched-attach durability
+
+**Files:**
+- Modify: `app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModel.kt`
+
+- [ ] **Step 1: Reconcile against the local store on open, before `prepare`**
+
+In `init { ... }`, after `timeline = session.timeline` (currently line 139) and before the speed/`meta` block, insert the reconcile. It computes the resume position and its timestamp:
+```kotlin
+            timeline = session.timeline
+            // Last-update-wins resume against the durable local store (mirrors the ebook reader): if
+            // our last listen position is newer than ABS's record — e.g. a final flush was dropped at
+            // teardown — resume from it; otherwise adopt the server position and stamp the local row so
+            // it does not re-push (ADR 0029).
+            val localSec = audiobookPositionStore.load(serverId, itemId)
+            val localTs = audiobookPositionStore.loadLocalUpdatedAt(serverId, itemId)
+            val resumeSec: Double
+            val resumeUpdatedAt: Long
+            when (
+                val decision = com.riffle.core.domain.AudiobookPositionReconciler.reconcile(
+                    localSec = localSec,
+                    localUpdatedAt = localTs,
+                    remoteSec = session.serverCurrentTimeSec,
+                    remoteUpdatedAt = session.serverLastUpdate,
+                )
+            ) {
+                is com.riffle.core.domain.AudiobookPositionReconciler.Decision.PullRemote -> {
+                    audiobookPositionStore.save(serverId, itemId, decision.positionSec)
+                    audiobookPositionStore.updateLocalTimestamp(serverId, itemId, decision.timestampMillis)
+                    resumeSec = decision.positionSec
+                    resumeUpdatedAt = decision.timestampMillis
+                }
+                is com.riffle.core.domain.AudiobookPositionReconciler.Decision.PushLocal -> {
+                    resumeSec = decision.positionSec
+                    resumeUpdatedAt = decision.timestampMillis
+                }
+                com.riffle.core.domain.AudiobookPositionReconciler.Decision.InSync -> {
+                    resumeSec = session.serverCurrentTimeSec
+                    resumeUpdatedAt = session.serverLastUpdate
+                }
+            }
+```
+
+- [ ] **Step 2: Resume the controller at the reconciled position**
+
+Change the `controller.prepare(...)` `startAtSec` argument (currently line 167) from `session.serverCurrentTimeSec` to `resumeSec`:
+```kotlin
+            controller.prepare(
+                trackUrls = session.trackUrls,
+                spans = session.tracks,
+                durationSec = session.timeline.durationSec,
+                startAtSec = resumeSec,
+            )
+```
+And change the `reconciledResumeSec` / seed lines (currently line 175 sets `reconciledResumeSec = session.serverCurrentTimeSec`) to use the reconciled values:
+```kotlin
+            reconciledResumeSec = resumeSec
+            localUpdatedAt = resumeUpdatedAt
+```
+(`localUpdatedAt` is declared at line 91; seeding it here means a local-won resume can lead the matched cycle.)
+
+- [ ] **Step 3: Give `attachReaderSync` an explicit position + timestamp**
+
+Change the signature of `attachReaderSync` (currently line 204) and its cycle call (line 211) so the open call can pass the reconciled resume (avoiding a transient live-clock read) and let a genuinely-newer local lead:
+```kotlin
+    private suspend fun attachReaderSync(atSec: Double, atUpdatedAt: Long): Boolean {
+        if (readerSync != null || serverId.isEmpty()) return readerSync != null
+        val rs = readerSyncFactory.createIfApplicable(itemId) ?: return false
+        readerSync = rs
+        // Seed the first cycle with the reconciled resume (not the live clock, which may not have
+        // settled) and its timestamp: a genuinely-newer local listen leads and propagates to the ebook
+        // CFI + audiobook record; a newer remote (e.g. an ABS-web read) still wins and seeks. Passing 0
+        // here (the self-heal mid-session attach) keeps it inbound-only so a not-yet-advanced position
+        // can never lead.
+        val r = rs.runAudioLedCycle(atSec, atUpdatedAt)
+        r.jumpToAudioSec?.let { controller.seekTo(it); reconciledResumeSec = it }
+        localUpdatedAt = maxOf(localUpdatedAt, r.canonicalLastUpdate)
+        return true
+    }
+```
+
+- [ ] **Step 4: Update the open-time attach call**
+
+In `init`, change the `attachReaderSync()` call (currently line 190) to pass the reconciled resume:
+```kotlin
+            attachReaderSync(resumeSec, resumeUpdatedAt)
+```
+
+- [ ] **Step 5: Update the self-heal attach call (keep it inbound-only)**
+
+In `startFollowLoop()`, change the self-heal call (currently line 230) to pass the live position with timestamp 0 (unchanged behavior — inbound-only):
+```kotlin
+                if (readerSync == null && attachReaderSync(controller.currentAbsoluteSec(), 0L)) continue
+```
+
+- [ ] **Step 6: Compile the app module**
+
+```bash
+export JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"
+./gradlew :app:compileDebugKotlin
+```
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModel.kt
+git commit -m "feat(audiobook): last-update-wins resume from the local position store"
+```
+
+---
+
+## Task 9: Full verification
+
+- [ ] **Step 1: Run the whole unit suite**
+
+```bash
+export JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"
+./gradlew test
+```
+Expected: BUILD SUCCESSFUL. (Per project memory, `./gradlew test` is required — module-specific `:testDebugUnitTest` misses pure-JVM modules' `:test`.)
+
+- [ ] **Step 2: Run the migration tests on the harness AVD**
+
+```bash
+make harness-test
+```
+Expected: `migration32To33_addsAudiobookPositionsTable` and `migrateFullChain` pass; no *new* failures introduced (see the known-pre-existing-fail note in Task 3).
+
+- [ ] **Step 3: Manual device verification (no VM unit test exists for this player)**
+
+The `AudiobookPlayerViewModel` has 15 constructor dependencies and is not unit-tested in this repo (only the pure `audiobookProgressFraction` helper is). Verify the wiring on a device/emulator:
+1. Open an audiobook, listen ~30s, force-stop the app (`adb shell am force-stop com.riffle.app`) — *without* a clean pause — to simulate a dropped final flush.
+2. Reopen the audiobook → it resumes at ~30s from the local store (not 0), confirming local-can-win.
+3. With the server reachable and a *newer* position set server-side (e.g. via ABS web), reopen → it pulls the server position (remote wins).
+
+- [ ] **Step 4: Final commit (if any verification fixups were needed)**
+
+```bash
+git add -A
+git commit -m "chore(audiobook): position persistence verification fixups"
+```
+
+---
+
+## Self-review notes (addressed)
+
+- **Spec coverage:** Shared base (§1) → Task 1; audiobook table/migration (§2) → Tasks 2-3; store (§3) → Task 4; reconciler (§4) → Task 5; `serverLastUpdate` + write/resume wiring (§5) → Tasks 6-8. All spec sections map to tasks.
+- **Type consistency:** `PositionStore<P>` / `TimestampedPositionStore<P>` method names (`save`/`load`/`loadLocalUpdatedAt`/`updateLocalTimestamp`) and the four template methods (`writePayload`/`readPayload`/`readUpdatedAt`/`writeUpdatedAt`) are used identically in Tasks 1 and 4. `AudiobookPositionReconciler.Decision.{PullRemote,PushLocal,InSync}` defined in Task 5 are consumed with matching shapes in Task 8. `AudiobookSession.serverLastUpdate` defined in Task 6 is read in Task 8.
+- **Known caveat (benign):** in the matched/synced write path, `save` stamps `now()` while the in-memory `localUpdatedAt` adopts the server stamp; on a later fresh open these differ by ~ms, resolving to the same position. Documented in the spec; not worth special-casing.

--- a/docs/superpowers/specs/2026-06-12-audiobook-position-persistence-design.md
+++ b/docs/superpowers/specs/2026-06-12-audiobook-position-persistence-design.md
@@ -1,0 +1,241 @@
+# Persist audiobook playback position locally (mirror of the ebook store)
+
+**Date:** 2026-06-12
+**Status:** Approved (design)
+
+## Problem
+
+The audiobook player keeps its playback position only in memory and on the
+Audiobookshelf (ABS) server. On open it resumes from ABS's `currentTime`
+(`AudiobookPlayerViewModel.kt:167`, `reconciledResumeSec` seeded at `:175` from
+`AudiobookSession.serverCurrentTimeSec`). There is **no local audiobook-seconds
+store** — the player's `PositionSaveCoordinator` is wired but its `savePosition`
+callback is intentionally absent (`AudiobookPlayerViewModel.kt:100-104`, "the audiobook
+resumes from ABS, so there is no local position to store").
+
+This is asymmetric with the **ebook reader**, whose position is backed by the durable
+`reading_positions` Room table (`ReadingPositionStore`) and which therefore:
+
+- resumes from a local position when the local row is newer than the server, and
+- participates as a **full, durable peer** in the matched-book reconciliation cycle —
+  it seeds `localUpdatedAt` from the store (`EpubReaderViewModel.kt:575`) and is written
+  back after the cycle (`:603-605`, `:659-665`), so it can *win* and survives process
+  death.
+
+Two concrete consequences of the missing audiobook store:
+
+1. **Dropped-final-flush loss.** If the final progress PATCH is dropped at teardown
+   (the `ProgressFlushScope` failure mode this codebase has hit), the last few seconds
+   of listening position are lost — there is no local record to recover from on reopen.
+2. **Matched-book asymmetry.** In a matched ebook↔audiobook book, the ebook side is a
+   durable peer in `ReaderSync`'s cycle while the audio side is only a volatile
+   in-memory peer (`AudiobookPlayerViewModel.kt:91, 243, 248`: `localUpdatedAt` resets to
+   `0L` on process death). A genuinely-freshest local audio position cannot survive a
+   restart to win the cycle.
+
+## Goal
+
+Give the audiobook a durable local position store that **mirrors the ebook
+implementation** — a full, durable last-update-wins peer on both the single-peer
+(unmatched) and matched paths — reusing and abstracting as much of the existing
+position-store machinery as Room allows.
+
+This is the implementation of the `pkmetski/audiobook-position-persistence` branch.
+
+## Constraints that shape the design
+
+- **Room forbids generic `@Entity`/`@Dao`.** Each table needs a concrete entity and DAO.
+  So the table layer (entity + DAO + migration) is *necessarily* mirrored per type; it
+  cannot be shared. The genuinely shareable surface is the **store contract** and the
+  **timestamp/stamping policy**.
+- **Last-update-wins is feasible.** ABS returns a server-side `lastUpdate` (ms) on the
+  media-progress record: `NetworkServerProgress.lastUpdate`
+  (`core/network/.../AbsSessionApi.kt:13-20`), read via `GET /api/me/progress/{itemId}`
+  (`AbsApiClient.getProgress`). The play-session open response
+  (`NetworkPlaybackSession`) carries `currentTimeSec` but **not** `lastUpdate`, so the
+  open path must additionally read the progress record to obtain the server timestamp.
+
+## Design
+
+Five layers. Layer 1 is the shared abstraction; layer 2 is the unavoidable per-type
+mirror; layers 3–5 build the audiobook store on top and wire it into the player.
+
+### 1. Shared store core (the abstraction)
+
+Extract the contract and stamping policy currently baked into `ReadingPositionStoreImpl`
+so both stores share it:
+
+- **`PositionStore<P>`** (core/domain) — generic over payload `P`:
+  ```kotlin
+  interface PositionStore<P> {
+      suspend fun save(serverId: String, itemId: String, payload: P)
+      suspend fun load(serverId: String, itemId: String): P?
+      suspend fun loadLocalUpdatedAt(serverId: String, itemId: String): Long
+      suspend fun updateLocalTimestamp(serverId: String, itemId: String, millis: Long)
+  }
+  ```
+- **`TimestampedPositionStore<P>`** (core/data) — abstract base implementing the shared
+  policy: `save` stamps `System.currentTimeMillis()`; `loadLocalUpdatedAt` returns the
+  stored timestamp `?: 0L`. It delegates the per-type storage to four template methods:
+  ```kotlin
+  protected abstract suspend fun writePayload(serverId, itemId, payload: P, updatedAt: Long)
+  protected abstract suspend fun readPayload(serverId, itemId): P?
+  protected abstract suspend fun readUpdatedAt(serverId, itemId): Long?
+  protected abstract suspend fun writeUpdatedAt(serverId, itemId, updatedAt: Long)
+  ```
+  `now()` is a `protected open` seam so tests can supply a fixed clock.
+- **Refactor** `ReadingPositionStore` to `: PositionStore<String>` and
+  `ReadingPositionStoreImpl` to `: TimestampedPositionStore<String>()`, implementing the
+  four template methods over `ReadingPositionDao`. **Behavior is identical**; the existing
+  `ReadingPositionStoreTest` is the regression guard.
+
+Room's per-type constraint means the base is deliberately thin (the contract + the
+stamping/default policy). That is the honest extent of what is shareable; the table
+layer below is mirrored, not shared.
+
+### 2. Audiobook table (per-type mirror)
+
+Modeled exactly on `reading_positions` = payload + timestamp.
+
+`audiobook_positions`:
+
+| column           | type    | notes                                              |
+|------------------|---------|----------------------------------------------------|
+| `serverId`       | TEXT    | PK part 1; FK → `servers(id)` ON DELETE CASCADE    |
+| `itemId`         | TEXT    | PK part 2                                           |
+| `positionSec`    | REAL    | book-absolute listen position, seconds             |
+| `localUpdatedAt` | INTEGER | `System.currentTimeMillis()` at write              |
+
+- **`AudiobookPositionEntity`** — composite PK `(serverId, itemId)`, FK cascade, index on
+  `serverId` (mirrors `ReadingPositionEntity` / `AudioPlaybackPreferencesEntity`).
+- **`AudiobookPositionDao`** — `upsert`, `getByItemId(serverId, itemId)`,
+  `updateLocalTimestamp(serverId, itemId, millis)` (mirrors `ReadingPositionDao`).
+- **Migration `32 → 33`** per the CLAUDE.md checklist:
+  - Bump `@Database(version = 33)`; register `AudiobookPositionEntity` + the DAO getter in
+    `RiffleDatabase.kt`.
+  - `MIGRATION_32_33` creating the table + the `serverId` index (pattern of
+    `MIGRATION_31_32`, `RiffleDatabase.kt:643-658`).
+  - Build so KSP exports `core/database/schemas/.../33.json`.
+  - Register `MIGRATION_32_33` in `DataModule`'s `addMigrations(...)`.
+  - `MigrationTest.migration32To33()` (insert a row at v32-equivalent state, validate the
+    new table/columns + data preserved) and extend `migrateFullChain`.
+
+This is server-**synced** data (unlike `readaloud_resume_positions`), so the FK-cascade +
+`(serverId, itemId)` keying matches `reading_positions`, not the device-local readaloud
+table.
+
+### 3. Audiobook store
+
+- **`AudiobookPositionStore : PositionStore<Double>`** (core/domain) — payload is plain
+  `Double` seconds, matching the ebook's "no wrapper" (raw `String` CFI) choice.
+- **`AudiobookPositionStoreImpl : TimestampedPositionStore<Double>()`** (core/data) over
+  `AudiobookPositionDao` — implements the four template methods.
+- DI: `@Binds` the store in `DataModule`; `@Provides` the DAO in `DatabaseModule`
+  (mirrors the reading-position wiring).
+
+### 4. Reconciler (pure, kept separate)
+
+- **`AudiobookPositionReconciler`** (core/domain) — pure last-update-wins over
+  `(localSec, localUpdatedAt)` vs `(remoteSec, remoteUpdatedAt)` →
+  `ResumeLocal(sec) / ResumeRemote(sec, remoteUpdatedAt) / InSync(sec)`. A near-twin of
+  `StorytellerPositionReconciler`.
+
+The two reconcilers are **kept as separate types**, not merged into one generic. The
+ebook reconciler is Storyteller-locator-string-specific; the audiobook one is
+seconds-specific. Forcing them into one parameterized type yields a leaky abstraction for
+no real saving (the bodies are a three-way timestamp comparison either way). This is the
+deliberate boundary of "abstract as much as possible" — share the *store*, not the
+*reconciler*. (Decision: B, not C.)
+
+### 5. Wiring into the player
+
+The audiobook VM injects `AudiobookPositionStore` directly, exactly as
+`EpubReaderViewModel` injects `ReadingPositionStore`.
+
+**Write paths (durability on both matched and unmatched):**
+
+- Make `positionSaveCoordinator.savePosition` actually persist:
+  `{ pos -> audiobookPositionStore.save(serverId, itemId, pos) }`.
+- Call `positionSaveCoordinator.onChanged(pos)` in the **10s follow loop** (currently only
+  the cold-path `onClose` runs — `pushProgressOnStop`, `:342`). This gives hot-path
+  durability against process death, mirroring the ebook's save-on-scroll. `onChanged` is
+  invoked on the *genuinely-advancing* ticks only (the existing
+  `pos >= reconciledResumeSec - SETTLE_EPS_SEC` settle guard), so transient pre-seek /
+  buffering positions are never persisted.
+
+**Resume / matched-cycle as a durable full peer:**
+
+- **`AudiobookSession` gains `serverLastUpdate: Long`** (ms). `openSession`
+  (`AudiobookRepositoryImpl.kt:29-63`) additionally reads the progress record's
+  `lastUpdate` to populate it. For an offline/local downloaded session
+  (`audiobookDownloadRepository.localSession`) `serverLastUpdate = 0L`, so a present local
+  row naturally wins.
+- **Unmatched (single-peer) open:** the VM loads the local row
+  (`load` + `loadLocalUpdatedAt`) and runs `AudiobookPositionReconciler` against
+  `(serverCurrentTimeSec, serverLastUpdate)`. `startAtSec` = the winner. On a remote win,
+  `updateLocalTimestamp(serverLastUpdate)` + `save` the remote position locally (the ebook
+  "pull" mirror); on a local win, the local seconds drive the resume (and the existing
+  follow-loop/stop push converges ABS).
+- **Matched open + cycle:** seed the cycle's `localUpdatedAt` from
+  `audiobookPositionStore.loadLocalUpdatedAt(serverId, itemId)` instead of a bare
+  in-memory wall-clock, and after each `runAudioLedCycle` write back
+  `updateLocalTimestamp(canonicalLastUpdate)` (plus persist the seeked position on a remote
+  jump). **The existing transient-guard is preserved unchanged**: pre-settle ticks still
+  pass `localUpdatedAt = 0L` (`AudiobookPlayerViewModel.kt:248`,
+  `attachReaderSync` `:211`) so the raw audio clock can never wrongly win. The *only*
+  change is that the local peer's timestamp is now persisted — so, exactly like the ebook,
+  it survives process death and can legitimately win on restart. This is additive to the
+  canonical reconciliation, not a rewrite of it.
+
+This makes the audio side a durable full peer symmetric to the ebook side
+(`reading_positions`): both seed `localUpdatedAt` from their store, both are written back
+after the cycle, both can win, both survive process death.
+
+## Layers touched
+
+- **core/database** — `AudiobookPositionEntity`, `AudiobookPositionDao`; `@Database`
+  v32→33 + entity/DAO registration; `MIGRATION_32_33`; exported `33.json`;
+  `MigrationTest.migration32To33()` + `migrateFullChain`.
+- **core/domain** — `PositionStore<P>`; `AudiobookPositionStore`;
+  `AudiobookPositionReconciler`; refactor `ReadingPositionStore` to extend
+  `PositionStore<String>`; `AudiobookSession.serverLastUpdate`.
+- **core/data** — `TimestampedPositionStore<P>`; `AudiobookPositionStoreImpl`; refactor
+  `ReadingPositionStoreImpl` onto the base; DI in `DataModule`/`DatabaseModule`;
+  `openSession` reads + returns `serverLastUpdate`.
+- **app** — `AudiobookPlayerViewModel`: inject the store; wire `savePosition`; add
+  `onChanged` to the follow loop; reconcile on unmatched open; seed/write-back the store in
+  the matched cycle.
+
+## Testing
+
+- **Shared base / ebook store** — existing `ReadingPositionStoreTest` must stay green
+  unchanged (proves the refactor preserved behavior).
+- **`AudiobookPositionStore` round-trip** — save→load returns the seconds; overwrite
+  replaces; `save` stamps `localUpdatedAt`; `loadLocalUpdatedAt` defaults to `0L`;
+  per-`(serverId, itemId)` isolation (mirror `ReadingPositionStoreTest`).
+- **`AudiobookPositionReconciler`** — pure-unit table: local newer → `ResumeLocal`; remote
+  newer → `ResumeRemote`; ties / no local → server (`InSync` / `ResumeRemote` per the
+  ebook reconciler's tie rule).
+- **Migration** — `MigrationTest.migration32To33()` (new table + columns, pre-existing data
+  preserved) + `migrateFullChain`. Run via the core:database androidTest suite.
+- **ViewModel** — unmatched open with a newer local row resumes from local, not ABS;
+  matched cycle seeds `localUpdatedAt` from the store and persists the canonical timestamp.
+  Phone-form-factor harness test via `make harness-test`.
+- Full unit suite via `./gradlew test` (covers pure-JVM modules) before claiming green.
+
+## Out of scope
+
+- Changing the canonical multi-peer reconciliation logic in `CanonicalSyncCycle` /
+  `ReaderSync` (the change is additive: persist the local peer's timestamp; the winner
+  math is untouched).
+- Merging `AudiobookPositionReconciler` and `StorytellerPositionReconciler` into one
+  generic type (deliberately kept separate — see §4).
+- Storing `durationSec` in the table (available from the live `timeline` / session at
+  reconcile and push time; the table stays payload + timestamp like `reading_positions`).
+- Any new ABS network endpoint — reuse `getProgress` / `syncAudiobookProgress`.
+
+## Migration version coordination
+
+This branch owns **32 → 33** (`audiobook_positions`). Any sibling branch also bumping the
+schema must renumber to **33 → 34** when it lands; the changes are independent (new table),
+so sequential migrations suffice.


### PR DESCRIPTION
## What

Gives the audiobook player a **durable local position store** that mirrors the ebook reader: a full last-update-wins peer on both the single-peer (unmatched) and matched paths. Previously the audiobook position lived only in memory + on ABS, so a dropped final flush at teardown lost the position, and in matched books the ebook side was a durable sync peer while the audio side was only volatile/in-memory.

Implements `pkmetski/audiobook-position-persistence`. Spec + plan: `docs/superpowers/specs/2026-06-12-audiobook-position-persistence-design.md`, `docs/superpowers/plans/2026-06-12-audiobook-position-persistence.md`.

## How

- **Shared store core (abstraction):** extract `PositionStore<P>` (domain) + `TimestampedPositionStore<P>` (data) — the stamping + missing-row policy — and refactor the existing ebook `ReadingPositionStore` onto it. Room forbids generic entities/DAOs, so the table layer is mirrored per type; this is the genuinely shareable layer.
- **New `audiobook_positions` table** (migration 32→33): `(serverId, itemId)` PK, `positionSec`, `localUpdatedAt`, FK→servers cascade — same shape/keying as `reading_positions`. Server-synced (not device-local like the readaloud table).
- **`AudiobookPositionStore` + impl** on the shared base; **`AudiobookPositionReconciler`** (pure last-update-wins, twin of `StorytellerPositionReconciler`).
- **`AudiobookSession.serverLastUpdate`**: `openSession` reads ABS's media-progress `lastUpdate` (the play-session response doesn't carry it) to enable last-update-wins resume.
- **Player wiring:** persist on the follow loop (hot) + close (cold); reconcile local-vs-ABS on open and resume from the winner; seed the matched audio-led cycle's `localUpdatedAt` from the store and write it back — so the audio side is a durable peer symmetric to the ebook side. The existing transient-guard (`0L` on pre-settle ticks) is preserved.

## Testing

- `./gradlew test` (unit + integration) — green
- `./gradlew lint` — green
- `:core:database:connectedDebugAndroidTest` (migrations) — 34/34 incl. new `migration32To33` + `migrateFullChain` (CI runs this)
- `make harness-test` (phone) — 193 tests, 0 failed
- `make harness-test-tablet` — 5 tests, 0 failed

Self-review caught and fixed one regression: the teardown path (`pushProgressOnStop`) lacked the follow-loop's settle guard, so a transient book-start position at close could regress the resume to 0 with the new durable store — now guarded.