### PR TITLE
fix(player): larger skip arrows with centred interval numbers

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/audio/PlayerSurface.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audio/PlayerSurface.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentWidth
@@ -64,6 +65,13 @@ import coil.compose.AsyncImage
 import coil.request.ImageRequest
 import com.riffle.app.feature.audiobook.SleepTimerMode
 import com.riffle.app.feature.audiobook.formatCountdown
+
+/**
+ * How far down (as a fraction of the icon size) to nudge the "15"/"30" interval number so it lands in
+ * the open centre of the [Icons.Filled.Replay] loop rather than over the arrowhead at the top. Shared
+ * by both this surface and the Readaloud mini-player so the two affordances stay visually identical.
+ */
+internal const val SKIP_NUMBER_DOWN_FRACTION = 0.09f
 
 /**
  * Everything [PlayerSurface] renders. Both the standalone Audiobook player and the in-reader
@@ -335,13 +343,16 @@ private fun TransportRow(state: PlayerSurfaceState, actions: PlayerSurfaceAction
     // 48dp/24dp default) and a 60dp primary play circle with a 32dp glyph, separated by 10dp gaps.
     val secondaryButton = 56.dp
     val secondaryIcon = 30.dp
+    // The rewind/forward circular-arrow glyphs are enlarged so the overlaid "15"/"30" interval
+    // numbers sit comfortably inside the arc rather than spilling past it.
+    val skipIcon = 38.dp
     Row(
         modifier = Modifier.fillMaxWidth(),
         horizontalArrangement = Arrangement.Center,
         verticalAlignment = Alignment.CenterVertically,
     ) {
         IconButton(onClick = actions.onRewind, modifier = Modifier.size(secondaryButton)) {
-            SkipIcon(seconds = state.rewindIntervalSeconds, forward = false, iconSize = secondaryIcon)
+            SkipIcon(seconds = state.rewindIntervalSeconds, forward = false, iconSize = skipIcon)
         }
         Spacer(Modifier.size(10.dp))
         IconButton(onClick = actions.onPreviousChapter, enabled = state.canPreviousChapter, modifier = Modifier.size(secondaryButton)) {
@@ -368,7 +379,7 @@ private fun TransportRow(state: PlayerSurfaceState, actions: PlayerSurfaceAction
         }
         Spacer(Modifier.size(10.dp))
         IconButton(onClick = actions.onForward, modifier = Modifier.size(secondaryButton)) {
-            SkipIcon(seconds = state.skipIntervalSeconds, forward = true, iconSize = secondaryIcon)
+            SkipIcon(seconds = state.skipIntervalSeconds, forward = true, iconSize = skipIcon)
         }
     }
 }
@@ -386,6 +397,10 @@ private fun SkipIcon(seconds: Int, forward: Boolean, iconSize: Dp) {
             text = "$seconds",
             style = MaterialTheme.typography.labelSmall,
             fontWeight = FontWeight.Bold,
+            // The Replay glyph's arrowhead sits at the top, so the loop's open centre is below the
+            // icon's geometric centre. Nudge the interval number down (proportional to the glyph) so
+            // it reads as centred inside the loop. Mirror-safe: the offset is vertical only.
+            modifier = Modifier.offset(y = iconSize * SKIP_NUMBER_DOWN_FRACTION),
         )
     }
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.MenuBook
@@ -42,7 +43,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.input.pointer.pointerInput
-import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -78,16 +79,24 @@ private data class BookmarkDraft(
     val chapterTitle: String,
 )
 
-/** Caption hinting that dragging the cover down switches to the read-along reader. */
+/**
+ * Small drag handle hinting that dragging the player down switches to the read-along reader. Mirrors
+ * the handle on the in-reader mini player (see ReadaloudPeek) so the swipe-down ↔ swipe-up gesture
+ * pair reads as one continuous affordance across both surfaces.
+ */
 @Composable
