### PR TITLE
docs: remove Codeberg references

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Riffle lets you browse your library, read EPUB and PDF files, listen to audioboo
 |---------|--------|
 | Google Play Store | Planned |
 | F-Droid | Planned |
-| Codeberg Releases | CI-built signed APK |
+| GitHub Releases | CI-built signed APK |
 
 ## Architecture
 


### PR DESCRIPTION
## What

The project is hosted on GitHub, but the README's Distribution table still listed **Codeberg Releases** as the channel for the CI-built signed APK. This was the only remaining Codeberg reference in the repo.

## Change

- `README.md`: rename the distribution row from `Codeberg Releases` to `GitHub Releases`.

Verified with `grep -rni codeberg` — no references remain.