### PR TITLE
feat(settings): global listening preferences + audiobook resume/speed fixes

### DIFF
--- a/app/src/androidTest/kotlin/com/riffle/app/feature/reader/readaloud/ReadaloudMiniPlayerTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/reader/readaloud/ReadaloudMiniPlayerTest.kt
@@ -46,6 +46,8 @@ class ReadaloudMiniPlayerTest {
                 onForward = onForward,
                 onPreviousChapter = onPreviousChapter,
                 onNextChapter = onNextChapter,
+                skipIntervalSeconds = 30,
+                rewindIntervalSeconds = 15,
                 onClose = {},
             )
         }
@@ -129,6 +131,8 @@ class ReadaloudMiniPlayerTest {
                 onForward = {},
                 onPreviousChapter = {},
                 onNextChapter = {},
+                skipIntervalSeconds = 30,
+                rewindIntervalSeconds = 15,
                 onClose = {},
             )
         }

--- a/app/src/androidTest/kotlin/com/riffle/app/feature/settings/AudioPlaybackSpeedPersistenceTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/settings/AudioPlaybackSpeedPersistenceTest.kt
@@ -1,0 +1,99 @@
+package com.riffle.app.feature.settings
+
+import androidx.room.Room
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.riffle.core.data.AudioPlaybackPreferencesStoreImpl
+import com.riffle.core.database.RiffleDatabase
+import com.riffle.core.database.ServerEntity
+import com.riffle.core.domain.AudioIdentity
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Device-level regression for per-book speed persistence (Bug 1).
+ *
+ * Before the fix in EpubReaderViewModel.setSpeed(), the debounce job called
+ * save(AudioIdentity("", bookId)) because audioSettingsIdentity was not yet
+ * resolved when the job ran. A subsequent load(AudioIdentity("srv-1", bookId))
+ * found nothing and fell back to the global default — the bug.
+ *
+ * These tests use a real Room database on-device to verify:
+ *   - save → load with the same correct identity succeeds
+ *   - save with empty serverId (old bug) is invisible to load with real serverId
+ */
+@RunWith(AndroidJUnit4::class)
+class AudioPlaybackSpeedPersistenceTest {
+
+    private lateinit var db: RiffleDatabase
+    private lateinit var store: AudioPlaybackPreferencesStoreImpl
+
+    @Before
+    fun setUp() {
+        db = Room.inMemoryDatabaseBuilder(
+            InstrumentationRegistry.getInstrumentation().targetContext,
+            RiffleDatabase::class.java,
+        ).allowMainThreadQueries().build()
+        runBlocking {
+            db.serverDao().upsert(
+                ServerEntity("srv-1", "http://abs", isActive = true, insecureConnectionAllowed = false, username = "test")
+            )
+        }
+        store = AudioPlaybackPreferencesStoreImpl(db.audioPlaybackPreferencesDao())
+    }
+
+    @After
+    fun tearDown() { db.close() }
+
+    @Test
+    fun savedSpeedIsLoadedBackWithSameIdentity() = runBlocking {
+        val identity = AudioIdentity("srv-1", "book-123")
+        store.save(identity, 1.5f)
+        assertEquals(1.5f, store.load(identity))
+    }
+
+    @Test
+    fun loadReturnsNullWhenNothingSaved() = runBlocking {
+        assertNull(store.load(AudioIdentity("srv-1", "book-missing")))
+    }
+
+    /**
+     * Directly reproduces Bug 1: before the fix, EpubReaderViewModel saved with
+     * AudioIdentity("", bookId). This test proves that such a save is not visible
+     * when loading with the real server identity — confirming why speed was lost.
+     */
+    @Test
+    fun saveWithEmptyServerIdIsNotVisibleToRealIdentityLoad() = runBlocking {
+        val buggyIdentity = AudioIdentity("", "book-123")
+        val realIdentity  = AudioIdentity("srv-1", "book-123")
+
+        runCatching { store.save(buggyIdentity, 1.75f) }
+
+        assertNull(
+            "Speed saved with empty serverId must not be returned for the real server identity — " +
+                "if this fails the pre-fix bug would have been invisible",
+            store.load(realIdentity),
+        )
+    }
+
+    @Test
+    fun updatedSpeedOverwritesPreviousRow() = runBlocking {
+        val identity = AudioIdentity("srv-1", "book-upd")
+        store.save(identity, 1.25f)
+        store.save(identity, 2.0f)
+        assertEquals(2.0f, store.load(identity))
+    }
+
+    @Test
+    fun savingDefaultSpeed1fRemovesTheRow() = runBlocking {
+        val identity = AudioIdentity("srv-1", "book-del")
+        store.save(identity, 1.5f)
+        store.save(identity, 1.0f)
+        assertNull(store.load(identity))
+    }
+}

--- a/app/src/androidTest/kotlin/com/riffle/app/feature/settings/AudioPlaybackSpeedPersistenceTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/settings/AudioPlaybackSpeedPersistenceTest.kt
@@ -90,10 +90,12 @@ class AudioPlaybackSpeedPersistenceTest {
     }
 
     @Test
-    fun savingDefaultSpeed1fRemovesTheRow() = runBlocking {
+    fun savingSpeed1fIsHonoredAndNotDeleted() = runBlocking {
+        // A deliberate 1.0x per-book choice must persist so it survives reopen even when the global
+        // default speed is faster — it must NOT be discarded as if it were the absence of a choice.
         val identity = AudioIdentity("srv-1", "book-del")
         store.save(identity, 1.5f)
         store.save(identity, 1.0f)
-        assertNull(store.load(identity))
+        assertEquals(1.0f, store.load(identity))
     }
 }

