### PR TITLE
feat(settings): reorder a server's libraries within the navigation drawer

### DIFF
--- a/app/src/androidTest/kotlin/com/riffle/app/feature/settings/ServerSettingsExpansionTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/settings/ServerSettingsExpansionTest.kt
@@ -1,9 +1,11 @@
 package com.riffle.app.feature.settings
 
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.isToggleable
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onFirst
+import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import com.riffle.core.domain.Library
@@ -45,6 +47,7 @@ class ServerSettingsExpansionTest {
                 libraryItems = listOf(libraryItem("Fiction"), libraryItem("Non-fiction")),
                 summary = null,
                 onSetLibraryVisible = { _, _ -> },
+                onReorderLibraries = {},
                 onOpenReadaloudMatches = {},
             )
         }
@@ -64,6 +67,7 @@ class ServerSettingsExpansionTest {
                 libraryItems = listOf(libraryItem("Fiction", visible = true)),
                 summary = null,
                 onSetLibraryVisible = { id, visible -> toggledLibrary = id; toggledVisible = visible },
+                onReorderLibraries = {},
                 onOpenReadaloudMatches = {},
             )
         }
@@ -75,6 +79,61 @@ class ServerSettingsExpansionTest {
     }
 
     @Test
+    fun movingALibraryDownPersistsTheSwappedOrder() {
+        var reordered: List<String>? = null
+        composeTestRule.setContent {
+            ServerSettingsExpansion(
+                server = server(ServerType.AUDIOBOOKSHELF, active = true),
+                libraryItems = listOf(libraryItem("Fiction"), libraryItem("Non-fiction")),
+                summary = null,
+                onSetLibraryVisible = { _, _ -> },
+                onReorderLibraries = { reordered = it },
+                onOpenReadaloudMatches = {},
+            )
+        }
+
+        composeTestRule.onNodeWithContentDescription("Move Fiction down").performClick()
+
+        assertEquals(listOf("Non-fiction", "Fiction"), reordered)
+    }
+
+    @Test
+    fun movingALibraryUpPersistsTheSwappedOrder() {
+        var reordered: List<String>? = null
+        composeTestRule.setContent {
+            ServerSettingsExpansion(
+                server = server(ServerType.AUDIOBOOKSHELF, active = true),
+                libraryItems = listOf(libraryItem("Fiction"), libraryItem("Non-fiction")),
+                summary = null,
+                onSetLibraryVisible = { _, _ -> },
+                onReorderLibraries = { reordered = it },
+                onOpenReadaloudMatches = {},
+            )
+        }
+
+        composeTestRule.onNodeWithContentDescription("Move Non-fiction up").performClick()
+
+        assertEquals(listOf("Non-fiction", "Fiction"), reordered)
+    }
+
+    @Test
+    fun firstLibraryCannotMoveUpAndLastCannotMoveDown() {
+        composeTestRule.setContent {
+            ServerSettingsExpansion(
+                server = server(ServerType.AUDIOBOOKSHELF, active = true),
+                libraryItems = listOf(libraryItem("Fiction"), libraryItem("Non-fiction")),
+                summary = null,
+                onSetLibraryVisible = { _, _ -> },
+                onReorderLibraries = {},
+                onOpenReadaloudMatches = {},
+            )
+        }
+
+        composeTestRule.onNodeWithContentDescription("Move Fiction up").assertIsNotEnabled()
+        composeTestRule.onNodeWithContentDescription("Move Non-fiction down").assertIsNotEnabled()
+    }
+
+    @Test
     fun inactiveAbsServerStillShowsItsLibraries() {
         composeTestRule.setContent {
             ServerSettingsExpansion(
@@ -82,6 +141,7 @@ class ServerSettingsExpansionTest {
                 libraryItems = listOf(libraryItem("Fiction")),
                 summary = null,
                 onSetLibraryVisible = { _, _ -> },
+                onReorderLibraries = {},
                 onOpenReadaloudMatches = {},
             )
         }
@@ -99,6 +159,7 @@ class ServerSettingsExpansionTest {
                 libraryItems = emptyList(),
                 summary = ReadaloudMatchSummary(unmatchedCount = 2, suggestedCount = 1, partiallyMatchedCount = 1, matchedCount = 3),
                 onSetLibraryVisible = { _, _ -> },
+                onReorderLibraries = {},
                 onOpenReadaloudMatches = { opened = true },
             )
         }

--- a/app/src/main/kotlin/com/riffle/app/feature/navigation/NavigationDrawerViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/navigation/NavigationDrawerViewModel.kt
@@ -4,8 +4,10 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.riffle.core.domain.ConnectivityObserver
 import com.riffle.core.domain.Library
+import com.riffle.core.domain.LibraryOrderPreferencesStore
 import com.riffle.core.domain.LibraryRepository
 import com.riffle.core.domain.LibraryVisibilityPreferencesStore
+import com.riffle.core.domain.orderLibraries
 import com.riffle.core.domain.Server
 import com.riffle.core.domain.ServerRepository
 import com.riffle.core.domain.ServerType
@@ -35,6 +37,7 @@ class NavigationDrawerViewModel @Inject constructor(
     private val serverRepository: ServerRepository,
     private val libraryRepository: LibraryRepository,
     private val visibilityStore: LibraryVisibilityPreferencesStore,
+    private val orderStore: LibraryOrderPreferencesStore,
     private val connectivityObserver: ConnectivityObserver,
     nowPlayingNavigator: NowPlayingNavigator,
     private val nowPlayingStore: NowPlayingStore,
@@ -65,9 +68,12 @@ class NavigationDrawerViewModel @Inject constructor(
             combine(
                 libraryRepository.observeLibraries(),
                 visibilityStore.hiddenLibraryIds(server.id),
-            ) { libraries, hiddenIds ->
-                // Exclude hidden libraries and the never-browsable Readaloud namespace row (ADR 0026).
-                libraries.filter { it.id !in hiddenIds && !it.isReadaloud }
+                orderStore.libraryOrder(server.id),
+            ) { libraries, hiddenIds, order ->
+                // Exclude hidden libraries and the never-browsable Readaloud namespace row (ADR 0026),
+                // then apply the user's custom per-server order (alphabetical fallback for the rest).
+                val visible = libraries.filter { it.id !in hiddenIds && !it.isReadaloud }
+                orderLibraries(visible, order)
             }
         }
         .stateIn(viewModelScope, SharingStarted.Eagerly, emptyList())

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/ReorderableLibraryList.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/ReorderableLibraryList.kt
@@ -1,0 +1,82 @@
+package com.riffle.app.feature.settings
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.KeyboardArrowUp
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.ListItemDefaults
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+
+/**
+ * The expanded-server "Enabled libraries" list. Each row carries up/down controls that move the
+ * library within the server's order, plus the visibility switch on the trailing edge.
+ *
+ * Reordering uses explicit move buttons rather than a drag gesture: this list lives inside the
+ * Settings vertical scroll, where a long-press-drag competes with the page scroll and drops are
+ * lost. A tap can't be stolen by the scroll, so each move reliably persists. On a move we hand the
+ * full new id order to [onReorder]; the displayed order then follows [items] from the ViewModel.
+ */
+@Composable
+internal fun ReorderableLibraryList(
+    items: List<LibraryUiItem>,
+    onSetLibraryVisible: (libraryId: String, visible: Boolean) -> Unit,
+    onReorder: (orderedLibraryIds: List<String>) -> Unit,
+) {
+    val transparentColors = ListItemDefaults.colors(containerColor = Color.Transparent)
+    items.forEachIndexed { index, item ->
+        ListItem(
+            colors = transparentColors,
+            modifier = Modifier.fillMaxWidth().padding(start = 24.dp),
+            headlineContent = { Text(item.library.name) },
+            trailingContent = {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    if (items.size > 1) {
+                        IconButton(
+                            onClick = { onReorder(items.idsWithSwap(index, index - 1)) },
+                            enabled = index > 0,
+                        ) {
+                            Icon(
+                                Icons.Filled.KeyboardArrowUp,
+                                contentDescription = "Move ${item.library.name} up",
+                            )
+                        }
+                        IconButton(
+                            onClick = { onReorder(items.idsWithSwap(index, index + 1)) },
+                            enabled = index < items.lastIndex,
+                        ) {
+                            Icon(
+                                Icons.Filled.KeyboardArrowDown,
+                                contentDescription = "Move ${item.library.name} down",
+                            )
+                        }
+                    }
+                    Switch(
+                        checked = item.isVisible,
+                        onCheckedChange = { visible -> onSetLibraryVisible(item.library.id, visible) },
+                        enabled = item.switchEnabled,
+                    )
+                }
+            },
+        )
+    }
+}
+
+/** The list's library ids with positions [i] and [j] swapped — the new full order to persist. */
+private fun List<LibraryUiItem>.idsWithSwap(i: Int, j: Int): List<String> {
+    val ids = map { it.library.id }.toMutableList()
+    val tmp = ids[i]
+    ids[i] = ids[j]
+    ids[j] = tmp
+    return ids
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsScreen.kt
@@ -29,7 +29,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SwipeToDismissBox
 import androidx.compose.material3.SwipeToDismissBoxValue
-import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
@@ -178,6 +177,9 @@ fun SettingsScreen(
                                     onSetLibraryVisible = { libraryId, visible ->
                                         viewModel.setLibraryVisible(server.id, libraryId, visible)
                                     },
+                                    onReorderLibraries = { orderedIds ->
+                                        viewModel.setLibraryOrder(server.id, orderedIds)
+                                    },
                                     onOpenReadaloudMatches = { viewModel.openReadaloudMatches(server.id) },
                                 )
                             }
@@ -301,6 +303,7 @@ internal fun ServerSettingsExpansion(
     libraryItems: List<LibraryUiItem>,
     summary: ReadaloudMatchSummary?,
     onSetLibraryVisible: (libraryId: String, visible: Boolean) -> Unit,
+    onReorderLibraries: (orderedLibraryIds: List<String>) -> Unit,
     onOpenReadaloudMatches: () -> Unit,
 ) {
     val transparentColors = ListItemDefaults.colors(containerColor = Color.Transparent)
@@ -315,20 +318,11 @@ internal fun ServerSettingsExpansion(
                 if (libraryItems.isEmpty()) {
                     ExpansionNote("No libraries found.")
                 } else {
-                    libraryItems.forEach { item ->
-                        ListItem(
-                            colors = transparentColors,
-                            modifier = Modifier.padding(start = 24.dp),
-                            headlineContent = { Text(item.library.name) },
-                            trailingContent = {
-                                Switch(
-                                    checked = item.isVisible,
-                                    onCheckedChange = { visible -> onSetLibraryVisible(item.library.id, visible) },
-                                    enabled = item.switchEnabled,
-                                )
-                            },
-                        )
-                    }
+                    ReorderableLibraryList(
+                        items = libraryItems,
+                        onSetLibraryVisible = onSetLibraryVisible,
+                        onReorder = onReorderLibraries,
+                    )
                 }
             }
             ServerType.STORYTELLER -> {

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsViewModel.kt
@@ -11,8 +11,10 @@ import com.riffle.core.domain.UpdateCheckResult
 import com.riffle.core.domain.UpdateDownloadState
 import com.riffle.core.domain.FormattingPreferences
 import com.riffle.core.domain.FormattingPreferencesStore
+import com.riffle.core.domain.LibraryOrderPreferencesStore
 import com.riffle.core.domain.LibraryRepository
 import com.riffle.core.domain.LibraryVisibilityPreferencesStore
+import com.riffle.core.domain.orderLibraries
 import com.riffle.core.domain.ReadaloudReviewRepository
 import com.riffle.core.domain.Server
 import com.riffle.core.domain.ServerType
@@ -42,6 +44,7 @@ class SettingsViewModel @Inject constructor(
     private val serverRepository: ServerRepository,
     private val libraryRepository: LibraryRepository,
     private val visibilityStore: LibraryVisibilityPreferencesStore,
+    private val orderStore: LibraryOrderPreferencesStore,
     private val wakeLockPreferencesStore: WakeLockPreferencesStore,
     private val volumeKeyPreferencesStore: VolumeKeyPreferencesStore,
     private val readaloudReviewRepository: ReadaloudReviewRepository,
@@ -172,9 +175,11 @@ class SettingsViewModel @Inject constructor(
                         combine(
                             libraryRepository.observeLibraries(server.id),
                             visibilityStore.hiddenLibraryIds(server.id),
-                        ) { libraries, hiddenIds ->
-                            val visibleCount = libraries.count { it.id !in hiddenIds }
-                            server.id to libraries.map { lib ->
+                            orderStore.libraryOrder(server.id),
+                        ) { libraries, hiddenIds, order ->
+                            val ordered = orderLibraries(libraries, order)
+                            val visibleCount = ordered.count { it.id !in hiddenIds }
+                            server.id to ordered.map { lib ->
                                 val isVisible = lib.id !in hiddenIds
                                 LibraryUiItem(
                                     library = lib,
@@ -237,6 +242,11 @@ class SettingsViewModel @Inject constructor(
             if (visible) visibilityStore.showLibrary(serverId, libraryId)
             else visibilityStore.hideLibrary(serverId, libraryId)
         }
+    }
+
+    /** Persist a new full ordering of [serverId]'s libraries after a drag-reorder in Settings. */
+    fun setLibraryOrder(serverId: String, orderedLibraryIds: List<String>) {
+        viewModelScope.launch { orderStore.setLibraryOrder(serverId, orderedLibraryIds) }
     }
 }
 

--- a/app/src/test/kotlin/com/riffle/app/feature/navigation/NavigationDrawerViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/navigation/NavigationDrawerViewModelTest.kt
@@ -9,6 +9,7 @@ import java.io.IOException
 import com.riffle.core.domain.Library
 import com.riffle.core.domain.LibraryItem
 import com.riffle.core.domain.LibraryRefreshResult
+import com.riffle.core.domain.LibraryOrderPreferencesStore
 import com.riffle.core.domain.LibraryRepository
 import com.riffle.core.domain.LibraryVisibilityPreferencesStore
 import com.riffle.core.domain.Series
@@ -119,6 +120,16 @@ class NavigationDrawerViewModelTest {
         }
     }
 
+    private val orderFlow = MutableStateFlow<Map<String, List<String>>>(emptyMap())
+
+    private fun fakeOrderStore(): LibraryOrderPreferencesStore = object : LibraryOrderPreferencesStore {
+        override fun libraryOrder(serverId: String): Flow<List<String>> =
+            orderFlow.map { it[serverId].orEmpty() }
+        override suspend fun setLibraryOrder(serverId: String, orderedIds: List<String>) {
+            orderFlow.update { it + (serverId to orderedIds) }
+        }
+    }
+
     private val isOnlineFlow = MutableStateFlow(true)
     private fun fakeConnectivity(): ConnectivityObserver = object : ConnectivityObserver {
         override val isOnline: kotlinx.coroutines.flow.StateFlow<Boolean> = isOnlineFlow
@@ -128,6 +139,7 @@ class NavigationDrawerViewModelTest {
         serverRepository = fakeServerRepo(),
         libraryRepository = fakeLibraryRepo(),
         visibilityStore = fakeVisibilityStore(),
+        orderStore = fakeOrderStore(),
         connectivityObserver = fakeConnectivity(),
         nowPlayingNavigator = com.riffle.app.playback.NowPlayingNavigator(),
         nowPlayingStore = com.riffle.app.playback.NowPlayingStore(),
@@ -240,6 +252,46 @@ class NavigationDrawerViewModelTest {
         testDispatcher.scheduler.advanceUntilIdle()
 
         assertEquals(listOf(library("lib-1")), vm.visibleLibraries.value)
+    }
+
+    @Test
+    fun `visibleLibraries applies the saved custom order`() = runTest {
+        serversFlow.value = listOf(server("srv-1", active = true))
+        librariesFlow.value = listOf(library("lib-1"), library("lib-2"), library("lib-3"))
+        orderFlow.value = mapOf("srv-1" to listOf("lib-3", "lib-1", "lib-2"))
+
+        val vm = makeVm()
+        backgroundScope.launch { vm.visibleLibraries.collect {} }
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(
+            listOf(library("lib-3"), library("lib-1"), library("lib-2")),
+            vm.visibleLibraries.value,
+        )
+    }
+
+    @Test
+    fun `visibleLibraries reorders live when the saved order changes after subscription`() = runTest {
+        // Mirrors the real bug report: the drawer is already showing libraries (alphabetical) when
+        // the user reorders in Settings — the new order must propagate to the open drawer.
+        serversFlow.value = listOf(server("srv-1", active = true))
+        librariesFlow.value = listOf(library("lib-1"), library("lib-2"), library("lib-3"))
+
+        val vm = makeVm()
+        backgroundScope.launch { vm.visibleLibraries.collect {} }
+        testDispatcher.scheduler.advanceUntilIdle()
+        assertEquals(
+            listOf(library("lib-1"), library("lib-2"), library("lib-3")),
+            vm.visibleLibraries.value,
+        )
+
+        orderFlow.value = mapOf("srv-1" to listOf("lib-2", "lib-3", "lib-1"))
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(
+            listOf(library("lib-2"), library("lib-3"), library("lib-1")),
+            vm.visibleLibraries.value,
+        )
     }
 
     @Test

--- a/app/src/test/kotlin/com/riffle/app/feature/settings/SettingsViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/settings/SettingsViewModelTest.kt
@@ -13,6 +13,7 @@ import com.riffle.core.domain.FormattingPreferencesStore
 import com.riffle.core.domain.Library
 import com.riffle.core.domain.LibraryItem
 import com.riffle.core.domain.LibraryRefreshResult
+import com.riffle.core.domain.LibraryOrderPreferencesStore
 import com.riffle.core.domain.LibraryRepository
 import com.riffle.core.domain.LibraryVisibilityPreferencesStore
 import com.riffle.core.domain.AbsPickerItem
@@ -96,6 +97,7 @@ class SettingsViewModelTest {
     private val serversFlow = MutableStateFlow<List<Server>>(emptyList())
     private val librariesFlow = MutableStateFlow<List<Library>>(emptyList())
     private val hiddenFlow = MutableStateFlow<Map<String, Set<String>>>(emptyMap())
+    private val orderFlow = MutableStateFlow<Map<String, List<String>>>(emptyMap())
 
     private fun fakeServerRepo(): ServerRepository = object : ServerRepository {
         override fun observeAll(): Flow<List<Server>> = serversFlow
@@ -150,6 +152,14 @@ class SettingsViewModelTest {
         }
     }
 
+    private fun fakeOrderStore(): LibraryOrderPreferencesStore = object : LibraryOrderPreferencesStore {
+        override fun libraryOrder(serverId: String): Flow<List<String>> =
+            orderFlow.map { it[serverId].orEmpty() }
+        override suspend fun setLibraryOrder(serverId: String, orderedIds: List<String>) {
+            orderFlow.update { it + (serverId to orderedIds) }
+        }
+    }
+
     private val isOnlineFlow = MutableStateFlow(true)
     private val fakeConnectivity = object : ConnectivityObserver {
         override val isOnline: kotlinx.coroutines.flow.StateFlow<Boolean> = isOnlineFlow
@@ -184,6 +194,7 @@ class SettingsViewModelTest {
         serverRepository = fakeServerRepo(),
         libraryRepository = fakeLibraryRepo(),
         visibilityStore = fakeVisibilityStore(),
+        orderStore = fakeOrderStore(),
         wakeLockPreferencesStore = noOpWakeLockStore,
         volumeKeyPreferencesStore = fakeVolumeKeyStore,
         readaloudReviewRepository = fakeReviewRepo,
@@ -301,6 +312,30 @@ class SettingsViewModelTest {
 
         val hidden = hiddenFlow.value["srv-1"].orEmpty()
         assertFalse("lib-1" in hidden)
+    }
+
+    @Test
+    fun `setLibraryOrder persists the given order to the store`() = runTest {
+        val vm = makeViewModel()
+        vm.setLibraryOrder("srv-1", listOf("lib-3", "lib-1", "lib-2"))
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(listOf("lib-3", "lib-1", "lib-2"), orderFlow.value["srv-1"])
+    }
+
+    @Test
+    fun `libraryUiItemsByServer reflects the saved custom order`() = runTest {
+        serversFlow.value = listOf(server("srv-1", active = true))
+        librariesFlow.value = listOf(library("lib-1"), library("lib-2"), library("lib-3"))
+        orderFlow.value = mapOf("srv-1" to listOf("lib-2", "lib-3", "lib-1"))
+        val vm = makeViewModel()
+        backgroundScope.launch { vm.libraryUiItemsByServer.collect {} }
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(
+            listOf("lib-2", "lib-3", "lib-1"),
+            vm.libraryUiItemsByServer.value["srv-1"].orEmpty().map { it.library.id },
+        )
     }
 
     @Test

--- a/core/data/src/main/kotlin/com/riffle/core/data/LibraryOrderPreferencesStoreImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/LibraryOrderPreferencesStoreImpl.kt
@@ -1,0 +1,32 @@
+package com.riffle.core.data
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import com.riffle.core.data.di.LibraryOrderPreferencesDataStore
+import com.riffle.core.domain.LibraryOrderPreferencesStore
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+
+class LibraryOrderPreferencesStoreImpl @Inject constructor(
+    @param:LibraryOrderPreferencesDataStore private val dataStore: DataStore<Preferences>,
+) : LibraryOrderPreferencesStore {
+
+    // Order matters, so we can't use a Preferences string-set (unordered). We persist the ordered
+    // ids as a single newline-delimited string; library ids are server-issued and never contain
+    // newlines.
+    override fun libraryOrder(serverId: String): Flow<List<String>> =
+        dataStore.data.map { prefs ->
+            prefs[key(serverId)]?.split('\n')?.filter { it.isNotEmpty() }.orEmpty()
+        }
+
+    override suspend fun setLibraryOrder(serverId: String, orderedIds: List<String>) {
+        dataStore.edit { prefs ->
+            prefs[key(serverId)] = orderedIds.joinToString("\n")
+        }
+    }
+
+    private fun key(serverId: String) = stringPreferencesKey("order_$serverId")
+}

--- a/core/data/src/main/kotlin/com/riffle/core/data/di/DataModule.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/di/DataModule.kt
@@ -18,6 +18,7 @@ import com.riffle.core.data.AudiobookDownloadRepositoryImpl
 import com.riffle.core.data.AudiobookRepositoryImpl
 import com.riffle.core.data.LibraryRepositoryImpl
 import com.riffle.core.data.AnnotationStoreImpl
+import com.riffle.core.data.LibraryOrderPreferencesStoreImpl
 import com.riffle.core.data.LibraryVisibilityPreferencesStoreImpl
 import com.riffle.core.data.LocalStoreImpl
 import com.riffle.core.data.LocalStoreMigrator
@@ -52,6 +53,7 @@ import com.riffle.core.domain.FormattingPreferencesStore
 import com.riffle.core.domain.AudiobookDownloadRepository
 import com.riffle.core.domain.AudiobookRepository
 import com.riffle.core.domain.LibraryRepository
+import com.riffle.core.domain.LibraryOrderPreferencesStore
 import com.riffle.core.domain.LibraryVisibilityPreferencesStore
 import com.riffle.core.domain.LocalStore
 import com.riffle.core.domain.LibraryItemOfflineAvailability
@@ -110,6 +112,10 @@ annotation class FormattingPreferencesDataStore
 @Qualifier
 @Retention(AnnotationRetention.BINARY)
 annotation class LibraryVisibilityPreferencesDataStore
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class LibraryOrderPreferencesDataStore
 
 @Qualifier
 @Retention(AnnotationRetention.BINARY)
@@ -262,6 +268,10 @@ abstract class DataModule {
     @Binds
     @Singleton
     abstract fun bindLibraryVisibilityPreferencesStore(impl: LibraryVisibilityPreferencesStoreImpl): LibraryVisibilityPreferencesStore
+
+    @Binds
+    @Singleton
+    abstract fun bindLibraryOrderPreferencesStore(impl: LibraryOrderPreferencesStoreImpl): LibraryOrderPreferencesStore
 
     @Binds
     @Singleton
@@ -548,6 +558,13 @@ abstract class DataModule {
             @ApplicationContext context: Context
         ): DataStore<Preferences> = context.libraryVisibilityPreferencesDataStore
 
+
+        @Provides
+        @Singleton
+        @LibraryOrderPreferencesDataStore
+        fun provideLibraryOrderPreferencesDataStore(
+            @ApplicationContext context: Context
+        ): DataStore<Preferences> = context.libraryOrderPreferencesDataStore
 
         @Provides
         @Singleton

--- a/core/data/src/main/kotlin/com/riffle/core/data/di/LibraryOrderPreferencesDataStoreExt.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/di/LibraryOrderPreferencesDataStoreExt.kt
@@ -1,0 +1,9 @@
+package com.riffle.core.data.di
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.preferencesDataStore
+
+val Context.libraryOrderPreferencesDataStore: DataStore<Preferences>
+    by preferencesDataStore(name = "library_order")

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/LibraryOrderPreferencesStore.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/LibraryOrderPreferencesStore.kt
@@ -1,0 +1,16 @@
+package com.riffle.core.domain
+
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Per-server, device-local custom ordering of a server's libraries. Sibling to
+ * [LibraryVisibilityPreferencesStore]: order is a personal display preference and is never synced.
+ *
+ * The stored list holds library ids in the user's chosen order. It may be partial — libraries not
+ * present in it (e.g. newly synced ones) fall back to their natural (alphabetical) position after
+ * the ordered ones, via [orderLibraries].
+ */
+interface LibraryOrderPreferencesStore {
+    fun libraryOrder(serverId: String): Flow<List<String>>
+    suspend fun setLibraryOrder(serverId: String, orderedIds: List<String>)
+}

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/LibraryOrdering.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/LibraryOrdering.kt
@@ -1,0 +1,17 @@
+package com.riffle.core.domain
+
+/**
+ * Applies a saved per-server [orderedIds] preference to [libraries]: libraries named in
+ * [orderedIds] come first, in that order; any library not named (e.g. newly synced) keeps its
+ * natural position by being appended afterwards, preserving the incoming relative order.
+ *
+ * Ids in [orderedIds] that no longer match a library are skipped.
+ */
+fun orderLibraries(libraries: List<Library>, orderedIds: List<String>): List<Library> {
+    if (orderedIds.isEmpty()) return libraries
+    val byId = libraries.associateBy { it.id }
+    val orderedSet = orderedIds.toHashSet()
+    val ordered = orderedIds.mapNotNull { byId[it] }
+    val remaining = libraries.filterNot { it.id in orderedSet }
+    return ordered + remaining
+}

--- a/core/domain/src/test/kotlin/com/riffle/core/domain/LibraryOrderingTest.kt
+++ b/core/domain/src/test/kotlin/com/riffle/core/domain/LibraryOrderingTest.kt
@@ -1,0 +1,47 @@
+package com.riffle.core.domain
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class LibraryOrderingTest {
+
+    private fun lib(id: String) = Library(id = id, name = id, mediaType = "book", isUnsupported = false)
+
+    @Test
+    fun `empty order preserves the incoming order`() {
+        val libs = listOf(lib("a"), lib("b"), lib("c"))
+        assertEquals(libs, orderLibraries(libs, emptyList()))
+    }
+
+    @Test
+    fun `full order reorders to match`() {
+        val libs = listOf(lib("a"), lib("b"), lib("c"))
+        assertEquals(
+            listOf(lib("c"), lib("a"), lib("b")),
+            orderLibraries(libs, listOf("c", "a", "b")),
+        )
+    }
+
+    @Test
+    fun `libraries not named in the order are appended in their incoming order`() {
+        // 'd' was synced after the order was saved — it falls to the end, keeping its natural spot.
+        val libs = listOf(lib("a"), lib("b"), lib("c"), lib("d"))
+        assertEquals(
+            listOf(lib("c"), lib("a"), lib("d")),
+            orderLibraries(listOf(lib("a"), lib("c"), lib("d")), listOf("c", "a", "b")),
+        )
+        assertEquals(
+            listOf(lib("b"), lib("a"), lib("c"), lib("d")),
+            orderLibraries(libs, listOf("b", "a")),
+        )
+    }
+
+    @Test
+    fun `ids in the order that no longer match a library are skipped`() {
+        val libs = listOf(lib("a"), lib("b"))
+        assertEquals(
+            listOf(lib("b"), lib("a")),
+            orderLibraries(libs, listOf("gone", "b", "a")),
+        )
+    }
+}


### PR DESCRIPTION
## What

Adds the ability to rearrange the libraries of a server. The order is set in **Settings** (each library in the expanded server row gets up/down move controls) and drives both the Settings list and the **navigation drawer** (burger menu), which previously always listed libraries alphabetically.

## How

- **Persistence** — a new per-server, device-local `library_order` Preferences DataStore, sibling to `library_visibility`. The order is stored as a newline-joined id string under `order_<serverId>` (a Preferences string-set can't preserve order). New `LibraryOrderPreferencesStore` domain interface + impl, wired in `DataModule` with its own qualifier and `@Singleton` binding.
- **Ordering** — a pure `orderLibraries(libraries, orderedIds)` helper in `core/domain`: saved ids first in order, any library not yet in the saved order (e.g. newly synced) falls back to its natural alphabetical position at the end. Applied in both `NavigationDrawerViewModel.visibleLibraries` and `SettingsViewModel.libraryUiItemsByServer`.
- **UI** — `ReorderableLibraryList` renders each library with up/down move buttons (first row's up / last row's down disabled) alongside the existing visibility switch.

### Why move buttons instead of drag
The list lives inside the Settings vertical scroll. A hand-rolled long-press-drag competes with the page scroll, so the drop is stolen and the new order never persists (verified failing on-device twice). A tap can't be stolen by the scroll, so each move reliably persists. If real drag handles are wanted later, a dedicated reorderable library (e.g. `sh.calvin.reorderable`) that handles nested scroll should be used rather than hand-rolling it.

## Tested

- `./gradlew test` (incl. new `LibraryOrderingTest`, and behavioral tests in `SettingsViewModelTest` / `NavigationDrawerViewModelTest` covering persist + live reorder of the drawer)
- `./gradlew lint`
- `make harness-test` — 202 tests, 0 failed (incl. `ServerSettingsExpansionTest`: move-down / move-up / disabled-edge cases)
- `make harness-test-tablet` — green