### PR TITLE
fix(audiobook): restart a finished book from the beginning

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModel.kt
@@ -49,6 +49,20 @@ internal fun audiobookResumeSec(
     if (hadTrackedPosition || readingProgressFraction <= 0f || durationSec <= 0.0) reconciledSec
     else (readingProgressFraction * durationSec).coerceIn(0.0, durationSec)
 
+/** How close to the end a resume position must sit to count the book as finished (and restart at 0). */
+internal const val AUDIOBOOK_FINISHED_EPS_SEC: Double = 1.0
+
+/**
+ * The position to actually start a normally-opened audiobook at. A resume that lands at (or within
+ * [AUDIOBOOK_FINISHED_EPS_SEC] of) the end means the book was finished: seeding the player there puts
+ * it at the end of the last track, where ExoPlayer is `STATE_ENDED` and `play()` is a no-op — the
+ * player sits silent with the seek bar pinned at the end. Reopening a finished book is a replay
+ * intent, so restart from the beginning instead. A position anywhere short of the end is honoured
+ * as-is. No-op when the duration is unknown (we can't tell what "the end" is).
+ */
+internal fun audiobookStartSec(resumeSec: Double, durationSec: Double): Double =
+    if (durationSec > 0.0 && resumeSec >= durationSec - AUDIOBOOK_FINISHED_EPS_SEC) 0.0 else resumeSec
+
 /** UI state for the full-screen [Audiobook Player] (ADR 0029). */
 data class AudiobookPlayerUiState(
     val loading: Boolean = true,
@@ -276,6 +290,13 @@ class AudiobookPlayerViewModel @Inject constructor(
                 readingProgressFraction = item.readingProgress,
                 durationSec = session.timeline.durationSec,
             )
+            // A finished book (resume at the end) is unplayable if seeded there — ExoPlayer lands in
+            // STATE_ENDED and play() is a no-op, leaving the player silent with the bar pinned at the
+            // end. Reopening it is a replay, so restart from 0. Only on a normal open: the handoff below
+            // sets an explicit position that must not be reset.
+            if (startAtSec < 0.0) {
+                resumeSec = audiobookStartSec(resumeSec, session.timeline.durationSec)
+            }
             // readaloud→audiobook swipe handoff: continue from exactly where the reader handed off,
             // overriding the store/server resume (which can lag the just-left listen position). Persist
             // it with a fresh stamp so it wins last-update-wins and isn't pulled back by a stale server.

--- a/app/src/test/kotlin/com/riffle/app/feature/audiobook/AudiobookResumeSecTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/audiobook/AudiobookResumeSecTest.kt
@@ -63,4 +63,38 @@ class AudiobookResumeSecTest {
             1e-9,
         )
     }
+
+    @Test
+    fun `restarts a finished book (resume at the end) from zero`() {
+        // The bug: a resume exactly at the duration seeds the player at the end of the last track, where
+        // ExoPlayer is STATE_ENDED and play() is a no-op — silent, bar pinned at the end. Replay from 0.
+        assertEquals(0.0, audiobookStartSec(resumeSec = 1000.0, durationSec = 1000.0), 1e-9)
+    }
+
+    @Test
+    fun `restarts when within the finished epsilon of the end`() {
+        // Rounding can leave the stored position a hair short of the duration; still unplayable, so reset.
+        assertEquals(
+            0.0,
+            audiobookStartSec(resumeSec = 1000.0 - AUDIOBOOK_FINISHED_EPS_SEC / 2, durationSec = 1000.0),
+            1e-9,
+        )
+    }
+
+    @Test
+    fun `honours a mid-book resume`() {
+        assertEquals(500.0, audiobookStartSec(resumeSec = 500.0, durationSec = 1000.0), 1e-9)
+    }
+
+    @Test
+    fun `keeps a resume just before the finished epsilon`() {
+        // A position more than the epsilon short of the end is a genuine mid-listen point — keep it.
+        assertEquals(990.0, audiobookStartSec(resumeSec = 990.0, durationSec = 1000.0), 1e-9)
+    }
+
+    @Test
+    fun `leaves the position alone when the duration is unknown`() {
+        // Can't tell where "the end" is, so never reset (don't restart a resume we can't classify).
+        assertEquals(42.0, audiobookStartSec(resumeSec = 42.0, durationSec = 0.0), 1e-9)
+    }
 }


### PR DESCRIPTION
## Problem

Opening an audiobook that was **finished** (resume position at the end) occasionally left the player silent with the seek bar pinned at the end, instead of playing. Reported as intermittent — it only happens when the stored position sits essentially *exactly* at the duration, which depends on how the book got finished, so most "already-played" books resume and play normally.

## Root cause

The resume path has no finished-book handling. When the resume position ≈ `duration`:

1. `audiobookResumeSec(...)` returns it unchanged (genuine tracked position).
2. `controller.prepare(startAtSec = duration)` → `AudiobookTracks.startPositionFor(duration, …)` resolves to the **last track at its end offset**, seeding ExoPlayer at the very end of the final media item.
3. ExoPlayer goes to `STATE_ENDED`; `ResumePlaybackGate` only starts on `STATE_READY`, and `play()` while ended is a no-op.

Result: no audio, seek bar at the end.

## Fix

New pure helper `audiobookStartSec(resumeSec, durationSec)` resets a resume that lands within `AUDIOBOOK_FINISHED_EPS_SEC` (1.0s) of the end back to `0.0` — reopening a finished book is a replay, so it restarts from the beginning. Applied **only on a normal open**; the readaloud→audiobook handoff's explicit position is left untouched. A position more than the epsilon short of the end is honoured as-is, and it's a no-op when the duration is unknown.

## Tests

`AudiobookResumeSecTest` adds 6 cases: restart at exact end, restart within epsilon, honour mid-book, keep just-before-epsilon, no-op on unknown duration. `./gradlew :app:testDebugUnitTest --tests AudiobookResumeSecTest` green.

## Caveats

- Defensive fix: it removes the only known unplayable state (seeding at the end) regardless of the exact ExoPlayer mechanism. The `STATE_ENDED` stall is a strong inference, **not** a device-verified repro.
- Behavioral note: reopening a finished book now restarts at 0, and listening forward overwrites the finished progress — intended replay behavior.