### PR TITLE
feat(reader): animated page-turn transitions in paged EPUB mode

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -102,6 +102,7 @@ import org.readium.r2.navigator.HyperlinkNavigator
 import org.readium.r2.navigator.epub.EpubNavigatorFactory
 import org.readium.r2.navigator.epub.EpubNavigatorFragment
 import org.readium.r2.navigator.input.InputListener
+import org.readium.r2.navigator.util.DirectionalNavigationAdapter
 import org.readium.r2.navigator.input.TapEvent
 import org.readium.r2.shared.ExperimentalReadiumApi
 import org.readium.r2.shared.publication.Link
@@ -1735,6 +1736,16 @@ private fun EpubNavigatorView(
                         ?: return@AndroidView
                     fragmentRef.value = fragment
                     fragmentDoublePageHolder[0] = isDoublePage
+                    // Readium's built-in ANIMATED page transition (Kotlin toolkit 3.2.0+): edge taps
+                    // turn the page with a smooth slide instead of an instant jump. Added before
+                    // tapListener so the adapter consumes horizontal edge taps and tapListener only
+                    // sees the center taps it doesn't handle.
+                    fragment.addInputListener(
+                        DirectionalNavigationAdapter(
+                            navigator = fragment,
+                            animatedTransition = true,
+                        ),
+                    )
                     fragment.addInputListener(tapListener)
                     coroutineScope.launch {
                         fragment.currentLocator.collect { locator ->


### PR DESCRIPTION
Enable Readium's built-in animated page transitions (Kotlin toolkit 3.2.0+) in the paged EPUB reader.

## What
Adds a `DirectionalNavigationAdapter(navigator = fragment, animatedTransition = true)` input listener to the EPUB navigator, mirroring the PDF reader's existing setup. Edge-tap page turns now slide smoothly instead of jumping instantly. `tapListener` continues to handle center taps (immersive toggle).

## Why
In paged mode the page turn was an abrupt instant jump with no transition. Readium ships an animated page transition since the 3.2.0 toolkit (we're on 3.3.0); this turns it on via the supported adapter API rather than custom gesture/animation code.

## Scope / notes
- Animates **edge-tap and key** page turns. Swipe gestures remain Readium's native instant turn (its adapter handles taps/keys only) — animating swipe is a possible follow-up.
- EPUB paged mode only; scroll mode, PDF, and fixed-layout are untouched.
- No page-curl (Readium doesn't support it).

## Testing
- Builds; JVM unit tests unaffected (no logic changed).
- Device feel-verification pending.