### PR TITLE
fix(library): preserve local readingProgress on library refresh

### DIFF
--- a/core/data/src/main/kotlin/com/riffle/core/data/LibraryRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/LibraryRepositoryImpl.kt
@@ -159,7 +159,6 @@ class LibraryRepositoryImpl @Inject constructor(
         return when (val result = api.getLibraryItems(server.url.value, libraryId, token, server.insecureConnectionAllowed)) {
             is NetworkLibraryItemsResult.Success -> {
                 val lastOpenedAtMap = libraryItemDao.getLastOpenedAtMap(libraryId).associate { it.id to it.lastOpenedAt }
-                val localProgressMap = libraryItemDao.getReadingProgressMap(libraryId).associate { it.id to it.readingProgress }
                 val entities = result.items
                     .sortedByDescending { it.isSupported }
                     .distinctBy { it.title.trim().lowercase() }
@@ -176,7 +175,10 @@ class LibraryRepositoryImpl @Inject constructor(
                             // its listen fraction into `ebookProgress` (AbsApiClient: ebookProgress ?:
                             // progress), so this single field is the unified "how far through this
                             // item" value that surfaces audiobooks in In Progress too (ADR 0029).
-                            readingProgress = serverProgress?.ebookProgress ?: item.readingProgress ?: localProgressMap[item.id] ?: 0f,
+                            // Note: for existing items the DAO's updateMetadata ignores this field and
+                            // preserves the locally-tracked value. It is only used when inserting a
+                            // new item for the first time.
+                            readingProgress = serverProgress?.ebookProgress ?: item.readingProgress ?: 0f,
                             ebookFileIno = item.ebookFileIno,
                             ebookFormat = item.ebookFormat.toStorageString(),
                             hasAudio = item.hasAudio,

--- a/core/data/src/test/kotlin/com/riffle/core/data/FakeLibraryItemDao.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/FakeLibraryItemDao.kt
@@ -85,9 +85,11 @@ internal class FakeLibraryItemDao : LibraryItemDao {
         }
     }
 
-    override suspend fun deleteRemovedFromLibrary(libraryId: String, serverItemIds: List<String>) {
+    override suspend fun deleteRemovedFromLibrary(serverId: String, libraryId: String, serverItemIds: List<String>) {
         val serverIdSet = serverItemIds.toSet()
-        roomData[libraryId]?.value = roomData[libraryId]?.value?.filter { it.id in serverIdSet } ?: emptyList()
+        roomData[libraryId]?.value = roomData[libraryId]?.value
+            ?.filter { it.serverId != serverId || it.id in serverIdSet }
+            ?: emptyList()
     }
 
     override suspend fun getById(serverId: String, itemId: String): LibraryItemEntity? =

--- a/core/data/src/test/kotlin/com/riffle/core/data/FakeLibraryItemDao.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/FakeLibraryItemDao.kt
@@ -3,6 +3,7 @@ package com.riffle.core.data
 import com.riffle.core.database.LastOpenedAtRow
 import com.riffle.core.database.LibraryItemDao
 import com.riffle.core.database.LibraryItemEntity
+import com.riffle.core.database.LibraryItemMetadata
 import com.riffle.core.database.MatchableItemRow
 import com.riffle.core.database.ReadingProgressRow
 import kotlinx.coroutines.flow.Flow
@@ -42,7 +43,52 @@ internal class FakeLibraryItemDao : LibraryItemDao {
         }
     }
 
-    // replaceAllForLibrary is intentionally inherited (deleteByLibraryId + upsertAll @Transaction default).
+    // replaceAllForLibrary is intentionally inherited (uses the three methods below).
+
+    override suspend fun insertOrIgnore(items: List<LibraryItemEntity>) {
+        items.groupBy { it.libraryId }.forEach { (libraryId, newItems) ->
+            val flow = roomData.getOrPut(libraryId) { MutableStateFlow(emptyList()) }
+            val existingIds = flow.value.map { it.id }.toSet()
+            val toInsert = newItems.filter { it.id !in existingIds }
+            if (toInsert.isNotEmpty()) {
+                upserted.addAll(toInsert)
+                flow.value = flow.value + toInsert
+            }
+        }
+    }
+
+    override suspend fun updateMetadata(metadata: LibraryItemMetadata) {
+        val flow = roomData[metadata.libraryId] ?: return
+        flow.value = flow.value.map { existing ->
+            if (existing.serverId == metadata.serverId && existing.id == metadata.id) {
+                existing.copy(
+                    libraryId = metadata.libraryId,
+                    title = metadata.title,
+                    author = metadata.author,
+                    coverUrl = metadata.coverUrl,
+                    ebookFileIno = metadata.ebookFileIno,
+                    ebookFormat = metadata.ebookFormat,
+                    hasAudio = metadata.hasAudio,
+                    audioDurationSec = metadata.audioDurationSec,
+                    description = metadata.description,
+                    seriesName = metadata.seriesName,
+                    publishedYear = metadata.publishedYear,
+                    genres = metadata.genres,
+                    publisher = metadata.publisher,
+                    language = metadata.language,
+                    lastOpenedAt = metadata.lastOpenedAt,
+                    addedAt = metadata.addedAt,
+                    isbn = metadata.isbn,
+                    asin = metadata.asin,
+                )
+            } else existing
+        }
+    }
+
+    override suspend fun deleteRemovedFromLibrary(libraryId: String, serverItemIds: List<String>) {
+        val serverIdSet = serverItemIds.toSet()
+        roomData[libraryId]?.value = roomData[libraryId]?.value?.filter { it.id in serverIdSet } ?: emptyList()
+    }
 
     override suspend fun getById(serverId: String, itemId: String): LibraryItemEntity? =
         roomData.values.flatMap { it.value }.firstOrNull { it.serverId == serverId && it.id == itemId }

--- a/core/data/src/test/kotlin/com/riffle/core/data/LibraryRepositoryTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/LibraryRepositoryTest.kt
@@ -345,9 +345,10 @@ class LibraryRepositoryTest {
                 NetworkCollectionResult.Success(emptyList())
         }
         makeRepo(libraryItemDao = dao, api = api).refreshLibraryItems("lib-1")
-        assertEquals(1, dao.upserted.size)
-        assertEquals("item-1", dao.upserted[0].id)
-        assertEquals(0.42f, dao.upserted[0].readingProgress, 0.001f)
+        val items = dao.itemsFor("lib-1")
+        assertEquals(1, items.size)
+        assertEquals("item-1", items[0].id)
+        assertEquals(0.42f, items[0].readingProgress, 0.001f)
     }
 
     @Test
@@ -370,7 +371,7 @@ class LibraryRepositoryTest {
                 NetworkCollectionResult.Success(emptyList())
         }
         makeRepo(libraryItemDao = dao, api = api).refreshLibraryItems("lib-1")
-        assertEquals(2, dao.upserted.size)
+        assertEquals(2, dao.itemsFor("lib-1").size)
     }
 
     @Test
@@ -398,7 +399,7 @@ class LibraryRepositoryTest {
                 NetworkCollectionResult.Success(emptyList())
         }
         makeRepo(libraryItemDao = dao, api = api).refreshLibraryItems("lib-1")
-        assertEquals(5_000L, dao.upserted.last { it.id == "item-1" }.lastOpenedAt)
+        assertEquals(5_000L, dao.itemsFor("lib-1").first { it.id == "item-1" }.lastOpenedAt)
     }
 
     @Test