--- a/app/src/androidTest/kotlin/com/riffle/app/harness/WakeLockHarnessTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/harness/WakeLockHarnessTest.kt
@@ -74,8 +74,10 @@ class WakeLockHarnessTest {
         // Disable "Keep screen on" in Settings before opening a book
         addServerAndNavigateToSettings()
 
-        // Open the Reading settings panel which now hosts the wake-lock toggle.
-        composeTestRule.onNodeWithText("Reading settings").performClick()
+        // Open the reader formatting panel (titled "Reading settings") which hosts the wake-lock
+        // toggle. On the Settings screen the entry is the "Formatting" item under the "Reading"
+        // section; "Reading settings" is only the panel's own title once it is open.
+        composeTestRule.onNodeWithText("Formatting").performClick()
         composeTestRule.waitForIdle()
 
         composeTestRule.onNodeWithText("Keep screen on").assertExists()

--- a/app/src/main/kotlin/com/riffle/app/feature/audio/PlayerSurface.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audio/PlayerSurface.kt
@@ -22,9 +22,9 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Bedtime
-import androidx.compose.material.icons.filled.Forward30
 import androidx.compose.material.icons.filled.Pause
 import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material.icons.filled.Replay
 import androidx.compose.material.icons.filled.SkipNext
 import androidx.compose.material.icons.filled.SkipPrevious
 import androidx.compose.material.icons.filled.Speed
@@ -52,15 +52,16 @@ import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.draw.scale
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.fromHtml
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
-import com.riffle.app.R
 import com.riffle.app.feature.audiobook.SleepTimerMode
 import com.riffle.app.feature.audiobook.formatCountdown
 
@@ -90,6 +91,7 @@ data class PlayerSurfaceState(
     val facts: String? = null,
     val description: String? = null,
     val sleepTimer: SleepTimerMode = SleepTimerMode.None,
+    val skipIntervalSeconds: Int = 30,
 )
 
 /** Callbacks the surface invokes. [onSeek] takes an absolute global position in seconds. */
@@ -338,7 +340,7 @@ private fun TransportRow(state: PlayerSurfaceState, actions: PlayerSurfaceAction
         verticalAlignment = Alignment.CenterVertically,
     ) {
         IconButton(onClick = actions.onRewind, modifier = Modifier.size(secondaryButton)) {
-            Icon(painterResource(R.drawable.ic_replay_15), contentDescription = "Rewind 15 seconds", modifier = Modifier.size(secondaryIcon))
+            SkipIcon(seconds = state.skipIntervalSeconds, forward = false, iconSize = secondaryIcon)
         }
         Spacer(Modifier.size(10.dp))
         IconButton(onClick = actions.onPreviousChapter, enabled = state.canPreviousChapter, modifier = Modifier.size(secondaryButton)) {
@@ -365,8 +367,25 @@ private fun TransportRow(state: PlayerSurfaceState, actions: PlayerSurfaceAction
         }
         Spacer(Modifier.size(10.dp))
         IconButton(onClick = actions.onForward, modifier = Modifier.size(secondaryButton)) {
-            Icon(Icons.Filled.Forward30, contentDescription = "Forward 30 seconds", modifier = Modifier.size(secondaryIcon))
+            SkipIcon(seconds = state.skipIntervalSeconds, forward = true, iconSize = secondaryIcon)
         }
+    }
+}
+
+@Composable
+private fun SkipIcon(seconds: Int, forward: Boolean, iconSize: Dp) {
+    Box(contentAlignment = Alignment.Center) {
+        Icon(
+            imageVector = Icons.Filled.Replay,
+            contentDescription = null,
+            modifier = if (forward) Modifier.size(iconSize).scale(scaleX = -1f, scaleY = 1f)
+                       else Modifier.size(iconSize),
+        )
+        Text(
+            text = "$seconds",
+            style = MaterialTheme.typography.labelSmall,
+            fontWeight = FontWeight.Bold,
+        )
     }
 }
 

--- a/app/src/main/kotlin/com/riffle/app/feature/audio/PlayerSurface.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audio/PlayerSurface.kt
@@ -92,6 +92,7 @@ data class PlayerSurfaceState(
     val description: String? = null,
     val sleepTimer: SleepTimerMode = SleepTimerMode.None,
     val skipIntervalSeconds: Int = 30,
+    val rewindIntervalSeconds: Int = 15,
 )
 
 /** Callbacks the surface invokes. [onSeek] takes an absolute global position in seconds. */
@@ -340,7 +341,7 @@ private fun TransportRow(state: PlayerSurfaceState, actions: PlayerSurfaceAction
         verticalAlignment = Alignment.CenterVertically,
     ) {
         IconButton(onClick = actions.onRewind, modifier = Modifier.size(secondaryButton)) {
-            SkipIcon(seconds = state.skipIntervalSeconds, forward = false, iconSize = secondaryIcon)
+            SkipIcon(seconds = state.rewindIntervalSeconds, forward = false, iconSize = secondaryIcon)
         }
         Spacer(Modifier.size(10.dp))
         IconButton(onClick = actions.onPreviousChapter, enabled = state.canPreviousChapter, modifier = Modifier.size(secondaryButton)) {

--- a/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerScreen.kt
@@ -213,6 +213,7 @@ fun AudiobookPlayerScreen(
                             description = state.description,
                             sleepTimer = state.sleepTimer,
                             skipIntervalSeconds = state.skipIntervalSeconds,
+                            rewindIntervalSeconds = state.rewindIntervalSeconds,
                         ),
                         twoColumn = twoColumn,
                         actions = PlayerSurfaceActions(

--- a/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerScreen.kt
@@ -212,6 +212,7 @@ fun AudiobookPlayerScreen(
                             facts = state.facts,
                             description = state.description,
                             sleepTimer = state.sleepTimer,
+                            skipIntervalSeconds = state.skipIntervalSeconds,
                         ),
                         twoColumn = twoColumn,
                         actions = PlayerSurfaceActions(

--- a/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModel.kt
@@ -132,6 +132,7 @@ data class AudiobookPlayerUiState(
     val bookmarksOffline: Boolean = false,
     val sleepTimer: SleepTimerMode = SleepTimerMode.None,
     val skipIntervalSeconds: Int = 30,
+    val rewindIntervalSeconds: Int = 15,
 )
 
 @HiltViewModel
@@ -327,6 +328,10 @@ class AudiobookPlayerViewModel(
         .map { it.toDouble() }
         .stateIn(viewModelScope, SharingStarted.Eagerly, ListeningPreferencesStore.DEFAULT_SKIP_INTERVAL_SECONDS.toDouble())
 
+    private val rewindIntervalSec: StateFlow<Double> = listeningPreferencesStore.rewindIntervalSeconds
+        .map { it.toDouble() }
+        .stateIn(viewModelScope, SharingStarted.Eagerly, ListeningPreferencesStore.DEFAULT_REWIND_INTERVAL_SECONDS.toDouble())
+
     val uiState: StateFlow<AudiobookPlayerUiState> =
         combine(meta, controller.state, controller.sleepTimer) { m, playback, timer ->
             val pos = playback.positionSec
@@ -349,6 +354,8 @@ class AudiobookPlayerViewModel(
             )
         }.combine(skipIntervalSec) { state, skip ->
             state.copy(skipIntervalSeconds = skip.toInt())
+        }.combine(rewindIntervalSec) { state, rewind ->
+            state.copy(rewindIntervalSeconds = rewind.toInt())
         }.stateIn(viewModelScope, SharingStarted.Eagerly, AudiobookPlayerUiState(loading = true))
 
     init {
@@ -657,9 +664,9 @@ class AudiobookPlayerViewModel(
     }
 
     fun rewind() {
-        val skipSec = skipIntervalSec.value
-        reconciledResumeSec = (controller.currentAbsoluteSec() - skipSec).coerceAtLeast(0.0)
-        controller.skipBy(-skipSec)
+        val rewindSec = rewindIntervalSec.value
+        reconciledResumeSec = (controller.currentAbsoluteSec() - rewindSec).coerceAtLeast(0.0)
+        controller.skipBy(-rewindSec)
     }
 
     fun forward() {
@@ -740,7 +747,9 @@ class AudiobookPlayerViewModel(
         speedSaveJob?.cancel()
         pendingSpeed = null
         if (serverId.isEmpty()) return
-        viewModelScope.launch { audioPlaybackPreferencesStore.save(audioSettingsIdentity, speed) }
+        // progressFlushScope, not viewModelScope: onCleared cancels viewModelScope before calling
+        // this, so a launch there never executes (same reasoning as pushProgressOnStop).
+        progressFlushScope.flush { audioPlaybackPreferencesStore.save(audioSettingsIdentity, speed) }
     }
 
     /**

--- a/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModel.kt
@@ -332,6 +332,10 @@ class AudiobookPlayerViewModel(
         .map { it.toDouble() }
         .stateIn(viewModelScope, SharingStarted.Eagerly, ListeningPreferencesStore.DEFAULT_REWIND_INTERVAL_SECONDS.toDouble())
 
+    private val rewindOnResumeSec: StateFlow<Double> = listeningPreferencesStore.rewindOnResumeSeconds
+        .map { it.toDouble() }
+        .stateIn(viewModelScope, SharingStarted.Eagerly, ListeningPreferencesStore.DEFAULT_REWIND_ON_RESUME_SECONDS.toDouble())
+
     val uiState: StateFlow<AudiobookPlayerUiState> =
         combine(meta, controller.state, controller.sleepTimer) { m, playback, timer ->
             val pos = playback.positionSec
@@ -652,6 +656,12 @@ class AudiobookPlayerViewModel(
             controller.pause()
             pushProgressOnStop()
         } else {
+            val rewindSec = rewindOnResumeSec.value
+            if (rewindSec > 0) {
+                val newPos = (controller.currentAbsoluteSec() - rewindSec).coerceAtLeast(0.0)
+                reconciledResumeSec = newPos
+                controller.seekTo(newPos)
+            }
             controller.play()
         }
     }

--- a/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModel.kt
@@ -448,17 +448,6 @@ class AudiobookPlayerViewModel(
             // sets an explicit position that must not be reset.
             if (startAtSec < 0.0) {
                 resumeSec = audiobookStartSec(resumeSec, session.timeline.durationSec)
-                // Rewind-on-resume also applies to reopening an in-progress book — the open path plays
-                // directly (below), bypassing togglePlayPause's resume rewind, so without this the setting
-                // would only ever fire on an in-player pause→play and look broken on the far more common
-                // "left and came back" resume. Read straight from the store (not the eager StateFlow, which
-                // may not have emitted yet this early in init). Guarded on resumeSec > 0 so a fresh/replayed
-                // book at the start has nothing to rewind; coerceAtLeast(0) holds the floor. Skipped for the
-                // readaloud→audiobook handoff branch, which must continue seamlessly from the hand-off point.
-                val rewindOnResume = listeningPreferencesStore.rewindOnResumeSeconds.first().toDouble()
-                if (rewindOnResume > 0.0 && resumeSec > 0.0) {
-                    resumeSec = (resumeSec - rewindOnResume).coerceAtLeast(0.0)
-                }
             }
             // readaloud→audiobook swipe handoff: continue from exactly where the reader handed off,
             // overriding the store/server resume (which can lag the just-left listen position). Persist
@@ -525,13 +514,31 @@ class AudiobookPlayerViewModel(
                 facts = buildAudiobookFacts(session.timeline.durationSec, item.genres),
                 description = item.description,
             )
+            // Rewind-on-resume also applies to reopening an in-progress book — the open path plays
+            // directly (below), bypassing togglePlayPause's resume rewind, so without this the setting
+            // would only ever fire on an in-player pause→play and look broken on the far more common
+            // "left and came back" resume. It shifts only where playback *starts*, NOT the resume floor
+            // (reconciledResumeSec stays at the true resumeSec below): seeding prepare() lower must not let
+            // the follow-loop / close-persist guards write that lower point back, or repeated open→close
+            // cycles would creep the saved position backward by rewindOnResume each time. Re-hearing the
+            // rewound seconds simply doesn't advance saved progress until playback passes the real resume.
+            // Read straight from the store (not the eager StateFlow, which may not have emitted this early in
+            // init). Guarded on resumeSec > 0 (a fresh/replayed book at the start has nothing to rewind) and
+            // on the normal-open branch only — the handoff must continue seamlessly from its hand-off point.
+            var playbackStartSec = resumeSec
+            if (startAtSec < 0.0) {
+                val rewindOnResume = listeningPreferencesStore.rewindOnResumeSeconds.first().toDouble()
+                if (rewindOnResume > 0.0 && resumeSec > 0.0) {
+                    playbackStartSec = (resumeSec - rewindOnResume).coerceAtLeast(0.0)
+                }
+            }
             // Resume at the server-recorded position (last-update-wins resume; ADR 0029) so the
             // audio-led canonical never starts behind.
             controller.prepare(
                 trackUrls = session.trackUrls,
                 spans = session.tracks,
                 durationSec = session.timeline.durationSec,
-                startAtSec = resumeSec,
+                startAtSec = playbackStartSec,
                 localZipFile = session.localZipFile,
                 coverUri = item.coverUrl,
             )

--- a/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModel.kt
@@ -448,6 +448,17 @@ class AudiobookPlayerViewModel(
             // sets an explicit position that must not be reset.
             if (startAtSec < 0.0) {
                 resumeSec = audiobookStartSec(resumeSec, session.timeline.durationSec)
+                // Rewind-on-resume also applies to reopening an in-progress book — the open path plays
+                // directly (below), bypassing togglePlayPause's resume rewind, so without this the setting
+                // would only ever fire on an in-player pause→play and look broken on the far more common
+                // "left and came back" resume. Read straight from the store (not the eager StateFlow, which
+                // may not have emitted yet this early in init). Guarded on resumeSec > 0 so a fresh/replayed
+                // book at the start has nothing to rewind; coerceAtLeast(0) holds the floor. Skipped for the
+                // readaloud→audiobook handoff branch, which must continue seamlessly from the hand-off point.
+                val rewindOnResume = listeningPreferencesStore.rewindOnResumeSeconds.first().toDouble()
+                if (rewindOnResume > 0.0 && resumeSec > 0.0) {
+                    resumeSec = (resumeSec - rewindOnResume).coerceAtLeast(0.0)
+                }
             }
             // readaloud→audiobook swipe handoff: continue from exactly where the reader handed off,
             // overriding the store/server resume (which can lag the just-left listen position). Persist

--- a/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModel.kt
@@ -7,6 +7,7 @@ import com.riffle.core.domain.AudioIdentity
 import com.riffle.core.domain.AudioIdentityResolver
 import com.riffle.core.domain.AudioPlaybackPreferencesStore
 import com.riffle.core.domain.AudiobookBookmark
+import com.riffle.core.domain.ListeningPreferencesStore
 import com.riffle.core.domain.AudiobookBookmarkStore
 import com.riffle.core.domain.AudiobookChapter
 import com.riffle.core.domain.AudiobookRepository
@@ -18,6 +19,7 @@ import com.riffle.core.domain.TokenStorage
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
@@ -141,6 +143,7 @@ class AudiobookPlayerViewModel(
     private val tokenStorage: TokenStorage,
     private val controller: AudiobookController,
     private val audioPlaybackPreferencesStore: AudioPlaybackPreferencesStore,
+    private val listeningPreferencesStore: ListeningPreferencesStore,
     private val audioIdentityResolver: AudioIdentityResolver,
     private val readerSyncFactory: com.riffle.app.feature.reader.ReaderSyncFactory,
     private val readaloudLinkRepository: com.riffle.core.domain.ReadaloudLinkRepository,
@@ -179,6 +182,7 @@ class AudiobookPlayerViewModel(
         tokenStorage: TokenStorage,
         controller: AudiobookController,
         audioPlaybackPreferencesStore: AudioPlaybackPreferencesStore,
+        listeningPreferencesStore: ListeningPreferencesStore,
         audioIdentityResolver: AudioIdentityResolver,
         readerSyncFactory: com.riffle.app.feature.reader.ReaderSyncFactory,
         readaloudLinkRepository: com.riffle.core.domain.ReadaloudLinkRepository,
@@ -202,6 +206,7 @@ class AudiobookPlayerViewModel(
         tokenStorage,
         controller,
         audioPlaybackPreferencesStore,
+        listeningPreferencesStore,
         audioIdentityResolver,
         readerSyncFactory,
         readaloudLinkRepository,
@@ -449,7 +454,7 @@ class AudiobookPlayerViewModel(
                 AudioIdentity(serverId, itemId)
             }
             val initialSpeed = audioPlaybackPreferencesStore.load(audioSettingsIdentity)
-                ?: AudioPlaybackPreferencesStore.DEFAULT_PLAYBACK_SPEED
+                ?: listeningPreferencesStore.defaultPlaybackSpeed.first()
             // Readaloud is only actually offerable when the synced bundle is present — the same gate the
             // reader applies (readaloudControlState): a Storyteller book always qualifies, a matched ABS
             // book only once its bundle is downloaded, an unmatched ABS book never. The bundle is keyed by

--- a/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModel.kt
@@ -22,6 +22,7 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -320,6 +321,10 @@ class AudiobookPlayerViewModel(
             ?: return
         readaloudResumeStore.save(serverId, ebookItemId, anchor)
     }
+
+    private val skipIntervalSec: StateFlow<Double> = listeningPreferencesStore.skipIntervalSeconds
+        .map { it.toDouble() }
+        .stateIn(viewModelScope, SharingStarted.Eagerly, ListeningPreferencesStore.DEFAULT_SKIP_INTERVAL_SECONDS.toDouble())
 
     val uiState: StateFlow<AudiobookPlayerUiState> =
         combine(meta, controller.state, controller.sleepTimer) { m, playback, timer ->
@@ -649,13 +654,15 @@ class AudiobookPlayerViewModel(
     }
 
     fun rewind() {
-        reconciledResumeSec = (controller.currentAbsoluteSec() - AudiobookController.REWIND_SEC).coerceAtLeast(0.0)
-        controller.rewind()
+        val skipSec = skipIntervalSec.value
+        reconciledResumeSec = (controller.currentAbsoluteSec() - skipSec).coerceAtLeast(0.0)
+        controller.skipBy(-skipSec)
     }
 
     fun forward() {
-        reconciledResumeSec = controller.currentAbsoluteSec() + AudiobookController.FORWARD_SEC
-        controller.forward()
+        val skipSec = skipIntervalSec.value
+        reconciledResumeSec = controller.currentAbsoluteSec() + skipSec
+        controller.skipBy(skipSec)
     }
 
     fun previousChapter() {

--- a/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModel.kt
@@ -131,6 +131,7 @@ data class AudiobookPlayerUiState(
     // Bookmarks sheet can show a quiet "Offline — bookmarks will sync" note. Sync is otherwise silent.
     val bookmarksOffline: Boolean = false,
     val sleepTimer: SleepTimerMode = SleepTimerMode.None,
+    val skipIntervalSeconds: Int = 30,
 )
 
 @HiltViewModel
@@ -346,6 +347,8 @@ class AudiobookPlayerViewModel(
                 bookmarksOffline = m.bookmarksOffline,
                 sleepTimer = timer,
             )
+        }.combine(skipIntervalSec) { state, skip ->
+            state.copy(skipIntervalSeconds = skip.toInt())
         }.stateIn(viewModelScope, SharingStarted.Eagerly, AudiobookPlayerUiState(loading = true))
 
     init {
@@ -718,11 +721,11 @@ class AudiobookPlayerViewModel(
      */
     fun setSpeed(speed: Float) {
         controller.setSpeed(speed)
-        if (serverId.isEmpty()) return
         pendingSpeed = speed
         speedSaveJob?.cancel()
         speedSaveJob = viewModelScope.launch {
             kotlinx.coroutines.delay(SPEED_SAVE_DEBOUNCE_MS)
+            if (serverId.isEmpty()) return@launch
             audioPlaybackPreferencesStore.save(audioSettingsIdentity, speed)
             pendingSpeed = null
         }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -247,6 +247,7 @@ fun EpubReaderScreen(
     val downloadPromptBytes by viewModel.downloadPromptBytes.collectAsState()
     val readaloudOfflineMessage by viewModel.readaloudOfflineMessage.collectAsState()
     val skipIntervalSec by viewModel.skipIntervalSec.collectAsState()
+    val rewindIntervalSec by viewModel.rewindIntervalSec.collectAsState()
     val downloadProgress by viewModel.downloadProgress.collectAsState()
 
     // Starting (or resuming) readaloud is a "lean back and listen" intent, so drop into
@@ -425,6 +426,7 @@ fun EpubReaderScreen(
                             isPlaying = playbackState.isPlaying,
                             speed = playbackState.speed,
                             skipIntervalSeconds = skipIntervalSec.toInt(),
+                            rewindIntervalSeconds = rewindIntervalSec.toInt(),
                             offlineMessage = readaloudOfflineMessage,
                             downloadProgress = downloadProgress,
                             canPreviousChapter = playbackState.currentChapterIndex > 0,

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -246,6 +246,7 @@ fun EpubReaderScreen(
     val sentenceChapters by viewModel.sentenceChapters.collectAsState()
     val downloadPromptBytes by viewModel.downloadPromptBytes.collectAsState()
     val readaloudOfflineMessage by viewModel.readaloudOfflineMessage.collectAsState()
+    val skipIntervalSec by viewModel.skipIntervalSec.collectAsState()
     val downloadProgress by viewModel.downloadProgress.collectAsState()
 
     // Starting (or resuming) readaloud is a "lean back and listen" intent, so drop into
@@ -423,6 +424,7 @@ fun EpubReaderScreen(
                         ReadaloudMiniPlayer(
                             isPlaying = playbackState.isPlaying,
                             speed = playbackState.speed,
+                            skipIntervalSeconds = skipIntervalSec.toInt(),
                             offlineMessage = readaloudOfflineMessage,
                             downloadProgress = downloadProgress,
                             canPreviousChapter = playbackState.currentChapterIndex > 0,

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -234,6 +234,10 @@ class EpubReaderViewModel @Inject constructor(
         .map { it.toDouble() }
         .stateIn(viewModelScope, SharingStarted.Eagerly, ListeningPreferencesStore.DEFAULT_SKIP_INTERVAL_SECONDS.toDouble())
 
+    val rewindIntervalSec: StateFlow<Double> = listeningPreferencesStore.rewindIntervalSeconds
+        .map { it.toDouble() }
+        .stateIn(viewModelScope, SharingStarted.Eagerly, ListeningPreferencesStore.DEFAULT_REWIND_INTERVAL_SECONDS.toDouble())
+
     val volumeNavEvents: SharedFlow<VolumeNavEvent> = volumeNavigationController.events
 
     // Per-field book overrides. null on a field means "follow global", so changing global later
@@ -1553,7 +1557,7 @@ class EpubReaderViewModel @Inject constructor(
         viewModelScope.launch { audioPlaybackPreferencesStore.save(audioSettingsIdentity, speed) }
     }
 
-    fun rewind() = playerCoordinator.skipBy(-skipIntervalSec.value)
+    fun rewind() = playerCoordinator.skipBy(-rewindIntervalSec.value)
 
     fun forward() = playerCoordinator.skipBy(skipIntervalSec.value)
 

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -16,6 +16,7 @@ import com.riffle.core.domain.AudioIdentity
 import com.riffle.core.domain.AudioIdentityResolver
 import com.riffle.core.domain.AudioPlaybackPreferencesStore
 import com.riffle.core.domain.BookFormattingOverrides
+import com.riffle.core.domain.ListeningPreferencesStore
 import com.riffle.core.domain.BookFormattingPreferencesStore
 import com.riffle.core.domain.ConnectivityObserver
 import com.riffle.core.domain.EpubOpenResult
@@ -130,6 +131,7 @@ class EpubReaderViewModel @Inject constructor(
     private val readaloudLinkRepository: ReadaloudLinkRepository,
     private val audioIdentityResolver: AudioIdentityResolver,
     private val audioPlaybackPreferencesStore: AudioPlaybackPreferencesStore,
+    private val listeningPreferencesStore: ListeningPreferencesStore,
     private val connectivityObserver: ConnectivityObserver,
     private val readerSyncFactory: ReaderSyncFactory,
     private val readingPositionStore: ReadingPositionStore,
@@ -459,7 +461,7 @@ class EpubReaderViewModel @Inject constructor(
                 AudioIdentity(activeServer?.id ?: "", itemId)
             }
             initialSpeed = audioPlaybackPreferencesStore.load(audioSettingsIdentity)
-                ?: AudioPlaybackPreferencesStore.DEFAULT_PLAYBACK_SPEED
+                ?: listeningPreferencesStore.defaultPlaybackSpeed.first()
 
             // Restore the readaloud resume position persisted when the book was last left, so the
             // first Play this session continues where narration stopped (same page) or starts at the

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -230,7 +230,7 @@ class EpubReaderViewModel @Inject constructor(
     val invertVolumeKeys: StateFlow<Boolean> = volumeKeyPreferencesStore.invertVolumeKeys
         .stateIn(viewModelScope, SharingStarted.Eagerly, false)
 
-    private val skipIntervalSec: StateFlow<Double> = listeningPreferencesStore.skipIntervalSeconds
+    val skipIntervalSec: StateFlow<Double> = listeningPreferencesStore.skipIntervalSeconds
         .map { it.toDouble() }
         .stateIn(viewModelScope, SharingStarted.Eagerly, ListeningPreferencesStore.DEFAULT_SKIP_INTERVAL_SECONDS.toDouble())
 

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -230,6 +230,10 @@ class EpubReaderViewModel @Inject constructor(
     val invertVolumeKeys: StateFlow<Boolean> = volumeKeyPreferencesStore.invertVolumeKeys
         .stateIn(viewModelScope, SharingStarted.Eagerly, false)
 
+    private val skipIntervalSec: StateFlow<Double> = listeningPreferencesStore.skipIntervalSeconds
+        .map { it.toDouble() }
+        .stateIn(viewModelScope, SharingStarted.Eagerly, ListeningPreferencesStore.DEFAULT_SKIP_INTERVAL_SECONDS.toDouble())
+
     val volumeNavEvents: SharedFlow<VolumeNavEvent> = volumeNavigationController.events
 
     // Per-field book overrides. null on a field means "follow global", so changing global later
@@ -1549,9 +1553,9 @@ class EpubReaderViewModel @Inject constructor(
         viewModelScope.launch { audioPlaybackPreferencesStore.save(audioSettingsIdentity, speed) }
     }
 
-    fun rewind() = playerCoordinator.rewind()
+    fun rewind() = playerCoordinator.skipBy(-skipIntervalSec.value)
 
-    fun forward() = playerCoordinator.forward()
+    fun forward() = playerCoordinator.skipBy(skipIntervalSec.value)
 
     /**
      * Swipe-up handoff to the single large player: capture the current listen second, release the

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -238,6 +238,10 @@ class EpubReaderViewModel @Inject constructor(
         .map { it.toDouble() }
         .stateIn(viewModelScope, SharingStarted.Eagerly, ListeningPreferencesStore.DEFAULT_REWIND_INTERVAL_SECONDS.toDouble())
 
+    private val rewindOnResumeSec: StateFlow<Double> = listeningPreferencesStore.rewindOnResumeSeconds
+        .map { it.toDouble() }
+        .stateIn(viewModelScope, SharingStarted.Eagerly, ListeningPreferencesStore.DEFAULT_REWIND_ON_RESUME_SECONDS.toDouble())
+
     val volumeNavEvents: SharedFlow<VolumeNavEvent> = volumeNavigationController.events
 
     // Per-field book overrides. null on a field means "follow global", so changing global later
@@ -1543,6 +1547,7 @@ class EpubReaderViewModel @Inject constructor(
         speedSaveJob?.cancel()
         speedSaveJob = viewModelScope.launch {
             delay(SPEED_SAVE_DEBOUNCE_MS)
+            if (audioSettingsIdentity.serverId.isEmpty()) return@launch
             audioPlaybackPreferencesStore.save(audioSettingsIdentity, speed)
             pendingSpeed = null
         }
@@ -1554,7 +1559,8 @@ class EpubReaderViewModel @Inject constructor(
         val speed = pendingSpeed ?: return
         speedSaveJob?.cancel()
         pendingSpeed = null
-        viewModelScope.launch { audioPlaybackPreferencesStore.save(audioSettingsIdentity, speed) }
+        if (audioSettingsIdentity.serverId.isEmpty()) return
+        progressFlushScope.flush { audioPlaybackPreferencesStore.save(audioSettingsIdentity, speed) }
     }
 
     fun rewind() = playerCoordinator.skipBy(-rewindIntervalSec.value)
@@ -1732,7 +1738,9 @@ class EpubReaderViewModel @Inject constructor(
         // Record the active readaloud so a media-notification tap reopens this book's reader.
         nowPlayingStore.set(com.riffle.app.playback.NowPlaying.Readaloud(itemId))
         if (readaloudStarted) {
-            // Resume after a pause: ExoPlayer kept its place, just play.
+            // Resume after a pause: rewind by the configured amount then play.
+            val rewindSec = rewindOnResumeSec.value
+            if (rewindSec > 0) playerCoordinator.skipBy(-rewindSec)
             playerCoordinator.play()
             return
         }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/PlayerCoordinator.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/PlayerCoordinator.kt
@@ -116,6 +116,8 @@ class PlayerCoordinator @Inject constructor(
         _narrationProgress.value = null
     }
 
+    fun skipBy(deltaSec: Double) = controller.skipBy(deltaSec)
+
     fun rewind() = controller.rewind()
 
     fun forward() = controller.forward()

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/PlayerCoordinator.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/PlayerCoordinator.kt
@@ -118,10 +118,6 @@ class PlayerCoordinator @Inject constructor(
 
     fun skipBy(deltaSec: Double) = controller.skipBy(deltaSec)
 
-    fun rewind() = controller.rewind()
-
-    fun forward() = controller.forward()
-
     fun previousChapter() = controller.previousChapter()
 
     fun nextChapter() = controller.nextChapter()

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/ReadaloudPlayerUi.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/ReadaloudPlayerUi.kt
@@ -106,6 +106,7 @@ fun ReadaloudMiniPlayer(
     isPlaying: Boolean,
     speed: Float,
     skipIntervalSeconds: Int,
+    rewindIntervalSeconds: Int,
     offlineMessage: Boolean,
     downloadProgress: Float?,
     canPreviousChapter: Boolean,
@@ -160,7 +161,7 @@ fun ReadaloudMiniPlayer(
                 SpeedControl(speed = speed, contentColor = contentColor, onSpeedChange = onSpeedChange)
                 Spacer(modifier = Modifier.weight(1f))
                 IconButton(onClick = onRewind, modifier = Modifier.testTag("readaloud_rewind")) {
-                    SkipIcon(seconds = skipIntervalSeconds, forward = false, tint = contentColor)
+                    SkipIcon(seconds = rewindIntervalSeconds, forward = false, tint = contentColor)
                 }
                 IconButton(
                     onClick = onPreviousChapter,

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/ReadaloudPlayerUi.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/ReadaloudPlayerUi.kt
@@ -2,17 +2,19 @@
 
 package com.riffle.app.feature.reader.readaloud
 
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
-import androidx.compose.material.icons.filled.Forward30
 import androidx.compose.material.icons.filled.Pause
 import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material.icons.filled.Replay
 import androidx.compose.material.icons.filled.SkipNext
 import androidx.compose.material.icons.filled.SkipPrevious
 import androidx.compose.material3.AlertDialog
@@ -31,12 +33,12 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.draw.scale
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import com.riffle.app.R
 import com.riffle.app.feature.audio.PlaybackSpeed
 import com.riffle.app.feature.audio.PlaybackSpeedControl
 
@@ -77,6 +79,25 @@ private fun SpeedControl(
 }
 
 
+@Composable
+private fun SkipIcon(seconds: Int, forward: Boolean, tint: Color, iconSize: Dp = 24.dp) {
+    Box(contentAlignment = Alignment.Center) {
+        Icon(
+            imageVector = Icons.Filled.Replay,
+            contentDescription = null,
+            tint = tint,
+            modifier = if (forward) Modifier.size(iconSize).scale(scaleX = -1f, scaleY = 1f)
+                       else Modifier.size(iconSize),
+        )
+        Text(
+            text = "$seconds",
+            style = MaterialTheme.typography.labelSmall,
+            fontWeight = FontWeight.Bold,
+            color = tint,
+        )
+    }
+}
+
 /**
  * Bottom mini-player bar. Sits above the chapter rail in the screen layout.
  */
@@ -84,6 +105,7 @@ private fun SpeedControl(
 fun ReadaloudMiniPlayer(
     isPlaying: Boolean,
     speed: Float,
+    skipIntervalSeconds: Int,
     offlineMessage: Boolean,
     downloadProgress: Float?,
     canPreviousChapter: Boolean,
@@ -138,11 +160,7 @@ fun ReadaloudMiniPlayer(
                 SpeedControl(speed = speed, contentColor = contentColor, onSpeedChange = onSpeedChange)
                 Spacer(modifier = Modifier.weight(1f))
                 IconButton(onClick = onRewind, modifier = Modifier.testTag("readaloud_rewind")) {
-                    Icon(
-                        painter = painterResource(R.drawable.ic_replay_15),
-                        contentDescription = "Rewind 15 seconds",
-                        tint = contentColor,
-                    )
+                    SkipIcon(seconds = skipIntervalSeconds, forward = false, tint = contentColor)
                 }
                 IconButton(
                     onClick = onPreviousChapter,
@@ -165,11 +183,7 @@ fun ReadaloudMiniPlayer(
                     Icon(Icons.Filled.SkipNext, contentDescription = "Next chapter")
                 }
                 IconButton(onClick = onForward, modifier = Modifier.testTag("readaloud_forward")) {
-                    Icon(
-                        imageVector = Icons.Filled.Forward30,
-                        contentDescription = "Forward 30 seconds",
-                        tint = contentColor,
-                    )
+                    SkipIcon(seconds = skipIntervalSeconds, forward = true, tint = contentColor)
                 }
                 Spacer(modifier = Modifier.weight(1f))
             }

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/ListeningPreferencesPanel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/ListeningPreferencesPanel.kt
@@ -35,6 +35,8 @@ fun ListeningPreferencesPanel(
     onDefaultSpeedChange: (Float) -> Unit,
     skipIntervalSeconds: Int,
     onSkipIntervalSecondsChange: (Int) -> Unit,
+    rewindIntervalSeconds: Int,
+    onRewindIntervalSecondsChange: (Int) -> Unit,
     rewindOnResumeSeconds: Int,
     onRewindOnResumeSecondsChange: (Int) -> Unit,
     onDismiss: () -> Unit,
@@ -75,7 +77,7 @@ fun ListeningPreferencesPanel(
 
                 Spacer(Modifier.height(16.dp))
 
-                Text("Skip interval", style = MaterialTheme.typography.labelMedium)
+                Text("Forward skip", style = MaterialTheme.typography.labelMedium)
                 Spacer(Modifier.height(8.dp))
                 val skipOptions = listOf(10, 15, 30, 45, 60)
                 SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
@@ -92,15 +94,32 @@ fun ListeningPreferencesPanel(
 
                 Spacer(Modifier.height(16.dp))
 
-                Text("Rewind on resume", style = MaterialTheme.typography.labelMedium)
+                Text("Backward rewind", style = MaterialTheme.typography.labelMedium)
                 Spacer(Modifier.height(8.dp))
-                val rewindOptions = listOf(0, 5, 10, 30)
+                val rewindOptions = listOf(5, 10, 15, 30)
                 SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
                     rewindOptions.forEachIndexed { index, seconds ->
                         SegmentedButton(
+                            selected = seconds == rewindIntervalSeconds,
+                            onClick = { onRewindIntervalSecondsChange(seconds) },
+                            shape = SegmentedButtonDefaults.itemShape(index = index, count = rewindOptions.size),
+                        ) {
+                            Text("${seconds}s")
+                        }
+                    }
+                }
+
+                Spacer(Modifier.height(16.dp))
+
+                Text("Rewind on resume", style = MaterialTheme.typography.labelMedium)
+                Spacer(Modifier.height(8.dp))
+                val resumeRewindOptions = listOf(0, 5, 10, 30)
+                SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
+                    resumeRewindOptions.forEachIndexed { index, seconds ->
+                        SegmentedButton(
                             selected = seconds == rewindOnResumeSeconds,
                             onClick = { onRewindOnResumeSecondsChange(seconds) },
-                            shape = SegmentedButtonDefaults.itemShape(index = index, count = rewindOptions.size),
+                            shape = SegmentedButtonDefaults.itemShape(index = index, count = resumeRewindOptions.size),
                         ) {
                             Text(if (seconds == 0) "Off" else "${seconds}s")
                         }

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/ListeningPreferencesPanel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/ListeningPreferencesPanel.kt
@@ -1,0 +1,112 @@
+package com.riffle.app.feature.settings
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SegmentedButton
+import androidx.compose.material3.SegmentedButtonDefaults
+import androidx.compose.material3.SingleChoiceSegmentedButtonRow
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.riffle.app.feature.audio.PlaybackSpeed
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ListeningPreferencesPanel(
+    defaultSpeed: Float,
+    onDefaultSpeedChange: (Float) -> Unit,
+    skipIntervalSeconds: Int,
+    onSkipIntervalSecondsChange: (Int) -> Unit,
+    rewindOnResumeSeconds: Int,
+    onRewindOnResumeSecondsChange: (Int) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    BackHandler(onBack = onDismiss)
+    Surface(
+        modifier = Modifier.fillMaxSize().statusBarsPadding(),
+        tonalElevation = 1.dp,
+    ) {
+        Column {
+            TopAppBar(
+                title = { Text("Listening settings") },
+                navigationIcon = {
+                    IconButton(onClick = onDismiss) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+            Column(
+                modifier = Modifier
+                    .verticalScroll(rememberScrollState())
+                    .padding(horizontal = 24.dp, vertical = 16.dp)
+                    .navigationBarsPadding(),
+            ) {
+                Text("Default speed", style = MaterialTheme.typography.labelMedium)
+                Spacer(Modifier.height(8.dp))
+                SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
+                    PlaybackSpeed.PRESETS.forEachIndexed { index, speed ->
+                        SegmentedButton(
+                            selected = speed == defaultSpeed,
+                            onClick = { onDefaultSpeedChange(speed) },
+                            shape = SegmentedButtonDefaults.itemShape(index = index, count = PlaybackSpeed.PRESETS.size),
+                        ) {
+                            Text(PlaybackSpeed.label(speed))
+                        }
+                    }
+                }
+
+                Spacer(Modifier.height(16.dp))
+
+                Text("Skip interval", style = MaterialTheme.typography.labelMedium)
+                Spacer(Modifier.height(8.dp))
+                val skipOptions = listOf(10, 15, 30, 45, 60)
+                SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
+                    skipOptions.forEachIndexed { index, seconds ->
+                        SegmentedButton(
+                            selected = seconds == skipIntervalSeconds,
+                            onClick = { onSkipIntervalSecondsChange(seconds) },
+                            shape = SegmentedButtonDefaults.itemShape(index = index, count = skipOptions.size),
+                        ) {
+                            Text("${seconds}s")
+                        }
+                    }
+                }
+
+                Spacer(Modifier.height(16.dp))
+
+                Text("Rewind on resume", style = MaterialTheme.typography.labelMedium)
+                Spacer(Modifier.height(8.dp))
+                val rewindOptions = listOf(0, 5, 10, 30)
+                SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
+                    rewindOptions.forEachIndexed { index, seconds ->
+                        SegmentedButton(
+                            selected = seconds == rewindOnResumeSeconds,
+                            onClick = { onRewindOnResumeSecondsChange(seconds) },
+                            shape = SegmentedButtonDefaults.itemShape(index = index, count = rewindOptions.size),
+                        ) {
+                            Text(if (seconds == 0) "Off" else "${seconds}s")
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsScreen.kt
@@ -61,7 +61,6 @@ import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
-import com.riffle.app.feature.audio.PlaybackSpeed
 import com.riffle.app.feature.reader.FormattingPanel
 import com.riffle.app.ui.TabletContentWidthContainer
 import com.riffle.core.domain.AppTheme
@@ -101,6 +100,7 @@ fun SettingsScreen(
     val expandedServers = remember { mutableStateMapOf<String, Boolean>() }
     var expanded by remember { mutableStateOf(false) }
     var showFormattingPanel by remember { mutableStateOf(false) }
+    var showListeningPanel by remember { mutableStateOf(false) }
 
     LaunchedEffect(Unit) {
         viewModel.navigationEvents.collect { event ->
@@ -246,19 +246,13 @@ fun SettingsScreen(
                     modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
                 )
                 HorizontalDivider()
-                ListeningSpeedRow(
-                    defaultSpeed = defaultPlaybackSpeed,
-                    onDefaultSpeedChange = { viewModel.setDefaultPlaybackSpeed(it) },
-                )
-                HorizontalDivider()
-                ListeningSkipIntervalRow(
-                    skipIntervalSeconds = skipIntervalSeconds,
-                    onSkipIntervalSecondsChange = { viewModel.setSkipIntervalSeconds(it) },
-                )
-                HorizontalDivider()
-                ListeningRewindRow(
-                    rewindOnResumeSeconds = rewindOnResumeSeconds,
-                    onRewindOnResumeSecondsChange = { viewModel.setRewindOnResumeSeconds(it) },
+                ListItem(
+                    modifier = Modifier.clickable { showListeningPanel = true },
+                    headlineContent = { Text("Listening settings") },
+                    supportingContent = { Text("Speed, skip interval, rewind on resume") },
+                    trailingContent = {
+                        TextButton(onClick = { showListeningPanel = true }) { Text("Edit") }
+                    },
                 )
                 HorizontalDivider()
 
@@ -374,6 +368,18 @@ fun SettingsScreen(
             fullScreen = true,
         )
     }
+
+    if (showListeningPanel) {
+        ListeningPreferencesPanel(
+            defaultSpeed = defaultPlaybackSpeed,
+            onDefaultSpeedChange = { viewModel.setDefaultPlaybackSpeed(it) },
+            skipIntervalSeconds = skipIntervalSeconds,
+            onSkipIntervalSecondsChange = { viewModel.setSkipIntervalSeconds(it) },
+            rewindOnResumeSeconds = rewindOnResumeSeconds,
+            onRewindOnResumeSecondsChange = { viewModel.setRewindOnResumeSeconds(it) },
+            onDismiss = { showListeningPanel = false },
+        )
+    }
 }
 
 /**
@@ -402,86 +408,6 @@ private fun AppThemeRow(
                 shape = SegmentedButtonDefaults.itemShape(index = index, count = options.size),
             ) {
                 Text(label)
-            }
-        }
-    }
-}
-
-@Composable
-private fun ListeningSpeedRow(
-    defaultSpeed: Float,
-    onDefaultSpeedChange: (Float) -> Unit,
-) {
-    ListItem(
-        headlineContent = { Text("Default speed") },
-        supportingContent = { Text("Starting speed when opening a book for the first time") },
-    )
-    SingleChoiceSegmentedButtonRow(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(horizontal = 16.dp, vertical = 4.dp),
-    ) {
-        PlaybackSpeed.PRESETS.forEachIndexed { index, speed ->
-            SegmentedButton(
-                selected = speed == defaultSpeed,
-                onClick = { onDefaultSpeedChange(speed) },
-                shape = SegmentedButtonDefaults.itemShape(index = index, count = PlaybackSpeed.PRESETS.size),
-            ) {
-                Text(PlaybackSpeed.label(speed))
-            }
-        }
-    }
-}
-
-@Composable
-private fun ListeningSkipIntervalRow(
-    skipIntervalSeconds: Int,
-    onSkipIntervalSecondsChange: (Int) -> Unit,
-) {
-    val options = listOf(10, 15, 30, 45, 60)
-    ListItem(
-        headlineContent = { Text("Skip interval") },
-        supportingContent = { Text("Seconds the ⏪/⏩ buttons jump") },
-    )
-    SingleChoiceSegmentedButtonRow(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(horizontal = 16.dp, vertical = 4.dp),
-    ) {
-        options.forEachIndexed { index, seconds ->
-            SegmentedButton(
-                selected = seconds == skipIntervalSeconds,
-                onClick = { onSkipIntervalSecondsChange(seconds) },
-                shape = SegmentedButtonDefaults.itemShape(index = index, count = options.size),
-            ) {
-                Text("${seconds}s")
-            }
-        }
-    }
-}
-
-@Composable
-private fun ListeningRewindRow(
-    rewindOnResumeSeconds: Int,
-    onRewindOnResumeSecondsChange: (Int) -> Unit,
-) {
-    val options = listOf(0, 5, 10, 30)
-    ListItem(
-        headlineContent = { Text("Rewind on resume") },
-        supportingContent = { Text("Seconds to rewind when resuming after a pause") },
-    )
-    SingleChoiceSegmentedButtonRow(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(horizontal = 16.dp, vertical = 4.dp),
-    ) {
-        options.forEachIndexed { index, seconds ->
-            SegmentedButton(
-                selected = seconds == rewindOnResumeSeconds,
-                onClick = { onRewindOnResumeSecondsChange(seconds) },
-                shape = SegmentedButtonDefaults.itemShape(index = index, count = options.size),
-            ) {
-                Text(if (seconds == 0) "Off" else "${seconds}s")
             }
         }
     }

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsScreen.kt
@@ -94,6 +94,7 @@ fun SettingsScreen(
     val readaloudPreferences by viewModel.readaloudPreferences.collectAsState()
     val defaultPlaybackSpeed by viewModel.defaultPlaybackSpeed.collectAsState()
     val skipIntervalSeconds by viewModel.skipIntervalSeconds.collectAsState()
+    val rewindIntervalSeconds by viewModel.rewindIntervalSeconds.collectAsState()
     val rewindOnResumeSeconds by viewModel.rewindOnResumeSeconds.collectAsState()
     val clipboard = LocalClipboard.current
     val scope = rememberCoroutineScope()
@@ -375,6 +376,8 @@ fun SettingsScreen(
             onDefaultSpeedChange = { viewModel.setDefaultPlaybackSpeed(it) },
             skipIntervalSeconds = skipIntervalSeconds,
             onSkipIntervalSecondsChange = { viewModel.setSkipIntervalSeconds(it) },
+            rewindIntervalSeconds = rewindIntervalSeconds,
+            onRewindIntervalSecondsChange = { viewModel.setRewindIntervalSeconds(it) },
             rewindOnResumeSeconds = rewindOnResumeSeconds,
             onRewindOnResumeSecondsChange = { viewModel.setRewindOnResumeSeconds(it) },
             onDismiss = { showListeningPanel = false },

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsScreen.kt
@@ -249,7 +249,7 @@ fun SettingsScreen(
                 HorizontalDivider()
                 ListItem(
                     modifier = Modifier.clickable { showListeningPanel = true },
-                    headlineContent = { Text("Listening settings") },
+                    headlineContent = { Text("Preferences") },
                     supportingContent = { Text("Speed, skip interval, rewind on resume") },
                     trailingContent = {
                         TextButton(onClick = { showListeningPanel = true }) { Text("Edit") }

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsScreen.kt
@@ -61,6 +61,7 @@ import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.riffle.app.feature.audio.PlaybackSpeed
 import com.riffle.app.feature.reader.FormattingPanel
 import com.riffle.app.ui.TabletContentWidthContainer
 import com.riffle.core.domain.AppTheme
@@ -92,6 +93,9 @@ fun SettingsScreen(
     val readaloudSummaries by viewModel.readaloudSummaries.collectAsState()
     val appUpdateState by viewModel.appUpdateState.collectAsState()
     val readaloudPreferences by viewModel.readaloudPreferences.collectAsState()
+    val defaultPlaybackSpeed by viewModel.defaultPlaybackSpeed.collectAsState()
+    val skipIntervalSeconds by viewModel.skipIntervalSeconds.collectAsState()
+    val rewindOnResumeSeconds by viewModel.rewindOnResumeSeconds.collectAsState()
     val clipboard = LocalClipboard.current
     val scope = rememberCoroutineScope()
     val expandedServers = remember { mutableStateMapOf<String, Boolean>() }
@@ -236,6 +240,26 @@ fun SettingsScreen(
                         TextButton(onClick = { showFormattingPanel = true }) { Text("Edit") }
                     },
                 )
+                Text(
+                    text = "Listening",
+                    style = MaterialTheme.typography.titleSmall,
+                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+                )
+                HorizontalDivider()
+                ListeningSpeedRow(
+                    defaultSpeed = defaultPlaybackSpeed,
+                    onDefaultSpeedChange = { viewModel.setDefaultPlaybackSpeed(it) },
+                )
+                HorizontalDivider()
+                ListeningSkipIntervalRow(
+                    skipIntervalSeconds = skipIntervalSeconds,
+                    onSkipIntervalSecondsChange = { viewModel.setSkipIntervalSeconds(it) },
+                )
+                HorizontalDivider()
+                ListeningRewindRow(
+                    rewindOnResumeSeconds = rewindOnResumeSeconds,
+                    onRewindOnResumeSecondsChange = { viewModel.setRewindOnResumeSeconds(it) },
+                )
                 HorizontalDivider()
 
                 Text(
@@ -378,6 +402,86 @@ private fun AppThemeRow(
                 shape = SegmentedButtonDefaults.itemShape(index = index, count = options.size),
             ) {
                 Text(label)
+            }
+        }
+    }
+}
+
+@Composable
+private fun ListeningSpeedRow(
+    defaultSpeed: Float,
+    onDefaultSpeedChange: (Float) -> Unit,
+) {
+    ListItem(
+        headlineContent = { Text("Default speed") },
+        supportingContent = { Text("Starting speed when opening a book for the first time") },
+    )
+    SingleChoiceSegmentedButtonRow(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 4.dp),
+    ) {
+        PlaybackSpeed.PRESETS.forEachIndexed { index, speed ->
+            SegmentedButton(
+                selected = speed == defaultSpeed,
+                onClick = { onDefaultSpeedChange(speed) },
+                shape = SegmentedButtonDefaults.itemShape(index = index, count = PlaybackSpeed.PRESETS.size),
+            ) {
+                Text(PlaybackSpeed.label(speed))
+            }
+        }
+    }
+}
+
+@Composable
+private fun ListeningSkipIntervalRow(
+    skipIntervalSeconds: Int,
+    onSkipIntervalSecondsChange: (Int) -> Unit,
+) {
+    val options = listOf(10, 15, 30, 45, 60)
+    ListItem(
+        headlineContent = { Text("Skip interval") },
+        supportingContent = { Text("Seconds the ⏪/⏩ buttons jump") },
+    )
+    SingleChoiceSegmentedButtonRow(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 4.dp),
+    ) {
+        options.forEachIndexed { index, seconds ->
+            SegmentedButton(
+                selected = seconds == skipIntervalSeconds,
+                onClick = { onSkipIntervalSecondsChange(seconds) },
+                shape = SegmentedButtonDefaults.itemShape(index = index, count = options.size),
+            ) {
+                Text("${seconds}s")
+            }
+        }
+    }
+}
+
+@Composable
+private fun ListeningRewindRow(
+    rewindOnResumeSeconds: Int,
+    onRewindOnResumeSecondsChange: (Int) -> Unit,
+) {
+    val options = listOf(0, 5, 10, 30)
+    ListItem(
+        headlineContent = { Text("Rewind on resume") },
+        supportingContent = { Text("Seconds to rewind when resuming after a pause") },
+    )
+    SingleChoiceSegmentedButtonRow(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 4.dp),
+    ) {
+        options.forEachIndexed { index, seconds ->
+            SegmentedButton(
+                selected = seconds == rewindOnResumeSeconds,
+                onClick = { onRewindOnResumeSecondsChange(seconds) },
+                shape = SegmentedButtonDefaults.itemShape(index = index, count = options.size),
+            ) {
+                Text(if (seconds == 0) "Off" else "${seconds}s")
             }
         }
     }

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsViewModel.kt
@@ -125,6 +125,9 @@ class SettingsViewModel @Inject constructor(
     val skipIntervalSeconds: StateFlow<Int> = listeningPreferencesStore.skipIntervalSeconds
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), ListeningPreferencesStore.DEFAULT_SKIP_INTERVAL_SECONDS)
 
+    val rewindIntervalSeconds: StateFlow<Int> = listeningPreferencesStore.rewindIntervalSeconds
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), ListeningPreferencesStore.DEFAULT_REWIND_INTERVAL_SECONDS)
+
     val rewindOnResumeSeconds: StateFlow<Int> = listeningPreferencesStore.rewindOnResumeSeconds
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), ListeningPreferencesStore.DEFAULT_REWIND_ON_RESUME_SECONDS)
 
@@ -254,6 +257,10 @@ class SettingsViewModel @Inject constructor(
 
     fun setSkipIntervalSeconds(seconds: Int) {
         viewModelScope.launch { listeningPreferencesStore.setSkipIntervalSeconds(seconds) }
+    }
+
+    fun setRewindIntervalSeconds(seconds: Int) {
+        viewModelScope.launch { listeningPreferencesStore.setRewindIntervalSeconds(seconds) }
     }
 
     fun setRewindOnResumeSeconds(seconds: Int) {

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsViewModel.kt
@@ -16,6 +16,7 @@ import com.riffle.core.domain.FormattingPreferencesStore
 import com.riffle.core.domain.LibraryOrderPreferencesStore
 import com.riffle.core.domain.LibraryRepository
 import com.riffle.core.domain.LibraryVisibilityPreferencesStore
+import com.riffle.core.domain.ListeningPreferencesStore
 import com.riffle.core.domain.orderLibraries
 import com.riffle.core.domain.ReadaloudHighlightColor
 import com.riffle.core.domain.ReadaloudPreferences
@@ -52,6 +53,7 @@ class SettingsViewModel @Inject constructor(
     private val orderStore: LibraryOrderPreferencesStore,
     private val wakeLockPreferencesStore: WakeLockPreferencesStore,
     private val volumeKeyPreferencesStore: VolumeKeyPreferencesStore,
+    private val listeningPreferencesStore: ListeningPreferencesStore,
     private val appThemeStore: AppThemeStore,
     private val readaloudReviewRepository: ReadaloudReviewRepository,
     private val connectivityObserver: ConnectivityObserver,
@@ -116,6 +118,15 @@ class SettingsViewModel @Inject constructor(
 
     val invertVolumeKeys: StateFlow<Boolean> = volumeKeyPreferencesStore.invertVolumeKeys
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), false)
+
+    val defaultPlaybackSpeed: StateFlow<Float> = listeningPreferencesStore.defaultPlaybackSpeed
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), ListeningPreferencesStore.DEFAULT_PLAYBACK_SPEED)
+
+    val skipIntervalSeconds: StateFlow<Int> = listeningPreferencesStore.skipIntervalSeconds
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), ListeningPreferencesStore.DEFAULT_SKIP_INTERVAL_SECONDS)
+
+    val rewindOnResumeSeconds: StateFlow<Int> = listeningPreferencesStore.rewindOnResumeSeconds
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), ListeningPreferencesStore.DEFAULT_REWIND_ON_RESUME_SECONDS)
 
     val appTheme: StateFlow<AppTheme> = appThemeStore.appTheme
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), AppTheme.System)
@@ -235,6 +246,18 @@ class SettingsViewModel @Inject constructor(
 
     fun setInvertVolumeKeys(value: Boolean) {
         viewModelScope.launch { volumeKeyPreferencesStore.setInvertVolumeKeys(value) }
+    }
+
+    fun setDefaultPlaybackSpeed(speed: Float) {
+        viewModelScope.launch { listeningPreferencesStore.setDefaultPlaybackSpeed(speed) }
+    }
+
+    fun setSkipIntervalSeconds(seconds: Int) {
+        viewModelScope.launch { listeningPreferencesStore.setSkipIntervalSeconds(seconds) }
+    }
+
+    fun setRewindOnResumeSeconds(seconds: Int) {
+        viewModelScope.launch { listeningPreferencesStore.setRewindOnResumeSeconds(seconds) }
     }
 
     fun removeServer(serverId: String) {

--- a/app/src/test/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModelBookmarkTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModelBookmarkTest.kt
@@ -412,9 +412,11 @@ class AudiobookPlayerViewModelBookmarkTest {
     private object FakeListeningPreferencesStore : ListeningPreferencesStore {
         override val defaultPlaybackSpeed = MutableStateFlow(ListeningPreferencesStore.DEFAULT_PLAYBACK_SPEED)
         override val skipIntervalSeconds = MutableStateFlow(ListeningPreferencesStore.DEFAULT_SKIP_INTERVAL_SECONDS)
+        override val rewindIntervalSeconds = MutableStateFlow(ListeningPreferencesStore.DEFAULT_REWIND_INTERVAL_SECONDS)
         override val rewindOnResumeSeconds = MutableStateFlow(ListeningPreferencesStore.DEFAULT_REWIND_ON_RESUME_SECONDS)
         override suspend fun setDefaultPlaybackSpeed(speed: Float) {}
         override suspend fun setSkipIntervalSeconds(seconds: Int) {}
+        override suspend fun setRewindIntervalSeconds(seconds: Int) {}
         override suspend fun setRewindOnResumeSeconds(seconds: Int) {}
     }
 

--- a/app/src/test/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModelBookmarkTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModelBookmarkTest.kt
@@ -53,12 +53,14 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
 import org.junit.Before
 import org.junit.Test
 import java.io.File
@@ -113,6 +115,8 @@ class AudiobookPlayerViewModelBookmarkTest {
         controller: FakeController,
         bookmarkStore: AudiobookBookmarkStore,
         connectivity: FakeConnectivityObserver = FakeConnectivityObserver(online = true),
+        prefsStore: AudioPlaybackPreferencesStore = FakePrefsStore,
+        listeningStore: ListeningPreferencesStore = FakeListeningPreferencesStore,
     ): AudiobookPlayerViewModel {
         val session = AudiobookSession(
             trackUrls = listOf("http://x/track0"),
@@ -130,8 +134,8 @@ class AudiobookPlayerViewModelBookmarkTest {
             serverRepository = FakeServerRepository(),
             tokenStorage = FakeTokenStorage,
             controller = controller,
-            audioPlaybackPreferencesStore = FakePrefsStore,
-            listeningPreferencesStore = FakeListeningPreferencesStore,
+            audioPlaybackPreferencesStore = prefsStore,
+            listeningPreferencesStore = listeningStore,
             audioIdentityResolver = FakeIdentityResolver,
             readerSyncFactory = TestReaderSyncFactory(),
             readaloudLinkRepository = FakeLinkRepository,
@@ -276,6 +280,69 @@ class AudiobookPlayerViewModelBookmarkTest {
         }
     }
 
+    // --- speed persistence ---
+
+    @Test
+    fun `setSpeed saves with the resolved identity after the debounce window`() = runTest(testDispatcher) {
+        val store = RecordingPrefsStore()
+        val vm = buildViewModel(FakeController(0.0), FakeBookmarkStore(), prefsStore = store)
+        runCurrent() // openBook() completes → audioSettingsIdentity = AudioIdentity(serverId, itemId)
+
+        vm.setSpeed(1.5f)
+        advanceTimeBy(401L) // > SPEED_SAVE_DEBOUNCE_MS (400ms)
+        runCurrent()
+
+        assertNotNull("save() must have been called", store.lastSave)
+        assertEquals(AudioIdentity(serverId, itemId), store.lastSave!!.first)
+        assertEquals(1.5f, store.lastSave!!.second)
+        vm.clearForTest()
+    }
+
+    // --- rewind on resume ---
+
+    @Test
+    fun `togglePlayPause when resuming seeks back by rewindOnResumeSeconds before playing`() = runTest(testDispatcher) {
+        val ctrl = FakeController(position = 30.0)
+        val store = MutableListeningPreferencesStore().apply { rewindOnResumeSeconds.value = 10 }
+        val vm = buildViewModel(ctrl, FakeBookmarkStore(), listeningStore = store)
+        runCurrent()
+
+        vm.togglePlayPause() // not playing → resume path
+        runCurrent()
+
+        // Must seek to 30 - 10 = 20 before playing
+        assertEquals(listOf(20.0), ctrl.seeks)
+        vm.clearForTest()
+    }
+
+    @Test
+    fun `togglePlayPause when resuming with zero rewindOnResumeSeconds does not seek`() = runTest(testDispatcher) {
+        val ctrl = FakeController(position = 30.0)
+        val store = MutableListeningPreferencesStore().apply { rewindOnResumeSeconds.value = 0 }
+        val vm = buildViewModel(ctrl, FakeBookmarkStore(), listeningStore = store)
+        runCurrent()
+
+        vm.togglePlayPause()
+        runCurrent()
+
+        assertEquals(emptyList<Double>(), ctrl.seeks)
+        vm.clearForTest()
+    }
+
+    @Test
+    fun `togglePlayPause when resuming at position less than rewindSec clamps to zero`() = runTest(testDispatcher) {
+        val ctrl = FakeController(position = 5.0)
+        val store = MutableListeningPreferencesStore().apply { rewindOnResumeSeconds.value = 10 }
+        val vm = buildViewModel(ctrl, FakeBookmarkStore(), listeningStore = store)
+        runCurrent()
+
+        vm.togglePlayPause()
+        runCurrent()
+
+        assertEquals(listOf(0.0), ctrl.seeks)
+        vm.clearForTest()
+    }
+
     // --- fakes ---
 
     private class FakeConnectivityObserver(online: Boolean) : com.riffle.core.domain.ConnectivityObserver {
@@ -409,6 +476,14 @@ class AudiobookPlayerViewModelBookmarkTest {
         override suspend fun rekey(old: AudioIdentity, new: AudioIdentity) {}
     }
 
+    private class RecordingPrefsStore : AudioPlaybackPreferencesStore {
+        var lastSave: Pair<AudioIdentity, Float>? = null
+        override suspend fun load(identity: AudioIdentity): Float? = null
+        override suspend fun save(identity: AudioIdentity, speed: Float) { lastSave = identity to speed }
+        override suspend fun clear(identity: AudioIdentity) {}
+        override suspend fun rekey(old: AudioIdentity, new: AudioIdentity) {}
+    }
+
     private object FakeListeningPreferencesStore : ListeningPreferencesStore {
         override val defaultPlaybackSpeed = MutableStateFlow(ListeningPreferencesStore.DEFAULT_PLAYBACK_SPEED)
         override val skipIntervalSeconds = MutableStateFlow(ListeningPreferencesStore.DEFAULT_SKIP_INTERVAL_SECONDS)
@@ -418,6 +493,17 @@ class AudiobookPlayerViewModelBookmarkTest {
         override suspend fun setSkipIntervalSeconds(seconds: Int) {}
         override suspend fun setRewindIntervalSeconds(seconds: Int) {}
         override suspend fun setRewindOnResumeSeconds(seconds: Int) {}
+    }
+
+    private class MutableListeningPreferencesStore : ListeningPreferencesStore {
+        override val defaultPlaybackSpeed = MutableStateFlow(ListeningPreferencesStore.DEFAULT_PLAYBACK_SPEED)
+        override val skipIntervalSeconds = MutableStateFlow(ListeningPreferencesStore.DEFAULT_SKIP_INTERVAL_SECONDS)
+        override val rewindIntervalSeconds = MutableStateFlow(ListeningPreferencesStore.DEFAULT_REWIND_INTERVAL_SECONDS)
+        override val rewindOnResumeSeconds = MutableStateFlow(ListeningPreferencesStore.DEFAULT_REWIND_ON_RESUME_SECONDS)
+        override suspend fun setDefaultPlaybackSpeed(speed: Float) { defaultPlaybackSpeed.value = speed }
+        override suspend fun setSkipIntervalSeconds(seconds: Int) { skipIntervalSeconds.value = seconds }
+        override suspend fun setRewindIntervalSeconds(seconds: Int) { rewindIntervalSeconds.value = seconds }
+        override suspend fun setRewindOnResumeSeconds(seconds: Int) { rewindOnResumeSeconds.value = seconds }
     }
 
     private object FakeIdentityResolver : AudioIdentityResolver {

--- a/app/src/test/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModelBookmarkTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModelBookmarkTest.kt
@@ -89,6 +89,7 @@ class AudiobookPlayerViewModelBookmarkTest {
     // members the VM actually touches are overridden; the heavy Media3/Context machinery is bypassed.
     private class FakeController(var position: Double) : AudiobookController() {
         val seeks = mutableListOf<Double>()
+        var preparedStartAtSec: Double? = null
         override val state = MutableStateFlow(PlaybackState())
         override suspend fun prepare(
             trackUrls: List<String>,
@@ -97,7 +98,7 @@ class AudiobookPlayerViewModelBookmarkTest {
             startAtSec: Double,
             localZipFile: File?,
             coverUri: String?,
-        ) { /* no-op */ }
+        ) { preparedStartAtSec = startAtSec }
         override fun play() {}
         override fun setSpeed(speed: Float) {}
         override fun currentAbsoluteSec(): Double = position
@@ -117,6 +118,7 @@ class AudiobookPlayerViewModelBookmarkTest {
         connectivity: FakeConnectivityObserver = FakeConnectivityObserver(online = true),
         prefsStore: AudioPlaybackPreferencesStore = FakePrefsStore,
         listeningStore: ListeningPreferencesStore = FakeListeningPreferencesStore,
+        positionStore: com.riffle.core.domain.AudiobookPositionStore = FakePositionStore(),
     ): AudiobookPlayerViewModel {
         val session = AudiobookSession(
             trackUrls = listOf("http://x/track0"),
@@ -141,7 +143,7 @@ class AudiobookPlayerViewModelBookmarkTest {
             readaloudLinkRepository = FakeLinkRepository,
             readaloudAudioRepository = FakeAudioRepo,
             nowPlayingStore = NowPlayingStore(),
-            audiobookPositionStore = FakePositionStore(),
+            audiobookPositionStore = positionStore,
             readingSyncStore = FakeSyncStore(),
             audioSyncStore = FakeSyncStoreDouble(),
             readaloudResumeStore = FakeResumeStore,
@@ -343,6 +345,58 @@ class AudiobookPlayerViewModelBookmarkTest {
         vm.clearForTest()
     }
 
+    @Test
+    fun `openBook resuming an in-progress book rewinds the start position by rewindOnResumeSeconds`() = runTest(testDispatcher) {
+        // Reopening a book is the most common "resume" and plays directly (no togglePlayPause), so the
+        // rewind has to be applied to the prepared start position — otherwise the setting only ever fires
+        // on an in-player pause→play and looks broken when you leave and come back.
+        val ctrl = FakeController(position = 0.0)
+        val store = MutableListeningPreferencesStore().apply { rewindOnResumeSeconds.value = 10 }
+        val vm = buildViewModel(
+            ctrl,
+            FakeBookmarkStore(),
+            listeningStore = store,
+            positionStore = FakePositionStore(savedSec = 540.0, savedUpdatedAt = fixedNow),
+        )
+        runCurrent()
+
+        // Resume position 540 rewound by 10 → prepared at 530.
+        assertEquals(530.0, ctrl.preparedStartAtSec!!, 0.0001)
+        vm.clearForTest()
+    }
+
+    @Test
+    fun `openBook with zero rewindOnResumeSeconds prepares at the unmodified resume position`() = runTest(testDispatcher) {
+        val ctrl = FakeController(position = 0.0)
+        val store = MutableListeningPreferencesStore().apply { rewindOnResumeSeconds.value = 0 }
+        val vm = buildViewModel(
+            ctrl,
+            FakeBookmarkStore(),
+            listeningStore = store,
+            positionStore = FakePositionStore(savedSec = 540.0, savedUpdatedAt = fixedNow),
+        )
+        runCurrent()
+
+        assertEquals(540.0, ctrl.preparedStartAtSec!!, 0.0001)
+        vm.clearForTest()
+    }
+
+    @Test
+    fun `openBook resuming near the start clamps the rewound position to zero`() = runTest(testDispatcher) {
+        val ctrl = FakeController(position = 0.0)
+        val store = MutableListeningPreferencesStore().apply { rewindOnResumeSeconds.value = 10 }
+        val vm = buildViewModel(
+            ctrl,
+            FakeBookmarkStore(),
+            listeningStore = store,
+            positionStore = FakePositionStore(savedSec = 4.0, savedUpdatedAt = fixedNow),
+        )
+        runCurrent()
+
+        assertEquals(0.0, ctrl.preparedStartAtSec!!, 0.0001)
+        vm.clearForTest()
+    }
+
     // --- fakes ---
 
     private class FakeConnectivityObserver(online: Boolean) : com.riffle.core.domain.ConnectivityObserver {
@@ -535,10 +589,13 @@ class AudiobookPlayerViewModelBookmarkTest {
         override suspend fun removeAudio(serverId: String, itemId: String): Long = 0
     }
 
-    private class FakePositionStore : com.riffle.core.domain.AudiobookPositionStore {
+    private class FakePositionStore(
+        private val savedSec: Double? = null,
+        private val savedUpdatedAt: Long = 0,
+    ) : com.riffle.core.domain.AudiobookPositionStore {
         override suspend fun save(serverId: String, itemId: String, payload: Double) {}
-        override suspend fun load(serverId: String, itemId: String): Double? = null
-        override suspend fun loadLocalUpdatedAt(serverId: String, itemId: String): Long = 0
+        override suspend fun load(serverId: String, itemId: String): Double? = savedSec
+        override suspend fun loadLocalUpdatedAt(serverId: String, itemId: String): Long = savedUpdatedAt
         override suspend fun updateLocalTimestamp(serverId: String, itemId: String, millis: Long) {}
     }
 

--- a/app/src/test/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModelBookmarkTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModelBookmarkTest.kt
@@ -13,6 +13,7 @@ import com.riffle.core.domain.AudioIdentity
 import com.riffle.core.domain.AudioIdentityResolver
 import com.riffle.core.domain.AudioPlaybackPreferencesStore
 import com.riffle.core.domain.AudiobookBookmark
+import com.riffle.core.domain.ListeningPreferencesStore
 import com.riffle.core.domain.AudiobookBookmarkStore
 import com.riffle.core.domain.AudiobookChapter
 import com.riffle.core.domain.AudiobookDownloadRepository
@@ -130,6 +131,7 @@ class AudiobookPlayerViewModelBookmarkTest {
             tokenStorage = FakeTokenStorage,
             controller = controller,
             audioPlaybackPreferencesStore = FakePrefsStore,
+            listeningPreferencesStore = FakeListeningPreferencesStore,
             audioIdentityResolver = FakeIdentityResolver,
             readerSyncFactory = TestReaderSyncFactory(),
             readaloudLinkRepository = FakeLinkRepository,
@@ -405,6 +407,15 @@ class AudiobookPlayerViewModelBookmarkTest {
         override suspend fun save(identity: AudioIdentity, speed: Float) {}
         override suspend fun clear(identity: AudioIdentity) {}
         override suspend fun rekey(old: AudioIdentity, new: AudioIdentity) {}
+    }
+
+    private object FakeListeningPreferencesStore : ListeningPreferencesStore {
+        override val defaultPlaybackSpeed = MutableStateFlow(ListeningPreferencesStore.DEFAULT_PLAYBACK_SPEED)
+        override val skipIntervalSeconds = MutableStateFlow(ListeningPreferencesStore.DEFAULT_SKIP_INTERVAL_SECONDS)
+        override val rewindOnResumeSeconds = MutableStateFlow(ListeningPreferencesStore.DEFAULT_REWIND_ON_RESUME_SECONDS)
+        override suspend fun setDefaultPlaybackSpeed(speed: Float) {}
+        override suspend fun setSkipIntervalSeconds(seconds: Int) {}
+        override suspend fun setRewindOnResumeSeconds(seconds: Int) {}
     }
 
     private object FakeIdentityResolver : AudioIdentityResolver {

--- a/app/src/test/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModelBookmarkTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModelBookmarkTest.kt
@@ -112,6 +112,10 @@ class AudiobookPlayerViewModelBookmarkTest {
         this.viewModelScope.cancel()
     }
 
+    // Captures the repo built by the most recent buildViewModel() so a test can read what progress the
+    // VM persisted (saveProgress) — used by the rewind-on-resume drift regression test.
+    private var lastAudiobookRepo: FakeAudiobookRepository? = null
+
     private fun buildViewModel(
         controller: FakeController,
         bookmarkStore: AudiobookBookmarkStore,
@@ -127,9 +131,11 @@ class AudiobookPlayerViewModelBookmarkTest {
             serverCurrentTimeSec = 0.0,
             serverLastUpdate = 0L,
         )
+        val repo = FakeAudiobookRepository(session)
+        lastAudiobookRepo = repo
         return AudiobookPlayerViewModel(
             savedStateHandle = SavedStateHandle(mapOf("itemId" to itemId)),
-            audiobookRepository = FakeAudiobookRepository(session),
+            audiobookRepository = repo,
             audiobookDownloadRepository = NoDownloadRepo,
             bundleAudiobookSource = NoBundleSource,
             libraryRepository = FakeLibraryRepository(),
@@ -397,6 +403,34 @@ class AudiobookPlayerViewModelBookmarkTest {
         vm.clearForTest()
     }
 
+    @Test
+    fun `open-path rewind shifts only playback start, not the persisted resume floor`() = runTest(testDispatcher) {
+        // Regression: the rewind must NOT lower the resume floor, or pausing/closing while still inside the
+        // rewound seconds would persist that lower position — letting repeated open→close cycles creep the
+        // saved position backward by rewindOnResume each time. Resume 540, rewind 10 → playback starts at
+        // 530, but the floor stays 540; pausing at the rewound 530 (below the floor) must persist nothing.
+        val ctrl = FakeController(position = 0.0)
+        val store = MutableListeningPreferencesStore().apply { rewindOnResumeSeconds.value = 10 }
+        val vm = buildViewModel(
+            ctrl,
+            FakeBookmarkStore(),
+            listeningStore = store,
+            positionStore = FakePositionStore(savedSec = 540.0, savedUpdatedAt = fixedNow),
+        )
+        runCurrent()
+        assertEquals(530.0, ctrl.preparedStartAtSec!!, 0.0001) // playback starts at the rewound point
+
+        // Simulate the controller settled at the rewound start and playing, then pause.
+        ctrl.position = 530.0
+        ctrl.state.value = AudiobookController.PlaybackState(isPlaying = true)
+        vm.togglePlayPause() // playing → pause → pushProgressOnStop
+        runCurrent()
+
+        // 530 is below the 540 floor, so no backward progress is written.
+        assertEquals(emptyList<Double>(), lastAudiobookRepo!!.savedProgress)
+        vm.clearForTest()
+    }
+
     // --- fakes ---
 
     private class FakeConnectivityObserver(online: Boolean) : com.riffle.core.domain.ConnectivityObserver {
@@ -429,8 +463,11 @@ class AudiobookPlayerViewModelBookmarkTest {
     }
 
     private class FakeAudiobookRepository(private val session: AudiobookSession) : AudiobookRepository {
+        val savedProgress = mutableListOf<Double>()
         override suspend fun openSession(serverId: String, itemId: String): AudiobookSession = session
-        override suspend fun saveProgress(serverId: String, itemId: String, positionSec: Double, durationSec: Double) {}
+        override suspend fun saveProgress(serverId: String, itemId: String, positionSec: Double, durationSec: Double) {
+            savedProgress.add(positionSec)
+        }
     }
 
     private object NoDownloadRepo : AudiobookDownloadRepository {

--- a/app/src/test/kotlin/com/riffle/app/feature/audiobook/SleepTimerTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/audiobook/SleepTimerTest.kt
@@ -455,9 +455,11 @@ class SleepTimerTest {
     private object FakeListeningPreferencesStore : ListeningPreferencesStore {
         override val defaultPlaybackSpeed = MutableStateFlow(ListeningPreferencesStore.DEFAULT_PLAYBACK_SPEED)
         override val skipIntervalSeconds = MutableStateFlow(ListeningPreferencesStore.DEFAULT_SKIP_INTERVAL_SECONDS)
+        override val rewindIntervalSeconds = MutableStateFlow(ListeningPreferencesStore.DEFAULT_REWIND_INTERVAL_SECONDS)
         override val rewindOnResumeSeconds = MutableStateFlow(ListeningPreferencesStore.DEFAULT_REWIND_ON_RESUME_SECONDS)
         override suspend fun setDefaultPlaybackSpeed(speed: Float) {}
         override suspend fun setSkipIntervalSeconds(seconds: Int) {}
+        override suspend fun setRewindIntervalSeconds(seconds: Int) {}
         override suspend fun setRewindOnResumeSeconds(seconds: Int) {}
     }
 

--- a/app/src/test/kotlin/com/riffle/app/feature/audiobook/SleepTimerTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/audiobook/SleepTimerTest.kt
@@ -13,6 +13,7 @@ import com.riffle.core.domain.AudioIdentity
 import com.riffle.core.domain.AudioIdentityResolver
 import com.riffle.core.domain.AudioPlaybackPreferencesStore
 import com.riffle.core.domain.AudiobookBookmark
+import com.riffle.core.domain.ListeningPreferencesStore
 import com.riffle.core.domain.AudiobookBookmarkStore
 import com.riffle.core.domain.AudiobookChapter
 import com.riffle.core.domain.AudiobookDownloadRepository
@@ -192,6 +193,7 @@ class SleepTimerTest {
             tokenStorage = FakeTokenStorage,
             controller = controller,
             audioPlaybackPreferencesStore = FakePrefsStore,
+            listeningPreferencesStore = FakeListeningPreferencesStore,
             audioIdentityResolver = FakeIdentityResolver,
             readerSyncFactory = TestReaderSyncFactory(),
             readaloudLinkRepository = FakeLinkRepository,
@@ -448,6 +450,15 @@ class SleepTimerTest {
         override suspend fun save(identity: AudioIdentity, speed: Float) {}
         override suspend fun clear(identity: AudioIdentity) {}
         override suspend fun rekey(old: AudioIdentity, new: AudioIdentity) {}
+    }
+
+    private object FakeListeningPreferencesStore : ListeningPreferencesStore {
+        override val defaultPlaybackSpeed = MutableStateFlow(ListeningPreferencesStore.DEFAULT_PLAYBACK_SPEED)
+        override val skipIntervalSeconds = MutableStateFlow(ListeningPreferencesStore.DEFAULT_SKIP_INTERVAL_SECONDS)
+        override val rewindOnResumeSeconds = MutableStateFlow(ListeningPreferencesStore.DEFAULT_REWIND_ON_RESUME_SECONDS)
+        override suspend fun setDefaultPlaybackSpeed(speed: Float) {}
+        override suspend fun setSkipIntervalSeconds(seconds: Int) {}
+        override suspend fun setRewindOnResumeSeconds(seconds: Int) {}
     }
 
     private object FakeIdentityResolver : AudioIdentityResolver {

--- a/app/src/test/kotlin/com/riffle/app/feature/settings/SettingsViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/settings/SettingsViewModelTest.kt
@@ -100,9 +100,11 @@ class SettingsViewModelTest {
     private val fakeListeningPreferencesStore = object : ListeningPreferencesStore {
         override val defaultPlaybackSpeed = MutableStateFlow(ListeningPreferencesStore.DEFAULT_PLAYBACK_SPEED)
         override val skipIntervalSeconds = MutableStateFlow(ListeningPreferencesStore.DEFAULT_SKIP_INTERVAL_SECONDS)
+        override val rewindIntervalSeconds = MutableStateFlow(ListeningPreferencesStore.DEFAULT_REWIND_INTERVAL_SECONDS)
         override val rewindOnResumeSeconds = MutableStateFlow(ListeningPreferencesStore.DEFAULT_REWIND_ON_RESUME_SECONDS)
         override suspend fun setDefaultPlaybackSpeed(speed: Float) { defaultPlaybackSpeed.value = speed }
         override suspend fun setSkipIntervalSeconds(seconds: Int) { skipIntervalSeconds.value = seconds }
+        override suspend fun setRewindIntervalSeconds(seconds: Int) { rewindIntervalSeconds.value = seconds }
         override suspend fun setRewindOnResumeSeconds(seconds: Int) { rewindOnResumeSeconds.value = seconds }
     }
 

--- a/app/src/test/kotlin/com/riffle/app/feature/settings/SettingsViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/settings/SettingsViewModelTest.kt
@@ -32,6 +32,7 @@ import com.riffle.core.domain.ServerRepository
 import com.riffle.core.domain.ServerType
 import com.riffle.core.domain.ServerUrl
 import com.riffle.core.domain.UnmatchedReadaloud
+import com.riffle.core.domain.ListeningPreferencesStore
 import com.riffle.core.domain.VolumeKeyPreferencesStore
 import com.riffle.core.domain.WakeLockPreferencesStore
 import kotlinx.coroutines.Dispatchers
@@ -94,6 +95,15 @@ class SettingsViewModelTest {
     private val fakeAppThemeStore = object : AppThemeStore {
         override val appTheme: Flow<AppTheme> = appThemeFlow
         override suspend fun setAppTheme(value: AppTheme) { appThemeFlow.value = value }
+    }
+
+    private val fakeListeningPreferencesStore = object : ListeningPreferencesStore {
+        override val defaultPlaybackSpeed = MutableStateFlow(ListeningPreferencesStore.DEFAULT_PLAYBACK_SPEED)
+        override val skipIntervalSeconds = MutableStateFlow(ListeningPreferencesStore.DEFAULT_SKIP_INTERVAL_SECONDS)
+        override val rewindOnResumeSeconds = MutableStateFlow(ListeningPreferencesStore.DEFAULT_REWIND_ON_RESUME_SECONDS)
+        override suspend fun setDefaultPlaybackSpeed(speed: Float) { defaultPlaybackSpeed.value = speed }
+        override suspend fun setSkipIntervalSeconds(seconds: Int) { skipIntervalSeconds.value = seconds }
+        override suspend fun setRewindOnResumeSeconds(seconds: Int) { rewindOnResumeSeconds.value = seconds }
     }
 
     private fun server(
@@ -215,6 +225,7 @@ class SettingsViewModelTest {
         orderStore = fakeOrderStore(),
         wakeLockPreferencesStore = noOpWakeLockStore,
         volumeKeyPreferencesStore = fakeVolumeKeyStore,
+        listeningPreferencesStore = fakeListeningPreferencesStore,
         appThemeStore = fakeAppThemeStore,
         readaloudReviewRepository = fakeReviewRepo,
         connectivityObserver = fakeConnectivity,

--- a/app/src/test/kotlin/com/riffle/app/feature/settings/SettingsViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/settings/SettingsViewModelTest.kt
@@ -552,4 +552,42 @@ class SettingsViewModelTest {
         assertEquals(ReadaloudHighlightColor.YELLOW, emitted.last())
         job.cancel()
     }
+
+    // --- listening preferences ---
+
+    @Test
+    fun `setDefaultPlaybackSpeed updates the store`() = runTest {
+        val vm = makeViewModel()
+        backgroundScope.launch { vm.defaultPlaybackSpeed.collect {} }
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        vm.setDefaultPlaybackSpeed(1.5f)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(1.5f, fakeListeningPreferencesStore.defaultPlaybackSpeed.first())
+    }
+
+    @Test
+    fun `setSkipIntervalSeconds updates the store`() = runTest {
+        val vm = makeViewModel()
+        backgroundScope.launch { vm.skipIntervalSeconds.collect {} }
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        vm.setSkipIntervalSeconds(15)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(15, fakeListeningPreferencesStore.skipIntervalSeconds.first())
+    }
+
+    @Test
+    fun `setRewindOnResumeSeconds updates the store`() = runTest {
+        val vm = makeViewModel()
+        backgroundScope.launch { vm.rewindOnResumeSeconds.collect {} }
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        vm.setRewindOnResumeSeconds(10)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(10, fakeListeningPreferencesStore.rewindOnResumeSeconds.first())
+    }
 }

--- a/core/data/src/main/kotlin/com/riffle/core/data/AudioPlaybackPreferencesStoreImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/AudioPlaybackPreferencesStoreImpl.kt
@@ -4,13 +4,18 @@ import com.riffle.core.database.AudioPlaybackPreferencesDao
 import com.riffle.core.database.AudioPlaybackPreferencesEntity
 import com.riffle.core.domain.AudioIdentity
 import com.riffle.core.domain.AudioPlaybackPreferencesStore
-import com.riffle.core.domain.AudioPlaybackPreferencesStore.Companion.DEFAULT_PLAYBACK_SPEED
 import javax.inject.Inject
 
 /**
  * Persists per-book audio playback settings keyed by the resolved [AudioIdentity] (ADR 0028). Unlike
  * the formatting store, the identity already carries (serverId, bookId), so no active-server lookup
- * is needed. Saving the default removes the row, keeping "no row == default".
+ * is needed.
+ *
+ * A row means "this book has a user-chosen speed"; its absence means "follow the global default speed"
+ * (the player resolves the fallback). The two are now distinct — the global default is configurable and
+ * may be anything — so [save] persists the chosen value verbatim and never deletes: deleting on a
+ * hardcoded 1.0× would silently discard a deliberate "play this one book at normal speed" choice and
+ * snap it back to the global default. Use [clear] to genuinely un-customise a book.
  */
 class AudioPlaybackPreferencesStoreImpl @Inject constructor(
     private val dao: AudioPlaybackPreferencesDao,
@@ -20,10 +25,6 @@ class AudioPlaybackPreferencesStoreImpl @Inject constructor(
         dao.get(identity.serverId, identity.bookId)?.speed
 
     override suspend fun save(identity: AudioIdentity, speed: Float) {
-        if (speed == DEFAULT_PLAYBACK_SPEED) {
-            dao.delete(identity.serverId, identity.bookId)
-            return
-        }
         dao.upsert(AudioPlaybackPreferencesEntity(identity.serverId, identity.bookId, speed))
     }
 

--- a/core/data/src/main/kotlin/com/riffle/core/data/ListeningPreferencesStoreImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/ListeningPreferencesStoreImpl.kt
@@ -8,6 +8,7 @@ import androidx.datastore.preferences.core.intPreferencesKey
 import com.riffle.core.data.di.ListeningPreferencesDataStore
 import com.riffle.core.domain.ListeningPreferencesStore
 import com.riffle.core.domain.ListeningPreferencesStore.Companion.DEFAULT_PLAYBACK_SPEED
+import com.riffle.core.domain.ListeningPreferencesStore.Companion.DEFAULT_REWIND_INTERVAL_SECONDS
 import com.riffle.core.domain.ListeningPreferencesStore.Companion.DEFAULT_REWIND_ON_RESUME_SECONDS
 import com.riffle.core.domain.ListeningPreferencesStore.Companion.DEFAULT_SKIP_INTERVAL_SECONDS
 import kotlinx.coroutines.flow.Flow
@@ -26,6 +27,10 @@ class ListeningPreferencesStoreImpl @Inject constructor(
         prefs[KEY_SKIP_INTERVAL_SECONDS] ?: DEFAULT_SKIP_INTERVAL_SECONDS
     }
 
+    override val rewindIntervalSeconds: Flow<Int> = dataStore.data.map { prefs ->
+        prefs[KEY_REWIND_INTERVAL_SECONDS] ?: DEFAULT_REWIND_INTERVAL_SECONDS
+    }
+
     override val rewindOnResumeSeconds: Flow<Int> = dataStore.data.map { prefs ->
         prefs[KEY_REWIND_ON_RESUME_SECONDS] ?: DEFAULT_REWIND_ON_RESUME_SECONDS
     }
@@ -38,6 +43,10 @@ class ListeningPreferencesStoreImpl @Inject constructor(
         dataStore.edit { prefs -> prefs[KEY_SKIP_INTERVAL_SECONDS] = seconds }
     }
 
+    override suspend fun setRewindIntervalSeconds(seconds: Int) {
+        dataStore.edit { prefs -> prefs[KEY_REWIND_INTERVAL_SECONDS] = seconds }
+    }
+
     override suspend fun setRewindOnResumeSeconds(seconds: Int) {
         dataStore.edit { prefs -> prefs[KEY_REWIND_ON_RESUME_SECONDS] = seconds }
     }
@@ -45,6 +54,7 @@ class ListeningPreferencesStoreImpl @Inject constructor(
     private companion object {
         val KEY_DEFAULT_PLAYBACK_SPEED = floatPreferencesKey("default_playback_speed")
         val KEY_SKIP_INTERVAL_SECONDS = intPreferencesKey("skip_interval_seconds")
+        val KEY_REWIND_INTERVAL_SECONDS = intPreferencesKey("rewind_interval_seconds")
         val KEY_REWIND_ON_RESUME_SECONDS = intPreferencesKey("rewind_on_resume_seconds")
     }
 }

--- a/core/data/src/main/kotlin/com/riffle/core/data/ListeningPreferencesStoreImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/ListeningPreferencesStoreImpl.kt
@@ -1,0 +1,50 @@
+package com.riffle.core.data
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.floatPreferencesKey
+import androidx.datastore.preferences.core.intPreferencesKey
+import com.riffle.core.data.di.ListeningPreferencesDataStore
+import com.riffle.core.domain.ListeningPreferencesStore
+import com.riffle.core.domain.ListeningPreferencesStore.Companion.DEFAULT_PLAYBACK_SPEED
+import com.riffle.core.domain.ListeningPreferencesStore.Companion.DEFAULT_REWIND_ON_RESUME_SECONDS
+import com.riffle.core.domain.ListeningPreferencesStore.Companion.DEFAULT_SKIP_INTERVAL_SECONDS
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+
+class ListeningPreferencesStoreImpl @Inject constructor(
+    @param:ListeningPreferencesDataStore private val dataStore: DataStore<Preferences>,
+) : ListeningPreferencesStore {
+
+    override val defaultPlaybackSpeed: Flow<Float> = dataStore.data.map { prefs ->
+        prefs[KEY_DEFAULT_PLAYBACK_SPEED] ?: DEFAULT_PLAYBACK_SPEED
+    }
+
+    override val skipIntervalSeconds: Flow<Int> = dataStore.data.map { prefs ->
+        prefs[KEY_SKIP_INTERVAL_SECONDS] ?: DEFAULT_SKIP_INTERVAL_SECONDS
+    }
+
+    override val rewindOnResumeSeconds: Flow<Int> = dataStore.data.map { prefs ->
+        prefs[KEY_REWIND_ON_RESUME_SECONDS] ?: DEFAULT_REWIND_ON_RESUME_SECONDS
+    }
+
+    override suspend fun setDefaultPlaybackSpeed(speed: Float) {
+        dataStore.edit { prefs -> prefs[KEY_DEFAULT_PLAYBACK_SPEED] = speed }
+    }
+
+    override suspend fun setSkipIntervalSeconds(seconds: Int) {
+        dataStore.edit { prefs -> prefs[KEY_SKIP_INTERVAL_SECONDS] = seconds }
+    }
+
+    override suspend fun setRewindOnResumeSeconds(seconds: Int) {
+        dataStore.edit { prefs -> prefs[KEY_REWIND_ON_RESUME_SECONDS] = seconds }
+    }
+
+    private companion object {
+        val KEY_DEFAULT_PLAYBACK_SPEED = floatPreferencesKey("default_playback_speed")
+        val KEY_SKIP_INTERVAL_SECONDS = intPreferencesKey("skip_interval_seconds")
+        val KEY_REWIND_ON_RESUME_SECONDS = intPreferencesKey("rewind_on_resume_seconds")
+    }
+}

--- a/core/data/src/main/kotlin/com/riffle/core/data/di/DataModule.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/di/DataModule.kt
@@ -44,6 +44,7 @@ import com.riffle.core.data.VolumeKeyPreferencesStoreImpl
 import com.riffle.core.data.ReadingSpeedStoreImpl
 import com.riffle.core.data.WakeLockPreferencesStoreImpl
 import com.riffle.core.data.ReadaloudPreferencesStoreImpl
+import com.riffle.core.data.ListeningPreferencesStoreImpl
 import com.riffle.core.domain.AnnotationStore
 import com.riffle.core.domain.AudioIdentityResolver
 import com.riffle.core.domain.AudioPlaybackPreferencesStore
@@ -80,6 +81,7 @@ import com.riffle.core.domain.VolumeKeyPreferencesStore
 import com.riffle.core.domain.ReadingSpeedStore
 import com.riffle.core.domain.WakeLockPreferencesStore
 import com.riffle.core.domain.ReadaloudPreferencesStore
+import com.riffle.core.domain.ListeningPreferencesStore
 import com.riffle.core.data.AudiobookBundleDownloader
 import com.riffle.core.data.ReadaloudAudioRepositoryImpl
 import com.riffle.core.data.StorytellerBundleAudiobookSource
@@ -158,6 +160,10 @@ annotation class ReadaloudPreferencesDataStore
 @Qualifier
 @Retention(AnnotationRetention.BINARY)
 annotation class ReadingSpeedDataStore
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class ListeningPreferencesDataStore
 
 @Qualifier
 @Retention(AnnotationRetention.BINARY)
@@ -314,6 +320,10 @@ abstract class DataModule {
     @Binds
     @Singleton
     abstract fun bindWakeLockPreferencesStore(impl: WakeLockPreferencesStoreImpl): WakeLockPreferencesStore
+
+    @Binds
+    @Singleton
+    abstract fun bindListeningPreferencesStore(impl: ListeningPreferencesStoreImpl): ListeningPreferencesStore
 
     @Binds
     @Singleton
@@ -641,6 +651,13 @@ abstract class DataModule {
         fun provideWakeLockPreferencesDataStore(
             @ApplicationContext context: Context
         ): DataStore<Preferences> = context.wakeLockPreferencesDataStore
+
+        @Provides
+        @Singleton
+        @ListeningPreferencesDataStore
+        fun provideListeningPreferencesDataStore(
+            @ApplicationContext context: Context
+        ): DataStore<Preferences> = context.listeningPreferencesDataStore
 
         @Provides
         @Singleton

--- a/core/data/src/main/kotlin/com/riffle/core/data/di/ListeningPreferencesDataStoreExt.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/di/ListeningPreferencesDataStoreExt.kt
@@ -1,0 +1,9 @@
+package com.riffle.core.data.di
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.preferencesDataStore
+
+val Context.listeningPreferencesDataStore: DataStore<Preferences>
+    by preferencesDataStore(name = "listening_preferences")

--- a/core/data/src/test/kotlin/com/riffle/core/data/AudioPlaybackPreferencesStoreImplTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/AudioPlaybackPreferencesStoreImplTest.kt
@@ -26,11 +26,14 @@ class AudioPlaybackPreferencesStoreImplTest {
     }
 
     @Test
-    fun `saving the default removes the record`() = runTest {
+    fun `saving 1x persists an explicit per-book choice and does not delete the row`() = runTest {
+        // 1.0x is a deliberate "play THIS book at normal speed" choice that must survive even when the
+        // global default speed is faster — deleting the row would snap the book back to that global
+        // default on reopen. (Pre-global-default this deleted the row under "no row == 1.0x default".)
         val store = AudioPlaybackPreferencesStoreImpl(FakeDao())
         store.save(id, 1.5f)
         store.save(id, DEFAULT_PLAYBACK_SPEED)
-        assertNull("default speed must not persist a row", store.load(id))
+        assertEquals(DEFAULT_PLAYBACK_SPEED, store.load(id))
     }
 
     @Test

--- a/core/data/src/test/kotlin/com/riffle/core/data/ListeningPreferencesStoreTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/ListeningPreferencesStoreTest.kt
@@ -57,6 +57,18 @@ class ListeningPreferencesStoreTest {
     }
 
     @Test
+    fun `default rewindIntervalSeconds is 15 when DataStore is empty`() = testScope.runTest {
+        assertEquals(15, buildStore().rewindIntervalSeconds.first())
+    }
+
+    @Test
+    fun `setRewindIntervalSeconds persists and reads back`() = testScope.runTest {
+        val store = buildStore()
+        store.setRewindIntervalSeconds(10)
+        assertEquals(10, store.rewindIntervalSeconds.first())
+    }
+
+    @Test
     fun `default rewindOnResumeSeconds is 0 when DataStore is empty`() = testScope.runTest {
         assertEquals(0, buildStore().rewindOnResumeSeconds.first())
     }
@@ -79,6 +91,7 @@ class ListeningPreferencesStoreTest {
             )
             store.setDefaultPlaybackSpeed(2.0f)
             store.setSkipIntervalSeconds(45)
+            store.setRewindIntervalSeconds(10)
             store.setRewindOnResumeSeconds(5)
         }
         writeScope.cancel()
@@ -89,6 +102,7 @@ class ListeningPreferencesStoreTest {
         )
         assertEquals(2.0f, runBlocking { store2.defaultPlaybackSpeed.first() })
         assertEquals(45, runBlocking { store2.skipIntervalSeconds.first() })
+        assertEquals(10, runBlocking { store2.rewindIntervalSeconds.first() })
         assertEquals(5, runBlocking { store2.rewindOnResumeSeconds.first() })
         readScope.cancel()
     }

--- a/core/data/src/test/kotlin/com/riffle/core/data/ListeningPreferencesStoreTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/ListeningPreferencesStoreTest.kt
@@ -1,0 +1,95 @@
+package com.riffle.core.data
+
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import com.riffle.core.domain.ListeningPreferencesStore
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ListeningPreferencesStoreTest {
+
+    @get:Rule
+    val tmp = TemporaryFolder()
+
+    private val dispatcher = UnconfinedTestDispatcher()
+    private val testScope = TestScope(dispatcher)
+
+    private fun buildStore() = ListeningPreferencesStoreImpl(
+        PreferenceDataStoreFactory.create(
+            scope = testScope.backgroundScope,
+            produceFile = { tmp.newFile("listening_prefs.preferences_pb") },
+        )
+    )
+
+    @Test
+    fun `default playback speed is 1_0 when DataStore is empty`() = testScope.runTest {
+        assertEquals(1.0f, buildStore().defaultPlaybackSpeed.first())
+    }
+
+    @Test
+    fun `setDefaultPlaybackSpeed persists and reads back`() = testScope.runTest {
+        val store = buildStore()
+        store.setDefaultPlaybackSpeed(1.5f)
+        assertEquals(1.5f, store.defaultPlaybackSpeed.first())
+    }
+
+    @Test
+    fun `default skipIntervalSeconds is 30 when DataStore is empty`() = testScope.runTest {
+        assertEquals(30, buildStore().skipIntervalSeconds.first())
+    }
+
+    @Test
+    fun `setSkipIntervalSeconds persists and reads back`() = testScope.runTest {
+        val store = buildStore()
+        store.setSkipIntervalSeconds(15)
+        assertEquals(15, store.skipIntervalSeconds.first())
+    }
+
+    @Test
+    fun `default rewindOnResumeSeconds is 0 when DataStore is empty`() = testScope.runTest {
+        assertEquals(0, buildStore().rewindOnResumeSeconds.first())
+    }
+
+    @Test
+    fun `setRewindOnResumeSeconds persists and reads back`() = testScope.runTest {
+        val store = buildStore()
+        store.setRewindOnResumeSeconds(10)
+        assertEquals(10, store.rewindOnResumeSeconds.first())
+    }
+
+    @Test
+    fun `settings persist across store instances`() {
+        val file = tmp.newFile("listening_round_trip.preferences_pb")
+
+        val writeScope = CoroutineScope(UnconfinedTestDispatcher() + Job())
+        runBlocking {
+            val store = ListeningPreferencesStoreImpl(
+                PreferenceDataStoreFactory.create(scope = writeScope, produceFile = { file })
+            )
+            store.setDefaultPlaybackSpeed(2.0f)
+            store.setSkipIntervalSeconds(45)
+            store.setRewindOnResumeSeconds(5)
+        }
+        writeScope.cancel()
+
+        val readScope = CoroutineScope(UnconfinedTestDispatcher() + Job())
+        val store2 = ListeningPreferencesStoreImpl(
+            PreferenceDataStoreFactory.create(scope = readScope, produceFile = { file })
+        )
+        assertEquals(2.0f, runBlocking { store2.defaultPlaybackSpeed.first() })
+        assertEquals(45, runBlocking { store2.skipIntervalSeconds.first() })
+        assertEquals(5, runBlocking { store2.rewindOnResumeSeconds.first() })
+        readScope.cancel()
+    }
+}

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/ListeningPreferencesStore.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/ListeningPreferencesStore.kt
@@ -1,0 +1,25 @@
+package com.riffle.core.domain
+
+import kotlinx.coroutines.flow.Flow
+
+interface ListeningPreferencesStore {
+
+    /** Global default playback speed applied when no per-book override exists. */
+    val defaultPlaybackSpeed: Flow<Float>
+
+    /** Seconds the ⏪/⏩ skip buttons jump. */
+    val skipIntervalSeconds: Flow<Int>
+
+    /** Seconds to rewind when resuming after a pause or stop. */
+    val rewindOnResumeSeconds: Flow<Int>
+
+    suspend fun setDefaultPlaybackSpeed(speed: Float)
+    suspend fun setSkipIntervalSeconds(seconds: Int)
+    suspend fun setRewindOnResumeSeconds(seconds: Int)
+
+    companion object {
+        const val DEFAULT_PLAYBACK_SPEED = 1.0f
+        const val DEFAULT_SKIP_INTERVAL_SECONDS = 30
+        const val DEFAULT_REWIND_ON_RESUME_SECONDS = 0
+    }
+}

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/ListeningPreferencesStore.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/ListeningPreferencesStore.kt
@@ -7,19 +7,24 @@ interface ListeningPreferencesStore {
     /** Global default playback speed applied when no per-book override exists. */
     val defaultPlaybackSpeed: Flow<Float>
 
-    /** Seconds the ⏪/⏩ skip buttons jump. */
+    /** Seconds the ⏩ forward button jumps. */
     val skipIntervalSeconds: Flow<Int>
+
+    /** Seconds the ⏪ rewind button jumps back. */
+    val rewindIntervalSeconds: Flow<Int>
 
     /** Seconds to rewind when resuming after a pause or stop. */
     val rewindOnResumeSeconds: Flow<Int>
 
     suspend fun setDefaultPlaybackSpeed(speed: Float)
     suspend fun setSkipIntervalSeconds(seconds: Int)
+    suspend fun setRewindIntervalSeconds(seconds: Int)
     suspend fun setRewindOnResumeSeconds(seconds: Int)
 
     companion object {
         const val DEFAULT_PLAYBACK_SPEED = 1.0f
         const val DEFAULT_SKIP_INTERVAL_SECONDS = 30
+        const val DEFAULT_REWIND_INTERVAL_SECONDS = 15
         const val DEFAULT_REWIND_ON_RESUME_SECONDS = 0
     }
 }

--- a/docs/superpowers/plans/2026-06-15-global-listening-preferences.md
+++ b/docs/superpowers/plans/2026-06-15-global-listening-preferences.md
@@ -1,0 +1,675 @@
+# Global Listening Preferences Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add three global listening settings (default playback speed, skip interval, auto-rewind on resume) to the Settings screen, with the default speed flowing into both player ViewModels as the per-book fallback.
+
+**Architecture:** A new `ListeningPreferencesStore` domain interface backed by a single DataStore file, following the identical pattern used by `WakeLockPreferencesStoreImpl` / `VolumeKeyPreferencesStoreImpl`. Settings are exposed in a new "Listening" section on the Settings screen via three inline `SingleChoiceSegmentedButtonRow` controls. Both `EpubReaderViewModel` and `AudiobookPlayerViewModel` receive the store via injection and swap their hardcoded `DEFAULT_PLAYBACK_SPEED` fallback for the live global value.
+
+**Tech Stack:** Kotlin, Jetpack Compose (Material 3 `SingleChoiceSegmentedButtonRow`), AndroidX DataStore Preferences, Hilt
+
+---
+
+## File Map
+
+| Status | File | Purpose |
+|---|---|---|
+| Create | `core/domain/src/main/kotlin/com/riffle/core/domain/ListeningPreferencesStore.kt` | Domain interface + constants |
+| Create | `core/data/src/main/kotlin/com/riffle/core/data/di/ListeningPreferencesDataStoreExt.kt` | DataStore extension property |
+| Create | `core/data/src/main/kotlin/com/riffle/core/data/ListeningPreferencesStoreImpl.kt` | DataStore-backed implementation |
+| Create | `core/data/src/test/kotlin/com/riffle/core/data/ListeningPreferencesStoreTest.kt` | Unit tests |
+| Modify | `core/data/src/main/kotlin/com/riffle/core/data/di/DataModule.kt` | Qualifier annotation + binding + provider |
+| Modify | `app/src/main/kotlin/com/riffle/app/feature/settings/SettingsViewModel.kt` | Inject store, expose 3 StateFlows + 3 setters |
+| Modify | `app/src/main/kotlin/com/riffle/app/feature/settings/SettingsScreen.kt` | "Listening" section with 3 segmented-button rows |
+| Modify | `app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt` | Inject store; replace hardcoded default fallback |
+| Modify | `app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModel.kt` | Inject store; replace hardcoded default fallback |
+
+---
+
+### Task 1: Domain interface
+
+**Files:**
+- Create: `core/domain/src/main/kotlin/com/riffle/core/domain/ListeningPreferencesStore.kt`
+
+- [ ] **Step 1: Create the domain interface**
+
+```kotlin
+package com.riffle.core.domain
+
+import kotlinx.coroutines.flow.Flow
+
+interface ListeningPreferencesStore {
+
+    /** Global default playback speed applied when no per-book override exists. */
+    val defaultPlaybackSpeed: Flow<Float>
+
+    /** Seconds the ⏪/⏩ skip buttons jump. */
+    val skipIntervalSeconds: Flow<Int>
+
+    /** Seconds to rewind when resuming after a pause or stop. */
+    val rewindOnResumeSeconds: Flow<Int>
+
+    suspend fun setDefaultPlaybackSpeed(speed: Float)
+    suspend fun setSkipIntervalSeconds(seconds: Int)
+    suspend fun setRewindOnResumeSeconds(seconds: Int)
+
+    companion object {
+        const val DEFAULT_PLAYBACK_SPEED = 1.0f
+        const val DEFAULT_SKIP_INTERVAL_SECONDS = 30
+        const val DEFAULT_REWIND_ON_RESUME_SECONDS = 0
+    }
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add core/domain/src/main/kotlin/com/riffle/core/domain/ListeningPreferencesStore.kt
+git commit -m "feat(domain): add ListeningPreferencesStore interface"
+```
+
+---
+
+### Task 2: DataStore extension + implementation
+
+**Files:**
+- Create: `core/data/src/main/kotlin/com/riffle/core/data/di/ListeningPreferencesDataStoreExt.kt`
+- Create: `core/data/src/main/kotlin/com/riffle/core/data/ListeningPreferencesStoreImpl.kt`
+
+- [ ] **Step 1: Create the DataStore extension property**
+
+```kotlin
+package com.riffle.core.data.di
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.preferencesDataStore
+
+val Context.listeningPreferencesDataStore: DataStore<Preferences>
+    by preferencesDataStore(name = "listening_preferences")
+```
+
+- [ ] **Step 2: Create the implementation**
+
+```kotlin
+package com.riffle.core.data
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.floatPreferencesKey
+import androidx.datastore.preferences.core.intPreferencesKey
+import com.riffle.core.data.di.ListeningPreferencesDataStore
+import com.riffle.core.domain.ListeningPreferencesStore
+import com.riffle.core.domain.ListeningPreferencesStore.Companion.DEFAULT_PLAYBACK_SPEED
+import com.riffle.core.domain.ListeningPreferencesStore.Companion.DEFAULT_REWIND_ON_RESUME_SECONDS
+import com.riffle.core.domain.ListeningPreferencesStore.Companion.DEFAULT_SKIP_INTERVAL_SECONDS
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+
+class ListeningPreferencesStoreImpl @Inject constructor(
+    @param:ListeningPreferencesDataStore private val dataStore: DataStore<Preferences>,
+) : ListeningPreferencesStore {
+
+    override val defaultPlaybackSpeed: Flow<Float> = dataStore.data.map { prefs ->
+        prefs[KEY_DEFAULT_PLAYBACK_SPEED] ?: DEFAULT_PLAYBACK_SPEED
+    }
+
+    override val skipIntervalSeconds: Flow<Int> = dataStore.data.map { prefs ->
+        prefs[KEY_SKIP_INTERVAL_SECONDS] ?: DEFAULT_SKIP_INTERVAL_SECONDS
+    }
+
+    override val rewindOnResumeSeconds: Flow<Int> = dataStore.data.map { prefs ->
+        prefs[KEY_REWIND_ON_RESUME_SECONDS] ?: DEFAULT_REWIND_ON_RESUME_SECONDS
+    }
+
+    override suspend fun setDefaultPlaybackSpeed(speed: Float) {
+        dataStore.edit { prefs -> prefs[KEY_DEFAULT_PLAYBACK_SPEED] = speed }
+    }
+
+    override suspend fun setSkipIntervalSeconds(seconds: Int) {
+        dataStore.edit { prefs -> prefs[KEY_SKIP_INTERVAL_SECONDS] = seconds }
+    }
+
+    override suspend fun setRewindOnResumeSeconds(seconds: Int) {
+        dataStore.edit { prefs -> prefs[KEY_REWIND_ON_RESUME_SECONDS] = seconds }
+    }
+
+    private companion object {
+        val KEY_DEFAULT_PLAYBACK_SPEED = floatPreferencesKey("default_playback_speed")
+        val KEY_SKIP_INTERVAL_SECONDS = intPreferencesKey("skip_interval_seconds")
+        val KEY_REWIND_ON_RESUME_SECONDS = intPreferencesKey("rewind_on_resume_seconds")
+    }
+}
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add core/data/src/main/kotlin/com/riffle/core/data/di/ListeningPreferencesDataStoreExt.kt
+git add core/data/src/main/kotlin/com/riffle/core/data/ListeningPreferencesStoreImpl.kt
+git commit -m "feat(data): add ListeningPreferencesStoreImpl backed by DataStore"
+```
+
+---
+
+### Task 3: Unit tests
+
+**Files:**
+- Create: `core/data/src/test/kotlin/com/riffle/core/data/ListeningPreferencesStoreTest.kt`
+
+The test follows the exact pattern of `WakeLockPreferencesStoreTest` — a `PreferenceDataStoreFactory` with `TemporaryFolder`, `TestScope(UnconfinedTestDispatcher())`, and a `buildStore()` helper.
+
+- [ ] **Step 1: Write the tests**
+
+```kotlin
+package com.riffle.core.data
+
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import com.riffle.core.domain.ListeningPreferencesStore
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ListeningPreferencesStoreTest {
+
+    @get:Rule
+    val tmp = TemporaryFolder()
+
+    private val dispatcher = UnconfinedTestDispatcher()
+    private val testScope = TestScope(dispatcher)
+
+    private fun buildStore() = ListeningPreferencesStoreImpl(
+        PreferenceDataStoreFactory.create(
+            scope = testScope.backgroundScope,
+            produceFile = { tmp.newFile("listening_prefs.preferences_pb") },
+        )
+    )
+
+    @Test
+    fun `default playback speed is 1_0 when DataStore is empty`() = testScope.runTest {
+        assertEquals(1.0f, buildStore().defaultPlaybackSpeed.first())
+    }
+
+    @Test
+    fun `setDefaultPlaybackSpeed persists and reads back`() = testScope.runTest {
+        val store = buildStore()
+        store.setDefaultPlaybackSpeed(1.5f)
+        assertEquals(1.5f, store.defaultPlaybackSpeed.first())
+    }
+
+    @Test
+    fun `default skipIntervalSeconds is 30 when DataStore is empty`() = testScope.runTest {
+        assertEquals(30, buildStore().skipIntervalSeconds.first())
+    }
+
+    @Test
+    fun `setSkipIntervalSeconds persists and reads back`() = testScope.runTest {
+        val store = buildStore()
+        store.setSkipIntervalSeconds(15)
+        assertEquals(15, store.skipIntervalSeconds.first())
+    }
+
+    @Test
+    fun `default rewindOnResumeSeconds is 0 when DataStore is empty`() = testScope.runTest {
+        assertEquals(0, buildStore().rewindOnResumeSeconds.first())
+    }
+
+    @Test
+    fun `setRewindOnResumeSeconds persists and reads back`() = testScope.runTest {
+        val store = buildStore()
+        store.setRewindOnResumeSeconds(10)
+        assertEquals(10, store.rewindOnResumeSeconds.first())
+    }
+
+    @Test
+    fun `settings persist across store instances`() {
+        val file = tmp.newFile("listening_round_trip.preferences_pb")
+
+        val writeScope = CoroutineScope(UnconfinedTestDispatcher() + Job())
+        runBlocking {
+            val store = ListeningPreferencesStoreImpl(
+                PreferenceDataStoreFactory.create(scope = writeScope, produceFile = { file })
+            )
+            store.setDefaultPlaybackSpeed(2.0f)
+            store.setSkipIntervalSeconds(45)
+            store.setRewindOnResumeSeconds(5)
+        }
+        writeScope.cancel()
+
+        val readScope = CoroutineScope(UnconfinedTestDispatcher() + Job())
+        val store2 = ListeningPreferencesStoreImpl(
+            PreferenceDataStoreFactory.create(scope = readScope, produceFile = { file })
+        )
+        assertEquals(2.0f, runBlocking { store2.defaultPlaybackSpeed.first() })
+        assertEquals(45, runBlocking { store2.skipIntervalSeconds.first() })
+        assertEquals(5, runBlocking { store2.rewindOnResumeSeconds.first() })
+        readScope.cancel()
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they pass**
+
+```bash
+export JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"
+./gradlew :core:data:test --tests "com.riffle.core.data.ListeningPreferencesStoreTest"
+```
+
+Expected: all 8 tests PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add core/data/src/test/kotlin/com/riffle/core/data/ListeningPreferencesStoreTest.kt
+git commit -m "test(data): add ListeningPreferencesStoreTest"
+```
+
+---
+
+### Task 4: DI registration in DataModule
+
+**Files:**
+- Modify: `core/data/src/main/kotlin/com/riffle/core/data/di/DataModule.kt`
+
+DataModule has three regions to edit:
+1. The qualifier annotations block (around line 132) — add `@ListeningPreferencesDataStore`
+2. The `@Binds` abstract functions block (around line 304) — add a binding for `ListeningPreferencesStore`
+3. The `@Provides` companion object (around line 628) — add a provider for the DataStore instance
+
+- [ ] **Step 1: Add the qualifier annotation**
+
+Find the block that declares `@WakeLockPreferencesDataStore` and `@VolumeKeyPreferencesDataStore`, and add directly below:
+
+```kotlin
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class ListeningPreferencesDataStore
+```
+
+- [ ] **Step 2: Add the `@Binds` binding**
+
+Find the line:
+```kotlin
+    abstract fun bindVolumeKeyPreferencesStore(impl: VolumeKeyPreferencesStoreImpl): VolumeKeyPreferencesStore
+```
+Add below it:
+
+```kotlin
+    @Binds
+    @Singleton
+    abstract fun bindListeningPreferencesStore(impl: ListeningPreferencesStoreImpl): ListeningPreferencesStore
+```
+
+Also add the required imports at the top of DataModule.kt:
+```kotlin
+import com.riffle.core.data.ListeningPreferencesStoreImpl
+import com.riffle.core.domain.ListeningPreferencesStore
+```
+
+- [ ] **Step 3: Add the `@Provides` DataStore provider**
+
+Find the `provideVolumeKeyPreferencesDataStore` function and add below it:
+
+```kotlin
+        @Provides
+        @Singleton
+        @ListeningPreferencesDataStore
+        fun provideListeningPreferencesDataStore(
+            @ApplicationContext context: Context
+        ): DataStore<Preferences> = context.listeningPreferencesDataStore
+```
+
+Also add the import:
+```kotlin
+import com.riffle.core.data.di.listeningPreferencesDataStore
+```
+
+- [ ] **Step 4: Verify the build compiles**
+
+```bash
+export JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"
+./gradlew :core:data:compileDebugKotlin
+```
+
+Expected: BUILD SUCCESSFUL with no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add core/data/src/main/kotlin/com/riffle/core/data/di/DataModule.kt
+git commit -m "feat(data): register ListeningPreferencesStore in DI"
+```
+
+---
+
+### Task 5: SettingsViewModel
+
+**Files:**
+- Modify: `app/src/main/kotlin/com/riffle/app/feature/settings/SettingsViewModel.kt`
+
+- [ ] **Step 1: Add the constructor parameter**
+
+Find the existing constructor parameter list. Add `listeningPreferencesStore` after `volumeKeyPreferencesStore`:
+
+```kotlin
+    private val listeningPreferencesStore: ListeningPreferencesStore,
+```
+
+Add the import:
+```kotlin
+import com.riffle.core.domain.ListeningPreferencesStore
+```
+
+- [ ] **Step 2: Expose three StateFlows**
+
+Find the block where `keepScreenOn`, `volumeKeyNavigationEnabled`, and `invertVolumeKeys` are declared and add below them:
+
+```kotlin
+    val defaultPlaybackSpeed: StateFlow<Float> = listeningPreferencesStore.defaultPlaybackSpeed
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), ListeningPreferencesStore.DEFAULT_PLAYBACK_SPEED)
+
+    val skipIntervalSeconds: StateFlow<Int> = listeningPreferencesStore.skipIntervalSeconds
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), ListeningPreferencesStore.DEFAULT_SKIP_INTERVAL_SECONDS)
+
+    val rewindOnResumeSeconds: StateFlow<Int> = listeningPreferencesStore.rewindOnResumeSeconds
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), ListeningPreferencesStore.DEFAULT_REWIND_ON_RESUME_SECONDS)
+```
+
+- [ ] **Step 3: Add three setter methods**
+
+Find the block where `setKeepScreenOn`, `setVolumeKeyNavigationEnabled`, and `setInvertVolumeKeys` are declared and add below them:
+
+```kotlin
+    fun setDefaultPlaybackSpeed(speed: Float) {
+        viewModelScope.launch { listeningPreferencesStore.setDefaultPlaybackSpeed(speed) }
+    }
+
+    fun setSkipIntervalSeconds(seconds: Int) {
+        viewModelScope.launch { listeningPreferencesStore.setSkipIntervalSeconds(seconds) }
+    }
+
+    fun setRewindOnResumeSeconds(seconds: Int) {
+        viewModelScope.launch { listeningPreferencesStore.setRewindOnResumeSeconds(seconds) }
+    }
+```
+
+- [ ] **Step 4: Verify build**
+
+```bash
+export JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"
+./gradlew :app:compileDebugKotlin
+```
+
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/kotlin/com/riffle/app/feature/settings/SettingsViewModel.kt
+git commit -m "feat(settings): expose listening preference StateFlows in SettingsViewModel"
+```
+
+---
+
+### Task 6: SettingsScreen UI
+
+**Files:**
+- Modify: `app/src/main/kotlin/com/riffle/app/feature/settings/SettingsScreen.kt`
+
+The "Listening" section goes between the existing "Reading" `HorizontalDivider` (after the reading `ListItem`) and the "Crash reports" section header.
+
+- [ ] **Step 1: Collect the three new StateFlows in the composable**
+
+Find the existing `collectAsState()` calls near line 77 and add:
+
+```kotlin
+    val defaultPlaybackSpeed by viewModel.defaultPlaybackSpeed.collectAsState()
+    val skipIntervalSeconds by viewModel.skipIntervalSeconds.collectAsState()
+    val rewindOnResumeSeconds by viewModel.rewindOnResumeSeconds.collectAsState()
+```
+
+Add the import (if not present — `PlaybackSpeed` lives in the same app module):
+```kotlin
+import com.riffle.app.feature.audio.PlaybackSpeed
+```
+
+- [ ] **Step 2: Add the Listening section to the column body**
+
+Find this code:
+```kotlin
+                HorizontalDivider()
+
+                Text(
+                    text = "Crash reports",
+```
+Insert the following block immediately before it:
+
+```kotlin
+                Text(
+                    text = "Listening",
+                    style = MaterialTheme.typography.titleSmall,
+                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+                )
+                HorizontalDivider()
+                ListeningSpeedRow(
+                    defaultSpeed = defaultPlaybackSpeed,
+                    onDefaultSpeedChange = { viewModel.setDefaultPlaybackSpeed(it) },
+                )
+                HorizontalDivider()
+                ListeningSkipIntervalRow(
+                    skipIntervalSeconds = skipIntervalSeconds,
+                    onSkipIntervalSecondsChange = { viewModel.setSkipIntervalSeconds(it) },
+                )
+                HorizontalDivider()
+                ListeningRewindRow(
+                    rewindOnResumeSeconds = rewindOnResumeSeconds,
+                    onRewindOnResumeSecondsChange = { viewModel.setRewindOnResumeSeconds(it) },
+                )
+                HorizontalDivider()
+
+```
+
+- [ ] **Step 3: Add the three private composables at the bottom of the file**
+
+Add after the closing brace of `AppThemeRow`:
+
+```kotlin
+@Composable
+private fun ListeningSpeedRow(
+    defaultSpeed: Float,
+    onDefaultSpeedChange: (Float) -> Unit,
+) {
+    ListItem(
+        headlineContent = { Text("Default speed") },
+        supportingContent = { Text("Starting speed when opening a book for the first time") },
+    )
+    SingleChoiceSegmentedButtonRow(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 4.dp),
+    ) {
+        PlaybackSpeed.PRESETS.forEachIndexed { index, speed ->
+            SegmentedButton(
+                selected = speed == defaultSpeed,
+                onClick = { onDefaultSpeedChange(speed) },
+                shape = SegmentedButtonDefaults.itemShape(index = index, count = PlaybackSpeed.PRESETS.size),
+            ) {
+                Text(PlaybackSpeed.label(speed))
+            }
+        }
+    }
+}
+
+@Composable
+private fun ListeningSkipIntervalRow(
+    skipIntervalSeconds: Int,
+    onSkipIntervalSecondsChange: (Int) -> Unit,
+) {
+    val options = listOf(10, 15, 30, 45, 60)
+    ListItem(
+        headlineContent = { Text("Skip interval") },
+        supportingContent = { Text("Seconds the ⏪/⏩ buttons jump") },
+    )
+    SingleChoiceSegmentedButtonRow(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 4.dp),
+    ) {
+        options.forEachIndexed { index, seconds ->
+            SegmentedButton(
+                selected = seconds == skipIntervalSeconds,
+                onClick = { onSkipIntervalSecondsChange(seconds) },
+                shape = SegmentedButtonDefaults.itemShape(index = index, count = options.size),
+            ) {
+                Text("${seconds}s")
+            }
+        }
+    }
+}
+
+@Composable
+private fun ListeningRewindRow(
+    rewindOnResumeSeconds: Int,
+    onRewindOnResumeSecondsChange: (Int) -> Unit,
+) {
+    val options = listOf(0, 5, 10, 30)
+    ListItem(
+        headlineContent = { Text("Rewind on resume") },
+        supportingContent = { Text("Seconds to rewind when resuming after a pause") },
+    )
+    SingleChoiceSegmentedButtonRow(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 4.dp),
+    ) {
+        options.forEachIndexed { index, seconds ->
+            SegmentedButton(
+                selected = seconds == rewindOnResumeSeconds,
+                onClick = { onRewindOnResumeSecondsChange(seconds) },
+                shape = SegmentedButtonDefaults.itemShape(index = index, count = options.size),
+            ) {
+                Text(if (seconds == 0) "Off" else "${seconds}s")
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Verify build**
+
+```bash
+export JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"
+./gradlew :app:compileDebugKotlin
+```
+
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/kotlin/com/riffle/app/feature/settings/SettingsScreen.kt
+git commit -m "feat(settings): add Listening section with speed, skip interval, and rewind settings"
+```
+
+---
+
+### Task 7: Player integration — use global default as per-book fallback
+
+The two spots that hardcode `AudioPlaybackPreferencesStore.DEFAULT_PLAYBACK_SPEED` as the per-book fallback need to use the global `ListeningPreferencesStore.defaultPlaybackSpeed` instead. Both are inside `suspend`-context coroutine blocks, so `.first()` is safe.
+
+**Files:**
+- Modify: `app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt`
+- Modify: `app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModel.kt`
+
+#### EpubReaderViewModel
+
+- [ ] **Step 1: Add constructor parameter**
+
+Find `private val audioPlaybackPreferencesStore: AudioPlaybackPreferencesStore,` in the constructor and add after it:
+
+```kotlin
+    private val listeningPreferencesStore: ListeningPreferencesStore,
+```
+
+Add the import:
+```kotlin
+import com.riffle.core.domain.ListeningPreferencesStore
+```
+
+- [ ] **Step 2: Replace the hardcoded fallback (line 449)**
+
+Find:
+```kotlin
+            initialSpeed = audioPlaybackPreferencesStore.load(audioSettingsIdentity)
+                ?: AudioPlaybackPreferencesStore.DEFAULT_PLAYBACK_SPEED
+```
+Replace with:
+```kotlin
+            initialSpeed = audioPlaybackPreferencesStore.load(audioSettingsIdentity)
+                ?: listeningPreferencesStore.defaultPlaybackSpeed.first()
+```
+
+Also add the import at the top of the file if not already present:
+```kotlin
+import kotlinx.coroutines.flow.first
+```
+
+#### AudiobookPlayerViewModel
+
+- [ ] **Step 3: Add constructor parameter**
+
+Find `private val audioPlaybackPreferencesStore: AudioPlaybackPreferencesStore,` in the constructor and add after it:
+
+```kotlin
+    private val listeningPreferencesStore: ListeningPreferencesStore,
+```
+
+Add the imports:
+```kotlin
+import com.riffle.core.domain.ListeningPreferencesStore
+import kotlinx.coroutines.flow.first
+```
+
+- [ ] **Step 4: Replace the hardcoded fallback (line 452)**
+
+Find:
+```kotlin
+            val initialSpeed = audioPlaybackPreferencesStore.load(audioSettingsIdentity)
+                ?: AudioPlaybackPreferencesStore.DEFAULT_PLAYBACK_SPEED
+```
+Replace with:
+```kotlin
+            val initialSpeed = audioPlaybackPreferencesStore.load(audioSettingsIdentity)
+                ?: listeningPreferencesStore.defaultPlaybackSpeed.first()
+```
+
+- [ ] **Step 5: Verify the full build and unit tests pass**
+
+```bash
+export JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"
+./gradlew test
+```
+
+Expected: BUILD SUCCESSFUL, all tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+git add app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModel.kt
+git commit -m "feat(player): use global default speed as per-book playback speed fallback"
+```


### PR DESCRIPTION
## Summary

Adds a global **Listening** settings section and fixes two long-standing audiobook player bugs.

### Listening settings (new)
A device-local `ListeningPreferencesStore` (DataStore) plus a dedicated **Listening** panel in Settings, exposing:
- **Default playback speed** — used as the fallback for any book with no per-book speed.
- **Forward skip** / **Backward rewind** intervals — wired into the player's transport icons.
- **Rewind on resume** — how far to back up when resuming.

### Bug fixes
1. **Rewind-on-resume only fired on an in-player pause→play, never on reopen.** Reopening an in-progress audiobook (the most common "left and came back" resume) plays directly via `openBook`, which bypassed the rewind. Now the configured rewind is applied to the prepared playback start on the normal-open path (skipped for the readaloud→audiobook handoff, which must continue seamlessly).
2. **An explicit per-book speed of 1.0× was silently discarded.** `AudioPlaybackPreferencesStore.save()` deleted the row whenever the speed equalled 1.0× under the old "no row == default" rule. With a configurable global default that can be faster than 1.0×, an explicit "play this book at normal speed" choice was erased and snapped back to the global default on reopen. `save()` now persists the chosen speed verbatim; `clear()` remains for genuine un-customization.

Plus a code-review follow-up: the open-path rewind shifts only the **playback start**, not the persisted resume floor (`reconciledResumeSec`), so re-hearing the rewound seconds can't let repeated open→close cycles creep saved progress backward.

### Tests
- New unit tests for the per-book speed persistence (verbatim save, including 1.0×) and the open-path rewind (rewind applied / zero = no rewind / clamps to 0 near start / **floor preserved**).
- Fixes a pre-existing stale selector in `WakeLockHarnessTest` (tapped "Reading settings" — now the panel's title; the Settings entry is the "Formatting" item). Harness tests don't run in CI, so it had gone red unnoticed on main.

## Testing
- `./gradlew test` — green
- `./gradlew lint` — green
- Harness phone subset (API-25 `Harness_Medium_Phone`): **211 tests, 5 skipped, 0 failed**
- Harness tablet subset (`@TabletLayout`): **5 tests, 0 failed**
- Both player fixes verified end-to-end on a device emulator (per-book 1× persisted across a force-stop/reopen against a 1.5× global default; reopen rewound exactly the configured 10s).
