### PR TITLE
feat(audiobook): local-first bookmarks with ABS sync

### DIFF
--- a/app/src/androidTest/kotlin/com/riffle/app/di/TestDatabaseModule.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/di/TestDatabaseModule.kt
@@ -5,6 +5,7 @@ import androidx.room.Room
 import com.riffle.core.data.di.DatabaseModule
 import com.riffle.core.database.AnnotationDao
 import com.riffle.core.database.AudioPlaybackPreferencesDao
+import com.riffle.core.database.AudiobookBookmarkDao
 import com.riffle.core.database.AudiobookPositionDao
 import com.riffle.core.database.BookFormattingPreferencesDao
 import com.riffle.core.database.CollectionDao
@@ -87,6 +88,10 @@ object TestDatabaseModule {
     @Provides
     @Singleton
     fun provideAudiobookPositionDao(db: RiffleDatabase): AudiobookPositionDao = db.audiobookPositionDao()
+
+    @Provides
+    @Singleton
+    fun provideAudiobookBookmarkDao(db: RiffleDatabase): AudiobookBookmarkDao = db.audiobookBookmarkDao()
 
     @Provides
     @Singleton

--- a/app/src/main/kotlin/com/riffle/app/feature/audio/PlayerSurface.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audio/PlayerSurface.kt
@@ -72,6 +72,9 @@ data class PlayerSurfaceState(
     val durationSec: Double = 0.0,
     val currentChapterTitle: String? = null,
     val chapterStartsSec: List<Double> = emptyList(),
+    // Absolute positions (seconds, global timeline) of the user's bookmarks, drawn as thin ticks on
+    // the scrubber for passive awareness of nearby bookmarks (variant B).
+    val bookmarkPositionsSec: List<Double> = emptyList(),
     val canPreviousChapter: Boolean = false,
     val canNextChapter: Boolean = false,
     // Book details shown in the landscape two-column layout. [facts] is a one-line summary
@@ -248,6 +251,7 @@ private fun PlayerControls(state: PlayerSurfaceState, actions: PlayerSurfaceActi
             positionSec = state.positionSec,
             durationSec = state.durationSec,
             chapterStartsSec = state.chapterStartsSec,
+            bookmarkPositionsSec = state.bookmarkPositionsSec,
             onSeek = actions.onSeek,
             modifier = Modifier.fillMaxWidth(),
         )
@@ -338,12 +342,16 @@ private fun ChapterSeekBar(
     positionSec: Double,
     durationSec: Double,
     chapterStartsSec: List<Double>,
+    bookmarkPositionsSec: List<Double>,
     onSeek: (Double) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val accent = MaterialTheme.colorScheme.primary
     val track = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.16f)
     val tickColor = MaterialTheme.colorScheme.background
+    // Bookmark ticks read over both the filled and unfilled track; onSurfaceVariant contrasts with
+    // the accent fill and the muted base track alike.
+    val bookmarkTickColor = MaterialTheme.colorScheme.onSurfaceVariant
     Box(
         modifier = modifier
             .height(24.dp)
@@ -374,6 +382,20 @@ private fun ChapterSeekBar(
                 chapterStartsSec.forEach { start ->
                     val x = (start / durationSec).toFloat().coerceIn(0f, 1f) * w
                     drawRect(color = tickColor, topLeft = Offset(x - 1f, 0f), size = Size(2f, h))
+                }
+                // bookmark ticks — thin marks that overshoot the track top & bottom so they're
+                // legible against the chapter ticks and the playhead. Visual-only (drawn inside the
+                // existing track Canvas, which never consumes the Box's drag/tap gestures).
+                val bmTickWidth = 2.5.dp.toPx()
+                val bmOvershoot = h * 0.6f
+                bookmarkPositionsSec.forEach { pos ->
+                    val x = (pos / durationSec).toFloat().coerceIn(0f, 1f) * w
+                    drawRoundRect(
+                        color = bookmarkTickColor,
+                        topLeft = Offset(x - bmTickWidth / 2f, -bmOvershoot),
+                        size = Size(bmTickWidth, h + bmOvershoot * 2f),
+                        cornerRadius = CornerRadius(bmTickWidth / 2f, bmTickWidth / 2f),
+                    )
                 }
             }
             // vertical playhead

--- a/app/src/main/kotlin/com/riffle/app/feature/audio/PlayerSurface.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audio/PlayerSurface.kt
@@ -409,11 +409,3 @@ private fun ChapterSeekBar(
         }
     }
 }
-
-private fun formatHms(totalSec: Double): String {
-    val s = totalSec.toLong().coerceAtLeast(0)
-    val h = s / 3600
-    val m = (s % 3600) / 60
-    val sec = s % 60
-    return if (h > 0) "%d:%02d:%02d".format(h, m, sec) else "%d:%02d".format(m, sec)
-}

--- a/app/src/main/kotlin/com/riffle/app/feature/audio/TimeFormat.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audio/TimeFormat.kt
@@ -1,0 +1,10 @@
+package com.riffle.app.feature.audio
+
+/** mm:ss under an hour, h:mm:ss otherwise. */
+internal fun formatHms(totalSec: Double): String {
+    val s = totalSec.toLong().coerceAtLeast(0)
+    val h = s / 3600
+    val m = (s % 3600) / 60
+    val sec = s % 60
+    return if (h > 0) "%d:%02d:%02d".format(h, m, sec) else "%d:%02d".format(m, sec)
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookController.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookController.kt
@@ -40,9 +40,14 @@ import kotlin.coroutines.resume
  * [com.riffle.app.feature.audio.PlaybackSpeed].
  */
 @Singleton
-class AudiobookController @Inject constructor(
-    @ApplicationContext private val context: Context,
+open class AudiobookController @Inject constructor(
+    @ApplicationContext private val context: Context?,
 ) {
+    // Test seam: a subclass that overrides every member the player touches needs no real Context (it's
+    // only consulted in [ensureConnected], which fakes never reach). Keeps the controller unit-fakeable
+    // without Robolectric.
+    protected constructor() : this(null)
+
     data class PlaybackState(
         val connected: Boolean = false,
         val isPlaying: Boolean = false,
@@ -53,7 +58,7 @@ class AudiobookController @Inject constructor(
 
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
     private val _state = MutableStateFlow(PlaybackState())
-    val state: StateFlow<PlaybackState> = _state.asStateFlow()
+    open val state: StateFlow<PlaybackState> = _state.asStateFlow()
 
     private var controller: MediaController? = null
     private var pollJob: Job? = null
@@ -80,7 +85,7 @@ class AudiobookController @Inject constructor(
      * Connects (if needed) and queues the audiobook's [trackUrls] (tokenised ABS URLs), one per
      * [spans] entry, then seeks to [startAtSec] on the book-absolute timeline.
      */
-    suspend fun prepare(
+    open suspend fun prepare(
         trackUrls: List<String>,
         spans: List<AudiobookTrackSpan>,
         durationSec: Double,
@@ -111,7 +116,7 @@ class AudiobookController @Inject constructor(
         pushState()
     }
 
-    fun play() {
+    open fun play() {
         // Latch the intent; [maybeStart] / the STATE_READY gate starts playback once the player is
         // buffered at the resume position (see [ResumePlaybackGate]).
         wantsToPlay = true
@@ -135,13 +140,13 @@ class AudiobookController @Inject constructor(
         pushState()
     }
 
-    fun setSpeed(speed: Float) {
+    open fun setSpeed(speed: Float) {
         controller?.setPlaybackSpeed(speed)
         pushState()
     }
 
     /** Seeks to a book-absolute position, resolving it to the right track + offset. */
-    fun seekTo(absoluteSec: Double) {
+    open fun seekTo(absoluteSec: Double) {
         val clamped = absoluteSec.coerceIn(0.0, if (durationSec > 0) durationSec else absoluteSec)
         val index = AudiobookTracks.trackIndexAt(clamped, spans)
         val offset = AudiobookTracks.offsetInTrackSec(clamped, spans)
@@ -153,7 +158,7 @@ class AudiobookController @Inject constructor(
     fun rewind() = skipBy(-REWIND_SEC)
     fun forward() = skipBy(FORWARD_SEC)
 
-    fun currentAbsoluteSec(): Double {
+    open fun currentAbsoluteSec(): Double {
         val c = controller ?: return 0.0
         return AudiobookTracks.absoluteSec(c.currentMediaItemIndex, c.currentPosition / 1000.0, spans)
     }
@@ -204,6 +209,7 @@ class AudiobookController @Inject constructor(
 
     private suspend fun ensureConnected(): MediaController? {
         controller?.let { return it }
+        val context = this.context ?: return null
         val token = SessionToken(context, ComponentName(context, AudioPlayerService::class.java))
         val future = MediaController.Builder(context, token).buildAsync()
         val c = suspendCancellableCoroutine<MediaController?> { cont ->

--- a/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerScreen.kt
@@ -66,6 +66,17 @@ private const val SWITCH_TO_READALOUD_THRESHOLD_PX = 160f
 /** Which list the shared [PlayerListSheet] is showing (no tabs — one kind at a time). */
 private enum class SheetKind { Chapters, Bookmarks }
 
+/**
+ * A snapshot taken when the New-bookmark dialog opens. Pinning the position (and the title/label
+ * derived from it) keeps the dialog stable while playback continues — otherwise the live playhead
+ * would rewrite the default title every second and wipe the user's edits.
+ */
+private data class BookmarkDraft(
+    val positionSec: Double,
+    val defaultTitle: String,
+    val chapterTitle: String,
+)
+
 /** Caption hinting that dragging the cover down switches to the read-along reader. */
 @Composable
 private fun ReadAlongSwipeHint() {
@@ -123,7 +134,9 @@ fun AudiobookPlayerScreen(
 
     // Local UI state for the sheets and dialogs (variant B).
     var openSheet by remember { mutableStateOf<SheetKind?>(null) }
-    var showCreate by remember { mutableStateOf(false) }
+    // Non-null while the New-bookmark dialog is open; carries the position/title pinned at open time so
+    // they don't drift with the still-running playhead while the user edits (see [BookmarkDraft]).
+    var createDraft by remember { mutableStateOf<BookmarkDraft?>(null) }
     var renaming by remember { mutableStateOf<AudiobookBookmark?>(null) }
 
     val snackbarHostState = remember { SnackbarHostState() }
@@ -226,9 +239,17 @@ fun AudiobookPlayerScreen(
             ) {
                 Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
             }
-            // One-tap bookmark-add, in the top app-bar row opposite the back arrow.
+            // One-tap bookmark-add, in the top app-bar row opposite the back arrow. Pin the position
+            // (and title/chapter derived from it) at tap time so the dialog is stable while playing.
             IconButton(
-                onClick = { showCreate = true },
+                onClick = {
+                    val positionSec = viewModel.currentPositionSec()
+                    createDraft = BookmarkDraft(
+                        positionSec = positionSec,
+                        defaultTitle = viewModel.defaultBookmarkTitle(positionSec),
+                        chapterTitle = state.currentChapterTitle?.trim().orEmpty(),
+                    )
+                },
                 modifier = Modifier.align(Alignment.TopEnd).statusBarsPadding().padding(4.dp),
             ) {
                 Icon(Icons.Filled.BookmarkAdd, contentDescription = "Add bookmark")
@@ -237,20 +258,18 @@ fun AudiobookPlayerScreen(
         }
     }
 
-    // Create dialog: pre-fill the default title and offer quick suggestions.
-    if (showCreate) {
-        val defaultTitle = viewModel.defaultBookmarkTitle()
-        val chapterTitle = state.currentChapterTitle?.trim().orEmpty()
-        val absolute = formatHms(state.positionSec)
-        val positionLabel = if (chapterTitle.isNotEmpty()) "$absolute · $chapterTitle" else absolute
-        val suggestions = listOf(defaultTitle, chapterTitle, absolute).filter { it.isNotBlank() }.distinct()
+    // Create dialog: pre-fill the default title and offer quick suggestions, all from the pinned draft.
+    createDraft?.let { draft ->
+        val absolute = formatHms(draft.positionSec)
+        val positionLabel = if (draft.chapterTitle.isNotEmpty()) "$absolute · ${draft.chapterTitle}" else absolute
+        val suggestions = listOf(draft.defaultTitle, draft.chapterTitle, absolute).filter { it.isNotBlank() }.distinct()
         BookmarkCreateDialog(
-            initialTitle = defaultTitle,
+            initialTitle = draft.defaultTitle,
             positionLabel = positionLabel,
             suggestions = suggestions,
             onConfirm = { title ->
-                viewModel.addBookmark(title)
-                showCreate = false
+                viewModel.addBookmark(title, draft.positionSec)
+                createDraft = null
                 scope.launch {
                     val result = snackbarHostState.showSnackbar(
                         message = "Bookmark saved",
@@ -263,7 +282,7 @@ fun AudiobookPlayerScreen(
                     }
                 }
             },
-            onDismiss = { showCreate = false },
+            onDismiss = { createDraft = null },
         )
     }
 

--- a/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerScreen.kt
@@ -2,8 +2,10 @@ package com.riffle.app.feature.audiobook
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.detectVerticalDragGestures
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -12,17 +14,29 @@ import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.MenuBook
+import androidx.compose.material.icons.filled.Bookmark
+import androidx.compose.material.icons.filled.BookmarkAdd
+import androidx.compose.material3.AssistChip
+import androidx.compose.material3.AssistChipDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.SnackbarResult
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.windowsizeclass.WindowHeightSizeClass
 import androidx.compose.material3.windowsizeclass.WindowSizeClass
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
@@ -34,6 +48,8 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.riffle.app.feature.audio.PlayerSurface
 import com.riffle.app.feature.audio.PlayerSurfaceActions
 import com.riffle.app.feature.audio.PlayerSurfaceState
+import com.riffle.core.domain.AudiobookBookmark
+import kotlinx.coroutines.launch
 
 /**
  * Full-screen [Audiobook Player] (ADR 0029): square cover, title/author, current-chapter label, a
@@ -46,6 +62,9 @@ import com.riffle.app.feature.audio.PlayerSurfaceState
 // deliberate swipe, not an accidental nudge.
 private const val SWITCH_TO_READALOUD_THRESHOLD_PX = 160f
 
+/** Which list the shared [PlayerListSheet] is showing (no tabs — one kind at a time). */
+private enum class SheetKind { Chapters, Bookmarks }
+
 /** Caption hinting that dragging the cover down switches to the read-along reader. */
 @Composable
 private fun ReadAlongSwipeHint() {
@@ -56,6 +75,35 @@ private fun ReadAlongSwipeHint() {
         modifier = Modifier.fillMaxWidth().padding(top = 6.dp),
         textAlign = TextAlign.Center,
     )
+}
+
+/** The two quiet affordances under the scrubber: Chapters and the bookmark count. */
+@Composable
+private fun PlayerListPills(
+    bookmarkCount: Int,
+    onOpenChapters: () -> Unit,
+    onOpenBookmarks: () -> Unit,
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(top = 12.dp),
+        horizontalArrangement = Arrangement.spacedBy(12.dp, Alignment.CenterHorizontally),
+    ) {
+        AssistChip(
+            onClick = onOpenChapters,
+            label = { Text("Chapters") },
+            leadingIcon = {
+                Icon(Icons.AutoMirrored.Filled.MenuBook, contentDescription = null, modifier = Modifier.size(AssistChipDefaults.IconSize))
+            },
+        )
+        val bookmarkLabel = if (bookmarkCount == 1) "1 bookmark" else "$bookmarkCount bookmarks"
+        AssistChip(
+            onClick = onOpenBookmarks,
+            label = { Text(bookmarkLabel) },
+            leadingIcon = {
+                Icon(Icons.Filled.Bookmark, contentDescription = null, modifier = Modifier.size(AssistChipDefaults.IconSize))
+            },
+        )
+    }
 }
 
 @Composable
@@ -71,6 +119,14 @@ fun AudiobookPlayerScreen(
     val twoColumn = windowSizeClass.heightSizeClass == WindowHeightSizeClass.Compact
     // Read fresh inside the gesture (it's keyed on Unit, so it must not capture a stale position).
     val latestState = rememberUpdatedState(state)
+
+    // Local UI state for the sheets and dialogs (variant B).
+    var openSheet by remember { mutableStateOf<SheetKind?>(null) }
+    var showCreate by remember { mutableStateOf(false) }
+    var renaming by remember { mutableStateOf<AudiobookBookmark?>(null) }
+
+    val snackbarHostState = remember { SnackbarHostState() }
+    val scope = rememberCoroutineScope()
 
     val gradient = Brush.verticalGradient(
         listOf(
@@ -118,34 +174,43 @@ fun AudiobookPlayerScreen(
                 state.failed -> Box(Modifier.fillMaxSize(), Alignment.Center) {
                     Text("This audiobook can't be played right now.", color = MaterialTheme.colorScheme.onSurfaceVariant)
                 }
-                else -> PlayerSurface(
-                    state = PlayerSurfaceState(
-                        title = state.title,
-                        author = state.author,
-                        coverUrl = state.coverUrl,
-                        authToken = state.authToken,
-                        isPlaying = state.isPlaying,
-                        speed = state.speed,
-                        positionSec = state.positionSec,
-                        durationSec = state.durationSec,
-                        currentChapterTitle = state.currentChapterTitle,
-                        chapterStartsSec = state.chapterStartsSec,
-                        canPreviousChapter = state.canPreviousChapter,
-                        canNextChapter = state.canNextChapter,
-                        facts = state.facts,
-                        description = state.description,
-                    ),
-                    twoColumn = twoColumn,
-                    actions = PlayerSurfaceActions(
-                        onSeek = viewModel::seekTo,
-                        onTogglePlayPause = viewModel::togglePlayPause,
-                        onRewind = viewModel::rewind,
-                        onForward = viewModel::forward,
-                        onPreviousChapter = viewModel::previousChapter,
-                        onNextChapter = viewModel::nextChapter,
-                        onSpeedChange = viewModel::setSpeed,
-                    ),
-                )
+                else -> Column(Modifier.fillMaxSize()) {
+                    PlayerSurface(
+                        modifier = Modifier.weight(1f),
+                        state = PlayerSurfaceState(
+                            title = state.title,
+                            author = state.author,
+                            coverUrl = state.coverUrl,
+                            authToken = state.authToken,
+                            isPlaying = state.isPlaying,
+                            speed = state.speed,
+                            positionSec = state.positionSec,
+                            durationSec = state.durationSec,
+                            currentChapterTitle = state.currentChapterTitle,
+                            chapterStartsSec = state.chapterStartsSec,
+                            canPreviousChapter = state.canPreviousChapter,
+                            canNextChapter = state.canNextChapter,
+                            facts = state.facts,
+                            description = state.description,
+                        ),
+                        twoColumn = twoColumn,
+                        actions = PlayerSurfaceActions(
+                            onSeek = viewModel::seekTo,
+                            onTogglePlayPause = viewModel::togglePlayPause,
+                            onRewind = viewModel::rewind,
+                            onForward = viewModel::forward,
+                            onPreviousChapter = viewModel::previousChapter,
+                            onNextChapter = viewModel::nextChapter,
+                            onSpeedChange = viewModel::setSpeed,
+                        ),
+                    )
+                    PlayerListPills(
+                        bookmarkCount = state.bookmarks.size,
+                        onOpenChapters = { openSheet = SheetKind.Chapters },
+                        onOpenBookmarks = { openSheet = SheetKind.Bookmarks },
+                    )
+                    Spacer(Modifier.size(12.dp))
+                }
                 }
             }
             // Exit affordance, overlaid OUTSIDE the swipe Column so its taps are never captured by the
@@ -159,6 +224,91 @@ fun AudiobookPlayerScreen(
             ) {
                 Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
             }
+            // One-tap bookmark-add, in the top app-bar row opposite the back arrow.
+            IconButton(
+                onClick = { showCreate = true },
+                modifier = Modifier.align(Alignment.TopEnd).statusBarsPadding().padding(4.dp),
+            ) {
+                Icon(Icons.Filled.BookmarkAdd, contentDescription = "Add bookmark")
+            }
+            SnackbarHost(snackbarHostState, modifier = Modifier.align(Alignment.BottomCenter))
         }
     }
+
+    // Create dialog: pre-fill the default title and offer quick suggestions.
+    if (showCreate) {
+        val defaultTitle = viewModel.defaultBookmarkTitle()
+        val chapterTitle = state.currentChapterTitle?.trim().orEmpty()
+        val absolute = formatHms(state.positionSec)
+        val positionLabel = if (chapterTitle.isNotEmpty()) "$absolute · $chapterTitle" else absolute
+        val suggestions = listOf(defaultTitle, chapterTitle, absolute).filter { it.isNotBlank() }.distinct()
+        BookmarkCreateDialog(
+            initialTitle = defaultTitle,
+            positionLabel = positionLabel,
+            suggestions = suggestions,
+            onConfirm = { title ->
+                viewModel.addBookmark(title)
+                showCreate = false
+                scope.launch {
+                    val result = snackbarHostState.showSnackbar(
+                        message = "Bookmark saved",
+                        actionLabel = "Undo",
+                    )
+                    if (result == SnackbarResult.ActionPerformed) {
+                        // The add is asynchronous; by the time Undo is tapped the id has been published
+                        // to uiState. Read it fresh from the ViewModel at click time.
+                        viewModel.uiState.value.lastCreatedBookmarkId?.let(viewModel::deleteBookmark)
+                    }
+                }
+            },
+            onDismiss = { showCreate = false },
+        )
+    }
+
+    // Rename reuses the create dialog with a different title and no suggestions.
+    renaming?.let { bookmark ->
+        BookmarkCreateDialog(
+            initialTitle = bookmark.title,
+            positionLabel = formatHms(bookmark.positionSec),
+            suggestions = emptyList(),
+            title = "Rename bookmark",
+            onConfirm = { title ->
+                viewModel.renameBookmark(bookmark.id, title)
+                renaming = null
+            },
+            onDismiss = { renaming = null },
+        )
+    }
+
+    when (openSheet) {
+        SheetKind.Chapters -> PlayerListSheet(
+            content = PlayerListContent.Chapters(
+                items = state.chapters,
+                currentIndex = state.currentChapterIndex,
+                // A chapter start is genuine user navigation — seekTo moves the resume baseline.
+                onSeek = { chapter -> viewModel.seekTo(chapter.startSec) },
+            ),
+            onDismiss = { openSheet = null },
+        )
+        SheetKind.Bookmarks -> PlayerListSheet(
+            content = PlayerListContent.Bookmarks(
+                items = state.bookmarks,
+                onSeek = { bm -> viewModel.seekToBookmark(bm.positionSec) },
+                onRename = { renaming = it },
+                onDelete = { viewModel.deleteBookmark(it.id) },
+                offlineNote = false,
+            ),
+            onDismiss = { openSheet = null },
+        )
+        null -> Unit
+    }
+}
+
+/** mm:ss under an hour, h:mm:ss otherwise — for the bookmark dialog position label. */
+private fun formatHms(totalSec: Double): String {
+    val s = totalSec.toLong().coerceAtLeast(0)
+    val h = s / 3600
+    val m = (s % 3600) / 60
+    val sec = s % 60
+    return if (h > 0) "%d:%02d:%02d".format(h, m, sec) else "%d:%02d".format(m, sec)
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerScreen.kt
@@ -297,7 +297,7 @@ fun AudiobookPlayerScreen(
                 onSeek = { bm -> viewModel.seekToBookmark(bm.positionSec) },
                 onRename = { renaming = it },
                 onDelete = { viewModel.deleteBookmark(it.id) },
-                offlineNote = false,
+                offlineNote = state.bookmarksOffline,
             ),
             onDismiss = { openSheet = null },
         )

--- a/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerScreen.kt
@@ -48,6 +48,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.riffle.app.feature.audio.PlayerSurface
 import com.riffle.app.feature.audio.PlayerSurfaceActions
 import com.riffle.app.feature.audio.PlayerSurfaceState
+import com.riffle.app.feature.audio.formatHms
 import com.riffle.core.domain.AudiobookBookmark
 import kotlinx.coroutines.launch
 
@@ -303,13 +304,4 @@ fun AudiobookPlayerScreen(
         )
         null -> Unit
     }
-}
-
-/** mm:ss under an hour, h:mm:ss otherwise — for the bookmark dialog position label. */
-private fun formatHms(totalSec: Double): String {
-    val s = totalSec.toLong().coerceAtLeast(0)
-    val h = s / 3600
-    val m = (s % 3600) / 60
-    val sec = s % 60
-    return if (h > 0) "%d:%02d:%02d".format(h, m, sec) else "%d:%02d".format(m, sec)
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.foundation.layout.size
@@ -188,7 +189,10 @@ fun AudiobookPlayerScreen(
                 state.failed -> Box(Modifier.fillMaxSize(), Alignment.Center) {
                     Text("This audiobook can't be played right now.", color = MaterialTheme.colorScheme.onSurfaceVariant)
                 }
-                else -> Column(Modifier.fillMaxSize()) {
+                // navigationBarsPadding so the pills row at the bottom clears the system nav bar —
+                // otherwise PlayerListPills renders behind it and the chapters/bookmarks entry point
+                // is invisible.
+                else -> Column(Modifier.fillMaxSize().navigationBarsPadding()) {
                     PlayerSurface(
                         modifier = Modifier.weight(1f),
                         state = PlayerSurfaceState(

--- a/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerScreen.kt
@@ -254,7 +254,9 @@ fun AudiobookPlayerScreen(
                         chapterTitle = state.currentChapterTitle?.trim().orEmpty(),
                     )
                 },
-                modifier = Modifier.align(Alignment.TopEnd).statusBarsPadding().padding(4.dp),
+                // safeDrawingPadding (mirrors the back arrow) so the icon clears the status bar, nav bar
+                // and any display cutout, including in landscape.
+                modifier = Modifier.align(Alignment.TopEnd).safeDrawingPadding().padding(4.dp),
             ) {
                 Icon(Icons.Filled.BookmarkAdd, contentDescription = "Add bookmark")
             }

--- a/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerScreen.kt
@@ -188,6 +188,7 @@ fun AudiobookPlayerScreen(
                             durationSec = state.durationSec,
                             currentChapterTitle = state.currentChapterTitle,
                             chapterStartsSec = state.chapterStartsSec,
+                            bookmarkPositionsSec = state.bookmarks.map { it.positionSec },
                             canPreviousChapter = state.canPreviousChapter,
                             canNextChapter = state.canNextChapter,
                             facts = state.facts,

--- a/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModel.kt
@@ -643,18 +643,25 @@ class AudiobookPlayerViewModel(
         timeline.nextChapterTargetSec(controller.currentAbsoluteSec())?.let { reconciledResumeSec = it; controller.seekTo(it) }
     }
 
-    /** The pre-filled (editable) default title for a new bookmark at the current listen position. */
-    fun defaultBookmarkTitle(): String =
-        BookmarkTitleBuilder.defaultTitle(timeline, controller.currentAbsoluteSec())
+    /**
+     * The book-absolute listen position right now. The UI snapshots this when the New-bookmark dialog
+     * opens so the title, position label and the eventually-saved row all agree, even if playback keeps
+     * running while the user edits the title.
+     */
+    fun currentPositionSec(): Double = controller.currentAbsoluteSec()
+
+    /** The pre-filled (editable) default title for a new bookmark at [positionSec]. */
+    fun defaultBookmarkTitle(positionSec: Double): String =
+        BookmarkTitleBuilder.defaultTitle(timeline, positionSec)
 
     /**
-     * Create a bookmark at the current book-absolute listen position. On success the new id is surfaced
-     * in [AudiobookPlayerUiState.lastCreatedBookmarkId] so the UI can offer an Undo; the new row arrives
+     * Create a bookmark at [positionSec] (the position pinned when the dialog opened — NOT the live
+     * playhead, which may have drifted while the user typed). On success the new id is surfaced in
+     * [AudiobookPlayerUiState.lastCreatedBookmarkId] so the UI can offer an Undo; the new row arrives
      * in [AudiobookPlayerUiState.bookmarks] via the store observation.
      */
-    fun addBookmark(title: String) {
+    fun addBookmark(title: String, positionSec: Double) {
         if (serverId.isEmpty()) return
-        val positionSec = controller.currentAbsoluteSec()
         viewModelScope.launch {
             val id = bookmarkStore.add(serverId, itemId, positionSec, title, now())
             meta.value = meta.value.copy(lastCreatedBookmarkId = id)

--- a/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModel.kt
@@ -8,6 +8,7 @@ import com.riffle.core.domain.AudioIdentityResolver
 import com.riffle.core.domain.AudioPlaybackPreferencesStore
 import com.riffle.core.domain.AudiobookBookmark
 import com.riffle.core.domain.AudiobookBookmarkStore
+import com.riffle.core.domain.AudiobookChapter
 import com.riffle.core.domain.AudiobookRepository
 import com.riffle.core.domain.AudiobookTimeline
 import com.riffle.core.domain.BookmarkTitleBuilder
@@ -106,6 +107,9 @@ data class AudiobookPlayerUiState(
     val durationSec: Double = 0.0,
     val currentChapterTitle: String? = null,
     val chapterStartsSec: List<Double> = emptyList(),
+    // The full chapter list + the index of the chapter the playhead is in, for the Chapters sheet.
+    val chapters: List<AudiobookChapter> = emptyList(),
+    val currentChapterIndex: Int = -1,
     val canPreviousChapter: Boolean = false,
     val canNextChapter: Boolean = false,
     // Book details for the landscape two-column player: a facts line and the blurb (ADR 0029).
@@ -316,6 +320,8 @@ class AudiobookPlayerViewModel(
                 durationSec = if (playback.durationSec > 0) playback.durationSec else m.durationSec,
                 currentChapterTitle = chapter?.title,
                 chapterStartsSec = timeline.chapters.map { it.startSec },
+                chapters = timeline.chapters,
+                currentChapterIndex = chapter?.index ?: -1,
                 canPreviousChapter = timeline.canPreviousChapter,
                 canNextChapter = timeline.canNextChapter,
                 bookmarks = m.bookmarks,

--- a/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModel.kt
@@ -115,7 +115,7 @@ data class AudiobookPlayerUiState(
     // item if it's a combined ebook+audio). Non-null enables swipe-down → switch to the readaloud
     // reader; null means there's no readaloud to switch to, so no swipe-down.
     val readaloudEbookItemId: String? = null,
-    // User bookmarks for this audiobook, observed live from the store (newest-first per the store).
+    // User bookmarks for this audiobook, observed live from the store (ordered by position, earliest first).
     val bookmarks: List<AudiobookBookmark> = emptyList(),
     // The id of the most recently added bookmark, so the UI can offer an Undo on the add. Null until
     // an add succeeds this session.
@@ -329,7 +329,7 @@ class AudiobookPlayerViewModel(
             serverId = server?.id ?: ""
             // Claim this audiobook so the durable sweep leaves it to this player's own cycle (ADR 0030).
             if (serverId.isNotEmpty()) openReconcileTargets.markOpen(serverId, itemId)
-            // Observe this book's bookmarks live into the UI state (newest-first per the store).
+            // Observe this book's bookmarks live into the UI state (ordered by position, earliest first).
             if (serverId.isNotEmpty()) {
                 viewModelScope.launch {
                     bookmarkStore.observe(serverId, itemId).collect { list ->
@@ -449,8 +449,12 @@ class AudiobookPlayerViewModel(
                     ?.absLibraryItemId
                     ?: itemId.takeIf { item.isReadable }
             }
-            meta.value = AudiobookPlayerUiState(
+            // copy() (not a fresh state) so any bookmarks the live collector already observed during
+            // the suspend points above carry forward — a fresh state would wipe them, leaving an
+            // existing book's bookmarks stuck empty until Room's Flow next re-emits (on add/rename/delete).
+            meta.value = meta.value.copy(
                 loading = false,
+                failed = false,
                 title = item.title,
                 author = item.author,
                 coverUrl = item.coverUrl,

--- a/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModel.kt
@@ -124,6 +124,9 @@ data class AudiobookPlayerUiState(
     // The id of the most recently added bookmark, so the UI can offer an Undo on the add. Null until
     // an add succeeds this session.
     val lastCreatedBookmarkId: String? = null,
+    // True only when this item has unsynced (dirty) bookmarks AND the device is offline, so the
+    // Bookmarks sheet can show a quiet "Offline — bookmarks will sync" note. Sync is otherwise silent.
+    val bookmarksOffline: Boolean = false,
 )
 
 @HiltViewModel
@@ -155,6 +158,7 @@ class AudiobookPlayerViewModel(
     private val openReconcileTargets: com.riffle.core.data.OpenReconcileTargets,
     private val progressFlushScope: com.riffle.app.feature.reader.ProgressFlushScope,
     private val bookmarkStore: AudiobookBookmarkStore,
+    private val connectivityObserver: com.riffle.core.domain.ConnectivityObserver,
     // Wall-clock for bookmark stamps (createdAt + dirty); a () -> Long for deterministic tests, the
     // established clock-injection pattern in this codebase (e.g. ReadaloudMatchingService).
     private val now: () -> Long = System::currentTimeMillis,
@@ -186,6 +190,7 @@ class AudiobookPlayerViewModel(
         openReconcileTargets: com.riffle.core.data.OpenReconcileTargets,
         progressFlushScope: com.riffle.app.feature.reader.ProgressFlushScope,
         bookmarkStore: AudiobookBookmarkStore,
+        connectivityObserver: com.riffle.core.domain.ConnectivityObserver,
     ) : this(
         savedStateHandle,
         audiobookRepository,
@@ -208,6 +213,7 @@ class AudiobookPlayerViewModel(
         openReconcileTargets,
         progressFlushScope,
         bookmarkStore,
+        connectivityObserver,
         System::currentTimeMillis,
     )
 
@@ -326,6 +332,7 @@ class AudiobookPlayerViewModel(
                 canNextChapter = timeline.canNextChapter,
                 bookmarks = m.bookmarks,
                 lastCreatedBookmarkId = m.lastCreatedBookmarkId,
+                bookmarksOffline = m.bookmarksOffline,
             )
         }.stateIn(viewModelScope, SharingStarted.Eagerly, AudiobookPlayerUiState(loading = true))
 
@@ -341,6 +348,17 @@ class AudiobookPlayerViewModel(
                     bookmarkStore.observe(serverId, itemId).collect { list ->
                         meta.value = meta.value.copy(bookmarks = list)
                     }
+                }
+                // Derive the quiet offline note: unsynced (dirty) bookmarks for this item AND offline.
+                // Sync is otherwise silent, so the note only shows when a push is genuinely blocked.
+                viewModelScope.launch {
+                    combine(
+                        bookmarkStore.observeHasUnsynced(serverId, itemId),
+                        connectivityObserver.isOnline,
+                    ) { hasUnsynced, isOnline -> hasUnsynced && !isOnline }
+                        .collect { offline ->
+                            meta.value = meta.value.copy(bookmarksOffline = offline)
+                        }
                 }
             }
             val token = server?.let { tokenStorage.getToken(it.id) } ?: ""

--- a/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModel.kt
@@ -6,8 +6,11 @@ import androidx.lifecycle.viewModelScope
 import com.riffle.core.domain.AudioIdentity
 import com.riffle.core.domain.AudioIdentityResolver
 import com.riffle.core.domain.AudioPlaybackPreferencesStore
+import com.riffle.core.domain.AudiobookBookmark
+import com.riffle.core.domain.AudiobookBookmarkStore
 import com.riffle.core.domain.AudiobookRepository
 import com.riffle.core.domain.AudiobookTimeline
+import com.riffle.core.domain.BookmarkTitleBuilder
 import com.riffle.core.domain.LibraryRepository
 import com.riffle.core.domain.ServerRepository
 import com.riffle.core.domain.TokenStorage
@@ -112,10 +115,15 @@ data class AudiobookPlayerUiState(
     // item if it's a combined ebook+audio). Non-null enables swipe-down → switch to the readaloud
     // reader; null means there's no readaloud to switch to, so no swipe-down.
     val readaloudEbookItemId: String? = null,
+    // User bookmarks for this audiobook, observed live from the store (newest-first per the store).
+    val bookmarks: List<AudiobookBookmark> = emptyList(),
+    // The id of the most recently added bookmark, so the UI can offer an Undo on the add. Null until
+    // an add succeeds this session.
+    val lastCreatedBookmarkId: String? = null,
 )
 
 @HiltViewModel
-class AudiobookPlayerViewModel @Inject constructor(
+class AudiobookPlayerViewModel(
     savedStateHandle: SavedStateHandle,
     private val audiobookRepository: AudiobookRepository,
     private val audiobookDownloadRepository: com.riffle.core.domain.AudiobookDownloadRepository,
@@ -142,7 +150,62 @@ class AudiobookPlayerViewModel @Inject constructor(
     // can't absorb a cross-device server-win the player hasn't seeked to (ADR 0030).
     private val openReconcileTargets: com.riffle.core.data.OpenReconcileTargets,
     private val progressFlushScope: com.riffle.app.feature.reader.ProgressFlushScope,
+    private val bookmarkStore: AudiobookBookmarkStore,
+    // Wall-clock for bookmark stamps (createdAt + dirty); a () -> Long for deterministic tests, the
+    // established clock-injection pattern in this codebase (e.g. ReadaloudMatchingService).
+    private val now: () -> Long = System::currentTimeMillis,
 ) : ViewModel() {
+
+    // Hilt entry point: it can't satisfy a `() -> Long` binding, so the injected constructor omits the
+    // clock and delegates to the real one (the established pattern, e.g. ReadaloudMatchingService). The
+    // primary constructor with the `now` default is what tests use for a deterministic clock.
+    @Inject
+    constructor(
+        savedStateHandle: SavedStateHandle,
+        audiobookRepository: AudiobookRepository,
+        audiobookDownloadRepository: com.riffle.core.domain.AudiobookDownloadRepository,
+        bundleAudiobookSource: com.riffle.core.domain.BundleAudiobookSource,
+        libraryRepository: LibraryRepository,
+        serverRepository: ServerRepository,
+        tokenStorage: TokenStorage,
+        controller: AudiobookController,
+        audioPlaybackPreferencesStore: AudioPlaybackPreferencesStore,
+        audioIdentityResolver: AudioIdentityResolver,
+        readerSyncFactory: com.riffle.app.feature.reader.ReaderSyncFactory,
+        readaloudLinkRepository: com.riffle.core.domain.ReadaloudLinkRepository,
+        readaloudAudioRepository: com.riffle.core.domain.ReadaloudAudioRepository,
+        nowPlayingStore: com.riffle.app.playback.NowPlayingStore,
+        audiobookPositionStore: com.riffle.core.domain.AudiobookPositionStore,
+        readingSyncStore: com.riffle.core.domain.SyncPositionStore<String>,
+        audioSyncStore: com.riffle.core.domain.SyncPositionStore<Double>,
+        readaloudResumeStore: com.riffle.core.domain.ReadaloudResumeStore,
+        openReconcileTargets: com.riffle.core.data.OpenReconcileTargets,
+        progressFlushScope: com.riffle.app.feature.reader.ProgressFlushScope,
+        bookmarkStore: AudiobookBookmarkStore,
+    ) : this(
+        savedStateHandle,
+        audiobookRepository,
+        audiobookDownloadRepository,
+        bundleAudiobookSource,
+        libraryRepository,
+        serverRepository,
+        tokenStorage,
+        controller,
+        audioPlaybackPreferencesStore,
+        audioIdentityResolver,
+        readerSyncFactory,
+        readaloudLinkRepository,
+        readaloudAudioRepository,
+        nowPlayingStore,
+        audiobookPositionStore,
+        readingSyncStore,
+        audioSyncStore,
+        readaloudResumeStore,
+        openReconcileTargets,
+        progressFlushScope,
+        bookmarkStore,
+        System::currentTimeMillis,
+    )
 
     private val itemId: String = savedStateHandle.get<String>("itemId") ?: ""
 
@@ -255,6 +318,8 @@ class AudiobookPlayerViewModel @Inject constructor(
                 chapterStartsSec = timeline.chapters.map { it.startSec },
                 canPreviousChapter = timeline.canPreviousChapter,
                 canNextChapter = timeline.canNextChapter,
+                bookmarks = m.bookmarks,
+                lastCreatedBookmarkId = m.lastCreatedBookmarkId,
             )
         }.stateIn(viewModelScope, SharingStarted.Eagerly, AudiobookPlayerUiState(loading = true))
 
@@ -264,6 +329,14 @@ class AudiobookPlayerViewModel @Inject constructor(
             serverId = server?.id ?: ""
             // Claim this audiobook so the durable sweep leaves it to this player's own cycle (ADR 0030).
             if (serverId.isNotEmpty()) openReconcileTargets.markOpen(serverId, itemId)
+            // Observe this book's bookmarks live into the UI state (newest-first per the store).
+            if (serverId.isNotEmpty()) {
+                viewModelScope.launch {
+                    bookmarkStore.observe(serverId, itemId).collect { list ->
+                        meta.value = meta.value.copy(bookmarks = list)
+                    }
+                }
+            }
             val token = server?.let { tokenStorage.getToken(it.id) } ?: ""
             val item = libraryRepository.getItem(itemId)
             // Prefer a dedicated audiobook download, then a downloaded readaloud bundle's audio, then
@@ -540,6 +613,37 @@ class AudiobookPlayerViewModel @Inject constructor(
 
     fun nextChapter() {
         timeline.nextChapterTargetSec(controller.currentAbsoluteSec())?.let { reconciledResumeSec = it; controller.seekTo(it) }
+    }
+
+    /** The pre-filled (editable) default title for a new bookmark at the current listen position. */
+    fun defaultBookmarkTitle(): String =
+        BookmarkTitleBuilder.defaultTitle(timeline, controller.currentAbsoluteSec())
+
+    /**
+     * Create a bookmark at the current book-absolute listen position. On success the new id is surfaced
+     * in [AudiobookPlayerUiState.lastCreatedBookmarkId] so the UI can offer an Undo; the new row arrives
+     * in [AudiobookPlayerUiState.bookmarks] via the store observation.
+     */
+    fun addBookmark(title: String) {
+        if (serverId.isEmpty()) return
+        val positionSec = controller.currentAbsoluteSec()
+        viewModelScope.launch {
+            val id = bookmarkStore.add(serverId, itemId, positionSec, title, now())
+            meta.value = meta.value.copy(lastCreatedBookmarkId = id)
+        }
+    }
+
+    fun renameBookmark(id: String, title: String) {
+        viewModelScope.launch { bookmarkStore.rename(id, title, now()) }
+    }
+
+    fun deleteBookmark(id: String) {
+        viewModelScope.launch { bookmarkStore.delete(id, now()) }
+    }
+
+    /** Jump the player to a saved bookmark's book-absolute position (genuine user navigation). */
+    fun seekToBookmark(positionSec: Double) {
+        seekTo(positionSec)
     }
 
     /**

--- a/app/src/main/kotlin/com/riffle/app/feature/audiobook/BookmarkCreateDialog.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audiobook/BookmarkCreateDialog.kt
@@ -1,0 +1,80 @@
+package com.riffle.app.feature.audiobook
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.SuggestionChip
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+/**
+ * Stateless dialog for naming a new bookmark (also reused for Rename — see Task 8 — via [title]).
+ *
+ * Everything except the local edit-field state is supplied by the caller: the pre-filled
+ * [initialTitle], the read-only [positionLabel] (e.g. "1:02:11 · The Conversation"), and the
+ * tappable [suggestions] (chapter+offset, chapter, absolute, date — already formatted upstream).
+ */
+@Composable
+fun BookmarkCreateDialog(
+    initialTitle: String,
+    positionLabel: String,
+    suggestions: List<String>,
+    onConfirm: (String) -> Unit,
+    onDismiss: () -> Unit,
+    title: String = "New bookmark",
+) {
+    var text by rememberSaveable(initialTitle) { mutableStateOf(initialTitle) }
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(title) },
+        text = {
+            Column {
+                Text(positionLabel, style = MaterialTheme.typography.bodySmall)
+                Spacer(Modifier.height(8.dp))
+                OutlinedTextField(
+                    value = text,
+                    onValueChange = { text = it },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                val distinctSuggestions = suggestions.distinct()
+                if (distinctSuggestions.isNotEmpty()) {
+                    Spacer(Modifier.height(8.dp))
+                    // Manual wrapping rows instead of FlowRow: this project deliberately avoids
+                    // FlowRow due to its compose-foundation 1.7 API mismatch (see FormattingPanel).
+                    distinctSuggestions.chunked(2).forEach { rowItems ->
+                        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                            rowItems.forEach { suggestion ->
+                                SuggestionChip(
+                                    onClick = { text = suggestion },
+                                    label = { Text(suggestion) },
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = { onConfirm(text.trim().ifEmpty { initialTitle }) }) {
+                Text("Save")
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) { Text("Cancel") }
+        },
+    )
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/audiobook/PlayerListSheet.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audiobook/PlayerListSheet.kt
@@ -1,0 +1,260 @@
+package com.riffle.app.feature.audiobook
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.GraphicEq
+import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.riffle.core.domain.AudiobookBookmark
+import com.riffle.core.domain.AudiobookChapter
+
+/**
+ * What a [PlayerListSheet] renders. The sheet is opened parameterized to exactly ONE kind — there are
+ * no tabs; the caller picks chapters OR bookmarks. Both share the same row markup (see [PlayerListRow])
+ * and differ only in the lead marker and trailing element.
+ */
+sealed interface PlayerListContent {
+    data class Chapters(
+        val items: List<AudiobookChapter>,
+        val currentIndex: Int,
+        val onSeek: (AudiobookChapter) -> Unit,
+    ) : PlayerListContent
+
+    data class Bookmarks(
+        val items: List<AudiobookBookmark>,
+        val onSeek: (AudiobookBookmark) -> Unit,
+        val onRename: (AudiobookBookmark) -> Unit,
+        val onDelete: (AudiobookBookmark) -> Unit,
+        // Slice 2 surfaces this; pass false for now.
+        val offlineNote: Boolean = false,
+    ) : PlayerListContent
+}
+
+/**
+ * One reusable [Audiobook Player] bottom sheet that shows either the chapters list or the bookmarks
+ * list, depending on [content]. Tapping a row seeks and dismisses; bookmark rows carry a ⋮ overflow
+ * for rename/delete.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun PlayerListSheet(
+    content: PlayerListContent,
+    onDismiss: () -> Unit,
+) {
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
+    ) {
+        val title = when (content) {
+            is PlayerListContent.Chapters -> "Chapters"
+            is PlayerListContent.Bookmarks -> "Bookmarks"
+        }
+        Text(
+            text = title,
+            style = MaterialTheme.typography.titleLarge,
+            modifier = Modifier.fillMaxWidth().padding(start = 16.dp, end = 16.dp, bottom = 8.dp),
+        )
+
+        when (content) {
+            is PlayerListContent.Chapters -> ChaptersList(content, onDismiss)
+            is PlayerListContent.Bookmarks -> BookmarksList(content, onDismiss)
+        }
+    }
+}
+
+@Composable
+private fun ChaptersList(content: PlayerListContent.Chapters, onDismiss: () -> Unit) {
+    LazyColumn(modifier = Modifier.fillMaxWidth()) {
+        items(content.items) { chapter ->
+            val isCurrent = chapter.index == content.currentIndex
+            val displayTitle = chapter.title.ifBlank { "Chapter ${chapter.index + 1}" }
+            PlayerListRow(
+                lead = {
+                    if (isCurrent) {
+                        Icon(
+                            Icons.Filled.GraphicEq,
+                            contentDescription = "Now playing",
+                            tint = MaterialTheme.colorScheme.primary,
+                        )
+                    } else {
+                        Text(
+                            text = "${chapter.index + 1}",
+                            style = MaterialTheme.typography.bodyLarge,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                },
+                title = displayTitle,
+                subtitle = if (isCurrent) "Now playing" else null,
+                trailing = {
+                    Text(
+                        text = formatClock(chapter.endSec - chapter.startSec),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                },
+                highlighted = isCurrent,
+                onClick = {
+                    content.onSeek(chapter)
+                    onDismiss()
+                },
+            )
+        }
+    }
+}
+
+@Composable
+private fun BookmarksList(content: PlayerListContent.Bookmarks, onDismiss: () -> Unit) {
+    if (content.offlineNote) {
+        Text(
+            text = "Offline — bookmarks will sync",
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.fillMaxWidth().padding(start = 16.dp, end = 16.dp, bottom = 8.dp),
+        )
+    }
+    if (content.items.isEmpty()) {
+        Text(
+            text = "No bookmarks yet.",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.fillMaxWidth().padding(16.dp),
+        )
+        return
+    }
+    LazyColumn(modifier = Modifier.fillMaxWidth()) {
+        items(content.items, key = { it.id }) { bookmark ->
+            PlayerListRow(
+                lead = {
+                    Icon(
+                        Icons.Filled.PlayArrow,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                },
+                title = bookmark.title,
+                subtitle = null,
+                trailing = { BookmarkOverflow(bookmark, content) },
+                highlighted = false,
+                onClick = {
+                    content.onSeek(bookmark)
+                    onDismiss()
+                },
+            )
+        }
+    }
+}
+
+@Composable
+private fun BookmarkOverflow(bookmark: AudiobookBookmark, content: PlayerListContent.Bookmarks) {
+    var expanded by remember { mutableStateOf(false) }
+    Box {
+        IconButton(onClick = { expanded = true }) {
+            Icon(Icons.Filled.MoreVert, contentDescription = "Bookmark options")
+        }
+        DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+            DropdownMenuItem(
+                text = { Text("Rename") },
+                leadingIcon = { Icon(Icons.Filled.Edit, contentDescription = null) },
+                onClick = {
+                    expanded = false
+                    content.onRename(bookmark)
+                },
+            )
+            DropdownMenuItem(
+                text = { Text("Delete") },
+                leadingIcon = { Icon(Icons.Filled.Delete, contentDescription = null) },
+                onClick = {
+                    expanded = false
+                    content.onDelete(bookmark)
+                },
+            )
+        }
+    }
+}
+
+/**
+ * The shared row markup for both chapters and bookmarks: a [lead] marker, a [title] with an optional
+ * [subtitle], and a [trailing] slot. [highlighted] tints the title (used for the current chapter).
+ */
+@Composable
+private fun PlayerListRow(
+    lead: @Composable () -> Unit,
+    title: String,
+    subtitle: String?,
+    trailing: @Composable () -> Unit,
+    highlighted: Boolean,
+    onClick: () -> Unit,
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+    ) {
+        Box(modifier = Modifier.size(32.dp), contentAlignment = Alignment.Center) {
+            lead()
+        }
+        Spacer(Modifier.width(16.dp))
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.bodyLarge,
+                fontWeight = if (highlighted) FontWeight.Bold else FontWeight.Normal,
+                color = if (highlighted) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurface,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+            )
+            if (subtitle != null) {
+                Text(
+                    text = subtitle,
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.primary,
+                )
+            }
+        }
+        Spacer(Modifier.width(16.dp))
+        trailing()
+    }
+}
+
+/** mm:ss under an hour, h:mm:ss otherwise. */
+private fun formatClock(sec: Double): String {
+    val s = sec.toLong().coerceAtLeast(0)
+    val h = s / 3600
+    val m = (s % 3600) / 60
+    val secs = s % 60
+    return if (h > 0) "%d:%02d:%02d".format(h, m, secs) else "%d:%02d".format(m, secs)
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/audiobook/PlayerListSheet.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audiobook/PlayerListSheet.kt
@@ -1,5 +1,6 @@
 package com.riffle.app.feature.audiobook
 
+import com.riffle.app.feature.audio.formatHms
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -119,7 +120,7 @@ private fun ChaptersList(content: PlayerListContent.Chapters, onDismiss: () -> U
                 subtitle = if (isCurrent) "Now playing" else null,
                 trailing = {
                     Text(
-                        text = formatClock(chapter.endSec - chapter.startSec),
+                        text = formatHms(chapter.endSec - chapter.startSec),
                         style = MaterialTheme.typography.bodyMedium,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
@@ -248,13 +249,4 @@ private fun PlayerListRow(
         Spacer(Modifier.width(16.dp))
         trailing()
     }
-}
-
-/** mm:ss under an hour, h:mm:ss otherwise. */
-private fun formatClock(sec: Double): String {
-    val s = sec.toLong().coerceAtLeast(0)
-    val h = s / 3600
-    val m = (s % 3600) / 60
-    val secs = s % 60
-    return if (h > 0) "%d:%02d:%02d".format(h, m, secs) else "%d:%02d".format(m, secs)
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderSync.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderSync.kt
@@ -156,6 +156,8 @@ class ReaderSyncCoordinator(
                     val remote = AbsAudiobookSyncRemote(absApi, it, bridge)
                     if (pushAudio) remote else InboundOnlyRemote(remote)
                 }
+                // Bookmarks are not a position remote — they reconcile via the sweep, not this cycle.
+                RemoteKind.ABS_BOOKMARK -> null
             }
         }
         val local = LocalCanonical(CanonicalReaderPosition(displayedLocatorJson), localUpdatedAt)

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderSyncFactory.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderSyncFactory.kt
@@ -25,7 +25,7 @@ import javax.inject.Inject
  * is built. Any miss returns `null`, leaving the reader on its existing single-peer path — so
  * the reconciliation cycle is strictly additive and never degrades the non-matched case.
  */
-class ReaderSyncFactory @Inject constructor(
+open class ReaderSyncFactory @Inject constructor(
     private val linkRepository: ReadaloudLinkRepository,
     private val serverRepository: ServerRepository,
     private val tokenStorage: TokenStorage,
@@ -40,7 +40,7 @@ class ReaderSyncFactory @Inject constructor(
      * @param itemId the ABS Library Item id the reader opened. A book is always read from the ABS
      *   side (ADR 0026), so the link is resolved by ABS item.
      */
-    suspend fun createIfApplicable(itemId: String): ReaderSyncCoordinator? {
+    open suspend fun createIfApplicable(itemId: String): ReaderSyncCoordinator? {
         val active = serverRepository.getActive() ?: return null
 
         // The readaloud bundle is the hub: route progress to whichever ABS items are matched to it.
@@ -119,7 +119,7 @@ class ReaderSyncFactory @Inject constructor(
      * [createIfApplicable] needs (ADR 0031). Lets readaloud sync to the audiobook in the window before
      * the index is built (or when it can't be). `null` when there is no audio target or no cached bundle.
      */
-    suspend fun createAudiobookFollowIfApplicable(itemId: String): AudiobookFollow? {
+    open suspend fun createAudiobookFollowIfApplicable(itemId: String): AudiobookFollow? {
         val active = serverRepository.getActive() ?: return null
         val openedLink = linkRepository.findByAbsItem(active.id, itemId) ?: return null
         val allLinks = linkRepository.findByStorytellerBook(openedLink.storytellerServerId, openedLink.storytellerBookId)

--- a/app/src/test/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModelBookmarkTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModelBookmarkTest.kt
@@ -147,26 +147,39 @@ class AudiobookPlayerViewModelBookmarkTest {
     }
 
     @Test
-    fun `defaultBookmarkTitle matches BookmarkTitleBuilder for the current position`() = runTest(testDispatcher) {
+    fun `currentPositionSec reports the controller's live book-absolute position`() = runTest(testDispatcher) {
+        val controller = FakeController(position = 540.0)
+        val vm = buildViewModel(controller, FakeBookmarkStore())
+        runCurrent()
+
+        assertEquals(540.0, vm.currentPositionSec(), 0.0001)
+        vm.clearForTest()
+    }
+
+    @Test
+    fun `defaultBookmarkTitle matches BookmarkTitleBuilder for the pinned position`() = runTest(testDispatcher) {
         val controller = FakeController(position = 540.0)
         val vm = buildViewModel(controller, FakeBookmarkStore())
         runCurrent()
 
         assertEquals(
             BookmarkTitleBuilder.defaultTitle(timeline, 540.0),
-            vm.defaultBookmarkTitle(),
+            vm.defaultBookmarkTitle(540.0),
         )
         vm.clearForTest()
     }
 
     @Test
-    fun `addBookmark forwards serverId itemId position title and the fixed clock to the store`() = runTest(testDispatcher) {
+    fun `addBookmark forwards serverId itemId the pinned position title and the fixed clock to the store`() = runTest(testDispatcher) {
         val controller = FakeController(position = 321.0)
         val store = FakeBookmarkStore()
         val vm = buildViewModel(controller, store)
         runCurrent()
 
-        vm.addBookmark("My title")
+        // The UI pins the position when the dialog opens; the live playhead has since drifted to 999,
+        // but the bookmark must be saved at the pinned 321.0, not the drifted position.
+        controller.position = 999.0
+        vm.addBookmark("My title", positionSec = 321.0)
         runCurrent()
 
         assertEquals(1, store.added.size)

--- a/app/src/test/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModelBookmarkTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModelBookmarkTest.kt
@@ -1,0 +1,491 @@
+package com.riffle.app.feature.audiobook
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.viewModelScope
+import com.riffle.app.feature.reader.ReaderSyncCoordinator
+import com.riffle.app.feature.reader.ReaderSyncFactory
+import com.riffle.app.feature.reader.ProgressFlushScope
+import com.riffle.app.feature.reader.AudiobookFollow
+import com.riffle.app.playback.NowPlayingStore
+import com.riffle.core.data.CrossEpubIndexBuildTrigger
+import com.riffle.core.data.OpenReconcileTargets
+import com.riffle.core.domain.AudioIdentity
+import com.riffle.core.domain.AudioIdentityResolver
+import com.riffle.core.domain.AudioPlaybackPreferencesStore
+import com.riffle.core.domain.AudiobookBookmark
+import com.riffle.core.domain.AudiobookBookmarkStore
+import com.riffle.core.domain.AudiobookChapter
+import com.riffle.core.domain.AudiobookDownloadRepository
+import com.riffle.core.domain.AudiobookRepository
+import com.riffle.core.domain.AudiobookSession
+import com.riffle.core.domain.AudiobookTimeline
+import com.riffle.core.domain.BookmarkTitleBuilder
+import com.riffle.core.domain.BundleAudiobookSource
+import com.riffle.core.domain.CrossEpubIndex
+import com.riffle.core.domain.CrossEpubIndexStore
+import com.riffle.core.domain.EbookFormat
+import com.riffle.core.domain.LibraryItem
+import com.riffle.core.domain.LibraryRepository
+import com.riffle.core.domain.LocalStore
+import com.riffle.core.domain.PositionSnapshot
+import com.riffle.core.domain.ReadaloudAudioRepository
+import com.riffle.core.domain.ReadaloudLink
+import com.riffle.core.domain.ReadaloudLinkRepository
+import com.riffle.core.domain.ReadaloudResumePosition
+import com.riffle.core.domain.ReadaloudResumeStore
+import com.riffle.core.domain.ReadaloudTrack
+import com.riffle.core.domain.Server
+import com.riffle.core.domain.ServerRepository
+import com.riffle.core.domain.ServerUrl
+import com.riffle.core.domain.StoredItemRef
+import com.riffle.core.domain.SyncPositionStore
+import com.riffle.core.domain.TokenStorage
+import com.riffle.core.network.AbsSessionApi
+import com.riffle.core.network.NetworkAudiobookProgressPayload
+import com.riffle.core.network.NetworkEbookProgressPayload
+import com.riffle.core.network.NetworkGetProgressResult
+import com.riffle.core.network.NetworkSyncSessionResult
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import java.io.File
+import java.io.InputStream
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class AudiobookPlayerViewModelBookmarkTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+
+    @Before fun setUp() { Dispatchers.setMain(testDispatcher) }
+    @After fun tearDown() { Dispatchers.resetMain() }
+
+    private val serverId = "srv-1"
+    private val itemId = "item-1"
+    private val fixedNow = 1_700_000_000_000L
+    private val timeline = AudiobookTimeline(
+        durationSec = 1000.0,
+        chapters = listOf(
+            AudiobookChapter(index = 0, startSec = 0.0, endSec = 500.0, title = "Chapter One"),
+            AudiobookChapter(index = 1, startSec = 500.0, endSec = 1000.0, title = "Chapter Two"),
+        ),
+    )
+
+    // A fake controller whose book-absolute position is settable and whose seekTo is recorded. Only the
+    // members the VM actually touches are overridden; the heavy Media3/Context machinery is bypassed.
+    private class FakeController(var position: Double) : AudiobookController() {
+        val seeks = mutableListOf<Double>()
+        override val state = MutableStateFlow(PlaybackState())
+        override suspend fun prepare(
+            trackUrls: List<String>,
+            spans: List<com.riffle.core.domain.AudiobookTrackSpan>,
+            durationSec: Double,
+            startAtSec: Double,
+            localZipFile: File?,
+        ) { /* no-op */ }
+        override fun play() {}
+        override fun setSpeed(speed: Float) {}
+        override fun currentAbsoluteSec(): Double = position
+        override fun seekTo(absoluteSec: Double) { seeks.add(absoluteSec) }
+    }
+
+    // Cancel the ViewModel's [viewModelScope] (the never-ending follow loop + bookmark observation) so
+    // runTest's end-of-body drain doesn't spin forever on the follow loop's recurring delay. Uses the
+    // public viewModelScope extension — the scope already exists (init touched it) — to cancel directly.
+    private fun AudiobookPlayerViewModel.clearForTest() {
+        this.viewModelScope.cancel()
+    }
+
+    private fun buildViewModel(
+        controller: FakeController,
+        bookmarkStore: AudiobookBookmarkStore,
+    ): AudiobookPlayerViewModel {
+        val session = AudiobookSession(
+            trackUrls = listOf("http://x/track0"),
+            tracks = listOf(com.riffle.core.domain.AudiobookTrackSpan(0, 0.0, 1000.0)),
+            timeline = timeline,
+            serverCurrentTimeSec = 0.0,
+            serverLastUpdate = 0L,
+        )
+        return AudiobookPlayerViewModel(
+            savedStateHandle = SavedStateHandle(mapOf("itemId" to itemId)),
+            audiobookRepository = FakeAudiobookRepository(session),
+            audiobookDownloadRepository = NoDownloadRepo,
+            bundleAudiobookSource = NoBundleSource,
+            libraryRepository = FakeLibraryRepository(),
+            serverRepository = FakeServerRepository(),
+            tokenStorage = FakeTokenStorage,
+            controller = controller,
+            audioPlaybackPreferencesStore = FakePrefsStore,
+            audioIdentityResolver = FakeIdentityResolver,
+            readerSyncFactory = TestReaderSyncFactory(),
+            readaloudLinkRepository = FakeLinkRepository,
+            readaloudAudioRepository = FakeAudioRepo,
+            nowPlayingStore = NowPlayingStore(),
+            audiobookPositionStore = FakePositionStore(),
+            readingSyncStore = FakeSyncStore(),
+            audioSyncStore = FakeSyncStoreDouble(),
+            readaloudResumeStore = FakeResumeStore,
+            openReconcileTargets = OpenReconcileTargets(),
+            progressFlushScope = ProgressFlushScope(CoroutineScope(testDispatcher)),
+            bookmarkStore = bookmarkStore,
+            now = { fixedNow },
+        )
+    }
+
+    @Test
+    fun `defaultBookmarkTitle matches BookmarkTitleBuilder for the current position`() = runTest(testDispatcher) {
+        val controller = FakeController(position = 540.0)
+        val vm = buildViewModel(controller, FakeBookmarkStore())
+        runCurrent()
+
+        assertEquals(
+            BookmarkTitleBuilder.defaultTitle(timeline, 540.0),
+            vm.defaultBookmarkTitle(),
+        )
+        vm.clearForTest()
+    }
+
+    @Test
+    fun `addBookmark forwards serverId itemId position title and the fixed clock to the store`() = runTest(testDispatcher) {
+        val controller = FakeController(position = 321.0)
+        val store = FakeBookmarkStore()
+        val vm = buildViewModel(controller, store)
+        runCurrent()
+
+        vm.addBookmark("My title")
+        runCurrent()
+
+        assertEquals(1, store.added.size)
+        assertEquals(
+            AddCall(serverId, itemId, 321.0, "My title", fixedNow),
+            store.added.single(),
+        )
+        // The new id is surfaced for an Undo.
+        assertEquals(store.lastId, vm.uiState.value.lastCreatedBookmarkId)
+        vm.clearForTest()
+    }
+
+    @Test
+    fun `bookmarks emitted by the store appear in uiState`() = runTest(testDispatcher) {
+        val controller = FakeController(position = 0.0)
+        val store = FakeBookmarkStore()
+        val vm = buildViewModel(controller, store)
+        runCurrent()
+
+        val bookmark = AudiobookBookmark(id = "bm-1", positionSec = 42.0, title = "Saved", createdAt = fixedNow)
+        store.flow.value = listOf(bookmark)
+        runCurrent()
+
+        assertEquals(listOf(bookmark), vm.uiState.value.bookmarks)
+        vm.clearForTest()
+    }
+
+    @Test
+    fun `seekToBookmark seeks the controller to the bookmark position`() = runTest(testDispatcher) {
+        val controller = FakeController(position = 0.0)
+        val vm = buildViewModel(controller, FakeBookmarkStore())
+        runCurrent()
+
+        vm.seekToBookmark(123.0)
+        runCurrent()
+
+        assertEquals(listOf(123.0), controller.seeks)
+        vm.clearForTest()
+    }
+
+    // --- fakes ---
+
+    private data class AddCall(
+        val serverId: String,
+        val itemId: String,
+        val positionSec: Double,
+        val title: String,
+        val now: Long,
+    )
+
+    private class FakeBookmarkStore : AudiobookBookmarkStore {
+        val flow = MutableStateFlow<List<AudiobookBookmark>>(emptyList())
+        val added = mutableListOf<AddCall>()
+        var lastId: String = ""
+        private var seq = 0
+        override fun observe(serverId: String, itemId: String): Flow<List<AudiobookBookmark>> = flow
+        override suspend fun add(serverId: String, itemId: String, positionSec: Double, title: String, now: Long): String {
+            added.add(AddCall(serverId, itemId, positionSec, title, now))
+            lastId = "bm-${seq++}"
+            return lastId
+        }
+        override suspend fun rename(id: String, title: String, now: Long) {}
+        override suspend fun delete(id: String, now: Long) {}
+    }
+
+    private class FakeAudiobookRepository(private val session: AudiobookSession) : AudiobookRepository {
+        override suspend fun openSession(serverId: String, itemId: String): AudiobookSession = session
+        override suspend fun saveProgress(serverId: String, itemId: String, positionSec: Double, durationSec: Double) {}
+    }
+
+    private object NoDownloadRepo : AudiobookDownloadRepository {
+        override fun isDownloaded(serverId: String, itemId: String) = false
+        override fun localSession(serverId: String, itemId: String): AudiobookSession? = null
+        override suspend fun download(
+            serverId: String,
+            itemId: String,
+            onProgress: (Long, Long) -> Unit,
+        ) = com.riffle.core.domain.AudiobookDownloadResult.Success
+        override suspend fun remove(serverId: String, itemId: String): Long = 0
+    }
+
+    private object NoBundleSource : BundleAudiobookSource {
+        override suspend fun localSession(serverId: String, itemId: String): AudiobookSession? = null
+        override fun isAvailableOffline(serverId: String, itemId: String) = false
+    }
+
+    private inner class FakeLibraryRepository : LibraryRepository {
+        private val item = LibraryItem(
+            id = itemId,
+            libraryId = "lib",
+            title = "Book",
+            author = "Author",
+            coverUrl = null,
+            readingProgress = 0f,
+            isCached = false,
+            isDownloaded = false,
+            ebookFormat = EbookFormat.Unsupported,
+            hasAudio = true,
+            audioDurationSec = 1000.0,
+            serverId = serverId,
+        )
+        override suspend fun getItem(itemId: String): LibraryItem = item
+        override suspend fun getItem(serverId: String, itemId: String): LibraryItem = item
+        override suspend fun updateReadingProgress(itemId: String, progress: Float) {}
+        override fun observeItem(itemId: String) = throw NotImplementedError()
+        override fun observeLibraries() = throw NotImplementedError()
+        override fun observeLibraries(serverId: String) = throw NotImplementedError()
+        override fun observeLibraryItems(libraryId: String) = throw NotImplementedError()
+        override fun observeUngroupedLibraryItems(libraryId: String) = throw NotImplementedError()
+        override fun observeInProgressItems(libraryId: String) = throw NotImplementedError()
+        override fun observeFinishedItems(libraryId: String) = throw NotImplementedError()
+        override fun observeRecentlyAddedItems(libraryId: String) = throw NotImplementedError()
+        override fun observeAllBooks(libraryId: String) = throw NotImplementedError()
+        override fun observeSeries(libraryId: String) = throw NotImplementedError()
+        override fun observeCollections(libraryId: String) = throw NotImplementedError()
+        override fun observeSeriesItems(seriesId: String) = throw NotImplementedError()
+        override fun observeCollectionItems(collectionId: String) = throw NotImplementedError()
+        override suspend fun getLibrary(libraryId: String) = throw NotImplementedError()
+        override suspend fun getSeriesIdForItem(serverId: String, itemId: String): String? = null
+        override suspend fun markItemOpened(itemId: String) {}
+        override suspend fun refreshLibraries() = throw NotImplementedError()
+        override suspend fun refreshLibraryItems(libraryId: String) = throw NotImplementedError()
+        override suspend fun refreshSeries(libraryId: String) = throw NotImplementedError()
+        override suspend fun refreshCollections(libraryId: String) = throw NotImplementedError()
+    }
+
+    private inner class FakeServerRepository : ServerRepository {
+        private val server = Server(
+            id = serverId,
+            url = ServerUrl.parse("http://example.com")!!,
+            isActive = true,
+            insecureConnectionAllowed = false,
+            username = "u",
+        )
+        override fun observeAll() = throw NotImplementedError()
+        override suspend fun getActive(): Server = server
+        override suspend fun getById(serverId: String): Server = server
+        override suspend fun authenticate(
+            url: ServerUrl,
+            username: String,
+            password: String,
+            insecureAllowed: Boolean,
+            serverType: com.riffle.core.domain.ServerType,
+        ) = throw NotImplementedError()
+        override suspend fun commit(
+            pending: com.riffle.core.domain.PendingServer,
+            hiddenLibraryIds: Set<String>,
+        ) = throw NotImplementedError()
+        override suspend fun setActive(serverId: String) {}
+        override suspend fun remove(serverId: String) {}
+        override suspend fun getServerVersion(serverId: String): String? = null
+    }
+
+    private object FakeTokenStorage : TokenStorage {
+        override suspend fun saveToken(serverId: String, token: String) {}
+        override suspend fun getToken(serverId: String): String = "token"
+        override suspend fun deleteToken(serverId: String) {}
+    }
+
+    private object FakePrefsStore : AudioPlaybackPreferencesStore {
+        override suspend fun load(identity: AudioIdentity): Float? = null
+        override suspend fun save(identity: AudioIdentity, speed: Float) {}
+        override suspend fun clear(identity: AudioIdentity) {}
+        override suspend fun rekey(old: AudioIdentity, new: AudioIdentity) {}
+    }
+
+    private object FakeIdentityResolver : AudioIdentityResolver {
+        override suspend fun resolveForStorytellerBook(
+            storytellerServerId: String,
+            storytellerBookId: String,
+        ) = AudioIdentity("", "")
+    }
+
+    private object FakeLinkRepository : ReadaloudLinkRepository {
+        override fun observeAll() = throw NotImplementedError()
+        override fun observeLinkedAbsItemIds() = throw NotImplementedError()
+        override suspend fun findByAbsItem(absServerId: String, absLibraryItemId: String): ReadaloudLink? = null
+        override suspend fun findByStorytellerBook(storytellerServerId: String, storytellerBookId: String): List<ReadaloudLink> = emptyList()
+        override suspend fun unlinkAbsItem(absServerId: String, absLibraryItemId: String) {}
+        override suspend fun countForServer(serverId: String): Int = 0
+    }
+
+    private object FakeAudioRepo : ReadaloudAudioRepository {
+        override fun isAudioAvailable(serverId: String, itemId: String) = false
+        override fun bundleFile(serverId: String, itemId: String): File? = null
+        override suspend fun readTrack(serverId: String, itemId: String): ReadaloudTrack? = null
+        override suspend fun probeSizeBytes(serverId: String, itemId: String): Long? = null
+        override suspend fun downloadAudio(
+            serverId: String,
+            bookId: String,
+            onProgress: (Long, Long) -> Unit,
+        ) = com.riffle.core.domain.AudioDownloadResult.NoBundle
+        override suspend fun removeAudio(serverId: String, itemId: String): Long = 0
+    }
+
+    private class FakePositionStore : com.riffle.core.domain.AudiobookPositionStore {
+        override suspend fun save(serverId: String, itemId: String, payload: Double) {}
+        override suspend fun load(serverId: String, itemId: String): Double? = null
+        override suspend fun loadLocalUpdatedAt(serverId: String, itemId: String): Long = 0
+        override suspend fun updateLocalTimestamp(serverId: String, itemId: String, millis: Long) {}
+    }
+
+    private class FakeSyncStore : SyncPositionStore<String> {
+        override suspend fun snapshot(serverId: String, itemId: String) = PositionSnapshot<String>(null, 0, 0)
+        override suspend fun acceptServerPosition(serverId: String, itemId: String, position: String, serverStamp: Long, ifLocalUpdatedAt: Long) = false
+        override suspend fun confirmPushed(serverId: String, itemId: String, serverStamp: Long, ifLocalUpdatedAt: Long) = false
+        override suspend fun confirmInSync(serverId: String, itemId: String, ifLocalUpdatedAt: Long) = false
+        override suspend fun mirror(serverId: String, itemId: String, position: String, localUpdatedAt: Long, lastSyncedAt: Long) {}
+    }
+
+    private class FakeSyncStoreDouble : SyncPositionStore<Double> {
+        override suspend fun snapshot(serverId: String, itemId: String) = PositionSnapshot<Double>(null, 0, 0)
+        override suspend fun acceptServerPosition(serverId: String, itemId: String, position: Double, serverStamp: Long, ifLocalUpdatedAt: Long) = false
+        override suspend fun confirmPushed(serverId: String, itemId: String, serverStamp: Long, ifLocalUpdatedAt: Long) = false
+        override suspend fun confirmInSync(serverId: String, itemId: String, ifLocalUpdatedAt: Long) = false
+        override suspend fun mirror(serverId: String, itemId: String, position: Double, localUpdatedAt: Long, lastSyncedAt: Long) {}
+    }
+
+    private object FakeResumeStore : ReadaloudResumeStore {
+        override suspend fun save(serverId: String, itemId: String, position: ReadaloudResumePosition) {}
+        override suspend fun load(serverId: String, itemId: String): ReadaloudResumePosition? = null
+    }
+
+    // A ReaderSyncFactory whose two attach methods return null, so the player stays on its single-peer
+    // path. The super-constructor deps are inert stubs — never touched once both methods short-circuit.
+    private class TestReaderSyncFactory : ReaderSyncFactory(
+        FakeLinkRepository,
+        StubServer,
+        FakeTokenStorage,
+        StubIndexStore,
+        StubAbsApi,
+        StubLibrary,
+        StubLocalStore,
+        StubLocalStore,
+        StubBuildTrigger,
+    ) {
+        override suspend fun createIfApplicable(itemId: String): ReaderSyncCoordinator? = null
+        override suspend fun createAudiobookFollowIfApplicable(itemId: String): AudiobookFollow? = null
+    }
+
+    private object StubServer : ServerRepository {
+        override fun observeAll() = throw NotImplementedError()
+        override suspend fun getActive(): Server? = null
+        override suspend fun authenticate(
+            url: ServerUrl,
+            username: String,
+            password: String,
+            insecureAllowed: Boolean,
+            serverType: com.riffle.core.domain.ServerType,
+        ) = throw NotImplementedError()
+        override suspend fun commit(pending: com.riffle.core.domain.PendingServer, hiddenLibraryIds: Set<String>) = throw NotImplementedError()
+        override suspend fun setActive(serverId: String) {}
+        override suspend fun remove(serverId: String) {}
+        override suspend fun getServerVersion(serverId: String): String? = null
+    }
+
+    private object StubLibrary : LibraryRepository {
+        override suspend fun getItem(itemId: String): LibraryItem? = null
+        override suspend fun getItem(serverId: String, itemId: String): LibraryItem? = null
+        override suspend fun updateReadingProgress(itemId: String, progress: Float) {}
+        override fun observeItem(itemId: String) = throw NotImplementedError()
+        override fun observeLibraries() = throw NotImplementedError()
+        override fun observeLibraries(serverId: String) = throw NotImplementedError()
+        override fun observeLibraryItems(libraryId: String) = throw NotImplementedError()
+        override fun observeUngroupedLibraryItems(libraryId: String) = throw NotImplementedError()
+        override fun observeInProgressItems(libraryId: String) = throw NotImplementedError()
+        override fun observeFinishedItems(libraryId: String) = throw NotImplementedError()
+        override fun observeRecentlyAddedItems(libraryId: String) = throw NotImplementedError()
+        override fun observeAllBooks(libraryId: String) = throw NotImplementedError()
+        override fun observeSeries(libraryId: String) = throw NotImplementedError()
+        override fun observeCollections(libraryId: String) = throw NotImplementedError()
+        override fun observeSeriesItems(seriesId: String) = throw NotImplementedError()
+        override fun observeCollectionItems(collectionId: String) = throw NotImplementedError()
+        override suspend fun getLibrary(libraryId: String) = throw NotImplementedError()
+        override suspend fun getSeriesIdForItem(serverId: String, itemId: String): String? = null
+        override suspend fun markItemOpened(itemId: String) {}
+        override suspend fun refreshLibraries() = throw NotImplementedError()
+        override suspend fun refreshLibraryItems(libraryId: String) = throw NotImplementedError()
+        override suspend fun refreshSeries(libraryId: String) = throw NotImplementedError()
+        override suspend fun refreshCollections(libraryId: String) = throw NotImplementedError()
+    }
+
+    private object StubIndexStore : CrossEpubIndexStore {
+        override suspend fun exists(absChecksum: String, storytellerChecksum: String) = false
+        override suspend fun put(absChecksum: String, storytellerChecksum: String, blob: String, builtAt: Long) {}
+        override suspend fun load(absChecksum: String, storytellerChecksum: String): CrossEpubIndex? = null
+    }
+
+    private object StubAbsApi : AbsSessionApi {
+        override suspend fun syncEbookProgress(
+            baseUrl: String,
+            libraryItemId: String,
+            payload: NetworkEbookProgressPayload,
+            token: String,
+            insecureAllowed: Boolean,
+        ) = NetworkSyncSessionResult.NetworkError(RuntimeException())
+        override suspend fun syncAudiobookProgress(
+            baseUrl: String,
+            libraryItemId: String,
+            payload: NetworkAudiobookProgressPayload,
+            token: String,
+            insecureAllowed: Boolean,
+        ) = NetworkSyncSessionResult.NetworkError(RuntimeException())
+        override suspend fun getProgress(
+            baseUrl: String,
+            libraryItemId: String,
+            token: String,
+            insecureAllowed: Boolean,
+        ) = NetworkGetProgressResult.NetworkError(RuntimeException())
+    }
+
+    private object StubLocalStore : LocalStore {
+        override fun get(serverId: String, itemId: String): File? = null
+        override suspend fun save(serverId: String, itemId: String, stream: InputStream): File = File("/dev/null")
+        override fun delete(serverId: String, itemId: String) {}
+        override fun deleteServer(serverId: String) {}
+        override fun clear() {}
+        override fun listItems(): List<StoredItemRef> = emptyList()
+    }
+
+    private object StubBuildTrigger : CrossEpubIndexBuildTrigger {
+        override fun enqueueBuild(link: ReadaloudLink) {}
+    }
+}

--- a/app/src/test/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModelBookmarkTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModelBookmarkTest.kt
@@ -110,6 +110,7 @@ class AudiobookPlayerViewModelBookmarkTest {
     private fun buildViewModel(
         controller: FakeController,
         bookmarkStore: AudiobookBookmarkStore,
+        connectivity: FakeConnectivityObserver = FakeConnectivityObserver(online = true),
     ): AudiobookPlayerViewModel {
         val session = AudiobookSession(
             trackUrls = listOf("http://x/track0"),
@@ -140,6 +141,7 @@ class AudiobookPlayerViewModelBookmarkTest {
             openReconcileTargets = OpenReconcileTargets(),
             progressFlushScope = ProgressFlushScope(CoroutineScope(testDispatcher)),
             bookmarkStore = bookmarkStore,
+            connectivityObserver = connectivity,
             now = { fixedNow },
         )
     }
@@ -222,7 +224,47 @@ class AudiobookPlayerViewModelBookmarkTest {
         vm.clearForTest()
     }
 
+    @Test
+    fun `bookmarksOffline is true only when there are unsynced bookmarks AND the device is offline`() = runTest(testDispatcher) {
+        // offline + unsynced → note shows
+        run {
+            val store = FakeBookmarkStore().apply { hasUnsynced.value = true }
+            val vm = buildViewModel(FakeController(0.0), store, FakeConnectivityObserver(online = false))
+            runCurrent()
+            assertEquals(true, vm.uiState.value.bookmarksOffline)
+            vm.clearForTest()
+        }
+        // offline + nothing unsynced → silent
+        run {
+            val store = FakeBookmarkStore().apply { hasUnsynced.value = false }
+            val vm = buildViewModel(FakeController(0.0), store, FakeConnectivityObserver(online = false))
+            runCurrent()
+            assertEquals(false, vm.uiState.value.bookmarksOffline)
+            vm.clearForTest()
+        }
+        // online + unsynced → silent (it'll sync)
+        run {
+            val store = FakeBookmarkStore().apply { hasUnsynced.value = true }
+            val vm = buildViewModel(FakeController(0.0), store, FakeConnectivityObserver(online = true))
+            runCurrent()
+            assertEquals(false, vm.uiState.value.bookmarksOffline)
+            vm.clearForTest()
+        }
+        // online + nothing unsynced → silent
+        run {
+            val store = FakeBookmarkStore().apply { hasUnsynced.value = false }
+            val vm = buildViewModel(FakeController(0.0), store, FakeConnectivityObserver(online = true))
+            runCurrent()
+            assertEquals(false, vm.uiState.value.bookmarksOffline)
+            vm.clearForTest()
+        }
+    }
+
     // --- fakes ---
+
+    private class FakeConnectivityObserver(online: Boolean) : com.riffle.core.domain.ConnectivityObserver {
+        override val isOnline = MutableStateFlow(online)
+    }
 
     private data class AddCall(
         val serverId: String,
@@ -234,10 +276,12 @@ class AudiobookPlayerViewModelBookmarkTest {
 
     private class FakeBookmarkStore : AudiobookBookmarkStore {
         val flow = MutableStateFlow<List<AudiobookBookmark>>(emptyList())
+        val hasUnsynced = MutableStateFlow(false)
         val added = mutableListOf<AddCall>()
         var lastId: String = ""
         private var seq = 0
         override fun observe(serverId: String, itemId: String): Flow<List<AudiobookBookmark>> = flow
+        override fun observeHasUnsynced(serverId: String, itemId: String): Flow<Boolean> = hasUnsynced
         override suspend fun add(serverId: String, itemId: String, positionSec: Double, title: String, now: Long): String {
             added.add(AddCall(serverId, itemId, positionSec, title, now))
             lastId = "bm-${seq++}"

--- a/app/src/test/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModelBookmarkTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModelBookmarkTest.kt
@@ -193,6 +193,23 @@ class AudiobookPlayerViewModelBookmarkTest {
     }
 
     @Test
+    fun `bookmarks observed during init survive the init success-path`() = runTest(testDispatcher) {
+        val controller = FakeController(position = 0.0)
+        val store = FakeBookmarkStore()
+        // Seed the store BEFORE the ViewModel is built, so the live collector observes it during init's
+        // suspend points — before the success-path writes the resolved metadata. A success path that
+        // builds a fresh state (rather than copy()) would wipe this; copy() carries it forward.
+        val bookmark = AudiobookBookmark(id = "bm-1", positionSec = 42.0, title = "Saved", createdAt = fixedNow)
+        store.flow.value = listOf(bookmark)
+
+        val vm = buildViewModel(controller, store)
+        runCurrent()
+
+        assertEquals(listOf(bookmark), vm.uiState.value.bookmarks)
+        vm.clearForTest()
+    }
+
+    @Test
     fun `seekToBookmark seeks the controller to the bookmark position`() = runTest(testDispatcher) {
         val controller = FakeController(position = 0.0)
         val vm = buildViewModel(controller, FakeBookmarkStore())

--- a/core/data/src/main/kotlin/com/riffle/core/data/AudiobookBookmarkReconciler.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/AudiobookBookmarkReconciler.kt
@@ -20,12 +20,24 @@ import kotlin.math.roundToInt
  * insert remote additions, accept remote renames onto clean rows, and remove rows deleted on
  * another device. Dirty rows (local intent pending) are never clobbered by the pull.
  */
-class AudiobookBookmarkReconciler @Inject constructor(
+class AudiobookBookmarkReconciler(
     private val dao: AudiobookBookmarkDao,
     private val api: AbsBookmarkApi,
     private val now: () -> Long = System::currentTimeMillis,
     private val newId: () -> String = { java.util.UUID.randomUUID().toString() },
 ) {
+    // Hilt can't satisfy the `() -> Long` / `() -> String` parameters (Dagger ignores Kotlin default
+    // values), so the injected constructor omits them and delegates to the real implementations — the
+    // established pattern in this codebase (e.g. AudiobookPlayerViewModel). Tests use the primary
+    // constructor with deterministic fakes.
+    @Inject
+    constructor(dao: AudiobookBookmarkDao, api: AbsBookmarkApi) : this(
+        dao,
+        api,
+        System::currentTimeMillis,
+        { java.util.UUID.randomUUID().toString() },
+    )
+
     suspend fun reconcile(
         serverId: String,
         itemId: String,

--- a/core/data/src/main/kotlin/com/riffle/core/data/AudiobookBookmarkReconciler.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/AudiobookBookmarkReconciler.kt
@@ -1,0 +1,102 @@
+package com.riffle.core.data
+
+import com.riffle.core.database.AudiobookBookmarkDao
+import com.riffle.core.database.AudiobookBookmarkEntity
+import com.riffle.core.network.AbsBookmarkApi
+import com.riffle.core.network.AbsBookmarkListResult
+import com.riffle.core.network.AbsBookmarkResult
+import javax.inject.Inject
+import kotlin.math.roundToInt
+
+/**
+ * Set-reconciler for audiobook bookmarks against Audiobookshelf (ADR 0030).
+ *
+ * Unlike positions (one value per item), bookmarks are a COLLECTION per (serverId, itemId),
+ * so this is a set-reconcile. ABS identity for a bookmark is (libraryItemId, time) where time
+ * is INTEGER seconds — there is NO per-bookmark id, so we key local<->server matches on
+ * `positionSec.roundToInt() == timeSec`.
+ *
+ * Policy: PUSH local intent first (creates / renames / deletes), then PULL the server set to
+ * insert remote additions, accept remote renames onto clean rows, and remove rows deleted on
+ * another device. Dirty rows (local intent pending) are never clobbered by the pull.
+ */
+class AudiobookBookmarkReconciler @Inject constructor(
+    private val dao: AudiobookBookmarkDao,
+    private val api: AbsBookmarkApi,
+    private val now: () -> Long = System::currentTimeMillis,
+    private val newId: () -> String = { java.util.UUID.randomUUID().toString() },
+) {
+    suspend fun reconcile(
+        serverId: String,
+        itemId: String,
+        baseUrl: String,
+        token: String,
+        insecureAllowed: Boolean,
+    ) {
+        // --- PUSH: send each dirty row's local intent. Capture ifStamp BEFORE the network call. ---
+        val dirty = dao.allForItem(serverId, itemId).filter { it.localUpdatedAt > it.lastSyncedAt }
+        for (row in dirty) {
+            val ifStamp = row.localUpdatedAt
+            if (row.deleted) {
+                val res = api.deleteBookmark(baseUrl, itemId, row.positionSec.roundToInt(), token, insecureAllowed)
+                if (res is AbsBookmarkResult.Success) {
+                    dao.hardDeleteIfUnchanged(row.id, ifLocalUpdatedAt = ifStamp)
+                }
+                // NetworkError -> leave the tombstone (retries next sweep).
+            } else {
+                val res = if (row.lastSyncedAt == 0L) {
+                    api.createBookmark(baseUrl, itemId, row.positionSec.roundToInt(), row.title, token, insecureAllowed)
+                } else {
+                    api.updateBookmark(baseUrl, itemId, row.positionSec.roundToInt(), row.title, token, insecureAllowed)
+                }
+                if (res is AbsBookmarkResult.Success) {
+                    dao.confirmPushedIfUnchanged(row.id, serverStamp = now(), ifLocalUpdatedAt = ifStamp)
+                }
+                // NetworkError -> leave dirty.
+            }
+        }
+
+        // --- PULL: only if we can read the server. ---
+        val listResult = api.listBookmarks(baseUrl, token, insecureAllowed)
+        val serverBookmarks = when (listResult) {
+            is AbsBookmarkListResult.Success -> listResult.bookmarks
+            is AbsBookmarkListResult.NetworkError -> return
+        }
+
+        val serverForItem = serverBookmarks.filter { it.libraryItemId == itemId }
+        val serverTimes = serverForItem.map { it.timeSec }.toSet()
+        // Re-read local AFTER push so confirmed deletes are already gone.
+        val local = dao.allForItem(serverId, itemId)
+
+        // Insert / update from server.
+        for (sb in serverForItem) {
+            val atTime = local.firstOrNull { it.positionSec.roundToInt() == sb.timeSec }
+            when {
+                atTime == null -> dao.upsert(
+                    AudiobookBookmarkEntity(
+                        id = newId(),
+                        serverId = serverId,
+                        itemId = itemId,
+                        positionSec = sb.timeSec.toDouble(),
+                        title = sb.title,
+                        createdAt = sb.createdAt,
+                        localUpdatedAt = now(),
+                        lastSyncedAt = now(),
+                        deleted = false,
+                    ),
+                )
+                atTime.localUpdatedAt <= atTime.lastSyncedAt && !atTime.deleted && atTime.title != sb.title ->
+                    dao.upsert(atTime.copy(title = sb.title, localUpdatedAt = now(), lastSyncedAt = now()))
+                // else: dirty or deleted-tombstone -> SKIP (local intent pending).
+            }
+        }
+
+        // Remove locally-stale: clean, non-deleted rows whose time is absent server-side
+        // were deleted on another device.
+        for (lb in local) {
+            if (!lb.deleted && lb.localUpdatedAt <= lb.lastSyncedAt && lb.positionSec.roundToInt() !in serverTimes) {
+                dao.hardDelete(lb.id)
+            }
+        }
+    }
+}

--- a/core/data/src/main/kotlin/com/riffle/core/data/AudiobookBookmarkStoreImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/AudiobookBookmarkStoreImpl.kt
@@ -1,0 +1,41 @@
+package com.riffle.core.data
+
+import com.riffle.core.database.AudiobookBookmarkDao
+import com.riffle.core.database.AudiobookBookmarkEntity
+import com.riffle.core.domain.AudiobookBookmark
+import com.riffle.core.domain.AudiobookBookmarkStore
+import java.util.UUID
+import javax.inject.Inject
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+class AudiobookBookmarkStoreImpl @Inject constructor(
+    private val dao: AudiobookBookmarkDao,
+) : AudiobookBookmarkStore {
+
+    override fun observe(serverId: String, itemId: String): Flow<List<AudiobookBookmark>> =
+        dao.observeForItem(serverId, itemId).map { rows ->
+            rows.map { AudiobookBookmark(it.id, it.positionSec, it.title, it.createdAt) }
+        }
+
+    override suspend fun add(serverId: String, itemId: String, positionSec: Double, title: String, now: Long): String {
+        val id = UUID.randomUUID().toString()
+        dao.upsert(
+            AudiobookBookmarkEntity(
+                id = id, serverId = serverId, itemId = itemId, positionSec = positionSec,
+                title = title, createdAt = now, localUpdatedAt = now, lastSyncedAt = 0, deleted = false,
+            ),
+        )
+        return id
+    }
+
+    override suspend fun rename(id: String, title: String, now: Long) {
+        val e = dao.getById(id) ?: return
+        dao.upsert(e.copy(title = title, localUpdatedAt = now))
+    }
+
+    override suspend fun delete(id: String, now: Long) {
+        val e = dao.getById(id) ?: return
+        dao.upsert(e.copy(deleted = true, localUpdatedAt = now))
+    }
+}

--- a/core/data/src/main/kotlin/com/riffle/core/data/AudiobookBookmarkStoreImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/AudiobookBookmarkStoreImpl.kt
@@ -18,6 +18,9 @@ class AudiobookBookmarkStoreImpl @Inject constructor(
             rows.map { AudiobookBookmark(it.id, it.positionSec, it.title, it.createdAt) }
         }
 
+    override fun observeHasUnsynced(serverId: String, itemId: String): Flow<Boolean> =
+        dao.observeDirtyCountForItem(serverId, itemId).map { it > 0 }
+
     override suspend fun add(serverId: String, itemId: String, positionSec: Double, title: String, now: Long): String {
         val id = UUID.randomUUID().toString()
         dao.upsert(

--- a/core/data/src/main/kotlin/com/riffle/core/data/ProgressSweep.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/ProgressSweep.kt
@@ -24,6 +24,20 @@ interface ProgressRemoteFactory {
     fun audio(server: Server, token: String, itemId: String): ProgressRemote<Double>
 }
 
+/** Enumerates the (server, item) pairs with at least one dirty audiobook-bookmark row to reconcile. */
+interface DirtyBookmarkLedger {
+    suspend fun serversWithDirty(): List<String>
+    suspend fun dirtyItems(serverId: String): List<String>
+}
+
+/**
+ * The set-reconcile of one item's audiobook bookmarks against ABS — the sweep's seam over
+ * `AudiobookBookmarkReconciler` so its orchestration stays testable without Room or the network.
+ */
+fun interface BookmarkReconcile {
+    suspend fun reconcile(serverId: String, itemId: String, baseUrl: String, token: String, insecureAllowed: Boolean)
+}
+
 /**
  * The durable, book-independent dirty sweep of ADR 0030: reconcile every dirty position row across
  * **all** servers when online, so offline progress is pushed without the book being reopened — while
@@ -39,9 +53,14 @@ class ProgressSweep(
     private val remoteFactory: ProgressRemoteFactory,
     private val locks: ProgressSyncLocks,
     private val openTargets: OpenReconcileTargets,
+    private val bookmarkLedger: DirtyBookmarkLedger,
+    private val bookmarkReconcile: BookmarkReconcile,
 ) {
     suspend fun run() {
-        for (serverId in ledger.serversWithDirty()) {
+        // Bookmarks ride the same cadence as positions: a server with only dirty bookmarks (no dirty
+        // positions) must still be reconciled, so process the union of both dirty sets (ADR 0030).
+        val servers = (ledger.serversWithDirty() + bookmarkLedger.serversWithDirty()).distinct()
+        for (serverId in servers) {
             val (server, token) = resolver.resolve(serverId) ?: continue
             for (itemId in ledger.dirtyEbookItems(serverId)) {
                 // Skip a book a live surface is driving — its own cycle owns inbound jumps (ADR 0030).
@@ -54,6 +73,17 @@ class ProgressSweep(
                 if (openTargets.isOpen(serverId, itemId)) continue
                 locks.withLock(serverId, itemId, RemoteKind.ABS_AUDIO) {
                     audioReconciler.reconcile(serverId, itemId, remoteFactory.audio(server, token, itemId))
+                }
+            }
+            for (itemId in bookmarkLedger.dirtyItems(serverId)) {
+                // Same open-book discipline as the audio pass: an open book's bookmarks reconcile once
+                // it closes. ABS_BOOKMARK is its own lock kind, so it never contends with the position
+                // passes for the same item.
+                if (openTargets.isOpen(serverId, itemId)) continue
+                locks.withLock(serverId, itemId, RemoteKind.ABS_BOOKMARK) {
+                    bookmarkReconcile.reconcile(
+                        serverId, itemId, server.url.value, token, server.insecureConnectionAllowed,
+                    )
                 }
             }
         }

--- a/core/data/src/main/kotlin/com/riffle/core/data/di/DataModule.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/di/DataModule.kt
@@ -29,6 +29,7 @@ import com.riffle.core.data.CrossEpubIndexStoreImpl
 import com.riffle.core.data.ReadaloudLinkRepositoryImpl
 import com.riffle.core.data.ReadaloudReviewRepositoryImpl
 import com.riffle.core.data.ReadaloudResumeStoreImpl
+import com.riffle.core.data.AudiobookBookmarkStoreImpl
 import com.riffle.core.data.AudiobookPositionStoreImpl
 import com.riffle.core.data.ReadingPositionStoreImpl
 import com.riffle.core.data.ReadingSessionRepositoryImpl
@@ -63,6 +64,7 @@ import com.riffle.core.domain.CrossEpubIndexStore
 import com.riffle.core.domain.ReadaloudLinkRepository
 import com.riffle.core.domain.ReadaloudReviewRepository
 import com.riffle.core.domain.ReadaloudResumeStore
+import com.riffle.core.domain.AudiobookBookmarkStore
 import com.riffle.core.domain.AudiobookPositionStore
 import com.riffle.core.domain.ReadingPositionStore
 import com.riffle.core.domain.ReadingSessionRepository
@@ -246,6 +248,10 @@ abstract class DataModule {
     @Binds
     @Singleton
     abstract fun bindAudiobookPositionStore(impl: AudiobookPositionStoreImpl): AudiobookPositionStore
+
+    @Binds
+    @Singleton
+    abstract fun bindAudiobookBookmarkStore(impl: AudiobookBookmarkStoreImpl): AudiobookBookmarkStore
 
     @Binds
     @Singleton

--- a/core/data/src/main/kotlin/com/riffle/core/data/di/DataModule.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/di/DataModule.kt
@@ -223,6 +223,10 @@ abstract class DataModule {
 
     @Binds
     @Singleton
+    abstract fun bindAbsBookmarkApi(impl: AbsApiClient): com.riffle.core.network.AbsBookmarkApi
+
+    @Binds
+    @Singleton
     abstract fun bindStorytellerApi(impl: StorytellerApiClient): StorytellerApi
 
     @Binds
@@ -354,12 +358,24 @@ abstract class DataModule {
             openTargets: com.riffle.core.data.OpenReconcileTargets,
             ebookStore: ReadingPositionStoreImpl,
             audioStore: AudiobookPositionStoreImpl,
+            bookmarkDao: com.riffle.core.database.AudiobookBookmarkDao,
+            bookmarkReconciler: com.riffle.core.data.AudiobookBookmarkReconciler,
         ): com.riffle.core.data.ProgressSweep =
             com.riffle.core.data.ProgressSweep(
                 ledger, resolver,
                 com.riffle.core.domain.ProgressReconciler(ebookStore),
                 com.riffle.core.domain.ProgressReconciler(audioStore),
                 remoteFactory, locks, openTargets,
+                // Bookmarks ride the sweep at the same cadence as positions: enumerate dirty
+                // (server, item) pairs straight off the bookmark DAO (ADR 0030, Task 12).
+                object : com.riffle.core.data.DirtyBookmarkLedger {
+                    override suspend fun serversWithDirty() = bookmarkDao.serversWithDirtyRows()
+                    override suspend fun dirtyItems(serverId: String) =
+                        bookmarkDao.dirtyForServer(serverId).map { it.itemId }.distinct()
+                },
+                com.riffle.core.data.BookmarkReconcile { serverId, itemId, baseUrl, token, insecureAllowed ->
+                    bookmarkReconciler.reconcile(serverId, itemId, baseUrl, token, insecureAllowed)
+                },
             )
 
         @Provides

--- a/core/data/src/main/kotlin/com/riffle/core/data/di/DatabaseModule.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/di/DatabaseModule.kt
@@ -113,6 +113,11 @@ object DatabaseModule {
 
     @Provides
     @Singleton
+    fun provideAudiobookBookmarkDao(db: RiffleDatabase): com.riffle.core.database.AudiobookBookmarkDao =
+        db.audiobookBookmarkDao()
+
+    @Provides
+    @Singleton
     fun provideReadaloudLinkDao(db: RiffleDatabase): ReadaloudLinkDao = db.readaloudLinkDao()
 
     @Provides

--- a/core/data/src/main/kotlin/com/riffle/core/data/di/DatabaseModule.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/di/DatabaseModule.kt
@@ -67,6 +67,7 @@ object DatabaseModule {
                 RiffleDatabase.MIGRATION_31_32,
                 RiffleDatabase.MIGRATION_32_33,
                 RiffleDatabase.MIGRATION_33_34,
+                RiffleDatabase.MIGRATION_34_35,
             )
             .build()
 

--- a/core/data/src/test/kotlin/com/riffle/core/data/AudiobookBookmarkReconcilerTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/AudiobookBookmarkReconcilerTest.kt
@@ -44,6 +44,11 @@ class AudiobookBookmarkReconcilerTest {
         override suspend fun serversWithDirtyRows() =
             rows.value.filter { it.localUpdatedAt > it.lastSyncedAt }.map { it.serverId }.distinct()
 
+        override fun observeDirtyCountForItem(serverId: String, itemId: String): Flow<Int> =
+            rows.map { list ->
+                list.count { it.serverId == serverId && it.itemId == itemId && it.localUpdatedAt > it.lastSyncedAt }
+            }
+
         override suspend fun confirmPushedIfUnchanged(id: String, serverStamp: Long, ifLocalUpdatedAt: Long): Int {
             val row = rows.value.firstOrNull { it.id == id && it.localUpdatedAt == ifLocalUpdatedAt } ?: return 0
             rows.value = rows.value.map {

--- a/core/data/src/test/kotlin/com/riffle/core/data/AudiobookBookmarkReconcilerTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/AudiobookBookmarkReconcilerTest.kt
@@ -1,0 +1,297 @@
+package com.riffle.core.data
+
+import com.riffle.core.database.AudiobookBookmarkDao
+import com.riffle.core.database.AudiobookBookmarkEntity
+import com.riffle.core.network.AbsBookmarkApi
+import com.riffle.core.network.AbsBookmarkListResult
+import com.riffle.core.network.AbsBookmarkResult
+import com.riffle.core.network.NetworkAbsBookmark
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AudiobookBookmarkReconcilerTest {
+
+    // A fake DAO that faithfully implements the compare-and-clear / hard-delete semantics
+    // so the reconciler's clean/dirty transitions can be asserted end-to-end.
+    private class FakeDao : AudiobookBookmarkDao {
+        val rows = MutableStateFlow<List<AudiobookBookmarkEntity>>(emptyList())
+
+        override suspend fun upsert(entity: AudiobookBookmarkEntity) {
+            rows.value = rows.value.filterNot { it.id == entity.id } + entity
+        }
+
+        override fun observeForItem(serverId: String, itemId: String): Flow<List<AudiobookBookmarkEntity>> =
+            rows.map { list ->
+                list.filter { it.serverId == serverId && it.itemId == itemId && !it.deleted }
+                    .sortedBy { it.positionSec }
+            }
+
+        override suspend fun getById(id: String) = rows.value.firstOrNull { it.id == id }
+
+        override suspend fun allForItem(serverId: String, itemId: String) =
+            rows.value.filter { it.serverId == serverId && it.itemId == itemId }
+
+        override suspend fun dirtyForServer(serverId: String) =
+            rows.value.filter { it.serverId == serverId && it.localUpdatedAt > it.lastSyncedAt }
+
+        override suspend fun serversWithDirtyRows() =
+            rows.value.filter { it.localUpdatedAt > it.lastSyncedAt }.map { it.serverId }.distinct()
+
+        override suspend fun confirmPushedIfUnchanged(id: String, serverStamp: Long, ifLocalUpdatedAt: Long): Int {
+            val row = rows.value.firstOrNull { it.id == id && it.localUpdatedAt == ifLocalUpdatedAt } ?: return 0
+            rows.value = rows.value.map {
+                if (it.id == id) it.copy(lastSyncedAt = serverStamp, localUpdatedAt = serverStamp) else it
+            }
+            return 1
+        }
+
+        override suspend fun hardDeleteIfUnchanged(id: String, ifLocalUpdatedAt: Long): Int {
+            val row = rows.value.firstOrNull { it.id == id && it.deleted && it.localUpdatedAt == ifLocalUpdatedAt }
+                ?: return 0
+            rows.value = rows.value.filterNot { it.id == id }
+            return 1
+        }
+
+        override suspend fun hardDelete(id: String) {
+            rows.value = rows.value.filterNot { it.id == id }
+        }
+    }
+
+    private class FakeApi(
+        var listResult: AbsBookmarkListResult = AbsBookmarkListResult.Success(emptyList()),
+    ) : AbsBookmarkApi {
+        data class Call(val kind: String, val itemId: String, val timeSec: Int, val title: String)
+
+        val calls = mutableListOf<Call>()
+        var createResult: AbsBookmarkResult = AbsBookmarkResult.Success(NetworkAbsBookmark("", "", 0, 0))
+        var updateResult: AbsBookmarkResult = AbsBookmarkResult.Success(NetworkAbsBookmark("", "", 0, 0))
+        var deleteResult: AbsBookmarkResult = AbsBookmarkResult.Success(NetworkAbsBookmark("", "", 0, 0))
+
+        override suspend fun createBookmark(
+            baseUrl: String,
+            itemId: String,
+            timeSec: Int,
+            title: String,
+            token: String,
+            insecureAllowed: Boolean,
+        ): AbsBookmarkResult {
+            calls += Call("create", itemId, timeSec, title)
+            return createResult
+        }
+
+        override suspend fun updateBookmark(
+            baseUrl: String,
+            itemId: String,
+            timeSec: Int,
+            title: String,
+            token: String,
+            insecureAllowed: Boolean,
+        ): AbsBookmarkResult {
+            calls += Call("update", itemId, timeSec, title)
+            return updateResult
+        }
+
+        override suspend fun deleteBookmark(
+            baseUrl: String,
+            itemId: String,
+            timeSec: Int,
+            token: String,
+            insecureAllowed: Boolean,
+        ): AbsBookmarkResult {
+            calls += Call("delete", itemId, timeSec, "")
+            return deleteResult
+        }
+
+        override suspend fun listBookmarks(
+            baseUrl: String,
+            token: String,
+            insecureAllowed: Boolean,
+        ): AbsBookmarkListResult = listResult
+    }
+
+    private val now = { 1000L }
+    private fun counterIds(): () -> String {
+        var n = 0
+        return { "gen-${n++}" }
+    }
+
+    private fun reconciler(dao: FakeDao, api: FakeApi) =
+        AudiobookBookmarkReconciler(dao, api, now = now, newId = counterIds())
+
+    private suspend fun AudiobookBookmarkReconciler.run() =
+        reconcile("s1", "i1", "http://abs", "tok", insecureAllowed = false)
+
+    @Test fun pushCreate() = runTest {
+        val dao = FakeDao()
+        dao.upsert(
+            AudiobookBookmarkEntity(
+                id = "a", serverId = "s1", itemId = "i1", positionSec = 12.4, title = "Intro",
+                createdAt = 500L, localUpdatedAt = 800L, lastSyncedAt = 0L, deleted = false,
+            ),
+        )
+        // Server echoes the bookmark back so the pull doesn't remove the now-clean row.
+        val api = FakeApi(listResult = AbsBookmarkListResult.Success(listOf(NetworkAbsBookmark("i1", "Intro", 12, 500L))))
+        reconciler(dao, api).run()
+
+        assertEquals(listOf(FakeApi.Call("create", "i1", 12, "Intro")), api.calls.filter { it.kind == "create" })
+        val row = dao.getById("a")!!
+        assertTrue("created row must become clean", row.localUpdatedAt <= row.lastSyncedAt)
+    }
+
+    @Test fun pushRename() = runTest {
+        val dao = FakeDao()
+        dao.upsert(
+            AudiobookBookmarkEntity(
+                id = "a", serverId = "s1", itemId = "i1", positionSec = 30.0, title = "New name",
+                createdAt = 500L, localUpdatedAt = 900L, lastSyncedAt = 600L, deleted = false,
+            ),
+        )
+        val api = FakeApi(listResult = AbsBookmarkListResult.Success(listOf(NetworkAbsBookmark("i1", "New name", 30, 500L))))
+        reconciler(dao, api).run()
+
+        assertEquals(listOf(FakeApi.Call("update", "i1", 30, "New name")), api.calls.filter { it.kind == "update" })
+        assertTrue(api.calls.none { it.kind == "create" })
+        val row = dao.getById("a")!!
+        assertTrue("renamed row must become clean", row.localUpdatedAt <= row.lastSyncedAt)
+    }
+
+    @Test fun pushDelete() = runTest {
+        val dao = FakeDao()
+        dao.upsert(
+            AudiobookBookmarkEntity(
+                id = "a", serverId = "s1", itemId = "i1", positionSec = 45.0, title = "x",
+                createdAt = 500L, localUpdatedAt = 900L, lastSyncedAt = 600L, deleted = true,
+            ),
+        )
+        val api = FakeApi()
+        reconciler(dao, api).run()
+
+        assertEquals(listOf(FakeApi.Call("delete", "i1", 45, "")), api.calls.filter { it.kind == "delete" })
+        assertNull("confirmed delete must be hard-removed", dao.getById("a"))
+    }
+
+    @Test fun pushDeleteNetworkFailureKeepsTombstone() = runTest {
+        val dao = FakeDao()
+        dao.upsert(
+            AudiobookBookmarkEntity(
+                id = "a", serverId = "s1", itemId = "i1", positionSec = 45.0, title = "x",
+                createdAt = 500L, localUpdatedAt = 900L, lastSyncedAt = 600L, deleted = true,
+            ),
+        )
+        val api = FakeApi()
+        api.deleteResult = AbsBookmarkResult.NetworkError(RuntimeException("boom"))
+        reconciler(dao, api).run()
+
+        val row = dao.getById("a")!!
+        assertEquals(true, row.deleted)
+        assertTrue("tombstone stays dirty for retry", row.localUpdatedAt > row.lastSyncedAt)
+    }
+
+    @Test fun pullInsert() = runTest {
+        val dao = FakeDao()
+        val api = FakeApi(listResult = AbsBookmarkListResult.Success(listOf(NetworkAbsBookmark("i1", "From server", 77, 1234L))))
+        reconciler(dao, api).run()
+
+        val row = dao.allForItem("s1", "i1").single()
+        assertEquals(77.0, row.positionSec, 0.0001)
+        assertEquals("From server", row.title)
+        assertEquals(1234L, row.createdAt)
+        assertEquals(false, row.deleted)
+        assertTrue("server-sourced row is clean", row.localUpdatedAt <= row.lastSyncedAt)
+    }
+
+    @Test fun pullRemovesCleanRowAbsentFromServer() = runTest {
+        val dao = FakeDao()
+        dao.upsert(
+            AudiobookBookmarkEntity(
+                id = "a", serverId = "s1", itemId = "i1", positionSec = 20.0, title = "stale",
+                createdAt = 500L, localUpdatedAt = 600L, lastSyncedAt = 600L, deleted = false,
+            ),
+        )
+        val api = FakeApi(listResult = AbsBookmarkListResult.Success(emptyList()))
+        reconciler(dao, api).run()
+
+        assertNull("clean row missing from server must be removed", dao.getById("a"))
+    }
+
+    @Test fun pullDoesNotClobberDirtyRows() = runTest {
+        val dao = FakeDao()
+        // Dirty local create whose time is absent server-side -> must NOT be removed.
+        dao.upsert(
+            AudiobookBookmarkEntity(
+                id = "create", serverId = "s1", itemId = "i1", positionSec = 20.0, title = "pending",
+                createdAt = 500L, localUpdatedAt = 900L, lastSyncedAt = 0L, deleted = false,
+            ),
+        )
+        // Dirty rename whose server title differs -> server title must NOT be applied.
+        dao.upsert(
+            AudiobookBookmarkEntity(
+                id = "rename", serverId = "s1", itemId = "i1", positionSec = 50.0, title = "local title",
+                createdAt = 500L, localUpdatedAt = 900L, lastSyncedAt = 600L, deleted = false,
+            ),
+        )
+        // Server returns the rename's time with a DIFFERENT title; the create's time is absent.
+        val api = FakeApi(
+            listResult = AbsBookmarkListResult.Success(listOf(NetworkAbsBookmark("i1", "server title", 50, 500L))),
+        )
+        // Pushes fail (network) so both rows stay DIRTY through the pull — that's the scenario
+        // under test: the pull must not clobber pending local intent.
+        api.createResult = AbsBookmarkResult.NetworkError(RuntimeException("down"))
+        api.updateResult = AbsBookmarkResult.NetworkError(RuntimeException("down"))
+        reconciler(dao, api).run()
+
+        val createRow = dao.getById("create")
+        assertNotNull("dirty pending create must survive pull", createRow)
+        val renameRow = dao.getById("rename")!!
+        assertEquals("dirty local title must NOT be clobbered", "local title", renameRow.title)
+    }
+
+    @Test fun listBookmarksNetworkErrorSkipsPullButPushesHappen() = runTest {
+        val dao = FakeDao()
+        // A dirty create to push.
+        dao.upsert(
+            AudiobookBookmarkEntity(
+                id = "a", serverId = "s1", itemId = "i1", positionSec = 12.0, title = "Intro",
+                createdAt = 500L, localUpdatedAt = 800L, lastSyncedAt = 0L, deleted = false,
+            ),
+        )
+        // A clean row that, if the pull ran, would be removed (absent server-side). It must survive.
+        dao.upsert(
+            AudiobookBookmarkEntity(
+                id = "clean", serverId = "s1", itemId = "i1", positionSec = 99.0, title = "keep",
+                createdAt = 500L, localUpdatedAt = 600L, lastSyncedAt = 600L, deleted = false,
+            ),
+        )
+        val api = FakeApi(listResult = AbsBookmarkListResult.NetworkError(RuntimeException("down")))
+        reconciler(dao, api).run()
+
+        assertEquals(listOf(FakeApi.Call("create", "i1", 12, "Intro")), api.calls.filter { it.kind == "create" })
+        assertNotNull("pull skipped: clean row must NOT be removed", dao.getById("clean"))
+    }
+
+    @Test fun crossItemIsolation() = runTest {
+        val dao = FakeDao()
+        val api = FakeApi(
+            listResult = AbsBookmarkListResult.Success(
+                listOf(
+                    NetworkAbsBookmark("OTHER", "other item", 10, 1L),
+                    NetworkAbsBookmark("i1", "ours", 20, 2L),
+                ),
+            ),
+        )
+        reconciler(dao, api).run()
+
+        val rows = dao.allForItem("s1", "i1")
+        assertEquals(1, rows.size)
+        assertEquals("ours", rows.single().title)
+        // No row inserted for the OTHER item.
+        assertTrue(dao.rows.value.none { it.itemId == "OTHER" })
+    }
+}

--- a/core/data/src/test/kotlin/com/riffle/core/data/AudiobookBookmarkStoreImplTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/AudiobookBookmarkStoreImplTest.kt
@@ -1,0 +1,70 @@
+package com.riffle.core.data
+
+import com.riffle.core.database.AudiobookBookmarkDao
+import com.riffle.core.database.AudiobookBookmarkEntity
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AudiobookBookmarkStoreImplTest {
+
+    private class FakeDao : AudiobookBookmarkDao {
+        val rows = MutableStateFlow<List<AudiobookBookmarkEntity>>(emptyList())
+        override suspend fun upsert(entity: AudiobookBookmarkEntity) {
+            rows.value = rows.value.filterNot { it.id == entity.id } + entity
+        }
+        override fun observeForItem(serverId: String, itemId: String): Flow<List<AudiobookBookmarkEntity>> =
+            rows.map { list -> list.filter { it.serverId == serverId && it.itemId == itemId && !it.deleted }.sortedBy { it.positionSec } }
+        override suspend fun getById(id: String) = rows.value.firstOrNull { it.id == id }
+        override suspend fun allForItem(serverId: String, itemId: String) =
+            rows.value.filter { it.serverId == serverId && it.itemId == itemId }
+        override suspend fun dirtyForServer(serverId: String) =
+            rows.value.filter { it.serverId == serverId && it.localUpdatedAt > it.lastSyncedAt }
+        override suspend fun serversWithDirtyRows() =
+            rows.value.filter { it.localUpdatedAt > it.lastSyncedAt }.map { it.serverId }.distinct()
+        override suspend fun confirmPushedIfUnchanged(id: String, serverStamp: Long, ifLocalUpdatedAt: Long) = 0
+        override suspend fun hardDeleteIfUnchanged(id: String, ifLocalUpdatedAt: Long) = 0
+        override suspend fun hardDelete(id: String) { rows.value = rows.value.filterNot { it.id == id } }
+    }
+
+    @Test fun addCreatesDirtyRow() = runTest {
+        val dao = FakeDao(); val store = AudiobookBookmarkStoreImpl(dao)
+        val id = store.add("s1", "i1", 765.0, "The Egg · 12:45", now = 1000L)
+        val row = dao.getById(id)!!
+        assertEquals(765.0, row.positionSec, 0.0001)
+        assertEquals("The Egg · 12:45", row.title)
+        assertEquals(1000L, row.createdAt)
+        assertTrue("new row must be dirty", row.localUpdatedAt > row.lastSyncedAt)
+        assertEquals(false, row.deleted)
+    }
+
+    @Test fun renameBumpsDirtyStamp() = runTest {
+        val dao = FakeDao(); val store = AudiobookBookmarkStoreImpl(dao)
+        val id = store.add("s1", "i1", 10.0, "old", now = 1000L)
+        store.rename(id, "new", now = 2000L)
+        val row = dao.getById(id)!!
+        assertEquals("new", row.title); assertEquals(2000L, row.localUpdatedAt)
+        assertTrue(row.localUpdatedAt > row.lastSyncedAt)
+    }
+
+    @Test fun deleteTombstonesNotHardRemoves() = runTest {
+        val dao = FakeDao(); val store = AudiobookBookmarkStoreImpl(dao)
+        val id = store.add("s1", "i1", 10.0, "x", now = 1000L)
+        store.delete(id, now = 3000L)
+        val row = dao.getById(id)!!
+        assertEquals(true, row.deleted); assertEquals(3000L, row.localUpdatedAt)
+        assertTrue("tombstone must be dirty", row.localUpdatedAt > row.lastSyncedAt)
+    }
+
+    @Test fun observeMapsToDomain() = runTest {
+        val dao = FakeDao(); val store = AudiobookBookmarkStoreImpl(dao)
+        store.add("s1", "i1", 10.0, "a", now = 1000L)
+        val list = store.observe("s1", "i1").first()
+        assertEquals(1, list.size); assertEquals("a", list[0].title)
+    }
+}

--- a/core/data/src/test/kotlin/com/riffle/core/data/AudiobookBookmarkStoreImplTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/AudiobookBookmarkStoreImplTest.kt
@@ -27,6 +27,8 @@ class AudiobookBookmarkStoreImplTest {
             rows.value.filter { it.serverId == serverId && it.localUpdatedAt > it.lastSyncedAt }
         override suspend fun serversWithDirtyRows() =
             rows.value.filter { it.localUpdatedAt > it.lastSyncedAt }.map { it.serverId }.distinct()
+        override fun observeDirtyCountForItem(serverId: String, itemId: String): Flow<Int> =
+            rows.map { list -> list.count { it.serverId == serverId && it.itemId == itemId && it.localUpdatedAt > it.lastSyncedAt } }
         override suspend fun confirmPushedIfUnchanged(id: String, serverStamp: Long, ifLocalUpdatedAt: Long) = 0
         override suspend fun hardDeleteIfUnchanged(id: String, ifLocalUpdatedAt: Long) = 0
         override suspend fun hardDelete(id: String) { rows.value = rows.value.filterNot { it.id == id } }

--- a/core/data/src/test/kotlin/com/riffle/core/data/ProgressSweepBookmarkTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/ProgressSweepBookmarkTest.kt
@@ -1,0 +1,138 @@
+package com.riffle.core.data
+
+import com.riffle.core.domain.ProgressReconciler
+import com.riffle.core.domain.ProgressRemote
+import com.riffle.core.domain.RemoteProgress
+import com.riffle.core.domain.Server
+import com.riffle.core.domain.ServerUrl
+import com.riffle.core.domain.SyncPositionStore
+import com.riffle.core.domain.PositionSnapshot
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The bookmark pass of the durable dirty sweep (ADR 0030, Task 12): bookmarks reconcile on the SAME
+ * cadence as positions. Per server (unioned with position-dirty servers), every itemId with at least
+ * one dirty bookmark row reconciles once under its own per-target lock. Exercised over fakes.
+ */
+class ProgressSweepBookmarkTest {
+
+    private class NoopStore<P> : SyncPositionStore<P> {
+        override suspend fun snapshot(serverId: String, itemId: String) = PositionSnapshot<P>(null, 0L, 0L)
+        override suspend fun acceptServerPosition(serverId: String, itemId: String, position: P, serverStamp: Long, ifLocalUpdatedAt: Long) = false
+        override suspend fun confirmPushed(serverId: String, itemId: String, serverStamp: Long, ifLocalUpdatedAt: Long) = false
+        override suspend fun confirmInSync(serverId: String, itemId: String, ifLocalUpdatedAt: Long) = false
+        override suspend fun mirror(serverId: String, itemId: String, position: P, localUpdatedAt: Long, lastSyncedAt: Long) {}
+    }
+
+    private class NoopFactory : ProgressRemoteFactory {
+        override fun ebook(server: Server, token: String, itemId: String): ProgressRemote<String> =
+            object : ProgressRemote<String> { override suspend fun get() = RemoteProgress("noop", 0L); override suspend fun patch(position: String) = 0L }
+        override fun audio(server: Server, token: String, itemId: String): ProgressRemote<Double> =
+            object : ProgressRemote<Double> { override suspend fun get() = RemoteProgress(0.0, 0L); override suspend fun patch(position: Double) = 0L }
+    }
+
+    /** Records every reconcile call's full arg tuple. */
+    private class RecordingBookmarkReconcile : BookmarkReconcile {
+        data class Call(val serverId: String, val itemId: String, val baseUrl: String, val token: String, val insecure: Boolean)
+        val calls = mutableListOf<Call>()
+        override suspend fun reconcile(serverId: String, itemId: String, baseUrl: String, token: String, insecureAllowed: Boolean) {
+            calls += Call(serverId, itemId, baseUrl, token, insecureAllowed)
+        }
+    }
+
+    private fun server(id: String) =
+        Server(id, ServerUrl.parse("http://$id")!!, isActive = false, insecureConnectionAllowed = false, username = "u")
+
+    private fun positionLedger(servers: List<String>) = object : DirtyProgressLedger {
+        override suspend fun serversWithDirty() = servers
+        override suspend fun dirtyEbookItems(serverId: String) = emptyList<String>()
+        override suspend fun dirtyAudioItems(serverId: String) = emptyList<String>()
+    }
+
+    private fun bookmarkLedger(
+        servers: List<String>,
+        items: Map<String, List<String>> = emptyMap(),
+    ) = object : DirtyBookmarkLedger {
+        override suspend fun serversWithDirty() = servers
+        override suspend fun dirtyItems(serverId: String) = items[serverId].orEmpty()
+    }
+
+    private fun sweep(
+        positionLedger: DirtyProgressLedger,
+        bookmarkLedger: DirtyBookmarkLedger,
+        bookmarkReconcile: BookmarkReconcile,
+        resolver: ServerTokenResolver,
+        openTargets: OpenReconcileTargets = OpenReconcileTargets(),
+    ) = ProgressSweep(
+        positionLedger, resolver,
+        ProgressReconciler(NoopStore<String>()), ProgressReconciler(NoopStore<Double>()),
+        NoopFactory(), ProgressSyncLocks(), openTargets,
+        bookmarkLedger, bookmarkReconcile,
+    )
+
+    @Test
+    fun `reconciles a dirty bookmark item with the resolved base url, token and insecure flag`() = runTest {
+        val rec = RecordingBookmarkReconcile()
+        val resolver = ServerTokenResolver { id ->
+            Server(id, ServerUrl.parse("https://$id")!!, isActive = false, insecureConnectionAllowed = true, username = "u") to "tok-$id"
+        }
+
+        sweep(
+            positionLedger(listOf("s1")),
+            bookmarkLedger(listOf("s1"), items = mapOf("s1" to listOf("i1"))),
+            rec, resolver,
+        ).run()
+
+        assertEquals(1, rec.calls.size)
+        assertEquals(
+            RecordingBookmarkReconcile.Call("s1", "i1", "https://s1", "tok-s1", true),
+            rec.calls.single(),
+        )
+    }
+
+    @Test
+    fun `a server with only dirty bookmarks and no dirty positions is still processed`() = runTest {
+        val rec = RecordingBookmarkReconcile()
+        val resolver = ServerTokenResolver { id -> server(id) to "tok" }
+
+        sweep(
+            positionLedger(emptyList()), // no position-dirty servers at all
+            bookmarkLedger(listOf("s9"), items = mapOf("s9" to listOf("i9"))),
+            rec, resolver,
+        ).run()
+
+        assertEquals(listOf("s9" to "i9"), rec.calls.map { it.serverId to it.itemId })
+    }
+
+    @Test
+    fun `skips a bookmark item the live player is currently driving, consistent with the audio pass`() = runTest {
+        val rec = RecordingBookmarkReconcile()
+        val openTargets = OpenReconcileTargets().apply { markOpen("s1", "open") }
+
+        sweep(
+            positionLedger(emptyList()),
+            bookmarkLedger(listOf("s1"), items = mapOf("s1" to listOf("open", "closed"))),
+            rec, ServerTokenResolver { id -> server(id) to "tok" }, openTargets,
+        ).run()
+
+        assertEquals(listOf("closed"), rec.calls.map { it.itemId })
+        assertTrue(rec.calls.none { it.itemId == "open" })
+    }
+
+    @Test
+    fun `skips a bookmark-dirty server with no token, leaving it for a later sweep`() = runTest {
+        val rec = RecordingBookmarkReconcile()
+        val resolver = ServerTokenResolver { id -> if (id == "s2") null else server(id) to "tok" }
+
+        sweep(
+            positionLedger(emptyList()),
+            bookmarkLedger(listOf("s1", "s2"), items = mapOf("s1" to listOf("i1"), "s2" to listOf("i2"))),
+            rec, resolver,
+        ).run()
+
+        assertEquals(listOf("s1" to "i1"), rec.calls.map { it.serverId to it.itemId })
+    }
+}

--- a/core/data/src/test/kotlin/com/riffle/core/data/ProgressSweepTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/ProgressSweepTest.kt
@@ -97,6 +97,11 @@ class ProgressSweepTest {
         ledger, resolver,
         ProgressReconciler(ebookStore), ProgressReconciler(audioStore),
         factory, ProgressSyncLocks(), openTargets,
+        object : DirtyBookmarkLedger {
+            override suspend fun serversWithDirty() = emptyList<String>()
+            override suspend fun dirtyItems(serverId: String) = emptyList<String>()
+        },
+        BookmarkReconcile { _, _, _, _, _ -> },
     )
 
     @Test

--- a/core/database/schemas/com.riffle.core.database.RiffleDatabase/35.json
+++ b/core/database/schemas/com.riffle.core.database.RiffleDatabase/35.json
@@ -1,0 +1,1291 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 35,
+    "identityHash": "47a7f067bfbfcb95fe753158f2cb2622",
+    "entities": [
+      {
+        "tableName": "servers",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `url` TEXT NOT NULL, `isActive` INTEGER NOT NULL, `insecureConnectionAllowed` INTEGER NOT NULL, `username` TEXT NOT NULL, `serverType` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "isActive",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "insecureConnectionAllowed",
+            "columnName": "insecureConnectionAllowed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "username",
+            "columnName": "username",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverType",
+            "columnName": "serverType",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "libraries",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `mediaType` TEXT NOT NULL, `serverId` TEXT NOT NULL, `isUnsupported` INTEGER NOT NULL, PRIMARY KEY(`serverId`, `id`), FOREIGN KEY(`serverId`) REFERENCES `servers`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaType",
+            "columnName": "mediaType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isUnsupported",
+            "columnName": "isUnsupported",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "serverId",
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_libraries_serverId",
+            "unique": false,
+            "columnNames": [
+              "serverId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_libraries_serverId` ON `${TABLE_NAME}` (`serverId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "servers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "serverId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "library_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`serverId` TEXT NOT NULL, `id` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `title` TEXT NOT NULL, `author` TEXT NOT NULL, `coverUrl` TEXT, `readingProgress` REAL NOT NULL, `ebookFileIno` TEXT, `ebookFormat` TEXT NOT NULL, `hasAudio` INTEGER NOT NULL, `audioDurationSec` REAL NOT NULL, `description` TEXT, `seriesName` TEXT, `publishedYear` TEXT, `genres` TEXT NOT NULL, `publisher` TEXT, `language` TEXT, `lastOpenedAt` INTEGER, `addedAt` INTEGER, `isbn` TEXT, `asin` TEXT, PRIMARY KEY(`serverId`, `id`), FOREIGN KEY(`serverId`) REFERENCES `servers`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "coverUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "readingProgress",
+            "columnName": "readingProgress",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ebookFileIno",
+            "columnName": "ebookFileIno",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "ebookFormat",
+            "columnName": "ebookFormat",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hasAudio",
+            "columnName": "hasAudio",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "audioDurationSec",
+            "columnName": "audioDurationSec",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seriesName",
+            "columnName": "seriesName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "publishedYear",
+            "columnName": "publishedYear",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "genres",
+            "columnName": "genres",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "publisher",
+            "columnName": "publisher",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "language",
+            "columnName": "language",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastOpenedAt",
+            "columnName": "lastOpenedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "isbn",
+            "columnName": "isbn",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "asin",
+            "columnName": "asin",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "serverId",
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_library_items_serverId",
+            "unique": false,
+            "columnNames": [
+              "serverId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_library_items_serverId` ON `${TABLE_NAME}` (`serverId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "servers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "serverId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "series",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `name` TEXT NOT NULL, `coverUrl` TEXT, `bookCount` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "coverUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "bookCount",
+            "columnName": "bookCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "collections",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `name` TEXT NOT NULL, `bookCount` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookCount",
+            "columnName": "bookCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "series_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`seriesId` TEXT NOT NULL, `serverId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `sequenceOrder` REAL NOT NULL, PRIMARY KEY(`seriesId`, `serverId`, `itemId`))",
+        "fields": [
+          {
+            "fieldPath": "seriesId",
+            "columnName": "seriesId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sequenceOrder",
+            "columnName": "sequenceOrder",
+            "affinity": "REAL",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "seriesId",
+            "serverId",
+            "itemId"
+          ]
+        }
+      },
+      {
+        "tableName": "collection_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`collectionId` TEXT NOT NULL, `serverId` TEXT NOT NULL, `itemId` TEXT NOT NULL, PRIMARY KEY(`collectionId`, `serverId`, `itemId`))",
+        "fields": [
+          {
+            "fieldPath": "collectionId",
+            "columnName": "collectionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "collectionId",
+            "serverId",
+            "itemId"
+          ]
+        }
+      },
+      {
+        "tableName": "reading_positions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`serverId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `cfi` TEXT NOT NULL, `localUpdatedAt` INTEGER NOT NULL, `lastSyncedAt` INTEGER NOT NULL, PRIMARY KEY(`serverId`, `itemId`), FOREIGN KEY(`serverId`) REFERENCES `servers`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cfi",
+            "columnName": "cfi",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localUpdatedAt",
+            "columnName": "localUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncedAt",
+            "columnName": "lastSyncedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "serverId",
+            "itemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_reading_positions_serverId",
+            "unique": false,
+            "columnNames": [
+              "serverId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_reading_positions_serverId` ON `${TABLE_NAME}` (`serverId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "servers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "serverId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "book_formatting_preferences",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`serverId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `fontSize` REAL, `theme` TEXT, `fontFamily` TEXT, `lineSpacing` REAL, `margins` REAL, `orientation` TEXT, `showChapterMap` INTEGER, `showReadingProgressLabels` INTEGER, `showCurrentChapterLabel` INTEGER, `doublePageSpread` INTEGER, `justifyText` INTEGER, PRIMARY KEY(`serverId`, `itemId`), FOREIGN KEY(`serverId`) REFERENCES `servers`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fontSize",
+            "columnName": "fontSize",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "theme",
+            "columnName": "theme",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "fontFamily",
+            "columnName": "fontFamily",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lineSpacing",
+            "columnName": "lineSpacing",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "margins",
+            "columnName": "margins",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "orientation",
+            "columnName": "orientation",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "showChapterMap",
+            "columnName": "showChapterMap",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "showReadingProgressLabels",
+            "columnName": "showReadingProgressLabels",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "showCurrentChapterLabel",
+            "columnName": "showCurrentChapterLabel",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "doublePageSpread",
+            "columnName": "doublePageSpread",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "justifyText",
+            "columnName": "justifyText",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "serverId",
+            "itemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_book_formatting_preferences_serverId",
+            "unique": false,
+            "columnNames": [
+              "serverId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_book_formatting_preferences_serverId` ON `${TABLE_NAME}` (`serverId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "servers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "serverId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "readaloud_links",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`absServerId` TEXT NOT NULL, `absLibraryItemId` TEXT NOT NULL, `storytellerServerId` TEXT NOT NULL, `storytellerBookId` TEXT NOT NULL, `state` TEXT NOT NULL, `userConfirmed` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`absServerId`, `absLibraryItemId`), FOREIGN KEY(`storytellerServerId`) REFERENCES `servers`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`absServerId`) REFERENCES `servers`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "absServerId",
+            "columnName": "absServerId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absLibraryItemId",
+            "columnName": "absLibraryItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerServerId",
+            "columnName": "storytellerServerId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerBookId",
+            "columnName": "storytellerBookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userConfirmed",
+            "columnName": "userConfirmed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "absServerId",
+            "absLibraryItemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_readaloud_links_storytellerServerId_storytellerBookId",
+            "unique": false,
+            "columnNames": [
+              "storytellerServerId",
+              "storytellerBookId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_readaloud_links_storytellerServerId_storytellerBookId` ON `${TABLE_NAME}` (`storytellerServerId`, `storytellerBookId`)"
+          },
+          {
+            "name": "index_readaloud_links_storytellerServerId",
+            "unique": false,
+            "columnNames": [
+              "storytellerServerId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_readaloud_links_storytellerServerId` ON `${TABLE_NAME}` (`storytellerServerId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "servers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "storytellerServerId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "servers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "absServerId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "readaloud_candidates",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`storytellerServerId` TEXT NOT NULL, `storytellerBookId` TEXT NOT NULL, `absServerId` TEXT NOT NULL, `absLibraryItemId` TEXT NOT NULL, `score` REAL NOT NULL, PRIMARY KEY(`storytellerServerId`, `storytellerBookId`, `absServerId`, `absLibraryItemId`), FOREIGN KEY(`storytellerServerId`) REFERENCES `servers`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`absServerId`) REFERENCES `servers`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "storytellerServerId",
+            "columnName": "storytellerServerId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerBookId",
+            "columnName": "storytellerBookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absServerId",
+            "columnName": "absServerId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absLibraryItemId",
+            "columnName": "absLibraryItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "score",
+            "columnName": "score",
+            "affinity": "REAL",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "storytellerServerId",
+            "storytellerBookId",
+            "absServerId",
+            "absLibraryItemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_readaloud_candidates_absServerId",
+            "unique": false,
+            "columnNames": [
+              "absServerId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_readaloud_candidates_absServerId` ON `${TABLE_NAME}` (`absServerId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "servers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "storytellerServerId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "servers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "absServerId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "readaloud_dismissals",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`storytellerServerId` TEXT NOT NULL, `storytellerBookId` TEXT NOT NULL, `scope` TEXT NOT NULL, `absServerId` TEXT NOT NULL, `absLibraryItemId` TEXT NOT NULL, PRIMARY KEY(`storytellerServerId`, `storytellerBookId`, `absServerId`, `absLibraryItemId`), FOREIGN KEY(`storytellerServerId`) REFERENCES `servers`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "storytellerServerId",
+            "columnName": "storytellerServerId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerBookId",
+            "columnName": "storytellerBookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scope",
+            "columnName": "scope",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absServerId",
+            "columnName": "absServerId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absLibraryItemId",
+            "columnName": "absLibraryItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "storytellerServerId",
+            "storytellerBookId",
+            "absServerId",
+            "absLibraryItemId"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "servers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "storytellerServerId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "cross_epub_index",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`absEpubChecksum` TEXT NOT NULL, `storytellerEpubChecksum` TEXT NOT NULL, `perChapterMapsBlob` TEXT NOT NULL, `builtAt` INTEGER NOT NULL, PRIMARY KEY(`absEpubChecksum`, `storytellerEpubChecksum`))",
+        "fields": [
+          {
+            "fieldPath": "absEpubChecksum",
+            "columnName": "absEpubChecksum",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerEpubChecksum",
+            "columnName": "storytellerEpubChecksum",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "perChapterMapsBlob",
+            "columnName": "perChapterMapsBlob",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "builtAt",
+            "columnName": "builtAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "absEpubChecksum",
+            "storytellerEpubChecksum"
+          ]
+        }
+      },
+      {
+        "tableName": "annotations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `serverId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `type` TEXT NOT NULL, `cfi` TEXT NOT NULL, `color` TEXT NOT NULL, `note` TEXT, `textSnippet` TEXT NOT NULL, `chapterHref` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `originDeviceId` TEXT NOT NULL, `lastModifiedByDeviceId` TEXT NOT NULL, `deleted` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`serverId`) REFERENCES `servers`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cfi",
+            "columnName": "cfi",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "color",
+            "columnName": "color",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "note",
+            "columnName": "note",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "textSnippet",
+            "columnName": "textSnippet",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chapterHref",
+            "columnName": "chapterHref",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "originDeviceId",
+            "columnName": "originDeviceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastModifiedByDeviceId",
+            "columnName": "lastModifiedByDeviceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deleted",
+            "columnName": "deleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_annotations_serverId_itemId",
+            "unique": false,
+            "columnNames": [
+              "serverId",
+              "itemId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_annotations_serverId_itemId` ON `${TABLE_NAME}` (`serverId`, `itemId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "servers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "serverId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "readaloud_resume_positions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`serverId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `href` TEXT NOT NULL, `progression` REAL, `fragmentRef` TEXT, `localUpdatedAt` INTEGER NOT NULL, PRIMARY KEY(`serverId`, `itemId`), FOREIGN KEY(`serverId`) REFERENCES `servers`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "href",
+            "columnName": "href",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "progression",
+            "columnName": "progression",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "fragmentRef",
+            "columnName": "fragmentRef",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localUpdatedAt",
+            "columnName": "localUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "serverId",
+            "itemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_readaloud_resume_positions_serverId",
+            "unique": false,
+            "columnNames": [
+              "serverId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_readaloud_resume_positions_serverId` ON `${TABLE_NAME}` (`serverId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "servers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "serverId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "audio_playback_preferences",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`serverId` TEXT NOT NULL, `bookId` TEXT NOT NULL, `speed` REAL, PRIMARY KEY(`serverId`, `bookId`), FOREIGN KEY(`serverId`) REFERENCES `servers`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "speed",
+            "columnName": "speed",
+            "affinity": "REAL"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "serverId",
+            "bookId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_audio_playback_preferences_serverId",
+            "unique": false,
+            "columnNames": [
+              "serverId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_audio_playback_preferences_serverId` ON `${TABLE_NAME}` (`serverId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "servers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "serverId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "audiobook_positions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`serverId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `positionSec` REAL NOT NULL, `localUpdatedAt` INTEGER NOT NULL, `lastSyncedAt` INTEGER NOT NULL, PRIMARY KEY(`serverId`, `itemId`), FOREIGN KEY(`serverId`) REFERENCES `servers`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "positionSec",
+            "columnName": "positionSec",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localUpdatedAt",
+            "columnName": "localUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncedAt",
+            "columnName": "lastSyncedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "serverId",
+            "itemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_audiobook_positions_serverId",
+            "unique": false,
+            "columnNames": [
+              "serverId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_audiobook_positions_serverId` ON `${TABLE_NAME}` (`serverId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "servers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "serverId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "audiobook_bookmarks",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `serverId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `positionSec` REAL NOT NULL, `title` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `localUpdatedAt` INTEGER NOT NULL, `lastSyncedAt` INTEGER NOT NULL, `deleted` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`serverId`) REFERENCES `servers`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "positionSec",
+            "columnName": "positionSec",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localUpdatedAt",
+            "columnName": "localUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncedAt",
+            "columnName": "lastSyncedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deleted",
+            "columnName": "deleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_audiobook_bookmarks_serverId",
+            "unique": false,
+            "columnNames": [
+              "serverId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_audiobook_bookmarks_serverId` ON `${TABLE_NAME}` (`serverId`)"
+          },
+          {
+            "name": "index_audiobook_bookmarks_serverId_itemId",
+            "unique": false,
+            "columnNames": [
+              "serverId",
+              "itemId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_audiobook_bookmarks_serverId_itemId` ON `${TABLE_NAME}` (`serverId`, `itemId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "servers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "serverId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '47a7f067bfbfcb95fe753158f2cb2622')"
+    ]
+  }
+}

--- a/core/database/src/androidTest/kotlin/com/riffle/core/database/AudiobookBookmarkDaoTest.kt
+++ b/core/database/src/androidTest/kotlin/com/riffle/core/database/AudiobookBookmarkDaoTest.kt
@@ -1,0 +1,74 @@
+package com.riffle.core.database
+
+import androidx.room.Room
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class AudiobookBookmarkDaoTest {
+
+    private lateinit var db: RiffleDatabase
+    private lateinit var dao: AudiobookBookmarkDao
+
+    @Before
+    fun setup() = runBlocking {
+        db = Room.inMemoryDatabaseBuilder(
+            InstrumentationRegistry.getInstrumentation().targetContext,
+            RiffleDatabase::class.java,
+        ).allowMainThreadQueries().build()
+        dao = db.audiobookBookmarkDao()
+        // audiobook_bookmarks.serverId is a FK to servers(id) (ON DELETE CASCADE); seed it first.
+        db.serverDao().upsert(
+            ServerEntity("s1", "http://s1", isActive = true, insecureConnectionAllowed = false, username = "u"),
+        )
+    }
+
+    @After
+    fun teardown() {
+        db.close()
+    }
+
+    @Test
+    fun observeReturnsNonDeletedOrderedByPosition() = runTest {
+        dao.upsert(AudiobookBookmarkEntity("b2", "s1", "i1", 200.0, "two", 2, 2, 0, false))
+        dao.upsert(AudiobookBookmarkEntity("b1", "s1", "i1", 100.0, "one", 1, 1, 0, false))
+        dao.upsert(AudiobookBookmarkEntity("bd", "s1", "i1", 50.0, "gone", 3, 3, 0, true))
+
+        val rows = dao.observeForItem("s1", "i1").first()
+
+        assertEquals(listOf("b1", "b2"), rows.map { it.id })
+    }
+
+    @Test
+    fun dirtyForServerReturnsDirtyIncludingTombstones() = runTest {
+        dao.upsert(AudiobookBookmarkEntity("clean", "s1", "i1", 10.0, "c", 1, 5, 5, false))
+        dao.upsert(AudiobookBookmarkEntity("dirty", "s1", "i1", 20.0, "d", 1, 6, 5, false))
+        dao.upsert(AudiobookBookmarkEntity("tomb", "s1", "i1", 30.0, "t", 1, 7, 5, true))
+
+        val dirty = dao.dirtyForServer("s1").map { it.id }.toSet()
+
+        assertEquals(setOf("dirty", "tomb"), dirty)
+    }
+
+    @Test
+    fun confirmPushedIfUnchangedClearsDirtyOnlyWhenStampMatches() = runTest {
+        dao.upsert(AudiobookBookmarkEntity("b", "s1", "i1", 10.0, "x", 1, 6, 5, false))
+
+        // stale stamp: no-op
+        assertEquals(0, dao.confirmPushedIfUnchanged("b", serverStamp = 9, ifLocalUpdatedAt = 999))
+        // matching stamp: clears dirty
+        assertEquals(1, dao.confirmPushedIfUnchanged("b", serverStamp = 9, ifLocalUpdatedAt = 6))
+
+        val row = dao.getById("b")!!
+        assertEquals(9L, row.localUpdatedAt)
+        assertEquals(9L, row.lastSyncedAt)
+    }
+}

--- a/core/database/src/androidTest/kotlin/com/riffle/core/database/MigrationTest.kt
+++ b/core/database/src/androidTest/kotlin/com/riffle/core/database/MigrationTest.kt
@@ -1440,6 +1440,44 @@ class MigrationTest {
     }
 
     @Test
+    fun migration34To35_addsAudiobookBookmarksTable() {
+        helper.createDatabase(TEST_DB, 34).use { db ->
+            db.execSQL(
+                "INSERT INTO servers (id, url, isActive, insecureConnectionAllowed, username, serverType) " +
+                    "VALUES ('s1', 'http://media-server', 1, 0, 'test', 'AUDIOBOOKSHELF')"
+            )
+        }
+
+        val db = helper.runMigrationsAndValidate(TEST_DB, 35, true, RiffleDatabase.MIGRATION_34_35)
+
+        db.query("SELECT COUNT(*) FROM audiobook_bookmarks").use { c ->
+            c.moveToFirst(); assertEquals(0, c.getInt(0))
+        }
+
+        db.execSQL(
+            "INSERT INTO audiobook_bookmarks (id, serverId, itemId, positionSec, title, createdAt, localUpdatedAt, lastSyncedAt, deleted) " +
+                "VALUES ('b1', 's1', '42', 765.0, 'The Egg', 1700000000000, 1700000000000, 0, 0)"
+        )
+        db.query(
+            "SELECT positionSec, title, createdAt, localUpdatedAt, lastSyncedAt, deleted FROM audiobook_bookmarks WHERE id = 'b1'"
+        ).use { c ->
+            assertEquals(1, c.count); c.moveToFirst()
+            assertEquals(765.0, c.getDouble(0), 0.0001)
+            assertEquals("The Egg", c.getString(1))
+            assertEquals(1700000000000L, c.getLong(2))
+            assertEquals(1700000000000L, c.getLong(3))
+            assertEquals(0L, c.getLong(4))
+            assertEquals(0, c.getInt(5))
+        }
+
+        db.execSQL("PRAGMA foreign_keys = ON")
+        db.execSQL("DELETE FROM servers WHERE id = 's1'")
+        db.query("SELECT COUNT(*) FROM audiobook_bookmarks").use { c ->
+            c.moveToFirst(); assertEquals(0, c.getInt(0))
+        }
+    }
+
+    @Test
     fun migrateFullChain() {
         helper.createDatabase(TEST_DB, 1).use { db ->
             db.execSQL(
@@ -1448,7 +1486,7 @@ class MigrationTest {
         }
 
         val db = helper.runMigrationsAndValidate(
-            TEST_DB, 34, true,
+            TEST_DB, 35, true,
             RiffleDatabase.MIGRATION_1_2,
             RiffleDatabase.MIGRATION_2_3,
             RiffleDatabase.MIGRATION_3_4,
@@ -1482,6 +1520,7 @@ class MigrationTest {
             RiffleDatabase.MIGRATION_31_32,
             RiffleDatabase.MIGRATION_32_33,
             RiffleDatabase.MIGRATION_33_34,
+            RiffleDatabase.MIGRATION_34_35,
         )
 
         db.query("SELECT url, username, serverType FROM servers WHERE id = 's1'").use { cursor ->

--- a/core/database/src/main/kotlin/com/riffle/core/database/AudiobookBookmarkDao.kt
+++ b/core/database/src/main/kotlin/com/riffle/core/database/AudiobookBookmarkDao.kt
@@ -33,6 +33,10 @@ interface AudiobookBookmarkDao {
     @Query("SELECT DISTINCT serverId FROM audiobook_bookmarks WHERE localUpdatedAt > lastSyncedAt")
     suspend fun serversWithDirtyRows(): List<String>
 
+    /** Live count of unsynced (dirty) rows for an item — drives the "Offline — will sync" note. */
+    @Query("SELECT COUNT(*) FROM audiobook_bookmarks WHERE serverId = :serverId AND itemId = :itemId AND localUpdatedAt > lastSyncedAt")
+    fun observeDirtyCountForItem(serverId: String, itemId: String): Flow<Int>
+
     /** Mark clean after a successful push, only if untouched since (compare-and-clear, ADR 0030). */
     @Query(
         "UPDATE audiobook_bookmarks SET lastSyncedAt = :serverStamp, localUpdatedAt = :serverStamp " +

--- a/core/database/src/main/kotlin/com/riffle/core/database/AudiobookBookmarkDao.kt
+++ b/core/database/src/main/kotlin/com/riffle/core/database/AudiobookBookmarkDao.kt
@@ -3,10 +3,47 @@ package com.riffle.core.database
 import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import kotlinx.coroutines.flow.Flow
 
 @Dao
 interface AudiobookBookmarkDao {
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun upsert(entity: AudiobookBookmarkEntity)
+
+    /** Live, user-visible bookmarks for an item: non-deleted, earliest position first. */
+    @Query(
+        "SELECT * FROM audiobook_bookmarks WHERE serverId = :serverId AND itemId = :itemId AND deleted = 0 " +
+            "ORDER BY positionSec ASC",
+    )
+    fun observeForItem(serverId: String, itemId: String): Flow<List<AudiobookBookmarkEntity>>
+
+    @Query("SELECT * FROM audiobook_bookmarks WHERE id = :id LIMIT 1")
+    suspend fun getById(id: String): AudiobookBookmarkEntity?
+
+    /** All rows for an item including tombstones (reconcile needs deletes). */
+    @Query("SELECT * FROM audiobook_bookmarks WHERE serverId = :serverId AND itemId = :itemId")
+    suspend fun allForItem(serverId: String, itemId: String): List<AudiobookBookmarkEntity>
+
+    /** Dirty rows for a server (creates, renames, AND tombstoned deletes). */
+    @Query("SELECT * FROM audiobook_bookmarks WHERE serverId = :serverId AND localUpdatedAt > lastSyncedAt")
+    suspend fun dirtyForServer(serverId: String): List<AudiobookBookmarkEntity>
+
+    @Query("SELECT DISTINCT serverId FROM audiobook_bookmarks WHERE localUpdatedAt > lastSyncedAt")
+    suspend fun serversWithDirtyRows(): List<String>
+
+    /** Mark clean after a successful push, only if untouched since (compare-and-clear, ADR 0030). */
+    @Query(
+        "UPDATE audiobook_bookmarks SET lastSyncedAt = :serverStamp, localUpdatedAt = :serverStamp " +
+            "WHERE id = :id AND localUpdatedAt = :ifLocalUpdatedAt",
+    )
+    suspend fun confirmPushedIfUnchanged(id: String, serverStamp: Long, ifLocalUpdatedAt: Long): Int
+
+    /** Hard-remove a confirmed-deleted tombstone, only if untouched since. */
+    @Query("DELETE FROM audiobook_bookmarks WHERE id = :id AND deleted = 1 AND localUpdatedAt = :ifLocalUpdatedAt")
+    suspend fun hardDeleteIfUnchanged(id: String, ifLocalUpdatedAt: Long): Int
+
+    @Query("DELETE FROM audiobook_bookmarks WHERE id = :id")
+    suspend fun hardDelete(id: String)
 }

--- a/core/database/src/main/kotlin/com/riffle/core/database/AudiobookBookmarkDao.kt
+++ b/core/database/src/main/kotlin/com/riffle/core/database/AudiobookBookmarkDao.kt
@@ -1,0 +1,12 @@
+package com.riffle.core.database
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+
+@Dao
+interface AudiobookBookmarkDao {
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsert(entity: AudiobookBookmarkEntity)
+}

--- a/core/database/src/main/kotlin/com/riffle/core/database/AudiobookBookmarkEntity.kt
+++ b/core/database/src/main/kotlin/com/riffle/core/database/AudiobookBookmarkEntity.kt
@@ -1,0 +1,34 @@
+package com.riffle.core.database
+
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+
+// A user bookmark in an audiobook: a titled point (book-absolute seconds) on a library item.
+// Unlike audiobook_positions (one value per item) this is a COLLECTION per (serverId, itemId).
+// Dirty-tracking + soft-delete mirror ADR 0030: a row is dirty when localUpdatedAt > lastSyncedAt;
+// a delete is a tombstone (deleted = 1) kept until the server delete is confirmed, then hard-removed.
+@Entity(
+    tableName = "audiobook_bookmarks",
+    primaryKeys = ["id"],
+    foreignKeys = [
+        ForeignKey(
+            entity = ServerEntity::class,
+            parentColumns = ["id"],
+            childColumns = ["serverId"],
+            onDelete = ForeignKey.CASCADE,
+        ),
+    ],
+    indices = [Index("serverId"), Index(value = ["serverId", "itemId"])],
+)
+data class AudiobookBookmarkEntity(
+    val id: String,
+    val serverId: String,
+    val itemId: String,
+    val positionSec: Double,
+    val title: String,
+    val createdAt: Long,
+    val localUpdatedAt: Long = 0,
+    val lastSyncedAt: Long = 0,
+    val deleted: Boolean = false,
+)

--- a/core/database/src/main/kotlin/com/riffle/core/database/RiffleDatabase.kt
+++ b/core/database/src/main/kotlin/com/riffle/core/database/RiffleDatabase.kt
@@ -24,8 +24,9 @@ import androidx.sqlite.db.SupportSQLiteDatabase
         ReadaloudResumePositionEntity::class,
         AudioPlaybackPreferencesEntity::class,
         AudiobookPositionEntity::class,
+        AudiobookBookmarkEntity::class,
     ],
-    version = 34,
+    version = 35,
     exportSchema = true,
 )
 abstract class RiffleDatabase : RoomDatabase() {
@@ -44,6 +45,7 @@ abstract class RiffleDatabase : RoomDatabase() {
     abstract fun readaloudResumePositionDao(): ReadaloudResumePositionDao
     abstract fun audioPlaybackPreferencesDao(): AudioPlaybackPreferencesDao
     abstract fun audiobookPositionDao(): AudiobookPositionDao
+    abstract fun audiobookBookmarkDao(): AudiobookBookmarkDao
 
     companion object {
         val MIGRATION_1_2 = object : Migration(1, 2) {
@@ -691,6 +693,36 @@ abstract class RiffleDatabase : RoomDatabase() {
                 )
                 db.execSQL(
                     "ALTER TABLE `audiobook_positions` ADD COLUMN `lastSyncedAt` INTEGER NOT NULL DEFAULT 0"
+                )
+            }
+        }
+
+        // Audiobook bookmarks (a COLLECTION of titled book-absolute positions per item, unlike the
+        // single-value audiobook_positions). Dirty-tracking + soft-delete mirror ADR 0030. serverId
+        // FK-cascades; indexed by serverId and (serverId, itemId) for per-item lookups.
+        val MIGRATION_34_35 = object : Migration(34, 35) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL(
+                    "CREATE TABLE IF NOT EXISTS `audiobook_bookmarks` (" +
+                        "`id` TEXT NOT NULL, " +
+                        "`serverId` TEXT NOT NULL, " +
+                        "`itemId` TEXT NOT NULL, " +
+                        "`positionSec` REAL NOT NULL, " +
+                        "`title` TEXT NOT NULL, " +
+                        "`createdAt` INTEGER NOT NULL, " +
+                        "`localUpdatedAt` INTEGER NOT NULL, " +
+                        "`lastSyncedAt` INTEGER NOT NULL, " +
+                        "`deleted` INTEGER NOT NULL, " +
+                        "PRIMARY KEY(`id`), " +
+                        "FOREIGN KEY(`serverId`) REFERENCES `servers`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE)"
+                )
+                db.execSQL(
+                    "CREATE INDEX IF NOT EXISTS `index_audiobook_bookmarks_serverId` " +
+                        "ON `audiobook_bookmarks` (`serverId`)"
+                )
+                db.execSQL(
+                    "CREATE INDEX IF NOT EXISTS `index_audiobook_bookmarks_serverId_itemId` " +
+                        "ON `audiobook_bookmarks` (`serverId`, `itemId`)"
                 )
             }
         }

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/ApplicableRemotes.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/ApplicableRemotes.kt
@@ -20,7 +20,7 @@ package com.riffle.core.domain
  * re-stamping `now` (see EpubReaderViewModel.pendingServerJumpStamp). Only a position genuinely written
  * by some other client outranks the reading position.
  */
-enum class RemoteKind { ABS_EBOOK, ABS_AUDIO }
+enum class RemoteKind { ABS_EBOOK, ABS_AUDIO, ABS_BOOKMARK }
 
 /**
  * The medium the open book is being driven from — i.e. which surface holds the canonical position.

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/AudiobookBookmark.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/AudiobookBookmark.kt
@@ -1,0 +1,9 @@
+package com.riffle.core.domain
+
+/** A user bookmark in an audiobook: a titled book-absolute position. */
+data class AudiobookBookmark(
+    val id: String,
+    val positionSec: Double,
+    val title: String,
+    val createdAt: Long,
+)

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/AudiobookBookmarkStore.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/AudiobookBookmarkStore.kt
@@ -1,0 +1,16 @@
+package com.riffle.core.domain
+
+import kotlinx.coroutines.flow.Flow
+
+/** Local-first CRUD for audiobook bookmarks, scoped per (serverId, itemId). */
+interface AudiobookBookmarkStore {
+    fun observe(serverId: String, itemId: String): Flow<List<AudiobookBookmark>>
+
+    /** Create a bookmark; returns its generated id. [now] is the wall-clock stamp (createdAt + dirty). */
+    suspend fun add(serverId: String, itemId: String, positionSec: Double, title: String, now: Long): String
+
+    suspend fun rename(id: String, title: String, now: Long)
+
+    /** Soft-delete (tombstone) so the deletion can be pushed to ABS, then hard-removed on confirm. */
+    suspend fun delete(id: String, now: Long)
+}

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/AudiobookBookmarkStore.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/AudiobookBookmarkStore.kt
@@ -6,6 +6,9 @@ import kotlinx.coroutines.flow.Flow
 interface AudiobookBookmarkStore {
     fun observe(serverId: String, itemId: String): Flow<List<AudiobookBookmark>>
 
+    /** Live: whether this item has unsynced (dirty) bookmarks pending a push to ABS. */
+    fun observeHasUnsynced(serverId: String, itemId: String): Flow<Boolean>
+
     /** Create a bookmark; returns its generated id. [now] is the wall-clock stamp (createdAt + dirty). */
     suspend fun add(serverId: String, itemId: String, positionSec: Double, title: String, now: Long): String
 

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/BookmarkTitleBuilder.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/BookmarkTitleBuilder.kt
@@ -1,0 +1,19 @@
+package com.riffle.core.domain
+
+/** Builds the pre-filled (editable) default title for a new bookmark from the timeline + position. */
+object BookmarkTitleBuilder {
+
+    fun defaultTitle(timeline: AudiobookTimeline, positionSec: Double): String {
+        val chapter = timeline.chapterAt(positionSec) ?: return clock(positionSec)
+        val offset = (positionSec - chapter.startSec).coerceAtLeast(0.0)
+        val label = chapter.title.trim().ifEmpty { "Chapter ${chapter.index + 1}" }
+        return "$label · ${clock(offset)}"
+    }
+
+    // mm:ss under an hour, h:mm:ss otherwise.
+    private fun clock(sec: Double): String {
+        val total = sec.toLong()
+        val h = total / 3600; val m = (total % 3600) / 60; val s = total % 60
+        return if (h > 0) "%d:%02d:%02d".format(h, m, s) else "%d:%02d".format(m, s)
+    }
+}

--- a/core/domain/src/test/kotlin/com/riffle/core/domain/BookmarkTitleBuilderTest.kt
+++ b/core/domain/src/test/kotlin/com/riffle/core/domain/BookmarkTitleBuilderTest.kt
@@ -1,0 +1,36 @@
+package com.riffle.core.domain
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class BookmarkTitleBuilderTest {
+    private fun timeline(vararg ch: AudiobookChapter) =
+        AudiobookTimeline(durationSec = 10_000.0, chapters = ch.toList())
+
+    @Test fun titledChapterUsesTitleAndOffset() {
+        val t = timeline(
+            AudiobookChapter(0, 0.0, 600.0, "Prologue"),
+            AudiobookChapter(1, 600.0, 5000.0, "The Egg"),
+        )
+        // 600 + 12*60 + 45 = 1365s -> offset into "The Egg" = 765s = 12:45
+        assertEquals("The Egg · 12:45", BookmarkTitleBuilder.defaultTitle(t, 1365.0))
+    }
+
+    @Test fun untitledChapterFallsBackToChapterNumber() {
+        val t = timeline(
+            AudiobookChapter(0, 0.0, 600.0, ""),
+            AudiobookChapter(1, 600.0, 5000.0, "   "),
+        )
+        assertEquals("Chapter 2 · 12:45", BookmarkTitleBuilder.defaultTitle(t, 1365.0))
+    }
+
+    @Test fun noChaptersFallsBackToAbsoluteTimestamp() {
+        val t = AudiobookTimeline(durationSec = 10_000.0, chapters = emptyList())
+        assertEquals("1:02:11", BookmarkTitleBuilder.defaultTitle(t, 3731.0))
+    }
+
+    @Test fun offsetUnderTenMinutesStillTwoDigitSeconds() {
+        val t = timeline(AudiobookChapter(0, 0.0, 5000.0, "One"))
+        assertEquals("One · 3:05", BookmarkTitleBuilder.defaultTitle(t, 185.0))
+    }
+}

--- a/core/network/src/main/kotlin/com/riffle/core/network/AbsApiClient.kt
+++ b/core/network/src/main/kotlin/com/riffle/core/network/AbsApiClient.kt
@@ -759,6 +759,13 @@ class AbsApiClient(private val httpClient: OkHttpClient) : AbsApi, AbsLibraryApi
         try {
             val response = client.newCall(request).execute()
             response.body?.close()
+            if (response.code == 404) {
+                // Deleting an already-absent bookmark is success (idempotent) — otherwise a
+                // delete-tombstone for a bookmark already gone on the server stays dirty forever.
+                return@withContext AbsBookmarkResult.Success(
+                    NetworkAbsBookmark(libraryItemId = itemId, title = "", timeSec = timeSec, createdAt = 0L)
+                )
+            }
             if (!response.isSuccessful) {
                 return@withContext AbsBookmarkResult.NetworkError(IOException("HTTP ${response.code}"))
             }

--- a/core/network/src/main/kotlin/com/riffle/core/network/AbsApiClient.kt
+++ b/core/network/src/main/kotlin/com/riffle/core/network/AbsApiClient.kt
@@ -26,6 +26,8 @@ import com.riffle.core.network.model.toNetworkCollection
 import com.riffle.core.network.model.toNetworkPlaylist
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import okhttp3.MediaType.Companion.toMediaType
@@ -46,7 +48,7 @@ sealed class NetworkLoginResult {
     data class InsecureConnection(val type: InsecureConnectionType) : NetworkLoginResult()
 }
 
-class AbsApiClient(private val httpClient: OkHttpClient) : AbsApi, AbsLibraryApi, AbsSessionApi, AbsServerInfoApi, AbsPlaybackApi {
+class AbsApiClient(private val httpClient: OkHttpClient) : AbsApi, AbsLibraryApi, AbsSessionApi, AbsServerInfoApi, AbsPlaybackApi, AbsBookmarkApi {
 
     private val json = Json { ignoreUnknownKeys = true; coerceInputValues = true }
     private val jsonMediaType = "application/json; charset=utf-8".toMediaType()
@@ -688,6 +690,117 @@ class AbsApiClient(private val httpClient: OkHttpClient) : AbsApi, AbsLibraryApi
         }
     }
 
+    override suspend fun createBookmark(
+        baseUrl: String,
+        itemId: String,
+        timeSec: Int,
+        title: String,
+        token: String,
+        insecureAllowed: Boolean,
+    ): AbsBookmarkResult = withContext(Dispatchers.IO) {
+        val client = if (insecureAllowed) httpClient.trustAllCerts() else httpClient
+        val body = json.encodeToString(AbsBookmarkRequest(timeSec, title)).toRequestBody(jsonMediaType)
+        val request = Request.Builder()
+            .url("$baseUrl/api/me/item/$itemId/bookmark")
+            .addHeader("Authorization", "Bearer $token")
+            .post(body)
+            .build()
+        executeBookmarkWrite(client, request)
+    }
+
+    override suspend fun updateBookmark(
+        baseUrl: String,
+        itemId: String,
+        timeSec: Int,
+        title: String,
+        token: String,
+        insecureAllowed: Boolean,
+    ): AbsBookmarkResult = withContext(Dispatchers.IO) {
+        val client = if (insecureAllowed) httpClient.trustAllCerts() else httpClient
+        val body = json.encodeToString(AbsBookmarkRequest(timeSec, title)).toRequestBody(jsonMediaType)
+        val request = Request.Builder()
+            .url("$baseUrl/api/me/item/$itemId/bookmark")
+            .addHeader("Authorization", "Bearer $token")
+            .patch(body)
+            .build()
+        executeBookmarkWrite(client, request)
+    }
+
+    private fun executeBookmarkWrite(client: OkHttpClient, request: Request): AbsBookmarkResult {
+        return try {
+            val response = client.newCall(request).execute()
+            if (!response.isSuccessful) {
+                response.body?.close()
+                return AbsBookmarkResult.NetworkError(IOException("HTTP ${response.code}"))
+            }
+            val raw = response.body?.string()
+            if (raw.isNullOrEmpty()) {
+                return AbsBookmarkResult.NetworkError(IOException("Empty response body"))
+            }
+            AbsBookmarkResult.Success(json.decodeFromString<AbsBookmarkJson>(raw).toNetworkAbsBookmark())
+        } catch (e: IOException) {
+            AbsBookmarkResult.NetworkError(e)
+        }
+    }
+
+    override suspend fun deleteBookmark(
+        baseUrl: String,
+        itemId: String,
+        timeSec: Int,
+        token: String,
+        insecureAllowed: Boolean,
+    ): AbsBookmarkResult = withContext(Dispatchers.IO) {
+        val client = if (insecureAllowed) httpClient.trustAllCerts() else httpClient
+        val request = Request.Builder()
+            .url("$baseUrl/api/me/item/$itemId/bookmark/$timeSec")
+            .addHeader("Authorization", "Bearer $token")
+            .delete()
+            .build()
+        try {
+            val response = client.newCall(request).execute()
+            response.body?.close()
+            if (!response.isSuccessful) {
+                return@withContext AbsBookmarkResult.NetworkError(IOException("HTTP ${response.code}"))
+            }
+            // DELETE returns plain-text "OK" with no JSON body, so synthesize the bookmark
+            // from the request inputs (identity is libraryItemId + time).
+            AbsBookmarkResult.Success(
+                NetworkAbsBookmark(libraryItemId = itemId, title = "", timeSec = timeSec, createdAt = 0L)
+            )
+        } catch (e: IOException) {
+            AbsBookmarkResult.NetworkError(e)
+        }
+    }
+
+    override suspend fun listBookmarks(
+        baseUrl: String,
+        token: String,
+        insecureAllowed: Boolean,
+    ): AbsBookmarkListResult = withContext(Dispatchers.IO) {
+        val client = if (insecureAllowed) httpClient.trustAllCerts() else httpClient
+        val request = Request.Builder()
+            .url("$baseUrl/api/me")
+            .addHeader("Authorization", "Bearer $token")
+            .get()
+            .build()
+        try {
+            val response = client.newCall(request).execute()
+            if (!response.isSuccessful) {
+                response.body?.close()
+                return@withContext AbsBookmarkListResult.NetworkError(IOException("HTTP ${response.code}"))
+            }
+            val raw = response.body?.string() ?: return@withContext AbsBookmarkListResult.NetworkError(
+                IOException("Empty response body")
+            )
+            // `/api/me` carries many fields; `json` is configured with ignoreUnknownKeys so the
+            // wrapper need only declare `bookmarks` (absent → empty via the default).
+            val parsed = json.decodeFromString<AbsMeBookmarksResponse>(raw)
+            AbsBookmarkListResult.Success(parsed.bookmarks.map { it.toNetworkAbsBookmark() })
+        } catch (e: IOException) {
+            AbsBookmarkListResult.NetworkError(e)
+        }
+    }
+
     private fun OkHttpClient.trustAllCerts(): OkHttpClient {
         val trustAll = object : X509TrustManager {
             override fun checkClientTrusted(chain: Array<out X509Certificate>, authType: String) = Unit
@@ -702,3 +815,29 @@ class AbsApiClient(private val httpClient: OkHttpClient) : AbsApi, AbsLibraryApi
             .build()
     }
 }
+
+@Serializable
+private data class AbsBookmarkRequest(
+    @SerialName("time") val time: Int,
+    @SerialName("title") val title: String,
+)
+
+@Serializable
+private data class AbsBookmarkJson(
+    val libraryItemId: String = "",
+    @SerialName("time") val timeSec: Int = 0,
+    val title: String = "",
+    val createdAt: Long = 0L,
+) {
+    fun toNetworkAbsBookmark() = NetworkAbsBookmark(
+        libraryItemId = libraryItemId,
+        title = title,
+        timeSec = timeSec,
+        createdAt = createdAt,
+    )
+}
+
+@Serializable
+private data class AbsMeBookmarksResponse(
+    val bookmarks: List<AbsBookmarkJson> = emptyList(),
+)

--- a/core/network/src/main/kotlin/com/riffle/core/network/AbsBookmarkApi.kt
+++ b/core/network/src/main/kotlin/com/riffle/core/network/AbsBookmarkApi.kt
@@ -1,0 +1,52 @@
+package com.riffle.core.network
+
+data class NetworkAbsBookmark(
+    val libraryItemId: String,
+    val title: String,
+    val timeSec: Int,
+    val createdAt: Long,
+)
+
+sealed interface AbsBookmarkResult {
+    data class Success(val bookmark: NetworkAbsBookmark) : AbsBookmarkResult
+    data class NetworkError(val cause: Throwable) : AbsBookmarkResult
+}
+
+sealed interface AbsBookmarkListResult {
+    data class Success(val bookmarks: List<NetworkAbsBookmark>) : AbsBookmarkListResult
+    data class NetworkError(val cause: Throwable) : AbsBookmarkListResult
+}
+
+interface AbsBookmarkApi {
+    suspend fun createBookmark(
+        baseUrl: String,
+        itemId: String,
+        timeSec: Int,
+        title: String,
+        token: String,
+        insecureAllowed: Boolean,
+    ): AbsBookmarkResult
+
+    suspend fun updateBookmark(
+        baseUrl: String,
+        itemId: String,
+        timeSec: Int,
+        title: String,
+        token: String,
+        insecureAllowed: Boolean,
+    ): AbsBookmarkResult
+
+    suspend fun deleteBookmark(
+        baseUrl: String,
+        itemId: String,
+        timeSec: Int,
+        token: String,
+        insecureAllowed: Boolean,
+    ): AbsBookmarkResult
+
+    suspend fun listBookmarks(
+        baseUrl: String,
+        token: String,
+        insecureAllowed: Boolean,
+    ): AbsBookmarkListResult
+}

--- a/core/network/src/test/kotlin/com/riffle/core/network/AbsBookmarkApiTest.kt
+++ b/core/network/src/test/kotlin/com/riffle/core/network/AbsBookmarkApiTest.kt
@@ -1,0 +1,139 @@
+package com.riffle.core.network
+
+import kotlinx.coroutines.test.runTest
+import okhttp3.OkHttpClient
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class AbsBookmarkApiTest {
+
+    private lateinit var server: MockWebServer
+    private lateinit var client: AbsApiClient
+
+    @Before
+    fun setUp() {
+        server = MockWebServer()
+        server.start()
+        client = AbsApiClient(OkHttpClient())
+    }
+
+    @After
+    fun tearDown() {
+        server.shutdown()
+    }
+
+    private fun baseUrl() = server.url("/").toString().trimEnd('/')
+
+    @Test
+    fun `createBookmark posts time and title and parses returned bookmark`() = runTest {
+        server.enqueue(
+            MockResponse().setResponseCode(200)
+                .addHeader("Content-Type", "application/json")
+                .setBody("""{"libraryItemId":"ITEM","time":123,"title":"x","createdAt":111}""")
+        )
+        val result = client.createBookmark(baseUrl(), "ITEM", 123, "x", "tok", false)
+
+        val req = server.takeRequest()
+        assertEquals("POST", req.method)
+        assertEquals("/api/me/item/ITEM/bookmark", req.path)
+        val body = req.body.readUtf8()
+        assertTrue(body.contains("\"time\":123"))
+        assertTrue(body.contains("\"title\":\"x\""))
+
+        assertTrue(result is AbsBookmarkResult.Success)
+        val bookmark = (result as AbsBookmarkResult.Success).bookmark
+        assertEquals("ITEM", bookmark.libraryItemId)
+        assertEquals(123, bookmark.timeSec)
+        assertEquals("x", bookmark.title)
+        assertEquals(111L, bookmark.createdAt)
+    }
+
+    @Test
+    fun `updateBookmark patches to same path and parses returned bookmark`() = runTest {
+        server.enqueue(
+            MockResponse().setResponseCode(200)
+                .addHeader("Content-Type", "application/json")
+                .setBody("""{"libraryItemId":"ITEM","time":123,"title":"x","createdAt":111}""")
+        )
+        val result = client.updateBookmark(baseUrl(), "ITEM", 123, "x", "tok", false)
+
+        val req = server.takeRequest()
+        assertEquals("PATCH", req.method)
+        assertEquals("/api/me/item/ITEM/bookmark", req.path)
+
+        assertTrue(result is AbsBookmarkResult.Success)
+        val bookmark = (result as AbsBookmarkResult.Success).bookmark
+        assertEquals(123, bookmark.timeSec)
+        assertEquals("x", bookmark.title)
+    }
+
+    @Test
+    fun `deleteBookmark deletes by time and synthesizes success from plain-text OK`() = runTest {
+        server.enqueue(
+            MockResponse().setResponseCode(200)
+                .addHeader("Content-Type", "text/plain")
+                .setBody("OK")
+        )
+        val result = client.deleteBookmark(baseUrl(), "ITEM", 123, "tok", false)
+
+        val req = server.takeRequest()
+        assertEquals("DELETE", req.method)
+        assertEquals("/api/me/item/ITEM/bookmark/123", req.path)
+
+        assertTrue(result is AbsBookmarkResult.Success)
+        val bookmark = (result as AbsBookmarkResult.Success).bookmark
+        assertEquals("ITEM", bookmark.libraryItemId)
+        assertEquals(123, bookmark.timeSec)
+    }
+
+    @Test
+    fun `listBookmarks parses bookmarks array from api me`() = runTest {
+        server.enqueue(
+            MockResponse().setResponseCode(200)
+                .addHeader("Content-Type", "application/json")
+                .setBody(
+                    """{"bookmarks":[{"libraryItemId":"ITEM","time":5,"title":"a","createdAt":1},""" +
+                        """{"libraryItemId":"ITEM","time":9,"title":"b","createdAt":2}],"id":"u","username":"x"}"""
+                )
+        )
+        val result = client.listBookmarks(baseUrl(), "tok", false)
+
+        val req = server.takeRequest()
+        assertEquals("GET", req.method)
+        assertEquals("/api/me", req.path)
+
+        assertTrue(result is AbsBookmarkListResult.Success)
+        val bookmarks = (result as AbsBookmarkListResult.Success).bookmarks
+        assertEquals(2, bookmarks.size)
+        assertEquals(5, bookmarks[0].timeSec)
+        assertEquals("a", bookmarks[0].title)
+        assertEquals(1L, bookmarks[0].createdAt)
+        assertEquals(9, bookmarks[1].timeSec)
+        assertEquals("b", bookmarks[1].title)
+    }
+
+    @Test
+    fun `listBookmarks returns empty list when bookmarks key absent`() = runTest {
+        server.enqueue(
+            MockResponse().setResponseCode(200)
+                .addHeader("Content-Type", "application/json")
+                .setBody("""{"id":"u","username":"x"}""")
+        )
+        val result = client.listBookmarks(baseUrl(), "tok", false)
+
+        assertTrue(result is AbsBookmarkListResult.Success)
+        assertTrue((result as AbsBookmarkListResult.Success).bookmarks.isEmpty())
+    }
+
+    @Test
+    fun `createBookmark returns NetworkError on non-2xx`() = runTest {
+        server.enqueue(MockResponse().setResponseCode(500).setBody("error"))
+        val result = client.createBookmark(baseUrl(), "ITEM", 123, "x", "tok", false)
+        assertTrue(result is AbsBookmarkResult.NetworkError)
+    }
+}

--- a/core/network/src/test/kotlin/com/riffle/core/network/AbsBookmarkApiTest.kt
+++ b/core/network/src/test/kotlin/com/riffle/core/network/AbsBookmarkApiTest.kt
@@ -92,6 +92,21 @@ class AbsBookmarkApiTest {
     }
 
     @Test
+    fun `deleteBookmark404IsTreatedAsSuccess`() = runTest {
+        server.enqueue(MockResponse().setResponseCode(404).setBody("Not found"))
+        val result = client.deleteBookmark(baseUrl(), "ITEM", 123, "tok", false)
+
+        val req = server.takeRequest()
+        assertEquals("DELETE", req.method)
+        assertEquals("/api/me/item/ITEM/bookmark/123", req.path)
+
+        assertTrue(result is AbsBookmarkResult.Success)
+        val bookmark = (result as AbsBookmarkResult.Success).bookmark
+        assertEquals("ITEM", bookmark.libraryItemId)
+        assertEquals(123, bookmark.timeSec)
+    }
+
+    @Test
     fun `listBookmarks parses bookmarks array from api me`() = runTest {
         server.enqueue(
             MockResponse().setResponseCode(200)

--- a/docs/superpowers/plans/2026-06-13-audiobook-bookmarks.md
+++ b/docs/superpowers/plans/2026-06-13-audiobook-bookmarks.md
@@ -1,0 +1,1073 @@
+# Audiobook Bookmarks Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let a listener mark a spot in an audiobook, give it an editable title, return to it, and have bookmarks sync to Audiobookshelf on the same cadence as audiobook progress.
+
+**Architecture:** New `audiobook_bookmarks` Room table is the local source of truth (DB v34→v35), with dirty-tracking columns mirroring `audiobook_positions` (ADR 0030). Unlike positions (one value per item), bookmarks are a *collection* per item, so sync is a **set reconcile** (push local creates/renames/deletes to ABS's native `/api/me/item/{id}/bookmark` endpoints; pull merges server-side bookmarks), driven by a dedicated reconciler hooked into the existing `ProgressSweep` so it runs at the same frequency as position sync. UI is variant B: a one-tap add icon, a create dialog with a pre-filled `Chapter · offset` title, two labeled pills (Chapters / Bookmarks) each opening a shared `PlayerListSheet`, and bookmark ticks on the scrubber.
+
+**Tech Stack:** Kotlin, Room, Hilt, Kotlinx Serialization, OkHttp, Jetpack Compose, Media3 (existing `AudiobookController`), JUnit/Turbine.
+
+**Spec:** `docs/superpowers/specs/2026-06-13-audiobook-bookmarks-design.md`
+
+---
+
+## Slices
+
+- **Slice 1 (Tasks 1–9):** Local bookmarks, fully working offline — store, domain title builder, ViewModel, create dialog, list sheet, rename/delete, scrubber ticks. No network.
+- **Slice 2 (Tasks 10–13):** ABS reconcile (`AbsBookmarkApi` + reconciler + sweep hook) and the offline note.
+
+Each slice produces working, testable software. Slice 1 ships a usable feature; Slice 2 adds sync.
+
+## File Structure
+
+**Slice 1**
+- Create `core/database/.../AudiobookBookmarkEntity.kt` — Room entity.
+- Create `core/database/.../AudiobookBookmarkDao.kt` — CRUD + dirty queries.
+- Modify `core/database/.../RiffleDatabase.kt` — version 35, entity, DAO accessor, `MIGRATION_34_35`.
+- Modify `core/data/.../DataModule.kt` — register migration + bindings.
+- Create `core/domain/.../AudiobookBookmark.kt` — domain model.
+- Create `core/domain/.../BookmarkTitleBuilder.kt` — default-title logic.
+- Create `core/domain/.../AudiobookBookmarkStore.kt` — store interface.
+- Create `core/data/.../AudiobookBookmarkStoreImpl.kt` — store impl.
+- Modify `app/.../audiobook/AudiobookPlayerViewModel.kt` — bookmark state + actions.
+- Modify `app/.../audiobook/AudiobookPlayerScreen.kt` — add icon, pills, ticks, wire sheets.
+- Create `app/.../audiobook/BookmarkCreateDialog.kt` — title dialog.
+- Create `app/.../audiobook/PlayerListSheet.kt` — shared chapters/bookmarks sheet.
+- Modify `core/database/src/androidTest/.../MigrationTest.kt` — v34→v35 test + chain.
+- Modify `app/.../TestDatabaseModule.kt` (androidTest) — provide the new DAO.
+
+**Slice 2**
+- Create `core/network/.../AbsBookmarkApi.kt` — interface + DTOs.
+- Modify `core/network/.../AbsApiClient.kt` — implement endpoints.
+- Create `core/data/.../AudiobookBookmarkReconciler.kt` — set reconcile.
+- Modify the `ProgressSweep` wiring (`core/data/.../ProgressSweep.kt` + its Hilt module) — invoke the reconciler per dirty item.
+- Modify `AudiobookPlayerViewModel`/`PlayerListSheet` — offline note.
+
+---
+
+## Slice 1 — Local bookmarks
+
+### Task 1: Bookmark entity + DB migration v34→v35
+
+**Files:**
+- Create: `core/database/src/main/kotlin/com/riffle/core/database/AudiobookBookmarkEntity.kt`
+- Modify: `core/database/src/main/kotlin/com/riffle/core/database/RiffleDatabase.kt`
+- Modify: `core/data/src/main/kotlin/com/riffle/core/data/di/DataModule.kt` (path: wherever `addMigrations(...)` lives)
+- Test: `core/database/src/androidTest/kotlin/com/riffle/core/database/MigrationTest.kt`
+
+- [ ] **Step 1: Write the entity**
+
+```kotlin
+package com.riffle.core.database
+
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+
+// A user bookmark in an audiobook: a titled point (book-absolute seconds) on a library item.
+// Unlike audiobook_positions (one value per item) this is a COLLECTION per (serverId, itemId).
+// Dirty-tracking + soft-delete mirror ADR 0030: a row is dirty when localUpdatedAt > lastSyncedAt;
+// a delete is a tombstone (deleted = 1) kept until the server delete is confirmed, then hard-removed.
+@Entity(
+    tableName = "audiobook_bookmarks",
+    primaryKeys = ["id"],
+    foreignKeys = [
+        ForeignKey(
+            entity = ServerEntity::class,
+            parentColumns = ["id"],
+            childColumns = ["serverId"],
+            onDelete = ForeignKey.CASCADE,
+        ),
+    ],
+    indices = [Index("serverId"), Index(value = ["serverId", "itemId"])],
+)
+data class AudiobookBookmarkEntity(
+    val id: String,
+    val serverId: String,
+    val itemId: String,
+    val positionSec: Double,
+    val title: String,
+    val createdAt: Long,
+    val localUpdatedAt: Long = 0,
+    val lastSyncedAt: Long = 0,
+    val deleted: Boolean = false,
+)
+```
+
+- [ ] **Step 2: Add the DAO accessor + entity + version bump in `RiffleDatabase.kt`**
+
+Add `AudiobookBookmarkEntity::class` to the `entities = [...]` list, change `version = 34` to `version = 35`, and add `abstract fun audiobookBookmarkDao(): AudiobookBookmarkDao` next to `audiobookPositionDao()`. Add the migration companion object:
+
+```kotlin
+val MIGRATION_34_35 = object : Migration(34, 35) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL(
+            "CREATE TABLE IF NOT EXISTS `audiobook_bookmarks` (" +
+                "`id` TEXT NOT NULL, " +
+                "`serverId` TEXT NOT NULL, " +
+                "`itemId` TEXT NOT NULL, " +
+                "`positionSec` REAL NOT NULL, " +
+                "`title` TEXT NOT NULL, " +
+                "`createdAt` INTEGER NOT NULL, " +
+                "`localUpdatedAt` INTEGER NOT NULL, " +
+                "`lastSyncedAt` INTEGER NOT NULL, " +
+                "`deleted` INTEGER NOT NULL, " +
+                "PRIMARY KEY(`id`), " +
+                "FOREIGN KEY(`serverId`) REFERENCES `servers`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE)"
+        )
+        db.execSQL(
+            "CREATE INDEX IF NOT EXISTS `index_audiobook_bookmarks_serverId` " +
+                "ON `audiobook_bookmarks` (`serverId`)"
+        )
+        db.execSQL(
+            "CREATE INDEX IF NOT EXISTS `index_audiobook_bookmarks_serverId_itemId` " +
+                "ON `audiobook_bookmarks` (`serverId`, `itemId`)"
+        )
+    }
+}
+```
+
+- [ ] **Step 3: Register the migration in `DataModule.kt`** — add `RiffleDatabase.MIGRATION_34_35` to the `addMigrations(...)` call.
+
+- [ ] **Step 4: Build so KSP exports the schema**
+
+Run: `JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home" ./gradlew :core:database:kspDebugKotlin`
+Expected: BUILD SUCCESSFUL, and `core/database/schemas/com.riffle.core.database.RiffleDatabase/35.json` now exists containing `audiobook_bookmarks`.
+
+- [ ] **Step 5: Write the migration test** (append to `MigrationTest.kt`)
+
+```kotlin
+@Test
+fun migration34To35_addsAudiobookBookmarksTable() {
+    helper.createDatabase(TEST_DB, 34).use { db ->
+        db.execSQL(
+            "INSERT INTO servers (id, url, isActive, insecureConnectionAllowed, username, serverType) " +
+                "VALUES ('s1', 'http://media-server', 1, 0, 'test', 'AUDIOBOOKSHELF')"
+        )
+    }
+
+    val db = helper.runMigrationsAndValidate(TEST_DB, 35, true, RiffleDatabase.MIGRATION_34_35)
+
+    db.query("SELECT COUNT(*) FROM audiobook_bookmarks").use { c ->
+        c.moveToFirst(); assertEquals(0, c.getInt(0))
+    }
+
+    db.execSQL(
+        "INSERT INTO audiobook_bookmarks (id, serverId, itemId, positionSec, title, createdAt, localUpdatedAt, lastSyncedAt, deleted) " +
+            "VALUES ('b1', 's1', '42', 765.0, 'The Egg · 12:45', 1700000000000, 1700000000000, 0, 0)"
+    )
+    db.query(
+        "SELECT positionSec, title, createdAt, localUpdatedAt, lastSyncedAt, deleted FROM audiobook_bookmarks WHERE id = 'b1'"
+    ).use { c ->
+        assertEquals(1, c.count); c.moveToFirst()
+        assertEquals(765.0, c.getDouble(0), 0.0001)
+        assertEquals("The Egg · 12:45", c.getString(1))
+        assertEquals(1700000000000L, c.getLong(2))
+        assertEquals(1700000000000L, c.getLong(3))
+        assertEquals(0L, c.getLong(4))
+        assertEquals(0, c.getInt(5))
+    }
+
+    // FK cascade: removing the server clears its bookmarks.
+    db.execSQL("PRAGMA foreign_keys = ON")
+    db.execSQL("DELETE FROM servers WHERE id = 's1'")
+    db.query("SELECT COUNT(*) FROM audiobook_bookmarks").use { c ->
+        c.moveToFirst(); assertEquals(0, c.getInt(0))
+    }
+}
+```
+
+Also add `RiffleDatabase.MIGRATION_34_35` to the end of the `migrateFullChain` test's `runMigrationsAndValidate(TEST_DB, 35, true, ...)` call (and change its target version to 35).
+
+- [ ] **Step 6: Run the migration test** (pinned to the self-booted Harness AVD per `reference_harness_macro_only_app_module`)
+
+Run (after booting Harness AVD and setting `ANDROID_SERIAL`):
+`JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home" ./gradlew :core:database:connectedDebugAndroidTest --tests "*MigrationTest.migration34To35_addsAudiobookBookmarksTable"`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add core/database core/data
+git commit -m "feat(audiobook): audiobook_bookmarks table + migration v34->v35"
+```
+
+---
+
+### Task 2: Bookmark DAO
+
+**Files:**
+- Create: `core/database/src/main/kotlin/com/riffle/core/database/AudiobookBookmarkDao.kt`
+- Test: `core/database/src/androidTest/kotlin/com/riffle/core/database/AudiobookBookmarkDaoTest.kt`
+
+- [ ] **Step 1: Write a failing DAO test**
+
+```kotlin
+package com.riffle.core.database
+
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class AudiobookBookmarkDaoTest {
+    private lateinit var db: RiffleDatabase
+    private lateinit var dao: AudiobookBookmarkDao
+
+    private fun server(id: String) = ServerEntity(
+        id = id, url = "http://x", isActive = true, insecureConnectionAllowed = false,
+        username = "u", serverType = "AUDIOBOOKSHELF",
+    )
+
+    @Before fun setup() {
+        db = Room.inMemoryDatabaseBuilder(
+            ApplicationProvider.getApplicationContext(), RiffleDatabase::class.java,
+        ).build()
+        dao = db.audiobookBookmarkDao()
+    }
+    @After fun teardown() = db.close()
+
+    @Test fun observeReturnsNonDeletedOrderedByPosition() = runTest {
+        db.serverDao().upsert(server("s1"))
+        dao.upsert(AudiobookBookmarkEntity("b2", "s1", "i1", 200.0, "two", 2, 2, 0, false))
+        dao.upsert(AudiobookBookmarkEntity("b1", "s1", "i1", 100.0, "one", 1, 1, 0, false))
+        dao.upsert(AudiobookBookmarkEntity("bd", "s1", "i1", 50.0, "gone", 3, 3, 0, true))
+
+        val rows = dao.observeForItem("s1", "i1").first()
+
+        assertEquals(listOf("b1", "b2"), rows.map { it.id })
+    }
+
+    @Test fun dirtyForServerReturnsDirtyIncludingTombstones() = runTest {
+        db.serverDao().upsert(server("s1"))
+        dao.upsert(AudiobookBookmarkEntity("clean", "s1", "i1", 10.0, "c", 1, 5, 5, false))
+        dao.upsert(AudiobookBookmarkEntity("dirty", "s1", "i1", 20.0, "d", 1, 6, 5, false))
+        dao.upsert(AudiobookBookmarkEntity("tomb", "s1", "i1", 30.0, "t", 1, 7, 5, true))
+
+        val dirty = dao.dirtyForServer("s1").map { it.id }.toSet()
+
+        assertEquals(setOf("dirty", "tomb"), dirty)
+    }
+}
+```
+
+(If `serverDao().upsert` differs, match the existing `ServerDao` insert method used in other DAO tests.)
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `./gradlew :core:database:connectedDebugAndroidTest --tests "*AudiobookBookmarkDaoTest"`
+Expected: FAIL — `audiobookBookmarkDao` unresolved.
+
+- [ ] **Step 3: Write the DAO**
+
+```kotlin
+package com.riffle.core.database
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface AudiobookBookmarkDao {
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsert(entity: AudiobookBookmarkEntity)
+
+    /** Live, user-visible bookmarks for an item: non-deleted, earliest position first. */
+    @Query(
+        "SELECT * FROM audiobook_bookmarks WHERE serverId = :serverId AND itemId = :itemId AND deleted = 0 " +
+            "ORDER BY positionSec ASC"
+    )
+    fun observeForItem(serverId: String, itemId: String): Flow<List<AudiobookBookmarkEntity>>
+
+    @Query("SELECT * FROM audiobook_bookmarks WHERE id = :id LIMIT 1")
+    suspend fun getById(id: String): AudiobookBookmarkEntity?
+
+    /** All rows for an item including tombstones (reconcile needs deletes). */
+    @Query("SELECT * FROM audiobook_bookmarks WHERE serverId = :serverId AND itemId = :itemId")
+    suspend fun allForItem(serverId: String, itemId: String): List<AudiobookBookmarkEntity>
+
+    /** Dirty rows for a server (creates, renames, AND tombstoned deletes). */
+    @Query("SELECT * FROM audiobook_bookmarks WHERE serverId = :serverId AND localUpdatedAt > lastSyncedAt")
+    suspend fun dirtyForServer(serverId: String): List<AudiobookBookmarkEntity>
+
+    @Query("SELECT DISTINCT serverId FROM audiobook_bookmarks WHERE localUpdatedAt > lastSyncedAt")
+    suspend fun serversWithDirtyRows(): List<String>
+
+    /** Mark clean after a successful push, only if untouched since (compare-and-clear, ADR 0030). */
+    @Query(
+        "UPDATE audiobook_bookmarks SET lastSyncedAt = :serverStamp, localUpdatedAt = :serverStamp " +
+            "WHERE id = :id AND localUpdatedAt = :ifLocalUpdatedAt"
+    )
+    suspend fun confirmPushedIfUnchanged(id: String, serverStamp: Long, ifLocalUpdatedAt: Long): Int
+
+    /** Hard-remove a confirmed-deleted tombstone, only if untouched since. */
+    @Query("DELETE FROM audiobook_bookmarks WHERE id = :id AND deleted = 1 AND localUpdatedAt = :ifLocalUpdatedAt")
+    suspend fun hardDeleteIfUnchanged(id: String, ifLocalUpdatedAt: Long): Int
+
+    @Query("DELETE FROM audiobook_bookmarks WHERE id = :id")
+    suspend fun hardDelete(id: String)
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `./gradlew :core:database:connectedDebugAndroidTest --tests "*AudiobookBookmarkDaoTest"`
+Expected: PASS.
+
+- [ ] **Step 5: Provide the DAO in the androidTest `TestDatabaseModule`** — add:
+
+```kotlin
+@Provides
+@Singleton
+fun provideAudiobookBookmarkDao(db: RiffleDatabase): AudiobookBookmarkDao = db.audiobookBookmarkDao()
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add core/database app
+git commit -m "feat(audiobook): AudiobookBookmarkDao + test"
+```
+
+---
+
+### Task 3: Domain model + default-title builder
+
+**Files:**
+- Create: `core/domain/src/main/kotlin/com/riffle/core/domain/AudiobookBookmark.kt`
+- Create: `core/domain/src/main/kotlin/com/riffle/core/domain/BookmarkTitleBuilder.kt`
+- Test: `core/domain/src/test/kotlin/com/riffle/core/domain/BookmarkTitleBuilderTest.kt`
+
+- [ ] **Step 1: Write the domain model**
+
+```kotlin
+package com.riffle.core.domain
+
+/** A user bookmark in an audiobook: a titled book-absolute position. */
+data class AudiobookBookmark(
+    val id: String,
+    val positionSec: Double,
+    val title: String,
+    val createdAt: Long,
+)
+```
+
+- [ ] **Step 2: Write the failing title-builder test**
+
+```kotlin
+package com.riffle.core.domain
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class BookmarkTitleBuilderTest {
+    private fun timeline(vararg ch: AudiobookChapter) =
+        AudiobookTimeline(durationSec = 10_000.0, chapters = ch.toList())
+
+    @Test fun titledChapterUsesTitleAndOffset() {
+        val t = timeline(
+            AudiobookChapter(0, 0.0, 600.0, "Prologue"),
+            AudiobookChapter(1, 600.0, 5000.0, "The Egg"),
+        )
+        // 600 + 12*60 + 45 = 1365s -> offset into "The Egg" = 765s = 12:45
+        assertEquals("The Egg · 12:45", BookmarkTitleBuilder.defaultTitle(t, 1365.0))
+    }
+
+    @Test fun untitledChapterFallsBackToChapterNumber() {
+        val t = timeline(
+            AudiobookChapter(0, 0.0, 600.0, ""),
+            AudiobookChapter(1, 600.0, 5000.0, "   "),
+        )
+        assertEquals("Chapter 2 · 12:45", BookmarkTitleBuilder.defaultTitle(t, 1365.0))
+    }
+
+    @Test fun noChaptersFallsBackToAbsoluteTimestamp() {
+        val t = AudiobookTimeline(durationSec = 10_000.0, chapters = emptyList())
+        // 1:02:11
+        assertEquals("1:02:11", BookmarkTitleBuilder.defaultTitle(t, 3731.0))
+    }
+
+    @Test fun offsetUnderTenMinutesStillTwoDigitSeconds() {
+        val t = timeline(AudiobookChapter(0, 0.0, 5000.0, "One"))
+        assertEquals("One · 3:05", BookmarkTitleBuilder.defaultTitle(t, 185.0))
+    }
+}
+```
+
+- [ ] **Step 3: Run it to verify it fails**
+
+Run: `./gradlew :core:domain:test --tests "*BookmarkTitleBuilderTest"`
+Expected: FAIL — `BookmarkTitleBuilder` unresolved.
+
+- [ ] **Step 4: Write the builder**
+
+```kotlin
+package com.riffle.core.domain
+
+/** Builds the pre-filled (editable) default title for a new bookmark from the timeline + position. */
+object BookmarkTitleBuilder {
+
+    fun defaultTitle(timeline: AudiobookTimeline, positionSec: Double): String {
+        val chapter = timeline.chapterAt(positionSec)
+        if (chapter == null) return absolute(positionSec)
+        val offset = (positionSec - chapter.startSec).coerceAtLeast(0.0)
+        val label = chapter.title.trim().ifEmpty { "Chapter ${chapter.index + 1}" }
+        return "$label · ${clock(offset)}"
+    }
+
+    // mm:ss when under an hour, h:mm:ss otherwise (offsets into a chapter are usually short).
+    private fun clock(sec: Double): String {
+        val total = sec.toLong()
+        val h = total / 3600; val m = (total % 3600) / 60; val s = total % 60
+        return if (h > 0) "%d:%02d:%02d".format(h, m, s) else "%d:%02d".format(m, s)
+    }
+
+    private fun absolute(sec: Double): String {
+        val total = sec.toLong()
+        val h = total / 3600; val m = (total % 3600) / 60; val s = total % 60
+        return if (h > 0) "%d:%02d:%02d".format(h, m, s) else "%d:%02d".format(m, s)
+    }
+}
+```
+
+(Confirm `AudiobookTimeline.chapterAt` returns `AudiobookChapter?` and `AudiobookChapter` has `index`, `startSec`, `title` — per the explored domain model. If `chapterAt` is non-null, adjust the null guard accordingly.)
+
+- [ ] **Step 5: Run to verify pass**
+
+Run: `./gradlew :core:domain:test --tests "*BookmarkTitleBuilderTest"`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add core/domain
+git commit -m "feat(audiobook): bookmark domain model + default-title builder"
+```
+
+---
+
+### Task 4: Bookmark store (interface + impl + bindings)
+
+**Files:**
+- Create: `core/domain/src/main/kotlin/com/riffle/core/domain/AudiobookBookmarkStore.kt`
+- Create: `core/data/src/main/kotlin/com/riffle/core/data/AudiobookBookmarkStoreImpl.kt`
+- Modify: `core/data/.../DataModule.kt` (bindings)
+- Test: `core/data/src/test/kotlin/com/riffle/core/data/AudiobookBookmarkStoreImplTest.kt`
+
+- [ ] **Step 1: Write the store interface**
+
+```kotlin
+package com.riffle.core.domain
+
+import kotlinx.coroutines.flow.Flow
+
+/** Local-first CRUD for audiobook bookmarks, scoped per (serverId, itemId). */
+interface AudiobookBookmarkStore {
+    fun observe(serverId: String, itemId: String): Flow<List<AudiobookBookmark>>
+
+    /** Create a bookmark; returns its generated id. [now] is the wall-clock stamp (createdAt + dirty). */
+    suspend fun add(serverId: String, itemId: String, positionSec: Double, title: String, now: Long): String
+
+    suspend fun rename(id: String, title: String, now: Long)
+
+    /** Soft-delete (tombstone) so the deletion can be pushed to ABS, then hard-removed on confirm. */
+    suspend fun delete(id: String, now: Long)
+}
+```
+
+- [ ] **Step 2: Write the failing store test** (uses a fake DAO)
+
+```kotlin
+package com.riffle.core.data
+
+import com.riffle.core.database.AudiobookBookmarkDao
+import com.riffle.core.database.AudiobookBookmarkEntity
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AudiobookBookmarkStoreImplTest {
+
+    // Minimal in-memory fake of the DAO surface the store uses.
+    private class FakeDao : AudiobookBookmarkDao {
+        val rows = MutableStateFlow<List<AudiobookBookmarkEntity>>(emptyList())
+        override suspend fun upsert(entity: AudiobookBookmarkEntity) {
+            rows.value = rows.value.filterNot { it.id == entity.id } + entity
+        }
+        override fun observeForItem(serverId: String, itemId: String): Flow<List<AudiobookBookmarkEntity>> =
+            rows.map { list -> list.filter { it.serverId == serverId && it.itemId == itemId && !it.deleted }.sortedBy { it.positionSec } }
+        override suspend fun getById(id: String) = rows.value.firstOrNull { it.id == id }
+        override suspend fun allForItem(serverId: String, itemId: String) =
+            rows.value.filter { it.serverId == serverId && it.itemId == itemId }
+        override suspend fun dirtyForServer(serverId: String) =
+            rows.value.filter { it.serverId == serverId && it.localUpdatedAt > it.lastSyncedAt }
+        override suspend fun serversWithDirtyRows() =
+            rows.value.filter { it.localUpdatedAt > it.lastSyncedAt }.map { it.serverId }.distinct()
+        override suspend fun confirmPushedIfUnchanged(id: String, serverStamp: Long, ifLocalUpdatedAt: Long) = 0
+        override suspend fun hardDeleteIfUnchanged(id: String, ifLocalUpdatedAt: Long) = 0
+        override suspend fun hardDelete(id: String) { rows.value = rows.value.filterNot { it.id == id } }
+    }
+
+    @Test fun addCreatesDirtyRow() = runTest {
+        val dao = FakeDao()
+        val store = AudiobookBookmarkStoreImpl(dao)
+
+        val id = store.add("s1", "i1", 765.0, "The Egg · 12:45", now = 1000L)
+
+        val row = dao.getById(id)!!
+        assertEquals(765.0, row.positionSec, 0.0001)
+        assertEquals("The Egg · 12:45", row.title)
+        assertEquals(1000L, row.createdAt)
+        assertTrue("new row must be dirty", row.localUpdatedAt > row.lastSyncedAt)
+        assertEquals(false, row.deleted)
+    }
+
+    @Test fun renameBumpsDirtyStamp() = runTest {
+        val dao = FakeDao()
+        val store = AudiobookBookmarkStoreImpl(dao)
+        val id = store.add("s1", "i1", 10.0, "old", now = 1000L)
+
+        store.rename(id, "new", now = 2000L)
+
+        val row = dao.getById(id)!!
+        assertEquals("new", row.title)
+        assertEquals(2000L, row.localUpdatedAt)
+        assertTrue(row.localUpdatedAt > row.lastSyncedAt)
+    }
+
+    @Test fun deleteTombstonesNotHardRemoves() = runTest {
+        val dao = FakeDao()
+        val store = AudiobookBookmarkStoreImpl(dao)
+        val id = store.add("s1", "i1", 10.0, "x", now = 1000L)
+
+        store.delete(id, now = 3000L)
+
+        val row = dao.getById(id)!!
+        assertEquals(true, row.deleted)
+        assertEquals(3000L, row.localUpdatedAt)
+        assertTrue("tombstone must be dirty", row.localUpdatedAt > row.lastSyncedAt)
+    }
+}
+```
+
+- [ ] **Step 3: Run to verify it fails**
+
+Run: `./gradlew :core:data:test --tests "*AudiobookBookmarkStoreImplTest"`
+Expected: FAIL — `AudiobookBookmarkStoreImpl` unresolved.
+
+- [ ] **Step 4: Write the impl**
+
+```kotlin
+package com.riffle.core.data
+
+import com.riffle.core.database.AudiobookBookmarkDao
+import com.riffle.core.database.AudiobookBookmarkEntity
+import com.riffle.core.domain.AudiobookBookmark
+import com.riffle.core.domain.AudiobookBookmarkStore
+import java.util.UUID
+import javax.inject.Inject
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+class AudiobookBookmarkStoreImpl @Inject constructor(
+    private val dao: AudiobookBookmarkDao,
+) : AudiobookBookmarkStore {
+
+    override fun observe(serverId: String, itemId: String): Flow<List<AudiobookBookmark>> =
+        dao.observeForItem(serverId, itemId).map { rows ->
+            rows.map { AudiobookBookmark(it.id, it.positionSec, it.title, it.createdAt) }
+        }
+
+    override suspend fun add(serverId: String, itemId: String, positionSec: Double, title: String, now: Long): String {
+        val id = UUID.randomUUID().toString()
+        dao.upsert(
+            AudiobookBookmarkEntity(
+                id = id, serverId = serverId, itemId = itemId, positionSec = positionSec,
+                title = title, createdAt = now, localUpdatedAt = now, lastSyncedAt = 0, deleted = false,
+            )
+        )
+        return id
+    }
+
+    override suspend fun rename(id: String, title: String, now: Long) {
+        val e = dao.getById(id) ?: return
+        dao.upsert(e.copy(title = title, localUpdatedAt = now))
+    }
+
+    override suspend fun delete(id: String, now: Long) {
+        val e = dao.getById(id) ?: return
+        dao.upsert(e.copy(deleted = true, localUpdatedAt = now))
+    }
+}
+```
+
+- [ ] **Step 5: Run to verify pass**
+
+Run: `./gradlew :core:data:test --tests "*AudiobookBookmarkStoreImplTest"`
+Expected: PASS.
+
+- [ ] **Step 6: Add the Hilt binding** in `DataModule.kt`:
+
+```kotlin
+@Binds
+@Singleton
+abstract fun bindAudiobookBookmarkStore(impl: AudiobookBookmarkStoreImpl): AudiobookBookmarkStore
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add core/domain core/data
+git commit -m "feat(audiobook): AudiobookBookmarkStore (local CRUD) + tests"
+```
+
+---
+
+### Task 5: ViewModel wiring
+
+**Files:**
+- Modify: `app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModel.kt`
+- Test: `app/src/test/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModelBookmarkTest.kt`
+
+**Context:** Read the existing ViewModel first. It already exposes `AudiobookPlayerUiState` (chapters, current position) and holds `serverId`/`itemId`, the `AudiobookController` (for `seekTo`/`positionSec`), and an `AudiobookTimeline`. Inject `AudiobookBookmarkStore` and a clock (`() -> Long`, default `System::currentTimeMillis`, so tests are deterministic — match how the codebase injects clocks elsewhere; if none, use a `Clock`/lambda parameter).
+
+- [ ] **Step 1: Write a failing ViewModel test** for the default title + add/seek
+
+```kotlin
+// Verifies: defaultBookmarkTitle reflects the live position via the timeline;
+// addBookmark(title) delegates to the store with the current position and clock;
+// bookmarks flow surfaces store emissions in UI state;
+// seekToBookmark(positionSec) calls controller.seekTo.
+```
+
+Write concrete assertions using fakes for `AudiobookBookmarkStore` and the controller (follow the existing ViewModel test's fakes). Assert:
+- `viewModel.defaultBookmarkTitle()` equals `BookmarkTitleBuilder.defaultTitle(timeline, currentPositionSec)`.
+- After `viewModel.addBookmark("My title")`, the fake store received `add(serverId, itemId, currentPositionSec, "My title", now=fixedClock)`.
+- Emitting two bookmarks from the fake store sets `uiState.value.bookmarks` to the mapped domain list.
+- `viewModel.seekToBookmark(123.0)` invoked `controller.seekTo(123.0)`.
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `./gradlew :app:testDebugUnitTest --tests "*AudiobookPlayerViewModelBookmarkTest"`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement** — add to the ViewModel:
+  - Collect `bookmarkStore.observe(serverId, itemId)` into `AudiobookPlayerUiState.bookmarks: List<AudiobookBookmark>` (add the field, default `emptyList()`).
+  - `fun defaultBookmarkTitle(): String = BookmarkTitleBuilder.defaultTitle(timeline, currentPositionSec())`.
+  - `fun addBookmark(title: String) { viewModelScope.launch { bookmarkStore.add(serverId, itemId, currentPositionSec(), title, clock()) } }`.
+  - `fun renameBookmark(id: String, title: String) { viewModelScope.launch { bookmarkStore.rename(id, title, clock()) } }`.
+  - `fun deleteBookmark(id: String) { viewModelScope.launch { bookmarkStore.delete(id, clock()) } }`.
+  - `fun seekToBookmark(positionSec: Double) = controller.seekTo(positionSec)` (use the controller's existing absolute-seek method).
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `./gradlew :app:testDebugUnitTest --tests "*AudiobookPlayerViewModelBookmarkTest"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app
+git commit -m "feat(audiobook): bookmark state + add/rename/delete/seek in player VM"
+```
+
+---
+
+### Task 6: Create dialog
+
+**Files:**
+- Create: `app/src/main/kotlin/com/riffle/app/feature/audiobook/BookmarkCreateDialog.kt`
+
+**Context:** Compose `AlertDialog`/`Dialog`. Stateless — takes the pre-filled title and callbacks. Follow existing dialog styling in the app (look for an existing `AlertDialog` usage for theme/buttons).
+
+- [ ] **Step 1: Implement the composable**
+
+```kotlin
+@Composable
+fun BookmarkCreateDialog(
+    initialTitle: String,
+    positionLabel: String,          // e.g. "1:02:11 · The Conversation"
+    suggestions: List<String>,      // chapter+offset, chapter, absolute, date
+    onConfirm: (String) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    var text by rememberSaveable(initialTitle) { mutableStateOf(initialTitle) }
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("New bookmark") },
+        text = {
+            Column {
+                Text(positionLabel, style = MaterialTheme.typography.bodySmall)
+                Spacer(Modifier.height(8.dp))
+                OutlinedTextField(value = text, onValueChange = { text = it }, singleLine = true,
+                    modifier = Modifier.fillMaxWidth())
+                Spacer(Modifier.height(8.dp))
+                FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    suggestions.distinct().forEach { s ->
+                        SuggestionChip(onClick = { text = s }, label = { Text(s) })
+                    }
+                }
+            }
+        },
+        confirmButton = { TextButton(onClick = { onConfirm(text.trim().ifEmpty { initialTitle }) }) { Text("Save") } },
+        dismissButton = { TextButton(onClick = onDismiss) { Text("Cancel") } },
+    )
+}
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `./gradlew :app:compileDebugKotlin`
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app
+git commit -m "feat(audiobook): bookmark create dialog with prefilled title + suggestions"
+```
+
+---
+
+### Task 7: Shared list sheet (chapters + bookmarks)
+
+**Files:**
+- Create: `app/src/main/kotlin/com/riffle/app/feature/audiobook/PlayerListSheet.kt`
+
+**Context:** One reusable `ModalBottomSheet` rendering a titled list. Parameterized by a sealed content type so chapters and bookmarks share the row layout but differ in trailing element. Follow the existing `ModalBottomSheet` usage in the audiobook/reader features for insets + theming.
+
+- [ ] **Step 1: Implement**
+
+```kotlin
+sealed interface PlayerListContent {
+    data class Chapters(val items: List<AudiobookChapter>, val currentIndex: Int, val onSeek: (AudiobookChapter) -> Unit) : PlayerListContent
+    data class Bookmarks(
+        val items: List<AudiobookBookmark>,
+        val onSeek: (AudiobookBookmark) -> Unit,
+        val onRename: (AudiobookBookmark) -> Unit,
+        val onDelete: (AudiobookBookmark) -> Unit,
+        val offlineNote: Boolean,    // Slice 2; pass false in Slice 1
+    ) : PlayerListContent
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun PlayerListSheet(content: PlayerListContent, onDismiss: () -> Unit) {
+    ModalBottomSheet(onDismissRequest = onDismiss) {
+        when (content) {
+            is PlayerListContent.Chapters -> {
+                Text("Chapters", style = MaterialTheme.typography.titleMedium, modifier = Modifier.padding(horizontal = 20.dp))
+                LazyColumn {
+                    itemsIndexed(content.items) { i, ch ->
+                        PlayerListRow(
+                            lead = { if (i == content.currentIndex) NowPlayingIcon() else Text("${i + 1}") },
+                            title = ch.title.ifBlank { "Chapter ${i + 1}" },
+                            subtitle = if (i == content.currentIndex) "Now playing" else null,
+                            trailing = { Text(formatClock(ch.endSec - ch.startSec)) },
+                            highlighted = i == content.currentIndex,
+                            onClick = { content.onSeek(ch); onDismiss() },
+                        )
+                    }
+                }
+            }
+            is PlayerListContent.Bookmarks -> {
+                Text("Bookmarks", style = MaterialTheme.typography.titleMedium, modifier = Modifier.padding(horizontal = 20.dp))
+                if (content.offlineNote) {
+                    Text("Offline — bookmarks will sync", style = MaterialTheme.typography.bodySmall,
+                        modifier = Modifier.padding(horizontal = 20.dp, vertical = 4.dp))
+                }
+                if (content.items.isEmpty()) {
+                    Text("No bookmarks yet.", modifier = Modifier.padding(20.dp))
+                } else {
+                    LazyColumn {
+                        items(content.items, key = { it.id }) { bm ->
+                            PlayerListRow(
+                                lead = { PlayIcon() },
+                                title = bm.title,
+                                subtitle = null,
+                                trailing = {
+                                    BookmarkOverflowMenu(
+                                        onRename = { content.onRename(bm) },
+                                        onDelete = { content.onDelete(bm) },
+                                    )
+                                },
+                                highlighted = false,
+                                onClick = { content.onSeek(bm); onDismiss() },
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+```
+
+Add the small helpers (`PlayerListRow`, `NowPlayingIcon`, `PlayIcon`, `BookmarkOverflowMenu`, `formatClock`) in the same file, using Material3 + existing icon set. `BookmarkOverflowMenu` is a `DropdownMenu` with "Rename" / "Delete".
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `./gradlew :app:compileDebugKotlin`
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app
+git commit -m "feat(audiobook): reusable PlayerListSheet for chapters + bookmarks"
+```
+
+---
+
+### Task 8: Wire player screen (add icon, pills, sheets, rename flow)
+
+**Files:**
+- Modify: `app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerScreen.kt`
+
+**Context:** Read the current screen. Add UI state for which sheet is open (`None | Chapters | Bookmarks`), the create dialog, and a rename dialog (reuse `BookmarkCreateDialog` with the bookmark's current title and an `onConfirm` that calls `renameBookmark`).
+
+- [ ] **Step 1: Add the bookmark-add icon** to the top app-bar row (right side, beside the existing speed control). On click: open the create dialog with `viewModel.defaultBookmarkTitle()` and suggestions (chapter+offset, chapter, absolute, created-date). On confirm: `viewModel.addBookmark(title)` then show a snackbar with **Undo** that calls `viewModel.deleteBookmark(lastId)` (capture the returned id — extend `addBookmark` to return the id via a callback or a `lastCreatedBookmarkId` state).
+
+- [ ] **Step 2: Add the two pills** under the scrubber: "Chapters" → set open sheet = Chapters; "N bookmarks" (count from `uiState.bookmarks.size`) → open sheet = Bookmarks.
+
+- [ ] **Step 3: Render `PlayerListSheet`** based on the open-sheet state, feeding chapters (with `currentIndex` from the timeline) or bookmarks (with seek/rename/delete callbacks; `offlineNote = false` for now). Rename opens the reuse dialog.
+
+- [ ] **Step 4: Verify compile + existing screen tests**
+
+Run: `./gradlew :app:compileDebugKotlin`
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app
+git commit -m "feat(audiobook): add bookmark icon + chapters/bookmarks pills + sheets on player"
+```
+
+---
+
+### Task 9: Scrubber bookmark ticks
+
+**Files:**
+- Modify: `app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerScreen.kt` (the scrubber composable)
+
+**Context:** The scrubber is a `Slider` (or custom). Overlay tick marks at `positionSec / durationSec` for each bookmark. If it's a Material `Slider`, draw ticks in a `Box` overlaying the track via `Canvas`/`drawBehind`, positioned by fraction. Make each tick tappable to `seekToBookmark`. Keep it lightweight — a thin vertical mark in `onSurface`.
+
+- [ ] **Step 1: Implement the tick overlay**
+
+```kotlin
+// Inside the scrubber Box, after the Slider:
+Canvas(Modifier.matchParentSize()) {
+    val trackTop = size.height / 2 - 7.dp.toPx()
+    bookmarks.forEach { bm ->
+        val x = (bm.positionSec / durationSec).toFloat().coerceIn(0f, 1f) * size.width
+        drawRect(
+            color = tickColor,
+            topLeft = Offset(x - 1.5.dp.toPx(), trackTop),
+            size = Size(3.dp.toPx(), 14.dp.toPx()),
+        )
+    }
+}
+```
+
+Add tap handling via `pointerInput` hit-testing the nearest tick within a tolerance (e.g. 12dp) → `seekToBookmark(bm.positionSec)`. (If precise tap-on-tick is fiddly, ship ticks as visual-only in this task and rely on the Bookmarks sheet for jumping; note that decision in the commit.)
+
+- [ ] **Step 2: Verify compile**
+
+Run: `./gradlew :app:compileDebugKotlin`
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 3: Run the JVM suites**
+
+Run: `JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home" ./gradlew test`
+Expected: PASS (all modules).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app
+git commit -m "feat(audiobook): bookmark ticks on the player scrubber"
+```
+
+**Slice 1 complete — local audiobook bookmarks fully usable offline.**
+
+---
+
+## Slice 2 — Audiobookshelf sync
+
+### Task 10: ABS bookmark API
+
+**Files:**
+- Create: `core/network/src/main/kotlin/com/riffle/core/network/AbsBookmarkApi.kt`
+- Modify: `core/network/src/main/kotlin/com/riffle/core/network/AbsApiClient.kt`
+- Test: `core/network/src/test/kotlin/com/riffle/core/network/AbsBookmarkApiTest.kt` (MockWebServer, matching existing network tests)
+
+**Context:** ABS endpoints (verify against the live server `http://media-server:13378`, login `test`/`test`, per `reference_abs_server`): `POST/PATCH /api/me/item/{itemId}/bookmark` with body `{ "time": <seconds:int>, "title": <string> }`; `DELETE /api/me/item/{itemId}/bookmark/{time}`. The user's bookmark list is on `GET /api/me` under a `bookmarks` array of `{ libraryItemId, title, time, createdAt }`. **ABS keys a bookmark by (libraryItemId, time) and has no per-bookmark updatedAt** — so pull-merge is identity-based on `time`, not timestamp-based.
+
+- [ ] **Step 1: Define the interface + DTOs**
+
+```kotlin
+package com.riffle.core.network
+
+data class NetworkAbsBookmark(val libraryItemId: String, val title: String, val timeSec: Int, val createdAt: Long)
+
+sealed interface AbsBookmarkResult {
+    data class Success(val bookmark: NetworkAbsBookmark) : AbsBookmarkResult
+    data class NetworkError(val cause: Throwable) : AbsBookmarkResult
+}
+
+sealed interface AbsBookmarkListResult {
+    data class Success(val bookmarks: List<NetworkAbsBookmark>) : AbsBookmarkListResult
+    data class NetworkError(val cause: Throwable) : AbsBookmarkListResult
+}
+
+interface AbsBookmarkApi {
+    suspend fun createBookmark(baseUrl: String, itemId: String, timeSec: Int, title: String, token: String, insecureAllowed: Boolean): AbsBookmarkResult
+    suspend fun updateBookmark(baseUrl: String, itemId: String, timeSec: Int, title: String, token: String, insecureAllowed: Boolean): AbsBookmarkResult
+    suspend fun deleteBookmark(baseUrl: String, itemId: String, timeSec: Int, token: String, insecureAllowed: Boolean): AbsBookmarkResult
+    suspend fun listBookmarks(baseUrl: String, token: String, insecureAllowed: Boolean): AbsBookmarkListResult
+}
+```
+
+- [ ] **Step 2: Write failing MockWebServer tests** for each verb (assert method + path + JSON body + parsed result). Follow the structure of the existing `AbsApiClient`/session tests in `core:network`.
+
+- [ ] **Step 3: Run to verify fail**
+
+Run: `./gradlew :core:network:test --tests "*AbsBookmarkApiTest"`
+Expected: FAIL.
+
+- [ ] **Step 4: Implement the four methods on `AbsApiClient`** following the verbatim `syncAudiobookProgress` pattern (OkHttp `Request.Builder`, `Bearer` header, `json.encodeToString(...).toRequestBody(jsonMediaType)`, `trustAllCerts()` when insecure, `withContext(Dispatchers.IO)`, map non-2xx/IOException to `NetworkError`). Add `AbsBookmarkApi` to the `AbsApiClient` class's implemented interfaces. Use `@Serializable` request/response DTOs mirroring `AbsAudiobookProgressRequest`.
+
+- [ ] **Step 5: Run to verify pass**
+
+Run: `./gradlew :core:network:test --tests "*AbsBookmarkApiTest"`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add core/network
+git commit -m "feat(network): ABS bookmark endpoints (create/update/delete/list)"
+```
+
+---
+
+### Task 11: Bookmark reconciler
+
+**Files:**
+- Create: `core/data/src/main/kotlin/com/riffle/core/data/AudiobookBookmarkReconciler.kt`
+- Test: `core/data/src/test/kotlin/com/riffle/core/data/AudiobookBookmarkReconcilerTest.kt`
+
+**Context:** A *set reconcile* per (serverId, itemId), invoked by the sweep. Because ABS has no per-bookmark updatedAt, the policy is **local-intent wins on dirty rows, server fills in the rest**:
+
+- For each **dirty, non-deleted** local row: PATCH if it was previously synced (`lastSyncedAt > 0` ⇒ exists on server) else POST create; on success `confirmPushedIfUnchanged(id, serverStamp, ifLocalUpdatedAt)`.
+- For each **dirty tombstone**: DELETE on server (by `time`); on success (or 404) `hardDeleteIfUnchanged(id, ifLocalUpdatedAt)`.
+- **Pull:** list server bookmarks for the item; for any server `(time, title)` with **no clean local row at that position**, insert a clean local row (a bookmark made on another device). For a **clean** local row whose `(time)` is absent server-side, hard-delete it (deleted elsewhere). Skip dirty rows in the pull phase (local intent pending).
+
+Identity within an item is `round(positionSec)` == server `time`.
+
+- [ ] **Step 1: Write failing tests** covering: push-create, push-rename, push-delete (tombstone → hard remove), pull-insert (new server bookmark), pull-remove (clean local gone server-side), and "dirty row not clobbered by pull". Use fakes for `AbsBookmarkApi` and the `AudiobookBookmarkDao`/store.
+
+- [ ] **Step 2: Run to verify fail**
+
+Run: `./gradlew :core:data:test --tests "*AudiobookBookmarkReconcilerTest"`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement `AudiobookBookmarkReconciler`** with a `suspend fun reconcile(serverId, itemId, baseUrl, token, insecureAllowed)` that performs push-then-pull as above, using `dao.allForItem`, `dao.dirtyForServer` (filtered to item), the API, and the compare-and-clear DAO ops. Derive `serverStamp` from `System.currentTimeMillis()` (or an injected clock) since ABS returns `createdAt` only.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `./gradlew :core:data:test --tests "*AudiobookBookmarkReconcilerTest"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add core/data
+git commit -m "feat(audiobook): bookmark set-reconcile against ABS"
+```
+
+---
+
+### Task 12: Hook reconciler into the progress sweep
+
+**Files:**
+- Modify: `core/data/src/main/kotlin/com/riffle/core/data/ProgressSweep.kt` (+ its Hilt provider module)
+- Test: `core/data/src/test/kotlin/com/riffle/core/data/ProgressSweepBookmarkTest.kt`
+
+**Context:** The sweep already iterates servers and dirty items. Inject the bookmark DAO (for `serversWithDirtyRows` / dirty items) + the reconciler. Per server, for each item with dirty bookmarks (`dao.dirtyForServer(serverId)` grouped by itemId, plus union with the existing dirty-audio items so bookmarks on a not-otherwise-dirty item still sync), call `bookmarkReconciler.reconcile(...)`. Respect the same `openTargets.isOpen` skip and `locks.withLock` discipline (add a `RemoteKind.ABS_BOOKMARK` lock kind, or reuse `ABS_AUDIO`). This is what makes bookmarks sync **at the same frequency as progress** — same worker, same sweep.
+
+- [ ] **Step 1: Write a failing sweep test** asserting that given a server with a dirty bookmark item, `run()` calls `bookmarkReconciler.reconcile(serverId, itemId, ...)`. Use a fake reconciler.
+
+- [ ] **Step 2: Run to verify fail**
+
+Run: `./gradlew :core:data:test --tests "*ProgressSweepBookmarkTest"`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement** the sweep changes + Hilt wiring (provide the reconciler with `AbsBookmarkApi` + DAO; extend `RoomDirtyProgressLedger` or query the bookmark DAO directly for dirty bookmark items).
+
+- [ ] **Step 4: Run to verify pass + full JVM suite**
+
+Run: `./gradlew :core:data:test --tests "*ProgressSweepBookmarkTest"` then `JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home" ./gradlew test`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add core/data
+git commit -m "feat(audiobook): sync bookmarks on the progress sweep (same cadence as position)"
+```
+
+---
+
+### Task 13: Offline note + final verification
+
+**Files:**
+- Modify: `app/.../audiobook/AudiobookPlayerViewModel.kt` (compute `bookmarksOffline`)
+- Modify: `app/.../audiobook/AudiobookPlayerScreen.kt` (pass `offlineNote`)
+
+**Context:** Surface the quiet "Offline — bookmarks will sync" note only when there are dirty (unsynced) bookmarks AND the device is offline. Reuse the app's existing connectivity signal (find how other features observe online/offline; if there's a `NetworkMonitor`, inject it). Compute `offlineNote = hasDirtyBookmarks && !isOnline`.
+
+- [ ] **Step 1: Implement** the derived state and pass it into `PlayerListContent.Bookmarks(offlineNote = ...)`.
+
+- [ ] **Step 2: Verify compile + full JVM suite**
+
+Run: `./gradlew :app:compileDebugKotlin && JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home" ./gradlew test`
+Expected: PASS.
+
+- [ ] **Step 3: Run harness UI smoke (if a player UI test exists)**
+
+Run: `make harness-test`
+Expected: PASS (or no new failures vs. the known pre-existing flakes in memory).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app
+git commit -m "feat(audiobook): quiet offline note for unsynced bookmarks"
+```
+
+**Slice 2 complete — bookmarks sync to ABS on the progress cadence.**
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** storage table + dirty tracking (T1–T2), default title `Chapter · offset` with fallbacks (T3), local CRUD (T4), ViewModel actions (T5), one-tap add + dialog (T6, T8), shared sheet / two labeled entry points / no tabs (T7–T8), scrubber ticks (T9), ABS native endpoints (T10), set reconcile + last-write-wins-ish given ABS's model (T11), same-cadence sync via the sweep (T12), silent sync + offline note (T13), read-along coexistence (T8 places the add icon in the app-bar row, not the read-along strip). YAGNI items (notes/search/cross-book) intentionally absent.
+- **Open question carried from the spec:** ABS bookmark identity is `(libraryItemId, time)` with no per-bookmark updatedAt — handled in T11 by identity-on-`time` merge and local-intent-wins. Verify the exact JSON shape against the live server in T10 before finalizing DTOs.
+- **Migration discipline:** T1 follows the `CLAUDE.md` checklist (version bump, schema export, DataModule registration, MigrationTest + chain). Run `MigrationTest` pinned to a self-booted Harness AVD (`reference_harness_macro_only_app_module`).

--- a/docs/superpowers/specs/2026-06-13-audiobook-bookmarks-design.md
+++ b/docs/superpowers/specs/2026-06-13-audiobook-bookmarks-design.md
@@ -1,0 +1,171 @@
+# Audiobook Bookmarks — Design
+
+**Date:** 2026-06-13
+**Status:** Approved (pending implementation plan)
+**Prototype:** `.context/bookmark-prototype/index.html` (variant B)
+
+## Summary
+
+Let a listener mark a spot in an audiobook, give it a title, and return to it later.
+Bookmarks are **local-first** (Room is the source of truth) and reconcile to
+Audiobookshelf's native bookmark API on the **same cadence as audiobook position
+sync**, so they appear in the ABS web UI and on other clients. The player UI stays
+minimal (variant B): a one-tap add icon, two labeled list affordances (Chapters and
+Bookmarks), and bookmark ticks on the scrubber.
+
+## Goals
+
+- One-tap "save my spot" from the audiobook player.
+- Editable, human-meaningful default title (chapter + offset).
+- Browse / seek-to / rename / delete bookmarks for the current book.
+- Bookmarks survive offline and sync to ABS automatically, silently.
+- Bookmarks interoperate with ABS (visible in the ABS web UI / other clients).
+
+## Non-goals (YAGNI)
+
+- Bookmark **notes** / annotations beyond a title.
+- **Search** within bookmarks.
+- A **cross-book** "all my bookmarks" view.
+- Folders / tags / colors.
+- Ebook (reader) bookmarks — that is a separate annotation track (ADR 0024); this
+  spec is audiobook-only.
+
+## Data model
+
+New Room entity `AudiobookBookmarkEntity`, mirroring the dirty-tracking shape of
+`AudiobookPositionEntity` (ADR 0030):
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | TEXT (PK) | UUID generated locally on create |
+| `serverId` | TEXT | FK → `servers`, `ON DELETE CASCADE` |
+| `itemId` | TEXT | ABS library item id |
+| `absBookmarkId` | TEXT? | ABS's identity for this bookmark once confirmed (ABS keys on `time`); null until first successful push |
+| `positionSec` | REAL | book-absolute seconds |
+| `title` | TEXT | user-editable label |
+| `createdAt` | INTEGER | wall-clock ms |
+| `localUpdatedAt` | INTEGER | bumped on create / rename / delete |
+| `lastSyncedAt` | INTEGER | row is **dirty** when `localUpdatedAt > lastSyncedAt` |
+| `deleted` | INTEGER | soft-delete tombstone (so a delete can be pushed to ABS, then hard-removed once confirmed) |
+
+Index on `(serverId, itemId)`. Bookmarks are scoped per library item, like positions.
+
+**DB migration: v34 → v35** — create `audiobook_bookmarks` table. Follow the
+migration checklist in `CLAUDE.md` (bump `@Database` version, export schema JSON,
+register in `DataModule`, add `MigrationTest.migration34To35()` + extend
+`migrateFullChain`).
+
+**Identity note:** ABS identifies a bookmark by its `time` (per library item), so two
+bookmarks at the exact same second are not representable server-side. We treat
+`(itemId, positionSec)` as the effective server key; on the rare collision the later
+write wins (the title is updated rather than a second row created).
+
+## Sync
+
+Bookmarks reuse the **same sync trigger and frequency as audiobook position sync** —
+they piggyback on the existing audiobook progress sync path (see
+`2026-06-12-audiobook-position-persistence-design.md` and
+`2026-06-07-readaloud-unified-progress-sync-design.md`). No separate timer or
+scheduler.
+
+ABS native endpoints (no Riffle cloud needed):
+
+- Create: `POST /api/me/item/{itemId}/bookmark` `{ time, title }`
+- Rename: `PATCH /api/me/item/{itemId}/bookmark` `{ time, title }`
+- Delete: `DELETE /api/me/item/{itemId}/bookmark/{time}`
+- Read (for pull/reconcile): bookmarks are included on the ABS media-progress / `me`
+  payload per library item.
+
+These land in a new `AbsBookmarkApi` interface implemented by `AbsApiClient`, parallel
+to `AbsSessionApi`/`AbsPlaybackApi`.
+
+**Reconciliation (last-write-wins, mirrors positions):**
+
+- **Push** dirty rows (`localUpdatedAt > lastSyncedAt`): create/rename/delete on ABS,
+  then `confirmPushedIfUnchanged` (set `lastSyncedAt`, store `absBookmarkId`;
+  hard-delete tombstoned rows once the server delete confirms).
+- **Pull** the server's bookmark set for the item: for rows not locally dirty, accept
+  server state (insert new, update title, remove ones deleted server-side) via the
+  `acceptServerIfUnchanged` compare-and-swap pattern.
+- Conflicts resolve by `localUpdatedAt` vs the server's `lastUpdate`, last write wins.
+
+**Silent UX:** no per-row sync badges. If there are dirty (unsynced) bookmarks **and**
+the device is offline, show a single quiet "Offline — bookmarks will sync" note at the
+top of the Bookmarks sheet. Otherwise the UI says nothing about sync.
+
+## UI (variant B — clean player)
+
+Surfaces on `AudiobookPlayerScreen`:
+
+- **Add (one tap):** bookmark icon in the top app-bar row (right side, beside the
+  persistent speed control). Tapping opens the **create dialog**.
+- **Create dialog:** single editable text field pre-filled with the default title,
+  plus suggestion chips; **Save** / **Cancel**. Save shows a toast with **UNDO**.
+- **Two labeled list affordances** under the scrubber: **Chapters** and
+  **N bookmarks**. Each opens a **dedicated bottom sheet** (no tabs).
+- **Scrubber ticks:** one tick per bookmark on the progress bar, tappable to seek.
+
+**Default title** (pre-filled, editable):
+
+1. `<chapter title> · <offset-into-chapter>` when the chapter has a real title
+   (e.g. `The Egg · 12:45`). Offset = time since the chapter started.
+2. `Chapter N · MM:SS` when there is no chapter title.
+3. Absolute book timestamp (`H:MM:SS`) when the book has no chapters.
+
+Suggestion chips offer: chapter+offset, chapter only, absolute timestamp, created
+date/time.
+
+**Shared sheet component.** Chapters and Bookmarks render through **one reusable list
+sheet** (e.g. `PlayerListSheet`) parameterized by content — same row layout
+(leading marker · title · subtitle · trailing). Chapters' trailing is a duration and
+the current chapter is highlighted with a now-playing marker; bookmarks' trailing is a
+`⋮` overflow (**Rename** / **Delete**). Tapping a row seeks and closes the sheet. This
+is the structural reason Chapters ships alongside Bookmarks here — they share the sheet.
+
+**Read-along coexistence.** On read-along-enabled audiobooks the swipe-down "Read
+along" hint occupies its own top strip, above the app-bar row that carries speed + the
+bookmark-add icon. The two never overlap.
+
+## Components & boundaries
+
+- `AudiobookBookmarkEntity` + `AudiobookBookmarkDao` (core/database) — storage + dirty
+  queries (`dirtyForServer`, `acceptServerIfUnchanged`, `confirmPushedIfUnchanged`,
+  upsert, soft-delete), parallel to `AudiobookPositionDao`.
+- `AudiobookBookmarkStore` (core/data) — domain-facing CRUD + the reconcile entry point
+  invoked by the existing audiobook sync path.
+- `AbsBookmarkApi` + impl on `AbsApiClient` (core/network) — ABS bookmark endpoints and
+  network DTOs.
+- Domain: a small `AudiobookBookmark(id, positionSec, title, createdAt)` and a default-
+  title builder that takes the `AudiobookTimeline` + current position (so the
+  `Chapter · offset` logic is unit-testable without UI).
+- `AudiobookPlayerViewModel` — expose `bookmarks: List<AudiobookBookmark>`, the
+  computed default title for the current position, and `addBookmark/rename/delete/seekTo`.
+- UI: bookmark-add icon, create dialog, `PlayerListSheet` (chapters + bookmarks),
+  scrubber ticks.
+
+## Error handling
+
+- **Create offline:** persists locally, dirty; pushed on the next sync tick. UNDO toast
+  works regardless of connectivity.
+- **Push failure:** row stays dirty, retried on the next sync; no user-facing error for
+  a transient failure.
+- **Delete:** soft-delete immediately (disappears from UI), tombstone pushed, hard-
+  removed on confirm; if the push fails the tombstone persists and retries.
+- **Title collision at same second:** later write updates the existing row's title
+  rather than creating a duplicate (matches ABS's `time`-keyed model).
+
+## Testing
+
+- DAO + migration tests (v34→v35) per `CLAUDE.md`.
+- Default-title builder unit tests: chapter+offset, no-title fallback, no-chapters
+  fallback, offset computation at chapter boundaries.
+- Reconcile unit tests: push create/rename/delete, pull insert/update/remove,
+  last-write-wins conflict, offline-then-sync, tombstone confirm.
+- ViewModel tests: add/rename/delete/seek, UNDO.
+- A harness/UI smoke test for add → list → seek if it fits existing patterns.
+
+## Open questions
+
+- Does ABS return a stable per-bookmark id, or only `time`? If only `time`, drop
+  `absBookmarkId` and key purely on `(itemId, positionSec)`. Confirm against the live
+  server during implementation.


### PR DESCRIPTION
## What

Adds **local-first, titled audiobook bookmarks** that sync to Audiobookshelf, following the ADR 0030 dirty-tracking / soft-delete model already used for positions.

### Data & sync
- New `audiobook_bookmarks` table (Room migration **v34 → v35**, schema exported, migration + FK-cascade tested). A bookmark is a COLLECTION per `(serverId, itemId)` — titled book-absolute seconds — with `localUpdatedAt > lastSyncedAt` dirty-tracking and tombstone soft-delete.
- `AudiobookBookmarkDao` + `AudiobookBookmarkStoreImpl` (local CRUD) and an `AudiobookBookmarkReconciler` that set-reconciles against ABS: push local intent (create/rename/delete) then pull the server set, keyed on `(libraryItemId, roundToInt(timeSec))`. Dirty rows are never clobbered by the pull.
- ABS bookmark endpoints (`POST/PATCH/DELETE /api/me/item/{id}/bookmark`, list via `/api/me`) on `AbsApiClient`; DELETE 404 treated as idempotent success (no zombie tombstone).
- Bookmarks ride the existing `ProgressSweep` at the same cadence as positions (own `ABS_BOOKMARK` lock kind; open-book discipline respected).

### UI (variant B)
- One-tap bookmark-add icon in the player top bar; reusable `PlayerListSheet` for both Chapters and Bookmarks; `Chapters` / `N bookmarks` chips under the scrubber; thin bookmark ticks on the scrubber; quiet "Offline — bookmarks will sync" note only when a push is genuinely blocked.

## Review fixes included
- **Dialog title reset bug:** the New-bookmark dialog recomputed its default title from the live playhead every recomposition, wiping the user's edits while playback continued. Now the position is pinned when the dialog opens and the saved row matches the title shown.
- **Pills invisible behind nav bar:** the player content wasn't inset for the system navigation bar, so the chapters/bookmarks chips rendered behind it. Added `navigationBarsPadding()`; bookmark-add icon switched to `safeDrawingPadding()` to match the back arrow.

## Tested
- `./gradlew test lint` — green
- `make harness-test` (phone) and `make harness-test-tablet` — green
- New unit tests: reconciler (push/pull/dirty-protection/network-error), store, sweep bookmark pass, DAO (instrumented), ABS bookmark API (MockWebServer), title builder, and the player VM bookmark behaviour.

## Notes / follow-ups (non-blocking)
- The sweep fetches `/api/me` once per dirty item; could be hoisted to once-per-server if multi-book-dirty sweeps become common (practically ~1 item).
- ABS keys bookmarks on integer seconds, so two bookmarks within the same rounded second collide — inherent to the ABS API.