### PR TITLE
fix(reader): remove permanent white strip in scroll mode

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -1554,21 +1554,14 @@ private fun EpubNavigatorView(
                 val fragmentContainer = container.getChildAt(0) as? FragmentContainerView
                     ?: return@AndroidView
 
-                // The top/bottom reading margin, reserved statically on our own fragment container
-                // BEFORE any chapter WebView paints and kept stable across turns, so the page never
-                // reflows after it appears. This replaces the old `margins` typography override, which
-                // injected `padding-top` on `:root` in onPageLoaded — AFTER first paint — so every fresh
-                // chapter visibly dropped by the margin amount the instant it appeared (the "page falls
-                // from above" bug). Readium's own vertical content padding is zeroed
-                // (res/values[-land]/dimens.xml) so this is the single source. Scales with the margins
-                // preference (top 0.8×, bottom 1.0×, ~20dp base — matching the override's old ratio) so
-                // the slider still moves the vertical margin. Applied to reflowable books in BOTH
-                // paginated and scroll mode (the removed override covered both); fixed-layout pages are
-                // pre-sized, so padding would letterbox them — they get no reserve.
-                val reflowableReserve = !isFixedLayout
+                val isScrollMode = formattingPrefs.orientation == ReaderOrientation.Vertical
                 val density = container.resources.displayMetrics.density
-                val topPx = if (reflowableReserve) (16f * formattingPrefs.margins * density + 0.5f).toInt() else 0
-                val bottomPx = if (reflowableReserve) (20f * formattingPrefs.margins * density + 0.5f).toInt() else 0
+                val (topPx, bottomPx) = readerContainerPaddingPx(
+                    margins = formattingPrefs.margins,
+                    density = density,
+                    isFixedLayout = isFixedLayout,
+                    isScrollMode = isScrollMode,
+                )
                 if (fragmentContainer.paddingTop != topPx || fragmentContainer.paddingBottom != bottomPx) {
                     fragmentContainer.setPadding(0, topPx, 0, bottomPx)
                 }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderContainerPadding.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderContainerPadding.kt
@@ -1,0 +1,22 @@
+package com.riffle.app.feature.reader
+
+// Top/bottom padding (px) to reserve on the Readium fragment container before any WebView paints.
+// Paginated reflowable only. In scroll mode the container fills the screen and the WebView sits
+// permanently below topPx — content scrolls inside the WebView, not the container, so that gap
+// never closes (permanent white strip). Fixed-layout pages are pre-sized; padding would letterbox
+// them.
+//
+// Top is 0.8× the horizontal gutter (~16dp base), bottom 1.0× (~20dp), both scaling with the
+// user's margins preference — matching the ratio of the old :root padding override that was
+// replaced by this static approach to fix the "page falls from above" bug (#175).
+internal fun readerContainerPaddingPx(
+    margins: Float,
+    density: Float,
+    isFixedLayout: Boolean,
+    isScrollMode: Boolean,
+): Pair<Int, Int> {
+    if (isFixedLayout || isScrollMode) return 0 to 0
+    val top = (16f * margins * density + 0.5f).toInt()
+    val bottom = (20f * margins * density + 0.5f).toInt()
+    return top to bottom
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/TypographyOverride.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/TypographyOverride.kt
@@ -72,12 +72,13 @@ internal val TYPOGRAPHY_OVERRIDES: Map<String, TypographyOverride> = mapOf(
  * maintainers don't accidentally add a field to this list as a way of silencing the test.
  */
 internal val EXCLUDED_FROM_TYPOGRAPHY_OVERRIDES: Map<String, String> = mapOf(
-    "margins" to "Page margins come from Readium's pre-paint layout: left/right from its built-in body " +
-        "padding (scales with --USER__pageMargins), top/bottom from its native container vertical padding " +
-        "(readium_navigator_epub_vertical_padding). We deliberately do NOT inject a :root padding override " +
-        "for the top/bottom margin: injected in onPageLoaded it lands AFTER first paint, so the page visibly " +
-        "dropped by the margin amount on every chapter start (the 'page falls from above' bug). Letting " +
-        "Readium own the vertical margin keeps it applied before the page is revealed, with no reflow.",
+    "margins" to "Page margins: left/right come from Readium's built-in body padding (scales with " +
+        "--USER__pageMargins). Top/bottom in PAGINATED mode come from static padding on our fragment " +
+        "container (applied before any WebView paints, so no reflow). In SCROLL mode no container " +
+        "padding is applied — container padding would create a permanent white strip because the WebView " +
+        "sits below topPx and content scrolls inside it (the gap never closes). We do NOT inject a " +
+        ":root override for top/bottom: in paginated mode that injected AFTER first paint, causing the " +
+        "'page falls from above' bug.",
     "fontSize" to "Applied via root-em multiplier; a per-element override would flatten the publisher's size hierarchy.",
     "theme" to "Multi-property (background, text colour, link colour, image filters) — handled by Readium's theme stylesheet, not a single override.",
     "orientation" to "Layout/scroll mode, not a CSS property.",

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ReaderContainerPaddingTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ReaderContainerPaddingTest.kt
@@ -1,0 +1,91 @@
+package com.riffle.app.feature.reader
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * [readerContainerPaddingPx] reserves a stable top/bottom margin on the Readium fragment
+ * container in paginated reflowable mode only. In scroll mode the container fills the screen
+ * and the WebView sits permanently below topPx — content scrolls *inside* the WebView so that
+ * gap never closes, producing a permanent white strip (regression in #175).
+ */
+class ReaderContainerPaddingTest {
+
+    private val density = 3f
+
+    // Regression guard for the #175 bug: scroll mode must produce zero container padding.
+    // Applying padding in scroll mode shifts the WebView below the container top permanently
+    // (content scrolls inside the WebView, not the container), leaving a visible white strip.
+    @Test
+    fun `scroll mode produces zero padding regardless of margins setting`() {
+        val (top, bottom) = readerContainerPaddingPx(
+            margins = 1.5f,
+            density = density,
+            isFixedLayout = false,
+            isScrollMode = true,
+        )
+        assertEquals("top must be 0 in scroll mode", 0, top)
+        assertEquals("bottom must be 0 in scroll mode", 0, bottom)
+    }
+
+    @Test
+    fun `fixed-layout produces zero padding regardless of scroll mode`() {
+        val paginated = readerContainerPaddingPx(
+            margins = 1.0f, density = density, isFixedLayout = true, isScrollMode = false,
+        )
+        val scroll = readerContainerPaddingPx(
+            margins = 1.0f, density = density, isFixedLayout = true, isScrollMode = true,
+        )
+        assertEquals(0, paginated.first)
+        assertEquals(0, paginated.second)
+        assertEquals(0, scroll.first)
+        assertEquals(0, scroll.second)
+    }
+
+    @Test
+    fun `paginated reflowable produces non-zero padding`() {
+        val (top, bottom) = readerContainerPaddingPx(
+            margins = 1.0f,
+            density = density,
+            isFixedLayout = false,
+            isScrollMode = false,
+        )
+        assertTrue("top must be > 0 for paginated reflowable", top > 0)
+        assertTrue("bottom must be > 0 for paginated reflowable", bottom > 0)
+    }
+
+    @Test
+    fun `top scales with margins preference`() {
+        val (top1, _) = readerContainerPaddingPx(margins = 1.0f, density = density, isFixedLayout = false, isScrollMode = false)
+        val (top2, _) = readerContainerPaddingPx(margins = 2.0f, density = density, isFixedLayout = false, isScrollMode = false)
+        assertTrue("top at margins=2.0 must exceed top at margins=1.0", top2 > top1)
+    }
+
+    @Test
+    fun `bottom is larger than top at same margins (1_0x vs 0_8x ratio)`() {
+        val (top, bottom) = readerContainerPaddingPx(
+            margins = 1.0f, density = density, isFixedLayout = false, isScrollMode = false,
+        )
+        assertTrue("bottom (1.0×) must exceed top (0.8×)", bottom > top)
+    }
+
+    // Concrete pixel values for density=3 and margins=1.0: top=16*1.0*3=48px, bottom=20*1.0*3=60px.
+    @Test
+    fun `produces expected pixel values at density 3 and margins 1_0`() {
+        val (top, bottom) = readerContainerPaddingPx(
+            margins = 1.0f, density = 3f, isFixedLayout = false, isScrollMode = false,
+        )
+        assertEquals(48, top)
+        assertEquals(60, bottom)
+    }
+
+    @Test
+    fun `zero margins yields zero padding even in paginated mode`() {
+        val (top, bottom) = readerContainerPaddingPx(
+            margins = 0f, density = density, isFixedLayout = false, isScrollMode = false,
+        )
+        assertEquals(0, top)
+        assertEquals(0, bottom)
+    }
+}


### PR DESCRIPTION
## What

In scroll mode, the ebook reader showed a permanent white strip at the top of the screen.

## Root cause

PR #175 fixed the "page falls from above" bug by moving vertical margin management from a `:root` CSS injection (post-paint, causing reflow) to static `padding-top`/`padding-bottom` on the Readium fragment container (pre-paint, stable). The fix correctly gated on `!isFixedLayout` but didn't exclude scroll mode.

In **paginated** mode, container padding is correct: the top edge of the container is off-screen between page turns, so `topPx` becomes the stable top margin of each page.

In **scroll** mode, the container fills the screen and the WebView is positioned permanently `topPx` below the container's top edge. Content scrolls *inside* the WebView — the container never moves — so that gap is always visible as a white strip.

## Fix

Gate `readerContainerPaddingPx` on `!isFixedLayout && !isScrollMode`. The "falls from above" bug was specific to paginated mode (discrete `onPageLoaded` per chapter); scroll mode has no such page-boundary reflow trigger.

The padding calculation is extracted into `ReaderContainerPadding.kt` so the scroll-mode zero and the paginated scaling are both unit-tested.

## Testing

- `ReaderContainerPaddingTest`: scroll mode → 0 padding; paginated reflowable → scaled by margins preference; fixed-layout → 0 in both orientations; concrete pixel values at density=3.
- `./gradlew test` ✓ — `./gradlew lint` ✓ — `make harness-test` ✓ — `make harness-test-tablet` ✓