### PR TITLE
feat(settings): manual in-app update from GitHub releases

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -7,6 +7,8 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <!-- Self-update: download the latest release APK and launch the system installer. -->
+    <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
 
     <application
         android:name=".RiffleApplication"

--- a/app/src/main/kotlin/com/riffle/app/RiffleApplication.kt
+++ b/app/src/main/kotlin/com/riffle/app/RiffleApplication.kt
@@ -28,6 +28,7 @@ class RiffleApplication : Application(), ImageLoaderFactory {
     interface MigratorEntryPoint {
         fun localStoreMigrator(): LocalStoreMigrator
         fun connectivityObserver(): com.riffle.core.domain.ConnectivityObserver
+        fun appUpdateRepository(): com.riffle.core.domain.AppUpdateRepository
     }
 
     override fun attachBaseContext(base: Context) {
@@ -50,6 +51,13 @@ class RiffleApplication : Application(), ImageLoaderFactory {
         val migrator = EntryPointAccessors.fromApplication(this, MigratorEntryPoint::class.java).localStoreMigrator()
         CoroutineScope(SupervisorJob() + Dispatchers.IO).launch {
             runCatching { migrator.migrate() }
+        }
+
+        // Reclaim any update APK left behind by a previous self-update: a successful install restarts
+        // the app before the download flow can delete it, so we sweep the update cache on launch.
+        val appUpdate = EntryPointAccessors.fromApplication(this, MigratorEntryPoint::class.java).appUpdateRepository()
+        CoroutineScope(SupervisorJob() + Dispatchers.IO).launch {
+            runCatching { appUpdate.sweepStaleApks() }
         }
 
         // Durable offline progress reconcile (ADR 0030): a foreground kick to flush any progress made

--- a/app/src/main/kotlin/com/riffle/app/di/AppModule.kt
+++ b/app/src/main/kotlin/com/riffle/app/di/AppModule.kt
@@ -56,6 +56,12 @@ object AppModule {
 
     @Provides
     @Singleton
+    fun provideApkInstaller(
+        impl: com.riffle.app.update.AndroidApkInstaller,
+    ): com.riffle.core.domain.ApkInstaller = impl
+
+    @Provides
+    @Singleton
     fun provideDefaultHttpClient(): DefaultHttpClient = DefaultHttpClient()
 
     @Provides

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsScreen.kt
@@ -11,12 +11,14 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -76,6 +78,7 @@ fun SettingsScreen(
     val serverVersions by viewModel.serverVersions.collectAsState()
     val libraryItemsByServer by viewModel.libraryUiItemsByServer.collectAsState()
     val readaloudSummaries by viewModel.readaloudSummaries.collectAsState()
+    val appUpdateState by viewModel.appUpdateState.collectAsState()
     val clipboard = LocalClipboard.current
     val scope = rememberCoroutineScope()
     val expandedServers = remember { mutableStateMapOf<String, Boolean>() }
@@ -252,6 +255,20 @@ fun SettingsScreen(
                     }
                 }
                 HorizontalDivider()
+
+                Text(
+                    text = "App version",
+                    style = MaterialTheme.typography.titleSmall,
+                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+                )
+                HorizontalDivider()
+                AppVersionRow(
+                    installedVersionName = viewModel.installedVersionName,
+                    state = appUpdateState,
+                    onCheckForUpdate = { viewModel.checkForUpdate() },
+                    onInstallUpdate = { viewModel.downloadAndInstallUpdate() },
+                )
+                HorizontalDivider()
             }
         }
     }
@@ -338,6 +355,51 @@ internal fun ServerSettingsExpansion(
             }
         }
     }
