### PR TITLE
fix(library): mark read/unread across the readaloud-coupled ebook + audiobook

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModel.kt
@@ -226,8 +226,7 @@ class LibraryItemDetailViewModel @Inject constructor(
 
     fun markAsRead() {
         viewModelScope.launch {
-            repository.updateReadingProgress(itemId, 1.0f)
-            sessionRepository.setProgress(itemId, 1.0f)
+            setFinishedAcrossCoupledItems(finished = true)
             val current = _uiState.value
             if (current is LibraryItemDetailUiState.Ready) {
                 // invariant: ADR 0018 — Read books are never in To Read
@@ -242,13 +241,42 @@ class LibraryItemDetailViewModel @Inject constructor(
 
     fun markAsUnread() {
         viewModelScope.launch {
-            repository.updateReadingProgress(itemId, 0.0f)
-            sessionRepository.setProgress(itemId, 0.0f)
+            setFinishedAcrossCoupledItems(finished = false)
             val current = _uiState.value
             if (current is LibraryItemDetailUiState.Ready) {
                 _uiState.value = current.copy(item = current.item.copy(readingProgress = 0.0f))
             }
         }
+    }
+
+    /**
+     * Mark read/unread across every ABS item coupled by the same readaloud bundle — the ebook AND
+     * its audiobook counterpart — so the two never disagree (a readaloud's ebook and audiobook are
+     * separate ABS items that should track one finished state). Falls back to just this item when
+     * there's no link or no active server.
+     */
+    private suspend fun setFinishedAcrossCoupledItems(finished: Boolean) {
+        val progress = if (finished) 1.0f else 0.0f
+        val serverId = serverRepository.getActive()?.id
+        val ids = if (serverId != null) coupledAbsItemIds(serverId) else listOf(itemId)
+        ids.forEach { id ->
+            repository.updateReadingProgress(id, progress)
+            sessionRepository.markFinished(id, finished)
+        }
+    }
+
+    /**
+     * The set of ABS item ids on the active server that share this item's readaloud bundle
+     * (always includes [itemId]). Cross-server matches are excluded — `markFinished` operates on
+     * the active server only.
+     */
+    private suspend fun coupledAbsItemIds(serverId: String): List<String> {
+        val link = readaloudLinkRepository.findByAbsItem(serverId, itemId) ?: return listOf(itemId)
+        val siblings = readaloudLinkRepository
+            .findByStorytellerBook(link.storytellerServerId, link.storytellerBookId)
+            .filter { it.absServerId == serverId }
+            .map { it.absLibraryItemId }
+        return (siblings + itemId).distinct()
     }
 
     fun toggleToRead() {

--- a/app/src/test/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModelBookmarkTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModelBookmarkTest.kt
@@ -655,6 +655,7 @@ class AudiobookPlayerViewModelBookmarkTest {
     private object FakeResumeStore : ReadaloudResumeStore {
         override suspend fun save(serverId: String, itemId: String, position: ReadaloudResumePosition) {}
         override suspend fun load(serverId: String, itemId: String): ReadaloudResumePosition? = null
+        override suspend fun clear(serverId: String, itemId: String) {}
     }
 
     // A ReaderSyncFactory whose two attach methods return null, so the player stays on its single-peer

--- a/app/src/test/kotlin/com/riffle/app/feature/audiobook/SleepTimerTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/audiobook/SleepTimerTest.kt
@@ -518,6 +518,7 @@ class SleepTimerTest {
     private object FakeResumeStore : ReadaloudResumeStore {
         override suspend fun save(serverId: String, itemId: String, position: ReadaloudResumePosition) {}
         override suspend fun load(serverId: String, itemId: String): ReadaloudResumePosition? = null
+        override suspend fun clear(serverId: String, itemId: String) {}
     }
 
     private class TestReaderSyncFactory : ReaderSyncFactory(

--- a/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModelTest.kt
@@ -185,7 +185,16 @@ class LibraryItemDetailViewModelTest {
     private val noOpSessionRepository = object : ReadingSessionRepository {
         override suspend fun syncProgress(itemId: String, payload: SessionPayload): SyncSessionResult = SyncSessionResult.Success
         override suspend fun runSyncCycle(itemId: String, payload: SessionPayload): ProgressSyncCycleResult = ProgressSyncCycleResult.InSync
-        override suspend fun setProgress(itemId: String, progress: Float) = Unit
+        override suspend fun markFinished(itemId: String, finished: Boolean) = Unit
+        override suspend fun touchOpenTimestamp(itemId: String) = Unit
+    }
+
+    /** Records every (itemId, finished) handed to markFinished so a test can assert the fan-out. */
+    private class RecordingSessionRepository : ReadingSessionRepository {
+        val markFinishedCalls = mutableListOf<Pair<String, Boolean>>()
+        override suspend fun syncProgress(itemId: String, payload: SessionPayload): SyncSessionResult = SyncSessionResult.Success
+        override suspend fun runSyncCycle(itemId: String, payload: SessionPayload): ProgressSyncCycleResult = ProgressSyncCycleResult.InSync
+        override suspend fun markFinished(itemId: String, finished: Boolean) { markFinishedCalls += itemId to finished }
         override suspend fun touchOpenTimestamp(itemId: String) = Unit
     }
 
@@ -242,6 +251,7 @@ class LibraryItemDetailViewModelTest {
         serverRepository: ServerRepository = noOpServerRepo,
         connectivityObserver: ConnectivityObserver = FakeConnectivityObserver(),
         downloadManager: DownloadManager = DownloadManager(kotlinx.coroutines.CoroutineScope(testDispatcher)),
+        sessionRepository: ReadingSessionRepository = noOpSessionRepository,
         readaloudLinkRepository: com.riffle.core.domain.ReadaloudLinkRepository = NoopReadaloudLinkRepository,
         readaloudAudioRepository: com.riffle.core.domain.ReadaloudAudioRepository = NoopReadaloudAudioRepository,
         crossEpubIndexBuildTrigger: com.riffle.core.data.CrossEpubIndexBuildTrigger = RecordingBuildTrigger(),
@@ -252,7 +262,7 @@ class LibraryItemDetailViewModelTest {
         tokenStorage = noOpTokenStorage,
         epubRepository = epubRepository,
         pdfRepository = pdfRepository,
-        sessionRepository = noOpSessionRepository,
+        sessionRepository = sessionRepository,
         toReadRepository = toReadRepo,
         readaloudLinkRepository = readaloudLinkRepository,
         readaloudAudioRepository = readaloudAudioRepository,
@@ -276,6 +286,22 @@ class LibraryItemDetailViewModelTest {
             override suspend fun findByStorytellerBook(storytellerServerId: String, storytellerBookId: String) = listOf(link)
             override suspend fun unlinkAbsItem(absServerId: String, absLibraryItemId: String) = Unit
             override suspend fun countForServer(serverId: String) = 1
+        }
+
+    /**
+     * A link repo where the opened item and [allLinks] all share one Storyteller book — models a
+     * readaloud's ebook + audiobook as two coupled ABS items.
+     */
+    private fun linkRepoCoupling(allLinks: List<com.riffle.core.domain.ReadaloudLink>) =
+        object : com.riffle.core.domain.ReadaloudLinkRepository {
+            override fun observeAll() = flowOf(allLinks)
+            override fun observeLinkedAbsItemIds() = flowOf(allLinks.map { it.absLibraryItemId }.toSet())
+            override suspend fun findByAbsItem(absServerId: String, absLibraryItemId: String) =
+                allLinks.firstOrNull { it.absServerId == absServerId && it.absLibraryItemId == absLibraryItemId }
+            override suspend fun findByStorytellerBook(storytellerServerId: String, storytellerBookId: String) =
+                allLinks.filter { it.storytellerServerId == storytellerServerId && it.storytellerBookId == storytellerBookId }
+            override suspend fun unlinkAbsItem(absServerId: String, absLibraryItemId: String) = Unit
+            override suspend fun countForServer(serverId: String) = allLinks.size
         }
 
     private fun serverRepoReturning(server: Server) = object : ServerRepository {
@@ -529,6 +555,62 @@ class LibraryItemDetailViewModelTest {
 
         assertEquals(listOf(knownItem.id to knownItem.libraryId), toRead.removeCalls)
         assertFalse((vm.uiState.value as Ready).isInToRead)
+    }
+
+    // Bug 1: marking the ebook read must also mark its readaloud-coupled audiobook (a separate ABS
+    // item) finished, so the two don't disagree.
+    @Test
+    fun `markAsRead marks every readaloud-coupled item finished`() = runTest {
+        val ebookLink = com.riffle.core.domain.ReadaloudLink(
+            storytellerServerId = "st-1", storytellerBookId = "book-1",
+            absServerId = "abs-1", absLibraryItemId = "item-1", userConfirmed = true,
+        )
+        val audiobookLink = ebookLink.copy(absLibraryItemId = "audio-2")
+        val session = RecordingSessionRepository()
+        val vm = makeVm(
+            repo = fakeRepo(knownItem),
+            serverRepository = serverRepoReturning(activeServer()),
+            sessionRepository = session,
+            readaloudLinkRepository = linkRepoCoupling(listOf(ebookLink, audiobookLink)),
+        )
+        backgroundScope.launch { vm.uiState.collect {} }
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        vm.markAsRead()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(
+            setOf("item-1" to true, "audio-2" to true),
+            session.markFinishedCalls.toSet(),
+        )
+    }
+
+    // Bug 2: marking unread must reset BOTH coupled items to 0 so a surviving audiobook progress
+    // can't reappear as ghost progress.
+    @Test
+    fun `markAsUnread marks every readaloud-coupled item not finished`() = runTest {
+        val ebookLink = com.riffle.core.domain.ReadaloudLink(
+            storytellerServerId = "st-1", storytellerBookId = "book-1",
+            absServerId = "abs-1", absLibraryItemId = "item-1", userConfirmed = true,
+        )
+        val audiobookLink = ebookLink.copy(absLibraryItemId = "audio-2")
+        val session = RecordingSessionRepository()
+        val vm = makeVm(
+            repo = fakeRepo(knownItem.copy(readingProgress = 1.0f)),
+            serverRepository = serverRepoReturning(activeServer()),
+            sessionRepository = session,
+            readaloudLinkRepository = linkRepoCoupling(listOf(ebookLink, audiobookLink)),
+        )
+        backgroundScope.launch { vm.uiState.collect {} }
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        vm.markAsUnread()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(
+            setOf("item-1" to false, "audio-2" to false),
+            session.markFinishedCalls.toSet(),
+        )
     }
 
     @Test

--- a/core/data/src/main/kotlin/com/riffle/core/data/ReadaloudResumeStoreImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/ReadaloudResumeStoreImpl.kt
@@ -27,4 +27,6 @@ class ReadaloudResumeStoreImpl @Inject constructor(
         dao.getByItemId(serverId, itemId)?.let {
             ReadaloudResumePosition(href = it.href, progression = it.progression, fragmentRef = it.fragmentRef)
         }
+
+    override suspend fun clear(serverId: String, itemId: String) = dao.deleteByItemId(serverId, itemId)
 }

--- a/core/data/src/main/kotlin/com/riffle/core/data/ReadingSessionRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/ReadingSessionRepositoryImpl.kt
@@ -1,6 +1,8 @@
 package com.riffle.core.data
 
+import com.riffle.core.domain.AudiobookPositionStore
 import com.riffle.core.domain.ProgressSyncCycleResult
+import com.riffle.core.domain.ReadaloudResumeStore
 import com.riffle.core.domain.ReadingPositionStore
 import com.riffle.core.domain.ReadingSessionRepository
 import com.riffle.core.domain.Server
@@ -20,6 +22,8 @@ class ReadingSessionRepositoryImpl @Inject constructor(
     private val serverRepository: ServerRepository,
     private val tokenStorage: TokenStorage,
     private val positionStore: ReadingPositionStore,
+    private val audiobookPositionStore: AudiobookPositionStore,
+    private val readaloudResumeStore: ReadaloudResumeStore,
 ) : ReadingSessionRepository {
 
     override suspend fun syncProgress(itemId: String, payload: SessionPayload): SyncSessionResult {
@@ -96,10 +100,20 @@ class ReadingSessionRepositoryImpl @Inject constructor(
         // Read = keep the saved page; unread = clear it so the reader reopens at the start and the
         // 0 progress isn't contradicted by a stale cfi.
         val ebookLocation = if (finished) (positionStore.load(server.id, itemId) ?: "") else ""
-        if (!finished) positionStore.save(server.id, itemId, "")
+        val now = System.currentTimeMillis()
+        if (!finished) {
+            // Wipe EVERY local position store that could otherwise restore a stale position the next
+            // time the book is opened (and re-save it, resurrecting the progress). The ebook reading
+            // position alone isn't enough: a matched/readaloud book also resumes from the audiobook
+            // position (translated back into an ebook locator on open) and the readaloud-resume row.
+            positionStore.save(server.id, itemId, "")
+            audiobookPositionStore.save(server.id, itemId, 0.0)
+            audiobookPositionStore.updateLocalTimestamp(server.id, itemId, now)
+            readaloudResumeStore.clear(server.id, itemId)
+        }
         // Bump before token check: marks the record dirty so the sync cycle pushes it
         // even if the token is missing right now.
-        positionStore.updateLocalTimestamp(server.id, itemId, System.currentTimeMillis())
+        positionStore.updateLocalTimestamp(server.id, itemId, now)
         val token = tokenStorage.getToken(server.id) ?: return
         api.syncEbookProgress(
             server.url.value, itemId,

--- a/core/data/src/main/kotlin/com/riffle/core/data/ReadingSessionRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/ReadingSessionRepositoryImpl.kt
@@ -91,16 +91,25 @@ class ReadingSessionRepositoryImpl @Inject constructor(
         )
     }
 
-    override suspend fun setProgress(itemId: String, progress: Float) {
+    override suspend fun markFinished(itemId: String, finished: Boolean) {
         val server = serverRepository.getActive() ?: return
-        val cfi = positionStore.load(server.id, itemId) ?: ""
+        // Read = keep the saved page; unread = clear it so the reader reopens at the start and the
+        // 0 progress isn't contradicted by a stale cfi.
+        val ebookLocation = if (finished) (positionStore.load(server.id, itemId) ?: "") else ""
+        if (!finished) positionStore.save(server.id, itemId, "")
         // Bump before token check: marks the record dirty so the sync cycle pushes it
         // even if the token is missing right now.
         positionStore.updateLocalTimestamp(server.id, itemId, System.currentTimeMillis())
         val token = tokenStorage.getToken(server.id) ?: return
         api.syncEbookProgress(
             server.url.value, itemId,
-            NetworkEbookProgressPayload(cfi, progress),
+            // isFinished resets the audio half of the record too: true→progress 1, false→currentTime
+            // and progress 0. Both halves move together so neither can re-shadow the other.
+            NetworkEbookProgressPayload(
+                ebookLocation = ebookLocation,
+                ebookProgress = if (finished) 1.0f else 0.0f,
+                isFinished = finished,
+            ),
             token, server.insecureConnectionAllowed,
         )
         // PATCH failure intentionally ignored — next sync cycle will push

--- a/core/data/src/test/kotlin/com/riffle/core/data/LibraryRepositoryTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/LibraryRepositoryTest.kt
@@ -223,7 +223,7 @@ class LibraryRepositoryTest {
             com.riffle.core.domain.SyncSessionResult.Success
         override suspend fun runSyncCycle(itemId: String, payload: com.riffle.core.domain.SessionPayload) =
             com.riffle.core.domain.ProgressSyncCycleResult.InSync
-        override suspend fun setProgress(itemId: String, progress: Float) = Unit
+        override suspend fun markFinished(itemId: String, finished: Boolean) = Unit
         override suspend fun touchOpenTimestamp(itemId: String) = Unit
     }
 
@@ -233,7 +233,7 @@ class LibraryRepositoryTest {
             com.riffle.core.domain.SyncSessionResult.Success
         override suspend fun runSyncCycle(itemId: String, payload: com.riffle.core.domain.SessionPayload) =
             com.riffle.core.domain.ProgressSyncCycleResult.InSync
-        override suspend fun setProgress(itemId: String, progress: Float) = Unit
+        override suspend fun markFinished(itemId: String, finished: Boolean) = Unit
         override suspend fun touchOpenTimestamp(itemId: String) { touchedItemIds += itemId }
     }
 

--- a/core/data/src/test/kotlin/com/riffle/core/data/MarkUnreadServerResetTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/MarkUnreadServerResetTest.kt
@@ -1,0 +1,172 @@
+package com.riffle.core.data
+
+import com.riffle.core.domain.AudiobookPositionStore
+import com.riffle.core.domain.AuthenticateResult
+import com.riffle.core.domain.CommitServerResult
+import com.riffle.core.domain.PendingServer
+import com.riffle.core.domain.ReadaloudResumePosition
+import com.riffle.core.domain.ReadaloudResumeStore
+import com.riffle.core.domain.ReadingPositionStore
+import com.riffle.core.domain.Server
+import com.riffle.core.domain.ServerRepository
+import com.riffle.core.domain.ServerUrl
+import com.riffle.core.domain.TokenStorage
+import com.riffle.core.network.AbsSessionApi
+import com.riffle.core.network.NetworkAudiobookProgressPayload
+import com.riffle.core.network.NetworkEbookProgressPayload
+import com.riffle.core.network.NetworkGetProgressResult
+import com.riffle.core.network.NetworkServerProgress
+import com.riffle.core.network.NetworkSyncSessionResult
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Reproduces the "phantom progress after mark-unread" bug at the layer that drives it: the reader's
+ * reconciliation reads each ABS item's media-progress from the SERVER on open, and the audiobook peer
+ * jumps the reader to `currentTime` whenever `currentTime > 0`. So an unread that doesn't zero the
+ * server's audio dimension lets the old position re-appear on reopen.
+ *
+ * The fake ABS here encodes the real server's verified semantics (checked live against
+ * media-server:13378, ABS 2.35.1): a PATCH carrying `isFinished=false` zeroes `currentTime`+`progress`;
+ * `isFinished=true` sets `progress=1`; ebook fields are independent. `markFinished` must drive that
+ * flag so both the ebook and audio dimensions reset to 0.
+ */
+class MarkUnreadServerResetTest {
+
+    private class Record(
+        var ebookLocation: String = "",
+        var ebookProgress: Float = 0f,
+        var currentTime: Double = 0.0,
+        var duration: Double = 0.0,
+        var progress: Double = 0.0,
+        var isFinished: Boolean = false,
+        var lastUpdate: Long = 0L,
+    )
+
+    /** Stateful ABS emulation — mirrors the live-verified `/api/me/progress/:id` PATCH semantics. */
+    private class StatefulAbsApi(private var clock: Long = 1_000L) : AbsSessionApi {
+        val records = mutableMapOf<String, Record>()
+        fun seed(itemId: String, r: Record) { records[itemId] = r }
+        private fun rec(itemId: String) = records.getOrPut(itemId) { Record() }
+
+        override suspend fun syncEbookProgress(
+            baseUrl: String, libraryItemId: String, payload: NetworkEbookProgressPayload,
+            token: String, insecureAllowed: Boolean,
+        ): NetworkSyncSessionResult {
+            val r = rec(libraryItemId)
+            r.ebookLocation = payload.ebookLocation
+            r.ebookProgress = payload.ebookProgress
+            when (payload.isFinished) {
+                true -> { r.isFinished = true; r.progress = 1.0 }
+                false -> { r.isFinished = false; r.progress = 0.0; r.currentTime = 0.0 }
+                null -> {}
+            }
+            r.lastUpdate = ++clock
+            return NetworkSyncSessionResult.Success(r.lastUpdate)
+        }
+
+        override suspend fun syncAudiobookProgress(
+            baseUrl: String, libraryItemId: String, payload: NetworkAudiobookProgressPayload,
+            token: String, insecureAllowed: Boolean,
+        ): NetworkSyncSessionResult {
+            val r = rec(libraryItemId)
+            r.currentTime = payload.currentTime
+            r.duration = payload.duration
+            r.lastUpdate = ++clock
+            return NetworkSyncSessionResult.Success(r.lastUpdate)
+        }
+
+        override suspend fun getProgress(
+            baseUrl: String, libraryItemId: String, token: String, insecureAllowed: Boolean,
+        ): NetworkGetProgressResult {
+            val r = records[libraryItemId] ?: return NetworkGetProgressResult.Success(NetworkServerProgress("", lastUpdate = 0L))
+            return NetworkGetProgressResult.Success(
+                NetworkServerProgress(r.ebookLocation, r.ebookProgress, r.currentTime, r.duration, r.lastUpdate)
+            )
+        }
+    }
+
+    private fun repo(api: AbsSessionApi) = ReadingSessionRepositoryImpl(
+        api = api,
+        serverRepository = object : ServerRepository {
+            val server = Server("s1", ServerUrl.parse("http://localhost")!!, true, false, "")
+            override fun observeAll(): Flow<List<Server>> = flowOf(listOf(server))
+            override suspend fun getActive(): Server = server
+            override suspend fun authenticate(url: ServerUrl, username: String, password: String, insecureAllowed: Boolean, serverType: com.riffle.core.domain.ServerType): AuthenticateResult = throw UnsupportedOperationException()
+            override suspend fun commit(pending: PendingServer, hiddenLibraryIds: Set<String>): CommitServerResult = throw UnsupportedOperationException()
+            override suspend fun setActive(serverId: String) = Unit
+            override suspend fun remove(serverId: String) = Unit
+            override suspend fun getServerVersion(serverId: String): String? = null
+        },
+        tokenStorage = object : TokenStorage {
+            override suspend fun saveToken(serverId: String, token: String) = Unit
+            override suspend fun getToken(serverId: String): String? = "tok"
+            override suspend fun deleteToken(serverId: String) = Unit
+        },
+        positionStore = object : ReadingPositionStore {
+            override suspend fun save(serverId: String, itemId: String, payload: String) = Unit
+            override suspend fun load(serverId: String, itemId: String): String? = null
+            override suspend fun loadLocalUpdatedAt(serverId: String, itemId: String): Long = 0L
+            override suspend fun updateLocalTimestamp(serverId: String, itemId: String, millis: Long) = Unit
+        },
+        audiobookPositionStore = object : AudiobookPositionStore {
+            override suspend fun save(serverId: String, itemId: String, payload: Double) = Unit
+            override suspend fun load(serverId: String, itemId: String): Double? = null
+            override suspend fun loadLocalUpdatedAt(serverId: String, itemId: String): Long = 0L
+            override suspend fun updateLocalTimestamp(serverId: String, itemId: String, millis: Long) = Unit
+        },
+        readaloudResumeStore = object : ReadaloudResumeStore {
+            override suspend fun save(serverId: String, itemId: String, position: ReadaloudResumePosition) = Unit
+            override suspend fun load(serverId: String, itemId: String): ReadaloudResumePosition? = null
+            override suspend fun clear(serverId: String, itemId: String) = Unit
+        },
+    )
+
+    // The crux of the phantom: an audiobook item read to the middle. After mark-unread the server's
+    // currentTime/progress MUST be 0, or the reader's audiobook peer reads currentTime>0 on reopen and
+    // jumps back to it (and re-saves the progress).
+    @Test
+    fun `mark-unread zeroes the server audiobook currentTime so the reconcile reads no position`() = runTest {
+        val api = StatefulAbsApi()
+        api.seed("audio-1", Record(currentTime = 5_000.0, duration = 10_000.0, progress = 0.5, lastUpdate = 100L))
+
+        repo(api).markFinished("audio-1", finished = false)
+
+        val r = api.records.getValue("audio-1")
+        assertEquals(0.0, r.currentTime, 1e-9)
+        assertEquals(0.0, r.progress, 1e-9)
+        assertEquals(false, r.isFinished)
+        // The audiobook reconcile peer returns EMPTY when currentTime <= 0 — i.e. no inbound position,
+        // so local (start) wins and the reader does not jump back.
+        val server = (api.getProgress("", "audio-1", "tok", false) as NetworkGetProgressResult.Success).progress
+        assertEquals(0.0, server.currentTime, 1e-9)
+    }
+
+    @Test
+    fun `mark-unread clears the server ebook location and progress`() = runTest {
+        val api = StatefulAbsApi()
+        api.seed("ebook-1", Record(ebookLocation = "epubcfi(/6/8!/4/1:0)", ebookProgress = 0.9f, lastUpdate = 100L))
+
+        repo(api).markFinished("ebook-1", finished = false)
+
+        val r = api.records.getValue("ebook-1")
+        assertEquals("", r.ebookLocation)
+        assertEquals(0f, r.ebookProgress)
+        assertEquals(false, r.isFinished)
+    }
+
+    @Test
+    fun `mark-read sets the server finished flag and full progress on a coupled audiobook`() = runTest {
+        val api = StatefulAbsApi()
+        api.seed("audio-1", Record(currentTime = 3_000.0, duration = 10_000.0, progress = 0.3, lastUpdate = 100L))
+
+        repo(api).markFinished("audio-1", finished = true)
+
+        val r = api.records.getValue("audio-1")
+        assertEquals(true, r.isFinished)
+        assertEquals(1.0, r.progress, 1e-9)
+    }
+}

--- a/core/data/src/test/kotlin/com/riffle/core/data/ProgressSyncCycleTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/ProgressSyncCycleTest.kt
@@ -20,6 +20,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -29,11 +30,20 @@ class ProgressSyncCycleTest {
 
     // --- fakes ---
 
-    private class FakePositionStore(var localUpdatedAt: Long = 0L) : ReadingPositionStore {
+    private class FakePositionStore(
+        var localUpdatedAt: Long = 0L,
+        private var storedCfi: String? = null,
+    ) : ReadingPositionStore {
         var updatedTimestamp: Long? = null
         var updatedServerId: String? = null
-        override suspend fun save(serverId: String, itemId: String, payload: String) = Unit
-        override suspend fun load(serverId: String, itemId: String): String? = null
+        var savedPayload: String? = null
+        var saveCalled = false
+        override suspend fun save(serverId: String, itemId: String, payload: String) {
+            saveCalled = true
+            savedPayload = payload
+            storedCfi = payload
+        }
+        override suspend fun load(serverId: String, itemId: String): String? = storedCfi
         override suspend fun loadLocalUpdatedAt(serverId: String, itemId: String): Long = localUpdatedAt
         override suspend fun updateLocalTimestamp(serverId: String, itemId: String, millis: Long) {
             updatedServerId = serverId
@@ -47,11 +57,13 @@ class ProgressSyncCycleTest {
         private val patchResult: NetworkSyncSessionResult = NetworkSyncSessionResult.Success(0L),
     ) : AbsSessionApi {
         var patchCallCount = 0
+        var lastEbookPayload: NetworkEbookProgressPayload? = null
         override suspend fun syncEbookProgress(
             baseUrl: String, libraryItemId: String, payload: NetworkEbookProgressPayload,
             token: String, insecureAllowed: Boolean,
         ): NetworkSyncSessionResult {
             patchCallCount++
+            lastEbookPayload = payload
             return patchResult
         }
         override suspend fun syncAudiobookProgress(
@@ -198,17 +210,49 @@ class ProgressSyncCycleTest {
     }
 
     @Test
-    fun `setProgress bumps localUpdatedAt and attempts PATCH`() = runTest {
-        val positionStore = FakePositionStore(localUpdatedAt = 1_000L)
+    fun `markFinished true PATCHes ebookProgress 1 and isFinished true, keeps saved position`() = runTest {
+        // Read = mark complete on BOTH dimensions. isFinished=true is what flips the audio
+        // `progress` to 100% (bug 1: "marking read doesn't mark the related audiobook").
+        val positionStore = FakePositionStore(localUpdatedAt = 1_000L, storedCfi = "epubcfi(/6/8!/4/1:0)")
         val api = FakeSessionApi(
             getResult = NetworkGetProgressResult.NetworkError(IOException("unused")),
             patchResult = NetworkSyncSessionResult.Success(2_000L),
         )
         val repo = buildRepo(api, positionStore)
 
-        repo.setProgress("item-1", 1.0f)
+        repo.markFinished("item-1", finished = true)
 
         assertEquals(1, api.patchCallCount)
+        assertEquals(1.0f, api.lastEbookPayload?.ebookProgress)
+        assertEquals(true, api.lastEbookPayload?.isFinished)
+        // Read keeps the page the user reached.
+        assertEquals("epubcfi(/6/8!/4/1:0)", api.lastEbookPayload?.ebookLocation)
+        assertFalse(positionStore.saveCalled)
+        assertNotNull(positionStore.updatedTimestamp)
+        assertTrue(positionStore.updatedTimestamp!! > 0L)
+    }
+
+    @Test
+    fun `markFinished false PATCHes ebookProgress 0 and isFinished false, clears the saved position`() = runTest {
+        // Unread = reset BOTH dimensions to 0. isFinished=false zeroes the audio currentTime/progress
+        // on the server so it can't re-shadow the 0 ebookProgress on the next refresh (bug 2:
+        // "marking unread restores an old progress").
+        val positionStore = FakePositionStore(localUpdatedAt = 1_000L, storedCfi = "epubcfi(/6/8!/4/1:0)")
+        val api = FakeSessionApi(
+            getResult = NetworkGetProgressResult.NetworkError(IOException("unused")),
+            patchResult = NetworkSyncSessionResult.Success(2_000L),
+        )
+        val repo = buildRepo(api, positionStore)
+
+        repo.markFinished("item-1", finished = false)
+
+        assertEquals(1, api.patchCallCount)
+        assertEquals(0.0f, api.lastEbookPayload?.ebookProgress)
+        assertEquals(false, api.lastEbookPayload?.isFinished)
+        assertEquals("", api.lastEbookPayload?.ebookLocation)
+        // Unread clears the local saved position so the reader reopens at the start.
+        assertTrue(positionStore.saveCalled)
+        assertEquals("", positionStore.savedPayload)
         assertNotNull(positionStore.updatedTimestamp)
         assertTrue(positionStore.updatedTimestamp!! > 0L)
     }
@@ -265,7 +309,7 @@ class ProgressSyncCycleTest {
     }
 
     @Test
-    fun `setProgress bumps localUpdatedAt even when PATCH fails`() = runTest {
+    fun `markFinished bumps localUpdatedAt even when PATCH fails`() = runTest {
         val positionStore = FakePositionStore(localUpdatedAt = 1_000L)
         val api = FakeSessionApi(
             getResult = NetworkGetProgressResult.NetworkError(IOException("unused")),
@@ -273,7 +317,7 @@ class ProgressSyncCycleTest {
         )
         val repo = buildRepo(api, positionStore)
 
-        repo.setProgress("item-1", 1.0f)
+        repo.markFinished("item-1", finished = true)
 
         assertEquals(1, api.patchCallCount)
         assertNotNull(positionStore.updatedTimestamp)

--- a/core/data/src/test/kotlin/com/riffle/core/data/ProgressSyncCycleTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/ProgressSyncCycleTest.kt
@@ -75,7 +75,34 @@ class ProgressSyncCycleTest {
         ): NetworkGetProgressResult = getResult
     }
 
-    private fun buildRepo(api: AbsSessionApi, positionStore: ReadingPositionStore) =
+    private class FakeAudiobookPositionStore : com.riffle.core.domain.AudiobookPositionStore {
+        var savedPayload: Double? = null
+        var saveCalled = false
+        var updatedTimestamp: Long? = null
+        override suspend fun save(serverId: String, itemId: String, payload: Double) {
+            saveCalled = true
+            savedPayload = payload
+        }
+        override suspend fun load(serverId: String, itemId: String): Double? = null
+        override suspend fun loadLocalUpdatedAt(serverId: String, itemId: String): Long = 0L
+        override suspend fun updateLocalTimestamp(serverId: String, itemId: String, millis: Long) {
+            updatedTimestamp = millis
+        }
+    }
+
+    private class FakeReadaloudResumeStore : com.riffle.core.domain.ReadaloudResumeStore {
+        var clearCalled = false
+        override suspend fun save(serverId: String, itemId: String, position: com.riffle.core.domain.ReadaloudResumePosition) = Unit
+        override suspend fun load(serverId: String, itemId: String): com.riffle.core.domain.ReadaloudResumePosition? = null
+        override suspend fun clear(serverId: String, itemId: String) { clearCalled = true }
+    }
+
+    private fun buildRepo(
+        api: AbsSessionApi,
+        positionStore: ReadingPositionStore,
+        audiobookPositionStore: com.riffle.core.domain.AudiobookPositionStore = FakeAudiobookPositionStore(),
+        readaloudResumeStore: com.riffle.core.domain.ReadaloudResumeStore = FakeReadaloudResumeStore(),
+    ) =
         ReadingSessionRepositoryImpl(
             api = api,
             serverRepository = object : ServerRepository {
@@ -94,6 +121,8 @@ class ProgressSyncCycleTest {
                 override suspend fun deleteToken(serverId: String) = Unit
             },
             positionStore = positionStore,
+            audiobookPositionStore = audiobookPositionStore,
+            readaloudResumeStore = readaloudResumeStore,
         )
 
     private val payload = SessionPayload("epubcfi(/6/4!/4/1:0)", 0.25f)
@@ -238,11 +267,13 @@ class ProgressSyncCycleTest {
         // on the server so it can't re-shadow the 0 ebookProgress on the next refresh (bug 2:
         // "marking unread restores an old progress").
         val positionStore = FakePositionStore(localUpdatedAt = 1_000L, storedCfi = "epubcfi(/6/8!/4/1:0)")
+        val audiobookStore = FakeAudiobookPositionStore()
+        val resumeStore = FakeReadaloudResumeStore()
         val api = FakeSessionApi(
             getResult = NetworkGetProgressResult.NetworkError(IOException("unused")),
             patchResult = NetworkSyncSessionResult.Success(2_000L),
         )
-        val repo = buildRepo(api, positionStore)
+        val repo = buildRepo(api, positionStore, audiobookStore, resumeStore)
 
         repo.markFinished("item-1", finished = false)
 
@@ -255,6 +286,28 @@ class ProgressSyncCycleTest {
         assertEquals("", positionStore.savedPayload)
         assertNotNull(positionStore.updatedTimestamp)
         assertTrue(positionStore.updatedTimestamp!! > 0L)
+        // ...and wipes the other stores that could otherwise restore the position on open.
+        assertTrue(audiobookStore.saveCalled)
+        assertEquals(0.0, audiobookStore.savedPayload)
+        assertNotNull(audiobookStore.updatedTimestamp)
+        assertTrue(resumeStore.clearCalled)
+    }
+
+    @Test
+    fun `markFinished true does not wipe audiobook or readaloud-resume stores`() = runTest {
+        val positionStore = FakePositionStore(localUpdatedAt = 1_000L, storedCfi = "epubcfi(/6/8!/4/1:0)")
+        val audiobookStore = FakeAudiobookPositionStore()
+        val resumeStore = FakeReadaloudResumeStore()
+        val api = FakeSessionApi(
+            getResult = NetworkGetProgressResult.NetworkError(IOException("unused")),
+            patchResult = NetworkSyncSessionResult.Success(2_000L),
+        )
+        val repo = buildRepo(api, positionStore, audiobookStore, resumeStore)
+
+        repo.markFinished("item-1", finished = true)
+
+        assertFalse(audiobookStore.saveCalled)
+        assertFalse(resumeStore.clearCalled)
     }
 
     // --- 404-equivalent (server has no progress record) ---

--- a/core/data/src/test/kotlin/com/riffle/core/data/ProgressSyncIntegrationTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/ProgressSyncIntegrationTest.kt
@@ -72,6 +72,17 @@ class ProgressSyncIntegrationTest {
             override suspend fun deleteToken(serverId: String) = Unit
         },
         positionStore = positionStore,
+        audiobookPositionStore = object : com.riffle.core.domain.AudiobookPositionStore {
+            override suspend fun save(serverId: String, itemId: String, payload: Double) = Unit
+            override suspend fun load(serverId: String, itemId: String): Double? = null
+            override suspend fun loadLocalUpdatedAt(serverId: String, itemId: String): Long = 0L
+            override suspend fun updateLocalTimestamp(serverId: String, itemId: String, millis: Long) = Unit
+        },
+        readaloudResumeStore = object : com.riffle.core.domain.ReadaloudResumeStore {
+            override suspend fun save(serverId: String, itemId: String, position: com.riffle.core.domain.ReadaloudResumePosition) = Unit
+            override suspend fun load(serverId: String, itemId: String): com.riffle.core.domain.ReadaloudResumePosition? = null
+            override suspend fun clear(serverId: String, itemId: String) = Unit
+        },
     )
 
     private fun json(code: Int, body: String) = MockResponse()

--- a/core/data/src/test/kotlin/com/riffle/core/data/ReadaloudResumeStoreTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/ReadaloudResumeStoreTest.kt
@@ -19,6 +19,9 @@ class ReadaloudResumeStoreTest {
         }
         override suspend fun getByItemId(serverId: String, itemId: String): ReadaloudResumePositionEntity? =
             entities[serverId to itemId]
+        override suspend fun deleteByItemId(serverId: String, itemId: String) {
+            entities.remove(serverId to itemId)
+        }
     }
 
     @Test
@@ -73,6 +76,15 @@ class ReadaloudResumeStoreTest {
         val after = System.currentTimeMillis()
         val ts = dao.store["server-A" to "item-1"]?.localUpdatedAt ?: 0L
         assert(ts in before..after) { "Expected timestamp in [$before..$after] but was $ts" }
+    }
+
+    @Test
+    fun `clear removes the saved position so load returns null`() = runTest {
+        val dao = FakeReadaloudResumePositionDao()
+        val store = ReadaloudResumeStoreImpl(dao)
+        store.save("server-A", "item-1", ReadaloudResumePosition("ch1.xhtml", 0.25, "ch1.xhtml#s5"))
+        store.clear("server-A", "item-1")
+        assertNull(store.load("server-A", "item-1"))
     }
 
     @Test

--- a/core/data/src/test/kotlin/com/riffle/core/data/ReadingSessionIntegrationTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/ReadingSessionIntegrationTest.kt
@@ -66,6 +66,17 @@ class ReadingSessionIntegrationTest {
             override suspend fun loadLocalUpdatedAt(serverId: String, itemId: String): Long = 0L
             override suspend fun updateLocalTimestamp(serverId: String, itemId: String, millis: Long) = Unit
         },
+        audiobookPositionStore = object : com.riffle.core.domain.AudiobookPositionStore {
+            override suspend fun save(serverId: String, itemId: String, payload: Double) = Unit
+            override suspend fun load(serverId: String, itemId: String): Double? = null
+            override suspend fun loadLocalUpdatedAt(serverId: String, itemId: String): Long = 0L
+            override suspend fun updateLocalTimestamp(serverId: String, itemId: String, millis: Long) = Unit
+        },
+        readaloudResumeStore = object : com.riffle.core.domain.ReadaloudResumeStore {
+            override suspend fun save(serverId: String, itemId: String, position: com.riffle.core.domain.ReadaloudResumePosition) = Unit
+            override suspend fun load(serverId: String, itemId: String): com.riffle.core.domain.ReadaloudResumePosition? = null
+            override suspend fun clear(serverId: String, itemId: String) = Unit
+        },
     )
 
     @Test

--- a/core/data/src/test/kotlin/com/riffle/core/data/SeriesIntegrationTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/SeriesIntegrationTest.kt
@@ -170,7 +170,7 @@ class SeriesIntegrationTest {
             com.riffle.core.domain.SyncSessionResult.Success
         override suspend fun runSyncCycle(itemId: String, payload: com.riffle.core.domain.SessionPayload) =
             com.riffle.core.domain.ProgressSyncCycleResult.InSync
-        override suspend fun setProgress(itemId: String, progress: Float) = Unit
+        override suspend fun markFinished(itemId: String, finished: Boolean) = Unit
         override suspend fun touchOpenTimestamp(itemId: String) = Unit
     }
 

--- a/core/database/src/main/kotlin/com/riffle/core/database/ReadaloudResumePositionDao.kt
+++ b/core/database/src/main/kotlin/com/riffle/core/database/ReadaloudResumePositionDao.kt
@@ -13,4 +13,7 @@ interface ReadaloudResumePositionDao {
 
     @Query("SELECT * FROM readaloud_resume_positions WHERE serverId = :serverId AND itemId = :itemId LIMIT 1")
     suspend fun getByItemId(serverId: String, itemId: String): ReadaloudResumePositionEntity?
+
+    @Query("DELETE FROM readaloud_resume_positions WHERE serverId = :serverId AND itemId = :itemId")
+    suspend fun deleteByItemId(serverId: String, itemId: String)
 }

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/ReadaloudResumeStore.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/ReadaloudResumeStore.kt
@@ -20,4 +20,7 @@ data class ReadaloudResumePosition(
 interface ReadaloudResumeStore {
     suspend fun save(serverId: String, itemId: String, position: ReadaloudResumePosition)
     suspend fun load(serverId: String, itemId: String): ReadaloudResumePosition?
+
+    /** Drop the saved resume position so a reopened book starts fresh (e.g. after "mark unread"). */
+    suspend fun clear(serverId: String, itemId: String)
 }

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/ReadingSessionRepository.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/ReadingSessionRepository.kt
@@ -3,7 +3,16 @@ package com.riffle.core.domain
 interface ReadingSessionRepository {
     suspend fun syncProgress(itemId: String, payload: SessionPayload): SyncSessionResult
     suspend fun runSyncCycle(itemId: String, payload: SessionPayload): ProgressSyncCycleResult
-    suspend fun setProgress(itemId: String, progress: Float)
+
+    /**
+     * Mark the item read/listened (`finished = true`) or unread/unlistened (`finished = false`)
+     * on ABS. Resets BOTH dimensions of the shared media-progress record in one PATCH: the ebook
+     * (`ebookProgress` → 1 or 0, `ebookLocation` cleared on unread) and the audio (`isFinished`
+     * flips `progress`/`currentTime`). Without the audio half, a finished/in-progress audiobook
+     * `progress` survives and re-shadows a 0 `ebookProgress` on the next library refresh (the
+     * "unread restores old progress" bug). Bumps the local position timestamp so the change syncs.
+     */
+    suspend fun markFinished(itemId: String, finished: Boolean)
 
     /**
      * Notify the ABS server that this user has just (re-)opened the item — used to drive the

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/ReadingSessionRepository.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/ReadingSessionRepository.kt
@@ -11,6 +11,10 @@ interface ReadingSessionRepository {
      * flips `progress`/`currentTime`). Without the audio half, a finished/in-progress audiobook
      * `progress` survives and re-shadows a 0 `ebookProgress` on the next library refresh (the
      * "unread restores old progress" bug). Bumps the local position timestamp so the change syncs.
+     *
+     * Unread additionally wipes every LOCAL position store for the item (reading position, audiobook
+     * position, readaloud resume) so reopening the book can't restore — and then re-save — a stale
+     * position from a store the server reset didn't cover.
      */
     suspend fun markFinished(itemId: String, finished: Boolean)
 

--- a/core/domain/src/test/kotlin/com/riffle/core/domain/ReadingSessionControllerTest.kt
+++ b/core/domain/src/test/kotlin/com/riffle/core/domain/ReadingSessionControllerTest.kt
@@ -22,7 +22,7 @@ class ReadingSessionControllerTest {
     ) = object : ReadingSessionRepository {
         override suspend fun syncProgress(itemId: String, payload: SessionPayload) = syncResult
         override suspend fun runSyncCycle(itemId: String, payload: SessionPayload): ProgressSyncCycleResult = ProgressSyncCycleResult.InSync
-        override suspend fun setProgress(itemId: String, progress: Float) = Unit
+        override suspend fun markFinished(itemId: String, finished: Boolean) = Unit
         override suspend fun touchOpenTimestamp(itemId: String) = Unit
     }
 
@@ -38,7 +38,7 @@ class ReadingSessionControllerTest {
                     return SyncSessionResult.Success
                 }
                 override suspend fun runSyncCycle(itemId: String, payload: SessionPayload): ProgressSyncCycleResult = ProgressSyncCycleResult.InSync
-                override suspend fun setProgress(itemId: String, progress: Float) = Unit
+                override suspend fun markFinished(itemId: String, finished: Boolean) = Unit
                 override suspend fun touchOpenTimestamp(itemId: String) = Unit
             },
             scope,
@@ -85,7 +85,7 @@ class ReadingSessionControllerTest {
                     return SyncSessionResult.Success
                 }
                 override suspend fun runSyncCycle(itemId: String, payload: SessionPayload): ProgressSyncCycleResult = ProgressSyncCycleResult.InSync
-                override suspend fun setProgress(itemId: String, progress: Float) = Unit
+                override suspend fun markFinished(itemId: String, finished: Boolean) = Unit
                 override suspend fun touchOpenTimestamp(itemId: String) = Unit
             },
             scope,

--- a/core/network/src/main/kotlin/com/riffle/core/network/AbsApiClient.kt
+++ b/core/network/src/main/kotlin/com/riffle/core/network/AbsApiClient.kt
@@ -522,7 +522,7 @@ class AbsApiClient(private val httpClient: OkHttpClient) : AbsApi, AbsLibraryApi
         insecureAllowed: Boolean,
     ): NetworkSyncSessionResult = withContext(Dispatchers.IO) {
         val client = if (insecureAllowed) httpClient.trustAllCerts() else httpClient
-        val body = json.encodeToString(AbsEbookProgressRequest(payload.ebookLocation, payload.ebookProgress))
+        val body = json.encodeToString(AbsEbookProgressRequest(payload.ebookLocation, payload.ebookProgress, payload.isFinished))
             .toRequestBody(jsonMediaType)
         val request = Request.Builder()
             .url("$baseUrl/api/me/progress/$libraryItemId")

--- a/core/network/src/main/kotlin/com/riffle/core/network/AbsSessionApi.kt
+++ b/core/network/src/main/kotlin/com/riffle/core/network/AbsSessionApi.kt
@@ -3,6 +3,11 @@ package com.riffle.core.network
 data class NetworkEbookProgressPayload(
     val ebookLocation: String,
     val ebookProgress: Float,
+    // When non-null, also flips ABS's item-level `isFinished` flag in the same PATCH. This is the
+    // only field that touches the AUDIO dimension (`currentTime`/`progress`) of the shared
+    // media-progress record — `true` sets `progress`=1, `false` zeroes `currentTime`+`progress`.
+    // Left null for ordinary reader position saves so the finished state is untouched.
+    val isFinished: Boolean? = null,
 )
 
 data class NetworkAudiobookProgressPayload(

--- a/core/network/src/main/kotlin/com/riffle/core/network/model/AbsSessionModels.kt
+++ b/core/network/src/main/kotlin/com/riffle/core/network/model/AbsSessionModels.kt
@@ -6,6 +6,9 @@ import kotlinx.serialization.Serializable
 internal data class AbsEbookProgressRequest(
     val ebookLocation: String,
     val ebookProgress: Float,
+    // Omitted from the JSON when null (encodeDefaults=false), so an ordinary position save sends
+    // only the ebook fields and never disturbs the item's finished/audio state.
+    val isFinished: Boolean? = null,
 )
 
 @Serializable

--- a/core/network/src/test/kotlin/com/riffle/core/network/AbsApiClientSessionTest.kt
+++ b/core/network/src/test/kotlin/com/riffle/core/network/AbsApiClientSessionTest.kt
@@ -57,6 +57,33 @@ class AbsApiClientSessionTest {
         assertTrue(body.contains("\"ebookProgress\":0.25"))
     }
 
+    // A plain reader position save (isFinished = null) must NOT carry isFinished, or every save
+    // would risk flipping the item's finished/audio state on the server.
+    @Test
+    fun `syncEbookProgress omits isFinished from body when null`() = runTest {
+        server.enqueue(MockResponse().setResponseCode(200).setBody("{}"))
+        client.syncEbookProgress(
+            baseUrl(), "item-1",
+            NetworkEbookProgressPayload("cfi", 0.25f, isFinished = null),
+            "tok", false,
+        )
+        val body = server.takeRequest().body.readUtf8()
+        assertTrue(!body.contains("isFinished"))
+    }
+
+    // A mark-read/unread carries isFinished so ABS also resets the audio dimension in the same PATCH.
+    @Test
+    fun `syncEbookProgress includes isFinished in body when set`() = runTest {
+        server.enqueue(MockResponse().setResponseCode(200).setBody("{}"))
+        client.syncEbookProgress(
+            baseUrl(), "item-1",
+            NetworkEbookProgressPayload("", 0.0f, isFinished = false),
+            "tok", false,
+        )
+        val body = server.takeRequest().body.readUtf8()
+        assertTrue(body.contains("\"isFinished\":false"))
+    }
+
     @Test
     fun `syncEbookProgress sends Authorization Bearer header`() = runTest {
         server.enqueue(MockResponse().setResponseCode(200).setBody("{}"))


### PR DESCRIPTION
## What

Marking a book **read** or **unread** only ever touched the *ebook* dimension of an ABS media-progress record, so two bugs surfaced on readaloud-coupled books (a readaloud's ebook and audiobook are separate ABS items sharing one bundle):

1. **Mark-read didn't mark the coupled audiobook.** Only the ebook item got `ebookProgress=1`; the audiobook item (and the audio dimension) stayed unfinished.
2. **Mark-unread restored an old progress.** Unread set `ebookProgress=0` but left the audio `progress`/`currentTime` alive. Riffle's display falls back to the audio `progress` when `ebookProgress` is 0 (ADR 0029), so the old % reappeared on the next library refresh — and reopening the book restored the position from local stores and re-saved it.

## How

- **Network:** add a nullable `isFinished` to `NetworkEbookProgressPayload` / `AbsEbookProgressRequest`, omitted from the JSON when null (so ordinary reader position saves are unchanged), passed through `AbsApiClient.syncEbookProgress`.
- **Repo:** replace `ReadingSessionRepository.setProgress(Float)` with `markFinished(itemId, Boolean)`, which resets **both** dimensions in one PATCH — read → `{keep cfi, ebookProgress=1, isFinished=true}`; unread → `{ebookLocation="", ebookProgress=0, isFinished=false}`. `isFinished` is the only field that resets the audio `currentTime`/`progress` (verified live against ABS 2.35.1).
- **Unread also wipes every local position store** for the item (reading position, audiobook position with a fresh timestamp, and readaloud-resume via a new `ReadaloudResumeStore.clear`) so reopening can't restore — and re-save — a stale position.
- **Fan-out:** `LibraryItemDetailViewModel` marks read/unread across every ABS item coupled by the same readaloud bundle (`findByAbsItem` → `findByStorytellerBook`, filtered to the active server), so the ebook and its audiobook track one finished state.

## Testing

- `./gradlew test` — green (unit + integration across all modules).
- `./gradlew lint` — green.
- New/updated suites: `MarkUnreadServerResetTest` (stateful ABS fake encoding the live-verified `isFinished` semantics proves the server audio `currentTime` is zeroed so the reconcile reads no position on reopen), `ProgressSyncCycleTest` (markFinished payloads + store wipes), `AbsApiClientSessionTest` (`isFinished` omitted when null / present when set), `ReadaloudResumeStoreTest` (`clear`), `LibraryItemDetailViewModelTest` (coupled fan-out).
- ABS PATCH/GET semantics verified live against the test server.
- Harness (instrumentation) tests skipped — the change has no UI/instrumentation surface; CI does not run connected tests.

Known limitation: the fan-out keys off the opened item being linked, so an unlinked ebook whose audiobook is linked separately won't propagate — a link-data completeness matter, not a code defect.