### PR TITLE
fix(sync): move the readaloud resume from the audiobook listen position on the index-free path (ADR 0031)

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModel.kt
@@ -153,6 +153,10 @@ class AudiobookPlayerViewModel @Inject constructor(
                 // Matched book: listening is also reading — persist the translated reading position
                 // locally so the durable sweep pushes the ebook record too, without reopening (ADR 0030).
                 mirrorListeningToReading(pos)
+                // …and the readaloud resume, so reopening the reader and pressing Play lands on the
+                // listened sentence rather than a stale one (ADR 0031). Runs on every save (hot path
+                // and close) so a process-death mid-listen still leaves a fresh resume.
+                writeListeningToReadaloud(pos)
             }
         },
     )
@@ -175,6 +179,23 @@ class AudiobookPlayerViewModel @Inject constructor(
             ?: return
         val snap = audioSyncStore.snapshot(serverId, itemId)
         readingSyncStore.mirror(serverId, ebookItemId, ebookLocator, snap.localUpdatedAt, snap.lastSyncedAt)
+    }
+
+    /**
+     * Dual-write the readaloud resume from the listen position (ADR 0031): map the listen seconds to the
+     * narrated sentence and persist it under the ebook item id, so reopening the reader and pressing Play
+     * resumes on that sentence instead of the stale saved one. Works index-free via the bundle SMIL
+     * ([AudiobookFollow.readaloudAnchorForAudioSeconds]) when the full coordinator isn't built — the
+     * common case the previous wiring missed (it only wrote the resume on the full-coordinator close path).
+     * No-op unless matched and the seconds narrate a sentence.
+     */
+    private suspend fun writeListeningToReadaloud(seconds: Double) {
+        if (serverId.isEmpty()) return
+        val ebookItemId = readerSync?.ebookItemId ?: audiobookFollow?.ebookItemId ?: return
+        val anchor = readerSync?.readaloudAnchorForAudioSeconds(seconds)
+            ?: audiobookFollow?.readaloudAnchorForAudioSeconds(seconds)
+            ?: return
+        readaloudResumeStore.save(serverId, ebookItemId, anchor)
     }
 
     val uiState: StateFlow<AudiobookPlayerUiState> =
@@ -505,17 +526,12 @@ class AudiobookPlayerViewModel @Inject constructor(
                 localUpdatedAt = System.currentTimeMillis()
                 val r = rs.runAudioLedCycle(pos, localUpdatedAt)
                 localUpdatedAt = maxOf(localUpdatedAt, r.canonicalLastUpdate)
-                // Write the readaloud resume from this listen position (ADR 0031), keyed by the ebook
-                // item id (readaloud resume lives in reader-locator space).
-                rs.ebookItemId?.let { ebookId ->
-                    rs.readaloudAnchorForAudioSeconds(pos)?.let { anchor ->
-                        readaloudResumeStore.save(serverId, ebookId, anchor)
-                    }
-                }
             } else {
                 audiobookRepository.saveProgress(serverId, itemId, pos, timeline.durationSec)
             }
-            // Shared cold-path local persistence (same policy as the ebook reader).
+            // Shared cold-path local persistence (same policy as the ebook reader): persists the
+            // audiobook position, mirrors the reading position, and writes the readaloud resume
+            // (writeListeningToReadaloud) for both the full-coordinator and index-free paths (ADR 0031).
             positionSaveCoordinator.onClose(pos, fraction)
         }
     }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderSync.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderSync.kt
@@ -325,4 +325,18 @@ class AudiobookFollow(
     /** PATCH the ABS audiobook record from the narrated sentence; returns the server stamp or `null`. */
     suspend fun pushFragment(fragmentRef: String): Long? =
         secondsForFragment(fragmentRef)?.let { absApi.writeAudiobookSeconds(endpoint, it) }
+
+    /**
+     * The readaloud resume anchor for an audio second, index-free via the bundle SMIL (ADR 0031): maps
+     * seconds → narrated sentence and carries that sentence ref. Lets the audiobook player persist the
+     * readaloud resume so reopening the reader and pressing Play lands on the listened sentence instead
+     * of a stale one — even without the cross-EPUB index. Unlike [ebookLocatorForAudioSeconds] it needs
+     * no quote: the readaloud start only needs the sentence ref, not a text anchor. `null` when the
+     * seconds narrate no sentence.
+     */
+    fun readaloudAnchorForAudioSeconds(seconds: Double): com.riffle.core.domain.ReadaloudResumePosition? {
+        val ref = fragmentForAudioSeconds(seconds) ?: return null
+        val href = ref.substringBefore('#').takeIf { it.isNotEmpty() } ?: return null
+        return com.riffle.core.domain.ReadaloudResumePosition(href = href, progression = null, fragmentRef = ref)
+    }
 }

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/AudiobookFollowTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/AudiobookFollowTest.kt
@@ -107,4 +107,30 @@ class AudiobookFollowTest {
         // 2s -> sentence s1, which has no quote entry -> cannot text-anchor -> null (no coarse write).
         assertNull(follow(FakeApi()).ebookLocatorForAudioSeconds(2.0))
     }
