### PR TITLE
fix(connectivity): delay isOnline=true until network is validated

### DIFF
--- a/core/data/src/main/kotlin/com/riffle/core/data/ConnectivityObserverImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/ConnectivityObserverImpl.kt
@@ -52,6 +52,7 @@ class ConnectivityObserverImpl @Inject constructor(
 
         val request = NetworkRequest.Builder()
             .addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+            .addCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED)
             .build()
         connectivityManager.registerNetworkCallback(request, callback)
 


### PR DESCRIPTION
## Summary

- `ConnectivityObserverImpl` registered a `NetworkCallback` with only `NET_CAPABILITY_INTERNET`, so `onAvailable` fired as soon as link-local connectivity was up — before Android's captive-portal probe confirmed actual internet access.
- On sleep-resume, this caused a premature `isOnline=true` emission that triggered the reconnection refresh in `LibraryItemsViewModel`. The network wasn't usable yet, so the refresh failed, `_refreshFailed` flipped `true`, and the only remaining recovery path was the polling loop — which delays 10 s before its first retry.
- Added `NET_CAPABILITY_VALIDATED` to the `NetworkRequest`. Android now withholds `onAvailable` until the internet probe passes, matching the existing `currentOnline()` check exactly. The reconnection refresh fires with a working network, succeeds on the first attempt, and the banner clears immediately.

## Test plan

- [ ] JVM tests: `./gradlew test` — BUILD SUCCESSFUL (85 tasks)
- [ ] Lint: `./gradlew lint` — BUILD SUCCESSFUL
- [ ] Harness phone: `make harness-test` — 206 tests passed on Harness_Medium_Phone (API 25)