### PR TITLE
feat(audiobook): offline playback from a downloaded readaloud bundle

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookController.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookController.kt
@@ -61,6 +61,10 @@ class AudiobookController @Inject constructor(
     private var durationSec: Double = 0.0
     private var prepared = false
     private var wantsToPlay = false
+    // True when this controller's current session pointed SharedBundle at a bundle file. Guards stop()
+    // so it only releases the bundle it set — never one a live Readaloud session owns (e.g. when this
+    // player opened a streaming session, or failed to prepare at all, while Readaloud is still playing).
+    private var ownsSharedBundle = false
 
     private val listener = object : Player.Listener {
         override fun onEvents(player: Player, events: Player.Events) {
@@ -87,7 +91,8 @@ class AudiobookController @Inject constructor(
         this.durationSec = durationSec
         // Bundle-backed audio: the track mediaIds are zip-entry paths the service reads from this file
         // via SharedBundle (the same channel Readaloud uses). Null for HTTP/file sessions, where the
-        // service never consults SharedBundle.
+        // service never consults SharedBundle (so we don't touch it and don't claim ownership).
+        ownsSharedBundle = localZipFile != null
         if (localZipFile != null) SharedBundle.current = localZipFile
         val c = ensureConnected() ?: return
         val items = trackUrls.map { url ->
@@ -166,9 +171,11 @@ class AudiobookController @Inject constructor(
         spans = emptyList()
         prepared = false
         wantsToPlay = false
-        // Release the bundle reference for parity with ReadaloudController.stop(); media items are
-        // already cleared, so nothing restores a zip URI after this.
-        SharedBundle.current = null
+        // Release the bundle reference only if THIS session set it (parity with ReadaloudController),
+        // never one a still-playing Readaloud owns — media items are already cleared, so nothing
+        // restores a zip URI after this.
+        if (ownsSharedBundle) SharedBundle.current = null
+        ownsSharedBundle = false
         _state.value = PlaybackState()
     }
 

--- a/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookController.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookController.kt
@@ -10,6 +10,7 @@ import androidx.media3.common.Player
 import androidx.media3.session.MediaController
 import androidx.media3.session.SessionToken
 import com.riffle.app.feature.reader.readaloud.AudioPlayerService
+import com.riffle.app.feature.reader.readaloud.SharedBundle
 import com.riffle.core.domain.AudiobookTrackSpan
 import com.riffle.core.domain.AudiobookTracks
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -23,6 +24,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
+import java.io.File
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlin.coroutines.resume
@@ -79,9 +81,14 @@ class AudiobookController @Inject constructor(
         spans: List<AudiobookTrackSpan>,
         durationSec: Double,
         startAtSec: Double,
+        localZipFile: File? = null,
     ) {
         this.spans = spans
         this.durationSec = durationSec
+        // Bundle-backed audio: the track mediaIds are zip-entry paths the service reads from this file
+        // via SharedBundle (the same channel Readaloud uses). Null for HTTP/file sessions, where the
+        // service never consults SharedBundle.
+        if (localZipFile != null) SharedBundle.current = localZipFile
         val c = ensureConnected() ?: return
         val items = trackUrls.map { url ->
             MediaItem.Builder().setMediaId(url).setUri(url).build()

--- a/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookController.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookController.kt
@@ -166,6 +166,9 @@ class AudiobookController @Inject constructor(
         spans = emptyList()
         prepared = false
         wantsToPlay = false
+        // Release the bundle reference for parity with ReadaloudController.stop(); media items are
+        // already cleared, so nothing restores a zip URI after this.
+        SharedBundle.current = null
         _state.value = PlaybackState()
     }
 

--- a/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModel.kt
@@ -29,15 +29,24 @@ internal fun audiobookProgressFraction(positionSec: Double, durationSec: Double)
     if (durationSec > 0.0) (positionSec / durationSec).toFloat().coerceIn(0f, 1f) else 0f
 
 /**
- * The book-absolute resume position. When the position reconcile found nothing — no local audiobook
- * position and no server position, e.g. offline with only a downloaded bundle — fall back to the
- * item's library [readingProgressFraction] mapped to seconds. This resumes near where the rest of the
- * app shows progress instead of restarting at 0, and (crucially) seeds the resume floor so the
- * close/follow persist guard never writes a ~0 over that progress — the offline-erase bug. A genuine
- * reconciled position ([reconciledSec] > 0) always wins, so online behaviour is unchanged.
+ * The book-absolute resume position. When NO position was tracked at all ([hadTrackedPosition] false —
+ * no local audiobook row and no server record, e.g. offline with only a downloaded bundle) fall back
+ * to the item's library [readingProgressFraction] mapped to seconds. This resumes near where the rest
+ * of the app shows progress instead of restarting at 0, and (crucially) seeds the resume floor so the
+ * close/follow persist guard never writes a ~0 over that progress — the offline-erase bug.
+ *
+ * Gating on [hadTrackedPosition] — not on `reconciledSec > 0` — is deliberate: a genuinely-tracked
+ * position of exactly 0 (a server record or local row that says "at the start", with a real
+ * timestamp) must be honoured, not replaced by the progress fallback. Online behaviour is unchanged
+ * because a server record always counts as a tracked position.
  */
-internal fun audiobookResumeSec(reconciledSec: Double, readingProgressFraction: Float, durationSec: Double): Double =
-    if (reconciledSec > 0.0 || readingProgressFraction <= 0f || durationSec <= 0.0) reconciledSec
+internal fun audiobookResumeSec(
+    reconciledSec: Double,
+    hadTrackedPosition: Boolean,
+    readingProgressFraction: Float,
+    durationSec: Double,
+): Double =
+    if (hadTrackedPosition || readingProgressFraction <= 0f || durationSec <= 0.0) reconciledSec
     else (readingProgressFraction * durationSec).coerceIn(0.0, durationSec)
 
 /** UI state for the full-screen [Audiobook Player] (ADR 0029). */
@@ -186,13 +195,18 @@ class AudiobookPlayerViewModel @Inject constructor(
                     resumeUpdatedAt = session.serverLastUpdate
                 }
             }
-            // No tracked position (offline with only a bundle: no local listen row, no server time,
-            // and the canonical bridge is unavailable) → fall back to the item's library progress so
-            // we resume near where the app shows it AND seed reconciledResumeSec as a floor, so the
-            // close/follow persist guard can't write a ~0 over that progress. resumeUpdatedAt stays as
-            // reconciled (0 here), keeping this approximate position inbound-only — it never leads the
-            // canonical record. A genuine reconciled position is left untouched.
-            resumeSec = audiobookResumeSec(resumeSec, item.readingProgress, session.timeline.durationSec)
+            // No tracked position at all (offline with only a bundle: no local listen row, no server
+            // record, and the canonical bridge is unavailable) → fall back to the item's library
+            // progress so we resume near where the app shows it AND seed reconciledResumeSec as a
+            // floor, so the close/follow persist guard can't write a ~0 over that progress. A tracked
+            // position (resumeUpdatedAt > 0), even one of exactly 0, is honoured as-is. resumeUpdatedAt
+            // stays as reconciled (0 here), keeping this approximate position inbound-only.
+            resumeSec = audiobookResumeSec(
+                reconciledSec = resumeSec,
+                hadTrackedPosition = resumeUpdatedAt > 0L,
+                readingProgressFraction = item.readingProgress,
+                durationSec = session.timeline.durationSec,
+            )
             // Per-book speed (ADR 0028), shared with the linked Readaloud. Resolve the audio-settings
             // key the *same* way the reader does — via the resolver on this audiobook's link — so both
             // land on the identical key regardless of the `hasAudio` flag or sort order. With no link,

--- a/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModel.kt
@@ -51,6 +51,7 @@ class AudiobookPlayerViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     private val audiobookRepository: AudiobookRepository,
     private val audiobookDownloadRepository: com.riffle.core.domain.AudiobookDownloadRepository,
+    private val bundleAudiobookSource: com.riffle.core.domain.BundleAudiobookSource,
     private val libraryRepository: LibraryRepository,
     private val serverRepository: ServerRepository,
     private val tokenStorage: TokenStorage,
@@ -131,9 +132,11 @@ class AudiobookPlayerViewModel @Inject constructor(
             serverId = server?.id ?: ""
             val token = server?.let { tokenStorage.getToken(it.id) } ?: ""
             val item = libraryRepository.getItem(itemId)
-            // Prefer the downloaded local copy (offline, file:// tracks); else stream from ABS (ADR 0029).
+            // Prefer a dedicated audiobook download, then a downloaded readaloud bundle's audio, then
+            // stream from ABS (connectivity-independent: a local copy always beats streaming).
             val session = if (serverId.isEmpty()) null
                 else audiobookDownloadRepository.localSession(serverId, itemId)
+                    ?: bundleAudiobookSource.localSession(serverId, itemId)
                     ?: audiobookRepository.openSession(serverId, itemId)
             if (item == null || session == null) {
                 meta.value = meta.value.copy(loading = false, failed = true)
@@ -199,6 +202,7 @@ class AudiobookPlayerViewModel @Inject constructor(
                 spans = session.tracks,
                 durationSec = session.timeline.durationSec,
                 startAtSec = resumeSec,
+                localZipFile = session.localZipFile,
             )
             // Record the active session so a media-notification tap reopens this audiobook player.
             nowPlayingStore.set(com.riffle.app.playback.NowPlaying.Audiobook(itemId))

--- a/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModel.kt
@@ -28,6 +28,18 @@ import javax.inject.Inject
 internal fun audiobookProgressFraction(positionSec: Double, durationSec: Double): Float =
     if (durationSec > 0.0) (positionSec / durationSec).toFloat().coerceIn(0f, 1f) else 0f
 
+/**
+ * The book-absolute resume position. When the position reconcile found nothing — no local audiobook
+ * position and no server position, e.g. offline with only a downloaded bundle — fall back to the
+ * item's library [readingProgressFraction] mapped to seconds. This resumes near where the rest of the
+ * app shows progress instead of restarting at 0, and (crucially) seeds the resume floor so the
+ * close/follow persist guard never writes a ~0 over that progress — the offline-erase bug. A genuine
+ * reconciled position ([reconciledSec] > 0) always wins, so online behaviour is unchanged.
+ */
+internal fun audiobookResumeSec(reconciledSec: Double, readingProgressFraction: Float, durationSec: Double): Double =
+    if (reconciledSec > 0.0 || readingProgressFraction <= 0f || durationSec <= 0.0) reconciledSec
+    else (readingProgressFraction * durationSec).coerceIn(0.0, durationSec)
+
 /** UI state for the full-screen [Audiobook Player] (ADR 0029). */
 data class AudiobookPlayerUiState(
     val loading: Boolean = true,
@@ -149,7 +161,7 @@ class AudiobookPlayerViewModel @Inject constructor(
             // it does not re-push (ADR 0029).
             val localSec = audiobookPositionStore.load(serverId, itemId)
             val localTs = audiobookPositionStore.loadLocalUpdatedAt(serverId, itemId)
-            val resumeSec: Double
+            var resumeSec: Double
             val resumeUpdatedAt: Long
             when (
                 val decision = com.riffle.core.domain.AudiobookPositionReconciler.reconcile(
@@ -174,6 +186,13 @@ class AudiobookPlayerViewModel @Inject constructor(
                     resumeUpdatedAt = session.serverLastUpdate
                 }
             }
+            // No tracked position (offline with only a bundle: no local listen row, no server time,
+            // and the canonical bridge is unavailable) → fall back to the item's library progress so
+            // we resume near where the app shows it AND seed reconciledResumeSec as a floor, so the
+            // close/follow persist guard can't write a ~0 over that progress. resumeUpdatedAt stays as
+            // reconciled (0 here), keeping this approximate position inbound-only — it never leads the
+            // canonical record. A genuine reconciled position is left untouched.
+            resumeSec = audiobookResumeSec(resumeSec, item.readingProgress, session.timeline.durationSec)
             // Per-book speed (ADR 0028), shared with the linked Readaloud. Resolve the audio-settings
             // key the *same* way the reader does — via the resolver on this audiobook's link — so both
             // land on the identical key regardless of the `hasAudio` flag or sort order. With no link,

--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemDetailScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemDetailScreen.kt
@@ -644,9 +644,12 @@ private fun ActionRow(
             }
         }
         if (item.isListenable) {
-            // The audiobook player streams from ABS (ADR 0029) unless it's been downloaded, in which
-            // case it plays the local files — so Listen needs connectivity only when not downloaded.
-            val listenBlockedOffline = isOffline && audiobookDownloadState != DownloadState.Downloaded
+            // The audiobook player resolves download > bundle > ABS stream (ADR 0029), so Listen needs
+            // connectivity only when neither a dedicated audiobook download nor a readaloud bundle is
+            // present locally — either local source plays offline.
+            val listenBlockedOffline = isOffline &&
+                audiobookDownloadState != DownloadState.Downloaded &&
+                readaloudDownloadState != DownloadState.Downloaded
             if (listenBlockedOffline) {
                 TooltipBox(
                     positionProvider = TooltipDefaults.rememberPlainTooltipPositionProvider(),

--- a/app/src/test/kotlin/com/riffle/app/feature/audiobook/AudiobookResumeSecTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/audiobook/AudiobookResumeSecTest.kt
@@ -6,30 +6,61 @@ import org.junit.Test
 class AudiobookResumeSecTest {
 
     @Test
-    fun `keeps the reconciled position when one was found`() {
+    fun `keeps the reconciled position when one was tracked`() {
         // A real tracked/server position wins; the library-progress fallback must not override it.
-        assertEquals(100.0, audiobookResumeSec(reconciledSec = 100.0, readingProgressFraction = 0.5f, durationSec = 1000.0), 1e-9)
+        assertEquals(
+            100.0,
+            audiobookResumeSec(reconciledSec = 100.0, hadTrackedPosition = true, readingProgressFraction = 0.5f, durationSec = 1000.0),
+            1e-9,
+        )
     }
 
     @Test
-    fun `falls back to library progress when no position was reconciled`() {
-        // Offline-with-only-a-bundle: reconcile yields 0, so resume from the fraction the rest of the
-        // app shows (and seed the guard floor that prevents the close-write erasing it).
-        assertEquals(500.0, audiobookResumeSec(reconciledSec = 0.0, readingProgressFraction = 0.5f, durationSec = 1000.0), 1e-9)
+    fun `honors a tracked position of exactly zero (does not fall back)`() {
+        // A genuine "at the start" record (e.g. server reset, with a real timestamp) must be kept, not
+        // replaced by the progress fallback — the falsy-zero trap.
+        assertEquals(
+            0.0,
+            audiobookResumeSec(reconciledSec = 0.0, hadTrackedPosition = true, readingProgressFraction = 0.5f, durationSec = 1000.0),
+            1e-9,
+        )
+    }
+
+    @Test
+    fun `falls back to library progress when no position was tracked`() {
+        // Offline-with-only-a-bundle: nothing tracked, so resume from the fraction the rest of the app
+        // shows (and seed the guard floor that prevents the close-write erasing it).
+        assertEquals(
+            500.0,
+            audiobookResumeSec(reconciledSec = 0.0, hadTrackedPosition = false, readingProgressFraction = 0.5f, durationSec = 1000.0),
+            1e-9,
+        )
     }
 
     @Test
     fun `stays at zero when there is no progress to fall back to`() {
-        assertEquals(0.0, audiobookResumeSec(reconciledSec = 0.0, readingProgressFraction = 0f, durationSec = 1000.0), 1e-9)
+        assertEquals(
+            0.0,
+            audiobookResumeSec(reconciledSec = 0.0, hadTrackedPosition = false, readingProgressFraction = 0f, durationSec = 1000.0),
+            1e-9,
+        )
     }
 
     @Test
     fun `stays at zero when the duration is unknown`() {
-        assertEquals(0.0, audiobookResumeSec(reconciledSec = 0.0, readingProgressFraction = 0.5f, durationSec = 0.0), 1e-9)
+        assertEquals(
+            0.0,
+            audiobookResumeSec(reconciledSec = 0.0, hadTrackedPosition = false, readingProgressFraction = 0.5f, durationSec = 0.0),
+            1e-9,
+        )
     }
 
     @Test
     fun `clamps a full-progress fallback to the duration`() {
-        assertEquals(1000.0, audiobookResumeSec(reconciledSec = 0.0, readingProgressFraction = 1f, durationSec = 1000.0), 1e-9)
+        assertEquals(
+            1000.0,
+            audiobookResumeSec(reconciledSec = 0.0, hadTrackedPosition = false, readingProgressFraction = 1f, durationSec = 1000.0),
+            1e-9,
+        )
     }
 }

--- a/app/src/test/kotlin/com/riffle/app/feature/audiobook/AudiobookResumeSecTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/audiobook/AudiobookResumeSecTest.kt
@@ -1,0 +1,35 @@
+package com.riffle.app.feature.audiobook
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class AudiobookResumeSecTest {
+
+    @Test
+    fun `keeps the reconciled position when one was found`() {
+        // A real tracked/server position wins; the library-progress fallback must not override it.
+        assertEquals(100.0, audiobookResumeSec(reconciledSec = 100.0, readingProgressFraction = 0.5f, durationSec = 1000.0), 1e-9)
+    }
+
+    @Test
+    fun `falls back to library progress when no position was reconciled`() {
+        // Offline-with-only-a-bundle: reconcile yields 0, so resume from the fraction the rest of the
+        // app shows (and seed the guard floor that prevents the close-write erasing it).
+        assertEquals(500.0, audiobookResumeSec(reconciledSec = 0.0, readingProgressFraction = 0.5f, durationSec = 1000.0), 1e-9)
+    }
+
+    @Test
+    fun `stays at zero when there is no progress to fall back to`() {
+        assertEquals(0.0, audiobookResumeSec(reconciledSec = 0.0, readingProgressFraction = 0f, durationSec = 1000.0), 1e-9)
+    }
+
+    @Test
+    fun `stays at zero when the duration is unknown`() {
+        assertEquals(0.0, audiobookResumeSec(reconciledSec = 0.0, readingProgressFraction = 0.5f, durationSec = 0.0), 1e-9)
+    }
+
+    @Test
+    fun `clamps a full-progress fallback to the duration`() {
+        assertEquals(1000.0, audiobookResumeSec(reconciledSec = 0.0, readingProgressFraction = 1f, durationSec = 1000.0), 1e-9)
+    }
+}

--- a/app/src/test/kotlin/com/riffle/app/feature/library/CollectionDetailViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/CollectionDetailViewModelTest.kt
@@ -11,6 +11,7 @@ import com.riffle.core.domain.EpubDownloadResult
 import com.riffle.core.domain.EpubOpenResult
 import com.riffle.core.domain.EpubRepository
 import com.riffle.core.domain.Library
+import com.riffle.core.domain.BundleAudiobookSource
 import com.riffle.core.domain.LibraryItem
 import com.riffle.core.domain.LibraryItemOfflineAvailability
 import com.riffle.core.domain.LibraryRefreshResult
@@ -167,6 +168,10 @@ class CollectionDetailViewModelTest {
             epubRepository,
             FakePdfRepository(),
             FakeAudiobookDownloadRepository(),
+            object : BundleAudiobookSource {
+                override suspend fun localSession(serverId: String, itemId: String) = null
+                override fun isAvailableOffline(serverId: String, itemId: String) = false
+            },
         ),
         connectivityObserver = connectivityObserver,
     )

--- a/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemsViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemsViewModelTest.kt
@@ -12,6 +12,7 @@ import com.riffle.core.domain.EpubOpenResult
 import com.riffle.core.domain.EpubRepository
 import com.riffle.core.domain.Library
 import com.riffle.core.domain.LibraryItem
+import com.riffle.core.domain.BundleAudiobookSource
 import com.riffle.core.domain.LibraryItemOfflineAvailability
 import com.riffle.core.domain.LibraryRefreshResult
 import com.riffle.core.domain.LibraryRepository
@@ -178,7 +179,15 @@ class LibraryItemsViewModelTest {
         libraryRepository,
         serverRepository,
         tokenStorage,
-        LibraryItemOfflineAvailability(epubRepository, pdfRepository, audiobookDownloadRepository),
+        LibraryItemOfflineAvailability(
+            epubRepository,
+            pdfRepository,
+            audiobookDownloadRepository,
+            object : BundleAudiobookSource {
+                override suspend fun localSession(serverId: String, itemId: String) = null
+                override fun isAvailableOffline(serverId: String, itemId: String) = false
+            },
+        ),
         connectivityObserver,
         toReadRepository,
         readaloudLinkRepository,

--- a/app/src/test/kotlin/com/riffle/app/feature/library/SeriesDetailViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/SeriesDetailViewModelTest.kt
@@ -11,6 +11,7 @@ import com.riffle.core.domain.EpubDownloadResult
 import com.riffle.core.domain.EpubOpenResult
 import com.riffle.core.domain.EpubRepository
 import com.riffle.core.domain.Library
+import com.riffle.core.domain.BundleAudiobookSource
 import com.riffle.core.domain.LibraryItem
 import com.riffle.core.domain.LibraryItemOfflineAvailability
 import com.riffle.core.domain.LibraryRefreshResult
@@ -140,6 +141,10 @@ class SeriesDetailViewModelTest {
             FakeEpubRepository(),
             FakePdfRepository(),
             FakeAudiobookDownloadRepository(),
+            object : BundleAudiobookSource {
+                override suspend fun localSession(serverId: String, itemId: String) = null
+                override fun isAvailableOffline(serverId: String, itemId: String) = false
+            },
         ),
         connectivityObserver = connectivityObserver,
     )

--- a/core/data/src/main/kotlin/com/riffle/core/data/BundleAudiobookSessionBuilder.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/BundleAudiobookSessionBuilder.kt
@@ -1,0 +1,57 @@
+package com.riffle.core.data
+
+import com.riffle.core.domain.AudiobookChapter
+import com.riffle.core.domain.AudiobookSession
+import com.riffle.core.domain.AudiobookTimeline
+import com.riffle.core.domain.AudiobookTrackSpan
+import com.riffle.core.domain.ReadaloudTrack
+import java.io.File
+
+/**
+ * Maps a bundle's Media Overlay [ReadaloudTrack] to a playable [AudiobookSession]: one span per
+ * distinct audio file (the same playlist order Readaloud queues), with cumulative book-absolute
+ * offsets, and chapters derived from the bundle's distinct chapter hrefs. The bundle audio is the
+ * same ABS source re-split into segments, so these spans are simply a different — but still
+ * contiguous — covering of the book timeline; the player's seek math works on any such covering.
+ *
+ * Track URLs are the audio files' zip-entry paths (a clip's `audioSrc`); the playback service routes
+ * any non-http/file mediaId through `ZipAudioDataSource`, reading from [bundle] via `SharedBundle`.
+ * Returns null when the bundle has no Media Overlay clips.
+ *
+ * Chapter titles are numbered ("Chapter N") — the SMIL overlay carries chapter hrefs and timings but
+ * not display titles. This is the accepted v1 offline degradation.
+ */
+internal fun buildBundleAudiobookSession(track: ReadaloudTrack, bundle: File): AudiobookSession? {
+    val files = track.clips.map { it.audioSrc }.distinct()
+    if (files.isEmpty()) return null
+
+    val durByFile = track.clips.groupBy { it.audioSrc }.mapValues { (_, cs) -> cs.maxOf { it.clipEndSec } }
+    var acc = 0.0
+    val spans = files.mapIndexed { i, src ->
+        val d = durByFile[src] ?: 0.0
+        AudiobookTrackSpan(index = i, startOffsetSec = acc, durationSec = d).also { acc += d }
+    }
+    val totalDuration = acc
+    val fileStart: Map<String, Double> = files.zip(spans).associate { (src, span) -> src to span.startOffsetSec }
+
+    val starts = (0 until track.chapterCount).mapNotNull { idx ->
+        track.firstClipOfChapter(idx)?.let { clip -> (fileStart[clip.audioSrc] ?: 0.0) + clip.clipBeginSec }
+    }.sorted()
+    val chapters = starts.mapIndexed { i, start ->
+        AudiobookChapter(
+            index = i,
+            startSec = start,
+            endSec = starts.getOrNull(i + 1) ?: totalDuration,
+            title = "Chapter ${i + 1}",
+        )
+    }
+
+    return AudiobookSession(
+        trackUrls = files,
+        tracks = spans,
+        timeline = AudiobookTimeline(durationSec = totalDuration, chapters = chapters),
+        serverCurrentTimeSec = 0.0,
+        serverLastUpdate = 0L,
+        localZipFile = bundle,
+    )
+}

--- a/core/data/src/main/kotlin/com/riffle/core/data/BundleAudiobookSessionBuilder.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/BundleAudiobookSessionBuilder.kt
@@ -28,11 +28,11 @@ internal fun buildBundleAudiobookSession(track: ReadaloudTrack, bundle: File): A
     val durByFile = track.clips.groupBy { it.audioSrc }.mapValues { (_, cs) -> cs.maxOf { it.clipEndSec } }
     var acc = 0.0
     val spans = files.mapIndexed { i, src ->
-        val d = durByFile[src] ?: 0.0
-        AudiobookTrackSpan(index = i, startOffsetSec = acc, durationSec = d).also { acc += d }
+        val dur = durByFile[src] ?: 0.0
+        AudiobookTrackSpan(index = i, startOffsetSec = acc, durationSec = dur).also { acc += dur }
     }
     val totalDuration = acc
-    val fileStart: Map<String, Double> = files.zip(spans).associate { (src, span) -> src to span.startOffsetSec }
+    val fileStart = files.zip(spans).associate { (src, span) -> src to span.startOffsetSec }
 
     val starts = (0 until track.chapterCount).mapNotNull { idx ->
         track.firstClipOfChapter(idx)?.let { clip -> (fileStart[clip.audioSrc] ?: 0.0) + clip.clipBeginSec }

--- a/core/data/src/main/kotlin/com/riffle/core/data/StorytellerBundleAudiobookSource.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/StorytellerBundleAudiobookSource.kt
@@ -16,21 +16,24 @@ import kotlinx.coroutines.launch
  *
  * [isAvailableOffline] must be synchronous (it backs the library's offline filter), so the suspend
  * link lookup is replaced on that path by a [linksByAbsItem] snapshot kept fresh from
- * [ReadaloudLinkRepository.observeAll] on an application-lifetime [scope] — the same self-managed IO
- * scope pattern as [CrossEpubIndexBuilderService].
+ * [ReadaloudLinkRepository.observeAll] on the [applicationScope] — the same self-managed background
+ * pattern as [CrossEpubIndexBuilderService]. The snapshot reads `emptyMap` until that collector's
+ * first emission; in production the application-lifetime scope starts well before any library query,
+ * so a downloaded bundle is reflected by the time the offline filter runs.
  */
 class StorytellerBundleAudiobookSource(
     private val readaloudLinkRepository: ReadaloudLinkRepository,
     private val readaloudAudioRepository: ReadaloudAudioRepository,
-    scope: CoroutineScope,
+    // Must outlive this singleton (application-lifetime); it owns the snapshot collector below.
+    applicationScope: CoroutineScope,
 ) : BundleAudiobookSource {
 
-    // ABS "serverId/itemId" -> link, so isAvailableOffline is a synchronous lookup.
+    // ABS (serverId, itemId) -> link, so isAvailableOffline is a synchronous lookup.
     @Volatile
     private var linksByAbsItem: Map<String, ReadaloudLink> = emptyMap()
 
     init {
-        scope.launch {
+        applicationScope.launch {
             readaloudLinkRepository.observeAll().collect { links ->
                 linksByAbsItem = links.associateBy { absKey(it.absServerId, it.absLibraryItemId) }
             }
@@ -51,5 +54,7 @@ class StorytellerBundleAudiobookSource(
         return readaloudAudioRepository.isAudioAvailable(link.storytellerServerId, link.storytellerBookId)
     }
 
-    private fun absKey(serverId: String, itemId: String) = "$serverId/$itemId"
+    // NUL separator: it can't occur in an ABS server or item id, so the key can't collide across
+    // different (serverId, itemId) splits the way a "/" join could.
+    private fun absKey(serverId: String, itemId: String) = "$serverId\u0000$itemId"
 }

--- a/core/data/src/main/kotlin/com/riffle/core/data/StorytellerBundleAudiobookSource.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/StorytellerBundleAudiobookSource.kt
@@ -1,0 +1,55 @@
+package com.riffle.core.data
+
+import com.riffle.core.domain.AudiobookSession
+import com.riffle.core.domain.BundleAudiobookSource
+import com.riffle.core.domain.ReadaloudAudioRepository
+import com.riffle.core.domain.ReadaloudLink
+import com.riffle.core.domain.ReadaloudLinkRepository
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+
+/**
+ * The sole [BundleAudiobookSource] implementation, and the only audiobook/library code that knows the
+ * offline audio can come from a Storyteller readaloud bundle (ADR 0023). It translates the player's
+ * ABS `(serverId, itemId)` to the bundle's Storyteller `(serverId, bookId)` via the [ReadaloudLink],
+ * then maps the bundle's Media Overlay track to an [AudiobookSession] ([buildBundleAudiobookSession]).
+ *
+ * [isAvailableOffline] must be synchronous (it backs the library's offline filter), so the suspend
+ * link lookup is replaced on that path by a [linksByAbsItem] snapshot kept fresh from
+ * [ReadaloudLinkRepository.observeAll] on an application-lifetime [scope] — the same self-managed IO
+ * scope pattern as [CrossEpubIndexBuilderService].
+ */
+class StorytellerBundleAudiobookSource(
+    private val readaloudLinkRepository: ReadaloudLinkRepository,
+    private val readaloudAudioRepository: ReadaloudAudioRepository,
+    scope: CoroutineScope,
+) : BundleAudiobookSource {
+
+    // ABS "serverId/itemId" -> link, so isAvailableOffline is a synchronous lookup.
+    @Volatile
+    private var linksByAbsItem: Map<String, ReadaloudLink> = emptyMap()
+
+    init {
+        scope.launch {
+            readaloudLinkRepository.observeAll().collect { links ->
+                linksByAbsItem = links.associateBy { absKey(it.absServerId, it.absLibraryItemId) }
+            }
+        }
+    }
+
+    override suspend fun localSession(serverId: String, itemId: String): AudiobookSession? {
+        val link = readaloudLinkRepository.findByAbsItem(serverId, itemId) ?: return null
+        val bundle = readaloudAudioRepository.bundleFile(link.storytellerServerId, link.storytellerBookId)
+            ?: return null
+        val track = readaloudAudioRepository.readTrack(link.storytellerServerId, link.storytellerBookId)
+            ?: return null
+        return buildBundleAudiobookSession(track, bundle)
+    }
+
+    override fun isAvailableOffline(serverId: String, itemId: String): Boolean {
+        val link = linksByAbsItem[absKey(serverId, itemId)] ?: return false
+        return readaloudAudioRepository.isAudioAvailable(link.storytellerServerId, link.storytellerBookId)
+    }
+
+    private fun absKey(serverId: String, itemId: String) = "$serverId/$itemId"
+}

--- a/core/data/src/main/kotlin/com/riffle/core/data/di/DataModule.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/di/DataModule.kt
@@ -65,6 +65,7 @@ import com.riffle.core.domain.VolumeKeyPreferencesStore
 import com.riffle.core.domain.WakeLockPreferencesStore
 import com.riffle.core.data.AudiobookBundleDownloader
 import com.riffle.core.data.ReadaloudAudioRepositoryImpl
+import com.riffle.core.data.StorytellerBundleAudiobookSource
 import com.riffle.core.data.StorytellerPositionSyncController
 import com.riffle.core.data.StorytellerReadaloudSyncer
 import com.riffle.core.database.LibraryItemDao
@@ -393,6 +394,20 @@ abstract class DataModule {
 
         @Provides
         @Singleton
+        fun provideBundleAudiobookSource(
+            readaloudLinkRepository: com.riffle.core.domain.ReadaloudLinkRepository,
+            readaloudAudioRepository: com.riffle.core.domain.ReadaloudAudioRepository,
+        ): com.riffle.core.domain.BundleAudiobookSource =
+            StorytellerBundleAudiobookSource(
+                readaloudLinkRepository = readaloudLinkRepository,
+                readaloudAudioRepository = readaloudAudioRepository,
+                applicationScope = kotlinx.coroutines.CoroutineScope(
+                    kotlinx.coroutines.SupervisorJob() + kotlinx.coroutines.Dispatchers.IO,
+                ),
+            )
+
+        @Provides
+        @Singleton
         fun provideEpubRepository(
             api: AbsLibraryApi,
             @EpubCacheStore cacheStore: LocalStore,
@@ -419,8 +434,9 @@ abstract class DataModule {
             epubRepository: EpubRepository,
             pdfRepository: PdfRepository,
             audiobookDownloadRepository: AudiobookDownloadRepository,
+            bundleAudiobookSource: com.riffle.core.domain.BundleAudiobookSource,
         ): LibraryItemOfflineAvailability =
-            LibraryItemOfflineAvailability(epubRepository, pdfRepository, audiobookDownloadRepository)
+            LibraryItemOfflineAvailability(epubRepository, pdfRepository, audiobookDownloadRepository, bundleAudiobookSource)
 
         @Provides
         @Singleton

--- a/core/data/src/test/kotlin/com/riffle/core/data/BundleAudiobookSessionBuilderTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/BundleAudiobookSessionBuilderTest.kt
@@ -60,6 +60,20 @@ class BundleAudiobookSessionBuilderTest {
     }
 
     @Test
+    fun `chapter starting mid-way into a non-first audio file gets correct global offset`() {
+        val track = ReadaloudTrack(
+            listOf(
+                clip("c1.xhtml#s0", "audio/0.mp3", 0.0, 60.0),
+                clip("c2.xhtml#s0", "audio/1.mp3", 5.0, 40.0), // chapter 2's first clip starts 5s into file 1
+            ),
+        )
+
+        val chapters = buildBundleAudiobookSession(track, bundle)!!.timeline.chapters
+
+        assertEquals(65.0, chapters[1].startSec, 1e-9) // 60 (fileStart of audio/1.mp3) + 5 (clipBeginSec)
+    }
+
+    @Test
     fun `returns null when the track has no clips`() {
         assertNull(buildBundleAudiobookSession(ReadaloudTrack(emptyList()), bundle))
     }

--- a/core/data/src/test/kotlin/com/riffle/core/data/BundleAudiobookSessionBuilderTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/BundleAudiobookSessionBuilderTest.kt
@@ -1,0 +1,66 @@
+package com.riffle.core.data
+
+import com.riffle.core.domain.MediaOverlayClip
+import com.riffle.core.domain.ReadaloudTrack
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import java.io.File
+
+class BundleAudiobookSessionBuilderTest {
+
+    private val bundle = File("/tmp/bundle.epub")
+
+    private fun clip(href: String, audio: String, begin: Double, end: Double) =
+        MediaOverlayClip(textFragmentRef = href, audioSrc = audio, clipBeginSec = begin, clipEndSec = end)
+
+    @Test
+    fun `builds one span per distinct audio file with cumulative offsets`() {
+        val track = ReadaloudTrack(
+            listOf(
+                clip("c1.xhtml#s0", "audio/0.mp3", 0.0, 30.0),
+                clip("c1.xhtml#s1", "audio/0.mp3", 30.0, 60.0),
+                clip("c2.xhtml#s0", "audio/1.mp3", 0.0, 45.0),
+            ),
+        )
+
+        val session = buildBundleAudiobookSession(track, bundle)!!
+
+        assertEquals(listOf("audio/0.mp3", "audio/1.mp3"), session.trackUrls)
+        assertEquals(2, session.tracks.size)
+        assertEquals(0.0, session.tracks[0].startOffsetSec, 1e-9)
+        assertEquals(60.0, session.tracks[0].durationSec, 1e-9)
+        assertEquals(60.0, session.tracks[1].startOffsetSec, 1e-9)
+        assertEquals(45.0, session.tracks[1].durationSec, 1e-9)
+        assertEquals(105.0, session.timeline.durationSec, 1e-9)
+        assertEquals(bundle, session.localZipFile)
+        assertEquals(0.0, session.serverCurrentTimeSec, 1e-9)
+        assertEquals(0L, session.serverLastUpdate)
+    }
+
+    @Test
+    fun `derives one chapter per distinct chapter href with boundaries on the global timeline`() {
+        val track = ReadaloudTrack(
+            listOf(
+                clip("c1.xhtml#s0", "audio/0.mp3", 0.0, 30.0),
+                clip("c2.xhtml#s0", "audio/0.mp3", 30.0, 60.0),
+                clip("c2.xhtml#s1", "audio/1.mp3", 0.0, 45.0),
+            ),
+        )
+
+        val chapters = buildBundleAudiobookSession(track, bundle)!!.timeline.chapters
+
+        assertEquals(2, chapters.size)
+        assertEquals(0.0, chapters[0].startSec, 1e-9)
+        assertEquals(30.0, chapters[0].endSec, 1e-9)
+        assertEquals(30.0, chapters[1].startSec, 1e-9)
+        assertEquals(105.0, chapters[1].endSec, 1e-9)
+        assertEquals("Chapter 1", chapters[0].title)
+        assertEquals("Chapter 2", chapters[1].title)
+    }
+
+    @Test
+    fun `returns null when the track has no clips`() {
+        assertNull(buildBundleAudiobookSession(ReadaloudTrack(emptyList()), bundle))
+    }
+}

--- a/core/data/src/test/kotlin/com/riffle/core/data/StorytellerBundleAudiobookSourceTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/StorytellerBundleAudiobookSourceTest.kt
@@ -5,10 +5,12 @@ import com.riffle.core.domain.ReadaloudAudioRepository
 import com.riffle.core.domain.ReadaloudLink
 import com.riffle.core.domain.ReadaloudLinkRepository
 import com.riffle.core.domain.ReadaloudTrack
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -87,13 +89,18 @@ class StorytellerBundleAudiobookSourceTest {
 
     @Test
     fun `isAvailableOffline reflects the link snapshot and bundle presence`() = runTest {
-        val present = StorytellerBundleAudiobookSource(FakeLinks(listOf(link)), FakeAudio(bundle, track), backgroundScope)
-        advanceUntilIdle()
-        assertTrue(present.isAvailableOffline("abs", "item-1"))
-        assertFalse(present.isAvailableOffline("abs", "other"))
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        try {
+            // Unconfined → the init collector runs eagerly to the StateFlow's first (current) value, so
+            // the snapshot is populated synchronously before these assertions, no scheduler advance needed.
+            val present = StorytellerBundleAudiobookSource(FakeLinks(listOf(link)), FakeAudio(bundle, track), scope)
+            assertTrue(present.isAvailableOffline("abs", "item-1"))
+            assertFalse(present.isAvailableOffline("abs", "other"))
 
-        val noBundle = StorytellerBundleAudiobookSource(FakeLinks(listOf(link)), FakeAudio(null, track), backgroundScope)
-        advanceUntilIdle()
-        assertFalse(noBundle.isAvailableOffline("abs", "item-1"))
+            val noBundle = StorytellerBundleAudiobookSource(FakeLinks(listOf(link)), FakeAudio(null, track), scope)
+            assertFalse(noBundle.isAvailableOffline("abs", "item-1"))
+        } finally {
+            scope.cancel()
+        }
     }
 }

--- a/core/data/src/test/kotlin/com/riffle/core/data/StorytellerBundleAudiobookSourceTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/StorytellerBundleAudiobookSourceTest.kt
@@ -61,7 +61,7 @@ class StorytellerBundleAudiobookSourceTest {
         val source = StorytellerBundleAudiobookSource(
             readaloudLinkRepository = FakeLinks(listOf(link)),
             readaloudAudioRepository = FakeAudio(bundle, track),
-            scope = backgroundScope,
+            applicationScope = backgroundScope,
         )
 
         val session = source.localSession("abs", "item-1")!!

--- a/core/data/src/test/kotlin/com/riffle/core/data/StorytellerBundleAudiobookSourceTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/StorytellerBundleAudiobookSourceTest.kt
@@ -1,0 +1,99 @@
+package com.riffle.core.data
+
+import com.riffle.core.domain.MediaOverlayClip
+import com.riffle.core.domain.ReadaloudAudioRepository
+import com.riffle.core.domain.ReadaloudLink
+import com.riffle.core.domain.ReadaloudLinkRepository
+import com.riffle.core.domain.ReadaloudTrack
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class StorytellerBundleAudiobookSourceTest {
+
+    private val link = ReadaloudLink(
+        storytellerServerId = "st", storytellerBookId = "book-1",
+        absServerId = "abs", absLibraryItemId = "item-1", userConfirmed = true,
+    )
+
+    private class FakeLinks(private val all: List<ReadaloudLink>) : ReadaloudLinkRepository {
+        override fun observeAll(): Flow<List<ReadaloudLink>> = MutableStateFlow(all)
+        override fun observeLinkedAbsItemIds() = MutableStateFlow(all.map { it.absLibraryItemId }.toSet())
+        override suspend fun findByAbsItem(absServerId: String, absLibraryItemId: String) =
+            all.firstOrNull { it.absServerId == absServerId && it.absLibraryItemId == absLibraryItemId }
+        override suspend fun findByStorytellerBook(storytellerServerId: String, storytellerBookId: String) =
+            all.filter { it.storytellerServerId == storytellerServerId && it.storytellerBookId == storytellerBookId }
+        override suspend fun unlinkAbsItem(absServerId: String, absLibraryItemId: String) = Unit
+        override suspend fun countForServer(serverId: String) = all.count { it.absServerId == serverId }
+    }
+
+    private class FakeAudio(
+        private val bundle: File?,
+        private val track: ReadaloudTrack?,
+    ) : ReadaloudAudioRepository {
+        override fun isAudioAvailable(serverId: String, itemId: String) = bundle != null
+        override fun bundleFile(serverId: String, itemId: String) = bundle
+        override suspend fun readTrack(serverId: String, itemId: String) = track
+        override suspend fun probeSizeBytes(serverId: String, itemId: String): Long? = null
+        override suspend fun downloadAudio(serverId: String, bookId: String, onProgress: (Long, Long) -> Unit) =
+            com.riffle.core.domain.AudioDownloadResult.Success
+        override suspend fun removeAudio(serverId: String, itemId: String) = 0L
+    }
+
+    private val track = ReadaloudTrack(
+        listOf(MediaOverlayClip("c1.xhtml#s0", "audio/0.mp3", 0.0, 30.0)),
+    )
+    private val bundle = File("/tmp/book-1.epub")
+
+    @Test
+    fun `localSession resolves link then bundle then builds a session`() = runTest {
+        val source = StorytellerBundleAudiobookSource(
+            readaloudLinkRepository = FakeLinks(listOf(link)),
+            readaloudAudioRepository = FakeAudio(bundle, track),
+            scope = backgroundScope,
+        )
+
+        val session = source.localSession("abs", "item-1")!!
+
+        assertEquals(listOf("audio/0.mp3"), session.trackUrls)
+        assertEquals(bundle, session.localZipFile)
+        assertEquals(30.0, session.timeline.durationSec, 1e-9)
+    }
+
+    @Test
+    fun `localSession is null with no link, no bundle, or no overlay`() = runTest {
+        assertNull(
+            StorytellerBundleAudiobookSource(FakeLinks(emptyList()), FakeAudio(bundle, track), backgroundScope)
+                .localSession("abs", "item-1"),
+        )
+        assertNull(
+            StorytellerBundleAudiobookSource(FakeLinks(listOf(link)), FakeAudio(null, track), backgroundScope)
+                .localSession("abs", "item-1"),
+        )
+        assertNull(
+            StorytellerBundleAudiobookSource(FakeLinks(listOf(link)), FakeAudio(bundle, null), backgroundScope)
+                .localSession("abs", "item-1"),
+        )
+    }
+
+    @Test
+    fun `isAvailableOffline reflects the link snapshot and bundle presence`() = runTest {
+        val present = StorytellerBundleAudiobookSource(FakeLinks(listOf(link)), FakeAudio(bundle, track), backgroundScope)
+        advanceUntilIdle()
+        assertTrue(present.isAvailableOffline("abs", "item-1"))
+        assertFalse(present.isAvailableOffline("abs", "other"))
+
+        val noBundle = StorytellerBundleAudiobookSource(FakeLinks(listOf(link)), FakeAudio(null, track), backgroundScope)
+        advanceUntilIdle()
+        assertFalse(noBundle.isAvailableOffline("abs", "item-1"))
+    }
+}

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/AudiobookRepository.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/AudiobookRepository.kt
@@ -1,5 +1,7 @@
 package com.riffle.core.domain
 
+import java.io.File
+
 /**
  * A ready-to-play [Audiobook] session resolved from ABS (ADR 0029): the ordered, directly-streamable
  * track URLs paired with their timeline [tracks], the [timeline] (duration + chapter markers), and the
@@ -13,6 +15,9 @@ data class AudiobookSession(
     // ABS's server-side `lastUpdate` (ms) for this item's media-progress record, for last-update-wins
     // resume against the durable local store. 0 when unknown (offline / downloaded session).
     val serverLastUpdate: Long = 0,
+    // The local zip archive backing zip-entry track URLs (a downloaded bundle), or null when tracks
+    // are HTTP/file URLs. The player points the playback service at this file before preparing.
+    val localZipFile: File? = null,
 )
 
 interface AudiobookRepository {

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/BundleAudiobookSource.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/BundleAudiobookSource.kt
@@ -1,0 +1,22 @@
+package com.riffle.core.domain
+
+/**
+ * Produces an [AudiobookSession] for an ABS item from a downloaded bundle's audio, when one exists.
+ * This is the third [AudiobookSession] producer (alongside [AudiobookRepository] for streaming and
+ * [AudiobookDownloadRepository] for the dedicated download); the player prefers a dedicated download,
+ * then a bundle, then streaming.
+ *
+ * All knowledge of which bundle type backs the audio (today: a Storyteller readaloud bundle) lives in
+ * the single implementation. Removing or replacing that bundle type is a one-class change behind this
+ * interface; the audiobook stack and the library are unaffected.
+ */
+interface BundleAudiobookSource {
+    /** A playable session backed by a downloaded bundle's audio for this ABS item, or null if none. */
+    suspend fun localSession(serverId: String, itemId: String): AudiobookSession?
+
+    /**
+     * True when a downloaded bundle can satisfy this ABS item's audio offline. Synchronous so it backs
+     * the library's offline filter without making that predicate suspend.
+     */
+    fun isAvailableOffline(serverId: String, itemId: String): Boolean
+}

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/LibraryItemOfflineAvailability.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/LibraryItemOfflineAvailability.kt
@@ -4,12 +4,14 @@ package com.riffle.core.domain
  * Decides whether a [LibraryItem] can be opened with no network — the single source of truth behind
  * the library's offline filtering. An item is available offline when its ebook is downloaded or
  * cached (EPUB/PDF), OR when its audiobook is downloaded. Audiobooks have a download-only tier (no
- * auto-cache), so the audio side is a plain `isDownloaded` check (ADR 0029).
+ * auto-cache), so the audio side is a plain `isDownloaded` check (ADR 0029). An item is ALSO
+ * offline-available when a downloaded readaloud bundle can supply its audio ([BundleAudiobookSource]).
  */
 class LibraryItemOfflineAvailability(
     private val epubRepository: EpubRepository,
     private val pdfRepository: PdfRepository,
     private val audiobookDownloadRepository: AudiobookDownloadRepository,
+    private val bundleAudiobookSource: BundleAudiobookSource,
 ) {
     fun isAvailableOffline(item: LibraryItem): Boolean {
         val ebookAvailable = when (item.ebookFormat) {
@@ -19,6 +21,8 @@ class LibraryItemOfflineAvailability(
                 pdfRepository.isDownloaded(item.serverId, item.id) || pdfRepository.isCached(item.serverId, item.id)
             EbookFormat.Unsupported -> false
         }
-        return ebookAvailable || audiobookDownloadRepository.isDownloaded(item.serverId, item.id)
+        return ebookAvailable ||
+            audiobookDownloadRepository.isDownloaded(item.serverId, item.id) ||
+            bundleAudiobookSource.isAvailableOffline(item.serverId, item.id)
     }
 }

--- a/core/domain/src/test/kotlin/com/riffle/core/domain/LibraryItemOfflineAvailabilityTest.kt
+++ b/core/domain/src/test/kotlin/com/riffle/core/domain/LibraryItemOfflineAvailabilityTest.kt
@@ -31,6 +31,7 @@ class LibraryItemOfflineAvailabilityTest {
             epubRepository = FakeEpubRepository(downloaded = true),
             pdfRepository = FakePdfRepository(),
             audiobookDownloadRepository = FakeAudiobookDownloadRepository(),
+            bundleAudiobookSource = FakeBundleAudiobookSource(),
         )
 
         assertTrue(availability.isAvailableOffline(item(EbookFormat.Epub)))
@@ -42,6 +43,7 @@ class LibraryItemOfflineAvailabilityTest {
             epubRepository = FakeEpubRepository(cached = true),
             pdfRepository = FakePdfRepository(),
             audiobookDownloadRepository = FakeAudiobookDownloadRepository(),
+            bundleAudiobookSource = FakeBundleAudiobookSource(),
         )
 
         assertTrue(availability.isAvailableOffline(item(EbookFormat.Epub)))
@@ -53,6 +55,7 @@ class LibraryItemOfflineAvailabilityTest {
             epubRepository = FakeEpubRepository(),
             pdfRepository = FakePdfRepository(downloaded = true),
             audiobookDownloadRepository = FakeAudiobookDownloadRepository(),
+            bundleAudiobookSource = FakeBundleAudiobookSource(),
         )
 
         assertTrue(availability.isAvailableOffline(item(EbookFormat.Pdf)))
@@ -64,6 +67,7 @@ class LibraryItemOfflineAvailabilityTest {
             epubRepository = FakeEpubRepository(),
             pdfRepository = FakePdfRepository(),
             audiobookDownloadRepository = FakeAudiobookDownloadRepository(downloaded = true),
+            bundleAudiobookSource = FakeBundleAudiobookSource(),
         )
 
         assertTrue(availability.isAvailableOffline(item(EbookFormat.Unsupported, hasAudio = true)))
@@ -75,6 +79,7 @@ class LibraryItemOfflineAvailabilityTest {
             epubRepository = FakeEpubRepository(), // ebook not downloaded/cached
             pdfRepository = FakePdfRepository(),
             audiobookDownloadRepository = FakeAudiobookDownloadRepository(downloaded = true),
+            bundleAudiobookSource = FakeBundleAudiobookSource(),
         )
 
         assertTrue(availability.isAvailableOffline(item(EbookFormat.Epub, hasAudio = true)))
@@ -86,9 +91,34 @@ class LibraryItemOfflineAvailabilityTest {
             epubRepository = FakeEpubRepository(),
             pdfRepository = FakePdfRepository(),
             audiobookDownloadRepository = FakeAudiobookDownloadRepository(),
+            bundleAudiobookSource = FakeBundleAudiobookSource(),
         )
 
         assertFalse(availability.isAvailableOffline(item(EbookFormat.Epub, hasAudio = true)))
+    }
+
+    @Test
+    fun `item with no ebook or audiobook download is offline-available when its bundle is downloaded`() {
+        val availability = LibraryItemOfflineAvailability(
+            epubRepository = FakeEpubRepository(),
+            pdfRepository = FakePdfRepository(),
+            audiobookDownloadRepository = FakeAudiobookDownloadRepository(),
+            bundleAudiobookSource = FakeBundleAudiobookSource(setOf("s1/i1")),
+        )
+
+        assertTrue(availability.isAvailableOffline(item(EbookFormat.Unsupported, hasAudio = true)))
+    }
+
+    @Test
+    fun `item with no downloads and no bundle is not offline-available`() {
+        val availability = LibraryItemOfflineAvailability(
+            epubRepository = FakeEpubRepository(),
+            pdfRepository = FakePdfRepository(),
+            audiobookDownloadRepository = FakeAudiobookDownloadRepository(),
+            bundleAudiobookSource = FakeBundleAudiobookSource(emptySet()),
+        )
+
+        assertFalse(availability.isAvailableOffline(item(EbookFormat.Unsupported, hasAudio = true)))
     }
 
     private class FakeEpubRepository(
@@ -132,5 +162,12 @@ class LibraryItemOfflineAvailabilityTest {
             onProgress: (downloaded: Long, total: Long) -> Unit,
         ) = error("unused")
         override suspend fun remove(serverId: String, itemId: String) = error("unused")
+    }
+
+    private class FakeBundleAudiobookSource(
+        private val offlineIds: Set<String> = emptySet(),
+    ) : BundleAudiobookSource {
+        override suspend fun localSession(serverId: String, itemId: String): AudiobookSession? = null
+        override fun isAvailableOffline(serverId: String, itemId: String) = "$serverId/$itemId" in offlineIds
     }
 }

--- a/docs/superpowers/plans/2026-06-12-offline-audiobook-from-bundle.md
+++ b/docs/superpowers/plans/2026-06-12-offline-audiobook-from-bundle.md
@@ -1,0 +1,799 @@
+# Offline Audiobook From Bundle — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let the standalone audiobook player play from a downloaded readaloud bundle (download > bundle > stream), and make the offline library list bundle-only items — all behind one removable `BundleAudiobookSource` interface.
+
+**Architecture:** The audiobook stack is driven by an `AudiobookSession` (track URLs + spans + timeline) plus book-absolute seconds, and `AudioPlayerService` already routes any non-http/file `mediaId` through `ZipAudioDataSource`. We add a third `AudiobookSession` producer — `BundleAudiobookSource`, implemented once by `StorytellerBundleAudiobookSource` (the only audiobook/library code that knows about readaloud bundles). The bundle session's track URLs are the bundle's zip-entry audio paths; the player points `SharedBundle.current` at the bundle file before preparing. Persistence/reconcile/the ADR-0030 sweep are inherited unchanged because position stays book-absolute seconds.
+
+**Tech Stack:** Kotlin, Hilt DI, Media3/ExoPlayer, kotlinx.coroutines, JUnit. Pure-JVM unit tests in `core/domain`, Robolectric/JVM tests in `core/data` and `app`.
+
+**Setup for every test/build command below:**
+```bash
+export JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"
+cd /Users/plamen.kmetski/conductor/workspaces/riffle/sao-paulo
+```
+
+---
+
+## File Structure
+
+- **Create** `core/domain/src/main/kotlin/com/riffle/core/domain/BundleAudiobookSource.kt` — the interface both consumers depend on.
+- **Create** `core/data/src/main/kotlin/com/riffle/core/data/BundleAudiobookSessionBuilder.kt` — pure mapping `ReadaloudTrack` + bundle `File` → `AudiobookSession`.
+- **Create** `core/data/src/main/kotlin/com/riffle/core/data/StorytellerBundleAudiobookSource.kt` — the single implementation (link→bundle translation, snapshot, builder call).
+- **Modify** `core/domain/src/main/kotlin/com/riffle/core/domain/AudiobookRepository.kt` — add `localZipFile` to `AudiobookSession`.
+- **Modify** `core/domain/src/main/kotlin/com/riffle/core/domain/LibraryItemOfflineAvailability.kt` — add dependency + OR clause.
+- **Modify** `app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookController.kt` — accept `localZipFile`, set `SharedBundle.current`.
+- **Modify** `app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModel.kt` — insert bundle source into the resolution chain.
+- **Modify** `core/data/src/main/kotlin/com/riffle/core/data/di/DataModule.kt` — bind `BundleAudiobookSource`, update the `LibraryItemOfflineAvailability` provider.
+- **Test (create)** `core/data/.../BundleAudiobookSessionBuilderTest.kt`, `core/data/.../StorytellerBundleAudiobookSourceTest.kt`.
+- **Test (modify)** `core/domain/.../LibraryItemOfflineAvailabilityTest.kt`.
+
+No database migration. No `AudioPlayerService` change (its scheme routing already covers zip-entry mediaIds).
+
+---
+
+## Task 1: Carry the local zip file on `AudiobookSession`
+
+**Files:**
+- Modify: `core/domain/src/main/kotlin/com/riffle/core/domain/AudiobookRepository.kt`
+
+- [ ] **Step 1: Add the field**
+
+In `AudiobookRepository.kt`, add an import at the top of the file (after the `package` line):
+```kotlin
+import java.io.File
+```
+Then add a field to the `AudiobookSession` data class, after `serverLastUpdate`:
+```kotlin
+    val serverLastUpdate: Long = 0,
+    // The local zip archive backing zip-entry track URLs (a downloaded bundle), or null when tracks
+    // are HTTP/file URLs. The player points the playback service at this file before preparing.
+    val localZipFile: File? = null,
+)
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `./gradlew :core:domain:compileDebugKotlin 2>/dev/null || ./gradlew :core:domain:test --tests 'nonexistent' 2>&1 | tail -5`
+Expected: BUILD SUCCESSFUL (no compile errors). (Existing two producers default `localZipFile` to null, so nothing else breaks.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add core/domain/src/main/kotlin/com/riffle/core/domain/AudiobookRepository.kt
+git commit -m "feat(audiobook): carry an optional local zip file on AudiobookSession"
+```
+
+---
+
+## Task 2: Define the `BundleAudiobookSource` interface
+
+**Files:**
+- Create: `core/domain/src/main/kotlin/com/riffle/core/domain/BundleAudiobookSource.kt`
+
+- [ ] **Step 1: Write the interface**
+
+```kotlin
+package com.riffle.core.domain
+
+/**
+ * Produces an [AudiobookSession] for an ABS item from a downloaded bundle's audio, when one exists.
+ * This is the third [AudiobookSession] producer (alongside [AudiobookRepository] for streaming and
+ * [AudiobookDownloadRepository] for the dedicated download); the player prefers a dedicated download,
+ * then a bundle, then streaming.
+ *
+ * All knowledge of which bundle type backs the audio (today: a Storyteller readaloud bundle) lives in
+ * the single implementation. Removing or replacing that bundle type is a one-class change behind this
+ * interface; the audiobook stack and the library are unaffected.
+ */
+interface BundleAudiobookSource {
+    /** A playable session backed by a downloaded bundle's audio for this ABS item, or null if none. */
+    suspend fun localSession(serverId: String, itemId: String): AudiobookSession?
+
+    /**
+     * True when a downloaded bundle can satisfy this ABS item's audio offline. Synchronous so it backs
+     * the library's offline filter without making that predicate suspend.
+     */
+    fun isAvailableOffline(serverId: String, itemId: String): Boolean
+}
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `./gradlew :core:domain:compileDebugKotlin 2>&1 | tail -5`
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add core/domain/src/main/kotlin/com/riffle/core/domain/BundleAudiobookSource.kt
+git commit -m "feat(audiobook): BundleAudiobookSource interface for offline bundle audio"
+```
+
+---
+
+## Task 3: Pure session builder (`ReadaloudTrack` + bundle file → `AudiobookSession`)
+
+This is the meat of the mapping and is pure/deterministic, so it gets thorough TDD.
+
+**Files:**
+- Create: `core/data/src/main/kotlin/com/riffle/core/data/BundleAudiobookSessionBuilder.kt`
+- Test: `core/data/src/test/kotlin/com/riffle/core/data/BundleAudiobookSessionBuilderTest.kt`
+
+- [ ] **Step 1: Write the failing test**
+
+```kotlin
+package com.riffle.core.data
+
+import com.riffle.core.domain.MediaOverlayClip
+import com.riffle.core.domain.ReadaloudTrack
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import java.io.File
+
+class BundleAudiobookSessionBuilderTest {
+
+    private val bundle = File("/tmp/bundle.epub")
+
+    private fun clip(href: String, audio: String, begin: Double, end: Double) =
+        MediaOverlayClip(textFragmentRef = href, audioSrc = audio, clipBeginSec = begin, clipEndSec = end)
+
+    @Test
+    fun `builds one span per distinct audio file with cumulative offsets`() {
+        val track = ReadaloudTrack(
+            listOf(
+                clip("c1.xhtml#s0", "audio/0.mp3", 0.0, 30.0),
+                clip("c1.xhtml#s1", "audio/0.mp3", 30.0, 60.0),
+                clip("c2.xhtml#s0", "audio/1.mp3", 0.0, 45.0),
+            ),
+        )
+
+        val session = buildBundleAudiobookSession(track, bundle)!!
+
+        // Two distinct audio files → two spans; durations are each file's last clipEnd.
+        assertEquals(listOf("audio/0.mp3", "audio/1.mp3"), session.trackUrls)
+        assertEquals(2, session.tracks.size)
+        assertEquals(0.0, session.tracks[0].startOffsetSec, 1e-9)
+        assertEquals(60.0, session.tracks[0].durationSec, 1e-9)
+        assertEquals(60.0, session.tracks[1].startOffsetSec, 1e-9) // starts after file 0
+        assertEquals(45.0, session.tracks[1].durationSec, 1e-9)
+        assertEquals(105.0, session.timeline.durationSec, 1e-9)    // 60 + 45
+        assertEquals(bundle, session.localZipFile)
+        assertEquals(0.0, session.serverCurrentTimeSec, 1e-9)
+        assertEquals(0L, session.serverLastUpdate)
+    }
+
+    @Test
+    fun `derives one chapter per distinct chapter href with boundaries on the global timeline`() {
+        val track = ReadaloudTrack(
+            listOf(
+                clip("c1.xhtml#s0", "audio/0.mp3", 0.0, 30.0),
+                clip("c2.xhtml#s0", "audio/0.mp3", 30.0, 60.0), // chapter 2 starts at global 30s
+                clip("c2.xhtml#s1", "audio/1.mp3", 0.0, 45.0),  // still chapter 2 (global 60s)
+            ),
+        )
+
+        val chapters = buildBundleAudiobookSession(track, bundle)!!.timeline.chapters
+
+        assertEquals(2, chapters.size)
+        assertEquals(0.0, chapters[0].startSec, 1e-9)
+        assertEquals(30.0, chapters[0].endSec, 1e-9)
+        assertEquals(30.0, chapters[1].startSec, 1e-9)
+        assertEquals(105.0, chapters[1].endSec, 1e-9) // last chapter ends at total duration
+        assertEquals("Chapter 1", chapters[0].title)
+        assertEquals("Chapter 2", chapters[1].title)
+    }
+
+    @Test
+    fun `returns null when the track has no clips`() {
+        assertNull(buildBundleAudiobookSession(ReadaloudTrack(emptyList()), bundle))
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `./gradlew :core:data:testDebugUnitTest --tests 'com.riffle.core.data.BundleAudiobookSessionBuilderTest' 2>&1 | tail -15`
+Expected: FAIL — `buildBundleAudiobookSession` unresolved reference.
+
+- [ ] **Step 3: Write the implementation**
+
+```kotlin
+package com.riffle.core.data
+
+import com.riffle.core.domain.AudiobookChapter
+import com.riffle.core.domain.AudiobookSession
+import com.riffle.core.domain.AudiobookTimeline
+import com.riffle.core.domain.AudiobookTrackSpan
+import com.riffle.core.domain.ReadaloudTrack
+import java.io.File
+
+/**
+ * Maps a bundle's Media Overlay [ReadaloudTrack] to a playable [AudiobookSession]: one span per
+ * distinct audio file (the same playlist order Readaloud queues), with cumulative book-absolute
+ * offsets, and chapters derived from the bundle's distinct chapter hrefs. The bundle audio is the
+ * same ABS source re-split into segments, so these spans are simply a different — but still
+ * contiguous — covering of the book timeline; the player's seek math works on any such covering.
+ *
+ * Track URLs are the audio files' zip-entry paths (a clip's `audioSrc`); [AudioPlayerService] routes
+ * any non-http/file mediaId through `ZipAudioDataSource`, reading from [bundle] via `SharedBundle`.
+ * Returns null when the bundle has no Media Overlay clips.
+ *
+ * Chapter titles are numbered ("Chapter N") — the SMIL overlay carries chapter hrefs and timings but
+ * not display titles. This is the accepted v1 offline degradation (a later pass can persist ABS
+ * chapter titles for offline use).
+ */
+internal fun buildBundleAudiobookSession(track: ReadaloudTrack, bundle: File): AudiobookSession? {
+    val files = track.clips.map { it.audioSrc }.distinct()
+    if (files.isEmpty()) return null
+
+    val durByFile = track.clips.groupBy { it.audioSrc }.mapValues { (_, cs) -> cs.maxOf { it.clipEndSec } }
+    var acc = 0.0
+    val spans = files.mapIndexed { i, src ->
+        val d = durByFile[src] ?: 0.0
+        AudiobookTrackSpan(index = i, startOffsetSec = acc, durationSec = d).also { acc += d }
+    }
+    val totalDuration = acc
+    val fileStart: Map<String, Double> = files.zip(spans).associate { (src, span) -> src to span.startOffsetSec }
+
+    // Chapter boundaries: each distinct chapter's first clip mapped onto the global timeline.
+    val starts = (0 until track.chapterCount).mapNotNull { idx ->
+        track.firstClipOfChapter(idx)?.let { clip -> (fileStart[clip.audioSrc] ?: 0.0) + clip.clipBeginSec }
+    }.sorted()
+    val chapters = starts.mapIndexed { i, start ->
+        AudiobookChapter(
+            index = i,
+            startSec = start,
+            endSec = starts.getOrNull(i + 1) ?: totalDuration,
+            title = "Chapter ${i + 1}",
+        )
+    }
+
+    return AudiobookSession(
+        trackUrls = files,
+        tracks = spans,
+        timeline = AudiobookTimeline(durationSec = totalDuration, chapters = chapters),
+        serverCurrentTimeSec = 0.0,
+        serverLastUpdate = 0L,
+        localZipFile = bundle,
+    )
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `./gradlew :core:data:testDebugUnitTest --tests 'com.riffle.core.data.BundleAudiobookSessionBuilderTest' 2>&1 | tail -15`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add core/data/src/main/kotlin/com/riffle/core/data/BundleAudiobookSessionBuilder.kt core/data/src/test/kotlin/com/riffle/core/data/BundleAudiobookSessionBuilderTest.kt
+git commit -m "feat(audiobook): map a readaloud bundle's overlay track to an AudiobookSession"
+```
+
+---
+
+## Task 4: `StorytellerBundleAudiobookSource` implementation
+
+**Files:**
+- Create: `core/data/src/main/kotlin/com/riffle/core/data/StorytellerBundleAudiobookSource.kt`
+- Test: `core/data/src/test/kotlin/com/riffle/core/data/StorytellerBundleAudiobookSourceTest.kt`
+
+- [ ] **Step 1: Write the failing test**
+
+```kotlin
+package com.riffle.core.data
+
+import com.riffle.core.domain.MediaOverlayClip
+import com.riffle.core.domain.ReadaloudAudioRepository
+import com.riffle.core.domain.ReadaloudLink
+import com.riffle.core.domain.ReadaloudLinkRepository
+import com.riffle.core.domain.ReadaloudTrack
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class StorytellerBundleAudiobookSourceTest {
+
+    private val link = ReadaloudLink(
+        storytellerServerId = "st", storytellerBookId = "book-1",
+        absServerId = "abs", absLibraryItemId = "item-1", userConfirmed = true,
+    )
+
+    private class FakeLinks(private val all: List<ReadaloudLink>) : ReadaloudLinkRepository {
+        override fun observeAll(): Flow<List<ReadaloudLink>> = MutableStateFlow(all)
+        override fun observeLinkedAbsItemIds() = MutableStateFlow(all.map { it.absLibraryItemId }.toSet())
+        override suspend fun findByAbsItem(absServerId: String, absLibraryItemId: String) =
+            all.firstOrNull { it.absServerId == absServerId && it.absLibraryItemId == absLibraryItemId }
+        override suspend fun findByStorytellerBook(storytellerServerId: String, storytellerBookId: String) =
+            all.filter { it.storytellerServerId == storytellerServerId && it.storytellerBookId == storytellerBookId }
+        override suspend fun unlinkAbsItem(absServerId: String, absLibraryItemId: String) = Unit
+        override suspend fun countForServer(serverId: String) = all.count { it.absServerId == serverId }
+    }
+
+    private class FakeAudio(
+        private val bundle: File?,
+        private val track: ReadaloudTrack?,
+    ) : ReadaloudAudioRepository {
+        override fun isAudioAvailable(serverId: String, itemId: String) = bundle != null
+        override fun bundleFile(serverId: String, itemId: String) = bundle
+        override suspend fun readTrack(serverId: String, itemId: String) = track
+        override suspend fun probeSizeBytes(serverId: String, itemId: String): Long? = null
+        override suspend fun downloadAudio(serverId: String, bookId: String, onProgress: (Long, Long) -> Unit) =
+            com.riffle.core.domain.AudioDownloadResult.Success
+        override suspend fun removeAudio(serverId: String, itemId: String) = 0L
+    }
+
+    private val track = ReadaloudTrack(
+        listOf(MediaOverlayClip("c1.xhtml#s0", "audio/0.mp3", 0.0, 30.0)),
+    )
+    private val bundle = File("/tmp/book-1.epub")
+
+    @Test
+    fun `localSession resolves link then bundle then builds a session`() = runTest {
+        val source = StorytellerBundleAudiobookSource(
+            readaloudLinkRepository = FakeLinks(listOf(link)),
+            readaloudAudioRepository = FakeAudio(bundle, track),
+            scope = backgroundScope,
+        )
+
+        val session = source.localSession("abs", "item-1")!!
+
+        assertEquals(listOf("audio/0.mp3"), session.trackUrls)
+        assertEquals(bundle, session.localZipFile)
+        assertEquals(30.0, session.timeline.durationSec, 1e-9)
+    }
+
+    @Test
+    fun `localSession is null with no link, no bundle, or no overlay`() = runTest {
+        assertNull(
+            StorytellerBundleAudiobookSource(FakeLinks(emptyList()), FakeAudio(bundle, track), backgroundScope)
+                .localSession("abs", "item-1"),
+        )
+        assertNull(
+            StorytellerBundleAudiobookSource(FakeLinks(listOf(link)), FakeAudio(null, track), backgroundScope)
+                .localSession("abs", "item-1"),
+        )
+        assertNull(
+            StorytellerBundleAudiobookSource(FakeLinks(listOf(link)), FakeAudio(bundle, null), backgroundScope)
+                .localSession("abs", "item-1"),
+        )
+    }
+
+    @Test
+    fun `isAvailableOffline reflects the link snapshot and bundle presence`() = runTest {
+        val present = StorytellerBundleAudiobookSource(FakeLinks(listOf(link)), FakeAudio(bundle, track), backgroundScope)
+        advanceUntilIdle() // let the snapshot collector run
+        assertTrue(present.isAvailableOffline("abs", "item-1"))
+        assertFalse(present.isAvailableOffline("abs", "other"))
+
+        val noBundle = StorytellerBundleAudiobookSource(FakeLinks(listOf(link)), FakeAudio(null, track), backgroundScope)
+        advanceUntilIdle()
+        assertFalse(noBundle.isAvailableOffline("abs", "item-1"))
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `./gradlew :core:data:testDebugUnitTest --tests 'com.riffle.core.data.StorytellerBundleAudiobookSourceTest' 2>&1 | tail -15`
+Expected: FAIL — `StorytellerBundleAudiobookSource` unresolved reference.
+
+- [ ] **Step 3: Write the implementation**
+
+```kotlin
+package com.riffle.core.data
+
+import com.riffle.core.domain.AudiobookSession
+import com.riffle.core.domain.BundleAudiobookSource
+import com.riffle.core.domain.ReadaloudAudioRepository
+import com.riffle.core.domain.ReadaloudLink
+import com.riffle.core.domain.ReadaloudLinkRepository
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+
+/**
+ * The sole [BundleAudiobookSource] implementation, and the only audiobook/library code that knows the
+ * offline audio can come from a Storyteller readaloud bundle (ADR 0023). It translates the player's
+ * ABS `(serverId, itemId)` to the bundle's Storyteller `(serverId, bookId)` via the [ReadaloudLink],
+ * then maps the bundle's Media Overlay track to an [AudiobookSession] ([buildBundleAudiobookSession]).
+ *
+ * [isAvailableOffline] must be synchronous (it backs the library's offline filter), so the suspend
+ * link lookup is replaced on that path by a [linksByAbsItem] snapshot kept fresh from
+ * [ReadaloudLinkRepository.observeAll] on an application-lifetime [scope] — the same self-managed IO
+ * scope pattern as [CrossEpubIndexBuilderService].
+ */
+class StorytellerBundleAudiobookSource(
+    private val readaloudLinkRepository: ReadaloudLinkRepository,
+    private val readaloudAudioRepository: ReadaloudAudioRepository,
+    scope: CoroutineScope,
+) : BundleAudiobookSource {
+
+    // ABS "serverId/itemId" -> link, so isAvailableOffline is a synchronous lookup.
+    @Volatile
+    private var linksByAbsItem: Map<String, ReadaloudLink> = emptyMap()
+
+    init {
+        scope.launch {
+            readaloudLinkRepository.observeAll().collect { links ->
+                linksByAbsItem = links.associateBy { absKey(it.absServerId, it.absLibraryItemId) }
+            }
+        }
+    }
+
+    override suspend fun localSession(serverId: String, itemId: String): AudiobookSession? {
+        val link = readaloudLinkRepository.findByAbsItem(serverId, itemId) ?: return null
+        val bundle = readaloudAudioRepository.bundleFile(link.storytellerServerId, link.storytellerBookId)
+            ?: return null
+        val track = readaloudAudioRepository.readTrack(link.storytellerServerId, link.storytellerBookId)
+            ?: return null
+        return buildBundleAudiobookSession(track, bundle)
+    }
+
+    override fun isAvailableOffline(serverId: String, itemId: String): Boolean {
+        val link = linksByAbsItem[absKey(serverId, itemId)] ?: return false
+        return readaloudAudioRepository.isAudioAvailable(link.storytellerServerId, link.storytellerBookId)
+    }
+
+    private fun absKey(serverId: String, itemId: String) = "$serverId/$itemId"
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `./gradlew :core:data:testDebugUnitTest --tests 'com.riffle.core.data.StorytellerBundleAudiobookSourceTest' 2>&1 | tail -15`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add core/data/src/main/kotlin/com/riffle/core/data/StorytellerBundleAudiobookSource.kt core/data/src/test/kotlin/com/riffle/core/data/StorytellerBundleAudiobookSourceTest.kt
+git commit -m "feat(audiobook): StorytellerBundleAudiobookSource (link translation + offline snapshot)"
+```
+
+---
+
+## Task 5: `AudiobookController` points the service at the bundle file
+
+**Files:**
+- Modify: `app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookController.kt`
+
+The controller already connects to `AudioPlayerService`, which restores a non-http/file `mediaId` to a `zipaudio://` URI and reads it from `SharedBundle.current`. So the only change is: set `SharedBundle.current` to the session's local zip file before queueing.
+
+- [ ] **Step 1: Add the import**
+
+In `AudiobookController.kt`, add to the imports (the readaloud package is in the same `:app` module, so `internal` `SharedBundle` is accessible):
+```kotlin
+import com.riffle.app.feature.reader.readaloud.SharedBundle
+import java.io.File
+```
+
+- [ ] **Step 2: Add the parameter and set the bundle**
+
+Change `prepare`'s signature to accept the optional zip file, and set `SharedBundle.current` at the top of the body. Find:
+```kotlin
+    suspend fun prepare(
+        trackUrls: List<String>,
+        spans: List<AudiobookTrackSpan>,
+        durationSec: Double,
+        startAtSec: Double,
+    ) {
+        this.spans = spans
+        this.durationSec = durationSec
+        val c = ensureConnected() ?: return
+```
+Replace with:
+```kotlin
+    suspend fun prepare(
+        trackUrls: List<String>,
+        spans: List<AudiobookTrackSpan>,
+        durationSec: Double,
+        startAtSec: Double,
+        localZipFile: File? = null,
+    ) {
+        this.spans = spans
+        this.durationSec = durationSec
+        // Bundle-backed audio: the track mediaIds are zip-entry paths the service reads from this file
+        // via SharedBundle (the same channel Readaloud uses). Null for HTTP/file sessions, where the
+        // service never consults SharedBundle.
+        if (localZipFile != null) SharedBundle.current = localZipFile
+        val c = ensureConnected() ?: return
+```
+
+- [ ] **Step 3: Verify it compiles**
+
+Run: `./gradlew :app:compileDebugKotlin 2>&1 | tail -8`
+Expected: BUILD SUCCESSFUL. (All existing `prepare(...)` callers omit `localZipFile`, defaulting to null.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookController.kt
+git commit -m "feat(audiobook): controller points the service at a bundle file when given one"
+```
+
+---
+
+## Task 6: Bind `BundleAudiobookSource` + wire the offline library check (DI + predicate)
+
+**Files:**
+- Modify: `core/domain/src/main/kotlin/com/riffle/core/domain/LibraryItemOfflineAvailability.kt`
+- Modify: `core/data/src/main/kotlin/com/riffle/core/data/di/DataModule.kt`
+- Test: `core/domain/src/test/kotlin/com/riffle/core/domain/LibraryItemOfflineAvailabilityTest.kt`
+
+- [ ] **Step 1: Write the failing test**
+
+Open `LibraryItemOfflineAvailabilityTest.kt`. First add a fake source next to the other `private class Fake…` definitions at the bottom (same package, so no import needed):
+```kotlin
+    private class FakeBundleAudiobookSource(
+        private val offlineIds: Set<String> = emptySet(),
+    ) : BundleAudiobookSource {
+        override suspend fun localSession(serverId: String, itemId: String): AudiobookSession? = null
+        override fun isAvailableOffline(serverId: String, itemId: String) = "$serverId/$itemId" in offlineIds
+    }
+```
+Every existing test constructs `LibraryItemOfflineAvailability(...)` with three arguments — there are **six** such call sites. Add the new fourth argument to each one:
+```kotlin
+            bundleAudiobookSource = FakeBundleAudiobookSource(),
+```
+For example, the first existing test becomes:
+```kotlin
+        val availability = LibraryItemOfflineAvailability(
+            epubRepository = FakeEpubRepository(downloaded = true),
+            pdfRepository = FakePdfRepository(),
+            audiobookDownloadRepository = FakeAudiobookDownloadRepository(),
+            bundleAudiobookSource = FakeBundleAudiobookSource(),
+        )
+```
+Apply the identical fourth argument to all six existing constructions. Then add the two new tests (the `item(...)` helper defaults to `serverId = "s1"`, `id = "i1"`, so the offline key is `"s1/i1"`):
+```kotlin
+    @Test
+    fun `item with no ebook or audiobook download is offline-available when its bundle is downloaded`() {
+        val availability = LibraryItemOfflineAvailability(
+            epubRepository = FakeEpubRepository(),
+            pdfRepository = FakePdfRepository(),
+            audiobookDownloadRepository = FakeAudiobookDownloadRepository(),
+            bundleAudiobookSource = FakeBundleAudiobookSource(setOf("s1/i1")),
+        )
+
+        assertTrue(availability.isAvailableOffline(item(EbookFormat.Unsupported, hasAudio = true)))
+    }
+
+    @Test
+    fun `item with no downloads and no bundle is not offline-available`() {
+        val availability = LibraryItemOfflineAvailability(
+            epubRepository = FakeEpubRepository(),
+            pdfRepository = FakePdfRepository(),
+            audiobookDownloadRepository = FakeAudiobookDownloadRepository(),
+            bundleAudiobookSource = FakeBundleAudiobookSource(emptySet()),
+        )
+
+        assertFalse(availability.isAvailableOffline(item(EbookFormat.Unsupported, hasAudio = true)))
+    }
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `./gradlew :core:domain:test --tests 'com.riffle.core.domain.LibraryItemOfflineAvailabilityTest' 2>&1 | tail -20`
+Expected: FAIL — `LibraryItemOfflineAvailability` has no `bundleAudiobookSource` parameter (compile error), since the production class is not yet updated.
+
+- [ ] **Step 3: Update the predicate**
+
+In `LibraryItemOfflineAvailability.kt`, add the constructor dependency and the OR clause:
+```kotlin
+class LibraryItemOfflineAvailability(
+    private val epubRepository: EpubRepository,
+    private val pdfRepository: PdfRepository,
+    private val audiobookDownloadRepository: AudiobookDownloadRepository,
+    private val bundleAudiobookSource: BundleAudiobookSource,
+) {
+    fun isAvailableOffline(item: LibraryItem): Boolean {
+        val ebookAvailable = when (item.ebookFormat) {
+            EbookFormat.Epub ->
+                epubRepository.isDownloaded(item.serverId, item.id) || epubRepository.isCached(item.serverId, item.id)
+            EbookFormat.Pdf ->
+                pdfRepository.isDownloaded(item.serverId, item.id) || pdfRepository.isCached(item.serverId, item.id)
+            EbookFormat.Unsupported -> false
+        }
+        return ebookAvailable ||
+            audiobookDownloadRepository.isDownloaded(item.serverId, item.id) ||
+            bundleAudiobookSource.isAvailableOffline(item.serverId, item.id)
+    }
+}
+```
+Also update the class KDoc's last sentence to mention the bundle:
+```kotlin
+ * cache), so the audio side is a plain `isDownloaded` check (ADR 0029). An item is ALSO offline if a
+ * downloaded readaloud bundle can supply its audio ([BundleAudiobookSource]).
+```
+
+- [ ] **Step 4: Provide the binding + update the provider in `DataModule.kt`**
+
+Add a provider for the new source. Place it near `provideReadaloudAudioRepository` (around line 378). It needs `ReadaloudLinkRepository`, `ReadaloudAudioRepository`, and a fresh app-lifetime scope:
+```kotlin
+        @Provides
+        @Singleton
+        fun provideBundleAudiobookSource(
+            readaloudLinkRepository: com.riffle.core.domain.ReadaloudLinkRepository,
+            readaloudAudioRepository: com.riffle.core.domain.ReadaloudAudioRepository,
+        ): com.riffle.core.domain.BundleAudiobookSource =
+            StorytellerBundleAudiobookSource(
+                readaloudLinkRepository = readaloudLinkRepository,
+                readaloudAudioRepository = readaloudAudioRepository,
+                scope = kotlinx.coroutines.CoroutineScope(
+                    kotlinx.coroutines.SupervisorJob() + kotlinx.coroutines.Dispatchers.IO,
+                ),
+            )
+```
+Then update `provideLibraryItemOfflineAvailability` (around line 418) to take and pass the source. Find:
+```kotlin
+        fun provideLibraryItemOfflineAvailability(
+            epubRepository: EpubRepository,
+            pdfRepository: PdfRepository,
+            audiobookDownloadRepository: AudiobookDownloadRepository,
+        ): LibraryItemOfflineAvailability =
+            LibraryItemOfflineAvailability(epubRepository, pdfRepository, audiobookDownloadRepository)
+```
+Replace with:
+```kotlin
+        fun provideLibraryItemOfflineAvailability(
+            epubRepository: EpubRepository,
+            pdfRepository: PdfRepository,
+            audiobookDownloadRepository: AudiobookDownloadRepository,
+            bundleAudiobookSource: com.riffle.core.domain.BundleAudiobookSource,
+        ): LibraryItemOfflineAvailability =
+            LibraryItemOfflineAvailability(epubRepository, pdfRepository, audiobookDownloadRepository, bundleAudiobookSource)
+```
+> NOTE: if `EpubRepository` / `PdfRepository` / `AudiobookDownloadRepository` / `LibraryItemOfflineAvailability` are already imported at the top of `DataModule.kt` (they are — see the existing provider), no new top-level imports are required; the fully-qualified names above avoid touching the import block.
+
+- [ ] **Step 5: Run the predicate test to verify it passes**
+
+Run: `./gradlew :core:domain:test --tests 'com.riffle.core.domain.LibraryItemOfflineAvailabilityTest' 2>&1 | tail -20`
+Expected: PASS (existing tests + 2 new).
+
+- [ ] **Step 6: Verify DI graph compiles**
+
+Run: `./gradlew :app:compileDebugKotlin 2>&1 | tail -12`
+Expected: BUILD SUCCESSFUL (Hilt resolves `BundleAudiobookSource`). If a Hilt androidTest graph error appears, check whether a test module needs the new binding (see memory: TestDatabaseModule hand-provides bindings) — but this binding is in the production `DataModule`, so app debug should be unaffected.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add core/domain/src/main/kotlin/com/riffle/core/domain/LibraryItemOfflineAvailability.kt core/domain/src/test/kotlin/com/riffle/core/domain/LibraryItemOfflineAvailabilityTest.kt core/data/src/main/kotlin/com/riffle/core/data/di/DataModule.kt
+git commit -m "feat(library): count a downloaded bundle as offline-available; bind BundleAudiobookSource"
+```
+
+---
+
+## Task 7: Insert the bundle source into the player's resolution chain
+
+**Files:**
+- Modify: `app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModel.kt`
+
+- [ ] **Step 1: Add the constructor dependency**
+
+In the `@HiltViewModel` constructor, after `private val audiobookDownloadRepository: com.riffle.core.domain.AudiobookDownloadRepository,` add:
+```kotlin
+    private val bundleAudiobookSource: com.riffle.core.domain.BundleAudiobookSource,
+```
+
+- [ ] **Step 2: Insert the bundle into the resolution chain**
+
+Find (in `init`):
+```kotlin
+            val session = if (serverId.isEmpty()) null
+                else audiobookDownloadRepository.localSession(serverId, itemId)
+                    ?: audiobookRepository.openSession(serverId, itemId)
+```
+Replace with:
+```kotlin
+            // Prefer a dedicated audiobook download, then a downloaded readaloud bundle's audio, then
+            // stream from ABS (connectivity-independent: a local copy always beats streaming).
+            val session = if (serverId.isEmpty()) null
+                else audiobookDownloadRepository.localSession(serverId, itemId)
+                    ?: bundleAudiobookSource.localSession(serverId, itemId)
+                    ?: audiobookRepository.openSession(serverId, itemId)
+```
+
+- [ ] **Step 3: Pass the local zip file to the controller**
+
+Find the `controller.prepare(...)` call in `init`:
+```kotlin
+            controller.prepare(
+                trackUrls = session.trackUrls,
+                spans = session.tracks,
+                durationSec = session.timeline.durationSec,
+                startAtSec = resumeSec,
+            )
+```
+Replace with:
+```kotlin
+            controller.prepare(
+                trackUrls = session.trackUrls,
+                spans = session.tracks,
+                durationSec = session.timeline.durationSec,
+                startAtSec = resumeSec,
+                localZipFile = session.localZipFile,
+            )
+```
+
+- [ ] **Step 4: Verify it compiles**
+
+Run: `./gradlew :app:compileDebugKotlin 2>&1 | tail -8`
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 5: Run the audiobook player VM tests (regression)**
+
+Run: `./gradlew :app:testDebugUnitTest --tests 'com.riffle.app.feature.audiobook.*' 2>&1 | tail -20`
+Expected: PASS. If `AudiobookPlayerViewModelTest` constructs the VM directly, add the new `bundleAudiobookSource` argument with a fake whose `localSession` returns null and `isAvailableOffline` returns false, so the existing download/stream resolution behavior is unchanged.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModel.kt app/src/test/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModelTest.kt
+git commit -m "feat(audiobook): play from a downloaded bundle when no dedicated download exists"
+```
+
+---
+
+## Task 8: Full test sweep
+
+**Files:** none (verification).
+
+- [ ] **Step 1: Run the full JVM test suite**
+
+Run: `./gradlew test 2>&1 | tail -30`
+Expected: BUILD SUCCESSFUL. (CI uses `./gradlew test`; module-specific runs miss pure-JVM modules.) Pre-existing flakes noted in project memory — `replaceAllForLibrary` emission tests and `AutoFollowJsTest` paginated-snap — are not caused by this change; re-run once if they appear. Any other failure is in scope: fix the cause or the test.
+
+- [ ] **Step 2: Build the debug APK to confirm the Hilt graph is whole**
+
+Run: `./gradlew :app:assembleDebug 2>&1 | tail -12`
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 3: Commit (only if a fix was required in Steps 1–2)**
+
+```bash
+git add -A && git commit -m "test(audiobook): fixes from full sweep for offline bundle playback"
+```
+
+---
+
+## Task 9: Device verification
+
+**Files:** none (manual verification on a real device — emulator audio-HAL and Chrome-55 WebView caveats make the emulator unreliable for audio; see project memory).
+
+- [ ] **Step 1: Verify offline playback**
+
+Set up a readaloud-matched audiobook with its bundle downloaded and **no** dedicated audiobook download (recipe in `reference_readaloud_e2e_test_setup` memory). Put the device in airplane mode. Open the audiobook player. Expected: it plays from the bundle (audio comes from `ZipAudioDataSource`; check Logcat for the `zipaudio` reads, no HTTP attempts), position/seek/chapter-prev-next work, chapter titles read "Chapter N".
+
+- [ ] **Step 2: Verify resolution precedence**
+
+With the device online and a dedicated audiobook download present, confirm the player still uses the download (not the bundle) — behavior unchanged. Remove the dedicated download; confirm it now uses the bundle even while online.
+
+- [ ] **Step 3: Verify the offline library listing**
+
+Offline, with only the bundle downloaded for a matched item (no ebook/audiobook download), confirm the item appears in the library lists (All Books, In Progress, series/collection groupings) instead of being filtered out.
+
+- [ ] **Step 4: Verify progress durability (inherited)**
+
+Listen offline for a bit, pause/close, kill the app, reconnect. Confirm the listen position persisted (it resumes correctly) and reaches ABS once online (the durable store + ADR-0030 sweep carry it — no new work here, just confirm the bundle path didn't break it).
+
+---
+
+## Self-Review notes
+
+- **Spec coverage:** isolation seam (Tasks 2, 4) ✓; download>bundle>stream (Task 7) ✓; offline library includes bundle (Task 6) ✓; chapters from bundle nav with numbered-title degradation (Task 3) ✓; no DB migration / no new download path ✓; no `AudioPlayerService` change (scheme routing already covers zip entries) ✓.
+- **Removal property:** deleting `provideBundleAudiobookSource` + `StorytellerBundleAudiobookSource` + `BundleAudiobookSessionBuilder`, dropping the chain line in Task 7, and reverting the Task 6 provider/predicate edit removes the feature with no other code touched — the `localZipFile` field defaults to null and is harmless if left.
+- **Type consistency:** `buildBundleAudiobookSession(track, bundle)` signature matches its test and its single caller; `prepare(..., localZipFile)` matches the VM call; `BundleAudiobookSource` methods match the fake and the impl.

--- a/docs/superpowers/specs/2026-06-12-offline-audiobook-from-bundle-design.md
+++ b/docs/superpowers/specs/2026-06-12-offline-audiobook-from-bundle-design.md
@@ -1,0 +1,172 @@
+# Offline audiobook playback from a downloaded readaloud bundle
+
+**Date:** 2026-06-12
+**Status:** Design approved, pending spec review
+**Relates to:** ADR 0023 (Storyteller synced bundle is the readaloud audio source), ADR 0029 (audiobook direct-ABS streaming + audio-led sync), ADR 0030 (durable offline progress reconcile)
+
+## Problem
+
+A downloaded readaloud bundle (a Storyteller synced EPUB zip) already contains the book's audio
+segments — the same ABS source file, re-split into fixed segments. Today that audio is reachable
+only by the in-reader readaloud player. The standalone **audiobook player** cannot use it: it streams
+from ABS, or plays from its own separate per-item download (`manifest.json`). So with only the bundle
+on disk and the device offline, the audiobook will not play, and the offline library does not even
+list the item.
+
+This is a real gap, not a bug: the bundle is treated purely as a sync/position-mapping aid, never as
+an audio content source for the standalone player.
+
+## Goal
+
+1. The standalone audiobook player plays from a downloaded bundle when no dedicated audiobook download
+   exists — online or offline.
+2. The offline library lists an item when its bundle is downloaded, the same way it lists items with a
+   downloaded ebook or audiobook.
+3. **Isolation:** all knowledge that "the offline audio can come from a Storyteller bundle" lives
+   behind one interface with a single implementation, so the feature can be removed — or the bundle
+   type swapped — as a unit, without touching the audiobook stack or the library.
+
+## Non-goals
+
+- No change to online streaming behaviour when a dedicated audiobook download is absent and no bundle
+  exists (still streams from ABS).
+- No new download UI or trigger. This consumes the *existing* readaloud bundle download.
+- No attempt to make chapter markers offline match ABS chapter boundaries exactly (see Degradation).
+- The ebook-from-bundle offline fallback is explicitly out of scope (separate, heavier work that
+  reopens ADR 0026).
+
+## Design
+
+### Isolation seam
+
+Everything downstream of "where does the audio come from" already speaks one neutral language: an
+`AudiobookSession` (ordered track URLs + their `AudiobookTrackSpan`s + an `AudiobookTimeline`) plus
+book-absolute seconds. The `AudiobookController`, the `AudiobookTracks` seek math, the timeline,
+durable local persistence, the last-write-wins reconcile, and the ADR-0030 dirty sweep are all
+source-agnostic. There are already two producers of `AudiobookSession`:
+
+- `AudiobookRepository.openSession()` — ABS direct stream (tokenised HTTP URLs).
+- `AudiobookDownloadRepository.localSession()` — dedicated offline download (`file://` URLs).
+
+We add a **third producer behind a new interface**, and confine all bundle specifics to its single
+implementation:
+
+```kotlin
+// core/domain
+interface BundleAudiobookSource {
+    /** A playable session backed by a downloaded bundle's audio, or null if none for this item. */
+    suspend fun localSession(serverId: String, itemId: String): AudiobookSession?
+
+    /** True when a downloaded bundle can satisfy this item's audio offline. */
+    suspend fun isAvailableOffline(serverId: String, itemId: String): Boolean
+}
+```
+
+- **Implementation:** `StorytellerBundleAudiobookSource` (core/data) is the *only* audiobook- or
+  library-side class that imports `ReadaloudLink` / `ReadaloudLinkRepository`,
+  `ReadaloudAudioRepository`, or the bundle's zip/SMIL internals.
+- **Removal / replacement:** delete the impl + its DI binding (or bind a no-op). The interface, both
+  consumers, and all downstream code are untouched. A different future bundle format is a new impl
+  behind the same interface.
+
+### Part 1 — Playback resolution (download > bundle > stream)
+
+In `AudiobookPlayerViewModel.init`, the session is resolved connectivity-independently:
+
+```
+session = downloadRepo.localSession(serverId, itemId)
+       ?: bundleAudiobookSource.localSession(serverId, itemId)
+       ?: audiobookRepository.openSession(serverId, itemId)
+```
+
+Rationale: if a download or a bundle is on disk, there is no reason to stream from the server. A
+dedicated audiobook download outranks the bundle (it is the user's explicit, ABS-track-aligned copy);
+the bundle outranks streaming.
+
+`StorytellerBundleAudiobookSource.localSession(serverId, itemId)`:
+
+1. `readaloudLinkRepository.findByAbsItem(serverId, itemId)` → `ReadaloudLink`. No link ⇒ `null`.
+2. `readaloudAudioRepository.bundleFile(link.storytellerServerId, link.storytellerBookId)`. No bundle
+   file ⇒ `null`.
+3. Read the bundle's ordered audio files and per-file durations (reusing the existing
+   `MediaOverlayReader` / `ReadaloudTrack` `fileOrder` + `fileDuration`).
+4. Build `AudiobookTrackSpan`s with cumulative `startOffsetSec` (the bundle's segments are simply a
+   different span set than ABS tracks; `AudiobookTracks.trackIndexAt` / `offsetInTrackSec` /
+   `startPositionFor` work unchanged on any contiguous span set).
+5. Build `trackUrls` as zip-entry references using the same scheme `ZipAudioDataSource` already
+   resolves; set `SharedBundle.current` to the bundle file before `controller.prepare()`, mirroring
+   what the readaloud player does.
+6. Build the `AudiobookTimeline`: `durationSec` from the summed segment durations; chapters derived
+   from the bundle's nav when present, else a single chapter spanning the book.
+7. `serverCurrentTimeSec = 0.0`, `serverLastUpdate = 0` — the resume position comes from the durable
+   local store via the existing reconcile (identical to the dedicated-download `localSession`).
+
+Everything after session resolution is unchanged. Persistence, the last-write-wins resume, and the
+ADR-0030 dirty sweep are inherited for free because the position is book-absolute seconds regardless
+of audio origin. The only correctness obligation: the bundle path must mark its position rows dirty
+exactly as the stream/download paths do, so the reconnect sweep pushes them to ABS. (It does — the
+follow loop and stop flush write through the same `AudiobookPositionStore`.)
+
+### Part 2 — Offline library filter
+
+`LibraryItemOfflineAvailability.isAvailableOffline(item)` is the single source of truth behind the
+library's offline filtering. It gains a `BundleAudiobookSource` dependency and ORs in the bundle:
+
+```
+ebookAvailable
+  || audiobookDownloadRepository.isDownloaded(serverId, id)
+  || bundleAudiobookSource.isAvailableOffline(serverId, id)
+```
+
+Because `findByAbsItem` is `suspend`, the predicate becomes `suspend`. The four library ViewModels
+(`LibraryItemsViewModel`, `FilteredBooksViewModel`, `CollectionDetailViewModel`,
+`SeriesDetailViewModel`) already filter inside `combine { … }` transforms, which are suspend lambdas,
+so the change is mechanical: replace each inline `list.filter { isAvailableOffline(it) }` with a
+suspend-aware filter (e.g. `buildList { for (i in list) if (isAvailableOffline(i)) add(i) }`).
+Centralization is preserved — still one predicate, now async.
+
+`StorytellerBundleAudiobookSource.isAvailableOffline` reuses steps 1–2 above (link present AND bundle
+file present), without reading audio.
+
+### Keying
+
+The bundle is keyed by Storyteller `(storytellerServerId, storytellerBookId)`; the library item and
+the audiobook player are keyed by ABS `(serverId, itemId)`. The `ReadaloudLink` is the bridge, and the
+translation lives entirely inside `StorytellerBundleAudiobookSource` — neither consumer sees Storyteller
+identifiers.
+
+## Error handling & degradation
+
+- No link, no bundle file, or an unreadable/truncated bundle ⇒ `localSession()` returns `null` and
+  `isAvailableOffline()` returns `false`. The player falls through to ABS stream; the library simply
+  omits the item. No crashes, no partially-built sessions.
+- **Known degradation:** offline chapter markers come from the bundle nav and may not align with ABS
+  chapter boundaries. Acceptable for v1; a later refinement can persist ABS chapters at last online
+  open and prefer them.
+
+## Testing
+
+- `StorytellerBundleAudiobookSourceTest` (core/data): link → bundle resolution; span/offset
+  construction from a fixture bundle; `durationSec` and chapter derivation; every null path (no link,
+  no bundle file, unreadable bundle).
+- `LibraryItemOfflineAvailabilityTest`: an item with no downloaded ebook/audiobook but a downloaded
+  bundle is offline-available; the same item with no bundle is not; existing ebook/audiobook cases
+  still pass.
+- Resolution-order unit coverage in the player VM: dedicated download wins over bundle; bundle wins
+  over stream; no-bundle falls through to stream.
+- Harness/device: offline bundle playback verified on a real device (per the known emulator audio-HAL
+  and Chrome-55 WebView caveats), plus the offline library listing the bundle-only item.
+
+## Files touched (anticipated)
+
+- New: `core/domain/.../BundleAudiobookSource.kt`, `core/data/.../StorytellerBundleAudiobookSource.kt`.
+- `core/domain/.../LibraryItemOfflineAvailability.kt` — add dependency, OR in bundle, make `suspend`.
+- The four library ViewModels — suspend-aware offline filter.
+- `app/.../audiobook/AudiobookPlayerViewModel.kt` — insert the bundle source into the resolution chain.
+- `app/.../reader/readaloud/AudioPlayerService.kt` — confirm/extend the zip-entry scheme routing for
+  audiobook bundle items, and `SharedBundle` handling, if the audiobook path needs a distinct restore.
+- DI wiring in `core/data/.../di/DataModule.kt` (bind `BundleAudiobookSource`; update the
+  `LibraryItemOfflineAvailability` provider).
+
+No database migration. No new download path. No ADR change required (this is an application of ADR
+0023 + ADR 0029); an ADR is optional if we want to record the precedence rule.

--- a/docs/superpowers/specs/2026-06-12-offline-audiobook-from-bundle-design.md
+++ b/docs/superpowers/specs/2026-06-12-offline-audiobook-from-bundle-design.md
@@ -118,15 +118,19 @@ ebookAvailable
   || bundleAudiobookSource.isAvailableOffline(serverId, id)
 ```
 
-Because `findByAbsItem` is `suspend`, the predicate becomes `suspend`. The four library ViewModels
-(`LibraryItemsViewModel`, `FilteredBooksViewModel`, `CollectionDetailViewModel`,
-`SeriesDetailViewModel`) already filter inside `combine { … }` transforms, which are suspend lambdas,
-so the change is mechanical: replace each inline `list.filter { isAvailableOffline(it) }` with a
-suspend-aware filter (e.g. `buildList { for (i in list) if (isAvailableOffline(i)) add(i) }`).
-Centralization is preserved — still one predicate, now async.
+`isAvailableOffline` stays **synchronous** so it drops into the 11 existing `.filter { … }` /
+`.any { … }` call sites across the four library ViewModels with **no ViewModel changes**. The one
+suspend dependency — `ReadaloudLinkRepository.findByAbsItem` — is avoided on the hot path:
+`StorytellerBundleAudiobookSource` collects `readaloudLinkRepository.observeAll()` on an
+application-lifetime scope into a `@Volatile` `Map<absKey, ReadaloudLink>` snapshot (the same
+self-managed-IO-scope pattern as `CrossEpubIndexBuilderService`), so `isAvailableOffline` is a
+synchronous map lookup plus the synchronous `ReadaloudAudioRepository.isAudioAvailable` bundle-file
+check. Trade-off: the snapshot populates a few ms after the source is first created; because links are
+only ever created while online and the offline filter recombines when connectivity flips, the snapshot
+is populated before any offline filtering pass in practice.
 
-`StorytellerBundleAudiobookSource.isAvailableOffline` reuses steps 1–2 above (link present AND bundle
-file present), without reading audio.
+`localSession` (called once on player open, off the hot path) uses the suspend `findByAbsItem`
+directly and needs no snapshot.
 
 ### Keying
 


### PR DESCRIPTION
## What

Lets the standalone audiobook player play audio from an already-downloaded readaloud bundle, and surfaces such items offline. Resolution precedence is **dedicated audiobook download > downloaded bundle > ABS stream**, connectivity-independent. All bundle-specific knowledge is isolated behind one interface so it can be removed or swapped as a unit.

- **Playback**: a third `AudiobookSession` producer, `BundleAudiobookSource` (sole impl `StorytellerBundleAudiobookSource`), maps the bundle's Media Overlay track to a session whose track URLs are the bundle's zip-entry audio paths. The player points `SharedBundle.current` at the bundle file; the existing `AudioPlayerService` zip-scheme routing plays it. No `AudioPlayerService` change, no DB migration.
- **Offline library**: `LibraryItemOfflineAvailability` (the single offline-filter predicate, kept synchronous via an observed link snapshot) now counts a downloaded bundle as available — so bundle-only items appear offline. The item-detail **Listen** button's offline gate was likewise extended to a downloaded bundle.
- **Resume / no-erase**: offline-bundle-only, the player can't reach the canonical/server position, so it resumes from the item's library `readingProgress` fraction when nothing else is tracked. This both honors the location (approximately) and seeds the persist-guard floor, fixing a data-loss bug where playing the bundle wrote a fresh ~0 over the displayed progress. A genuinely-tracked position (even exactly 0) is always honored.

## Isolation

Removing the feature = delete `StorytellerBundleAudiobookSource` + its DI binding + the one resolution-chain line + revert the predicate/Listen-gate edits. The `AudiobookSession.localZipFile` field defaults null and is inert. A different future bundle format is a new impl behind the same interface.

## Tested

- `./gradlew test` (unit + integration) — green
- `./gradlew lint` — green
- `make harness-test` + `make harness-test-tablet` — green
- New unit tests: bundle session mapper, `StorytellerBundleAudiobookSource` (resolution + offline snapshot), `LibraryItemOfflineAvailability` bundle case, `audiobookResumeSec` (incl. genuine-zero handling)
- Device-verified offline: playback works, offline library lists the item, Listen enabled, position no longer erased

Spec + plan: `docs/superpowers/specs/2026-06-12-offline-audiobook-from-bundle-design.md`, `docs/superpowers/plans/2026-06-12-offline-audiobook-from-bundle.md`.

## Known limitation

Offline, the resume point is derived from the unified library progress fraction (accurate to the fraction; the exact audio second isn't recoverable offline-bundle-only). Chapter titles offline are numbered ("Chapter N") — documented v1 degradation.