### PR TITLE
fix(navigation): keep HOME as the back-stack base so the NavHost can never blank

### DIFF
--- a/app/src/androidTest/kotlin/com/riffle/app/navigation/NavigateAsRootTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/navigation/NavigateAsRootTest.kt
@@ -15,14 +15,18 @@ import org.junit.runner.RunWith
 /**
  * Regression: an intermittent blank white screen ("burger menu blank").
  *
- * The graph's start destination (HOME) is popped inclusively as soon as a library resolves at
- * launch, so the old `popUpTo(HOME) { inclusive = true }` used by every root-switch navigation
- * matched nothing afterwards. Each server/library switch then pushed a *duplicate* library_items
- * root instead of replacing it, and backing out of the accumulated roots could empty the back
- * stack entirely — leaving the NavHost with no destination (a blank screen).
+ * Every root-switch navigation goes through [navigateAsRoot]. It keeps HOME as the permanent base
+ * of the back stack (popUpTo(HOME) { inclusive = false }) so the active surface always sits ON TOP
+ * of home — the stack is [home, route], never a single sole entry.
  *
- * [navigateAsRoot] anchors the pop on the root graph id instead, so a single destination is always
- * the sole root.
+ * Two failure modes this guards against:
+ *  - **Blank screen.** If the active surface were the *only* entry, a Back that reaches the
+ *    NavHost's own callback (e.g. while the drawer is animating open, when no screen-level handler
+ *    owns it) pops that lone entry to an EMPTY back stack — a blank NavHost. Keeping home beneath
+ *    it means such a Back lands on home instead.
+ *  - **Duplicate roots.** The original popUpTo(HOME) { inclusive = true } removed home, so later
+ *    popUpTo(HOME) calls matched nothing and stacked duplicate roots. Never removing home keeps
+ *    popUpTo(HOME) matching, so each switch replaces the surface.
  */
 @RunWith(AndroidJUnit4::class)
 class NavigateAsRootTest {
@@ -32,6 +36,9 @@ class NavigateAsRootTest {
 
     private fun libraryRoots(nav: NavHostController) =
         nav.currentBackStack.value.count { it.destination.route?.startsWith("lib/") == true }
+
+    private fun hasRoute(nav: NavHostController, route: String): Boolean =
+        nav.currentBackStack.value.any { it.destination.route == route }
 
     @Test
     fun switchingRootsNeverAccumulatesOrEmptiesBackStack() {
@@ -45,30 +52,36 @@ class NavigateAsRootTest {
             }
         }
 
-        // Launch router: resolve a library and pop HOME inclusively (mirrors HomeScreen).
+        // Launch router: resolve a library (mirrors HomeScreen). HOME must REMAIN as the base.
         composeTestRule.runOnUiThread { nav.navigateAsRoot("lib/a") }
         composeTestRule.waitForIdle()
-        assertEquals("HOME should be gone after launch", null, currentRoute(nav, "home"))
+        assertTrue("HOME must stay at the base of the stack", hasRoute(nav, "home"))
+        // destination.route is the registered template; the resolved arg confirms WHICH library.
+        assertEquals("a library surface is on top", "lib/{id}", nav.currentBackStackEntry?.destination?.route)
+        assertEquals("specifically lib/a", "a", nav.currentBackStackEntry?.arguments?.getString("id"))
 
-        // Switch libraries several times — each must REPLACE the root, never accumulate.
+        // Switch libraries several times — each must REPLACE the surface, never accumulate.
         composeTestRule.runOnUiThread { nav.navigateAsRoot("lib/b") }
         composeTestRule.runOnUiThread { nav.navigateAsRoot("lib/c") }
         composeTestRule.waitForIdle()
         assertEquals("library root must not accumulate on switch", 1, libraryRoots(nav))
+        assertTrue("HOME still the base after switches", hasRoute(nav, "home"))
 
-        // Drill into a detail, then back out: the stack must return to the single root, never empty.
+        // Drill into a detail, then back out: returns to the single library surface.
         composeTestRule.runOnUiThread { nav.navigate("detail/x") }
         composeTestRule.waitForIdle()
         composeTestRule.runOnUiThread { nav.popBackStack() }
         composeTestRule.waitForIdle()
+        assertEquals("back from detail returns to the single library surface", 1, libraryRoots(nav))
 
-        assertEquals("back from detail returns to the single library root", 1, libraryRoots(nav))
-        assertTrue(
-            "back stack must still have a current destination (not blank)",
-            nav.currentBackStackEntry?.destination?.route != null,
+        // THE blank-screen case: a Back that reaches the NavHost pops the library *root* itself.
+        // It must land on HOME — never an empty stack with no current destination.
+        composeTestRule.runOnUiThread { nav.popBackStack() }
+        composeTestRule.waitForIdle()
+        assertEquals(
+            "popping the root surface lands on HOME, not a blank NavHost",
+            "home",
+            nav.currentBackStackEntry?.destination?.route,
         )
     }
-
-    private fun currentRoute(nav: NavHostController, route: String): String? =
-        nav.currentBackStack.value.firstOrNull { it.destination.route == route }?.destination?.route
 }

--- a/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
@@ -409,18 +409,24 @@ fun MainScreen(
     }
 }
 
