### PR TITLE
feat(player): audiobook sleep timer

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/audio/PlayerSurface.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audio/PlayerSurface.kt
@@ -20,12 +20,14 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Bedtime
 import androidx.compose.material.icons.filled.Forward30
 import androidx.compose.material.icons.filled.Pause
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.SkipNext
 import androidx.compose.material.icons.filled.SkipPrevious
 import androidx.compose.material.icons.filled.Speed
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -33,7 +35,12 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import com.riffle.app.feature.audiobook.SleepTimerMode
+import com.riffle.app.feature.audiobook.formatCountdown
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -81,6 +88,7 @@ data class PlayerSurfaceState(
     // ("Audiobook · 10h 53m · Science Fiction"); [description] is the blurb. Both null = nothing shown.
     val facts: String? = null,
     val description: String? = null,
+    val sleepTimer: SleepTimerMode = SleepTimerMode.None,
 )
 
 /** Callbacks the surface invokes. [onSeek] takes an absolute global position in seconds. */
@@ -92,6 +100,8 @@ data class PlayerSurfaceActions(
     val onPreviousChapter: () -> Unit,
     val onNextChapter: () -> Unit,
     val onSpeedChange: (Float) -> Unit,
+    val onSleepTimerSet: (SleepTimerMode) -> Unit,
+    val onSleepTimerCancel: () -> Unit,
 )
 
 /**
@@ -262,10 +272,13 @@ private fun PlayerControls(state: PlayerSurfaceState, actions: PlayerSurfaceActi
         TransportRow(state, actions)
 
         Spacer(Modifier.height(20.dp))
-        // Speed control sits apart from the transport (keeps play centered). The filled-tonal pill
-        // reads as a deliberate control; tapping it opens the shared granular speed sheet (any 0.05×
-        // step in 0.5–3.0×) — the same control as the Read Aloud mini-player.
-        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+        // Speed + sleep pills sit side-by-side, keeping play centered in the transport row above.
+        var sleepSheetOpen by remember { mutableStateOf(false) }
+
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
             PlaybackSpeedControl(
                 speed = state.speed,
                 onSpeedChange = actions.onSpeedChange,
@@ -277,7 +290,36 @@ private fun PlayerControls(state: PlayerSurfaceState, actions: PlayerSurfaceActi
                     Text(PlaybackSpeed.label(state.speed), style = MaterialTheme.typography.titleSmall)
                 }
             }
-            Text("Speed", style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+
+            val timerActive = state.sleepTimer !is SleepTimerMode.None
+            val timerLabel = when (val t = state.sleepTimer) {
+                is SleepTimerMode.CountDown -> t.formatCountdown()
+                is SleepTimerMode.EndOfChapter -> "End of ch."
+                else -> "Sleep"
+            }
+            FilledTonalButton(
+                onClick = { sleepSheetOpen = true },
+                shape = RoundedCornerShape(50),
+                colors = if (timerActive)
+                    ButtonDefaults.filledTonalButtonColors(
+                        containerColor = MaterialTheme.colorScheme.primaryContainer,
+                        contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                    )
+                else ButtonDefaults.filledTonalButtonColors(),
+            ) {
+                Icon(Icons.Filled.Bedtime, contentDescription = "Sleep timer", modifier = Modifier.size(18.dp))
+                Spacer(Modifier.size(6.dp))
+                Text(timerLabel, style = MaterialTheme.typography.titleSmall)
+            }
+        }
+
+        if (sleepSheetOpen) {
+            SleepTimerControl(
+                timerMode = state.sleepTimer,
+                onSetTimer = actions.onSleepTimerSet,
+                onCancel = actions.onSleepTimerCancel,
+                onDismiss = { sleepSheetOpen = false },
+            )
         }
     }
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/audio/PlayerSurface.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audio/PlayerSurface.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.shape.CircleShape
@@ -39,8 +40,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import com.riffle.app.feature.audiobook.SleepTimerMode
-import com.riffle.app.feature.audiobook.formatCountdown
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -62,6 +61,8 @@ import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
 import com.riffle.app.R
+import com.riffle.app.feature.audiobook.SleepTimerMode
+import com.riffle.app.feature.audiobook.formatCountdown
 
 /**
  * Everything [PlayerSurface] renders. Both the standalone Audiobook player and the in-reader
@@ -276,6 +277,7 @@ private fun PlayerControls(state: PlayerSurfaceState, actions: PlayerSurfaceActi
         var sleepSheetOpen by remember { mutableStateOf(false) }
 
         Row(
+            modifier = Modifier.wrapContentWidth(),
             horizontalArrangement = Arrangement.spacedBy(8.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
@@ -293,9 +295,9 @@ private fun PlayerControls(state: PlayerSurfaceState, actions: PlayerSurfaceActi
 
             val timerActive = state.sleepTimer !is SleepTimerMode.None
             val timerLabel = when (val t = state.sleepTimer) {
+                SleepTimerMode.None -> "Sleep"
                 is SleepTimerMode.CountDown -> t.formatCountdown()
-                is SleepTimerMode.EndOfChapter -> "End of ch."
-                else -> "Sleep"
+                SleepTimerMode.EndOfChapter -> "End of ch."
             }
             FilledTonalButton(
                 onClick = { sleepSheetOpen = true },

--- a/app/src/main/kotlin/com/riffle/app/feature/audio/SleepTimerControl.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audio/SleepTimerControl.kt
@@ -1,0 +1,143 @@
+package com.riffle.app.feature.audio
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Bedtime
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.riffle.app.feature.audiobook.SleepTimerMode
+import com.riffle.app.feature.audiobook.formatCountdown
+
+private val PRESETS_MINUTES = listOf(15, 30, 45, 60, 90)
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SleepTimerControl(
+    timerMode: SleepTimerMode,
+    onSetTimer: (SleepTimerMode) -> Unit,
+    onCancel: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    ModalBottomSheet(onDismissRequest = onDismiss) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp)
+                .padding(bottom = 24.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Text(
+                text = "Sleep Timer",
+                style = MaterialTheme.typography.titleMedium,
+            )
+
+            // Active timer banner — shown only when a timer is already running.
+            if (timerMode !is SleepTimerMode.None) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    val bannerText = when (timerMode) {
+                        is SleepTimerMode.CountDown ->
+                            "Sleeping in ${timerMode.formatCountdown()}"
+                        is SleepTimerMode.EndOfChapter ->
+                            "Sleeping at end of chapter"
+                        is SleepTimerMode.None -> ""
+                    }
+                    Text(
+                        text = bannerText,
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.primary,
+                    )
+                    IconButton(onClick = { onCancel(); onDismiss() }) {
+                        Icon(Icons.Filled.Close, contentDescription = "Cancel timer")
+                    }
+                }
+            }
+
+            // End of chapter — full-width.
+            FilledTonalButton(
+                onClick = { onSetTimer(SleepTimerMode.EndOfChapter); onDismiss() },
+                modifier = Modifier.fillMaxWidth(),
+                shape = RoundedCornerShape(50),
+            ) {
+                Icon(Icons.Filled.Bedtime, contentDescription = null, modifier = Modifier.size(18.dp))
+                Spacer(Modifier.size(6.dp))
+                Text("End of chapter")
+            }
+
+            // 3-column preset grid: row 1 = 15/30/45, row 2 = 60/90/(blank).
+            val rowOne = PRESETS_MINUTES.take(3)
+            val rowTwo = PRESETS_MINUTES.drop(3)
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                rowOne.forEach { minutes ->
+                    PresetButton(
+                        minutes = minutes,
+                        onSetTimer = onSetTimer,
+                        onDismiss = onDismiss,
+                        modifier = Modifier.weight(1f),
+                    )
+                }
+            }
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                rowTwo.forEach { minutes ->
+                    PresetButton(
+                        minutes = minutes,
+                        onSetTimer = onSetTimer,
+                        onDismiss = onDismiss,
+                        modifier = Modifier.weight(1f),
+                    )
+                }
+                // Blank cell to keep alignment.
+                Spacer(Modifier.weight(1f))
+            }
+        }
+    }
+}
+
+@Composable
+private fun PresetButton(
+    minutes: Int,
+    onSetTimer: (SleepTimerMode) -> Unit,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    OutlinedButton(
+        onClick = {
+            onSetTimer(SleepTimerMode.CountDown(minutes * 60 * 1_000L))
+            onDismiss()
+        },
+        modifier = modifier,
+        shape = RoundedCornerShape(50),
+    ) {
+        Text("$minutes min", style = MaterialTheme.typography.labelLarge)
+    }
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/audio/SleepTimerControl.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audio/SleepTimerControl.kt
@@ -26,7 +26,7 @@ import androidx.compose.ui.unit.dp
 import com.riffle.app.feature.audiobook.SleepTimerMode
 import com.riffle.app.feature.audiobook.formatCountdown
 
-private val PRESETS_MINUTES = listOf(15, 30, 45, 60, 90)
+private val PRESETS_MINUTES = listOf(5, 15, 30, 45, 60, 90)
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -86,7 +86,7 @@ fun SleepTimerControl(
                 Text("End of chapter")
             }
 
-            // 3-column preset grid: row 1 = 15/30/45, row 2 = 60/90/(blank).
+            // 3-column preset grid: row 1 = 5/15/30, row 2 = 45/60/90.
             val rowOne = PRESETS_MINUTES.take(3)
             val rowTwo = PRESETS_MINUTES.drop(3)
 
@@ -116,9 +116,7 @@ fun SleepTimerControl(
                         modifier = Modifier.weight(1f),
                     )
                 }
-                // Blank cell to keep alignment.
-                Spacer(Modifier.weight(1f))
-            }
+}
         }
     }
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/audio/SleepTimerControl.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audio/SleepTimerControl.kt
@@ -116,7 +116,7 @@ fun SleepTimerControl(
                         modifier = Modifier.weight(1f),
                     )
                 }
-}
+            }
         }
     }
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookController.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookController.kt
@@ -215,6 +215,7 @@ open class AudiobookController @Inject constructor(
     }
 
     fun stop() {
+        cancelSleepTimer()
         pollJob?.cancel()
         pollJob = null
         controller?.run {
@@ -243,9 +244,11 @@ open class AudiobookController @Inject constructor(
      * is about to start (the "swipe down pauses readaloud" bug). Leaves the bundle for readaloud.
      */
     fun releaseForHandoff() {
+        cancelSleepTimer()
         pollJob?.cancel()
         pollJob = null
         controller?.run {
+            setVolume(1f)
             pause()
             removeListener(listener)
             release()

--- a/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookController.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookController.kt
@@ -60,6 +60,10 @@ open class AudiobookController @Inject constructor(
     private val _state = MutableStateFlow(PlaybackState())
     open val state: StateFlow<PlaybackState> = _state.asStateFlow()
 
+    private val _sleepTimer = MutableStateFlow<SleepTimerMode>(SleepTimerMode.None)
+    open val sleepTimer: StateFlow<SleepTimerMode> = _sleepTimer.asStateFlow()
+    private var timerJob: Job? = null
+
     private var controller: MediaController? = null
     private var pollJob: Job? = null
     private var spans: List<AudiobookTrackSpan> = emptyList()
@@ -137,6 +141,9 @@ open class AudiobookController @Inject constructor(
     }
 
     fun pause() {
+        timerJob?.cancel()
+        timerJob = null
+        _sleepTimer.value = SleepTimerMode.None
         wantsToPlay = false
         controller?.pause()
         pollJob?.cancel()
@@ -147,6 +154,46 @@ open class AudiobookController @Inject constructor(
     open fun setSpeed(speed: Float) {
         controller?.setPlaybackSpeed(speed)
         pushState()
+    }
+
+    open fun setSleepTimer(mode: SleepTimerMode) {
+        timerJob?.cancel()
+        _sleepTimer.value = mode
+        if (mode is SleepTimerMode.CountDown) {
+            timerJob = scope.launch {
+                var remaining = mode.remainingMs
+                while (remaining > 0L) {
+                    delay(1_000L)
+                    remaining -= 1_000L
+                    _sleepTimer.value = SleepTimerMode.CountDown(remaining.coerceAtLeast(0L))
+                }
+                fadeAndStop()
+            }
+        }
+        // EndOfChapter: no countdown needed; ViewModel calls triggerSleepNow() on chapter change.
+    }
+
+    open fun cancelSleepTimer() {
+        timerJob?.cancel()
+        timerJob = null
+        _sleepTimer.value = SleepTimerMode.None
+    }
+
+    // Called by ViewModel when a chapter boundary is crossed in EndOfChapter mode.
+    open fun triggerSleepNow() {
+        timerJob?.cancel()
+        timerJob = scope.launch { fadeAndStop() }
+    }
+
+    private suspend fun fadeAndStop() {
+        repeat(FADE_STEPS) { i ->
+            controller?.setVolume((1f - (i + 1f) / FADE_STEPS).coerceAtLeast(0f))
+            delay(FADE_STEP_MS)
+        }
+        pollJob?.cancel()
+        controller?.pause()
+        controller?.setVolume(1f)
+        _sleepTimer.value = SleepTimerMode.None
     }
 
     /** Seeks to a book-absolute position, resolving it to the right track + offset. */
@@ -250,6 +297,8 @@ open class AudiobookController @Inject constructor(
         const val REWIND_SEC = 15.0
         const val FORWARD_SEC = 30.0
         private const val POLL_INTERVAL_MS = 250L
+        private const val FADE_STEPS = 50
+        private const val FADE_STEP_MS = 100L
         private const val LOG = "RIFFLE_AB"
     }
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookController.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookController.kt
@@ -164,9 +164,9 @@ open class AudiobookController @Inject constructor(
             timerJob = scope.launch {
                 var remaining = mode.remainingMs
                 while (remaining > 0L) {
+                    _sleepTimer.value = SleepTimerMode.CountDown(remaining)
                     delay(1_000L)
                     remaining -= 1_000L
-                    _sleepTimer.value = SleepTimerMode.CountDown(remaining.coerceAtLeast(0L))
                 }
                 fadeAndStop()
             }

--- a/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookController.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookController.kt
@@ -158,6 +158,7 @@ open class AudiobookController @Inject constructor(
 
     open fun setSleepTimer(mode: SleepTimerMode) {
         timerJob?.cancel()
+        timerJob = null
         _sleepTimer.value = mode
         if (mode is SleepTimerMode.CountDown) {
             timerJob = scope.launch {

--- a/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerScreen.kt
@@ -211,6 +211,7 @@ fun AudiobookPlayerScreen(
                             canNextChapter = state.canNextChapter,
                             facts = state.facts,
                             description = state.description,
+                            sleepTimer = state.sleepTimer,
                         ),
                         twoColumn = twoColumn,
                         actions = PlayerSurfaceActions(
@@ -221,6 +222,8 @@ fun AudiobookPlayerScreen(
                             onPreviousChapter = viewModel::previousChapter,
                             onNextChapter = viewModel::nextChapter,
                             onSpeedChange = viewModel::setSpeed,
+                            onSleepTimerSet = viewModel::setSleepTimer,
+                            onSleepTimerCancel = viewModel::cancelSleepTimer,
                         ),
                     )
                     PlayerListPills(

--- a/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModel.kt
@@ -127,6 +127,7 @@ data class AudiobookPlayerUiState(
     // True only when this item has unsynced (dirty) bookmarks AND the device is offline, so the
     // Bookmarks sheet can show a quiet "Offline — bookmarks will sync" note. Sync is otherwise silent.
     val bookmarksOffline: Boolean = false,
+    val sleepTimer: SleepTimerMode = SleepTimerMode.None,
 )
 
 @HiltViewModel
@@ -316,7 +317,7 @@ class AudiobookPlayerViewModel(
     }
 
     val uiState: StateFlow<AudiobookPlayerUiState> =
-        combine(meta, controller.state) { m, playback ->
+        combine(meta, controller.state, controller.sleepTimer) { m, playback, timer ->
             val pos = playback.positionSec
             val chapter = timeline.chapterAt(pos)
             m.copy(
@@ -333,6 +334,7 @@ class AudiobookPlayerViewModel(
                 bookmarks = m.bookmarks,
                 lastCreatedBookmarkId = m.lastCreatedBookmarkId,
                 bookmarksOffline = m.bookmarksOffline,
+                sleepTimer = timer,
             )
         }.stateIn(viewModelScope, SharingStarted.Eagerly, AudiobookPlayerUiState(loading = true))
 
@@ -528,6 +530,21 @@ class AudiobookPlayerViewModel(
             // audiobook record (ADR 0029). Without this a plain audiobook only synced on pause/close.
             startFollowLoop()
         }
+
+        // End-of-chapter sleep timer: fire when chapter index advances while EoC mode is active.
+        var eocPrevChapterIndex = -1
+        viewModelScope.launch {
+            uiState.collect { state ->
+                val idx = state.currentChapterIndex
+                if (eocPrevChapterIndex >= 0
+                    && idx != eocPrevChapterIndex
+                    && controller.sleepTimer.value is SleepTimerMode.EndOfChapter
+                ) {
+                    controller.triggerSleepNow()
+                }
+                eocPrevChapterIndex = idx
+            }
+        }
     }
 
     /**
@@ -698,6 +715,9 @@ class AudiobookPlayerViewModel(
             pendingSpeed = null
         }
     }
+
+    fun setSleepTimer(mode: SleepTimerMode) = controller.setSleepTimer(mode)
+    fun cancelSleepTimer() = controller.cancelSleepTimer()
 
     /** Persist a speed change that the debounce window hadn't flushed yet (e.g. on close). */
     private fun flushPendingSpeed() {

--- a/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModel.kt
@@ -538,7 +538,7 @@ class AudiobookPlayerViewModel(
                 val idx = state.currentChapterIndex
                 if (eocPrevChapterIndex >= 0
                     && idx > eocPrevChapterIndex
-                    && controller.sleepTimer.value is SleepTimerMode.EndOfChapter
+                    && state.sleepTimer is SleepTimerMode.EndOfChapter
                 ) {
                     controller.triggerSleepNow()
                 }

--- a/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModel.kt
@@ -537,7 +537,7 @@ class AudiobookPlayerViewModel(
             uiState.collect { state ->
                 val idx = state.currentChapterIndex
                 if (eocPrevChapterIndex >= 0
-                    && idx != eocPrevChapterIndex
+                    && idx > eocPrevChapterIndex
                     && controller.sleepTimer.value is SleepTimerMode.EndOfChapter
                 ) {
                     controller.triggerSleepNow()

--- a/app/src/main/kotlin/com/riffle/app/feature/audiobook/SleepTimerMode.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audiobook/SleepTimerMode.kt
@@ -1,0 +1,15 @@
+package com.riffle.app.feature.audiobook
+
+sealed interface SleepTimerMode {
+    data object None : SleepTimerMode
+    data class CountDown(val remainingMs: Long) : SleepTimerMode
+    data object EndOfChapter : SleepTimerMode
+}
+
+fun SleepTimerMode.formatCountdown(): String {
+    if (this !is SleepTimerMode.CountDown) return ""
+    val totalSec = remainingMs / 1_000L
+    val min = totalSec / 60
+    val sec = totalSec % 60
+    return "%d:%02d".format(min, sec)
+}

--- a/app/src/test/kotlin/com/riffle/app/feature/audiobook/SleepTimerTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/audiobook/SleepTimerTest.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
@@ -23,17 +24,17 @@ class SleepTimerTest {
     @Before fun setUp() { Dispatchers.setMain(testDispatcher) }
     @After fun tearDown() { Dispatchers.resetMain() }
 
-    // ── formatCountdown ─────────────────────────────────────────────────────────
+    // ── formatCountdown ──────────────────────────────────────────────────────────
 
     @Test
     fun `formatCountdown formats minutes and seconds`() {
-        val mode = SleepTimerMode.CountDown(remainingMs = 30 * 60 * 1_000L) // 30 min
+        val mode = SleepTimerMode.CountDown(remainingMs = 30 * 60 * 1_000L)
         assertEquals("30:00", mode.formatCountdown())
     }
 
     @Test
     fun `formatCountdown pads seconds with leading zero`() {
-        val mode = SleepTimerMode.CountDown(remainingMs = 5 * 60 * 1_000L + 7_000L) // 5:07
+        val mode = SleepTimerMode.CountDown(remainingMs = 5 * 60 * 1_000L + 7_000L)
         assertEquals("5:07", mode.formatCountdown())
     }
 
@@ -43,7 +44,7 @@ class SleepTimerTest {
         assertEquals("", SleepTimerMode.EndOfChapter.formatCountdown())
     }
 
-    // ── FakeController behaviour ─────────────────────────────────────────────────
+    // ── FakeController ───────────────────────────────────────────────────────────
 
     private class FakeController : AudiobookController() {
         private val _sleepTimer = MutableStateFlow<SleepTimerMode>(SleepTimerMode.None)
@@ -69,12 +70,11 @@ class SleepTimerTest {
         }
     }
 
-    // ── ViewModel delegation ─────────────────────────────────────────────────────
+    // ── delegation tests ─────────────────────────────────────────────────────────
 
     @Test
-    fun `setSleepTimer delegates to controller with CountDown mode`() = runTest {
+    fun `setSleepTimer delegates to controller with CountDown mode`() = runTest(UnconfinedTestDispatcher()) {
         val controller = FakeController()
-        // setSleepTimer is a direct delegation — no ViewModel needed for unit test.
         controller.setSleepTimer(SleepTimerMode.CountDown(30 * 60_000L))
 
         assertEquals(1, controller.setSleepTimerCalls.size)
@@ -83,7 +83,7 @@ class SleepTimerTest {
     }
 
     @Test
-    fun `setSleepTimer delegates to controller with EndOfChapter mode`() = runTest {
+    fun `setSleepTimer delegates to controller with EndOfChapter mode`() = runTest(UnconfinedTestDispatcher()) {
         val controller = FakeController()
         controller.setSleepTimer(SleepTimerMode.EndOfChapter)
 
@@ -92,7 +92,7 @@ class SleepTimerTest {
     }
 
     @Test
-    fun `cancelSleepTimer resets timer to None`() = runTest {
+    fun `cancelSleepTimer resets timer to None`() = runTest(UnconfinedTestDispatcher()) {
         val controller = FakeController()
         controller.setSleepTimer(SleepTimerMode.CountDown(30 * 60_000L))
         controller.cancelSleepTimer()
@@ -102,7 +102,7 @@ class SleepTimerTest {
     }
 
     @Test
-    fun `setting a new timer replaces the previous one`() = runTest {
+    fun `setting a new timer replaces the previous one`() = runTest(UnconfinedTestDispatcher()) {
         val controller = FakeController()
         controller.setSleepTimer(SleepTimerMode.CountDown(30 * 60_000L))
         controller.setSleepTimer(SleepTimerMode.EndOfChapter)

--- a/app/src/test/kotlin/com/riffle/app/feature/audiobook/SleepTimerTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/audiobook/SleepTimerTest.kt
@@ -1,13 +1,62 @@
 package com.riffle.app.feature.audiobook
 
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.viewModelScope
+import com.riffle.app.feature.reader.AudiobookFollow
+import com.riffle.app.feature.reader.ProgressFlushScope
+import com.riffle.app.feature.reader.ReaderSyncCoordinator
+import com.riffle.app.feature.reader.ReaderSyncFactory
+import com.riffle.app.playback.NowPlayingStore
+import com.riffle.core.data.CrossEpubIndexBuildTrigger
+import com.riffle.core.data.OpenReconcileTargets
+import com.riffle.core.domain.AudioIdentity
+import com.riffle.core.domain.AudioIdentityResolver
+import com.riffle.core.domain.AudioPlaybackPreferencesStore
+import com.riffle.core.domain.AudiobookBookmark
+import com.riffle.core.domain.AudiobookBookmarkStore
+import com.riffle.core.domain.AudiobookChapter
+import com.riffle.core.domain.AudiobookDownloadRepository
+import com.riffle.core.domain.AudiobookRepository
+import com.riffle.core.domain.AudiobookSession
+import com.riffle.core.domain.AudiobookTimeline
+import com.riffle.core.domain.AudiobookTrackSpan
+import com.riffle.core.domain.BookmarkTitleBuilder
+import com.riffle.core.domain.BundleAudiobookSource
+import com.riffle.core.domain.CrossEpubIndex
+import com.riffle.core.domain.CrossEpubIndexStore
+import com.riffle.core.domain.EbookFormat
+import com.riffle.core.domain.LibraryItem
+import com.riffle.core.domain.LibraryRepository
+import com.riffle.core.domain.LocalStore
+import com.riffle.core.domain.PositionSnapshot
+import com.riffle.core.domain.ReadaloudAudioRepository
+import com.riffle.core.domain.ReadaloudLink
+import com.riffle.core.domain.ReadaloudLinkRepository
+import com.riffle.core.domain.ReadaloudResumePosition
+import com.riffle.core.domain.ReadaloudResumeStore
+import com.riffle.core.domain.ReadaloudTrack
+import com.riffle.core.domain.Server
+import com.riffle.core.domain.ServerRepository
+import com.riffle.core.domain.ServerUrl
+import com.riffle.core.domain.StoredItemRef
+import com.riffle.core.domain.SyncPositionStore
+import com.riffle.core.domain.TokenStorage
+import com.riffle.core.network.AbsSessionApi
+import com.riffle.core.network.NetworkAudiobookProgressPayload
+import com.riffle.core.network.NetworkEbookProgressPayload
+import com.riffle.core.network.NetworkGetProgressResult
+import com.riffle.core.network.NetworkSyncSessionResult
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.test.StandardTestDispatcher
-import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.junit.After
@@ -15,6 +64,8 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
+import java.io.File
+import java.io.InputStream
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class SleepTimerTest {
@@ -44,15 +95,58 @@ class SleepTimerTest {
         assertEquals("", SleepTimerMode.EndOfChapter.formatCountdown())
     }
 
+    @Test
+    fun `formatCountdown handles sub-minute duration`() {
+        val mode = SleepTimerMode.CountDown(remainingMs = 30_000L)
+        assertEquals("0:30", mode.formatCountdown())
+    }
+
+    @Test
+    fun `formatCountdown handles zero remaining`() {
+        val mode = SleepTimerMode.CountDown(remainingMs = 0L)
+        assertEquals("0:00", mode.formatCountdown())
+    }
+
+    // ── shared timeline ──────────────────────────────────────────────────────────
+
+    private val serverId = "srv-1"
+    private val itemId = "item-1"
+    private val timeline = AudiobookTimeline(
+        durationSec = 1000.0,
+        chapters = listOf(
+            AudiobookChapter(index = 0, startSec = 0.0, endSec = 500.0, title = "Chapter One"),
+            AudiobookChapter(index = 1, startSec = 500.0, endSec = 1000.0, title = "Chapter Two"),
+        ),
+    )
+
     // ── FakeController ───────────────────────────────────────────────────────────
 
-    private class FakeController : AudiobookController() {
+    private class FakeController(position: Double = 0.0) : AudiobookController() {
+        var position: Double = position
+
+        override val state = MutableStateFlow(AudiobookController.PlaybackState(positionSec = position))
+
         private val _sleepTimer = MutableStateFlow<SleepTimerMode>(SleepTimerMode.None)
         override val sleepTimer: StateFlow<SleepTimerMode> = _sleepTimer.asStateFlow()
 
         val setSleepTimerCalls = mutableListOf<SleepTimerMode>()
         var cancelCalled = 0
         var triggerNowCalled = 0
+        val seeks = mutableListOf<Double>()
+
+        override suspend fun prepare(
+            trackUrls: List<String>,
+            spans: List<AudiobookTrackSpan>,
+            durationSec: Double,
+            startAtSec: Double,
+            localZipFile: File?,
+            coverUri: String?,
+        ) { /* no-op */ }
+
+        override fun play() {}
+        override fun setSpeed(speed: Float) {}
+        override fun currentAbsoluteSec(): Double = position
+        override fun seekTo(absoluteSec: Double) { seeks.add(absoluteSec) }
 
         override fun setSleepTimer(mode: SleepTimerMode) {
             setSleepTimerCalls.add(mode)
@@ -70,44 +164,444 @@ class SleepTimerTest {
         }
     }
 
+    // ── ViewModel helpers ─────────────────────────────────────────────────────────
+
+    private fun AudiobookPlayerViewModel.clearForTest() {
+        this.viewModelScope.cancel()
+    }
+
+    private fun buildViewModel(
+        controller: FakeController,
+        bookmarkStore: AudiobookBookmarkStore = FakeBookmarkStore(),
+        connectivity: FakeConnectivityObserver = FakeConnectivityObserver(online = true),
+    ): AudiobookPlayerViewModel {
+        val session = AudiobookSession(
+            trackUrls = listOf("http://x/track0"),
+            tracks = listOf(AudiobookTrackSpan(0, 0.0, 1000.0)),
+            timeline = timeline,
+            serverCurrentTimeSec = 0.0,
+            serverLastUpdate = 0L,
+        )
+        return AudiobookPlayerViewModel(
+            savedStateHandle = SavedStateHandle(mapOf("itemId" to itemId)),
+            audiobookRepository = FakeAudiobookRepository(session),
+            audiobookDownloadRepository = NoDownloadRepo,
+            bundleAudiobookSource = NoBundleSource,
+            libraryRepository = FakeLibraryRepository(),
+            serverRepository = FakeServerRepository(),
+            tokenStorage = FakeTokenStorage,
+            controller = controller,
+            audioPlaybackPreferencesStore = FakePrefsStore,
+            audioIdentityResolver = FakeIdentityResolver,
+            readerSyncFactory = TestReaderSyncFactory(),
+            readaloudLinkRepository = FakeLinkRepository,
+            readaloudAudioRepository = FakeAudioRepo,
+            nowPlayingStore = NowPlayingStore(),
+            audiobookPositionStore = FakePositionStore(),
+            readingSyncStore = FakeSyncStore(),
+            audioSyncStore = FakeSyncStoreDouble(),
+            readaloudResumeStore = FakeResumeStore,
+            openReconcileTargets = OpenReconcileTargets(),
+            progressFlushScope = ProgressFlushScope(CoroutineScope(testDispatcher)),
+            bookmarkStore = bookmarkStore,
+            connectivityObserver = connectivity,
+            now = { 0L },
+        )
+    }
+
     // ── delegation tests ─────────────────────────────────────────────────────────
 
     @Test
-    fun `setSleepTimer delegates to controller with CountDown mode`() = runTest(UnconfinedTestDispatcher()) {
+    fun `setSleepTimer delegates to controller with CountDown mode`() = runTest(testDispatcher) {
         val controller = FakeController()
-        controller.setSleepTimer(SleepTimerMode.CountDown(30 * 60_000L))
+        val vm = buildViewModel(controller)
+        runCurrent()
+
+        vm.setSleepTimer(SleepTimerMode.CountDown(30 * 60_000L))
+        runCurrent()
 
         assertEquals(1, controller.setSleepTimerCalls.size)
         assertTrue(controller.setSleepTimerCalls[0] is SleepTimerMode.CountDown)
         assertEquals(30 * 60_000L, (controller.setSleepTimerCalls[0] as SleepTimerMode.CountDown).remainingMs)
+        vm.clearForTest()
     }
 
     @Test
-    fun `setSleepTimer delegates to controller with EndOfChapter mode`() = runTest(UnconfinedTestDispatcher()) {
+    fun `setSleepTimer delegates to controller with EndOfChapter mode`() = runTest(testDispatcher) {
         val controller = FakeController()
-        controller.setSleepTimer(SleepTimerMode.EndOfChapter)
+        val vm = buildViewModel(controller)
+        runCurrent()
+
+        vm.setSleepTimer(SleepTimerMode.EndOfChapter)
+        runCurrent()
 
         assertEquals(SleepTimerMode.EndOfChapter, controller.setSleepTimerCalls[0])
         assertEquals(SleepTimerMode.EndOfChapter, controller.sleepTimer.value)
+        vm.clearForTest()
     }
 
     @Test
-    fun `cancelSleepTimer resets timer to None`() = runTest(UnconfinedTestDispatcher()) {
+    fun `cancelSleepTimer resets timer to None`() = runTest(testDispatcher) {
         val controller = FakeController()
-        controller.setSleepTimer(SleepTimerMode.CountDown(30 * 60_000L))
-        controller.cancelSleepTimer()
+        val vm = buildViewModel(controller)
+        runCurrent()
+
+        vm.setSleepTimer(SleepTimerMode.CountDown(30 * 60_000L))
+        runCurrent()
+        vm.cancelSleepTimer()
+        runCurrent()
 
         assertEquals(1, controller.cancelCalled)
         assertEquals(SleepTimerMode.None, controller.sleepTimer.value)
+        vm.clearForTest()
     }
 
     @Test
-    fun `setting a new timer replaces the previous one`() = runTest(UnconfinedTestDispatcher()) {
+    fun `setting a new timer replaces the previous one`() = runTest(testDispatcher) {
         val controller = FakeController()
-        controller.setSleepTimer(SleepTimerMode.CountDown(30 * 60_000L))
-        controller.setSleepTimer(SleepTimerMode.EndOfChapter)
+        val vm = buildViewModel(controller)
+        runCurrent()
+
+        vm.setSleepTimer(SleepTimerMode.CountDown(30 * 60_000L))
+        runCurrent()
+        vm.setSleepTimer(SleepTimerMode.EndOfChapter)
+        runCurrent()
 
         assertEquals(2, controller.setSleepTimerCalls.size)
         assertEquals(SleepTimerMode.EndOfChapter, controller.sleepTimer.value)
+        vm.clearForTest()
+    }
+
+    // ── EoC detection tests ───────────────────────────────────────────────────────
+
+    @Test
+    fun `EoC mode fires triggerSleepNow when chapter index advances`() = runTest(testDispatcher) {
+        // Start in chapter 0 (positionSec = 0.0)
+        val controller = FakeController(position = 0.0)
+        val vm = buildViewModel(controller)
+        runCurrent()
+
+        // Arm the EoC timer
+        vm.setSleepTimer(SleepTimerMode.EndOfChapter)
+        runCurrent()
+
+        // Advance to chapter 1 by moving position into [500, 1000)
+        controller.state.value = AudiobookController.PlaybackState(positionSec = 600.0)
+        runCurrent()
+
+        assertEquals(1, controller.triggerNowCalled)
+        vm.clearForTest()
+    }
+
+    @Test
+    fun `EoC mode does NOT fire triggerSleepNow when chapter index decreases`() = runTest(testDispatcher) {
+        // Start in chapter 1 (positionSec = 600.0)
+        val controller = FakeController(position = 600.0)
+        controller.state.value = AudiobookController.PlaybackState(positionSec = 600.0)
+        val vm = buildViewModel(controller)
+        runCurrent()
+
+        // Arm the EoC timer
+        vm.setSleepTimer(SleepTimerMode.EndOfChapter)
+        runCurrent()
+
+        // Go backward to chapter 0
+        controller.state.value = AudiobookController.PlaybackState(positionSec = 100.0)
+        runCurrent()
+
+        assertEquals(0, controller.triggerNowCalled)
+        vm.clearForTest()
+    }
+
+    @Test
+    fun `CountDown mode does NOT fire triggerSleepNow when chapter advances`() = runTest(testDispatcher) {
+        // Start in chapter 0
+        val controller = FakeController(position = 0.0)
+        val vm = buildViewModel(controller)
+        runCurrent()
+
+        // Arm a CountDown timer (not EoC)
+        vm.setSleepTimer(SleepTimerMode.CountDown(30 * 60_000L))
+        runCurrent()
+
+        // Advance to chapter 1
+        controller.state.value = AudiobookController.PlaybackState(positionSec = 600.0)
+        runCurrent()
+
+        assertEquals(0, controller.triggerNowCalled)
+        vm.clearForTest()
+    }
+
+    // ── fakes ─────────────────────────────────────────────────────────────────────
+
+    private class FakeConnectivityObserver(online: Boolean) : com.riffle.core.domain.ConnectivityObserver {
+        override val isOnline = MutableStateFlow(online)
+    }
+
+    private class FakeBookmarkStore : AudiobookBookmarkStore {
+        val flow = MutableStateFlow<List<AudiobookBookmark>>(emptyList())
+        val hasUnsynced = MutableStateFlow(false)
+        override fun observe(serverId: String, itemId: String): Flow<List<AudiobookBookmark>> = flow
+        override fun observeHasUnsynced(serverId: String, itemId: String): Flow<Boolean> = hasUnsynced
+        override suspend fun add(serverId: String, itemId: String, positionSec: Double, title: String, now: Long): String = "bm-0"
+        override suspend fun rename(id: String, title: String, now: Long) {}
+        override suspend fun delete(id: String, now: Long) {}
+    }
+
+    private class FakeAudiobookRepository(private val session: AudiobookSession) : AudiobookRepository {
+        override suspend fun openSession(serverId: String, itemId: String): AudiobookSession = session
+        override suspend fun saveProgress(serverId: String, itemId: String, positionSec: Double, durationSec: Double) {}
+    }
+
+    private object NoDownloadRepo : AudiobookDownloadRepository {
+        override fun isDownloaded(serverId: String, itemId: String) = false
+        override fun localSession(serverId: String, itemId: String): AudiobookSession? = null
+        override suspend fun download(
+            serverId: String,
+            itemId: String,
+            onProgress: (Long, Long) -> Unit,
+        ) = com.riffle.core.domain.AudiobookDownloadResult.Success
+        override suspend fun remove(serverId: String, itemId: String): Long = 0
+    }
+
+    private object NoBundleSource : BundleAudiobookSource {
+        override suspend fun localSession(serverId: String, itemId: String): AudiobookSession? = null
+        override fun isAvailableOffline(serverId: String, itemId: String) = false
+    }
+
+    private inner class FakeLibraryRepository : LibraryRepository {
+        private val item = LibraryItem(
+            id = itemId,
+            libraryId = "lib",
+            title = "Book",
+            author = "Author",
+            coverUrl = null,
+            readingProgress = 0f,
+            isCached = false,
+            isDownloaded = false,
+            ebookFormat = EbookFormat.Unsupported,
+            hasAudio = true,
+            audioDurationSec = 1000.0,
+            serverId = serverId,
+        )
+        override suspend fun getItem(itemId: String): LibraryItem = item
+        override suspend fun getItem(serverId: String, itemId: String): LibraryItem = item
+        override suspend fun updateReadingProgress(itemId: String, progress: Float) {}
+        override fun observeItem(itemId: String) = throw NotImplementedError()
+        override fun observeLibraries() = throw NotImplementedError()
+        override fun observeLibraries(serverId: String) = throw NotImplementedError()
+        override fun observeLibraryItems(libraryId: String) = throw NotImplementedError()
+        override fun observeUngroupedLibraryItems(libraryId: String) = throw NotImplementedError()
+        override fun observeInProgressItems(libraryId: String) = throw NotImplementedError()
+        override fun observeFinishedItems(libraryId: String) = throw NotImplementedError()
+        override fun observeRecentlyAddedItems(libraryId: String) = throw NotImplementedError()
+        override fun observeAllBooks(libraryId: String) = throw NotImplementedError()
+        override fun observeSeries(libraryId: String) = throw NotImplementedError()
+        override fun observeCollections(libraryId: String) = throw NotImplementedError()
+        override fun observeSeriesItems(seriesId: String) = throw NotImplementedError()
+        override fun observeCollectionItems(collectionId: String) = throw NotImplementedError()
+        override suspend fun getLibrary(libraryId: String) = throw NotImplementedError()
+        override suspend fun getSeriesIdForItem(serverId: String, itemId: String): String? = null
+        override suspend fun markItemOpened(itemId: String) {}
+        override suspend fun refreshLibraries() = throw NotImplementedError()
+        override suspend fun refreshLibraryItems(libraryId: String) = throw NotImplementedError()
+        override suspend fun refreshSeries(libraryId: String) = throw NotImplementedError()
+        override suspend fun refreshCollections(libraryId: String) = throw NotImplementedError()
+    }
+
+    private inner class FakeServerRepository : ServerRepository {
+        private val server = Server(
+            id = serverId,
+            url = ServerUrl.parse("http://example.com")!!,
+            isActive = true,
+            insecureConnectionAllowed = false,
+            username = "u",
+        )
+        override fun observeAll() = throw NotImplementedError()
+        override suspend fun getActive(): Server = server
+        override suspend fun getById(serverId: String): Server = server
+        override suspend fun authenticate(
+            url: ServerUrl,
+            username: String,
+            password: String,
+            insecureAllowed: Boolean,
+            serverType: com.riffle.core.domain.ServerType,
+        ) = throw NotImplementedError()
+        override suspend fun commit(
+            pending: com.riffle.core.domain.PendingServer,
+            hiddenLibraryIds: Set<String>,
+        ) = throw NotImplementedError()
+        override suspend fun setActive(serverId: String) {}
+        override suspend fun remove(serverId: String) {}
+        override suspend fun getServerVersion(serverId: String): String? = null
+    }
+
+    private object FakeTokenStorage : TokenStorage {
+        override suspend fun saveToken(serverId: String, token: String) {}
+        override suspend fun getToken(serverId: String): String = "token"
+        override suspend fun deleteToken(serverId: String) {}
+    }
+
+    private object FakePrefsStore : AudioPlaybackPreferencesStore {
+        override suspend fun load(identity: AudioIdentity): Float? = null
+        override suspend fun save(identity: AudioIdentity, speed: Float) {}
+        override suspend fun clear(identity: AudioIdentity) {}
+        override suspend fun rekey(old: AudioIdentity, new: AudioIdentity) {}
+    }
+
+    private object FakeIdentityResolver : AudioIdentityResolver {
+        override suspend fun resolveForStorytellerBook(
+            storytellerServerId: String,
+            storytellerBookId: String,
+        ) = AudioIdentity("", "")
+    }
+
+    private object FakeLinkRepository : ReadaloudLinkRepository {
+        override fun observeAll() = throw NotImplementedError()
+        override fun observeLinkedAbsItemIds() = throw NotImplementedError()
+        override suspend fun findByAbsItem(absServerId: String, absLibraryItemId: String): ReadaloudLink? = null
+        override suspend fun findByStorytellerBook(storytellerServerId: String, storytellerBookId: String): List<ReadaloudLink> = emptyList()
+        override suspend fun unlinkAbsItem(absServerId: String, absLibraryItemId: String) {}
+        override suspend fun countForServer(serverId: String): Int = 0
+    }
+
+    private object FakeAudioRepo : ReadaloudAudioRepository {
+        override fun isAudioAvailable(serverId: String, itemId: String) = false
+        override fun bundleFile(serverId: String, itemId: String): File? = null
+        override suspend fun readTrack(serverId: String, itemId: String): ReadaloudTrack? = null
+        override suspend fun probeSizeBytes(serverId: String, itemId: String): Long? = null
+        override suspend fun downloadAudio(
+            serverId: String,
+            bookId: String,
+            onProgress: (Long, Long) -> Unit,
+        ) = com.riffle.core.domain.AudioDownloadResult.NoBundle
+        override suspend fun removeAudio(serverId: String, itemId: String): Long = 0
+    }
+
+    private class FakePositionStore : com.riffle.core.domain.AudiobookPositionStore {
+        override suspend fun save(serverId: String, itemId: String, payload: Double) {}
+        override suspend fun load(serverId: String, itemId: String): Double? = null
+        override suspend fun loadLocalUpdatedAt(serverId: String, itemId: String): Long = 0
+        override suspend fun updateLocalTimestamp(serverId: String, itemId: String, millis: Long) {}
+    }
+
+    private class FakeSyncStore : SyncPositionStore<String> {
+        override suspend fun snapshot(serverId: String, itemId: String) = PositionSnapshot<String>(null, 0, 0)
+        override suspend fun acceptServerPosition(serverId: String, itemId: String, position: String, serverStamp: Long, ifLocalUpdatedAt: Long) = false
+        override suspend fun confirmPushed(serverId: String, itemId: String, serverStamp: Long, ifLocalUpdatedAt: Long) = false
+        override suspend fun confirmInSync(serverId: String, itemId: String, ifLocalUpdatedAt: Long) = false
+        override suspend fun mirror(serverId: String, itemId: String, position: String, localUpdatedAt: Long, lastSyncedAt: Long) {}
+    }
+
+    private class FakeSyncStoreDouble : SyncPositionStore<Double> {
+        override suspend fun snapshot(serverId: String, itemId: String) = PositionSnapshot<Double>(null, 0, 0)
+        override suspend fun acceptServerPosition(serverId: String, itemId: String, position: Double, serverStamp: Long, ifLocalUpdatedAt: Long) = false
+        override suspend fun confirmPushed(serverId: String, itemId: String, serverStamp: Long, ifLocalUpdatedAt: Long) = false
+        override suspend fun confirmInSync(serverId: String, itemId: String, ifLocalUpdatedAt: Long) = false
+        override suspend fun mirror(serverId: String, itemId: String, position: Double, localUpdatedAt: Long, lastSyncedAt: Long) {}
+    }
+
+    private object FakeResumeStore : ReadaloudResumeStore {
+        override suspend fun save(serverId: String, itemId: String, position: ReadaloudResumePosition) {}
+        override suspend fun load(serverId: String, itemId: String): ReadaloudResumePosition? = null
+    }
+
+    private class TestReaderSyncFactory : ReaderSyncFactory(
+        FakeLinkRepository,
+        StubServer,
+        FakeTokenStorage,
+        StubIndexStore,
+        StubAbsApi,
+        StubLibrary,
+        StubLocalStore,
+        StubLocalStore,
+        StubBuildTrigger,
+    ) {
+        override suspend fun createIfApplicable(itemId: String): ReaderSyncCoordinator? = null
+        override suspend fun createAudiobookFollowIfApplicable(itemId: String): AudiobookFollow? = null
+    }
+
+    private object StubServer : ServerRepository {
+        override fun observeAll() = throw NotImplementedError()
+        override suspend fun getActive(): Server? = null
+        override suspend fun authenticate(
+            url: ServerUrl,
+            username: String,
+            password: String,
+            insecureAllowed: Boolean,
+            serverType: com.riffle.core.domain.ServerType,
+        ) = throw NotImplementedError()
+        override suspend fun commit(pending: com.riffle.core.domain.PendingServer, hiddenLibraryIds: Set<String>) = throw NotImplementedError()
+        override suspend fun setActive(serverId: String) {}
+        override suspend fun remove(serverId: String) {}
+        override suspend fun getServerVersion(serverId: String): String? = null
+    }
+
+    private object StubLibrary : LibraryRepository {
+        override suspend fun getItem(itemId: String): LibraryItem? = null
+        override suspend fun getItem(serverId: String, itemId: String): LibraryItem? = null
+        override suspend fun updateReadingProgress(itemId: String, progress: Float) {}
+        override fun observeItem(itemId: String) = throw NotImplementedError()
+        override fun observeLibraries() = throw NotImplementedError()
+        override fun observeLibraries(serverId: String) = throw NotImplementedError()
+        override fun observeLibraryItems(libraryId: String) = throw NotImplementedError()
+        override fun observeUngroupedLibraryItems(libraryId: String) = throw NotImplementedError()
+        override fun observeInProgressItems(libraryId: String) = throw NotImplementedError()
+        override fun observeFinishedItems(libraryId: String) = throw NotImplementedError()
+        override fun observeRecentlyAddedItems(libraryId: String) = throw NotImplementedError()
+        override fun observeAllBooks(libraryId: String) = throw NotImplementedError()
+        override fun observeSeries(libraryId: String) = throw NotImplementedError()
+        override fun observeCollections(libraryId: String) = throw NotImplementedError()
+        override fun observeSeriesItems(seriesId: String) = throw NotImplementedError()
+        override fun observeCollectionItems(collectionId: String) = throw NotImplementedError()
+        override suspend fun getLibrary(libraryId: String) = throw NotImplementedError()
+        override suspend fun getSeriesIdForItem(serverId: String, itemId: String): String? = null
+        override suspend fun markItemOpened(itemId: String) {}
+        override suspend fun refreshLibraries() = throw NotImplementedError()
+        override suspend fun refreshLibraryItems(libraryId: String) = throw NotImplementedError()
+        override suspend fun refreshSeries(libraryId: String) = throw NotImplementedError()
+        override suspend fun refreshCollections(libraryId: String) = throw NotImplementedError()
+    }
+
+    private object StubIndexStore : CrossEpubIndexStore {
+        override suspend fun exists(absChecksum: String, storytellerChecksum: String) = false
+        override suspend fun put(absChecksum: String, storytellerChecksum: String, blob: String, builtAt: Long) {}
+        override suspend fun load(absChecksum: String, storytellerChecksum: String): CrossEpubIndex? = null
+    }
+
+    private object StubAbsApi : AbsSessionApi {
+        override suspend fun syncEbookProgress(
+            baseUrl: String,
+            libraryItemId: String,
+            payload: NetworkEbookProgressPayload,
+            token: String,
+            insecureAllowed: Boolean,
+        ) = NetworkSyncSessionResult.NetworkError(RuntimeException())
+        override suspend fun syncAudiobookProgress(
+            baseUrl: String,
+            libraryItemId: String,
+            payload: NetworkAudiobookProgressPayload,
+            token: String,
+            insecureAllowed: Boolean,
+        ) = NetworkSyncSessionResult.NetworkError(RuntimeException())
+        override suspend fun getProgress(
+            baseUrl: String,
+            libraryItemId: String,
+            token: String,
+            insecureAllowed: Boolean,
+        ) = NetworkGetProgressResult.NetworkError(RuntimeException())
+    }
+
+    private object StubLocalStore : LocalStore {
+        override fun get(serverId: String, itemId: String): File? = null
+        override suspend fun save(serverId: String, itemId: String, stream: InputStream): File = File("/dev/null")
+        override fun delete(serverId: String, itemId: String) {}
+        override fun deleteServer(serverId: String) {}
+        override fun clear() {}
+        override fun listItems(): List<StoredItemRef> = emptyList()
+    }
+
+    private object StubBuildTrigger : CrossEpubIndexBuildTrigger {
+        override fun enqueueBuild(link: ReadaloudLink) {}
     }
 }

--- a/app/src/test/kotlin/com/riffle/app/feature/audiobook/SleepTimerTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/audiobook/SleepTimerTest.kt
@@ -1,0 +1,113 @@
+package com.riffle.app.feature.audiobook
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class SleepTimerTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+
+    @Before fun setUp() { Dispatchers.setMain(testDispatcher) }
+    @After fun tearDown() { Dispatchers.resetMain() }
+
+    // ── formatCountdown ─────────────────────────────────────────────────────────
+
+    @Test
+    fun `formatCountdown formats minutes and seconds`() {
+        val mode = SleepTimerMode.CountDown(remainingMs = 30 * 60 * 1_000L) // 30 min
+        assertEquals("30:00", mode.formatCountdown())
+    }
+
+    @Test
+    fun `formatCountdown pads seconds with leading zero`() {
+        val mode = SleepTimerMode.CountDown(remainingMs = 5 * 60 * 1_000L + 7_000L) // 5:07
+        assertEquals("5:07", mode.formatCountdown())
+    }
+
+    @Test
+    fun `formatCountdown returns empty string for non-CountDown mode`() {
+        assertEquals("", SleepTimerMode.None.formatCountdown())
+        assertEquals("", SleepTimerMode.EndOfChapter.formatCountdown())
+    }
+
+    // ── FakeController behaviour ─────────────────────────────────────────────────
+
+    private class FakeController : AudiobookController() {
+        private val _sleepTimer = MutableStateFlow<SleepTimerMode>(SleepTimerMode.None)
+        override val sleepTimer: StateFlow<SleepTimerMode> = _sleepTimer.asStateFlow()
+
+        val setSleepTimerCalls = mutableListOf<SleepTimerMode>()
+        var cancelCalled = 0
+        var triggerNowCalled = 0
+
+        override fun setSleepTimer(mode: SleepTimerMode) {
+            setSleepTimerCalls.add(mode)
+            _sleepTimer.value = mode
+        }
+
+        override fun cancelSleepTimer() {
+            cancelCalled++
+            _sleepTimer.value = SleepTimerMode.None
+        }
+
+        override fun triggerSleepNow() {
+            triggerNowCalled++
+            _sleepTimer.value = SleepTimerMode.None
+        }
+    }
+
+    // ── ViewModel delegation ─────────────────────────────────────────────────────
+
+    @Test
+    fun `setSleepTimer delegates to controller with CountDown mode`() = runTest {
+        val controller = FakeController()
+        // setSleepTimer is a direct delegation — no ViewModel needed for unit test.
+        controller.setSleepTimer(SleepTimerMode.CountDown(30 * 60_000L))
+
+        assertEquals(1, controller.setSleepTimerCalls.size)
+        assertTrue(controller.setSleepTimerCalls[0] is SleepTimerMode.CountDown)
+        assertEquals(30 * 60_000L, (controller.setSleepTimerCalls[0] as SleepTimerMode.CountDown).remainingMs)
+    }
+
+    @Test
+    fun `setSleepTimer delegates to controller with EndOfChapter mode`() = runTest {
+        val controller = FakeController()
+        controller.setSleepTimer(SleepTimerMode.EndOfChapter)
+
+        assertEquals(SleepTimerMode.EndOfChapter, controller.setSleepTimerCalls[0])
+        assertEquals(SleepTimerMode.EndOfChapter, controller.sleepTimer.value)
+    }
+
+    @Test
+    fun `cancelSleepTimer resets timer to None`() = runTest {
+        val controller = FakeController()
+        controller.setSleepTimer(SleepTimerMode.CountDown(30 * 60_000L))
+        controller.cancelSleepTimer()
+
+        assertEquals(1, controller.cancelCalled)
+        assertEquals(SleepTimerMode.None, controller.sleepTimer.value)
+    }
+
+    @Test
+    fun `setting a new timer replaces the previous one`() = runTest {
+        val controller = FakeController()
+        controller.setSleepTimer(SleepTimerMode.CountDown(30 * 60_000L))
+        controller.setSleepTimer(SleepTimerMode.EndOfChapter)
+
+        assertEquals(2, controller.setSleepTimerCalls.size)
+        assertEquals(SleepTimerMode.EndOfChapter, controller.sleepTimer.value)
+    }
+}

--- a/docs/superpowers/plans/2026-06-14-audiobook-sleep-timer.md
+++ b/docs/superpowers/plans/2026-06-14-audiobook-sleep-timer.md
@@ -1,0 +1,738 @@
+# Audiobook Sleep Timer Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a sleep timer to the audiobook player that fades out and pauses playback after a set duration or at the end of the current chapter.
+
+**Architecture:** Timer countdown and fade live in `AudiobookController` (singleton, survives backgrounding); the ViewModel detects end-of-chapter transitions and delegates to the controller; the UI is a matched speed+sleep pill row with a bottom sheet grid picker.
+
+**Tech Stack:** Kotlin, Jetpack Compose, Media3 MediaController, kotlinx.coroutines StateFlow/combine
+
+---
+
+## File Map
+
+| Action | Path |
+|---|---|
+| Create | `app/src/main/kotlin/com/riffle/app/feature/audiobook/SleepTimerMode.kt` |
+| Modify | `app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookController.kt` |
+| Modify | `app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModel.kt` |
+| Create | `app/src/main/kotlin/com/riffle/app/feature/audio/SleepTimerControl.kt` |
+| Modify | `app/src/main/kotlin/com/riffle/app/feature/audio/PlayerSurface.kt` |
+| Modify | `app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerScreen.kt` |
+| Create | `app/src/test/kotlin/com/riffle/app/feature/audiobook/SleepTimerTest.kt` |
+
+---
+
+### Task 1: SleepTimerMode domain model
+
+**Files:**
+- Create: `app/src/main/kotlin/com/riffle/app/feature/audiobook/SleepTimerMode.kt`
+
+- [ ] **Step 1: Create the file**
+
+```kotlin
+package com.riffle.app.feature.audiobook
+
+sealed interface SleepTimerMode {
+    data object None : SleepTimerMode
+    data class CountDown(val remainingMs: Long) : SleepTimerMode
+    data object EndOfChapter : SleepTimerMode
+}
+
+fun SleepTimerMode.formatCountdown(): String {
+    if (this !is SleepTimerMode.CountDown) return ""
+    val totalSec = remainingMs / 1_000L
+    val min = totalSec / 60
+    val sec = totalSec % 60
+    return "%d:%02d".format(min, sec)
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add app/src/main/kotlin/com/riffle/app/feature/audiobook/SleepTimerMode.kt
+git commit -m "feat(player): add SleepTimerMode sealed interface"
+```
+
+---
+
+### Task 2: AudiobookController — timer logic
+
+**Files:**
+- Modify: `app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookController.kt`
+
+The controller already has `private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)` and `private var pollJob: Job?`. The Media3 `controller` field (of type `MediaController?`) implements `Player`, which exposes `setVolume(Float)`.
+
+- [ ] **Step 1: Add timer state fields after the existing `_state` declaration**
+
+```kotlin
+private val _sleepTimer = MutableStateFlow<SleepTimerMode>(SleepTimerMode.None)
+open val sleepTimer: StateFlow<SleepTimerMode> = _sleepTimer.asStateFlow()
+private var timerJob: Job? = null
+
+companion object {
+    // add alongside existing POLL_INTERVAL_MS, REWIND_SEC, FORWARD_SEC:
+    private const val FADE_STEPS = 50
+    private const val FADE_STEP_MS = 100L
+}
+```
+
+- [ ] **Step 2: Add the public timer API and private fade helper**
+
+Add these functions to the class body (after `setSpeed`):
+
+```kotlin
+open fun setSleepTimer(mode: SleepTimerMode) {
+    timerJob?.cancel()
+    _sleepTimer.value = mode
+    if (mode is SleepTimerMode.CountDown) {
+        timerJob = scope.launch {
+            var remaining = mode.remainingMs
+            while (remaining > 0L) {
+                delay(1_000L)
+                remaining -= 1_000L
+                _sleepTimer.value = SleepTimerMode.CountDown(remaining.coerceAtLeast(0L))
+            }
+            fadeAndStop()
+        }
+    }
+    // EndOfChapter: no countdown needed; ViewModel calls triggerSleepNow() on chapter change.
+}
+
+open fun cancelSleepTimer() {
+    timerJob?.cancel()
+    timerJob = null
+    _sleepTimer.value = SleepTimerMode.None
+}
+
+// Called by ViewModel when a chapter boundary is crossed in EndOfChapter mode.
+open fun triggerSleepNow() {
+    timerJob?.cancel()
+    timerJob = scope.launch { fadeAndStop() }
+}
+
+private suspend fun fadeAndStop() {
+    repeat(FADE_STEPS) { i ->
+        controller?.setVolume((1f - (i + 1f) / FADE_STEPS).coerceAtLeast(0f))
+        delay(FADE_STEP_MS)
+    }
+    pollJob?.cancel()
+    controller?.pause()
+    controller?.setVolume(1f)
+    _sleepTimer.value = SleepTimerMode.None
+}
+```
+
+- [ ] **Step 3: Cancel the timer in `pause()` (manual pause)**
+
+Find the existing `pause()` function and add two lines at the top of its body:
+
+```kotlin
+fun pause() {
+    timerJob?.cancel()          // ← add
+    timerJob = null             // ← add
+    _sleepTimer.value = SleepTimerMode.None  // ← add
+    // ... rest of existing pause() body unchanged ...
+}
+```
+
+- [ ] **Step 4: Build to confirm no compilation errors**
+
+```bash
+export JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"
+./gradlew :app:compileDebugKotlin 2>&1 | tail -20
+```
+
+Expected: `BUILD SUCCESSFUL`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookController.kt
+git commit -m "feat(player): add sleep timer countdown and fade-to-pause in AudiobookController"
+```
+
+---
+
+### Task 3: AudiobookPlayerViewModel — expose timer state and EoC detection
+
+**Files:**
+- Modify: `app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModel.kt`
+
+- [ ] **Step 1: Add `sleepTimer` to `AudiobookPlayerUiState`**
+
+Find the `data class AudiobookPlayerUiState(` declaration and add one field:
+
+```kotlin
+val sleepTimer: SleepTimerMode = SleepTimerMode.None,
+```
+
+- [ ] **Step 2: Include `controller.sleepTimer` in the `uiState` combine**
+
+The current combine is `combine(meta, controller.state) { m, playback -> ... }`. Change it to a 3-flow combine:
+
+```kotlin
+val uiState: StateFlow<AudiobookPlayerUiState> =
+    combine(meta, controller.state, controller.sleepTimer) { m, playback, timer ->
+        val pos = playback.positionSec
+        val chapter = timeline.chapterAt(pos)
+        m.copy(
+            isPlaying = playback.isPlaying,
+            speed = playback.speed,
+            positionSec = pos,
+            durationSec = playback.durationSec,
+            currentChapterTitle = chapter?.title,
+            chapterStartsSec = timeline.chapterStartsSec,
+            chapters = timeline.chapters,
+            currentChapterIndex = timeline.chapterIndexAt(pos),
+            canPreviousChapter = timeline.hasPreviousChapter(pos),
+            canNextChapter = timeline.hasNextChapter(pos),
+            sleepTimer = timer,       // ← new
+        )
+    }.stateIn(viewModelScope, SharingStarted.Eagerly, AudiobookPlayerUiState(loading = true))
+```
+
+(Keep all existing fields — only the lambda signature changes from `{ m, playback ->` to `{ m, playback, timer ->` and `sleepTimer = timer` is appended to the `m.copy(...)` block.)
+
+- [ ] **Step 3: Add EoC chapter-change detection in `init {}`**
+
+Add this block inside `init {}` after any existing init logic:
+
+```kotlin
+// End-of-chapter sleep timer: fire when chapter index advances while EoC mode is active.
+var eocPrevChapterIndex = -1
+viewModelScope.launch {
+    uiState.collect { state ->
+        val idx = state.currentChapterIndex
+        if (eocPrevChapterIndex >= 0
+            && idx != eocPrevChapterIndex
+            && controller.sleepTimer.value is SleepTimerMode.EndOfChapter
+        ) {
+            controller.triggerSleepNow()
+        }
+        eocPrevChapterIndex = idx
+    }
+}
+```
+
+- [ ] **Step 4: Add public timer delegation functions**
+
+Add after the existing `setSpeed()` function:
+
+```kotlin
+fun setSleepTimer(mode: SleepTimerMode) = controller.setSleepTimer(mode)
+fun cancelSleepTimer() = controller.cancelSleepTimer()
+```
+
+- [ ] **Step 5: Build**
+
+```bash
+export JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"
+./gradlew :app:compileDebugKotlin 2>&1 | tail -20
+```
+
+Expected: `BUILD SUCCESSFUL`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModel.kt
+git commit -m "feat(player): wire sleep timer state and EoC detection in AudiobookPlayerViewModel"
+```
+
+---
+
+### Task 4: SleepTimerControl composable
+
+**Files:**
+- Create: `app/src/main/kotlin/com/riffle/app/feature/audio/SleepTimerControl.kt`
+
+- [ ] **Step 1: Create the file**
+
+```kotlin
+package com.riffle.app.feature.audio
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Bedtime
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.riffle.app.feature.audiobook.SleepTimerMode
+import com.riffle.app.feature.audiobook.formatCountdown
+
+private val PRESETS_MINUTES = listOf(15, 30, 45, 60, 90)
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SleepTimerControl(
+    timerMode: SleepTimerMode,
+    onSetTimer: (SleepTimerMode) -> Unit,
+    onCancel: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    ModalBottomSheet(onDismissRequest = onDismiss) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp)
+                .padding(bottom = 24.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Text(
+                text = "Sleep Timer",
+                style = MaterialTheme.typography.titleMedium,
+            )
+
+            // Active timer banner — shown only when a timer is already running.
+            if (timerMode !is SleepTimerMode.None) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    val bannerText = when (timerMode) {
+                        is SleepTimerMode.CountDown ->
+                            "Sleeping in ${timerMode.formatCountdown()}"
+                        is SleepTimerMode.EndOfChapter ->
+                            "Sleeping at end of chapter"
+                        else -> ""
+                    }
+                    Text(
+                        text = bannerText,
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.primary,
+                    )
+                    IconButton(onClick = { onCancel(); onDismiss() }) {
+                        Icon(Icons.Filled.Close, contentDescription = "Cancel timer")
+                    }
+                }
+            }
+
+            // End of chapter — full-width.
+            FilledTonalButton(
+                onClick = { onSetTimer(SleepTimerMode.EndOfChapter); onDismiss() },
+                modifier = Modifier.fillMaxWidth(),
+                shape = RoundedCornerShape(50),
+            ) {
+                Icon(Icons.Filled.Bedtime, contentDescription = null, modifier = Modifier.size(18.dp))
+                Spacer(Modifier.size(6.dp))
+                Text("End of chapter")
+            }
+
+            // 3-column preset grid: row 1 = 15/30/45, row 2 = 60/90/(blank).
+            val rowOne = PRESETS_MINUTES.take(3)
+            val rowTwo = PRESETS_MINUTES.drop(3)
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                rowOne.forEach { minutes ->
+                    PresetButton(
+                        minutes = minutes,
+                        onSetTimer = onSetTimer,
+                        onDismiss = onDismiss,
+                        modifier = Modifier.weight(1f),
+                    )
+                }
+            }
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                rowTwo.forEach { minutes ->
+                    PresetButton(
+                        minutes = minutes,
+                        onSetTimer = onSetTimer,
+                        onDismiss = onDismiss,
+                        modifier = Modifier.weight(1f),
+                    )
+                }
+                // Blank cell to keep alignment.
+                Spacer(Modifier.weight(1f))
+            }
+        }
+    }
+}
+
+@Composable
+private fun PresetButton(
+    minutes: Int,
+    onSetTimer: (SleepTimerMode) -> Unit,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    OutlinedButton(
+        onClick = {
+            onSetTimer(SleepTimerMode.CountDown(minutes * 60 * 1_000L))
+            onDismiss()
+        },
+        modifier = modifier,
+        shape = RoundedCornerShape(50),
+    ) {
+        Text("$minutes min", style = MaterialTheme.typography.labelLarge)
+    }
+}
+```
+
+- [ ] **Step 2: Build**
+
+```bash
+export JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"
+./gradlew :app:compileDebugKotlin 2>&1 | tail -20
+```
+
+Expected: `BUILD SUCCESSFUL`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/src/main/kotlin/com/riffle/app/feature/audio/SleepTimerControl.kt
+git commit -m "feat(player): add SleepTimerControl bottom sheet with preset grid"
+```
+
+---
+
+### Task 5: PlayerSurface — speed + sleep pill row
+
+**Files:**
+- Modify: `app/src/main/kotlin/com/riffle/app/feature/audio/PlayerSurface.kt`
+
+The existing standalone `PlaybackSpeedControl` wrapped in a `Column` (inside `PlayerControls`) becomes one half of a `Row` that also holds the new sleep pill.
+
+- [ ] **Step 1: Add `sleepTimer` to `PlayerSurfaceState`**
+
+Find the `data class PlayerSurfaceState(` declaration and add:
+
+```kotlin
+val sleepTimer: SleepTimerMode = SleepTimerMode.None,
+```
+
+Add the import at the top of the file:
+```kotlin
+import com.riffle.app.feature.audiobook.SleepTimerMode
+import com.riffle.app.feature.audiobook.formatCountdown
+```
+
+- [ ] **Step 2: Add sleep timer actions to `PlayerSurfaceActions`**
+
+Find the `data class PlayerSurfaceActions(` declaration and add:
+
+```kotlin
+val onSleepTimerSet: (SleepTimerMode) -> Unit,
+val onSleepTimerCancel: () -> Unit,
+```
+
+- [ ] **Step 3: Replace the standalone speed `Column` in `PlayerControls` with a Row**
+
+Find this block inside `PlayerControls` (the speed pill section):
+
+```kotlin
+Column(horizontalAlignment = Alignment.CenterHorizontally) {
+    PlaybackSpeedControl(
+        speed = state.speed,
+        onSpeedChange = actions.onSpeedChange,
+        tagPrefix = "audiobook",
+    ) { onClick ->
+        FilledTonalButton(onClick = onClick, shape = RoundedCornerShape(50)) {
+            Icon(Icons.Filled.Speed, contentDescription = null, modifier = Modifier.size(18.dp))
+            Spacer(Modifier.size(6.dp))
+            Text(PlaybackSpeed.label(state.speed), style = MaterialTheme.typography.titleSmall)
+        }
+    }
+    Text("Speed", style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+}
+```
+
+Replace it with:
+
+```kotlin
+var sleepSheetOpen by remember { mutableStateOf(false) }
+
+Row(
+    horizontalArrangement = Arrangement.spacedBy(8.dp),
+    verticalAlignment = Alignment.CenterVertically,
+) {
+    PlaybackSpeedControl(
+        speed = state.speed,
+        onSpeedChange = actions.onSpeedChange,
+        tagPrefix = "audiobook",
+    ) { onClick ->
+        FilledTonalButton(onClick = onClick, shape = RoundedCornerShape(50)) {
+            Icon(Icons.Filled.Speed, contentDescription = null, modifier = Modifier.size(18.dp))
+            Spacer(Modifier.size(6.dp))
+            Text(PlaybackSpeed.label(state.speed), style = MaterialTheme.typography.titleSmall)
+        }
+    }
+
+    val timerActive = state.sleepTimer !is SleepTimerMode.None
+    val timerLabel = when (val t = state.sleepTimer) {
+        is SleepTimerMode.CountDown -> t.formatCountdown()
+        is SleepTimerMode.EndOfChapter -> "End of ch."
+        else -> "Sleep"
+    }
+    FilledTonalButton(
+        onClick = { sleepSheetOpen = true },
+        shape = RoundedCornerShape(50),
+        colors = if (timerActive)
+            ButtonDefaults.filledTonalButtonColors(
+                containerColor = MaterialTheme.colorScheme.primaryContainer,
+                contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+            )
+        else ButtonDefaults.filledTonalButtonColors(),
+    ) {
+        Icon(Icons.Filled.Bedtime, contentDescription = "Sleep timer", modifier = Modifier.size(18.dp))
+        Spacer(Modifier.size(6.dp))
+        Text(timerLabel, style = MaterialTheme.typography.titleSmall)
+    }
+}
+
+if (sleepSheetOpen) {
+    SleepTimerControl(
+        timerMode = state.sleepTimer,
+        onSetTimer = actions.onSleepTimerSet,
+        onCancel = actions.onSleepTimerCancel,
+        onDismiss = { sleepSheetOpen = false },
+    )
+}
+```
+
+Add any missing imports (Bedtime, ButtonDefaults, SleepTimerControl, etc.):
+
+```kotlin
+import androidx.compose.material.icons.filled.Bedtime
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import com.riffle.app.feature.audio.SleepTimerControl
+```
+
+- [ ] **Step 4: Build**
+
+```bash
+export JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"
+./gradlew :app:compileDebugKotlin 2>&1 | tail -20
+```
+
+Expected: `BUILD SUCCESSFUL`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/kotlin/com/riffle/app/feature/audio/PlayerSurface.kt
+git commit -m "feat(player): add sleep timer pill alongside speed control in PlayerSurface"
+```
+
+---
+
+### Task 6: Wire state and actions in AudiobookPlayerScreen
+
+**Files:**
+- Modify: `app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerScreen.kt`
+
+- [ ] **Step 1: Add `sleepTimer` to the `PlayerSurfaceState(...)` construction**
+
+Find the `PlayerSurfaceState(` call (around lines 196–225) and add:
+
+```kotlin
+sleepTimer = state.sleepTimer,
+```
+
+- [ ] **Step 2: Add sleep timer actions to the `PlayerSurfaceActions(...)` construction**
+
+Find the `PlayerSurfaceActions(` call and add:
+
+```kotlin
+onSleepTimerSet = viewModel::setSleepTimer,
+onSleepTimerCancel = viewModel::cancelSleepTimer,
+```
+
+- [ ] **Step 3: Build**
+
+```bash
+export JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"
+./gradlew :app:compileDebugKotlin 2>&1 | tail -20
+```
+
+Expected: `BUILD SUCCESSFUL`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerScreen.kt
+git commit -m "feat(player): wire sleep timer state and actions in AudiobookPlayerScreen"
+```
+
+---
+
+### Task 7: JVM tests
+
+**Files:**
+- Create: `app/src/test/kotlin/com/riffle/app/feature/audiobook/SleepTimerTest.kt`
+
+The pattern follows `AudiobookPlayerViewModelBookmarkTest`: `StandardTestDispatcher`, `FakeController` subclassing `AudiobookController`, `runTest`, `runCurrent()`.
+
+- [ ] **Step 1: Write the test file**
+
+```kotlin
+package com.riffle.app.feature.audiobook
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.runCurrent
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class SleepTimerTest {
+
+    // ── formatCountdown ─────────────────────────────────────────────────────────
+
+    @Test
+    fun `formatCountdown formats minutes and seconds`() {
+        val mode = SleepTimerMode.CountDown(remainingMs = 30 * 60 * 1_000L) // 30 min
+        assertEquals("30:00", mode.formatCountdown())
+    }
+
+    @Test
+    fun `formatCountdown pads seconds with leading zero`() {
+        val mode = SleepTimerMode.CountDown(remainingMs = 5 * 60 * 1_000L + 7_000L) // 5:07
+        assertEquals("5:07", mode.formatCountdown())
+    }
+
+    @Test
+    fun `formatCountdown returns empty string for non-CountDown mode`() {
+        assertEquals("", SleepTimerMode.None.formatCountdown())
+        assertEquals("", SleepTimerMode.EndOfChapter.formatCountdown())
+    }
+
+    // ── FakeController behaviour ─────────────────────────────────────────────────
+
+    private class FakeController : AudiobookController() {
+        private val _sleepTimer = MutableStateFlow<SleepTimerMode>(SleepTimerMode.None)
+        override val sleepTimer: StateFlow<SleepTimerMode> = _sleepTimer.asStateFlow()
+
+        val setSleepTimerCalls = mutableListOf<SleepTimerMode>()
+        var cancelCalled = 0
+        var triggerNowCalled = 0
+
+        override fun setSleepTimer(mode: SleepTimerMode) {
+            setSleepTimerCalls.add(mode)
+            _sleepTimer.value = mode
+        }
+
+        override fun cancelSleepTimer() {
+            cancelCalled++
+            _sleepTimer.value = SleepTimerMode.None
+        }
+
+        override fun triggerSleepNow() {
+            triggerNowCalled++
+            _sleepTimer.value = SleepTimerMode.None
+        }
+    }
+
+    // ── ViewModel delegation ─────────────────────────────────────────────────────
+
+    @Test
+    fun `setSleepTimer delegates to controller with CountDown mode`() = runTest {
+        val controller = FakeController()
+        // setSleepTimer is a direct delegation — no ViewModel needed for unit test.
+        controller.setSleepTimer(SleepTimerMode.CountDown(30 * 60_000L))
+
+        assertEquals(1, controller.setSleepTimerCalls.size)
+        assertTrue(controller.setSleepTimerCalls[0] is SleepTimerMode.CountDown)
+        assertEquals(30 * 60_000L, (controller.setSleepTimerCalls[0] as SleepTimerMode.CountDown).remainingMs)
+    }
+
+    @Test
+    fun `setSleepTimer delegates to controller with EndOfChapter mode`() = runTest {
+        val controller = FakeController()
+        controller.setSleepTimer(SleepTimerMode.EndOfChapter)
+
+        assertEquals(SleepTimerMode.EndOfChapter, controller.setSleepTimerCalls[0])
+        assertEquals(SleepTimerMode.EndOfChapter, controller.sleepTimer.value)
+    }
+
+    @Test
+    fun `cancelSleepTimer resets timer to None`() = runTest {
+        val controller = FakeController()
+        controller.setSleepTimer(SleepTimerMode.CountDown(30 * 60_000L))
+        controller.cancelSleepTimer()
+
+        assertEquals(1, controller.cancelCalled)
+        assertEquals(SleepTimerMode.None, controller.sleepTimer.value)
+    }
+
+    @Test
+    fun `setting a new timer replaces the previous one`() = runTest {
+        val controller = FakeController()
+        controller.setSleepTimer(SleepTimerMode.CountDown(30 * 60_000L))
+        controller.setSleepTimer(SleepTimerMode.EndOfChapter)
+
+        assertEquals(2, controller.setSleepTimerCalls.size)
+        assertEquals(SleepTimerMode.EndOfChapter, controller.sleepTimer.value)
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests**
+
+```bash
+export JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"
+./gradlew :app:test --tests "com.riffle.app.feature.audiobook.SleepTimerTest" 2>&1 | tail -20
+```
+
+Expected: `BUILD SUCCESSFUL` with all tests passing.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/src/test/kotlin/com/riffle/app/feature/audiobook/SleepTimerTest.kt
+git commit -m "test(player): add JVM tests for SleepTimerMode formatting and controller delegation"
+```
+
+---
+
+## Done
+
+All tasks complete when:
+- `./gradlew test` passes
+- The player shows a `[🌙 Sleep]` pill beside the speed pill
+- Tapping it opens a bottom sheet with "End of chapter" + a 3-column grid of 15/30/45/60/90 min
+- Selecting a preset lights the pill purple with a live countdown
+- When the countdown reaches zero, playback fades out over 5 seconds then pauses
+- Manual pause cancels the timer
+- The timer survives the screen being locked (audio continues in the background)

--- a/docs/superpowers/specs/2026-06-14-audiobook-sleep-timer-design.md
+++ b/docs/superpowers/specs/2026-06-14-audiobook-sleep-timer-design.md
@@ -1,0 +1,123 @@
+# Audiobook Sleep Timer
+
+**Date:** 2026-06-14
+**Status:** Approved
+
+## Overview
+
+A sleep timer for the audiobook player. The user sets a duration (or end-of-chapter) and playback fades out and pauses automatically. Targeted at the falling-asleep use case: set it, put the phone down, done.
+
+## UI
+
+### Speed + Sleep row
+
+A matched pair of pills sits directly below the transport controls, replacing the standalone speed pill that exists today:
+
+```
+⏮  ⏪  ▶  ⏩  ⏭
+
+[ 🐢 1× ]   [ 🌙 Sleep ]        ← idle (sleep pill muted)
+[ 🐢 1× ]   [ 🌙 24:00 ]        ← active, counting down (purple)
+[ 🐢 1× ]   [ 🌙 End of ch. ]   ← end-of-chapter mode (purple)
+```
+
+Both pills are the same size and visual weight. The speed pill's tap behaviour is unchanged (opens the existing speed sheet). The sleep pill is always present; it is visually muted when no timer is set.
+
+### Sleep timer bottom sheet
+
+Opens when the user taps the sleep pill (in either idle or active state).
+
+**Layout:**
+```
+  ───────  (drag handle)
+  SLEEP TIMER
+
+  [ 🌙 Sleeping in 24:00  ✕ ]   ← shown only when a timer is already running
+                                   ✕ cancels the timer
+
+  [ 🌙 End of chapter          ]  ← full-width pill
+
+  [ 15 min ]  [ 30 min ]  [ 45 min ]
+  [ 60 min ]  [ 90 min ]  [        ]   ← 3-column grid
+```
+
+- Tapping any preset immediately sets the timer and dismisses the sheet.
+- Tapping a preset when a timer is already running replaces it (no extra confirmation).
+- The active-timer banner lets the user cancel without picking a new duration.
+- The sixth grid cell is empty (5 presets + 1 blank), which is fine.
+
+### Presets
+
+| Option | Duration |
+|---|---|
+| End of chapter | Fires at the next chapter boundary |
+| 15 min | 15:00 countdown |
+| 30 min | 30:00 countdown |
+| 45 min | 45:00 countdown |
+| 60 min | 60:00 countdown |
+| 90 min | 90:00 countdown |
+
+## Behaviour
+
+### Timer firing
+1. Volume fades linearly from current level to 0 over 5 seconds via `AudiobookController`.
+2. Playback pauses at the end of the fade.
+3. No notification, no sound — silent stop (the user is likely asleep).
+
+### Cancellation
+The timer is cancelled when:
+- The user taps ✕ in the active-timer banner.
+- The user pauses playback manually.
+- The app process is killed / the app restarts (no persistence).
+
+Navigating away from the player screen does **not** cancel the timer — background playback keeps the timer alive.
+
+### End-of-chapter mode
+The controller listens for chapter-boundary events from Media3. When the current chapter ends, it triggers the same fade-and-pause sequence as a countdown timer reaching zero.
+
+## Architecture
+
+### Where the timer lives
+
+The countdown and fade logic live in `AudiobookController` (which runs inside `AudioPlayerService`), so the timer survives the player screen being backgrounded or the ViewModel being cleared.
+
+```
+AudiobookController
+  ├── sleepTimer: SleepTimer          (new)
+  │     ├── mode: CountDown(ms) | EndOfChapter | None
+  │     ├── remainingMs: StateFlow<Long>
+  │     └── cancel()
+  └── onChapterChanged()              (triggers EoC check)
+
+AudiobookPlayerViewModel
+  └── sleepTimerState: StateFlow<SleepTimerUiState>
+        = Idle | Active(remainingMs) | EndOfChapter
+
+AudiobookPlayerScreen / PlayerSurface
+  └── SleepTimerPill(state, onClick)  (new composable)
+
+SleepTimerSheet                       (new composable, bottom sheet)
+  └── presets grid + active banner
+```
+
+### SleepTimer class (in AudiobookController)
+
+- Holds a `CoroutineScope` tied to the service lifetime.
+- `CountDown` mode: ticks every second, exposes `remainingMs` as a `StateFlow`.
+- `EndOfChapter` mode: no tick needed; `AudiobookController.onChapterChanged()` calls `checkEndOfChapter()`.
+- Fade: adjusts `player.volume` in 100 ms steps over 5 seconds, then calls `player.pause()` and resets to `None`.
+
+### ViewModel
+
+Collects `sleepTimer.remainingMs` and maps it to `SleepTimerUiState` for the UI. Exposes `setSleepTimer(mode)` and `cancelSleepTimer()`.
+
+### UI
+
+`PlayerSurface` gains a `sleepTimerState` parameter and renders the new row. `SleepTimerSheet` is a `ModalBottomSheet` with the grid; selecting a preset calls `viewModel.setSleepTimer(mode)`.
+
+## What is not in scope
+
+- Custom duration picker.
+- "Shake to extend" or extend-on-notification.
+- Persistence across restarts.
+- A notification countdown while the timer is running.


### PR DESCRIPTION
## Summary

- Adds a sleep timer to the audiobook player with countdown and end-of-chapter modes
- Sleep pill sits on the same row as the speed control, below the transport controls; turns primary-container colour when active
- Tapping opens a bottom sheet with an End of Chapter button and a 3×2 grid of presets (5 / 15 / 30 / 45 / 60 / 90 min)
- Countdown ticks in `AudiobookController` (supervisor-job scope, survives backgrounding); expiry fades volume over 5 s then pauses
- EoC detection runs in `AudiobookPlayerViewModel`, forward-only to avoid false-fires on prev-chapter
- Timer cancelled on `pause()`, `stop()`, and `releaseForHandoff()`; volume restored to 1.0 before handoff

## Test plan

- [x] `./gradlew test` — 12 new JVM tests: `SleepTimerMode.formatCountdown`, ViewModel delegation, EoC detection
- [x] `./gradlew lint` — clean
- [x] `make harness-test` — 206 tests, 0 failed
- [x] `make harness-test-tablet` — 5 tests, 0 failed