### PR TITLE
feat(player): rewind-15s and forward-30s in media notification

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookController.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookController.kt
@@ -91,6 +91,7 @@ open class AudiobookController @Inject constructor(
         durationSec: Double,
         startAtSec: Double,
         localZipFile: File? = null,
+        coverUri: String? = null,
     ) {
         this.spans = spans
         this.durationSec = durationSec
@@ -100,8 +101,11 @@ open class AudiobookController @Inject constructor(
         ownsSharedBundle = localZipFile != null
         if (localZipFile != null) SharedBundle.current = localZipFile
         val c = ensureConnected() ?: return
+        val metadata = androidx.media3.common.MediaMetadata.Builder()
+            .apply { if (coverUri != null) setArtworkUri(android.net.Uri.parse(coverUri)) }
+            .build()
         val items = trackUrls.map { url ->
-            MediaItem.Builder().setMediaId(url).setUri(url).build()
+            MediaItem.Builder().setMediaId(url).setUri(url).setMediaMetadata(metadata).build()
         }
         // Seed the start position *into* setMediaItems rather than seeking after prepare(): a seek
         // after prepare() lets ExoPlayer briefly buffer/play the first track from 0 before the seek

--- a/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModel.kt
@@ -496,6 +496,7 @@ class AudiobookPlayerViewModel(
                 durationSec = session.timeline.durationSec,
                 startAtSec = resumeSec,
                 localZipFile = session.localZipFile,
+                coverUri = item.coverUrl,
             )
             // Record the active session so a media-notification tap reopens this audiobook player.
             nowPlayingStore.set(com.riffle.app.playback.NowPlaying.Audiobook(itemId))

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/AudioPlayerService.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/AudioPlayerService.kt
@@ -3,6 +3,7 @@ package com.riffle.app.feature.reader.readaloud
 import android.app.PendingIntent
 import android.content.Intent
 import android.net.Uri
+import android.os.Bundle
 import com.riffle.app.MainActivity
 import androidx.annotation.OptIn
 import androidx.media3.common.AudioAttributes
@@ -13,9 +14,13 @@ import androidx.media3.datasource.DataSource
 import androidx.media3.datasource.DefaultHttpDataSource
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
+import androidx.media3.session.CommandButton
 import androidx.media3.session.DefaultMediaNotificationProvider
 import androidx.media3.session.MediaSession
 import androidx.media3.session.MediaSessionService
+import androidx.media3.session.SessionCommand
+import androidx.media3.session.SessionResult
+import com.google.common.collect.ImmutableList
 import com.google.common.util.concurrent.Futures
 import com.google.common.util.concurrent.ListenableFuture
 import com.riffle.app.R
@@ -90,6 +95,8 @@ class AudioPlayerService : MediaSessionService() {
      * from it (see [ZipAudioDataSource]).
      */
     private object MediaItemUriRestoringCallback : MediaSession.Callback {
+
+        // ── existing override (unchanged) ──────────────────────────────────────
         override fun onAddMediaItems(
             mediaSession: MediaSession,
             controller: MediaSession.ControllerInfo,
@@ -111,6 +118,55 @@ class AudioPlayerService : MediaSessionService() {
                 }
             }.toMutableList()
             return Futures.immediateFuture(restored)
+        }
+
+        // ── new: advertise commands and set the two-button notification layout ──
+        override fun onConnect(
+            session: MediaSession,
+            controller: MediaSession.ControllerInfo,
+        ): MediaSession.ConnectionResult {
+            val commands = MediaSession.ConnectionResult.DEFAULT_SESSION_AND_LIBRARY_COMMANDS
+                .buildUpon()
+                .add(CMD_REWIND)
+                .add(CMD_FORWARD)
+                .build()
+
+            val rewindButton = CommandButton.Builder(CommandButton.ICON_SKIP_BACK_15)
+                .setDisplayName("Rewind 15 seconds")
+                .setSessionCommand(CMD_REWIND)
+                .build()
+
+            val forwardButton = CommandButton.Builder(CommandButton.ICON_SKIP_FORWARD_30)
+                .setDisplayName("Forward 30 seconds")
+                .setSessionCommand(CMD_FORWARD)
+                .build()
+
+            return MediaSession.ConnectionResult.AcceptedResultBuilder(session)
+                .setAvailableSessionCommands(commands)
+                .setCustomLayout(ImmutableList.of(rewindButton, forwardButton))
+                .build()
+        }
+
+        // ── new: dispatch custom button taps to the player ──────────────────────
+        override fun onCustomCommand(
+            session: MediaSession,
+            controller: MediaSession.ControllerInfo,
+            customCommand: SessionCommand,
+            args: Bundle,
+        ): ListenableFuture<SessionResult> {
+            val player = session.player
+            when (customCommand.customAction) {
+                CMD_REWIND.customAction -> {
+                    val target = (player.currentPosition - 15_000L).coerceAtLeast(0L)
+                    player.seekTo(target)
+                }
+                CMD_FORWARD.customAction -> {
+                    val target = player.currentPosition + 30_000L
+                    val duration = player.duration
+                    player.seekTo(if (duration != C.TIME_UNSET) target.coerceAtMost(duration) else target)
+                }
+            }
+            return Futures.immediateFuture(SessionResult(SessionResult.RESULT_SUCCESS))
         }
     }
 
@@ -173,5 +229,10 @@ class AudioPlayerService : MediaSessionService() {
         }
         mediaSession = null
         super.onDestroy()
+    }
+
+    companion object {
+        val CMD_REWIND  = SessionCommand("com.riffle.REWIND_15",  Bundle.EMPTY)
+        val CMD_FORWARD = SessionCommand("com.riffle.FORWARD_30", Bundle.EMPTY)
     }
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/AudioPlayerService.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/AudioPlayerService.kt
@@ -14,6 +14,7 @@ import androidx.media3.datasource.DataSource
 import androidx.media3.datasource.DefaultHttpDataSource
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
+import androidx.media3.common.Player
 import androidx.media3.session.CommandButton
 import androidx.media3.session.DefaultMediaNotificationProvider
 import androidx.media3.session.MediaSession
@@ -66,6 +67,28 @@ class AudioPlayerService : MediaSessionService() {
             .setCallback(MediaItemUriRestoringCallback)
             .setSessionActivity(openRiffleIntent())
             .build()
+            .also { session ->
+                // setMediaButtonPreferences controls the exact button order in the notification and
+                // lock-screen player across all Android versions — slot hints on CommandButton are
+                // only honoured on API 33+. Listing rewind + play/pause + forward here gives the
+                // desired ⟲15 · ▶/⏸ · ⟳30 layout without a custom notification provider.
+                session.setMediaButtonPreferences(
+                    ImmutableList.of(
+                        CommandButton.Builder(CommandButton.ICON_SKIP_BACK_15)
+                            .setDisplayName("Rewind 15 seconds")
+                            .setSessionCommand(CMD_REWIND)
+                            .build(),
+                        CommandButton.Builder(CommandButton.ICON_UNDEFINED)
+                            .setPlayerCommand(Player.COMMAND_PLAY_PAUSE)
+                            .setDisplayName("Play / Pause")
+                            .build(),
+                        CommandButton.Builder(CommandButton.ICON_SKIP_FORWARD_30)
+                            .setDisplayName("Forward 30 seconds")
+                            .setSessionCommand(CMD_FORWARD)
+                            .build(),
+                    )
+                )
+            }
     }
 
     /**
@@ -119,7 +142,9 @@ class AudioPlayerService : MediaSessionService() {
             return Futures.immediateFuture(restored)
         }
 
-        // ── new: advertise commands and set the two-button notification layout ──
+        // Advertise the two custom seek commands so controllers can dispatch them.
+        // Button ordering is handled by setMediaButtonPreferences() in onCreate() —
+        // setCustomLayout() here is intentionally omitted.
         override fun onConnect(
             session: MediaSession,
             controller: MediaSession.ControllerInfo,
@@ -129,22 +154,8 @@ class AudioPlayerService : MediaSessionService() {
                 .add(CMD_REWIND)
                 .add(CMD_FORWARD)
                 .build()
-
-            val rewindButton = CommandButton.Builder(CommandButton.ICON_SKIP_BACK_15)
-                .setDisplayName("Rewind 15 seconds")
-                .setSessionCommand(CMD_REWIND)
-                .setSlots(CommandButton.SLOT_BACK)
-                .build()
-
-            val forwardButton = CommandButton.Builder(CommandButton.ICON_SKIP_FORWARD_30)
-                .setDisplayName("Forward 30 seconds")
-                .setSessionCommand(CMD_FORWARD)
-                .setSlots(CommandButton.SLOT_FORWARD)
-                .build()
-
             return MediaSession.ConnectionResult.AcceptedResultBuilder(session)
                 .setAvailableSessionCommands(commands)
-                .setCustomLayout(ImmutableList.of(rewindButton, forwardButton))
                 .build()
         }
 

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/AudioPlayerService.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/AudioPlayerService.kt
@@ -133,11 +133,13 @@ class AudioPlayerService : MediaSessionService() {
             val rewindButton = CommandButton.Builder(CommandButton.ICON_SKIP_BACK_15)
                 .setDisplayName("Rewind 15 seconds")
                 .setSessionCommand(CMD_REWIND)
+                .setSlots(CommandButton.SLOT_BACK)
                 .build()
 
             val forwardButton = CommandButton.Builder(CommandButton.ICON_SKIP_FORWARD_30)
                 .setDisplayName("Forward 30 seconds")
                 .setSessionCommand(CMD_FORWARD)
+                .setSlots(CommandButton.SLOT_FORWARD)
                 .build()
 
             return MediaSession.ConnectionResult.AcceptedResultBuilder(session)

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/AudioPlayerService.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/AudioPlayerService.kt
@@ -96,7 +96,6 @@ class AudioPlayerService : MediaSessionService() {
      */
     private object MediaItemUriRestoringCallback : MediaSession.Callback {
 
-        // ── existing override (unchanged) ──────────────────────────────────────
         override fun onAddMediaItems(
             mediaSession: MediaSession,
             controller: MediaSession.ControllerInfo,
@@ -155,18 +154,20 @@ class AudioPlayerService : MediaSessionService() {
             args: Bundle,
         ): ListenableFuture<SessionResult> {
             val player = session.player
-            when (customCommand.customAction) {
+            return when (customCommand.customAction) {
                 CMD_REWIND.customAction -> {
                     val target = (player.currentPosition - 15_000L).coerceAtLeast(0L)
                     player.seekTo(target)
+                    Futures.immediateFuture(SessionResult(SessionResult.RESULT_SUCCESS))
                 }
                 CMD_FORWARD.customAction -> {
                     val target = player.currentPosition + 30_000L
                     val duration = player.duration
                     player.seekTo(if (duration != C.TIME_UNSET) target.coerceAtMost(duration) else target)
+                    Futures.immediateFuture(SessionResult(SessionResult.RESULT_SUCCESS))
                 }
+                else -> super.onCustomCommand(session, controller, customCommand, args)
             }
-            return Futures.immediateFuture(SessionResult(SessionResult.RESULT_SUCCESS))
         }
     }
 

--- a/app/src/test/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModelBookmarkTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModelBookmarkTest.kt
@@ -93,6 +93,7 @@ class AudiobookPlayerViewModelBookmarkTest {
             durationSec: Double,
             startAtSec: Double,
             localZipFile: File?,
+            coverUri: String?,
         ) { /* no-op */ }
         override fun play() {}
         override fun setSpeed(speed: Float) {}


### PR DESCRIPTION
## Summary

- Adds **⟲15 · ▶/⏸ · ⟳30** controls to the Android media notification and lock-screen player for audiobook (and readaloud) playback
- Uses `MediaSession.setMediaButtonPreferences()` to define the exact button order, which works reliably across all Android versions (slot hints on `CommandButton` are only honoured on API 33+)
- Rewind/forward are wired as `SessionCommand`s handled in `MediaSession.Callback.onCustomCommand()` directly on the `ExoPlayer` — no custom notification provider needed
- Passes the book's cover URL (`item.coverUrl`) through `AudiobookController.prepare()` as `MediaMetadata.artworkUri` so the notification shows the book cover

## Test plan

- [x] JVM unit tests (`./gradlew test`) — green
- [x] Lint (`./gradlew lint`) — green
- [x] Harness phone tests (`make harness-test`) — green
- [x] Harness tablet tests (`make harness-test-tablet`) — green
- [ ] Device: expanded notification shows ⟲15 · ▶/⏸ · ⟳30 with book cover
- [ ] Device: lock-screen player shows same 3 controls
- [ ] Device: rewind/forward taps seek correctly; forward clamps at end of book