@@ -426,7 +427,62 @@ class LibraryRepositoryTest {
                 NetworkCollectionResult.Success(emptyList())
         }
         makeRepo(libraryItemDao = dao, api = api).refreshLibraryItems("lib-1")
-        assertEquals(9_000L, dao.upserted.last { it.id == "item-1" }.lastOpenedAt)
+        assertEquals(9_000L, dao.itemsFor("lib-1").first { it.id == "item-1" }.lastOpenedAt)
+    }
+
+    @Test
+    fun `refreshLibraryItems keeps local readingProgress over stale server value`() = runTest {
+        // Reproduces the offline-read regression: server has old 0.42, local has 0.75 from an
+        // offline session. Refresh must not revert the library card back to the server value.
+        fakeServerRepository.activeServer = activeServer()
+        fakeTokenStorage.tokens["s1"] = "tok"
+        val dao = FakeLibraryItemDao()
+        dao.upsertAll(listOf(
+            LibraryItemEntity("s1", "item-1", "lib-1", "My Book", "Author A", null, 0.75f),
+        ))
+        val api = object : AbsLibraryApi {
+            override suspend fun getUserProgress(baseUrl: String, token: String, insecureAllowed: Boolean) =
+                com.riffle.core.network.NetworkUserProgressResult.Success(
+                    mapOf("item-1" to com.riffle.core.network.NetworkUserMediaProgress(ebookProgress = 0.42f, lastUpdate = 1_000L))
+                )
+            override suspend fun getLibraries(baseUrl: String, token: String, insecureAllowed: Boolean) =
+                NetworkLibrariesResult.Success(emptyList())
+            override suspend fun getLibraryItems(baseUrl: String, libraryId: String, token: String, insecureAllowed: Boolean) =
+                NetworkLibraryItemsResult.Success(listOf(
+                    NetworkLibraryItem("item-1", "lib-1", "My Book", "Author A", 0.42f, ebookFormat = EbookFormat.Epub)
+                ))
+            override suspend fun getSeries(baseUrl: String, libraryId: String, token: String, insecureAllowed: Boolean) =
+                NetworkSeriesResult.Success(emptyList())
+            override suspend fun getCollections(baseUrl: String, libraryId: String, token: String, insecureAllowed: Boolean) =
+                NetworkCollectionResult.Success(emptyList())
+        }
+        makeRepo(libraryItemDao = dao, api = api).refreshLibraryItems("lib-1")
+        assertEquals(0.75f, dao.itemsFor("lib-1").first { it.id == "item-1" }.readingProgress, 0.001f)
+    }
+
+    @Test
+    fun `refreshLibraryItems uses server readingProgress when no local record exists`() = runTest {
+        fakeServerRepository.activeServer = activeServer()
+        fakeTokenStorage.tokens["s1"] = "tok"
+        val dao = FakeLibraryItemDao() // no pre-existing items
+        val api = object : AbsLibraryApi {
+            override suspend fun getUserProgress(baseUrl: String, token: String, insecureAllowed: Boolean) =
+                com.riffle.core.network.NetworkUserProgressResult.Success(
+                    mapOf("item-1" to com.riffle.core.network.NetworkUserMediaProgress(ebookProgress = 0.80f, lastUpdate = 1_000L))
+                )
+            override suspend fun getLibraries(baseUrl: String, token: String, insecureAllowed: Boolean) =
+                NetworkLibrariesResult.Success(emptyList())
+            override suspend fun getLibraryItems(baseUrl: String, libraryId: String, token: String, insecureAllowed: Boolean) =
+                NetworkLibraryItemsResult.Success(listOf(
+                    NetworkLibraryItem("item-1", "lib-1", "My Book", "Author A", 0f, ebookFormat = EbookFormat.Epub)
+                ))
+            override suspend fun getSeries(baseUrl: String, libraryId: String, token: String, insecureAllowed: Boolean) =
+                NetworkSeriesResult.Success(emptyList())
+            override suspend fun getCollections(baseUrl: String, libraryId: String, token: String, insecureAllowed: Boolean) =
+                NetworkCollectionResult.Success(emptyList())
+        }
+        makeRepo(libraryItemDao = dao, api = api).refreshLibraryItems("lib-1")
+        assertEquals(0.80f, dao.itemsFor("lib-1").first { it.id == "item-1" }.readingProgress, 0.001f)
     }
 
     @Test
