### PR TITLE
feat(reader): Back card to undo an off-page internal-link jump

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ColumnSnap.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ColumnSnap.kt
@@ -86,10 +86,13 @@ internal object ColumnSnap {
     /**
      * Snaps the current resource so the column containing [fragmentId] sits flush — for an in-document
      * cross-reference tap ("Figure 4.1"), where the element is already in this document (no go()).
+     *
+     * Returns true iff the snap actually moved the page to a different column — i.e. the target was
+     * off-screen. A target already on the visible page snaps to the same column (returns false), so the
+     * caller can suppress a "return here" affordance there is nothing to come back from.
      */
-    suspend fun snapToElementColumn(fragment: EpubNavigatorFragment, fragmentId: String) {
-        fragment.evaluateJavascript(scrollToColumnJs(fragmentId))
-    }
+    suspend fun snapToElementColumn(fragment: EpubNavigatorFragment, fragmentId: String): Boolean =
+        fragment.evaluateJavascript(scrollToColumnJs(fragmentId))?.trim('"') == "moved"
 
     /**
      * Follows the narrated sentence [text] to its column on a sentence change. Returns "on" (followed, or
@@ -340,15 +343,29 @@ internal object ColumnSnap {
             "if(!(se.scrollWidth > iw + 4))return 'false';" +
             "return (se.scrollLeft + iw >= se.scrollWidth - 4)?'true':'false';})()"
 
-    // Scrolls the current resource so the column CONTAINING [fragmentId] sits flush at the viewport's
-    // left edge — for an in-document cross-reference tap ("Figure 4.1"). go(cssSelector) lands flush to
-    // the element's box (a little inside its column → a sliver of the neighbour shows); flooring
-    // scrollLeft to a multiple of innerWidth lands on the column boundary.
+    // Brings the element [fragmentId] onto the page for an in-document cross-reference tap ("Figure
+    // 4.1"). Mode-aware, because the reader paginates horizontally OR scrolls vertically:
+    //  - paginated: FLOOR scrollLeft to the column the element starts in (go(cssSelector) lands flush to
+    //    the box → a sliver of the neighbour shows; flooring to innerWidth lands on the column boundary).
+    //  - scroll mode (scrollHeight > innerHeight): there is no column grid, so scroll VERTICALLY to bring
+    //    the element to the top of the viewport; an element already fully on screen isn't moved.
+    // Returns 'moved' when the snap changed the visible page (target was off-page → offer a return),
+    // 'same' when it was already visible, or 'absent' when the id isn't in this document.
     internal fun scrollToColumnJs(fragmentId: String): String =
         "(function(){var el=document.getElementById(${JSONObject.quote(fragmentId)});" +
-            "if(!el)return;var se=document.scrollingElement;var iw=window.innerWidth;" +
-            "var abs=el.getBoundingClientRect().left+se.scrollLeft;" +
-            "se.scrollLeft=Math.floor(abs/iw)*iw;})()"
+            "if(!el)return 'absent';" +
+            "var se=document.scrollingElement||document.documentElement;" +
+            "var r=el.getBoundingClientRect();" +
+            "if(se.scrollHeight > window.innerHeight + 4){" + // scroll (vertical) mode → no column grid
+            "if(r.top>=0 && r.bottom<=window.innerHeight)return 'same';" + // already fully visible
+            "var beforeTop=se.scrollTop;" +
+            "se.scrollTop=Math.max(0, r.top + se.scrollTop - 8);" +
+            "return (Math.abs(se.scrollTop-beforeTop)>1)?'moved':'same';}" +
+            "var iw=window.innerWidth;" +
+            "var before=se.scrollLeft;" +
+            "var abs=r.left+se.scrollLeft;" +
+            "var target=Math.floor(abs/iw)*iw;se.scrollLeft=target;" +
+            "return (Math.abs(target-before)>1)?'moved':'same';})()"
 
     // The AT-REST backstop: a debounced scroll-idle listener that, once horizontal scrolling has gone quiet
     // in paginated mode, rounds scrollLeft to the NEAREST column boundary so the page can never come to REST

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -305,6 +305,9 @@ fun EpubReaderScreen(
                         onTap = immersiveState::toggle,
                         latestLocator = { viewModel.latestLocator },
                         onFootnoteTapped = viewModel::showFootnotePopup,
+                        returnNavEvents = viewModel.returnNavEvents,
+                        onCaptureReturnTarget = viewModel::captureReturnTarget,
+                        onFollowInternalLink = viewModel::followInternalLink,
                         activeFragmentRef = activeFragmentRef,
                         sentenceQuotes = sentenceQuotes,
                         narrationProgress = viewModel.narrationProgress,
@@ -498,6 +501,13 @@ fun EpubReaderScreen(
             FootnotePopup(
                 state = popupState,
                 onDismiss = viewModel::dismissFootnotePopup,
+            )
+        }
+        val returnTarget by viewModel.returnTarget.collectAsState()
+        if (returnTarget != null) {
+            ReturnToPositionCard(
+                onReturn = viewModel::returnToCapturedPosition,
+                onDismiss = viewModel::dismissReturnTarget,
             )
         }
     }
@@ -730,6 +740,9 @@ private fun EpubNavigatorView(
     onTap: () -> Unit,
     latestLocator: () -> Locator?,
     onFootnoteTapped: (content: FootnoteContent) -> Unit,
+    returnNavEvents: Flow<Locator>,
+    onCaptureReturnTarget: (Locator) -> Unit,
+    onFollowInternalLink: (Link, Locator) -> Unit,
     activeFragmentRef: String?,
     sentenceQuotes: Map<String, SentenceQuote>,
     narrationProgress: Flow<PlayerCoordinator.NarrationProgress?>,
@@ -767,6 +780,9 @@ private fun EpubNavigatorView(
     // without needing to be re-created when onTap changes.
     val currentOnTap by rememberUpdatedState(onTap)
     val currentOnFootnoteTapped by rememberUpdatedState(onFootnoteTapped)
+    val currentLatestLocator by rememberUpdatedState(latestLocator)
+    val currentOnCaptureReturnTarget by rememberUpdatedState(onCaptureReturnTarget)
+    val currentOnFollowInternalLink by rememberUpdatedState(onFollowInternalLink)
     val currentOnPlayFromHere by rememberUpdatedState(onPlayFromHere)
     val currentSentenceQuotes by rememberUpdatedState(sentenceQuotes)
     val currentOnHighlight by rememberUpdatedState(onHighlight)
@@ -915,9 +931,17 @@ private fun EpubNavigatorView(
                 link: Link,
                 context: HyperlinkNavigator.LinkContext?,
             ): Boolean {
-                if (context !is HyperlinkNavigator.FootnoteContext) return true
-                val content = FootnoteResolver.footnoteContent(context.noteContent) ?: return true
-                currentOnFootnoteTapped(content)
+                if (context is HyperlinkNavigator.FootnoteContext) {
+                    val content = FootnoteResolver.footnoteContent(context.noteContent) ?: return true
+                    currentOnFootnoteTapped(content)
+                    return false
+                }
+                // A non-footnote internal link (a cross-resource cross-reference — same-document anchors
+                // are intercepted earlier by the JS bridge). Drive the navigation ourselves so we can
+                // remember the origin and offer a return; defer to Readium only if we don't yet know
+                // where we are. It always lands in another resource, so it's never a same-page jump.
+                val origin = currentLatestLocator() ?: return true
+                currentOnFollowInternalLink(link, origin)
                 return false
             }
 
@@ -1039,8 +1063,13 @@ private fun EpubNavigatorView(
                     true
                 }
                 FootnoteResolver.AnchorTarget.CrossReference -> {
+                    // Capture where we are BEFORE the snap; offer a way back only if the target was
+                    // actually off-page (the snap reports whether it changed columns).
+                    val origin = currentLatestLocator()
                     coroutineScope.launch(Dispatchers.Main) {
-                        fragmentRef.value?.let { ColumnSnap.snapToElementColumn(it, fragmentId) }
+                        val moved = fragmentRef.value
+                            ?.let { ColumnSnap.snapToElementColumn(it, fragmentId) } ?: false
+                        if (moved && origin != null) currentOnCaptureReturnTarget(origin)
                     }
                     true
                 }
@@ -1078,6 +1107,24 @@ private fun EpubNavigatorView(
             // fragment; preserve where go() landed (round to the column grid) instead of snapping to
             // the chapter top, so the reader lands on the actual synced page.
             ColumnSnap.goAndSnap(fragment, locator, landAtStartWhenNoTarget = false)
+        }
+    }
+
+    LaunchedEffect(returnNavEvents) {
+        returnNavEvents.collect { locator ->
+            // "Back" on the return card: go to the captured origin and snap it to the grid where go()
+            // landed (don't yank to the chapter top — landAtStartWhenNoTarget=false). Cover only a
+            // cross-resource trip back, exactly like a forward jump.
+            val fragment = fragmentRef.value ?: return@collect
+            val cover = locator.href.toString().substringBefore('#') !=
+                currentHrefHolder[0]?.substringBefore('#')
+            navigating = cover
+            try {
+                ColumnSnap.goAndSnap(fragment, locator, landAtStartWhenNoTarget = false)
+                if (cover) delay(NAV_COVER_SETTLE_MS)
+            } finally {
+                navigating = false
+            }
         }
     }
 

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -1110,41 +1110,30 @@ private fun EpubNavigatorView(
         }
     }
 
-    LaunchedEffect(returnNavEvents) {
-        returnNavEvents.collect { locator ->
-            // "Back" on the return card: go to the captured origin and snap it to the grid where go()
-            // landed (don't yank to the chapter top — landAtStartWhenNoTarget=false). Cover only a
-            // cross-resource trip back, exactly like a forward jump.
-            val fragment = fragmentRef.value ?: return@collect
-            val cover = locator.href.toString().substringBefore('#') !=
-                currentHrefHolder[0]?.substringBefore('#')
-            navigating = cover
-            try {
-                ColumnSnap.goAndSnap(fragment, locator, landAtStartWhenNoTarget = false)
-                if (cover) delay(NAV_COVER_SETTLE_MS)
-            } finally {
-                navigating = false
-            }
+    // Navigate to a within-chapter [locator] and snap the page to the grid where go() landed
+    // (landAtStartWhenNoTarget=false — don't yank to the chapter top), covering only a cross-resource
+    // trip with the load mask. Shared by the search-hit and return-card routes: both carry an
+    // occurrence/position-specific progression with no #fragment, so the snap must round THAT page to
+    // the grid rather than column 0 (the default), which would lose the hit / the saved position.
+    val goAndSnapWithCover: suspend (Locator) -> Unit = goAndSnapWithCover@{ locator ->
+        val fragment = fragmentRef.value ?: return@goAndSnapWithCover
+        val cover = locator.href.toString().substringBefore('#') !=
+            currentHrefHolder[0]?.substringBefore('#')
+        navigating = cover
+        try {
+            ColumnSnap.goAndSnap(fragment, locator, landAtStartWhenNoTarget = false)
+            if (cover) delay(NAV_COVER_SETTLE_MS)
+        } finally {
+            navigating = false
         }
     }
 
+    LaunchedEffect(returnNavEvents) {
+        returnNavEvents.collect { goAndSnapWithCover(it) }
+    }
+
     LaunchedEffect(searchNavigationEvents) {
-        searchNavigationEvents.collect { locator ->
-            val fragment = fragmentRef.value ?: return@collect
-            val cover = locator.href.toString().substringBefore('#') !=
-                currentHrefHolder[0]?.substringBefore('#')
-            navigating = cover
-            try {
-                // Search locators carry an occurrence-specific progression but no #fragment, so go()
-                // lands on the right hit and we must round THAT page to the grid — not snap to column 0
-                // (the default), which would yank to the chapter top and lose the hit. Same route as the
-                // resume/peer background sync above.
-                ColumnSnap.goAndSnap(fragment, locator, landAtStartWhenNoTarget = false)
-                if (cover) delay(NAV_COVER_SETTLE_MS)
-            } finally {
-                navigating = false
-            }
-        }
+        searchNavigationEvents.collect { goAndSnapWithCover(it) }
     }
 
     // Resolve "top of the current page" when readaloud reopens on a different page: ask the WebView

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -746,6 +746,37 @@ class EpubReaderViewModel @Inject constructor(
         _footnotePopup.value = null
     }
 
+    // Return-to-position: when tapping an internal link (an in-document cross-reference like "Figure
+    // 4.1", or a cross-chapter reference) lands the reader off the page it was on, we remember that
+    // origin so a "Back" card can restore it. The behaviour (single-level, survives page turns, cleared
+    // on return/dismiss) lives in [ReturnNavigator] so it's unit-testable; the VM only wires it up.
+    private val returnNavigator = ReturnNavigator<Locator>()
+    val returnTarget: StateFlow<Locator?> = returnNavigator.target
+    val returnNavEvents: Flow<Locator> = returnNavigator.navEvents
+
+    // The in-document cross-reference path (FootnoteAnchorBridge → ColumnSnap) calls this after it has
+    // confirmed the snap actually moved the page off [origin].
+    fun captureReturnTarget(origin: Locator) {
+        returnNavigator.capture(origin)
+    }
+
+    // The cross-resource internal-link path (Readium's shouldFollowInternalLink). We drive the
+    // navigation ourselves (so we can remember [origin]) instead of letting Readium follow it.
+    fun followInternalLink(link: Link, origin: Locator) {
+        returnNavigator.capture(origin)
+        _navigationEvents.trySend(link)
+    }
+
+    // "Back" tapped — navigate to the captured origin and clear the card.
+    fun returnToCapturedPosition() {
+        returnNavigator.returnToOrigin()
+    }
+
+    // "✕" tapped — drop the card (and the captured origin) without navigating.
+    fun dismissReturnTarget() {
+        returnNavigator.dismiss()
+    }
+
     fun onPositionChanged(locator: Locator) {
         lastLocator = locator
         _currentLocatorHref.value = locator.href.toString()
@@ -1111,6 +1142,9 @@ class EpubReaderViewModel @Inject constructor(
     fun navigateToEntry(entry: TocEntry) {
         val pub = (state.value as? ReaderState.Ready)?.publication ?: return
         val link = pub.tableOfContents.findLinkByHref(entry.href) ?: return
+        // A deliberate TOC jump is a "go somewhere new" gesture, not a link tap — drop any pending
+        // return card so it can't linger pointing back to a pre-jump position.
+        returnNavigator.dismiss()
         _navigationEvents.trySend(link)
         _tocVisible.value = false
     }
@@ -1118,6 +1152,7 @@ class EpubReaderViewModel @Inject constructor(
     fun navigateToSegment(segment: RailSegment) {
         val pub = (state.value as? ReaderState.Ready)?.publication ?: return
         val link = pub.tableOfContents.findLinkByHref(segment.href) ?: return
+        returnNavigator.dismiss()
         _navigationEvents.trySend(link)
     }
 

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ReturnNavigator.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ReturnNavigator.kt
@@ -1,0 +1,48 @@
+package com.riffle.app.feature.reader
+
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
+
+/**
+ * Holds the single "page to return to" after an internal-link jump moved the reader off it, and the
+ * one-shot navigation request the screen acts on when the reader taps "Back".
+ *
+ * Generic over the position type [T] (the reader uses Readium's `Locator`) so it carries no Android /
+ * Readium navigator deps — the return-affordance behaviour (capture, replace, return, dismiss) is then
+ * unit-testable in isolation from [EpubReaderViewModel], which owns the bound instance and surfaces its
+ * flows.
+ *
+ * Single-level by design: a later off-page jump replaces the target; a return or a dismiss clears it.
+ * It does NOT clear on page turns — the caller reads around the target and can still go back.
+ */
+class ReturnNavigator<T : Any> {
+    private val _target = MutableStateFlow<T?>(null)
+
+    /** Non-null while a "Back" affordance should be shown; its value is where Back goes. */
+    val target: StateFlow<T?> = _target
+
+    private val _navChannel = Channel<T>(Channel.CONFLATED)
+
+    /** Emits once per [returnToOrigin]; the screen navigates the reader to the emitted position. */
+    val navEvents: Flow<T> = _navChannel.receiveAsFlow()
+
+    /** Remember [origin] as the page to return to. Replaces any previously captured origin. */
+    fun capture(origin: T) {
+        _target.value = origin
+    }
+
+    /** "Back" tapped — request navigation to the captured origin and clear the affordance. No-op if none. */
+    fun returnToOrigin() {
+        val origin = _target.value ?: return
+        _target.value = null
+        _navChannel.trySend(origin)
+    }
+
+    /** "✕" tapped — drop the affordance and the captured origin without navigating. */
+    fun dismiss() {
+        _target.value = null
+    }
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ReturnToPositionCard.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ReturnToPositionCard.kt
@@ -1,0 +1,96 @@
+package com.riffle.app.feature.reader
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.dp
+
+const val TAG_RETURN_CARD = "return_to_position_card"
+const val TAG_RETURN_BACK = "return_to_position_back"
+const val TAG_RETURN_DISMISS = "return_to_position_dismiss"
+
+/**
+ * A bottom card offering to undo an internal-link jump. Styled to match [FootnotePopup] (same
+ * full-width Material surface, corner radius, and elevation) so the two reader cards read as one
+ * family. Unlike the footnote popup it does NOT lay a full-screen scrim behind itself: the reader
+ * stays interactive (you can turn pages while it's up), so only the surface itself captures taps —
+ * the empty area above it has no gesture handler and falls through to the page.
+ *
+ * Tapping the "Back" body returns to the captured origin; the ✕ dismisses without navigating.
+ */
+@Composable
+fun ReturnToPositionCard(
+    onReturn: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    Box(modifier = Modifier.fillMaxSize()) {
+        Surface(
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .fillMaxWidth()
+                .navigationBarsPadding()
+                .padding(horizontal = 12.dp, vertical = 12.dp)
+                .testTag(TAG_RETURN_CARD)
+                .semantics { contentDescription = "Return to previous position" },
+            shape = RoundedCornerShape(16.dp),
+            tonalElevation = 8.dp,
+            shadowElevation = 8.dp,
+        ) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Row(
+                    modifier = Modifier
+                        .weight(1f)
+                        .clickable(onClick = onReturn)
+                        .padding(start = 16.dp, top = 14.dp, bottom = 14.dp, end = 12.dp)
+                        .testTag(TAG_RETURN_BACK),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Icon(
+                        Icons.AutoMirrored.Filled.ArrowBack,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.primary,
+                    )
+                    Spacer(Modifier.width(10.dp))
+                    Text(
+                        text = "Back",
+                        style = MaterialTheme.typography.titleSmall,
+                        color = MaterialTheme.colorScheme.primary,
+                    )
+                }
+                IconButton(
+                    onClick = onDismiss,
+                    modifier = Modifier
+                        .padding(end = 4.dp)
+                        .testTag(TAG_RETURN_DISMISS),
+                ) {
+                    Icon(
+                        Icons.Default.Close,
+                        contentDescription = "Dismiss",
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ReaderWebViewScriptsTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ReaderWebViewScriptsTest.kt
@@ -23,6 +23,28 @@ class ReaderWebViewScriptsTest {
         assertTrue(ColumnSnap.scrollToColumnJs("ftn.ch01fn01").contains("getElementById(\"ftn.ch01fn01\")"))
     }
 
+    // scrollToColumnJs reports whether the snap changed columns, so the caller can offer a "return"
+    // affordance only when the cross-reference was actually off the visible page ('moved') and suppress
+    // it for an on-page target ('same') or a missing id ('absent').
+    @Test
+    fun `scrollToColumnJs reports moved versus same versus absent`() {
+        val js = ColumnSnap.scrollToColumnJs("c04-fig-0001")
+        assertTrue("absent when the id isn't found", js.contains("return 'absent'"))
+        assertTrue("captures the pre-snap scroll", js.contains("var before=se.scrollLeft"))
+        assertTrue("reports moved/same by the column delta", js.contains("'moved':'same'"))
+    }
+
+    // In scroll (vertical) mode there is no column grid, so the cross-reference snap must scroll
+    // VERTICALLY to the element instead of flooring scrollLeft (a no-op there) — otherwise a figure
+    // link does nothing. An element already fully on screen reports 'same'.
+    @Test
+    fun `scrollToColumnJs scrolls vertically in scroll mode`() {
+        val js = ColumnSnap.scrollToColumnJs("c04-fig-0001")
+        assertTrue("detects scroll mode by content height", js.contains("scrollHeight > window.innerHeight"))
+        assertTrue("moves the vertical scroll", js.contains("se.scrollTop="))
+        assertTrue("leaves an already-visible target alone", js.contains("r.bottom<=window.innerHeight"))
+    }
+
     // snapToTargetColumnJs anchors a go()-based TOC/search jump to the column the TARGET occupies,
     // re-applying it across the async typography reflow until scrollWidth settles — the fix for the
     // "TOC lands a page before/after" bug where a one-shot snap locked onto the pre-reflow column.

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ReturnNavigatorTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ReturnNavigatorTest.kt
@@ -1,0 +1,76 @@
+package com.riffle.app.feature.reader
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+// ReturnNavigator is generic over the position type so it stays free of Readium's Locator (which can't
+// be built in a JVM unit test — it needs android.net.Uri). String stand-ins exercise the same logic the
+// reader relies on with a real Locator.
+@OptIn(ExperimentalCoroutinesApi::class)
+class ReturnNavigatorTest {
+
+    @Test
+    fun `capture exposes the origin as the target`() = runTest(UnconfinedTestDispatcher()) {
+        val nav = ReturnNavigator<String>()
+        assertNull("no target before any capture", nav.target.value)
+
+        nav.capture("chapter12@0.4")
+
+        assertEquals("chapter12@0.4", nav.target.value)
+    }
+
+    @Test
+    fun `a second capture replaces the first (single-level)`() = runTest(UnconfinedTestDispatcher()) {
+        val nav = ReturnNavigator<String>()
+        nav.capture("chapter12@0.4")
+        nav.capture("chapter4@0.1")
+
+        assertEquals("chapter4@0.1", nav.target.value)
+    }
+
+    @Test
+    fun `returnToOrigin emits the captured origin and clears the target`() =
+        runTest(UnconfinedTestDispatcher()) {
+            val nav = ReturnNavigator<String>()
+            val emitted = mutableListOf<String>()
+            backgroundScope.launch { nav.navEvents.toList(emitted) }
+
+            nav.capture("chapter12@0.4")
+            nav.returnToOrigin()
+
+            assertEquals(listOf("chapter12@0.4"), emitted)
+            assertNull("target cleared after returning", nav.target.value)
+        }
+
+    @Test
+    fun `returnToOrigin with no captured target is a no-op`() = runTest(UnconfinedTestDispatcher()) {
+        val nav = ReturnNavigator<String>()
+        val emitted = mutableListOf<String>()
+        backgroundScope.launch { nav.navEvents.toList(emitted) }
+
+        nav.returnToOrigin()
+
+        assertNull(nav.target.value)
+        assertEquals("no navigation emitted", 0, emitted.size)
+    }
+
+    @Test
+    fun `dismiss clears the target without emitting a navigation`() =
+        runTest(UnconfinedTestDispatcher()) {
+            val nav = ReturnNavigator<String>()
+            val emitted = mutableListOf<String>()
+            backgroundScope.launch { nav.navEvents.toList(emitted) }
+
+            nav.capture("chapter12@0.4")
+            nav.dismiss()
+
+            assertNull("target cleared", nav.target.value)
+            assertEquals("dismiss emits no navigation", 0, emitted.size)
+        }
+}


### PR DESCRIPTION
## What

When an in-text link navigates the EPUB reader **off the page it was on**, show a bottom **"Back"** card to return to where you were. Tapping an internal cross-reference ("Figure 4.1") or a cross-chapter reference no longer strands you — you can jump to the target, read around it, and tap Back to return.

## How

Both internal-link paths are intercepted:
- **Same-document cross-reference** (the `FootnoteAnchorBridge` JS path → `ColumnSnap.snapToElementColumn`): the snap now reports whether it actually changed the visible page, so a return target is captured **only when the jump was off-page** (an on-page reference shows no card).
- **Cross-resource link** (Readium's `shouldFollowInternalLink`): we now drive the navigation ourselves (instead of deferring to Readium) so we can remember the origin, then navigate via the existing nav channel.

The cross-reference snap is also now **mode-aware**: in scroll (vertical) mode it scrolls vertically to the element instead of doing column math (which was a no-op there — figure links did nothing in scroll mode).

Return navigates back to the captured origin via `goAndSnap(..., landAtStartWhenNoTarget=false)`. The card persists across page turns, is cleared on Back / ✕, and a deliberate TOC or chapter-rail jump dismisses any pending card.

The capture/replace/return/dismiss behaviour lives in a small generic `ReturnNavigator<T>` (free of Readium's `Locator`, which needs `android.net.Uri`) so it's unit-testable. The return-card UI (`ReturnToPositionCard`) mirrors `FootnotePopup`'s styling.

## Behaviour notes
- Single-level: a later off-page jump replaces the return target.
- Suppressed for same-page jumps (nothing to come back from).
- Search and the return route now share one `goAndSnapWithCover` helper (removed a duplicated collector).

## Tested
- `./gradlew test lint` — green (incl. new `ReturnNavigatorTest`, `ReaderWebViewScriptsTest` cases).
- `make harness-test` — 198 tests green (incl. `EpubFootnoteHarnessTest`).
- `make harness-test-tablet` — green.
- **Not yet device-verified** by hand (the on-device feel of the cover flash / scroll-mode landing offset is worth an eyeball on a real device).