### PR TITLE
feat(library): show downloaded audiobooks in the library when offline

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/library/CollectionDetailViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/CollectionDetailViewModel.kt
@@ -7,12 +7,10 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.riffle.core.domain.ConnectivityObserver
-import com.riffle.core.domain.EbookFormat
-import com.riffle.core.domain.EpubRepository
 import com.riffle.core.domain.LibraryItem
+import com.riffle.core.domain.LibraryItemOfflineAvailability
 import com.riffle.core.domain.LibraryRefreshResult
 import com.riffle.core.domain.LibraryRepository
-import com.riffle.core.domain.PdfRepository
 import com.riffle.core.domain.ServerRepository
 import com.riffle.core.domain.TokenStorage
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -34,8 +32,7 @@ class CollectionDetailViewModel @Inject constructor(
     private val libraryRepository: LibraryRepository,
     private val serverRepository: ServerRepository,
     private val tokenStorage: TokenStorage,
-    private val epubRepository: EpubRepository,
-    private val pdfRepository: PdfRepository,
+    private val offlineAvailability: LibraryItemOfflineAvailability,
     private val connectivityObserver: ConnectivityObserver,
 ) : ViewModel() {
 
@@ -55,7 +52,7 @@ class CollectionDetailViewModel @Inject constructor(
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
 
     val items: StateFlow<List<LibraryItem>> = combine(allItems, isOffline) { items, offline ->
-        if (offline) items.filter { isAvailableOffline(it) } else items
+        if (offline) items.filter { offlineAvailability.isAvailableOffline(it) } else items
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
 
     var authToken: String by mutableStateOf("")
@@ -97,12 +94,6 @@ class CollectionDetailViewModel @Inject constructor(
 
     private suspend fun runRefresh() {
         _refreshFailed.value = libraryRepository.refreshCollections(libraryId) is LibraryRefreshResult.NetworkError
-    }
-
-    private fun isAvailableOffline(item: LibraryItem): Boolean = when (item.ebookFormat) {
-        EbookFormat.Epub -> epubRepository.isDownloaded(item.serverId, item.id) || epubRepository.isCached(item.serverId, item.id)
-        EbookFormat.Pdf -> pdfRepository.isDownloaded(item.serverId, item.id) || pdfRepository.isCached(item.serverId, item.id)
-        else -> false
     }
 
     private companion object {

--- a/app/src/main/kotlin/com/riffle/app/feature/library/FilteredBooksViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/FilteredBooksViewModel.kt
@@ -7,11 +7,9 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.riffle.core.domain.ConnectivityObserver
-import com.riffle.core.domain.EbookFormat
-import com.riffle.core.domain.EpubRepository
 import com.riffle.core.domain.LibraryItem
+import com.riffle.core.domain.LibraryItemOfflineAvailability
 import com.riffle.core.domain.LibraryRepository
-import com.riffle.core.domain.PdfRepository
 import com.riffle.core.domain.ReadaloudLinkRepository
 import com.riffle.core.domain.ServerRepository
 import com.riffle.core.domain.TokenStorage
@@ -37,8 +35,7 @@ class FilteredBooksViewModel @Inject constructor(
     private val libraryRepository: LibraryRepository,
     private val serverRepository: ServerRepository,
     private val tokenStorage: TokenStorage,
-    private val epubRepository: EpubRepository,
-    private val pdfRepository: PdfRepository,
+    private val offlineAvailability: LibraryItemOfflineAvailability,
     private val connectivityObserver: ConnectivityObserver,
     readaloudLinkRepository: ReadaloudLinkRepository,
 ) : ViewModel() {
@@ -59,7 +56,7 @@ class FilteredBooksViewModel @Inject constructor(
         connectivityObserver.isOnline,
     ) { all, linkedIds, online ->
         val matched = all.filter { facetMatches(it, facetType, facetValue, linkedIds) }
-        if (!online) matched.filter { isAvailableOffline(it) } else matched
+        if (!online) matched.filter { offlineAvailability.isAvailableOffline(it) } else matched
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
 
     var authToken: String by mutableStateOf("")
@@ -72,11 +69,5 @@ class FilteredBooksViewModel @Inject constructor(
                 authToken = tokenStorage.getToken(server.id) ?: ""
             }
         }
-    }
-
-    private fun isAvailableOffline(item: LibraryItem): Boolean = when (item.ebookFormat) {
-        EbookFormat.Epub -> epubRepository.isDownloaded(item.serverId, item.id) || epubRepository.isCached(item.serverId, item.id)
-        EbookFormat.Pdf -> pdfRepository.isDownloaded(item.serverId, item.id) || pdfRepository.isCached(item.serverId, item.id)
-        else -> false
     }
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsViewModel.kt
@@ -8,12 +8,10 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.riffle.core.domain.Collection
 import com.riffle.core.domain.ConnectivityObserver
-import com.riffle.core.domain.EbookFormat
-import com.riffle.core.domain.EpubRepository
 import com.riffle.core.domain.LibraryItem
+import com.riffle.core.domain.LibraryItemOfflineAvailability
 import com.riffle.core.domain.LibraryRefreshResult
 import com.riffle.core.domain.LibraryRepository
-import com.riffle.core.domain.PdfRepository
 import com.riffle.core.domain.Series
 import com.riffle.core.data.ToReadRepository
 import com.riffle.core.domain.ServerRepository
@@ -50,8 +48,7 @@ class LibraryItemsViewModel @Inject constructor(
     private val libraryRepository: LibraryRepository,
     private val serverRepository: ServerRepository,
     private val tokenStorage: TokenStorage,
-    private val epubRepository: EpubRepository,
-    private val pdfRepository: PdfRepository,
+    private val offlineAvailability: LibraryItemOfflineAvailability,
     private val connectivityObserver: ConnectivityObserver,
     private val toReadRepository: ToReadRepository,
     private val readaloudLinkRepository: com.riffle.core.domain.ReadaloudLinkRepository,
@@ -161,30 +158,30 @@ class LibraryItemsViewModel @Inject constructor(
     val filteredUngroupedItems: StateFlow<List<LibraryItem>> = combine(ungroupedItems, allItems, searchQuery, isOffline) { ungrouped, all, query, offline ->
         val base = if (query.isEmpty()) ungrouped
             else all.filter { it.title.contains(query, ignoreCase = true) || it.author.contains(query, ignoreCase = true) }
-        if (offline) base.filter { isAvailableOffline(it) } else base
+        if (offline) base.filter { offlineAvailability.isAvailableOffline(it) } else base
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
 
     val filteredInProgress: StateFlow<List<LibraryItem>> = combine(inProgress, isOffline) { items, offline ->
-        if (offline) items.filter { isAvailableOffline(it) } else items
+        if (offline) items.filter { offlineAvailability.isAvailableOffline(it) } else items
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
 
     val filteredFinished: StateFlow<List<LibraryItem>> = combine(finished, isOffline) { items, offline ->
-        if (offline) items.filter { isAvailableOffline(it) } else items
+        if (offline) items.filter { offlineAvailability.isAvailableOffline(it) } else items
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
 
     val filteredRecentlyAdded: StateFlow<List<LibraryItem>> = combine(recentlyAdded, isOffline) { items, offline ->
-        val filtered = if (offline) items.filter { isAvailableOffline(it) } else items
+        val filtered = if (offline) items.filter { offlineAvailability.isAvailableOffline(it) } else items
         filtered.take(50)
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
 
     val filteredAllBooks: StateFlow<List<LibraryItem>> = combine(allBooks, isOffline) { items, offline ->
-        if (offline) items.filter { isAvailableOffline(it) } else items
+        if (offline) items.filter { offlineAvailability.isAvailableOffline(it) } else items
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
 
     val toReadItems: StateFlow<List<LibraryItem>> = combine(toReadItemIds, allBooks, isOffline) { ids, all, offline ->
         val byId = all.associateBy { it.id }
         val items = ids.mapNotNull { byId[it] }
-        if (offline) items.filter { isAvailableOffline(it) } else items
+        if (offline) items.filter { offlineAvailability.isAvailableOffline(it) } else items
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
 
     var authToken: String by mutableStateOf("")
@@ -265,7 +262,7 @@ class LibraryItemsViewModel @Inject constructor(
         if (!offline || collections.isEmpty()) return flowOf(collections)
         return combine(collections.map { col -> libraryRepository.observeCollectionItems(col.id) }) { itemArrays ->
             collections.zip(itemArrays.toList())
-                .filter { (_, items) -> items.any { isAvailableOffline(it) } }
+                .filter { (_, items) -> items.any { offlineAvailability.isAvailableOffline(it) } }
                 .map { (col, _) -> col }
         }
     }
@@ -274,15 +271,9 @@ class LibraryItemsViewModel @Inject constructor(
         if (!offline || series.isEmpty()) return flowOf(series)
         return combine(series.map { s -> libraryRepository.observeSeriesItems(s.id) }) { itemArrays ->
             series.zip(itemArrays.toList())
-                .filter { (_, items) -> items.any { isAvailableOffline(it) } }
+                .filter { (_, items) -> items.any { offlineAvailability.isAvailableOffline(it) } }
                 .map { (s, _) -> s }
         }
-    }
-
-    private fun isAvailableOffline(item: LibraryItem): Boolean = when (item.ebookFormat) {
-        EbookFormat.Epub -> epubRepository.isDownloaded(item.serverId, item.id) || epubRepository.isCached(item.serverId, item.id)
-        EbookFormat.Pdf -> pdfRepository.isDownloaded(item.serverId, item.id) || pdfRepository.isCached(item.serverId, item.id)
-        else -> false
     }
 
     private companion object {

--- a/app/src/main/kotlin/com/riffle/app/feature/library/SeriesDetailViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/SeriesDetailViewModel.kt
@@ -7,12 +7,10 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.riffle.core.domain.ConnectivityObserver
-import com.riffle.core.domain.EbookFormat
-import com.riffle.core.domain.EpubRepository
 import com.riffle.core.domain.LibraryItem
+import com.riffle.core.domain.LibraryItemOfflineAvailability
 import com.riffle.core.domain.LibraryRefreshResult
 import com.riffle.core.domain.LibraryRepository
-import com.riffle.core.domain.PdfRepository
 import com.riffle.core.domain.ServerRepository
 import com.riffle.core.domain.TokenStorage
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -34,8 +32,7 @@ class SeriesDetailViewModel @Inject constructor(
     private val libraryRepository: LibraryRepository,
     private val serverRepository: ServerRepository,
     private val tokenStorage: TokenStorage,
-    private val epubRepository: EpubRepository,
-    private val pdfRepository: PdfRepository,
+    private val offlineAvailability: LibraryItemOfflineAvailability,
     private val connectivityObserver: ConnectivityObserver,
 ) : ViewModel() {
 
@@ -55,7 +52,7 @@ class SeriesDetailViewModel @Inject constructor(
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), false)
 
     val items: StateFlow<List<LibraryItem>> = combine(allItems, isOffline) { items, offline ->
-        if (offline) items.filter { isAvailableOffline(it) } else items
+        if (offline) items.filter { offlineAvailability.isAvailableOffline(it) } else items
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
 
     var authToken: String by mutableStateOf("")
@@ -97,12 +94,6 @@ class SeriesDetailViewModel @Inject constructor(
 
     private suspend fun runRefresh() {
         _refreshFailed.value = libraryRepository.refreshSeries(libraryId) is LibraryRefreshResult.NetworkError
-    }
-
-    private fun isAvailableOffline(item: LibraryItem): Boolean = when (item.ebookFormat) {
-        EbookFormat.Epub -> epubRepository.isDownloaded(item.serverId, item.id) || epubRepository.isCached(item.serverId, item.id)
-        EbookFormat.Pdf -> pdfRepository.isDownloaded(item.serverId, item.id) || pdfRepository.isCached(item.serverId, item.id)
-        else -> false
     }
 
     private companion object {

--- a/app/src/test/kotlin/com/riffle/app/feature/library/CollectionDetailViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/CollectionDetailViewModelTest.kt
@@ -1,6 +1,9 @@
 package com.riffle.app.feature.library
 
 import androidx.lifecycle.SavedStateHandle
+import com.riffle.core.domain.AudiobookDownloadRepository
+import com.riffle.core.domain.AudiobookDownloadResult
+import com.riffle.core.domain.AudiobookSession
 import com.riffle.core.domain.Collection
 import com.riffle.core.domain.ConnectivityObserver
 import com.riffle.core.domain.EbookFormat
@@ -9,6 +12,7 @@ import com.riffle.core.domain.EpubOpenResult
 import com.riffle.core.domain.EpubRepository
 import com.riffle.core.domain.Library
 import com.riffle.core.domain.LibraryItem
+import com.riffle.core.domain.LibraryItemOfflineAvailability
 import com.riffle.core.domain.LibraryRefreshResult
 import com.riffle.core.domain.LibraryRepository
 import com.riffle.core.domain.PdfDownloadResult
@@ -137,6 +141,14 @@ class CollectionDetailViewModelTest {
         override suspend fun saveReadingPosition(itemId: String, locatorJson: String) {}
     }
 
+    private class FakeAudiobookDownloadRepository : AudiobookDownloadRepository {
+        override fun isDownloaded(serverId: String, itemId: String): Boolean = false
+        override fun localSession(serverId: String, itemId: String): AudiobookSession? = null
+        override suspend fun download(serverId: String, itemId: String, onProgress: (Long, Long) -> Unit) =
+            AudiobookDownloadResult.Success
+        override suspend fun remove(serverId: String, itemId: String): Long = 0L
+    }
+
     private class FakeConnectivityObserver(online: Boolean = true) : ConnectivityObserver {
         val state = MutableStateFlow(online)
         override val isOnline: StateFlow<Boolean> = state
@@ -151,8 +163,11 @@ class CollectionDetailViewModelTest {
         libraryRepository = libraryRepository,
         serverRepository = noOpServerRepo,
         tokenStorage = noOpTokenStorage,
-        epubRepository = epubRepository,
-        pdfRepository = FakePdfRepository(),
+        offlineAvailability = LibraryItemOfflineAvailability(
+            epubRepository,
+            FakePdfRepository(),
+            FakeAudiobookDownloadRepository(),
+        ),
         connectivityObserver = connectivityObserver,
     )
 

--- a/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemsViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemsViewModelTest.kt
@@ -1,6 +1,9 @@
 package com.riffle.app.feature.library
 
 import androidx.lifecycle.SavedStateHandle
+import com.riffle.core.domain.AudiobookDownloadRepository
+import com.riffle.core.domain.AudiobookDownloadResult
+import com.riffle.core.domain.AudiobookSession
 import com.riffle.core.domain.Collection
 import com.riffle.core.domain.ConnectivityObserver
 import com.riffle.core.domain.EbookFormat
@@ -9,6 +12,7 @@ import com.riffle.core.domain.EpubOpenResult
 import com.riffle.core.domain.EpubRepository
 import com.riffle.core.domain.Library
 import com.riffle.core.domain.LibraryItem
+import com.riffle.core.domain.LibraryItemOfflineAvailability
 import com.riffle.core.domain.LibraryRefreshResult
 import com.riffle.core.domain.LibraryRepository
 import com.riffle.core.domain.PdfDownloadResult
@@ -124,6 +128,15 @@ class LibraryItemsViewModelTest {
         override suspend fun saveReadingPosition(itemId: String, locatorJson: String) {}
     }
 
+    private fun fakeAudiobookDownloadRepo(downloadedIds: Set<String> = emptySet()): AudiobookDownloadRepository =
+        object : AudiobookDownloadRepository {
+            override fun isDownloaded(serverId: String, itemId: String): Boolean = itemId in downloadedIds
+            override fun localSession(serverId: String, itemId: String): AudiobookSession? = null
+            override suspend fun download(serverId: String, itemId: String, onProgress: (Long, Long) -> Unit): AudiobookDownloadResult =
+                AudiobookDownloadResult.Success
+            override suspend fun remove(serverId: String, itemId: String): Long = 0L
+        }
+
     private class FakeConnectivityObserver(online: Boolean = true) : ConnectivityObserver {
         val state = MutableStateFlow(online)
         override val isOnline: StateFlow<Boolean> = state
@@ -153,6 +166,7 @@ class LibraryItemsViewModelTest {
         connectivityObserver: ConnectivityObserver = FakeConnectivityObserver(),
         epubRepository: EpubRepository = fakeEpubRepo(),
         pdfRepository: PdfRepository = fakePdfRepo(),
+        audiobookDownloadRepository: AudiobookDownloadRepository = fakeAudiobookDownloadRepo(),
         libraryRepository: LibraryRepository = fakeRepo(),
         serverRepository: ServerRepository = fakeServerRepo(),
         tokenStorage: TokenStorage = fakeTokenStorage(),
@@ -164,8 +178,7 @@ class LibraryItemsViewModelTest {
         libraryRepository,
         serverRepository,
         tokenStorage,
-        epubRepository,
-        pdfRepository,
+        LibraryItemOfflineAvailability(epubRepository, pdfRepository, audiobookDownloadRepository),
         connectivityObserver,
         toReadRepository,
         readaloudLinkRepository,
@@ -448,6 +461,24 @@ class LibraryItemsViewModelTest {
         testDispatcher.scheduler.advanceUntilIdle()
         assertEquals(listOf(item("Dune", "Frank Herbert")), vm.filteredUngroupedItems.value)
         assertEquals(true, vm.isOffline.value)
+    }
+
+    @Test
+    fun `when offline a downloaded audiobook-only item is shown`() = runTest {
+        val audiobook = LibraryItem(
+            "id-The Martian", "lib-1", "The Martian", "Andy Weir", null, 0f, false, false,
+            EbookFormat.Unsupported, hasAudio = true,
+        )
+        val vm = makeViewModel(
+            connectivityObserver = FakeConnectivityObserver(online = false),
+            epubRepository = fakeEpubRepoWithDownloads(emptySet()),
+            audiobookDownloadRepository = fakeAudiobookDownloadRepo(setOf("id-The Martian")),
+        )
+        backgroundScope.launch { vm.filteredUngroupedItems.collect {} }
+        backgroundScope.launch { vm.isOffline.collect {} }
+        itemsFlow.value = listOf(audiobook, item("Foundation", "Isaac Asimov"))
+        testDispatcher.scheduler.advanceUntilIdle()
+        assertEquals(listOf(audiobook), vm.filteredUngroupedItems.value)
     }
 
     @Test

--- a/app/src/test/kotlin/com/riffle/app/feature/library/SeriesDetailViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/SeriesDetailViewModelTest.kt
@@ -1,6 +1,9 @@
 package com.riffle.app.feature.library
 
 import androidx.lifecycle.SavedStateHandle
+import com.riffle.core.domain.AudiobookDownloadRepository
+import com.riffle.core.domain.AudiobookDownloadResult
+import com.riffle.core.domain.AudiobookSession
 import com.riffle.core.domain.Collection
 import com.riffle.core.domain.ConnectivityObserver
 import com.riffle.core.domain.EbookFormat
@@ -9,6 +12,7 @@ import com.riffle.core.domain.EpubOpenResult
 import com.riffle.core.domain.EpubRepository
 import com.riffle.core.domain.Library
 import com.riffle.core.domain.LibraryItem
+import com.riffle.core.domain.LibraryItemOfflineAvailability
 import com.riffle.core.domain.LibraryRefreshResult
 import com.riffle.core.domain.LibraryRepository
 import com.riffle.core.domain.PdfDownloadResult
@@ -111,6 +115,14 @@ class SeriesDetailViewModelTest {
         override suspend fun saveReadingPosition(itemId: String, locatorJson: String) {}
     }
 
+    private class FakeAudiobookDownloadRepository : AudiobookDownloadRepository {
+        override fun isDownloaded(serverId: String, itemId: String): Boolean = false
+        override fun localSession(serverId: String, itemId: String): AudiobookSession? = null
+        override suspend fun download(serverId: String, itemId: String, onProgress: (Long, Long) -> Unit) =
+            AudiobookDownloadResult.Success
+        override suspend fun remove(serverId: String, itemId: String): Long = 0L
+    }
+
     private class FakeConnectivityObserver(online: Boolean = true) : ConnectivityObserver {
         val state = MutableStateFlow(online)
         override val isOnline: StateFlow<Boolean> = state
@@ -124,8 +136,11 @@ class SeriesDetailViewModelTest {
         libraryRepository = libraryRepository,
         serverRepository = noOpServerRepo,
         tokenStorage = noOpTokenStorage,
-        epubRepository = FakeEpubRepository(),
-        pdfRepository = FakePdfRepository(),
+        offlineAvailability = LibraryItemOfflineAvailability(
+            FakeEpubRepository(),
+            FakePdfRepository(),
+            FakeAudiobookDownloadRepository(),
+        ),
         connectivityObserver = connectivityObserver,
     )
 

--- a/core/data/src/main/kotlin/com/riffle/core/data/di/DataModule.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/di/DataModule.kt
@@ -49,6 +49,7 @@ import com.riffle.core.domain.AudiobookRepository
 import com.riffle.core.domain.LibraryRepository
 import com.riffle.core.domain.LibraryVisibilityPreferencesStore
 import com.riffle.core.domain.LocalStore
+import com.riffle.core.domain.LibraryItemOfflineAvailability
 import com.riffle.core.domain.PdfRepository
 import com.riffle.core.domain.CrossEpubIndexStore
 import com.riffle.core.domain.ReadaloudLinkRepository
@@ -405,6 +406,15 @@ abstract class DataModule {
             serverRepository: ServerRepository,
             tokenStorage: TokenStorage,
         ): PdfRepository = PdfRepositoryImpl(api, cacheStore, downloadsStore, positionStore, serverRepository, tokenStorage)
+
+        @Provides
+        @Singleton
+        fun provideLibraryItemOfflineAvailability(
+            epubRepository: EpubRepository,
+            pdfRepository: PdfRepository,
+            audiobookDownloadRepository: AudiobookDownloadRepository,
+        ): LibraryItemOfflineAvailability =
+            LibraryItemOfflineAvailability(epubRepository, pdfRepository, audiobookDownloadRepository)
 
         @Provides
         @Singleton

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/LibraryItemOfflineAvailability.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/LibraryItemOfflineAvailability.kt
@@ -1,0 +1,24 @@
+package com.riffle.core.domain
+
+/**
+ * Decides whether a [LibraryItem] can be opened with no network — the single source of truth behind
+ * the library's offline filtering. An item is available offline when its ebook is downloaded or
+ * cached (EPUB/PDF), OR when its audiobook is downloaded. Audiobooks have a download-only tier (no
+ * auto-cache), so the audio side is a plain `isDownloaded` check (ADR 0029).
+ */
+class LibraryItemOfflineAvailability(
+    private val epubRepository: EpubRepository,
+    private val pdfRepository: PdfRepository,
+    private val audiobookDownloadRepository: AudiobookDownloadRepository,
+) {
+    fun isAvailableOffline(item: LibraryItem): Boolean {
+        val ebookAvailable = when (item.ebookFormat) {
+            EbookFormat.Epub ->
+                epubRepository.isDownloaded(item.serverId, item.id) || epubRepository.isCached(item.serverId, item.id)
+            EbookFormat.Pdf ->
+                pdfRepository.isDownloaded(item.serverId, item.id) || pdfRepository.isCached(item.serverId, item.id)
+            EbookFormat.Unsupported -> false
+        }
+        return ebookAvailable || audiobookDownloadRepository.isDownloaded(item.serverId, item.id)
+    }
+}

--- a/core/domain/src/test/kotlin/com/riffle/core/domain/LibraryItemOfflineAvailabilityTest.kt
+++ b/core/domain/src/test/kotlin/com/riffle/core/domain/LibraryItemOfflineAvailabilityTest.kt
@@ -1,0 +1,136 @@
+package com.riffle.core.domain
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class LibraryItemOfflineAvailabilityTest {
+
+    private fun item(
+        ebookFormat: EbookFormat,
+        hasAudio: Boolean = false,
+        serverId: String = "s1",
+        id: String = "i1",
+    ) = LibraryItem(
+        id = id,
+        libraryId = "lib",
+        title = "t",
+        author = "a",
+        coverUrl = null,
+        readingProgress = 0f,
+        isCached = false,
+        isDownloaded = false,
+        ebookFormat = ebookFormat,
+        hasAudio = hasAudio,
+        serverId = serverId,
+    )
+
+    @Test
+    fun `epub that is downloaded is available offline`() {
+        val availability = LibraryItemOfflineAvailability(
+            epubRepository = FakeEpubRepository(downloaded = true),
+            pdfRepository = FakePdfRepository(),
+            audiobookDownloadRepository = FakeAudiobookDownloadRepository(),
+        )
+
+        assertTrue(availability.isAvailableOffline(item(EbookFormat.Epub)))
+    }
+
+    @Test
+    fun `epub that is only cached is available offline`() {
+        val availability = LibraryItemOfflineAvailability(
+            epubRepository = FakeEpubRepository(cached = true),
+            pdfRepository = FakePdfRepository(),
+            audiobookDownloadRepository = FakeAudiobookDownloadRepository(),
+        )
+
+        assertTrue(availability.isAvailableOffline(item(EbookFormat.Epub)))
+    }
+
+    @Test
+    fun `pdf that is downloaded is available offline`() {
+        val availability = LibraryItemOfflineAvailability(
+            epubRepository = FakeEpubRepository(),
+            pdfRepository = FakePdfRepository(downloaded = true),
+            audiobookDownloadRepository = FakeAudiobookDownloadRepository(),
+        )
+
+        assertTrue(availability.isAvailableOffline(item(EbookFormat.Pdf)))
+    }
+
+    @Test
+    fun `downloaded audiobook-only item is available offline`() {
+        val availability = LibraryItemOfflineAvailability(
+            epubRepository = FakeEpubRepository(),
+            pdfRepository = FakePdfRepository(),
+            audiobookDownloadRepository = FakeAudiobookDownloadRepository(downloaded = true),
+        )
+
+        assertTrue(availability.isAvailableOffline(item(EbookFormat.Unsupported, hasAudio = true)))
+    }
+
+    @Test
+    fun `matched item with only the audiobook downloaded is available offline`() {
+        val availability = LibraryItemOfflineAvailability(
+            epubRepository = FakeEpubRepository(), // ebook not downloaded/cached
+            pdfRepository = FakePdfRepository(),
+            audiobookDownloadRepository = FakeAudiobookDownloadRepository(downloaded = true),
+        )
+
+        assertTrue(availability.isAvailableOffline(item(EbookFormat.Epub, hasAudio = true)))
+    }
+
+    @Test
+    fun `item with nothing downloaded or cached is not available offline`() {
+        val availability = LibraryItemOfflineAvailability(
+            epubRepository = FakeEpubRepository(),
+            pdfRepository = FakePdfRepository(),
+            audiobookDownloadRepository = FakeAudiobookDownloadRepository(),
+        )
+
+        assertFalse(availability.isAvailableOffline(item(EbookFormat.Epub, hasAudio = true)))
+    }
+
+    private class FakeEpubRepository(
+        private val downloaded: Boolean = false,
+        private val cached: Boolean = false,
+    ) : EpubRepository {
+        override fun isDownloaded(serverId: String, itemId: String) = downloaded
+        override fun isCached(serverId: String, itemId: String) = cached
+        override suspend fun openEpub(item: LibraryItem) = error("unused")
+        override suspend fun downloadEpub(
+            item: LibraryItem,
+            onProgress: (downloaded: Long, total: Long) -> Unit,
+        ) = error("unused")
+        override suspend fun removeDownload(serverId: String, itemId: String) = error("unused")
+        override suspend fun saveReadingPosition(itemId: String, cfi: String) = error("unused")
+    }
+
+    private class FakePdfRepository(
+        private val downloaded: Boolean = false,
+        private val cached: Boolean = false,
+    ) : PdfRepository {
+        override fun isDownloaded(serverId: String, itemId: String) = downloaded
+        override fun isCached(serverId: String, itemId: String) = cached
+        override suspend fun openPdf(item: LibraryItem) = error("unused")
+        override suspend fun downloadPdf(
+            item: LibraryItem,
+            onProgress: (downloaded: Long, total: Long) -> Unit,
+        ) = error("unused")
+        override suspend fun removeDownload(serverId: String, itemId: String) = error("unused")
+        override suspend fun saveReadingPosition(itemId: String, locatorJson: String) = error("unused")
+    }
+
+    private class FakeAudiobookDownloadRepository(
+        private val downloaded: Boolean = false,
+    ) : AudiobookDownloadRepository {
+        override fun isDownloaded(serverId: String, itemId: String) = downloaded
+        override fun localSession(serverId: String, itemId: String): AudiobookSession? = null
+        override suspend fun download(
+            serverId: String,
+            itemId: String,
+            onProgress: (downloaded: Long, total: Long) -> Unit,
+        ) = error("unused")
+        override suspend fun remove(serverId: String, itemId: String) = error("unused")
+    }
+}

--- a/docs/superpowers/specs/2026-06-12-offline-audiobooks-in-library-design.md
+++ b/docs/superpowers/specs/2026-06-12-offline-audiobooks-in-library-design.md
@@ -1,0 +1,106 @@
+# Downloaded audiobooks appear in the library when offline
+
+**Date:** 2026-06-12
+**Status:** Approved
+
+## Problem
+
+When the device is offline, the library shows only items that are available locally.
+Downloaded **ebooks** (EPUB/PDF) correctly appear; downloaded **audiobooks** do not —
+they vanish from every library surface, even though their files are on disk and the
+audiobook player can already open them offline.
+
+### Root cause
+
+Each library ViewModel filters offline items through a private `isAvailableOffline`:
+
+```kotlin
+private fun isAvailableOffline(item: LibraryItem): Boolean = when (item.ebookFormat) {
+    EbookFormat.Epub -> epubRepository.isDownloaded(..) || epubRepository.isCached(..)
+    EbookFormat.Pdf  -> pdfRepository.isDownloaded(..) || pdfRepository.isCached(..)
+    else -> false
+}
+```
+
+The check only consults `ebookFormat`. An audiobook-only item has
+`ebookFormat == Unsupported` and falls through the `else -> false` branch, so it is
+filtered out offline regardless of download state. `AudiobookDownloadRepository`
+already knows the item is downloaded (via its `manifest.json` marker) and the player
+already reconstructs an offline `localSession()` from it — but the library never asks.
+
+This identical method is duplicated across four ViewModels:
+
+- `app/.../feature/library/LibraryItemsViewModel.kt`
+- `app/.../feature/library/SeriesDetailViewModel.kt`
+- `app/.../feature/library/CollectionDetailViewModel.kt`
+- `app/.../feature/library/FilteredBooksViewModel.kt`
+
+Each independently injects `EpubRepository` and `PdfRepository`.
+
+## Goal
+
+Exact parity with ebooks: **if an item is downloaded (or, for ebooks, cached), it shows
+in the library when offline.** No visual change, no new badge — a downloaded audiobook
+simply appears in the grid like any other offline-available item, and tapping it opens
+the audiobook player offline (already supported via `localSession()`).
+
+## Design
+
+### 1. The rule
+
+An item is available offline when **either**:
+
+- its ebook is downloaded or cached (existing behaviour, unchanged), **or**
+- its audiobook is downloaded — `audiobookDownloadRepository.isDownloaded(serverId, id)`.
+
+This is purely additive. It changes nothing for ebook-only items and naturally covers:
+
+- audiobook-only item (`ebookFormat == Unsupported`, downloaded) → now shows
+- matched item where only the audiobook was downloaded → now shows
+- ebook downloaded → unchanged
+
+Audiobooks have only a downloaded state (no "cached" tier), so the audiobook side of
+the check is just `isDownloaded`.
+
+### 2. Extract a shared checker
+
+Replace the four duplicated private methods with a single injectable checker.
+
+- New class `LibraryItemOfflineAvailability` in `core/domain`, depending on the three
+  repository interfaces (`EpubRepository`, `PdfRepository`, `AudiobookDownloadRepository`
+  — all already in `core/domain`).
+- Single method: `fun isAvailableOffline(item: LibraryItem): Boolean`.
+- Each of the four ViewModels injects `LibraryItemOfflineAvailability`, deletes its
+  private `isAvailableOffline`, and drops the now-unused `EpubRepository` /
+  `PdfRepository` constructor params **only if** they are not used elsewhere in that
+  ViewModel (verify per file before removing).
+- Provide it via Hilt the same way the repositories are provided (constructor
+  `@Inject`; no module change needed if it is a plain injectable class).
+
+### 3. No other changes
+
+- No DB migration.
+- No `LibraryItem` model change (`hasAudio` already exists; download state is queried
+  live from the repository, exactly as ebooks do).
+- No UI change.
+- No player change — `localSession()` already opens downloaded audiobooks offline.
+
+## Testing
+
+Unit test `LibraryItemOfflineAvailability` (pure logic over fake/mock repositories):
+
+- ebook downloaded → true
+- ebook cached (not downloaded) → true
+- audiobook-only, downloaded → true
+- matched item, only audiobook downloaded → true
+- matched item, only ebook downloaded → true
+- nothing downloaded/cached → false
+
+The four ViewModels keep their existing offline-filter tests (if any); behaviour for
+ebooks is unchanged.
+
+## Out of scope
+
+- Any download badge or visual indicator.
+- Audiobook "cached" tier (audiobooks are downloaded-only).
+- Changes to how audiobooks are downloaded or played.


### PR DESCRIPTION
## What

When the device is offline, the library now shows **downloaded audiobooks** alongside downloaded/cached ebooks — exact parity with how ebooks behave. Tapping one opens the audiobook player offline via the existing `localSession()`.

### The gap
Each library ViewModel filtered offline items through an identical private `isAvailableOffline` that only inspected `ebookFormat`:

```kotlin
when (item.ebookFormat) {
    Epub -> epubRepository.isDownloaded(..) || epubRepository.isCached(..)
    Pdf  -> pdfRepository.isDownloaded(..) || pdfRepository.isCached(..)
    else -> false   // ← audiobooks always hid offline
}
```

An audiobook-only item has `ebookFormat == Unsupported` and fell through `else`, even though `AudiobookDownloadRepository.isDownloaded()` already knew it was on disk.

## How

- New **`LibraryItemOfflineAvailability`** (core/domain) — the single source of truth: available offline when the ebook is downloaded/cached **or** the audiobook is downloaded. Additive — ebook behavior is unchanged; audiobook-only and matched-but-only-audiobook-downloaded items now appear.
- All four library ViewModels (`LibraryItemsViewModel`, `SeriesDetailViewModel`, `CollectionDetailViewModel`, `FilteredBooksViewModel`) route through it; their duplicated private checks are deleted.
- Provided via Hilt `@Provides` in `DataModule`.

No DB migration, no `LibraryItem` model change, no UI change, no player change.

## Tests
- `LibraryItemOfflineAvailabilityTest` — 6 cases (ebook downloaded/cached, pdf, audiobook-only downloaded, matched-audio-only, nothing-downloaded).
- New `LibraryItemsViewModelTest` case: a downloaded audiobook-only item shows in the offline grid.
- Updated the three ViewModel tests to wrap their existing fakes in the real checker; existing offline assertions stay green.

**Verified:** `./gradlew test lint` ✅ · phone harness (193, 0 failed) ✅ · tablet harness (5, 0 failed) ✅