### PR TITLE
fix(audiobook): flush close/pause progress on a survivable scope

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/di/AppModule.kt
+++ b/app/src/main/kotlin/com/riffle/app/di/AppModule.kt
@@ -30,6 +30,16 @@ import javax.inject.Singleton
 @Retention(AnnotationRetention.BINARY)
 annotation class DownloadScope
 
+/**
+ * Application-lifetime [CoroutineScope] for terminal progress writes (the close / pause flush) that
+ * must survive the screen's ViewModel being cleared — see `ProgressFlushScope`. Without it, a flush
+ * launched on `viewModelScope` is cancelled mid-PATCH when the user leaves the screen right after
+ * triggering it.
+ */
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class ProgressFlush
+
 @Module
 @InstallIn(SingletonComponent::class)
 object AppModule {
@@ -38,6 +48,11 @@ object AppModule {
     @Singleton
     @DownloadScope
     fun provideDownloadScope(): CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    @Provides
+    @Singleton
+    @ProgressFlush
+    fun provideProgressFlushScope(): CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
     @Provides
     @Singleton

--- a/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModel.kt
@@ -62,6 +62,7 @@ class AudiobookPlayerViewModel @Inject constructor(
     private val crossEpubIndexBuilder: com.riffle.core.data.CrossEpubIndexBuilderService,
     private val nowPlayingStore: com.riffle.app.playback.NowPlayingStore,
     private val audiobookPositionStore: com.riffle.core.domain.AudiobookPositionStore,
+    private val progressFlushScope: com.riffle.app.feature.reader.ProgressFlushScope,
 ) : ViewModel() {
 
     private val itemId: String = savedStateHandle.get<String>("itemId") ?: ""
@@ -372,7 +373,10 @@ class AudiobookPlayerViewModel @Inject constructor(
         // 0 on the next open — the same fresh-stamped-0 erase the follow loop already guards against.
         if (pos < reconciledResumeSec - SETTLE_EPS_SEC) return
         val fraction = audiobookProgressFraction(pos, timeline.durationSec)
-        viewModelScope.launch {
+        // Flush scope, not viewModelScope: pushProgressOnStop runs from onCleared, by which point the
+        // viewModelScope is already cancelled — a launch there never executes, so the final close
+        // position was silently dropped. The survivable scope guarantees the PATCH completes.
+        progressFlushScope.flush {
             // Backend (ABS) sync — outside the coordinator, like the reader's progress-sync cycle.
             val rs = readerSync
             if (rs != null) {

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -128,6 +128,7 @@ class EpubReaderViewModel @Inject constructor(
     private val readaloudResumeStore: ReadaloudResumeStore,
     private val annotationStore: AnnotationStore,
     private val nowPlayingStore: com.riffle.app.playback.NowPlayingStore,
+    private val progressFlushScope: ProgressFlushScope,
 ) : AndroidViewModel(application) {
 
     private val itemId: String = checkNotNull(savedStateHandle["itemId"])
@@ -691,6 +692,10 @@ class EpubReaderViewModel @Inject constructor(
             persistReadaloudResumePosition(lastLocator, playerCoordinator.activeFragmentRef.value)
         }
         val locator = lastLocator ?: return
+        // Stays on viewModelScope: runReaderSyncCycle mutates reader state (lastLocator,
+        // pendingServerJumpStamp, …) and posts the inbound-jump channel, which must run on the main
+        // thread while the screen is alive — it is not safe to relocate to a background flush scope.
+        // The durable reading-position write survives a reopen/the offline sweep (ADR 0030).
         viewModelScope.launch {
             val payload = locator.toPayload()
             positionSaveCoordinator.onClose(locator.toJSON().toString(), payload.ebookProgress)
@@ -1102,7 +1107,9 @@ class EpubReaderViewModel @Inject constructor(
         playerCoordinator.close()
         // Use the fragment captured above — close() has nulled the live one. Passing the live value
         // here would push the page top (chapter start) instead of the sentence we stopped on.
-        if (hadFragment) viewModelScope.launch { pushAudiobookFromReadingPosition(resumeFragmentRef) }
+        // On the flush scope, not viewModelScope: closing readaloud is routinely followed by leaving
+        // the book at once, which cancels viewModelScope and would abort this PATCH mid-write.
+        if (hadFragment) progressFlushScope.flush { pushAudiobookFromReadingPosition(resumeFragmentRef) }
     }
 
     /**
@@ -1138,7 +1145,9 @@ class EpubReaderViewModel @Inject constructor(
             // is about to go false), derived from the reading position via the bundle.
             val pausedFragment = playerCoordinator.activeFragmentRef.value
             playerCoordinator.pause()
-            if (pausedFragment != null) viewModelScope.launch { pushAudiobookFromReadingPosition(pausedFragment) }
+            // Flush scope (see closeReadaloud): a pause is often immediately followed by leaving the
+            // book, which would cancel a viewModelScope-launched PATCH before it reaches ABS.
+            if (pausedFragment != null) progressFlushScope.flush { pushAudiobookFromReadingPosition(pausedFragment) }
         } else {
             onPlayTapped()
         }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ProgressFlushScope.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ProgressFlushScope.kt
@@ -1,0 +1,29 @@
+package com.riffle.app.feature.reader
+
+import com.riffle.app.di.ProgressFlush
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Runs a final progress write (the close / pause flush) on an application-lifetime scope so it isn't
+ * cancelled mid-network-write when the user leaves the screen the instant they trigger it.
+ *
+ * The hazard this exists for: a reader / audiobook ViewModel launching its close flush on
+ * `viewModelScope` loses the in-flight ABS PATCH the moment the ViewModel is cleared — which on the
+ * audiobook player's `onCleared` is *always* (the scope is already cancelled by then), and on the
+ * reader's readaloud-close is a race lost whenever the user backs out of the book before the PATCH
+ * round-trip finishes ("close, then leave right away"). In-session periodic syncs stay on
+ * `viewModelScope` — they *should* stop when the screen goes away; only the terminal flush comes here.
+ *
+ * Mirrors the existing [ProgressFlush]/download scope rationale in `AppModule`.
+ */
+@Singleton
+class ProgressFlushScope @Inject constructor(
+    @ProgressFlush private val scope: CoroutineScope,
+) {
+    /** Launch [write] on the survivable scope; returns its [Job] (for tests / awaiting if needed). */
+    fun flush(write: suspend () -> Unit): Job = scope.launch { write() }
+}

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ProgressFlushScopeTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ProgressFlushScopeTest.kt
@@ -1,0 +1,61 @@
+package com.riffle.app.feature.reader
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ProgressFlushScopeTest {
+
+    // The fix: a close/pause progress write handed to the flush scope completes even when the screen's
+    // own scope is torn down the instant after — the "press X / pause, then leave the book right away"
+    // case where the in-flight ABS PATCH was being cancelled mid-network-write.
+    @Test
+    fun `a flush completes even when the caller's scope is cancelled immediately after submitting`() = runTest {
+        val flusher = ProgressFlushScope(CoroutineScope(StandardTestDispatcher(testScheduler) + SupervisorJob()))
+        var completed = false
+
+        // Model the screen's viewModelScope: the user submits a close flush from it, then leaves the
+        // book — tearing this scope down before the network write finishes.
+        val viewModelScope = CoroutineScope(StandardTestDispatcher(testScheduler) + Job())
+        viewModelScope.launch {
+            flusher.flush {
+                delay(100) // an ABS PATCH in flight
+                completed = true
+            }
+        }
+        advanceTimeBy(10)
+        viewModelScope.cancel() // leave the book right away
+
+        advanceUntilIdle()
+        assertTrue("the close flush must survive screen teardown", completed)
+    }
+
+    // Documents the bug being fixed: the identical write launched directly on the (cancellable) caller
+    // scope is lost when the screen tears down first.
+    @Test
+    fun `the buggy pattern — a write launched on the caller scope is lost when it is cancelled`() = runTest {
+        var completed = false
+        val viewModelScope = CoroutineScope(StandardTestDispatcher(testScheduler) + Job())
+        viewModelScope.launch {
+            delay(100)
+            completed = true
+        }
+        advanceTimeBy(10)
+        viewModelScope.cancel()
+
+        advanceUntilIdle()
+        assertFalse("a write on the cancelled scope is lost — this is the bug", completed)
+    }
+}

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ReaderSyncCoordinatorTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ReaderSyncCoordinatorTest.kt
@@ -12,6 +12,15 @@ import com.riffle.core.network.NetworkEbookProgressPayload
 import com.riffle.core.network.NetworkGetProgressResult
 import com.riffle.core.network.NetworkServerProgress
 import com.riffle.core.network.NetworkSyncSessionResult
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.json.JSONObject
 import org.junit.Assert.assertEquals
@@ -20,6 +29,7 @@ import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class ReaderSyncCoordinatorTest {
 
     // Identity cross-EPUB index → Storyteller and ABS progressions coincide. The SMIL maps both ways:
@@ -268,5 +278,46 @@ class ReaderSyncCoordinatorTest {
         assertTrue("the cycle reads the ebook item", "ebook-item" in abs.getProgressItemIds)
         assertTrue("the cycle reconciles the audiobook item", "audiobook-item" in abs.getProgressItemIds)
         assertEquals("audiobook writes target the audiobook item", "audiobook-item", abs.audioPatchItemId)
+    }
+
+    // ── teardown-time flush survives "close, then leave right away" ──────────────────
+    // The bug: the close/pause audiobook push was launched on the screen's viewModelScope, so leaving
+    // the book / player the instant after closing cancelled the in-flight ABS PATCH and nothing
+    // reached the server. Routed through ProgressFlushScope, the PATCH must complete regardless.
+
+    @Test
+    fun `closing readaloud flushes the exact narrated sentence to ABS even when the reader is torn down at once`() = runTest {
+        val abs = FakeAbs(NetworkServerProgress(ebookLocation = "", lastUpdate = 0L))
+        val coordinator = coordinator(abs)
+        val flusher = ProgressFlushScope(CoroutineScope(StandardTestDispatcher(testScheduler) + SupervisorJob()))
+
+        // closeReadaloud(): fire the precise audiobook push (narrated fragment f9 → 90s) on the flush
+        // scope, then the user immediately leaves the book — cancelling the reader's viewModelScope.
+        val viewModelScope = CoroutineScope(StandardTestDispatcher(testScheduler) + Job())
+        viewModelScope.launch { flusher.flush { coordinator.pushAudiobookForFragment("f9", null) } }
+        advanceTimeBy(1)
+        viewModelScope.cancel()
+
+        advanceUntilIdle()
+        assertNotNull("the audiobook position must reach ABS despite teardown", abs.audioPatch)
+        assertEquals("the precise narrated sentence (f9 clip start) is synced", 90.0, abs.audioPatch!!.currentTime, 1e-9)
+    }
+
+    @Test
+    fun `the audiobook player's stop flush reaches ABS through the survivable scope after onCleared`() = runTest {
+        val abs = FakeAbs(NetworkServerProgress(ebookLocation = "", lastUpdate = 0L))
+        val coordinator = coordinator(abs)
+        val flusher = ProgressFlushScope(CoroutineScope(StandardTestDispatcher(testScheduler) + SupervisorJob()))
+
+        // The audiobook player's pushProgressOnStop runs an audio-led cycle (listen at 90s). On the
+        // player's onCleared the viewModelScope is already cancelled, so it must run on the flush scope.
+        val viewModelScope = CoroutineScope(StandardTestDispatcher(testScheduler) + Job())
+        viewModelScope.launch { flusher.flush { coordinator.runAudioLedCycle(currentAudioSec = 90.0, localUpdatedAt = 9_000L) } }
+        advanceTimeBy(1)
+        viewModelScope.cancel()
+
+        advanceUntilIdle()
+        assertNotNull("the listen position must reach ABS despite teardown", abs.audioPatch)
+        assertEquals(90.0, abs.audioPatch!!.currentTime, 1e-9)
     }
 }


### PR DESCRIPTION
## Problem

The audiobook player's `pushProgressOnStop` runs from `onCleared`, and the reader's readaloud close/pause audiobook pushes run as the user leaves the book — all launched on `viewModelScope`, which the framework cancels at ViewModel teardown:

- On the **audiobook player's `onCleared`** the scope is *already cancelled* by the time `onCleared` runs (the closeables, including `viewModelScope`, are closed right before `onCleared` per AndroidX lifecycle 2.10), so the final close PATCH **never executes** — 100% drop.
- On the **reader's readaloud close (X) / pause** it's a race lost whenever the user backs out of the book before the PATCH round-trips ("close, then leave right away").

Either way the final listen position was silently dropped on the way to ABS.

## Fix

Route those **terminal** writes through an application-scoped `ProgressFlushScope` (mirrors the existing `@DownloadScope`) so the PATCH completes regardless of screen teardown. In-session periodic syncs stay on `viewModelScope` (they *should* stop with the screen).

The reader's `onReaderClosed` reconcile **stays on `viewModelScope`** — `runReaderSyncCycle` mutates reader state (`lastLocator`, `pendingServerJumpStamp`, …) and posts the inbound-jump channel, which must run on the main thread; only the audiobook close/pause pushes (which are pure ABS/store writes) move to the flush scope.

This is complementary to the durable local position stores (ADR 0030): the survivable flush is what lets the close-time write actually land, so the offline sweep has the final position to push.

## Tests
- `ProgressFlushScopeTest` — a flush completes even when the caller's scope is cancelled immediately after submitting (+ the buggy-pattern counter-test).
- `ReaderSyncCoordinatorTest` — teardown-survival cases for the readaloud-close push and the audiobook-player stop push.
- `./gradlew test` and `./gradlew lint` green.

## Not covered here (deliberately)
The "play-from-here → audiobook resumes at chapter start" resume bug is **not** in this PR — its correct fix is the ADR 0030 matched-book dual-write (readaloud writing `AudiobookPositionStore`), which belongs with the `abs-offline-sync-reconcile` work. Earlier attempts at a forward-only inbound-jump guard / `resumeFragmentRef` fallback were dropped as band-aids that contradict ADR 0029 §49 and collide with the upcoming `CanonicalSyncCycle` refactor.

## Testing note
Harness (instrumented) tests were not run locally — `Harness_Medium_Phone` is currently occupied by a parallel workspace. This change is a DI/coroutine-scope reroute with no instrumented-behavior change, and is covered by the JVM suite.