### PR TITLE
feat(library): dynamic two-row section preview for + X more tile

### DIFF
--- a/app/src/androidTest/kotlin/com/riffle/app/feature/library/BookSectionGridTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/library/BookSectionGridTest.kt
@@ -5,7 +5,6 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithContentDescription
-import androidx.compose.ui.test.onNode
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.riffle.core.domain.EbookFormat
 import com.riffle.core.domain.LibraryItem

--- a/app/src/androidTest/kotlin/com/riffle/app/feature/library/BookSectionGridTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/library/BookSectionGridTest.kt
@@ -1,0 +1,123 @@
+package com.riffle.app.feature.library
+
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithContentDescription
+import androidx.compose.ui.test.onNode
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.riffle.core.domain.EbookFormat
+import com.riffle.core.domain.LibraryItem
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Verifies that [BookSectionGrid] applies the two-row dynamic preview rule:
+ * show cols×2−1 cover tiles then a SeeMore tile that fills the last slot of
+ * row 2 (never orphaned on its own row).
+ */
+@RunWith(AndroidJUnit4::class)
+class BookSectionGridTest {
+
+    @get:Rule
+    val rule = createComposeRule()
+
+    // ── helpers ───────────────────────────────────────────────────────────────
+
+    private fun fakeItems(n: Int) = List(n) { i ->
+        LibraryItem(
+            id = "$i",
+            libraryId = "lib",
+            title = "Book $i",
+            author = "Author",
+            coverUrl = null,
+            readingProgress = 0f,
+            isCached = false,
+            isDownloaded = false,
+            ebookFormat = EbookFormat.Epub,
+        )
+    }
+
+    private fun setGridContent(itemCount: Int, onSeeMore: (() -> Unit)?) {
+        rule.setContent {
+            CompositionLocalProvider(LocalCoverGridScale provides 1f) {
+                BookSectionGrid(
+                    items = fakeItems(itemCount),
+                    token = "",
+                    onItemSelected = {},
+                    onSeeMore = onSeeMore,
+                )
+            }
+        }
+    }
+
+    // ── presence / absence of the SeeMore tile ────────────────────────────────
+
+    @Test
+    fun seeMoreAppearsWhenItemsExceedTwoRowCapacity() {
+        // 20 items far exceeds any 2-row limit (max preview ≈ 15 at 0.7× tablet)
+        setGridContent(itemCount = 20, onSeeMore = {})
+        rule.onNode(hasText("more", substring = true)).assertIsDisplayed()
+    }
+
+    @Test
+    fun seeMoreAbsentWhenItemsCountIsOne() {
+        setGridContent(itemCount = 1, onSeeMore = {})
+        assertTrue(
+            "SeeMore should not appear for a single item",
+            rule.onAllNodes(hasText("more", substring = true)).fetchSemanticsNodes().isEmpty(),
+        )
+    }
+
+    @Test
+    fun seeMoreAbsentWhenCallbackIsNull() {
+        // null onSeeMore means the caller wants all items displayed
+        setGridContent(itemCount = 20, onSeeMore = null)
+        assertTrue(
+            "SeeMore should not appear when onSeeMore is null",
+            rule.onAllNodes(hasText("more", substring = true)).fetchSemanticsNodes().isEmpty(),
+        )
+    }
+
+    // ── no-orphan: SeeMore tile shares its row with ≥ 1 cover tile ───────────
+
+    @Test
+    fun seeMoreTileSharesRowWithAtLeastOneCoverTile() {
+        setGridContent(itemCount = 20, onSeeMore = {})
+
+        val seeMoreNode = rule.onNode(hasText("more", substring = true)).fetchSemanticsNode()
+        val seeMoreTop = seeMoreNode.boundsInRoot.top
+
+        // BookCoverTile uses contentDescription = item.title → "Book 0", "Book 1", …
+        val coverNodes = rule
+            .onAllNodesWithContentDescription("Book", substring = true)
+            .fetchSemanticsNodes()
+
+        val coversSameRow = coverNodes.count { it.boundsInRoot.top == seeMoreTop }
+        assertTrue(
+            "SeeMore should share its row with ≥ 1 cover tile (was alone), " +
+                "seeMoreTop=$seeMoreTop, coverTops=${coverNodes.map { it.boundsInRoot.top }}",
+            coversSameRow >= 1,
+        )
+    }
+
+    // ── overflow count in the tile label ─────────────────────────────────────
+
+    @Test
+    fun seeMoreDisplaysCorrectOverflowCount() {
+        // Render with 20 items. Count how many cover tiles are actually visible, then
+        // derive the expected overflow and check the tile's text.
+        setGridContent(itemCount = 20, onSeeMore = {})
+
+        val coverNodes = rule
+            .onAllNodesWithContentDescription("Book", substring = true)
+            .fetchSemanticsNodes()
+        val shown = coverNodes.size
+        val expectedOverflow = 20 - shown
+
+        rule.onNode(hasText("+$expectedOverflow", substring = true)).assertIsDisplayed()
+    }
+}