+}
+
+/**
+ * Inline "App version" row: shows the installed version and the manual update-check status, advancing
+ * through check → (up-to-date | update available → download % → install) as the user taps.
+ */
+@Composable
+private fun AppVersionRow(
+    installedVersionName: String,
+    state: AppUpdateUiState,
+    onCheckForUpdate: () -> Unit,
+    onInstallUpdate: () -> Unit,
+) {
+    val supporting = when (state) {
+        is AppUpdateUiState.Idle -> "Installed: v$installedVersionName"
+        is AppUpdateUiState.Checking -> "Checking for updates…"
+        is AppUpdateUiState.UpToDate -> "Installed: v$installedVersionName · Up to date"
+        is AppUpdateUiState.UpdateAvailable -> "Update available: v${state.versionName}"
+        is AppUpdateUiState.Downloading -> "Downloading update… ${state.percent}%"
+        is AppUpdateUiState.Installing -> "Starting installer…"
+        is AppUpdateUiState.Failed -> "Update check failed: ${state.message}"
+    }
+    ListItem(
+        headlineContent = { Text("Riffle") },
+        supportingContent = { Text(supporting) },
+        trailingContent = {
+            when (state) {
+                is AppUpdateUiState.Checking ->
+                    CircularProgressIndicator(modifier = Modifier.size(24.dp), strokeWidth = 2.dp)
+                is AppUpdateUiState.Downloading ->
+                    CircularProgressIndicator(
+                        progress = { state.percent / 100f },
+                        modifier = Modifier.size(24.dp),
+                        strokeWidth = 2.dp,
+                    )
+                is AppUpdateUiState.Installing -> {}
+                is AppUpdateUiState.UpdateAvailable ->
+                    Button(onClick = onInstallUpdate) { Text("Update") }
+                is AppUpdateUiState.Failed ->
+                    TextButton(onClick = onCheckForUpdate) { Text("Retry") }
+                else ->
+                    TextButton(onClick = onCheckForUpdate) { Text("Check for updates") }
+            }
+        },
+    )
 }
 
 @Composable

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsViewModel.kt
@@ -2,9 +2,13 @@ package com.riffle.app.feature.settings
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.riffle.app.BuildConfig
+import com.riffle.core.domain.AppUpdateRepository
 import com.riffle.core.domain.ConnectivityObserver
 import com.riffle.core.domain.CrashReport
 import com.riffle.core.domain.CrashReportRepository
+import com.riffle.core.domain.UpdateCheckResult
+import com.riffle.core.domain.UpdateDownloadState
 import com.riffle.core.domain.FormattingPreferences
 import com.riffle.core.domain.FormattingPreferencesStore
 import com.riffle.core.domain.LibraryRepository
