### PR TITLE
feat(settings): app-wide dark/light/system theme toggle

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/MainActivity.kt
+++ b/app/src/main/kotlin/com/riffle/app/MainActivity.kt
@@ -9,12 +9,18 @@ import android.view.ViewGroup
 import androidx.activity.SystemBarStyle
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSizeClassApi
 import androidx.compose.material3.windowsizeclass.calculateWindowSizeClass
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalView
+import androidx.core.view.WindowCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
 import androidx.fragment.app.FragmentFactory
@@ -27,6 +33,8 @@ import com.riffle.app.navigation.MainScreen
 import com.riffle.app.playback.NowPlayingNavigator
 import com.riffle.app.ui.BottomNavBarScrim
 import com.riffle.app.ui.theme.RiffleTheme
+import com.riffle.core.domain.AppTheme
+import com.riffle.core.domain.AppThemeStore
 import com.riffle.core.domain.VolumeKeyPreferencesStore
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.SharingStarted
@@ -41,10 +49,12 @@ class MainActivity : FragmentActivity() {
     @Inject lateinit var volumeNavigationController: VolumeNavigationController
     @Inject lateinit var readerStateHolder: ReaderStateHolder
     @Inject lateinit var volumeKeyPreferencesStore: VolumeKeyPreferencesStore
+    @Inject lateinit var appThemeStore: AppThemeStore
     @Inject lateinit var nowPlayingNavigator: NowPlayingNavigator
 
     private lateinit var volumeNavEnabled: StateFlow<Boolean>
     private lateinit var invertVolumeKeys: StateFlow<Boolean>
+    private lateinit var appTheme: StateFlow<AppTheme>
 
     override fun onCreate(savedInstanceState: Bundle?) {
         if (savedInstanceState != null) {
@@ -62,6 +72,8 @@ class MainActivity : FragmentActivity() {
             .stateIn(lifecycleScope, SharingStarted.Eagerly, true)
         invertVolumeKeys = volumeKeyPreferencesStore.invertVolumeKeys
             .stateIn(lifecycleScope, SharingStarted.Eagerly, false)
+        appTheme = appThemeStore.appTheme
+            .stateIn(lifecycleScope, SharingStarted.Eagerly, AppTheme.System)
         // Both system bars are fully transparent at the OS level. The app draws its own
         // scrim under the nav-bar inset area (BottomNavBarScrim, applied globally in
         // setContent below) so the look is identical across gesture-nav devices (where
@@ -79,7 +91,19 @@ class MainActivity : FragmentActivity() {
         }
         handleIntent(intent)
         setContent {
-            RiffleTheme {
+            val theme by appTheme.collectAsState()
+            val isDark = theme.isDark(isSystemInDarkTheme())
+            // Keep the transparent system-bar icon contrast in step with the chosen chrome theme,
+            // overriding the system-driven default from enableEdgeToEdge above (otherwise a forced
+            // Dark theme under a Light OS would render dark icons on the dark top app bar).
+            val view = LocalView.current
+            SideEffect {
+                WindowCompat.getInsetsController(window, view).run {
+                    isAppearanceLightStatusBars = !isDark
+                    isAppearanceLightNavigationBars = !isDark
+                }
+            }
+            RiffleTheme(darkTheme = isDark) {
                 @OptIn(ExperimentalMaterial3WindowSizeClassApi::class)
                 val windowSizeClass = calculateWindowSizeClass(this)
                 Box(Modifier.fillMaxSize()) {

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsScreen.kt
@@ -27,6 +27,9 @@ import androidx.compose.material3.ListItem
 import androidx.compose.material3.ListItemDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SegmentedButton
+import androidx.compose.material3.SegmentedButtonDefaults
+import androidx.compose.material3.SingleChoiceSegmentedButtonRow
 import androidx.compose.material3.SwipeToDismissBox
 import androidx.compose.material3.SwipeToDismissBoxValue
 import androidx.compose.material3.Switch
@@ -54,6 +57,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.riffle.app.feature.reader.FormattingPanel
 import com.riffle.app.ui.TabletContentWidthContainer
+import com.riffle.core.domain.AppTheme
 import com.riffle.core.domain.Server
 import com.riffle.core.domain.ServerType
 import kotlinx.coroutines.launch
@@ -74,6 +78,7 @@ fun SettingsScreen(
     val keepScreenOn by viewModel.keepScreenOn.collectAsState()
     val volumeKeyNavigationEnabled by viewModel.volumeKeyNavigationEnabled.collectAsState()
     val invertVolumeKeys by viewModel.invertVolumeKeys.collectAsState()
+    val appTheme by viewModel.appTheme.collectAsState()
     val servers by viewModel.servers.collectAsState()
     val serverVersions by viewModel.serverVersions.collectAsState()
     val libraryItemsByServer by viewModel.libraryUiItemsByServer.collectAsState()
@@ -195,6 +200,18 @@ fun SettingsScreen(
                 HorizontalDivider()
 
                 Text(
+                    text = "Appearance",
+                    style = MaterialTheme.typography.titleSmall,
+                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+                )
+                HorizontalDivider()
+                AppThemeRow(
+                    appTheme = appTheme,
+                    onAppThemeChange = { viewModel.setAppTheme(it) },
+                )
+                HorizontalDivider()
+
+                Text(
                     text = "Reading",
                     style = MaterialTheme.typography.titleSmall,
                     modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
@@ -288,6 +305,37 @@ fun SettingsScreen(
             onInvertVolumeKeysChange = { viewModel.setInvertVolumeKeys(it) },
             fullScreen = true,
         )
+    }
+}
+
+/**
+ * App-chrome theme selector (Light / Dark / System). Independent of the reader's content theme —
+ * this drives the Material color scheme of everything outside the reading surface.
+ */
+@Composable
+private fun AppThemeRow(
+    appTheme: AppTheme,
+    onAppThemeChange: (AppTheme) -> Unit,
+) {
+    val options = listOf(
+        AppTheme.Light to "Light",
+        AppTheme.Dark to "Dark",
+        AppTheme.System to "System",
+    )
+    SingleChoiceSegmentedButtonRow(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 8.dp),
+    ) {
+        options.forEachIndexed { index, (theme, label) ->
+            SegmentedButton(
+                selected = theme == appTheme,
+                onClick = { onAppThemeChange(theme) },
+                shape = SegmentedButtonDefaults.itemShape(index = index, count = options.size),
+            ) {
+                Text(label)
+            }
+        }
     }
 }
 

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsViewModel.kt
@@ -3,6 +3,8 @@ package com.riffle.app.feature.settings
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.riffle.app.BuildConfig
+import com.riffle.core.domain.AppTheme
+import com.riffle.core.domain.AppThemeStore
 import com.riffle.core.domain.AppUpdateRepository
 import com.riffle.core.domain.ConnectivityObserver
 import com.riffle.core.domain.CrashReport
@@ -44,6 +46,7 @@ class SettingsViewModel @Inject constructor(
     private val visibilityStore: LibraryVisibilityPreferencesStore,
     private val wakeLockPreferencesStore: WakeLockPreferencesStore,
     private val volumeKeyPreferencesStore: VolumeKeyPreferencesStore,
+    private val appThemeStore: AppThemeStore,
     private val readaloudReviewRepository: ReadaloudReviewRepository,
     private val connectivityObserver: ConnectivityObserver,
     private val appUpdateRepository: AppUpdateRepository,
@@ -102,6 +105,9 @@ class SettingsViewModel @Inject constructor(
 
     val invertVolumeKeys: StateFlow<Boolean> = volumeKeyPreferencesStore.invertVolumeKeys
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), false)
+
+    val appTheme: StateFlow<AppTheme> = appThemeStore.appTheme
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), AppTheme.System)
 
     val servers: StateFlow<List<Server>> = serverRepository.observeAll()
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
@@ -198,6 +204,10 @@ class SettingsViewModel @Inject constructor(
 
     fun setKeepScreenOn(value: Boolean) {
         viewModelScope.launch { wakeLockPreferencesStore.setKeepScreenOn(value) }
+    }
+
+    fun setAppTheme(value: AppTheme) {
+        viewModelScope.launch { appThemeStore.setAppTheme(value) }
     }
 
     fun setVolumeKeyNavigationEnabled(value: Boolean) {

--- a/app/src/test/kotlin/com/riffle/app/feature/settings/SettingsViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/settings/SettingsViewModelTest.kt
@@ -1,5 +1,7 @@
 package com.riffle.app.feature.settings
 
+import com.riffle.core.domain.AppTheme
+import com.riffle.core.domain.AppThemeStore
 import com.riffle.core.domain.AuthenticateResult
 import com.riffle.core.domain.CommitServerResult
 import com.riffle.core.domain.Collection
@@ -76,6 +78,12 @@ class SettingsViewModelTest {
         override val invertVolumeKeys: Flow<Boolean> = invertVolumeKeysFlow
         override suspend fun setVolumeKeyNavigationEnabled(value: Boolean) { volumeNavEnabledFlow.value = value }
         override suspend fun setInvertVolumeKeys(value: Boolean) { invertVolumeKeysFlow.value = value }
+    }
+
+    private val appThemeFlow = MutableStateFlow(AppTheme.System)
+    private val fakeAppThemeStore = object : AppThemeStore {
+        override val appTheme: Flow<AppTheme> = appThemeFlow
+        override suspend fun setAppTheme(value: AppTheme) { appThemeFlow.value = value }
     }
 
     private fun server(
@@ -186,6 +194,7 @@ class SettingsViewModelTest {
         visibilityStore = fakeVisibilityStore(),
         wakeLockPreferencesStore = noOpWakeLockStore,
         volumeKeyPreferencesStore = fakeVolumeKeyStore,
+        appThemeStore = fakeAppThemeStore,
         readaloudReviewRepository = fakeReviewRepo,
         connectivityObserver = fakeConnectivity,
         appUpdateRepository = fakeAppUpdateRepo,
@@ -446,5 +455,29 @@ class SettingsViewModelTest {
         testDispatcher.scheduler.advanceUntilIdle()
 
         assertEquals(true, invertVolumeKeysFlow.first())
+    }
+
+    // --- app theme ---
+
+    @Test
+    fun `appTheme StateFlow reflects store default value`() = runTest {
+        appThemeFlow.value = AppTheme.System
+        val vm = makeViewModel()
+        backgroundScope.launch { vm.appTheme.collect {} }
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(AppTheme.System, vm.appTheme.value)
+    }
+
+    @Test
+    fun `setAppTheme Dark updates the store`() = runTest {
+        val vm = makeViewModel()
+        backgroundScope.launch { vm.appTheme.collect {} }
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        vm.setAppTheme(AppTheme.Dark)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(AppTheme.Dark, appThemeFlow.first())
     }
 }

--- a/core/data/src/main/kotlin/com/riffle/core/data/AppThemeStoreImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/AppThemeStoreImpl.kt
@@ -1,0 +1,32 @@
+package com.riffle.core.data
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import com.riffle.core.data.di.AppThemePreferencesDataStore
+import com.riffle.core.domain.AppTheme
+import com.riffle.core.domain.AppThemeStore
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+
+class AppThemeStoreImpl @Inject constructor(
+    @param:AppThemePreferencesDataStore private val dataStore: DataStore<Preferences>,
+) : AppThemeStore {
+
+    override val appTheme: Flow<AppTheme> = dataStore.data.map { prefs ->
+        // Unknown/missing values fall back to System rather than crashing on a renamed enum.
+        prefs[KEY_APP_THEME]?.let { stored ->
+            AppTheme.entries.firstOrNull { it.name == stored }
+        } ?: AppTheme.System
+    }
+
+    override suspend fun setAppTheme(value: AppTheme) {
+        dataStore.edit { prefs -> prefs[KEY_APP_THEME] = value.name }
+    }
+
+    private companion object {
+        val KEY_APP_THEME = stringPreferencesKey("app_theme")
+    }
+}

--- a/core/data/src/main/kotlin/com/riffle/core/data/di/AppThemePreferencesDataStoreExt.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/di/AppThemePreferencesDataStoreExt.kt
@@ -1,0 +1,9 @@
+package com.riffle.core.data.di
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.preferencesDataStore
+
+val Context.appThemePreferencesDataStore: DataStore<Preferences>
+    by preferencesDataStore(name = "app_theme_preferences")

--- a/core/data/src/main/kotlin/com/riffle/core/data/di/DataModule.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/di/DataModule.kt
@@ -36,6 +36,7 @@ import com.riffle.core.data.ServerRepositoryImpl
 import com.riffle.core.data.ToReadRepository
 import com.riffle.core.data.ToReadRepositoryImpl
 import com.riffle.core.data.CoverGridDensityStoreImpl
+import com.riffle.core.data.AppThemeStoreImpl
 import com.riffle.core.data.VolumeKeyPreferencesStoreImpl
 import com.riffle.core.data.WakeLockPreferencesStoreImpl
 import com.riffle.core.domain.AnnotationStore
@@ -66,6 +67,7 @@ import com.riffle.core.domain.ReadingSessionRepository
 import com.riffle.core.domain.ServerRepository
 import com.riffle.core.domain.TokenStorage
 import com.riffle.core.domain.CoverGridDensityStore
+import com.riffle.core.domain.AppThemeStore
 import com.riffle.core.domain.VolumeKeyPreferencesStore
 import com.riffle.core.domain.WakeLockPreferencesStore
 import com.riffle.core.data.AudiobookBundleDownloader
@@ -118,6 +120,10 @@ annotation class WakeLockPreferencesDataStore
 @Qualifier
 @Retention(AnnotationRetention.BINARY)
 annotation class VolumeKeyPreferencesDataStore
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class AppThemePreferencesDataStore
 
 @Qualifier
 @Retention(AnnotationRetention.BINARY)
@@ -270,6 +276,10 @@ abstract class DataModule {
     @Binds
     @Singleton
     abstract fun bindVolumeKeyPreferencesStore(impl: VolumeKeyPreferencesStoreImpl): VolumeKeyPreferencesStore
+
+    @Binds
+    @Singleton
+    abstract fun bindAppThemeStore(impl: AppThemeStoreImpl): AppThemeStore
 
     @Binds
     @Singleton
@@ -562,6 +572,13 @@ abstract class DataModule {
         fun provideVolumeKeyPreferencesDataStore(
             @ApplicationContext context: Context
         ): DataStore<Preferences> = context.volumeKeyPreferencesDataStore
+
+        @Provides
+        @Singleton
+        @AppThemePreferencesDataStore
+        fun provideAppThemePreferencesDataStore(
+            @ApplicationContext context: Context
+        ): DataStore<Preferences> = context.appThemePreferencesDataStore
 
         @Provides
         @Singleton

--- a/core/data/src/test/kotlin/com/riffle/core/data/AppThemeStoreTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/AppThemeStoreTest.kt
@@ -1,0 +1,75 @@
+package com.riffle.core.data
+
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import com.riffle.core.domain.AppTheme
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class AppThemeStoreTest {
+
+    @get:Rule
+    val tmp = TemporaryFolder()
+
+    private val dispatcher = UnconfinedTestDispatcher()
+    private val testScope = TestScope(dispatcher)
+
+    private fun buildStore() = AppThemeStoreImpl(
+        PreferenceDataStoreFactory.create(
+            scope = testScope.backgroundScope,
+            produceFile = { tmp.newFile("app_theme_prefs.preferences_pb") },
+        )
+    )
+
+    @Test
+    fun `default appTheme is System when DataStore is empty`() = testScope.runTest {
+        assertEquals(AppTheme.System, buildStore().appTheme.first())
+    }
+
+    @Test
+    fun `setAppTheme Dark returns Dark on read`() = testScope.runTest {
+        val store = buildStore()
+        store.setAppTheme(AppTheme.Dark)
+        assertEquals(AppTheme.Dark, store.appTheme.first())
+    }
+
+    @Test
+    fun `setAppTheme Light after Dark returns Light`() = testScope.runTest {
+        val store = buildStore()
+        store.setAppTheme(AppTheme.Dark)
+        store.setAppTheme(AppTheme.Light)
+        assertEquals(AppTheme.Light, store.appTheme.first())
+    }
+
+    @Test
+    fun `appTheme persists across store instances`() {
+        val file = tmp.newFile("app_theme_round_trip.preferences_pb")
+
+        val writeScope = CoroutineScope(UnconfinedTestDispatcher() + Job())
+        runBlocking {
+            val store = AppThemeStoreImpl(
+                PreferenceDataStoreFactory.create(scope = writeScope, produceFile = { file })
+            )
+            store.setAppTheme(AppTheme.Dark)
+        }
+        writeScope.cancel()
+
+        val readScope = CoroutineScope(UnconfinedTestDispatcher() + Job())
+        val store2 = AppThemeStoreImpl(
+            PreferenceDataStoreFactory.create(scope = readScope, produceFile = { file })
+        )
+        assertEquals(AppTheme.Dark, runBlocking { store2.appTheme.first() })
+        readScope.cancel()
+    }
+}

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/AppTheme.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/AppTheme.kt
@@ -1,0 +1,30 @@
+package com.riffle.core.domain
+
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * The user-selected theme for the app chrome (everything outside the reading surface). Deliberately
+ * separate from the reader's content theme ([FormattingPreferences.theme]): this controls the
+ * Material color scheme of the library, home, settings and player, while the reader keeps its own
+ * Light/Dark/DarkDim/Sepia/Auto reading-comfort setting.
+ */
+enum class AppTheme {
+    Light,
+    Dark,
+
+    /** Follow the OS dark-mode setting. */
+    System;
+
+    /** Resolves this choice to a concrete light/dark decision given the current system setting. */
+    fun isDark(systemInDark: Boolean): Boolean = when (this) {
+        Light -> false
+        Dark -> true
+        System -> systemInDark
+    }
+}
+
+/** Device-local persistence for the app-chrome theme. Defaults to [AppTheme.System]. */
+interface AppThemeStore {
+    val appTheme: Flow<AppTheme>
+    suspend fun setAppTheme(value: AppTheme)
+}

--- a/core/domain/src/test/kotlin/com/riffle/core/domain/AppThemeTest.kt
+++ b/core/domain/src/test/kotlin/com/riffle/core/domain/AppThemeTest.kt
@@ -1,0 +1,25 @@
+package com.riffle.core.domain
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class AppThemeTest {
+
+    @Test
+    fun `Light is never dark`() {
+        assertEquals(false, AppTheme.Light.isDark(systemInDark = true))
+        assertEquals(false, AppTheme.Light.isDark(systemInDark = false))
+    }
+
+    @Test
+    fun `Dark is always dark`() {
+        assertEquals(true, AppTheme.Dark.isDark(systemInDark = true))
+        assertEquals(true, AppTheme.Dark.isDark(systemInDark = false))
+    }
+
+    @Test
+    fun `System follows the OS setting`() {
+        assertEquals(true, AppTheme.System.isDark(systemInDark = true))
+        assertEquals(false, AppTheme.System.isDark(systemInDark = false))
+    }
+}


### PR DESCRIPTION
## What

Adds a user-selectable **app-chrome theme** — Light / Dark / System (default System) — controlling the Material color scheme of everything outside the reading surface (library, home, settings, player). It is **fully independent** of the reader's existing content theme (Light/Dark/DarkDim/Sepia/Auto), which stays unchanged.

## How

- **`core/domain`** — new `AppTheme { Light, Dark, System }` enum with `isDark(systemInDark)`, plus an `AppThemeStore` interface.
- **`core/data`** — `AppThemeStoreImpl` backed by a new device-local `app_theme_preferences` DataStore (string-keyed, tolerant of unknown values, defaults to `System`); wired in `DataModule` following the existing VolumeKey/WakeLock pattern.
- **`MainActivity`** — resolves the chosen theme against `isSystemInDarkTheme()`, passes it to `RiffleTheme`, and syncs the transparent system-bar icon contrast via a `SideEffect`. The reader keeps its own explicit `RiffleTheme(darkTheme = …)`, so reading content remains independent.
- **Settings** — new "Appearance" section with a three-segment Light/Dark/System control, wired through `SettingsViewModel`.

## Testing

- `AppThemeTest` — `isDark` resolution across all three values × system light/dark.
- `AppThemeStoreTest` — defaults, round-trips, persistence across store instances.
- `SettingsViewModelTest` — added a fake store, default-reflection and `setAppTheme` tests.
- `./gradlew test` ✅ · `./gradlew lint` ✅
- `make harness-test` (phone, 199 tests) ✅ · `make harness-test-tablet` (5 tests) ✅

Not yet device-verified by eye (chrome switching / status-bar contrast); behavior is covered by unit tests.