### PR TITLE
fix(landscape): treat a phone in landscape as a phone (detail + audiobook player)

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/audio/PlayerSurface.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audio/PlayerSurface.kt
@@ -1,5 +1,6 @@
 package com.riffle.app.feature.audio
 
+import android.content.res.Configuration
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.gestures.detectHorizontalDragGestures
 import androidx.compose.foundation.gestures.detectTapGestures
@@ -13,6 +14,9 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
@@ -39,8 +43,11 @@ import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.fromHtml
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -66,6 +73,10 @@ data class PlayerSurfaceState(
     val chapterStartsSec: List<Double> = emptyList(),
     val canPreviousChapter: Boolean = false,
     val canNextChapter: Boolean = false,
+    // Book details shown in the landscape two-column layout. [facts] is a one-line summary
+    // ("Audiobook · 10h 53m · Science Fiction"); [description] is the blurb. Both null = nothing shown.
+    val facts: String? = null,
+    val description: String? = null,
 )
 
 /** Callbacks the surface invokes. [onSeek] takes an absolute global position in seconds. */
@@ -91,34 +102,142 @@ fun PlayerSurface(
     state: PlayerSurfaceState,
     actions: PlayerSurfaceActions,
     modifier: Modifier = Modifier,
+    // A phone in landscape (Compact height): split into cover+details on the left and the controls on
+    // the right so the transport never gets pushed off the short screen. Otherwise the vertical layout.
+    twoColumn: Boolean = false,
 ) {
+    if (twoColumn) {
+        PlayerSurfaceTwoColumn(state, actions, modifier)
+    } else {
+        PlayerSurfaceVertical(state, actions, modifier)
+    }
+}
+
+@Composable
+private fun PlayerSurfaceVertical(
+    state: PlayerSurfaceState,
+    actions: PlayerSurfaceActions,
+    modifier: Modifier,
+) {
+    // Portrait phone gets a larger, more immersive cover; a (tall) landscape window stays smaller so
+    // the square cover doesn't overflow the shorter vertical space.
+    val isPortrait = LocalConfiguration.current.orientation == Configuration.ORIENTATION_PORTRAIT
+    val coverWidthFraction = if (isPortrait) 0.90f else 0.72f
     Column(
         modifier = modifier.fillMaxSize(),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         Spacer(Modifier.weight(1f))
-        AsyncImage(
-            model = ImageRequest.Builder(LocalContext.current)
-                .data(state.coverUrl)
-                .addHeader("Authorization", "Bearer ${state.authToken}")
-                .build(),
-            contentDescription = null,
-            contentScale = ContentScale.Crop,
-            modifier = Modifier
-                .fillMaxWidth(0.72f)
-                .aspectRatio(1f) // audiobook covers are square (ADR 0029)
-                .shadow(16.dp, RoundedCornerShape(12.dp))
-                .clip(RoundedCornerShape(12.dp)),
+        PlayerCover(
+            state = state,
+            modifier = Modifier.fillMaxWidth(coverWidthFraction),
         )
         Spacer(Modifier.height(20.dp))
+        PlayerTitleBlock(state, horizontalAlignment = Alignment.CenterHorizontally)
+
+        Spacer(Modifier.height(18.dp))
+        PlayerControls(state, actions)
+        Spacer(Modifier.weight(1f))
+    }
+}
+
+@Composable
+private fun PlayerSurfaceTwoColumn(
+    state: PlayerSurfaceState,
+    actions: PlayerSurfaceActions,
+    modifier: Modifier,
+) {
+    Row(
+        modifier = modifier.fillMaxSize(),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Column(
+            modifier = Modifier
+                .width(300.dp)
+                .verticalScroll(rememberScrollState()),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            PlayerCover(state = state, modifier = Modifier.size(150.dp))
+            Spacer(Modifier.height(14.dp))
+            PlayerTitleBlock(state, horizontalAlignment = Alignment.CenterHorizontally)
+            PlayerDetails(state)
+        }
+        Spacer(Modifier.width(28.dp))
+        Column(
+            modifier = Modifier.weight(1f),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            PlayerControls(state, actions)
+        }
+    }
+}
+
+/** Square audiobook cover (ADR 0029). [modifier] supplies the size (fraction of width, or fixed). */
+@Composable
+private fun PlayerCover(state: PlayerSurfaceState, modifier: Modifier) {
+    AsyncImage(
+        model = ImageRequest.Builder(LocalContext.current)
+            .data(state.coverUrl)
+            .addHeader("Authorization", "Bearer ${state.authToken}")
+            .build(),
+        contentDescription = null,
+        contentScale = ContentScale.Crop,
+        modifier = modifier
+            .aspectRatio(1f)
+            .shadow(16.dp, RoundedCornerShape(12.dp))
+            .clip(RoundedCornerShape(12.dp)),
+    )
+}
+
+@Composable
+private fun PlayerTitleBlock(
+    state: PlayerSurfaceState,
+    horizontalAlignment: Alignment.Horizontal,
+) {
+    Column(horizontalAlignment = horizontalAlignment) {
         Text(state.title, style = MaterialTheme.typography.titleLarge, maxLines = 2, overflow = TextOverflow.Ellipsis, textAlign = TextAlign.Center)
         Text(state.author, style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
         if (state.currentChapterTitle != null) {
             Spacer(Modifier.height(10.dp))
             Text(state.currentChapterTitle, style = MaterialTheme.typography.labelLarge, color = MaterialTheme.colorScheme.primary)
         }
+    }
+}
 
-        Spacer(Modifier.height(18.dp))
+/** Facts line + a clamped blurb, shown beneath the cover in the landscape two-column layout. */
+@Composable
+private fun PlayerDetails(state: PlayerSurfaceState) {
+    if (state.facts == null && state.description == null) return
+    Spacer(Modifier.height(12.dp))
+    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+        state.facts?.let {
+            Text(
+                it,
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center,
+            )
+        }
+        state.description?.takeIf { it.isNotBlank() }?.let {
+            Spacer(Modifier.height(6.dp))
+            Text(
+                AnnotatedString.fromHtml(it),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 3,
+                overflow = TextOverflow.Ellipsis,
+                textAlign = TextAlign.Center,
+            )
+        }
+    }
+}
+
+@Composable
+private fun PlayerControls(state: PlayerSurfaceState, actions: PlayerSurfaceActions) {
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
         ChapterSeekBar(
             positionSec = state.positionSec,
             durationSec = state.durationSec,
@@ -150,7 +269,6 @@ fun PlayerSurface(
             }
             Text("Speed", style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
         }
-        Spacer(Modifier.weight(1f))
     }
 }
 

--- a/app/src/main/kotlin/com/riffle/app/feature/audio/PlayerSurface.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audio/PlayerSurface.kt
@@ -33,6 +33,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -207,7 +208,12 @@ private fun PlayerTitleBlock(
 /** Facts line + a clamped blurb, shown beneath the cover in the landscape two-column layout. */
 @Composable
 private fun PlayerDetails(state: PlayerSurfaceState) {
-    if (state.facts == null && state.description == null) return
+    val blurb = state.description?.takeIf { it.isNotBlank() }
+    // Nothing to show → render nothing (no stray Spacer). A blank-but-non-null description counts as
+    // nothing, hence the isNotBlank filter above rather than a bare null check.
+    if (state.facts == null && blurb == null) return
+    // The player recomposes on every position tick; parse the HTML once per description, not per frame.
+    val formattedBlurb = remember(blurb) { blurb?.let { AnnotatedString.fromHtml(it) } }
     Spacer(Modifier.height(12.dp))
     Column(horizontalAlignment = Alignment.CenterHorizontally) {
         state.facts?.let {
@@ -218,10 +224,10 @@ private fun PlayerDetails(state: PlayerSurfaceState) {
                 textAlign = TextAlign.Center,
             )
         }
-        state.description?.takeIf { it.isNotBlank() }?.let {
+        formattedBlurb?.let {
             Spacer(Modifier.height(6.dp))
             Text(
-                AnnotatedString.fromHtml(it),
+                it,
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 maxLines = 3,

--- a/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerScreen.kt
@@ -18,6 +18,9 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.windowsizeclass.WindowHeightSizeClass
+import androidx.compose.material3.windowsizeclass.WindowSizeClass
+import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberUpdatedState
@@ -58,11 +61,16 @@ private fun ReadAlongSwipeHint() {
 
 @Composable
 fun AudiobookPlayerScreen(
+    windowSizeClass: WindowSizeClass,
     onNavigateBack: () -> Unit,
     onSwitchToReadaloud: (ebookItemId: String, atSec: Double) -> Unit = { _, _ -> },
     viewModel: AudiobookPlayerViewModel = hiltViewModel(),
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
+    // A phone in landscape crosses the Expanded width breakpoint but stays Compact in height; there
+    // the vertical layout pushes the controls off-screen, so split into cover+details / controls.
+    val twoColumn = windowSizeClass.widthSizeClass == WindowWidthSizeClass.Expanded &&
+        windowSizeClass.heightSizeClass == WindowHeightSizeClass.Compact
     // Read fresh inside the gesture (it's keyed on Unit, so it must not capture a stale position).
     val latestState = rememberUpdatedState(state)
 
@@ -126,7 +134,10 @@ fun AudiobookPlayerScreen(
                         chapterStartsSec = state.chapterStartsSec,
                         canPreviousChapter = state.canPreviousChapter,
                         canNextChapter = state.canNextChapter,
+                        facts = state.facts,
+                        description = state.description,
                     ),
+                    twoColumn = twoColumn,
                     actions = PlayerSurfaceActions(
                         onSeek = viewModel::seekTo,
                         onTogglePlayPause = viewModel::togglePlayPause,

--- a/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerScreen.kt
@@ -8,8 +8,8 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.CircularProgressIndicator
@@ -151,8 +151,11 @@ fun AudiobookPlayerScreen(
             // Exit affordance, overlaid OUTSIDE the swipe Column so its taps are never captured by the
             // swipe-down gesture. A plain back arrow (not a down-chevron) — distinct from swipe=read.
             IconButton(
+                // safeDrawingPadding (not just statusBarsPadding) so the arrow clears the status bar,
+                // nav bar AND any display cutout — in landscape the cutout/short status bar otherwise
+                // sits right under it.
                 onClick = onNavigateBack,
-                modifier = Modifier.align(Alignment.TopStart).statusBarsPadding().padding(4.dp),
+                modifier = Modifier.align(Alignment.TopStart).safeDrawingPadding().padding(4.dp),
             ) {
                 Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
             }

--- a/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerScreen.kt
@@ -20,7 +20,6 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.windowsizeclass.WindowHeightSizeClass
 import androidx.compose.material3.windowsizeclass.WindowSizeClass
-import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberUpdatedState
@@ -67,10 +66,9 @@ fun AudiobookPlayerScreen(
     viewModel: AudiobookPlayerViewModel = hiltViewModel(),
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
-    // A phone in landscape crosses the Expanded width breakpoint but stays Compact in height; there
-    // the vertical layout pushes the controls off-screen, so split into cover+details / controls.
-    val twoColumn = windowSizeClass.widthSizeClass == WindowWidthSizeClass.Expanded &&
-        windowSizeClass.heightSizeClass == WindowHeightSizeClass.Compact
+    // Any short (Compact-height) window — i.e. a phone in landscape — is too short for the vertical
+    // layout (the square cover pushes the controls off-screen), so split into cover+details / controls.
+    val twoColumn = windowSizeClass.heightSizeClass == WindowHeightSizeClass.Compact
     // Read fresh inside the gesture (it's keyed on Unit, so it must not capture a stale position).
     val latestState = rememberUpdatedState(state)
 

--- a/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModel.kt
@@ -63,6 +63,32 @@ internal const val AUDIOBOOK_FINISHED_EPS_SEC: Double = 1.0
 internal fun audiobookStartSec(resumeSec: Double, durationSec: Double): Double =
     if (durationSec > 0.0 && resumeSec >= durationSec - AUDIOBOOK_FINISHED_EPS_SEC) 0.0 else resumeSec
 
+/**
+ * The one-line facts shown beneath the cover on the landscape player, e.g.
+ * "Audiobook · 10h 53m · Science Fiction & Fantasy". Duration is omitted when unknown; at most two
+ * genres are listed to keep it tidy. Null when there's nothing to show.
+ */
+internal fun buildAudiobookFacts(durationSec: Double, genres: List<String>): String? {
+    val parts = buildList {
+        add("Audiobook")
+        if (durationSec > 0.0) {
+            val total = durationSec.toLong()
+            val h = total / 3600
+            val m = (total % 3600) / 60
+            add(
+                when {
+                    h > 0 && m > 0 -> "${h}h ${m}m"
+                    h > 0 -> "${h}h"
+                    else -> "${m}m"
+                },
+            )
+        }
+        genres.take(2).forEach { add(it) }
+    }
+    // "Audiobook" alone is just the medium label with no real facts — not worth a line.
+    return if (parts.size > 1) parts.joinToString(" · ") else null
+}
+
 /** UI state for the full-screen [Audiobook Player] (ADR 0029). */
 data class AudiobookPlayerUiState(
     val loading: Boolean = true,
@@ -79,6 +105,9 @@ data class AudiobookPlayerUiState(
     val chapterStartsSec: List<Double> = emptyList(),
     val canPreviousChapter: Boolean = false,
     val canNextChapter: Boolean = false,
+    // Book details for the landscape two-column player: a facts line and the blurb (ADR 0029).
+    val facts: String? = null,
+    val description: String? = null,
     // The linked readaloud EBOOK item id, when this title has one (split-library ebook, or this same
     // item if it's a combined ebook+audio). Non-null enables swipe-down → switch to the readaloud
     // reader; null means there's no readaloud to switch to, so no swipe-down.
@@ -355,6 +384,8 @@ class AudiobookPlayerViewModel @Inject constructor(
                 authToken = token,
                 durationSec = session.timeline.durationSec,
                 readaloudEbookItemId = readaloudEbookItemId,
+                facts = buildAudiobookFacts(session.timeline.durationSec, item.genres),
+                description = item.description,
             )
             // Resume at the server-recorded position (last-update-wins resume; ADR 0029) so the
             // audio-led canonical never starts behind.

--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemDetailScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemDetailScreen.kt
@@ -46,6 +46,7 @@ import androidx.compose.material3.TooltipBox
 import androidx.compose.material3.TooltipDefaults
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.rememberTooltipState
+import androidx.compose.material3.windowsizeclass.WindowHeightSizeClass
 import androidx.compose.material3.windowsizeclass.WindowSizeClass
 import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.runtime.Composable
@@ -160,13 +161,44 @@ fun LibraryItemDetailScreen(
                 }
                 val isExpanded =
                     windowSizeClass.widthSizeClass == WindowWidthSizeClass.Expanded
+                // A phone in landscape reaches Expanded width but stays Compact in height; there the
+                // permanent drawer is hidden (MainScreen) so the screen runs full-width — use a layout
+                // with a big cover instead of the tablet's small one. A real tablet is taller.
+                val isPhoneLandscape = isExpanded &&
+                    windowSizeClass.heightSizeClass == WindowHeightSizeClass.Compact
                 val onFacet: (FacetType, String) -> Unit = { facet, value ->
                     onNavigateToFacet(state.item.libraryId, facet, value)
                 }
                 val onSeriesClick: (String, String) -> Unit = { seriesId, seriesName ->
                     onNavigateToSeries(state.item.libraryId, seriesId, seriesName)
                 }
-                if (isExpanded) {
+                if (isPhoneLandscape) {
+                    LibraryItemDetailContentPhoneLandscape(
+                        item = state.item,
+                        seriesId = state.seriesId,
+                        onFacet = onFacet,
+                        onSeriesClick = onSeriesClick,
+                        isInToRead = state.isInToRead,
+                        token = viewModel.authToken,
+                        downloadState = downloadState,
+                        isCachedOrDownloaded = state.isCachedOrDownloaded,
+                        isOffline = state.isOffline,
+                        readaloudDownloadState = readaloudDownloadState,
+                        audiobookDownloadState = audiobookDownloadState,
+                        onReadItem = { item -> viewModel.markOpened(); onReadItem(item) },
+                        onListenItem = { item -> viewModel.markOpened(); onListenItem(item) },
+                        onMarkAsRead = { viewModel.markAsRead() },
+                        onMarkAsUnread = { viewModel.markAsUnread() },
+                        onToggleToRead = { viewModel.toggleToRead() },
+                        onDownload = { viewModel.startDownload() },
+                        onRemove = onRemove,
+                        onDownloadReadaloud = viewModel::onDownloadReadaloud,
+                        onRemoveReadaloud = viewModel::onRemoveReadaloud,
+                        onDownloadAudiobook = viewModel::onDownloadAudiobook,
+                        onRemoveAudiobook = viewModel::onRemoveAudiobook,
+                        modifier = Modifier.padding(padding),
+                    )
+                } else if (isExpanded) {
                     LibraryItemDetailContentTablet(
                         item = state.item,
                         seriesId = state.seriesId,
@@ -487,6 +519,117 @@ internal fun LibraryItemDetailContentTablet(
             }
             item.seriesName?.let { series ->
                 SeriesLine(seriesName = series, seriesId = seriesId, onSeriesClick = onSeriesClick)
+            }
+            MetadataLines(item = item, onFacet = onFacet)
+        }
+    }
+}
+
+/**
+ * The detail layout for a phone in landscape (Expanded width, Compact height). The permanent drawer
+ * is hidden (MainScreen) so the screen is full-width. Unlike the tablet layout, the title/author move
+ * to the scrollable right column so the left column's whole height belongs to a large cover — the
+ * "bigger cover" the small tablet caps deny. Identical for ebook and audiobook (ActionRow adapts).
+ */
+@Composable
+internal fun LibraryItemDetailContentPhoneLandscape(
+    item: LibraryItem,
+    seriesId: String? = null,
+    onFacet: (FacetType, String) -> Unit = { _, _ -> },
+    onSeriesClick: (String, String) -> Unit = { _, _ -> },
+    isInToRead: Boolean,
+    token: String,
+    downloadState: DownloadState,
+    isCachedOrDownloaded: Boolean,
+    isOffline: Boolean,
+    readaloudDownloadState: DownloadState?,
+    audiobookDownloadState: DownloadState? = null,
+    onReadItem: (LibraryItem) -> Unit,
+    onListenItem: (LibraryItem) -> Unit = {},
+    onMarkAsRead: () -> Unit,
+    onMarkAsUnread: () -> Unit,
+    onToggleToRead: () -> Unit,
+    onDownload: () -> Unit,
+    onRemove: () -> Unit,
+    onDownloadReadaloud: () -> Unit = {},
+    onRemoveReadaloud: () -> Unit = {},
+    onDownloadAudiobook: () -> Unit = {},
+    onRemoveAudiobook: () -> Unit = {},
+    modifier: Modifier = Modifier,
+) {
+    Row(modifier = modifier.fillMaxSize()) {
+        Column(
+            modifier = Modifier
+                .testTag(LIBRARY_ITEM_DETAIL_LEFT_PANE_TAG)
+                .width(260.dp)
+                .fillMaxHeight()
+                .padding(horizontal = 16.dp, vertical = 8.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(10.dp),
+        ) {
+            item.coverUrl?.let { url ->
+                // weight(fill = false) gives the cover all the height the action row and progress
+                // don't need — in a short landscape window height is the binding constraint, so this
+                // yields the largest cover that still keeps the buttons on screen.
+                AsyncImage(
+                    model = ImageRequest.Builder(LocalContext.current)
+                        .data(url)
+                        .addHeader("Authorization", "Bearer $token")
+                        .build(),
+                    contentDescription = null,
+                    contentScale = ContentScale.Fit,
+                    modifier = Modifier
+                        .weight(1f, fill = false)
+                        .aspectRatio(2f / 3f),
+                )
+            }
+            if (item.readingProgress > 0f) {
+                ReadingProgressIndicator(progress = item.readingProgress, listened = item.isListenable && !item.isReadable)
+            }
+            ActionRow(
+                item = item,
+                isInToRead = isInToRead,
+                downloadState = downloadState,
+                isCachedOrDownloaded = isCachedOrDownloaded,
+                isOffline = isOffline,
+                readaloudDownloadState = readaloudDownloadState,
+                audiobookDownloadState = audiobookDownloadState,
+                onReadItem = onReadItem,
+                onListenItem = onListenItem,
+                onMarkAsRead = onMarkAsRead,
+                onMarkAsUnread = onMarkAsUnread,
+                onToggleToRead = onToggleToRead,
+                onDownload = onDownload,
+                onRemove = onRemove,
+                onDownloadReadaloud = onDownloadReadaloud,
+                onRemoveReadaloud = onRemoveReadaloud,
+                onDownloadAudiobook = onDownloadAudiobook,
+                onRemoveAudiobook = onRemoveAudiobook,
+            )
+        }
+        Column(
+            modifier = Modifier
+                .testTag(LIBRARY_ITEM_DETAIL_RIGHT_PANE_TAG)
+                .weight(1f)
+                .fillMaxHeight()
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 16.dp, vertical = 8.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            TitleWithReadaloudIndicator(
+                title = item.title,
+                hasReadaloud = readaloudDownloadState != null,
+                onReadaloudClick = { onFacet(FacetType.READALOUD, "all") },
+            )
+            AuthorByline(author = item.author, onAuthorClick = { onFacet(FacetType.AUTHOR, it) })
+            item.seriesName?.let { series ->
+                SeriesLine(seriesName = series, seriesId = seriesId, onSeriesClick = onSeriesClick)
+            }
+            if (item.isListenable && item.audioDurationSec > 0) {
+                AudiobookDurationLine(item.audioDurationSec)
+            }
+            item.description?.takeIf { it.isNotBlank() }?.let { desc ->
+                CollapsibleDescription(desc)
             }
             MetadataLines(item = item, onFacet = onFacet)
         }

--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemDetailScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemDetailScreen.kt
@@ -46,9 +46,7 @@ import androidx.compose.material3.TooltipBox
 import androidx.compose.material3.TooltipDefaults
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.rememberTooltipState
-import androidx.compose.material3.windowsizeclass.WindowHeightSizeClass
 import androidx.compose.material3.windowsizeclass.WindowSizeClass
-import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -73,6 +71,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
+import com.riffle.app.ui.isTabletLayout
 import com.riffle.core.domain.LibraryItem
 import kotlinx.coroutines.launch
 
@@ -159,46 +158,16 @@ fun LibraryItemDetailScreen(
                         )
                     }
                 }
-                val isExpanded =
-                    windowSizeClass.widthSizeClass == WindowWidthSizeClass.Expanded
-                // A phone in landscape reaches Expanded width but stays Compact in height; there the
-                // permanent drawer is hidden (MainScreen) so the screen runs full-width — use a layout
-                // with a big cover instead of the tablet's small one. A real tablet is taller.
-                val isPhoneLandscape = isExpanded &&
-                    windowSizeClass.heightSizeClass == WindowHeightSizeClass.Compact
+                // A phone in landscape is NOT a tablet (ADR 0019): it reaches Expanded width but stays
+                // Compact in height, so it renders the single-column phone layout, not the two-pane one.
+                val isTablet = windowSizeClass.isTabletLayout()
                 val onFacet: (FacetType, String) -> Unit = { facet, value ->
                     onNavigateToFacet(state.item.libraryId, facet, value)
                 }
                 val onSeriesClick: (String, String) -> Unit = { seriesId, seriesName ->
                     onNavigateToSeries(state.item.libraryId, seriesId, seriesName)
                 }
-                if (isPhoneLandscape) {
-                    LibraryItemDetailContentPhoneLandscape(
-                        item = state.item,
-                        seriesId = state.seriesId,
-                        onFacet = onFacet,
-                        onSeriesClick = onSeriesClick,
-                        isInToRead = state.isInToRead,
-                        token = viewModel.authToken,
-                        downloadState = downloadState,
-                        isCachedOrDownloaded = state.isCachedOrDownloaded,
-                        isOffline = state.isOffline,
-                        readaloudDownloadState = readaloudDownloadState,
-                        audiobookDownloadState = audiobookDownloadState,
-                        onReadItem = { item -> viewModel.markOpened(); onReadItem(item) },
-                        onListenItem = { item -> viewModel.markOpened(); onListenItem(item) },
-                        onMarkAsRead = { viewModel.markAsRead() },
-                        onMarkAsUnread = { viewModel.markAsUnread() },
-                        onToggleToRead = { viewModel.toggleToRead() },
-                        onDownload = { viewModel.startDownload() },
-                        onRemove = onRemove,
-                        onDownloadReadaloud = viewModel::onDownloadReadaloud,
-                        onRemoveReadaloud = viewModel::onRemoveReadaloud,
-                        onDownloadAudiobook = viewModel::onDownloadAudiobook,
-                        onRemoveAudiobook = viewModel::onRemoveAudiobook,
-                        modifier = Modifier.padding(padding),
-                    )
-                } else if (isExpanded) {
+                if (isTablet) {
                     LibraryItemDetailContentTablet(
                         item = state.item,
                         seriesId = state.seriesId,
@@ -519,117 +488,6 @@ internal fun LibraryItemDetailContentTablet(
             }
             item.seriesName?.let { series ->
                 SeriesLine(seriesName = series, seriesId = seriesId, onSeriesClick = onSeriesClick)
-            }
-            MetadataLines(item = item, onFacet = onFacet)
-        }
-    }
-}
-
-/**
- * The detail layout for a phone in landscape (Expanded width, Compact height). The permanent drawer
- * is hidden (MainScreen) so the screen is full-width. Unlike the tablet layout, the title/author move
- * to the scrollable right column so the left column's whole height belongs to a large cover — the
- * "bigger cover" the small tablet caps deny. Identical for ebook and audiobook (ActionRow adapts).
- */
-@Composable
-internal fun LibraryItemDetailContentPhoneLandscape(
-    item: LibraryItem,
-    seriesId: String? = null,
-    onFacet: (FacetType, String) -> Unit = { _, _ -> },
-    onSeriesClick: (String, String) -> Unit = { _, _ -> },
-    isInToRead: Boolean,
-    token: String,
-    downloadState: DownloadState,
-    isCachedOrDownloaded: Boolean,
-    isOffline: Boolean,
-    readaloudDownloadState: DownloadState?,
-    audiobookDownloadState: DownloadState? = null,
-    onReadItem: (LibraryItem) -> Unit,
-    onListenItem: (LibraryItem) -> Unit = {},
-    onMarkAsRead: () -> Unit,
-    onMarkAsUnread: () -> Unit,
-    onToggleToRead: () -> Unit,
-    onDownload: () -> Unit,
-    onRemove: () -> Unit,
-    onDownloadReadaloud: () -> Unit = {},
-    onRemoveReadaloud: () -> Unit = {},
-    onDownloadAudiobook: () -> Unit = {},
-    onRemoveAudiobook: () -> Unit = {},
-    modifier: Modifier = Modifier,
-) {
-    Row(modifier = modifier.fillMaxSize()) {
-        Column(
-            modifier = Modifier
-                .testTag(LIBRARY_ITEM_DETAIL_LEFT_PANE_TAG)
-                .width(260.dp)
-                .fillMaxHeight()
-                .padding(horizontal = 16.dp, vertical = 8.dp),
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.spacedBy(10.dp),
-        ) {
-            item.coverUrl?.let { url ->
-                // weight(fill = false) gives the cover all the height the action row and progress
-                // don't need — in a short landscape window height is the binding constraint, so this
-                // yields the largest cover that still keeps the buttons on screen.
-                AsyncImage(
-                    model = ImageRequest.Builder(LocalContext.current)
-                        .data(url)
-                        .addHeader("Authorization", "Bearer $token")
-                        .build(),
-                    contentDescription = null,
-                    contentScale = ContentScale.Fit,
-                    modifier = Modifier
-                        .weight(1f, fill = false)
-                        .aspectRatio(2f / 3f),
-                )
-            }
-            if (item.readingProgress > 0f) {
-                ReadingProgressIndicator(progress = item.readingProgress, listened = item.isListenable && !item.isReadable)
-            }
-            ActionRow(
-                item = item,
-                isInToRead = isInToRead,
-                downloadState = downloadState,
-                isCachedOrDownloaded = isCachedOrDownloaded,
-                isOffline = isOffline,
-                readaloudDownloadState = readaloudDownloadState,
-                audiobookDownloadState = audiobookDownloadState,
-                onReadItem = onReadItem,
-                onListenItem = onListenItem,
-                onMarkAsRead = onMarkAsRead,
-                onMarkAsUnread = onMarkAsUnread,
-                onToggleToRead = onToggleToRead,
-                onDownload = onDownload,
-                onRemove = onRemove,
-                onDownloadReadaloud = onDownloadReadaloud,
-                onRemoveReadaloud = onRemoveReadaloud,
-                onDownloadAudiobook = onDownloadAudiobook,
-                onRemoveAudiobook = onRemoveAudiobook,
-            )
-        }
-        Column(
-            modifier = Modifier
-                .testTag(LIBRARY_ITEM_DETAIL_RIGHT_PANE_TAG)
-                .weight(1f)
-                .fillMaxHeight()
-                .verticalScroll(rememberScrollState())
-                .padding(horizontal = 16.dp, vertical = 8.dp),
-            verticalArrangement = Arrangement.spacedBy(12.dp),
-        ) {
-            TitleWithReadaloudIndicator(
-                title = item.title,
-                hasReadaloud = readaloudDownloadState != null,
-                onReadaloudClick = { onFacet(FacetType.READALOUD, "all") },
-            )
-            AuthorByline(author = item.author, onAuthorClick = { onFacet(FacetType.AUTHOR, it) })
-            item.seriesName?.let { series ->
-                SeriesLine(seriesName = series, seriesId = seriesId, onSeriesClick = onSeriesClick)
-            }
-            if (item.isListenable && item.audioDurationSec > 0) {
-                AudiobookDurationLine(item.audioDurationSec)
-            }
-            item.description?.takeIf { it.isNotBlank() }?.let { desc ->
-                CollapsibleDescription(desc)
             }
             MetadataLines(item = item, onFacet = onFacet)
         }

--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemDetailScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemDetailScreen.kt
@@ -71,6 +71,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
+import com.riffle.app.ui.isPhoneLandscape
 import com.riffle.app.ui.isTabletLayout
 import com.riffle.core.domain.LibraryItem
 import kotlinx.coroutines.launch
@@ -158,16 +159,44 @@ fun LibraryItemDetailScreen(
                         )
                     }
                 }
-                // A phone in landscape is NOT a tablet (ADR 0019): it reaches Expanded width but stays
-                // Compact in height, so it renders the single-column phone layout, not the two-pane one.
                 val isTablet = windowSizeClass.isTabletLayout()
+                // A phone in landscape is wide-but-short: it keeps the phone chrome (modal drawer) but
+                // is still wide enough for a two-column cover-beside-text detail layout, which scrolls
+                // far less than the single tall column the phone-portrait layout would give here.
+                val isPhoneLandscape = windowSizeClass.isPhoneLandscape()
                 val onFacet: (FacetType, String) -> Unit = { facet, value ->
                     onNavigateToFacet(state.item.libraryId, facet, value)
                 }
                 val onSeriesClick: (String, String) -> Unit = { seriesId, seriesName ->
                     onNavigateToSeries(state.item.libraryId, seriesId, seriesName)
                 }
-                if (isTablet) {
+                if (isPhoneLandscape) {
+                    LibraryItemDetailContentPhoneLandscape(
+                        item = state.item,
+                        seriesId = state.seriesId,
+                        onFacet = onFacet,
+                        onSeriesClick = onSeriesClick,
+                        isInToRead = state.isInToRead,
+                        token = viewModel.authToken,
+                        downloadState = downloadState,
+                        isCachedOrDownloaded = state.isCachedOrDownloaded,
+                        isOffline = state.isOffline,
+                        readaloudDownloadState = readaloudDownloadState,
+                        audiobookDownloadState = audiobookDownloadState,
+                        onReadItem = { item -> viewModel.markOpened(); onReadItem(item) },
+                        onListenItem = { item -> viewModel.markOpened(); onListenItem(item) },
+                        onMarkAsRead = { viewModel.markAsRead() },
+                        onMarkAsUnread = { viewModel.markAsUnread() },
+                        onToggleToRead = { viewModel.toggleToRead() },
+                        onDownload = { viewModel.startDownload() },
+                        onRemove = onRemove,
+                        onDownloadReadaloud = viewModel::onDownloadReadaloud,
+                        onRemoveReadaloud = viewModel::onRemoveReadaloud,
+                        onDownloadAudiobook = viewModel::onDownloadAudiobook,
+                        onRemoveAudiobook = viewModel::onRemoveAudiobook,
+                        modifier = Modifier.padding(padding),
+                    )
+                } else if (isTablet) {
                     LibraryItemDetailContentTablet(
                         item = state.item,
                         seriesId = state.seriesId,
@@ -488,6 +517,114 @@ internal fun LibraryItemDetailContentTablet(
             }
             item.seriesName?.let { series ->
                 SeriesLine(seriesName = series, seriesId = seriesId, onSeriesClick = onSeriesClick)
+            }
+            MetadataLines(item = item, onFacet = onFacet)
+        }
+    }
+}
+
+/**
+ * Detail layout for a phone in landscape (wide-but-short). The cover sits alone in the left column so
+ * it gets the full screen height — a big cover — while everything else (title, author, actions,
+ * Summary, metadata) scrolls in the wide right column. Keeping the cover out of the scrolling column
+ * means far less scrolling than the single-column phone layout, and the wide right column leaves the
+ * action row room to lay out horizontally (no squished Read/Listen button). Ebook + audiobook alike.
+ */
+@Composable
+internal fun LibraryItemDetailContentPhoneLandscape(
+    item: LibraryItem,
+    seriesId: String? = null,
+    onFacet: (FacetType, String) -> Unit = { _, _ -> },
+    onSeriesClick: (String, String) -> Unit = { _, _ -> },
+    isInToRead: Boolean,
+    token: String,
+    downloadState: DownloadState,
+    isCachedOrDownloaded: Boolean,
+    isOffline: Boolean,
+    readaloudDownloadState: DownloadState?,
+    audiobookDownloadState: DownloadState? = null,
+    onReadItem: (LibraryItem) -> Unit,
+    onListenItem: (LibraryItem) -> Unit = {},
+    onMarkAsRead: () -> Unit,
+    onMarkAsUnread: () -> Unit,
+    onToggleToRead: () -> Unit,
+    onDownload: () -> Unit,
+    onRemove: () -> Unit,
+    onDownloadReadaloud: () -> Unit = {},
+    onRemoveReadaloud: () -> Unit = {},
+    onDownloadAudiobook: () -> Unit = {},
+    onRemoveAudiobook: () -> Unit = {},
+    modifier: Modifier = Modifier,
+) {
+    Row(modifier = modifier.fillMaxSize()) {
+        item.coverUrl?.let { url ->
+            Box(
+                modifier = Modifier
+                    .testTag(LIBRARY_ITEM_DETAIL_LEFT_PANE_TAG)
+                    .fillMaxHeight()
+                    .padding(start = 16.dp, top = 8.dp, bottom = 8.dp, end = 8.dp),
+                contentAlignment = Alignment.Center,
+            ) {
+                AsyncImage(
+                    model = ImageRequest.Builder(LocalContext.current)
+                        .data(url)
+                        .addHeader("Authorization", "Bearer $token")
+                        .build(),
+                    contentDescription = null,
+                    contentScale = ContentScale.Fit,
+                    // The cover owns the column's full height; aspectRatio derives its width from that.
+                    modifier = Modifier
+                        .fillMaxHeight()
+                        .aspectRatio(2f / 3f, matchHeightConstraintsFirst = true),
+                )
+            }
+        }
+        Column(
+            modifier = Modifier
+                .testTag(LIBRARY_ITEM_DETAIL_RIGHT_PANE_TAG)
+                .weight(1f)
+                .fillMaxHeight()
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 16.dp, vertical = 8.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            TitleWithReadaloudIndicator(
+                title = item.title,
+                hasReadaloud = readaloudDownloadState != null,
+                onReadaloudClick = { onFacet(FacetType.READALOUD, "all") },
+            )
+            AuthorByline(author = item.author, onAuthorClick = { onFacet(FacetType.AUTHOR, it) })
+            item.seriesName?.let { series ->
+                SeriesLine(seriesName = series, seriesId = seriesId, onSeriesClick = onSeriesClick)
+            }
+            if (item.isListenable && item.audioDurationSec > 0) {
+                AudiobookDurationLine(item.audioDurationSec)
+            }
+            if (item.readingProgress > 0f) {
+                ReadingProgressIndicator(progress = item.readingProgress, listened = item.isListenable && !item.isReadable)
+            }
+            ActionRow(
+                item = item,
+                isInToRead = isInToRead,
+                downloadState = downloadState,
+                isCachedOrDownloaded = isCachedOrDownloaded,
+                isOffline = isOffline,
+                readaloudDownloadState = readaloudDownloadState,
+                audiobookDownloadState = audiobookDownloadState,
+                onReadItem = onReadItem,
+                onListenItem = onListenItem,
+                onMarkAsRead = onMarkAsRead,
+                onMarkAsUnread = onMarkAsUnread,
+                onToggleToRead = onToggleToRead,
+                onDownload = onDownload,
+                onRemove = onRemove,
+                onDownloadReadaloud = onDownloadReadaloud,
+                onRemoveReadaloud = onRemoveReadaloud,
+                onDownloadAudiobook = onDownloadAudiobook,
+                onRemoveAudiobook = onRemoveAudiobook,
+            )
+            item.description?.takeIf { it.isNotBlank() }?.let { desc ->
+                CollapsibleDescription(desc)
             }
             MetadataLines(item = item, onFacet = onFacet)
         }

--- a/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
@@ -3,6 +3,7 @@ package com.riffle.app.navigation
 import androidx.activity.compose.BackHandler
 import androidx.compose.material3.DrawerValue
 import androidx.compose.material3.rememberDrawerState
+import androidx.compose.material3.windowsizeclass.WindowHeightSizeClass
 import androidx.compose.material3.windowsizeclass.WindowSizeClass
 import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.runtime.Composable
@@ -75,6 +76,12 @@ fun MainScreen(
     // configuration changes (rotation, foldable unfold, ChromeOS resize, split-screen)
     // re-evaluate automatically.
     val isExpanded = windowSizeClass.widthSizeClass == WindowWidthSizeClass.Expanded
+    // A large phone in landscape crosses the Expanded width breakpoint (so it gets the tablet
+    // layouts) but stays Compact in height (< 480dp) — a real tablet is taller in both
+    // orientations. This pair distinguishes "phone landscape" from "tablet" so the detail and
+    // player screens can reclaim the drawer's width without touching the tablet view.
+    val isPhoneLandscape = isExpanded &&
+        windowSizeClass.heightSizeClass == WindowHeightSizeClass.Compact
 
     val activeServer by viewModel.activeServer.collectAsState()
     val allServers by viewModel.allServers.collectAsState()
@@ -88,8 +95,11 @@ fun MainScreen(
     val currentRoute = currentBackStack?.destination?.route
     val usePermanentDrawer = isExpanded
     // Reader screens are immersive — collapse the permanent side panel so the book/PDF
-    // fills the width, matching the modal drawer's gesture suppression on phones.
-    val hidePermanentDrawerPanel = isReaderRoute(currentRoute)
+    // fills the width, matching the modal drawer's gesture suppression on phones. The item
+    // detail and audiobook player additionally collapse it on a phone in landscape, where the
+    // 280dp sheet would crowd the (short, wide) screen — but only there, so the tablet keeps it.
+    val hidePermanentDrawerPanel = isReaderRoute(currentRoute) ||
+        (isPhoneLandscape && isDetailOrPlayerRoute(currentRoute))
 
     // Material3's ModalNavigationDrawer doesn't install its own BackHandler — so when the
     // drawer is open we add one here. Registered above the NavHost so screen-level handlers
@@ -424,6 +434,7 @@ fun MainScreen(
                 )
             ) {
                 AudiobookPlayerScreen(
+                    windowSizeClass = windowSizeClass,
                     onNavigateBack = { navController.popBackStack() },
                     // Swipe down → switch to the readaloud reader for the linked ebook, continuing from
                     // the audiobook position. Pop the player off the stack so leaving readaloud doesn't
@@ -465,3 +476,8 @@ internal fun NavController.navigateAsRoot(route: String) {
 internal fun isReaderRoute(route: String?): Boolean =
     route?.startsWith(EPUB_READER.substringBefore("{")) == true ||
         route?.startsWith(PDF_READER.substringBefore("{")) == true
+
+// The two full-screen surfaces that reclaim the permanent drawer's width on a phone in landscape.
+internal fun isDetailOrPlayerRoute(route: String?): Boolean =
+    route?.startsWith(LIBRARY_ITEM_DETAIL.substringBefore("{")) == true ||
+        route?.startsWith(AUDIOBOOK_PLAYER.substringBefore("{")) == true

--- a/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
@@ -3,9 +3,7 @@ package com.riffle.app.navigation
 import androidx.activity.compose.BackHandler
 import androidx.compose.material3.DrawerValue
 import androidx.compose.material3.rememberDrawerState
-import androidx.compose.material3.windowsizeclass.WindowHeightSizeClass
 import androidx.compose.material3.windowsizeclass.WindowSizeClass
-import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -42,6 +40,7 @@ import com.riffle.app.feature.server.ServerSetupViewModel
 import com.riffle.app.feature.settings.SettingsScreen
 import com.riffle.app.feature.settings.readaloud.ReadaloudMatchesScreen
 import com.riffle.app.playback.NowPlaying
+import com.riffle.app.ui.isTabletLayout
 import kotlinx.coroutines.launch
 import java.net.URLDecoder
 import java.net.URLEncoder
@@ -71,17 +70,12 @@ fun MainScreen(
     val navController = rememberNavController()
     val drawerState = rememberDrawerState(DrawerValue.Closed)
     val scope = rememberCoroutineScope()
-    // ADR 0019: Tablet Layout activates only on Expanded (≥ 840dp). Compact and Medium
-    // both render the phone UI. The threshold is evaluated at composition time so
-    // configuration changes (rotation, foldable unfold, ChromeOS resize, split-screen)
-    // re-evaluate automatically.
-    val isExpanded = windowSizeClass.widthSizeClass == WindowWidthSizeClass.Expanded
-    // A large phone in landscape crosses the Expanded width breakpoint (so it gets the tablet
-    // layouts) but stays Compact in height (< 480dp) — a real tablet is taller in both
-    // orientations. This pair distinguishes "phone landscape" from "tablet" so the detail and
-    // player screens can reclaim the drawer's width without touching the tablet view.
-    val isPhoneLandscape = isExpanded &&
-        windowSizeClass.heightSizeClass == WindowHeightSizeClass.Compact
+    // ADR 0019: the Tablet Layout activates only when the window is large in BOTH dimensions —
+    // Expanded width (≥ 840dp) and non-Compact height. A large phone in landscape crosses the
+    // Expanded width breakpoint but stays Compact in height, so it renders the phone UI (modal
+    // drawer, single-column detail). Re-evaluated at composition time, so rotation / unfold /
+    // resize switch automatically.
+    val isTablet = windowSizeClass.isTabletLayout()
 
     val activeServer by viewModel.activeServer.collectAsState()
     val allServers by viewModel.allServers.collectAsState()
@@ -93,13 +87,10 @@ fun MainScreen(
         ?.takeIf { it.destination.route?.startsWith("library_items/") == true }
         ?.arguments?.getString("libraryId")
     val currentRoute = currentBackStack?.destination?.route
-    val usePermanentDrawer = isExpanded
+    val usePermanentDrawer = isTablet
     // Reader screens are immersive — collapse the permanent side panel so the book/PDF
-    // fills the width, matching the modal drawer's gesture suppression on phones. The item
-    // detail and audiobook player additionally collapse it on a phone in landscape, where the
-    // 280dp sheet would crowd the (short, wide) screen — but only there, so the tablet keeps it.
-    val hidePermanentDrawerPanel = isReaderRoute(currentRoute) ||
-        (isPhoneLandscape && isDetailOrPlayerRoute(currentRoute))
+    // fills the width, matching the modal drawer's gesture suppression on phones.
+    val hidePermanentDrawerPanel = isReaderRoute(currentRoute)
 
     // Material3's ModalNavigationDrawer doesn't install its own BackHandler — so when the
     // drawer is open we add one here. Registered above the NavHost so screen-level handlers
@@ -476,8 +467,3 @@ internal fun NavController.navigateAsRoot(route: String) {
 internal fun isReaderRoute(route: String?): Boolean =
     route?.startsWith(EPUB_READER.substringBefore("{")) == true ||
         route?.startsWith(PDF_READER.substringBefore("{")) == true
-
-// The two full-screen surfaces that reclaim the permanent drawer's width on a phone in landscape.
-internal fun isDetailOrPlayerRoute(route: String?): Boolean =
-    route?.startsWith(LIBRARY_ITEM_DETAIL.substringBefore("{")) == true ||
-        route?.startsWith(AUDIOBOOK_PLAYER.substringBefore("{")) == true

--- a/app/src/main/kotlin/com/riffle/app/ui/TabletLayout.kt
+++ b/app/src/main/kotlin/com/riffle/app/ui/TabletLayout.kt
@@ -17,3 +17,13 @@ import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 fun WindowSizeClass.isTabletLayout(): Boolean =
     widthSizeClass == WindowWidthSizeClass.Expanded &&
         heightSizeClass != WindowHeightSizeClass.Compact
+
+/**
+ * A wide-but-short window — a large phone in landscape: Expanded width (≥ 840dp) but Compact height
+ * (< 480dp). It is NOT a tablet (so it keeps the phone chrome — modal drawer), but it is wide enough
+ * to host a two-column *content* layout (e.g. the item-detail cover beside the text) instead of one
+ * tall scrolling column. A real tablet is non-Compact height, so it never matches this.
+ */
+fun WindowSizeClass.isPhoneLandscape(): Boolean =
+    widthSizeClass == WindowWidthSizeClass.Expanded &&
+        heightSizeClass == WindowHeightSizeClass.Compact

--- a/app/src/main/kotlin/com/riffle/app/ui/TabletLayout.kt
+++ b/app/src/main/kotlin/com/riffle/app/ui/TabletLayout.kt
@@ -1,0 +1,19 @@
+package com.riffle.app.ui
+
+import androidx.compose.material3.windowsizeclass.WindowHeightSizeClass
+import androidx.compose.material3.windowsizeclass.WindowSizeClass
+import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
+
+/**
+ * Whether this window should render the Tablet Layout (ADR 0019).
+ *
+ * The width must be Expanded (≥ 840dp), AND the height must not be Compact. The original ADR keyed
+ * on Expanded width alone, on the assumption that a phone in landscape stays in the Medium width
+ * bucket — but a *large* phone in landscape crosses 840dp, so width alone hands it the permanent
+ * drawer and two-pane layouts next to a postcard-height (Compact) area. The height guard restores the
+ * ADR's stated intent: a landscape phone (Compact height) is treated as a phone, a real tablet
+ * (taller in both orientations) as a tablet.
+ */
+fun WindowSizeClass.isTabletLayout(): Boolean =
+    widthSizeClass == WindowWidthSizeClass.Expanded &&
+        heightSizeClass != WindowHeightSizeClass.Compact

--- a/app/src/test/kotlin/com/riffle/app/feature/audiobook/BuildAudiobookFactsTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/audiobook/BuildAudiobookFactsTest.kt
@@ -1,0 +1,46 @@
+package com.riffle.app.feature.audiobook
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * The facts line shown beneath the cover on the landscape two-column player. Joins the medium label,
+ * duration and up to two genres; collapses to null when only the bare "Audiobook" label would show.
+ */
+class BuildAudiobookFactsTest {
+
+    @Test
+    fun `joins duration and genres after the medium label`() {
+        assertEquals(
+            "Audiobook · 10h 53m · Science Fiction & Fantasy · Adventure",
+            buildAudiobookFacts(
+                durationSec = 10 * 3600.0 + 53 * 60,
+                genres = listOf("Science Fiction & Fantasy", "Adventure"),
+            ),
+        )
+    }
+
+    @Test
+    fun `caps at two genres`() {
+        assertEquals(
+            "Audiobook · 5h · A · B",
+            buildAudiobookFacts(durationSec = 5 * 3600.0, genres = listOf("A", "B", "C")),
+        )
+    }
+
+    @Test
+    fun `minutes-only duration omits the hours segment`() {
+        assertEquals("Audiobook · 42m", buildAudiobookFacts(durationSec = 42 * 60.0, genres = emptyList()))
+    }
+
+    @Test
+    fun `unknown duration and no genres collapses to null`() {
+        assertNull(buildAudiobookFacts(durationSec = 0.0, genres = emptyList()))
+    }
+
+    @Test
+    fun `genres alone still produce a line`() {
+        assertEquals("Audiobook · Memoir", buildAudiobookFacts(durationSec = 0.0, genres = listOf("Memoir")))
+    }
+}

--- a/app/src/test/kotlin/com/riffle/app/navigation/IsReaderRouteTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/navigation/IsReaderRouteTest.kt
@@ -36,3 +36,23 @@ class IsReaderRouteTest {
         assertFalse(isReaderRoute("library_item_detail/item-id"))
     }
 }
+
+class IsDetailOrPlayerRouteTest {
+
+    @Test
+    fun `library item detail route is recognized`() {
+        assertTrue(isDetailOrPlayerRoute("library_item_detail/item-id"))
+    }
+
+    @Test
+    fun `audiobook player route is recognized`() {
+        assertTrue(isDetailOrPlayerRoute("audiobook_player/item-id?startAtSec=12.0"))
+    }
+
+    @Test
+    fun `reader and library routes are not detail-or-player routes`() {
+        assertFalse(isDetailOrPlayerRoute("epub_reader/item-id"))
+        assertFalse(isDetailOrPlayerRoute("library_items/lib-1/My%20Library"))
+        assertFalse(isDetailOrPlayerRoute(null))
+    }
+}

--- a/app/src/test/kotlin/com/riffle/app/navigation/IsReaderRouteTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/navigation/IsReaderRouteTest.kt
@@ -36,23 +36,3 @@ class IsReaderRouteTest {
         assertFalse(isReaderRoute("library_item_detail/item-id"))
     }
 }
-
-class IsDetailOrPlayerRouteTest {
-
-    @Test
-    fun `library item detail route is recognized`() {
-        assertTrue(isDetailOrPlayerRoute("library_item_detail/item-id"))
-    }
-
-    @Test
-    fun `audiobook player route is recognized`() {
-        assertTrue(isDetailOrPlayerRoute("audiobook_player/item-id?startAtSec=12.0"))
-    }
-
-    @Test
-    fun `reader and library routes are not detail-or-player routes`() {
-        assertFalse(isDetailOrPlayerRoute("epub_reader/item-id"))
-        assertFalse(isDetailOrPlayerRoute("library_items/lib-1/My%20Library"))
-        assertFalse(isDetailOrPlayerRoute(null))
-    }
-}

--- a/docs/adr/0019-tablet-layout-only-on-expanded-size-class.md
+++ b/docs/adr/0019-tablet-layout-only-on-expanded-size-class.md
@@ -14,7 +14,9 @@ The load-bearing decision is what to do with **Medium**, because it contains two
 
 ## Decision
 
-**The Tablet Layout activates only on the Expanded size class (≥ 840dp).** Compact and Medium both render the standard phone UI. There is no intermediate Medium-specific variant.
+**The Tablet Layout activates only when the window is large in *both* dimensions — the Expanded width class (≥ 840dp) AND a non-Compact height class.** Compact and Medium width both render the standard phone UI, and so does an Expanded-width window that is Compact in height. There is no intermediate Medium-specific variant.
+
+The height guard exists because the width-only rule over-captured one case it was meant to exclude: a **large phone in landscape** crosses 840dp of width, so width alone handed it the permanent drawer and two-pane layouts next to a postcard-height area — the exact outcome the "Decision" was written to avoid. A landscape phone is Compact in height (< 480dp); a real tablet is taller in both orientations. The single predicate `WindowSizeClass.isTabletLayout()` (Expanded width && non-Compact height) encodes this and is the only thing layout code should branch on.
 
 This means:
 
@@ -34,6 +36,6 @@ This means:
 ## Consequences
 
 - **Landscape phones do not get the Tablet Layout.** This is deliberate. Users with foldables in particular should expect the phone UI most of the time.
-- **The 840dp threshold is what code reads, not "is this a tablet."** The codebase should not have helpers named `isTablet()` — the signal is `WindowSizeClass.Expanded`, evaluated at composition time. This keeps behaviour consistent across foldables, ChromeOS, and split-screen, where "tablet" as a noun is meaningless.
+- **Code reads a window-size predicate, not "is this a tablet" as a device fact.** The single helper `WindowSizeClass.isTabletLayout()` (Expanded width && non-Compact height) is evaluated at composition time. It is deliberately phrased about the *layout* the window can host, not the device — the same window predicate keeps behaviour consistent across foldables, ChromeOS, and split-screen, where "tablet" as a noun is meaningless. Do not reintroduce a device-shape `isTablet()`.
 - **Configuration changes are load-bearing.** Unfolding, resizing, and rotating all cross the threshold. The framework's automatic `WindowSizeClass` recomputation plus `rememberSaveable` is trusted to preserve in-app state across these transitions. No bespoke handling.
 - **Tests need to exercise both sides of the threshold.** A second harness AVD ("Harness Medium Tablet") and a separate `make harness-test-tablet` target cover this — only tests annotated for tablet behaviour run on the tablet AVD, so the full suite does not double-run.

--- a/docs/superpowers/specs/2026-06-13-phone-landscape-detail-and-player-design.md
+++ b/docs/superpowers/specs/2026-06-13-phone-landscape-detail-and-player-design.md
@@ -1,0 +1,112 @@
+# Phone-landscape: detail screen & audiobook player
+
+**Date:** 2026-06-13
+**Status:** Approved design, pending implementation plan
+
+## Problem
+
+A large phone in **landscape** is wide enough (≥ 840 dp) to cross the `WindowWidthSizeClass.Expanded`
+breakpoint, so it renders the **tablet** layouts: a 280 dp `PermanentNavigationDrawer` pinned to the
+left, the two-pane item-detail layout, and the vertical audiobook player.
+
+On such a window this is wrong:
+
+1. **Item detail** (ebook *and* audiobook) — the permanent drawer eats ~280 dp, and the cover ends
+   up tiny because it competes for the short landscape height inside the 360 dp left pane.
+2. **Audiobook player** — the drawer is shown, and `PlayerSurface` is a single vertical column with a
+   `fillMaxWidth(0.72f)` square cover; in the short landscape height the cover pushes the transport
+   controls off the bottom of the screen. The screen also shows no book details.
+
+A real **tablet** (Expanded width in *either* orientation) is fine as-is and must not change.
+
+## Discriminator: "phone landscape" vs "tablet"
+
+A phone in landscape has `widthSizeClass == Expanded` **and** `heightSizeClass == Compact`
+(height < 480 dp). A tablet has a taller height class in both orientations. So:
+
+```
+isPhoneLandscape = widthSizeClass == Expanded && heightSizeClass == Compact
+```
+
+`heightSizeClass` is not currently used anywhere in the app; it is available on the existing
+`WindowSizeClass` already threaded through `MainScreen` and the screens. This keeps the tablet view
+untouched (it never has Compact height).
+
+## Changes
+
+### 1. Hide the permanent drawer on detail + player (phone-landscape only)
+
+`MainScreen.kt` already hides the permanent drawer panel on reader routes via
+`hidePermanentDrawerPanel`. Extend it:
+
+```
+hidePermanentDrawerPanel = isReaderRoute(currentRoute) ||
+    (isPhoneLandscape && isDetailOrPlayerRoute(currentRoute))
+```
+
+where `isDetailOrPlayerRoute` matches the `library_item_detail/…` and `audiobook_player/…` route
+prefixes. `usePermanentDrawer` (= `isExpanded`) is unchanged, so the surface still gets the full
+width; only the 280 dp sheet is suppressed. On a tablet `isPhoneLandscape` is false, so the drawer
+stays. No new back/gesture behaviour — these routes are full-screen with their own back arrow.
+
+### 2. Item detail — new phone-landscape layout (larger cover)
+
+Add a third content composable, `LibraryItemDetailContentPhoneLandscape`, selected in
+`LibraryItemDetailScreen` when `isPhoneLandscape`:
+
+- `isPhoneLandscape` → `LibraryItemDetailContentPhoneLandscape`
+- else `isExpanded` → existing `LibraryItemDetailContentTablet` (tablet, unchanged)
+- else → existing `LibraryItemDetailContent` (phone portrait / small phone, unchanged)
+
+Layout (a `Row` of two columns, mirroring mockup #1):
+
+- **Left column** (fixed ~240 dp, non-scrolling): a large cover that fills the available pane height
+  (`weight(1f, fill = false)` + `aspectRatio(2f/3f)`), then `ReadingProgressIndicator`, the
+  `AudiobookDurationLine` (when listenable), then `ActionRow`. Moving title/author **out** of this
+  column is what lets the cover be tall — that is the "larger cover".
+- **Right column** (`weight(1f)`, vertically scrollable): `TitleWithReadaloudIndicator`,
+  `AuthorByline`, `SeriesLine`, `CollapsibleDescription` (Summary), `MetadataLines`.
+
+Reuses the existing sub-composables; no new metadata. Identical for ebook and audiobook (the action
+row already adapts to `isReadable` / `isListenable`).
+
+### 3. Audiobook player — two-column landscape layout (Option A) + book details
+
+**Data.** Add two fields to `PlayerSurfaceState`:
+
+- `facts: String? = null` — a one-line summary built by the view-model, e.g.
+  `"Audiobook · 10h 53m · Science Fiction & Fantasy"` (duration + first genre(s); omit empties).
+- `description: String? = null` — the book blurb (`item.description`).
+
+`AudiobookPlayerViewModel` already loads the full `LibraryItem`, so it populates both into `meta`.
+Both default to null, so nothing else changes.
+
+**Layout.** Thread `windowSizeClass` from `MainScreen` → `AudiobookPlayerScreen`; compute
+`twoColumn = heightSizeClass == Compact` and pass it to `PlayerSurface`.
+
+- `twoColumn == false` (portrait phone, tablet) → **existing vertical layout, unchanged.** Details are
+  not shown here (out of scope — the request was about the landscape view).
+- `twoColumn == true` → a `Row`:
+  - **Left column** (fixed ~280 dp, centered): square cover at a fixed ~150 dp (not `fillMaxWidth`),
+    `title`, `author`, `currentChapterTitle`, then `facts` and a 3-line-clamped `description`.
+  - **Right column** (`weight(1f)`, vertically centered): `ChapterSeekBar`, `DualTime`,
+    `TransportRow`, and the speed pill — the existing controls, unchanged, just relocated. Because
+    the controls own their own column they are always fully visible regardless of window height.
+
+The back arrow and the swipe-down-to-read-along gesture in `AudiobookPlayerScreen` are unaffected
+(they wrap the whole surface).
+
+## Out of scope
+
+- Real tablet layouts (Expanded width, taller height) — unchanged.
+- Phone portrait detail and player — unchanged.
+- Book details on the portrait player.
+- Narrator (no field exists on `LibraryItem`); `facts` uses duration + genres.
+
+## Testing
+
+- Unit/Robolectric: `PlayerSurface` renders the transport controls when `twoColumn = true` (regression
+  for the off-screen-controls bug); `facts`/`description` shown when present.
+- `LibraryItemDetailScreen` selects the phone-landscape composable for Expanded-width + Compact-height
+  and the tablet composable for Expanded-width + non-Compact-height.
+- Manual device check on the Harness Medium Phone (landscape) and a tablet AVD for no-regression.

--- a/docs/superpowers/specs/2026-06-13-phone-landscape-detail-and-player-design.md
+++ b/docs/superpowers/specs/2026-06-13-phone-landscape-detail-and-player-design.md
@@ -19,56 +19,47 @@ On such a window this is wrong:
 
 A real **tablet** (Expanded width in *either* orientation) is fine as-is and must not change.
 
-## Discriminator: "phone landscape" vs "tablet"
+## Discriminator: "phone landscape" vs "tablet" (revised)
 
-A phone in landscape has `widthSizeClass == Expanded` **and** `heightSizeClass == Compact`
-(height < 480 dp). A tablet has a taller height class in both orientations. So:
+> Revised after device review: the first cut kept the tablet layouts on a phone-landscape window
+> and merely hid the drawer + added a bespoke detail layout. On a real device that looked wrong (a
+> squished Listen button, and the library still showed the permanent sidebar *and* a hamburger). The
+> simpler, correct framing is **"a phone in landscape is a phone"** — it must not get the tablet
+> layout at all. That is also ADR 0019's stated intent.
+
+The Tablet Layout now requires the window to be large in **both** dimensions:
 
 ```
-isPhoneLandscape = widthSizeClass == Expanded && heightSizeClass == Compact
+fun WindowSizeClass.isTabletLayout() =
+    widthSizeClass == Expanded && heightSizeClass != Compact
 ```
 
-`heightSizeClass` is not currently used anywhere in the app; it is available on the existing
-`WindowSizeClass` already threaded through `MainScreen` and the screens. This keeps the tablet view
-untouched (it never has Compact height).
+A large phone in landscape crosses Expanded width but is Compact in height (< 480 dp), so
+`isTabletLayout()` is false → phone UI. A real tablet is taller in both orientations → true. This one
+predicate (in `ui/TabletLayout.kt`) replaces the bare `widthSizeClass == Expanded` checks. ADR 0019
+is amended to match.
 
 ## Changes
 
-### 1. Hide the permanent drawer on detail + player (phone-landscape only)
+### 1. Phone-landscape uses the phone form factor
 
-`MainScreen.kt` already hides the permanent drawer panel on reader routes via
-`hidePermanentDrawerPanel`. Extend it:
+`MainScreen.kt`: `usePermanentDrawer = windowSizeClass.isTabletLayout()`. A phone in landscape
+therefore gets the **modal** drawer (hamburger) like any phone — no permanent sidebar, so the
+library no longer shows a sidebar *and* a hamburger. `hidePermanentDrawerPanel` reverts to
+`isReaderRoute(currentRoute)` only. The tablet is unaffected (still non-Compact height → permanent
+drawer).
 
-```
-hidePermanentDrawerPanel = isReaderRoute(currentRoute) ||
-    (isPhoneLandscape && isDetailOrPlayerRoute(currentRoute))
-```
+### 2. Item detail — the existing phone layout (no new composable)
 
-where `isDetailOrPlayerRoute` matches the `library_item_detail/…` and `audiobook_player/…` route
-prefixes. `usePermanentDrawer` (= `isExpanded`) is unchanged, so the surface still gets the full
-width; only the 280 dp sheet is suppressed. On a tablet `isPhoneLandscape` is false, so the drawer
-stays. No new back/gesture behaviour — these routes are full-screen with their own back arrow.
+`LibraryItemDetailScreen` selects on `isTabletLayout()`:
 
-### 2. Item detail — new phone-landscape layout (larger cover)
+- `isTabletLayout()` → existing `LibraryItemDetailContentTablet` (unchanged)
+- else → existing `LibraryItemDetailContent` (single-column phone layout)
 
-Add a third content composable, `LibraryItemDetailContentPhoneLandscape`, selected in
-`LibraryItemDetailScreen` when `isPhoneLandscape`:
-
-- `isPhoneLandscape` → `LibraryItemDetailContentPhoneLandscape`
-- else `isExpanded` → existing `LibraryItemDetailContentTablet` (tablet, unchanged)
-- else → existing `LibraryItemDetailContent` (phone portrait / small phone, unchanged)
-
-Layout (a `Row` of two columns, mirroring mockup #1):
-
-- **Left column** (fixed ~240 dp, non-scrolling): a large cover that fills the available pane height
-  (`weight(1f, fill = false)` + `aspectRatio(2f/3f)`), then `ReadingProgressIndicator`, the
-  `AudiobookDurationLine` (when listenable), then `ActionRow`. Moving title/author **out** of this
-  column is what lets the cover be tall — that is the "larger cover".
-- **Right column** (`weight(1f)`, vertically scrollable): `TitleWithReadaloudIndicator`,
-  `AuthorByline`, `SeriesLine`, `CollapsibleDescription` (Summary), `MetadataLines`.
-
-Reuses the existing sub-composables; no new metadata. Identical for ebook and audiobook (the action
-row already adapts to `isReadable` / `isListenable`).
+The phone layout already handles landscape (`fillMaxWidth(0.4f)` cover, single scrollable column), so
+a phone in landscape now gets a clean, familiar layout with a larger cover than the old tablet caps —
+without a bespoke composable. The custom `LibraryItemDetailContentPhoneLandscape` from the first cut
+is deleted.
 
 ### 3. Audiobook player — two-column landscape layout (Option A) + book details
 
@@ -82,7 +73,8 @@ row already adapts to `isReadable` / `isListenable`).
 Both default to null, so nothing else changes.
 
 **Layout.** Thread `windowSizeClass` from `MainScreen` → `AudiobookPlayerScreen`; compute
-`twoColumn = heightSizeClass == Compact` and pass it to `PlayerSurface`.
+`twoColumn = heightSizeClass == Compact` (any short window, i.e. a phone in landscape) and pass it to
+`PlayerSurface`. The player is full-screen (no drawer either way), so it keys on height alone.
 
 - `twoColumn == false` (portrait phone, tablet) → **existing vertical layout, unchanged.** Details are
   not shown here (out of scope — the request was about the landscape view).


### PR DESCRIPTION
## Summary

A large phone in **landscape** crosses the Material 3 `Expanded` width breakpoint (≥ 840dp), so it was wrongly inheriting the full **tablet** treatment: a permanent nav drawer, the two-pane item-detail layout (which squished the Read/Listen button), and a vertical audiobook player whose square cover pushed the transport controls off the short screen. This contradicted ADR 0019's own stated intent ("landscape phones do not get the Tablet Layout") — the ADR just assumed landscape phones stay in the Medium width bucket, which large phones don't.

This PR makes "a phone in landscape is a phone", and gives the detail + player layouts that suit a wide-but-short window.

## Changes

- **New predicate `WindowSizeClass.isTabletLayout()`** = Expanded width **AND** non-Compact height. A landscape phone is Compact-height, so it no longer qualifies as a tablet; a real tablet (taller in both orientations) still does. Replaces the bare `widthSizeClass == Expanded` checks in `MainScreen` (permanent vs modal drawer) and `LibraryItemDetailScreen`. **ADR 0019 amended** to document the height guard.
- **Item detail (phone-landscape):** a two-column layout — the cover sits alone in the left column at full height (a big cover), and everything else (title, author, actions, Summary, metadata) scrolls in the wide right column. Far less scrolling than the single column, and the wide right column gives the action row room so Read/Listen no longer squishes. Gated by a new `WindowSizeClass.isPhoneLandscape()`. Tablet two-pane and phone-portrait layouts are unchanged.
- **Audiobook player (phone-landscape):** a two-column `PlayerSurface` (cover + book details on the left, transport controls on the right) gated on Compact height, so the controls are never pushed off-screen. Adds a facts line (`Audiobook · 10h 53m · genre`) + a clamped blurb, sourced from the `LibraryItem` the view-model already loads. The back button uses `safeDrawingPadding()` so it clears the status bar / nav bar / display cutout in landscape.

## Tests

- `./gradlew test` — green (incl. new `BuildAudiobookFactsTest`).
- `./gradlew lint` — green.
- `make harness-test` (phone) — green (194 tests).
- `make harness-test-tablet` — green (5 tests, incl. `TabletContentWidthContainerTest` confirming the tablet path is unchanged).

## Review follow-ups addressed

- Memoized the player blurb's `AnnotatedString.fromHtml` parse (the player recomposes per position tick) and tightened the empty-details guard to treat a blank-but-non-null description as "no details".