### PR TITLE
feat(readaloud): saturated highlight palette, clearer picker, dark-theme legibility

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -1390,7 +1390,7 @@ private fun EpubNavigatorView(
     // also re-keys on [sentenceQuotes] so the highlight re-applies with text once the quotes (built
     // off the main thread after the track loads) become available.
     val hasReadaloudDecoration = remember { mutableStateOf(false) }
-    LaunchedEffect(activeFragmentRef, reflowGeneration, pageLoadGeneration.value, sentenceQuotes, readaloudHighlightColor) {
+    LaunchedEffect(activeFragmentRef, reflowGeneration, pageLoadGeneration.value, sentenceQuotes, readaloudHighlightColor, formattingPrefs.theme) {
         val fragment = fragmentRef.value as? DecorableNavigator ?: return@LaunchedEffect
         val ref = activeFragmentRef
         if (ref == null) {
@@ -1407,9 +1407,10 @@ private fun EpubNavigatorView(
         val decoration = Decoration(
             id = "readaloud_active",
             locator = locator,
-            style = Decoration.Style.Highlight(
-                tint = readaloudHighlightColor.argb,
-                isActive = false,
+            // Dedicated readaloud style/template: opacity follows the tint's alpha so the highlight
+            // is stronger on dark reading themes and stays legible behind the white body text.
+            style = ReadaloudHighlightStyle(
+                tint = readaloudHighlightColor.readerTint(formattingPrefs.theme),
             ),
         )
         // Clear the group before re-applying. After the fragment is recreated (rotation) or its page

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/FormattingPreferencesMapper.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/FormattingPreferencesMapper.kt
@@ -11,6 +11,7 @@ import org.readium.r2.navigator.epub.EpubNavigatorFragment
 import org.readium.r2.navigator.epub.EpubPreferences
 import org.readium.r2.navigator.epub.css.ColCount
 import org.readium.r2.navigator.epub.css.RsProperties
+import org.readium.r2.navigator.html.HtmlDecorationTemplates
 import org.readium.r2.navigator.preferences.Color
 import org.readium.r2.navigator.preferences.FontFamily
 import org.readium.r2.navigator.preferences.Spread
@@ -82,6 +83,12 @@ fun FormattingPreferences.toFragmentConfiguration(
         // falls back to the default serif — Literata/Merriweather/OpenDyslexic would all
         // render identically.
         servedAssets = listOf("fonts/.*"),
+        // Keep Readium's built-in templates (used by persisted + search highlights) and add a
+        // dedicated readaloud highlight template whose opacity tracks the tint's alpha channel,
+        // so the synced highlight can be strengthened on dark reading themes (see readerTint()).
+        decorationTemplates = HtmlDecorationTemplates.defaultTemplates().apply {
+            set(ReadaloudHighlightStyle::class, readaloudHighlightTemplate())
+        },
         readiumCssRsProperties = when {
             isDoublePage -> RsProperties(
                 colCount = ColCount.TWO,

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ReadaloudHighlightDecoration.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ReadaloudHighlightDecoration.kt
@@ -1,0 +1,79 @@
+package com.riffle.app.feature.reader
+
+import android.graphics.Color
+import android.os.Parcel
+import android.os.Parcelable
+import androidx.annotation.ColorInt
+import com.riffle.core.domain.ReaderTheme
+import com.riffle.core.domain.ReadaloudHighlightColor
+import org.readium.r2.navigator.Decoration
+import org.readium.r2.navigator.html.HtmlDecorationTemplate
+import org.readium.r2.navigator.html.toCss
+
+// Readium's default highlight template (Style.Highlight) bakes a FIXED alpha (0.3) into the CSS and
+// ignores the tint's own alpha channel. That makes the readaloud highlight too faint on the Dark
+// reading theme — 0.3 of a colour over a black page is barely visible behind the white body text.
+//
+// We give the readaloud highlight its OWN decoration style + template so we can vary the alpha per
+// theme without touching persisted/search highlights (which keep the shared Style.Highlight). The
+// template below honours the tint's alpha channel (`toCss()` with no override), so the caller picks
+// the strength by baking an alpha byte into the tint — see readerTint().
+
+/** Dedicated decoration style for the readaloud synced highlight. */
+class ReadaloudHighlightStyle(
+    @ColorInt override val tint: Int,
+) : Decoration.Style, Decoration.Style.Tinted {
+
+    override fun describeContents(): Int = 0
+
+    override fun writeToParcel(dest: Parcel, flags: Int) {
+        dest.writeInt(tint)
+    }
+
+    companion object {
+        @JvmField
+        val CREATOR: Parcelable.Creator<ReadaloudHighlightStyle> =
+            object : Parcelable.Creator<ReadaloudHighlightStyle> {
+                override fun createFromParcel(source: Parcel) = ReadaloudHighlightStyle(source.readInt())
+                override fun newArray(size: Int): Array<ReadaloudHighlightStyle?> = arrayOfNulls(size)
+            }
+    }
+}
+
+private const val READALOUD_HIGHLIGHT_CLASS = "riffle-readaloud-highlight"
+
+/**
+ * Highlight template for [ReadaloudHighlightStyle]. Geometry mirrors Readium's built-in highlight
+ * (BOXES layout, 1px horizontal padding, 3px corner radius) so positioning is unchanged; the only
+ * difference is that the fill opacity comes from the tint's alpha channel rather than a fixed value.
+ */
+fun readaloudHighlightTemplate(): HtmlDecorationTemplate =
+    HtmlDecorationTemplate(
+        layout = HtmlDecorationTemplate.Layout.BOXES,
+        element = { decoration ->
+            val tint = (decoration.style as? Decoration.Style.Tinted)?.tint ?: Color.YELLOW
+            """<div class="$READALOUD_HIGHLIGHT_CLASS" style="background-color: ${tint.toCss()} !important;"/>"""
+        },
+        stylesheet = """
+            .$READALOUD_HIGHLIGHT_CLASS {
+                margin: 0px -1px 0 0;
+                padding: 0 2px 0 0;
+                border-radius: 3px;
+                box-sizing: border-box;
+            }
+        """.trimIndent(),
+    )
+
+/**
+ * The tint to paint the readaloud highlight with on the given reading [theme]. Dark/DarkDim pages
+ * use a stronger alpha so the highlight reads as a clear "selection box" behind the white body text;
+ * light and sepia pages use Readium's usual ~30% so the dark body text stays legible.
+ */
+@ColorInt
+fun ReadaloudHighlightColor.readerTint(theme: ReaderTheme): Int {
+    val alpha = when (theme) {
+        ReaderTheme.Dark, ReaderTheme.DarkDim -> 0x73 // ~45%
+        else -> 0x4D // ~30%
+    }
+    return (argb and 0x00FFFFFF) or (alpha shl 24)
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ReadaloudHighlightDecoration.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ReadaloudHighlightDecoration.kt
@@ -19,6 +19,11 @@ import org.readium.r2.navigator.html.toCss
 // template below honours the tint's alpha channel (`toCss()` with no override), so the caller picks
 // the strength by baking an alpha byte into the tint — see readerTint().
 
+// Fill opacity baked into the tint's alpha channel per reading theme (see readerTint). Dark pages
+// need a stronger alpha so the highlight reads as a clear selection box behind the white body text.
+internal const val READALOUD_HIGHLIGHT_ALPHA_DARK = 0x73 // ~45%
+internal const val READALOUD_HIGHLIGHT_ALPHA_LIGHT = 0x4D // ~30%
+
 /** Dedicated decoration style for the readaloud synced highlight. */
 class ReadaloudHighlightStyle(
     @ColorInt override val tint: Int,
@@ -29,6 +34,13 @@ class ReadaloudHighlightStyle(
     override fun writeToParcel(dest: Parcel, flags: Int) {
         dest.writeInt(tint)
     }
+
+    // Value semantics so Readium's decoration diff (DecorationChange.areContentsTheSame compares
+    // style ==) treats an unchanged tint as unchanged, mirroring the built-in data-class styles.
+    override fun equals(other: Any?): Boolean =
+        this === other || (other is ReadaloudHighlightStyle && other.tint == tint)
+
+    override fun hashCode(): Int = tint
 
     companion object {
         @JvmField
@@ -61,7 +73,7 @@ fun readaloudHighlightTemplate(): HtmlDecorationTemplate =
                 border-radius: 3px;
                 box-sizing: border-box;
             }
-        """.trimIndent(),
+        """.trimIndent(), // geometry matches Readium's built-in highlight (BOXES, 1px h-padding)
     )
 
 /**
@@ -72,8 +84,8 @@ fun readaloudHighlightTemplate(): HtmlDecorationTemplate =
 @ColorInt
 fun ReadaloudHighlightColor.readerTint(theme: ReaderTheme): Int {
     val alpha = when (theme) {
-        ReaderTheme.Dark, ReaderTheme.DarkDim -> 0x73 // ~45%
-        else -> 0x4D // ~30%
+        ReaderTheme.Dark, ReaderTheme.DarkDim -> READALOUD_HIGHLIGHT_ALPHA_DARK
+        else -> READALOUD_HIGHLIGHT_ALPHA_LIGHT
     }
     return (argb and 0x00FFFFFF) or (alpha shl 24)
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material.icons.filled.Check
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -50,6 +51,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.rotate
@@ -269,21 +271,40 @@ fun SettingsScreen(
                         Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                             ReadaloudHighlightColor.entries.forEach { color ->
                                 val isSelected = readaloudPreferences.highlightColor == color
+                                val swatchColor = Color(color.argb.toLong() and 0xFFFFFFFFL)
+                                // Selected swatch reads clearly in both themes: an offset ring
+                                // (onSurface ring at the outer edge, separated from the swatch by a
+                                // transparent gap) plus a centred checkmark. The swatch keeps a
+                                // constant 28dp size whether or not it's selected — the 4dp padding
+                                // is always reserved, so the row layout doesn't shift on selection.
                                 Box(
+                                    contentAlignment = Alignment.Center,
                                     modifier = Modifier
-                                        .size(28.dp)
+                                        .size(36.dp)
                                         .clip(CircleShape)
-                                        .background(Color(color.argb.toLong() and 0xFFFFFFFFL))
+                                        .clickable { viewModel.updateReadaloudHighlightColor(color) }
                                         .then(
                                             if (isSelected) Modifier.border(2.dp, MaterialTheme.colorScheme.onSurface, CircleShape)
                                             else Modifier
                                         )
+                                        .padding(4.dp)
+                                        .clip(CircleShape)
+                                        .background(swatchColor)
                                         .semantics {
                                             contentDescription = color.name.lowercase()
-                                                .replaceFirstChar { it.uppercase() } + " highlight"
-                                        }
-                                        .clickable { viewModel.updateReadaloudHighlightColor(color) },
-                                )
+                                                .replaceFirstChar { it.uppercase() } + " highlight" +
+                                                if (isSelected) ", selected" else ""
+                                        },
+                                ) {
+                                    if (isSelected) {
+                                        Icon(
+                                            imageVector = Icons.Default.Check,
+                                            contentDescription = null,
+                                            tint = Color(0xDD000000),
+                                            modifier = Modifier.size(16.dp),
+                                        )
+                                    }
+                                }
                             }
                         }
                     },

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ReadaloudHighlightDecorationTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ReadaloudHighlightDecorationTest.kt
@@ -19,7 +19,7 @@ class ReadaloudHighlightDecorationTest {
     fun darkThemesUseStrongerAlpha() {
         for (theme in listOf(ReaderTheme.Dark, ReaderTheme.DarkDim)) {
             val tint = ReadaloudHighlightColor.BLUE.readerTint(theme)
-            assertEquals("alpha for $theme", 0x73, alpha(tint))
+            assertEquals("alpha for $theme", READALOUD_HIGHLIGHT_ALPHA_DARK, alpha(tint))
             // The hue itself is preserved; only the alpha byte changes.
             assertEquals(rgb(ReadaloudHighlightColor.BLUE.argb), rgb(tint))
         }
@@ -29,7 +29,7 @@ class ReadaloudHighlightDecorationTest {
     fun lightThemesUseDefaultAlpha() {
         for (theme in listOf(ReaderTheme.Light, ReaderTheme.Sepia, ReaderTheme.Auto)) {
             val tint = ReadaloudHighlightColor.GREEN.readerTint(theme)
-            assertEquals("alpha for $theme", 0x4D, alpha(tint))
+            assertEquals("alpha for $theme", READALOUD_HIGHLIGHT_ALPHA_LIGHT, alpha(tint))
             assertEquals(rgb(ReadaloudHighlightColor.GREEN.argb), rgb(tint))
         }
     }

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ReadaloudHighlightDecorationTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ReadaloudHighlightDecorationTest.kt
@@ -1,0 +1,45 @@
+@file:OptIn(org.readium.r2.shared.ExperimentalReadiumApi::class)
+
+package com.riffle.app.feature.reader
+
+import com.riffle.core.domain.FormattingPreferences
+import com.riffle.core.domain.ReadaloudHighlightColor
+import com.riffle.core.domain.ReaderTheme
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+import org.readium.r2.navigator.Decoration
+
+class ReadaloudHighlightDecorationTest {
+
+    private fun alpha(argb: Int): Int = (argb ushr 24) and 0xFF
+    private fun rgb(argb: Int): Int = argb and 0x00FFFFFF
+
+    @Test
+    fun darkThemesUseStrongerAlpha() {
+        for (theme in listOf(ReaderTheme.Dark, ReaderTheme.DarkDim)) {
+            val tint = ReadaloudHighlightColor.BLUE.readerTint(theme)
+            assertEquals("alpha for $theme", 0x73, alpha(tint))
+            // The hue itself is preserved; only the alpha byte changes.
+            assertEquals(rgb(ReadaloudHighlightColor.BLUE.argb), rgb(tint))
+        }
+    }
+
+    @Test
+    fun lightThemesUseDefaultAlpha() {
+        for (theme in listOf(ReaderTheme.Light, ReaderTheme.Sepia, ReaderTheme.Auto)) {
+            val tint = ReadaloudHighlightColor.GREEN.readerTint(theme)
+            assertEquals("alpha for $theme", 0x4D, alpha(tint))
+            assertEquals(rgb(ReadaloudHighlightColor.GREEN.argb), rgb(tint))
+        }
+    }
+
+    @Test
+    fun fragmentConfigurationRegistersReadaloudTemplateAlongsideDefaults() {
+        val templates = FormattingPreferences().toFragmentConfiguration().decorationTemplates
+        // Our dedicated readaloud style is registered...
+        assertNotNull(templates[ReadaloudHighlightStyle::class])
+        // ...without dropping the built-in highlight used by persisted + search highlights.
+        assertNotNull(templates[Decoration.Style.Highlight::class])
+    }
+}

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/ReadaloudPreferences.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/ReadaloudPreferences.kt
@@ -2,12 +2,17 @@ package com.riffle.core.domain
 
 import kotlinx.coroutines.flow.Flow
 
+// Medium-saturation (Tailwind ~400-level) hues: vivid enough to tell apart in the picker and to
+// read clearly behind text, without being neon. `argb` carries the full-opacity base color used
+// for the settings swatch; the reader applies a theme-dependent alpha (see readerTint()).
+// Enum names are intentionally unchanged from the original pastels so persisted preferences (which
+// store the name string) keep resolving without a migration.
 enum class ReadaloudHighlightColor(val argb: Int) {
-    BLUE(0xFF7DD3FC.toInt()),
-    YELLOW(0xFFFDE68A.toInt()),
-    GREEN(0xFF86EFAC.toInt()),
-    PINK(0xFFFDA4AF.toInt()),
-    PURPLE(0xFFC4B5FD.toInt()),
+    BLUE(0xFF38BDF8.toInt()),
+    YELLOW(0xFFFBBF24.toInt()),
+    GREEN(0xFF34D399.toInt()),
+    PINK(0xFFFB7185.toInt()),
+    PURPLE(0xFFA78BFA.toInt()),
 }
 
 data class ReadaloudPreferences(

--- a/docs/superpowers/specs/2026-06-16-readaloud-highlight-color-visibility-design.md
+++ b/docs/superpowers/specs/2026-06-16-readaloud-highlight-color-visibility-design.md
@@ -125,5 +125,8 @@ if needed.
 
 ## Out of scope / follow-ups
 
-- Theme-aware rendering for persisted and search highlights (same dark-page washout).
+- Theme-aware rendering for persisted and search highlights (same dark-page washout). When this is
+  picked up, generalize the existing mechanism (the `readerTint`-style alpha-by-theme + a single
+  alpha-honoring template) rather than cloning `ReadaloudHighlightStyle` / `readaloudHighlightTemplate()`
+  per highlight kind, to avoid three near-identical templates.
 - Per-color alpha tuning beyond a single shared dark-page alpha, if it proves necessary.

--- a/docs/superpowers/specs/2026-06-16-readaloud-highlight-color-visibility-design.md
+++ b/docs/superpowers/specs/2026-06-16-readaloud-highlight-color-visibility-design.md
@@ -1,0 +1,127 @@
+# Readaloud highlight color — visibility & saturation
+
+**Date:** 2026-06-16
+**Branch:** pkmetski/nagoya
+**Status:** Approved design, pending implementation plan
+
+## Problem
+
+The readaloud sentence-highlight color setting (added in #191) has three rough edges:
+
+1. **Selection indicator is hard to read in dark theme.** The selected swatch is marked
+   only by a thin 2dp `onSurface` border. Against the dark settings background, a pale
+   pastel swatch with a thin light border looks almost identical to the unselected ones —
+   you cannot tell at a glance which color is picked.
+2. **The palette is washed out.** The five options are near-white pastels
+   (`#7DD3FC`, `#FDE68A`, `#86EFAC`, `#FDA4AF`, `#C4B5FD`), which read as low-contrast and
+   hard to tell apart.
+3. **The highlight is illegible / invisible on a dark reading page.** Readium's default
+   `Decoration.Style.Highlight` paints the tint with `mix-blend-mode: multiply`. On the
+   Dark/DarkDim reading themes the page background is black, and `multiply(black, tint)`
+   collapses to black — so the highlight effectively disappears behind the white book text.
+
+## Goals
+
+- Make the currently-selected swatch unmistakable in both light and dark app themes.
+- Replace the pastels with a more saturated, easier-to-distinguish palette.
+- Make the readaloud highlight legible on dark reading pages without harming light/sepia pages,
+  and without recoloring the book's own text.
+
+## Non-goals
+
+- Recoloring the book's highlighted **text** glyphs (e.g. forcing black text). Readium draws
+  the highlight as a separate layer *behind* the text, not as a wrapper around it, so the only
+  way to recolor glyphs is fragile JS span-injection that fights Readium's reflow. Rejected.
+- Fixing the same dark-page washout for **persisted** highlights (yellow) and **search**
+  highlights (orange/yellow). They share the root cause but are out of scope here; noted as a
+  possible follow-up.
+- Changing where the selector lives in Settings, its size, or adding labels. Indicator only.
+
+## Design
+
+### 1. Selection indicator — offset ring + checkmark
+
+Replace the thin inset border with a Material-style selection treatment that reads on any
+swatch color in any theme:
+
+- **Offset ring:** an outer ring separated from the swatch by a surface-colored gap (so the
+  ring always floats clearly, regardless of the swatch's own color). In Compose terms: the
+  selected swatch is wrapped so it shows `surface`-colored padding, then a 2dp
+  `onSurface` ring around that.
+- **Checkmark:** a centered check glyph inside the selected swatch. Because the swatches are
+  light/medium in luminance, the check is drawn in a dark color (e.g. `Color(0xDD000000)`) for
+  contrast on every option. Unselected swatches show no check and no ring.
+
+This makes "this one is selected" unambiguous even at a glance, in both light and dark.
+
+### 2. Palette — replace pastels with saturated hues
+
+Keep the existing enum **names** (so no persistence migration is needed — `ReadaloudPreferences`
+stores the enum name string), and change only the `argb` values:
+
+| Enum entry | Old (pastel) | New (saturated) |
+|------------|--------------|-----------------|
+| `BLUE`     | `#7DD3FC`    | **`#38BDF8`**   |
+| `YELLOW`   | `#FDE68A`    | **`#FBBF24`**   |
+| `GREEN`    | `#86EFAC`    | **`#34D399`**   |
+| `PINK`     | `#FDA4AF`    | **`#FB7185`**   |
+| `PURPLE`   | `#C4B5FD`    | **`#A78BFA`**   |
+
+These are medium-saturation (Tailwind ~400-level): clearly vivid in the selector and on the
+page, but not neon, so they still sit behind reading text without crushing legibility.
+
+### 3. Dark-page legibility — theme-aware highlight rendering
+
+Render the readaloud highlight differently depending on the current **reading** theme
+(`FormattingPreferences.theme`, which is independent of the app's Material theme):
+
+- **Light / Sepia pages:** keep the vivid `multiply` look — `multiply(lightBackground, tint)`
+  shows the saturated tint and the dark book text stays sharp. (Unchanged from today.)
+- **Dark / DarkDim pages:** render the highlight as a **translucent "selection box"** — the
+  saturated tint at ~45% alpha with `mix-blend-mode: normal`. White book text then sits on a
+  tinted block (exactly like a dark-editor text selection) and stays legible. The book's text
+  color is untouched.
+
+**Mechanism.** Readium's default highlight style is not theme-aware and its blend mode is fixed
+in the template. To control blend mode + alpha we register **custom `HtmlDecorationTemplate`(s)**
+on the navigator and select which to use when building the readaloud decoration, keyed off the
+current `ReaderTheme`. Concretely:
+
+- Register custom decoration style(s)/template(s): one "vivid/multiply" and one
+  "translucent/normal ~45% alpha".
+- The `LaunchedEffect` that applies the `readaloud_active` decoration
+  (`EpubReaderScreen.kt` ~1393–1427) gains the current reading theme as an input, and chooses
+  the multiply style for Light/Sepia or the translucent style for Dark/DarkDim.
+- A clean dark signal already exists:
+  `theme == ReaderTheme.Dark || theme == ReaderTheme.DarkDim`.
+
+**Implementation fallback (decided at plan time):** if registering and selecting between two
+templates proves awkward in Readium, a single uniform translucent normal-blend template
+(`rgba(tint, ~0.4)`) is an acceptable simpler alternative — it tints toward whatever the page
+background is, so it self-adapts to light and dark. The tradeoff is a slightly paler look on
+light pages than today's multiply. Prefer the theme-aware two-template approach; fall back only
+if needed.
+
+## Affected code
+
+- `core/domain/.../ReadaloudPreferences.kt` — new `argb` values (names unchanged).
+- `app/.../feature/settings/SettingsScreen.kt` — swatch selection indicator (offset ring + check).
+- `app/.../feature/reader/EpubReaderScreen.kt` — custom decoration template(s) + theme-aware
+  style selection for the `readaloud_active` decoration; thread the reading theme into the
+  applying `LaunchedEffect`.
+- Possibly a small new file for the custom `HtmlDecorationTemplate` definitions.
+
+## Risks / verification
+
+- **Device verification required.** The dark-page highlight and the custom Readium template can
+  only be truly judged on a device/emulator with a real EPUB in Dark and Light reading themes.
+  The browser prototype approximates blend behavior but is not authoritative.
+- Confirm the saturated palette still reads acceptably behind text on **Sepia** as well as
+  Light and Dark.
+- Confirm no regression to persisted/search highlights (they keep the default style).
+- No DB or persistence migration (enum names unchanged).
+
+## Out of scope / follow-ups
+
+- Theme-aware rendering for persisted and search highlights (same dark-page washout).
+- Per-color alpha tuning beyond a single shared dark-page alpha, if it proves necessary.

--- a/docs/superpowers/specs/2026-06-16-readaloud-highlight-color-visibility-design.md
+++ b/docs/superpowers/specs/2026-06-16-readaloud-highlight-color-visibility-design.md
@@ -15,10 +15,12 @@ The readaloud sentence-highlight color setting (added in #191) has three rough e
 2. **The palette is washed out.** The five options are near-white pastels
    (`#7DD3FC`, `#FDE68A`, `#86EFAC`, `#FDA4AF`, `#C4B5FD`), which read as low-contrast and
    hard to tell apart.
-3. **The highlight is illegible / invisible on a dark reading page.** Readium's default
-   `Decoration.Style.Highlight` paints the tint with `mix-blend-mode: multiply`. On the
-   Dark/DarkDim reading themes the page background is black, and `multiply(black, tint)`
-   collapses to black — so the highlight effectively disappears behind the white book text.
+3. **The highlight is too faint on a dark reading page.** Readium's default
+   `Decoration.Style.Highlight` paints the tint as `background-color: rgba(tint, 0.3)` (normal
+   blend, a fixed 30% alpha). On the Dark/DarkDim themes the page background is black, so 30% of
+   a colour over black reads as a barely-visible dim wash behind the white body text.
+   *(Correction: an earlier draft assumed `mix-blend-mode: multiply`; the actual Readium 3.3.0
+   template uses a fixed-alpha rgba fill. The fix below is unchanged either way.)*
 
 ## Goals
 


### PR DESCRIPTION
## What & why

The readaloud sentence-highlight color setting had three rough edges, all addressed here:

1. **Picker selection was hard to read in dark theme.** The selected swatch was marked only by a thin `onSurface` border — nearly invisible against a dark settings background. It now uses an **offset ring + centered checkmark**, which reads clearly in both light and dark app themes. The swatch stays a constant 28dp (4dp gap always reserved), so the row doesn't shift on selection.

2. **The palette was washed-out.** Replaced the near-white pastels with **medium-saturation hues** (BLUE `#38BDF8`, YELLOW `#FBBF24`, GREEN `#34D399`, PINK `#FB7185`, PURPLE `#A78BFA`). Enum **names are unchanged**, so persisted preferences keep resolving — no migration.

3. **The highlight was too faint on dark reading pages.** Readium's built-in highlight paints `rgba(tint, 0.3)` at a fixed alpha, so on a black page it's barely visible behind white body text. A dedicated `ReadaloudHighlightStyle` + custom decoration template whose opacity tracks the **tint's alpha channel** lets the reader apply a stronger alpha (~45%) on Dark/DarkDim themes and the usual ~30% on light/sepia. The shared built-in highlight (used by **persisted + search highlights**) is untouched.

## Scope notes

- Persisted and search highlights still use the stock template, so they keep the same dark-page faintness — explicitly deferred as a follow-up (see design doc); the follow-up should generalize this mechanism rather than clone it.

## Testing

- `./gradlew test` — green (incl. new `ReadaloudHighlightDecorationTest`: per-theme alpha packing + template registration).
- `./gradlew lint` — green.
- Harness suites skipped for this run.
- **Not yet device-verified** — the dark-page highlight + custom Readium template should be eyeballed on a device with a real readaloud EPUB in Dark vs Light reading themes before relying on it.

Design doc: `docs/superpowers/specs/2026-06-16-readaloud-highlight-color-visibility-design.md`