### PR TITLE
fix(audiobook): gate read-along swipe hint on bundle presence + drop back button below status bar

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.CircularProgressIndicator
@@ -142,7 +143,7 @@ fun AudiobookPlayerScreen(
             // swipe-down gesture. A plain back arrow (not a down-chevron) — distinct from swipe=read.
             IconButton(
                 onClick = onNavigateBack,
-                modifier = Modifier.align(Alignment.TopStart).padding(4.dp),
+                modifier = Modifier.align(Alignment.TopStart).statusBarsPadding().padding(4.dp),
             ) {
                 Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
             }

--- a/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModel.kt
@@ -85,6 +85,7 @@ class AudiobookPlayerViewModel @Inject constructor(
     private val audioIdentityResolver: AudioIdentityResolver,
     private val readerSyncFactory: com.riffle.app.feature.reader.ReaderSyncFactory,
     private val readaloudLinkRepository: com.riffle.core.domain.ReadaloudLinkRepository,
+    private val readaloudAudioRepository: com.riffle.core.domain.ReadaloudAudioRepository,
     private val nowPlayingStore: com.riffle.app.playback.NowPlayingStore,
     private val audiobookPositionStore: com.riffle.core.domain.AudiobookPositionStore,
     // Sync-store views for the matched dual-write (ADR 0030): read this audiobook's row stamps and
@@ -300,10 +301,23 @@ class AudiobookPlayerViewModel @Inject constructor(
             }
             val initialSpeed = audioPlaybackPreferencesStore.load(audioSettingsIdentity)
                 ?: AudioPlaybackPreferencesStore.DEFAULT_PLAYBACK_SPEED
+            // Readaloud is only actually offerable when the synced bundle is present — the same gate the
+            // reader applies (readaloudControlState): a Storyteller book always qualifies, a matched ABS
+            // book only once its bundle is downloaded, an unmatched ABS book never. The bundle is keyed by
+            // the linked Storyteller book (or this item, on a Storyteller server), NOT the ABS item id.
+            val isStoryteller = server?.serverType == com.riffle.core.domain.ServerType.STORYTELLER
+            val audioServerId = link?.storytellerServerId ?: serverId
+            val audioBookId = link?.storytellerBookId ?: itemId
+            val readaloudAvailable = com.riffle.app.feature.reader.readaloudControlState(
+                isStoryteller = isStoryteller,
+                isMatchedAbs = link != null,
+                bundlePresent = readaloudAudioRepository.isAudioAvailable(audioServerId, audioBookId),
+            ).enabled
             // The readaloud EBOOK to switch to on swipe-down: among this Storyteller book's ABS targets,
             // the readable one (the ebook in a split library); or this same item if it's a combined
-            // ebook+audio. Null when there's no readaloud ebook, which disables the swipe entirely.
-            val readaloudEbookItemId: String? = link?.let { l ->
+            // ebook+audio. Null when there's no readaloud ebook OR no synced bundle yet, which keeps the
+            // swipe-down hint hidden and the gesture inert until read-along can actually happen.
+            val readaloudEbookItemId: String? = if (!readaloudAvailable) null else link?.let { l ->
                 readaloudLinkRepository.findByStorytellerBook(l.storytellerServerId, l.storytellerBookId)
                     .firstOrNull { t ->
                         t.absLibraryItemId != itemId &&


### PR DESCRIPTION
## What

Two fixes to the full-screen audiobook player:

1. **"Swipe down to read along" was shown for every audiobook** — even ones with no readaloud bundle available/downloaded. The hint (and the swipe-down gesture) were gated only on a *linked readable ebook existing* (`readaloudEbookItemId != null`), not on the readaloud sync bundle actually being present. So swiping down would land in a plain reader with no read-along.

   Now the player computes readaloud availability with the **same gate the reader uses** (`readaloudControlState`): a Storyteller book always qualifies; a matched ABS book only once its synced bundle is downloaded; an unmatched ABS book never. The bundle is keyed by the linked Storyteller book (or the item itself on a Storyteller server), mirroring `EpubReaderViewModel`. `readaloudEbookItemId` stays `null` unless read-along can actually happen, so the hint is hidden and the gesture is inert otherwise.

2. **Back button sat too high, almost touching the status bar** — the `IconButton` had only `padding(4.dp)` at `TopStart`, ignoring the system bar inset. Added `statusBarsPadding()`.

## Testing

- `./gradlew test` — BUILD SUCCESSFUL
- `./gradlew lint` — BUILD SUCCESSFUL
- `make harness-test` — 199 tests, 0 failed (5 skipped)
- `make harness-test-tablet` — 5 tests, 0 failed

Not device-verified; the original screenshot already demonstrated both issues, and the gating reuses the reader's existing (tested) `readaloudControlState` mechanism.
