### PR TITLE
feat(navigation): remember last opened library per server and reopen on app start

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/navigation/HomeViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/navigation/HomeViewModel.kt
@@ -1,6 +1,7 @@
 package com.riffle.app.feature.navigation
 
 import androidx.lifecycle.ViewModel
+import com.riffle.core.domain.LastOpenedLibraryStore
 import com.riffle.core.domain.LibraryRefreshResult
 import com.riffle.core.domain.LibraryRepository
 import com.riffle.core.domain.LibraryVisibilityPreferencesStore
@@ -16,6 +17,7 @@ class HomeViewModel @Inject constructor(
     private val serverRepository: ServerRepository,
     private val libraryRepository: LibraryRepository,
     private val visibilityStore: LibraryVisibilityPreferencesStore,
+    private val lastOpenedLibraryStore: LastOpenedLibraryStore,
 ) : ViewModel() {
 
     sealed class StartDestination {
@@ -43,7 +45,13 @@ class HomeViewModel @Inject constructor(
         }
 
         val hiddenIds = visibilityStore.hiddenLibraryIds(activeServer.id).first()
-        val firstVisible = libraries.firstOrNull { it.id !in hiddenIds } ?: libraries.first()
-        StartDestination.Library(firstVisible.id, firstVisible.name)
+        val visible = libraries.filter { it.id !in hiddenIds }
+        // Reopen the library the user last had open on this server, as long as it's still visible;
+        // otherwise fall back to the first visible library.
+        val lastOpenedId = lastOpenedLibraryStore.lastOpenedLibrary(activeServer.id).first()
+        val target = visible.firstOrNull { it.id == lastOpenedId }
+            ?: visible.firstOrNull()
+            ?: libraries.first()
+        StartDestination.Library(target.id, target.name)
     }
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/navigation/NavigationDrawerViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/navigation/NavigationDrawerViewModel.kt
@@ -84,9 +84,15 @@ class NavigationDrawerViewModel @Inject constructor(
 
     fun setActiveLibrary(libraryId: String) {
         _lastActiveLibraryId.value = libraryId
-        // Remember it per-server so app start reopens this library (see HomeViewModel).
-        val serverId = activeServer.value?.id ?: return
-        viewModelScope.launch { lastOpenedLibraryStore.setLastOpenedLibrary(serverId, libraryId) }
+        // Remember it per-server so app start reopens this library (see HomeViewModel). Resolve the
+        // active server authoritatively from the repository — the same source getStartDestination
+        // reads. The activeServer StateFlow can lag a just-committed server switch, which would
+        // persist this library under the previous server's key (or drop it when still null on cold
+        // start).
+        viewModelScope.launch {
+            val serverId = serverRepository.getActive()?.id ?: return@launch
+            lastOpenedLibraryStore.setLastOpenedLibrary(serverId, libraryId)
+        }
     }
 
     private val _redirectToLibrary = MutableSharedFlow<Library>(extraBufferCapacity = 1)

--- a/app/src/main/kotlin/com/riffle/app/feature/navigation/NavigationDrawerViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/navigation/NavigationDrawerViewModel.kt
@@ -3,6 +3,7 @@ package com.riffle.app.feature.navigation
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.riffle.core.domain.ConnectivityObserver
+import com.riffle.core.domain.LastOpenedLibraryStore
 import com.riffle.core.domain.Library
 import com.riffle.core.domain.LibraryOrderPreferencesStore
 import com.riffle.core.domain.LibraryRepository
@@ -38,6 +39,7 @@ class NavigationDrawerViewModel @Inject constructor(
     private val libraryRepository: LibraryRepository,
     private val visibilityStore: LibraryVisibilityPreferencesStore,
     private val orderStore: LibraryOrderPreferencesStore,
+    private val lastOpenedLibraryStore: LastOpenedLibraryStore,
     private val connectivityObserver: ConnectivityObserver,
     nowPlayingNavigator: NowPlayingNavigator,
     private val nowPlayingStore: NowPlayingStore,
@@ -82,6 +84,9 @@ class NavigationDrawerViewModel @Inject constructor(
 
     fun setActiveLibrary(libraryId: String) {
         _lastActiveLibraryId.value = libraryId
+        // Remember it per-server so app start reopens this library (see HomeViewModel).
+        val serverId = activeServer.value?.id ?: return
+        viewModelScope.launch { lastOpenedLibraryStore.setLastOpenedLibrary(serverId, libraryId) }
     }
 
     private val _redirectToLibrary = MutableSharedFlow<Library>(extraBufferCapacity = 1)

--- a/app/src/test/kotlin/com/riffle/app/feature/navigation/HomeViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/navigation/HomeViewModelTest.kt
@@ -4,6 +4,7 @@ import com.riffle.core.domain.AuthenticateResult
 import com.riffle.core.domain.CommitServerResult
 import com.riffle.core.domain.Collection
 import com.riffle.core.domain.PendingServer
+import com.riffle.core.domain.LastOpenedLibraryStore
 import com.riffle.core.domain.Library
 import com.riffle.core.domain.LibraryItem
 import com.riffle.core.domain.LibraryRefreshResult
@@ -29,6 +30,7 @@ class HomeViewModelTest {
     private val serversFlow = MutableStateFlow<List<Server>>(emptyList())
     private val librariesFlow = MutableStateFlow<List<Library>>(emptyList())
     private val hiddenFlow = MutableStateFlow<Map<String, Set<String>>>(emptyMap())
+    private val lastOpenedFlow = MutableStateFlow<Map<String, String>>(emptyMap())
 
     private fun server(id: String, active: Boolean = false) = Server(
         id = id,
@@ -91,10 +93,19 @@ class HomeViewModelTest {
         override suspend fun showLibrary(serverId: String, libraryId: String) {}
     }
 
+    private fun fakeLastOpenedStore(): LastOpenedLibraryStore = object : LastOpenedLibraryStore {
+        override fun lastOpenedLibrary(serverId: String): Flow<String?> =
+            lastOpenedFlow.map { it[serverId] }
+        override suspend fun setLastOpenedLibrary(serverId: String, libraryId: String) {
+            lastOpenedFlow.update { it + (serverId to libraryId) }
+        }
+    }
+
     private fun makeVm(libraryRepo: LibraryRepository = fakeLibraryRepo()) = HomeViewModel(
         serverRepository = fakeServerRepo(),
         libraryRepository = libraryRepo,
         visibilityStore = fakeVisibilityStore(),
+        lastOpenedLibraryStore = fakeLastOpenedStore(),
     )
 
     @Test
@@ -152,6 +163,52 @@ class HomeViewModelTest {
         val result = makeVm(repo).getStartDestination()
 
         assertEquals(HomeViewModel.StartDestination.NoLibraries, result)
+    }
+
+    @Test
+    fun `getStartDestination reopens the last opened library when still visible`() = runTest {
+        serversFlow.value = listOf(server("srv-1", active = true))
+        librariesFlow.value = listOf(library("lib-1"), library("lib-2"), library("lib-3"))
+        lastOpenedFlow.value = mapOf("srv-1" to "lib-2")
+
+        val result = makeVm().getStartDestination()
+
+        assertEquals(HomeViewModel.StartDestination.Library("lib-2", "lib-2"), result)
+    }
+
+    @Test
+    fun `getStartDestination falls back to first visible when last opened library is now hidden`() = runTest {
+        serversFlow.value = listOf(server("srv-1", active = true))
+        librariesFlow.value = listOf(library("lib-1"), library("lib-2"))
+        lastOpenedFlow.value = mapOf("srv-1" to "lib-2")
+        hiddenFlow.value = mapOf("srv-1" to setOf("lib-2"))
+
+        val result = makeVm().getStartDestination()
+
+        assertEquals(HomeViewModel.StartDestination.Library("lib-1", "lib-1"), result)
+    }
+
+    @Test
+    fun `getStartDestination falls back to first visible when last opened library no longer exists`() = runTest {
+        serversFlow.value = listOf(server("srv-1", active = true))
+        librariesFlow.value = listOf(library("lib-1"), library("lib-2"))
+        lastOpenedFlow.value = mapOf("srv-1" to "lib-gone")
+
+        val result = makeVm().getStartDestination()
+
+        assertEquals(HomeViewModel.StartDestination.Library("lib-1", "lib-1"), result)
+    }
+
+    @Test
+    fun `getStartDestination ignores a last opened library remembered for a different server`() = runTest {
+        serversFlow.value = listOf(server("srv-1", active = true))
+        librariesFlow.value = listOf(library("lib-1"), library("lib-2"))
+        // Remembered for srv-2, not the active srv-1.
+        lastOpenedFlow.value = mapOf("srv-2" to "lib-2")
+
+        val result = makeVm().getStartDestination()
+
+        assertEquals(HomeViewModel.StartDestination.Library("lib-1", "lib-1"), result)
     }
 
     @Test

--- a/app/src/test/kotlin/com/riffle/app/feature/navigation/NavigationDrawerViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/navigation/NavigationDrawerViewModelTest.kt
@@ -179,14 +179,15 @@ class NavigationDrawerViewModelTest {
     }
 
     @Test
-    fun `setActiveLibrary persists the library for the active server`() = runTest(testDispatcher) {
+    fun `setActiveLibrary persists under the repository's active server, not the lagging StateFlow`() = runTest(testDispatcher) {
         serversFlow.value = listOf(server("srv-1", active = true))
         librariesFlow.value = listOf(library("lib-1"), library("lib-2"))
 
         val vm = makeVm()
-        backgroundScope.launch { vm.activeServer.collect {} }
-        testScheduler.advanceUntilIdle()
-
+        // Deliberately do NOT collect vm.activeServer, so its eagerly-started StateFlow stays at its
+        // initial null — mirroring the window right after a server switch. Persistence must still
+        // resolve the active server from the repository (the old activeServer.value path would drop
+        // the write or use a stale server here).
         vm.setActiveLibrary("lib-2")
         testScheduler.advanceUntilIdle()
 

--- a/app/src/test/kotlin/com/riffle/app/feature/navigation/NavigationDrawerViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/navigation/NavigationDrawerViewModelTest.kt
@@ -6,6 +6,7 @@ import com.riffle.core.domain.Collection
 import com.riffle.core.domain.ConnectivityObserver
 import com.riffle.core.domain.PendingServer
 import java.io.IOException
+import com.riffle.core.domain.LastOpenedLibraryStore
 import com.riffle.core.domain.Library
 import com.riffle.core.domain.LibraryItem
 import com.riffle.core.domain.LibraryRefreshResult
@@ -130,6 +131,16 @@ class NavigationDrawerViewModelTest {
         }
     }
 
+    private val lastOpenedFlow = MutableStateFlow<Map<String, String>>(emptyMap())
+
+    private fun fakeLastOpenedStore(): LastOpenedLibraryStore = object : LastOpenedLibraryStore {
+        override fun lastOpenedLibrary(serverId: String): Flow<String?> =
+            lastOpenedFlow.map { it[serverId] }
+        override suspend fun setLastOpenedLibrary(serverId: String, libraryId: String) {
+            lastOpenedFlow.update { it + (serverId to libraryId) }
+        }
+    }
+
     private val isOnlineFlow = MutableStateFlow(true)
     private fun fakeConnectivity(): ConnectivityObserver = object : ConnectivityObserver {
         override val isOnline: kotlinx.coroutines.flow.StateFlow<Boolean> = isOnlineFlow
@@ -140,6 +151,7 @@ class NavigationDrawerViewModelTest {
         libraryRepository = fakeLibraryRepo(),
         visibilityStore = fakeVisibilityStore(),
         orderStore = fakeOrderStore(),
+        lastOpenedLibraryStore = fakeLastOpenedStore(),
         connectivityObserver = fakeConnectivity(),
         nowPlayingNavigator = com.riffle.app.playback.NowPlayingNavigator(),
         nowPlayingStore = com.riffle.app.playback.NowPlayingStore(),
@@ -164,6 +176,21 @@ class NavigationDrawerViewModelTest {
         testScheduler.advanceUntilIdle()
 
         assertEquals(library("lib-2"), redirect.await())
+    }
+
+    @Test
+    fun `setActiveLibrary persists the library for the active server`() = runTest(testDispatcher) {
+        serversFlow.value = listOf(server("srv-1", active = true))
+        librariesFlow.value = listOf(library("lib-1"), library("lib-2"))
+
+        val vm = makeVm()
+        backgroundScope.launch { vm.activeServer.collect {} }
+        testScheduler.advanceUntilIdle()
+
+        vm.setActiveLibrary("lib-2")
+        testScheduler.advanceUntilIdle()
+
+        assertEquals("lib-2", lastOpenedFlow.value["srv-1"])
     }
 
     @Test

--- a/core/data/src/main/kotlin/com/riffle/core/data/LastOpenedLibraryStoreImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/LastOpenedLibraryStoreImpl.kt
@@ -1,0 +1,27 @@
+package com.riffle.core.data
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import com.riffle.core.data.di.LastOpenedLibraryDataStore
+import com.riffle.core.domain.LastOpenedLibraryStore
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+
+class LastOpenedLibraryStoreImpl @Inject constructor(
+    @param:LastOpenedLibraryDataStore private val dataStore: DataStore<Preferences>,
+) : LastOpenedLibraryStore {
+
+    override fun lastOpenedLibrary(serverId: String): Flow<String?> =
+        dataStore.data.map { prefs -> prefs[key(serverId)] }
+
+    override suspend fun setLastOpenedLibrary(serverId: String, libraryId: String) {
+        dataStore.edit { prefs ->
+            prefs[key(serverId)] = libraryId
+        }
+    }
+
+    private fun key(serverId: String) = stringPreferencesKey("last_$serverId")
+}

--- a/core/data/src/main/kotlin/com/riffle/core/data/di/DataModule.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/di/DataModule.kt
@@ -18,6 +18,7 @@ import com.riffle.core.data.AudiobookDownloadRepositoryImpl
 import com.riffle.core.data.AudiobookRepositoryImpl
 import com.riffle.core.data.LibraryRepositoryImpl
 import com.riffle.core.data.AnnotationStoreImpl
+import com.riffle.core.data.LastOpenedLibraryStoreImpl
 import com.riffle.core.data.LibraryOrderPreferencesStoreImpl
 import com.riffle.core.data.LibraryVisibilityPreferencesStoreImpl
 import com.riffle.core.data.LocalStoreImpl
@@ -55,6 +56,7 @@ import com.riffle.core.domain.FormattingPreferencesStore
 import com.riffle.core.domain.AudiobookDownloadRepository
 import com.riffle.core.domain.AudiobookRepository
 import com.riffle.core.domain.LibraryRepository
+import com.riffle.core.domain.LastOpenedLibraryStore
 import com.riffle.core.domain.LibraryOrderPreferencesStore
 import com.riffle.core.domain.LibraryVisibilityPreferencesStore
 import com.riffle.core.domain.LocalStore
@@ -120,6 +122,10 @@ annotation class LibraryVisibilityPreferencesDataStore
 @Qualifier
 @Retention(AnnotationRetention.BINARY)
 annotation class LibraryOrderPreferencesDataStore
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class LastOpenedLibraryDataStore
 
 @Qualifier
 @Retention(AnnotationRetention.BINARY)
@@ -288,6 +294,10 @@ abstract class DataModule {
     @Binds
     @Singleton
     abstract fun bindLibraryOrderPreferencesStore(impl: LibraryOrderPreferencesStoreImpl): LibraryOrderPreferencesStore
+
+    @Binds
+    @Singleton
+    abstract fun bindLastOpenedLibraryStore(impl: LastOpenedLibraryStoreImpl): LastOpenedLibraryStore
 
     @Binds
     @Singleton
@@ -597,6 +607,13 @@ abstract class DataModule {
         fun provideLibraryOrderPreferencesDataStore(
             @ApplicationContext context: Context
         ): DataStore<Preferences> = context.libraryOrderPreferencesDataStore
+
+        @Provides
+        @Singleton
+        @LastOpenedLibraryDataStore
+        fun provideLastOpenedLibraryDataStore(
+            @ApplicationContext context: Context
+        ): DataStore<Preferences> = context.lastOpenedLibraryDataStore
 
         @Provides
         @Singleton

--- a/core/data/src/main/kotlin/com/riffle/core/data/di/LastOpenedLibraryDataStoreExt.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/di/LastOpenedLibraryDataStoreExt.kt
@@ -1,0 +1,9 @@
+package com.riffle.core.data.di
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.preferencesDataStore
+
+val Context.lastOpenedLibraryDataStore: DataStore<Preferences>
+    by preferencesDataStore(name = "last_opened_library")

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/LastOpenedLibraryStore.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/LastOpenedLibraryStore.kt
@@ -1,0 +1,16 @@
+package com.riffle.core.domain
+
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Per-server, device-local memory of the library the user last opened. Sibling to
+ * [LibraryOrderPreferencesStore] and [LibraryVisibilityPreferencesStore]: it is a personal display
+ * preference and is never synced.
+ *
+ * On app start the active server's remembered library is reopened (falling back to the first visible
+ * library when nothing is remembered, or when the remembered library is now hidden or gone).
+ */
+interface LastOpenedLibraryStore {
+    fun lastOpenedLibrary(serverId: String): Flow<String?>
+    suspend fun setLastOpenedLibrary(serverId: String, libraryId: String)
+}


### PR DESCRIPTION
## What

The app now remembers the **last opened library per server** and reopens it on startup. Previously it always opened the *first visible* library, ignoring what you last had open.

## How

- New device-local `LastOpenedLibraryStore` (DataStore-backed, keyed `last_<serverId>`), mirroring the existing `LibraryOrderPreferencesStore` pattern — a personal display preference, never synced.
- **Write:** `NavigationDrawerViewModel.setActiveLibrary()` — the single chokepoint hit by drawer taps, hide-redirects, and startup nav — persists the library for the active server. The active server is resolved authoritatively from `ServerRepository.getActive()` (not the `activeServer` StateFlow, which can lag a just-committed server switch and persist under the wrong server's key).
- **Read:** `HomeViewModel.getStartDestination()` reopens the remembered library **if it's still visible**, otherwise falls back to the prior "first visible" behavior. Handles: nothing remembered, remembered-but-hidden, remembered-but-deleted, and remembered-for-another-server.

Scope kept tight: per-server only, no global "most recent", no migration (absence → fall back), no new UI surface.

## Testing

- `./gradlew test` ✅ (incl. new `HomeViewModelTest` cases: reopen / fall back when hidden / gone / other-server; `NavigationDrawerViewModelTest`: persists under the repository's active server independent of the StateFlow)
- `./gradlew lint` ✅
- `make harness-test` ✅ (202 tests, 0 failed)
- `make harness-test-tablet` ✅ (5 tests, 0 failed)
