### PR TITLE
fix(library): refresh on resume so the offline banner clears immediately on wake

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsScreen.kt
@@ -153,6 +153,10 @@ fun LibraryItemsScreen(
             if (event == Lifecycle.Event.ON_RESUME) {
                 focusManager.clearFocus(force = true)
                 keyboardController?.hide()
+                // Re-check the server on every resume (e.g. wake from sleep) so a stale offline
+                // banner left by an earlier failed refresh clears immediately, rather than only
+                // when the periodic retry next fires.
+                viewModel.refresh()
             }
         }
         lifecycleOwner.lifecycle.addObserver(observer)


### PR DESCRIPTION
## Problem

Returning to the library from sleep could leave a stale **"Offline"** banner up for up to ~10 seconds even though the device and server were both reachable.

Mechanism: on wake the radio is still settling, so a refresh fires and fails, latching `refreshFailed = true`. Because connectivity itself never transitioned `false → true`, the on-reconnect listener never fires — and the only thing left to clear the banner is the periodic 10s retry poll. So you sit staring at a wrong banner until the timer happens to tick.

Connectivity detection itself is already event-driven (`ConnectivityObserverImpl` via `NetworkCallback`) and was not the problem — the gap is purely the *server re-check* on resume.

## Fix

Re-check the server on every `ON_RESUME` in `LibraryItemsScreen` (the handler already existed for keyboard/focus). This clears a stranded banner in one round-trip instead of waiting on the 10s poll.

Four lines, scoped to the main library view. The 10s retry poll is unchanged — it only matters now for the rare "server down while you're actively watching" case, where 10s is fine.

## Testing

- `:app:testDebugUnitTest` for the library ViewModel tests: green.
- Resume-refresh is a Composable lifecycle effect, so it's not unit-covered and has **not** been device-verified yet.