@@ -42,9 +46,49 @@ class SettingsViewModel @Inject constructor(
     private val volumeKeyPreferencesStore: VolumeKeyPreferencesStore,
     private val readaloudReviewRepository: ReadaloudReviewRepository,
     private val connectivityObserver: ConnectivityObserver,
+    private val appUpdateRepository: AppUpdateRepository,
 ) : ViewModel() {
 
     val lastCrashReport: CrashReport? = crashReportRepository.getLastCrashReport()
+
+    /** The currently installed app version, shown as the update row's subtitle. */
+    val installedVersionName: String = BuildConfig.VERSION_NAME
+
+    private val _appUpdateState = MutableStateFlow<AppUpdateUiState>(AppUpdateUiState.Idle)
+    val appUpdateState: StateFlow<AppUpdateUiState> = _appUpdateState.asStateFlow()
+
+    /** Manually triggered from Settings: ask GitHub whether a newer release exists. */
+    fun checkForUpdate() {
+        if (_appUpdateState.value is AppUpdateUiState.Checking ||
+            _appUpdateState.value is AppUpdateUiState.Downloading
+        ) {
+            return
+        }
+        _appUpdateState.value = AppUpdateUiState.Checking
+        viewModelScope.launch {
+            _appUpdateState.value = when (val result = appUpdateRepository.checkForUpdate(BuildConfig.VERSION_CODE)) {
+                is UpdateCheckResult.UpToDate -> AppUpdateUiState.UpToDate
+                is UpdateCheckResult.Failed -> AppUpdateUiState.Failed(result.message)
+                is UpdateCheckResult.UpdateAvailable ->
+                    AppUpdateUiState.UpdateAvailable(result.update.versionName, result.update)
+            }
+        }
+    }
+
+    /** Download the available update's APK and launch the system installer. */
+    fun downloadAndInstallUpdate() {
+        val available = _appUpdateState.value as? AppUpdateUiState.UpdateAvailable ?: return
+        _appUpdateState.value = AppUpdateUiState.Downloading(0)
+        viewModelScope.launch {
+            appUpdateRepository.downloadAndInstall(available.update).collect { step ->
+                _appUpdateState.value = when (step) {
+                    is UpdateDownloadState.Downloading -> AppUpdateUiState.Downloading(step.percent)
+                    is UpdateDownloadState.Installing -> AppUpdateUiState.Installing
+                    is UpdateDownloadState.Failed -> AppUpdateUiState.Failed(step.message)
+                }
+            }
+        }
+    }
 
     val globalFormattingPreferences: StateFlow<FormattingPreferences> =
         formattingPreferencesStore.preferences
@@ -203,3 +247,19 @@ data class ReadaloudMatchSummary(
     val partiallyMatchedCount: Int,
     val matchedCount: Int,
 )
+
+/** Drives the "App version" settings row: an inline status that the user advances by tapping. */
+sealed interface AppUpdateUiState {
+    /** No check run yet (or it was reset). */
+    data object Idle : AppUpdateUiState
+    data object Checking : AppUpdateUiState
+    data object UpToDate : AppUpdateUiState
+    data class UpdateAvailable(
+        val versionName: String,
+        val update: com.riffle.core.domain.AvailableUpdate,
+    ) : AppUpdateUiState
+    data class Downloading(val percent: Int) : AppUpdateUiState
+    /** APK downloaded; the system installer has been launched. */
+    data object Installing : AppUpdateUiState
+    data class Failed(val message: String) : AppUpdateUiState
+}

--- a/app/src/main/kotlin/com/riffle/app/update/AndroidApkInstaller.kt
+++ b/app/src/main/kotlin/com/riffle/app/update/AndroidApkInstaller.kt
@@ -1,0 +1,34 @@
+package com.riffle.app.update
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import androidx.core.content.FileProvider
+import com.riffle.core.domain.ApkInstaller
+import dagger.hilt.android.qualifiers.ApplicationContext
+import java.io.File
+import javax.inject.Inject
+
+/**
+ * Launches the system package installer for a downloaded APK via the app's [FileProvider]. The
+ * install is signed with the same release key, so Android performs an in-place update; the user
+ * still confirms at the system install prompt (and grants "install unknown apps" the first time).
+ */
+class AndroidApkInstaller @Inject constructor(
+    @ApplicationContext private val context: Context,
+) : ApkInstaller {
+
+    override fun install(apk: File) {
+        val uri: Uri = FileProvider.getUriForFile(
+            context,
+            "${context.packageName}.fileprovider",
+            apk,
+        )
+        val intent = Intent(Intent.ACTION_VIEW).apply {
+            setDataAndType(uri, "application/vnd.android.package-archive")
+            addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
+        context.startActivity(intent)
+    }
+}

--- a/app/src/main/res/xml/file_paths.xml
+++ b/app/src/main/res/xml/file_paths.xml
@@ -1,4 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <paths>
     <files-path name="crash_reports" path="." />
+    <!-- Downloaded update APKs handed to the system installer (see AppUpdateRepository). -->
+    <cache-path name="updates" path="updates/" />
 </paths>

--- a/app/src/test/kotlin/com/riffle/app/feature/settings/SettingsViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/settings/SettingsViewModelTest.kt
@@ -155,6 +155,14 @@ class SettingsViewModelTest {
         override val isOnline: kotlinx.coroutines.flow.StateFlow<Boolean> = isOnlineFlow
     }
 
+    private val fakeAppUpdateRepo = object : com.riffle.core.domain.AppUpdateRepository {
+        override suspend fun checkForUpdate(currentVersionCode: Int) =
+            com.riffle.core.domain.UpdateCheckResult.UpToDate
+        override fun downloadAndInstall(update: com.riffle.core.domain.AvailableUpdate):
+            Flow<com.riffle.core.domain.UpdateDownloadState> = kotlinx.coroutines.flow.emptyFlow()
+        override fun sweepStaleApks() = Unit
+    }
+
     private val reviewsFlow = MutableStateFlow<Map<String, ReadaloudReview>>(emptyMap())
     private val fakeReviewRepo = object : ReadaloudReviewRepository {
         override fun observeReview(storytellerServerId: String): Flow<ReadaloudReview> =
@@ -180,6 +188,7 @@ class SettingsViewModelTest {
         volumeKeyPreferencesStore = fakeVolumeKeyStore,
         readaloudReviewRepository = fakeReviewRepo,
         connectivityObserver = fakeConnectivity,
+        appUpdateRepository = fakeAppUpdateRepo,
     )
 
     // --- existing crash report tests (unchanged) ---

--- a/core/data/src/main/kotlin/com/riffle/core/data/AppUpdateRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/AppUpdateRepositoryImpl.kt
@@ -1,0 +1,95 @@
+package com.riffle.core.data
+
+import android.content.Context
+import com.riffle.core.domain.ApkInstaller
+import com.riffle.core.domain.AppUpdateRepository
+import com.riffle.core.domain.AvailableUpdate
+import com.riffle.core.domain.UpdateCheckResult
+import com.riffle.core.domain.UpdateDownloadState
+import com.riffle.core.network.GitHubRelease
+import com.riffle.core.network.GitHubReleaseApi
+import com.riffle.core.network.GitHubReleaseResult
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.flowOn
+import java.io.File
+import javax.inject.Inject
+
+class AppUpdateRepositoryImpl @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val releaseApi: GitHubReleaseApi,
+    private val installer: ApkInstaller,
+) : AppUpdateRepository {
+
+    private val updateDir: File
+        get() = File(context.cacheDir, UPDATE_DIR_NAME)
+
+    override suspend fun checkForUpdate(currentVersionCode: Int): UpdateCheckResult =
+        when (val result = releaseApi.latestRelease(REPO)) {
+            is GitHubReleaseResult.Failed -> UpdateCheckResult.Failed(result.message)
+            is GitHubReleaseResult.Success -> evaluate(currentVersionCode, result.release)
+        }
+
+    override fun downloadAndInstall(update: AvailableUpdate): Flow<UpdateDownloadState> = channelFlow {
+        // Start clean: drop any half-finished APK from a prior attempt before downloading.
+        sweepStaleApks()
+        val apk = File(updateDir.apply { mkdirs() }, "riffle-${update.versionName}.apk")
+        send(UpdateDownloadState.Downloading(0))
+        val ok = releaseApi.download(update.downloadUrl, apk) { percent ->
+            trySend(UpdateDownloadState.Downloading(percent))
+        }
+        if (ok) {
+            installer.install(apk)
+            send(UpdateDownloadState.Installing)
+        } else {
+            apk.delete()
+            send(UpdateDownloadState.Failed("Couldn't download the update"))
+        }
+    }.flowOn(Dispatchers.IO)
+
+    override fun sweepStaleApks() {
+        updateDir.listFiles()?.forEach { it.delete() }
+    }
+
+    companion object {
+        const val REPO = "pkmetski/riffle"
+        const val UPDATE_DIR_NAME = "updates"
+
+        /**
+         * Pure comparison of [release] against the installed [currentVersionCode]. An unparseable tag
+         * is a [UpdateCheckResult.Failed]; an equal-or-lower code (e.g. a dev build at a higher code)
+         * is [UpdateCheckResult.UpToDate].
+         */
+        fun evaluate(currentVersionCode: Int, release: GitHubRelease): UpdateCheckResult {
+            val versionName = release.tagName.removePrefix("v")
+            val versionCode = versionCodeOf(versionName)
+                ?: return UpdateCheckResult.Failed("Unrecognized release tag '${release.tagName}'")
+            return if (versionCode <= currentVersionCode) {
+                UpdateCheckResult.UpToDate
+            } else {
+                UpdateCheckResult.UpdateAvailable(
+                    AvailableUpdate(
+                        versionName = versionName,
+                        versionCode = versionCode,
+                        downloadUrl = release.apkUrl,
+                        sizeBytes = release.apkSizeBytes,
+                    )
+                )
+            }
+        }
+
+        /**
+         * Mirrors the release workflow's tag→code formula:
+         * vMAJOR.MINOR.PATCH → MAJOR*10000 + MINOR*100 + PATCH. Returns null for any tag that is not
+         * three numeric dot-separated parts.
+         */
+        fun versionCodeOf(versionName: String): Int? {
+            val parts = versionName.trim().split(".")
+            if (parts.size != 3) return null
+            val (maj, min, pat) = parts.map { it.toIntOrNull() ?: return null }
+            return maj * 10000 + min * 100 + pat
+        }
+    }
+}

--- a/core/data/src/main/kotlin/com/riffle/core/data/di/DataModule.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/di/DataModule.kt
@@ -3,6 +3,7 @@ package com.riffle.core.data.di
 import android.content.Context
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
+import com.riffle.core.data.AppUpdateRepositoryImpl
 import com.riffle.core.data.AudioIdentityResolverImpl
 import com.riffle.core.data.AudioPlaybackPreferencesStoreImpl
 import com.riffle.core.data.BookFormattingPreferencesStoreImpl
@@ -216,6 +217,10 @@ abstract class DataModule {
 
     @Binds
     @Singleton
+    abstract fun bindAppUpdateRepository(impl: AppUpdateRepositoryImpl): com.riffle.core.domain.AppUpdateRepository
+
+    @Binds
+    @Singleton
     abstract fun bindCrossEpubIndexStore(impl: CrossEpubIndexStoreImpl): CrossEpubIndexStore
 
     @Binds
@@ -334,6 +339,11 @@ abstract class DataModule {
         @Provides
         @Singleton
         fun provideOkHttpClient(): OkHttpClient = OkHttpClient.Builder().build()
+
+        @Provides
+        @Singleton
+        fun provideGitHubReleaseApi(okHttpClient: OkHttpClient): com.riffle.core.network.GitHubReleaseApi =
+            com.riffle.core.network.GitHubReleaseApi(okHttpClient)
 
         @Provides
         @Singleton

--- a/core/data/src/test/kotlin/com/riffle/core/data/AppUpdateRepositoryImplTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/AppUpdateRepositoryImplTest.kt
@@ -1,0 +1,62 @@
+package com.riffle.core.data
+
+import com.riffle.core.data.AppUpdateRepositoryImpl.Companion.evaluate
+import com.riffle.core.data.AppUpdateRepositoryImpl.Companion.versionCodeOf
+import com.riffle.core.domain.UpdateCheckResult
+import com.riffle.core.network.GitHubRelease
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AppUpdateRepositoryImplTest {
+
+    @Test
+    fun `versionCodeOf mirrors the release workflow formula`() {
+        assertEquals(10400, versionCodeOf("1.4.0"))
+        assertEquals(10203, versionCodeOf("1.2.3"))
+        assertEquals(0, versionCodeOf("0.0.0"))
+        assertEquals(120015, versionCodeOf("12.0.15"))
+    }
+
+    @Test
+    fun `versionCodeOf rejects malformed tags`() {
+        assertNull(versionCodeOf("1.4"))
+        assertNull(versionCodeOf("1.4.0-rc1"))
+        assertNull(versionCodeOf("v1.4.0"))
+        assertNull(versionCodeOf("latest"))
+        assertNull(versionCodeOf(""))
+    }
+
+    @Test
+    fun `evaluate reports an update when the release is ahead`() {
+        val release = GitHubRelease("v1.5.0", "https://example/riffle.apk", 4_200L)
+
+        val result = evaluate(currentVersionCode = 10400, release = release)
+
+        assertTrue(result is UpdateCheckResult.UpdateAvailable)
+        val update = (result as UpdateCheckResult.UpdateAvailable).update
+        assertEquals("1.5.0", update.versionName)
+        assertEquals(10500, update.versionCode)
+        assertEquals("https://example/riffle.apk", update.downloadUrl)
+        assertEquals(4_200L, update.sizeBytes)
+    }
+
+    @Test
+    fun `evaluate reports up-to-date when the installed build matches or leads`() {
+        val release = GitHubRelease("v1.4.0", "https://example/riffle.apk", 1L)
+
+        assertEquals(UpdateCheckResult.UpToDate, evaluate(10400, release))
+        // A local dev build can carry a higher code than any release; never offer a downgrade.
+        assertEquals(UpdateCheckResult.UpToDate, evaluate(99999, release))
+    }
+
+    @Test
+    fun `evaluate fails on an unparseable tag`() {
+        val release = GitHubRelease("nightly", "https://example/riffle.apk", 1L)
+
+        val result = evaluate(10400, release)
+
+        assertTrue(result is UpdateCheckResult.Failed)
+    }
+}

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/AppUpdateRepository.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/AppUpdateRepository.kt
@@ -1,0 +1,58 @@
+package com.riffle.core.domain
+
+import kotlinx.coroutines.flow.Flow
+import java.io.File
+
+/**
+ * Self-updates the app from its GitHub releases. Riffle is sideloaded (direct APK / F-Droid), so
+ * there is no store to push updates: the user checks manually from Settings, and when the installed
+ * build is behind the latest release we download its signed APK and hand it to the system installer.
+ */
+interface AppUpdateRepository {
+    /** Compares the installed [currentVersionCode] against the latest GitHub release. */
+    suspend fun checkForUpdate(currentVersionCode: Int): UpdateCheckResult
+
+    /**
+     * Downloads [update]'s APK into the update cache, emitting download progress, then launches the
+     * system installer. The APK is deliberately left on disk for the installer to read — a successful
+     * update restarts the app before any post-install cleanup could run, so [sweepStaleApks] reclaims
+     * it on the next launch instead.
+     */
+    fun downloadAndInstall(update: AvailableUpdate): Flow<UpdateDownloadState>
+
+    /** Deletes any APKs left in the update cache by a previous download. Safe to call on startup. */
+    fun sweepStaleApks()
+}
+
+/** Outcome of an [AppUpdateRepository.checkForUpdate] call. */
+sealed interface UpdateCheckResult {
+    /** The installed build is the latest — or newer, e.g. a local dev build. */
+    data object UpToDate : UpdateCheckResult
+
+    data class UpdateAvailable(val update: AvailableUpdate) : UpdateCheckResult
+
+    data class Failed(val message: String) : UpdateCheckResult
+}
+
+/** A newer release available for download. */
+data class AvailableUpdate(
+    val versionName: String,
+    val versionCode: Int,
+    val downloadUrl: String,
+    val sizeBytes: Long,
+)
+
+/** Progress of [AppUpdateRepository.downloadAndInstall]. */
+sealed interface UpdateDownloadState {
+    data class Downloading(val percent: Int) : UpdateDownloadState
+
+    /** The APK finished downloading and the system installer has been launched. */
+    data object Installing : UpdateDownloadState
+
+    data class Failed(val message: String) : UpdateDownloadState
+}
+
+/** Launches Android's package installer for a downloaded APK. */
+interface ApkInstaller {
+    fun install(apk: File)
+}

--- a/core/network/src/main/kotlin/com/riffle/core/network/GitHubReleaseApi.kt
+++ b/core/network/src/main/kotlin/com/riffle/core/network/GitHubReleaseApi.kt
@@ -1,0 +1,121 @@
+package com.riffle.core.network
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import java.io.File
+import java.io.IOException
+
+/**
+ * Reads release metadata and APK assets from a public GitHub repository's Releases API. No auth is
+ * needed because the Riffle repo is public.
+ */
+class GitHubReleaseApi(
+    private val httpClient: OkHttpClient,
+    /** Overridable so tests can point at a local MockWebServer; defaults to the public GitHub API. */
+    private val apiBaseUrl: String = "https://api.github.com",
+) {
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    /** Fetches the repo's latest (non-prerelease) release and its APK asset. */
+    suspend fun latestRelease(repo: String): GitHubReleaseResult = withContext(Dispatchers.IO) {
+        val request = Request.Builder()
+            .url("$apiBaseUrl/repos/$repo/releases/latest")
+            .header("Accept", "application/vnd.github+json")
+            .get()
+            .build()
+        try {
+            httpClient.newCall(request).execute().use { response ->
+                if (!response.isSuccessful) {
+                    return@use GitHubReleaseResult.Failed("HTTP ${response.code}")
+                }
+                val raw = response.body?.string()
+                    ?: return@use GitHubReleaseResult.Failed("Empty response")
+                val parsed = json.decodeFromString<ReleaseResponse>(raw)
+                val apk = parsed.assets.firstOrNull { it.name.endsWith(".apk", ignoreCase = true) }
+                    ?: return@use GitHubReleaseResult.Failed("Release has no APK asset")
+                GitHubReleaseResult.Success(
+                    GitHubRelease(
+                        tagName = parsed.tagName,
+                        apkUrl = apk.downloadUrl,
+                        apkSizeBytes = apk.size,
+                    )
+                )
+            }
+        } catch (e: IOException) {
+            GitHubReleaseResult.Failed(e.message ?: "Network error")
+        }
+    }
+
+    /**
+     * Streams [url] into [dest], reporting whole-percent progress. Returns true on success. On any
+     * failure [dest] is deleted, so a truncated APK is never handed to the installer.
+     */
+    suspend fun download(url: String, dest: File, onProgress: (percent: Int) -> Unit): Boolean =
+        withContext(Dispatchers.IO) {
+            val request = Request.Builder().url(url).get().build()
+            try {
+                httpClient.newCall(request).execute().use { response ->
+                    val body = response.body
+                    if (!response.isSuccessful || body == null) {
+                        dest.delete()
+                        return@use false
+                    }
+                    val total = body.contentLength()
+                    body.byteStream().use { input ->
+                        dest.outputStream().use { output ->
+                            val buffer = ByteArray(64 * 1024)
+                            var copied = 0L
+                            var lastPercent = -1
+                            while (true) {
+                                val read = input.read(buffer)
+                                if (read == -1) break
+                                output.write(buffer, 0, read)
+                                copied += read
+                                if (total > 0) {
+                                    val percent = ((copied * 100) / total).toInt().coerceIn(0, 100)
+                                    if (percent != lastPercent) {
+                                        lastPercent = percent
+                                        onProgress(percent)
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    true
+                }
+            } catch (e: IOException) {
+                dest.delete()
+                false
+            }
+        }
+}
+
+sealed interface GitHubReleaseResult {
+    data class Success(val release: GitHubRelease) : GitHubReleaseResult
+    data class Failed(val message: String) : GitHubReleaseResult
+}
+
+data class GitHubRelease(
+    val tagName: String,
+    val apkUrl: String,
+    val apkSizeBytes: Long,
+)
+
+@Serializable
+private data class ReleaseResponse(
+    @SerialName("tag_name") val tagName: String,
+    val assets: List<AssetResponse> = emptyList(),
+)
+
+@Serializable
+private data class AssetResponse(
+    val name: String,
+    @SerialName("browser_download_url") val downloadUrl: String,
+    val size: Long = 0,
+)

--- a/core/network/src/test/kotlin/com/riffle/core/network/GitHubReleaseApiTest.kt
+++ b/core/network/src/test/kotlin/com/riffle/core/network/GitHubReleaseApiTest.kt
@@ -1,0 +1,102 @@
+package com.riffle.core.network
+
+import kotlinx.coroutines.test.runTest
+import okhttp3.OkHttpClient
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import java.io.File
+import java.nio.file.Files
+
+class GitHubReleaseApiTest {
+
+    private lateinit var server: MockWebServer
+    private lateinit var api: GitHubReleaseApi
+
+    @Before
+    fun setUp() {
+        server = MockWebServer().also { it.start() }
+        val baseUrl = server.url("/").toString().trimEnd('/')
+        api = GitHubReleaseApi(OkHttpClient(), apiBaseUrl = baseUrl)
+    }
+
+    @After
+    fun tearDown() {
+        server.shutdown()
+    }
+
+    @Test
+    fun `latestRelease picks the apk asset`() = runTest {
+        server.enqueue(
+            MockResponse().setBody(
+                """
+                {
+                  "tag_name": "v1.5.0",
+                  "assets": [
+                    { "name": "mapping.txt", "browser_download_url": "https://x/mapping.txt", "size": 10 },
+                    { "name": "riffle-1.5.0.apk", "browser_download_url": "https://x/riffle.apk", "size": 4200 }
+                  ]
+                }
+                """.trimIndent()
+            )
+        )
+
+        val result = api.latestRelease("pkmetski/riffle")
+
+        assertTrue(result is GitHubReleaseResult.Success)
+        val release = (result as GitHubReleaseResult.Success).release
+        assertEquals("v1.5.0", release.tagName)
+        assertEquals("https://x/riffle.apk", release.apkUrl)
+        assertEquals(4200L, release.apkSizeBytes)
+    }
+
+    @Test
+    fun `latestRelease fails when no apk asset is present`() = runTest {
+        server.enqueue(
+            MockResponse().setBody(
+                """{ "tag_name": "v1.5.0", "assets": [ { "name": "notes.txt", "browser_download_url": "https://x/n", "size": 1 } ] }"""
+            )
+        )
+
+        assertTrue(api.latestRelease("pkmetski/riffle") is GitHubReleaseResult.Failed)
+    }
+
+    @Test
+    fun `latestRelease fails on an error response`() = runTest {
+        server.enqueue(MockResponse().setResponseCode(404).setBody("not found"))
+
+        assertTrue(api.latestRelease("pkmetski/riffle") is GitHubReleaseResult.Failed)
+    }
+
+    @Test
+    fun `download writes the body and reports progress`() = runTest {
+        val payload = ByteArray(200_000) { (it % 251).toByte() }
+        server.enqueue(MockResponse().setBody(okio.Buffer().write(payload)))
+        val dest = File(Files.createTempDirectory("upd").toFile(), "riffle.apk")
+        val seen = mutableListOf<Int>()
+
+        val ok = api.download(server.url("/riffle.apk").toString(), dest) { seen.add(it) }
+
+        assertTrue(ok)
+        assertEquals(payload.size.toLong(), dest.length())
+        assertTrue(dest.readBytes().contentEquals(payload))
+        assertTrue("expected progress callbacks", seen.isNotEmpty())
+        assertEquals(100, seen.last())
+    }
+
+    @Test
+    fun `download deletes a partial file on an error response`() = runTest {
+        server.enqueue(MockResponse().setResponseCode(500))
+        val dest = File(Files.createTempDirectory("upd").toFile(), "riffle.apk")
+
+        val ok = api.download(server.url("/riffle.apk").toString(), dest) {}
+
+        assertFalse(ok)
+        assertFalse(dest.exists())
+    }
+}


### PR DESCRIPTION
## What

Adds a manually-triggered self-update from the Settings **App version** row. Riffle is sideloaded (direct APK / F-Droid), so there's no store to push updates — the user checks on demand, and when the installed build is behind the latest GitHub release we download the signed APK and hand it to the system installer.

**Flow:** `Check for updates` → queries the latest GitHub release → if behind, shows `Update available: vX.Y.Z` with an **Update** button → streams the APK into `cacheDir/updates/` (live %) → launches the system installer → the leftover APK is swept on next launch.

## Changes

- **core/domain** — `AppUpdateRepository` + `UpdateCheckResult` / `AvailableUpdate` / `UpdateDownloadState`, and an `ApkInstaller` seam.
- **core/network** — `GitHubReleaseApi`: hits the public `releases/latest` endpoint (no auth — repo is public), picks the `.apk` asset, and streams the download reporting whole-percent progress (deletes partials on failure). API base URL is injectable for tests.
- **core/data** — `AppUpdateRepositoryImpl`: orchestrates check/download/install/sweep. Pure `versionCodeOf` + `evaluate` mirror the release workflow's `MAJ*10000 + MIN*100 + PAT` formula, so it never offers a downgrade (a dev build at a higher code reads as up-to-date).
- **app** — `AndroidApkInstaller` (FileProvider + `ACTION_VIEW` install intent); inline `AppVersionRow` state machine in Settings; sweep-on-launch wired into `RiffleApplication`.
- **Manifest** — `REQUEST_INSTALL_PACKAGES`; `file_paths.xml` gains a `<cache-path name="updates" …/>` entry.

## Notes / limitations

- The "Installing" row label is terminal: on a successful update the OS restarts the app (so you just reopen on the new version), but on a cancelled/failed system install the label doesn't reset. A `PackageInstaller`-session fix to surface failures is a possible follow-up.
- A self-update only installs over a build signed with the **same key** as the Releases APK. Debug builds and F-Droid (re-signed) installs will be rejected by the OS with a signature mismatch — F-Droid users update through F-Droid anyway. (A signature-gate to hide the row on mismatched builds was prototyped and reverted; can revisit if wanted.)
- Not device-verified end-to-end for a *successful* install (requires a release-signed install + the system install prompt, which unit tests can't exercise). Download/parse/compare logic is unit-tested.

## Tests

- `./gradlew test lint` — green
- `make harness-test` (phone) — 199 tests, 0 failed
- `make harness-test-tablet` — 5 tests, 0 failed
- New unit tests: `GitHubReleaseApiTest` (5, MockWebServer) + `AppUpdateRepositoryImplTest` (5, version-compare/parse logic)