### PR TITLE
feat(library): adaptive cover grids with pinch-to-zoom + tablet detail cover sizing

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/library/CoverGridSizing.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/CoverGridSizing.kt
@@ -1,7 +1,14 @@
 package com.riffle.app.feature.library
 
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.foundation.gestures.calculateZoom
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.ReadOnlyComposable
+import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -9,15 +16,77 @@ import androidx.compose.ui.unit.dp
 private val PhoneCoverMinCellSize = 112.dp
 private val ExpandedCoverMinCellSize = 160.dp
 
+// Base sizes at scale 1.0; the user's pinch zoom multiplies them via
+// [LocalCoverGridScale]. Phone matches the browse tabs (~3 per row); tablet packs
+// a little tighter (~5-6) so the wider screen isn't dominated by huge covers.
+private val PhoneShelfCoverMinCellSize = 112.dp
+private val ExpandedShelfCoverMinCellSize = 140.dp
+
+/** Lower/upper bounds for the user's pinch-to-zoom multiplier. */
+const val MIN_COVER_SCALE = 0.7f
+const val MAX_COVER_SCALE = 1.6f
+
+/**
+ * The user's persisted cover-grid zoom multiplier (1.0 = shipped defaults).
+ * Provided once at the library screen root; every [coverGridMinCellSize] /
+ * [shelfCoverMinCellSize] reader scales off it, so a pinch anywhere reflows
+ * every cover grid consistently.
+ */
+val LocalCoverGridScale = compositionLocalOf { 1f }
+
 /**
  * Minimum cell size for `GridCells.Adaptive` cover grids, indexed on the current
  * window width per ADR 0019: Compact and Medium use the phone size; Expanded
  * (≥ 840dp) uses a larger cell so tablet covers feel browseable instead of
- * dense phone-sized thumbnails. Re-evaluated on configuration change.
+ * dense phone-sized thumbnails. Re-evaluated on configuration change and scaled
+ * by the user's pinch zoom.
  */
 @Composable
 @ReadOnlyComposable
 fun coverGridMinCellSize(): Dp {
     val widthDp = LocalConfiguration.current.screenWidthDp
-    return if (widthDp >= 840) ExpandedCoverMinCellSize else PhoneCoverMinCellSize
+    val base = if (widthDp >= 840) ExpandedCoverMinCellSize else PhoneCoverMinCellSize
+    return base * LocalCoverGridScale.current
+}
+
+/**
+ * Minimum cell size for the denser home-shelf / To Read cover grids. Same
+ * Expanded (≥ 840dp) breakpoint as [coverGridMinCellSize] but smaller cells so
+ * the row shows ~4 covers on a phone and ~5-6 on a tablet instead of 3. Scaled
+ * by the user's pinch zoom.
+ */
+@Composable
+@ReadOnlyComposable
+fun shelfCoverMinCellSize(): Dp {
+    val widthDp = LocalConfiguration.current.screenWidthDp
+    val base = if (widthDp >= 840) ExpandedShelfCoverMinCellSize else PhoneShelfCoverMinCellSize
+    return base * LocalCoverGridScale.current
+}
+
+/**
+ * Pinch-to-zoom for cover grids. Only two-finger gestures are claimed (and only
+ * those events consumed), so single-finger scrolling on the underlying lazy grid
+ * is untouched. Reports the new, clamped [LocalCoverGridScale] value via
+ * [onScaleChange]; the caller persists it.
+ */
+@Composable
+fun Modifier.pinchCoverZoom(onScaleChange: (Float) -> Unit): Modifier {
+    val scale = rememberUpdatedState(LocalCoverGridScale.current)
+    val onChange = rememberUpdatedState(onScaleChange)
+    return this.pointerInput(Unit) {
+        awaitEachGesture {
+            awaitFirstDown(requireUnconsumed = false)
+            do {
+                val event = awaitPointerEvent()
+                if (event.changes.count { it.pressed } >= 2) {
+                    val zoom = event.calculateZoom()
+                    if (zoom != 1f) {
+                        val next = (scale.value * zoom).coerceIn(MIN_COVER_SCALE, MAX_COVER_SCALE)
+                        onChange.value(next)
+                        event.changes.forEach { if (it.pressed) it.consume() }
+                    }
+                }
+            } while (event.changes.any { it.pressed })
+        }
+    }
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemDetailScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemDetailScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
@@ -282,7 +283,18 @@ private fun LibraryItemDetailContent(
         verticalArrangement = Arrangement.spacedBy(12.dp),
     ) {
         item.coverUrl?.let { url ->
-            val isLandscape = LocalConfiguration.current.orientation == Configuration.ORIENTATION_LANDSCAPE
+            val configuration = LocalConfiguration.current
+            val isLandscape = configuration.orientation == Configuration.ORIENTATION_LANDSCAPE
+            // A tablet in portrait is below the 840dp Expanded breakpoint (ADR 0019), so it
+            // lands on this single-column phone layout. fillMaxWidth() makes the cover span
+            // the whole tablet width — ginormous. Cap it on tablet-wide screens; real phones
+            // (< 600dp) keep the full-bleed cover.
+            val isWideScreen = configuration.screenWidthDp >= 600
+            val coverWidth = when {
+                isLandscape -> Modifier.fillMaxWidth(0.4f)
+                isWideScreen -> Modifier.widthIn(max = 280.dp)
+                else -> Modifier.fillMaxWidth()
+            }
             AsyncImage(
                 model = ImageRequest.Builder(LocalContext.current)
                     .data(url)
@@ -291,7 +303,7 @@ private fun LibraryItemDetailContent(
                 contentDescription = null,
                 contentScale = ContentScale.Fit,
                 modifier = Modifier
-                    .then(if (isLandscape) Modifier.fillMaxWidth(0.4f) else Modifier.fillMaxWidth())
+                    .then(coverWidth)
                     .aspectRatio(2f / 3f)
                     .align(Alignment.CenterHorizontally),
             )
@@ -406,8 +418,14 @@ internal fun LibraryItemDetailContentTablet(
             item.coverUrl?.let { url ->
                 // The left pane is non-scrolling (CONTEXT.md / ADR 0020), so the cover
                 // must yield height to the action row. weight(fill = false) lets the
-                // cover claim its aspect-ratio preferred size when there's room, but
-                // shrink in landscape so the Read button stays visible.
+                // cover shrink if it can't fit, keeping the Read button visible.
+                //
+                // The cap is orientation-aware: in portrait the pane is tall, so an
+                // uncapped cover dominates — cap it small. In landscape the pane is
+                // short and wide, so a small cap leaves the cover looking lost — allow
+                // it larger (weight still shrinks it if the action row needs the room).
+                val isLandscape =
+                    LocalConfiguration.current.orientation == Configuration.ORIENTATION_LANDSCAPE
                 AsyncImage(
                     model = ImageRequest.Builder(LocalContext.current)
                         .data(url)
@@ -417,6 +435,7 @@ internal fun LibraryItemDetailContentTablet(
                     contentScale = ContentScale.Fit,
                     modifier = Modifier
                         .weight(1f, fill = false)
+                        .widthIn(max = if (isLandscape) 230.dp else 100.dp)
                         .aspectRatio(2f / 3f)
                         .align(Alignment.CenterHorizontally),
                 )

--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsScreen.kt
@@ -6,8 +6,8 @@ import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.focusable
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer

--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsScreen.kt
@@ -1,12 +1,12 @@
 package com.riffle.app.feature.library
 
-import android.content.res.Configuration
 import androidx.activity.compose.BackHandler
 import androidx.activity.compose.LocalActivity
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.focusable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -62,6 +62,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -81,7 +82,6 @@ import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.painter.ColorPainter
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.text.style.TextAlign
@@ -98,6 +98,8 @@ import com.riffle.app.R
 import com.riffle.core.domain.Collection
 import com.riffle.core.domain.LibraryItem
 import com.riffle.core.domain.Series
+import kotlin.math.floor
+import kotlin.math.max
 
 private const val SECTION_PREVIEW_LIMIT = 5
 
@@ -140,6 +142,16 @@ fun LibraryItemsScreen(
     val coversAreSquare by viewModel.coversAreSquare.collectAsState()
     var selectedTab by rememberSaveable { mutableIntStateOf(0) }
 
+    // Drive the grids off a local live scale so a pinch reflows instantly; the
+    // persisted value (collected here) seeds it and wins on any external change.
+    val persistedCoverScale by viewModel.coverGridScale.collectAsState()
+    var liveCoverScale by remember { mutableFloatStateOf(persistedCoverScale) }
+    LaunchedEffect(persistedCoverScale) { liveCoverScale = persistedCoverScale }
+    val onCoverScaleChange: (Float) -> Unit = {
+        liveCoverScale = it
+        viewModel.setCoverGridScale(it)
+    }
+
     val focusManager = LocalFocusManager.current
     val keyboardController = LocalSoftwareKeyboardController.current
     LaunchedEffect(Unit) {
@@ -175,7 +187,10 @@ fun LibraryItemsScreen(
         }
     }
 
-    CompositionLocalProvider(LocalCoversAreSquare provides coversAreSquare) {
+    CompositionLocalProvider(
+        LocalCoversAreSquare provides coversAreSquare,
+        LocalCoverGridScale provides liveCoverScale,
+    ) {
     Scaffold(
         topBar = {
             LibrarySearchHeader(
@@ -220,6 +235,7 @@ fun LibraryItemsScreen(
                         onItemSelected = onItemSelected,
                         onSectionSeeMore = onSectionSeeMore,
                         linkedItemIds = linkedItemIds,
+                        onCoverScaleChange = onCoverScaleChange,
                     )
                     1 -> ToReadTabContent(
                         items = toReadItems,
@@ -227,12 +243,14 @@ fun LibraryItemsScreen(
                         token = viewModel.authToken,
                         onItemSelected = onItemSelected,
                         linkedItemIds = linkedItemIds,
+                        onCoverScaleChange = onCoverScaleChange,
                     )
                     2 -> SeriesTabContent(
                         items = series,
                         isLoading = isLoading,
                         token = viewModel.authToken,
                         onSeriesSelected = onSeriesSelected,
+                        onCoverScaleChange = onCoverScaleChange,
                     )
                     3 -> CollectionsTabContent(
                         items = collections,
@@ -240,6 +258,7 @@ fun LibraryItemsScreen(
                         token = viewModel.authToken,
                         collectionCoverUrls = collectionCoverUrls,
                         onCollectionSelected = onCollectionSelected,
+                        onCoverScaleChange = onCoverScaleChange,
                     )
                     4 -> AllBooksTabContent(
                         items = allBooks,
@@ -247,6 +266,7 @@ fun LibraryItemsScreen(
                         token = viewModel.authToken,
                         onItemSelected = onItemSelected,
                         linkedItemIds = linkedItemIds,
+                        onCoverScaleChange = onCoverScaleChange,
                     )
                     else -> {}
                 }
@@ -381,7 +401,7 @@ fun CollectionsSectionGrid(
     }
 }
 
-// --- Generic 3-column grid layout ---
+// --- Generic adaptive cover grid layout ---
 
 @Composable
 private fun CoverGrid(
@@ -389,19 +409,25 @@ private fun CoverGrid(
     modifier: Modifier = Modifier,
     content: @Composable (index: Int) -> Unit,
 ) {
-    val isLandscape = LocalConfiguration.current.orientation == Configuration.ORIENTATION_LANDSCAPE
-    val columns = if (isLandscape) 5 else 3
-    val rows = (count + columns - 1) / columns
-    Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(8.dp)) {
-        for (row in 0 until rows) {
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-            ) {
-                for (col in 0 until columns) {
-                    val index = row * columns + col
-                    Box(modifier = Modifier.weight(1f)) {
-                        if (index < count) content(index)
+    val minCell = shelfCoverMinCellSize()
+    val spacing = 8.dp
+    // Mirror GridCells.Adaptive: as many columns as fit at >= minCell, then split
+    // the row evenly. Driven off the same shelf sizing as the To Read grid so the
+    // home previews reflow to ~4 covers on a phone and ~5-6 on a tablet.
+    BoxWithConstraints(modifier = modifier) {
+        val columns = max(1, floor((maxWidth + spacing) / (minCell + spacing)).toInt())
+        val rows = (count + columns - 1) / columns
+        Column(verticalArrangement = Arrangement.spacedBy(spacing)) {
+            for (row in 0 until rows) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(spacing),
+                ) {
+                    for (col in 0 until columns) {
+                        val index = row * columns + col
+                        Box(modifier = Modifier.weight(1f)) {
+                            if (index < count) content(index)
+                        }
                     }
                 }
             }
@@ -937,6 +963,7 @@ private fun HomeTabContent(
     onItemSelected: (LibraryItem) -> Unit,
     onSectionSeeMore: (LibrarySectionType) -> Unit,
     linkedItemIds: Set<String> = emptySet(),
+    onCoverScaleChange: (Float) -> Unit = {},
 ) {
     if (isLoading) return
     if (inProgress.isEmpty() && recentlyAdded.isEmpty() && finished.isEmpty()) {
@@ -946,7 +973,9 @@ private fun HomeTabContent(
         return
     }
     LazyColumn(
-        modifier = Modifier.fillMaxSize(),
+        modifier = Modifier
+            .pinchCoverZoom(onCoverScaleChange)
+            .fillMaxSize(),
         contentPadding = PaddingValues(bottom = 16.dp),
     ) {
         if (inProgress.isNotEmpty()) {
@@ -1000,6 +1029,7 @@ private fun SeriesTabContent(
     isLoading: Boolean,
     token: String,
     onSeriesSelected: (Series) -> Unit,
+    onCoverScaleChange: (Float) -> Unit = {},
 ) {
     if (isLoading) return
     if (items.isEmpty()) {
@@ -1013,7 +1043,9 @@ private fun SeriesTabContent(
         contentPadding = PaddingValues(
             start = 12.dp, end = 12.dp, bottom = 16.dp,
         ),
-        modifier = Modifier.fillMaxSize(),
+        modifier = Modifier
+            .pinchCoverZoom(onCoverScaleChange)
+            .fillMaxSize(),
     ) {
         item(span = { GridItemSpan(maxLineSpan) }) {
             SectionHeader("Series (${items.size})")
@@ -1033,6 +1065,7 @@ private fun CollectionsTabContent(
     token: String,
     collectionCoverUrls: Map<String, List<String>>,
     onCollectionSelected: (Collection) -> Unit,
+    onCoverScaleChange: (Float) -> Unit = {},
 ) {
     if (isLoading) return
     if (items.isEmpty()) {
@@ -1046,7 +1079,9 @@ private fun CollectionsTabContent(
         contentPadding = PaddingValues(
             start = 12.dp, end = 12.dp, bottom = 16.dp,
         ),
-        modifier = Modifier.fillMaxSize(),
+        modifier = Modifier
+            .pinchCoverZoom(onCoverScaleChange)
+            .fillMaxSize(),
     ) {
         item(span = { GridItemSpan(maxLineSpan) }) {
             SectionHeader("Collections (${items.size})")
@@ -1071,6 +1106,7 @@ private fun ToReadTabContent(
     token: String,
     onItemSelected: (LibraryItem) -> Unit,
     linkedItemIds: Set<String> = emptySet(),
+    onCoverScaleChange: (Float) -> Unit = {},
 ) {
     if (isLoading) return
     if (items.isEmpty()) {
@@ -1080,11 +1116,13 @@ private fun ToReadTabContent(
         return
     }
     LazyVerticalGrid(
-        columns = GridCells.Fixed(3),
+        columns = GridCells.Adaptive(shelfCoverMinCellSize()),
         contentPadding = PaddingValues(
             start = 12.dp, end = 12.dp, bottom = 16.dp,
         ),
-        modifier = Modifier.fillMaxSize(),
+        modifier = Modifier
+            .pinchCoverZoom(onCoverScaleChange)
+            .fillMaxSize(),
     ) {
         item(span = { GridItemSpan(maxLineSpan) }) {
             SectionHeader("To Read (${items.size})")
@@ -1104,6 +1142,7 @@ private fun AllBooksTabContent(
     token: String,
     onItemSelected: (LibraryItem) -> Unit,
     linkedItemIds: Set<String> = emptySet(),
+    onCoverScaleChange: (Float) -> Unit = {},
 ) {
     if (isLoading) return
     if (items.isEmpty()) {
@@ -1117,7 +1156,9 @@ private fun AllBooksTabContent(
         contentPadding = PaddingValues(
             start = 12.dp, end = 12.dp, bottom = 16.dp,
         ),
-        modifier = Modifier.fillMaxSize(),
+        modifier = Modifier
+            .pinchCoverZoom(onCoverScaleChange)
+            .fillMaxSize(),
     ) {
         item(span = { GridItemSpan(maxLineSpan) }) {
             SectionHeader("All Books (${items.size})")

--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsViewModel.kt
@@ -20,6 +20,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -61,8 +62,18 @@ class LibraryItemsViewModel @Inject constructor(
     val coverGridScale: StateFlow<Float> = coverGridDensityStore.scale
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), 1f)
 
+    private var coverScalePersistJob: Job? = null
+
     fun setCoverGridScale(value: Float) {
-        viewModelScope.launch { coverGridDensityStore.setScale(value) }
+        // A pinch fires many events per gesture. Debounce the DataStore write so we
+        // persist once the gesture settles instead of hammering it on every frame —
+        // this also stops the persisted-scale flow from re-emitting mid-gesture and
+        // clobbering the live scale the UI is being driven from.
+        coverScalePersistJob?.cancel()
+        coverScalePersistJob = viewModelScope.launch {
+            delay(200)
+            coverGridDensityStore.setScale(value)
+        }
     }
 
     val series: StateFlow<List<Series>> = libraryRepository.observeSeries(libraryId)

--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsViewModel.kt
@@ -52,9 +52,18 @@ class LibraryItemsViewModel @Inject constructor(
     private val connectivityObserver: ConnectivityObserver,
     private val toReadRepository: ToReadRepository,
     private val readaloudLinkRepository: com.riffle.core.domain.ReadaloudLinkRepository,
+    private val coverGridDensityStore: com.riffle.core.domain.CoverGridDensityStore,
 ) : ViewModel() {
 
     val libraryId: String = savedStateHandle.get<String>("libraryId") ?: ""
+
+    /** User's persisted pinch-to-zoom multiplier for the cover grids (1.0 = defaults). */
+    val coverGridScale: StateFlow<Float> = coverGridDensityStore.scale
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), 1f)
+
+    fun setCoverGridScale(value: Float) {
+        viewModelScope.launch { coverGridDensityStore.setScale(value) }
+    }
 
     val series: StateFlow<List<Series>> = libraryRepository.observeSeries(libraryId)
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())

--- a/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemsViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemsViewModelTest.kt
@@ -174,6 +174,10 @@ class LibraryItemsViewModelTest {
         toReadRepository: ToReadRepository = FakeToReadRepository(),
         savedStateHandle: SavedStateHandle = SavedStateHandle(mapOf("libraryId" to "lib-1")),
         readaloudLinkRepository: com.riffle.core.domain.ReadaloudLinkRepository = NoopReadaloudLinkRepository,
+        coverGridDensityStore: com.riffle.core.domain.CoverGridDensityStore = object : com.riffle.core.domain.CoverGridDensityStore {
+            override val scale = kotlinx.coroutines.flow.flowOf(1f)
+            override suspend fun setScale(value: Float) {}
+        },
     ) = LibraryItemsViewModel(
         savedStateHandle,
         libraryRepository,
@@ -191,6 +195,7 @@ class LibraryItemsViewModelTest {
         connectivityObserver,
         toReadRepository,
         readaloudLinkRepository,
+        coverGridDensityStore,
     )
 
     private fun series(name: String) = Series("id-$name", "lib-1", name, null, 1)

--- a/core/data/src/main/kotlin/com/riffle/core/data/CoverGridDensityStoreImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/CoverGridDensityStoreImpl.kt
@@ -1,0 +1,29 @@
+package com.riffle.core.data
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.floatPreferencesKey
+import com.riffle.core.data.di.CoverGridDensityDataStore
+import com.riffle.core.domain.CoverGridDensityStore
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+
+class CoverGridDensityStoreImpl @Inject constructor(
+    @param:CoverGridDensityDataStore private val dataStore: DataStore<Preferences>,
+) : CoverGridDensityStore {
+
+    override val scale: Flow<Float> = dataStore.data.map { prefs ->
+        prefs[KEY_SCALE] ?: DEFAULT_SCALE
+    }
+
+    override suspend fun setScale(value: Float) {
+        dataStore.edit { prefs -> prefs[KEY_SCALE] = value }
+    }
+
+    private companion object {
+        const val DEFAULT_SCALE = 1f
+        val KEY_SCALE = floatPreferencesKey("cover_grid_scale")
+    }
+}

--- a/core/data/src/main/kotlin/com/riffle/core/data/di/CoverGridDensityDataStoreExt.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/di/CoverGridDensityDataStoreExt.kt
@@ -1,0 +1,9 @@
+package com.riffle.core.data.di
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.preferencesDataStore
+
+val Context.coverGridDensityDataStore: DataStore<Preferences>
+    by preferencesDataStore(name = "cover_grid_density")

--- a/core/data/src/main/kotlin/com/riffle/core/data/di/DataModule.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/di/DataModule.kt
@@ -34,6 +34,7 @@ import com.riffle.core.data.ServerFilesCleanerImpl
 import com.riffle.core.data.ServerRepositoryImpl
 import com.riffle.core.data.ToReadRepository
 import com.riffle.core.data.ToReadRepositoryImpl
+import com.riffle.core.data.CoverGridDensityStoreImpl
 import com.riffle.core.data.VolumeKeyPreferencesStoreImpl
 import com.riffle.core.data.WakeLockPreferencesStoreImpl
 import com.riffle.core.domain.AnnotationStore
@@ -63,6 +64,7 @@ import com.riffle.core.domain.ReadingPositionStore
 import com.riffle.core.domain.ReadingSessionRepository
 import com.riffle.core.domain.ServerRepository
 import com.riffle.core.domain.TokenStorage
+import com.riffle.core.domain.CoverGridDensityStore
 import com.riffle.core.domain.VolumeKeyPreferencesStore
 import com.riffle.core.domain.WakeLockPreferencesStore
 import com.riffle.core.data.AudiobookBundleDownloader
@@ -115,6 +117,10 @@ annotation class WakeLockPreferencesDataStore
 @Qualifier
 @Retention(AnnotationRetention.BINARY)
 annotation class VolumeKeyPreferencesDataStore
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class CoverGridDensityDataStore
 
 @Qualifier
 @Retention(AnnotationRetention.BINARY)
@@ -259,6 +265,9 @@ abstract class DataModule {
     @Binds
     @Singleton
     abstract fun bindVolumeKeyPreferencesStore(impl: VolumeKeyPreferencesStoreImpl): VolumeKeyPreferencesStore
+
+    @Binds
+    abstract fun bindCoverGridDensityStore(impl: CoverGridDensityStoreImpl): CoverGridDensityStore
 
     @Binds
     @Singleton
@@ -542,6 +551,13 @@ abstract class DataModule {
         fun provideVolumeKeyPreferencesDataStore(
             @ApplicationContext context: Context
         ): DataStore<Preferences> = context.volumeKeyPreferencesDataStore
+
+        @Provides
+        @Singleton
+        @CoverGridDensityDataStore
+        fun provideCoverGridDensityDataStore(
+            @ApplicationContext context: Context
+        ): DataStore<Preferences> = context.coverGridDensityDataStore
 
         @Provides
         @Singleton

--- a/core/data/src/main/kotlin/com/riffle/core/data/di/DataModule.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/di/DataModule.kt
@@ -267,6 +267,7 @@ abstract class DataModule {
     abstract fun bindVolumeKeyPreferencesStore(impl: VolumeKeyPreferencesStoreImpl): VolumeKeyPreferencesStore
 
     @Binds
+    @Singleton
     abstract fun bindCoverGridDensityStore(impl: CoverGridDensityStoreImpl): CoverGridDensityStore
 
     @Binds

--- a/core/data/src/test/kotlin/com/riffle/core/data/CoverGridDensityStoreTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/CoverGridDensityStoreTest.kt
@@ -1,0 +1,73 @@
+package com.riffle.core.data
+
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class CoverGridDensityStoreTest {
+
+    @get:Rule
+    val tmp = TemporaryFolder()
+
+    private val dispatcher = UnconfinedTestDispatcher()
+    private val testScope = TestScope(dispatcher)
+
+    private fun buildStore() = CoverGridDensityStoreImpl(
+        PreferenceDataStoreFactory.create(
+            scope = testScope.backgroundScope,
+            produceFile = { tmp.newFile("cover_grid_density.preferences_pb") },
+        )
+    )
+
+    @Test
+    fun `default scale is 1 when DataStore is empty`() = testScope.runTest {
+        assertEquals(1f, buildStore().scale.first())
+    }
+
+    @Test
+    fun `setScale round-trips on read`() = testScope.runTest {
+        val store = buildStore()
+        store.setScale(1.4f)
+        assertEquals(1.4f, store.scale.first())
+    }
+
+    @Test
+    fun `scale persists across store instances`() {
+        val file = tmp.newFile("cover_grid_density_round_trip.preferences_pb")
+
+        // DataStore disallows concurrent instances on the same file, so the write scope
+        // must be fully cancelled before a second instance reads.
+        val writeScope = CoroutineScope(UnconfinedTestDispatcher() + Job())
+        runBlocking {
+            CoverGridDensityStoreImpl(
+                PreferenceDataStoreFactory.create(
+                    scope = writeScope,
+                    produceFile = { file },
+                )
+            ).setScale(0.8f)
+        }
+        writeScope.cancel()
+
+        val readScope = CoroutineScope(UnconfinedTestDispatcher() + Job())
+        val store2 = CoverGridDensityStoreImpl(
+            PreferenceDataStoreFactory.create(
+                scope = readScope,
+                produceFile = { file },
+            )
+        )
+        assertEquals(0.8f, runBlocking { store2.scale.first() })
+        readScope.cancel()
+    }
+}

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/CoverGridDensityStore.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/CoverGridDensityStore.kt
@@ -1,0 +1,18 @@
+package com.riffle.core.domain
+
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Persisted, per-device cover-grid zoom. [scale] is a multiplier applied to the
+ * default cover-grid cell sizes: 1.0 keeps the shipped defaults, > 1.0 zooms in
+ * (bigger covers, fewer per row), < 1.0 zooms out (smaller covers, more per row).
+ *
+ * Intentionally global — not scoped by server or library — like the reader
+ * formatting / volume-key / wake-lock preferences (ADR 0025): it's an ergonomic
+ * UI preference about how dense the browse grids feel, not a property of any
+ * library's content.
+ */
+interface CoverGridDensityStore {
+    val scale: Flow<Float>
+    suspend fun setScale(value: Float)
+}


### PR DESCRIPTION
## What changed

### Adaptive cover grids + pinch-to-zoom density
- Home shelves and the **To Read** grid were hardcoded to 3 columns. They now use `GridCells.Adaptive` driven by a new `shelfCoverMinCellSize()` (phone 112dp / tablet 140dp), and the home `CoverGrid` computes columns from width via the Compose Adaptive formula.
- Added a **global, per-device pinch-to-zoom** that scales every cover grid through `LocalCoverGridScale` (clamped 0.7–1.6, 1.0 = defaults). The gesture only consumes two-finger events, so single-finger scrolling is untouched.
- Persistence is a new `CoverGridDensityStore` backed by a DataStore, mirroring the existing `VolumeKeyPreferencesStore` pattern. It is intentionally **not** scoped by server or library (per the ADR 0025 per-device-preference precedent).
- The persist is debounced in the ViewModel so a pinch writes once it settles rather than on every frame.

### Book-detail cover sizing
- The detail cover spanned the full screen width on tablets. A tablet in **portrait** is below the 840dp Expanded breakpoint (ADR 0019), so it renders the single-column phone layout, where the cover used `fillMaxWidth()`.
- Phone layout now caps the cover at 280dp on tablet-wide screens (≥600dp) while leaving real phones full-bleed.
- The two-pane tablet branch caps the cover orientation-aware (230dp landscape / 100dp portrait), still yielding height to the action row.

## Testing
- `./gradlew test` ✓
- `./gradlew lint` ✓
- `make harness-test` (phone) ✓ — 198 tests, 0 failed
- `make harness-test-tablet` ✓ — 5 tests, 0 failed
- New unit tests: `CoverGridDensityStoreTest`; updated `LibraryItemsViewModelTest`.

