### PR TITLE
fix(reader): stop the page "falling from above" on chapter start

### DIFF
--- a/app/src/androidTest/kotlin/com/riffle/app/feature/reader/TypographyOverrideWebViewTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/reader/TypographyOverrideWebViewTest.kt
@@ -103,13 +103,13 @@ class TypographyOverrideWebViewTest {
         }
     }
 
-    // Margins override targets :root (not body) so every column in paginated mode gets equal
-    // top/bottom whitespace. Without --USER__pageMargins set the gate doesn't match and :root
-    // padding stays at the fixture default. With it set, padding-top/bottom should resolve to
-    // calc(--RS__pageGutter * --USER__pageMargins * 0.8). We simulate Readium's gutter with
-    // an explicit --RS__pageGutter on :root so the calc has a concrete value.
+    // There is deliberately NO :root vertical-padding margin override. It used to inject
+    // padding-top/bottom on :root in onPageLoaded — after first paint — so the page visibly dropped
+    // by the margin amount on every chapter start (the "page falls from above" bug). The top/bottom
+    // reading margin is now reserved before paint as native fragment-container padding (see
+    // EpubReaderScreen), so the injected CSS must never pad :root, even with --USER__pageMargins set.
     @Test
-    fun marginsOverrideAppliesVerticalPaddingToRootWhenUserVariableIsSet() {
+    fun injectedCssNeverPadsRootEvenWhenUserMarginsAreSet() {
         withWebViewFixture(hostileSboFixture) { webView ->
             webView.evalSync("document.documentElement.style.setProperty('--RS__pageGutter', '20px')")
             webView.evalSync("document.documentElement.style.setProperty('--USER__pageMargins', '2')")
@@ -120,24 +120,8 @@ class TypographyOverrideWebViewTest {
             val paddingBottom = webView.evalSync(
                 "window.getComputedStyle(document.documentElement).paddingBottom"
             ).toCssPx()
-            // Top is 0.8× the horizontal gutter — slightly narrower than the side margins and
-            // the bottom (both 1.0×). See TypographyOverride.kt "margins" entry.
-            // 20px gutter × 2 (pageMargins) × 0.8 = 32px top; × 1.0 = 40px bottom.
-            assertEquals("padding-top should reflect --USER__pageMargins × gutter × 0.8", 32.0, paddingTop, 0.5)
-            assertEquals("padding-bottom should reflect --USER__pageMargins × gutter × 1.0", 40.0, paddingBottom, 0.5)
-        }
-    }
-
-    @Test
-    fun marginsOverrideIsInertWhenUserVariableIsNotSet() {
-        withWebViewFixture(hostileSboFixture) { webView ->
-            webView.evalSync("document.documentElement.style.setProperty('--RS__pageGutter', '20px')")
-            webView.evalSync(typographyOverrideInjectionJs())
-            // No --USER__pageMargins → gate doesn't match → :root padding stays at fixture default (0).
-            val paddingTop = webView.evalSync(
-                "window.getComputedStyle(document.documentElement).paddingTop"
-            ).toCssPx()
-            assertEquals("padding-top must be untouched when user hasn't customised margins", 0.0, paddingTop, 0.5)
+            assertEquals("injected CSS must not pad :root top (would reflow post-paint)", 0.0, paddingTop, 0.5)
+            assertEquals("injected CSS must not pad :root bottom (would reflow post-paint)", 0.0, paddingBottom, 0.5)
         }
     }
 

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -1553,6 +1553,24 @@ private fun EpubNavigatorView(
 
                 val fragmentContainer = container.getChildAt(0) as? FragmentContainerView
                     ?: return@AndroidView
+
+                // The paginated top/bottom reading margin, reserved statically on our own fragment
+                // container BEFORE any chapter WebView paints and kept stable across turns, so the page
+                // never reflows after it appears. This replaces the old `margins` typography override,
+                // which injected `padding-top` on `:root` in onPageLoaded — AFTER first paint — so every
+                // fresh chapter visibly dropped by the margin amount the instant it appeared (the "page
+                // falls from above" bug). Readium's own vertical content padding is zeroed
+                // (res/values[-land]/dimens.xml) so this is the single source. Scales with the margins
+                // preference (top 0.8×, bottom 1.0×, ~20dp base — matching the override's old ratio) so
+                // the slider still moves the vertical margin. Paginated only; scroll mode flows freely.
+                val paginatedReserve = formattingPrefs.orientation != ReaderOrientation.Vertical
+                val density = container.resources.displayMetrics.density
+                val topPx = if (paginatedReserve) (16f * formattingPrefs.margins * density + 0.5f).toInt() else 0
+                val bottomPx = if (paginatedReserve) (20f * formattingPrefs.margins * density + 0.5f).toInt() else 0
+                if (fragmentContainer.paddingTop != topPx || fragmentContainer.paddingBottom != bottomPx) {
+                    fragmentContainer.setPadding(0, topPx, 0, bottomPx)
+                }
+
                 val fm = fragmentActivity.supportFragmentManager
 
                 // RS properties (colCount/colWidth) are baked into the fragment at creation time and

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -1554,19 +1554,21 @@ private fun EpubNavigatorView(
                 val fragmentContainer = container.getChildAt(0) as? FragmentContainerView
                     ?: return@AndroidView
 
-                // The paginated top/bottom reading margin, reserved statically on our own fragment
-                // container BEFORE any chapter WebView paints and kept stable across turns, so the page
-                // never reflows after it appears. This replaces the old `margins` typography override,
-                // which injected `padding-top` on `:root` in onPageLoaded — AFTER first paint — so every
-                // fresh chapter visibly dropped by the margin amount the instant it appeared (the "page
-                // falls from above" bug). Readium's own vertical content padding is zeroed
+                // The top/bottom reading margin, reserved statically on our own fragment container
+                // BEFORE any chapter WebView paints and kept stable across turns, so the page never
+                // reflows after it appears. This replaces the old `margins` typography override, which
+                // injected `padding-top` on `:root` in onPageLoaded — AFTER first paint — so every fresh
+                // chapter visibly dropped by the margin amount the instant it appeared (the "page falls
+                // from above" bug). Readium's own vertical content padding is zeroed
                 // (res/values[-land]/dimens.xml) so this is the single source. Scales with the margins
                 // preference (top 0.8×, bottom 1.0×, ~20dp base — matching the override's old ratio) so
-                // the slider still moves the vertical margin. Paginated only; scroll mode flows freely.
-                val paginatedReserve = formattingPrefs.orientation != ReaderOrientation.Vertical
+                // the slider still moves the vertical margin. Applied to reflowable books in BOTH
+                // paginated and scroll mode (the removed override covered both); fixed-layout pages are
+                // pre-sized, so padding would letterbox them — they get no reserve.
+                val reflowableReserve = !isFixedLayout
                 val density = container.resources.displayMetrics.density
-                val topPx = if (paginatedReserve) (16f * formattingPrefs.margins * density + 0.5f).toInt() else 0
-                val bottomPx = if (paginatedReserve) (20f * formattingPrefs.margins * density + 0.5f).toInt() else 0
+                val topPx = if (reflowableReserve) (16f * formattingPrefs.margins * density + 0.5f).toInt() else 0
+                val bottomPx = if (reflowableReserve) (20f * formattingPrefs.margins * density + 0.5f).toInt() else 0
                 if (fragmentContainer.paddingTop != topPx || fragmentContainer.paddingBottom != bottomPx) {
                     fragmentContainer.setPadding(0, topPx, 0, bottomPx)
                 }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/TypographyOverride.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/TypographyOverride.kt
@@ -64,30 +64,6 @@ internal val TYPOGRAPHY_OVERRIDES: Map<String, TypographyOverride> = mapOf(
         // Headings included so picking a reading font feels consistent across body and titles.
         elements = "body, p, li, blockquote, dd, dt, h1, h2, h3, h4, h5, h6, figcaption",
     ),
-    // Readium's built-in rule (`:root[style*="--USER__pageMargins"] body { padding: 0 X !important }`)
-    // applies user margins only to body's left/right. We add a top/bottom margin on every page
-    // by padding the multicol container itself — `:root` — not `body`. Padding on body would
-    // only show on the very first/last column because body is fragmented as a single block
-    // across columns; padding on `:root` shrinks the column height (since `:root` has
-    // `height: 100vh` + `box-sizing: border-box`), so every column gets equal top/bottom
-    // whitespace. The selector `:root[style*="--USER__pageMargins"]` has higher specificity
-    // (0,2,0) than Readium's `:root { padding: 0 !important }` (0,1,0), so our padding-top /
-    // padding-bottom longhands win regardless of source order. In scroll mode (`readium-scroll-on`)
-    // `:root` is `height: auto`, so this becomes whitespace at the start/end of each loaded
-    // resource — still the desired "margin" semantics.
-    //
-    // Top is 0.8× the horizontal gutter — close to the left/right side margins (Readium's
-    // built-in body padding, 1.0×) and the bottom (1.0×), but slightly narrower per conventional
-    // book typography. Both scale with --USER__pageMargins, so cranking up margins keeps the
-    // ratio constant.
-    "margins" to TypographyOverride(
-        userPropertyName = "--USER__pageMargins",
-        declarations = listOf(
-            "padding-top" to "calc(var(--RS__pageGutter) * var(--USER__pageMargins) * 0.8)",
-            "padding-bottom" to "calc(var(--RS__pageGutter) * var(--USER__pageMargins) * 1.0)",
-        ),
-        elements = "",  // empty → rule targets `:root` itself, not a descendant
-    ),
 )
 
 /**
@@ -96,6 +72,12 @@ internal val TYPOGRAPHY_OVERRIDES: Map<String, TypographyOverride> = mapOf(
  * maintainers don't accidentally add a field to this list as a way of silencing the test.
  */
 internal val EXCLUDED_FROM_TYPOGRAPHY_OVERRIDES: Map<String, String> = mapOf(
+    "margins" to "Page margins come from Readium's pre-paint layout: left/right from its built-in body " +
+        "padding (scales with --USER__pageMargins), top/bottom from its native container vertical padding " +
+        "(readium_navigator_epub_vertical_padding). We deliberately do NOT inject a :root padding override " +
+        "for the top/bottom margin: injected in onPageLoaded it lands AFTER first paint, so the page visibly " +
+        "dropped by the margin amount on every chapter start (the 'page falls from above' bug). Letting " +
+        "Readium own the vertical margin keeps it applied before the page is revealed, with no reflow.",
     "fontSize" to "Applied via root-em multiplier; a per-element override would flatten the publisher's size hierarchy.",
     "theme" to "Multi-property (background, text colour, link colour, image filters) — handled by Readium's theme stylesheet, not a single override.",
     "orientation" to "Layout/scroll mode, not a CSS property.",

--- a/app/src/main/res/values-land/dimens.xml
+++ b/app/src/main/res/values-land/dimens.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Landscape counterpart of the values/ override; see that file. Riffle reserves the vertical
+         margin statically on the fragment container instead. -->
+    <dimen name="readium_navigator_epub_vertical_padding">0dp</dimen>
+</resources>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!--
+      Zero Readium's own paginated top/bottom content padding so the reader's vertical margin has a
+      single, deterministic source: the static padding Riffle reserves on the fragment container
+      BEFORE the chapter WebView paints (see EpubReaderScreen's AndroidView update block). Readium
+      applied its padding via containerView.setPadding on a RESUMED-lifecycle coroutine and, in
+      Riffle's host, did not render a usable margin anyway; the margin used to come from a :root
+      padding typography override injected in onPageLoaded — after first paint — which dropped the
+      page by the margin amount on every chapter start (the "page falls from above" bug).
+    -->
+    <dimen name="readium_navigator_epub_vertical_padding">0dp</dimen>
+</resources>

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/TypographyOverrideTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/TypographyOverrideTest.kt
@@ -3,6 +3,7 @@ package com.riffle.app.feature.reader
 import com.riffle.core.domain.FormattingPreferences
 import java.lang.reflect.Modifier
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -98,25 +99,16 @@ class TypographyOverrideTest {
         }
     }
 
-    // Regression guard: an earlier attempt at applying margins to top/bottom set
-    // `elements = "body"`, which silently did nothing because CSS multicol fragments body as a
-    // single block — padding-top only shows on the first column, padding-bottom only on the
-    // last. The fix targets `:root` (the multicol container) so every page gets equal
-    // vertical whitespace. Encoding it as a test so a future refactor doesn't quietly regress.
+    // No margins typography override: the page's top/bottom margin is owned by Readium's pre-paint
+    // layout (native container vertical padding), not a :root padding injected in onPageLoaded. An
+    // injected :root padding lands after first paint and visibly dropped the page on every chapter
+    // start (the "page falls from above" bug), so `margins` is intentionally excluded.
     @Test
-    fun margins_override_targets_root_not_a_descendant() {
-        val override = TYPOGRAPHY_OVERRIDES.getValue("margins")
-        assertEquals(
-            "Margins must pad :root (multicol container); padding on body wouldn't show per-page",
-            "", override.elements,
-        )
-        val css = typographyOverrideCss()
-        // The rule for margins must be exactly the gate selector with no descendant —
-        // i.e. `:root[style*="--USER__pageMargins"] {`, not `... body {` or similar.
-        assertTrue(
-            "Margins rule must be scoped to :root itself, not a descendant. CSS was:\n$css",
-            css.contains(":root[style*=\"--USER__pageMargins\"] {"),
-        )
+    fun margins_has_no_post_paint_root_padding_override() {
+        assertFalse(TYPOGRAPHY_OVERRIDES.containsKey("margins"))
+        assertTrue(EXCLUDED_FROM_TYPOGRAPHY_OVERRIDES.containsKey("margins"))
+        // No injected rule may pad :root for the page margin (that is the reflow that caused the fall).
+        assertFalse(typographyOverrideCss().contains("padding-top"))
     }
 
     // Regression guard: text-align is the one user property where ReadiumCSS's own rule uses


### PR DESCRIPTION
## What

Every chapter turn made the page visibly **drop by its top margin the instant it appeared** — worst on one-page chapters, on both swipe and volume turns, at default settings.

## Root cause (proven on-device)

The `margins` entry in `TypographyOverride.kt` injected `padding-top`/`padding-bottom` on `:root` via `typographyOverrideInjectionJs()` inside `paginationListener.onPageLoaded` — i.e. **after the WebView had already painted**. The page painted, then the `<style>` landed and the content reflowed downward. It fired even at default margins because Readium sets `--USER__pageMargins` inline (=1), so the gate `:root[style*="--USER__pageMargins"]` matched.

Confirmed with a temporary `onPageLoaded` rAF probe logging computed style each frame: before the fix, `:root` `padding-top` went `0 → 16px` and the heading top `23 → 39` at ~27ms, with `scrollTop` constant 0 (a layout reflow, not a scroll, not a font swap). After the fix both stay flat.

## The fix

- Remove the `margins` `:root` padding override (the post-paint reflow source); `margins` is now in `EXCLUDED_FROM_TYPOGRAPHY_OVERRIDES`.
- Reserve the top/bottom reading margin as **static padding on the fragment container** (`EpubReaderScreen`), applied *before* the chapter paints and stable across turns — so there's no post-paint reflow. It scales with the margins preference (top 0.8× / bottom 1.0×), and Readium's own (non-rendering, late-applied) vertical padding is zeroed via `dimens.xml` so this is the single source.
- Applies to reflowable books in **both paginated and scroll mode** (the removed override covered both); fixed-layout pages are pre-sized, so they get no reserve (avoids letterboxing).

## Testing

- `./gradlew test lint` — green
- `make harness-test` (phone) — 201 tests, 0 failed
- `make harness-test-tablet` — 5 tests, 0 failed
- Manual on-device (API 33 / WebView 109): the heading no longer reflows after load (probe shows `:root` padding-top stays 0); top/bottom margins present on title and content pages. Author also confirmed on their physical device that the fall is gone and margins are intact.
- Updated the JVM + instrumented `TypographyOverride` contract tests to guard that no injected rule pads `:root`.