-// Resets the back stack so [route] becomes the sole root. Used by every "switch the active
-// surface" navigation — launch router, server/library switch, redirect, server-setup completion.
+// Switches the active surface, keeping HOME as the permanent base of the back stack so [route]
+// sits directly on top of it. Used by every "switch the active surface" navigation — launch
+// router, server/library switch, redirect, server-setup completion.
 //
-// We deliberately do NOT anchor on popUpTo(HOME): HOME is the graph's start destination but it is
-// popped inclusively the moment a library resolves at launch, so popUpTo(HOME) afterwards matches
-// nothing ("Ignoring popBackStack to route home"), the inclusive pop is skipped, and each switch
-// pushes a duplicate root instead of replacing it. Backing out of those accumulated roots can empty
-// the stack entirely, leaving the NavHost with no destination — a blank white screen. Popping the
-// root graph id clears the whole stack regardless of whether HOME is still present.
+// popUpTo(HOME) with inclusive = FALSE is deliberate and load-bearing:
+//   * It clears everything ABOVE home but never removes home, so the stack is always [home, route]
+//     — never a single sole entry. Back from the root therefore pops to home (which re-routes to a
+//     library) instead of emptying the NavHost. An empty NavHost renders a blank white screen, and
+//     that is exactly what happened when this used popUpTo(graph.id) { inclusive = true }: a Back
+//     reaching the NavHost's own callback (e.g. while the drawer is animating open, when the
+//     screen-level handlers don't own it) popped the lone root to nothing.
+//   * Because home is never removed, popUpTo(HOME) always matches, so each switch REPLACES the
+//     previous surface instead of stacking a duplicate root — the earlier popUpTo(HOME) {
+//     inclusive = true } bug (which DID remove home, making later popUpTo(HOME) a no-op that piled
+//     up duplicate roots) cannot recur here.
 internal fun NavController.navigateAsRoot(route: String) {
     navigate(route) {
-        popUpTo(graph.id) { inclusive = true }
+        popUpTo(HOME) { inclusive = false }
         launchSingleTop = true
     }
 }


### PR DESCRIPTION
## The bug

An intermittent **blank white screen** (Back from it exits the app). Reproduced deterministically:

> On a library list → open a book/audiobook → **Back** (land back on the list) → tap the **burger** → **Back again while the drawer is still animating open.**

The back stack collapsed to empty and the NavHost rendered nothing.

## Root cause

`navigateAsRoot` used `popUpTo(graph.id) { inclusive = true }`, leaving the active library as the **sole** back-stack entry. Android `BackHandler`s fire newest-registered-first, so during the drawer-open window — when `LibraryItemsScreen` disables its layered Back and the drawer's own handler is registered *below* the NavHost — a Back reaches the **NavHost's own callback**, which pops that lone entry to an empty stack.

PR #137 fixed an unrelated *duplicate-root* collapse; this is a different path to the same blank and survived it. Four attempts to win the Back-ownership race at the handler level proved unreliable (Compose re-registers the NavHost's Back callback on every navigation), so this fixes the **invariant** instead.

## The fix

`navigateAsRoot` now uses `popUpTo(HOME) { inclusive = false }`, keeping `HOME` as a permanent base. The stack is always `[home, surface]`:

- A Back that reaches the NavHost pops to **home** (which re-routes to a library) instead of emptying it — there is no empty state to land in, regardless of which handler wins the race.
- Because home is never removed, `popUpTo(HOME)` always matches, so each switch still **replaces** the surface — the duplicate-root regression #137 fixed cannot recur (that only happened because `inclusive = true` *removed* home).

Behaviour traced regression-free: back-to-exit still works (`LibraryItemsScreen`'s Exit→`finish()` outranks the NavHost); server switch / setup completion / drawer library-switch all keep home at the base.

### Known cosmetic residual
In the rare race you may see a brief screen dim that restores (the Back pops to home → re-routes to the library, flashing the drawer scrim) instead of a blank. Harmless; could be polished separately.

## Tests
- `NavigateAsRootTest` rewritten to assert HOME stays at the base **and** to pop the library *root* itself (the actual blank trigger — the old test only popped a detail, which is why it passed while the bug shipped).
- `./gradlew test` ✅
- `./gradlew lint` ✅
- `make harness-test-class CLASS=com.riffle.app.navigation.NavigateAsRootTest` ✅ (on Harness_Medium_Phone)
- User-verified on-device: the blank can no longer be reproduced.