### PR TITLE
feat(library): show total and remaining time on audiobook detail screen

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemDetailScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemDetailScreen.kt
@@ -372,7 +372,7 @@ private fun LibraryItemDetailContent(
         }
 
         if (item.isListenable && item.audioDurationSec > 0) {
-            AudiobookDurationLine(item.audioDurationSec)
+            AudiobookDurationLine(item.audioDurationSec, item.readingProgress)
         }
 
         if (item.readingProgress > 0f) {
@@ -387,11 +387,19 @@ private fun LibraryItemDetailContent(
     }
 }
 
-/** Total audiobook length on the detail screen (ADR 0029). */
+/** Total audiobook length on the detail screen, with remaining time when in progress (ADR 0029). */
 @Composable
-private fun AudiobookDurationLine(durationSec: Double) {
+private fun AudiobookDurationLine(durationSec: Double, readingProgress: Float = 0f) {
+    val text = when {
+        readingProgress >= READ_PROGRESS_THRESHOLD -> "${formatAudiobookDuration(durationSec)} total"
+        readingProgress > 0f -> {
+            val remainingSec = ((1f - readingProgress) * durationSec).coerceAtLeast(0.0)
+            "${formatAudiobookDuration(durationSec)} total · ${formatAudiobookDuration(remainingSec)} remaining"
+        }
+        else -> "Audiobook · ${formatAudiobookDuration(durationSec)}"
+    }
     Text(
-        text = "Audiobook · ${formatAudiobookDuration(durationSec)}",
+        text = text,
         style = MaterialTheme.typography.bodyMedium,
         color = MaterialTheme.colorScheme.onSurfaceVariant,
     )
@@ -477,7 +485,7 @@ internal fun LibraryItemDetailContentTablet(
             )
             AuthorByline(author = item.author, onAuthorClick = { onFacet(FacetType.AUTHOR, it) })
             if (item.isListenable && item.audioDurationSec > 0) {
-                AudiobookDurationLine(item.audioDurationSec)
+                AudiobookDurationLine(item.audioDurationSec, item.readingProgress)
             }
             if (item.readingProgress > 0f) {
                 ReadingProgressIndicator(progress = item.readingProgress, listened = item.isListenable && !item.isReadable)
@@ -598,7 +606,7 @@ internal fun LibraryItemDetailContentPhoneLandscape(
                 SeriesLine(seriesName = series, seriesId = seriesId, onSeriesClick = onSeriesClick)
             }
             if (item.isListenable && item.audioDurationSec > 0) {
-                AudiobookDurationLine(item.audioDurationSec)
+                AudiobookDurationLine(item.audioDurationSec, item.readingProgress)
             }
             if (item.readingProgress > 0f) {
                 ReadingProgressIndicator(progress = item.readingProgress, listened = item.isListenable && !item.isReadable)

--- a/docs/superpowers/specs/2026-06-14-audiobook-detail-time-labels-design.md
+++ b/docs/superpowers/specs/2026-06-14-audiobook-detail-time-labels-design.md
@@ -1,0 +1,47 @@
+# Audiobook Detail — Total & Remaining Time Labels
+
+## Problem
+
+The item detail screen shows total audiobook duration as `"Audiobook · 12h 4m"`. When the user has started listening, a percentage progress bar reads `"47% listened"` but gives no sense of absolute time left. It's unclear at a glance how much listening remains.
+
+## Goal
+
+Replace the opaque percentage with explicit labeled time, so users can immediately judge "do I have time to finish this?"
+
+## Design
+
+### String format by state
+
+| State | Duration line | Progress indicator |
+|---|---|---|
+| Not started (`readingProgress == 0`) | `"Audiobook · 12h 4m"` (unchanged) | hidden (unchanged) |
+| In-progress (`0 < progress < READ_THRESHOLD`) | `"12h 4m total · 6h 17m remaining"` | unchanged (progress bar + "47% listened") |
+| Finished (`progress ≥ READ_THRESHOLD`) | `"12h 4m total"` | unchanged ("100% listened") |
+
+The "Audiobook ·" prefix is dropped in the in-progress and finished states because the framing shifts from type-identification to time-accounting; context makes the content type obvious.
+
+### Computation
+
+```
+remainingSec = (1f - readingProgress) * durationSec
+```
+
+`readingProgress` is a `Float` in `[0, 1]`. The existing `formatAudiobookDuration(durationSec)` utility is reused for both the total and remaining values.
+
+### Component change
+
+`AudiobookDurationLine(durationSec: Double)` gains a second parameter:
+
+```kotlin
+fun AudiobookDurationLine(durationSec: Double, readingProgress: Float = 0f)
+```
+
+The composable selects the string based on the thresholds above. All three call sites (`LibraryItemDetailContentPhone`, `LibraryItemDetailContentTablet`, and the landscape two-column layout) already have `item.readingProgress` in scope and pass it in.
+
+`READ_PROGRESS_THRESHOLD` (the existing constant) is reused to define the finished boundary.
+
+## Out of scope
+
+- Changing how the progress bar or percentage label looks
+- Any changes to the audiobook player screen's `DualTime` row
+- Ebook reading progress (this change is audiobook-only, gated by `item.isListenable`)


### PR DESCRIPTION
## Summary

- `AudiobookDurationLine` now accepts `readingProgress` and adapts its label to three states:
  - **Not started**: `"Audiobook · 12h 4m"` (unchanged)
  - **In-progress**: `"12h 4m total · 6h 17m remaining"`
  - **Finished**: `"12h 4m total"`
- All three call sites (phone, tablet, phone-landscape) updated to pass `item.readingProgress`.

## Test plan

- [x] `./gradlew test` — JVM unit tests green
- [x] `./gradlew lint` — no new issues
- [x] `make harness-test` — 206 phone harness tests green
- [x] `make harness-test-tablet` — 5 tablet harness tests green