### PR TITLE
fix(readaloud): scope play-from-here resolver to the current chapter

### DIFF
--- a/app/src/androidTest/kotlin/com/riffle/app/feature/reader/ReaderWebViewScriptsTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/reader/ReaderWebViewScriptsTest.kt
@@ -254,6 +254,40 @@ class ReaderWebViewScriptsTest {
         }
     }
 
+    // A punctuation-only "sentence" — Storyteller emits fragments like `…”` as their own narrated span.
+    // Its 1–2 char key matches that SAME punctuation INSIDE a real compound sentence ("…to save lives,
+    // I'd…" He thought…"), and, sitting later than the real sentence's start, would wrongly win. The
+    // resolver must skip such degenerate keys. Mirrors the real The Martian ch16 within-chapter misfire
+    // (a tap inside id34-s833 resolved to the `…”` fragment id34-s213).
+    private val degenerateFixture = """
+        <!DOCTYPE html>
+        <html><head><meta name="viewport" content="width=device-width, initial-scale=1"></head>
+          <body style="margin:0">
+            <p>“But if I wasn’t willing to take risks to save lives, I’d…” He thought for a moment.</p>
+          </body>
+        </html>
+    """.trimIndent()
+
+    private val degenerateSentences = listOf(
+        "s-deg" to "…”",
+        "s-real" to "“But if I wasn’t willing to take risks to save lives, I’d…” He thought for a moment.",
+    )
+
+    @Test
+    fun resolveSelectionSkipsPunctuationOnlySentenceFragments() {
+        withSizedWebViewFixture(degenerateFixture, widthPx = 1080, heightPx = 1600) { webView ->
+            webView.awaitInnerHeight()
+            webView.evalSync(SELECTION_SPAN_TRACKER_JS)
+            webView.selectNthOccurrence("thought", 1) // inside the real compound sentence, after the `…”`
+            assertTrue(webView.awaitSelRect())
+            assertEquals(
+                "must resolve to the real compound sentence, not the punctuation-only `…”` fragment that matches mid-sentence",
+                "s-real",
+                webView.evalSync(resolveSelectionSentenceJs(degenerateSentences)).trim('"'),
+            )
+        }
+    }
+
     @Test
     fun resolveSelectionReturnsEmptyWhenNoSelectionRectIsStashed() {
         withSizedWebViewFixture(strippedFixture, widthPx = 1080, heightPx = 1600) { webView ->

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -235,6 +235,7 @@ fun EpubReaderScreen(
     val playbackState by viewModel.playbackState.collectAsState()
     val activeFragmentRef by viewModel.activeFragmentRef.collectAsState()
     val sentenceQuotes by viewModel.sentenceQuotes.collectAsState()
+    val sentenceChapters by viewModel.sentenceChapters.collectAsState()
     val downloadPromptBytes by viewModel.downloadPromptBytes.collectAsState()
     val readaloudOfflineMessage by viewModel.readaloudOfflineMessage.collectAsState()
     val downloadProgress by viewModel.downloadProgress.collectAsState()
@@ -307,6 +308,7 @@ fun EpubReaderScreen(
                         onFootnoteTapped = viewModel::showFootnotePopup,
                         activeFragmentRef = activeFragmentRef,
                         sentenceQuotes = sentenceQuotes,
+                        sentenceChapters = sentenceChapters,
                         narrationProgress = viewModel.narrationProgress,
                         pageTopProbeRequests = viewModel.pageTopProbeRequests,
                         onPageTopResolved = viewModel::onPageTopResolved,
@@ -681,6 +683,28 @@ private fun fragmentLocator(ref: String, quote: SentenceQuote? = null): Locator?
     Locator.fromJSON(readaloudLocatorJson(ref, quote))
 
 /**
+ * The narrated sentences (span id → text) to feed [resolveSelectionSentenceJs] for a "Play from here"
+ * tap, scoped to the chapter being read ([currentHref]). The resolver locates a tapped sentence by
+ * searching the rendered page for each sentence's short text prefix; handed the WHOLE book it can match
+ * a FOREIGN chapter's sentence whose text recurs inside a current-chapter sentence (The Martian ch16's
+ * "…I'd… He thought for a moment." contains ch8's standalone "He thought for a moment.") and seek that
+ * chapter instead. Scoping to [currentHref] removes the cross-chapter matches. Falls back to the whole
+ * book when no sentence maps to this chapter (e.g. the rendered href can't be reconciled with the
+ * bundle), preserving behaviour rather than yielding an empty resolver.
+ */
+internal fun scopeSentencesToChapter(
+    quotes: Map<String, SentenceQuote>,
+    chapters: Map<String, String>,
+    currentHref: String,
+): List<Pair<String, String>> {
+    fun base(h: String) = h.substringBefore('#').substringAfterLast('/')
+    val cur = base(currentHref)
+    val scoped = quotes.entries.filter { base(chapters[it.key] ?: "") == cur && cur.isNotEmpty() }
+    val use = if (scoped.isNotEmpty()) scoped else quotes.entries.toList()
+    return use.map { it.key to it.value.highlight }
+}
+
+/**
  * The Readium Locator JSON for a readaloud fragment ref. Extracted (and `internal`) so the
  * text-anchoring contract is unit-testable without a navigator: when a [quote] is present the JSON
  * MUST carry a `text` block (highlight + before/after), because that's what lets Readium position
@@ -732,6 +756,7 @@ private fun EpubNavigatorView(
     onFootnoteTapped: (content: FootnoteContent) -> Unit,
     activeFragmentRef: String?,
     sentenceQuotes: Map<String, SentenceQuote>,
+    sentenceChapters: Map<String, String>,
     narrationProgress: Flow<PlayerCoordinator.NarrationProgress?>,
     pageTopProbeRequests: Flow<String>,
     onPageTopResolved: (href: String, fragmentId: String?) -> Unit,
@@ -769,6 +794,7 @@ private fun EpubNavigatorView(
     val currentOnFootnoteTapped by rememberUpdatedState(onFootnoteTapped)
     val currentOnPlayFromHere by rememberUpdatedState(onPlayFromHere)
     val currentSentenceQuotes by rememberUpdatedState(sentenceQuotes)
+    val currentSentenceChapters by rememberUpdatedState(sentenceChapters)
     val currentOnHighlight by rememberUpdatedState(onHighlight)
     val currentAnnotationsAvailable by rememberUpdatedState(annotationsAvailable)
     val currentReadaloudAvailable by rememberUpdatedState(readaloudAvailable)
@@ -869,8 +895,9 @@ private fun EpubNavigatorView(
                             // pages whose spans survived (pure-Storyteller rendering) or before the quotes
                             // map is ready. Empty → falls back to the locator fragment, then the bare href
                             // (chapter start).
-                            val sentences = currentSentenceQuotes.entries
-                                .map { it.key to it.value.highlight }
+                            val sentences = scopeSentencesToChapter(
+                                currentSentenceQuotes, currentSentenceChapters, loc.href.toString(),
+                            )
                             val byText = if (sentences.isNotEmpty() && nav != null) {
                                 nav.evaluateJavascript(resolveSelectionSentenceJs(sentences))
                                     ?.trim('"')?.takeIf { it.isNotEmpty() }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -333,6 +333,11 @@ class EpubReaderViewModel @Inject constructor(
     private val _sentenceQuotes = MutableStateFlow<Map<String, com.riffle.core.domain.SentenceQuote>>(emptyMap())
     val sentenceQuotes: StateFlow<Map<String, com.riffle.core.domain.SentenceQuote>> = _sentenceQuotes
 
+    // span id → bundle chapter href, so "Play from here" can scope the sentence resolver to the chapter
+    // being read (a phrase that recurs across chapters otherwise resolves to the wrong chapter's clip).
+    private val _sentenceChapters = MutableStateFlow<Map<String, String>>(emptyMap())
+    val sentenceChapters: StateFlow<Map<String, String>> = _sentenceChapters
+
     // Download-prompt state: non-null size means "show the download dialog".
     private val _downloadPromptBytes = MutableStateFlow<Long?>(null)
     val downloadPromptBytes: StateFlow<Long?> = _downloadPromptBytes
@@ -1617,6 +1622,7 @@ class EpubReaderViewModel @Inject constructor(
             try {
                 val chapters = com.riffle.core.domain.EpubContentExtractor.extract(bundle)?.chapters ?: return@launch
                 _sentenceQuotes.value = com.riffle.core.domain.ReadaloudTextQuotes.build(chapters)
+                _sentenceChapters.value = com.riffle.core.domain.ReadaloudTextQuotes.sentenceChapterHrefs(chapters)
             } catch (e: Throwable) {
                 // Never let the highlight-quote parse crash playback; the highlight just stays absent.
                 android.util.Log.e("RIFFLE_RA", "buildSentenceQuotes failed", e)

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderWebViewScripts.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderWebViewScripts.kt
@@ -112,7 +112,17 @@ internal val SELECTION_SPAN_TRACKER_JS = """
  */
 internal fun resolveSelectionSentenceJs(sentences: List<Pair<String, String>>): String {
     val sents = JSONArray(
-        sentences.map { (id, text) -> JSONArray(listOf(id, text.trim().take(12))) },
+        sentences.map { (id, text) ->
+            // Drop punctuation-only "sentences" (Storyteller emits fragments like `…”` as their own
+            // narrated span). Their 1–2 char key matches that same punctuation INSIDE a real sentence —
+            // e.g. the `…”` in The Martian ch16's "…to save lives, I'd…" He thought…" — and, sitting later
+            // than the real sentence's start, wrongly wins. Require a few letters/digits to be a usable
+            // locator; the JS skips empty keys. (Cross-chapter false matches are handled upstream by
+            // scoping the list to the chapter being read — see scopeSentencesToChapter.)
+            val key = text.trim().take(12)
+            val usable = if (key.count(Char::isLetterOrDigit) >= 3) key else ""
+            JSONArray(listOf(id, usable))
+        },
     ).toString()
     return """
     (function(){

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ScopeSentencesToChapterTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ScopeSentencesToChapterTest.kt
@@ -1,0 +1,68 @@
+package com.riffle.app.feature.reader
+
+import com.riffle.core.domain.SentenceQuote
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Unit tests for [scopeSentencesToChapter], the fix for "Play from here jumps to a completely different
+ * chapter" (The Martian ch16 → ch8). The selection resolver locates a tapped sentence by searching the
+ * rendered page for each candidate sentence's short text prefix; handed the WHOLE book it matches a
+ * FOREIGN chapter's sentence whose text recurs inside a current-chapter sentence and seeks that chapter.
+ * Scoping the candidate list to the chapter being read removes the cross-chapter matches.
+ */
+class ScopeSentencesToChapterTest {
+
+    private fun q(text: String) = SentenceQuote(before = "", highlight = text, after = "")
+
+    // The real Martian collision: ch8's standalone "He thought for a moment." (id26-s205) is embedded
+    // verbatim inside ch16's compound sentence (id34-s833). With the whole book in scope, a tap inside
+    // ch16's "He thought for a moment." run resolves to the ch8 sentence; scoping to ch16 prevents it.
+    private val quotes = mapOf(
+        "id26-s205" to q("He thought for a moment."),
+        "id26-s206" to q("“Sorry, Mitch, I’m with Venkat on this one,” he said."),
+        "id34-s832" to q("Mitch shrugged."),
+        "id34-s833" to q("“But if I wasn’t willing to take risks to save lives, I’d…” He thought for a moment."),
+        "id34-s834" to q("“Well, I guess I’d be you.”"),
+    )
+    private val chapters = mapOf(
+        "id26-s205" to "text/part0013.html",
+        "id26-s206" to "text/part0013.html",
+        "id34-s832" to "text/part0021.html",
+        "id34-s833" to "text/part0021.html",
+        "id34-s834" to "text/part0021.html",
+    )
+
+    @Test
+    fun scopesToTheChapterBeingRead_excludingForeignChapterSentences() {
+        val scoped = scopeSentencesToChapter(quotes, chapters, "text/part0021.html")
+        val ids = scoped.map { it.first }.toSet()
+        assertEquals(setOf("id34-s832", "id34-s833", "id34-s834"), ids)
+        assertTrue("ch8 sentences must be excluded so the resolver can't seat on them", "id26-s205" !in ids)
+        assertTrue("id26-s206" !in ids)
+    }
+
+    @Test
+    fun reconcilesHrefByBasename_soAnOpfFolderPrefixDoesNotBreakScoping() {
+        // The rendered (ABS) href may carry a folder prefix the bundle href doesn't (or vice versa);
+        // matching on the file basename keeps scoping working when only the directory differs.
+        val scoped = scopeSentencesToChapter(quotes, chapters, "OEBPS/text/part0021.html#frag")
+        assertEquals(setOf("id34-s832", "id34-s833", "id34-s834"), scoped.map { it.first }.toSet())
+    }
+
+    @Test
+    fun fallsBackToWholeBookWhenNoSentenceMapsToTheCurrentChapter() {
+        // An unmatched href (chapter can't be reconciled with the bundle) must not yield an empty list —
+        // that would break "Play from here" entirely; fall back to the whole book (prior behaviour).
+        val scoped = scopeSentencesToChapter(quotes, chapters, "text/unknown-chapter.html")
+        assertEquals(quotes.keys, scoped.map { it.first }.toSet())
+    }
+
+    @Test
+    fun fallsBackToWholeBookWhenChapterMapIsEmpty() {
+        // Quotes built but the chapter map not yet populated → don't return empty.
+        val scoped = scopeSentencesToChapter(quotes, emptyMap(), "text/part0021.html")
+        assertEquals(quotes.keys, scoped.map { it.first }.toSet())
+    }
+}

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/ReadaloudTextQuotes.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/ReadaloudTextQuotes.kt
@@ -54,6 +54,24 @@ object ReadaloudTextQuotes {
         return out
     }
 
+    /**
+     * Map every sentence span id across [chapters] to the href of the chapter it lives in.
+     *
+     * "Play from here" resolves the tapped sentence by searching the rendered page for each sentence's
+     * short text prefix. Run against the WHOLE book that misfires when a phrase recurs: e.g. The Martian
+     * ch16's compound sentence "…I'd… He thought for a moment." contains the standalone ch8 sentence
+     * "He thought for a moment." — selecting inside it matches the FOREIGN ch8 sentence's start and jumps
+     * narration there. Scoping the candidate sentences to the chapter being read removes the cross-chapter
+     * matches, so the resolver can only land on a sentence that genuinely belongs to this page.
+     */
+    fun sentenceChapterHrefs(chapters: List<EpubChapterHtml>): Map<String, String> {
+        val out = LinkedHashMap<String, String>()
+        for (chapter in chapters) {
+            for (id in quotesForChapter(chapter.html).keys) out[id] = chapter.href
+        }
+        return out
+    }
+
     /** Map each sentence span's id → its [SentenceQuote] within one chapter's [html]. */
     fun quotesForChapter(html: String): Map<String, SentenceQuote> {
         val doc = try { Jsoup.parse(html) } catch (_: Exception) { return emptyMap() }

--- a/core/domain/src/test/kotlin/com/riffle/core/domain/ReadaloudTextQuotesTest.kt
+++ b/core/domain/src/test/kotlin/com/riffle/core/domain/ReadaloudTextQuotesTest.kt
@@ -99,6 +99,22 @@ class ReadaloudTextQuotesTest {
         assertEquals("Real text.", quotes["x-s1"]!!.highlight)
     }
 
+    // Feeds "Play from here" chapter-scoping (so a phrase recurring across chapters can't resolve to
+    // the wrong chapter's clip — The Martian ch16 → ch8). Every sentence id maps to the href it lives in.
+    @Test
+    fun `sentenceChapterHrefs maps each span id to its chapter href`() {
+        val chapters = listOf(
+            EpubChapterHtml(href = "text/part0013.html", html = martianChapter),
+            EpubChapterHtml(href = "text/part0021.html", html = phmChapter),
+        )
+        val map = ReadaloudTextQuotes.sentenceChapterHrefs(chapters)
+        assertEquals("text/part0013.html", map["id259-s1"])
+        assertEquals("text/part0013.html", map["id259-s3"])
+        assertEquals("text/part0021.html", map["c008-s0"])
+        // structural / non-sentence ids never enter the map
+        assertNull(map["calibre_pb_1"])
+    }
+
     @Test
     fun `unparseable or empty chapter contributes nothing, never throws`() {
         assertTrue(ReadaloudTextQuotes.quotesForChapter("").isEmpty())


### PR DESCRIPTION
## Problem

"Play from here" could start narration in a **completely different chapter**. Repro: in *The Martian*, tapping a sentence on chapter 16's last page jumped the reader (and audio) to chapter 8 ("Sorry, Mitch, I'm with Venkat on this one").

## Root cause (two compounding collisions)

`resolveSelectionSentenceJs` was handed the **whole book's** sentence list and located a tapped sentence by matching each one's short text prefix on the rendered page.

1. **Cross-chapter** — a foreign chapter's *standalone* sentence whose text is *embedded* in a current-chapter compound sentence won. ch8's "He thought for a moment." (`id26-s205`) is contained in ch16's *"…to save lives, I'd…" He thought for a moment."* (`id34-s833`); tapping there resolved to ch8, and `resolveStartClip`'s bare-id fallback seeked that chapter.
2. **Punctuation-only fragment** — Storyteller emits fragments like `…”` as their own narrated span (ch16 `id34-s213`). Its ≤2-char key matches the same `…”` *inside* `id34-s833`, sitting later than the real sentence's start, so it wins. (This is why scoping alone wasn't enough — it then misfired *within* ch16 onto the Venkat scene.)

## Fix

- **Scope to the chapter being read** — `ReadaloudTextQuotes.sentenceChapterHrefs()` maps span id → chapter href; the ViewModel exposes `sentenceChapters`; `scopeSentencesToChapter()` filters the resolver's candidate list to the current chapter (basename href match, with a whole-book fallback when the href can't be reconciled, so no regression for books whose rendered/bundle hrefs diverge).
- **Drop punctuation-only keys** in `resolveSelectionSentenceJs` (require ≥3 letters/digits; the JS already skips empty keys).

## Testing

- **Device e2e** (The Martian on emulator): tapping "He thought for a moment." on ch16's last page now resolves to `id34-s833`, the reader **stays on chapter 16** and narrates the tapped sentence. Confirmed via instrumentation that the whole-book resolver returned the ch8 id while the scoped resolver returns the correct ch16 id.
- `ScopeSentencesToChapterTest` (JVM) — scoping, basename reconciliation, and both fallbacks.
- `ReadaloudTextQuotesTest#sentenceChapterHrefs…` (JVM).
- `ReaderWebViewScriptsTest#resolveSelectionSkipsPunctuationOnlySentenceFragments` (harness, real WebView).
- `./gradlew test lint` ✅, `make harness-test` (199 tests, 0 failed) ✅, `make harness-test-tablet` (5 tests, 0 failed) ✅.

## Note

The same whole-book assumption still exists in `firstVisibleSentenceJs` (first-visible detection, not play-from-here) — likely benign, left for a follow-up.