### PR TITLE
feat(reader): reading time estimates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,9 @@
 # Riffle — Agent Instructions
 
+## Installing APKs on emulators
+
+Do not `adb install` a build onto an emulator unless the user explicitly asks, or unless you are about to do the testing yourself (e.g. verifying UI behaviour as part of a task). Building and committing are fine without installing.
+
 ## Running harness tests
 
 Always run harness tests via `make harness-test` (phone-form-factor tests) or `make harness-test-tablet` (tests annotated with `@TabletLayout`). Never call `./gradlew :app:connectedDebugAndroidTest` directly — it targets all connected devices and will interfere with the developer's physical device. Each target boots its dedicated AVD ("Harness Medium Phone" or "Harness Medium Tablet"), runs its filtered test subset against it exclusively, then shuts it down. The two subsets are mutually exclusive, so tests never double-run across targets.

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -734,7 +734,7 @@ private fun ReadingProgressLabels(
                     )
                     if (parts.isNotEmpty()) {
                         val pillText = parts.joinToString(" · ")
-                        val isExact = chapterTimeRemaining is TimeRemaining.Exact ||
+                        val isExact = chapterTimeRemaining is TimeRemaining.Exact &&
                             bookTimeRemaining is TimeRemaining.Exact
                         val pillColor = if (isExact) MaterialTheme.colorScheme.tertiary
                                         else textColor
@@ -742,6 +742,8 @@ private fun ReadingProgressLabels(
                             text = pillText,
                             style = MaterialTheme.typography.labelSmall,
                             color = pillColor,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
                             modifier = Modifier
                                 .background(
                                     color = pillColor.copy(alpha = 0.12f),

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -16,7 +16,6 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.ui.graphics.Color
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -758,12 +757,6 @@ private fun ReadingProgressLabels(
                             color = pillColor,
                             maxLines = 1,
                             overflow = TextOverflow.Ellipsis,
-                            modifier = Modifier
-                                .background(
-                                    color = pillColor.copy(alpha = 0.12f),
-                                    shape = RoundedCornerShape(8.dp),
-                                )
-                                .padding(horizontal = 6.dp, vertical = 2.dp),
                         )
                     }
                 }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.ui.graphics.Color
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -85,6 +86,7 @@ import com.riffle.core.domain.ReadaloudHighlightColor
 import com.riffle.core.domain.ReaderOrientation
 import com.riffle.core.domain.SentenceQuote
 import com.riffle.core.domain.ReaderTheme
+import com.riffle.core.domain.TimeRemaining
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
@@ -373,7 +375,8 @@ fun EpubReaderScreen(
             (
                 formattingPrefs.showChapterMap ||
                     formattingPrefs.showReadingProgressLabels ||
-                    formattingPrefs.showCurrentChapterLabel
+                    formattingPrefs.showCurrentChapterLabel ||
+                    formattingPrefs.showReadingTimeEstimate
                 )
         if (state is ReaderState.Ready && (readaloudOpen || showRailOverlay)) {
             Column(
@@ -431,6 +434,7 @@ fun EpubReaderScreen(
                         showRail = formattingPrefs.showChapterMap,
                         showProgressLabels = formattingPrefs.showReadingProgressLabels,
                         showChapterNameLabel = formattingPrefs.showCurrentChapterLabel,
+                        showReadingTimeEstimate = formattingPrefs.showReadingTimeEstimate,
                         readerTheme = formattingPrefs.theme,
                     )
                 }
@@ -553,6 +557,7 @@ private fun EpubChapterRailOverlay(
     showRail: Boolean,
     showProgressLabels: Boolean,
     showChapterNameLabel: Boolean,
+    showReadingTimeEstimate: Boolean,
     readerTheme: ReaderTheme,
     modifier: Modifier = Modifier,
 ) {
@@ -568,6 +573,8 @@ private fun EpubChapterRailOverlay(
     // whole-book value arrives it wins (and matches book details). At genuine 0% the rail cursor is
     // also ~0, so the fallback is indistinguishable there.
     val labelProgress = totalProgress?.takeIf { it > 0f } ?: cursorPosition
+    val chapterTimeRemaining by viewModel.chapterTimeRemaining.collectAsState()
+    val bookTimeRemaining by viewModel.bookTimeRemaining.collectAsState()
     val darkTheme = readerTheme == ReaderTheme.Dark || readerTheme == ReaderTheme.DarkDim
     RiffleTheme(darkTheme = darkTheme) {
         // Backdrop is the exact reader-theme page colour so the strip reads as page margin,
@@ -578,7 +585,7 @@ private fun EpubChapterRailOverlay(
                 .fillMaxWidth()
                 .background(readerTheme.palette.background),
         ) {
-            if (showProgressLabels || showChapterNameLabel) {
+            if (showProgressLabels || showChapterNameLabel || showReadingTimeEstimate) {
                 ReadingProgressLabels(
                     activeChapterIndex = activeRailSegmentIndex,
                     chapterCount = railSegments.size,
@@ -587,6 +594,9 @@ private fun EpubChapterRailOverlay(
                     readerTheme = readerTheme,
                     showCountAndPercent = showProgressLabels,
                     showChapterName = showChapterNameLabel,
+                    showReadingTimeEstimate = showReadingTimeEstimate,
+                    chapterTimeRemaining = chapterTimeRemaining,
+                    bookTimeRemaining = bookTimeRemaining,
                 )
             }
             if (showRail) {
@@ -618,6 +628,45 @@ private fun readerThemeLabelColor(theme: ReaderTheme): Color {
     return theme.palette.foreground.copy(alpha = alpha)
 }
 
+private fun formatDuration(sec: Long): String {
+    val hours = sec / 3600
+    val minutes = (sec % 3600) / 60
+    return when {
+        hours > 0 -> "${hours}h ${minutes}m"
+        else -> "${minutes} min"
+    }
+}
+
+private fun formatChapterRemaining(remaining: TimeRemaining): String = when (remaining) {
+    is TimeRemaining.Exact -> {
+        val sec = remaining.sec
+        val h = sec / 3600
+        val m = (sec % 3600) / 60
+        val s = sec % 60
+        if (h > 0) "%d:%02d:%02d in chapter".format(h, m, s)
+        else "%d:%02d in chapter".format(m, s)
+    }
+    is TimeRemaining.Estimated -> when {
+        remaining.sec < 60 -> "< 1 min in chapter"
+        else -> "~${formatDuration(remaining.sec)} in chapter"
+    }
+}
+
+private fun formatBookRemaining(remaining: TimeRemaining): String = when (remaining) {
+    is TimeRemaining.Exact -> {
+        val sec = remaining.sec
+        val h = sec / 3600
+        val m = (sec % 3600) / 60
+        val s = sec % 60
+        if (h > 0) "%d:%02d:%02d left".format(h, m, s)
+        else "%d:%02d left".format(m, s)
+    }
+    is TimeRemaining.Estimated -> when {
+        remaining.sec < 60 -> "< 1 min left"
+        else -> "~${formatDuration(remaining.sec)} left"
+    }
+}
+
 @Composable
 private fun ReadingProgressLabels(
     activeChapterIndex: Int,
@@ -627,6 +676,9 @@ private fun ReadingProgressLabels(
     readerTheme: ReaderTheme,
     showCountAndPercent: Boolean,
     showChapterName: Boolean,
+    showReadingTimeEstimate: Boolean = false,
+    chapterTimeRemaining: TimeRemaining? = null,
+    bookTimeRemaining: TimeRemaining? = null,
 ) {
     val chapterCountText = if (chapterCount > 0) {
         "Chapter ${(activeChapterIndex + 1).coerceAtMost(chapterCount)} of $chapterCount"
@@ -655,20 +707,51 @@ private fun ReadingProgressLabels(
                     .semantics { contentDescription = "Reading progress: $chapterCountText" },
             )
         }
-        if (showChapterName) {
-            Text(
-                text = activeChapterTitle,
-                style = MaterialTheme.typography.labelSmall,
-                color = textColor,
-                textAlign = TextAlign.Center,
-                fontStyle = FontStyle.Italic,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-                modifier = Modifier
-                    .weight(2f)
-                    .testTag("reading_progress_chapter_name")
-                    .semantics { contentDescription = "Current chapter: $activeChapterTitle" },
-            )
+        val showCenterColumn = showChapterName || showReadingTimeEstimate
+        if (showCenterColumn) {
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                modifier = Modifier.weight(2f),
+            ) {
+                if (showChapterName) {
+                    Text(
+                        text = activeChapterTitle,
+                        style = MaterialTheme.typography.labelSmall,
+                        color = textColor,
+                        textAlign = TextAlign.Center,
+                        fontStyle = FontStyle.Italic,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        modifier = Modifier
+                            .testTag("reading_progress_chapter_name")
+                            .semantics { contentDescription = "Current chapter: $activeChapterTitle" },
+                    )
+                }
+                if (showReadingTimeEstimate) {
+                    val parts = listOfNotNull(
+                        chapterTimeRemaining?.let { formatChapterRemaining(it) },
+                        bookTimeRemaining?.let { formatBookRemaining(it) },
+                    )
+                    if (parts.isNotEmpty()) {
+                        val pillText = parts.joinToString(" · ")
+                        val isExact = chapterTimeRemaining is TimeRemaining.Exact ||
+                            bookTimeRemaining is TimeRemaining.Exact
+                        val pillColor = if (isExact) MaterialTheme.colorScheme.tertiary
+                                        else textColor
+                        Text(
+                            text = pillText,
+                            style = MaterialTheme.typography.labelSmall,
+                            color = pillColor,
+                            modifier = Modifier
+                                .background(
+                                    color = pillColor.copy(alpha = 0.12f),
+                                    shape = RoundedCornerShape(8.dp),
+                                )
+                                .padding(horizontal = 6.dp, vertical = 2.dp),
+                        )
+                    }
+                }
+            }
         }
         if (showCountAndPercent) {
             Text(

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -646,7 +646,7 @@ private fun formatDuration(sec: Long): String {
     val minutes = (sec % 3600) / 60
     return when {
         hours > 0 -> "${hours}h ${minutes}m"
-        else -> "${minutes} min"
+        else -> "${minutes}m"
     }
 }
 
@@ -656,12 +656,12 @@ private fun formatChapterRemaining(remaining: TimeRemaining): String = when (rem
         val h = sec / 3600
         val m = (sec % 3600) / 60
         val s = sec % 60
-        if (h > 0) "%d:%02d:%02d chapter".format(h, m, s)
-        else "%d:%02d chapter".format(m, s)
+        if (h > 0) "%d:%02d:%02d left".format(h, m, s)
+        else "%d:%02d left".format(m, s)
     }
     is TimeRemaining.Estimated -> when {
-        remaining.sec < 60 -> "< 1 min chapter"
-        else -> "~${formatDuration(remaining.sec)} chapter"
+        remaining.sec < 60 -> "< 1m left"
+        else -> "~${formatDuration(remaining.sec)} left"
     }
 }
 
@@ -675,7 +675,7 @@ private fun formatBookRemaining(remaining: TimeRemaining): String = when (remain
         else "%d:%02d left".format(m, s)
     }
     is TimeRemaining.Estimated -> when {
-        remaining.sec < 60 -> "< 1 min left"
+        remaining.sec < 60 -> "< 1m left"
         else -> "~${formatDuration(remaining.sec)} left"
     }
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -645,8 +645,8 @@ private fun formatDuration(sec: Long): String {
     val hours = sec / 3600
     val minutes = (sec % 3600) / 60
     return when {
-        hours > 0 -> "${hours}h ${minutes}m"
-        else -> "${minutes}m"
+        hours > 0 -> "${hours}h ${minutes}min"
+        else -> "${minutes}min"
     }
 }
 
@@ -656,12 +656,12 @@ private fun formatChapterRemaining(remaining: TimeRemaining): String = when (rem
         val h = sec / 3600
         val m = (sec % 3600) / 60
         val s = sec % 60
-        if (h > 0) "%d:%02d:%02d left".format(h, m, s)
-        else "%d:%02d left".format(m, s)
+        if (h > 0) "%d:%02d:%02d chapter".format(h, m, s)
+        else "%d:%02d chapter".format(m, s)
     }
     is TimeRemaining.Estimated -> when {
-        remaining.sec < 60 -> "< 1m left"
-        else -> "~${formatDuration(remaining.sec)} left"
+        remaining.sec < 60 -> "< 1min chapter"
+        else -> "~${formatDuration(remaining.sec)} chapter"
     }
 }
 
@@ -671,12 +671,12 @@ private fun formatBookRemaining(remaining: TimeRemaining): String = when (remain
         val h = sec / 3600
         val m = (sec % 3600) / 60
         val s = sec % 60
-        if (h > 0) "%d:%02d:%02d left".format(h, m, s)
-        else "%d:%02d left".format(m, s)
+        if (h > 0) "%d:%02d:%02d total".format(h, m, s)
+        else "%d:%02d total".format(m, s)
     }
     is TimeRemaining.Estimated -> when {
-        remaining.sec < 60 -> "< 1m left"
-        else -> "~${formatDuration(remaining.sec)} left"
+        remaining.sec < 60 -> "< 1min total"
+        else -> "~${formatDuration(remaining.sec)} total"
     }
 }
 

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -57,6 +57,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.contentDescription
@@ -87,6 +88,7 @@ import com.riffle.core.domain.ReaderOrientation
 import com.riffle.core.domain.SentenceQuote
 import com.riffle.core.domain.ReaderTheme
 import com.riffle.core.domain.TimeRemaining
+import kotlin.math.roundToInt
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
@@ -266,6 +268,16 @@ fun EpubReaderScreen(
         paginated = formattingPrefs.orientation != ReaderOrientation.Vertical,
     )
 
+    // Track the rendered height of the chapter rail overlay so its pixels can be added to the CSS
+    // reserve, preventing Readium from paginating text behind the overlay in paged mode.
+    var railOverlayHeightPx by remember { mutableStateOf(0) }
+    val density = LocalDensity.current
+    val paginated = formattingPrefs.orientation != ReaderOrientation.Vertical
+    val railReserveCssPx: Int = if (paginated) {
+        (railOverlayHeightPx / density.density).roundToInt()
+    } else 0
+    val totalReserveCssPx: Int = readaloudReservePx + railReserveCssPx
+
     // TopAppBar floats as an overlay so its show/hide never resizes the content area —
     // eliminates the compound flicker that Scaffold's topBar slot caused by reflowing the
     // WebView simultaneously with the system-bar animation.
@@ -324,7 +336,7 @@ fun EpubReaderScreen(
                         onPageTopResolved = viewModel::onPageTopResolved,
                         onPlayFromHere = viewModel::playFromHere,
                         readaloudAvailable = readaloudAvailable,
-                        readaloudReservePx = readaloudReservePx,
+                        readaloudReservePx = totalReserveCssPx,
                         readaloudHighlightColor = readaloudHighlightColor,
                         annotationsAvailable = annotationsAvailable,
                         highlightRenders = highlightRenders,
@@ -436,6 +448,7 @@ fun EpubReaderScreen(
                         showChapterNameLabel = formattingPrefs.showCurrentChapterLabel,
                         showReadingTimeEstimate = formattingPrefs.showReadingTimeEstimate,
                         readerTheme = formattingPrefs.theme,
+                        modifier = Modifier.onSizeChanged { railOverlayHeightPx = it.height },
                     )
                 }
             }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -392,7 +392,8 @@ fun EpubReaderScreen(
                 )
         if (state is ReaderState.Ready && (readaloudOpen || showRailOverlay)) {
             Column(
-                modifier = Modifier.align(Alignment.BottomCenter),
+                modifier = Modifier.align(Alignment.BottomCenter).fillMaxWidth(),
+                horizontalAlignment = Alignment.CenterHorizontally,
             ) {
                 if (readaloudOpen) {
                     // Reference the reader-theme palette so the player matches the chapter-rail

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -700,6 +700,13 @@ private fun ReadingProgressLabels(
     }
     val pctText = "%.1f%%".format(totalProgress.coerceIn(0f, 1f) * 100f)
     val textColor = readerThemeLabelColor(readerTheme)
+    val isExact = chapterTimeRemaining is TimeRemaining.Exact &&
+        bookTimeRemaining is TimeRemaining.Exact
+    val timeColor = if (isExact) MaterialTheme.colorScheme.tertiary else textColor
+    val chapterTimeText = chapterTimeRemaining?.let { formatChapterRemaining(it) }
+    val bookTimeText = bookTimeRemaining?.let { formatBookRemaining(it) }
+    val showLeftColumn = showCountAndPercent || (showReadingTimeEstimate && chapterTimeText != null)
+    val showRightColumn = showCountAndPercent || (showReadingTimeEstimate && bookTimeText != null)
     Row(
         modifier = Modifier
             .fillMaxWidth()
@@ -707,73 +714,81 @@ private fun ReadingProgressLabels(
             .testTag("reading_progress_labels"),
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        if (showCountAndPercent) {
-            Text(
-                text = chapterCountText,
-                style = MaterialTheme.typography.labelSmall,
-                color = textColor,
-                textAlign = TextAlign.Start,
-                maxLines = 1,
+        if (showLeftColumn) {
+            Column(
                 modifier = Modifier
                     .weight(1f)
-                    .testTag("reading_progress_chapter")
-                    .semantics { contentDescription = "Reading progress: $chapterCountText" },
-            )
-        }
-        val showCenterColumn = showChapterName || showReadingTimeEstimate
-        if (showCenterColumn) {
-            Column(
-                horizontalAlignment = Alignment.CenterHorizontally,
-                modifier = Modifier.weight(2f),
+                    .testTag("reading_progress_chapter"),
             ) {
-                if (showChapterName) {
+                if (showCountAndPercent) {
                     Text(
-                        text = activeChapterTitle,
+                        text = chapterCountText,
                         style = MaterialTheme.typography.labelSmall,
                         color = textColor,
-                        textAlign = TextAlign.Center,
-                        fontStyle = FontStyle.Italic,
+                        textAlign = TextAlign.Start,
                         maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
-                        modifier = Modifier
-                            .testTag("reading_progress_chapter_name")
-                            .semantics { contentDescription = "Current chapter: $activeChapterTitle" },
+                        modifier = Modifier.semantics {
+                            contentDescription = "Reading progress: $chapterCountText"
+                        },
                     )
                 }
-                if (showReadingTimeEstimate) {
-                    val parts = listOfNotNull(
-                        chapterTimeRemaining?.let { formatChapterRemaining(it) },
-                        bookTimeRemaining?.let { formatBookRemaining(it) },
+                if (showReadingTimeEstimate && chapterTimeText != null) {
+                    Text(
+                        text = chapterTimeText,
+                        style = MaterialTheme.typography.labelSmall,
+                        color = timeColor,
+                        textAlign = TextAlign.Start,
+                        maxLines = 1,
+                        modifier = Modifier.testTag("reading_progress_chapter_time"),
                     )
-                    if (parts.isNotEmpty()) {
-                        val pillText = parts.joinToString(" · ")
-                        val isExact = chapterTimeRemaining is TimeRemaining.Exact &&
-                            bookTimeRemaining is TimeRemaining.Exact
-                        val pillColor = if (isExact) MaterialTheme.colorScheme.tertiary
-                                        else textColor
-                        Text(
-                            text = pillText,
-                            style = MaterialTheme.typography.labelSmall,
-                            color = pillColor,
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis,
-                        )
-                    }
                 }
             }
         }
-        if (showCountAndPercent) {
+        if (showChapterName) {
             Text(
-                text = pctText,
+                text = activeChapterTitle,
                 style = MaterialTheme.typography.labelSmall,
                 color = textColor,
-                textAlign = TextAlign.End,
+                textAlign = TextAlign.Center,
+                fontStyle = FontStyle.Italic,
                 maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier
+                    .weight(2f)
+                    .testTag("reading_progress_chapter_name")
+                    .semantics { contentDescription = "Current chapter: $activeChapterTitle" },
+            )
+        }
+        if (showRightColumn) {
+            Column(
+                horizontalAlignment = Alignment.End,
                 modifier = Modifier
                     .weight(1f)
-                    .testTag("reading_progress_percent")
-                    .semantics { contentDescription = "Total progress: $pctText" },
-            )
+                    .testTag("reading_progress_percent"),
+            ) {
+                if (showCountAndPercent) {
+                    Text(
+                        text = pctText,
+                        style = MaterialTheme.typography.labelSmall,
+                        color = textColor,
+                        textAlign = TextAlign.End,
+                        maxLines = 1,
+                        modifier = Modifier.semantics {
+                            contentDescription = "Total progress: $pctText"
+                        },
+                    )
+                }
+                if (showReadingTimeEstimate && bookTimeText != null) {
+                    Text(
+                        text = bookTimeText,
+                        style = MaterialTheme.typography.labelSmall,
+                        color = timeColor,
+                        textAlign = TextAlign.End,
+                        maxLines = 1,
+                        modifier = Modifier.testTag("reading_progress_book_time"),
+                    )
+                }
+            }
         }
     }
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -567,7 +567,7 @@ private fun EpubChapterRailOverlay(
     // cursor then so the label shows a sensible estimate instead of sticking at 0%. Once a real
     // whole-book value arrives it wins (and matches book details). At genuine 0% the rail cursor is
     // also ~0, so the fallback is indistinguishable there.
-    val labelProgress = if (totalProgress > 0f) totalProgress else cursorPosition
+    val labelProgress = totalProgress?.takeIf { it > 0f } ?: cursorPosition
     val darkTheme = readerTheme == ReaderTheme.Dark || readerTheme == ReaderTheme.DarkDim
     RiffleTheme(darkTheme = darkTheme) {
         // Backdrop is the exact reader-theme page colour so the strip reads as page margin,

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -656,12 +656,12 @@ private fun formatChapterRemaining(remaining: TimeRemaining): String = when (rem
         val h = sec / 3600
         val m = (sec % 3600) / 60
         val s = sec % 60
-        if (h > 0) "%d:%02d:%02d in chapter".format(h, m, s)
-        else "%d:%02d in chapter".format(m, s)
+        if (h > 0) "%d:%02d:%02d chapter".format(h, m, s)
+        else "%d:%02d chapter".format(m, s)
     }
     is TimeRemaining.Estimated -> when {
-        remaining.sec < 60 -> "< 1 min in chapter"
-        else -> "~${formatDuration(remaining.sec)} in chapter"
+        remaining.sec < 60 -> "< 1 min chapter"
+        else -> "~${formatDuration(remaining.sec)} chapter"
     }
 }
 

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -41,7 +41,10 @@ import com.riffle.core.domain.ReadaloudHighlightColor
 import com.riffle.core.domain.ReadaloudPreferencesStore
 import com.riffle.core.domain.ReadaloudResumeStore
 import com.riffle.core.domain.ReadingPositionStore
+import com.riffle.core.domain.ReadingSpeedStore
+import com.riffle.core.domain.ReadingSpeedTracker
 import com.riffle.core.domain.SessionPayload
+import com.riffle.core.domain.TimeRemaining
 import com.riffle.core.domain.resolveEpubHref
 import com.riffle.core.domain.withResolvedTheme
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -142,6 +145,7 @@ class EpubReaderViewModel @Inject constructor(
     private val nowPlayingStore: com.riffle.app.playback.NowPlayingStore,
     private val progressFlushScope: ProgressFlushScope,
     private val readaloudPreferencesStore: ReadaloudPreferencesStore,
+    private val readingSpeedStore: ReadingSpeedStore,
 ) : AndroidViewModel(application) {
 
     private val itemId: String = checkNotNull(savedStateHandle["itemId"])
@@ -340,6 +344,7 @@ class EpubReaderViewModel @Inject constructor(
 
     // The track is parsed once on first play and reused.
     private var readaloudTrack: com.riffle.core.domain.ReadaloudTrack? = null
+    private val _readaloudTrackFlow = MutableStateFlow<com.riffle.core.domain.ReadaloudTrack?>(null)
 
     // fragmentRef → sentence text quote, so the synced highlight can be anchored by text when
     // Readium has stripped the sentence spans from the rendered (ABS) EPUB. Built once, off the
@@ -858,6 +863,8 @@ class EpubReaderViewModel @Inject constructor(
         readerStateHolder.isReaderActive = true
         closeSyncDone = false
         initialLocatorSeen = false
+        sessionStartProgression = currentLocatorTotalProgression.value
+        sessionStartMs = System.currentTimeMillis()
         if (_state.value is ReaderState.Ready) {
             syncCurrentPosition()
             startPeriodicSync()
@@ -865,6 +872,7 @@ class EpubReaderViewModel @Inject constructor(
     }
 
     fun onReaderClosed() {
+        flushReadingSession()
         readerStateHolder.isReaderActive = false
         readerStateHolder.isPanelOpen = false
         readerStateHolder.isAudioPlaying = false
@@ -1120,6 +1128,85 @@ class EpubReaderViewModel @Inject constructor(
     ) { activeIndex, segments, progression ->
         weightedRailCursorPosition(activeIndex, segments, progression)
     }.stateIn(viewModelScope, SharingStarted.Eagerly, 0f)
+
+    // ---- Reading speed tracking & time-remaining estimates -----------------------------------
+
+    private var sessionStartProgression: Float? = null
+    private var sessionStartMs: Long = 0L
+
+    private fun flushReadingSession() {
+        val startProg = sessionStartProgression ?: return
+        sessionStartProgression = null
+        val timeDeltaSec = (System.currentTimeMillis() - sessionStartMs) / 1000.0
+        val totalProg = currentLocatorTotalProgression.value
+        val progressDelta = totalProg - startProg
+        val totalPos = railSegments.value.fold(0f) { acc, seg -> acc + seg.weight }
+        if (totalPos == 0f) return
+        viewModelScope.launch {
+            val prior = readingSpeedStore.speedSecPerPosition.first()
+            val updated = ReadingSpeedTracker.recordSession(progressDelta, timeDeltaSec, totalPos, prior)
+            if (updated != null) readingSpeedStore.updateSpeed(updated)
+        }
+    }
+
+    val chapterTimeRemaining: StateFlow<TimeRemaining?> = combine(
+        combine(currentLocatorTotalProgression, currentLocatorProgression, railSegments, activeRailSegmentIndex) { tp, cp, segs, idx ->
+            arrayOf<Any?>(tp, cp, segs, idx)
+        },
+        playbackState,
+        _readaloudTrackFlow,
+        readingSpeedStore.speedSecPerPosition,
+    ) { quad, pbState, raTrack, speed ->
+        val totalProg = quad[0] as Float
+        val chapterProg = quad[1] as Float
+        @Suppress("UNCHECKED_CAST")
+        val segments = quad[2] as List<RailSegment>
+        val segIdx = quad[3] as Int
+
+        val totalPositions = segments.fold(0f) { acc, seg -> acc + seg.weight }
+        if (totalPositions == 0f) return@combine null
+
+        if (pbState.connected && raTrack != null) {
+            val posGlobal = pbState.positionGlobalSec
+            val chapterIdx = pbState.currentChapterIndex
+            val chapterEndSec = if (chapterIdx >= 0 && chapterIdx + 1 < raTrack.chapterStartsSec.size) {
+                raTrack.chapterStartsSec[chapterIdx + 1]
+            } else {
+                raTrack.totalDurationSec
+            }
+            val sec = (chapterEndSec - posGlobal).toLong().coerceAtLeast(0L)
+            return@combine TimeRemaining.Exact(sec)
+        }
+
+        val chapterWeight = segments.getOrNull(segIdx)?.weight?.toFloat() ?: return@combine null
+        val sec = ((1f - chapterProg) * chapterWeight * speed).toLong().coerceAtLeast(0L)
+        TimeRemaining.Estimated(sec)
+    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), null)
+
+    val bookTimeRemaining: StateFlow<TimeRemaining?> = combine(
+        combine(currentLocatorTotalProgression, currentLocatorProgression, railSegments, activeRailSegmentIndex) { tp, cp, segs, idx ->
+            arrayOf<Any?>(tp, cp, segs, idx)
+        },
+        playbackState,
+        _readaloudTrackFlow,
+        readingSpeedStore.speedSecPerPosition,
+    ) { quad, pbState, raTrack, speed ->
+        val totalProg = quad[0] as Float
+        @Suppress("UNCHECKED_CAST")
+        val segments = quad[2] as List<RailSegment>
+
+        val totalPositions = segments.fold(0f) { acc, seg -> acc + seg.weight }
+        if (totalPositions == 0f) return@combine null
+
+        if (pbState.connected && raTrack != null) {
+            val posGlobal = pbState.positionGlobalSec
+            val sec = (raTrack.totalDurationSec - posGlobal).toLong().coerceAtLeast(0L)
+            return@combine TimeRemaining.Exact(sec)
+        }
+
+        val sec = ((1f - totalProg) * totalPositions * speed).toLong().coerceAtLeast(0L)
+        TimeRemaining.Estimated(sec)
+    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), null)
 
     fun openSearch() {
         _isSearchActive.value = true
@@ -1721,6 +1808,7 @@ class EpubReaderViewModel @Inject constructor(
         readaloudTrack?.let { return it }
         val track = readaloudAudioRepository.readTrack(audioServerId, audioBookId) ?: return null
         readaloudTrack = track
+        _readaloudTrackFlow.value = track
         // Defer the (heavy, whole-bundle) sentence-quote parse until audio is actually playing, so it
         // never competes with ExoPlayer's audio-start I/O on the same multi-hundred-MB zip. The
         // highlight is only meaningful once playback is running anyway, so a beat's delay is invisible.

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -1176,6 +1176,11 @@ class EpubReaderViewModel @Inject constructor(
         val totalPositions = segments.fold(0f) { acc, seg -> acc + seg.weight }
         if (totalPositions == 0f) return@combine null
 
+        // If every segment has fallback weight 1f, position data wasn't available — estimates
+        // would be meaningless (always ~1 min). Return null until real data is loaded.
+        val hasRealPositions = segments.size <= 1 || segments.any { it.weight != 1f }
+        if (!hasRealPositions) return@combine null
+
         if (pbState.connected && raTrack != null) {
             val posGlobal = pbState.positionGlobalSec
             val chapterIdx = pbState.currentChapterIndex
@@ -1204,6 +1209,11 @@ class EpubReaderViewModel @Inject constructor(
 
         val totalPositions = segments.fold(0f) { acc, seg -> acc + seg.weight }
         if (totalPositions == 0f) return@combine null
+
+        // If every segment has fallback weight 1f, position data wasn't available — estimates
+        // would be meaningless (always ~1 min). Return null until real data is loaded.
+        val hasRealPositions = segments.size <= 1 || segments.any { it.weight != 1f }
+        if (!hasRealPositions) return@combine null
 
         if (pbState.connected && raTrack != null) {
             val posGlobal = pbState.positionGlobalSec

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -1120,15 +1120,30 @@ class EpubReaderViewModel @Inject constructor(
         findActiveSegmentIndex(segments, href, spineHrefs)
     }.stateIn(viewModelScope, SharingStarted.Eagerly, 0)
 
-    // Cursor position within the rail (0..1). Active segment + within-chapter progression are
-    // mapped through cumulative segment weights so the cursor stays inside the highlighted
-    // (active) segment even when segments have unequal widths.
+    // Cursor position within the rail (0..1). Driven by totalProgression (monotonically
+    // increasing across the whole book) rather than chapterProgression (resets to 0 at each
+    // new spine resource). Using chapterProgression caused the cursor to jump backward every
+    // time a new spine resource loaded within the same segment (e.g. reading SOL 376 → SOL 380
+    // inside a single "Chapter 20" segment). totalProgression is converted to a within-segment
+    // fraction so the cursor stays inside the active segment's bounds.
     val railCursorPosition: StateFlow<Float> = combine(
         activeRailSegmentIndex,
         railSegments,
-        currentLocatorProgression,
-    ) { activeIndex, segments, progression ->
-        weightedRailCursorPosition(activeIndex, segments, progression ?: 0f)
+        currentLocatorTotalProgression,
+    ) { activeIndex, segments, totalProg ->
+        if (totalProg == null || segments.isEmpty()) return@combine 0f
+        val totalWeight = segments.fold(0f) { acc, s -> acc + s.weight }
+        if (totalWeight == 0f) return@combine 0f
+        val i = activeIndex.coerceIn(0, segments.size - 1)
+        var weightBefore = 0f
+        for (k in 0 until i) weightBefore += segments[k].weight
+        val segWeight = (segments.getOrNull(i)?.weight ?: 0f).coerceAtLeast(0f)
+        val withinSeg = if (segWeight > 0f) {
+            ((totalProg * totalWeight - weightBefore) / segWeight).coerceIn(0f, 1f)
+        } else {
+            0f
+        }
+        weightedRailCursorPosition(i, segments, withinSeg)
     }.stateIn(viewModelScope, SharingStarted.Eagerly, 0f)
 
     // ---- Reading speed tracking & time-remaining estimates -----------------------------------

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -829,7 +829,7 @@ class EpubReaderViewModel @Inject constructor(
     fun onPositionChanged(locator: Locator) {
         lastLocator = locator
         _currentLocatorHref.value = locator.href.toString()
-        _currentLocatorProgression.value = locator.locations.progression?.toFloat() ?: 0f
+        _currentLocatorProgression.value = locator.locations.progression?.toFloat()
         locator.locations.totalProgression?.toFloat()?.let { _currentLocatorTotalProgression.value = it }
         // Leaving the page readaloud stopped on ends the "park": the position is now genuine reading,
         // so reading→audiobook resumes its normal page-top tracking (ADR 0031).
@@ -1069,16 +1069,17 @@ class EpubReaderViewModel @Inject constructor(
     private val _currentLocatorHref = MutableStateFlow<String?>(null)
     val currentLocatorHref: StateFlow<String?> = _currentLocatorHref
 
-    private val _currentLocatorProgression = MutableStateFlow(0f)
-    val currentLocatorProgression: StateFlow<Float> = _currentLocatorProgression
+    private val _currentLocatorProgression = MutableStateFlow<Float?>(null)
+    val currentLocatorProgression: StateFlow<Float?> = _currentLocatorProgression
 
     // Whole-book progress (0..1) for the reading "% read" label — the same coordinate persisted as
     // ebookProgress and shown in book details. Distinct from railCursorPosition, which is a
     // chapter-weighted fraction over TOC segments only and so diverges from the stored progress.
     // Updated only when the navigator emits a non-null totalProgression: a null (positions not yet
     // computed) holds the last real value rather than falling back to the within-chapter progression.
-    private val _currentLocatorTotalProgression = MutableStateFlow(0f)
-    val currentLocatorTotalProgression: StateFlow<Float> = _currentLocatorTotalProgression
+    // Null before the first Readium locator arrives so callers can distinguish "unknown" from 0%.
+    private val _currentLocatorTotalProgression = MutableStateFlow<Float?>(null)
+    val currentLocatorTotalProgression: StateFlow<Float?> = _currentLocatorTotalProgression
 
     private val _tocVisible = MutableStateFlow(false)
     val tocVisible: StateFlow<Boolean> = _tocVisible
@@ -1126,7 +1127,7 @@ class EpubReaderViewModel @Inject constructor(
         railSegments,
         currentLocatorProgression,
     ) { activeIndex, segments, progression ->
-        weightedRailCursorPosition(activeIndex, segments, progression)
+        weightedRailCursorPosition(activeIndex, segments, progression ?: 0f)
     }.stateIn(viewModelScope, SharingStarted.Eagerly, 0f)
 
     // ---- Reading speed tracking & time-remaining estimates -----------------------------------
@@ -1138,7 +1139,7 @@ class EpubReaderViewModel @Inject constructor(
         val startProg = sessionStartProgression ?: return
         sessionStartProgression = null
         val timeDeltaSec = (System.currentTimeMillis() - sessionStartMs) / 1000.0
-        val totalProg = currentLocatorTotalProgression.value
+        val totalProg = currentLocatorTotalProgression.value ?: return
         val progressDelta = totalProg - startProg
         val totalPos = railSegments.value.fold(0f) { acc, seg -> acc + seg.weight }
         if (totalPos == 0f) return
@@ -1157,8 +1158,6 @@ class EpubReaderViewModel @Inject constructor(
         _readaloudTrackFlow,
         readingSpeedStore.speedSecPerPosition,
     ) { quad, pbState, raTrack, speed ->
-        val totalProg = quad[0] as Float
-        val chapterProg = quad[1] as Float
         @Suppress("UNCHECKED_CAST")
         val segments = quad[2] as List<RailSegment>
         val segIdx = quad[3] as Int
@@ -1178,6 +1177,7 @@ class EpubReaderViewModel @Inject constructor(
             return@combine TimeRemaining.Exact(sec)
         }
 
+        val chapterProg = quad[1] as? Float ?: return@combine null
         val chapterWeight = segments.getOrNull(segIdx)?.weight?.toFloat() ?: return@combine null
         val sec = ((1f - chapterProg) * chapterWeight * speed).toLong().coerceAtLeast(0L)
         TimeRemaining.Estimated(sec)
@@ -1191,7 +1191,6 @@ class EpubReaderViewModel @Inject constructor(
         _readaloudTrackFlow,
         readingSpeedStore.speedSecPerPosition,
     ) { quad, pbState, raTrack, speed ->
-        val totalProg = quad[0] as Float
         @Suppress("UNCHECKED_CAST")
         val segments = quad[2] as List<RailSegment>
 
@@ -1204,6 +1203,7 @@ class EpubReaderViewModel @Inject constructor(
             return@combine TimeRemaining.Exact(sec)
         }
 
+        val totalProg = quad[0] as? Float ?: return@combine null
         val sec = ((1f - totalProg) * totalPositions * speed).toLong().coerceAtLeast(0L)
         TimeRemaining.Estimated(sec)
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), null)

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -1103,7 +1103,8 @@ class EpubReaderViewModel @Inject constructor(
             }
             val spineHrefs = pub.readingOrder.map { it.url().toString() }
             val positionCounts = positions.map { it.size }
-            weightSegmentsByChapterLength(base, spineHrefs, positionCounts)
+            val weighted = weightSegmentsByChapterLength(base, spineHrefs, positionCounts)
+            weighted
         }
         .stateIn(viewModelScope, SharingStarted.Eagerly, emptyList())
 
@@ -1193,9 +1194,16 @@ class EpubReaderViewModel @Inject constructor(
             return@combine TimeRemaining.Exact(sec)
         }
 
-        val chapterProg = snap.chapterProgression ?: return@combine null
-        val chapterWeight = segments.getOrNull(segIdx)?.weight?.toFloat() ?: return@combine null
-        val sec = ((1f - chapterProg) * chapterWeight * speed).toLong().coerceAtLeast(0L)
+        val chapterWeight = segments.getOrNull(segIdx)?.weight ?: return@combine null
+        val totalProg = snap.totalProgression ?: return@combine null
+        // Compute where this chapter ends as a fraction of the total book. This works even when a
+        // TOC entry spans multiple spine resources (e.g. a "Part I" title page followed by several
+        // chapter files) because totalProgression increases monotonically across all resources.
+        var weightBefore = 0f
+        for (k in 0 until segIdx) weightBefore += segments[k].weight
+        val chapterEndFrac = (weightBefore + chapterWeight) / totalPositions
+        val remainingFrac = (chapterEndFrac - totalProg).coerceAtLeast(0f)
+        val sec = (remainingFrac * totalPositions * speed).toLong().coerceAtLeast(0L)
         TimeRemaining.Estimated(sec)
     }.distinctUntilChanged().stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), null)
 

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -1150,17 +1150,28 @@ class EpubReaderViewModel @Inject constructor(
         }
     }
 
+    private data class PositionSnapshot(
+        val totalProgression: Float?,
+        val chapterProgression: Float?,
+        val segments: List<RailSegment>,
+        val activeSegmentIndex: Int,
+    )
+
+    private val positionSnapshot: Flow<PositionSnapshot> = combine(
+        currentLocatorTotalProgression,
+        currentLocatorProgression,
+        railSegments,
+        activeRailSegmentIndex,
+    ) { tp, cp, segs, idx -> PositionSnapshot(tp, cp, segs, idx) }
+
     val chapterTimeRemaining: StateFlow<TimeRemaining?> = combine(
-        combine(currentLocatorTotalProgression, currentLocatorProgression, railSegments, activeRailSegmentIndex) { tp, cp, segs, idx ->
-            arrayOf<Any?>(tp, cp, segs, idx)
-        },
+        positionSnapshot,
         playbackState,
         _readaloudTrackFlow,
         readingSpeedStore.speedSecPerPosition,
-    ) { quad, pbState, raTrack, speed ->
-        @Suppress("UNCHECKED_CAST")
-        val segments = quad[2] as List<RailSegment>
-        val segIdx = quad[3] as Int
+    ) { snap, pbState, raTrack, speed ->
+        val segments = snap.segments
+        val segIdx = snap.activeSegmentIndex
 
         val totalPositions = segments.fold(0f) { acc, seg -> acc + seg.weight }
         if (totalPositions == 0f) return@combine null
@@ -1177,22 +1188,19 @@ class EpubReaderViewModel @Inject constructor(
             return@combine TimeRemaining.Exact(sec)
         }
 
-        val chapterProg = quad[1] as? Float ?: return@combine null
+        val chapterProg = snap.chapterProgression ?: return@combine null
         val chapterWeight = segments.getOrNull(segIdx)?.weight?.toFloat() ?: return@combine null
         val sec = ((1f - chapterProg) * chapterWeight * speed).toLong().coerceAtLeast(0L)
         TimeRemaining.Estimated(sec)
-    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), null)
+    }.distinctUntilChanged().stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), null)
 
     val bookTimeRemaining: StateFlow<TimeRemaining?> = combine(
-        combine(currentLocatorTotalProgression, currentLocatorProgression, railSegments, activeRailSegmentIndex) { tp, cp, segs, idx ->
-            arrayOf<Any?>(tp, cp, segs, idx)
-        },
+        positionSnapshot,
         playbackState,
         _readaloudTrackFlow,
         readingSpeedStore.speedSecPerPosition,
-    ) { quad, pbState, raTrack, speed ->
-        @Suppress("UNCHECKED_CAST")
-        val segments = quad[2] as List<RailSegment>
+    ) { snap, pbState, raTrack, speed ->
+        val segments = snap.segments
 
         val totalPositions = segments.fold(0f) { acc, seg -> acc + seg.weight }
         if (totalPositions == 0f) return@combine null
@@ -1203,10 +1211,10 @@ class EpubReaderViewModel @Inject constructor(
             return@combine TimeRemaining.Exact(sec)
         }
 
-        val totalProg = quad[0] as? Float ?: return@combine null
+        val totalProg = snap.totalProgression ?: return@combine null
         val sec = ((1f - totalProg) * totalPositions * speed).toLong().coerceAtLeast(0L)
         TimeRemaining.Estimated(sec)
-    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), null)
+    }.distinctUntilChanged().stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), null)
 
     fun openSearch() {
         _isSearchActive.value = true

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/FormattingPanel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/FormattingPanel.kt
@@ -355,6 +355,21 @@ fun FormattingPanel(
                 )
             }
 
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text(
+                    "Time remaining",
+                    style = MaterialTheme.typography.bodyLarge,
+                    modifier = Modifier.weight(1f),
+                )
+                Switch(
+                    checked = prefs.showReadingTimeEstimate,
+                    onCheckedChange = { onPrefsChange(prefs.copy(showReadingTimeEstimate = it)) },
+                )
+            }
+
             Spacer(Modifier.height(8.dp))
             TextButton(
                 onClick = onReset,

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/FormattingPanel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/FormattingPanel.kt
@@ -330,13 +330,13 @@ fun FormattingPanel(
                 modifier = Modifier.fillMaxWidth(),
             ) {
                 Text(
-                    "Reading progress labels",
+                    "Current chapter label",
                     style = MaterialTheme.typography.bodyLarge,
                     modifier = Modifier.weight(1f),
                 )
                 Switch(
-                    checked = prefs.showReadingProgressLabels,
-                    onCheckedChange = { onPrefsChange(prefs.copy(showReadingProgressLabels = it)) },
+                    checked = prefs.showCurrentChapterLabel,
+                    onCheckedChange = { onPrefsChange(prefs.copy(showCurrentChapterLabel = it)) },
                 )
             }
 
@@ -345,13 +345,13 @@ fun FormattingPanel(
                 modifier = Modifier.fillMaxWidth(),
             ) {
                 Text(
-                    "Current chapter label",
+                    "Reading progress labels",
                     style = MaterialTheme.typography.bodyLarge,
                     modifier = Modifier.weight(1f),
                 )
                 Switch(
-                    checked = prefs.showCurrentChapterLabel,
-                    onCheckedChange = { onPrefsChange(prefs.copy(showCurrentChapterLabel = it)) },
+                    checked = prefs.showReadingProgressLabels,
+                    onCheckedChange = { onPrefsChange(prefs.copy(showReadingProgressLabels = it)) },
                 )
             }
 

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/RailSegmentGenerator.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/RailSegmentGenerator.kt
@@ -17,11 +17,19 @@ private fun expandIfRedundant(entry: TocEntry, bookTitleNorm: String): List<Rail
         entry.title.isBlank() ||
             (bookTitleNorm.isNotEmpty() && entry.title.normalize() == bookTitleNorm)
         )
-    return if (isRedundantContainer) {
-        entry.children.flatMap { expandIfRedundant(it, bookTitleNorm) }
-    } else {
-        listOf(RailSegment(entry.title, entry.href))
+    if (isRedundantContainer) {
+        return entry.children.flatMap { expandIfRedundant(it, bookTitleNorm) }
     }
+    // If this entry's children point to different spine files it's a grouping container
+    // (e.g. "Part I" whose TOC children are actual chapter files). Expand into children so
+    // estimates are per-chapter rather than per-part.
+    val entryBaseHref = entry.href.substringBefore('#')
+    if (entry.children.isNotEmpty() &&
+        entry.children.any { it.href.substringBefore('#') != entryBaseHref }
+    ) {
+        return entry.children.flatMap { expandIfRedundant(it, bookTitleNorm) }
+    }
+    return listOf(RailSegment(entry.title, entry.href))
 }
 
 private fun String.normalize(): String = trim().lowercase().replace(Regex("\\s+"), " ")

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/RailSegmentGenerator.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/RailSegmentGenerator.kt
@@ -79,16 +79,27 @@ fun weightSegmentsByChapterLength(
     if (segments.isEmpty()) return segments
     val hrefToSpine: Map<String, Int> = spineHrefs.withIndex().associate { (i, h) -> h to i }
     val spineForSegment: List<Int?> = segments.map { hrefToSpine[it.href.substringBefore('#')] }
-    val countsBySpine: Map<Int, Int> = spineForSegment
+    // When multiple TOC entries point to the same spine resource (sub-sections of one file),
+    // split that file's positions equally across them. When a TOC entry is the sole entry for
+    // its resource, accumulate positions for ALL spine resources up to the next TOC entry —
+    // this handles EPUBs where chapter files have no individual TOC entries and are grouped
+    // under a part/section title page.
+    val sharedCounts: Map<Int, Int> = spineForSegment
         .filterNotNull()
         .groupingBy { it }
         .eachCount()
     return segments.mapIndexed { i, seg ->
-        val spine = spineForSegment[i]
-        val length = spine?.let { positionCounts.getOrNull(it) } ?: 0
-        val share = if (spine != null && length > 0) {
-            length.toFloat() / (countsBySpine[spine] ?: 1)
-        } else 1f
+        val spineStart = spineForSegment[i] ?: return@mapIndexed seg.copy(weight = 1f)
+        val share = if ((sharedCounts[spineStart] ?: 1) > 1) {
+            val length = positionCounts.getOrElse(spineStart) { 0 }
+            if (length > 0) length.toFloat() / (sharedCounts[spineStart] ?: 1) else 1f
+        } else {
+            val nextSpineIdx = ((i + 1)..segments.lastIndex)
+                .firstNotNullOfOrNull { j -> spineForSegment[j] }
+                ?: spineHrefs.size
+            val total = (spineStart until nextSpineIdx).sumOf { positionCounts.getOrElse(it) { 0 } }
+            if (total > 0) total.toFloat() else 1f
+        }
         seg.copy(weight = share)
     }
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/RailSegmentGenerator.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/RailSegmentGenerator.kt
@@ -20,13 +20,15 @@ private fun expandIfRedundant(entry: TocEntry, bookTitleNorm: String): List<Rail
     if (isRedundantContainer) {
         return entry.children.flatMap { expandIfRedundant(it, bookTitleNorm) }
     }
-    // If this entry's children point to different spine files it's a grouping container
-    // (e.g. "Part I" whose TOC children are actual chapter files). Expand into children so
-    // estimates are per-chapter rather than per-part.
+    // If children point to different spine files AND those children themselves have children
+    // (e.g. "Part I → [Ch1 with section anchors, Ch2 with section anchors]"), the parent is
+    // a grouping container — expand so estimates are per-chapter rather than per-part.
+    // The grandchildren check is the key guard: without it, "Chapter 20 → [SOL 376, SOL 380]"
+    // (leaf log-entry files with no sub-entries) would also be expanded, causing the cursor to
+    // jump between log-entry segments on every page turn within the chapter.
     val entryBaseHref = entry.href.substringBefore('#')
-    if (entry.children.isNotEmpty() &&
-        entry.children.any { it.href.substringBefore('#') != entryBaseHref }
-    ) {
+    val crossFileChildren = entry.children.filter { it.href.substringBefore('#') != entryBaseHref }
+    if (crossFileChildren.isNotEmpty() && crossFileChildren.any { it.children.isNotEmpty() }) {
         return entry.children.flatMap { expandIfRedundant(it, bookTitleNorm) }
     }
     return listOf(RailSegment(entry.title, entry.href))

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/TypographyOverride.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/TypographyOverride.kt
@@ -86,6 +86,7 @@ internal val EXCLUDED_FROM_TYPOGRAPHY_OVERRIDES: Map<String, String> = mapOf(
     "showChapterMap" to "UI affordance outside the reader content; no CSS implication.",
     "showReadingProgressLabels" to "UI affordance outside the reader content; no CSS implication.",
     "showCurrentChapterLabel" to "UI affordance outside the reader content; no CSS implication.",
+    "showReadingTimeEstimate" to "UI affordance outside the reader content; no CSS implication.",
     "themeSchedule" to "Schedule metadata used to derive the resolved theme at runtime; has no direct CSS implication.",
 )
 

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/RailSegmentGeneratorTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/RailSegmentGeneratorTest.kt
@@ -208,12 +208,15 @@ class RailSegmentGeneratorTest {
     // ── buildRailSegments: multi-file children (part→chapter expansion) ───
 
     @Test
-    fun `part entry with chapter children on different spine files is expanded into chapters`() {
-        // "Influence without authority" structure: Part I → [ch1, ch2, ch3], Part II → [ch4, ch5]
-        val ch1 = TocEntry("Chapter 1", "c01.xhtml")
+    fun `part entry with chapter children that have section anchors is expanded into chapters`() {
+        // "Influence without authority" structure: Part I → [ch1 (with sections), ch2, ch3]
+        // The section anchors on ch1/ch2 are the grandchildren signal that triggers expansion.
+        val sec1 = TocEntry("1.1", "c01.xhtml#s1")
+        val sec4 = TocEntry("4.1", "c04.xhtml#s1")
+        val ch1 = TocEntry("Chapter 1", "c01.xhtml", listOf(sec1))
         val ch2 = TocEntry("Chapter 2", "c02.xhtml")
         val ch3 = TocEntry("Chapter 3", "c03.xhtml")
-        val ch4 = TocEntry("Chapter 4", "c04.xhtml")
+        val ch4 = TocEntry("Chapter 4", "c04.xhtml", listOf(sec4))
         val ch5 = TocEntry("Chapter 5", "c05.xhtml")
         val part1 = TocEntry("Part I", "part01.xhtml", listOf(ch1, ch2, ch3))
         val part2 = TocEntry("Part II", "part02.xhtml", listOf(ch4, ch5))
@@ -266,11 +269,11 @@ class RailSegmentGeneratorTest {
     }
 
     @Test
-    fun `part with mixed children - some same-file anchors, some different files - expands`() {
-        // Children include both a same-file anchor and a different-file chapter. The
-        // presence of ANY different-file child triggers expansion.
+    fun `part with mixed children expands when the cross-file child has grandchildren`() {
+        // Same-file anchor intro + cross-file chapter that itself has section anchors.
+        val sec1 = TocEntry("Ch 1 intro", "c01.xhtml#s1")
         val intro = TocEntry("Intro", "part01.xhtml#intro")
-        val ch1 = TocEntry("Chapter 1", "c01.xhtml")
+        val ch1 = TocEntry("Chapter 1", "c01.xhtml", listOf(sec1))
         val part1 = TocEntry("Part I", "part01.xhtml", listOf(intro, ch1))
 
         assertEquals(
@@ -279,6 +282,21 @@ class RailSegmentGeneratorTest {
                 RailSegment("Chapter 1", "c01.xhtml"),
             ),
             buildRailSegments(listOf(part1)),
+        )
+    }
+
+    @Test
+    fun `chapter with cross-file leaf children and no grandchildren is NOT expanded`() {
+        // "The Martian" structure: Chapter 20 → [SOL 376 (leaf), SOL 380 (leaf)].
+        // Log-entry files have no sub-entries, so the grandchildren guard blocks expansion.
+        // Without this guard, the cursor would jump between log-entry segments on page turn.
+        val sol376 = TocEntry("LOG ENTRY: SOL 376", "sol376.xhtml")  // leaf — no children
+        val sol380 = TocEntry("LOG ENTRY: SOL 380", "sol380.xhtml")  // leaf — no children
+        val ch20 = TocEntry("Chapter 20", "chapter20.xhtml", listOf(sol376, sol380))
+
+        assertEquals(
+            listOf(RailSegment("Chapter 20", "chapter20.xhtml")),
+            buildRailSegments(listOf(ch20)),
         )
     }
 

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/RailSegmentGeneratorTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/RailSegmentGeneratorTest.kt
@@ -400,6 +400,25 @@ class RailSegmentGeneratorTest {
         assertEquals(1f, weighted[1].weight, 0f)
     }
 
+    @Test
+    fun `segment spanning multiple spine resources accumulates all their positions`() {
+        // "Part I" TOC entry at part01.xhtml (1 pos) owns c01.xhtml (20) + c02.xhtml (30)
+        // until the next TOC entry "Part II" at part02.xhtml.
+        val segs = listOf(
+            RailSegment("Part I", "part01.xhtml"),
+            RailSegment("Part II", "part02.xhtml"),
+        )
+        val weighted = weightSegmentsByChapterLength(
+            segs,
+            spineHrefs = listOf("part01.xhtml", "c01.xhtml", "c02.xhtml", "part02.xhtml", "c03.xhtml"),
+            positionCounts = listOf(1, 20, 30, 1, 15),
+        )
+        // Part I spans indices 0..2 (part01+c01+c02 = 1+20+30 = 51)
+        assertEquals(51f, weighted[0].weight, 0f)
+        // Part II spans indices 3..4 (part02+c03 = 1+15 = 16)
+        assertEquals(16f, weighted[1].weight, 0f)
+    }
+
     // ── railSegmentBounds ─────────────────────────────────────────────────
 
     @Test

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/RailSegmentGeneratorTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/RailSegmentGeneratorTest.kt
@@ -145,8 +145,9 @@ class RailSegmentGeneratorTest {
     @Test
     fun `container whose title is a prefix of book title is NOT flattened`() {
         // Guards against "Бай Ганьо тръгна по Европа" being treated as "Бай Ганьо".
-        val ch1 = TocEntry("Ch 1", "ch1.xhtml")
-        val container = TocEntry("Foo Bar Baz", "container.xhtml", listOf(ch1))
+        // Children are same-file anchors — only book-title-match is under test here.
+        val s1 = TocEntry("Section 1", "container.xhtml#s1")
+        val container = TocEntry("Foo Bar Baz", "container.xhtml", listOf(s1))
         val segments = buildRailSegments(listOf(container), bookTitle = "Foo")
         assertEquals(1, segments.size)
         assertEquals(RailSegment("Foo Bar Baz", "container.xhtml"), segments[0])
@@ -154,8 +155,9 @@ class RailSegmentGeneratorTest {
 
     @Test
     fun `container whose title differs from book title is NOT flattened`() {
-        val ch1 = TocEntry("Ch 1", "ch1.xhtml")
-        val container = TocEntry("Appendix", "appendix.xhtml", listOf(ch1))
+        // Children are same-file anchors — only book-title-match is under test here.
+        val s1 = TocEntry("Part 1", "appendix.xhtml#p1")
+        val container = TocEntry("Appendix", "appendix.xhtml", listOf(s1))
         val other = TocEntry("Chapter 1", "real-ch1.xhtml")
         val toc = listOf(other, container)
 
@@ -172,8 +174,9 @@ class RailSegmentGeneratorTest {
     fun `empty book title disables book-title-match rule`() {
         // A container whose title happens to be "" would still flatten via blank-title rule,
         // but a non-blank container should NOT be flattened when no book title is provided.
-        val ch1 = TocEntry("Ch 1", "ch1.xhtml")
-        val container = TocEntry("Some Container", "container.xhtml", listOf(ch1))
+        // Children are same-file anchors — only book-title-match is under test here.
+        val s1 = TocEntry("Section 1", "container.xhtml#s1")
+        val container = TocEntry("Some Container", "container.xhtml", listOf(s1))
         val segments = buildRailSegments(listOf(container), bookTitle = "")
         assertEquals(1, segments.size)
         assertEquals("Some Container", segments[0].title)
@@ -199,6 +202,97 @@ class RailSegmentGeneratorTest {
         assertEquals(
             listOf(RailSegment("Leaf", "leaf.xhtml")),
             buildRailSegments(listOf(outer), bookTitle = "My Book"),
+        )
+    }
+
+    // ── buildRailSegments: multi-file children (part→chapter expansion) ───
+
+    @Test
+    fun `part entry with chapter children on different spine files is expanded into chapters`() {
+        // "Influence without authority" structure: Part I → [ch1, ch2, ch3], Part II → [ch4, ch5]
+        val ch1 = TocEntry("Chapter 1", "c01.xhtml")
+        val ch2 = TocEntry("Chapter 2", "c02.xhtml")
+        val ch3 = TocEntry("Chapter 3", "c03.xhtml")
+        val ch4 = TocEntry("Chapter 4", "c04.xhtml")
+        val ch5 = TocEntry("Chapter 5", "c05.xhtml")
+        val part1 = TocEntry("Part I", "part01.xhtml", listOf(ch1, ch2, ch3))
+        val part2 = TocEntry("Part II", "part02.xhtml", listOf(ch4, ch5))
+
+        assertEquals(
+            listOf(
+                RailSegment("Chapter 1", "c01.xhtml"),
+                RailSegment("Chapter 2", "c02.xhtml"),
+                RailSegment("Chapter 3", "c03.xhtml"),
+                RailSegment("Chapter 4", "c04.xhtml"),
+                RailSegment("Chapter 5", "c05.xhtml"),
+            ),
+            buildRailSegments(listOf(part1, part2)),
+        )
+    }
+
+    @Test
+    fun `chapter entry with same-file section heading children is kept as-is`() {
+        // "Lean Customer Development" structure: Chapter → [section anchors on same file]
+        val s1 = TocEntry("Section 1", "ch01.html#s1")
+        val s2 = TocEntry("Section 2", "ch01.html#s2")
+        val ch1 = TocEntry("Chapter 1", "ch01.html", listOf(s1, s2))
+        val ch2 = TocEntry("Chapter 2", "ch02.html")
+
+        assertEquals(
+            listOf(
+                RailSegment("Chapter 1", "ch01.html"),
+                RailSegment("Chapter 2", "ch02.html"),
+            ),
+            buildRailSegments(listOf(ch1, ch2)),
+        )
+    }
+
+    @Test
+    fun `three-level nesting — part expands to chapters, chapters keep and drop same-file section anchors`() {
+        val sec1a = TocEntry("1a", "c01.xhtml#s1")
+        val sec1b = TocEntry("1b", "c01.xhtml#s2")
+        val sec2a = TocEntry("2a", "c02.xhtml#s1")
+        val ch1 = TocEntry("Chapter 1", "c01.xhtml", listOf(sec1a, sec1b))
+        val ch2 = TocEntry("Chapter 2", "c02.xhtml", listOf(sec2a))
+        val part1 = TocEntry("Part I", "part01.xhtml", listOf(ch1, ch2))
+
+        assertEquals(
+            listOf(
+                RailSegment("Chapter 1", "c01.xhtml"),
+                RailSegment("Chapter 2", "c02.xhtml"),
+            ),
+            buildRailSegments(listOf(part1)),
+        )
+    }
+
+    @Test
+    fun `part with mixed children - some same-file anchors, some different files - expands`() {
+        // Children include both a same-file anchor and a different-file chapter. The
+        // presence of ANY different-file child triggers expansion.
+        val intro = TocEntry("Intro", "part01.xhtml#intro")
+        val ch1 = TocEntry("Chapter 1", "c01.xhtml")
+        val part1 = TocEntry("Part I", "part01.xhtml", listOf(intro, ch1))
+
+        assertEquals(
+            listOf(
+                RailSegment("Intro", "part01.xhtml#intro"),
+                RailSegment("Chapter 1", "c01.xhtml"),
+            ),
+            buildRailSegments(listOf(part1)),
+        )
+    }
+
+    @Test
+    fun `entry with children all on same file is NOT expanded (title kept)`() {
+        // An entry whose every child is a same-file anchor should stay as one segment —
+        // this is the normal Chapter → [Section headings] pattern.
+        val s1 = TocEntry("Section A", "ch.xhtml#secA")
+        val s2 = TocEntry("Section B", "ch.xhtml#secB")
+        val ch = TocEntry("The Chapter", "ch.xhtml", listOf(s1, s2))
+
+        assertEquals(
+            listOf(RailSegment("The Chapter", "ch.xhtml")),
+            buildRailSegments(listOf(ch)),
         )
     }
 

--- a/core/data/src/main/kotlin/com/riffle/core/data/BookFormattingPreferencesStoreImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/BookFormattingPreferencesStoreImpl.kt
@@ -33,6 +33,7 @@ class BookFormattingPreferencesStoreImpl @Inject constructor(
             showCurrentChapterLabel = entity.showCurrentChapterLabel,
             doublePageSpread = entity.doublePageSpread,
             justifyText = entity.justifyText,
+            showReadingTimeEstimate = entity.showReadingTimeEstimate,
         )
     }
 
@@ -57,6 +58,7 @@ class BookFormattingPreferencesStoreImpl @Inject constructor(
                 showCurrentChapterLabel = overrides.showCurrentChapterLabel,
                 doublePageSpread = overrides.doublePageSpread,
                 justifyText = overrides.justifyText,
+                showReadingTimeEstimate = overrides.showReadingTimeEstimate,
             )
         )
     }

--- a/core/data/src/main/kotlin/com/riffle/core/data/FormattingPreferencesStoreImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/FormattingPreferencesStoreImpl.kt
@@ -40,6 +40,7 @@ class FormattingPreferencesStoreImpl @Inject constructor(
             showChapterMap = prefs[KEY_SHOW_CHAPTER_MAP] ?: true,
             showReadingProgressLabels = prefs[KEY_SHOW_READING_PROGRESS_LABELS] ?: false,
             showCurrentChapterLabel = prefs[KEY_SHOW_CURRENT_CHAPTER_LABEL] ?: false,
+            showReadingTimeEstimate = prefs[KEY_SHOW_READING_TIME_ESTIMATE] ?: true,
             doublePageSpread = prefs[KEY_DOUBLE_PAGE_SPREAD] ?: false,
             justifyText = prefs[KEY_JUSTIFY_TEXT] ?: false,
             themeSchedule = ThemeSchedule(
@@ -70,6 +71,7 @@ class FormattingPreferencesStoreImpl @Inject constructor(
             prefs[KEY_SHOW_CHAPTER_MAP] = preferences.showChapterMap
             prefs[KEY_SHOW_READING_PROGRESS_LABELS] = preferences.showReadingProgressLabels
             prefs[KEY_SHOW_CURRENT_CHAPTER_LABEL] = preferences.showCurrentChapterLabel
+            prefs[KEY_SHOW_READING_TIME_ESTIMATE] = preferences.showReadingTimeEstimate
             prefs[KEY_DOUBLE_PAGE_SPREAD] = preferences.doublePageSpread
             prefs[KEY_JUSTIFY_TEXT] = preferences.justifyText
             prefs[KEY_SCHEDULE_DAY_START] = preferences.themeSchedule.dayStart.toMinuteOfDay()
@@ -89,6 +91,7 @@ class FormattingPreferencesStoreImpl @Inject constructor(
         val KEY_SHOW_CHAPTER_MAP = booleanPreferencesKey("show_chapter_map")
         val KEY_SHOW_READING_PROGRESS_LABELS = booleanPreferencesKey("show_reading_progress_labels")
         val KEY_SHOW_CURRENT_CHAPTER_LABEL = booleanPreferencesKey("show_current_chapter_label")
+        val KEY_SHOW_READING_TIME_ESTIMATE = booleanPreferencesKey("show_reading_time_estimate")
         val KEY_DOUBLE_PAGE_SPREAD = booleanPreferencesKey("double_page_spread")
         val KEY_JUSTIFY_TEXT = booleanPreferencesKey("justify_text")
         val KEY_SCHEDULE_DAY_START = intPreferencesKey("theme_schedule_day_start_minute_of_day")

--- a/core/data/src/main/kotlin/com/riffle/core/data/FormattingPreferencesStoreImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/FormattingPreferencesStoreImpl.kt
@@ -40,7 +40,7 @@ class FormattingPreferencesStoreImpl @Inject constructor(
             showChapterMap = prefs[KEY_SHOW_CHAPTER_MAP] ?: true,
             showReadingProgressLabels = prefs[KEY_SHOW_READING_PROGRESS_LABELS] ?: false,
             showCurrentChapterLabel = prefs[KEY_SHOW_CURRENT_CHAPTER_LABEL] ?: false,
-            showReadingTimeEstimate = prefs[KEY_SHOW_READING_TIME_ESTIMATE] ?: true,
+            showReadingTimeEstimate = prefs[KEY_SHOW_READING_TIME_ESTIMATE] ?: false,
             doublePageSpread = prefs[KEY_DOUBLE_PAGE_SPREAD] ?: false,
             justifyText = prefs[KEY_JUSTIFY_TEXT] ?: false,
             themeSchedule = ThemeSchedule(

--- a/core/data/src/main/kotlin/com/riffle/core/data/ReadingSpeedStoreImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/ReadingSpeedStoreImpl.kt
@@ -1,0 +1,29 @@
+package com.riffle.core.data
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.doublePreferencesKey
+import androidx.datastore.preferences.core.edit
+import com.riffle.core.data.di.ReadingSpeedDataStore
+import com.riffle.core.domain.ReadingSpeedStore
+import com.riffle.core.domain.ReadingSpeedTracker
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+
+class ReadingSpeedStoreImpl @Inject constructor(
+    @param:ReadingSpeedDataStore private val dataStore: DataStore<Preferences>,
+) : ReadingSpeedStore {
+
+    override val speedSecPerPosition: Flow<Double> = dataStore.data.map { prefs ->
+        prefs[KEY_SECS_PER_POSITION] ?: ReadingSpeedTracker.DEFAULT_SECS_PER_POSITION
+    }
+
+    override suspend fun updateSpeed(newSecPerPosition: Double) {
+        dataStore.edit { prefs -> prefs[KEY_SECS_PER_POSITION] = newSecPerPosition }
+    }
+
+    private companion object {
+        val KEY_SECS_PER_POSITION = doublePreferencesKey("reading_speed_secs_per_position")
+    }
+}

--- a/core/data/src/main/kotlin/com/riffle/core/data/di/DataModule.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/di/DataModule.kt
@@ -41,6 +41,7 @@ import com.riffle.core.data.ToReadRepositoryImpl
 import com.riffle.core.data.CoverGridDensityStoreImpl
 import com.riffle.core.data.AppThemeStoreImpl
 import com.riffle.core.data.VolumeKeyPreferencesStoreImpl
+import com.riffle.core.data.ReadingSpeedStoreImpl
 import com.riffle.core.data.WakeLockPreferencesStoreImpl
 import com.riffle.core.data.ReadaloudPreferencesStoreImpl
 import com.riffle.core.domain.AnnotationStore
@@ -76,6 +77,7 @@ import com.riffle.core.domain.TokenStorage
 import com.riffle.core.domain.CoverGridDensityStore
 import com.riffle.core.domain.AppThemeStore
 import com.riffle.core.domain.VolumeKeyPreferencesStore
+import com.riffle.core.domain.ReadingSpeedStore
 import com.riffle.core.domain.WakeLockPreferencesStore
 import com.riffle.core.domain.ReadaloudPreferencesStore
 import com.riffle.core.data.AudiobookBundleDownloader
@@ -152,6 +154,10 @@ annotation class DeviceIdDataStore
 @Qualifier
 @Retention(AnnotationRetention.BINARY)
 annotation class ReadaloudPreferencesDataStore
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class ReadingSpeedDataStore
 
 @Qualifier
 @Retention(AnnotationRetention.BINARY)
@@ -336,6 +342,10 @@ abstract class DataModule {
     @Binds
     @Singleton
     abstract fun bindAnnotationStore(impl: AnnotationStoreImpl): AnnotationStore
+
+    @Binds
+    @Singleton
+    abstract fun bindReadingSpeedStore(impl: ReadingSpeedStoreImpl): ReadingSpeedStore
 
     @Binds
     @Singleton
@@ -666,6 +676,13 @@ abstract class DataModule {
         fun provideReadaloudPreferencesDataStore(
             @ApplicationContext context: Context
         ): DataStore<Preferences> = context.readaloudPreferencesDataStore
+
+        @Provides
+        @Singleton
+        @ReadingSpeedDataStore
+        fun provideReadingSpeedDataStore(
+            @ApplicationContext context: Context
+        ): DataStore<Preferences> = context.readingSpeedDataStore
 
         @Provides
         @Singleton

--- a/core/data/src/main/kotlin/com/riffle/core/data/di/DatabaseModule.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/di/DatabaseModule.kt
@@ -68,6 +68,7 @@ object DatabaseModule {
                 RiffleDatabase.MIGRATION_32_33,
                 RiffleDatabase.MIGRATION_33_34,
                 RiffleDatabase.MIGRATION_34_35,
+                RiffleDatabase.MIGRATION_35_36,
             )
             .build()
 

--- a/core/data/src/main/kotlin/com/riffle/core/data/di/ReadingSpeedDataStoreExt.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/di/ReadingSpeedDataStoreExt.kt
@@ -1,0 +1,9 @@
+package com.riffle.core.data.di
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.preferencesDataStore
+
+val Context.readingSpeedDataStore: DataStore<Preferences>
+    by preferencesDataStore(name = "reading_speed_preferences")

--- a/core/data/src/test/kotlin/com/riffle/core/data/ReadingSpeedStoreTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/ReadingSpeedStoreTest.kt
@@ -1,0 +1,75 @@
+package com.riffle.core.data
+
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import com.riffle.core.domain.ReadingSpeedTracker
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ReadingSpeedStoreTest {
+
+    @get:Rule
+    val tmp = TemporaryFolder()
+
+    private val dispatcher = UnconfinedTestDispatcher()
+    private val testScope = TestScope(dispatcher)
+
+    private fun buildStore() = ReadingSpeedStoreImpl(
+        PreferenceDataStoreFactory.create(
+            scope = testScope.backgroundScope,
+            produceFile = { tmp.newFile("reading_speed.preferences_pb") },
+        )
+    )
+
+    @Test
+    fun `default speed equals ReadingSpeedTracker DEFAULT_SECS_PER_POSITION`() = testScope.runTest {
+        assertEquals(
+            ReadingSpeedTracker.DEFAULT_SECS_PER_POSITION,
+            buildStore().speedSecPerPosition.first(),
+            0.001,
+        )
+    }
+
+    @Test
+    fun `updateSpeed stores and re-reads the value`() = testScope.runTest {
+        val store = buildStore()
+        store.updateSpeed(50.0)
+        assertEquals(50.0, store.speedSecPerPosition.first(), 0.001)
+    }
+
+    @Test
+    fun `updated value persists across store instances`() {
+        val file = tmp.newFile("reading_speed_round_trip.preferences_pb")
+        val writeScope = CoroutineScope(UnconfinedTestDispatcher() + Job())
+        runBlocking {
+            ReadingSpeedStoreImpl(
+                PreferenceDataStoreFactory.create(
+                    scope = writeScope,
+                    produceFile = { file },
+                )
+            ).updateSpeed(45.0)
+        }
+        writeScope.cancel()
+
+        val readScope = CoroutineScope(UnconfinedTestDispatcher() + Job())
+        val store2 = ReadingSpeedStoreImpl(
+            PreferenceDataStoreFactory.create(
+                scope = readScope,
+                produceFile = { file },
+            )
+        )
+        assertEquals(45.0, runBlocking { store2.speedSecPerPosition.first() }, 0.001)
+        readScope.cancel()
+    }
+}

--- a/core/database/schemas/com.riffle.core.database.RiffleDatabase/36.json
+++ b/core/database/schemas/com.riffle.core.database.RiffleDatabase/36.json
@@ -1,0 +1,1296 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 36,
+    "identityHash": "1d79140e7ecf89249f257661b8d3130e",
+    "entities": [
+      {
+        "tableName": "servers",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `url` TEXT NOT NULL, `isActive` INTEGER NOT NULL, `insecureConnectionAllowed` INTEGER NOT NULL, `username` TEXT NOT NULL, `serverType` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "isActive",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "insecureConnectionAllowed",
+            "columnName": "insecureConnectionAllowed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "username",
+            "columnName": "username",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverType",
+            "columnName": "serverType",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "libraries",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `mediaType` TEXT NOT NULL, `serverId` TEXT NOT NULL, `isUnsupported` INTEGER NOT NULL, PRIMARY KEY(`serverId`, `id`), FOREIGN KEY(`serverId`) REFERENCES `servers`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaType",
+            "columnName": "mediaType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isUnsupported",
+            "columnName": "isUnsupported",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "serverId",
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_libraries_serverId",
+            "unique": false,
+            "columnNames": [
+              "serverId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_libraries_serverId` ON `${TABLE_NAME}` (`serverId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "servers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "serverId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "library_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`serverId` TEXT NOT NULL, `id` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `title` TEXT NOT NULL, `author` TEXT NOT NULL, `coverUrl` TEXT, `readingProgress` REAL NOT NULL, `ebookFileIno` TEXT, `ebookFormat` TEXT NOT NULL, `hasAudio` INTEGER NOT NULL, `audioDurationSec` REAL NOT NULL, `description` TEXT, `seriesName` TEXT, `publishedYear` TEXT, `genres` TEXT NOT NULL, `publisher` TEXT, `language` TEXT, `lastOpenedAt` INTEGER, `addedAt` INTEGER, `isbn` TEXT, `asin` TEXT, PRIMARY KEY(`serverId`, `id`), FOREIGN KEY(`serverId`) REFERENCES `servers`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "coverUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "readingProgress",
+            "columnName": "readingProgress",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ebookFileIno",
+            "columnName": "ebookFileIno",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "ebookFormat",
+            "columnName": "ebookFormat",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hasAudio",
+            "columnName": "hasAudio",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "audioDurationSec",
+            "columnName": "audioDurationSec",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seriesName",
+            "columnName": "seriesName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "publishedYear",
+            "columnName": "publishedYear",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "genres",
+            "columnName": "genres",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "publisher",
+            "columnName": "publisher",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "language",
+            "columnName": "language",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastOpenedAt",
+            "columnName": "lastOpenedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "isbn",
+            "columnName": "isbn",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "asin",
+            "columnName": "asin",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "serverId",
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_library_items_serverId",
+            "unique": false,
+            "columnNames": [
+              "serverId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_library_items_serverId` ON `${TABLE_NAME}` (`serverId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "servers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "serverId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "series",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `name` TEXT NOT NULL, `coverUrl` TEXT, `bookCount` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "coverUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "bookCount",
+            "columnName": "bookCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "collections",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `name` TEXT NOT NULL, `bookCount` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookCount",
+            "columnName": "bookCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "series_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`seriesId` TEXT NOT NULL, `serverId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `sequenceOrder` REAL NOT NULL, PRIMARY KEY(`seriesId`, `serverId`, `itemId`))",
+        "fields": [
+          {
+            "fieldPath": "seriesId",
+            "columnName": "seriesId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sequenceOrder",
+            "columnName": "sequenceOrder",
+            "affinity": "REAL",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "seriesId",
+            "serverId",
+            "itemId"
+          ]
+        }
+      },
+      {
+        "tableName": "collection_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`collectionId` TEXT NOT NULL, `serverId` TEXT NOT NULL, `itemId` TEXT NOT NULL, PRIMARY KEY(`collectionId`, `serverId`, `itemId`))",
+        "fields": [
+          {
+            "fieldPath": "collectionId",
+            "columnName": "collectionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "collectionId",
+            "serverId",
+            "itemId"
+          ]
+        }
+      },
+      {
+        "tableName": "reading_positions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`serverId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `cfi` TEXT NOT NULL, `localUpdatedAt` INTEGER NOT NULL, `lastSyncedAt` INTEGER NOT NULL, PRIMARY KEY(`serverId`, `itemId`), FOREIGN KEY(`serverId`) REFERENCES `servers`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cfi",
+            "columnName": "cfi",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localUpdatedAt",
+            "columnName": "localUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncedAt",
+            "columnName": "lastSyncedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "serverId",
+            "itemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_reading_positions_serverId",
+            "unique": false,
+            "columnNames": [
+              "serverId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_reading_positions_serverId` ON `${TABLE_NAME}` (`serverId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "servers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "serverId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "book_formatting_preferences",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`serverId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `fontSize` REAL, `theme` TEXT, `fontFamily` TEXT, `lineSpacing` REAL, `margins` REAL, `orientation` TEXT, `showChapterMap` INTEGER, `showReadingProgressLabels` INTEGER, `showCurrentChapterLabel` INTEGER, `doublePageSpread` INTEGER, `justifyText` INTEGER, `showReadingTimeEstimate` INTEGER, PRIMARY KEY(`serverId`, `itemId`), FOREIGN KEY(`serverId`) REFERENCES `servers`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fontSize",
+            "columnName": "fontSize",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "theme",
+            "columnName": "theme",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "fontFamily",
+            "columnName": "fontFamily",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lineSpacing",
+            "columnName": "lineSpacing",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "margins",
+            "columnName": "margins",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "orientation",
+            "columnName": "orientation",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "showChapterMap",
+            "columnName": "showChapterMap",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "showReadingProgressLabels",
+            "columnName": "showReadingProgressLabels",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "showCurrentChapterLabel",
+            "columnName": "showCurrentChapterLabel",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "doublePageSpread",
+            "columnName": "doublePageSpread",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "justifyText",
+            "columnName": "justifyText",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "showReadingTimeEstimate",
+            "columnName": "showReadingTimeEstimate",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "serverId",
+            "itemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_book_formatting_preferences_serverId",
+            "unique": false,
+            "columnNames": [
+              "serverId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_book_formatting_preferences_serverId` ON `${TABLE_NAME}` (`serverId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "servers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "serverId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "readaloud_links",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`absServerId` TEXT NOT NULL, `absLibraryItemId` TEXT NOT NULL, `storytellerServerId` TEXT NOT NULL, `storytellerBookId` TEXT NOT NULL, `state` TEXT NOT NULL, `userConfirmed` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`absServerId`, `absLibraryItemId`), FOREIGN KEY(`storytellerServerId`) REFERENCES `servers`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`absServerId`) REFERENCES `servers`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "absServerId",
+            "columnName": "absServerId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absLibraryItemId",
+            "columnName": "absLibraryItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerServerId",
+            "columnName": "storytellerServerId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerBookId",
+            "columnName": "storytellerBookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userConfirmed",
+            "columnName": "userConfirmed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "absServerId",
+            "absLibraryItemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_readaloud_links_storytellerServerId_storytellerBookId",
+            "unique": false,
+            "columnNames": [
+              "storytellerServerId",
+              "storytellerBookId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_readaloud_links_storytellerServerId_storytellerBookId` ON `${TABLE_NAME}` (`storytellerServerId`, `storytellerBookId`)"
+          },
+          {
+            "name": "index_readaloud_links_storytellerServerId",
+            "unique": false,
+            "columnNames": [
+              "storytellerServerId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_readaloud_links_storytellerServerId` ON `${TABLE_NAME}` (`storytellerServerId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "servers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "storytellerServerId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "servers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "absServerId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "readaloud_candidates",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`storytellerServerId` TEXT NOT NULL, `storytellerBookId` TEXT NOT NULL, `absServerId` TEXT NOT NULL, `absLibraryItemId` TEXT NOT NULL, `score` REAL NOT NULL, PRIMARY KEY(`storytellerServerId`, `storytellerBookId`, `absServerId`, `absLibraryItemId`), FOREIGN KEY(`storytellerServerId`) REFERENCES `servers`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`absServerId`) REFERENCES `servers`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "storytellerServerId",
+            "columnName": "storytellerServerId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerBookId",
+            "columnName": "storytellerBookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absServerId",
+            "columnName": "absServerId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absLibraryItemId",
+            "columnName": "absLibraryItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "score",
+            "columnName": "score",
+            "affinity": "REAL",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "storytellerServerId",
+            "storytellerBookId",
+            "absServerId",
+            "absLibraryItemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_readaloud_candidates_absServerId",
+            "unique": false,
+            "columnNames": [
+              "absServerId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_readaloud_candidates_absServerId` ON `${TABLE_NAME}` (`absServerId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "servers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "storytellerServerId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "servers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "absServerId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "readaloud_dismissals",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`storytellerServerId` TEXT NOT NULL, `storytellerBookId` TEXT NOT NULL, `scope` TEXT NOT NULL, `absServerId` TEXT NOT NULL, `absLibraryItemId` TEXT NOT NULL, PRIMARY KEY(`storytellerServerId`, `storytellerBookId`, `absServerId`, `absLibraryItemId`), FOREIGN KEY(`storytellerServerId`) REFERENCES `servers`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "storytellerServerId",
+            "columnName": "storytellerServerId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerBookId",
+            "columnName": "storytellerBookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scope",
+            "columnName": "scope",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absServerId",
+            "columnName": "absServerId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absLibraryItemId",
+            "columnName": "absLibraryItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "storytellerServerId",
+            "storytellerBookId",
+            "absServerId",
+            "absLibraryItemId"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "servers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "storytellerServerId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "cross_epub_index",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`absEpubChecksum` TEXT NOT NULL, `storytellerEpubChecksum` TEXT NOT NULL, `perChapterMapsBlob` TEXT NOT NULL, `builtAt` INTEGER NOT NULL, PRIMARY KEY(`absEpubChecksum`, `storytellerEpubChecksum`))",
+        "fields": [
+          {
+            "fieldPath": "absEpubChecksum",
+            "columnName": "absEpubChecksum",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerEpubChecksum",
+            "columnName": "storytellerEpubChecksum",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "perChapterMapsBlob",
+            "columnName": "perChapterMapsBlob",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "builtAt",
+            "columnName": "builtAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "absEpubChecksum",
+            "storytellerEpubChecksum"
+          ]
+        }
+      },
+      {
+        "tableName": "annotations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `serverId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `type` TEXT NOT NULL, `cfi` TEXT NOT NULL, `color` TEXT NOT NULL, `note` TEXT, `textSnippet` TEXT NOT NULL, `chapterHref` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `originDeviceId` TEXT NOT NULL, `lastModifiedByDeviceId` TEXT NOT NULL, `deleted` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`serverId`) REFERENCES `servers`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cfi",
+            "columnName": "cfi",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "color",
+            "columnName": "color",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "note",
+            "columnName": "note",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "textSnippet",
+            "columnName": "textSnippet",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chapterHref",
+            "columnName": "chapterHref",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "originDeviceId",
+            "columnName": "originDeviceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastModifiedByDeviceId",
+            "columnName": "lastModifiedByDeviceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deleted",
+            "columnName": "deleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_annotations_serverId_itemId",
+            "unique": false,
+            "columnNames": [
+              "serverId",
+              "itemId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_annotations_serverId_itemId` ON `${TABLE_NAME}` (`serverId`, `itemId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "servers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "serverId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "readaloud_resume_positions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`serverId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `href` TEXT NOT NULL, `progression` REAL, `fragmentRef` TEXT, `localUpdatedAt` INTEGER NOT NULL, PRIMARY KEY(`serverId`, `itemId`), FOREIGN KEY(`serverId`) REFERENCES `servers`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "href",
+            "columnName": "href",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "progression",
+            "columnName": "progression",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "fragmentRef",
+            "columnName": "fragmentRef",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localUpdatedAt",
+            "columnName": "localUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "serverId",
+            "itemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_readaloud_resume_positions_serverId",
+            "unique": false,
+            "columnNames": [
+              "serverId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_readaloud_resume_positions_serverId` ON `${TABLE_NAME}` (`serverId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "servers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "serverId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "audio_playback_preferences",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`serverId` TEXT NOT NULL, `bookId` TEXT NOT NULL, `speed` REAL, PRIMARY KEY(`serverId`, `bookId`), FOREIGN KEY(`serverId`) REFERENCES `servers`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "speed",
+            "columnName": "speed",
+            "affinity": "REAL"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "serverId",
+            "bookId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_audio_playback_preferences_serverId",
+            "unique": false,
+            "columnNames": [
+              "serverId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_audio_playback_preferences_serverId` ON `${TABLE_NAME}` (`serverId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "servers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "serverId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "audiobook_positions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`serverId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `positionSec` REAL NOT NULL, `localUpdatedAt` INTEGER NOT NULL, `lastSyncedAt` INTEGER NOT NULL, PRIMARY KEY(`serverId`, `itemId`), FOREIGN KEY(`serverId`) REFERENCES `servers`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "positionSec",
+            "columnName": "positionSec",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localUpdatedAt",
+            "columnName": "localUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncedAt",
+            "columnName": "lastSyncedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "serverId",
+            "itemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_audiobook_positions_serverId",
+            "unique": false,
+            "columnNames": [
+              "serverId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_audiobook_positions_serverId` ON `${TABLE_NAME}` (`serverId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "servers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "serverId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "audiobook_bookmarks",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `serverId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `positionSec` REAL NOT NULL, `title` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `localUpdatedAt` INTEGER NOT NULL, `lastSyncedAt` INTEGER NOT NULL, `deleted` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`serverId`) REFERENCES `servers`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "positionSec",
+            "columnName": "positionSec",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localUpdatedAt",
+            "columnName": "localUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncedAt",
+            "columnName": "lastSyncedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deleted",
+            "columnName": "deleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_audiobook_bookmarks_serverId",
+            "unique": false,
+            "columnNames": [
+              "serverId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_audiobook_bookmarks_serverId` ON `${TABLE_NAME}` (`serverId`)"
+          },
+          {
+            "name": "index_audiobook_bookmarks_serverId_itemId",
+            "unique": false,
+            "columnNames": [
+              "serverId",
+              "itemId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_audiobook_bookmarks_serverId_itemId` ON `${TABLE_NAME}` (`serverId`, `itemId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "servers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "serverId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '1d79140e7ecf89249f257661b8d3130e')"
+    ]
+  }
+}

--- a/core/database/src/androidTest/kotlin/com/riffle/core/database/MigrationTest.kt
+++ b/core/database/src/androidTest/kotlin/com/riffle/core/database/MigrationTest.kt
@@ -1478,6 +1478,50 @@ class MigrationTest {
     }
 
     @Test
+    fun migration35To36_addsShowReadingTimeEstimateColumn() {
+        helper.createDatabase(TEST_DB, 35).use { db ->
+            db.execSQL(
+                "INSERT INTO servers (id, url, isActive, insecureConnectionAllowed, username, serverType) " +
+                    "VALUES ('s1', 'http://media-server', 1, 0, 'test', 'AUDIOBOOKSHELF')"
+            )
+            // A pre-existing formatting-pref row with all v35 columns.
+            db.execSQL(
+                "INSERT INTO book_formatting_preferences (serverId, itemId, fontSize, theme, fontFamily, lineSpacing, margins, orientation, showChapterMap, showReadingProgressLabels, showCurrentChapterLabel, doublePageSpread, justifyText) " +
+                    "VALUES ('s1', 'item1', 1.3, 'Dark', 'Serif', 1.5, 1.2, 'Vertical', 1, 1, 0, 0, 1)"
+            )
+        }
+
+        val db = helper.runMigrationsAndValidate(TEST_DB, 36, true, RiffleDatabase.MIGRATION_35_36)
+
+        // Pre-existing data preserved; new column defaults to NULL = follow global.
+        db.query(
+            "SELECT serverId, itemId, fontSize, theme, justifyText, showReadingTimeEstimate FROM book_formatting_preferences WHERE itemId = 'item1'"
+        ).use { cursor ->
+            assertEquals(1, cursor.count)
+            cursor.moveToFirst()
+            assertEquals("s1", cursor.getString(0))
+            assertEquals("item1", cursor.getString(1))
+            assertEquals(1.3, cursor.getDouble(2), 0.001)
+            assertEquals("Dark", cursor.getString(3))
+            assertEquals(1, cursor.getInt(4))
+            assertTrue("showReadingTimeEstimate should be null for legacy rows", cursor.isNull(5))
+        }
+
+        // New writes can populate the new column.
+        db.execSQL(
+            "INSERT INTO book_formatting_preferences (serverId, itemId, showReadingTimeEstimate) " +
+                "VALUES ('s1', 'item2', 1)"
+        )
+        db.query(
+            "SELECT showReadingTimeEstimate FROM book_formatting_preferences WHERE itemId = 'item2'"
+        ).use { cursor ->
+            assertEquals(1, cursor.count)
+            cursor.moveToFirst()
+            assertEquals(1, cursor.getInt(0))
+        }
+    }
+
+    @Test
     fun migrateFullChain() {
         helper.createDatabase(TEST_DB, 1).use { db ->
             db.execSQL(
@@ -1486,7 +1530,7 @@ class MigrationTest {
         }
 
         val db = helper.runMigrationsAndValidate(
-            TEST_DB, 35, true,
+            TEST_DB, 36, true,
             RiffleDatabase.MIGRATION_1_2,
             RiffleDatabase.MIGRATION_2_3,
             RiffleDatabase.MIGRATION_3_4,
@@ -1521,6 +1565,7 @@ class MigrationTest {
             RiffleDatabase.MIGRATION_32_33,
             RiffleDatabase.MIGRATION_33_34,
             RiffleDatabase.MIGRATION_34_35,
+            RiffleDatabase.MIGRATION_35_36,
         )
 
         db.query("SELECT url, username, serverType FROM servers WHERE id = 's1'").use { cursor ->

--- a/core/database/src/main/kotlin/com/riffle/core/database/BookFormattingPreferencesEntity.kt
+++ b/core/database/src/main/kotlin/com/riffle/core/database/BookFormattingPreferencesEntity.kt
@@ -35,4 +35,5 @@ data class BookFormattingPreferencesEntity(
     val showCurrentChapterLabel: Boolean? = null,
     val doublePageSpread: Boolean? = null,
     val justifyText: Boolean? = null,
+    val showReadingTimeEstimate: Boolean? = null,
 )

--- a/core/database/src/main/kotlin/com/riffle/core/database/RiffleDatabase.kt
+++ b/core/database/src/main/kotlin/com/riffle/core/database/RiffleDatabase.kt
@@ -26,7 +26,7 @@ import androidx.sqlite.db.SupportSQLiteDatabase
         AudiobookPositionEntity::class,
         AudiobookBookmarkEntity::class,
     ],
-    version = 35,
+    version = 36,
     exportSchema = true,
 )
 abstract class RiffleDatabase : RoomDatabase() {
@@ -694,6 +694,12 @@ abstract class RiffleDatabase : RoomDatabase() {
                 db.execSQL(
                     "ALTER TABLE `audiobook_positions` ADD COLUMN `lastSyncedAt` INTEGER NOT NULL DEFAULT 0"
                 )
+            }
+        }
+
+        val MIGRATION_35_36 = object : Migration(35, 36) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("ALTER TABLE `book_formatting_preferences` ADD COLUMN `showReadingTimeEstimate` INTEGER DEFAULT NULL")
             }
         }
 

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/BookFormattingOverrides.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/BookFormattingOverrides.kt
@@ -10,6 +10,7 @@ data class BookFormattingOverrides(
     val showChapterMap: Boolean? = null,
     val showReadingProgressLabels: Boolean? = null,
     val showCurrentChapterLabel: Boolean? = null,
+    val showReadingTimeEstimate: Boolean? = null,
     val doublePageSpread: Boolean? = null,
     val justifyText: Boolean? = null,
 ) {
@@ -23,6 +24,7 @@ data class BookFormattingOverrides(
             showChapterMap == null &&
             showReadingProgressLabels == null &&
             showCurrentChapterLabel == null &&
+            showReadingTimeEstimate == null &&
             doublePageSpread == null &&
             justifyText == null
 
@@ -36,6 +38,7 @@ data class BookFormattingOverrides(
         showChapterMap = showChapterMap ?: global.showChapterMap,
         showReadingProgressLabels = showReadingProgressLabels ?: global.showReadingProgressLabels,
         showCurrentChapterLabel = showCurrentChapterLabel ?: global.showCurrentChapterLabel,
+        showReadingTimeEstimate = showReadingTimeEstimate ?: global.showReadingTimeEstimate,
         doublePageSpread = doublePageSpread ?: global.doublePageSpread,
         justifyText = justifyText ?: global.justifyText,
         // themeSchedule is intentionally global-only (no per-book override). Threading
@@ -59,6 +62,7 @@ data class BookFormattingOverrides(
         showChapterMap = if (new.showChapterMap != previous.showChapterMap) new.showChapterMap else showChapterMap,
         showReadingProgressLabels = if (new.showReadingProgressLabels != previous.showReadingProgressLabels) new.showReadingProgressLabels else showReadingProgressLabels,
         showCurrentChapterLabel = if (new.showCurrentChapterLabel != previous.showCurrentChapterLabel) new.showCurrentChapterLabel else showCurrentChapterLabel,
+        showReadingTimeEstimate = if (new.showReadingTimeEstimate != previous.showReadingTimeEstimate) new.showReadingTimeEstimate else showReadingTimeEstimate,
         doublePageSpread = if (new.doublePageSpread != previous.doublePageSpread) new.doublePageSpread else doublePageSpread,
         justifyText = if (new.justifyText != previous.justifyText) new.justifyText else justifyText,
     )

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/FormattingPreferences.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/FormattingPreferences.kt
@@ -12,6 +12,7 @@ data class FormattingPreferences(
     val showChapterMap: Boolean = DEFAULT_SHOW_CHAPTER_MAP,
     val showReadingProgressLabels: Boolean = DEFAULT_SHOW_READING_PROGRESS_LABELS,
     val showCurrentChapterLabel: Boolean = DEFAULT_SHOW_CURRENT_CHAPTER_LABEL,
+    val showReadingTimeEstimate: Boolean = DEFAULT_SHOW_READING_TIME_ESTIMATE,
     val doublePageSpread: Boolean = DEFAULT_DOUBLE_PAGE_SPREAD,
     val justifyText: Boolean = DEFAULT_JUSTIFY_TEXT,
     val themeSchedule: ThemeSchedule = ThemeSchedule(),
@@ -23,6 +24,7 @@ data class FormattingPreferences(
         const val DEFAULT_SHOW_CHAPTER_MAP: Boolean = true
         const val DEFAULT_SHOW_READING_PROGRESS_LABELS: Boolean = false
         const val DEFAULT_SHOW_CURRENT_CHAPTER_LABEL: Boolean = false
+        const val DEFAULT_SHOW_READING_TIME_ESTIMATE: Boolean = true
         const val DEFAULT_DOUBLE_PAGE_SPREAD: Boolean = false
         const val DEFAULT_JUSTIFY_TEXT: Boolean = false
         val DEFAULT_THEME: ReaderTheme = ReaderTheme.Light

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/FormattingPreferences.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/FormattingPreferences.kt
@@ -24,7 +24,7 @@ data class FormattingPreferences(
         const val DEFAULT_SHOW_CHAPTER_MAP: Boolean = true
         const val DEFAULT_SHOW_READING_PROGRESS_LABELS: Boolean = false
         const val DEFAULT_SHOW_CURRENT_CHAPTER_LABEL: Boolean = false
-        const val DEFAULT_SHOW_READING_TIME_ESTIMATE: Boolean = true
+        const val DEFAULT_SHOW_READING_TIME_ESTIMATE: Boolean = false
         const val DEFAULT_DOUBLE_PAGE_SPREAD: Boolean = false
         const val DEFAULT_JUSTIFY_TEXT: Boolean = false
         val DEFAULT_THEME: ReaderTheme = ReaderTheme.Light

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/ReadingSpeedStore.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/ReadingSpeedStore.kt
@@ -1,0 +1,8 @@
+package com.riffle.core.domain
+
+import kotlinx.coroutines.flow.Flow
+
+interface ReadingSpeedStore {
+    val speedSecPerPosition: Flow<Double>
+    suspend fun updateSpeed(newSecPerPosition: Double)
+}

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/ReadingSpeedTracker.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/ReadingSpeedTracker.kt
@@ -1,0 +1,28 @@
+package com.riffle.core.domain
+
+object ReadingSpeedTracker {
+
+    const val DEFAULT_SECS_PER_POSITION = 63.0
+
+    private const val MIN_SESSION_SEC = 30.0
+    private const val MIN_POSITIONS_DELTA = 0.5
+    private const val ALPHA = 0.2
+    private const val WORDS_PER_POSITION = 250.0
+    private const val MIN_WPM = 20.0
+    private const val MAX_WPM = 1000.0
+
+    fun recordSession(
+        progressDelta: Float,
+        timeDeltaSec: Double,
+        totalPositions: Float,
+        priorSecPerPosition: Double,
+    ): Double? {
+        if (timeDeltaSec < MIN_SESSION_SEC) return null
+        val positionsDelta = progressDelta * totalPositions
+        if (positionsDelta < MIN_POSITIONS_DELTA) return null
+        val observedRate = timeDeltaSec / positionsDelta
+        val impliedWpm = (WORDS_PER_POSITION / observedRate) * 60.0
+        if (impliedWpm < MIN_WPM || impliedWpm > MAX_WPM + 0.001) return null
+        return ALPHA * observedRate + (1.0 - ALPHA) * priorSecPerPosition
+    }
+}

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/TimeRemaining.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/TimeRemaining.kt
@@ -1,0 +1,6 @@
+package com.riffle.core.domain
+
+sealed class TimeRemaining(val sec: Long) {
+    class Estimated(sec: Long) : TimeRemaining(sec)
+    class Exact(sec: Long) : TimeRemaining(sec)
+}

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/TimeRemaining.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/TimeRemaining.kt
@@ -1,6 +1,7 @@
 package com.riffle.core.domain
 
-sealed class TimeRemaining(val sec: Long) {
-    class Estimated(sec: Long) : TimeRemaining(sec)
-    class Exact(sec: Long) : TimeRemaining(sec)
+sealed class TimeRemaining {
+    abstract val sec: Long
+    data class Estimated(override val sec: Long) : TimeRemaining()
+    data class Exact(override val sec: Long) : TimeRemaining()
 }

--- a/core/domain/src/test/kotlin/com/riffle/core/domain/BookFormattingOverridesTest.kt
+++ b/core/domain/src/test/kotlin/com/riffle/core/domain/BookFormattingOverridesTest.kt
@@ -110,18 +110,18 @@ class BookFormattingOverridesTest {
 
     @Test
     fun `applyTo threads showReadingTimeEstimate`() {
-        val effective = BookFormattingOverrides(showReadingTimeEstimate = false).applyTo(global)
-        assertFalse(effective.showReadingTimeEstimate)
-        // Global default is true
-        assertTrue(BookFormattingOverrides().applyTo(global).showReadingTimeEstimate)
+        val effective = BookFormattingOverrides(showReadingTimeEstimate = true).applyTo(global)
+        assertTrue(effective.showReadingTimeEstimate)
+        // Global default is false
+        assertFalse(BookFormattingOverrides().applyTo(global).showReadingTimeEstimate)
     }
 
     @Test
     fun `withChanges records showReadingTimeEstimate when changed`() {
-        val prev = global
-        val new = global.copy(showReadingTimeEstimate = false)
+        val prev = global  // showReadingTimeEstimate = false (default)
+        val new = global.copy(showReadingTimeEstimate = true)
         val overrides = BookFormattingOverrides().withChanges(prev, new)
-        assertEquals(false, overrides.showReadingTimeEstimate)
+        assertEquals(true, overrides.showReadingTimeEstimate)
         assertNull(overrides.fontSize)
     }
 }

--- a/core/domain/src/test/kotlin/com/riffle/core/domain/BookFormattingOverridesTest.kt
+++ b/core/domain/src/test/kotlin/com/riffle/core/domain/BookFormattingOverridesTest.kt
@@ -102,4 +102,26 @@ class BookFormattingOverridesTest {
         val updated = BookFormattingOverrides().withChanges(previous, new)
         assertTrue(updated.isEmpty)
     }
+
+    @Test
+    fun `isEmpty is false when showReadingTimeEstimate is set`() {
+        assertFalse(BookFormattingOverrides(showReadingTimeEstimate = false).isEmpty)
+    }
+
+    @Test
+    fun `applyTo threads showReadingTimeEstimate`() {
+        val effective = BookFormattingOverrides(showReadingTimeEstimate = false).applyTo(global)
+        assertFalse(effective.showReadingTimeEstimate)
+        // Global default is true
+        assertTrue(BookFormattingOverrides().applyTo(global).showReadingTimeEstimate)
+    }
+
+    @Test
+    fun `withChanges records showReadingTimeEstimate when changed`() {
+        val prev = global
+        val new = global.copy(showReadingTimeEstimate = false)
+        val overrides = BookFormattingOverrides().withChanges(prev, new)
+        assertEquals(false, overrides.showReadingTimeEstimate)
+        assertNull(overrides.fontSize)
+    }
 }

--- a/core/domain/src/test/kotlin/com/riffle/core/domain/ReadingSpeedTrackerTest.kt
+++ b/core/domain/src/test/kotlin/com/riffle/core/domain/ReadingSpeedTrackerTest.kt
@@ -1,0 +1,79 @@
+package com.riffle.core.domain
+
+import org.junit.Assert.*
+import org.junit.Test
+
+class ReadingSpeedTrackerTest {
+
+    @Test
+    fun `valid session blends observed rate into prior via EWMA`() {
+        val result = ReadingSpeedTracker.recordSession(
+            progressDelta = 25f / 500f,
+            timeDeltaSec = 1250.0,
+            totalPositions = 500f,
+            priorSecPerPosition = 63.0,
+        )
+        assertNotNull(result)
+        assertEquals(60.4, result!!, 0.01)
+    }
+
+    @Test
+    fun `session shorter than 30 seconds is discarded`() {
+        val result = ReadingSpeedTracker.recordSession(
+            progressDelta = 10f / 500f,
+            timeDeltaSec = 29.0,
+            totalPositions = 500f,
+            priorSecPerPosition = 63.0,
+        )
+        assertNull(result)
+    }
+
+    @Test
+    fun `session moving fewer than 0·5 positions is discarded`() {
+        val result = ReadingSpeedTracker.recordSession(
+            progressDelta = 0.4f / 500f,
+            timeDeltaSec = 60.0,
+            totalPositions = 500f,
+            priorSecPerPosition = 63.0,
+        )
+        assertNull(result)
+    }
+
+    @Test
+    fun `session implying fewer than 20 WPM is discarded (left book open)`() {
+        val result = ReadingSpeedTracker.recordSession(
+            progressDelta = 1f / 500f,
+            timeDeltaSec = 760.0,
+            totalPositions = 500f,
+            priorSecPerPosition = 63.0,
+        )
+        assertNull(result)
+    }
+
+    @Test
+    fun `session implying more than 1000 WPM is discarded (scanning)`() {
+        val result = ReadingSpeedTracker.recordSession(
+            progressDelta = 1f / 500f,
+            timeDeltaSec = 14.0,
+            totalPositions = 500f,
+            priorSecPerPosition = 63.0,
+        )
+        assertNull(result)
+    }
+
+    @Test
+    fun `session at exactly the WPM upper bound is kept`() {
+        val result = ReadingSpeedTracker.recordSession(
+            progressDelta = 2f / 500f,
+            timeDeltaSec = 30.0,
+            totalPositions = 500f,
+            priorSecPerPosition = 63.0,
+        )
+        assertNotNull(result)
+    }
+
+    @Test
+    fun `default secs per position constant equals 63`() {
+        assertEquals(63.0, ReadingSpeedTracker.DEFAULT_SECS_PER_POSITION, 0.001)
+    }
+}

--- a/docs/superpowers/plans/2026-06-14-reading-time-estimate.md
+++ b/docs/superpowers/plans/2026-06-14-reading-time-estimate.md
@@ -1,0 +1,1161 @@
+# Reading Time Estimate Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Show chapter and book time remaining in a pill beneath the chapter title in the reader; estimated from an adaptive per-device reading speed, or exact (teal) when read aloud is active.
+
+**Architecture:** Three new domain types (`TimeRemaining`, `ReadingSpeedStore`, `ReadingSpeedTracker`) feed two new `StateFlow`s on `EpubReaderViewModel`. The display toggle (`showReadingTimeEstimate`) is wired into the existing formatting-preferences system (global DataStore + per-book Room override). A Room migration 35→36 adds the nullable column.
+
+**Tech Stack:** Kotlin, Jetpack Compose, Room, DataStore Preferences, Hilt, Readium SDK (positions). All new logic is in JVM unit tests; the Room migration gets a connected test via the existing `MigrationTest` harness.
+
+---
+
+## File Map
+
+### New files
+| File | Purpose |
+|---|---|
+| `core/domain/…/TimeRemaining.kt` | Sealed class: `Estimated(sec)` / `Exact(sec)` |
+| `core/domain/…/ReadingSpeedTracker.kt` | Pure EWMA logic; JVM-testable |
+| `core/domain/…/ReadingSpeedStore.kt` | Interface: `speedSecPerPosition: Flow<Double>`, `updateSpeed(Double)` |
+| `core/data/…/ReadingSpeedStoreImpl.kt` | DataStore-backed impl |
+| `core/data/…/di/ReadingSpeedDataStoreExt.kt` | Context extension `readingSpeedDataStore` |
+| `core/domain/src/test/…/ReadingSpeedTrackerTest.kt` | JVM tests for EWMA |
+| `core/data/src/test/…/ReadingSpeedStoreTest.kt` | JVM tests for DataStore round-trip |
+
+### Modified files
+| File | Change |
+|---|---|
+| `core/domain/…/FormattingPreferences.kt` | Add `showReadingTimeEstimate: Boolean = true` |
+| `core/domain/…/BookFormattingOverrides.kt` | Add nullable field; wire into `isEmpty`, `applyTo`, `withChanges` |
+| `core/domain/src/test/…/BookFormattingOverridesTest.kt` | Extend for new field |
+| `core/database/…/BookFormattingPreferencesEntity.kt` | Add `showReadingTimeEstimate: Boolean?` |
+| `core/database/…/RiffleDatabase.kt` | Bump to v36, add `MIGRATION_35_36` |
+| `core/database/src/androidTest/…/MigrationTest.kt` | Add step test + chain test |
+| `core/data/…/FormattingPreferencesStoreImpl.kt` | Add key + read/write |
+| `core/data/…/di/DataModule.kt` | Add qualifier, DataStore provider, bind `ReadingSpeedStore` |
+| `app/…/reader/EpubReaderViewModel.kt` | Session tracking; `_readaloudTrackFlow`; `chapterTimeRemaining`/`bookTimeRemaining` flows |
+| `app/…/reader/FormattingPanel.kt` | Add "Time remaining" toggle row |
+| `app/…/reader/EpubReaderScreen.kt` | Collect flows; update visibility guard; pass to `ReadingProgressLabels` |
+
+---
+
+## Task 1: `TimeRemaining` sealed class
+
+**Files:**
+- Create: `core/domain/src/main/kotlin/com/riffle/core/domain/TimeRemaining.kt`
+
+- [ ] **Step 1: Create the sealed class**
+
+```kotlin
+package com.riffle.core.domain
+
+sealed class TimeRemaining(val sec: Long) {
+    class Estimated(sec: Long) : TimeRemaining(sec)
+    class Exact(sec: Long) : TimeRemaining(sec)
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add core/domain/src/main/kotlin/com/riffle/core/domain/TimeRemaining.kt
+git commit -m "feat(reader): add TimeRemaining sealed class"
+```
+
+---
+
+## Task 2: `ReadingSpeedTracker` (pure) + JVM tests
+
+**Files:**
+- Create: `core/domain/src/main/kotlin/com/riffle/core/domain/ReadingSpeedTracker.kt`
+- Create: `core/domain/src/test/kotlin/com/riffle/core/domain/ReadingSpeedTrackerTest.kt`
+
+- [ ] **Step 1: Write the failing tests**
+
+```kotlin
+package com.riffle.core.domain
+
+import org.junit.Assert.*
+import org.junit.Test
+
+class ReadingSpeedTrackerTest {
+
+    @Test
+    fun `valid session blends observed rate into prior via EWMA`() {
+        // Prior = 63.0 s/pos. Observed = 50.0 s/pos over 25 positions in 1250s.
+        // New = 0.2 * 50 + 0.8 * 63 = 10 + 50.4 = 60.4
+        val result = ReadingSpeedTracker.recordSession(
+            progressDelta = 25f / 500f,   // 25 positions out of 500 total
+            timeDeltaSec = 1250.0,
+            totalPositions = 500f,
+            priorSecPerPosition = 63.0,
+        )
+        assertNotNull(result)
+        assertEquals(60.4, result!!, 0.01)
+    }
+
+    @Test
+    fun `session shorter than 30 seconds is discarded`() {
+        val result = ReadingSpeedTracker.recordSession(
+            progressDelta = 10f / 500f,
+            timeDeltaSec = 29.0,
+            totalPositions = 500f,
+            priorSecPerPosition = 63.0,
+        )
+        assertNull(result)
+    }
+
+    @Test
+    fun `session moving fewer than 0·5 positions is discarded`() {
+        val result = ReadingSpeedTracker.recordSession(
+            progressDelta = 0.4f / 500f,
+            timeDeltaSec = 60.0,
+            totalPositions = 500f,
+            priorSecPerPosition = 63.0,
+        )
+        assertNull(result)
+    }
+
+    @Test
+    fun `session implying fewer than 20 WPM is discarded (left book open)`() {
+        // 20 WPM → 250 words/pos ÷ 20 WPM × 60 = 750 s/pos. Just over that → discard.
+        val result = ReadingSpeedTracker.recordSession(
+            progressDelta = 1f / 500f,       // 1 position
+            timeDeltaSec = 760.0,            // 760 s/pos → ~19.7 WPM → discard
+            totalPositions = 500f,
+            priorSecPerPosition = 63.0,
+        )
+        assertNull(result)
+    }
+
+    @Test
+    fun `session implying more than 1000 WPM is discarded (scanning)`() {
+        // 1000 WPM → 250/1000×60 = 15 s/pos. Just under that → discard.
+        val result = ReadingSpeedTracker.recordSession(
+            progressDelta = 1f / 500f,
+            timeDeltaSec = 14.0,             // faster than 30s guard too — caught by min-time first
+            totalPositions = 500f,
+            priorSecPerPosition = 63.0,
+        )
+        assertNull(result)
+    }
+
+    @Test
+    fun `session at exactly the WPM upper bound is kept`() {
+        // 1000 WPM → 15 s/pos. timeDelta = 15s × 1 pos = 15s — but min-time is 30s, so need 2+ pos.
+        // 2 positions at 1000 WPM → 30s exactly. Should be kept (boundary inclusive).
+        val result = ReadingSpeedTracker.recordSession(
+            progressDelta = 2f / 500f,
+            timeDeltaSec = 30.0,
+            totalPositions = 500f,
+            priorSecPerPosition = 63.0,
+        )
+        assertNotNull(result)
+    }
+
+    @Test
+    fun `default secs per position constant equals 63`() {
+        assertEquals(63.0, ReadingSpeedTracker.DEFAULT_SECS_PER_POSITION, 0.001)
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+export JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"
+./gradlew :core:domain:test --tests "com.riffle.core.domain.ReadingSpeedTrackerTest" 2>&1 | tail -20
+```
+
+Expected: FAIL with "object ReadingSpeedTracker is not defined" (or similar).
+
+- [ ] **Step 3: Implement `ReadingSpeedTracker`**
+
+```kotlin
+package com.riffle.core.domain
+
+object ReadingSpeedTracker {
+
+    const val DEFAULT_SECS_PER_POSITION = 63.0  // 250 words ÷ 238 WPM × 60s
+
+    private const val MIN_SESSION_SEC = 30.0
+    private const val MIN_POSITIONS_DELTA = 0.5
+    private const val ALPHA = 0.2
+    private const val WORDS_PER_POSITION = 250.0
+    private const val MIN_WPM = 20.0
+    private const val MAX_WPM = 1000.0
+
+    /**
+     * Returns the updated EWMA rate (seconds per Readium position), or null if the session
+     * should be discarded as unreliable.
+     */
+    fun recordSession(
+        progressDelta: Float,
+        timeDeltaSec: Double,
+        totalPositions: Float,
+        priorSecPerPosition: Double,
+    ): Double? {
+        if (timeDeltaSec < MIN_SESSION_SEC) return null
+        val positionsDelta = progressDelta * totalPositions
+        if (positionsDelta < MIN_POSITIONS_DELTA) return null
+        val observedRate = timeDeltaSec / positionsDelta
+        val impliedWpm = (WORDS_PER_POSITION / observedRate) * 60.0
+        if (impliedWpm < MIN_WPM || impliedWpm > MAX_WPM) return null
+        return ALPHA * observedRate + (1.0 - ALPHA) * priorSecPerPosition
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+./gradlew :core:domain:test --tests "com.riffle.core.domain.ReadingSpeedTrackerTest" 2>&1 | tail -10
+```
+
+Expected: all 7 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add core/domain/src/main/kotlin/com/riffle/core/domain/ReadingSpeedTracker.kt \
+        core/domain/src/test/kotlin/com/riffle/core/domain/ReadingSpeedTrackerTest.kt
+git commit -m "feat(reader): add ReadingSpeedTracker with EWMA session logic"
+```
+
+---
+
+## Task 3: `ReadingSpeedStore` interface + impl + DI
+
+**Files:**
+- Create: `core/domain/src/main/kotlin/com/riffle/core/domain/ReadingSpeedStore.kt`
+- Create: `core/data/src/main/kotlin/com/riffle/core/data/ReadingSpeedStoreImpl.kt`
+- Create: `core/data/src/main/kotlin/com/riffle/core/data/di/ReadingSpeedDataStoreExt.kt`
+- Create: `core/data/src/test/kotlin/com/riffle/core/data/ReadingSpeedStoreTest.kt`
+- Modify: `core/data/src/main/kotlin/com/riffle/core/data/di/DataModule.kt`
+
+- [ ] **Step 1: Write the failing store test**
+
+```kotlin
+package com.riffle.core.data
+
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import com.riffle.core.domain.ReadingSpeedTracker
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ReadingSpeedStoreTest {
+
+    @get:Rule
+    val tmp = TemporaryFolder()
+
+    private val dispatcher = UnconfinedTestDispatcher()
+    private val testScope = TestScope(dispatcher)
+
+    private fun buildStore() = ReadingSpeedStoreImpl(
+        PreferenceDataStoreFactory.create(
+            scope = testScope.backgroundScope,
+            produceFile = { tmp.newFile("reading_speed.preferences_pb") },
+        )
+    )
+
+    @Test
+    fun `default speed equals ReadingSpeedTracker DEFAULT_SECS_PER_POSITION`() = testScope.runTest {
+        assertEquals(
+            ReadingSpeedTracker.DEFAULT_SECS_PER_POSITION,
+            buildStore().speedSecPerPosition.first(),
+            0.001,
+        )
+    }
+
+    @Test
+    fun `updateSpeed stores and re-reads the value`() = testScope.runTest {
+        val store = buildStore()
+        store.updateSpeed(50.0)
+        assertEquals(50.0, store.speedSecPerPosition.first(), 0.001)
+    }
+
+    @Test
+    fun `updated value persists across store instances`() {
+        val file = tmp.newFile("reading_speed_round_trip.preferences_pb")
+        val writeScope = CoroutineScope(UnconfinedTestDispatcher() + Job())
+        runBlocking {
+            ReadingSpeedStoreImpl(
+                PreferenceDataStoreFactory.create(
+                    scope = writeScope,
+                    produceFile = { file },
+                )
+            ).updateSpeed(45.0)
+        }
+        writeScope.cancel()
+
+        val readScope = CoroutineScope(UnconfinedTestDispatcher() + Job())
+        val store2 = ReadingSpeedStoreImpl(
+            PreferenceDataStoreFactory.create(
+                scope = readScope,
+                produceFile = { file },
+            )
+        )
+        assertEquals(45.0, runBlocking { store2.speedSecPerPosition.first() }, 0.001)
+        readScope.cancel()
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+export JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"
+./gradlew :core:data:test --tests "com.riffle.core.data.ReadingSpeedStoreTest" 2>&1 | tail -20
+```
+
+Expected: FAIL with class not found.
+
+- [ ] **Step 3: Create `ReadingSpeedStore` interface**
+
+```kotlin
+// core/domain/src/main/kotlin/com/riffle/core/domain/ReadingSpeedStore.kt
+package com.riffle.core.domain
+
+import kotlinx.coroutines.flow.Flow
+
+interface ReadingSpeedStore {
+    val speedSecPerPosition: Flow<Double>
+    suspend fun updateSpeed(newSecPerPosition: Double)
+}
+```
+
+- [ ] **Step 4: Create the DataStore extension**
+
+```kotlin
+// core/data/src/main/kotlin/com/riffle/core/data/di/ReadingSpeedDataStoreExt.kt
+package com.riffle.core.data.di
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.preferencesDataStore
+
+val Context.readingSpeedDataStore: DataStore<Preferences>
+    by preferencesDataStore(name = "reading_speed_preferences")
+```
+
+- [ ] **Step 5: Create `ReadingSpeedStoreImpl`**
+
+```kotlin
+// core/data/src/main/kotlin/com/riffle/core/data/ReadingSpeedStoreImpl.kt
+package com.riffle.core.data
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.doublePreferencesKey
+import androidx.datastore.preferences.core.edit
+import com.riffle.core.data.di.ReadingSpeedDataStore
+import com.riffle.core.domain.ReadingSpeedStore
+import com.riffle.core.domain.ReadingSpeedTracker
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+
+class ReadingSpeedStoreImpl @Inject constructor(
+    @param:ReadingSpeedDataStore private val dataStore: DataStore<Preferences>,
+) : ReadingSpeedStore {
+
+    override val speedSecPerPosition: Flow<Double> = dataStore.data.map { prefs ->
+        prefs[KEY_SECS_PER_POSITION] ?: ReadingSpeedTracker.DEFAULT_SECS_PER_POSITION
+    }
+
+    override suspend fun updateSpeed(newSecPerPosition: Double) {
+        dataStore.edit { prefs -> prefs[KEY_SECS_PER_POSITION] = newSecPerPosition }
+    }
+
+    private companion object {
+        val KEY_SECS_PER_POSITION = doublePreferencesKey("reading_speed_secs_per_position")
+    }
+}
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+```bash
+./gradlew :core:data:test --tests "com.riffle.core.data.ReadingSpeedStoreTest" 2>&1 | tail -10
+```
+
+Expected: all 3 PASS.
+
+- [ ] **Step 7: Wire DI in `DataModule.kt`**
+
+Add the Hilt qualifier annotation alongside the others (around line 148):
+```kotlin
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class ReadingSpeedDataStore
+```
+
+Add the DataStore provider in the `@Module @InstallIn(SingletonComponent::class) object` block (alongside other DataStore providers, around line 620):
+```kotlin
+@Provides
+@Singleton
+@ReadingSpeedDataStore
+fun provideReadingSpeedDataStore(
+    @ApplicationContext context: Context
+): DataStore<Preferences> = context.readingSpeedDataStore
+```
+
+Add the store binding in the `@Module @InstallIn(SingletonComponent::class) abstract class` section (alongside `bindWakeLockPreferencesStore`, around line 304):
+```kotlin
+@Binds
+@Singleton
+abstract fun bindReadingSpeedStore(impl: ReadingSpeedStoreImpl): ReadingSpeedStore
+```
+
+Add the imports:
+```kotlin
+import com.riffle.core.data.ReadingSpeedStoreImpl
+import com.riffle.core.domain.ReadingSpeedStore
+```
+
+- [ ] **Step 8: Verify DI compiles**
+
+```bash
+./gradlew :core:data:compileDebugKotlin 2>&1 | tail -20
+```
+
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add core/domain/src/main/kotlin/com/riffle/core/domain/ReadingSpeedStore.kt \
+        core/data/src/main/kotlin/com/riffle/core/data/ReadingSpeedStoreImpl.kt \
+        core/data/src/main/kotlin/com/riffle/core/data/di/ReadingSpeedDataStoreExt.kt \
+        core/data/src/main/kotlin/com/riffle/core/data/di/DataModule.kt \
+        core/data/src/test/kotlin/com/riffle/core/data/ReadingSpeedStoreTest.kt
+git commit -m "feat(reader): add ReadingSpeedStore with DataStore-backed adaptive speed"
+```
+
+---
+
+## Task 4: `showReadingTimeEstimate` toggle — domain layer
+
+**Files:**
+- Modify: `core/domain/src/main/kotlin/com/riffle/core/domain/FormattingPreferences.kt`
+- Modify: `core/domain/src/main/kotlin/com/riffle/core/domain/BookFormattingOverrides.kt`
+- Modify: `core/domain/src/test/kotlin/com/riffle/core/domain/BookFormattingOverridesTest.kt`
+
+- [ ] **Step 1: Add to `FormattingPreferences`**
+
+In `data class FormattingPreferences(...)`, add after `justifyText`:
+```kotlin
+val showReadingTimeEstimate: Boolean = DEFAULT_SHOW_READING_TIME_ESTIMATE,
+```
+
+In the `companion object`, add:
+```kotlin
+const val DEFAULT_SHOW_READING_TIME_ESTIMATE: Boolean = true
+```
+
+- [ ] **Step 2: Add to `BookFormattingOverrides`**
+
+In `data class BookFormattingOverrides(...)`, add after `justifyText`:
+```kotlin
+val showReadingTimeEstimate: Boolean? = null,
+```
+
+In `isEmpty`, extend the last `&&` chain:
+```kotlin
+justifyText == null &&
+showReadingTimeEstimate == null
+```
+
+In `applyTo(global)`, add after the `justifyText` line:
+```kotlin
+showReadingTimeEstimate = showReadingTimeEstimate ?: global.showReadingTimeEstimate,
+```
+
+In `withChanges(previous, new)`, add after the `justifyText` line:
+```kotlin
+showReadingTimeEstimate = if (new.showReadingTimeEstimate != previous.showReadingTimeEstimate) new.showReadingTimeEstimate else showReadingTimeEstimate,
+```
+
+- [ ] **Step 3: Write failing tests in `BookFormattingOverridesTest`**
+
+Add these tests to `BookFormattingOverridesTest`:
+```kotlin
+@Test
+fun `isEmpty is false when only showReadingTimeEstimate is set`() {
+    assertFalse(BookFormattingOverrides(showReadingTimeEstimate = false).isEmpty)
+}
+
+@Test
+fun `applyTo threads showReadingTimeEstimate override`() {
+    val effective = BookFormattingOverrides(showReadingTimeEstimate = false).applyTo(global)
+    assertFalse(effective.showReadingTimeEstimate)
+    // Default is true, so null override → global default of true
+    assertTrue(BookFormattingOverrides().applyTo(global).showReadingTimeEstimate)
+}
+
+@Test
+fun `withChanges records showReadingTimeEstimate when it differs`() {
+    val previous = global // showReadingTimeEstimate = true (default)
+    val new = global.copy(showReadingTimeEstimate = false)
+    val overrides = BookFormattingOverrides().withChanges(previous, new)
+    assertEquals(false, overrides.showReadingTimeEstimate)
+}
+```
+
+Note: the existing `global` val in the test has `showReadingTimeEstimate` default = true; you don't need to change it. The test accesses it via `.showReadingTimeEstimate` which will resolve to `true` after the field is added to `FormattingPreferences`.
+
+- [ ] **Step 4: Run tests**
+
+```bash
+export JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"
+./gradlew :core:domain:test --tests "com.riffle.core.domain.BookFormattingOverridesTest" 2>&1 | tail -10
+```
+
+Expected: all pass (existing + 3 new).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add core/domain/src/main/kotlin/com/riffle/core/domain/FormattingPreferences.kt \
+        core/domain/src/main/kotlin/com/riffle/core/domain/BookFormattingOverrides.kt \
+        core/domain/src/test/kotlin/com/riffle/core/domain/BookFormattingOverridesTest.kt
+git commit -m "feat(reader): add showReadingTimeEstimate formatting toggle"
+```
+
+---
+
+## Task 5: Room migration 35 → 36
+
+**Files:**
+- Modify: `core/database/src/main/kotlin/com/riffle/core/database/BookFormattingPreferencesEntity.kt`
+- Modify: `core/database/src/main/kotlin/com/riffle/core/database/RiffleDatabase.kt`
+- Modify: `core/database/src/androidTest/kotlin/com/riffle/core/database/MigrationTest.kt`
+
+Per CLAUDE.md: bump version → build (exports schema JSON) → register migration → write test.
+
+- [ ] **Step 1: Add column to `BookFormattingPreferencesEntity`**
+
+Add after `justifyText`:
+```kotlin
+val showReadingTimeEstimate: Boolean? = null,
+```
+
+- [ ] **Step 2: Bump DB version and add migration in `RiffleDatabase.kt`**
+
+Change `version = 35` → `version = 36`.
+
+Add after `MIGRATION_34_35`:
+```kotlin
+val MIGRATION_35_36 = object : Migration(35, 36) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL(
+            "ALTER TABLE `book_formatting_preferences` ADD COLUMN `showReadingTimeEstimate` INTEGER DEFAULT NULL"
+        )
+    }
+}
+```
+
+- [ ] **Step 3: Register migration in `DataModule.kt`**
+
+In `addMigrations(...)`, add `RiffleDatabase.MIGRATION_35_36` to the list.
+
+- [ ] **Step 4: Export the schema JSON**
+
+```bash
+export JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"
+./gradlew :core:database:kspDebugKotlin 2>&1 | tail -10
+```
+
+Expected: BUILD SUCCESSFUL. A new file `core/database/schemas/com.riffle.core.database.RiffleDatabase/36.json` is created.
+
+- [ ] **Step 5: Write migration test in `MigrationTest.kt`**
+
+Add before `migrateFullChain()`:
+```kotlin
+@Test
+fun migration35To36_addsShowReadingTimeEstimateColumn() {
+    helper.createDatabase(TEST_DB, 35).use { db ->
+        db.execSQL(
+            "INSERT INTO servers (id, url, isActive, insecureConnectionAllowed, username, serverType) " +
+                "VALUES ('s1', 'http://media-server', 1, 0, 'test', 'AUDIOBOOKSHELF')"
+        )
+        db.execSQL(
+            "INSERT INTO book_formatting_preferences " +
+                "(serverId, itemId, fontSize, theme, fontFamily, lineSpacing, margins, orientation, " +
+                "showChapterMap, showReadingProgressLabels, showCurrentChapterLabel, doublePageSpread, justifyText) " +
+                "VALUES ('s1', 'item1', 1.0, 'Light', 'Serif', 1.2, 1.0, 'Horizontal', 1, 0, 0, 0, 0)"
+        )
+    }
+
+    val db = helper.runMigrationsAndValidate(TEST_DB, 36, true, RiffleDatabase.MIGRATION_35_36)
+
+    db.query(
+        "SELECT showReadingTimeEstimate FROM book_formatting_preferences WHERE itemId = 'item1'"
+    ).use { c ->
+        assertEquals(1, c.count)
+        c.moveToFirst()
+        assertTrue(c.isNull(0)) // NULL default — per-book not set
+    }
+}
+```
+
+In `migrateFullChain()`, update the final migration call:
+```kotlin
+// Change:
+val db = helper.runMigrationsAndValidate(
+    TEST_DB, 35, true,
+    ...
+    RiffleDatabase.MIGRATION_34_35,
+)
+// To:
+val db = helper.runMigrationsAndValidate(
+    TEST_DB, 36, true,
+    ...
+    RiffleDatabase.MIGRATION_34_35,
+    RiffleDatabase.MIGRATION_35_36,
+)
+```
+
+- [ ] **Step 6: Run migration tests**
+
+Run per CLAUDE.md — the MigrationTest lives in `core:database` (not `:app`), so pin it to the Harness AVD manually:
+
+```bash
+# Boot the Harness Medium Phone AVD if not already running
+# (see reference_api25_avd_boot_incantation.md in memory for incantation)
+# Then with ANDROID_SERIAL set to that emulator:
+export JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"
+./gradlew :core:database:connectedDebugAndroidTest \
+  --tests "com.riffle.core.database.MigrationTest.migration35To36_addsShowReadingTimeEstimateColumn" \
+  --tests "com.riffle.core.database.MigrationTest.migrateFullChain" 2>&1 | tail -20
+```
+
+Expected: both PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add core/database/src/main/kotlin/com/riffle/core/database/BookFormattingPreferencesEntity.kt \
+        core/database/src/main/kotlin/com/riffle/core/database/RiffleDatabase.kt \
+        core/database/schemas/com.riffle.core.database.RiffleDatabase/36.json \
+        core/database/src/androidTest/kotlin/com/riffle/core/database/MigrationTest.kt \
+        core/data/src/main/kotlin/com/riffle/core/data/di/DataModule.kt
+git commit -m "feat(reader): Room migration 35→36 adds showReadingTimeEstimate column"
+```
+
+---
+
+## Task 6: `FormattingPreferencesStoreImpl` — persist the new toggle
+
+**Files:**
+- Modify: `core/data/src/main/kotlin/com/riffle/core/data/FormattingPreferencesStoreImpl.kt`
+
+- [ ] **Step 1: Add the key and wire read/write**
+
+In the `preferences: Flow<FormattingPreferences>` map block, add after `justifyText`:
+```kotlin
+showReadingTimeEstimate = prefs[KEY_SHOW_READING_TIME_ESTIMATE] ?: true,
+```
+
+In `update(preferences)` inside `dataStore.edit { prefs -> ... }`, add after `justifyText`:
+```kotlin
+prefs[KEY_SHOW_READING_TIME_ESTIMATE] = preferences.showReadingTimeEstimate
+```
+
+In the `companion object`, add:
+```kotlin
+val KEY_SHOW_READING_TIME_ESTIMATE = booleanPreferencesKey("show_reading_time_estimate")
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+```bash
+export JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"
+./gradlew :core:data:compileDebugKotlin 2>&1 | tail -10
+```
+
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add core/data/src/main/kotlin/com/riffle/core/data/FormattingPreferencesStoreImpl.kt
+git commit -m "feat(reader): persist showReadingTimeEstimate in global formatting DataStore"
+```
+
+---
+
+## Task 7: `EpubReaderViewModel` — session tracking + time remaining flows
+
+**Files:**
+- Modify: `app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt`
+
+- [ ] **Step 1: Add `_readaloudTrackFlow` alongside the existing `private var readaloudTrack`**
+
+Find the line `private var readaloudTrack: com.riffle.core.domain.ReadaloudTrack? = null` (around line 339) and add directly below it:
+```kotlin
+private val _readaloudTrackFlow = MutableStateFlow<com.riffle.core.domain.ReadaloudTrack?>(null)
+```
+
+Find the method `getOrLoadReadaloudTrack` (around line 1713). After the line `readaloudTrack = track`, add:
+```kotlin
+_readaloudTrackFlow.value = track
+```
+
+- [ ] **Step 2: Inject `ReadingSpeedStore`**
+
+In the `@HiltViewModel class EpubReaderViewModel @Inject constructor(...)`, add `ReadingSpeedStore` to the constructor (alphabetically with the other stores):
+```kotlin
+private val readingSpeedStore: ReadingSpeedStore,
+```
+
+Add the import:
+```kotlin
+import com.riffle.core.domain.ReadingSpeedStore
+```
+
+- [ ] **Step 3: Add session-tracking fields and hook into `onReaderResumed` / `onReaderClosed`**
+
+Add two private fields near the other session-state fields (e.g., around `closeSyncDone`):
+```kotlin
+private var sessionStartProgression: Float? = null
+private var sessionStartMs: Long = 0L
+```
+
+In `onReaderResumed()`, after the existing body, add:
+```kotlin
+// Snapshot reading position for adaptive speed tracking.
+val totalPositions = railSegments.value.sumOf { it.weight.toDouble() }.toFloat()
+if (totalPositions > 0f && _currentLocatorTotalProgression.value > 0f) {
+    sessionStartProgression = _currentLocatorTotalProgression.value
+    sessionStartMs = System.currentTimeMillis()
+}
+```
+
+In `onReaderClosed()`, at the top of the method (before existing body), add:
+```kotlin
+flushReadingSession()
+```
+
+Add the private flush method (place it near the other private helpers):
+```kotlin
+private fun flushReadingSession() {
+    val startProg = sessionStartProgression ?: return
+    sessionStartProgression = null
+    val timeDeltaSec = (System.currentTimeMillis() - sessionStartMs) / 1000.0
+    val progressDelta = _currentLocatorTotalProgression.value - startProg
+    if (progressDelta <= 0f) return
+    val totalPositions = railSegments.value.sumOf { it.weight.toDouble() }.toFloat()
+    viewModelScope.launch {
+        val prior = readingSpeedStore.speedSecPerPosition.first()
+        val updated = ReadingSpeedTracker.recordSession(
+            progressDelta = progressDelta,
+            timeDeltaSec = timeDeltaSec,
+            totalPositions = totalPositions,
+            priorSecPerPosition = prior,
+        ) ?: return@launch
+        readingSpeedStore.updateSpeed(updated)
+    }
+}
+```
+
+Add the import:
+```kotlin
+import com.riffle.core.domain.ReadingSpeedTracker
+import kotlinx.coroutines.flow.first
+```
+
+- [ ] **Step 4: Add `chapterTimeRemaining` and `bookTimeRemaining` StateFlows**
+
+Add after the existing `railCursorPosition` flow (around line 1115):
+
+```kotlin
+val chapterTimeRemaining: StateFlow<TimeRemaining?> = combine(
+    combine(_readaloudTrackFlow, playbackState) { track, ps -> track to ps },
+    combine(currentLocatorProgression, railSegments, activeRailSegmentIndex) { prog, segs, idx ->
+        Triple(prog, segs, idx)
+    },
+    readingSpeedStore.speedSecPerPosition,
+) { (track, ps), (chapterProg, segments, activeIdx), secsPerPos ->
+    if (ps.connected && track != null) {
+        val chapterEnd = track.chapterStartsSec.getOrNull(ps.currentChapterIndex + 1)
+            ?: track.totalDurationSec
+        val sec = ((chapterEnd - ps.positionGlobalSec) / ps.speed).toLong().coerceAtLeast(0L)
+        TimeRemaining.Exact(sec)
+    } else {
+        val weight = segments.getOrNull(activeIdx)?.weight?.takeIf { it > 0f }
+            ?: return@combine null
+        TimeRemaining.Estimated(
+            ((1f - chapterProg) * weight * secsPerPos).toLong().coerceAtLeast(0L)
+        )
+    }
+}.stateIn(viewModelScope, SharingStarted.Eagerly, null)
+
+val bookTimeRemaining: StateFlow<TimeRemaining?> = combine(
+    combine(_readaloudTrackFlow, playbackState) { track, ps -> track to ps },
+    combine(currentLocatorTotalProgression, railSegments) { prog, segs -> prog to segs },
+    readingSpeedStore.speedSecPerPosition,
+) { (track, ps), (totalProg, segments), secsPerPos ->
+    if (ps.connected && track != null) {
+        val sec = ((track.totalDurationSec - ps.positionGlobalSec) / ps.speed)
+            .toLong().coerceAtLeast(0L)
+        TimeRemaining.Exact(sec)
+    } else {
+        if (totalProg <= 0f) return@combine null
+        val totalPositions = segments.sumOf { it.weight.toDouble() }
+        if (totalPositions <= 0.0) return@combine null
+        TimeRemaining.Estimated(
+            ((1.0 - totalProg) * totalPositions * secsPerPos).toLong().coerceAtLeast(0L)
+        )
+    }
+}.stateIn(viewModelScope, SharingStarted.Eagerly, null)
+```
+
+Add the import:
+```kotlin
+import com.riffle.core.domain.TimeRemaining
+```
+
+- [ ] **Step 5: Verify it compiles**
+
+```bash
+export JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"
+./gradlew :app:compileDebugKotlin 2>&1 | tail -20
+```
+
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 6: Run all JVM tests to catch regressions**
+
+```bash
+./gradlew test 2>&1 | tail -20
+```
+
+Expected: BUILD SUCCESSFUL, no new failures.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+git commit -m "feat(reader): adaptive session tracking and time remaining flows in ViewModel"
+```
+
+---
+
+## Task 8: `FormattingPanel` — "Time remaining" toggle
+
+**Files:**
+- Modify: `app/src/main/kotlin/com/riffle/app/feature/reader/FormattingPanel.kt`
+
+- [ ] **Step 1: Add the toggle row after the `showCurrentChapterLabel` block**
+
+Find this block (around line 353):
+```kotlin
+Row(
+    verticalAlignment = Alignment.CenterVertically,
+    modifier = Modifier.fillMaxWidth(),
+) {
+    Text(
+        "Current chapter label",
+        style = MaterialTheme.typography.bodyLarge,
+        modifier = Modifier.weight(1f),
+    )
+    Switch(
+        checked = prefs.showCurrentChapterLabel,
+        onCheckedChange = { onPrefsChange(prefs.copy(showCurrentChapterLabel = it)) },
+    )
+}
+```
+
+Add immediately after it:
+```kotlin
+Row(
+    verticalAlignment = Alignment.CenterVertically,
+    modifier = Modifier.fillMaxWidth(),
+) {
+    Text(
+        "Time remaining",
+        style = MaterialTheme.typography.bodyLarge,
+        modifier = Modifier.weight(1f),
+    )
+    Switch(
+        checked = prefs.showReadingTimeEstimate,
+        onCheckedChange = { onPrefsChange(prefs.copy(showReadingTimeEstimate = it)) },
+    )
+}
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+```bash
+export JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"
+./gradlew :app:compileDebugKotlin 2>&1 | tail -10
+```
+
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/src/main/kotlin/com/riffle/app/feature/reader/FormattingPanel.kt
+git commit -m "feat(reader): add time remaining toggle to formatting panel"
+```
+
+---
+
+## Task 9: `EpubReaderScreen` — the pill UI
+
+**Files:**
+- Modify: `app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt`
+
+- [ ] **Step 1: Update the visibility guard (line ~372)**
+
+Find:
+```kotlin
+formattingPrefs.showReadingProgressLabels ||
+formattingPrefs.showCurrentChapterLabel
+```
+
+Replace with:
+```kotlin
+formattingPrefs.showReadingProgressLabels ||
+formattingPrefs.showCurrentChapterLabel ||
+formattingPrefs.showReadingTimeEstimate
+```
+
+- [ ] **Step 2: Collect the new time flows and pass them to `EpubChapterRailOverlay`**
+
+In the main composable body where the `formattingPrefs` is collected (around line 161), add:
+```kotlin
+val chapterTimeRemaining by viewModel.chapterTimeRemaining.collectAsState()
+val bookTimeRemaining by viewModel.bookTimeRemaining.collectAsState()
+```
+
+Find the `EpubChapterRailOverlay(...)` call (around line 426) and add the two new parameters:
+```kotlin
+EpubChapterRailOverlay(
+    viewModel = viewModel,
+    modifier = ...,
+    showProgressLabels = formattingPrefs.showReadingProgressLabels,
+    showChapterNameLabel = formattingPrefs.showCurrentChapterLabel,
+    showReadingTimeEstimate = formattingPrefs.showReadingTimeEstimate,   // new
+    chapterTimeRemaining = chapterTimeRemaining,                          // new
+    bookTimeRemaining = bookTimeRemaining,                                // new
+    ...
+)
+```
+
+- [ ] **Step 3: Add parameters to `EpubChapterRailOverlay`**
+
+Find `private fun EpubChapterRailOverlay(` (around line 548) and add the three new parameters:
+```kotlin
+private fun EpubChapterRailOverlay(
+    viewModel: EpubReaderViewModel,
+    modifier: Modifier = Modifier,
+    showProgressLabels: Boolean,
+    showChapterNameLabel: Boolean,
+    showReadingTimeEstimate: Boolean,       // new
+    chapterTimeRemaining: TimeRemaining?,   // new
+    bookTimeRemaining: TimeRemaining?,      // new
+    ...
+)
+```
+
+Add import:
+```kotlin
+import com.riffle.core.domain.TimeRemaining
+```
+
+Pass them through to `ReadingProgressLabels(...)`:
+```kotlin
+ReadingProgressLabels(
+    activeChapterIndex = activeRailSegmentIndex,
+    chapterCount = railSegments.size,
+    activeChapterTitle = railSegments.getOrNull(activeRailSegmentIndex)?.title.orEmpty(),
+    totalProgress = ...,
+    readerTheme = ...,
+    showCountAndPercent = showProgressLabels,
+    showChapterName = showChapterNameLabel,
+    showReadingTimeEstimate = showReadingTimeEstimate,   // new
+    chapterTimeRemaining = chapterTimeRemaining,          // new
+    bookTimeRemaining = bookTimeRemaining,                // new
+)
+```
+
+- [ ] **Step 4: Update `ReadingProgressLabels` to render the pill**
+
+Find `private fun ReadingProgressLabels(` (around line 619) and add the three new parameters:
+```kotlin
+private fun ReadingProgressLabels(
+    activeChapterIndex: Int,
+    chapterCount: Int,
+    activeChapterTitle: String,
+    totalProgress: Float,
+    readerTheme: ReaderTheme,
+    showCountAndPercent: Boolean,
+    showChapterName: Boolean,
+    showReadingTimeEstimate: Boolean,       // new
+    chapterTimeRemaining: TimeRemaining?,   // new
+    bookTimeRemaining: TimeRemaining?,      // new
+)
+```
+
+In the function body, change the centre slot from a plain `Text` to a `Column`:
+
+Replace:
+```kotlin
+if (showChapterName) {
+    Text(
+        text = activeChapterTitle,
+        style = MaterialTheme.typography.labelSmall,
+        color = textColor,
+        textAlign = TextAlign.Center,
+        fontStyle = FontStyle.Italic,
+        maxLines = 1,
+        overflow = TextOverflow.Ellipsis,
+        modifier = Modifier
+            .weight(2f)
+            .testTag("reading_progress_chapter_name")
+            .semantics { contentDescription = "Current chapter: $activeChapterTitle" },
+    )
+}
+```
+
+With:
+```kotlin
+if (showChapterName || showReadingTimeEstimate) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = Modifier.weight(2f),
+    ) {
+        if (showChapterName) {
+            Text(
+                text = activeChapterTitle,
+                style = MaterialTheme.typography.labelSmall,
+                color = textColor,
+                textAlign = TextAlign.Center,
+                fontStyle = FontStyle.Italic,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier
+                    .testTag("reading_progress_chapter_name")
+                    .semantics { contentDescription = "Current chapter: $activeChapterTitle" },
+            )
+        }
+        if (showReadingTimeEstimate && chapterTimeRemaining != null && bookTimeRemaining != null) {
+            val isExact = chapterTimeRemaining is TimeRemaining.Exact
+            val pillColor = if (isExact) MaterialTheme.colorScheme.tertiary else textColor
+            val pillBgColor = if (isExact) MaterialTheme.colorScheme.tertiary.copy(alpha = 0.12f)
+                              else textColor.copy(alpha = 0.08f)
+            val pillText = "${chapterTimeRemaining.formatChapter()} · ${bookTimeRemaining.formatBook()}"
+            Text(
+                text = pillText,
+                style = MaterialTheme.typography.labelSmall,
+                color = pillColor,
+                textAlign = TextAlign.Center,
+                maxLines = 1,
+                modifier = Modifier
+                    .background(color = pillBgColor, shape = RoundedCornerShape(8.dp))
+                    .padding(horizontal = 6.dp, vertical = 2.dp)
+                    .testTag("reading_time_remaining")
+                    .semantics { contentDescription = "Time remaining: $pillText" },
+            )
+        }
+    }
+}
+```
+
+- [ ] **Step 5: Add the formatting helpers**
+
+Add these two private extension functions at the bottom of the file (or just below `ReadingProgressLabels`):
+
+```kotlin
+private fun TimeRemaining.formatChapter(): String = formatDuration(sec, suffix = "in chapter")
+
+private fun TimeRemaining.formatBook(): String = formatDuration(sec, suffix = "left")
+
+private fun TimeRemaining.formatDuration(sec: Long, suffix: String): String {
+    val hours = sec / 3600
+    val minutes = (sec % 3600) / 60
+    return when (this) {
+        is TimeRemaining.Estimated -> {
+            val time = when {
+                sec < 60 -> "< 1 min"
+                hours > 0 -> "~${hours}h ${minutes}m"
+                else -> "~${minutes} min"
+            }
+            "$time $suffix"
+        }
+        is TimeRemaining.Exact -> {
+            val time = if (hours > 0) "%d:%02d:%02d".format(hours, minutes, sec % 60)
+                       else "%d:%02d".format(minutes, sec % 60)
+            "$time $suffix"
+        }
+    }
+}
+```
+
+Add any missing imports:
+```kotlin
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.shape.RoundedCornerShape
+import com.riffle.core.domain.TimeRemaining
+```
+
+- [ ] **Step 6: Verify full build**
+
+```bash
+export JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"
+./gradlew :app:compileDebugKotlin 2>&1 | tail -20
+```
+
+Expected: BUILD SUCCESSFUL with no errors.
+
+- [ ] **Step 7: Run all JVM tests**
+
+```bash
+./gradlew test 2>&1 | tail -20
+```
+
+Expected: BUILD SUCCESSFUL, no new failures.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+git commit -m "feat(reader): reading time remaining pill in chapter label area"
+```
+
+---
+
+## Self-review checklist
+
+- [x] `TimeRemaining` sealed class → Task 1
+- [x] `ReadingSpeedTracker` pure EWMA + tests → Task 2
+- [x] `ReadingSpeedStore` interface + impl + DataStore ext + DI → Task 3
+- [x] `showReadingTimeEstimate` in `FormattingPreferences` + `BookFormattingOverrides` + test → Task 4
+- [x] Room migration 35→36 + schema JSON + `MigrationTest` → Task 5
+- [x] `FormattingPreferencesStoreImpl` key → Task 6
+- [x] ViewModel: `_readaloudTrackFlow`, session tracking, `chapterTimeRemaining` / `bookTimeRemaining` → Task 7
+- [x] `FormattingPanel` toggle → Task 8
+- [x] UI pill with estimated/exact formatting → Task 9
+- [x] Visibility guard updated → Task 9 Step 1
+- [x] Exact mode uses `MaterialTheme.colorScheme.tertiary` → Task 9 Step 4
+- [x] Global DataStore key for toggle → Task 6
+- [x] Per-book Room column for toggle → Task 5
+- [x] `ReadingSpeedStore` on its own DataStore (not FormattingPreferences) → Task 3

--- a/docs/superpowers/specs/2026-06-14-reading-time-estimate-design.md
+++ b/docs/superpowers/specs/2026-06-14-reading-time-estimate-design.md
@@ -46,13 +46,14 @@ Readium *positions* are used as the proxy for text length. A position is one scr
 
 ### Storage
 
-A new **`ReadingSpeedStore`** backed by the existing `FormattingPreferencesDataStore` (same DataStore instance, new key) — device-wide, not per-book. Reading speed is a property of the reader, not the book; pooling sessions across all books converges 5–10× faster than per-book tracking and avoids a cold-start problem on every new book.
+A new **`ReadingSpeedStore`** backed by its own `@ReadingSpeedDataStore`-qualified `DataStore<Preferences>` created in `DataModule` — device-wide, not per-book. Reading speed is a property of the reader, not the book; pooling sessions across all books converges 5–10× faster than per-book tracking and avoids a cold-start problem on every new book. Giving it a dedicated DataStore keeps `FormattingPreferencesDataStore` scoped to formatting only.
 
 ```kotlin
 val KEY_READING_SPEED_SECS_PER_POSITION = doublePreferencesKey("reading_speed_secs_per_position")
+// DataStore file name: "reading_speed_preferences"
 ```
 
-`ReadingSpeedStore` is a new domain interface + `ReadingSpeedStoreImpl` in `core/data`. Injected into `EpubReaderViewModel`.
+`ReadingSpeedStore` is a new domain interface + `ReadingSpeedStoreImpl` in `core/data`, bound in `DataModule` alongside the other store bindings. Injected into `EpubReaderViewModel`.
 
 ### Time calculations (estimated mode)
 
@@ -197,7 +198,7 @@ The pill is a `Text` with `labelSmall`, `background(shape = RoundedCornerShape(8
 
 Combined pill text: `"~8 min in chapter · ~2h 14m left"` (bullet separator).
 
-Colour: same `readerThemeLabelColor()` as other labels for estimated; **teal** (`MaterialTheme.colorScheme.tertiary` or a fixed `Color(0xFF5BB8A0)`) for exact to distinguish audio-derived precision.
+Colour: same `readerThemeLabelColor()` as other labels for estimated; **`MaterialTheme.colorScheme.tertiary`** for exact to distinguish audio-derived precision (follows the active theme rather than a hardcoded hex).
 
 ### Visibility guard
 

--- a/docs/superpowers/specs/2026-06-14-reading-time-estimate-design.md
+++ b/docs/superpowers/specs/2026-06-14-reading-time-estimate-design.md
@@ -1,0 +1,245 @@
+# Reading Time Estimate — Design Spec
+
+**Date:** 2026-06-14  
+**Branch target:** main
+
+---
+
+## Overview
+
+Show estimated (or exact, when read aloud is active) time remaining in the current chapter and in the whole book. The estimate adapts silently to the user's actual reading speed via a per-device EWMA over reading sessions. Togglable in the formatting panel with both a global default and a per-book override, following the same pattern as all other formatting toggles.
+
+---
+
+## 1. Adaptive Reading Speed Engine
+
+### Unit of measure
+
+Readium *positions* are used as the proxy for text length. A position is one screen-pageful of text (~250 words). Position counts are already computed per chapter as `RailSegment.weight`; their sum = `totalPositions`. This avoids needing actual word counts.
+
+**Default rate:** 63 s/position (= 250 words ÷ 238 WPM, the average adult reading speed).
+
+### Session tracking
+
+`EpubReaderViewModel` already calls `onReaderResumed()` / `onReaderPaused()` via lifecycle hooks. Reading sessions are tracked there:
+
+- **On `onReaderResumed()`:** snapshot `(totalProgression: Float, wallClockMs: Long)`.
+- **On `onReaderPaused()`:** compute:
+
+  ```
+  progressDelta  = currentProgression - startProgression
+  timeDeltaSec   = (nowMs - startMs) / 1000
+  positionsDelta = progressDelta × totalPositions
+  observedRate   = timeDeltaSec / positionsDelta   // seconds per position
+  ```
+
+- **Discard** the session if any of:
+  - `timeDeltaSec < 30` (too short — user just glanced at the book)
+  - `positionsDelta < 0.5` (less than half a position moved — probably didn't read)
+  - Implied WPM outside `[20, 1000]` (sanity bounds on `250 / observedRate × 60`)
+
+- **EWMA update** (on valid sessions only):
+  ```
+  adaptedRate = 0.2 × observedRate + 0.8 × priorRate
+  ```
+  α = 0.2 gives slow, stable adaptation: roughly 5 sessions to shift meaningfully.
+
+### Storage
+
+A new **`ReadingSpeedStore`** backed by the existing `FormattingPreferencesDataStore` (same DataStore instance, new key) — device-wide, not per-book. Reading speed is a property of the reader, not the book; pooling sessions across all books converges 5–10× faster than per-book tracking and avoids a cold-start problem on every new book.
+
+```kotlin
+val KEY_READING_SPEED_SECS_PER_POSITION = doublePreferencesKey("reading_speed_secs_per_position")
+```
+
+`ReadingSpeedStore` is a new domain interface + `ReadingSpeedStoreImpl` in `core/data`. Injected into `EpubReaderViewModel`.
+
+### Time calculations (estimated mode)
+
+```
+totalPositions        = railSegments.sumOf { it.weight }
+bookRemainingSec      = (1 - totalProgression) × totalPositions × secsPerPosition
+chapterRemainingSec   = (1 - chapterProgression) × chapterWeight × secsPerPosition
+```
+
+`chapterWeight` = `railSegments[activeRailSegmentIndex].weight`.
+
+---
+
+## 2. Readaloud Exact Mode
+
+When readaloud is connected (`playbackState.connected == true` and `readaloudTrack != null`), use the audio timeline directly — no inference needed.
+
+```
+chapterEndSec       = chapterStartsSec[chapterIndex + 1]  // totalDurationSec for last chapter
+chapterRemainingSec = (chapterEndSec - positionGlobalSec) / speed
+bookRemainingSec    = (totalDurationSec - positionGlobalSec) / speed
+```
+
+Both values update live as `positionGlobalSec` ticks in `PlaybackState`.
+
+If readaloud is connected but `readaloudTrack` is not yet loaded, fall back to estimated mode.
+
+---
+
+## 3. ViewModel Surface
+
+### New sealed class
+
+```kotlin
+sealed class TimeRemaining {
+    data class Estimated(val sec: Long) : TimeRemaining()
+    data class Exact(val sec: Long) : TimeRemaining()
+}
+```
+
+### New `StateFlow`s on `EpubReaderViewModel`
+
+```kotlin
+val chapterTimeRemaining: StateFlow<TimeRemaining?>
+val bookTimeRemaining: StateFlow<TimeRemaining?>
+```
+
+Both emit `null` when `totalProgression` is unknown (Readium hasn't computed positions yet) or when `totalPositions == 0`.
+
+These are `combine()` expressions over `currentLocatorTotalProgression`, `currentLocatorProgression`, `railSegments`, `activeRailSegmentIndex`, `playbackState`, `readaloudTrack`, and `readingSpeed` from `ReadingSpeedStore`.
+
+### New classes
+
+| Class | Location | Purpose |
+|---|---|---|
+| `ReadingSpeedStore` | `core/domain` | Interface: `flow: Flow<Double>`, `update(Double)` |
+| `ReadingSpeedStoreImpl` | `core/data` | DataStore-backed implementation |
+| `ReadingSpeedTracker` | `core/domain` | Pure: `recordSession(progressDelta, timeDeltaSec, totalPositions, priorRate): Double?` — returns new EWMA rate or null if session is discarded |
+
+`ReadingSpeedTracker` is a pure function object with no Android dependencies — JVM unit-testable.
+
+---
+
+## 4. Toggle — `showReadingTimeEstimate`
+
+Follows the exact same 4-file pattern as `showReadingProgressLabels` and `showCurrentChapterLabel`.
+
+### `FormattingPreferences.kt`
+```kotlin
+val showReadingTimeEstimate: Boolean = DEFAULT_SHOW_READING_TIME_ESTIMATE,
+
+// in companion:
+const val DEFAULT_SHOW_READING_TIME_ESTIMATE: Boolean = true
+```
+
+Default is **true** — on by default so users discover the feature without needing to opt in.
+
+### `BookFormattingOverrides.kt`
+```kotlin
+val showReadingTimeEstimate: Boolean? = null
+```
+
+Add to `isEmpty`, `applyTo()`, and `withChanges()` following the identical pattern of the other Boolean? fields.
+
+### `BookFormattingPreferencesEntity.kt`
+```kotlin
+val showReadingTimeEstimate: Boolean? = null
+```
+
+Requires **Room migration 35 → 36**:
+```sql
+ALTER TABLE book_formatting_preferences ADD COLUMN showReadingTimeEstimate INTEGER;
+```
+
+Add `MIGRATION_35_36` to `RiffleDatabase`, register in `DataModule.addMigrations(...)`, and add a migration test in `MigrationTest`.
+
+### `FormattingPreferencesStoreImpl.kt`
+```kotlin
+showReadingTimeEstimate = prefs[KEY_SHOW_READING_TIME_ESTIMATE] ?: true,
+// in update():
+prefs[KEY_SHOW_READING_TIME_ESTIMATE] = preferences.showReadingTimeEstimate
+// companion:
+val KEY_SHOW_READING_TIME_ESTIMATE = booleanPreferencesKey("show_reading_time_estimate")
+```
+
+### `FormattingPanel.kt`
+Add a toggle row after the `showCurrentChapterLabel` row, same chip/switch pattern:
+
+```
+"Time remaining"   [toggle]
+```
+
+---
+
+## 5. UI — The Pill
+
+### Placement
+
+In `ReadingProgressLabels`, the centre slot becomes a `Column` when either the chapter title or the time pill is visible:
+
+```
+[Ch X of N]  [  Chapter Title (italic)  ]  [XX.X%]
+             [ ~8 min · ~2h 14m left    ]
+```
+
+If only `showReadingTimeEstimate` is on (chapter title off), the pill alone occupies the centre:
+
+```
+[Ch X of N]  [ ~8 min · ~2h 14m left   ]  [XX.X%]
+```
+
+The pill is a `Text` with `labelSmall`, `background(shape = RoundedCornerShape(8.dp))` at low alpha, padded `2dp` vertical / `6dp` horizontal.
+
+### Format
+
+| Mode | Chapter remaining | Book remaining |
+|---|---|---|
+| Estimated | `~8 min in chapter` | `~2h 14m left` |
+| Estimated < 1 min | `< 1 min in chapter` | `< 1 min left` |
+| Exact (readaloud) | `8:32 in chapter` | `2:14:07 left` |
+| Exact < 1 hr | `8:32 in chapter` | `14:07 left` |
+
+Combined pill text: `"~8 min in chapter · ~2h 14m left"` (bullet separator).
+
+Colour: same `readerThemeLabelColor()` as other labels for estimated; **teal** (`MaterialTheme.colorScheme.tertiary` or a fixed `Color(0xFF5BB8A0)`) for exact to distinguish audio-derived precision.
+
+### Visibility guard
+
+`EpubChapterRailOverlay` gate — add `|| formattingPrefs.showReadingTimeEstimate` to the existing `showReadingProgressLabels || showCurrentChapterLabel` condition at line 372.
+
+### `ReadingProgressLabels` signature change
+
+```kotlin
+private fun ReadingProgressLabels(
+    // existing params...
+    chapterTimeRemaining: TimeRemaining?,   // new
+    bookTimeRemaining: TimeRemaining?,      // new
+    showReadingTimeEstimate: Boolean,       // new
+)
+```
+
+---
+
+## 6. Files Changed
+
+| File | Change |
+|---|---|
+| `core/domain/…/FormattingPreferences.kt` | Add `showReadingTimeEstimate` field + constant |
+| `core/domain/…/BookFormattingOverrides.kt` | Add nullable field, wire into `isEmpty`, `applyTo`, `withChanges` |
+| `core/domain/…/ReadingSpeedStore.kt` | **New** — interface |
+| `core/domain/…/ReadingSpeedTracker.kt` | **New** — pure session EWMA logic |
+| `core/domain/…/TimeRemaining.kt` | **New** — sealed class |
+| `core/data/…/FormattingPreferencesStoreImpl.kt` | Add key + read/write for `showReadingTimeEstimate` |
+| `core/data/…/ReadingSpeedStoreImpl.kt` | **New** — DataStore impl |
+| `core/data/…/di/DataModule.kt` | Bind `ReadingSpeedStore` |
+| `core/database/…/BookFormattingPreferencesEntity.kt` | Add `showReadingTimeEstimate: Boolean?` |
+| `core/database/…/RiffleDatabase.kt` | Bump to v36, add `MIGRATION_35_36` |
+| `core/database/…/MigrationTest.kt` | Add `migration35To36()` + chain test |
+| `app/…/reader/EpubReaderViewModel.kt` | Inject `ReadingSpeedStore`, session tracking, expose `chapterTimeRemaining` / `bookTimeRemaining` |
+| `app/…/reader/FormattingPanel.kt` | Add `showReadingTimeEstimate` toggle row |
+| `app/…/reader/EpubReaderScreen.kt` | Collect time flows, pass to `ReadingProgressLabels`, update visibility guard |
+
+---
+
+## 7. Tests
+
+- **`ReadingSpeedTrackerTest`** (JVM): valid session updates EWMA; sessions below 30 s / < 0.5 pos / outside WPM bounds are discarded; EWMA converges correctly over N sessions.
+- **`ReadingTimeRemainingTest`** (JVM, on ViewModel or a pure helper): correct chapter/book seconds for estimated mode; correct values in exact mode with speed != 1.
+- **`MigrationTest.migration35To36()`**: column added with NULL default; prior rows unaffected.
+- **`BookFormattingOverridesTest`**: extend existing tests for new `showReadingTimeEstimate` field.


### PR DESCRIPTION
## Summary

- Adds per-chapter and whole-book reading time estimates to the EPUB reader chrome, displayed below the chapter count and percentage labels respectively
- Tracks reading speed per device using an EWMA (DataStore-backed), defaulting to ~250 wpm until enough sessions are recorded
- Shows exact countdown (from audio duration) when readaloud is active; estimated mode uses Readium position weights per TOC segment
- Fixes rail cursor to use `totalProgression` (monotonically increasing) instead of `chapterProgression` (resets at each spine resource boundary) — prevents cursor jumps when a single TOC chapter spans multiple spine files (e.g. The Martian)
- Expands Part→Chapter TOC structures so estimates are per-chapter rather than per-part, with a grandchildren guard to avoid expanding leaf log-entry sequences (The Martian ch20 → SOL entries)
- Adds Room migration v35→v36 (`showReadingTimeEstimate` column on `book_formatting_preferences`)
- Toggle is off by default and persisted per-book as a formatting override; settings panel groups it adjacent to "Reading progress labels"

## Test plan

- [x] Enable "Time remaining" in formatting panel; verify `~Xmin chapter` and `~Xmin total` appear below their respective labels
- [x] Start readaloud; verify labels switch to exact `M:SS chapter` / `M:SS total` countdown
- [x] Read across a chapter boundary; verify chapter time resets and rail cursor does not jump
- [x] Open a Part→Chapter book (e.g. "Influence without authority"); verify estimates are per-chapter, not per-part
- [x] Open The Martian; verify cursor does not jump between SOL entries within a chapter
- [x] Toggle off; verify labels disappear, no layout shift
- [x] Fresh install (or cleared data): verify default speed (~250 wpm) produces plausible estimates