### PR TITLE
fix(reader): land backward chapter turn on the previous chapter's last page

### DIFF
--- a/app/src/androidTest/kotlin/com/riffle/app/feature/reader/BackwardChapterSnapJsTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/reader/BackwardChapterSnapJsTest.kt
@@ -1,0 +1,126 @@
+package com.riffle.app.feature.reader
+
+import android.webkit.WebView
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Verifies [ColumnSnap.snapToEndColumnJs] — the probe a backward chapter turn runs so the previous
+ * chapter's LAST page lands as "one page back".
+ *
+ * The bug it guards: the swipe-back-at-a-chapter-start route used a raw `go()` to a `progression = 1.0`
+ * locator, which resolves 1.0 against the freshly loaded chapter's PRE-reflow column count and is then
+ * left stranded several columns short of the true end once the typography reflow adds columns — the
+ * "previous chapter overshoots 4-5 pages back" report. The end-snap must drive the page onto the last
+ * column regardless of where the navigation landed.
+ */
+@RunWith(AndroidJUnit4::class)
+class BackwardChapterSnapJsTest {
+
+    // A page far wider than the viewport → paginated, with many columns. The mid-page scrollLeft the test
+    // sets before snapping stands in for the pre-reflow overshoot; the snap must reach the last column.
+    private val wideFixture = """
+        <!DOCTYPE html>
+        <html><head><meta name="viewport" content="width=device-width, initial-scale=1"></head>
+          <body style="margin:0; height:40px; position:relative">
+            <div style="position:absolute; left:20px;   top:5px; width:240px; height:25px">First page content</div>
+            <div style="position:absolute; left:7000px; top:5px; width:240px; height:25px">Last page content</div>
+          </body>
+        </html>
+    """.trimIndent()
+
+    // A document much taller than the viewport → scroll (karaoke) mode. The backward end-snap should land
+    // at the bottom, never gaining a horizontal offset.
+    private val tallFixture = """
+        <!DOCTYPE html>
+        <html><head><meta name="viewport" content="width=device-width, initial-scale=1"></head>
+          <body style="margin:0; height:6000px; position:relative">
+            <div style="position:absolute; left:20px; top:3000px; width:240px; height:25px">Deep content</div>
+          </body>
+        </html>
+    """.trimIndent()
+
+    @Test
+    fun paginatedBackwardTurnLandsOnTheLastColumn() {
+        withSizedWebViewFixture(wideFixture, widthPx = 1080, heightPx = 1600) { webView ->
+            webView.awaitInnerHeight()
+            val iw = webView.innerWidth()
+            assertTrue("viewport must have a real width", iw > 100)
+            val sw = webView.scrollWidth()
+            assertTrue("fixture must be much wider than one page (sw=$sw iw=$iw)", sw > iw * 4)
+
+            // Stand in for the pre-reflow overshoot: a go(progression=1.0) that left the page a few
+            // columns short of the end. The backward-turn snap must drive it onto the LAST column.
+            webView.evalSync("document.scrollingElement.scrollLeft=$iw")
+            webView.evalSync(ColumnSnap.snapToEndColumnJs())
+
+            val sx = webView.scrollX()
+            assertEquals("lands flush on the column grid (sx=$sx iw=$iw)", 0, sx % iw)
+            assertTrue(
+                "lands on the LAST page — no whole column remains to the right (sx=$sx sw=$sw iw=$iw)",
+                sx + iw > sw - iw,
+            )
+            assertTrue("moves forward to the end from the overshoot (sx=$sx iw=$iw)", sx > iw)
+        }
+    }
+
+    @Test
+    fun landedAtEndDetectsReadiumsEndPlacement() {
+        withSizedWebViewFixture(wideFixture, widthPx = 1080, heightPx = 1600) { webView ->
+            webView.awaitInnerHeight()
+            val iw = webView.innerWidth()
+            val sw = webView.scrollWidth()
+
+            // Column 0 (a forward turn / TOC chapter-top landing) is NOT an end landing.
+            webView.evalSync("document.scrollingElement.scrollLeft=0")
+            assertEquals("column 0 is not the end", "false", webView.evalSync(ColumnSnap.LANDED_AT_END_JS).trim('"'))
+
+            // A mid-resource position (a resume to the middle) is NOT an end landing.
+            webView.evalSync("document.scrollingElement.scrollLeft=$iw")
+            assertEquals("a middle column is not the end", "false", webView.evalSync(ColumnSnap.LANDED_AT_END_JS).trim('"'))
+
+            // The last column (Readium's backward-turn placement) IS an end landing.
+            webView.evalSync("document.scrollingElement.scrollLeft=${sw - iw}")
+            assertEquals("the last column is the end", "true", webView.evalSync(ColumnSnap.LANDED_AT_END_JS).trim('"'))
+        }
+    }
+
+    @Test
+    fun landedAtEndIsFalseForASinglePageResource() {
+        // A resource that fits one page has no backward-overshoot to correct; never report an end landing.
+        withSizedWebViewFixture(tallFixture.replace("height:6000px", "height:40px"), widthPx = 1080, heightPx = 1600) { webView ->
+            webView.awaitInnerHeight()
+            assertEquals("a single-page resource is not an end landing", "false", webView.evalSync(ColumnSnap.LANDED_AT_END_JS).trim('"'))
+        }
+    }
+
+    @Test
+    fun landedAtEndIsFalseInScrollMode() {
+        withSizedWebViewFixture(tallFixture, widthPx = 1080, heightPx = 1600) { webView ->
+            webView.awaitInnerHeight()
+            assertEquals("scroll mode has no column grid → not an end landing", "false", webView.evalSync(ColumnSnap.LANDED_AT_END_JS).trim('"'))
+        }
+    }
+
+    @Test
+    fun scrollModeBackwardTurnLandsAtTheBottom() {
+        withSizedWebViewFixture(tallFixture, widthPx = 1080, heightPx = 1600) { webView ->
+            val h = webView.awaitInnerHeight()
+            webView.evalSync("document.scrollingElement.scrollTop=0")
+            webView.evalSync(ColumnSnap.snapToEndColumnJs())
+            val sy = webView.scrollY()
+            val sh = webView.scrollHeight()
+            assertTrue("scroll mode lands at the bottom (sy=$sy sh=$sh h=$h)", sy + h >= sh - 4)
+            assertEquals("scroll mode must never gain a horizontal offset", 0, webView.scrollX())
+        }
+    }
+
+    private fun WebView.innerWidth(): Int = evalSync("window.innerWidth").trim('"').toDouble().toInt()
+    private fun WebView.scrollWidth(): Int = evalSync("document.scrollingElement.scrollWidth").trim('"').toDouble().toInt()
+    private fun WebView.scrollHeight(): Int = evalSync("document.scrollingElement.scrollHeight").trim('"').toDouble().toInt()
+    private fun WebView.scrollX(): Int = evalSync("window.scrollX").trim('"').toDouble().toInt()
+    private fun WebView.scrollY(): Int = evalSync("window.scrollY").trim('"').toDouble().toInt()
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ColumnSnap.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ColumnSnap.kt
@@ -64,6 +64,26 @@ internal object ColumnSnap {
     }
 
     /**
+     * Re-pins the current page to its LAST column, tracking the chapter's async typography reflow — for
+     * a backward cross-resource page turn that Readium handled itself (paginated mode), which our nav
+     * handlers never see. Call from `onPageLoaded` when [landedAtEnd] reports the resource was placed at
+     * its end, so the imminent reflow can't strand the page several columns short of the true end.
+     */
+    suspend fun snapToEnd(fragment: EpubNavigatorFragment) {
+        fragment.evaluateJavascript(snapToEndColumnJs())
+    }
+
+    /**
+     * "true" iff the freshly loaded paginated page is resting on its LAST column — i.e. Readium
+     * positioned this resource at its end, which is what a backward cross-resource swipe does. "false"
+     * in scroll mode, for a single-page resource, or anywhere but the last column (a forward turn lands
+     * at column 0; a TOC jump lands at the chapter top). Read at `onPageLoaded`, BEFORE the typography
+     * injection reflows the page, so the check sees Readium's landing position against the base width.
+     */
+    suspend fun landedAtEnd(fragment: EpubNavigatorFragment): Boolean =
+        fragment.evaluateJavascript(LANDED_AT_END_JS)?.trim('"') == "true"
+
+    /**
      * Snaps the current resource so the column containing [fragmentId] sits flush — for an in-document
      * cross-reference tap ("Figure 4.1"), where the element is already in this document (no go()).
      */
@@ -282,6 +302,43 @@ internal object ColumnSnap {
           return "on";
         })()
         """.trimIndent()
+
+    // Lands a backward chapter turn on the LAST column of the freshly loaded resource and KEEPS it there
+    // until that chapter's typography reflow settles — the end-of-resource counterpart to
+    // [snapToTargetColumnJs]. A requestAnimationFrame loop that, every frame, pins scrollLeft to the last
+    // column boundary (`floor((scrollWidth - innerWidth) / innerWidth) * innerWidth`), so as reflow grows
+    // the content and adds columns the page tracks the moving end instead of being stranded several
+    // columns short — the "previous chapter overshoots 4-5 pages back" bug, which a raw `go()` to a
+    // `progression = 1.0` locator produces because it resolves 1.0 against the pre-reflow column count.
+    // Stops once scrollWidth has held steady for a few frames or a safety cap elapses. Shares
+    // `window.__riffleSnapGen` so a later jump supersedes an in-flight end-snap. The first snap runs
+    // synchronously (before the first rAF) so a non-reflowing page lands immediately. Vertical (scroll)
+    // mode pins scrollTop to the bottom instead; a page that fits the viewport is left untouched.
+    internal fun snapToEndColumnJs(): String =
+        "(function(){var se=document.scrollingElement;if(!se)return;" +
+            "var gen=(window.__riffleSnapGen=(window.__riffleSnapGen||0)+1);" +
+            "var lastW=-1,lastH=-1,stable=0,frames=0;" +
+            "function snap(){var iw=window.innerWidth;if(!(iw>0))return;" +
+            "if(se.scrollWidth > iw + 4){" + // paginated → last column
+            "se.scrollLeft=Math.max(0,Math.floor((se.scrollWidth - iw)/iw)*iw);}" +
+            "else if(se.scrollHeight > window.innerHeight + 4){" + // scroll mode → bottom
+            "se.scrollTop=Math.max(0,se.scrollHeight - window.innerHeight);}}" +
+            "function tick(){if(gen!==window.__riffleSnapGen)return;" + // a newer jump superseded us
+            "var w=se.scrollWidth,h=se.scrollHeight;" +
+            "if(w===lastW&&h===lastH)stable++;else{stable=0;lastW=w;lastH=h;}" +
+            "snap();" +
+            "if((stable>=3&&frames>=2)||frames++>72){snap();return;}" + // settled, or ~1.2s safety cap
+            "requestAnimationFrame(tick);}" +
+            "tick();})()"
+
+    // Reports whether the freshly loaded paginated page is resting on its LAST column — the signature of
+    // a backward cross-resource turn (Readium positions the previous resource at its end). Paginated only
+    // (scrollWidth > innerWidth); "false" otherwise. Pairs with [snapToEnd] in onPageLoaded.
+    internal val LANDED_AT_END_JS: String =
+        "(function(){var se=document.scrollingElement;if(!se)return 'false';" +
+            "var iw=window.innerWidth;if(!(iw>0))return 'false';" +
+            "if(!(se.scrollWidth > iw + 4))return 'false';" +
+            "return (se.scrollLeft + iw >= se.scrollWidth - 4)?'true':'false';})()"
 
     // Scrolls the current resource so the column CONTAINING [fragmentId] sits flush at the viewport's
     // left edge — for an in-document cross-reference tap ("Figure 4.1"). go(cssSelector) lands flush to

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -961,6 +961,12 @@ private fun EpubNavigatorView(
                     // the page can't be stranded several columns short of the true end (the "previous
                     // chapter overshoots 4-5 pages back" bug). A forward turn lands at column 0 and a TOC
                     // jump at the chapter top, so neither reports landedAtEnd.
+                    //
+                    // onPageLoaded fires for offscreen-preloaded resources too, and evaluateJavascript
+                    // binds to whatever resource is current at call time — so capture the resource we
+                    // measure here and only re-snap below if it is still current, otherwise a swipe during
+                    // the awaited injections could end-snap a DIFFERENT chapter (a forward overshoot).
+                    val hrefAtLoad = currentHrefHolder[0]
                     val landedAtEnd = ColumnSnap.landedAtEnd(fragment)
                     fragment.evaluateJavascript(RECT_TO_JSON_POLYFILL_JS)
                     fragment.evaluateJavascript(SELECTION_SPAN_TRACKER_JS)
@@ -984,7 +990,7 @@ private fun EpubNavigatorView(
                     // EXCEPTION: a backward cross-resource turn has no nav handler in paginated mode (it's
                     // Readium's own ViewPager), so there is no post-go snap to keep the end pinned through
                     // the reflow. Re-pin to the last column here; snapToEnd's rAF loop tracks the reflow.
-                    if (landedAtEnd) {
+                    if (landedAtEnd && currentHrefHolder[0] == hrefAtLoad) {
                         ColumnSnap.snapToEnd(fragment)
                     }
                 }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -954,6 +954,14 @@ private fun EpubNavigatorView(
                 pageLoadGeneration.value += 1
                 val fragment = fragmentRef.value ?: return
                 coroutineScope.launch {
+                    // A backward cross-resource page turn (swipe-back at a chapter start) is handled by
+                    // Readium itself in paginated mode — our nav handlers never see it — and Readium
+                    // positions the previous resource at its END. Capture that BEFORE the typography
+                    // injection below reflows (widens) the page; the end re-snap then tracks the reflow so
+                    // the page can't be stranded several columns short of the true end (the "previous
+                    // chapter overshoots 4-5 pages back" bug). A forward turn lands at column 0 and a TOC
+                    // jump at the chapter top, so neither reports landedAtEnd.
+                    val landedAtEnd = ColumnSnap.landedAtEnd(fragment)
                     fragment.evaluateJavascript(RECT_TO_JSON_POLYFILL_JS)
                     fragment.evaluateJavascript(SELECTION_SPAN_TRACKER_JS)
                     fragment.evaluateJavascript(typographyOverrideInjectionJs())
@@ -968,10 +976,17 @@ private fun EpubNavigatorView(
                     // paginated mode it rounds to the nearest column, so the page can never REST between
                     // two pages no matter what moved it. Idempotent; defers to the rAF trackers.
                     ColumnSnap.installBackstop(fragment)
-                    // NOTE: do NOT snap to the column grid here. The typography injection above
-                    // reflows the page asynchronously, so a snap at this point rounds a pre-reflow
-                    // position and lands close-but-not-exact. The post-go() snap in the navigation
-                    // handlers runs after the reflow has settled and is the authoritative one.
+                    // NOTE: do NOT snap to the column grid here for the general case. The typography
+                    // injection above reflows the page asynchronously, so a snap at this point rounds a
+                    // pre-reflow position and lands close-but-not-exact. The post-go() snap in the
+                    // navigation handlers runs after the reflow has settled and is the authoritative one.
+                    //
+                    // EXCEPTION: a backward cross-resource turn has no nav handler in paginated mode (it's
+                    // Readium's own ViewPager), so there is no post-go snap to keep the end pinned through
+                    // the reflow. Re-pin to the last column here; snapToEnd's rAF loop tracks the reflow.
+                    if (landedAtEnd) {
+                        ColumnSnap.snapToEnd(fragment)
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Problem

In The Martian, swiping back to the previous chapter (e.g. ch17 → ch16) landed **4-5 pages short** of the chapter's end instead of on its last page ("one page back").

## Root cause

In **paginated** mode the backward cross-resource page turn is handled entirely by **Readium's own ViewPager** — the `ScrollBoundaryNavigationContainer` and its `onNavigateBackward`/boundary logic are gated to scroll (Vertical) mode only, so our nav handlers never see the paginated swipe.

Readium positions the previous resource at its **end** against the page's *base* width. Then `onPageLoaded`'s typography / readaloud-reserve injection **reflows and widens** the page, so that end position becomes a *middle* column; the at-rest backstop only rounds to the *nearest* column, leaving the page stranded mid-chapter. (Same reflow-race family as the TOC-nav bug, but on Readium's swipe path.)

This was confirmed on-device by instrumenting `onPageLoaded` (the scroll-mode `onNavigateBackward` handler never fired).

## Fix

All in `onPageLoaded` + `ColumnSnap`:

- Before the typography injection, read `ColumnSnap.landedAtEnd()` — true only when Readium placed the fresh page on its **last column** (the signature of a backward turn; forward turns land at column 0, TOC jumps at the chapter top → false).
- If true, after injection call `ColumnSnap.snapToEnd()` — an rAF loop (`snapToEndColumnJs`) that re-pins to the last column every frame until the reflow settles (the end-of-resource counterpart to the existing `snapToTargetColumnJs`).
- Guard: capture the resource href at load and only end-snap if it's still current, since `onPageLoaded` fires for offscreen-preloaded resources and `evaluateJavascript` binds to the current item — preventing a swipe mid-injection from end-snapping a different chapter.

## Testing

- New `BackwardChapterSnapJsTest` (real WebView, 5 tests): last-column snap, `landedAtEnd` detection (col 0 / mid / last column), single-page and scroll-mode guards, scroll-mode bottom landing.
- **Device-verified** on The Martian (own ephemeral API-33 AVD, book from ABS):
  - backward swipe ch17 → ch16 now lands on ch16's **last page**;
  - forward swipe ch16 → ch17 lands at ch17 **start** (`landedAtEnd=false`);
  - TOC jump to ch12 lands at ch12 **start**.
- `./gradlew test` ✅, `./gradlew lint` ✅, `make harness-test` (198 tests, 0 failed) ✅, `make harness-test-tablet` (5 tests, 0 failed) ✅.