### PR TITLE
fix(library): mark-as-read leaves book stuck in In Progress with two ABS servers

### DIFF
--- a/core/data/src/main/kotlin/com/riffle/core/data/LibraryRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/LibraryRepositoryImpl.kt
@@ -28,6 +28,7 @@ import com.riffle.core.network.NetworkLibraryItemsResult
 import com.riffle.core.network.NetworkSeriesResult
 import com.riffle.core.network.NetworkUserProgressResult
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
@@ -61,22 +62,42 @@ class LibraryRepositoryImpl @Inject constructor(
         libraryDao.observeByServerId(serverId).map { list -> list.map { it.toDomain() } }
 
     override fun observeLibraryItems(libraryId: String): Flow<List<LibraryItem>> =
-        libraryItemDao.observeByLibraryId(libraryId).map { list -> list.distinctBy { it.id }.map { it.toDomain() } }
+        libraryItemDao.observeByLibraryId(libraryId).scopedToActiveServer()
 
     override fun observeUngroupedLibraryItems(libraryId: String): Flow<List<LibraryItem>> =
-        libraryItemDao.observeUngroupedByLibraryId(libraryId).map { list -> list.distinctBy { it.id }.map { it.toDomain() } }
+        libraryItemDao.observeUngroupedByLibraryId(libraryId).scopedToActiveServer()
 
     override fun observeInProgressItems(libraryId: String): Flow<List<LibraryItem>> =
-        libraryItemDao.observeInProgress(libraryId).map { list -> list.distinctBy { it.id }.map { it.toDomain() } }
+        libraryItemDao.observeInProgress(libraryId).scopedToActiveServer()
 
     override fun observeFinishedItems(libraryId: String): Flow<List<LibraryItem>> =
-        libraryItemDao.observeFinished(libraryId).map { list -> list.distinctBy { it.id }.map { it.toDomain() } }
+        libraryItemDao.observeFinished(libraryId).scopedToActiveServer()
 
     override fun observeRecentlyAddedItems(libraryId: String): Flow<List<LibraryItem>> =
-        libraryItemDao.observeRecentlyAdded(libraryId).map { list -> list.distinctBy { it.id }.map { it.toDomain() } }
+        libraryItemDao.observeRecentlyAdded(libraryId).scopedToActiveServer()
 
     override fun observeAllBooks(libraryId: String): Flow<List<LibraryItem>> =
-        libraryItemDao.observeAllBooks(libraryId).map { list -> list.distinctBy { it.id }.map { it.toDomain() } }
+        libraryItemDao.observeAllBooks(libraryId).scopedToActiveServer()
+
+    // Id of the Server whose libraries the user is currently browsing. The nav drawer only ever
+    // lists the active Server's libraries, so the visible library always belongs to it.
+    private val activeServerId: Flow<String?> =
+        serverRepository.observeAll()
+            .map { servers -> servers.firstOrNull { it.isActive }?.id }
+            .distinctUntilChanged()
+
+    // Two Servers pointing at the same Audiobookshelf instance emit identical library and item ids
+    // (issue #113), so the libraryId-keyed item-shelf queries return a row per Server. Keep only the
+    // active Server's copy — the one book detail reads and markAsRead/the reader write. Without this,
+    // an inactive duplicate's stale progress keeps a finished book pinned to In Progress even though
+    // detail shows 100%. No active Server → pass rows through (nothing is being browsed anyway), still
+    // collapsing any duplicate ids. Mirrors how observeLibraries/getLibrary/getItem scope by Server.
+    private fun Flow<List<LibraryItemEntity>>.scopedToActiveServer(): Flow<List<LibraryItem>> =
+        combine(activeServerId) { list, serverId ->
+            list.filter { serverId == null || it.serverId == serverId }
+                .distinctBy { it.id }
+                .map { it.toDomain() }
+        }
 
     override fun observeSeries(libraryId: String): Flow<List<Series>> =
         seriesDao.observeByLibraryId(libraryId).map { list -> list.map { it.toDomain() } }
@@ -85,13 +106,13 @@ class LibraryRepositoryImpl @Inject constructor(
         collectionDao.observeByLibraryId(libraryId).map { list -> list.map { it.toDomain() } }
 
     override fun observeSeriesItems(seriesId: String): Flow<List<LibraryItem>> =
-        seriesDao.observeItemsBySeriesId(seriesId).map { list -> list.map { it.toDomain() } }
+        seriesDao.observeItemsBySeriesId(seriesId).scopedToActiveServer()
 
     override fun observeContinueSeriesItems(libraryId: String): Flow<List<LibraryItem>> =
-        seriesDao.observeContinueSeriesItems(libraryId).map { list -> list.map { it.toDomain() } }
+        seriesDao.observeContinueSeriesItems(libraryId).scopedToActiveServer()
 
     override fun observeCollectionItems(collectionId: String): Flow<List<LibraryItem>> =
-        collectionDao.observeItemsByCollectionId(collectionId).map { list -> list.map { it.toDomain() } }
+        collectionDao.observeItemsByCollectionId(collectionId).scopedToActiveServer()
 
     // Item ids are only unique within a Server (ADR 0025); reads/writes here target the active
     // Server's copy, mirroring how reading positions are keyed. No active Server → nothing to do.

--- a/core/data/src/test/kotlin/com/riffle/core/data/LibraryRepositoryTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/LibraryRepositoryTest.kt
@@ -621,6 +621,51 @@ class LibraryRepositoryTest {
         assertFalse(result[0].isCached)
     }
 
+    // ── issue #113: two Servers, colliding item ids — shelves follow the active Server ─────────
+
+    @Test
+    fun `marking read on the active server clears In Progress despite a stale duplicate on another server`() = runTest {
+        // Two ABS Servers point at the same instance, so item ids and libraryId collide (issue
+        // #113). markAsRead set the active Server's (s1) row to finished (1.0); the inactive
+        // duplicate (s2) still holds the old fraction. The In Progress shelf must follow the
+        // active Server, not surface the stale duplicate — otherwise the finished book stays
+        // pinned to In Progress while book detail (which reads the active Server's row) shows 100%.
+        fakeServerRepository.activeServer = activeServer(id = "s1")
+        val dao = FakeLibraryItemDao()
+        dao.upsertAll(listOf(
+            LibraryItemEntity("s1", "item-1", "lib-1", "My Book", "Author A", null, 1.0f),
+            LibraryItemEntity("s2", "item-1", "lib-1", "My Book", "Author A", null, 0.45f),
+        ))
+        val repo = makeRepo(libraryItemDao = dao)
+
+        val inProgress = repo.observeInProgressItems("lib-1").first()
+        val finished = repo.observeFinishedItems("lib-1").first()
+
+        assertTrue("a finished book must not remain in In Progress", inProgress.isEmpty())
+        assertEquals(listOf("item-1"), finished.map { it.id })
+    }
+
+    @Test
+    fun `library shelves exclude rows owned by inactive duplicate servers`() = runTest {
+        // The active Server (s1) has the in-progress copy; an inactive duplicate (s2) carries a
+        // different fraction for the same id. Every shelf must show only the active Server's row.
+        fakeServerRepository.activeServer = activeServer(id = "s1")
+        val dao = FakeLibraryItemDao()
+        // Seed the inactive duplicate first so a naive distinctBy{id} would keep the wrong row.
+        dao.upsertAll(listOf(
+            LibraryItemEntity("s2", "item-1", "lib-1", "My Book", "Author A", null, 0.9f),
+            LibraryItemEntity("s1", "item-1", "lib-1", "My Book", "Author A", null, 0.5f),
+        ))
+        val repo = makeRepo(libraryItemDao = dao)
+
+        val all = repo.observeLibraryItems("lib-1").first()
+        val inProgress = repo.observeInProgressItems("lib-1").first()
+
+        assertEquals(1, all.size)
+        assertEquals(0.5f, all[0].readingProgress, 0.001f)
+        assertEquals(listOf(0.5f), inProgress.map { it.readingProgress })
+    }
+
     // ── toDomain: ebookFormat → isReadable (regression) ─────────────────────
 
     @Test


### PR DESCRIPTION
## The bug

Marking a book as read kept it pinned to the **In Progress** shelf at its old
progress, even though the book detail screen correctly showed **100%**. The
stuck state survived an app restart.

## Root cause

With **two ABS servers** pointing at the same Audiobookshelf instance,
`library_items` holds **two rows per book** — identical `id`/`libraryId`,
different `serverId` (issue #113).

The handling was inconsistent:

- **`markAsRead` and the detail screen** scope to the **active** server's row.
  `markAsRead` sets it to `1.0`; detail reads that same row → 100%. (Detail's
  100% is also an optimistic in-memory copy that `observeItem` only reverts when
  the row actually changes, so it sticks.)
- **The library shelves** (`observeInProgress`/`observeFinished`/etc.) queried by
  `libraryId` **only**, then `distinctBy { it.id }` — ignoring `serverId`. So
  they kept surfacing the **inactive duplicate's** row, still at the old fraction
  (`< 0.99`), keeping the book in In Progress.

The single-read paths (`getItem`, `getLibrary`, `observeLibraries`) already scope
to the active server (ADR 0025) — the shelf queries were the anomaly.

## The fix

Add a `scopedToActiveServer()` helper in `LibraryRepositoryImpl` that filters each
item-shelf flow to the active server's rows (then dedups), and apply it to:

- All library-item shelves: In Progress, Finished, All Books, Recently Added,
  Ungrouped, All Items.
- The series/collection item shelves (`observeSeriesItems`,
  `observeContinueSeriesItems`, `observeCollectionItems`), which previously had
  **no dedup at all** — so two servers would also show duplicate rows and a stale
  "Continue series."

When there is no active server, rows pass through unchanged (nothing is being
browsed anyway), still collapsing duplicate ids.

## Tests

Adds two pure-JVM regression tests at the repository seam in
`LibraryRepositoryTest`. The primary one reproduces the exact scenario — active
row finished, inactive duplicate still in progress — and fails before the fix,
passes after.

## Note / follow-up

The underlying fragility is that library-item queries are keyed by `libraryId`
alone when the true identity is `(serverId, libraryId)`. This PR closes the read
path; a convention or lint ensuring every library query carries `serverId` would
prevent this class of bug recurring.