### PR TITLE
fix(library): crash on '+X more' tap and duplicate books in Continue Series

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
@@ -26,6 +26,7 @@ import com.riffle.app.feature.library.FilteredBooksScreen
 import com.riffle.app.feature.audiobook.AudiobookPlayerScreen
 import com.riffle.app.feature.library.LibraryItemDetailScreen
 import com.riffle.app.feature.library.LibraryItemsScreen
+import com.riffle.app.feature.library.LibraryItemsViewModel
 import com.riffle.app.feature.library.LibrarySectionScreen
 import com.riffle.app.feature.library.LibrarySectionType
 import com.riffle.app.feature.library.SeriesDetailScreen
@@ -289,8 +290,16 @@ fun MainScreen(
                 val sectionType = LibrarySectionType.valueOf(
                     backStackEntry.arguments?.getString("sectionType") ?: LibrarySectionType.IN_PROGRESS.name
                 )
+                // Reuse the library-items ViewModel from the parent back stack entry instead of
+                // creating a new one. A fresh LibraryItemsViewModel triggers a full library
+                // refresh concurrently with the main screen's refresh, which can cause data races
+                // in shared singletons (e.g. StorytellerReadaloudSyncer).
+                val parentEntry = remember(backStackEntry) {
+                    navController.getBackStackEntry(LIBRARY_ITEMS)
+                }
                 LibrarySectionScreen(
                     sectionType = sectionType,
+                    viewModel = hiltViewModel<LibraryItemsViewModel>(parentEntry),
                     onItemSelected = { item ->
                         val encodedId = URLEncoder.encode(item.id, "UTF-8")
                         navController.navigate("library_item_detail/$encodedId")

--- a/app/src/test/kotlin/com/riffle/app/feature/audiobook/SleepTimerTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/audiobook/SleepTimerTest.kt
@@ -399,6 +399,7 @@ class SleepTimerTest {
         override fun observeSeries(libraryId: String) = throw NotImplementedError()
         override fun observeCollections(libraryId: String) = throw NotImplementedError()
         override fun observeSeriesItems(seriesId: String) = throw NotImplementedError()
+        override fun observeContinueSeriesItems(libraryId: String) = throw NotImplementedError()
         override fun observeCollectionItems(collectionId: String) = throw NotImplementedError()
         override suspend fun getLibrary(libraryId: String) = throw NotImplementedError()
         override suspend fun getSeriesIdForItem(serverId: String, itemId: String): String? = null
@@ -553,6 +554,7 @@ class SleepTimerTest {
         override fun observeSeries(libraryId: String) = throw NotImplementedError()
         override fun observeCollections(libraryId: String) = throw NotImplementedError()
         override fun observeSeriesItems(seriesId: String) = throw NotImplementedError()
+        override fun observeContinueSeriesItems(libraryId: String) = throw NotImplementedError()
         override fun observeCollectionItems(collectionId: String) = throw NotImplementedError()
         override suspend fun getLibrary(libraryId: String) = throw NotImplementedError()
         override suspend fun getSeriesIdForItem(serverId: String, itemId: String): String? = null

--- a/core/data/src/main/kotlin/com/riffle/core/data/StorytellerReadaloudSyncer.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/StorytellerReadaloudSyncer.kt
@@ -10,6 +10,7 @@ import com.riffle.core.domain.TokenStorage
 import com.riffle.core.network.NetworkStorytellerBook
 import com.riffle.core.network.NetworkStorytellerBooksResult
 import com.riffle.core.network.StorytellerLibraryApi
+import java.util.concurrent.ConcurrentHashMap
 import kotlinx.coroutines.flow.first
 
 /**
@@ -68,7 +69,7 @@ open class StorytellerReadaloudSyncer(
     private val clock: () -> Long,
     private val ttlMillis: Long = STORYTELLER_SYNC_TTL_MILLIS,
 ) {
-    private val lastSyncedAt = mutableMapOf<String, Long>()
+    private val lastSyncedAt = ConcurrentHashMap<String, Long>()
 
     /** Best-effort: fetch+store readalouds for each stale Storyteller server. Never throws. */
     open suspend fun syncStale() {

--- a/core/database/src/androidTest/kotlin/com/riffle/core/database/SeriesDaoTest.kt
+++ b/core/database/src/androidTest/kotlin/com/riffle/core/database/SeriesDaoTest.kt
@@ -208,4 +208,27 @@ class SeriesDaoTest {
         // Both series appear; series-ts (real timestamp) before series-null (null → COALESCE 0)
         assertEquals(listOf("ts-next", "null-next"), result.map { it.id })
     }
+
+    // C5 — a book that qualifies as the "next" book in two different series must appear exactly once
+    @Test
+    fun observeContinueSeriesItems_deduplicatesBookInMultipleSeries() = runTest {
+        // shared-next is the next unread book in both series-A and series-B
+        db.libraryItemDao().upsertAll(listOf(
+            LibraryItemEntity(serverId = "s1", id = "a-done", libraryId = "lib1", title = "AD", author = "A", coverUrl = null, readingProgress = 1.0f, lastOpenedAt = 1000L),
+            LibraryItemEntity(serverId = "s1", id = "b-done", libraryId = "lib1", title = "BD", author = "A", coverUrl = null, readingProgress = 1.0f, lastOpenedAt = 2000L),
+            LibraryItemEntity(serverId = "s1", id = "shared-next", libraryId = "lib1", title = "SN", author = "A", coverUrl = null, readingProgress = 0f),
+        ))
+        dao.upsertAll(listOf(series("series-A"), series("series-B")))
+        dao.upsertAllItems(listOf(
+            SeriesItemEntity("series-A", serverId = "s1", itemId = "a-done", sequenceOrder = 1f),
+            SeriesItemEntity("series-A", serverId = "s1", itemId = "shared-next", sequenceOrder = 2f),
+            SeriesItemEntity("series-B", serverId = "s1", itemId = "b-done", sequenceOrder = 1f),
+            SeriesItemEntity("series-B", serverId = "s1", itemId = "shared-next", sequenceOrder = 2f),
+        ))
+
+        val result = dao.observeContinueSeriesItems("lib1").first()
+
+        // shared-next qualifies via both series but must only appear once
+        assertEquals(listOf("shared-next"), result.map { it.id })
+    }
 }

--- a/core/database/src/main/kotlin/com/riffle/core/database/SeriesDao.kt
+++ b/core/database/src/main/kotlin/com/riffle/core/database/SeriesDao.kt
@@ -23,37 +23,44 @@ interface SeriesDao {
 
     @Query("""
         SELECT li.* FROM library_items li
-        INNER JOIN series_items si ON li.serverId = si.serverId AND li.id = si.itemId
         WHERE li.libraryId = :libraryId
           AND li.readingProgress < 0.99
-          AND si.seriesId IN (
-              SELECT DISTINCT si2.seriesId
-              FROM series_items si2
-              INNER JOIN library_items li2 ON li2.serverId = si2.serverId AND li2.id = si2.itemId
-              WHERE li2.libraryId = :libraryId AND li2.readingProgress >= 0.99
-          )
-          AND si.seriesId NOT IN (
-              SELECT DISTINCT si5.seriesId
-              FROM series_items si5
-              INNER JOIN library_items li5 ON li5.serverId = si5.serverId AND li5.id = si5.itemId
-              WHERE li5.libraryId = :libraryId
-                AND li5.readingProgress >= 0.05
-                AND li5.readingProgress < 0.99
-          )
-          AND si.sequenceOrder = (
-              SELECT MIN(si3.sequenceOrder)
-              FROM series_items si3
-              INNER JOIN library_items li3 ON li3.serverId = si3.serverId AND li3.id = si3.itemId
-              WHERE si3.seriesId = si.seriesId
-                AND li3.libraryId = :libraryId
-                AND li3.readingProgress < 0.99
+          AND EXISTS (
+              SELECT 1 FROM series_items si
+              WHERE si.serverId = li.serverId
+                AND si.itemId = li.id
+                AND si.seriesId IN (
+                    SELECT DISTINCT si2.seriesId
+                    FROM series_items si2
+                    INNER JOIN library_items li2 ON li2.serverId = si2.serverId AND li2.id = si2.itemId
+                    WHERE li2.libraryId = :libraryId AND li2.readingProgress >= 0.99
+                )
+                AND si.seriesId NOT IN (
+                    SELECT DISTINCT si5.seriesId
+                    FROM series_items si5
+                    INNER JOIN library_items li5 ON li5.serverId = si5.serverId AND li5.id = si5.itemId
+                    WHERE li5.libraryId = :libraryId
+                      AND li5.readingProgress >= 0.05
+                      AND li5.readingProgress < 0.99
+                )
+                AND si.sequenceOrder = (
+                    SELECT MIN(si3.sequenceOrder)
+                    FROM series_items si3
+                    INNER JOIN library_items li3 ON li3.serverId = si3.serverId AND li3.id = si3.itemId
+                    WHERE si3.seriesId = si.seriesId
+                      AND li3.libraryId = :libraryId
+                      AND li3.readingProgress < 0.99
+                )
           )
         ORDER BY COALESCE(
             (
                 SELECT MAX(li4.lastOpenedAt)
                 FROM series_items si4
                 INNER JOIN library_items li4 ON li4.serverId = si4.serverId AND li4.id = si4.itemId
-                WHERE si4.seriesId = si.seriesId
+                WHERE si4.seriesId IN (
+                    SELECT si_self.seriesId FROM series_items si_self
+                    WHERE si_self.serverId = li.serverId AND si_self.itemId = li.id
+                )
                   AND li4.libraryId = :libraryId
                   AND li4.readingProgress >= 0.99
             ), 0


### PR DESCRIPTION
## Summary

- **Crash on '+X more'** — `LibrarySectionScreen` was creating a new `LibraryItemsViewModel` via `hiltViewModel()`, triggering a full library refresh concurrently with the main screen's ViewModel's refresh. The two coroutines raced on `StorytellerReadaloudSyncer.lastSyncedAt` (a non-thread-safe `HashMap`), crashing the IO dispatcher. Fixed by reusing the parent back stack entry's ViewModel and switching `lastSyncedAt` to `ConcurrentHashMap`.
- **Duplicate books in Continue Series** — `observeContinueSeriesItems` used `INNER JOIN series_items` which multiplied rows for books that belong to multiple series. Restructured to `EXISTS` so each `library_items` row appears exactly once. The `ORDER BY` subquery was also fixed to reference `li.serverId/li.id` instead of the now-unreachable `si.seriesId`.

## Changed files

| File | Change |
|------|--------|
| `MainScreen.kt` | Reuse parent ViewModel in `library_section` composable |
| `StorytellerReadaloudSyncer.kt` | `mutableMapOf` → `ConcurrentHashMap` |
| `SeriesDao.kt` | INNER JOIN → EXISTS; fix ORDER BY scope |
| `SeriesDaoTest.kt` | Add C5: deduplication when book is next in two series |
| `SleepTimerTest.kt` | Add missing `observeContinueSeriesItems` stub to two fakes |

## Test plan

- [x] `./gradlew test` — green
- [x] `./gradlew lint` — green
- [x] `make harness-test` — 206 tests, 0 failed
- [x] `make harness-test-tablet` — 5 tests, 0 failed