@@ -460,7 +516,7 @@ class LibraryRepositoryTest {
                 NetworkCollectionResult.Success(emptyList())
         }
         makeRepo(libraryItemDao = dao, api = api).refreshLibraryItems("lib-1")
-        assertEquals(99_000L, dao.upserted.last { it.id == "item-1" }.lastOpenedAt)
+        assertEquals(99_000L, dao.itemsFor("lib-1").first { it.id == "item-1" }.lastOpenedAt)
     }
 
     @Test
@@ -481,7 +537,7 @@ class LibraryRepositoryTest {
                 NetworkCollectionResult.Success(emptyList())
         }
         makeRepo(libraryItemDao = dao, api = api).refreshLibraryItems("lib-1")
-        assertEquals(1_708_369_906_982L, dao.upserted[0].addedAt)
+        assertEquals(1_708_369_906_982L, dao.itemsFor("lib-1").first().addedAt)
     }
 
     @Test

--- a/core/data/src/test/kotlin/com/riffle/core/data/NoopLibraryDaos.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/NoopLibraryDaos.kt
@@ -5,6 +5,7 @@ import com.riffle.core.database.LibraryDao
 import com.riffle.core.database.LibraryEntity
 import com.riffle.core.database.LibraryItemDao
 import com.riffle.core.database.LibraryItemEntity