+
+    @Test
+    fun `readaloudAnchorForAudioSeconds yields the narrated sentence (index-free)`() {
+        // 7s -> sentence s2; the readaloud resume is the sentence ref, so reopening the reader and
+        // pressing Play lands on the listened sentence rather than a stale one (ADR 0031).
+        val anchor = follow(FakeApi()).readaloudAnchorForAudioSeconds(7.0)
+        assertNotNull(anchor)
+        assertEquals("c1.html#s2", anchor!!.fragmentRef)
+        assertEquals("c1.html", anchor.href)
+    }
+
+    @Test
+    fun `readaloudAnchorForAudioSeconds resolves even without a quote (the sentence ref is the anchor)`() {
+        // 2s -> sentence s1, which has NO quote. Unlike ebookLocatorForAudioSeconds (which needs the
+        // quote to text-anchor), the readaloud resume only needs the sentence ref to start narration,
+        // so it must still resolve — else the audiobook can't move the readaloud resume here.
+        val anchor = follow(FakeApi()).readaloudAnchorForAudioSeconds(2.0)
+        assertNotNull(anchor)
+        assertEquals("c1.html#s1", anchor!!.fragmentRef)
+    }
+
+    @Test
+    fun `readaloudAnchorForAudioSeconds is null when the second has no narrated sentence`() {
+        // A second past the last clip maps to no fragment -> nothing to anchor.
+        assertNull(follow(FakeApi()).readaloudAnchorForAudioSeconds(99_999.0))
+    }
 }


### PR DESCRIPTION
## Problem

When the audiobook had progressed, switching to the reader and starting readaloud resumed at a **stale** sentence — readaloud lagged behind where listening had reached.

Root cause: the audiobook player persisted `readaloud_resume_positions` in exactly one place — `pushProgressOnStop`'s **full-coordinator** branch (cross-EPUB index built). On the common **index-free** path (bundle present, no index → `AudiobookFollow`), and on the hot path, the readaloud resume was never written. Reopening the reader then loaded the old `resumeFragmentRef`, and the readaloud-start anchor can't override it (a post-mirror timestamp tie resolves to "reading wins", by design), so Play landed behind the audiobook.

The ebook reading position was *not* the gap — the player already mirrors it via `mirrorListeningToReading`. Only the readaloud resume was missing.

## Fix

- **`AudiobookFollow.readaloudAnchorForAudioSeconds()`** — produces the readaloud resume from audio seconds index-free via the bundle SMIL. Quote-free (unlike `ebookLocatorForAudioSeconds`): the readaloud start needs only the sentence ref, not a text anchor, so it resolves even for sentences without a quote.
- **`AudiobookPlayerViewModel.writeListeningToReadaloud()`** — writes the resume on every save (hot path ~10s *and* close) for both the full-coordinator and index-free paths, preferring the full coordinator's anchor then the index-free follow. Moving the write into the shared `savePosition` lambda also covers the close path via `onClose` (inside the survivable flush scope), so the now-redundant full-coordinator-only block in `pushProgressOnStop` was removed.

Completes the audiobook→readaloud half of ADR 0031, which had only been wired for the full-coordinator close path.

## Tests

- New `AudiobookFollowTest` cases: the anchor yields the narrated sentence, resolves without a quote, and is null when the second narrates nothing.
- `./gradlew test` ✅ · `./gradlew lint` ✅ · `make harness-test` (194, 0 failed) ✅ · `make harness-test-tablet` (5, 0 failed) ✅

## Not covered / caveat

The VM wiring (that `writeListeningToReadaloud` is invoked on save/close) has no clean unit seam — `AudiobookPlayerViewModel` has ~20 deps and a live controller. The translation logic is unit-tested; the wiring is verified by compile + reasoning. Worth a device check on a matched book in the index-free state before relying on it in the field.