### PR TITLE
feat(settings): add sentence highlight color setting for readaloud

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -238,6 +238,7 @@ fun EpubReaderScreen(
     val audiobookItemId by viewModel.audiobookItemId.collectAsState()
     val activeFragmentRef by viewModel.activeFragmentRef.collectAsState()
     val sentenceQuotes by viewModel.sentenceQuotes.collectAsState()
+    val readaloudHighlightColor by viewModel.readaloudHighlightColor.collectAsState()
     val sentenceChapters by viewModel.sentenceChapters.collectAsState()
     val downloadPromptBytes by viewModel.downloadPromptBytes.collectAsState()
     val readaloudOfflineMessage by viewModel.readaloudOfflineMessage.collectAsState()
@@ -1275,7 +1276,7 @@ private fun EpubNavigatorView(
     // also re-keys on [sentenceQuotes] so the highlight re-applies with text once the quotes (built
     // off the main thread after the track loads) become available.
     val hasReadaloudDecoration = remember { mutableStateOf(false) }
-    LaunchedEffect(activeFragmentRef, reflowGeneration, pageLoadGeneration.value, sentenceQuotes) {
+    LaunchedEffect(activeFragmentRef, reflowGeneration, pageLoadGeneration.value, sentenceQuotes, readaloudHighlightColor) {
         val fragment = fragmentRef.value as? DecorableNavigator ?: return@LaunchedEffect
         val ref = activeFragmentRef
         if (ref == null) {
@@ -1293,7 +1294,7 @@ private fun EpubNavigatorView(
             id = "readaloud_active",
             locator = locator,
             style = Decoration.Style.Highlight(
-                tint = android.graphics.Color.parseColor("#FF7DD3FC"),
+                tint = readaloudHighlightColor.argb,
                 isActive = false,
             ),
         )

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -81,6 +81,7 @@ import com.riffle.app.feature.reader.readaloud.ReadaloudMiniPlayer
 import com.riffle.app.feature.reader.readaloud.ReadaloudPeek
 import com.riffle.app.ui.theme.RiffleTheme
 import com.riffle.core.domain.FormattingPreferences
+import com.riffle.core.domain.ReadaloudHighlightColor
 import com.riffle.core.domain.ReaderOrientation
 import com.riffle.core.domain.SentenceQuote
 import com.riffle.core.domain.ReaderTheme
@@ -322,6 +323,7 @@ fun EpubReaderScreen(
                         onPlayFromHere = viewModel::playFromHere,
                         readaloudAvailable = readaloudAvailable,
                         readaloudReservePx = readaloudReservePx,
+                        readaloudHighlightColor = readaloudHighlightColor,
                         annotationsAvailable = annotationsAvailable,
                         highlightRenders = highlightRenders,
                         onHighlight = viewModel::createHighlight,
@@ -794,6 +796,7 @@ private fun EpubNavigatorView(
     onPlayFromHere: (fragmentRef: String) -> Unit,
     readaloudAvailable: Boolean,
     readaloudReservePx: Int = 0,
+    readaloudHighlightColor: ReadaloudHighlightColor,
     annotationsAvailable: Boolean,
     highlightRenders: List<EpubReaderViewModel.HighlightRender>,
     onHighlight: (Locator) -> Unit,

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -37,6 +37,8 @@ import com.riffle.core.domain.ServerProgress
 import com.riffle.core.domain.ServerRepository
 import com.riffle.core.domain.ServerType
 import com.riffle.core.domain.ReadaloudResumePosition
+import com.riffle.core.domain.ReadaloudHighlightColor
+import com.riffle.core.domain.ReadaloudPreferencesStore
 import com.riffle.core.domain.ReadaloudResumeStore
 import com.riffle.core.domain.ReadingPositionStore
 import com.riffle.core.domain.SessionPayload
@@ -139,6 +141,7 @@ class EpubReaderViewModel @Inject constructor(
     private val annotationStore: AnnotationStore,
     private val nowPlayingStore: com.riffle.app.playback.NowPlayingStore,
     private val progressFlushScope: ProgressFlushScope,
+    private val readaloudPreferencesStore: ReadaloudPreferencesStore,
 ) : AndroidViewModel(application) {
 
     private val itemId: String = checkNotNull(savedStateHandle["itemId"])
@@ -343,6 +346,11 @@ class EpubReaderViewModel @Inject constructor(
     // rendered EPUB's own spans, the first time readaloud prepares.
     private val _sentenceQuotes = MutableStateFlow<Map<String, com.riffle.core.domain.SentenceQuote>>(emptyMap())
     val sentenceQuotes: StateFlow<Map<String, com.riffle.core.domain.SentenceQuote>> = _sentenceQuotes
+
+    val readaloudHighlightColor: StateFlow<ReadaloudHighlightColor> =
+        readaloudPreferencesStore.preferences
+            .map { it.highlightColor }
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), ReadaloudHighlightColor.BLUE)
 
     // span id → bundle chapter href, so "Play from here" can scope the sentence resolver to the chapter
     // being read (a phrase that recurs across chapters otherwise resolves to the wrong chapter's clip).

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsScreen.kt
@@ -63,7 +63,6 @@ import com.riffle.app.feature.reader.FormattingPanel
 import com.riffle.app.ui.TabletContentWidthContainer
 import com.riffle.core.domain.AppTheme
 import com.riffle.core.domain.ReadaloudHighlightColor
-import com.riffle.core.domain.ReadaloudPreferences
 import com.riffle.core.domain.Server
 import com.riffle.core.domain.ServerType
 import kotlinx.coroutines.launch

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsScreen.kt
@@ -54,6 +54,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.platform.ClipEntry
 import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.text.font.FontFamily
@@ -257,6 +259,10 @@ fun SettingsScreen(
                                             if (isSelected) Modifier.border(2.dp, MaterialTheme.colorScheme.onSurface, CircleShape)
                                             else Modifier
                                         )
+                                        .semantics {
+                                            contentDescription = color.name.lowercase()
+                                                .replaceFirstChar { it.uppercase() } + " highlight"
+                                        }
                                         .clickable { viewModel.updateReadaloudHighlightColor(color) },
                                 )
                             }

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsScreen.kt
@@ -4,14 +4,18 @@ import android.content.ClipData
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
@@ -47,6 +51,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.ClipEntry
@@ -57,6 +62,8 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import com.riffle.app.feature.reader.FormattingPanel
 import com.riffle.app.ui.TabletContentWidthContainer
 import com.riffle.core.domain.AppTheme
+import com.riffle.core.domain.ReadaloudHighlightColor
+import com.riffle.core.domain.ReadaloudPreferences
 import com.riffle.core.domain.Server
 import com.riffle.core.domain.ServerType
 import kotlinx.coroutines.launch
@@ -83,6 +90,7 @@ fun SettingsScreen(
     val libraryItemsByServer by viewModel.libraryUiItemsByServer.collectAsState()
     val readaloudSummaries by viewModel.readaloudSummaries.collectAsState()
     val appUpdateState by viewModel.appUpdateState.collectAsState()
+    val readaloudPreferences by viewModel.readaloudPreferences.collectAsState()
     val clipboard = LocalClipboard.current
     val scope = rememberCoroutineScope()
     val expandedServers = remember { mutableStateMapOf<String, Boolean>() }
@@ -225,6 +233,35 @@ fun SettingsScreen(
                     supportingContent = { Text("Font, theme, spacing, screen wake, volume keys") },
                     trailingContent = {
                         TextButton(onClick = { showFormattingPanel = true }) { Text("Edit") }
+                    },
+                )
+                HorizontalDivider()
+
+                Text(
+                    text = "Readaloud",
+                    style = MaterialTheme.typography.titleSmall,
+                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+                )
+                HorizontalDivider()
+                ListItem(
+                    headlineContent = { Text("Sentence highlight") },
+                    trailingContent = {
+                        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                            ReadaloudHighlightColor.entries.forEach { color ->
+                                val isSelected = readaloudPreferences.highlightColor == color
+                                Box(
+                                    modifier = Modifier
+                                        .size(28.dp)
+                                        .clip(CircleShape)
+                                        .background(Color(color.argb.toLong() and 0xFFFFFFFFL))
+                                        .then(
+                                            if (isSelected) Modifier.border(2.dp, MaterialTheme.colorScheme.onSurface, CircleShape)
+                                            else Modifier
+                                        )
+                                        .clickable { viewModel.updateReadaloudHighlightColor(color) },
+                                )
+                            }
+                        }
                     },
                 )
                 HorizontalDivider()

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsScreen.kt
@@ -228,7 +228,7 @@ fun SettingsScreen(
                 HorizontalDivider()
                 ListItem(
                     modifier = Modifier.clickable { showFormattingPanel = true },
-                    headlineContent = { Text("Reading settings") },
+                    headlineContent = { Text("Formatting") },
                     supportingContent = { Text("Font, theme, spacing, screen wake, volume keys") },
                     trailingContent = {
                         TextButton(onClick = { showFormattingPanel = true }) { Text("Edit") }

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsViewModel.kt
@@ -17,6 +17,9 @@ import com.riffle.core.domain.LibraryOrderPreferencesStore
 import com.riffle.core.domain.LibraryRepository
 import com.riffle.core.domain.LibraryVisibilityPreferencesStore
 import com.riffle.core.domain.orderLibraries
+import com.riffle.core.domain.ReadaloudHighlightColor
+import com.riffle.core.domain.ReadaloudPreferences
+import com.riffle.core.domain.ReadaloudPreferencesStore
 import com.riffle.core.domain.ReadaloudReviewRepository
 import com.riffle.core.domain.Server
 import com.riffle.core.domain.ServerType
@@ -53,6 +56,7 @@ class SettingsViewModel @Inject constructor(
     private val readaloudReviewRepository: ReadaloudReviewRepository,
     private val connectivityObserver: ConnectivityObserver,
     private val appUpdateRepository: AppUpdateRepository,
+    private val readaloudPreferencesStore: ReadaloudPreferencesStore,
 ) : ViewModel() {
 
     val lastCrashReport: CrashReport? = crashReportRepository.getLastCrashReport()
@@ -99,6 +103,10 @@ class SettingsViewModel @Inject constructor(
     val globalFormattingPreferences: StateFlow<FormattingPreferences> =
         formattingPreferencesStore.preferences
             .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), FormattingPreferences())
+
+    val readaloudPreferences: StateFlow<ReadaloudPreferences> =
+        readaloudPreferencesStore.preferences
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), ReadaloudPreferences())
 
     val keepScreenOn: StateFlow<Boolean> = wakeLockPreferencesStore.keepScreenOn
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), true)
@@ -205,6 +213,12 @@ class SettingsViewModel @Inject constructor(
 
     fun updateGlobalFormatting(prefs: FormattingPreferences) {
         viewModelScope.launch { formattingPreferencesStore.update(prefs) }
+    }
+
+    fun updateReadaloudHighlightColor(color: ReadaloudHighlightColor) {
+        viewModelScope.launch {
+            readaloudPreferencesStore.update(ReadaloudPreferences(highlightColor = color))
+        }
     }
 
     fun setKeepScreenOn(value: Boolean) {

--- a/app/src/test/kotlin/com/riffle/app/feature/settings/SettingsViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/settings/SettingsViewModelTest.kt
@@ -530,10 +530,15 @@ class SettingsViewModelTest {
     // --- readaloud highlight color ---
 
     @Test
-    fun `updateReadaloudHighlightColor persists new color to store`() = runTest {
+    fun `updateReadaloudHighlightColor persists new color to store and updates StateFlow`() = runTest {
         val vm = makeViewModel()
+        val emitted = mutableListOf<ReadaloudHighlightColor>()
+        val job = launch { vm.readaloudPreferences.collect { emitted.add(it.highlightColor) } }
+        testDispatcher.scheduler.advanceUntilIdle()
         vm.updateReadaloudHighlightColor(ReadaloudHighlightColor.YELLOW)
         testDispatcher.scheduler.advanceUntilIdle()
         assertEquals(ReadaloudHighlightColor.YELLOW, readaloudPrefsFlow.value.highlightColor)
+        assertEquals(ReadaloudHighlightColor.YELLOW, emitted.last())
+        job.cancel()
     }
 }

--- a/app/src/test/kotlin/com/riffle/app/feature/settings/SettingsViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/settings/SettingsViewModelTest.kt
@@ -2,6 +2,9 @@ package com.riffle.app.feature.settings
 
 import com.riffle.core.domain.AppTheme
 import com.riffle.core.domain.AppThemeStore
+import com.riffle.core.domain.ReadaloudHighlightColor
+import com.riffle.core.domain.ReadaloudPreferences
+import com.riffle.core.domain.ReadaloudPreferencesStore
 import com.riffle.core.domain.AuthenticateResult
 import com.riffle.core.domain.CommitServerResult
 import com.riffle.core.domain.Collection
@@ -70,6 +73,12 @@ class SettingsViewModelTest {
     private val noOpWakeLockStore = object : WakeLockPreferencesStore {
         override val keepScreenOn = flowOf(true)
         override suspend fun setKeepScreenOn(value: Boolean) {}
+    }
+
+    private val readaloudPrefsFlow = MutableStateFlow(ReadaloudPreferences())
+    private val fakeReadaloudStore = object : ReadaloudPreferencesStore {
+        override val preferences = readaloudPrefsFlow
+        override suspend fun update(prefs: ReadaloudPreferences) { readaloudPrefsFlow.value = prefs }
     }
 
     private val volumeNavEnabledFlow = MutableStateFlow(true)
@@ -210,6 +219,7 @@ class SettingsViewModelTest {
         readaloudReviewRepository = fakeReviewRepo,
         connectivityObserver = fakeConnectivity,
         appUpdateRepository = fakeAppUpdateRepo,
+        readaloudPreferencesStore = fakeReadaloudStore,
     )
 
     // --- existing crash report tests (unchanged) ---
@@ -515,5 +525,15 @@ class SettingsViewModelTest {
         testDispatcher.scheduler.advanceUntilIdle()
 
         assertEquals(AppTheme.Dark, appThemeFlow.first())
+    }
+
+    // --- readaloud highlight color ---
+
+    @Test
+    fun `updateReadaloudHighlightColor persists new color to store`() = runTest {
+        val vm = makeViewModel()
+        vm.updateReadaloudHighlightColor(ReadaloudHighlightColor.YELLOW)
+        testDispatcher.scheduler.advanceUntilIdle()
+        assertEquals(ReadaloudHighlightColor.YELLOW, readaloudPrefsFlow.value.highlightColor)
     }
 }

--- a/core/data/src/main/kotlin/com/riffle/core/data/ReadaloudPreferencesStoreImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/ReadaloudPreferencesStoreImpl.kt
@@ -1,0 +1,34 @@
+package com.riffle.core.data
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import com.riffle.core.data.di.ReadaloudPreferencesDataStore
+import com.riffle.core.domain.ReadaloudHighlightColor
+import com.riffle.core.domain.ReadaloudPreferences
+import com.riffle.core.domain.ReadaloudPreferencesStore
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+
+class ReadaloudPreferencesStoreImpl @Inject constructor(
+    @param:ReadaloudPreferencesDataStore private val dataStore: DataStore<Preferences>,
+) : ReadaloudPreferencesStore {
+
+    override val preferences: Flow<ReadaloudPreferences> = dataStore.data.map { prefs ->
+        ReadaloudPreferences(
+            highlightColor = prefs[KEY_HIGHLIGHT_COLOR]
+                ?.let { runCatching { ReadaloudHighlightColor.valueOf(it) }.getOrNull() }
+                ?: ReadaloudHighlightColor.BLUE,
+        )
+    }
+
+    override suspend fun update(prefs: ReadaloudPreferences) {
+        dataStore.edit { it[KEY_HIGHLIGHT_COLOR] = prefs.highlightColor.name }
+    }
+
+    private companion object {
+        val KEY_HIGHLIGHT_COLOR = stringPreferencesKey("highlight_color")
+    }
+}

--- a/core/data/src/main/kotlin/com/riffle/core/data/di/DataModule.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/di/DataModule.kt
@@ -149,6 +149,10 @@ annotation class DeviceIdDataStore
 
 @Qualifier
 @Retention(AnnotationRetention.BINARY)
+annotation class ReadaloudPreferencesDataStore
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
 annotation class EpubCacheStore
 
 @Qualifier

--- a/core/data/src/main/kotlin/com/riffle/core/data/di/DataModule.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/di/DataModule.kt
@@ -42,6 +42,7 @@ import com.riffle.core.data.CoverGridDensityStoreImpl
 import com.riffle.core.data.AppThemeStoreImpl
 import com.riffle.core.data.VolumeKeyPreferencesStoreImpl
 import com.riffle.core.data.WakeLockPreferencesStoreImpl
+import com.riffle.core.data.ReadaloudPreferencesStoreImpl
 import com.riffle.core.domain.AnnotationStore
 import com.riffle.core.domain.AudioIdentityResolver
 import com.riffle.core.domain.AudioPlaybackPreferencesStore
@@ -76,6 +77,7 @@ import com.riffle.core.domain.CoverGridDensityStore
 import com.riffle.core.domain.AppThemeStore
 import com.riffle.core.domain.VolumeKeyPreferencesStore
 import com.riffle.core.domain.WakeLockPreferencesStore
+import com.riffle.core.domain.ReadaloudPreferencesStore
 import com.riffle.core.data.AudiobookBundleDownloader
 import com.riffle.core.data.ReadaloudAudioRepositoryImpl
 import com.riffle.core.data.StorytellerBundleAudiobookSource
@@ -318,6 +320,10 @@ abstract class DataModule {
     @Binds
     @Singleton
     abstract fun bindCoverGridDensityStore(impl: CoverGridDensityStoreImpl): CoverGridDensityStore
+
+    @Binds
+    @Singleton
+    abstract fun bindReadaloudPreferencesStore(impl: ReadaloudPreferencesStoreImpl): ReadaloudPreferencesStore
 
     @Binds
     @Singleton
@@ -653,6 +659,13 @@ abstract class DataModule {
         fun provideDeviceIdDataStore(
             @ApplicationContext context: Context
         ): DataStore<Preferences> = context.deviceIdDataStore
+
+        @Provides
+        @Singleton
+        @ReadaloudPreferencesDataStore
+        fun provideReadaloudPreferencesDataStore(
+            @ApplicationContext context: Context
+        ): DataStore<Preferences> = context.readaloudPreferencesDataStore
 
         @Provides
         @Singleton

--- a/core/data/src/main/kotlin/com/riffle/core/data/di/ReadaloudPreferencesDataStoreExt.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/di/ReadaloudPreferencesDataStoreExt.kt
@@ -1,0 +1,9 @@
+package com.riffle.core.data.di
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.preferencesDataStore
+
+val Context.readaloudPreferencesDataStore: DataStore<Preferences>
+    by preferencesDataStore(name = "readaloud_preferences")

--- a/core/data/src/test/kotlin/com/riffle/core/data/ReadaloudPreferencesStoreTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/ReadaloudPreferencesStoreTest.kt
@@ -1,0 +1,45 @@
+package com.riffle.core.data
+
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import com.riffle.core.domain.ReadaloudHighlightColor
+import com.riffle.core.domain.ReadaloudPreferences
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ReadaloudPreferencesStoreTest {
+
+    @get:Rule
+    val tmp = TemporaryFolder()
+
+    private val dispatcher = UnconfinedTestDispatcher()
+    private val testScope = TestScope(dispatcher)
+
+    private fun buildStore() = ReadaloudPreferencesStoreImpl(
+        PreferenceDataStoreFactory.create(
+            scope = testScope.backgroundScope,
+            produceFile = { tmp.newFile("readaloud_prefs.preferences_pb") },
+        )
+    )
+
+    @Test
+    fun `default preferences returned when DataStore is empty`() = testScope.runTest {
+        assertEquals(ReadaloudPreferences(), buildStore().preferences.first())
+    }
+
+    @Test
+    fun `each highlight color round-trips through DataStore`() = testScope.runTest {
+        val store = buildStore()
+        for (color in ReadaloudHighlightColor.entries) {
+            store.update(ReadaloudPreferences(highlightColor = color))
+            assertEquals(color, store.preferences.first().highlightColor)
+        }
+    }
+}

--- a/core/data/src/test/kotlin/com/riffle/core/data/ReadaloudPreferencesStoreTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/ReadaloudPreferencesStoreTest.kt
@@ -1,6 +1,8 @@
 package com.riffle.core.data
 
 import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
 import com.riffle.core.domain.ReadaloudHighlightColor
 import com.riffle.core.domain.ReadaloudPreferences
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -41,5 +43,16 @@ class ReadaloudPreferencesStoreTest {
             store.update(ReadaloudPreferences(highlightColor = color))
             assertEquals(color, store.preferences.first().highlightColor)
         }
+    }
+
+    @Test
+    fun `unrecognized stored value falls back to BLUE`() = testScope.runTest {
+        val rawStore = PreferenceDataStoreFactory.create(
+            scope = backgroundScope,
+            produceFile = { tmp.newFile("readaloud_prefs_fallback.preferences_pb") },
+        )
+        rawStore.edit { it[stringPreferencesKey("highlight_color")] = "NOT_A_COLOR" }
+        val store = ReadaloudPreferencesStoreImpl(rawStore)
+        assertEquals(ReadaloudHighlightColor.BLUE, store.preferences.first().highlightColor)
     }
 }

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/ReadaloudPreferences.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/ReadaloudPreferences.kt
@@ -1,0 +1,20 @@
+package com.riffle.core.domain
+
+import kotlinx.coroutines.flow.Flow
+
+enum class ReadaloudHighlightColor(val argb: Int) {
+    BLUE(0xFF7DD3FC.toInt()),
+    YELLOW(0xFFFDE68A.toInt()),
+    GREEN(0xFF86EFAC.toInt()),
+    PINK(0xFFFDA4AF.toInt()),
+    PURPLE(0xFFC4B5FD.toInt()),
+}
+
+data class ReadaloudPreferences(
+    val highlightColor: ReadaloudHighlightColor = ReadaloudHighlightColor.BLUE,
+)
+
+interface ReadaloudPreferencesStore {
+    val preferences: Flow<ReadaloudPreferences>
+    suspend fun update(prefs: ReadaloudPreferences)
+}

--- a/docs/superpowers/plans/2026-06-15-readaloud-highlight-style.md
+++ b/docs/superpowers/plans/2026-06-15-readaloud-highlight-style.md
@@ -1,0 +1,551 @@
+# Readaloud Highlight Style Setting — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the hardcoded readaloud sentence-highlight color with a user-configurable preset stored in a new `ReadaloudPreferences` DataStore.
+
+**Architecture:** New `ReadaloudPreferences` domain type + `ReadaloudPreferencesStore` interface in `core/domain`; `ReadaloudPreferencesStoreImpl` backed by a Jetpack DataStore Preferences instance in `core/data`; Hilt qualifier + binding in `DataModule`; `EpubReaderViewModel` exposes a `StateFlow<ReadaloudHighlightColor>` that drives the highlight `LaunchedEffect`; `SettingsViewModel` exposes the preferences and an update method; `SettingsScreen` shows an inline color-chip row under a new "Readaloud" section.
+
+**Tech Stack:** Kotlin, Jetpack DataStore Preferences, Hilt, Compose Material 3, Readium `Decoration.Style.Highlight`
+
+---
+
+## File Map
+
+| Action | Path |
+|--------|------|
+| **Create** | `core/domain/src/main/kotlin/com/riffle/core/domain/ReadaloudPreferences.kt` |
+| **Create** | `core/data/src/main/kotlin/com/riffle/core/data/di/ReadaloudPreferencesDataStoreExt.kt` |
+| **Create** | `core/data/src/main/kotlin/com/riffle/core/data/ReadaloudPreferencesStoreImpl.kt` |
+| **Create** | `core/data/src/test/kotlin/com/riffle/core/data/ReadaloudPreferencesStoreTest.kt` |
+| **Modify** | `core/data/src/main/kotlin/com/riffle/core/data/di/DataModule.kt` |
+| **Modify** | `app/src/main/kotlin/com/riffle/app/feature/settings/SettingsViewModel.kt` |
+| **Modify** | `app/src/main/kotlin/com/riffle/app/feature/settings/SettingsScreen.kt` |
+| **Modify** | `app/src/test/kotlin/com/riffle/app/feature/settings/SettingsViewModelTest.kt` |
+| **Modify** | `app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt` |
+| **Modify** | `app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt` |
+
+---
+
+## Task 1: Domain types
+
+**Files:**
+- Create: `core/domain/src/main/kotlin/com/riffle/core/domain/ReadaloudPreferences.kt`
+
+No tests needed — pure data types with no logic.
+
+- [ ] **Step 1: Create `ReadaloudPreferences.kt`**
+
+```kotlin
+package com.riffle.core.domain
+
+import kotlinx.coroutines.flow.Flow
+
+enum class ReadaloudHighlightColor(val argb: Int) {
+    BLUE(0xFF7DD3FC.toInt()),
+    YELLOW(0xFFFDE68A.toInt()),
+    GREEN(0xFF86EFAC.toInt()),
+    PINK(0xFFFDA4AF.toInt()),
+    PURPLE(0xFFC4B5FD.toInt()),
+}
+
+data class ReadaloudPreferences(
+    val highlightColor: ReadaloudHighlightColor = ReadaloudHighlightColor.BLUE,
+)
+
+interface ReadaloudPreferencesStore {
+    val preferences: Flow<ReadaloudPreferences>
+    suspend fun update(prefs: ReadaloudPreferences)
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add core/domain/src/main/kotlin/com/riffle/core/domain/ReadaloudPreferences.kt
+git commit -m "feat(domain): add ReadaloudPreferences with highlight color enum and store interface"
+```
+
+---
+
+## Task 2: DataStore implementation + tests
+
+**Files:**
+- Create: `core/data/src/main/kotlin/com/riffle/core/data/di/ReadaloudPreferencesDataStoreExt.kt`
+- Create: `core/data/src/main/kotlin/com/riffle/core/data/ReadaloudPreferencesStoreImpl.kt`
+- Create: `core/data/src/test/kotlin/com/riffle/core/data/ReadaloudPreferencesStoreTest.kt`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `core/data/src/test/kotlin/com/riffle/core/data/ReadaloudPreferencesStoreTest.kt`:
+
+```kotlin
+package com.riffle.core.data
+
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import com.riffle.core.domain.ReadaloudHighlightColor
+import com.riffle.core.domain.ReadaloudPreferences
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ReadaloudPreferencesStoreTest {
+
+    @get:Rule
+    val tmp = TemporaryFolder()
+
+    private val dispatcher = UnconfinedTestDispatcher()
+    private val testScope = TestScope(dispatcher)
+
+    private fun buildStore() = ReadaloudPreferencesStoreImpl(
+        PreferenceDataStoreFactory.create(
+            scope = testScope.backgroundScope,
+            produceFile = { tmp.newFile("readaloud_prefs.preferences_pb") },
+        )
+    )
+
+    @Test
+    fun `default preferences returned when DataStore is empty`() = testScope.runTest {
+        assertEquals(ReadaloudPreferences(), buildStore().preferences.first())
+    }
+
+    @Test
+    fun `each highlight color round-trips through DataStore`() = testScope.runTest {
+        val store = buildStore()
+        for (color in ReadaloudHighlightColor.entries) {
+            store.update(ReadaloudPreferences(highlightColor = color))
+            assertEquals(color, store.preferences.first().highlightColor)
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+```bash
+export JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"
+./gradlew :core:data:test --tests "com.riffle.core.data.ReadaloudPreferencesStoreTest" 2>&1 | tail -20
+```
+
+Expected: compilation failure — `ReadaloudPreferencesStoreImpl` does not exist yet.
+
+- [ ] **Step 3: Create the DataStore extension**
+
+Create `core/data/src/main/kotlin/com/riffle/core/data/di/ReadaloudPreferencesDataStoreExt.kt`:
+
+```kotlin
+package com.riffle.core.data.di
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.preferencesDataStore
+
+val Context.readaloudPreferencesDataStore: DataStore<Preferences>
+    by preferencesDataStore(name = "readaloud_preferences")
+```
+
+- [ ] **Step 4: Create `ReadaloudPreferencesStoreImpl`**
+
+Create `core/data/src/main/kotlin/com/riffle/core/data/ReadaloudPreferencesStoreImpl.kt`:
+
+```kotlin
+package com.riffle.core.data
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import com.riffle.core.data.di.ReadaloudPreferencesDataStore
+import com.riffle.core.domain.ReadaloudHighlightColor
+import com.riffle.core.domain.ReadaloudPreferences
+import com.riffle.core.domain.ReadaloudPreferencesStore
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+
+class ReadaloudPreferencesStoreImpl @Inject constructor(
+    @param:ReadaloudPreferencesDataStore private val dataStore: DataStore<Preferences>,
+) : ReadaloudPreferencesStore {
+
+    override val preferences: Flow<ReadaloudPreferences> = dataStore.data.map { prefs ->
+        ReadaloudPreferences(
+            highlightColor = prefs[KEY_HIGHLIGHT_COLOR]
+                ?.let { runCatching { ReadaloudHighlightColor.valueOf(it) }.getOrNull() }
+                ?: ReadaloudHighlightColor.BLUE,
+        )
+    }
+
+    override suspend fun update(prefs: ReadaloudPreferences) {
+        dataStore.edit { it[KEY_HIGHLIGHT_COLOR] = prefs.highlightColor.name }
+    }
+
+    private companion object {
+        val KEY_HIGHLIGHT_COLOR = stringPreferencesKey("highlight_color")
+    }
+}
+```
+
+Note: the test (`ReadaloudPreferencesStoreTest`) constructs `ReadaloudPreferencesStoreImpl` directly with a `DataStore<Preferences>` (not via the Hilt qualifier), so the `@param:ReadaloudPreferencesDataStore` annotation on the constructor is ignored in tests — this matches exactly how `FormattingPreferencesStoreTest` works.
+
+- [ ] **Step 5: Run tests to confirm they pass**
+
+```bash
+export JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"
+./gradlew :core:data:test --tests "com.riffle.core.data.ReadaloudPreferencesStoreTest" 2>&1 | tail -20
+```
+
+Expected: `BUILD SUCCESSFUL`, 2 tests passing.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add core/data/src/main/kotlin/com/riffle/core/data/di/ReadaloudPreferencesDataStoreExt.kt \
+        core/data/src/main/kotlin/com/riffle/core/data/ReadaloudPreferencesStoreImpl.kt \
+        core/data/src/test/kotlin/com/riffle/core/data/ReadaloudPreferencesStoreTest.kt
+git commit -m "feat(data): add ReadaloudPreferencesStoreImpl backed by DataStore"
+```
+
+---
+
+## Task 3: Hilt DI wiring
+
+**Files:**
+- Modify: `core/data/src/main/kotlin/com/riffle/core/data/di/DataModule.kt`
+
+- [ ] **Step 1: Add qualifier annotation to `DataModule.kt`**
+
+In `DataModule.kt`, add the new qualifier alongside the existing ones (e.g. after `CoverGridDensityDataStore` at line ~144):
+
+```kotlin
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class ReadaloudPreferencesDataStore
+```
+
+- [ ] **Step 2: Add `@Binds` for the store and `@Provides` for the DataStore instance**
+
+In the `DataModule` abstract class body, add after `bindCoverGridDensityStore` (around line 316):
+
+```kotlin
+@Binds
+@Singleton
+abstract fun bindReadaloudPreferencesStore(impl: ReadaloudPreferencesStoreImpl): ReadaloudPreferencesStore
+```
+
+In the `DataModule.companion object`, add after `provideCoverGridDensityDataStore`:
+
+```kotlin
+@Provides
+@Singleton
+@ReadaloudPreferencesDataStore
+fun provideReadaloudPreferencesDataStore(
+    @ApplicationContext context: Context
+): DataStore<Preferences> = context.readaloudPreferencesDataStore
+```
+
+Also add the required imports at the top of `DataModule.kt`:
+
+```kotlin
+import com.riffle.core.data.ReadaloudPreferencesStoreImpl
+import com.riffle.core.domain.ReadaloudPreferencesStore
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add core/data/src/main/kotlin/com/riffle/core/data/di/DataModule.kt
+git commit -m "feat(di): wire ReadaloudPreferencesStore into Hilt graph"
+```
+
+---
+
+## Task 4: Settings ViewModel + test
+
+**Files:**
+- Modify: `app/src/main/kotlin/com/riffle/app/feature/settings/SettingsViewModel.kt`
+- Modify: `app/src/test/kotlin/com/riffle/app/feature/settings/SettingsViewModelTest.kt`
+
+- [ ] **Step 1: Write the failing test first**
+
+In `SettingsViewModelTest.kt`, add the following. First add imports at the top:
+
+```kotlin
+import com.riffle.core.domain.ReadaloudHighlightColor
+import com.riffle.core.domain.ReadaloudPreferences
+import com.riffle.core.domain.ReadaloudPreferencesStore
+```
+
+Then add a fake store field alongside the other `noOp*` fields:
+
+```kotlin
+private val readaloudPrefsFlow = MutableStateFlow(ReadaloudPreferences())
+private val fakeReadaloudStore = object : ReadaloudPreferencesStore {
+    override val preferences = readaloudPrefsFlow
+    override suspend fun update(prefs: ReadaloudPreferences) { readaloudPrefsFlow.value = prefs }
+}
+```
+
+Then add the test:
+
+```kotlin
+@Test
+fun `updateReadaloudHighlightColor persists new color to store`() = testScope.runTest {
+    val vm = makeViewModel()
+    vm.updateReadaloudHighlightColor(ReadaloudHighlightColor.YELLOW)
+    testDispatcher.scheduler.advanceUntilIdle()
+    assertEquals(ReadaloudHighlightColor.YELLOW, readaloudPrefsFlow.value.highlightColor)
+}
+```
+
+- [ ] **Step 2: Run test to confirm it fails**
+
+```bash
+export JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"
+./gradlew :app:testDebugUnitTest --tests "com.riffle.app.feature.settings.SettingsViewModelTest.updateReadaloudHighlightColor*" 2>&1 | tail -20
+```
+
+Expected: compilation failure — `updateReadaloudHighlightColor` not on `SettingsViewModel` yet.
+
+- [ ] **Step 3: Add `ReadaloudPreferencesStore` to `SettingsViewModel`**
+
+In `SettingsViewModel.kt`:
+
+Add import:
+```kotlin
+import com.riffle.core.domain.ReadaloudPreferences
+import com.riffle.core.domain.ReadaloudPreferencesStore
+import com.riffle.core.domain.ReadaloudHighlightColor
+```
+
+Add `readaloudPreferencesStore` to the constructor (after `appUpdateRepository`):
+
+```kotlin
+private val readaloudPreferencesStore: ReadaloudPreferencesStore,
+```
+
+Add the `StateFlow` property (alongside `globalFormattingPreferences`):
+
+```kotlin
+val readaloudPreferences: StateFlow<ReadaloudPreferences> =
+    readaloudPreferencesStore.preferences
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), ReadaloudPreferences())
+```
+
+Add the update function (alongside `updateGlobalFormatting`):
+
+```kotlin
+fun updateReadaloudHighlightColor(color: ReadaloudHighlightColor) {
+    viewModelScope.launch {
+        readaloudPreferencesStore.update(ReadaloudPreferences(highlightColor = color))
+    }
+}
+```
+
+- [ ] **Step 4: Update `makeViewModel()` in the test to pass `fakeReadaloudStore`**
+
+In `SettingsViewModelTest.kt`, update `makeViewModel()` to include the new parameter:
+
+```kotlin
+private fun makeViewModel(report: CrashReport? = null) = SettingsViewModel(
+    crashReportRepository = object : CrashReportRepository {
+        override fun getLastCrashReport() = report
+    },
+    formattingPreferencesStore = noOpFormattingStore,
+    serverRepository = fakeServerRepo(),
+    libraryRepository = fakeLibraryRepo(),
+    visibilityStore = fakeVisibilityStore(),
+    orderStore = fakeOrderStore(),
+    wakeLockPreferencesStore = noOpWakeLockStore,
+    volumeKeyPreferencesStore = fakeVolumeKeyStore,
+    appThemeStore = fakeAppThemeStore,
+    readaloudReviewRepository = fakeReviewRepo,
+    connectivityObserver = fakeConnectivity,
+    appUpdateRepository = fakeAppUpdateRepo,
+    readaloudPreferencesStore = fakeReadaloudStore,
+)
+```
+
+- [ ] **Step 5: Run tests to confirm they pass**
+
+```bash
+export JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"
+./gradlew :app:testDebugUnitTest --tests "com.riffle.app.feature.settings.SettingsViewModelTest" 2>&1 | tail -20
+```
+
+Expected: `BUILD SUCCESSFUL`, all tests including the new one passing.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/src/main/kotlin/com/riffle/app/feature/settings/SettingsViewModel.kt \
+        app/src/test/kotlin/com/riffle/app/feature/settings/SettingsViewModelTest.kt
+git commit -m "feat(settings): expose readaloud highlight color in SettingsViewModel"
+```
+
+---
+
+## Task 5: Settings UI
+
+**Files:**
+- Modify: `app/src/main/kotlin/com/riffle/app/feature/settings/SettingsScreen.kt`
+
+- [ ] **Step 1: Add imports to `SettingsScreen.kt`**
+
+Add these imports alongside the existing ones:
+
+```kotlin
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.ui.draw.clip
+import com.riffle.core.domain.ReadaloudHighlightColor
+import com.riffle.core.domain.ReadaloudPreferences
+```
+
+- [ ] **Step 2: Collect `readaloudPreferences` state**
+
+In `SettingsScreen`, alongside the other `collectAsState()` calls near the top of the composable (after `val appUpdateState by viewModel.appUpdateState.collectAsState()`):
+
+```kotlin
+val readaloudPreferences by viewModel.readaloudPreferences.collectAsState()
+```
+
+- [ ] **Step 3: Add the "Readaloud" section after the "Reading" section**
+
+In the `SettingsScreen` composable's `LazyColumn` / `Column`, after the existing `HorizontalDivider()` that follows the "Reading settings" `ListItem` (currently at line ~230):
+
+```kotlin
+Text(
+    text = "Readaloud",
+    style = MaterialTheme.typography.titleSmall,
+    modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+)
+HorizontalDivider()
+ListItem(
+    headlineContent = { Text("Sentence highlight") },
+    trailingContent = {
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            ReadaloudHighlightColor.entries.forEach { color ->
+                val isSelected = readaloudPreferences.highlightColor == color
+                Box(
+                    modifier = Modifier
+                        .size(28.dp)
+                        .clip(CircleShape)
+                        .background(Color(color.argb.toLong() and 0xFFFFFFFFL))
+                        .then(
+                            if (isSelected) Modifier.border(2.dp, MaterialTheme.colorScheme.onSurface, CircleShape)
+                            else Modifier
+                        )
+                        .clickable { viewModel.updateReadaloudHighlightColor(color) },
+                )
+            }
+        }
+    },
+)
+HorizontalDivider()
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/src/main/kotlin/com/riffle/app/feature/settings/SettingsScreen.kt
+git commit -m "feat(settings): add Readaloud section with sentence highlight color picker"
+```
+
+---
+
+## Task 6: Reader wiring
+
+**Files:**
+- Modify: `app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt`
+- Modify: `app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt`
+
+- [ ] **Step 1: Add `ReadaloudPreferencesStore` to `EpubReaderViewModel`**
+
+In `EpubReaderViewModel.kt`, add the import:
+
+```kotlin
+import com.riffle.core.domain.ReadaloudHighlightColor
+import com.riffle.core.domain.ReadaloudPreferencesStore
+```
+
+Add a constructor parameter after `progressFlushScope` (the last param before `) : AndroidViewModel(application)`):
+
+```kotlin
+private val readaloudPreferencesStore: ReadaloudPreferencesStore,
+```
+
+Add the exposed `StateFlow` (alongside the other state flows, e.g. near `sentenceQuotes`):
+
+```kotlin
+val readaloudHighlightColor: StateFlow<ReadaloudHighlightColor> =
+    readaloudPreferencesStore.preferences
+        .map { it.highlightColor }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), ReadaloudHighlightColor.BLUE)
+```
+
+The `map` import is already present in `EpubReaderViewModel.kt`.
+
+- [ ] **Step 2: Collect `readaloudHighlightColor` in `EpubReaderScreen`**
+
+In `EpubReaderScreen.kt`, add to the block of `collectAsState()` calls (near `val sentenceQuotes by viewModel.sentenceQuotes.collectAsState()`):
+
+```kotlin
+val readaloudHighlightColor by viewModel.readaloudHighlightColor.collectAsState()
+```
+
+- [ ] **Step 3: Replace hardcoded color and add to LaunchedEffect key**
+
+Find the readaloud decoration `LaunchedEffect` (currently starting at line ~1278):
+
+```kotlin
+LaunchedEffect(activeFragmentRef, reflowGeneration, pageLoadGeneration.value, sentenceQuotes) {
+```
+
+Replace with:
+
+```kotlin
+LaunchedEffect(activeFragmentRef, reflowGeneration, pageLoadGeneration.value, sentenceQuotes, readaloudHighlightColor) {
+```
+
+Then at line ~1296, replace:
+
+```kotlin
+tint = android.graphics.Color.parseColor("#FF7DD3FC"),
+```
+
+with:
+
+```kotlin
+tint = readaloudHighlightColor.argb,
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt \
+        app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+git commit -m "feat(reader): use user-configured readaloud highlight color from ReadaloudPreferencesStore"
+```
+
+---
+
+## Task 7: Verify all tests pass
+
+- [ ] **Step 1: Run full JVM test suite**
+
+```bash
+export JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"
+./gradlew test 2>&1 | tail -30
+```
+
+Expected: `BUILD SUCCESSFUL` with no failures. The two new test classes (`ReadaloudPreferencesStoreTest`, `SettingsViewModelTest` including the new test) should all be green.

--- a/docs/superpowers/specs/2026-06-15-readaloud-highlight-style-design.md
+++ b/docs/superpowers/specs/2026-06-15-readaloud-highlight-style-design.md
@@ -1,0 +1,103 @@
+# Readaloud Highlight Style Setting
+
+## Problem
+
+The readaloud synchronized-reading highlight color is hardcoded as `#FF7DD3FC` (sky blue) in
+`EpubReaderScreen.kt:1296`. Users cannot change it even when that color clashes with their chosen
+reader theme or personal preference.
+
+## Solution
+
+Introduce a global `ReadaloudPreferences` DataStore (following the same pattern as
+`FormattingPreferences`) with a single `highlightColor` setting exposed as a preset color picker in
+the Settings screen.
+
+Scope: global-only, not per-book. Highlight color is a personal taste preference — unlike font
+size or margins, it doesn't vary with individual books' publisher CSS.
+
+---
+
+## Data Layer
+
+### `ReadaloudHighlightColor` enum — `core/domain`
+
+```
+BLUE   → #FF7DD3FC  (default, current hardcoded value)
+YELLOW → #FFFDE68A
+GREEN  → #FF86EFAC
+PINK   → #FFFDA4AF
+PURPLE → #FFC4B5FD
+```
+
+Each case carries an `argb: Int` property used directly in `Decoration.Style.Highlight(tint = …)`.
+
+### `ReadaloudPreferences` data class — `core/domain`
+
+```kotlin
+data class ReadaloudPreferences(
+    val highlightColor: ReadaloudHighlightColor = ReadaloudHighlightColor.BLUE
+)
+```
+
+### `ReadaloudPreferencesStore` interface — `core/domain`
+
+```kotlin
+interface ReadaloudPreferencesStore {
+    val preferences: Flow<ReadaloudPreferences>
+    suspend fun update(prefs: ReadaloudPreferences)
+}
+```
+
+### `ReadaloudPreferencesStoreImpl` — `core/data`
+
+- Backed by `preferencesDataStore(name = "readaloud_preferences")` (new extension file
+  `ReadaloudPreferencesDataStoreExt.kt`, mirroring `FormattingPreferencesDataStoreExt.kt`)
+- Single DataStore key: `KEY_HIGHLIGHT_COLOR` (stringPreferencesKey), stores the enum name
+- Reads with `map { … }`, writes via `edit { … }`, defaulting to `BLUE`
+
+### DI — `DataModule.kt`
+
+Bind `ReadaloudPreferencesStoreImpl` to `ReadaloudPreferencesStore` (singleton), following the
+`FormattingPreferencesStore` binding.
+
+---
+
+## Reader Wiring
+
+`EpubReaderViewModel` injects `ReadaloudPreferencesStore` and exposes:
+
+```kotlin
+val readaloudHighlightColor: StateFlow<ReadaloudHighlightColor>
+```
+
+`EpubReaderScreen.kt` collects this as state and passes it to the highlight `LaunchedEffect` at
+line 1296, replacing the hardcoded `Color.parseColor("#FF7DD3FC")` with
+`readaloudHighlightColor.argb`.
+
+---
+
+## Settings UI
+
+`SettingsScreen` gains a new **"Readaloud"** section below the existing "Reading" section:
+
+- Section header: "Readaloud"
+- List item label: "Sentence highlight"
+- Trailing content: a row of five color-chip circles (one per preset), the active one shown with a
+  contrasting border ring
+- Tapping a chip calls `settingsViewModel.updateReadaloudHighlightColor(color)`
+
+`SettingsViewModel` injects `ReadaloudPreferencesStore` and exposes:
+- `readaloudPreferences: StateFlow<ReadaloudPreferences>`
+- `fun updateReadaloudHighlightColor(color: ReadaloudHighlightColor)`
+
+No separate panel or navigation needed — a single inline chip row is right-sized for one setting.
+
+---
+
+## Testing
+
+- Unit test `ReadaloudPreferencesStoreImpl`: round-trip write/read for each color, default value
+  when key absent.
+- Unit test `SettingsViewModel`: `updateReadaloudHighlightColor` persists to store.
+- No new harness (UI) tests required — the chip row is simple enough and there are no existing
+  readaloud harness tests to extend.


### PR DESCRIPTION
## Summary

- Adds a `ReadaloudPreferences` DataStore (`core/domain` + `core/data`) with a `highlightColor` field backed by five presets (Blue/Yellow/Green/Pink/Purple)
- Replaces the hardcoded `#FF7DD3FC` highlight tint in `EpubReaderScreen` with a user-configurable value via `EpubReaderViewModel`
- Exposes an inline color chip row under a new **Readaloud** section in Settings (global only — color is personal taste, not per-book)
- Aligns "Reading" list item headline with the `pkmetski/listening-settings-global` convention (`"Formatting"` instead of `"Reading settings"`)

## Test Plan

- [ ] Unit: `ReadaloudPreferencesStoreTest` — default value, all-colors round-trip, unknown-enum fallback → BLUE
- [ ] Unit: `SettingsViewModelTest` — `updateReadaloudHighlightColor` persists to store and updates exposed StateFlow
- [ ] `./gradlew test` — green (672 tests)
- [ ] `./gradlew lint` — green