--- a/app/src/androidTest/kotlin/com/riffle/app/feature/library/BookSectionGridTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/library/BookSectionGridTest.kt
@@ -73,12 +73,19 @@ class BookSectionGridTest {
     }
 
     @Test
-    fun seeMoreAbsentWhenCallbackIsNull() {
-        // null onSeeMore means the caller wants all items displayed
+    fun seeMoreAbsentAndAllItemsShownWhenCallbackIsNull() {
+        // null onSeeMore: no tile, and all items must be displayed (no truncation)
         setGridContent(itemCount = 20, onSeeMore = null)
         assertTrue(
             "SeeMore should not appear when onSeeMore is null",
             rule.onAllNodes(hasText("more", substring = true)).fetchSemanticsNodes().isEmpty(),
+        )
+        val coverNodes = rule
+            .onAllNodesWithContentDescription("Book", substring = true)
+            .fetchSemanticsNodes()
+        assertTrue(
+            "All 20 items should be visible when onSeeMore is null, got ${coverNodes.size}",
+            coverNodes.size == 20,
         )
     }
 

--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsScreen.kt
@@ -346,7 +346,7 @@ fun BookSectionGrid(
         val columns = max(1, floor((maxWidth + spacing) / (minCell + spacing)).toInt())
         val previewCount = max(1, columns * 2 - 1)
         val showSeeMore = onSeeMore != null && items.size > previewCount
-        val preview = items.take(previewCount)
+        val preview = if (onSeeMore != null) items.take(previewCount) else items
         val overflowCount = items.size - previewCount
         CoverGridLayout(
             count = preview.size + (if (showSeeMore) 1 else 0),
@@ -376,7 +376,7 @@ fun SeriesSectionGrid(
         val columns = max(1, floor((maxWidth + spacing) / (minCell + spacing)).toInt())
         val previewCount = max(1, columns * 2 - 1)
         val showSeeMore = onSeeMore != null && items.size > previewCount
-        val preview = items.take(previewCount)
+        val preview = if (onSeeMore != null) items.take(previewCount) else items
         val overflowCount = items.size - previewCount
         CoverGridLayout(
             count = preview.size + (if (showSeeMore) 1 else 0),
@@ -407,7 +407,7 @@ fun CollectionsSectionGrid(
         val columns = max(1, floor((maxWidth + spacing) / (minCell + spacing)).toInt())
         val previewCount = max(1, columns * 2 - 1)
         val showSeeMore = onSeeMore != null && items.size > previewCount
-        val preview = items.take(previewCount)
+        val preview = if (onSeeMore != null) items.take(previewCount) else items
         val overflowCount = items.size - previewCount
         CoverGridLayout(
             count = preview.size + (if (showSeeMore) 1 else 0),
@@ -453,23 +453,6 @@ private fun CoverGridLayout(
                 }
             }
         }
-    }
-}
-
-@Composable
-private fun CoverGrid(
-    count: Int,
-    modifier: Modifier = Modifier,
-    content: @Composable (index: Int) -> Unit,
-) {
-    val minCell = shelfCoverMinCellSize()
-    val spacing = 8.dp
-    // Mirror GridCells.Adaptive: as many columns as fit at >= minCell, then split
-    // the row evenly. Driven off the same shelf sizing as the To Read grid so the
-    // home previews reflow to ~4 covers on a phone and ~5-6 on a tablet.
-    BoxWithConstraints(modifier = modifier) {
-        val columns = max(1, floor((maxWidth + spacing) / (minCell + spacing)).toInt())
-        CoverGridLayout(count = count, columns = columns, spacing = spacing, content = content)
     }
 }
 

--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsScreen.kt
@@ -86,6 +86,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
@@ -101,7 +102,6 @@ import com.riffle.core.domain.Series
 import kotlin.math.floor
 import kotlin.math.max
 
-private const val SECTION_PREVIEW_LIMIT = 5
 
 /**
  * True within an audiobooks-only library, so cover tiles that carry no per-item audio signal —
@@ -340,17 +340,25 @@ fun BookSectionGrid(
     onSeeMore: (() -> Unit)? = null,
     linkedItemIds: Set<String> = emptySet(),
 ) {
-    val preview = if (onSeeMore != null) items.take(SECTION_PREVIEW_LIMIT) else items
-    val overflowCount = items.size - SECTION_PREVIEW_LIMIT
-    CoverGrid(
-        count = preview.size + (if (onSeeMore != null) 1 else 0),
-        modifier = Modifier.padding(horizontal = 12.dp),
-    ) { index ->
-        if (onSeeMore != null && index == preview.size) {
-            SeeMoreTile(overflowCount = overflowCount, onClick = onSeeMore)
-        } else {
-            val item = preview[index]
-            BookCoverTile(item = item, token = token, onClick = { onItemSelected(item) }, hasReadaloudLink = item.id in linkedItemIds)
+    val minCell = shelfCoverMinCellSize()
+    val spacing = 8.dp
+    BoxWithConstraints(Modifier.padding(horizontal = 12.dp)) {
+        val columns = max(1, floor((maxWidth + spacing) / (minCell + spacing)).toInt())
+        val previewCount = max(1, columns * 2 - 1)
+        val showSeeMore = onSeeMore != null && items.size > previewCount
+        val preview = items.take(previewCount)
+        val overflowCount = items.size - previewCount
+        CoverGridLayout(
+            count = preview.size + (if (showSeeMore) 1 else 0),
+            columns = columns,
+            spacing = spacing,
+        ) { index ->
+            if (showSeeMore && index == preview.size) {
+                SeeMoreTile(overflowCount = overflowCount, onClick = onSeeMore!!)
+            } else {
+                val item = preview[index]
+                BookCoverTile(item = item, token = token, onClick = { onItemSelected(item) }, hasReadaloudLink = item.id in linkedItemIds)
+            }
         }
     }
 }
@@ -362,17 +370,25 @@ fun SeriesSectionGrid(
     onSeriesSelected: (Series) -> Unit,
     onSeeMore: (() -> Unit)? = null,
 ) {
-    val preview = if (onSeeMore != null) items.take(SECTION_PREVIEW_LIMIT) else items
-    val overflowCount = items.size - SECTION_PREVIEW_LIMIT
-    CoverGrid(
-        count = preview.size + (if (onSeeMore != null) 1 else 0),
-        modifier = Modifier.padding(horizontal = 12.dp),
-    ) { index ->
-        if (onSeeMore != null && index == preview.size) {
-            SeeMoreTile(overflowCount = overflowCount, onClick = onSeeMore)
-        } else {
-            val s = preview[index]
-            SeriesCoverTile(series = s, token = token, onClick = { onSeriesSelected(s) })
+    val minCell = shelfCoverMinCellSize()
+    val spacing = 8.dp
+    BoxWithConstraints(Modifier.padding(horizontal = 12.dp)) {
+        val columns = max(1, floor((maxWidth + spacing) / (minCell + spacing)).toInt())
+        val previewCount = max(1, columns * 2 - 1)
+        val showSeeMore = onSeeMore != null && items.size > previewCount
+        val preview = items.take(previewCount)
+        val overflowCount = items.size - previewCount
+        CoverGridLayout(
+            count = preview.size + (if (showSeeMore) 1 else 0),
+            columns = columns,
+            spacing = spacing,
+        ) { index ->
+            if (showSeeMore && index == preview.size) {
+                SeeMoreTile(overflowCount = overflowCount, onClick = onSeeMore!!)
+            } else {
+                val s = preview[index]
+                SeriesCoverTile(series = s, token = token, onClick = { onSeriesSelected(s) })
+            }
         }
     }
 }
@@ -385,27 +401,60 @@ fun CollectionsSectionGrid(
     onCollectionSelected: (Collection) -> Unit,
     onSeeMore: (() -> Unit)? = null,
 ) {
-    val preview = if (onSeeMore != null) items.take(SECTION_PREVIEW_LIMIT) else items
-    val overflowCount = items.size - SECTION_PREVIEW_LIMIT
-    CoverGrid(
-        count = preview.size + (if (onSeeMore != null) 1 else 0),
-        modifier = Modifier.padding(horizontal = 12.dp),
-    ) { index ->
-        if (onSeeMore != null && index == preview.size) {
-            SeeMoreTile(overflowCount = overflowCount, onClick = onSeeMore)
-        } else {
-            val col = preview[index]
-            CollectionCoverTile(
-                collection = col,
-                coverUrls = coverUrls[col.id].orEmpty(),
-                token = token,
-                onClick = { onCollectionSelected(col) },
-            )
+    val minCell = shelfCoverMinCellSize()
+    val spacing = 8.dp
+    BoxWithConstraints(Modifier.padding(horizontal = 12.dp)) {
+        val columns = max(1, floor((maxWidth + spacing) / (minCell + spacing)).toInt())
+        val previewCount = max(1, columns * 2 - 1)
+        val showSeeMore = onSeeMore != null && items.size > previewCount
+        val preview = items.take(previewCount)
+        val overflowCount = items.size - previewCount
+        CoverGridLayout(
+            count = preview.size + (if (showSeeMore) 1 else 0),
+            columns = columns,
+            spacing = spacing,
+        ) { index ->
+            if (showSeeMore && index == preview.size) {
+                SeeMoreTile(overflowCount = overflowCount, onClick = onSeeMore!!)
+            } else {
+                val col = preview[index]
+                CollectionCoverTile(
+                    collection = col,
+                    coverUrls = coverUrls[col.id].orEmpty(),
+                    token = token,
+                    onClick = { onCollectionSelected(col) },
+                )
+            }
         }
     }
 }
 
 // --- Generic adaptive cover grid layout ---
+
+@Composable
+private fun CoverGridLayout(
+    count: Int,
+    columns: Int,
+    spacing: Dp = 8.dp,
+    content: @Composable (index: Int) -> Unit,
+) {
+    val rows = (count + columns - 1) / columns
+    Column(verticalArrangement = Arrangement.spacedBy(spacing)) {
+        for (row in 0 until rows) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(spacing),
+            ) {
+                for (col in 0 until columns) {
+                    val index = row * columns + col
+                    Box(modifier = Modifier.weight(1f)) {
+                        if (index < count) content(index)
+                    }
+                }
+            }
+        }
+    }
+}
 
 @Composable
 private fun CoverGrid(
@@ -420,22 +469,7 @@ private fun CoverGrid(
     // home previews reflow to ~4 covers on a phone and ~5-6 on a tablet.
     BoxWithConstraints(modifier = modifier) {
         val columns = max(1, floor((maxWidth + spacing) / (minCell + spacing)).toInt())
-        val rows = (count + columns - 1) / columns
-        Column(verticalArrangement = Arrangement.spacedBy(spacing)) {
-            for (row in 0 until rows) {
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.spacedBy(spacing),
-                ) {
-                    for (col in 0 until columns) {
-                        val index = row * columns + col
-                        Box(modifier = Modifier.weight(1f)) {
-                            if (index < count) content(index)
-                        }
-                    }
-                }
-            }
-        }
+        CoverGridLayout(count = count, columns = columns, spacing = spacing, content = content)
     }
 }
 
@@ -989,9 +1023,7 @@ private fun HomeTabContent(
                     items = inProgress,
                     token = token,
                     onItemSelected = onItemSelected,
-                    onSeeMore = if (inProgress.size > SECTION_PREVIEW_LIMIT + 1) {
-                        { onSectionSeeMore(LibrarySectionType.IN_PROGRESS) }
-                    } else null,
+                    onSeeMore = { onSectionSeeMore(LibrarySectionType.IN_PROGRESS) },
                     linkedItemIds = linkedItemIds,
                 )
             }
@@ -1003,9 +1035,7 @@ private fun HomeTabContent(
                     items = recentlyAdded,
                     token = token,
                     onItemSelected = onItemSelected,
-                    onSeeMore = if (recentlyAdded.size > SECTION_PREVIEW_LIMIT + 1) {
-                        { onSectionSeeMore(LibrarySectionType.RECENTLY_ADDED) }
-                    } else null,
+                    onSeeMore = { onSectionSeeMore(LibrarySectionType.RECENTLY_ADDED) },
                     linkedItemIds = linkedItemIds,
                 )
             }
@@ -1017,9 +1047,7 @@ private fun HomeTabContent(
                     items = finished,
                     token = token,
                     onItemSelected = onItemSelected,
-                    onSeeMore = if (finished.size > SECTION_PREVIEW_LIMIT + 1) {
-                        { onSectionSeeMore(LibrarySectionType.FINISHED) }
-                    } else null,
+                    onSeeMore = { onSectionSeeMore(LibrarySectionType.FINISHED) },
                     linkedItemIds = linkedItemIds,
                 )
             }

--- a/app/src/test/kotlin/com/riffle/app/feature/library/SectionPreviewCountTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/SectionPreviewCountTest.kt
@@ -1,0 +1,112 @@
+package com.riffle.app.feature.library
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import kotlin.math.floor
+import kotlin.math.max
+
+/**
+ * Verifies the column/preview-count arithmetic used by [BookSectionGrid] and friends.
+ * No Compose infrastructure needed — the formula is pure math.
+ *
+ * Rule: show max(1, cols × 2 − 1) items then the SeeMore tile, so the SeeMore tile
+ * always fills the last slot of the second row (never orphaned on its own row).
+ */
+class SectionPreviewCountTest {
+
+    // Mirrors the formula in BookSectionGrid / CoverGrid.
+    private fun columns(availableWidthDp: Float, minCellDp: Float, spacingDp: Float = 8f): Int =
+        max(1, floor((availableWidthDp + spacingDp) / (minCellDp + spacingDp)).toInt())
+
+    private fun previewCount(cols: Int): Int = max(1, cols * 2 - 1)
+
+    // ── Column counts for canonical screen sizes ──────────────────────────────
+
+    @Test
+    fun `typical phone 412dp gives 3 columns`() {
+        // 412dp screen − 24dp horizontal padding = 388dp available
+        // floor((388 + 8) / (112 + 8)) = floor(3.3) = 3
+        assertEquals(3, columns(availableWidthDp = 388f, minCellDp = 112f))
+    }
+
+    @Test
+    fun `typical tablet 840dp gives 5 columns`() {
+        // 840dp screen − 24dp padding = 816dp available, tablet min cell = 140dp
+        // floor((816 + 8) / (140 + 8)) = floor(5.57) = 5
+        assertEquals(5, columns(availableWidthDp = 816f, minCellDp = 140f))
+    }
+
+    @Test
+    fun `very narrow container falls back to 1 column`() {
+        assertEquals(1, columns(availableWidthDp = 60f, minCellDp = 112f))
+    }
+
+    // ── Preview counts ────────────────────────────────────────────────────────
+
+    @Test
+    fun `phone 3 columns yields preview of 5`() {
+        assertEquals(5, previewCount(3))
+    }
+
+    @Test
+    fun `tablet 5 columns yields preview of 9`() {
+        assertEquals(9, previewCount(5))
+    }
+
+    @Test
+    fun `single column yields preview of 1`() {
+        // max(1, 1×2−1) = max(1, 1) = 1
+        assertEquals(1, previewCount(1))
+    }
+
+    // ── No-orphan invariant ───────────────────────────────────────────────────
+
+    @Test
+    fun `seeMore tile always fills last slot in its row for any column count`() {
+        // With cols columns, previewCount = cols×2−1, so total slots = cols×2.
+        // cols×2 is always a multiple of cols → SeeMore lands at end of row 2, never alone.
+        for (cols in 1..10) {
+            val preview = previewCount(cols)
+            val totalSlots = preview + 1 // covers + SeeMore tile
+            assertEquals(
+                "cols=$cols: SeeMore tile at slot $totalSlots should end a complete row",
+                0, totalSlots % cols,
+            )
+        }
+    }
+
+    // ── SeeMore show/hide boundary ────────────────────────────────────────────
+
+    @Test
+    fun `seeMore shown only when items exceed preview count`() {
+        val cols = 3
+        val preview = previewCount(cols) // 5
+
+        assertTrue("6 items should trigger SeeMore", 6 > preview)
+        assertFalse("5 items exactly fits — no SeeMore", 5 > preview)
+        assertFalse("4 items fits — no SeeMore", 4 > preview)
+    }
+
+    @Test
+    fun `seeMore is shown at maximum pinch-zoom scale`() {
+        // At 1.6× scale the min cell grows; column count shrinks; preview shrinks too.
+        // Enough items (20) should still produce a SeeMore tile.
+        val scaledMinCell = 112f * 1.6f // 179.2dp
+        val cols = columns(availableWidthDp = 388f, minCellDp = scaledMinCell)
+        assertTrue("expect ≥ 1 column", cols >= 1)
+        val preview = previewCount(cols)
+        assertTrue("20 items should exceed preview at max zoom", 20 > preview)
+    }
+
+    @Test
+    fun `seeMore is shown at minimum pinch-zoom scale`() {
+        // At 0.7× scale cells are smaller, more columns, larger preview.
+        // 20 items should still overflow.
+        val scaledMinCell = 112f * 0.7f // 78.4dp
+        val cols = columns(availableWidthDp = 388f, minCellDp = scaledMinCell)
+        val preview = previewCount(cols)
+        assertTrue("20 items should exceed preview at min zoom", 20 > preview)
+    }
+}


### PR DESCRIPTION
## Summary

- Replaces the hardcoded `SECTION_PREVIEW_LIMIT = 5` with a column-aware rule: show `cols × 2 − 1` covers then the SeeMore tile, so it always fills the last slot of row 2 and is never orphaned on its own row
- On a phone (3 cols) the preview stays at 5 — matching the old value. On a 5-column tablet it expands to 9, eliminating the lone-tile-on-row-2 bug
- `CoverGridLayout` extracted from `CoverGrid` so section grids can share the layout logic while computing their own column/preview counts; dead `CoverGrid` removed
- Home tab sections now pass `onSeeMore` unconditionally; the section grid decides internally whether to render the tile based on actual column capacity

## Test plan

- `SectionPreviewCountTest` — JVM unit tests for column/preview-count arithmetic and the no-orphan invariant
- `BookSectionGridTest` — Compose instrumented tests: SeeMore appears with overflow, is absent for one item, is absent (and all items shown) when `onSeeMore=null`, shares its row with ≥ 1 cover tile, and shows the correct overflow count
- `AdaptiveCoverGridTest` (@TabletLayout) — existing tablet grid test, still green
- `./gradlew test` — full JVM suite green
- `./gradlew lint` — clean
- `make harness-test` (phone AVD) — green
- `make harness-test-tablet` (tablet AVD) — green