+import com.riffle.core.database.LibraryItemMetadata
 import com.riffle.core.database.MatchableItemRow
 import com.riffle.core.database.ReadingProgressRow
 import kotlinx.coroutines.flow.Flow
@@ -19,10 +20,13 @@ internal object ThrowingLibraryItemDao : LibraryItemDao {
     override fun observeRecentlyAdded(libraryId: String): Flow<List<LibraryItemEntity>> = flowOf(emptyList())
     override fun observeAllBooks(libraryId: String): Flow<List<LibraryItemEntity>> = flowOf(emptyList())
     override suspend fun upsertAll(items: List<LibraryItemEntity>) = Unit
+    override suspend fun insertOrIgnore(items: List<LibraryItemEntity>) = Unit
+    override suspend fun updateMetadata(metadata: LibraryItemMetadata) = Unit
     override suspend fun getById(serverId: String, itemId: String): LibraryItemEntity? = null
     override fun observeById(serverId: String, itemId: String): Flow<LibraryItemEntity?> = flowOf(null)
     override suspend fun findServerIdForItem(itemId: String): String? = null
     override suspend fun deleteByLibraryId(libraryId: String) = Unit
+    override suspend fun deleteRemovedFromLibrary(libraryId: String, serverItemIds: List<String>) = Unit
     override suspend fun updateLastOpenedAt(serverId: String, itemId: String, timestamp: Long) = Unit
     override suspend fun updateReadingProgress(serverId: String, itemId: String, progress: Float) = Unit
     override suspend fun getLastOpenedAtMap(libraryId: String): List<LastOpenedAtRow> = emptyList()

--- a/core/data/src/test/kotlin/com/riffle/core/data/NoopLibraryDaos.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/NoopLibraryDaos.kt
@@ -26,7 +26,7 @@ internal object ThrowingLibraryItemDao : LibraryItemDao {
     override fun observeById(serverId: String, itemId: String): Flow<LibraryItemEntity?> = flowOf(null)
     override suspend fun findServerIdForItem(itemId: String): String? = null
     override suspend fun deleteByLibraryId(libraryId: String) = Unit
-    override suspend fun deleteRemovedFromLibrary(libraryId: String, serverItemIds: List<String>) = Unit
+    override suspend fun deleteRemovedFromLibrary(serverId: String, libraryId: String, serverItemIds: List<String>) = Unit
     override suspend fun updateLastOpenedAt(serverId: String, itemId: String, timestamp: Long) = Unit
     override suspend fun updateReadingProgress(serverId: String, itemId: String, progress: Float) = Unit
     override suspend fun getLastOpenedAtMap(libraryId: String): List<LastOpenedAtRow> = emptyList()

--- a/core/data/src/test/kotlin/com/riffle/core/data/ReadaloudMatchingServiceTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/ReadaloudMatchingServiceTest.kt
@@ -330,10 +330,13 @@ class ReadaloudMatchingServiceTest {
         override fun observeRecentlyAdded(libraryId: String): Flow<List<LibraryItemEntity>> = flowOf(emptyList())
         override fun observeAllBooks(libraryId: String): Flow<List<LibraryItemEntity>> = flowOf(emptyList())
         override suspend fun upsertAll(items: List<LibraryItemEntity>) = Unit
+        override suspend fun insertOrIgnore(items: List<LibraryItemEntity>) = Unit
+        override suspend fun updateMetadata(metadata: com.riffle.core.database.LibraryItemMetadata) = Unit
         override suspend fun getById(serverId: String, itemId: String): LibraryItemEntity? = byId[itemId]
         override fun observeById(serverId: String, itemId: String): Flow<LibraryItemEntity?> = flowOf(byId[itemId])
         override suspend fun findServerIdForItem(itemId: String): String? = byId[itemId]?.serverId
         override suspend fun deleteByLibraryId(libraryId: String) = Unit
+        override suspend fun deleteRemovedFromLibrary(libraryId: String, serverItemIds: List<String>) = Unit
         override suspend fun updateLastOpenedAt(serverId: String, itemId: String, timestamp: Long) = Unit
         override suspend fun updateReadingProgress(serverId: String, itemId: String, progress: Float) = Unit
         override suspend fun getLastOpenedAtMap(libraryId: String): List<LastOpenedAtRow> = emptyList()

--- a/core/data/src/test/kotlin/com/riffle/core/data/ReadaloudMatchingServiceTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/ReadaloudMatchingServiceTest.kt
@@ -336,7 +336,7 @@ class ReadaloudMatchingServiceTest {
         override fun observeById(serverId: String, itemId: String): Flow<LibraryItemEntity?> = flowOf(byId[itemId])
         override suspend fun findServerIdForItem(itemId: String): String? = byId[itemId]?.serverId
         override suspend fun deleteByLibraryId(libraryId: String) = Unit
-        override suspend fun deleteRemovedFromLibrary(libraryId: String, serverItemIds: List<String>) = Unit
+        override suspend fun deleteRemovedFromLibrary(serverId: String, libraryId: String, serverItemIds: List<String>) = Unit
         override suspend fun updateLastOpenedAt(serverId: String, itemId: String, timestamp: Long) = Unit
         override suspend fun updateReadingProgress(serverId: String, itemId: String, progress: Float) = Unit
         override suspend fun getLastOpenedAtMap(libraryId: String): List<LastOpenedAtRow> = emptyList()

--- a/core/data/src/test/kotlin/com/riffle/core/data/SeriesIntegrationTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/SeriesIntegrationTest.kt
@@ -116,7 +116,10 @@ class SeriesIntegrationTest {
         override fun observeById(serverId: String, itemId: String): Flow<LibraryItemEntity?> = MutableStateFlow(null)
         override suspend fun findServerIdForItem(itemId: String): String? = null
         override suspend fun upsertAll(items: List<LibraryItemEntity>) {}
+        override suspend fun insertOrIgnore(items: List<LibraryItemEntity>) {}
+        override suspend fun updateMetadata(metadata: com.riffle.core.database.LibraryItemMetadata) {}
         override suspend fun deleteByLibraryId(libraryId: String) {}
+        override suspend fun deleteRemovedFromLibrary(libraryId: String, serverItemIds: List<String>) {}
         override suspend fun updateLastOpenedAt(serverId: String, itemId: String, timestamp: Long) {}
         override suspend fun getLastOpenedAtMap(libraryId: String): List<LastOpenedAtRow> = emptyList()
         override suspend fun getReadingProgressMap(libraryId: String): List<ReadingProgressRow> = emptyList()

--- a/core/data/src/test/kotlin/com/riffle/core/data/SeriesIntegrationTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/SeriesIntegrationTest.kt
@@ -119,7 +119,7 @@ class SeriesIntegrationTest {
         override suspend fun insertOrIgnore(items: List<LibraryItemEntity>) {}
         override suspend fun updateMetadata(metadata: com.riffle.core.database.LibraryItemMetadata) {}
         override suspend fun deleteByLibraryId(libraryId: String) {}
-        override suspend fun deleteRemovedFromLibrary(libraryId: String, serverItemIds: List<String>) {}
+        override suspend fun deleteRemovedFromLibrary(serverId: String, libraryId: String, serverItemIds: List<String>) {}
         override suspend fun updateLastOpenedAt(serverId: String, itemId: String, timestamp: Long) {}
         override suspend fun getLastOpenedAtMap(libraryId: String): List<LastOpenedAtRow> = emptyList()
         override suspend fun getReadingProgressMap(libraryId: String): List<ReadingProgressRow> = emptyList()

--- a/core/data/src/test/kotlin/com/riffle/core/data/ServerRepositoryTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/ServerRepositoryTest.kt
@@ -140,7 +140,7 @@ class ServerRepositoryTest {
             deletedLibraryIds += libraryId
             rows.remove(libraryId)
         }
-        override suspend fun deleteRemovedFromLibrary(libraryId: String, serverItemIds: List<String>) = Unit
+        override suspend fun deleteRemovedFromLibrary(serverId: String, libraryId: String, serverItemIds: List<String>) = Unit
         override suspend fun updateLastOpenedAt(serverId: String, itemId: String, timestamp: Long) {}
         override suspend fun getLastOpenedAtMap(libraryId: String) = emptyList<com.riffle.core.database.LastOpenedAtRow>()
         override suspend fun getReadingProgressMap(libraryId: String) = emptyList<com.riffle.core.database.ReadingProgressRow>()

--- a/core/data/src/test/kotlin/com/riffle/core/data/ServerRepositoryTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/ServerRepositoryTest.kt
@@ -134,10 +134,13 @@ class ServerRepositoryTest {
                 rows.getOrPut(libraryId) { mutableListOf() }.addAll(entities)
             }
         }
+        override suspend fun insertOrIgnore(items: List<com.riffle.core.database.LibraryItemEntity>) = Unit
+        override suspend fun updateMetadata(metadata: com.riffle.core.database.LibraryItemMetadata) = Unit
         override suspend fun deleteByLibraryId(libraryId: String) {
             deletedLibraryIds += libraryId
             rows.remove(libraryId)
         }
+        override suspend fun deleteRemovedFromLibrary(libraryId: String, serverItemIds: List<String>) = Unit
         override suspend fun updateLastOpenedAt(serverId: String, itemId: String, timestamp: Long) {}
         override suspend fun getLastOpenedAtMap(libraryId: String) = emptyList<com.riffle.core.database.LastOpenedAtRow>()
         override suspend fun getReadingProgressMap(libraryId: String) = emptyList<com.riffle.core.database.ReadingProgressRow>()

--- a/core/database/src/main/kotlin/com/riffle/core/database/LibraryItemDao.kt
+++ b/core/database/src/main/kotlin/com/riffle/core/database/LibraryItemDao.kt
@@ -5,6 +5,7 @@ import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import androidx.room.Transaction
+import androidx.room.Update
 import kotlinx.coroutines.flow.Flow
 
 @Dao
@@ -31,6 +32,22 @@ interface LibraryItemDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun upsertAll(items: List<LibraryItemEntity>)
 
+    /** Inserts items that do not yet exist; skips rows that already have a matching primary key. */
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    suspend fun insertOrIgnore(items: List<LibraryItemEntity>)
+
+    /**
+     * Updates all metadata columns for an existing row, intentionally excluding [readingProgress].
+     * Progress is owned by the reader-close path ([updateReadingProgress]) and must not be
+     * overwritten by a library refresh carrying a stale server value.
+     */
+    @Update(entity = LibraryItemEntity::class)
+    suspend fun updateMetadata(metadata: LibraryItemMetadata)
+
+    /** Removes library items whose id is no longer present on the server. */
+    @Query("DELETE FROM library_items WHERE libraryId = :libraryId AND id NOT IN (:serverItemIds)")
+    suspend fun deleteRemovedFromLibrary(libraryId: String, serverItemIds: List<String>)
+
     @Query("SELECT * FROM library_items WHERE serverId = :serverId AND id = :itemId LIMIT 1")
     suspend fun getById(serverId: String, itemId: String): LibraryItemEntity?
 
@@ -51,8 +68,16 @@ interface LibraryItemDao {
 
     @Transaction
     suspend fun replaceAllForLibrary(libraryId: String, items: List<LibraryItemEntity>) {
-        deleteByLibraryId(libraryId)
-        upsertAll(items)
+        if (items.isEmpty()) {
+            deleteByLibraryId(libraryId)
+            return
+        }
+        // Remove items no longer present on the server.
+        deleteRemovedFromLibrary(libraryId, items.map { it.id })
+        // Insert truly new items — they get the server's readingProgress as the initial seed.
+        insertOrIgnore(items)
+        // Update metadata for all items, preserving each row's local readingProgress.
+        items.forEach { updateMetadata(LibraryItemMetadata.from(it)) }
     }
 
     @Query("""
@@ -100,6 +125,59 @@ interface LibraryItemDao {
             "WHERE s.serverType = :serverType"
     )
     suspend fun listMatchableByServerType(serverType: String): List<MatchableItemRow>
+}
+
+/**
+ * Partial-update POJO for [LibraryItemEntity] that excludes [LibraryItemEntity.readingProgress].
+ * Used by [LibraryItemDao.updateMetadata] so that library refreshes never overwrite locally-tracked
+ * reading progress with a stale server value.
+ */
+data class LibraryItemMetadata(
+    val serverId: String,
+    val id: String,
+    val libraryId: String,
+    val title: String,
+    val author: String,
+    val coverUrl: String?,
+    val ebookFileIno: String?,
+    val ebookFormat: String,
+    val hasAudio: Boolean,
+    val audioDurationSec: Double,
+    val description: String?,
+    val seriesName: String?,
+    val publishedYear: String?,
+    val genres: String,
+    val publisher: String?,
+    val language: String?,
+    val lastOpenedAt: Long?,
+    val addedAt: Long?,
+    val isbn: String?,
+    val asin: String?,
+) {
+    companion object {
+        fun from(entity: LibraryItemEntity) = LibraryItemMetadata(
+            serverId = entity.serverId,
+            id = entity.id,
+            libraryId = entity.libraryId,
+            title = entity.title,
+            author = entity.author,
+            coverUrl = entity.coverUrl,
+            ebookFileIno = entity.ebookFileIno,
+            ebookFormat = entity.ebookFormat,
+            hasAudio = entity.hasAudio,
+            audioDurationSec = entity.audioDurationSec,
+            description = entity.description,
+            seriesName = entity.seriesName,
+            publishedYear = entity.publishedYear,
+            genres = entity.genres,
+            publisher = entity.publisher,
+            language = entity.language,
+            lastOpenedAt = entity.lastOpenedAt,
+            addedAt = entity.addedAt,
+            isbn = entity.isbn,
+            asin = entity.asin,
+        )
+    }
 }
 
 data class LastOpenedAtRow(val id: String, val lastOpenedAt: Long)

--- a/core/database/src/main/kotlin/com/riffle/core/database/LibraryItemDao.kt
+++ b/core/database/src/main/kotlin/com/riffle/core/database/LibraryItemDao.kt
@@ -45,8 +45,8 @@ interface LibraryItemDao {
     suspend fun updateMetadata(metadata: LibraryItemMetadata)
 
     /** Removes library items whose id is no longer present on the server. */
-    @Query("DELETE FROM library_items WHERE libraryId = :libraryId AND id NOT IN (:serverItemIds)")
-    suspend fun deleteRemovedFromLibrary(libraryId: String, serverItemIds: List<String>)
+    @Query("DELETE FROM library_items WHERE serverId = :serverId AND libraryId = :libraryId AND id NOT IN (:serverItemIds)")
+    suspend fun deleteRemovedFromLibrary(serverId: String, libraryId: String, serverItemIds: List<String>)
 
     @Query("SELECT * FROM library_items WHERE serverId = :serverId AND id = :itemId LIMIT 1")
     suspend fun getById(serverId: String, itemId: String): LibraryItemEntity?
@@ -73,7 +73,7 @@ interface LibraryItemDao {
             return
         }
         // Remove items no longer present on the server.
-        deleteRemovedFromLibrary(libraryId, items.map { it.id })
+        deleteRemovedFromLibrary(items.first().serverId, libraryId, items.map { it.id })
         // Insert truly new items — they get the server's readingProgress as the initial seed.
         insertOrIgnore(items)
         // Update metadata for all items, preserving each row's local readingProgress.


### PR DESCRIPTION
## Summary

- **Bug:** After reading offline, going online triggered a library refresh that reverted the progress shown on the library card to the stale server value — and caused ProgressSweep to push that wrong fraction to ABS, permanently losing the offline read.
- **Root cause:** `replaceAllForLibrary` did `DELETE + INSERT`, which clobbered `readingProgress` with whatever the server returned. `AbsProgressRemoteFactory` then read the corrupted value when patching ABS.
- **Fix:** `replaceAllForLibrary` now uses a 3-step approach in the DAO: delete items removed from the server, insert-or-ignore new items (seeding server progress as initial value), and update metadata for existing rows via `LibraryItemMetadata` — a partial POJO that omits `readingProgress`. Room's `@Update(entity=...)` generates an UPDATE that leaves that column untouched. `LibraryRepositoryImpl` passes server data through unchanged; the DAO owns the conflict-resolution policy.
- **Review fix:** `deleteRemovedFromLibrary` was also missing a `serverId` filter — `libraryId` is only unique within an ABS instance, so two server rows pointing at the same instance share library IDs (documented in `LibraryEntity.kt`). Added `AND serverId = :serverId` to the DELETE query.

## Test plan

- [ ] New unit tests: `refreshLibraryItems keeps local readingProgress over stale server value` and `refreshLibraryItems uses server readingProgress when no local record exists`
- [ ] Full JVM suite (`./gradlew test`) — green
- [ ] Lint (`./gradlew lint`) — green
- [ ] Phone harness (`make harness-test`) — green
- [ ] Tablet harness (`make harness-test-tablet`) — green