-private fun ReadAlongSwipeHint() {
-    Text(
-        "Swipe down to read along",
-        style = MaterialTheme.typography.labelSmall,
-        color = MaterialTheme.colorScheme.onSurfaceVariant,
+private fun ReadAlongDragHandle() {
+    Box(
         modifier = Modifier.fillMaxWidth().padding(top = 6.dp),
-        textAlign = TextAlign.Center,
-    )
+        contentAlignment = Alignment.Center,
+    ) {
+        Box(
+            Modifier
+                .clip(RoundedCornerShape(2.dp))
+                .background(MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f))
+                .size(width = 32.dp, height = 4.dp),
+        )
+    }
 }
 
 /** The two quiet affordances under the scrubber: Chapters and the bookmark count. */
@@ -178,10 +187,10 @@ fun AudiobookPlayerScreen(
                     }
                     .padding(horizontal = 24.dp),
             ) {
-                // Leave room for the back button overlaid above, plus the read-along hint when present.
+                // Leave room for the back button overlaid above, plus the read-along handle when present.
                 Spacer(Modifier.size(48.dp))
                 if (state.readaloudEbookItemId != null) {
-                    ReadAlongSwipeHint()
+                    ReadAlongDragHandle()
                 }
 
                 when {

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/ReadaloudPlayerUi.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/ReadaloudPlayerUi.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -41,6 +42,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.riffle.app.feature.audio.PlaybackSpeed
 import com.riffle.app.feature.audio.PlaybackSpeedControl
+import com.riffle.app.feature.audio.SKIP_NUMBER_DOWN_FRACTION
 
 /**
  * The mini-player speed control: a compact chip on the bar that opens the shared granular speed
@@ -80,7 +82,9 @@ private fun SpeedControl(
 
 
 @Composable
-private fun SkipIcon(seconds: Int, forward: Boolean, tint: Color, iconSize: Dp = 24.dp) {
+// The circular-arrow glyph is enlarged (from the 24dp default) so the overlaid "15"/"30" interval
+// numbers fit inside the arc rather than spilling past its edges.
+private fun SkipIcon(seconds: Int, forward: Boolean, tint: Color, iconSize: Dp = 32.dp) {
     Box(contentAlignment = Alignment.Center) {
         Icon(
             imageVector = Icons.Filled.Replay,
@@ -94,6 +98,10 @@ private fun SkipIcon(seconds: Int, forward: Boolean, tint: Color, iconSize: Dp =
             style = MaterialTheme.typography.labelSmall,
             fontWeight = FontWeight.Bold,
             color = tint,
+            // The Replay glyph's arrowhead sits at the top, so the loop's open centre is below the
+            // icon's geometric centre. Nudge the interval number down (proportional to the glyph) so
+            // it reads as centred inside the loop. Mirror-safe: the offset is vertical only.
+            modifier = Modifier.offset(y = iconSize * SKIP_NUMBER_DOWN_FRACTION),
         )
     }
 }


### PR DESCRIPTION
## What

Polish for the two media players (audiobook + readaloud), based on visual feedback.

1. **Larger skip arrows.** The rewind/forward circular-arrow glyphs were too small for the overlaid `15`/`30` interval numbers, which spilled past the arc. Enlarged the glyphs — audiobook **38dp** (was 30dp, shared with prev/next), readaloud **32dp** (was 24dp).
2. **Centred interval numbers.** `Icons.Filled.Replay` puts its arrowhead at the top, so the loop's open centre is *below* the icon's geometric centre — the number rode high over the arrowhead. Both `SkipIcon`s now nudge the number down by a shared fraction of the icon size (`SKIP_NUMBER_DOWN_FRACTION = 0.09f`). Vertical-only, so it stays correct for the mirrored forward glyph.
3. **Audiobook read-along hint → drag handle.** Replaced the "Swipe down to read along" caption with the same small grey drag handle used by the in-reader mini player (`ReadaloudPeek`), so the swipe-down ↔ swipe-up gesture pair reads as one continuous affordance across both surfaces.

## Test

- `./gradlew :app:compileDebugKotlin` — clean.
- Harness tests skipped per request.

> Note: the `0.09` centring fraction is derived from the glyph geometry + the reporter's screenshots, not device-verified. It's a single shared constant, easy to dial in (raise toward ~0.12 to sink lower, lower toward ~0.06 to raise) if it's slightly off on real hardware.
