### PR TITLE
feat(reader): continuous (endless-scroll) reading mode

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ChapterWebView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ChapterWebView.kt
@@ -64,6 +64,23 @@ internal class ChapterWebView(context: Context) : WebView(context) {
     /** Called on the main thread when the user taps an external (http/https) link. */
     var onExternalLink: ((url: String) -> Unit)? = null
 
+    /**
+     * Called on the main thread with the resolved footnote body when the user taps a same-document
+     * footnote anchor. The host shows the footnote popup. Continuous mode resolves the note from the
+     * chapter's own HTML (see [rawChapterHtml]) using [FootnoteResolver].
+     */
+    var onFootnoteContent: ((FootnoteContent) -> Unit)? = null
+
+    /**
+     * The raw HTML of the chapter document currently loaded, retained so a footnote tap can resolve
+     * the note body without a re-fetch. Set the first time an HTML resource is served for a load (the
+     * main document is fetched first), cleared on each [loadChapter]. The parsed form is cached lazily
+     * in [footnoteDoc].
+     */
+    @Volatile
+    private var rawChapterHtml: String? = null
+    private var footnoteDoc: org.jsoup.nodes.Document? = null
+
     /** When true, the text-selection menu offers "Play from here" (readaloud books only). */
     var readaloudAvailable: Boolean = false
 
@@ -198,8 +215,11 @@ internal class ChapterWebView(context: Context) : WebView(context) {
                 // --USER__ settings attribute Readium injects, so the first paint is already styled
                 // (no FOUC) AND renders identically to Scroll/Paginated mode.
                 val finalBytes = if (isHtml) {
-                    ContinuousStyleInjector.injectInto(String(bytes, Charsets.UTF_8), currentPrefs)
-                        .toByteArray(Charsets.UTF_8)
+                    val html = String(bytes, Charsets.UTF_8)
+                    // Retain the first HTML document served for this load (the main chapter, fetched
+                    // before any sub-resource) so a footnote tap can resolve the note body locally.
+                    if (rawChapterHtml == null) rawChapterHtml = html
+                    ContinuousStyleInjector.injectInto(html, currentPrefs).toByteArray(Charsets.UTF_8)
                 } else {
                     bytes
                 }
@@ -217,6 +237,8 @@ internal class ChapterWebView(context: Context) : WebView(context) {
     fun loadChapter(href: String, chapterUrl: String, prefs: FormattingPreferences) {
         chapterHref = href
         currentPrefs = prefs
+        rawChapterHtml = null
+        footnoteDoc = null
         loadToken++
         loadUrl(chapterUrl)
     }
@@ -235,6 +257,7 @@ internal class ChapterWebView(context: Context) : WebView(context) {
         evaluateJavascript("window.__riffleToken=$loadToken;", null)
         evaluateJavascript(ContinuousStyleInjector.HEIGHT_MEASUREMENT_JS, null)
         evaluateJavascript(ContinuousStyleInjector.TAP_LISTENER_JS, null)
+        evaluateJavascript(ContinuousStyleInjector.FOOTNOTE_LISTENER_JS, null)
     }
 
     /** Re-inject user styles and re-measure after a preference change. */
@@ -370,6 +393,21 @@ internal class ChapterWebView(context: Context) : WebView(context) {
         @JavascriptInterface
         fun onTap() {
             post { this@ChapterWebView.onTap?.invoke() }
+        }
+
+        /**
+         * Resolve the same-document anchor [id] against this chapter's HTML. Returns true (so the JS
+         * suppresses the default in-page scroll) and posts the note body to [onFootnoteContent] when
+         * the target is a footnote; false for a regular cross-reference (left to default handling).
+         * Runs on the JS binder thread — Jsoup parsing here is safe.
+         */
+        @JavascriptInterface
+        fun onFootnoteAnchorTap(id: String): Boolean {
+            val html = rawChapterHtml ?: return false
+            val doc = footnoteDoc ?: FootnoteResolver.parse(html).also { footnoteDoc = it }
+            val content = FootnoteResolver.extractFootnoteContent(doc, id) ?: return false
+            post { this@ChapterWebView.onFootnoteContent?.invoke(content) }
+            return true
         }
     }
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ChapterWebView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ChapterWebView.kt
@@ -9,7 +9,7 @@ import android.webkit.WebView
 import android.webkit.WebViewClient
 import kotlinx.coroutines.runBlocking
 import org.readium.r2.shared.publication.Publication
-import org.readium.r2.shared.util.toAbsoluteUrl
+import org.readium.r2.shared.util.Url
 
 /**
  * A [WebView] that:
@@ -28,6 +28,13 @@ internal class ChapterWebView(context: Context) : WebView(context) {
 
     /** Called on the main thread once the page finishes loading (before height is known). */
     var onPageFinished: (() -> Unit)? = null
+
+    /**
+     * Called on the main thread when the user taps the chapter (no scroll movement).
+     * Wire this to the reader's chrome toggle so taps in Continuous mode show/hide the
+     * top/bottom bars, matching the behaviour of the standard Readium navigator.
+     */
+    var onTap: (() -> Unit)? = null
 
     /** The chapter href this view is currently loading (e.g. `"EPUB/chapter01.xhtml"`). */
     var chapterHref: String = ""
@@ -60,12 +67,17 @@ internal class ChapterWebView(context: Context) : WebView(context) {
                 if (uri.host != "readium_package") return super.shouldInterceptRequest(view, request)
                 val pub = this@ChapterWebView.publication
                     ?: return super.shouldInterceptRequest(view, request)
-                val absoluteUrl = uri.toAbsoluteUrl()
+                // Publication.get() resolves against the publication container using paths relative
+                // to the publication root (e.g. "text/part0022_split_000.html"). Passing the full
+                // https://readium_package/... absolute URL doesn't work because pub.get() doesn't
+                // know the readium_package virtual hostname; it just understands relative paths.
+                val path = uri.path?.trimStart('/').takeIf { !it.isNullOrEmpty() }
+                    ?: return super.shouldInterceptRequest(view, request)
+                val relUrl = Url(path)
                     ?: return super.shouldInterceptRequest(view, request)
                 // shouldInterceptRequest is called on a background thread; runBlocking is safe here.
-                val bytes = runBlocking { pub.get(absoluteUrl)?.read()?.getOrNull() }
+                val bytes = runBlocking { pub.get(relUrl)?.read()?.getOrNull() }
                     ?: return super.shouldInterceptRequest(view, request)
-                val path = uri.path.orEmpty()
                 val mimeType = mimeTypeForPath(path)
                 val encoding = if (mimeType.startsWith("text/") || mimeType.contains("xml") || mimeType.contains("javascript")) "utf-8" else null
                 return WebResourceResponse(mimeType, encoding, bytes.inputStream())
@@ -91,6 +103,7 @@ internal class ChapterWebView(context: Context) : WebView(context) {
         evaluateJavascript(variableJs, null)
         evaluateJavascript(typographyOverrideInjectionJs(), null)
         evaluateJavascript(ContinuousStyleInjector.HEIGHT_MEASUREMENT_JS, null)
+        evaluateJavascript(ContinuousStyleInjector.TAP_LISTENER_JS, null)
     }
 
     /** Re-measure after a preference change. */
@@ -100,6 +113,11 @@ internal class ChapterWebView(context: Context) : WebView(context) {
         @JavascriptInterface
         fun onHeightMeasured(height: Int) {
             post { this@ChapterWebView.onHeightMeasured?.invoke(height) }
+        }
+
+        @JavascriptInterface
+        fun onTap() {
+            post { this@ChapterWebView.onTap?.invoke() }
         }
     }
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ChapterWebView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ChapterWebView.kt
@@ -51,6 +51,16 @@ internal class ChapterWebView(context: Context) : WebView(context) {
     @Volatile
     private var currentPrefs: FormattingPreferences = FormattingPreferences()
 
+    /**
+     * Incremented on every [loadChapter]. Each loaded page stamps this value into
+     * `window.__riffleToken` (see [injectStylesAndMeasure]) and echoes it back with every height
+     * report. [HeightBridge] drops reports whose token != the current one, so a recycled WebView's
+     * *previous* chapter — whose ResizeObserver / delayed re-measure timers may still fire for a
+     * moment after the view is reused — can't deliver a stale (typically much taller) height to the
+     * new chapter and leave it over-sized (a large white gap below the content).
+     */
+    private var loadToken = 0
+
     /** Must be called before [loadChapter] so [shouldInterceptRequest] can serve EPUB resources. */
     fun setPublication(pub: Publication) {
         publication = pub
@@ -136,6 +146,7 @@ internal class ChapterWebView(context: Context) : WebView(context) {
     fun loadChapter(href: String, chapterUrl: String, prefs: FormattingPreferences) {
         chapterHref = href
         currentPrefs = prefs
+        loadToken++
         loadUrl(chapterUrl)
     }
 
@@ -147,6 +158,10 @@ internal class ChapterWebView(context: Context) : WebView(context) {
      */
     fun injectStylesAndMeasure(styleJs: String) {
         evaluateJavascript(styleJs, null)
+        // Stamp this page with the current load token BEFORE wiring measurement, so every height
+        // report (including late ResizeObserver / timeout fires) carries it and the bridge can
+        // reject reports from a recycled WebView's previous page.
+        evaluateJavascript("window.__riffleToken=$loadToken;", null)
         evaluateJavascript(ContinuousStyleInjector.HEIGHT_MEASUREMENT_JS, null)
         evaluateJavascript(ContinuousStyleInjector.TAP_LISTENER_JS, null)
     }
@@ -156,8 +171,9 @@ internal class ChapterWebView(context: Context) : WebView(context) {
 
     private inner class HeightBridge {
         @JavascriptInterface
-        fun onHeightMeasured(height: Int) {
-            post { this@ChapterWebView.onHeightMeasured?.invoke(height) }
+        fun onHeightMeasured(height: Int, token: Int) {
+            // Drop reports from a previous chapter still settling in this (recycled) WebView.
+            post { if (token == loadToken) this@ChapterWebView.onHeightMeasured?.invoke(height) }
         }
 
         @JavascriptInterface

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ChapterWebView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ChapterWebView.kt
@@ -240,6 +240,28 @@ internal class ChapterWebView(context: Context) : WebView(context) {
     /** Re-inject user styles and re-measure after a preference change. */
     fun reinjectAndRemeasure(styleJs: String) = injectStylesAndMeasure(styleJs)
 
+    /**
+     * Resolve [fragment] (an element id / name from a TOC or cross-reference link) to its top offset
+     * within this chapter, in DEVICE px (so it composes with the chapter's layout height). Calls
+     * [callback] with null when the element isn't found. Used to land a TOC/anchor jump on the actual
+     * heading instead of the resource top.
+     */
+    fun anchorOffsetTopDevicePx(fragment: String, callback: (Int?) -> Unit) {
+        val esc = fragment.replace("\\", "\\\\").replace("'", "\\'")
+        val js = """(function(){
+            var e = document.getElementById('$esc') ||
+                    document.querySelector("[id='$esc'], [name='$esc'], a[name='$esc']");
+            if (!e) return -1;
+            var r = e.getBoundingClientRect();
+            var y = r.top + (window.pageYOffset || document.documentElement.scrollTop || 0);
+            return Math.max(0, Math.round(y * (window.devicePixelRatio || 1)));
+        })()"""
+        evaluateJavascript(js) { raw ->
+            val v = raw?.trim('"')?.toIntOrNull()
+            callback(if (v == null || v < 0) null else v)
+        }
+    }
+
     // ── Text-selection menu ──────────────────────────────────────────────────────
     // The Readium fragment provides Riffle's custom selection menu in paged/scroll mode; in
     // Continuous mode selection happens in these WebViews, so we wrap their action mode to offer the

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ChapterWebView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ChapterWebView.kt
@@ -25,6 +25,14 @@ import org.readium.r2.shared.util.Url
 @SuppressLint("SetJavaScriptEnabled")
 internal class ChapterWebView(context: Context) : WebView(context) {
 
+    private companion object {
+        // Text-selection menu item ids (see wrapSelectionCallback).
+        const val MENU_COPY = android.view.Menu.FIRST
+        const val MENU_PLAY = android.view.Menu.FIRST + 1
+        const val MENU_SEARCH = android.view.Menu.FIRST + 2
+        const val MENU_SHARE = android.view.Menu.FIRST + 3
+    }
+
     /** Called on the main thread once the content height is known. */
     var onHeightMeasured: ((heightPx: Int) -> Unit)? = null
 
@@ -55,6 +63,15 @@ internal class ChapterWebView(context: Context) : WebView(context) {
 
     /** Called on the main thread when the user taps an external (http/https) link. */
     var onExternalLink: ((url: String) -> Unit)? = null
+
+    /** When true, the text-selection menu offers "Play from here" (readaloud books only). */
+    var readaloudAvailable: Boolean = false
+
+    /**
+     * Called on the main thread with the selected text when the user taps "Play from here".
+     * The host resolves it to a narrated sentence and starts playback there.
+     */
+    var onPlayFromHere: ((selectedText: String) -> Unit)? = null
 
     /** The chapter href this view is currently loading (e.g. `"EPUB/chapter01.xhtml"`). */
     var chapterHref: String = ""
@@ -222,6 +239,89 @@ internal class ChapterWebView(context: Context) : WebView(context) {
 
     /** Re-inject user styles and re-measure after a preference change. */
     fun reinjectAndRemeasure(styleJs: String) = injectStylesAndMeasure(styleJs)
+
+    // ── Text-selection menu ──────────────────────────────────────────────────────
+    // The Readium fragment provides Riffle's custom selection menu in paged/scroll mode; in
+    // Continuous mode selection happens in these WebViews, so we wrap their action mode to offer the
+    // same items (Copy / Search / Share, plus "Play from here" for readaloud books) instead of the
+    // bare browser default. Both startActionMode overloads are wrapped to cover the floating menu.
+
+    override fun startActionMode(callback: android.view.ActionMode.Callback): android.view.ActionMode =
+        super.startActionMode(wrapSelectionCallback(callback))
+
+    override fun startActionMode(callback: android.view.ActionMode.Callback, type: Int): android.view.ActionMode =
+        super.startActionMode(wrapSelectionCallback(callback), type)
+
+    private fun wrapSelectionCallback(inner: android.view.ActionMode.Callback) =
+        object : android.view.ActionMode.Callback {
+            override fun onCreateActionMode(mode: android.view.ActionMode, menu: android.view.Menu): Boolean {
+                menu.clear()
+                menu.add(0, MENU_COPY, 0, android.R.string.copy)
+                if (readaloudAvailable) menu.add(0, MENU_PLAY, 1, "Play from here")
+                menu.add(0, MENU_SEARCH, 2, "Search")
+                menu.add(0, MENU_SHARE, 3, "Share")
+                return true
+            }
+
+            override fun onPrepareActionMode(mode: android.view.ActionMode, menu: android.view.Menu) = false
+
+            override fun onActionItemClicked(mode: android.view.ActionMode, item: android.view.MenuItem): Boolean {
+                when (item.itemId) {
+                    MENU_COPY -> withSelectionText { copyToClipboard(it) }
+                    MENU_SEARCH -> withSelectionText { webSearch(it) }
+                    MENU_SHARE -> withSelectionText { shareText(it) }
+                    MENU_PLAY -> withSelectionText { onPlayFromHere?.invoke(it) }
+                    else -> return inner.onActionItemClicked(mode, item)
+                }
+                mode.finish()
+                return true
+            }
+
+            override fun onDestroyActionMode(mode: android.view.ActionMode) {
+                inner.onDestroyActionMode(mode)
+            }
+        }
+
+    /** Read the current selection's plain text (async, on the JS thread) then run [block] with it. */
+    private fun withSelectionText(block: (String) -> Unit) {
+        evaluateJavascript("(window.getSelection ? window.getSelection().toString() : '')") { raw ->
+            val text = decodeJsString(raw)
+            if (text.isNotBlank()) block(text)
+            evaluateJavascript("window.getSelection && window.getSelection().removeAllRanges()", null)
+        }
+    }
+
+    private fun decodeJsString(raw: String?): String {
+        if (raw == null || raw == "null") return ""
+        return try {
+            org.json.JSONArray("[$raw]").getString(0)
+        } catch (_: Exception) {
+            raw.trim('"')
+        }
+    }
+
+    private fun copyToClipboard(text: String) {
+        val cm = context.getSystemService(Context.CLIPBOARD_SERVICE) as android.content.ClipboardManager
+        cm.setPrimaryClip(android.content.ClipData.newPlainText("Riffle", text))
+    }
+
+    private fun webSearch(text: String) {
+        val intent = android.content.Intent(android.content.Intent.ACTION_WEB_SEARCH)
+            .putExtra(android.app.SearchManager.QUERY, text)
+            .addFlags(android.content.Intent.FLAG_ACTIVITY_NEW_TASK)
+        if (intent.resolveActivity(context.packageManager) != null) runCatching { context.startActivity(intent) }
+    }
+
+    private fun shareText(text: String) {
+        val send = android.content.Intent(android.content.Intent.ACTION_SEND)
+            .setType("text/plain")
+            .putExtra(android.content.Intent.EXTRA_TEXT, text)
+        runCatching {
+            context.startActivity(
+                android.content.Intent.createChooser(send, null).addFlags(android.content.Intent.FLAG_ACTIVITY_NEW_TASK),
+            )
+        }
+    }
 
     private inner class HeightBridge {
         @JavascriptInterface

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ChapterWebView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ChapterWebView.kt
@@ -7,6 +7,7 @@ import android.webkit.WebResourceRequest
 import android.webkit.WebResourceResponse
 import android.webkit.WebView
 import android.webkit.WebViewClient
+import com.riffle.core.domain.FormattingPreferences
 import kotlinx.coroutines.runBlocking
 import org.readium.r2.shared.publication.Publication
 import org.readium.r2.shared.util.Url
@@ -41,6 +42,14 @@ internal class ChapterWebView(context: Context) : WebView(context) {
         private set
 
     private var publication: Publication? = null
+
+    /**
+     * Formatting preferences used to inject CSS at request-intercept time (background thread).
+     * @Volatile ensures the main-thread write in [loadChapter] is visible to the WebCore thread
+     * that calls [shouldInterceptRequest] immediately after [loadUrl].
+     */
+    @Volatile
+    private var currentPrefs: FormattingPreferences = FormattingPreferences()
 
     /** Must be called before [loadChapter] so [shouldInterceptRequest] can serve EPUB resources. */
     fun setPublication(pub: Publication) {
@@ -83,16 +92,32 @@ internal class ChapterWebView(context: Context) : WebView(context) {
                     ?: return super.shouldInterceptRequest(view, request)
                 val mimeType = mimeTypeForPath(path)
                 val encoding = if (mimeType.startsWith("text/") || mimeType.contains("xml") || mimeType.contains("javascript")) "utf-8" else null
-                return WebResourceResponse(mimeType, encoding, bytes.inputStream())
+
+                // For HTML/XHTML chapter resources, inject the user-preference CSS into <head>
+                // so the very first paint is already styled. Without this, evaluateJavascript
+                // style injection races with page rendering: the WebView paints with the EPUB's
+                // own CSS first, then reflowing ~50 ms later when the JS fires — producing a
+                // flash of unstyled content and apparent inconsistency between chapters that
+                // happen to load at different speeds.
+                val finalBytes = if (mimeType == "text/html" || mimeType == "application/xhtml+xml") {
+                    injectCssIntoHtml(bytes, ContinuousStyleInjector.buildCss(currentPrefs))
+                } else {
+                    bytes
+                }
+                return WebResourceResponse(mimeType, encoding, finalBytes.inputStream())
             }
         }
     }
 
     /**
-     * Load [chapterUrl] (absolute URL from Readium's HTTP server) for chapter at [href].
+     * Load [chapterUrl] for chapter at [href], styled with [prefs].
+     * [prefs] is stored before [loadUrl] so [shouldInterceptRequest] (which runs on the WebCore
+     * thread immediately after) can inject the CSS directly into the HTML bytes, eliminating the
+     * flash of unstyled content that occurs when styles are injected via JS after page load.
      */
-    fun loadChapter(href: String, chapterUrl: String) {
+    fun loadChapter(href: String, chapterUrl: String, prefs: FormattingPreferences) {
         chapterHref = href
+        currentPrefs = prefs
         loadUrl(chapterUrl)
     }
 
@@ -122,6 +147,23 @@ internal class ChapterWebView(context: Context) : WebView(context) {
             post { this@ChapterWebView.onTap?.invoke() }
         }
     }
+}
+
+/**
+ * Inserts [css] as a `<style id="_riffle_user">` tag just before `</head>` in [htmlBytes].
+ * If no `</head>` is found (malformed EPUB HTML), prepends the tag at the start of the document.
+ * Returns a new byte array — the input is not mutated.
+ */
+private fun injectCssIntoHtml(htmlBytes: ByteArray, css: String): ByteArray {
+    val html = String(htmlBytes, Charsets.UTF_8)
+    val styleTag = "<style id='_riffle_user'>$css</style>"
+    val insertAt = html.indexOf("</head>").takeIf { it >= 0 }
+        ?: html.indexOf("</HEAD>").takeIf { it >= 0 }
+    val injected = if (insertAt != null)
+        html.substring(0, insertAt) + styleTag + html.substring(insertAt)
+    else
+        styleTag + html
+    return injected.toByteArray(Charsets.UTF_8)
 }
 
 private fun mimeTypeForPath(path: String): String = when {

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ChapterWebView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ChapterWebView.kt
@@ -72,18 +72,28 @@ internal class ChapterWebView(context: Context) : WebView(context) {
 
             override fun shouldInterceptRequest(view: WebView, request: WebResourceRequest): WebResourceResponse? {
                 val uri = request.url
-                // Readium serves EPUB content via https://readium_package/ — a custom domain
-                // backed by shouldInterceptRequest in EpubNavigatorFragment's own WebViewClient.
-                // Self-managed ChapterWebViews don't have that interceptor, so we replicate it
-                // here by serving resources directly from the Publication container.
+                // All resources we serve use the readium_package virtual host so the WebView
+                // treats them as same-origin with the EPUB chapter content.
                 if (uri.host != "readium_package") return super.shouldInterceptRequest(view, request)
-                val pub = this@ChapterWebView.publication
-                    ?: return super.shouldInterceptRequest(view, request)
-                // Publication.get() resolves against the publication container using paths relative
-                // to the publication root (e.g. "text/part0022_split_000.html"). Passing the full
-                // https://readium_package/... absolute URL doesn't work because pub.get() doesn't
-                // know the readium_package virtual hostname; it just understands relative paths.
+
                 val path = uri.path?.trimStart('/').takeIf { !it.isNullOrEmpty() }
+                    ?: return super.shouldInterceptRequest(view, request)
+
+                // App-bundled fonts (Literata, Merriweather, OpenDyslexic) are served from
+                // Android assets at readium_package/readium/fonts/<name>. The @font-face
+                // declarations in buildCss() reference these URLs so the WebView loads them
+                // at the same origin as the EPUB content — no cross-origin block.
+                if (path.startsWith("readium/fonts/")) {
+                    val assetName = "fonts/${path.removePrefix("readium/fonts/")}"
+                    val mimeType = mimeTypeForPath(path)
+                    return try {
+                        WebResourceResponse(mimeType, null, context.assets.open(assetName))
+                    } catch (_: Exception) {
+                        super.shouldInterceptRequest(view, request)
+                    }
+                }
+
+                val pub = this@ChapterWebView.publication
                     ?: return super.shouldInterceptRequest(view, request)
                 val relUrl = Url(path)
                     ?: return super.shouldInterceptRequest(view, request)
@@ -94,11 +104,7 @@ internal class ChapterWebView(context: Context) : WebView(context) {
                 val encoding = if (mimeType.startsWith("text/") || mimeType.contains("xml") || mimeType.contains("javascript")) "utf-8" else null
 
                 // For HTML/XHTML chapter resources, inject the user-preference CSS into <head>
-                // so the very first paint is already styled. Without this, evaluateJavascript
-                // style injection races with page rendering: the WebView paints with the EPUB's
-                // own CSS first, then reflowing ~50 ms later when the JS fires — producing a
-                // flash of unstyled content and apparent inconsistency between chapters that
-                // happen to load at different speeds.
+                // so the very first paint is already styled, eliminating flash of unstyled content.
                 val finalBytes = if (mimeType == "text/html" || mimeType == "application/xhtml+xml") {
                     injectCssIntoHtml(bytes, ContinuousStyleInjector.buildCss(currentPrefs))
                 } else {

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ChapterWebView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ChapterWebView.kt
@@ -79,10 +79,20 @@ internal class ChapterWebView(context: Context) : WebView(context) {
                 val path = uri.path?.trimStart('/').takeIf { !it.isNullOrEmpty() }
                     ?: return super.shouldInterceptRequest(view, request)
 
-                // App-bundled fonts (Literata, Merriweather, OpenDyslexic) are served from
-                // Android assets at readium_package/readium/fonts/<name>. The @font-face
-                // declarations in buildCss() reference these URLs so the WebView loads them
-                // at the same origin as the EPUB content — no cross-origin block.
+                // Readium assets served from the merged Android assets so Continuous-mode chapters
+                // use the exact same stylesheets and fonts as the Readium navigator:
+                //   readium/readium-css/<file>  → assets/readium/readium-css/<file>
+                //   readium/fonts/<file>        → assets/fonts/<file>  (app's own bundled fonts)
+                // Both are referenced from injected <link>/@font-face at the readium_package origin,
+                // so the WebView loads them same-origin with the EPUB content (no cross-origin block).
+                if (path.startsWith("readium/readium-css/")) {
+                    val assetName = "readium/readium-css/${path.removePrefix("readium/readium-css/")}"
+                    return try {
+                        WebResourceResponse(mimeTypeForPath(path), null, context.assets.open(assetName))
+                    } catch (_: Exception) {
+                        super.shouldInterceptRequest(view, request)
+                    }
+                }
                 if (path.startsWith("readium/fonts/")) {
                     val assetName = "fonts/${path.removePrefix("readium/fonts/")}"
                     val mimeType = mimeTypeForPath(path)
@@ -103,10 +113,12 @@ internal class ChapterWebView(context: Context) : WebView(context) {
                 val mimeType = mimeTypeForPath(path)
                 val encoding = if (mimeType.startsWith("text/") || mimeType.contains("xml") || mimeType.contains("javascript")) "utf-8" else null
 
-                // For HTML/XHTML chapter resources, inject the user-preference CSS into <head>
-                // so the very first paint is already styled, eliminating flash of unstyled content.
+                // For HTML/XHTML chapter resources, inject the same ReadiumCSS stylesheets + the
+                // --USER__ settings attribute Readium injects, so the first paint is already styled
+                // (no FOUC) AND renders identically to Scroll/Paginated mode.
                 val finalBytes = if (mimeType == "text/html" || mimeType == "application/xhtml+xml") {
-                    injectCssIntoHtml(bytes, ContinuousStyleInjector.buildCss(currentPrefs))
+                    ContinuousStyleInjector.injectInto(String(bytes, Charsets.UTF_8), currentPrefs)
+                        .toByteArray(Charsets.UTF_8)
                 } else {
                     bytes
                 }
@@ -153,23 +165,6 @@ internal class ChapterWebView(context: Context) : WebView(context) {
             post { this@ChapterWebView.onTap?.invoke() }
         }
     }
-}
-
-/**
- * Inserts [css] as a `<style id="_riffle_user">` tag just before `</head>` in [htmlBytes].
- * If no `</head>` is found (malformed EPUB HTML), prepends the tag at the start of the document.
- * Returns a new byte array — the input is not mutated.
- */
-private fun injectCssIntoHtml(htmlBytes: ByteArray, css: String): ByteArray {
-    val html = String(htmlBytes, Charsets.UTF_8)
-    val styleTag = "<style id='_riffle_user'>$css</style>"
-    val insertAt = html.indexOf("</head>").takeIf { it >= 0 }
-        ?: html.indexOf("</HEAD>").takeIf { it >= 0 }
-    val injected = if (insertAt != null)
-        html.substring(0, insertAt) + styleTag + html.substring(insertAt)
-    else
-        styleTag + html
-    return injected.toByteArray(Charsets.UTF_8)
 }
 
 private fun mimeTypeForPath(path: String): String = when {

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ChapterWebView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ChapterWebView.kt
@@ -46,6 +46,16 @@ internal class ChapterWebView(context: Context) : WebView(context) {
      */
     var onRenderGone: (() -> Unit)? = null
 
+    /**
+     * Called on the main thread when the user taps an in-book link (footnote / cross-reference).
+     * [href] is the target EPUB resource path with any `#fragment`. The WebView does NOT follow the
+     * link itself (that would replace this chapter's content); the parent navigates instead.
+     */
+    var onInternalLink: ((href: String) -> Unit)? = null
+
+    /** Called on the main thread when the user taps an external (http/https) link. */
+    var onExternalLink: ((url: String) -> Unit)? = null
+
     /** The chapter href this view is currently loading (e.g. `"EPUB/chapter01.xhtml"`). */
     var chapterHref: String = ""
         private set
@@ -87,6 +97,22 @@ internal class ChapterWebView(context: Context) : WebView(context) {
         webViewClient = object : WebViewClient() {
             override fun onPageFinished(view: WebView?, url: String?) {
                 this@ChapterWebView.onPageFinished?.invoke()
+            }
+
+            override fun shouldOverrideUrlLoading(view: WebView, request: WebResourceRequest): Boolean {
+                // Not called for the initial loadChapter() load, only for navigations the page
+                // initiates — i.e. a tapped link. Intercept so the link doesn't replace this
+                // chapter's content; route in-book links to the parent (which navigates the reader
+                // with a return card) and external links out to a browser.
+                val url = request.url.toString()
+                val internal = ContinuousPositionTracker.internalLinkHref(url)
+                return if (internal != null) {
+                    onInternalLink?.invoke(internal)
+                    true
+                } else {
+                    onExternalLink?.invoke(url)
+                    true
+                }
             }
 
             override fun onRenderProcessGone(view: WebView?, detail: RenderProcessGoneDetail?): Boolean {

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ChapterWebView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ChapterWebView.kt
@@ -51,6 +51,9 @@ internal class ChapterWebView(context: Context) : WebView(context) {
         isScrollContainer = false
         isVerticalScrollBarEnabled = false
         isHorizontalScrollBarEnabled = false
+        // Disable WebView's own over-scroll rubber-band so it doesn't compete with the parent
+        // ContinuousReaderView (NestedScrollView) for scroll ownership at the edges.
+        overScrollMode = OVER_SCROLL_NEVER
         settings.javaScriptEnabled = true
         addJavascriptInterface(HeightBridge(), "RiffleChapter")
         webViewClient = object : WebViewClient() {

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ChapterWebView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ChapterWebView.kt
@@ -120,13 +120,23 @@ internal class ChapterWebView(context: Context) : WebView(context) {
                 // shouldInterceptRequest is called on a background thread; runBlocking is safe here.
                 val bytes = runBlocking { pub.get(relUrl)?.read()?.getOrNull() }
                     ?: return super.shouldInterceptRequest(view, request)
-                val mimeType = mimeTypeForPath(path)
+                val rawMime = mimeTypeForPath(path)
+                val isHtml = rawMime == "text/html" || rawMime == "application/xhtml+xml"
+                // EPUB content documents are XHTML even when their file extension is .htm/.html.
+                // Serving them as text/html makes the WebView use the lenient HTML parser, which
+                // ignores XML self-closing syntax on non-void elements — e.g. `<h1 class="chapter"/>`
+                // with no `</h1>` is treated as an *open* heading that then wraps the entire chapter
+                // body, so every paragraph inherits the heading's `text-align: center`. Serving as
+                // application/xhtml+xml (as Readium's own navigator does) selects the XHTML parser,
+                // which honours the self-close, leaving the heading empty and the body correctly
+                // aligned. EPUB requires well-formed XHTML, so strict parsing is safe here.
+                val mimeType = if (isHtml) "application/xhtml+xml" else rawMime
                 val encoding = if (mimeType.startsWith("text/") || mimeType.contains("xml") || mimeType.contains("javascript")) "utf-8" else null
 
                 // For HTML/XHTML chapter resources, inject the same ReadiumCSS stylesheets + the
                 // --USER__ settings attribute Readium injects, so the first paint is already styled
                 // (no FOUC) AND renders identically to Scroll/Paginated mode.
-                val finalBytes = if (mimeType == "text/html" || mimeType == "application/xhtml+xml") {
+                val finalBytes = if (isHtml) {
                     ContinuousStyleInjector.injectInto(String(bytes, Charsets.UTF_8), currentPrefs)
                         .toByteArray(Charsets.UTF_8)
                 } else {

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ChapterWebView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ChapterWebView.kt
@@ -3,8 +3,13 @@ package com.riffle.app.feature.reader
 import android.annotation.SuppressLint
 import android.content.Context
 import android.webkit.JavascriptInterface
+import android.webkit.WebResourceRequest
+import android.webkit.WebResourceResponse
 import android.webkit.WebView
 import android.webkit.WebViewClient
+import kotlinx.coroutines.runBlocking
+import org.readium.r2.shared.publication.Publication
+import org.readium.r2.shared.util.toAbsoluteUrl
 
 /**
  * A [WebView] that:
@@ -28,6 +33,13 @@ internal class ChapterWebView(context: Context) : WebView(context) {
     var chapterHref: String = ""
         private set
 
+    private var publication: Publication? = null
+
+    /** Must be called before [loadChapter] so [shouldInterceptRequest] can serve EPUB resources. */
+    fun setPublication(pub: Publication) {
+        publication = pub
+    }
+
     init {
         isScrollContainer = false
         isVerticalScrollBarEnabled = false
@@ -37,6 +49,26 @@ internal class ChapterWebView(context: Context) : WebView(context) {
         webViewClient = object : WebViewClient() {
             override fun onPageFinished(view: WebView?, url: String?) {
                 this@ChapterWebView.onPageFinished?.invoke()
+            }
+
+            override fun shouldInterceptRequest(view: WebView, request: WebResourceRequest): WebResourceResponse? {
+                val uri = request.url
+                // Readium serves EPUB content via https://readium_package/ — a custom domain
+                // backed by shouldInterceptRequest in EpubNavigatorFragment's own WebViewClient.
+                // Self-managed ChapterWebViews don't have that interceptor, so we replicate it
+                // here by serving resources directly from the Publication container.
+                if (uri.host != "readium_package") return super.shouldInterceptRequest(view, request)
+                val pub = this@ChapterWebView.publication
+                    ?: return super.shouldInterceptRequest(view, request)
+                val absoluteUrl = uri.toAbsoluteUrl()
+                    ?: return super.shouldInterceptRequest(view, request)
+                // shouldInterceptRequest is called on a background thread; runBlocking is safe here.
+                val bytes = runBlocking { pub.get(absoluteUrl)?.read()?.getOrNull() }
+                    ?: return super.shouldInterceptRequest(view, request)
+                val path = uri.path.orEmpty()
+                val mimeType = mimeTypeForPath(path)
+                val encoding = if (mimeType.startsWith("text/") || mimeType.contains("xml") || mimeType.contains("javascript")) "utf-8" else null
+                return WebResourceResponse(mimeType, encoding, bytes.inputStream())
             }
         }
     }
@@ -70,4 +102,20 @@ internal class ChapterWebView(context: Context) : WebView(context) {
             post { this@ChapterWebView.onHeightMeasured?.invoke(height) }
         }
     }
+}
+
+private fun mimeTypeForPath(path: String): String = when {
+    path.endsWith(".xhtml") -> "application/xhtml+xml"
+    path.endsWith(".html") || path.endsWith(".htm") -> "text/html"
+    path.endsWith(".css") -> "text/css"
+    path.endsWith(".js") -> "application/javascript"
+    path.endsWith(".png") -> "image/png"
+    path.endsWith(".jpg") || path.endsWith(".jpeg") -> "image/jpeg"
+    path.endsWith(".gif") -> "image/gif"
+    path.endsWith(".svg") -> "image/svg+xml"
+    path.endsWith(".woff") -> "font/woff"
+    path.endsWith(".woff2") -> "font/woff2"
+    path.endsWith(".ttf") -> "font/ttf"
+    path.endsWith(".otf") -> "font/otf"
+    else -> "application/octet-stream"
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ChapterWebView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ChapterWebView.kt
@@ -3,6 +3,7 @@ package com.riffle.app.feature.reader
 import android.annotation.SuppressLint
 import android.content.Context
 import android.webkit.JavascriptInterface
+import android.webkit.RenderProcessGoneDetail
 import android.webkit.WebResourceRequest
 import android.webkit.WebResourceResponse
 import android.webkit.WebView
@@ -36,6 +37,14 @@ internal class ChapterWebView(context: Context) : WebView(context) {
      * top/bottom bars, matching the behaviour of the standard Readium navigator.
      */
     var onTap: (() -> Unit)? = null
+
+    /**
+     * Called on the main thread when this WebView's renderer process is gone (reclaimed by the
+     * system under memory pressure, or crashed). The dead WebView renders blank from here on, so
+     * the parent must rebuild it. If this event is not consumed the platform's default behaviour is
+     * to crash the whole app.
+     */
+    var onRenderGone: (() -> Unit)? = null
 
     /** The chapter href this view is currently loading (e.g. `"EPUB/chapter01.xhtml"`). */
     var chapterHref: String = ""
@@ -78,6 +87,15 @@ internal class ChapterWebView(context: Context) : WebView(context) {
         webViewClient = object : WebViewClient() {
             override fun onPageFinished(view: WebView?, url: String?) {
                 this@ChapterWebView.onPageFinished?.invoke()
+            }
+
+            override fun onRenderProcessGone(view: WebView?, detail: RenderProcessGoneDetail?): Boolean {
+                // The renderer process backing this WebView is gone — typically reclaimed by the
+                // system under memory pressure (large chapters held in several stacked WebViews make
+                // this likelier). Returning true tells the platform we've handled it, so the app is
+                // NOT killed; the parent rebuilds the (now-dead, permanently blank) WebView.
+                this@ChapterWebView.onRenderGone?.invoke()
+                return true
             }
 
             override fun shouldInterceptRequest(view: WebView, request: WebResourceRequest): WebResourceResponse? {

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ChapterWebView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ChapterWebView.kt
@@ -275,7 +275,22 @@ internal class ChapterWebView(context: Context) : WebView(context) {
         super.startActionMode(wrapSelectionCallback(callback), type)
 
     private fun wrapSelectionCallback(inner: android.view.ActionMode.Callback) =
-        object : android.view.ActionMode.Callback {
+        object : android.view.ActionMode.Callback2() {
+            // The floating selection toolbar anchors to the rect returned here. We MUST forward to
+            // the WebView's own callback (a Callback2 that reports the selection's bounds in view
+            // coordinates): in Continuous mode each ChapterWebView is sized to its whole chapter
+            // (up to tens of thousands of px) and scrolled far above the screen, so the default
+            // content rect — the view's full bounds — would anchor the toolbar to the top of that
+            // giant rect, making the menu appear at the top of the screen instead of next to the
+            // selection. Forwarding gives the framework the real selection rect to map to screen.
+            override fun onGetContentRect(mode: android.view.ActionMode, view: android.view.View, outRect: android.graphics.Rect) {
+                if (inner is android.view.ActionMode.Callback2) {
+                    inner.onGetContentRect(mode, view, outRect)
+                } else {
+                    super.onGetContentRect(mode, view, outRect)
+                }
+            }
+
             override fun onCreateActionMode(mode: android.view.ActionMode, menu: android.view.Menu): Boolean {
                 menu.clear()
                 menu.add(0, MENU_COPY, 0, android.R.string.copy)

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ChapterWebView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ChapterWebView.kt
@@ -1,0 +1,73 @@
+package com.riffle.app.feature.reader
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.webkit.JavascriptInterface
+import android.webkit.WebView
+import android.webkit.WebViewClient
+
+/**
+ * A [WebView] that:
+ * - Has internal scrolling disabled so the parent [ContinuousReaderView] owns all scroll.
+ * - Measures its content height via a [JavascriptInterface] callback after fonts load.
+ * - Injects CSS variables and the TypographyOverride stylesheet on page load.
+ *
+ * Set [onHeightMeasured] before calling [loadChapter]. Height arrives asynchronously on
+ * the main thread after [ContinuousStyleInjector.HEIGHT_MEASUREMENT_JS] fires.
+ */
+@SuppressLint("SetJavaScriptEnabled")
+internal class ChapterWebView(context: Context) : WebView(context) {
+
+    /** Called on the main thread once the content height is known. */
+    var onHeightMeasured: ((heightPx: Int) -> Unit)? = null
+
+    /** Called on the main thread once the page finishes loading (before height is known). */
+    var onPageFinished: (() -> Unit)? = null
+
+    /** The chapter href this view is currently loading (e.g. `"EPUB/chapter01.xhtml"`). */
+    var chapterHref: String = ""
+        private set
+
+    init {
+        isScrollContainer = false
+        isVerticalScrollBarEnabled = false
+        isHorizontalScrollBarEnabled = false
+        settings.javaScriptEnabled = true
+        addJavascriptInterface(HeightBridge(), "RiffleChapter")
+        webViewClient = object : WebViewClient() {
+            override fun onPageFinished(view: WebView?, url: String?) {
+                this@ChapterWebView.onPageFinished?.invoke()
+            }
+        }
+    }
+
+    /**
+     * Load [chapterUrl] (absolute URL from Readium's HTTP server) for chapter at [href].
+     */
+    fun loadChapter(href: String, chapterUrl: String) {
+        chapterHref = href
+        loadUrl(chapterUrl)
+    }
+
+    /**
+     * Inject style variables + TypographyOverride + trigger height measurement.
+     * Call this from [onPageFinished] after Readium's server has served the page.
+     *
+     * @param variableJs output of [ContinuousStyleInjector.buildVariableInjectionJs]
+     */
+    fun injectStylesAndMeasure(variableJs: String) {
+        evaluateJavascript(variableJs, null)
+        evaluateJavascript(typographyOverrideInjectionJs(), null)
+        evaluateJavascript(ContinuousStyleInjector.HEIGHT_MEASUREMENT_JS, null)
+    }
+
+    /** Re-measure after a preference change. */
+    fun reinjectAndRemeasure(variableJs: String) = injectStylesAndMeasure(variableJs)
+
+    private inner class HeightBridge {
+        @JavascriptInterface
+        fun onHeightMeasured(height: Int) {
+            post { this@ChapterWebView.onHeightMeasured?.invoke(height) }
+        }
+    }
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ChapterWebView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ChapterWebView.kt
@@ -79,6 +79,10 @@ internal class ChapterWebView(context: Context) : WebView(context) {
      */
     @Volatile
     private var rawChapterHtml: String? = null
+    // @Volatile: reset on the main thread in loadChapter() but read + lazily cached on the WebView
+    // JS binder thread in onFootnoteAnchorTap(); without it the binder thread could miss the reset
+    // after a recycle and resolve a footnote against the previous chapter's parsed document.
+    @Volatile
     private var footnoteDoc: org.jsoup.nodes.Document? = null
 
     /** When true, the text-selection menu offers "Play from here" (readaloud books only). */

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ChapterWebView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ChapterWebView.kt
@@ -94,20 +94,19 @@ internal class ChapterWebView(context: Context) : WebView(context) {
     }
 
     /**
-     * Inject style variables + TypographyOverride + trigger height measurement.
-     * Call this from [onPageFinished] after Readium's server has served the page.
+     * Inject user styles + trigger height measurement.
+     * Call this from [onPageFinished] after the page has loaded.
      *
-     * @param variableJs output of [ContinuousStyleInjector.buildVariableInjectionJs]
+     * @param styleJs output of [ContinuousStyleInjector.buildStyleInjectionJs]
      */
-    fun injectStylesAndMeasure(variableJs: String) {
-        evaluateJavascript(variableJs, null)
-        evaluateJavascript(typographyOverrideInjectionJs(), null)
+    fun injectStylesAndMeasure(styleJs: String) {
+        evaluateJavascript(styleJs, null)
         evaluateJavascript(ContinuousStyleInjector.HEIGHT_MEASUREMENT_JS, null)
         evaluateJavascript(ContinuousStyleInjector.TAP_LISTENER_JS, null)
     }
 
-    /** Re-measure after a preference change. */
-    fun reinjectAndRemeasure(variableJs: String) = injectStylesAndMeasure(variableJs)
+    /** Re-inject user styles and re-measure after a preference change. */
+    fun reinjectAndRemeasure(styleJs: String) = injectStylesAndMeasure(styleJs)
 
     private inner class HeightBridge {
         @JavascriptInterface

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousPositionTracker.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousPositionTracker.kt
@@ -32,12 +32,21 @@ internal object ContinuousPositionTracker {
     }
 
     /**
-     * Indicates whether the window (3 chapters: [topIndex, topIndex+2]) needs a FORWARD shift.
+     * Indicates whether the loaded window needs a FORWARD shift to keep enough chapters
+     * buffered ahead of the reader.
      *
-     * FORWARD fires when the viewport **bottom** edge enters the last chapter ([topIndex+2]).
-     * Using the viewport bottom (not the midpoint) is critical for short chapters: if the last
-     * chapter is shorter than half the viewport height, the midpoint never enters it and the
-     * shift would never fire.
+     * Trigger is **look-ahead based**, not "you can see the last slot": FORWARD fires as soon as
+     * the chapter at the viewport **midpoint** has advanced more than [chaptersBehind] slots past
+     * the top of the window. Each shift drops the topmost chapter and appends one at the bottom,
+     * so after a shift the midpoint chapter sits exactly [chaptersBehind] slots from the top again
+     * and the condition clears — no oscillation.
+     *
+     * Why midpoint, not the viewport bottom: the previous bottom-edge trigger only fired once the
+     * reader could already *see* the final loaded slot, giving the next chapter zero time to load.
+     * With short "CHAPTER N" divider pages each eating a whole slot, the real content chapter then
+     * started loading exactly when the reader reached it — producing the blank gap + spinner + jump
+     * at every chapter boundary. Triggering on the midpoint keeps several chapters loaded *beyond*
+     * the reader so the next one is already rendered and measured before they arrive.
      *
      * BACKWARD is NOT handled here — it is checked at the call site via a scrollY threshold
      * (`scrollY < firstChapterHeight / 2`). A chapter-index-based backward condition would
@@ -45,8 +54,14 @@ internal object ContinuousPositionTracker {
      * lands in the new first chapter), causing an infinite oscillation.
      */
     fun forwardShiftNeeded(
-        viewportBottomChapterIndex: Int,
+        viewportChapterIndex: Int,
         topIndex: Int,
+        loadedChapterCount: Int,
         readingOrderSize: Int,
-    ): Boolean = viewportBottomChapterIndex > topIndex + 1 && topIndex + 3 < readingOrderSize
+        chaptersBehind: Int,
+    ): Boolean {
+        val moreChaptersExist = topIndex + loadedChapterCount < readingOrderSize
+        val pastBehindBudget = viewportChapterIndex - topIndex > chaptersBehind
+        return moreChaptersExist && pastBehindBudget
+    }
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousPositionTracker.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousPositionTracker.kt
@@ -31,6 +31,36 @@ internal object ContinuousPositionTracker {
         return (slot.top + progression * slot.height).toInt()
     }
 
+    /** Host that [ChapterWebView] serves all EPUB resources from. */
+    const val RESOURCE_HOST = "readium_package"
+
+    /**
+     * Resolve a URL the WebView is about to navigate to (a tapped in-book link) to the EPUB resource
+     * href it points at (keeping any `#fragment`), or null when it points outside the book (an
+     * external http(s) URL). In-book resources are served at `https://[RESOURCE_HOST]/<href>`.
+     */
+    fun internalLinkHref(url: String): String? {
+        val marker = "://$RESOURCE_HOST/"
+        val i = url.indexOf(marker)
+        return if (i >= 0) url.substring(i + marker.length) else null
+    }
+
+    /**
+     * Index into [hrefs] (the reading order) of the chapter [targetHref] refers to, comparing on the
+     * resource path so a `#fragment` on either side doesn't prevent a match. -1 when not found.
+     */
+    fun chapterIndexForHref(hrefs: List<String>, targetHref: String): Int {
+        val target = targetHref.substringBefore('#')
+        return hrefs.indexOfFirst { it.substringBefore('#') == target }
+    }
+
+    /**
+     * Pixels to scroll for a volume-key "page" in continuous mode: one viewport minus a small overlap
+     * so the line at the seam isn't skipped. Returns 0 for a non-positive viewport.
+     */
+    fun pageScrollDelta(viewportHeightPx: Int): Int =
+        if (viewportHeightPx <= 0) 0 else (viewportHeightPx * 0.9f).toInt()
+
     /**
      * Indicates whether the loaded window needs a FORWARD shift to keep enough chapters
      * buffered ahead of the reader.

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousPositionTracker.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousPositionTracker.kt
@@ -11,6 +11,7 @@ internal object ContinuousPositionTracker {
      * Falls back to the last slot if [scrollY] is past all content.
      */
     fun locatorAt(scrollY: Int, viewportHeight: Int, window: List<ChapterSlot>): Pair<String, Float> {
+        require(window.isNotEmpty()) { "ChapterSlot window must not be empty" }
         val midY = scrollY + viewportHeight / 2
         val slot = window.lastOrNull { midY >= it.top } ?: window.first()
         val progression = if (slot.height > 0) {

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousPositionTracker.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousPositionTracker.kt
@@ -1,0 +1,44 @@
+package com.riffle.app.feature.reader
+
+internal object ContinuousPositionTracker {
+
+    data class ChapterSlot(val href: String, val top: Int, val height: Int)
+
+    enum class ShiftDirection { NONE, FORWARD, BACKWARD }
+
+    /**
+     * Returns the chapter href and within-chapter progression (0..1) at the viewport midpoint.
+     * Falls back to the last slot if [scrollY] is past all content.
+     */
+    fun locatorAt(scrollY: Int, viewportHeight: Int, window: List<ChapterSlot>): Pair<String, Float> {
+        val midY = scrollY + viewportHeight / 2
+        val slot = window.lastOrNull { midY >= it.top } ?: window.first()
+        val progression = if (slot.height > 0) {
+            ((midY - slot.top).toFloat() / slot.height).coerceIn(0f, 1f)
+        } else {
+            0f
+        }
+        return slot.href to progression
+    }
+
+    /**
+     * Returns the content offset (from the top of the scroll view) for a given
+     * chapter + progression. Returns null if [href] is not in [window].
+     */
+    fun scrollOffsetFor(href: String, progression: Float, window: List<ChapterSlot>): Int? {
+        val slot = window.firstOrNull { it.href == href } ?: return null
+        return (slot.top + progression * slot.height).toInt()
+    }
+
+    /**
+     * Indicates whether the window (3 chapters: [topIndex, topIndex+2]) needs to shift
+     * because [currentChapterIndex] has moved outside it.
+     */
+    fun shiftNeeded(currentChapterIndex: Int, topIndex: Int, readingOrderSize: Int): ShiftDirection {
+        return when {
+            currentChapterIndex < topIndex && topIndex > 0 -> ShiftDirection.BACKWARD
+            currentChapterIndex > topIndex + 2 && topIndex + 3 < readingOrderSize -> ShiftDirection.FORWARD
+            else -> ShiftDirection.NONE
+        }
+    }
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousPositionTracker.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousPositionTracker.kt
@@ -62,6 +62,21 @@ internal object ContinuousPositionTracker {
         if (viewportHeightPx <= 0) 0 else (viewportHeightPx * 0.9f).toInt()
 
     /**
+     * Resolve a text selection to the narrated-sentence id whose sentence contains it, for
+     * "Play from here" in Continuous mode. [quoteTexts] maps sentence id → sentence text (built from
+     * the readaloud quote map). Returns the id of the sentence that contains the selection (prefer a
+     * full-text containment; fall back to containing the selection's leading chunk so a partial
+     * selection still resolves), or null if nothing matches / the selection is blank.
+     */
+    fun sentenceIdForSelection(selectedText: String, quoteTexts: Map<String, String>): String? {
+        val needle = selectedText.trim()
+        if (needle.isEmpty()) return null
+        quoteTexts.entries.firstOrNull { it.value.contains(needle) }?.let { return it.key }
+        val head = needle.take(20)
+        return quoteTexts.entries.firstOrNull { it.value.contains(head) }?.key
+    }
+
+    /**
      * Indicates whether the loaded window needs a FORWARD shift to keep enough chapters
      * buffered ahead of the reader.
      *

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousPositionTracker.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousPositionTracker.kt
@@ -31,6 +31,21 @@ internal object ContinuousPositionTracker {
         return (slot.top + progression * slot.height).toInt()
     }
 
+    /**
+     * The scrollY that lands [progression] within a chapter at [slotTop]/[slotHeight] — the inverse
+     * of [locatorAt]. Because [locatorAt] measures progression at the viewport MIDPOINT, a restored
+     * mid-chapter progression must be placed back at the midpoint (subtract half the viewport),
+     * NOT at the top. Placing it at the top shifts the view down by half a viewport, so a saved
+     * reading position would drift forward by half a screen on every reopen. A chapter start
+     * (progression ~0, e.g. a TOC jump) stays top-aligned so it doesn't scroll up into the previous
+     * chapter. Never negative.
+     */
+    fun scrollYForProgression(slotTop: Int, slotHeight: Int, progression: Float, viewportHeight: Int): Int {
+        val base = slotTop + (progression * slotHeight).toInt()
+        val y = if (progression <= 0.001f) base else base - viewportHeight / 2
+        return y.coerceAtLeast(0)
+    }
+
     /** Host that [ChapterWebView] serves all EPUB resources from. */
     const val RESOURCE_HOST = "readium_package"
 

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousPositionTracker.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousPositionTracker.kt
@@ -32,14 +32,21 @@ internal object ContinuousPositionTracker {
     }
 
     /**
-     * Indicates whether the window (3 chapters: [topIndex, topIndex+2]) needs to shift
-     * because [currentChapterIndex] has moved outside it.
+     * Indicates whether the window (3 chapters: [topIndex, topIndex+2]) needs a FORWARD shift.
+     *
+     * FORWARD fires when the viewport **bottom** edge enters the last chapter ([topIndex+2]).
+     * Using the viewport bottom (not the midpoint) is critical for short chapters: if the last
+     * chapter is shorter than half the viewport height, the midpoint never enters it and the
+     * shift would never fire.
+     *
+     * BACKWARD is NOT handled here — it is checked at the call site via a scrollY threshold
+     * (`scrollY < firstChapterHeight / 2`). A chapter-index-based backward condition would
+     * immediately re-trigger after every FORWARD shift (the forward scrollBy adjustment always
+     * lands in the new first chapter), causing an infinite oscillation.
      */
-    fun shiftNeeded(currentChapterIndex: Int, topIndex: Int, readingOrderSize: Int): ShiftDirection {
-        return when {
-            currentChapterIndex < topIndex && topIndex > 0 -> ShiftDirection.BACKWARD
-            currentChapterIndex > topIndex + 2 && topIndex + 3 < readingOrderSize -> ShiftDirection.FORWARD
-            else -> ShiftDirection.NONE
-        }
-    }
+    fun forwardShiftNeeded(
+        viewportBottomChapterIndex: Int,
+        topIndex: Int,
+        readingOrderSize: Int,
+    ): Boolean = viewportBottomChapterIndex > topIndex + 1 && topIndex + 3 < readingOrderSize
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
@@ -241,11 +241,13 @@ internal class ContinuousReaderView @JvmOverloads constructor(
 
     /**
      * Builds the sliding window with [initialHref] at the top and scrolls to [initialProgression]
-     * once it has measured. Used both for the first open and to recover after the WebView renderer
+     * (or, when [anchorFragment] names an element, to that element) once the target has measured.
+     * Used for the first open, for a far TOC/link jump, and to recover after the WebView renderer
      * process is killed (see [onRenderProcessGone] wiring in [appendChapter]).
      */
-    private fun openWindowAt(initialHref: String, initialProgression: Float) {
-        val centerIndex = allChapters.indexOfFirst { it.link.href.toString() == initialHref }
+    private fun openWindowAt(initialHref: String, initialProgression: Float, anchorFragment: String = "") {
+        val centerIndex = ContinuousPositionTracker
+            .chapterIndexForHref(allChapters.map { it.link.href.toString() }, initialHref)
             .coerceAtLeast(0)
 
         // Open with the TARGET chapter at the top of the window (no behind buffer yet). The behind
@@ -259,30 +261,39 @@ internal class ContinuousReaderView @JvmOverloads constructor(
         pendingInitialMeasureIndices.clear()
         pendingInitialMeasureIndices.add(0) // the target chapter only
         pendingInitialScroll = {
-            val window = buildWindow()
-            val offset = ContinuousPositionTracker.scrollOffsetFor(initialHref, initialProgression, window)
-            // Top-align the opening position rather than centring it. Centring (offset - height/2)
-            // scrolls the target point to mid-screen, which leaves the top half showing the
-            // *previous* content — or blank, when opening at a chapter start or the book's front
-            // matter (title/epigraph pages that are mostly whitespace). Top-aligning puts the target
-            // line at the top of the viewport so the reader sees content immediately, with unread
-            // text below — the natural "resume / open here" position. (navigateTo keeps centring so
-            // a search hit / link target lands comfortably in the middle.)
-            if (offset != null) scrollTo(0, offset.coerceAtLeast(0))
-            // Now that the target is visible, fill in the behind buffer for smooth backward
-            // scrolling. prependChapter compensates scroll for the added height, so the content the
-            // user is already looking at stays visually anchored — no post-paint jump.
-            // shiftInProgress guards the compensating scrollBy from re-entering handleScrollChange
-            // and oscillating (the same guard the on-scroll shifts use).
-            post {
-                shiftInProgress = true
-                repeat(CHAPTERS_BEHIND) {
-                    if (topIndex > 0) {
-                        topIndex--
-                        prependChapter(topIndex)
+            // Fill the behind buffer for smooth backward scrolling — but only AFTER the target scroll
+            // has landed. prependChapter compensates scroll for the added height, so the content the
+            // user is now looking at stays anchored; running it before the (possibly async, anchor-
+            // resolving) scroll would shift the layout and land us in the wrong place.
+            val fillBehindBuffer = {
+                post {
+                    shiftInProgress = true
+                    repeat(CHAPTERS_BEHIND) {
+                        if (topIndex > 0) {
+                            topIndex--
+                            prependChapter(topIndex)
+                        }
                     }
+                    shiftInProgress = false
                 }
-                shiftInProgress = false
+            }
+            val window = buildWindow()
+            val slot = window.firstOrNull { it.href.substringBefore('#') == initialHref.substringBefore('#') }
+            // Top-align the opening position rather than centring it: centring would leave the top
+            // half showing the *previous* content (or blank at a chapter start / front matter), so the
+            // reader wouldn't "focus on the correct page". With an anchor fragment (a TOC/cross-ref
+            // target) land on that element instead of the resource top, so entries pointing past
+            // front-matter inside a resource are accurate. The target is at window-index 0 here
+            // (slot.top == 0), so the scroll lands cleanly before the behind buffer is added.
+            val targetWv = webViews.firstOrNull { it.chapterHref.substringBefore('#') == initialHref.substringBefore('#') }
+            if (slot != null && anchorFragment.isNotEmpty() && targetWv != null) {
+                targetWv.anchorOffsetTopDevicePx(anchorFragment) { anchorOffset ->
+                    scrollTo(0, (slot.top + (anchorOffset ?: (initialProgression * slot.height).toInt())).coerceAtLeast(0))
+                    fillBehindBuffer()
+                }
+            } else {
+                if (slot != null) scrollTo(0, (slot.top + (initialProgression * slot.height).toInt()).coerceAtLeast(0))
+                fillBehindBuffer()
             }
         }
 
@@ -329,20 +340,15 @@ internal class ContinuousReaderView @JvmOverloads constructor(
         // TOC entries / chapter-map segments / internal links may carry a #fragment that the spine
         // hrefs don't have; match on the resource path so the chapter is still found.
         val target = href.substringBefore('#')
+        val fragment = href.substringAfter('#', "")
         val targetIndex = ContinuousPositionTracker.chapterIndexForHref(
             allChapters.map { it.link.href.toString() }, href,
         )
         if (targetIndex < 0) return
         val inWindow = targetIndex in topIndex until (topIndex + webViews.size)
         if (inWindow) {
-            // Already loaded and measured: scroll straight to it, centring the target (good for a
-            // nearby search hit).
-            post {
-                val window = buildWindow()
-                val matchHref = window.firstOrNull { it.href.substringBefore('#') == target }?.href ?: target
-                val offset = ContinuousPositionTracker.scrollOffsetFor(matchHref, progression, window)
-                if (offset != null) smoothScrollTo(0, (offset - height / 2).coerceAtLeast(0))
-            }
+            // Already loaded and measured: scroll straight to it.
+            post { scrollToLoadedChapter(target, progression, fragment, smooth = true) }
         } else {
             // Far jump (typical TOC / chapter-map tap): rebuild the window around the target and land
             // via the open path, which defers the scroll until the target's REAL height is known.
@@ -354,7 +360,34 @@ internal class ContinuousReaderView @JvmOverloads constructor(
             container.removeAllViews()
             recycledViews.forEach { it.destroy() }
             recycledViews.clear()
-            openWindowAt(target, progression)
+            openWindowAt(target, progression, fragment)
+        }
+    }
+
+    /**
+     * Scroll the (already loaded) chapter [target] into view. When [fragment] names an element, land
+     * on that element (so a TOC/cross-ref anchor lands at the heading, not the resource top). With no
+     * fragment, a chapter start ([progression] ~0) is TOP-aligned — centring it would push the
+     * previous chapter into the top half ("wrong page"); a mid-chapter position (search hit) is
+     * centred so the hit is comfortably visible.
+     */
+    private fun scrollToLoadedChapter(target: String, progression: Float, fragment: String, smooth: Boolean) {
+        val window = buildWindow()
+        val slot = window.firstOrNull { it.href.substringBefore('#') == target } ?: return
+        fun go(y: Int) {
+            val clamped = y.coerceAtLeast(0)
+            if (smooth) smoothScrollTo(0, clamped) else scrollTo(0, clamped)
+        }
+        val wvIndex = webViews.indexOfFirst { it.chapterHref.substringBefore('#') == target }
+        if (fragment.isNotEmpty() && wvIndex >= 0) {
+            webViews[wvIndex].anchorOffsetTopDevicePx(fragment) { anchorOffset ->
+                if (anchorOffset != null) go(slot.top + anchorOffset)
+                else go(slot.top + (progression * slot.height).toInt())
+            }
+        } else {
+            val base = slot.top + (progression * slot.height).toInt()
+            // Top-align a chapter start; centre a mid-chapter target.
+            go(if (progression <= 0.001f) base else base - height / 2)
         }
     }
 

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
@@ -262,59 +262,50 @@ internal class ContinuousReaderView @JvmOverloads constructor(
      * process is killed (see [onRenderProcessGone] wiring in [appendChapter]).
      */
     private fun openWindowAt(initialHref: String, initialProgression: Float, anchorFragment: String = "") {
-        val centerIndex = ContinuousPositionTracker
+        val targetIndex = ContinuousPositionTracker
             .chapterIndexForHref(allChapters.map { it.link.href.toString() }, initialHref)
             .coerceAtLeast(0)
 
-        // Open with the TARGET chapter at the top of the window (no behind buffer yet). The behind
-        // buffer exists only for smooth *backward* scrolling, which the reader can't do until after
-        // the first frame — so blocking the first paint on it just makes opening slow. With the
-        // target at window-index 0 its layout top is 0, so the initial scroll offset depends only on
-        // the target's own height: we wait for exactly one chapter to measure, not two.
-        topIndex = centerIndex
-        val initialAhead = minOf(1 + CHAPTERS_AHEAD, allChapters.size - topIndex)
+        // Build the full window — behind buffer + target + ahead buffer — up front, with the behind
+        // buffer included from the start. The target then sits at window index [targetWindowIndex],
+        // and we land on it with the SAME slot-based math the in-window (chapter-map) path uses:
+        // scroll to (sum of the measured heights before the target) + the in-chapter offset. This is
+        // exact and needs no incremental scroll compensation.
+        //
+        // Earlier this opened with the target at window-index 0 and filled the behind buffer
+        // afterwards via prependChapter's running scrollBy compensation. That async compensation
+        // landed imprecisely — a far TOC jump came to rest about a screen above the target (the
+        // previous chapter showing, the target's heading pushed to the bottom). Waiting for the
+        // behind buffer to measure costs one extra chapter's load before the first paint, which is
+        // an acceptable trade for landing exactly where the TOC entry points.
+        val behind = minOf(CHAPTERS_BEHIND, targetIndex)
+        topIndex = targetIndex - behind
+        val targetWindowIndex = behind
+        val totalChapters = minOf(behind + 1 + CHAPTERS_AHEAD, allChapters.size - topIndex)
 
+        // Land only once every chapter up to and including the target has reported its real height,
+        // so the target's slot.top (the sum of the heights before it) is exact.
         pendingInitialMeasureIndices.clear()
-        pendingInitialMeasureIndices.add(0) // the target chapter only
+        pendingInitialMeasureIndices.addAll(0..targetWindowIndex)
         pendingInitialScroll = {
-            // Fill the behind buffer for smooth backward scrolling — but only AFTER the target scroll
-            // has landed. prependChapter compensates scroll for the added height, so the content the
-            // user is now looking at stays anchored; running it before the (possibly async, anchor-
-            // resolving) scroll would shift the layout and land us in the wrong place.
-            val fillBehindBuffer = {
-                post {
-                    shiftInProgress = true
-                    repeat(CHAPTERS_BEHIND) {
-                        if (topIndex > 0) {
-                            topIndex--
-                            prependChapter(topIndex)
-                        }
+            val slot = buildWindow().getOrNull(targetWindowIndex)
+            val targetWv = webViews.getOrNull(targetWindowIndex)
+            if (slot != null) {
+                // With an anchor fragment (TOC/cross-ref target) land on that element inside the
+                // resource; otherwise land at the resource top (progression 0) or the saved
+                // progression offset (resume).
+                if (anchorFragment.isNotEmpty() && targetWv != null) {
+                    targetWv.anchorOffsetTopDevicePx(anchorFragment) { anchorOffset ->
+                        val within = anchorOffset ?: (initialProgression * slot.height).toInt()
+                        scrollTo(0, (slot.top + within).coerceAtLeast(0))
                     }
-                    shiftInProgress = false
+                } else {
+                    scrollTo(0, (slot.top + (initialProgression * slot.height).toInt()).coerceAtLeast(0))
                 }
-            }
-            // The target chapter is window-index 0 right after the rebuild — its layout top is 0 —
-            // and this runs from index 0's own measurement, so address it directly rather than
-            // looking it up by href in the window (that lookup could miss if the window changed and
-            // would then silently skip the scroll, leaving the reader on the previous chapter — the
-            // "navigates to a position that is not the TOC href" bug).
-            // Top-align the opening position (centring would put the *previous* chapter in the top
-            // half). With an anchor fragment (TOC/cross-ref target) land on that element instead of
-            // the resource top, so entries pointing past front-matter inside a resource are accurate.
-            val targetWv = webViews.firstOrNull()
-            val targetHeight = measuredHeights.firstOrNull() ?: 0
-            if (targetWv != null && anchorFragment.isNotEmpty()) {
-                targetWv.anchorOffsetTopDevicePx(anchorFragment) { anchorOffset ->
-                    scrollTo(0, (anchorOffset ?: (initialProgression * targetHeight).toInt()).coerceAtLeast(0))
-                    fillBehindBuffer()
-                }
-            } else {
-                if (targetWv != null) scrollTo(0, (initialProgression * targetHeight).toInt().coerceAtLeast(0))
-                fillBehindBuffer()
             }
         }
 
-        repeat(initialAhead) { i -> appendChapter(topIndex + i) }
+        repeat(totalChapters) { i -> appendChapter(topIndex + i) }
     }
 
     /**

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
@@ -8,6 +8,7 @@ import android.widget.LinearLayout
 import androidx.core.widget.NestedScrollView
 import com.riffle.core.domain.FormattingPreferences
 import org.readium.r2.shared.publication.Link
+import org.readium.r2.shared.publication.Publication
 
 /**
  * Renders the entire book as a single vertical scroll by stacking a sliding window of 3
@@ -41,6 +42,9 @@ internal class ContinuousReaderView @JvmOverloads constructor(
     /** Current formatting preferences for CSS injection. */
     private var formattingPrefs: FormattingPreferences = FormattingPreferences()
 
+    /** Publication used by [ChapterWebView] to serve EPUB resources via shouldInterceptRequest. */
+    private var publication: Publication? = null
+
     /**
      * Index into [allChapters] of the topmost loaded chapter.
      * The window covers [topIndex, topIndex+1, topIndex+2] (clamped to list bounds).
@@ -72,9 +76,11 @@ internal class ContinuousReaderView @JvmOverloads constructor(
         prefs: FormattingPreferences,
         initialHref: String,
         initialProgression: Float,
+        publication: Publication,
     ) {
         allChapters = chapters
         formattingPrefs = prefs
+        this.publication = publication
         val centerIndex = chapters.indexOfFirst { it.link.href.toString() == initialHref }
             .coerceAtLeast(0)
         topIndex = (centerIndex - 1).coerceAtLeast(0)
@@ -128,6 +134,7 @@ internal class ContinuousReaderView @JvmOverloads constructor(
     private fun appendChapter(index: Int) {
         val entry = allChapters[index]
         val wv = ChapterWebView(context)
+        publication?.let { wv.setPublication(it) }
         val placeholder = placeholderHeight
         wv.onHeightMeasured = { measuredPx ->
             val i = webViews.indexOf(wv)
@@ -154,6 +161,7 @@ internal class ContinuousReaderView @JvmOverloads constructor(
     private fun prependChapter(index: Int) {
         val entry = allChapters[index]
         val wv = ChapterWebView(context)
+        publication?.let { wv.setPublication(it) }
         val placeholder = placeholderHeight
         wv.onHeightMeasured = { measuredPx ->
             val i = webViews.indexOf(wv)

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
@@ -35,12 +35,15 @@ internal class ContinuousReaderView @JvmOverloads constructor(
         private const val CHAPTERS_BEHIND = 1
 
         /**
-         * Chapters kept loaded ahead of the reader. Must be ≥2 so that a short "CHAPTER N"
-         * divider page and the real content chapter that follows it are BOTH loaded and measured
-         * before the reader arrives — otherwise the content chapter starts loading exactly when
-         * the reader scrolls into it, producing a blank gap, a spinner, and a jump at the seam.
+         * Chapters kept loaded ahead of the reader. The buffer is count-based, but EPUBs split a
+         * book into many small spine files (e.g. The Martian: 168 spine items for 31 TOC chapters —
+         * short "LOG ENTRY" entries and "CHAPTER N" divider pages), so a few chapters ahead can be
+         * less than one screen of pixels. When the reader scrolls faster than those tiny chapters
+         * load, it reaches one that hasn't rendered yet — a blank gap (and loading spinner) at the
+         * seam. A larger ahead-buffer keeps enough *pixels* loaded across runs of short chapters.
+         * (A pixel-aware buffer would be more precise; this is the low-risk mitigation.)
          */
-        private const val CHAPTERS_AHEAD = 3
+        private const val CHAPTERS_AHEAD = 6
 
         /** Total sliding-window size: the reader's chapter plus the behind/ahead buffers. */
         private const val WINDOW_SIZE = CHAPTERS_BEHIND + 1 + CHAPTERS_AHEAD

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
@@ -44,6 +44,14 @@ internal class ContinuousReaderView @JvmOverloads constructor(
 
         /** Total sliding-window size: the reader's chapter plus the behind/ahead buffers. */
         private const val WINDOW_SIZE = CHAPTERS_BEHIND + 1 + CHAPTERS_AHEAD
+
+        /**
+         * Grace period after a window (re)build before the initial scroll is forced to fire even if
+         * not every required chapter has measured — so a slow/failed measurement can't strand the
+         * reader on a blank position. Long enough that a normal load measures first (chapters
+         * typically measure in <300ms), short enough that a stuck case recovers quickly.
+         */
+        private const val INITIAL_SCROLL_FALLBACK_MS = 700L
     }
 
     data class ChapterEntry(val link: Link, val url: String)
@@ -239,7 +247,7 @@ internal class ContinuousReaderView @JvmOverloads constructor(
      * count on a debug device.
      */
     private val maxFlingVelocity =
-        (android.view.ViewConfiguration.get(context).scaledMaximumFlingVelocity * 0.45f).toInt()
+        (android.view.ViewConfiguration.get(context).scaledMaximumFlingVelocity * 0.60f).toInt()
 
     override fun fling(velocityY: Int) {
         super.fling(velocityY.coerceIn(-maxFlingVelocity, maxFlingVelocity))
@@ -313,6 +321,21 @@ internal class ContinuousReaderView @JvmOverloads constructor(
         }
 
         repeat(totalChapters) { i -> appendChapter(topIndex + i) }
+
+        // Safety net: the scroll above waits for the behind buffer AND the target to measure. If a
+        // chapter is slow to load/measure (large resource, slow device, transient renderer hiccup),
+        // never leave the window stranded on a stale scroll offset showing a blank — fire the scroll
+        // after a short grace period with whatever heights are known. Lands the target at the behind
+        // buffer's placeholder height; the index-0 height compensation then corrects it to the exact
+        // top once the behind buffer's real height arrives. A no-op if the normal path already fired.
+        postDelayed({
+            if (pendingInitialScroll != null) {
+                val scroll = pendingInitialScroll
+                pendingInitialScroll = null
+                pendingInitialMeasureIndices.clear()
+                scroll?.invoke()
+            }
+        }, INITIAL_SCROLL_FALLBACK_MS)
     }
 
     /**

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
@@ -277,22 +277,23 @@ internal class ContinuousReaderView @JvmOverloads constructor(
                     shiftInProgress = false
                 }
             }
-            val window = buildWindow()
-            val slot = window.firstOrNull { it.href.substringBefore('#') == initialHref.substringBefore('#') }
-            // Top-align the opening position rather than centring it: centring would leave the top
-            // half showing the *previous* content (or blank at a chapter start / front matter), so the
-            // reader wouldn't "focus on the correct page". With an anchor fragment (a TOC/cross-ref
-            // target) land on that element instead of the resource top, so entries pointing past
-            // front-matter inside a resource are accurate. The target is at window-index 0 here
-            // (slot.top == 0), so the scroll lands cleanly before the behind buffer is added.
-            val targetWv = webViews.firstOrNull { it.chapterHref.substringBefore('#') == initialHref.substringBefore('#') }
-            if (slot != null && anchorFragment.isNotEmpty() && targetWv != null) {
+            // The target chapter is window-index 0 right after the rebuild — its layout top is 0 —
+            // and this runs from index 0's own measurement, so address it directly rather than
+            // looking it up by href in the window (that lookup could miss if the window changed and
+            // would then silently skip the scroll, leaving the reader on the previous chapter — the
+            // "navigates to a position that is not the TOC href" bug).
+            // Top-align the opening position (centring would put the *previous* chapter in the top
+            // half). With an anchor fragment (TOC/cross-ref target) land on that element instead of
+            // the resource top, so entries pointing past front-matter inside a resource are accurate.
+            val targetWv = webViews.firstOrNull()
+            val targetHeight = measuredHeights.firstOrNull() ?: 0
+            if (targetWv != null && anchorFragment.isNotEmpty()) {
                 targetWv.anchorOffsetTopDevicePx(anchorFragment) { anchorOffset ->
-                    scrollTo(0, (slot.top + (anchorOffset ?: (initialProgression * slot.height).toInt())).coerceAtLeast(0))
+                    scrollTo(0, (anchorOffset ?: (initialProgression * targetHeight).toInt()).coerceAtLeast(0))
                     fillBehindBuffer()
                 }
             } else {
-                if (slot != null) scrollTo(0, (slot.top + (initialProgression * slot.height).toInt()).coerceAtLeast(0))
+                if (targetWv != null) scrollTo(0, (initialProgression * targetHeight).toInt().coerceAtLeast(0))
                 fillBehindBuffer()
             }
         }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
@@ -35,15 +35,12 @@ internal class ContinuousReaderView @JvmOverloads constructor(
         private const val CHAPTERS_BEHIND = 1
 
         /**
-         * Chapters kept loaded ahead of the reader. The buffer is count-based, but EPUBs split a
-         * book into many small spine files (e.g. The Martian: 168 spine items for 31 TOC chapters —
-         * short "LOG ENTRY" entries and "CHAPTER N" divider pages), so a few chapters ahead can be
-         * less than one screen of pixels. When the reader scrolls faster than those tiny chapters
-         * load, it reaches one that hasn't rendered yet — a blank gap (and loading spinner) at the
-         * seam. A larger ahead-buffer keeps enough *pixels* loaded across runs of short chapters.
-         * (A pixel-aware buffer would be more precise; this is the low-risk mitigation.)
+         * Chapters kept loaded ahead of the reader. Must be ≥2 so that a short "CHAPTER N"
+         * divider page and the real content chapter that follows it are BOTH loaded and measured
+         * before the reader arrives — otherwise the content chapter starts loading exactly when
+         * the reader scrolls into it, producing a blank gap, a spinner, and a jump at the seam.
          */
-        private const val CHAPTERS_AHEAD = 6
+        private const val CHAPTERS_AHEAD = 3
 
         /** Total sliding-window size: the reader's chapter plus the behind/ahead buffers. */
         private const val WINDOW_SIZE = CHAPTERS_BEHIND + 1 + CHAPTERS_AHEAD

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
@@ -223,6 +223,22 @@ internal class ContinuousReaderView @JvmOverloads constructor(
     private val touchSlop = android.view.ViewConfiguration.get(context).scaledTouchSlop
 
     /**
+     * Cap fling velocity. A very fast fling demands new raster tiles faster than the WebView
+     * renderer's shared tile-memory budget can satisfy across the stacked full-height chapter
+     * WebViews — Chromium then logs "tile memory limits exceeded, some content may not draw" and
+     * drops tiles, which shows as blank regions until they re-rasterize (briefly on a fast GPU,
+     * for longer on a slower device). Clamping the launch velocity keeps the per-frame tile demand
+     * within budget while still allowing a brisk fling. Tuned against the tile-overflow warning
+     * count on a debug device.
+     */
+    private val maxFlingVelocity =
+        (android.view.ViewConfiguration.get(context).scaledMaximumFlingVelocity * 0.45f).toInt()
+
+    override fun fling(velocityY: Int) {
+        super.fling(velocityY.coerceIn(-maxFlingVelocity, maxFlingVelocity))
+    }
+
+    /**
      * Initialize the view at [initialHref] + [initialProgression].
      * Call once after attaching to the window.
      */

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
@@ -6,6 +6,7 @@ import android.view.MotionEvent
 import android.view.ViewGroup.LayoutParams.MATCH_PARENT
 import android.view.ViewGroup.LayoutParams.WRAP_CONTENT
 import android.widget.LinearLayout
+import android.widget.OverScroller
 import androidx.core.widget.NestedScrollView
 import com.riffle.core.domain.FormattingPreferences
 import org.readium.r2.shared.publication.Link
@@ -72,8 +73,14 @@ internal class ContinuousReaderView @JvmOverloads constructor(
     /** Measured content heights for each WebView in the current window. */
     private val measuredHeights = mutableListOf<Int>()
 
-    /** Placeholder height (3× screen height) used before real measurement arrives. */
-    private val placeholderHeight: Int get() = resources.displayMetrics.heightPixels * 3
+    /**
+     * Placeholder height used before real measurement arrives. One screen height keeps the
+     * forward-shift trigger working (the last chapter needs enough height to scroll into) while
+     * minimising the phantom space the user can fling into before the real height is known.
+     * Three screen heights caused a large snap-back when short chapters (e.g. chapter-number
+     * divider pages) measured far below the placeholder.
+     */
+    private val placeholderHeight: Int get() = resources.displayMetrics.heightPixels
 
     init {
         addView(container, LayoutParams(MATCH_PARENT, WRAP_CONTENT))
@@ -185,17 +192,26 @@ internal class ContinuousReaderView @JvmOverloads constructor(
                 val wasPlaceholder = measuredHeights[i] == placeholder
                 val oldHeight = measuredHeights[i]
                 val delta = measuredPx - oldHeight
-                // For non-first chapters whose placeholder shrank to the real height: clamp
-                // scrollY to the new content boundary BEFORE updating layoutParams. Without this,
-                // NestedScrollView runs its own implicit clamp in the layout pass — which fires
-                // invisibly and snaps the user back, appearing as the page "fighting" the scroll.
+                // For non-first chapters whose placeholder shrank to the real height: abort the
+                // fling and clamp scrollY to the new content boundary BEFORE updating layoutParams.
+                //
+                // Without aborting the fling: NestedScrollView.computeScroll() continues running
+                // the OverScroller between our scrollTo() call and the layout pass, overwriting
+                // the clamped position before onLayout's scrollTo() re-clamps with the new height
+                // — the user sees the same "snap back" because the fling won the race.
+                //
+                // Without the pre-layout scrollTo: the implicit clamp in NestedScrollView.onLayout
+                // fires invisibly with no smooth-scroll, producing a jarring jump.
+                //
                 // Short EPUB chapters (separator pages, chapter-number dividers) hit this path
-                // regularly because their real height (e.g. 100 px) is far less than the 3×
-                // screen placeholder.
+                // regularly — their real height (e.g. 100 px) is far less than the placeholder.
                 if (wasPlaceholder && i != 0 && delta < 0) {
                     measuredHeights[i] = measuredPx
                     val newMaxScroll = (measuredHeights.sum() - height).coerceAtLeast(0)
-                    if (scrollY > newMaxScroll) scrollTo(0, newMaxScroll)
+                    if (scrollY > newMaxScroll) {
+                        abortFling()
+                        scrollTo(0, newMaxScroll)
+                    }
                 } else {
                     measuredHeights[i] = measuredPx
                 }
@@ -218,7 +234,7 @@ internal class ContinuousReaderView @JvmOverloads constructor(
         webViews.add(wv)
         measuredHeights.add(placeholder)
         container.addView(wv, LinearLayout.LayoutParams(MATCH_PARENT, placeholder))
-        wv.loadChapter(entry.link.href.toString(), entry.url)
+        wv.loadChapter(entry.link.href.toString(), entry.url, formattingPrefs)
     }
 
     private fun prependChapter(index: Int) {
@@ -245,7 +261,7 @@ internal class ContinuousReaderView @JvmOverloads constructor(
         measuredHeights.add(0, placeholder)
         container.addView(wv, 0, LinearLayout.LayoutParams(MATCH_PARENT, placeholder))
         scrollBy(0, placeholder)
-        wv.loadChapter(entry.link.href.toString(), entry.url)
+        wv.loadChapter(entry.link.href.toString(), entry.url, formattingPrefs)
     }
 
     private fun removeTop() {
@@ -334,5 +350,23 @@ internal class ContinuousReaderView @JvmOverloads constructor(
     private fun webViewIndexFor(href: String): Int? {
         val i = webViews.indexOfFirst { it.chapterHref == href }
         return if (i >= 0) i else null
+    }
+
+    /**
+     * Abort any in-progress fling animation so that the OverScroller stops updating scrollY.
+     * Called before a programmatic scrollTo when a chapter measures shorter than its placeholder:
+     * without this, computeScroll() would continue advancing the fling position between our
+     * scrollTo() call and the layout pass, overwriting the clamped scroll before onLayout's own
+     * clamp fires with the updated (smaller) content height.
+     *
+     * NestedScrollView does not expose a public abort-fling API, so we reach the mScroller field
+     * via reflection. The field name is stable across all AOSP/AndroidX versions.
+     */
+    private fun abortFling() {
+        try {
+            val f = NestedScrollView::class.java.getDeclaredField("mScroller")
+            f.isAccessible = true
+            (f.get(this) as? OverScroller)?.abortAnimation()
+        } catch (_: Exception) {}
     }
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
@@ -117,9 +117,10 @@ internal class ContinuousReaderView @JvmOverloads constructor(
 
     /** Update preferences and re-inject styles + remeasure all loaded chapters. */
     fun updatePreferences(prefs: FormattingPreferences) {
+        if (prefs == formattingPrefs) return
         formattingPrefs = prefs
-        val variableJs = ContinuousStyleInjector.buildVariableInjectionJs(prefs)
-        webViews.forEach { wv -> wv.reinjectAndRemeasure(variableJs) }
+        val styleJs = ContinuousStyleInjector.buildStyleInjectionJs(prefs)
+        webViews.forEach { wv -> wv.reinjectAndRemeasure(styleJs) }
     }
 
     /** Scroll to [href] at [progression]. Loads the chapter into the window if needed. */
@@ -179,8 +180,8 @@ internal class ContinuousReaderView @JvmOverloads constructor(
             }
         }
         wv.onPageFinished = {
-            val variableJs = ContinuousStyleInjector.buildVariableInjectionJs(formattingPrefs)
-            wv.injectStylesAndMeasure(variableJs)
+            val styleJs = ContinuousStyleInjector.buildStyleInjectionJs(formattingPrefs)
+            wv.injectStylesAndMeasure(styleJs)
         }
         webViews.add(wv)
         measuredHeights.add(placeholder)
@@ -205,8 +206,8 @@ internal class ContinuousReaderView @JvmOverloads constructor(
             }
         }
         wv.onPageFinished = {
-            val variableJs = ContinuousStyleInjector.buildVariableInjectionJs(formattingPrefs)
-            wv.injectStylesAndMeasure(variableJs)
+            val styleJs = ContinuousStyleInjector.buildStyleInjectionJs(formattingPrefs)
+            wv.injectStylesAndMeasure(styleJs)
         }
         webViews.add(0, wv)
         measuredHeights.add(0, placeholder)

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
@@ -185,7 +185,20 @@ internal class ContinuousReaderView @JvmOverloads constructor(
                 val wasPlaceholder = measuredHeights[i] == placeholder
                 val oldHeight = measuredHeights[i]
                 val delta = measuredPx - oldHeight
-                measuredHeights[i] = measuredPx
+                // For non-first chapters whose placeholder shrank to the real height: clamp
+                // scrollY to the new content boundary BEFORE updating layoutParams. Without this,
+                // NestedScrollView runs its own implicit clamp in the layout pass — which fires
+                // invisibly and snaps the user back, appearing as the page "fighting" the scroll.
+                // Short EPUB chapters (separator pages, chapter-number dividers) hit this path
+                // regularly because their real height (e.g. 100 px) is far less than the 3×
+                // screen placeholder.
+                if (wasPlaceholder && i != 0 && delta < 0) {
+                    measuredHeights[i] = measuredPx
+                    val newMaxScroll = (measuredHeights.sum() - height).coerceAtLeast(0)
+                    if (scrollY > newMaxScroll) scrollTo(0, newMaxScroll)
+                } else {
+                    measuredHeights[i] = measuredPx
+                }
                 wv.layoutParams = wv.layoutParams.also { it.height = measuredPx }
                 // Compensate scroll for ch0 only when:
                 // - chapter shrank (delta < 0): visible content above would shift without compensation

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
@@ -83,6 +83,12 @@ internal class ContinuousReaderView @JvmOverloads constructor(
      */
     var onPlayFromHereSelection: ((href: String, selectedText: String) -> Unit)? = null
 
+    /**
+     * Called on the main thread with the resolved footnote body when the user taps a footnote
+     * anchor in a chapter. The host shows the footnote popup.
+     */
+    var onFootnoteContent: ((FootnoteContent) -> Unit)? = null
+
     private val container = LinearLayout(context).apply {
         orientation = LinearLayout.VERTICAL
     }
@@ -176,6 +182,7 @@ internal class ContinuousReaderView @JvmOverloads constructor(
         wv.onInternalLink = null
         wv.onExternalLink = null
         wv.onPlayFromHere = null
+        wv.onFootnoteContent = null
         if (recycledViews.size < WINDOW_SIZE) recycledViews.addLast(wv) else wv.destroy()
     }
 
@@ -429,6 +436,7 @@ internal class ContinuousReaderView @JvmOverloads constructor(
         wv.onExternalLink = { onExternalLinkTapped?.invoke(it) }
         wv.readaloudAvailable = readaloudAvailable
         wv.onPlayFromHere = { text -> onPlayFromHereSelection?.invoke(wv.chapterHref, text) }
+        wv.onFootnoteContent = { onFootnoteContent?.invoke(it) }
         val placeholder = placeholderHeight
         wv.onHeightMeasured = { measuredPx ->
             val i = webViews.indexOf(wv)
@@ -508,6 +516,7 @@ internal class ContinuousReaderView @JvmOverloads constructor(
         wv.onExternalLink = { onExternalLinkTapped?.invoke(it) }
         wv.readaloudAvailable = readaloudAvailable
         wv.onPlayFromHere = { text -> onPlayFromHereSelection?.invoke(wv.chapterHref, text) }
+        wv.onFootnoteContent = { onFootnoteContent?.invoke(it) }
         val placeholder = placeholderHeight
         wv.onHeightMeasured = { measuredPx ->
             val i = webViews.indexOf(wv)

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
@@ -635,6 +635,11 @@ internal class ContinuousReaderView @JvmOverloads constructor(
      */
     private fun maybeShift() {
         if (shiftInProgress) return
+        // Don't shift the window until the initial scroll has landed. The initial-scroll latch keys
+        // on window indices; a shift here (from an early scroll/re-measure during the open) would
+        // renumber the slots out from under it, so it could fire against the wrong chapter or never
+        // empty. Once the target is positioned, normal shifting resumes.
+        if (pendingInitialScroll != null) return
         val window = buildWindow()
         if (window.isEmpty()) return
         val sY = scrollY

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
@@ -70,6 +70,19 @@ internal class ContinuousReaderView @JvmOverloads constructor(
      */
     var onExternalLinkTapped: ((url: String) -> Unit)? = null
 
+    /** Whether the text-selection menu should offer "Play from here" (readaloud books only). */
+    var readaloudAvailable: Boolean = false
+        set(value) {
+            field = value
+            webViews.forEach { it.readaloudAvailable = value }
+        }
+
+    /**
+     * Called on the main thread with (chapter href, selected text) when the user taps
+     * "Play from here". The host resolves the selection to a narrated sentence and starts playback.
+     */
+    var onPlayFromHereSelection: ((href: String, selectedText: String) -> Unit)? = null
+
     private val container = LinearLayout(context).apply {
         orientation = LinearLayout.VERTICAL
     }
@@ -162,6 +175,7 @@ internal class ContinuousReaderView @JvmOverloads constructor(
         wv.onRenderGone = null
         wv.onInternalLink = null
         wv.onExternalLink = null
+        wv.onPlayFromHere = null
         if (recycledViews.size < WINDOW_SIZE) recycledViews.addLast(wv) else wv.destroy()
     }
 
@@ -372,6 +386,8 @@ internal class ContinuousReaderView @JvmOverloads constructor(
         wv.onRenderGone = { recoverFromRendererGone() }
         wv.onInternalLink = { onInternalLinkTapped?.invoke(it) }
         wv.onExternalLink = { onExternalLinkTapped?.invoke(it) }
+        wv.readaloudAvailable = readaloudAvailable
+        wv.onPlayFromHere = { text -> onPlayFromHereSelection?.invoke(wv.chapterHref, text) }
         val placeholder = placeholderHeight
         wv.onHeightMeasured = { measuredPx ->
             val i = webViews.indexOf(wv)
@@ -449,6 +465,8 @@ internal class ContinuousReaderView @JvmOverloads constructor(
         wv.onRenderGone = { recoverFromRendererGone() }
         wv.onInternalLink = { onInternalLinkTapped?.invoke(it) }
         wv.onExternalLink = { onExternalLinkTapped?.invoke(it) }
+        wv.readaloudAvailable = readaloudAvailable
+        wv.onPlayFromHere = { text -> onPlayFromHereSelection?.invoke(wv.chapterHref, text) }
         val placeholder = placeholderHeight
         wv.onHeightMeasured = { measuredPx ->
             val i = webViews.indexOf(wv)

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
@@ -113,11 +113,46 @@ internal class ContinuousReaderView @JvmOverloads constructor(
      */
     private val placeholderHeight: Int get() = resources.displayMetrics.heightPixels
 
+    /**
+     * Pool of detached [ChapterWebView]s kept for reuse across window shifts. Constructing a WebView
+     * costs ~5-15ms on the main thread — doing it inside the scroll callback at every chapter border
+     * drops a frame and reads as a stutter. Recycling the WebView that just scrolled off the far end
+     * into the one being added at the near end keeps shifts cheap (a reload, no construction/destroy).
+     * Capped at [WINDOW_SIZE]; any excess is destroyed.
+     */
+    private val recycledViews = ArrayDeque<ChapterWebView>()
+
+    /** A recycled WebView if one is available, else a freshly constructed one. */
+    private fun obtainWebView(): ChapterWebView =
+        recycledViews.removeFirstOrNull() ?: ChapterWebView(context)
+
+    /**
+     * Detach [wv] from active use and pool it for reuse (or destroy it if the pool is full).
+     * Callbacks are cleared so an in-flight measure/page-finished from its previous chapter can't
+     * fire against stale state before the WebView is reloaded for its next chapter.
+     */
+    private fun recycle(wv: ChapterWebView) {
+        wv.onHeightMeasured = null
+        wv.onPageFinished = null
+        wv.onTap = null
+        if (recycledViews.size < WINDOW_SIZE) recycledViews.addLast(wv) else wv.destroy()
+    }
+
     init {
         addView(container, LayoutParams(MATCH_PARENT, WRAP_CONTENT))
         setOnScrollChangeListener { _, _, scrollY, _, _ ->
             handleScrollChange(scrollY)
         }
+    }
+
+    override fun onDetachedFromWindow() {
+        super.onDetachedFromWindow()
+        // Destroy every WebView we hold — both the live window and the recycle pool — so they don't
+        // leak when the reader screen goes away.
+        webViews.forEach { it.destroy() }
+        webViews.clear()
+        recycledViews.forEach { it.destroy() }
+        recycledViews.clear()
     }
 
     // ChapterWebViews detect vertical motion and call requestDisallowInterceptTouchEvent(true),
@@ -162,24 +197,39 @@ internal class ContinuousReaderView @JvmOverloads constructor(
         this.publication = publication
         val centerIndex = chapters.indexOfFirst { it.link.href.toString() == initialHref }
             .coerceAtLeast(0)
-        topIndex = (centerIndex - CHAPTERS_BEHIND).coerceAtLeast(0)
-        val windowSize = minOf(WINDOW_SIZE, chapters.size - topIndex)
 
-        // Defer the initial scroll until every chapter AT OR BEFORE the target chapter has
-        // reported its real height. Using placeholder heights produces an inaccurate initial
-        // position: if the preceding chapter is taller than the placeholder, the scroll
-        // compensation in onHeightMeasured pushes the viewport past the intended intra-chapter
-        // offset. Waiting for real heights means a single, correct scrollTo with no follow-up jump.
-        val centerInWindow = (centerIndex - topIndex).coerceIn(0, windowSize - 1)
+        // Open with the TARGET chapter at the top of the window (no behind buffer yet). The behind
+        // buffer exists only for smooth *backward* scrolling, which the reader can't do until after
+        // the first frame — so blocking the first paint on it just makes opening slow. With the
+        // target at window-index 0 its layout top is 0, so the initial scroll offset depends only on
+        // the target's own height: we wait for exactly one chapter to measure, not two.
+        topIndex = centerIndex
+        val initialAhead = minOf(1 + CHAPTERS_AHEAD, chapters.size - topIndex)
+
         pendingInitialMeasureIndices.clear()
-        for (i in 0..centerInWindow) pendingInitialMeasureIndices.add(i)
+        pendingInitialMeasureIndices.add(0) // the target chapter only
         pendingInitialScroll = {
             val window = buildWindow()
             val offset = ContinuousPositionTracker.scrollOffsetFor(initialHref, initialProgression, window)
             if (offset != null) scrollTo(0, (offset - height / 2).coerceAtLeast(0))
+            // Now that the target is visible, fill in the behind buffer for smooth backward
+            // scrolling. prependChapter compensates scroll for the added height, so the content the
+            // user is already looking at stays visually anchored — no post-paint jump.
+            // shiftInProgress guards the compensating scrollBy from re-entering handleScrollChange
+            // and oscillating (the same guard the on-scroll shifts use).
+            post {
+                shiftInProgress = true
+                repeat(CHAPTERS_BEHIND) {
+                    if (topIndex > 0) {
+                        topIndex--
+                        prependChapter(topIndex)
+                    }
+                }
+                shiftInProgress = false
+            }
         }
 
-        repeat(windowSize) { i -> appendChapter(topIndex + i) }
+        repeat(initialAhead) { i -> appendChapter(topIndex + i) }
     }
 
     /** Update preferences and re-inject styles + remeasure all loaded chapters. */
@@ -223,7 +273,7 @@ internal class ContinuousReaderView @JvmOverloads constructor(
 
     private fun appendChapter(index: Int) {
         val entry = allChapters[index]
-        val wv = ChapterWebView(context)
+        val wv = obtainWebView()
         publication?.let { wv.setPublication(it) }
         wv.onTap = { onTap?.invoke() }
         val placeholder = placeholderHeight
@@ -297,7 +347,7 @@ internal class ContinuousReaderView @JvmOverloads constructor(
 
     private fun prependChapter(index: Int) {
         val entry = allChapters[index]
-        val wv = ChapterWebView(context)
+        val wv = obtainWebView()
         publication?.let { wv.setPublication(it) }
         wv.onTap = { onTap?.invoke() }
         val placeholder = placeholderHeight
@@ -329,7 +379,7 @@ internal class ContinuousReaderView @JvmOverloads constructor(
         val h = measuredHeights.removeAt(0)
         val wv = webViews.removeAt(0)
         container.removeView(wv)
-        wv.destroy()
+        recycle(wv)
         // h is the stored measured height at removal time. If the WebView was still loading when
         // removeTop() fires (h == placeholderHeight), the scroll offset may be over-compensated
         // and produce a brief jump. Rare in practice: removeTop() only fires after the user scrolls
@@ -343,7 +393,7 @@ internal class ContinuousReaderView @JvmOverloads constructor(
         measuredHeights.removeAt(measuredHeights.lastIndex)
         val wv = webViews.removeAt(webViews.lastIndex)
         container.removeView(wv)
-        wv.destroy()
+        recycle(wv)
     }
 
     private fun handleScrollChange(scrollY: Int) {

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
@@ -158,10 +158,11 @@ internal class ContinuousReaderView @JvmOverloads constructor(
         wv.onHeightMeasured = { measuredPx ->
             val i = webViews.indexOf(wv)
             if (i >= 0) {
+                val wasPlaceholder = measuredHeights[i] == placeholder
                 val delta = measuredPx - measuredHeights[i]
                 measuredHeights[i] = measuredPx
                 wv.layoutParams = wv.layoutParams.also { it.height = measuredPx }
-                scrollBy(0, delta)
+                if (wasPlaceholder) scrollBy(0, delta)
             }
         }
         wv.onPageFinished = {
@@ -211,9 +212,9 @@ internal class ContinuousReaderView @JvmOverloads constructor(
                 if (nextIndex < allChapters.size) appendChapter(nextIndex)
             }
             ContinuousPositionTracker.ShiftDirection.BACKWARD -> {
-                removeBottom()
                 val prevIndex = topIndex - 1
                 if (prevIndex >= 0) {
+                    removeBottom()
                     topIndex--
                     prependChapter(prevIndex)
                 }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
@@ -57,6 +57,19 @@ internal class ContinuousReaderView @JvmOverloads constructor(
      */
     var onTap: (() -> Unit)? = null
 
+    /**
+     * Called on the main thread when the user taps an in-book link inside a chapter (footnote,
+     * cross-reference). [href] is the target resource path (with any `#fragment`). The host wires
+     * this to the return-aware navigation path so a "Back" card can restore the pre-jump position.
+     */
+    var onInternalLinkTapped: ((href: String) -> Unit)? = null
+
+    /**
+     * Called on the main thread when the user taps an external (http/https) link. [url] is the
+     * absolute URL; the host opens it in a browser.
+     */
+    var onExternalLinkTapped: ((url: String) -> Unit)? = null
+
     private val container = LinearLayout(context).apply {
         orientation = LinearLayout.VERTICAL
     }
@@ -147,6 +160,8 @@ internal class ContinuousReaderView @JvmOverloads constructor(
         wv.onPageFinished = null
         wv.onTap = null
         wv.onRenderGone = null
+        wv.onInternalLink = null
+        wv.onExternalLink = null
         if (recycledViews.size < WINDOW_SIZE) recycledViews.addLast(wv) else wv.destroy()
     }
 
@@ -300,7 +315,9 @@ internal class ContinuousReaderView @JvmOverloads constructor(
         // TOC entries / chapter-map segments / internal links may carry a #fragment that the spine
         // hrefs don't have; match on the resource path so the chapter is still found.
         val target = href.substringBefore('#')
-        val targetIndex = allChapters.indexOfFirst { it.link.href.toString().substringBefore('#') == target }
+        val targetIndex = ContinuousPositionTracker.chapterIndexForHref(
+            allChapters.map { it.link.href.toString() }, href,
+        )
         if (targetIndex < 0) return
         val inWindow = targetIndex in topIndex until (topIndex + webViews.size)
         if (inWindow) {
@@ -327,6 +344,12 @@ internal class ContinuousReaderView @JvmOverloads constructor(
         }
     }
 
+    /** Scroll one viewport-page forward/backward (wired to the volume keys). */
+    fun scrollByPage(forward: Boolean) {
+        val delta = ContinuousPositionTracker.pageScrollDelta(height)
+        smoothScrollBy(0, if (forward) delta else -delta)
+    }
+
     /** Inject a highlight for [text] in the chapter matching [href]. Clear if blank. */
     fun highlightInChapter(href: String, text: String) {
         val i = webViewIndexFor(href) ?: return
@@ -347,6 +370,8 @@ internal class ContinuousReaderView @JvmOverloads constructor(
         publication?.let { wv.setPublication(it) }
         wv.onTap = { onTap?.invoke() }
         wv.onRenderGone = { recoverFromRendererGone() }
+        wv.onInternalLink = { onInternalLinkTapped?.invoke(it) }
+        wv.onExternalLink = { onExternalLinkTapped?.invoke(it) }
         val placeholder = placeholderHeight
         wv.onHeightMeasured = { measuredPx ->
             val i = webViews.indexOf(wv)
@@ -422,6 +447,8 @@ internal class ContinuousReaderView @JvmOverloads constructor(
         publication?.let { wv.setPublication(it) }
         wv.onTap = { onTap?.invoke() }
         wv.onRenderGone = { recoverFromRendererGone() }
+        wv.onInternalLink = { onInternalLinkTapped?.invoke(it) }
+        wv.onExternalLink = { onExternalLinkTapped?.invoke(it) }
         val placeholder = placeholderHeight
         wv.onHeightMeasured = { measuredPx ->
             val i = webViews.indexOf(wv)

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
@@ -101,6 +101,9 @@ internal class ContinuousReaderView @JvmOverloads constructor(
         if (targetIndex < topIndex || targetIndex > topIndex + 2) {
             rebuildWindowAround(targetIndex)
         }
+        // Scroll is computed against current measuredHeights, which may still hold placeholder
+        // values if newly-loaded chapters haven't measured yet. The position is approximate until
+        // real heights arrive. TODO: add a post-measurement correction callback for navigateTo.
         post {
             val window = buildWindow()
             val offset = ContinuousPositionTracker.scrollOffsetFor(href, progression, window)
@@ -178,6 +181,10 @@ internal class ContinuousReaderView @JvmOverloads constructor(
         val wv = webViews.removeAt(0)
         container.removeView(wv)
         wv.destroy()
+        // h is the stored measured height at removal time. If the WebView was still loading when
+        // removeTop() fires (h == placeholderHeight), the scroll offset may be over-compensated
+        // and produce a brief jump. Rare in practice: removeTop() only fires after the user scrolls
+        // past the bottom of the top chapter, by which time it has typically measured.
         scrollBy(0, -h)
         topIndex++
     }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
@@ -2,6 +2,7 @@ package com.riffle.app.feature.reader
 
 import android.content.Context
 import android.util.AttributeSet
+import android.view.MotionEvent
 import android.view.ViewGroup.LayoutParams.MATCH_PARENT
 import android.view.ViewGroup.LayoutParams.WRAP_CONTENT
 import android.widget.LinearLayout
@@ -9,6 +10,7 @@ import androidx.core.widget.NestedScrollView
 import com.riffle.core.domain.FormattingPreferences
 import org.readium.r2.shared.publication.Link
 import org.readium.r2.shared.publication.Publication
+import kotlin.math.abs
 
 /**
  * Renders the entire book as a single vertical scroll by stacking a sliding window of 3
@@ -88,6 +90,23 @@ internal class ContinuousReaderView @JvmOverloads constructor(
         if (disallowIntercept) return
         super.requestDisallowInterceptTouchEvent(false)
     }
+
+    // Intercept vertical movement as soon as it exceeds a minimal threshold (half the system
+    // touch slop). NestedScrollView's default is to wait for a full touch slop before
+    // intercepting, which leaves the WebView handling touch for long enough that the user
+    // perceives scroll resistance ("fighting"). Intercepting earlier gives us scroll ownership
+    // from the very first detectable movement, matching native smooth-scroll feel.
+    private var interceptDownY = 0f
+    override fun onInterceptTouchEvent(ev: MotionEvent): Boolean {
+        when (ev.actionMasked) {
+            MotionEvent.ACTION_DOWN -> interceptDownY = ev.y
+            MotionEvent.ACTION_MOVE ->
+                if (abs(ev.y - interceptDownY) > touchSlop / 2f) return true
+        }
+        return super.onInterceptTouchEvent(ev)
+    }
+
+    private val touchSlop = android.view.ViewConfiguration.get(context).scaledTouchSlop
 
     /**
      * Initialize the view at [initialHref] + [initialProgression].

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
@@ -94,6 +94,10 @@ internal class ContinuousReaderView @JvmOverloads constructor(
      */
     private var shiftPending = false
 
+    /** True while rebuilding the window after a WebView renderer-process death (debounces the
+     * per-WebView onRenderProcessGone events that all fire at once). */
+    private var rendererRecovering = false
+
     /** Measured content heights for each WebView in the current window. */
     private val measuredHeights = mutableListOf<Int>()
 
@@ -142,6 +146,7 @@ internal class ContinuousReaderView @JvmOverloads constructor(
         wv.onHeightMeasured = null
         wv.onPageFinished = null
         wv.onTap = null
+        wv.onRenderGone = null
         if (recycledViews.size < WINDOW_SIZE) recycledViews.addLast(wv) else wv.destroy()
     }
 
@@ -202,7 +207,16 @@ internal class ContinuousReaderView @JvmOverloads constructor(
         allChapters = chapters
         formattingPrefs = prefs
         this.publication = publication
-        val centerIndex = chapters.indexOfFirst { it.link.href.toString() == initialHref }
+        openWindowAt(initialHref, initialProgression)
+    }
+
+    /**
+     * Builds the sliding window with [initialHref] at the top and scrolls to [initialProgression]
+     * once it has measured. Used both for the first open and to recover after the WebView renderer
+     * process is killed (see [onRenderProcessGone] wiring in [appendChapter]).
+     */
+    private fun openWindowAt(initialHref: String, initialProgression: Float) {
+        val centerIndex = allChapters.indexOfFirst { it.link.href.toString() == initialHref }
             .coerceAtLeast(0)
 
         // Open with the TARGET chapter at the top of the window (no behind buffer yet). The behind
@@ -211,7 +225,7 @@ internal class ContinuousReaderView @JvmOverloads constructor(
         // target at window-index 0 its layout top is 0, so the initial scroll offset depends only on
         // the target's own height: we wait for exactly one chapter to measure, not two.
         topIndex = centerIndex
-        val initialAhead = minOf(1 + CHAPTERS_AHEAD, chapters.size - topIndex)
+        val initialAhead = minOf(1 + CHAPTERS_AHEAD, allChapters.size - topIndex)
 
         pendingInitialMeasureIndices.clear()
         pendingInitialMeasureIndices.add(0) // the target chapter only
@@ -244,6 +258,33 @@ internal class ContinuousReaderView @JvmOverloads constructor(
         }
 
         repeat(initialAhead) { i -> appendChapter(topIndex + i) }
+    }
+
+    /**
+     * Recover after the shared WebView renderer process is gone (Android reclaims it under memory
+     * pressure — likelier with very large chapters held in several stacked WebViews). All WebViews
+     * become permanently blank, and if [ChapterWebView] did not consume the event the whole app
+     * would crash. We capture the current reading position, tear down every (now-dead) WebView, and
+     * rebuild the window around that position so the reader restores itself in place instead of
+     * showing blank pages. Debounced because the event fires once per live WebView at the same time.
+     */
+    private fun recoverFromRendererGone() {
+        if (rendererRecovering) return
+        rendererRecovering = true
+        val window = buildWindow()
+        val (href, progression) = if (window.isNotEmpty()) {
+            ContinuousPositionTracker.locatorAt(scrollY, height, window)
+        } else {
+            (allChapters.getOrNull(topIndex)?.link?.href?.toString() ?: "") to 0f
+        }
+        webViews.forEach { it.destroy() }
+        webViews.clear()
+        measuredHeights.clear()
+        container.removeAllViews()
+        recycledViews.forEach { it.destroy() }
+        recycledViews.clear()
+        if (href.isNotEmpty()) openWindowAt(href, progression)
+        post { rendererRecovering = false }
     }
 
     /** Update preferences and re-inject styles + remeasure all loaded chapters. */
@@ -290,6 +331,7 @@ internal class ContinuousReaderView @JvmOverloads constructor(
         val wv = obtainWebView()
         publication?.let { wv.setPublication(it) }
         wv.onTap = { onTap?.invoke() }
+        wv.onRenderGone = { recoverFromRendererGone() }
         val placeholder = placeholderHeight
         wv.onHeightMeasured = { measuredPx ->
             val i = webViews.indexOf(wv)
@@ -364,6 +406,7 @@ internal class ContinuousReaderView @JvmOverloads constructor(
         val wv = obtainWebView()
         publication?.let { wv.setPublication(it) }
         wv.onTap = { onTap?.invoke() }
+        wv.onRenderGone = { recoverFromRendererGone() }
         val placeholder = placeholderHeight
         wv.onHeightMeasured = { measuredPx ->
             val i = webViews.indexOf(wv)

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
@@ -1,0 +1,240 @@
+package com.riffle.app.feature.reader
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.ViewGroup.LayoutParams.MATCH_PARENT
+import android.view.ViewGroup.LayoutParams.WRAP_CONTENT
+import android.widget.LinearLayout
+import androidx.core.widget.NestedScrollView
+import com.riffle.core.domain.FormattingPreferences
+import org.readium.r2.shared.publication.Link
+
+/**
+ * Renders the entire book as a single vertical scroll by stacking a sliding window of 3
+ * [ChapterWebView]s (previous, current, next) inside a [LinearLayout].
+ *
+ * Scrolling is owned entirely by this [NestedScrollView]; each [ChapterWebView] has its
+ * internal scrolling disabled and its height fixed to its measured content height.
+ *
+ * Window shifting: when [currentChapterIndex] advances past the bottom chapter or retreats
+ * past the top chapter, the far end is destroyed and a new chapter is added at the other end.
+ * Adding a chapter at the TOP adjusts [scrollY] by the new chapter's height to keep the
+ * visible content stable.
+ */
+internal class ContinuousReaderView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+) : NestedScrollView(context, attrs) {
+
+    data class ChapterEntry(val link: Link, val url: String)
+
+    /** Called on main thread when position changes; supplies `href` and `progression`. */
+    var onPositionChanged: ((href: String, progression: Float) -> Unit)? = null
+
+    private val container = LinearLayout(context).apply {
+        orientation = LinearLayout.VERTICAL
+    }
+
+    /** All chapters in reading order. Set once via [initialize]. */
+    private var allChapters: List<ChapterEntry> = emptyList()
+
+    /** Current formatting preferences for CSS injection. */
+    private var formattingPrefs: FormattingPreferences = FormattingPreferences()
+
+    /**
+     * Index into [allChapters] of the topmost loaded chapter.
+     * The window covers [topIndex, topIndex+1, topIndex+2] (clamped to list bounds).
+     */
+    private var topIndex: Int = 0
+
+    /** Parallel list to the loaded WebViews; index i matches container.getChildAt(i). */
+    private val webViews = mutableListOf<ChapterWebView>()
+
+    /** Measured content heights for each WebView in the current window. */
+    private val measuredHeights = mutableListOf<Int>()
+
+    /** Placeholder height (3× screen height) used before real measurement arrives. */
+    private val placeholderHeight: Int get() = resources.displayMetrics.heightPixels * 3
+
+    init {
+        addView(container, LayoutParams(MATCH_PARENT, WRAP_CONTENT))
+        setOnScrollChangeListener { _, _, scrollY, _, _ ->
+            handleScrollChange(scrollY)
+        }
+    }
+
+    /**
+     * Initialize the view at [initialHref] + [initialProgression].
+     * Call once after attaching to the window.
+     */
+    fun initialize(
+        chapters: List<ChapterEntry>,
+        prefs: FormattingPreferences,
+        initialHref: String,
+        initialProgression: Float,
+    ) {
+        allChapters = chapters
+        formattingPrefs = prefs
+        val centerIndex = chapters.indexOfFirst { it.link.href.toString() == initialHref }
+            .coerceAtLeast(0)
+        topIndex = (centerIndex - 1).coerceAtLeast(0)
+        val windowSize = minOf(3, chapters.size - topIndex)
+        repeat(windowSize) { i -> appendChapter(topIndex + i) }
+        post {
+            val window = buildWindow()
+            val offset = ContinuousPositionTracker.scrollOffsetFor(initialHref, initialProgression, window)
+            if (offset != null) scrollTo(0, (offset - height / 2).coerceAtLeast(0))
+        }
+    }
+
+    /** Update preferences and re-inject styles + remeasure all loaded chapters. */
+    fun updatePreferences(prefs: FormattingPreferences) {
+        formattingPrefs = prefs
+        val variableJs = ContinuousStyleInjector.buildVariableInjectionJs(prefs)
+        webViews.forEach { wv -> wv.reinjectAndRemeasure(variableJs) }
+    }
+
+    /** Scroll to [href] at [progression]. Loads the chapter into the window if needed. */
+    fun navigateTo(href: String, progression: Float) {
+        val targetIndex = allChapters.indexOfFirst { it.link.href.toString() == href }
+        if (targetIndex < 0) return
+        if (targetIndex < topIndex || targetIndex > topIndex + 2) {
+            rebuildWindowAround(targetIndex)
+        }
+        post {
+            val window = buildWindow()
+            val offset = ContinuousPositionTracker.scrollOffsetFor(href, progression, window)
+            if (offset != null) smoothScrollTo(0, (offset - height / 2).coerceAtLeast(0))
+        }
+    }
+
+    /** Inject a highlight for [text] in the chapter matching [href]. Clear if blank. */
+    fun highlightInChapter(href: String, text: String) {
+        val i = webViewIndexFor(href) ?: return
+        webViews[i].evaluateJavascript(ContinuousStyleInjector.highlightTextJs(text), null)
+    }
+
+    /** Clear any active highlight in the chapter at [href]. */
+    fun clearHighlightInChapter(href: String) {
+        val i = webViewIndexFor(href) ?: return
+        webViews[i].evaluateJavascript(ContinuousStyleInjector.CLEAR_HIGHLIGHT_JS, null)
+    }
+
+    // ── private ────────────────────────────────────────────────────────────────
+
+    private fun appendChapter(index: Int) {
+        val entry = allChapters[index]
+        val wv = ChapterWebView(context)
+        val placeholder = placeholderHeight
+        wv.onHeightMeasured = { measuredPx ->
+            val i = webViews.indexOf(wv)
+            if (i >= 0) {
+                val wasPlaceholder = measuredHeights[i] == placeholder
+                val delta = measuredPx - measuredHeights[i]
+                measuredHeights[i] = measuredPx
+                wv.layoutParams = wv.layoutParams.also { it.height = measuredPx }
+                if (wasPlaceholder && i == 0 && scrollY > 0) {
+                    scrollBy(0, delta)
+                }
+            }
+        }
+        wv.onPageFinished = {
+            val variableJs = ContinuousStyleInjector.buildVariableInjectionJs(formattingPrefs)
+            wv.injectStylesAndMeasure(variableJs)
+        }
+        webViews.add(wv)
+        measuredHeights.add(placeholder)
+        container.addView(wv, LinearLayout.LayoutParams(MATCH_PARENT, placeholder))
+        wv.loadChapter(entry.link.href.toString(), entry.url)
+    }
+
+    private fun prependChapter(index: Int) {
+        val entry = allChapters[index]
+        val wv = ChapterWebView(context)
+        val placeholder = placeholderHeight
+        wv.onHeightMeasured = { measuredPx ->
+            val i = webViews.indexOf(wv)
+            if (i >= 0) {
+                val delta = measuredPx - measuredHeights[i]
+                measuredHeights[i] = measuredPx
+                wv.layoutParams = wv.layoutParams.also { it.height = measuredPx }
+                scrollBy(0, delta)
+            }
+        }
+        wv.onPageFinished = {
+            val variableJs = ContinuousStyleInjector.buildVariableInjectionJs(formattingPrefs)
+            wv.injectStylesAndMeasure(variableJs)
+        }
+        webViews.add(0, wv)
+        measuredHeights.add(0, placeholder)
+        container.addView(wv, 0, LinearLayout.LayoutParams(MATCH_PARENT, placeholder))
+        scrollBy(0, placeholder)
+        wv.loadChapter(entry.link.href.toString(), entry.url)
+    }
+
+    private fun removeTop() {
+        if (webViews.isEmpty()) return
+        val h = measuredHeights.removeAt(0)
+        val wv = webViews.removeAt(0)
+        container.removeView(wv)
+        wv.destroy()
+        scrollBy(0, -h)
+        topIndex++
+    }
+
+    private fun removeBottom() {
+        if (webViews.isEmpty()) return
+        measuredHeights.removeAt(measuredHeights.lastIndex)
+        val wv = webViews.removeAt(webViews.lastIndex)
+        container.removeView(wv)
+        wv.destroy()
+    }
+
+    private fun handleScrollChange(scrollY: Int) {
+        val window = buildWindow()
+        if (window.isEmpty()) return
+        val (href, progression) = ContinuousPositionTracker.locatorAt(scrollY, height, window)
+        onPositionChanged?.invoke(href, progression)
+
+        val currentChapterIndex = allChapters.indexOfFirst { it.link.href.toString() == href }
+        when (ContinuousPositionTracker.shiftNeeded(currentChapterIndex, topIndex, allChapters.size)) {
+            ContinuousPositionTracker.ShiftDirection.FORWARD -> {
+                removeTop()
+                val nextIndex = topIndex + 2 // topIndex already incremented in removeTop()
+                if (nextIndex < allChapters.size) appendChapter(nextIndex)
+            }
+            ContinuousPositionTracker.ShiftDirection.BACKWARD -> {
+                removeBottom()
+                val prevIndex = topIndex - 1
+                if (prevIndex >= 0) {
+                    topIndex--
+                    prependChapter(prevIndex)
+                }
+            }
+            ContinuousPositionTracker.ShiftDirection.NONE -> Unit
+        }
+    }
+
+    private fun rebuildWindowAround(centerIndex: Int) {
+        webViews.forEach { it.destroy() }
+        webViews.clear()
+        measuredHeights.clear()
+        container.removeAllViews()
+        topIndex = (centerIndex - 1).coerceAtLeast(0)
+        val windowSize = minOf(3, allChapters.size - topIndex)
+        repeat(windowSize) { i -> appendChapter(topIndex + i) }
+    }
+
+    private fun buildWindow(): List<ContinuousPositionTracker.ChapterSlot> {
+        var top = 0
+        return webViews.mapIndexed { i, wv ->
+            val h = measuredHeights[i]
+            ContinuousPositionTracker.ChapterSlot(wv.chapterHref, top, h).also { top += h }
+        }
+    }
+
+    private fun webViewIndexFor(href: String): Int? {
+        val i = webViews.indexOfFirst { it.chapterHref == href }
+        return if (i >= 0) i else null
+    }
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
@@ -297,18 +297,33 @@ internal class ContinuousReaderView @JvmOverloads constructor(
 
     /** Scroll to [href] at [progression]. Loads the chapter into the window if needed. */
     fun navigateTo(href: String, progression: Float) {
-        val targetIndex = allChapters.indexOfFirst { it.link.href.toString() == href }
+        // TOC entries / chapter-map segments / internal links may carry a #fragment that the spine
+        // hrefs don't have; match on the resource path so the chapter is still found.
+        val target = href.substringBefore('#')
+        val targetIndex = allChapters.indexOfFirst { it.link.href.toString().substringBefore('#') == target }
         if (targetIndex < 0) return
-        if (targetIndex < topIndex || targetIndex > topIndex + webViews.size - 1) {
-            rebuildWindowAround(targetIndex)
-        }
-        // Scroll is computed against current measuredHeights, which may still hold placeholder
-        // values if newly-loaded chapters haven't measured yet. The position is approximate until
-        // real heights arrive. TODO: add a post-measurement correction callback for navigateTo.
-        post {
-            val window = buildWindow()
-            val offset = ContinuousPositionTracker.scrollOffsetFor(href, progression, window)
-            if (offset != null) smoothScrollTo(0, (offset - height / 2).coerceAtLeast(0))
+        val inWindow = targetIndex in topIndex until (topIndex + webViews.size)
+        if (inWindow) {
+            // Already loaded and measured: scroll straight to it, centring the target (good for a
+            // nearby search hit).
+            post {
+                val window = buildWindow()
+                val matchHref = window.firstOrNull { it.href.substringBefore('#') == target }?.href ?: target
+                val offset = ContinuousPositionTracker.scrollOffsetFor(matchHref, progression, window)
+                if (offset != null) smoothScrollTo(0, (offset - height / 2).coerceAtLeast(0))
+            }
+        } else {
+            // Far jump (typical TOC / chapter-map tap): rebuild the window around the target and land
+            // via the open path, which defers the scroll until the target's REAL height is known.
+            // Scrolling immediately against placeholder heights would misposition and flash blank
+            // until measurement settled.
+            webViews.forEach { it.destroy() }
+            webViews.clear()
+            measuredHeights.clear()
+            container.removeAllViews()
+            recycledViews.forEach { it.destroy() }
+            recycledViews.clear()
+            openWindowAt(target, progression)
         }
     }
 
@@ -534,15 +549,6 @@ internal class ContinuousReaderView @JvmOverloads constructor(
         }
     }
 
-    private fun rebuildWindowAround(centerIndex: Int) {
-        webViews.forEach { it.destroy() }
-        webViews.clear()
-        measuredHeights.clear()
-        container.removeAllViews()
-        topIndex = (centerIndex - CHAPTERS_BEHIND).coerceAtLeast(0)
-        val windowSize = minOf(WINDOW_SIZE, allChapters.size - topIndex)
-        repeat(windowSize) { i -> appendChapter(topIndex + i) }
-    }
 
     private fun buildWindow(): List<ContinuousPositionTracker.ChapterSlot> {
         var top = 0

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
@@ -30,6 +30,22 @@ internal class ContinuousReaderView @JvmOverloads constructor(
     attrs: AttributeSet? = null,
 ) : NestedScrollView(context, attrs) {
 
+    companion object {
+        /** Chapters kept loaded behind the reader (for smooth backward scrolling). */
+        private const val CHAPTERS_BEHIND = 1
+
+        /**
+         * Chapters kept loaded ahead of the reader. Must be ≥2 so that a short "CHAPTER N"
+         * divider page and the real content chapter that follows it are BOTH loaded and measured
+         * before the reader arrives — otherwise the content chapter starts loading exactly when
+         * the reader scrolls into it, producing a blank gap, a spinner, and a jump at the seam.
+         */
+        private const val CHAPTERS_AHEAD = 3
+
+        /** Total sliding-window size: the reader's chapter plus the behind/ahead buffers. */
+        private const val WINDOW_SIZE = CHAPTERS_BEHIND + 1 + CHAPTERS_AHEAD
+    }
+
     data class ChapterEntry(val link: Link, val url: String)
 
     /** Called on main thread when position changes; supplies `href` and `progression`. */
@@ -56,7 +72,8 @@ internal class ContinuousReaderView @JvmOverloads constructor(
 
     /**
      * Index into [allChapters] of the topmost loaded chapter.
-     * The window covers [topIndex, topIndex+1, topIndex+2] (clamped to list bounds).
+     * The window covers [topIndex .. topIndex + loadedCount - 1] (clamped to list bounds),
+     * keeping [CHAPTERS_BEHIND] chapters behind the reader and [CHAPTERS_AHEAD] ahead.
      */
     private var topIndex: Int = 0
 
@@ -145,8 +162,8 @@ internal class ContinuousReaderView @JvmOverloads constructor(
         this.publication = publication
         val centerIndex = chapters.indexOfFirst { it.link.href.toString() == initialHref }
             .coerceAtLeast(0)
-        topIndex = (centerIndex - 1).coerceAtLeast(0)
-        val windowSize = minOf(3, chapters.size - topIndex)
+        topIndex = (centerIndex - CHAPTERS_BEHIND).coerceAtLeast(0)
+        val windowSize = minOf(WINDOW_SIZE, chapters.size - topIndex)
 
         // Defer the initial scroll until every chapter AT OR BEFORE the target chapter has
         // reported its real height. Using placeholder heights produces an inaccurate initial
@@ -177,7 +194,7 @@ internal class ContinuousReaderView @JvmOverloads constructor(
     fun navigateTo(href: String, progression: Float) {
         val targetIndex = allChapters.indexOfFirst { it.link.href.toString() == href }
         if (targetIndex < 0) return
-        if (targetIndex < topIndex || targetIndex > topIndex + 2) {
+        if (targetIndex < topIndex || targetIndex > topIndex + webViews.size - 1) {
             rebuildWindowAround(targetIndex)
         }
         // Scroll is computed against current measuredHeights, which may still hold placeholder
@@ -337,17 +354,19 @@ internal class ContinuousReaderView @JvmOverloads constructor(
         // A scrollY threshold is immune to that because the post-shift scrollY is deep inside
         // the first chapter (far past the midpoint), not near the top.
         //
-        // FORWARD: fire when the viewport bottom enters the last chapter of the window, using
-        // the chapter index. Using the bottom edge (not the midpoint) handles short last chapters
-        // (shorter than half the viewport) that a midpoint check would never enter.
+        // FORWARD: look-ahead based — fire when the viewport-midpoint chapter has advanced more
+        // than CHAPTERS_BEHIND slots past the window top, so several chapters stay loaded ahead
+        // of the reader (see ContinuousPositionTracker.forwardShiftNeeded).
         val firstChapterHeight = window.firstOrNull()?.height ?: 0
-        val totalH = window.sumOf { it.height }
-        val (bottomHref, _) = ContinuousPositionTracker.locatorAt(
-            (scrollY + height).coerceIn(0, (totalH - 1).coerceAtLeast(0)), 0, window
-        )
-        val viewportBottomIndex = allChapters.indexOfFirst { it.link.href.toString() == bottomHref }
+        val viewportMidIndex = allChapters.indexOfFirst { it.link.href.toString() == href }
         val shouldShiftBackward = scrollY < firstChapterHeight / 2 && topIndex > 0
-        val shouldShiftForward = ContinuousPositionTracker.forwardShiftNeeded(viewportBottomIndex, topIndex, allChapters.size)
+        val shouldShiftForward = ContinuousPositionTracker.forwardShiftNeeded(
+            viewportChapterIndex = viewportMidIndex,
+            topIndex = topIndex,
+            loadedChapterCount = webViews.size,
+            readingOrderSize = allChapters.size,
+            chaptersBehind = CHAPTERS_BEHIND,
+        )
         when {
             shouldShiftBackward -> {
                 shiftInProgress = true
@@ -358,8 +377,10 @@ internal class ContinuousReaderView @JvmOverloads constructor(
             }
             shouldShiftForward -> {
                 shiftInProgress = true
-                removeTop()
-                val nextIndex = topIndex + 2 // topIndex already incremented in removeTop()
+                removeTop() // topIndex already incremented inside removeTop()
+                // After removeTop the window covers [topIndex .. topIndex + size - 1]; the next
+                // chapter to append is the one immediately past the current last slot.
+                val nextIndex = topIndex + webViews.size
                 if (nextIndex < allChapters.size) appendChapter(nextIndex)
                 shiftInProgress = false
             }
@@ -371,8 +392,8 @@ internal class ContinuousReaderView @JvmOverloads constructor(
         webViews.clear()
         measuredHeights.clear()
         container.removeAllViews()
-        topIndex = (centerIndex - 1).coerceAtLeast(0)
-        val windowSize = minOf(3, allChapters.size - topIndex)
+        topIndex = (centerIndex - CHAPTERS_BEHIND).coerceAtLeast(0)
+        val windowSize = minOf(WINDOW_SIZE, allChapters.size - topIndex)
         repeat(windowSize) { i -> appendChapter(topIndex + i) }
     }
 

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
@@ -87,6 +87,13 @@ internal class ContinuousReaderView @JvmOverloads constructor(
      */
     private var shiftInProgress = false
 
+    /**
+     * True while a window-shift is scheduled (posted) but not yet executed. Shifts are deferred off
+     * the scroll callback (see [handleScrollChange]); this coalesces the many scroll events during a
+     * fling into a single pending shift so we don't queue a backlog of redundant shift runnables.
+     */
+    private var shiftPending = false
+
     /** Measured content heights for each WebView in the current window. */
     private val measuredHeights = mutableListOf<Int>()
 
@@ -403,6 +410,34 @@ internal class ContinuousReaderView @JvmOverloads constructor(
         val (href, progression) = ContinuousPositionTracker.locatorAt(scrollY, height, window)
         onPositionChanged?.invoke(href, progression)
 
+        // Defer window shifts off the scroll callback. A shift's compensating scrollBy() would
+        // otherwise run re-entrantly inside NestedScrollView.computeScroll() (this callback fires
+        // synchronously from there during a fling); computeScroll then mis-reads the extra scroll
+        // delta as having hit a content edge and aborts the OverScroller — killing the fling's
+        // momentum at every chapter boundary. Running the shift in a posted runnable (next message,
+        // outside computeScroll) lets the fling continue smoothly across the seam. shiftPending
+        // coalesces the per-frame scroll events into a single scheduled shift.
+        if (!shiftPending) {
+            shiftPending = true
+            post {
+                shiftPending = false
+                maybeShift()
+            }
+        }
+    }
+
+    /**
+     * Evaluate the current scroll position and shift the sliding window by one chapter if needed.
+     * Runs from a posted runnable (never re-entrantly inside the fling computation) so the
+     * compensating scrollBy() does not abort an in-progress fling.
+     */
+    private fun maybeShift() {
+        if (shiftInProgress) return
+        val window = buildWindow()
+        if (window.isEmpty()) return
+        val sY = scrollY
+        val (href, _) = ContinuousPositionTracker.locatorAt(sY, height, window)
+
         // BACKWARD: fire when scrollY is in the first half of the first chapter. This gives a
         // hysteresis gap that prevents the oscillation that a chapter-index check causes —
         // after every FORWARD shift, the scrollBy adjustment lands the viewport inside the new
@@ -415,7 +450,7 @@ internal class ContinuousReaderView @JvmOverloads constructor(
         // of the reader (see ContinuousPositionTracker.forwardShiftNeeded).
         val firstChapterHeight = window.firstOrNull()?.height ?: 0
         val viewportMidIndex = allChapters.indexOfFirst { it.link.href.toString() == href }
-        val shouldShiftBackward = scrollY < firstChapterHeight / 2 && topIndex > 0
+        val shouldShiftBackward = sY < firstChapterHeight / 2 && topIndex > 0
         val shouldShiftForward = ContinuousPositionTracker.forwardShiftNeeded(
             viewportChapterIndex = viewportMidIndex,
             topIndex = topIndex,

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
@@ -74,6 +74,20 @@ internal class ContinuousReaderView @JvmOverloads constructor(
     private val measuredHeights = mutableListOf<Int>()
 
     /**
+     * Window indices (0-based) of chapters that must report their real height before the
+     * initial scroll fires. Populated in [initialize]; cleared as each chapter measures.
+     * When the set empties, [pendingInitialScroll] is invoked and nulled out.
+     */
+    private val pendingInitialMeasureIndices = mutableSetOf<Int>()
+
+    /**
+     * Closure that performs the initial [scrollTo] once all chapters in
+     * [pendingInitialMeasureIndices] have reported their real heights.
+     * Null after the initial scroll has fired or when opening at position 0.
+     */
+    private var pendingInitialScroll: (() -> Unit)? = null
+
+    /**
      * Placeholder height used before real measurement arrives. One screen height keeps the
      * forward-shift trigger working (the last chapter needs enough height to scroll into) while
      * minimising the phantom space the user can fling into before the real height is known.
@@ -133,12 +147,22 @@ internal class ContinuousReaderView @JvmOverloads constructor(
             .coerceAtLeast(0)
         topIndex = (centerIndex - 1).coerceAtLeast(0)
         val windowSize = minOf(3, chapters.size - topIndex)
-        repeat(windowSize) { i -> appendChapter(topIndex + i) }
-        post {
+
+        // Defer the initial scroll until every chapter AT OR BEFORE the target chapter has
+        // reported its real height. Using placeholder heights produces an inaccurate initial
+        // position: if the preceding chapter is taller than the placeholder, the scroll
+        // compensation in onHeightMeasured pushes the viewport past the intended intra-chapter
+        // offset. Waiting for real heights means a single, correct scrollTo with no follow-up jump.
+        val centerInWindow = (centerIndex - topIndex).coerceIn(0, windowSize - 1)
+        pendingInitialMeasureIndices.clear()
+        for (i in 0..centerInWindow) pendingInitialMeasureIndices.add(i)
+        pendingInitialScroll = {
             val window = buildWindow()
             val offset = ContinuousPositionTracker.scrollOffsetFor(initialHref, initialProgression, window)
             if (offset != null) scrollTo(0, (offset - height / 2).coerceAtLeast(0))
         }
+
+        repeat(windowSize) { i -> appendChapter(topIndex + i) }
     }
 
     /** Update preferences and re-inject styles + remeasure all loaded chapters. */
@@ -222,8 +246,21 @@ internal class ContinuousReaderView @JvmOverloads constructor(
                 //   ch0 growing pushes ch1+ down; compensate to keep ch1 in place.
                 // Never compensate for a growing ch0 we're still scrolled within — that would
                 // fire a spurious forward jump and immediately re-trigger a backward shift.
-                if (wasPlaceholder && i == 0 && (delta < 0 || scrollY >= oldHeight)) {
+                // Suppressed while initial scroll is pending: the deferred scrollTo below
+                // computes the correct position from real heights and fires once; a premature
+                // scrollBy here would shift the viewport before that calculation runs.
+                if (pendingInitialScroll == null && wasPlaceholder && i == 0 && (delta < 0 || scrollY >= oldHeight)) {
                     scrollBy(0, delta)
+                }
+
+                // Fire the initial scroll once every chapter at or before the target chapter
+                // has reported its real height so the scroll position is accurate.
+                if (wasPlaceholder && pendingInitialMeasureIndices.remove(i) &&
+                    pendingInitialMeasureIndices.isEmpty()
+                ) {
+                    val scroll = pendingInitialScroll
+                    pendingInitialScroll = null
+                    scroll?.invoke()
                 }
             }
         }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
@@ -32,6 +32,12 @@ internal class ContinuousReaderView @JvmOverloads constructor(
     /** Called on main thread when position changes; supplies `href` and `progression`. */
     var onPositionChanged: ((href: String, progression: Float) -> Unit)? = null
 
+    /**
+     * Called on main thread when the user taps a chapter without scrolling.
+     * Wire to the reader's chrome toggle so top/bottom bars show/hide on tap.
+     */
+    var onTap: (() -> Unit)? = null
+
     private val container = LinearLayout(context).apply {
         orientation = LinearLayout.VERTICAL
     }
@@ -54,6 +60,13 @@ internal class ContinuousReaderView @JvmOverloads constructor(
     /** Parallel list to the loaded WebViews; index i matches container.getChildAt(i). */
     private val webViews = mutableListOf<ChapterWebView>()
 
+    /**
+     * True while a window-shift operation (removeTop/removeBottom/prependChapter) is in
+     * progress. Prevents re-entrant handleScrollChange calls — programmatic scrollBy() calls
+     * inside removeTop() and prependChapter() would otherwise fire a second shift mid-operation.
+     */
+    private var shiftInProgress = false
+
     /** Measured content heights for each WebView in the current window. */
     private val measuredHeights = mutableListOf<Int>()
 
@@ -65,6 +78,15 @@ internal class ContinuousReaderView @JvmOverloads constructor(
         setOnScrollChangeListener { _, _, scrollY, _, _ ->
             handleScrollChange(scrollY)
         }
+    }
+
+    // ChapterWebViews detect vertical motion and call requestDisallowInterceptTouchEvent(true),
+    // which would prevent NestedScrollView from intercepting and owning the scroll — exactly the
+    // same bug ScrollBoundaryNavigationContainer solves for Readium WebViews. We are the scroll
+    // owner, so we never yield the right to intercept.
+    override fun requestDisallowInterceptTouchEvent(disallowIntercept: Boolean) {
+        if (disallowIntercept) return
+        super.requestDisallowInterceptTouchEvent(false)
     }
 
     /**
@@ -135,15 +157,23 @@ internal class ContinuousReaderView @JvmOverloads constructor(
         val entry = allChapters[index]
         val wv = ChapterWebView(context)
         publication?.let { wv.setPublication(it) }
+        wv.onTap = { onTap?.invoke() }
         val placeholder = placeholderHeight
         wv.onHeightMeasured = { measuredPx ->
             val i = webViews.indexOf(wv)
             if (i >= 0) {
                 val wasPlaceholder = measuredHeights[i] == placeholder
-                val delta = measuredPx - measuredHeights[i]
+                val oldHeight = measuredHeights[i]
+                val delta = measuredPx - oldHeight
                 measuredHeights[i] = measuredPx
                 wv.layoutParams = wv.layoutParams.also { it.height = measuredPx }
-                if (wasPlaceholder && i == 0 && scrollY > 0) {
+                // Compensate scroll for ch0 only when:
+                // - chapter shrank (delta < 0): visible content above would shift without compensation
+                // - scrollY is past old ch0 boundary (delta > 0 but user has scrolled past ch0):
+                //   ch0 growing pushes ch1+ down; compensate to keep ch1 in place.
+                // Never compensate for a growing ch0 we're still scrolled within — that would
+                // fire a spurious forward jump and immediately re-trigger a backward shift.
+                if (wasPlaceholder && i == 0 && (delta < 0 || scrollY >= oldHeight)) {
                     scrollBy(0, delta)
                 }
             }
@@ -162,6 +192,7 @@ internal class ContinuousReaderView @JvmOverloads constructor(
         val entry = allChapters[index]
         val wv = ChapterWebView(context)
         publication?.let { wv.setPublication(it) }
+        wv.onTap = { onTap?.invoke() }
         val placeholder = placeholderHeight
         wv.onHeightMeasured = { measuredPx ->
             val i = webViews.indexOf(wv)
@@ -207,27 +238,45 @@ internal class ContinuousReaderView @JvmOverloads constructor(
     }
 
     private fun handleScrollChange(scrollY: Int) {
+        if (shiftInProgress) return
         val window = buildWindow()
         if (window.isEmpty()) return
         val (href, progression) = ContinuousPositionTracker.locatorAt(scrollY, height, window)
         onPositionChanged?.invoke(href, progression)
 
-        val currentChapterIndex = allChapters.indexOfFirst { it.link.href.toString() == href }
-        when (ContinuousPositionTracker.shiftNeeded(currentChapterIndex, topIndex, allChapters.size)) {
-            ContinuousPositionTracker.ShiftDirection.FORWARD -> {
+        // BACKWARD: fire when scrollY is in the first half of the first chapter. This gives a
+        // hysteresis gap that prevents the oscillation that a chapter-index check causes —
+        // after every FORWARD shift, the scrollBy adjustment lands the viewport inside the new
+        // first chapter (midIdx == topIdx), which would immediately re-trigger BACKWARD.
+        // A scrollY threshold is immune to that because the post-shift scrollY is deep inside
+        // the first chapter (far past the midpoint), not near the top.
+        //
+        // FORWARD: fire when the viewport bottom enters the last chapter of the window, using
+        // the chapter index. Using the bottom edge (not the midpoint) handles short last chapters
+        // (shorter than half the viewport) that a midpoint check would never enter.
+        val firstChapterHeight = window.firstOrNull()?.height ?: 0
+        val totalH = window.sumOf { it.height }
+        val (bottomHref, _) = ContinuousPositionTracker.locatorAt(
+            (scrollY + height).coerceIn(0, (totalH - 1).coerceAtLeast(0)), 0, window
+        )
+        val viewportBottomIndex = allChapters.indexOfFirst { it.link.href.toString() == bottomHref }
+        val shouldShiftBackward = scrollY < firstChapterHeight / 2 && topIndex > 0
+        val shouldShiftForward = ContinuousPositionTracker.forwardShiftNeeded(viewportBottomIndex, topIndex, allChapters.size)
+        when {
+            shouldShiftBackward -> {
+                shiftInProgress = true
+                removeBottom()
+                topIndex--
+                prependChapter(topIndex)
+                shiftInProgress = false
+            }
+            shouldShiftForward -> {
+                shiftInProgress = true
                 removeTop()
                 val nextIndex = topIndex + 2 // topIndex already incremented in removeTop()
                 if (nextIndex < allChapters.size) appendChapter(nextIndex)
+                shiftInProgress = false
             }
-            ContinuousPositionTracker.ShiftDirection.BACKWARD -> {
-                val prevIndex = topIndex - 1
-                if (prevIndex >= 0) {
-                    removeBottom()
-                    topIndex--
-                    prependChapter(prevIndex)
-                }
-            }
-            ContinuousPositionTracker.ShiftDirection.NONE -> Unit
         }
     }
 

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
@@ -218,7 +218,14 @@ internal class ContinuousReaderView @JvmOverloads constructor(
         pendingInitialScroll = {
             val window = buildWindow()
             val offset = ContinuousPositionTracker.scrollOffsetFor(initialHref, initialProgression, window)
-            if (offset != null) scrollTo(0, (offset - height / 2).coerceAtLeast(0))
+            // Top-align the opening position rather than centring it. Centring (offset - height/2)
+            // scrolls the target point to mid-screen, which leaves the top half showing the
+            // *previous* content — or blank, when opening at a chapter start or the book's front
+            // matter (title/epigraph pages that are mostly whitespace). Top-aligning puts the target
+            // line at the top of the viewport so the reader sees content immediately, with unread
+            // text below — the natural "resume / open here" position. (navigateTo keeps centring so
+            // a search hit / link target lands comfortably in the middle.)
+            if (offset != null) scrollTo(0, offset.coerceAtLeast(0))
             // Now that the target is visible, fill in the behind buffer for smooth backward
             // scrolling. prependChapter compensates scroll for the added height, so the content the
             // user is already looking at stays visually anchored — no post-paint jump.
@@ -430,6 +437,12 @@ internal class ContinuousReaderView @JvmOverloads constructor(
      * Evaluate the current scroll position and shift the sliding window by one chapter if needed.
      * Runs from a posted runnable (never re-entrantly inside the fling computation) so the
      * compensating scrollBy() does not abort an in-progress fling.
+     *
+     * Deliberately at most one shift per call: each shift's scroll compensation uses the *stored*
+     * height of the chapter it removes, which is only accurate once that chapter has measured.
+     * Shifting several times in one pass (to chase a fast fling) can remove not-yet-measured
+     * chapters, so the compensation drifts and opens a blank gap. One shift per frame keeps the
+     * compensation correct; the look-ahead buffer (CHAPTERS_AHEAD) absorbs the lead a fling needs.
      */
     private fun maybeShift() {
         if (shiftInProgress) return

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
@@ -311,11 +311,25 @@ internal class ContinuousReaderView @JvmOverloads constructor(
                 // progression offset (resume).
                 if (anchorFragment.isNotEmpty() && targetWv != null) {
                     targetWv.anchorOffsetTopDevicePx(anchorFragment) { anchorOffset ->
-                        val within = anchorOffset ?: (initialProgression * slot.height).toInt()
-                        scrollTo(0, (slot.top + within).coerceAtLeast(0))
+                        val y = if (anchorOffset != null) {
+                            (slot.top + anchorOffset).coerceAtLeast(0)
+                        } else {
+                            ContinuousPositionTracker.scrollYForProgression(
+                                slot.top, slot.height, initialProgression, height,
+                            )
+                        }
+                        scrollTo(0, y)
                     }
                 } else {
-                    scrollTo(0, (slot.top + (initialProgression * slot.height).toInt()).coerceAtLeast(0))
+                    // Restore at the viewport midpoint (inverse of locatorAt) so a resumed position
+                    // doesn't drift forward half a screen on every reopen; a chapter start stays at
+                    // the top.
+                    scrollTo(
+                        0,
+                        ContinuousPositionTracker.scrollYForProgression(
+                            slot.top, slot.height, initialProgression, height,
+                        ),
+                    )
                 }
             }
         }
@@ -423,9 +437,8 @@ internal class ContinuousReaderView @JvmOverloads constructor(
                 else go(slot.top + (progression * slot.height).toInt())
             }
         } else {
-            val base = slot.top + (progression * slot.height).toInt()
-            // Top-align a chapter start; centre a mid-chapter target.
-            go(if (progression <= 0.001f) base else base - height / 2)
+            // Top-align a chapter start; centre a mid-chapter target (inverse of locatorAt).
+            go(ContinuousPositionTracker.scrollYForProgression(slot.top, slot.height, progression, height))
         }
     }
 

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
@@ -263,10 +263,14 @@ internal class ContinuousReaderView @JvmOverloads constructor(
                 //   ch0 growing pushes ch1+ down; compensate to keep ch1 in place.
                 // Never compensate for a growing ch0 we're still scrolled within — that would
                 // fire a spurious forward jump and immediately re-trigger a backward shift.
+                // Applies to BOTH the first real measurement (wasPlaceholder) and any later
+                // re-measure: a chapter can grow after first paint (late font swap, image decode,
+                // type-scale settle), and uncompensated growth of an above-viewport ch0 would jump
+                // the line being read.
                 // Suppressed while initial scroll is pending: the deferred scrollTo below
                 // computes the correct position from real heights and fires once; a premature
                 // scrollBy here would shift the viewport before that calculation runs.
-                if (pendingInitialScroll == null && wasPlaceholder && i == 0 && (delta < 0 || scrollY >= oldHeight)) {
+                if (pendingInitialScroll == null && i == 0 && delta != 0 && (delta < 0 || scrollY >= oldHeight)) {
                     scrollBy(0, delta)
                 }
 
@@ -300,11 +304,13 @@ internal class ContinuousReaderView @JvmOverloads constructor(
         wv.onHeightMeasured = { measuredPx ->
             val i = webViews.indexOf(wv)
             if (i >= 0) {
-                val wasPlaceholder = measuredHeights[i] == placeholder
                 val delta = measuredPx - measuredHeights[i]
                 measuredHeights[i] = measuredPx
                 wv.layoutParams = wv.layoutParams.also { it.height = measuredPx }
-                if (wasPlaceholder) scrollBy(0, delta)
+                // A prepended chapter is above the viewport, so any height change (the first real
+                // measurement replacing the placeholder, or a later reflow re-measure) must be
+                // compensated to keep the content the user is reading visually anchored.
+                if (delta != 0) scrollBy(0, delta)
             }
         }
         wv.onPageFinished = {

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjector.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjector.kt
@@ -56,13 +56,17 @@ internal object ContinuousStyleInjector {
         }
 
         // Font family mapping mirrors FormattingPreferencesMapper.toEpubPreferences():
-        //   Serif      → null (Readium default) → system generic `serif`
+        //   Serif      → null (Readium default): NO font-family override, so the publisher's
+        //                own font (or the system serif fallback) renders — exactly what Readium
+        //                does in advanced mode when --USER__fontFamily is unset. Forcing
+        //                `serif` here diverged from Scroll/Paginated mode whenever the EPUB
+        //                declared its own body font, which is the "fonts differ" the user saw.
         //   SansSerif  → FontFamily("sans-serif") → system generic `sans-serif`
         //   Monospace  → FontFamily("monospace")  → system generic `monospace`
         //   Literata/Merriweather/OpenDyslexic → app-bundled fonts served from assets via
         //     shouldInterceptRequest at FONT_BASE; declared here with @font-face.
-        val fontFamily: String = when (prefs.fontFamily) {
-            ReaderFontFamily.Serif -> "serif"
+        val fontFamily: String? = when (prefs.fontFamily) {
+            ReaderFontFamily.Serif -> null
             ReaderFontFamily.SansSerif -> "sans-serif"
             ReaderFontFamily.Monospace -> "monospace"
             ReaderFontFamily.Literata -> "Literata, serif"
@@ -107,7 +111,7 @@ internal object ContinuousStyleInjector {
             append("body{")
             if (bg != null) append("background-color:$bg!important;")
             if (fg != null) append("color:$fg!important;")
-            append("font-family:$fontFamily!important;")
+            if (fontFamily != null) append("font-family:$fontFamily!important;")
             append("line-height:${prefs.lineSpacing}!important;")
             append("text-align:$textAlign!important;")
             append("padding-left:${paddingPct}%!important;padding-right:${paddingPct}%!important;")
@@ -130,9 +134,11 @@ internal object ContinuousStyleInjector {
             append("line-height:${prefs.lineSpacing}!important;")
             append("}\n")
 
-            append("p,li,blockquote,dd,dt,h1,h2,h3,h4,h5,h6,figcaption{")
-            append("font-family:$fontFamily!important;")
-            append("}\n")
+            if (fontFamily != null) {
+                append("p,li,blockquote,dd,dt,h1,h2,h3,h4,h5,h6,figcaption{")
+                append("font-family:$fontFamily!important;")
+                append("}\n")
+            }
         }
     }
 

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjector.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjector.kt
@@ -1,146 +1,199 @@
 package com.riffle.app.feature.reader
 
+import androidx.compose.ui.graphics.toArgb
 import com.riffle.core.domain.FormattingPreferences
 import com.riffle.core.domain.ReaderFontFamily
 import com.riffle.core.domain.ReaderTheme
 
+/**
+ * Produces the CSS injection for Continuous-mode chapters.
+ *
+ * Continuous mode renders each chapter in its own [ChapterWebView] from the raw EPUB HTML, so it
+ * does NOT go through Readium's navigator. To keep Continuous mode pixel-identical to Scroll and
+ * Paginated mode, we inject the *exact same ReadiumCSS* Readium itself injects:
+ *
+ *   1. `<link>` to `ReadiumCSS-before.css` at the start of `<head>` (+ a `ReadiumCSS-default.css`
+ *      link when the chapter has no author styles, matching Readium's CSS06 ordering rule).
+ *   2. `<link>` to `ReadiumCSS-after.css` before `</head>`, plus our bundled `@font-face` rules.
+ *   3. A `style="--USER__…: … !important; …"` attribute on `<html>` carrying the user-settings
+ *      CSS variables and the `readium-*-on` flags — computed exactly as Readium's
+ *      `EpubSettings`/`UserProperties.toCss()` does for the same preferences.
+ *
+ * Because the actual styling is then performed by the very same ReadiumCSS stylesheets that Scroll
+ * mode uses, heading sizes (type scale), font switching, line-height compensation, page margins,
+ * justification and theme colours all match Scroll mode by construction — there is no hand-rolled
+ * CSS left to drift. The CSS files and bundled fonts are served from Android assets by
+ * [ChapterWebView.shouldInterceptRequest] under the `readium/readium-css/` and `readium/fonts/`
+ * paths on the `readium_package` virtual host.
+ */
 internal object ContinuousStyleInjector {
 
+    /** Virtual-host base for the bundled ReadiumCSS stylesheets (served from assets). */
+    private const val CSS_BASE = "https://readium_package/readium/readium-css"
+
+    /** Virtual-host base for the app's bundled font files (served from assets). */
+    private const val FONT_BASE = "https://readium_package/readium/fonts"
+
+    /** ReaderThemePalette.DARK_DIM_TEXT as a ReadiumCSS hex colour (matches FormattingPreferencesMapper). */
+    private val DARK_DIM_TEXT_HEX: String = String.format("#%06X", 0xFFFFFF and DARK_DIM_TEXT.toArgb())
+
     /**
-     * Produces JS that injects a `<style id="_riffle_user">` element with real CSS properties
-     * derived from [prefs]. Unlike the `--USER__*` Readium CSS-variable approach, this works
-     * without ReadiumCSS being loaded — ChapterWebViews serve raw EPUB HTML and do not have
-     * Readium's stylesheet present.
+     * Builds the value of the `style` attribute injected onto `<html>` — the `--USER__*` CSS
+     * variables plus `readium-*-on` flags. Mirrors Readium's `EpubSettings.update()` →
+     * `UserProperties.toCss()` for our [FormattingPreferencesMapper] mapping, so Continuous mode
+     * resolves identically to Scroll/Paginated mode.
      *
-     * Colours mirror [ReaderThemePalette]; keep in sync if the palette values change.
-     * Font-size is set on `html` so EPUB content that uses `em`/`rem` scales correctly.
-     * Margins are expressed as body padding (percent of viewport width).
-     * All rules carry `!important` to beat typical publisher CSS specificity.
+     * Continuous mode is always scrolled (`readium-scroll-on`) and always runs in advanced mode
+     * (`readium-advanced-on`, i.e. publisherStyles=false) — the same as our Scroll-mode config.
+     */
+    fun buildHtmlStyleAttr(prefs: FormattingPreferences): String {
+        val props = LinkedHashMap<String, String>()
+
+        // View: always scrolled in Continuous mode.
+        props["--USER__view"] = "readium-scroll-on"
+
+        // Page margins (Readium passes the raw Double via putCss → Double.toString()).
+        props["--USER__pageMargins"] = prefs.margins.toDouble().toString()
+
+        // Appearance + DarkDim text colour (mirrors FormattingPreferencesMapper).
+        when (prefs.theme) {
+            ReaderTheme.Dark, ReaderTheme.DarkDim -> props["--USER__appearance"] = "readium-night-on"
+            ReaderTheme.Sepia -> props["--USER__appearance"] = "readium-sepia-on"
+            ReaderTheme.Light, ReaderTheme.Auto -> { /* no appearance flag */ }
+        }
+        if (prefs.theme == ReaderTheme.DarkDim) {
+            props["--USER__textColor"] = DARK_DIM_TEXT_HEX
+        }
+
+        // Font family: Serif maps to null (no override → publisher/system font, exactly like
+        // Readium). Other families set --USER__fontFamily + the readium-font-on flag.
+        val fontStack = fontFamilyStack(prefs.fontFamily)
+        if (fontStack != null) {
+            props["--USER__fontOverride"] = "readium-font-on"
+            props["--USER__fontFamily"] = fontStack.joinToString(", ") { "\"$it\"" }
+        }
+
+        // Font size as a percentage (Length.Percent → value*100, max 2 fraction digits).
+        props["--USER__fontSize"] = percentCss(prefs.fontSize)
+
+        // Advanced settings: Continuous always runs with publisherStyles off (advanced on).
+        props["--USER__advancedSettings"] = "readium-advanced-on"
+
+        // Text alignment mirrors FormattingPreferencesMapper: justify, else start.
+        props["--USER__textAlign"] = if (prefs.justifyText) "justify" else "start"
+
+        // Line height only when the user moved it off the default (mirrors the mapper's null-gating).
+        if (prefs.lineSpacing != FormattingPreferences.DEFAULT_LINE_SPACING) {
+            props["--USER__lineHeight"] = prefs.lineSpacing.toDouble().toString()
+        }
+
+        return props.entries.joinToString(" ") { "${it.key}: ${it.value} !important;" }
+    }
+
+    /**
+     * The font stack for [family], or null when no override should be emitted (Serif → publisher
+     * font). Mirrors Readium's `resolveFontStack`: our app registers Literata/Merriweather/
+     * OpenDyslexic with no alternates, so each resolves to a single-entry stack — identical to
+     * what Scroll mode produces.
+     */
+    private fun fontFamilyStack(family: ReaderFontFamily): List<String>? = when (family) {
+        ReaderFontFamily.Serif -> null
+        ReaderFontFamily.SansSerif -> listOf("sans-serif")
+        ReaderFontFamily.Monospace -> listOf("monospace")
+        ReaderFontFamily.Literata -> listOf("Literata")
+        ReaderFontFamily.Merriweather -> listOf("Merriweather")
+        ReaderFontFamily.OpenDyslexic -> listOf("OpenDyslexic")
+    }
+
+    /** Formats [value] (e.g. 1.0, 1.5) as a ReadiumCSS percentage ("100%", "150%"). */
+    private fun percentCss(value: Float): String {
+        val pct = value * 100.0
+        val rounded = Math.round(pct * 100.0) / 100.0
+        return if (rounded % 1.0 == 0.0) "${rounded.toInt()}%" else "$rounded%"
+    }
+
+    /**
+     * `@font-face` declarations for the app's bundled fonts, served from assets at [FONT_BASE].
+     * Injected unconditionally (like Readium's `fontsInjectableCss`) so the chosen
+     * --USER__fontFamily can resolve whichever bundled font the user selects.
+     */
+    private fun bundledFontFaces(): String = buildString {
+        append("@font-face{font-family:Literata;font-style:normal;font-weight:400;")
+        append("src:url('$FONT_BASE/Literata-Regular.ttf') format('truetype');}\n")
+        append("@font-face{font-family:Merriweather;font-style:normal;font-weight:400;")
+        append("src:url('$FONT_BASE/Merriweather-Regular.ttf') format('truetype');}\n")
+        append("@font-face{font-family:OpenDyslexic;font-style:normal;font-weight:400;")
+        append("src:url('$FONT_BASE/OpenDyslexic-Regular.otf') format('opentype');}\n")
+    }
+
+    /**
+     * Injects ReadiumCSS + the user-settings `style` attribute into a raw EPUB chapter [html],
+     * returning the styled HTML. Mirrors Readium's `ReadiumCss.injectHtml`.
+     */
+    fun injectInto(html: String, prefs: FormattingPreferences): String {
+        var out = html
+
+        // 1. Before-CSS (+ default-CSS when the chapter has no author styles) at <head> start.
+        val hasAuthorStyles = html.contains("<link ", ignoreCase = true) ||
+            html.contains(" style=", ignoreCase = true) ||
+            Regex("<style", RegexOption.IGNORE_CASE).containsMatchIn(html)
+        val headOpen = Regex("<head[^>]*>", RegexOption.IGNORE_CASE).find(out)
+        val beforeBlock = buildString {
+            append("\n<link rel=\"stylesheet\" type=\"text/css\" href=\"$CSS_BASE/ReadiumCSS-before.css\"/>\n")
+            // Match Readium's overflow fix so scroll layout behaves identically.
+            append("<style>:root[style], :root { overflow: visible !important; }")
+            append(":root[style] > body, :root > body { overflow: visible !important; }</style>\n")
+            if (!hasAuthorStyles) {
+                append("<link rel=\"stylesheet\" type=\"text/css\" href=\"$CSS_BASE/ReadiumCSS-default.css\"/>\n")
+            }
+        }
+        out = if (headOpen != null) {
+            out.substring(0, headOpen.range.last + 1) + beforeBlock + out.substring(headOpen.range.last + 1)
+        } else {
+            beforeBlock + out
+        }
+
+        // 2. After-CSS + bundled @font-face before </head>.
+        val afterBlock = buildString {
+            append("\n<link rel=\"stylesheet\" type=\"text/css\" href=\"$CSS_BASE/ReadiumCSS-after.css\"/>\n")
+            append("<style type=\"text/css\">\n")
+            append(bundledFontFaces())
+            append("</style>\n")
+        }
+        val headCloseIdx = out.indexOf("</head>", ignoreCase = true)
+        out = if (headCloseIdx >= 0) {
+            out.substring(0, headCloseIdx) + afterBlock + out.substring(headCloseIdx)
+        } else {
+            out + afterBlock
+        }
+
+        // 3. The --USER__ style attribute on <html>.
+        val styleAttr = buildHtmlStyleAttr(prefs).replace("\"", "&quot;")
+        val htmlTag = Regex("<html[^>]*", RegexOption.IGNORE_CASE).find(out)
+        if (htmlTag != null) {
+            val insertAt = htmlTag.range.last + 1
+            out = out.substring(0, insertAt) + " style=\"$styleAttr\"" + out.substring(insertAt)
+        }
+        return out
+    }
+
+    /**
+     * JS that re-applies the user-settings `style` attribute on `<html>` after a live preference
+     * change (no reload), then re-measures. ReadiumCSS reads the `--USER__*` variables and
+     * `readium-*-on` flags straight from this attribute via its `[style*=…]` selectors, so setting
+     * the whole attribute string is enough to re-style without reloading the chapter.
      */
     fun buildStyleInjectionJs(prefs: FormattingPreferences): String {
-        val css = buildCss(prefs)
+        val styleAttr = buildHtmlStyleAttr(prefs)
             .replace("\\", "\\\\")
             .replace("'", "\\'")
-            .replace("\n", " ")
         return """
             (function() {
-                var s = document.getElementById('_riffle_user');
-                if (!s) {
-                    s = document.createElement('style');
-                    s.id = '_riffle_user';
-                    document.head.appendChild(s);
-                }
-                s.textContent = '$css';
+                document.documentElement.setAttribute('style', '$styleAttr');
             })();
         """.trimIndent()
     }
 
-    /**
-     * URL prefix under which we serve the app's bundled fonts from [ChapterWebView].
-     * These paths are intercepted in `shouldInterceptRequest` and served from Android assets.
-     */
-    private const val FONT_BASE = "https://readium_package/readium/fonts"
-
-    internal fun buildCss(prefs: FormattingPreferences): String {
-        // Theme colours — mirrors ReaderThemePalette (keep in sync).
-        val bg = when (prefs.theme) {
-            ReaderTheme.Dark, ReaderTheme.DarkDim -> "#000000"
-            ReaderTheme.Sepia -> "#FAF4E8"
-            else -> null
-        }
-        val fg = when (prefs.theme) {
-            ReaderTheme.Dark -> "#FEFEFE"
-            ReaderTheme.DarkDim -> "#AAAAAA"
-            ReaderTheme.Sepia -> "#121212"
-            else -> null
-        }
-
-        // Font family mapping mirrors FormattingPreferencesMapper.toEpubPreferences():
-        //   Serif      → null (Readium default): NO font-family override, so the publisher's
-        //                own font (or the system serif fallback) renders — exactly what Readium
-        //                does in advanced mode when --USER__fontFamily is unset. Forcing
-        //                `serif` here diverged from Scroll/Paginated mode whenever the EPUB
-        //                declared its own body font, which is the "fonts differ" the user saw.
-        //   SansSerif  → FontFamily("sans-serif") → system generic `sans-serif`
-        //   Monospace  → FontFamily("monospace")  → system generic `monospace`
-        //   Literata/Merriweather/OpenDyslexic → app-bundled fonts served from assets via
-        //     shouldInterceptRequest at FONT_BASE; declared here with @font-face.
-        val fontFamily: String? = when (prefs.fontFamily) {
-            ReaderFontFamily.Serif -> null
-            ReaderFontFamily.SansSerif -> "sans-serif"
-            ReaderFontFamily.Monospace -> "monospace"
-            ReaderFontFamily.Literata -> "Literata, serif"
-            ReaderFontFamily.Merriweather -> "Merriweather, serif"
-            ReaderFontFamily.OpenDyslexic -> "OpenDyslexic, sans-serif"
-        }
-
-        // Include @font-face declarations for bundled fonts whenever one of them is active.
-        // The font files are served by ChapterWebView.shouldInterceptRequest from Android assets.
-        val needsBundledFonts = prefs.fontFamily in setOf(
-            ReaderFontFamily.Literata,
-            ReaderFontFamily.Merriweather,
-            ReaderFontFamily.OpenDyslexic,
-        )
-
-        val textAlign = if (prefs.justifyText) "justify" else "left"
-        // margins: 1.0 = normal ≈ 6 % per side (matches Readium's --RS__pageGutter × pageMargins).
-        val paddingPct = (prefs.margins * 6f).toInt().coerceIn(1, 14)
-
-        return buildString {
-            // @font-face declarations must come before any rule that references the font name.
-            if (needsBundledFonts) {
-                append("@font-face{font-family:Literata;font-style:normal;font-weight:400;")
-                append("src:url('$FONT_BASE/Literata-Regular.ttf') format('truetype');}\n")
-                append("@font-face{font-family:Merriweather;font-style:normal;font-weight:400;")
-                append("src:url('$FONT_BASE/Merriweather-Regular.ttf') format('truetype');}\n")
-                append("@font-face{font-family:OpenDyslexic;font-style:normal;font-weight:400;")
-                append("src:url('$FONT_BASE/OpenDyslexic-Regular.otf') format('opentype');}\n")
-            }
-
-            // ReadiumCSS sets -webkit-text-size-adjust:100% on :root to prevent Chrome's
-            // "font inflation" feature from boosting small text on mobile. Without it,
-            // Continuous mode can render text at a different size than Scroll/Paginated mode.
-            append("html{")
-            if (bg != null) append("background-color:$bg!important;")
-            if (fg != null) append("color:$fg!important;")
-            // font-size on html so em/rem-based EPUB content scales with the user preference.
-            append("font-size:${prefs.fontSize}rem!important;")
-            append("-webkit-text-size-adjust:100%!important;text-size-adjust:100%!important;")
-            append("}\n")
-
-            append("body{")
-            if (bg != null) append("background-color:$bg!important;")
-            if (fg != null) append("color:$fg!important;")
-            if (fontFamily != null) append("font-family:$fontFamily!important;")
-            append("line-height:${prefs.lineSpacing}!important;")
-            append("text-align:$textAlign!important;")
-            append("padding-left:${paddingPct}%!important;padding-right:${paddingPct}%!important;")
-            // Zero out all body margin/vertical-padding so the default 8px browser body margin
-            // doesn't appear as a visible gap at every chapter boundary in the stacked layout.
-            append("margin:0!important;padding-top:0!important;padding-bottom:0!important;")
-            append("}\n")
-
-            // ReadiumCSS advanced mode (publisherStyles=false) sets font-size:1rem!important on
-            // content elements to strip EPUB per-element font-size overrides. Without this,
-            // EPUB rules like `p { font-size: 0.9em }` make paragraphs smaller in Continuous
-            // mode than in Scroll/Paginated mode where ReadiumCSS overrides them.
-            append("p,li,dd,div{")
-            append("font-size:1rem!important;")
-            append("}\n")
-
-            // Push text-align and line-height down to the elements publishers commonly override.
-            append("p,li,blockquote,dd,dt,figcaption{")
-            append("text-align:$textAlign!important;")
-            append("line-height:${prefs.lineSpacing}!important;")
-            append("}\n")
-
-            if (fontFamily != null) {
-                append("p,li,blockquote,dd,dt,h1,h2,h3,h4,h5,h6,figcaption{")
-                append("font-family:$fontFamily!important;")
-                append("}\n")
-            }
-        }
-    }
 
     /**
      * JS that calls `window.RiffleChapter.onHeightMeasured` with the chapter's CSS-pixel

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjector.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjector.kt
@@ -1,0 +1,111 @@
+package com.riffle.app.feature.reader
+
+import com.riffle.core.domain.FormattingPreferences
+import com.riffle.core.domain.ReaderFontFamily
+import com.riffle.core.domain.ReaderTheme
+
+internal object ContinuousStyleInjector {
+
+    /**
+     * Produces JS that sets the same `--USER__*` CSS custom properties on `:root` that
+     * Readium's `EpubNavigatorFragment` sets via `submitPreferences()`. The null-gating
+     * logic mirrors [FormattingPreferencesMapper.toEpubPreferences]: when a value equals
+     * the default, Readium passes null — leaving the variable unset so publisher defaults
+     * are preserved. We match that behaviour with `removeProperty`.
+     *
+     * NOTE: verify after any Readium SDK upgrade that the variable names and value formats
+     * still match. Run DevTools on a Scroll-mode chapter and compare with the output of
+     * this function for the same [FormattingPreferences].
+     */
+    fun buildVariableInjectionJs(prefs: FormattingPreferences): String {
+        val lines = mutableListOf<String>()
+        val r = "document.documentElement.style"
+
+        // fontSize — always set (Readium always passes it as a Double)
+        lines += "$r.setProperty('--USER__fontSize', '${prefs.fontSize}rem');"
+
+        // lineHeight — null-gated (matches FormattingPreferencesMapper: null when == default)
+        if (prefs.lineSpacing != FormattingPreferences.DEFAULT_LINE_SPACING) {
+            lines += "$r.setProperty('--USER__lineHeight', '${prefs.lineSpacing}');"
+        } else {
+            lines += "$r.removeProperty('--USER__lineHeight');"
+        }
+
+        // pageMargins — always set
+        lines += "$r.setProperty('--USER__pageMargins', '${prefs.margins}');"
+
+        // textAlign — null-gated
+        if (prefs.justifyText) {
+            lines += "$r.setProperty('--USER__textAlign', 'justify');"
+        } else {
+            lines += "$r.removeProperty('--USER__textAlign');"
+        }
+
+        // fontFamily — null-gated (Serif is default → no variable, matching mapper)
+        val fontFamilyValue = when (prefs.fontFamily) {
+            ReaderFontFamily.Serif -> null
+            ReaderFontFamily.SansSerif -> "sans-serif"
+            ReaderFontFamily.Monospace -> "monospace"
+            ReaderFontFamily.Literata -> "Literata"
+            ReaderFontFamily.Merriweather -> "Merriweather"
+            ReaderFontFamily.OpenDyslexic -> "OpenDyslexic"
+        }
+        if (fontFamilyValue != null) {
+            lines += "$r.setProperty('--USER__fontFamily', '$fontFamilyValue');"
+        } else {
+            lines += "$r.removeProperty('--USER__fontFamily');"
+        }
+
+        // textColor — DarkDim only. 0xFFAAAAAA = ReaderThemePalette.DARK_DIM_TEXT
+        if (prefs.theme == ReaderTheme.DarkDim) {
+            lines += "$r.setProperty('--USER__textColor', '#AAAAAA');"
+        } else {
+            lines += "$r.removeProperty('--USER__textColor');"
+        }
+
+        return lines.joinToString("\n")
+    }
+
+    /**
+     * JS that fires after fonts load + one rAF and calls `window.RiffleChapter.onHeightMeasured`
+     * with `document.body.scrollHeight`. Requires the calling [ChapterWebView] to have
+     * registered a `JavascriptInterface` named `RiffleChapter`.
+     */
+    const val HEIGHT_MEASUREMENT_JS = """
+        document.fonts.ready.then(function() {
+            requestAnimationFrame(function() {
+                window.RiffleChapter.onHeightMeasured(document.body.scrollHeight);
+            });
+        });
+    """
+
+    /**
+     * JS that highlights [escapedText] via `window.find` + DOM `<mark>` injection, replacing
+     * any existing mark with id `_riffle_hl`. Pass an empty string to clear.
+     */
+    fun highlightTextJs(escapedText: String): String {
+        if (escapedText.isBlank()) return CLEAR_HIGHLIGHT_JS
+        return """
+            (function() {
+                var existing = document.getElementById('_riffle_hl');
+                if (existing) { existing.outerHTML = existing.innerHTML; }
+                if (!window.find('$escapedText', false, false, false, false, false, false)) return;
+                var sel = window.getSelection();
+                if (!sel || sel.rangeCount === 0) return;
+                var range = sel.getRangeAt(0);
+                var mark = document.createElement('mark');
+                mark.id = '_riffle_hl';
+                mark.style.cssText = 'background:#7DD3FC;color:inherit;';
+                try { range.surroundContents(mark); } catch(e) {}
+                sel.removeAllRanges();
+            })();
+        """.trimIndent()
+    }
+
+    const val CLEAR_HIGHLIGHT_JS = """
+        (function() {
+            var m = document.getElementById('_riffle_hl');
+            if (m) m.outerHTML = m.innerHTML;
+        })();
+    """
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjector.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjector.kt
@@ -7,89 +7,109 @@ import com.riffle.core.domain.ReaderTheme
 internal object ContinuousStyleInjector {
 
     /**
-     * Produces JS that sets the same `--USER__*` CSS custom properties on `:root` that
-     * Readium's `EpubNavigatorFragment` sets via `submitPreferences()`. The null-gating
-     * logic mirrors [FormattingPreferencesMapper.toEpubPreferences]: when a value equals
-     * the default, Readium passes null — leaving the variable unset so publisher defaults
-     * are preserved. We match that behaviour with `removeProperty`.
+     * Produces JS that injects a `<style id="_riffle_user">` element with real CSS properties
+     * derived from [prefs]. Unlike the `--USER__*` Readium CSS-variable approach, this works
+     * without ReadiumCSS being loaded — ChapterWebViews serve raw EPUB HTML and do not have
+     * Readium's stylesheet present.
      *
-     * NOTE: verify after any Readium SDK upgrade that the variable names and value formats
-     * still match. Run DevTools on a Scroll-mode chapter and compare with the output of
-     * this function for the same [FormattingPreferences].
+     * Colours mirror [ReaderThemePalette]; keep in sync if the palette values change.
+     * Font-size is set on `html` so EPUB content that uses `em`/`rem` scales correctly.
+     * Margins are expressed as body padding (percent of viewport width).
+     * All rules carry `!important` to beat typical publisher CSS specificity.
      */
-    fun buildVariableInjectionJs(prefs: FormattingPreferences): String {
-        val lines = mutableListOf<String>()
-        val r = "document.documentElement.style"
+    fun buildStyleInjectionJs(prefs: FormattingPreferences): String {
+        val css = buildCss(prefs)
+            .replace("\\", "\\\\")
+            .replace("'", "\\'")
+            .replace("\n", " ")
+        return """
+            (function() {
+                var s = document.getElementById('_riffle_user');
+                if (!s) {
+                    s = document.createElement('style');
+                    s.id = '_riffle_user';
+                    document.head.appendChild(s);
+                }
+                s.textContent = '$css';
+            })();
+        """.trimIndent()
+    }
 
-        // fontSize — always set (Readium always passes it as a Double)
-        lines += "$r.setProperty('--USER__fontSize', '${prefs.fontSize}rem');"
-
-        // lineHeight — null-gated (matches FormattingPreferencesMapper: null when == default)
-        if (prefs.lineSpacing != FormattingPreferences.DEFAULT_LINE_SPACING) {
-            lines += "$r.setProperty('--USER__lineHeight', '${prefs.lineSpacing}');"
-        } else {
-            lines += "$r.removeProperty('--USER__lineHeight');"
+    private fun buildCss(prefs: FormattingPreferences): String {
+        // Theme colours — mirrors ReaderThemePalette (keep in sync).
+        val bg = when (prefs.theme) {
+            ReaderTheme.Dark, ReaderTheme.DarkDim -> "#000000"
+            ReaderTheme.Sepia -> "#FAF4E8"
+            else -> null
+        }
+        val fg = when (prefs.theme) {
+            ReaderTheme.Dark -> "#FEFEFE"
+            ReaderTheme.DarkDim -> "#AAAAAA"
+            ReaderTheme.Sepia -> "#121212"
+            else -> null
         }
 
-        // pageMargins — always set
-        lines += "$r.setProperty('--USER__pageMargins', '${prefs.margins}');"
-
-        // textAlign — null-gated
-        if (prefs.justifyText) {
-            lines += "$r.setProperty('--USER__textAlign', 'justify');"
-        } else {
-            lines += "$r.removeProperty('--USER__textAlign');"
-        }
-
-        // fontFamily — null-gated (Serif is default → no variable, matching mapper)
-        val fontFamilyValue = when (prefs.fontFamily) {
+        // Font family — Serif keeps the EPUB's own font; others override with a system stack.
+        // Readium-bundled fonts (Literata, Merriweather, OpenDyslexic) are not available in
+        // ChapterWebViews since those fonts are served by the Readium HTTP server, not ours.
+        val fontFamily = when (prefs.fontFamily) {
             ReaderFontFamily.Serif -> null
-            ReaderFontFamily.SansSerif -> "sans-serif"
-            ReaderFontFamily.Monospace -> "monospace"
-            ReaderFontFamily.Literata -> "Literata"
-            ReaderFontFamily.Merriweather -> "Merriweather"
-            ReaderFontFamily.OpenDyslexic -> "OpenDyslexic"
-        }
-        if (fontFamilyValue != null) {
-            lines += "$r.setProperty('--USER__fontFamily', '$fontFamilyValue');"
-        } else {
-            lines += "$r.removeProperty('--USER__fontFamily');"
+            ReaderFontFamily.SansSerif -> "Arial, Helvetica, sans-serif"
+            ReaderFontFamily.Monospace -> "'Courier New', Courier, monospace"
+            ReaderFontFamily.Literata -> "Georgia, serif"
+            ReaderFontFamily.Merriweather -> "Georgia, serif"
+            ReaderFontFamily.OpenDyslexic -> "sans-serif"
         }
 
-        // textColor — DarkDim only. #AAAAAA = ReaderThemePalette.DARK_DIM_TEXT; keep in sync if the palette changes
-        if (prefs.theme == ReaderTheme.DarkDim) {
-            lines += "$r.setProperty('--USER__textColor', '#AAAAAA');"
-        } else {
-            lines += "$r.removeProperty('--USER__textColor');"
-        }
+        val textAlign = if (prefs.justifyText) "justify" else "left"
+        // margins: 1.0 = normal ≈ 6 % per side; range is typically 0.5–2.0.
+        val paddingPct = (prefs.margins * 6f).toInt().coerceIn(1, 14)
 
-        // backgroundColor — theme-dependent; mirrors --RS__backgroundColor from Readium's CSS
-        when (prefs.theme) {
-            ReaderTheme.Dark, ReaderTheme.DarkDim -> {
-                lines += "$r.setProperty('--USER__backgroundColor', '#000000');"
-            }
-            ReaderTheme.Sepia -> {
-                // #FAF4E8 = ReaderThemePalette.Sepia.background; keep in sync if the palette changes
-                lines += "$r.setProperty('--USER__backgroundColor', '#FAF4E8');"
-            }
-            else -> {
-                lines += "$r.removeProperty('--USER__backgroundColor');"
+        return buildString {
+            // Background and text colour on both html and body to cover all EPUB layouts.
+            append("html,body{")
+            if (bg != null) append("background-color:$bg!important;")
+            if (fg != null) append("color:$fg!important;")
+            // font-size on html so em/rem-based EPUB content scales correctly.
+            append("font-size:${prefs.fontSize}rem!important;")
+            append("}\n")
+
+            append("body{")
+            if (fontFamily != null) append("font-family:$fontFamily!important;")
+            append("line-height:${prefs.lineSpacing}!important;")
+            append("text-align:$textAlign!important;")
+            append("padding-left:${paddingPct}%!important;padding-right:${paddingPct}%!important;")
+            // Clear any body margin so padding is the sole horizontal spacing control.
+            append("margin-left:0!important;margin-right:0!important;")
+            append("}\n")
+
+            // Push text-align and line-height down to the elements publishers commonly override.
+            append("p,li,blockquote,dd,dt,figcaption{")
+            append("text-align:$textAlign!important;")
+            append("line-height:${prefs.lineSpacing}!important;")
+            append("}\n")
+
+            if (fontFamily != null) {
+                append("p,li,blockquote,dd,dt,h1,h2,h3,h4,h5,h6,figcaption{")
+                append("font-family:$fontFamily!important;")
+                append("}\n")
             }
         }
-
-        return lines.joinToString("\n")
     }
 
     /**
-     * JS that calls `window.RiffleChapter.onHeightMeasured` with the chapter height in device
-     * pixels. Uses `window.devicePixelRatio` to convert from CSS pixels so `LayoutParams.height`
-     * receives the correct device-pixel value regardless of whether the EPUB has a viewport meta
-     * tag. `document.fonts.ready` is tried first; a 500 ms timeout fires as a fallback in case
-     * the promise never resolves (older WebViews or EPUBs with failing font loads).
+     * JS that calls `window.RiffleChapter.onHeightMeasured` with the chapter's CSS-pixel
+     * scroll height once fonts have settled. A `fired` guard prevents the double-call that
+     * would otherwise occur when both `document.fonts.ready` and the 500 ms safety timeout
+     * resolve — on modern Chrome both always fire, and a second `onHeightMeasured` can cause
+     * a spurious layout change or scrollBy in the parent [ContinuousReaderView].
      */
     val HEIGHT_MEASUREMENT_JS = """
         (function() {
+            var fired = false;
             function measure() {
+                if (fired) return;
+                fired = true;
                 var h = document.body.scrollHeight;
                 if (h > 0) window.RiffleChapter.onHeightMeasured(h);
             }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjector.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjector.kt
@@ -49,11 +49,13 @@ internal object ContinuousStyleInjector {
             else -> null
         }
 
-        // Font family — Serif keeps the EPUB's own font; others override with a system stack.
-        // Readium-bundled fonts (Literata, Merriweather, OpenDyslexic) are not available in
-        // ChapterWebViews since those fonts are served by the Readium HTTP server, not ours.
+        // Font family — all choices override with a system stack. Serif uses Georgia (Android's
+        // standard serif) because without ReadiumCSS the WebView default is sans-serif, so
+        // leaving Serif as null would render the wrong font entirely.
+        // Readium-bundled custom fonts (Literata, Merriweather, OpenDyslexic) are not available
+        // in ChapterWebViews since those fonts are served by the Readium HTTP server, not ours.
         val fontFamily = when (prefs.fontFamily) {
-            ReaderFontFamily.Serif -> null
+            ReaderFontFamily.Serif -> "Georgia, 'Times New Roman', serif"
             ReaderFontFamily.SansSerif -> "Arial, Helvetica, sans-serif"
             ReaderFontFamily.Monospace -> "'Courier New', Courier, monospace"
             ReaderFontFamily.Literata -> "Georgia, serif"
@@ -79,8 +81,9 @@ internal object ContinuousStyleInjector {
             append("line-height:${prefs.lineSpacing}!important;")
             append("text-align:$textAlign!important;")
             append("padding-left:${paddingPct}%!important;padding-right:${paddingPct}%!important;")
-            // Clear any body margin so padding is the sole horizontal spacing control.
-            append("margin-left:0!important;margin-right:0!important;")
+            // Zero out all body margin/vertical-padding so the default 8px browser body margin
+            // doesn't appear as a visible gap at every chapter boundary in the stacked layout.
+            append("margin:0!important;padding-top:0!important;padding-bottom:0!important;")
             append("}\n")
 
             // Push text-align and line-height down to the elements publishers commonly override.

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjector.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjector.kt
@@ -56,11 +56,25 @@ internal object ContinuousStyleInjector {
             lines += "$r.removeProperty('--USER__fontFamily');"
         }
 
-        // textColor — DarkDim only. 0xFFAAAAAA = ReaderThemePalette.DARK_DIM_TEXT
+        // textColor — DarkDim only. #AAAAAA = ReaderThemePalette.DARK_DIM_TEXT; keep in sync if the palette changes
         if (prefs.theme == ReaderTheme.DarkDim) {
             lines += "$r.setProperty('--USER__textColor', '#AAAAAA');"
         } else {
             lines += "$r.removeProperty('--USER__textColor');"
+        }
+
+        // backgroundColor — theme-dependent; mirrors --RS__backgroundColor from Readium's CSS
+        when (prefs.theme) {
+            ReaderTheme.Dark, ReaderTheme.DarkDim -> {
+                lines += "$r.setProperty('--USER__backgroundColor', '#000000');"
+            }
+            ReaderTheme.Sepia -> {
+                // #FAF4E8 = ReaderThemePalette.Sepia.background; keep in sync if the palette changes
+                lines += "$r.setProperty('--USER__backgroundColor', '#FAF4E8');"
+            }
+            else -> {
+                lines += "$r.removeProperty('--USER__backgroundColor');"
+            }
         }
 
         return lines.joinToString("\n")
@@ -93,7 +107,7 @@ internal object ContinuousStyleInjector {
      */
     fun highlightTextJs(text: String): String {
         if (text.isBlank()) return CLEAR_HIGHLIGHT_JS
-        val safe = text.replace("\\", "\\\\").replace("'", "\\'")
+        val safe = text.replace("\\", "\\\\").replace("'", "\\'").replace("\n", "\\n").replace("\r", "\\r")
         return """
             (function() {
                 var existing = document.getElementById('_riffle_hl');

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjector.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjector.kt
@@ -238,7 +238,9 @@ internal object ContinuousStyleInjector {
                 var h = currentHeight();
                 if (h > 0 && h !== last) {
                     last = h;
-                    window.RiffleChapter.onHeightMeasured(h);
+                    // Pass this page's load token so the parent can reject stale reports from a
+                    // previous chapter still settling in a recycled WebView (see ChapterWebView).
+                    window.RiffleChapter.onHeightMeasured(h, (window.__riffleToken | 0));
                 }
             }
             report();

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjector.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjector.kt
@@ -35,6 +35,12 @@ internal object ContinuousStyleInjector {
         """.trimIndent()
     }
 
+    /**
+     * URL prefix under which we serve the app's bundled fonts from [ChapterWebView].
+     * These paths are intercepted in `shouldInterceptRequest` and served from Android assets.
+     */
+    private const val FONT_BASE = "https://readium_package/readium/fonts"
+
     internal fun buildCss(prefs: FormattingPreferences): String {
         // Theme colours — mirrors ReaderThemePalette (keep in sync).
         val bg = when (prefs.theme) {
@@ -49,30 +55,49 @@ internal object ContinuousStyleInjector {
             else -> null
         }
 
-        // Font family — all choices override with a system stack. Serif uses Georgia (Android's
-        // standard serif) because without ReadiumCSS the WebView default is sans-serif, so
-        // leaving Serif as null would render the wrong font entirely.
-        // Readium-bundled custom fonts (Literata, Merriweather, OpenDyslexic) are not available
-        // in ChapterWebViews since those fonts are served by the Readium HTTP server, not ours.
+        // Font family mapping mirrors FormattingPreferencesMapper.toEpubPreferences():
+        //   Serif      → null (Readium default) → system generic `serif`
+        //   SansSerif  → FontFamily("sans-serif") → system generic `sans-serif`
+        //   Monospace  → FontFamily("monospace")  → system generic `monospace`
+        //   Literata/Merriweather/OpenDyslexic → app-bundled fonts served from assets via
+        //     shouldInterceptRequest at FONT_BASE; declared here with @font-face.
         val fontFamily: String = when (prefs.fontFamily) {
-            ReaderFontFamily.Serif -> "Georgia, 'Times New Roman', serif"
-            ReaderFontFamily.SansSerif -> "Arial, Helvetica, sans-serif"
-            ReaderFontFamily.Monospace -> "'Courier New', Courier, monospace"
-            ReaderFontFamily.Literata -> "Georgia, serif"
-            ReaderFontFamily.Merriweather -> "Georgia, serif"
-            ReaderFontFamily.OpenDyslexic -> "sans-serif"
+            ReaderFontFamily.Serif -> "serif"
+            ReaderFontFamily.SansSerif -> "sans-serif"
+            ReaderFontFamily.Monospace -> "monospace"
+            ReaderFontFamily.Literata -> "Literata, serif"
+            ReaderFontFamily.Merriweather -> "Merriweather, serif"
+            ReaderFontFamily.OpenDyslexic -> "OpenDyslexic, sans-serif"
         }
 
+        // Include @font-face declarations for bundled fonts whenever one of them is active.
+        // The font files are served by ChapterWebView.shouldInterceptRequest from Android assets.
+        val needsBundledFonts = prefs.fontFamily in setOf(
+            ReaderFontFamily.Literata,
+            ReaderFontFamily.Merriweather,
+            ReaderFontFamily.OpenDyslexic,
+        )
+
         val textAlign = if (prefs.justifyText) "justify" else "left"
-        // margins: 1.0 = normal ≈ 6 % per side; range is typically 0.5–2.0.
+        // margins: 1.0 = normal ≈ 6 % per side (matches Readium's --RS__pageGutter × pageMargins).
         val paddingPct = (prefs.margins * 6f).toInt().coerceIn(1, 14)
 
         return buildString {
+            // @font-face declarations must come before any rule that references the font name.
+            if (needsBundledFonts) {
+                append("@font-face{font-family:Literata;font-style:normal;font-weight:400;")
+                append("src:url('$FONT_BASE/Literata-Regular.ttf') format('truetype');}\n")
+                append("@font-face{font-family:Merriweather;font-style:normal;font-weight:400;")
+                append("src:url('$FONT_BASE/Merriweather-Regular.ttf') format('truetype');}\n")
+                append("@font-face{font-family:OpenDyslexic;font-style:normal;font-weight:400;")
+                append("src:url('$FONT_BASE/OpenDyslexic-Regular.otf') format('opentype');}\n")
+            }
+
             // Background and text colour on both html and body to cover all EPUB layouts.
             append("html,body{")
             if (bg != null) append("background-color:$bg!important;")
             if (fg != null) append("color:$fg!important;")
-            // font-size on html so em/rem-based EPUB content scales correctly.
+            // font-size on html so em/rem-based EPUB content scales with the user preference.
             append("font-size:${prefs.fontSize}rem!important;")
             append("}\n")
 

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjector.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjector.kt
@@ -93,15 +93,20 @@ internal object ContinuousStyleInjector {
                 append("src:url('$FONT_BASE/OpenDyslexic-Regular.otf') format('opentype');}\n")
             }
 
-            // Background and text colour on both html and body to cover all EPUB layouts.
-            append("html,body{")
+            // ReadiumCSS sets -webkit-text-size-adjust:100% on :root to prevent Chrome's
+            // "font inflation" feature from boosting small text on mobile. Without it,
+            // Continuous mode can render text at a different size than Scroll/Paginated mode.
+            append("html{")
             if (bg != null) append("background-color:$bg!important;")
             if (fg != null) append("color:$fg!important;")
             // font-size on html so em/rem-based EPUB content scales with the user preference.
             append("font-size:${prefs.fontSize}rem!important;")
+            append("-webkit-text-size-adjust:100%!important;text-size-adjust:100%!important;")
             append("}\n")
 
             append("body{")
+            if (bg != null) append("background-color:$bg!important;")
+            if (fg != null) append("color:$fg!important;")
             append("font-family:$fontFamily!important;")
             append("line-height:${prefs.lineSpacing}!important;")
             append("text-align:$textAlign!important;")
@@ -109,6 +114,14 @@ internal object ContinuousStyleInjector {
             // Zero out all body margin/vertical-padding so the default 8px browser body margin
             // doesn't appear as a visible gap at every chapter boundary in the stacked layout.
             append("margin:0!important;padding-top:0!important;padding-bottom:0!important;")
+            append("}\n")
+
+            // ReadiumCSS advanced mode (publisherStyles=false) sets font-size:1rem!important on
+            // content elements to strip EPUB per-element font-size overrides. Without this,
+            // EPUB rules like `p { font-size: 0.9em }` make paragraphs smaller in Continuous
+            // mode than in Scroll/Paginated mode where ReadiumCSS overrides them.
+            append("p,li,dd,div{")
+            append("font-size:1rem!important;")
             append("}\n")
 
             // Push text-align and line-height down to the elements publishers commonly override.

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjector.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjector.kt
@@ -35,7 +35,7 @@ internal object ContinuousStyleInjector {
         """.trimIndent()
     }
 
-    private fun buildCss(prefs: FormattingPreferences): String {
+    internal fun buildCss(prefs: FormattingPreferences): String {
         // Theme colours — mirrors ReaderThemePalette (keep in sync).
         val bg = when (prefs.theme) {
             ReaderTheme.Dark, ReaderTheme.DarkDim -> "#000000"
@@ -54,7 +54,7 @@ internal object ContinuousStyleInjector {
         // leaving Serif as null would render the wrong font entirely.
         // Readium-bundled custom fonts (Literata, Merriweather, OpenDyslexic) are not available
         // in ChapterWebViews since those fonts are served by the Readium HTTP server, not ours.
-        val fontFamily = when (prefs.fontFamily) {
+        val fontFamily: String = when (prefs.fontFamily) {
             ReaderFontFamily.Serif -> "Georgia, 'Times New Roman', serif"
             ReaderFontFamily.SansSerif -> "Arial, Helvetica, sans-serif"
             ReaderFontFamily.Monospace -> "'Courier New', Courier, monospace"
@@ -77,7 +77,7 @@ internal object ContinuousStyleInjector {
             append("}\n")
 
             append("body{")
-            if (fontFamily != null) append("font-family:$fontFamily!important;")
+            append("font-family:$fontFamily!important;")
             append("line-height:${prefs.lineSpacing}!important;")
             append("text-align:$textAlign!important;")
             append("padding-left:${paddingPct}%!important;padding-right:${paddingPct}%!important;")
@@ -92,11 +92,9 @@ internal object ContinuousStyleInjector {
             append("line-height:${prefs.lineSpacing}!important;")
             append("}\n")
 
-            if (fontFamily != null) {
-                append("p,li,blockquote,dd,dt,h1,h2,h3,h4,h5,h6,figcaption{")
-                append("font-family:$fontFamily!important;")
-                append("}\n")
-            }
+            append("p,li,blockquote,dd,dt,h1,h2,h3,h4,h5,h6,figcaption{")
+            append("font-family:$fontFamily!important;")
+            append("}\n")
         }
     }
 

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjector.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjector.kt
@@ -196,25 +196,62 @@ internal object ContinuousStyleInjector {
 
 
     /**
-     * JS that calls `window.RiffleChapter.onHeightMeasured` with the chapter's CSS-pixel
-     * scroll height once fonts have settled. A `fired` guard prevents the double-call that
-     * would otherwise occur when both `document.fonts.ready` and the 500 ms safety timeout
-     * resolve — on modern Chrome both always fire, and a second `onHeightMeasured` can cause
-     * a spurious layout change or scrollBy in the parent [ContinuousReaderView].
+     * JS that reports the chapter's CSS-pixel content height to
+     * `window.RiffleChapter.onHeightMeasured`, and KEEPS reporting whenever the height changes.
+     *
+     * A single measurement is fragile: if it lands before the final reflow (late web-font swap,
+     * image decode, ReadiumCSS type-scale settling) the WebView's height is locked too short,
+     * which clips the last line of the chapter and makes content jump when the sliding window
+     * shifts using the stale height. Instead we:
+     *
+     *  - Measure the *document* height (`documentElement.scrollHeight`, maxed with body and the
+     *    offset heights) so the root's page-margin padding and any bottom margin are included —
+     *    `document.body.scrollHeight` alone omits the `:root` padding ReadiumCSS adds in scroll
+     *    mode, leaving the chapter short.
+     *  - Convert CSS px → device px via `window.devicePixelRatio` before reporting. The parent sizes
+     *    `WebView.layoutParams.height` (device px) directly from this value, so without the
+     *    conversion a chapter measured at e.g. 2602 CSS px on a 2.625-density screen would get a
+     *    2602-device-px view — only ~38% of its true height — clipping the rest of the chapter.
+     *  - Re-report on every later layout change via a [ResizeObserver] (plus a couple of delayed
+     *    safety re-measures), de-duplicated so a stable height reports exactly once. The parent
+     *    [ContinuousReaderView] compensates scroll for height changes above the viewport, so late
+     *    growth never shifts the line being read.
      */
     val HEIGHT_MEASUREMENT_JS = """
         (function() {
-            var fired = false;
-            function measure() {
-                if (fired) return;
-                fired = true;
-                var h = document.body.scrollHeight;
-                if (h > 0) window.RiffleChapter.onHeightMeasured(h);
+            if (window.__riffleMeasureWired) return;
+            window.__riffleMeasureWired = true;
+            function currentHeight() {
+                var de = document.documentElement;
+                var b = document.body;
+                var cssH = Math.max(
+                    de ? de.scrollHeight : 0,
+                    de ? de.offsetHeight : 0,
+                    b ? b.scrollHeight : 0,
+                    b ? b.offsetHeight : 0
+                );
+                // Report device px so the parent can use it as WebView.layoutParams.height directly.
+                return Math.ceil(cssH * (window.devicePixelRatio || 1));
+            }
+            var last = -1;
+            function report() {
+                var h = currentHeight();
+                if (h > 0 && h !== last) {
+                    last = h;
+                    window.RiffleChapter.onHeightMeasured(h);
+                }
+            }
+            report();
+            if (window.ResizeObserver) {
+                var ro = new ResizeObserver(function() { report(); });
+                ro.observe(document.documentElement);
+                if (document.body) ro.observe(document.body);
             }
             if (document.fonts && document.fonts.ready) {
-                document.fonts.ready.then(function() { requestAnimationFrame(measure); });
+                document.fonts.ready.then(function() { requestAnimationFrame(report); });
             }
-            setTimeout(measure, 500);
+            setTimeout(report, 300);
+            setTimeout(report, 1000);
         })();
     """.trimIndent()
 

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjector.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjector.kt
@@ -282,7 +282,18 @@ internal object ContinuousStyleInjector {
         (function() {
             if (document.__riffleTapWired) return;
             document.__riffleTapWired = true;
-            document.addEventListener('click', function() {
+            document.addEventListener('click', function(e) {
+                // Only a tap on the background toggles the reader chrome. A tap on a link (footnote,
+                // cross-reference, external) or other interactive control must NOT also toggle the
+                // bars — otherwise following an internal link in Continuous mode flips out of
+                // immersive mode at the same time (the link's own handler navigates separately).
+                var t = e.target;
+                while (t && t.nodeType === 1) {
+                    var tag = t.tagName ? t.tagName.toLowerCase() : '';
+                    if (tag === 'a' || tag === 'button' || tag === 'input' ||
+                        tag === 'select' || tag === 'textarea' || tag === 'label') return;
+                    t = t.parentNode;
+                }
                 window.RiffleChapter.onTap();
             }, false);
         })();

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjector.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjector.kt
@@ -71,25 +71,34 @@ internal object ContinuousStyleInjector {
      * with `document.body.scrollHeight`. Requires the calling [ChapterWebView] to have
      * registered a `JavascriptInterface` named `RiffleChapter`.
      */
-    const val HEIGHT_MEASUREMENT_JS = """
+    val HEIGHT_MEASUREMENT_JS = """
         document.fonts.ready.then(function() {
             requestAnimationFrame(function() {
                 window.RiffleChapter.onHeightMeasured(document.body.scrollHeight);
             });
         });
-    """
+    """.trimIndent()
+
+    val CLEAR_HIGHLIGHT_JS = """
+        (function() {
+            var m = document.getElementById('_riffle_hl');
+            if (m) m.outerHTML = m.innerHTML;
+        })();
+    """.trimIndent()
 
     /**
-     * JS that highlights [escapedText] via `window.find` + DOM `<mark>` injection, replacing
+     * JS that highlights [text] via `window.find` + DOM `<mark>` injection, replacing
      * any existing mark with id `_riffle_hl`. Pass an empty string to clear.
+     * Single quotes and backslashes in [text] are escaped before embedding in JS.
      */
-    fun highlightTextJs(escapedText: String): String {
-        if (escapedText.isBlank()) return CLEAR_HIGHLIGHT_JS
+    fun highlightTextJs(text: String): String {
+        if (text.isBlank()) return CLEAR_HIGHLIGHT_JS
+        val safe = text.replace("\\", "\\\\").replace("'", "\\'")
         return """
             (function() {
                 var existing = document.getElementById('_riffle_hl');
                 if (existing) { existing.outerHTML = existing.innerHTML; }
-                if (!window.find('$escapedText', false, false, false, false, false, false)) return;
+                if (!window.find('$safe', false, false, false, false, false, false)) return;
                 var sel = window.getSelection();
                 if (!sel || sel.rangeCount === 0) return;
                 var range = sel.getRangeAt(0);
@@ -101,11 +110,4 @@ internal object ContinuousStyleInjector {
             })();
         """.trimIndent()
     }
-
-    const val CLEAR_HIGHLIGHT_JS = """
-        (function() {
-            var m = document.getElementById('_riffle_hl');
-            if (m) m.outerHTML = m.innerHTML;
-        })();
-    """
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjector.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjector.kt
@@ -204,10 +204,11 @@ internal object ContinuousStyleInjector {
      * which clips the last line of the chapter and makes content jump when the sliding window
      * shifts using the stale height. Instead we:
      *
-     *  - Measure the *document* height (`documentElement.scrollHeight`, maxed with body and the
-     *    offset heights) so the root's page-margin padding and any bottom margin are included —
-     *    `document.body.scrollHeight` alone omits the `:root` padding ReadiumCSS adds in scroll
-     *    mode, leaving the chapter short.
+     *  - Measure the true content extent — the body's bottom edge plus the `:root` bottom padding
+     *    ReadiumCSS adds in scroll mode — maxed with the body/root *offset* heights. We avoid
+     *    `documentElement.scrollHeight`: the root scrolling element's scrollHeight is clamped to
+     *    `max(content, viewport)`, so a chapter shorter than the viewport (a chapter-title divider
+     *    page) would measure a full screen tall and insert a large blank gap after it.
      *  - Convert CSS px → device px via `window.devicePixelRatio` before reporting. The parent sizes
      *    `WebView.layoutParams.height` (device px) directly from this value, so without the
      *    conversion a chapter measured at e.g. 2602 CSS px on a 2.625-density screen would get a
@@ -224,11 +225,26 @@ internal object ContinuousStyleInjector {
             function currentHeight() {
                 var de = document.documentElement;
                 var b = document.body;
+                // True content extent = body's bottom edge in document space + the :root bottom
+                // padding ReadiumCSS adds in scroll mode. We deliberately do NOT use
+                // documentElement.scrollHeight here: the root scrolling element's scrollHeight is
+                // clamped to max(content, viewport) by spec, so a chapter shorter than the viewport
+                // (e.g. a chapter-title divider page with only a heading) would measure a full
+                // screen tall and insert a large blank gap after it in the continuous stack.
+                // de.offsetHeight / b.offsetHeight are border-box heights and are NOT viewport-
+                // clamped, so they (and the body-bottom measure) give the real height for both
+                // short and tall chapters.
+                var bodyBottom = b ? (b.getBoundingClientRect().bottom + (window.pageYOffset || 0)) : 0;
+                var rootPadBottom = 0;
+                if (de) {
+                    var pb = parseFloat(getComputedStyle(de).paddingBottom);
+                    if (pb === pb) rootPadBottom = pb; // NaN-guard without isNaN()
+                }
                 var cssH = Math.max(
-                    de ? de.scrollHeight : 0,
+                    bodyBottom + rootPadBottom,
                     de ? de.offsetHeight : 0,
-                    b ? b.scrollHeight : 0,
-                    b ? b.offsetHeight : 0
+                    b ? b.offsetHeight : 0,
+                    b ? b.scrollHeight : 0
                 );
                 // Report device px so the parent can use it as WebView.layoutParams.height directly.
                 return Math.ceil(cssH * (window.devicePixelRatio || 1));

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjector.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjector.kt
@@ -299,6 +299,37 @@ internal object ContinuousStyleInjector {
         })();
     """.trimIndent()
 
+    /**
+     * JS that intercepts taps on same-document anchors (`<a href="#id">`) in the capture phase,
+     * before the WebView performs its default in-page scroll, and asks the native side whether the
+     * target is a footnote via `window.RiffleChapter.onFootnoteAnchorTap(id)`. When it is (returns
+     * true) the default scroll is suppressed so the reader shows the footnote popup instead. In
+     * Continuous mode the WebView's own scrolling is disabled, so without this a footnote tap would
+     * do nothing at all. Mirrors the paged-mode [FootnoteAnchorBridge], but per-WebView (each stacked
+     * chapter resolves against its own document) rather than via the single shared bridge.
+     */
+    val FOOTNOTE_LISTENER_JS = """
+        (function() {
+            if (document.__riffleFootnoteWired) return;
+            document.__riffleFootnoteWired = true;
+            document.addEventListener('click', function(e) {
+                var t = e.target;
+                while (t && t.nodeType === 1 && (!t.tagName || t.tagName.toLowerCase() !== 'a')) t = t.parentNode;
+                if (!t || !t.tagName || t.tagName.toLowerCase() !== 'a') return;
+                var href = t.getAttribute('href');
+                if (!href || href.charAt(0) !== '#') return;
+                var id = href.substring(1);
+                if (!id) return;
+                try {
+                    if (window.RiffleChapter.onFootnoteAnchorTap(id)) {
+                        e.preventDefault();
+                        e.stopPropagation();
+                    }
+                } catch (err) {}
+            }, true);
+        })();
+    """.trimIndent()
+
     val CLEAR_HIGHLIGHT_JS = """
         (function() {
             var m = document.getElementById('_riffle_hl');

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjector.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjector.kt
@@ -81,16 +81,38 @@ internal object ContinuousStyleInjector {
     }
 
     /**
-     * JS that fires after fonts load + one rAF and calls `window.RiffleChapter.onHeightMeasured`
-     * with `document.body.scrollHeight`. Requires the calling [ChapterWebView] to have
-     * registered a `JavascriptInterface` named `RiffleChapter`.
+     * JS that calls `window.RiffleChapter.onHeightMeasured` with the chapter height in device
+     * pixels. Uses `window.devicePixelRatio` to convert from CSS pixels so `LayoutParams.height`
+     * receives the correct device-pixel value regardless of whether the EPUB has a viewport meta
+     * tag. `document.fonts.ready` is tried first; a 500 ms timeout fires as a fallback in case
+     * the promise never resolves (older WebViews or EPUBs with failing font loads).
      */
     val HEIGHT_MEASUREMENT_JS = """
-        document.fonts.ready.then(function() {
-            requestAnimationFrame(function() {
-                window.RiffleChapter.onHeightMeasured(document.body.scrollHeight);
-            });
-        });
+        (function() {
+            function measure() {
+                var h = document.body.scrollHeight;
+                if (h > 0) window.RiffleChapter.onHeightMeasured(h);
+            }
+            if (document.fonts && document.fonts.ready) {
+                document.fonts.ready.then(function() { requestAnimationFrame(measure); });
+            }
+            setTimeout(measure, 500);
+        })();
+    """.trimIndent()
+
+    /**
+     * JS that forwards single taps on the document body to `window.RiffleChapter.onTap` so the
+     * Continuous-mode reader chrome (top/bottom bars) can toggle on tap, matching the standard
+     * Readium navigator's [InputListener.onTap] behaviour. The listener is idempotent.
+     */
+    val TAP_LISTENER_JS = """
+        (function() {
+            if (document.__riffleTapWired) return;
+            document.__riffleTapWired = true;
+            document.addEventListener('click', function() {
+                window.RiffleChapter.onTap();
+            }, false);
+        })();
     """.trimIndent()
 
     val CLEAR_HIGHLIGHT_JS = """

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/DisplaySection.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/DisplaySection.kt
@@ -80,7 +80,11 @@ fun DisplaySection(
         Text("Reading mode", style = MaterialTheme.typography.labelMedium)
         Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
             ReaderOrientation.entries.forEach { orientation ->
-                val label = if (orientation == ReaderOrientation.Horizontal) "Paginated" else "Scroll"
+                val label = when (orientation) {
+                    ReaderOrientation.Horizontal -> "Paginated"
+                    ReaderOrientation.Vertical -> "Scroll"
+                    ReaderOrientation.Continuous -> "Continuous"
+                }
                 FilterChip(
                     selected = prefs.orientation == orientation,
                     onClick = { onPrefsChange(prefs.copy(orientation = orientation)) },

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -1272,10 +1272,19 @@ private fun EpubNavigatorView(
         }
     }
 
-    LaunchedEffect(serverLocatorEvents) {
+    LaunchedEffect(serverLocatorEvents, isContinuous) {
         serverLocatorEvents.collect { locator ->
-            // Background position sync (peer/resume): navigate and snap onto the target's column, tracked
-            // through the new chapter's reflow, but never cover — a cover here would flash mid-reading.
+            // Background position sync (peer/resume/audiobook handoff): in Continuous mode the
+            // fragment is the invisible server-keeper, so route the jump to the continuous view.
+            if (isContinuous) {
+                continuousViewRef.value?.navigateTo(
+                    locator.href.toString(),
+                    locator.locations.progression?.toFloat() ?: 0f,
+                )
+                return@collect
+            }
+            // Paginated/scroll: navigate and snap onto the target's column, tracked through the new
+            // chapter's reflow, but never cover — a cover here would flash mid-reading.
             val fragment = fragmentRef.value ?: return@collect
             // A background sync (audiobook/peer) carries a within-chapter progression but no DOM
             // fragment; preserve where go() landed (round to the column grid) instead of snapping to
@@ -1302,8 +1311,17 @@ private fun EpubNavigatorView(
         }
     }
 
-    LaunchedEffect(returnNavEvents) {
-        returnNavEvents.collect { goAndSnapWithCover(it) }
+    LaunchedEffect(returnNavEvents, isContinuous) {
+        returnNavEvents.collect { locator ->
+            if (isContinuous) {
+                continuousViewRef.value?.navigateTo(
+                    locator.href.toString(),
+                    locator.locations.progression?.toFloat() ?: 0f,
+                )
+            } else {
+                goAndSnapWithCover(locator)
+            }
+        }
     }
 
     LaunchedEffect(searchNavigationEvents, isContinuous) {
@@ -1580,8 +1598,12 @@ private fun EpubNavigatorView(
         }
     }
 
-    LaunchedEffect(volumeNavEvents) {
+    LaunchedEffect(volumeNavEvents, isContinuous) {
         volumeNavEvents.collect { event ->
+            if (isContinuous) {
+                continuousViewRef.value?.scrollByPage(forward = event == VolumeNavEvent.Forward)
+                return@collect
+            }
             val fragment = fragmentRef.value ?: return@collect
             val container = containerRef.value
             if (currentFormattingPrefs.orientation != ReaderOrientation.Horizontal && container != null) {
@@ -1889,6 +1911,29 @@ private fun EpubNavigatorView(
                             if (locator != null) onPositionChanged(locator)
                         }
                         view.onTap = currentOnTap
+                        view.onInternalLinkTapped = onInternalLinkTapped@{ href ->
+                            // Reuse the return-aware internal-link path: capture the origin (for the
+                            // "Back" card) and navigate. Look up the spine Link so the existing
+                            // followInternalLink wiring (capture + navigation event) handles it; fall
+                            // back to a direct jump for a target outside the reading order.
+                            val origin = currentLatestLocator()
+                            val path = href.substringBefore('#')
+                            val link = state.publication.readingOrder
+                                .firstOrNull { it.href.toString() == path }
+                            if (link != null && origin != null) {
+                                currentOnFollowInternalLink(link, origin)
+                            } else {
+                                view.navigateTo(href, 0f)
+                            }
+                        }
+                        view.onExternalLinkTapped = { url ->
+                            runCatching {
+                                ctx.startActivity(
+                                    android.content.Intent(android.content.Intent.ACTION_VIEW, android.net.Uri.parse(url))
+                                        .addFlags(android.content.Intent.FLAG_ACTIVITY_NEW_TASK),
+                                )
+                            }
+                        }
                     }
                 },
                 update = { _ -> },

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -1934,9 +1934,20 @@ private fun EpubNavigatorView(
                                 )
                             }
                         }
+                        view.readaloudAvailable = currentReadaloudAvailable
+                        view.onPlayFromHereSelection = { chapterHref, selectedText ->
+                            // Resolve the selection to a narrated sentence id and start playback there.
+                            val sid = ContinuousPositionTracker.sentenceIdForSelection(
+                                selectedText,
+                                currentSentenceQuotes.mapValues { it.value.highlight },
+                            )
+                            if (sid != null) currentOnPlayFromHere("$chapterHref#$sid")
+                        }
                     }
                 },
-                update = { _ -> },
+                // readaloudAvailability can flip mid-session (e.g. a bundle finishes downloading),
+                // so keep the selection menu's "Play from here" gate in sync.
+                update = { it.readaloudAvailable = readaloudAvailable },
                 modifier = readerModifier,
             )
             // Key on the view ref: AndroidView.factory (which sets continuousViewRef) runs as a

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -1242,8 +1242,13 @@ private fun EpubNavigatorView(
         onDispose { FootnoteAnchorBridge.setHandler(null) }
     }
 
-    LaunchedEffect(onNavigationEvents) {
+    LaunchedEffect(onNavigationEvents, isContinuous) {
         onNavigationEvents.collect { link ->
+            // In Continuous mode the Readium fragment is a server-keeper only (invisible,
+            // height=0). Internal-link taps are handled by ContinuousReaderView.navigateTo;
+            // fragment.go() would suspend forever on the invisible WebView, leaving
+            // navigating=true and covering the reader with a permanent blank overlay.
+            if (isContinuous) return@collect
             val fragment = fragmentRef.value ?: return@collect
             // Cover only a cross-resource jump (where the load flash happens); a same-chapter jump
             // is instant and needs no mask.
@@ -1608,6 +1613,13 @@ private fun EpubNavigatorView(
         continuousViewRef.value?.updatePreferences(formattingPrefs)
     }
 
+    // If the user switches TO Continuous mode while a navigating cover was active (the
+    // onNavigationEvents LaunchedEffect gets cancelled mid-goAndSnap), navigating would stay
+    // true indefinitely. Clear it whenever isContinuous becomes true.
+    LaunchedEffect(isContinuous) {
+        if (isContinuous) navigating = false
+    }
+
     // In Continuous mode, the fragment is zero-height (HTTP server keeper only).
     // Once it emits its first locator, extract the HTTP base URL for ContinuousReaderView.
     LaunchedEffect(fragmentRef.value, isContinuous) {
@@ -1879,6 +1891,7 @@ private fun EpubNavigatorView(
                             )
                             if (locator != null) onPositionChanged(locator)
                         }
+                        view.onTap = currentOnTap
                     }
                 },
                 update = { _ -> },

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -267,7 +267,7 @@ fun EpubReaderScreen(
     // needs no reserve (the player floats over a freely-scrollable page). See ReadaloudReserve.kt.
     val readaloudReservePx: Int = readaloudReserveDp(
         readaloudAvailable = readaloudAvailable,
-        paginated = formattingPrefs.orientation != ReaderOrientation.Vertical,
+        paginated = formattingPrefs.orientation == ReaderOrientation.Horizontal,
     )
 
     // Track the rendered height of the chapter rail overlay so its pixels can be added to the CSS
@@ -1529,7 +1529,7 @@ private fun EpubNavigatorView(
         volumeNavEvents.collect { event ->
             val fragment = fragmentRef.value ?: return@collect
             val container = containerRef.value
-            if (currentFormattingPrefs.orientation == ReaderOrientation.Vertical && container != null) {
+            if (currentFormattingPrefs.orientation != ReaderOrientation.Horizontal && container != null) {
                 when (event) {
                     VolumeNavEvent.Forward -> {
                         val atBottom = fragment.evaluateJavascript(
@@ -1596,7 +1596,7 @@ private fun EpubNavigatorView(
     // touch even when scroll position hasn't moved, which broke the previous staleness check.
     LaunchedEffect(fragmentRef.value, currentFormattingPrefs.orientation) {
         val fragment = fragmentRef.value ?: return@LaunchedEffect
-        if (currentFormattingPrefs.orientation != ReaderOrientation.Vertical) return@LaunchedEffect
+        if (currentFormattingPrefs.orientation == ReaderOrientation.Horizontal) return@LaunchedEffect
         while (true) {
             val container = containerRef.value
             if (container != null) {
@@ -1628,7 +1628,7 @@ private fun EpubNavigatorView(
     // page-coloured gutter behind). Scroll / fixed-layout / double-page keep fillMaxSize and the
     // bare modifier, untouched. See reference_reader_right_margin_is_column_snap_bug.
     val density = LocalDensity.current.density
-    val isPaginated = !isFixedLayout && formattingPrefs.orientation != ReaderOrientation.Vertical
+    val isPaginated = !isFixedLayout && formattingPrefs.orientation == ReaderOrientation.Horizontal
     val isDoublePage = isPaginated && formattingPrefs.doublePageSpread && isLandscape
     val alignViewport = isPaginated && !isDoublePage
     val containerModifier = if (alignViewport) {
@@ -1666,12 +1666,12 @@ private fun EpubNavigatorView(
                 }.also { containerRef.value = it }
             },
             update = { container ->
-                container.isScrollMode = formattingPrefs.orientation == ReaderOrientation.Vertical
+                container.isScrollMode = formattingPrefs.orientation != ReaderOrientation.Horizontal
 
                 val fragmentContainer = container.getChildAt(0) as? FragmentContainerView
                     ?: return@AndroidView
 
-                val isScrollMode = formattingPrefs.orientation == ReaderOrientation.Vertical
+                val isScrollMode = formattingPrefs.orientation != ReaderOrientation.Horizontal
                 val density = container.resources.displayMetrics.density
                 val (topPx, bottomPx) = readerContainerPaddingPx(
                     margins = formattingPrefs.margins,
@@ -1689,7 +1689,7 @@ private fun EpubNavigatorView(
                 // cannot be changed via submitPreferences. Recreate the fragment whenever the
                 // double-page mode changes so the new RS config takes effect.
                 val isDoublePage = !isFixedLayout &&
-                    formattingPrefs.orientation != ReaderOrientation.Vertical &&
+                    formattingPrefs.orientation == ReaderOrientation.Horizontal &&
                     formattingPrefs.doublePageSpread &&
                     isLandscape
                 val existingFrag = fragmentRef.value

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -1295,8 +1295,19 @@ private fun EpubNavigatorView(
         returnNavEvents.collect { goAndSnapWithCover(it) }
     }
 
-    LaunchedEffect(searchNavigationEvents) {
-        searchNavigationEvents.collect { goAndSnapWithCover(it) }
+    LaunchedEffect(searchNavigationEvents, isContinuous) {
+        searchNavigationEvents.collect { locator ->
+            if (isContinuous) {
+                val view = continuousViewRef.value ?: return@collect
+                val href = locator.href.toString()
+                val progression = locator.locations.progression?.toFloat() ?: 0f
+                val highlightText = locator.text.highlight?.take(40) ?: ""
+                view.navigateTo(href, progression)
+                if (highlightText.isNotBlank()) view.highlightInChapter(href, highlightText)
+            } else {
+                goAndSnapWithCover(locator)
+            }
+        }
     }
 
     // Resolve "top of the current page" when readaloud reopens on a different page: ask the WebView
@@ -1334,6 +1345,7 @@ private fun EpubNavigatorView(
     // re-applies are idempotent (same id + locator). Re-keys on reflow/pageLoad as well for rotation and
     // formatting reflows, matching the readaloud and annotations decoration effects.
     LaunchedEffect(searchResults, currentSearchIndex, reflowGeneration, pageLoadGeneration.value) {
+        if (isContinuous) return@LaunchedEffect  // ContinuousReaderView uses window.find via highlightInChapter
         if (searchResults.isEmpty()) {
             if (!hasActiveDecorations.value) return@LaunchedEffect
             val fragment = fragmentRef.value as? DecorableNavigator ?: return@LaunchedEffect

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -1244,10 +1244,17 @@ private fun EpubNavigatorView(
     LaunchedEffect(onNavigationEvents, isContinuous) {
         onNavigationEvents.collect { link ->
             // In Continuous mode the Readium fragment is a server-keeper only (invisible,
-            // height=0). Internal-link taps are handled by ContinuousReaderView.navigateTo;
-            // fragment.go() would suspend forever on the invisible WebView, leaving
-            // navigating=true and covering the reader with a permanent blank overlay.
-            if (isContinuous) return@collect
+            // height=0): fragment.go() would suspend forever on the invisible WebView, leaving
+            // navigating=true and covering the reader with a permanent blank overlay. So TOC entries,
+            // chapter-map segments and internal links are routed to ContinuousReaderView.navigateTo
+            // instead of the fragment.
+            if (isContinuous) {
+                val view = continuousViewRef.value ?: return@collect
+                // TOC entries / chapter-map segments are Links (no progression) — land at the start
+                // of the target chapter.
+                view.navigateTo(link.href.toString(), 0f)
+                return@collect
+            }
             val fragment = fragmentRef.value ?: return@collect
             // Cover only a cross-resource jump (where the load flash happens); a same-chapter jump
             // is instant and needs no mask.

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -1395,6 +1395,7 @@ private fun EpubNavigatorView(
     // off the main thread after the track loads) become available.
     val hasReadaloudDecoration = remember { mutableStateOf(false) }
     LaunchedEffect(activeFragmentRef, reflowGeneration, pageLoadGeneration.value, sentenceQuotes, readaloudHighlightColor, formattingPrefs.theme) {
+        if (isContinuous) return@LaunchedEffect  // handled in the Continuous-mode effect below
         val fragment = fragmentRef.value as? DecorableNavigator ?: return@LaunchedEffect
         val ref = activeFragmentRef
         if (ref == null) {
@@ -1429,6 +1430,33 @@ private fun EpubNavigatorView(
             fragment.applyDecorations(listOf(decoration), group = "readaloud")
         }
         hasReadaloudDecoration.value = true
+    }
+
+    // ---- Continuous-mode readaloud highlight -----------------------------------------------
+    // In Continuous mode, decoration APIs are not used. Instead we call ContinuousReaderView's
+    // highlightInChapter / clearHighlightInChapter directly, keyed by the 12-char text prefix
+    // (same heuristic as autoFollowSnapJs). prevHighlightHref tracks the chapter that currently
+    // carries the mark so we can clear it if the narrated chapter changes or playback stops.
+    val prevHighlightHref = remember { mutableStateOf<String?>(null) }
+    LaunchedEffect(activeFragmentRef, isContinuous, sentenceQuotes) {
+        if (!isContinuous) return@LaunchedEffect
+        val view = continuousViewRef.value ?: return@LaunchedEffect
+        val ref = activeFragmentRef
+        if (ref == null) {
+            // Readaloud stopped — clear the last known chapter's highlight
+            prevHighlightHref.value?.let { view.clearHighlightInChapter(it) }
+            prevHighlightHref.value = null
+            return@LaunchedEffect
+        }
+        val chapterHref = ref.substringBefore('#')
+        val sid = ref.substringAfter('#', "")
+        val quote = sentenceQuotes[sid]
+        val highlightText = quote?.highlight?.take(12) ?: return@LaunchedEffect
+        // If the chapter changed, clear the previous chapter's mark
+        val prev = prevHighlightHref.value
+        if (prev != null && prev != chapterHref) view.clearHighlightInChapter(prev)
+        prevHighlightHref.value = chapterHref
+        view.highlightInChapter(chapterHref, highlightText)
     }
 
     // ---- Persisted highlights (ADR 0024) ---------------------------------------------------
@@ -1481,6 +1509,7 @@ private fun EpubNavigatorView(
     // so the narrated sentence is re-centred after those relayouts. The player floats over the page and
     // no longer reflows it, so opening it doesn't move the narrated sentence's column.
     LaunchedEffect(activeFragmentRef, sentenceQuotes, reflowGeneration, pageLoadGeneration.value) {
+        if (isContinuous) return@LaunchedEffect
         val ref = activeFragmentRef ?: return@LaunchedEffect
         val fragment = fragmentRef.value ?: return@LaunchedEffect
         if (ref.indexOf('#') < 0) return@LaunchedEffect

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -922,7 +922,6 @@ private fun EpubNavigatorView(
     val fragmentRef = remember { mutableStateOf<EpubNavigatorFragment?>(null) }
     val containerRef = remember { mutableStateOf<ScrollBoundaryNavigationContainer?>(null) }
     val continuousViewRef = remember { mutableStateOf<ContinuousReaderView?>(null) }
-    val serverBaseUrl = remember { mutableStateOf<String?>(null) }
     val isContinuous = formattingPrefs.orientation == ReaderOrientation.Continuous
     // Covers the reader with a plain page-coloured screen while a cross-resource jump (TOC/search)
     // loads the new chapter. Readium briefly paints the new resource's opener (a figure/graphic) or
@@ -1620,20 +1619,6 @@ private fun EpubNavigatorView(
         if (isContinuous) navigating = false
     }
 
-    // In Continuous mode, the fragment is zero-height (HTTP server keeper only).
-    // Once it emits its first locator, extract the HTTP base URL for ContinuousReaderView.
-    LaunchedEffect(fragmentRef.value, isContinuous) {
-        if (!isContinuous) return@LaunchedEffect
-        val fragment = fragmentRef.value ?: return@LaunchedEffect
-        fragment.currentLocator.collect { locator ->
-            if (serverBaseUrl.value != null) return@collect
-            val absoluteUrl = fragment.evaluateJavascript("window.location.href") ?: return@collect
-            val relHref = locator.href.toString().trimStart('/')
-            val base = absoluteUrl.trim('"').removeSuffix("/$relHref")
-            serverBaseUrl.value = base
-        }
-    }
-
     DisposableEffect(tapListener) {
         onDispose { fragmentRef.value?.removeInputListener(tapListener) }
     }
@@ -1871,11 +1856,16 @@ private fun EpubNavigatorView(
             },
             modifier = readerModifier,
         )
-        val base = serverBaseUrl.value
-        if (isContinuous && base != null) {
-            val chapters = remember(base) {
+        if (isContinuous) {
+            // Readium always serves EPUB resources at https://readium_package/<href>.
+            // ChapterWebView intercepts that virtual host and fetches from the Publication object,
+            // so we can construct chapter URLs directly without querying the fragment's WebView.
+            val chapters = remember {
                 state.publication.readingOrder.map { link ->
-                    ContinuousReaderView.ChapterEntry(link, "$base/${link.href.toString().trimStart('/')}")
+                    ContinuousReaderView.ChapterEntry(
+                        link,
+                        "https://readium_package/${link.href.toString().trimStart('/')}",
+                    )
                 }
             }
             AndroidView(
@@ -1897,14 +1887,22 @@ private fun EpubNavigatorView(
                 update = { _ -> },
                 modifier = readerModifier,
             )
-            LaunchedEffect(base) {
-                val view = continuousViewRef.value ?: return@LaunchedEffect
-                val initialLocator = latestLocator() ?: state.initialLocator ?: return@LaunchedEffect
+            // Key on the view ref: AndroidView.factory (which sets continuousViewRef) runs as a
+            // layout-phase effect, while LaunchedEffect runs as a composition-phase effect — there
+            // is no guaranteed order between the two on first composition. Keying on the ref means
+            // this coroutine only fires (or re-fires) once the factory has actually populated it.
+            val continuousView = continuousViewRef.value
+            LaunchedEffect(continuousView) {
+                val view = continuousView ?: return@LaunchedEffect
+                val initialLocator = latestLocator() ?: state.initialLocator
+                val initialHref = initialLocator?.href?.toString()
+                    ?: chapters.firstOrNull()?.link?.href?.toString()
+                    ?: return@LaunchedEffect
                 view.initialize(
                     chapters = chapters,
                     prefs = formattingPrefs,
-                    initialHref = initialLocator.href.toString(),
-                    initialProgression = initialLocator.locations.progression?.toFloat() ?: 0f,
+                    initialHref = initialHref,
+                    initialProgression = initialLocator?.locations?.progression?.toFloat() ?: 0f,
                     publication = state.publication,
                 )
             }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -1934,6 +1934,7 @@ private fun EpubNavigatorView(
                                 )
                             }
                         }
+                        view.onFootnoteContent = { content -> currentOnFootnoteTapped(content) }
                         view.readaloudAvailable = currentReadaloudAvailable
                         view.onPlayFromHereSelection = { chapterHref, selectedText ->
                             // Resolve the selection to a narrated sentence id and start playback there.

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -1820,8 +1820,10 @@ private fun EpubNavigatorView(
         )
         val base = serverBaseUrl.value
         if (isContinuous && base != null) {
-            val chapters = state.publication.readingOrder.map { link ->
-                ContinuousReaderView.ChapterEntry(link, "$base/${link.href.toString().trimStart('/')}")
+            val chapters = remember(base) {
+                state.publication.readingOrder.map { link ->
+                    ContinuousReaderView.ChapterEntry(link, "$base/${link.href.toString().trimStart('/')}")
+                }
             }
             AndroidView(
                 factory = { ctx ->
@@ -1841,7 +1843,7 @@ private fun EpubNavigatorView(
                 update = { _ -> },
                 modifier = readerModifier,
             )
-            LaunchedEffect(base, chapters) {
+            LaunchedEffect(base) {
                 val view = continuousViewRef.value ?: return@LaunchedEffect
                 val initialLocator = latestLocator() ?: state.initialLocator ?: return@LaunchedEffect
                 view.initialize(

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -921,6 +921,9 @@ private fun EpubNavigatorView(
     val coroutineScope = rememberCoroutineScope()
     val fragmentRef = remember { mutableStateOf<EpubNavigatorFragment?>(null) }
     val containerRef = remember { mutableStateOf<ScrollBoundaryNavigationContainer?>(null) }
+    val continuousViewRef = remember { mutableStateOf<ContinuousReaderView?>(null) }
+    val serverBaseUrl = remember { mutableStateOf<String?>(null) }
+    val isContinuous = formattingPrefs.orientation == ReaderOrientation.Continuous
     // Covers the reader with a plain page-coloured screen while a cross-resource jump (TOC/search)
     // loads the new chapter. Readium briefly paints the new resource's opener (a figure/graphic) or
     // a white blank before scrolling to the target, and the column-snap nudges the page a beat after;
@@ -1561,6 +1564,21 @@ private fun EpubNavigatorView(
     // after rotation (isLandscape changes while fragmentRef is null, so the call would be lost).
     LaunchedEffect(formattingPrefs, isLandscape, fragmentRef.value) {
         fragmentRef.value?.submitPreferences(formattingPrefs.toEpubPreferences(isLandscape, isFixedLayout))
+        continuousViewRef.value?.updatePreferences(formattingPrefs)
+    }
+
+    // In Continuous mode, the fragment is zero-height (HTTP server keeper only).
+    // Once it emits its first locator, extract the HTTP base URL for ContinuousReaderView.
+    LaunchedEffect(fragmentRef.value, isContinuous) {
+        if (!isContinuous) return@LaunchedEffect
+        val fragment = fragmentRef.value ?: return@LaunchedEffect
+        fragment.currentLocator.collect { locator ->
+            if (serverBaseUrl.value != null) return@collect
+            val absoluteUrl = fragment.evaluateJavascript("window.location.href") ?: return@collect
+            val relHref = locator.href.toString().trimStart('/')
+            val base = absoluteUrl.trim('"').removeSuffix("/$relHref")
+            serverBaseUrl.value = base
+        }
     }
 
     DisposableEffect(tapListener) {
@@ -1596,7 +1614,7 @@ private fun EpubNavigatorView(
     // touch even when scroll position hasn't moved, which broke the previous staleness check.
     LaunchedEffect(fragmentRef.value, currentFormattingPrefs.orientation) {
         val fragment = fragmentRef.value ?: return@LaunchedEffect
-        if (currentFormattingPrefs.orientation == ReaderOrientation.Horizontal) return@LaunchedEffect
+        if (currentFormattingPrefs.orientation != ReaderOrientation.Vertical) return@LaunchedEffect
         while (true) {
             val container = containerRef.value
             if (container != null) {
@@ -1666,6 +1684,15 @@ private fun EpubNavigatorView(
                 }.also { containerRef.value = it }
             },
             update = { container ->
+                // In Continuous mode the fragment is kept alive only to maintain the HTTP server.
+                // Collapse it to zero-height so ContinuousReaderView takes the full screen.
+                if (formattingPrefs.orientation == ReaderOrientation.Continuous) {
+                    container.layoutParams = container.layoutParams?.apply { height = 0 }
+                    container.visibility = View.INVISIBLE
+                } else {
+                    container.layoutParams = container.layoutParams?.apply { height = FrameLayout.LayoutParams.MATCH_PARENT }
+                    container.visibility = View.VISIBLE
+                }
                 container.isScrollMode = formattingPrefs.orientation != ReaderOrientation.Horizontal
 
                 val fragmentContainer = container.getChildAt(0) as? FragmentContainerView
@@ -1791,6 +1818,40 @@ private fun EpubNavigatorView(
             },
             modifier = readerModifier,
         )
+        val base = serverBaseUrl.value
+        if (isContinuous && base != null) {
+            val chapters = state.publication.readingOrder.map { link ->
+                ContinuousReaderView.ChapterEntry(link, "$base/${link.href.toString().trimStart('/')}")
+            }
+            AndroidView(
+                factory = { ctx ->
+                    ContinuousReaderView(ctx).also { view ->
+                        continuousViewRef.value = view
+                        view.onPositionChanged = { href, progression ->
+                            val locator = Locator.fromJSON(
+                                org.json.JSONObject()
+                                    .put("href", href)
+                                    .put("type", "application/xhtml+xml")
+                                    .put("locations", org.json.JSONObject().put("progression", progression.toDouble()))
+                            )
+                            if (locator != null) onPositionChanged(locator)
+                        }
+                    }
+                },
+                update = { _ -> },
+                modifier = readerModifier,
+            )
+            LaunchedEffect(base, chapters) {
+                val view = continuousViewRef.value ?: return@LaunchedEffect
+                val initialLocator = latestLocator() ?: state.initialLocator ?: return@LaunchedEffect
+                view.initialize(
+                    chapters = chapters,
+                    prefs = formattingPrefs,
+                    initialHref = initialLocator.href.toString(),
+                    initialProgression = initialLocator.locations.progression?.toFloat() ?: 0f,
+                )
+            }
+        }
         AnimatedVisibility(
             visible = pullActive,
             enter = slideInVertically(initialOffsetY = { if (pullForward) it else -it }) + fadeIn(),

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -1938,10 +1938,16 @@ private fun EpubNavigatorView(
                         view.readaloudAvailable = currentReadaloudAvailable
                         view.onPlayFromHereSelection = { chapterHref, selectedText ->
                             // Resolve the selection to a narrated sentence id and start playback there.
-                            val sid = ContinuousPositionTracker.sentenceIdForSelection(
-                                selectedText,
-                                currentSentenceQuotes.mapValues { it.value.highlight },
-                            )
+                            // Scope the candidate sentences to the TAPPED chapter first (same as the
+                            // paged path): handed the whole book, a short selection can match a foreign
+                            // chapter's sentence whose text recurs in this one, so playback would jump to
+                            // a completely different sentence (and the highlight, keyed on this chapter,
+                            // would never appear). scopeSentencesToChapter removes the cross-chapter
+                            // candidates; within one chapter the text containment match is reliable.
+                            val scoped = scopeSentencesToChapter(
+                                currentSentenceQuotes, currentSentenceChapters, chapterHref,
+                            ).toMap()
+                            val sid = ContinuousPositionTracker.sentenceIdForSelection(selectedText, scoped)
                             if (sid != null) currentOnPlayFromHere("$chapterHref#$sid")
                         }
                     }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -1892,6 +1892,7 @@ private fun EpubNavigatorView(
                     prefs = formattingPrefs,
                     initialHref = initialLocator.href.toString(),
                     initialProgression = initialLocator.locations.progression?.toFloat() ?: 0f,
+                    publication = state.publication,
                 )
             }
         }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -1814,7 +1814,7 @@ class EpubReaderViewModel @Inject constructor(
         resumeFragmentRef = null
         val loc = lastLocator
         val plan = ReadaloudResumePlanner.plan(
-            isScroll = effectiveFormattingPreferences.value.orientation == ReaderOrientation.Vertical,
+            isScroll = effectiveFormattingPreferences.value.orientation != ReaderOrientation.Horizontal,
             closeHref = closed?.href?.toString(),
             closeProgression = closed?.locations?.progression,
             resumeFragmentRef = resume,

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/FormattingPreferencesMapper.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/FormattingPreferencesMapper.kt
@@ -53,9 +53,11 @@ fun FormattingPreferences.toEpubPreferences(
             ReaderFontFamily.Merriweather -> FontFamily("Merriweather")
             ReaderFontFamily.OpenDyslexic -> FontFamily("OpenDyslexic")
         },
-        // TextAlign.START (not null) when justify is off: explicitly overrides any EPUB-level
-        // text-align:justify so the result matches Continuous mode's text-align:left!important.
-        textAlign = if (justifyText) TextAlign.JUSTIFY else TextAlign.START,
+        // null (not TextAlign.START) when justify is off, so --USER__textAlign stays unset and the
+        // publisher's text alignment is preserved — the original Paginated/Scroll contract (see
+        // FormattingPreferencesMapperTest.justifyTextFalseMapsToNullTextAlign). Continuous mode sets
+        // its own text-align in ContinuousStyleInjector and does not depend on this mapper.
+        textAlign = if (justifyText) TextAlign.JUSTIFY else null,
         // lineHeight only takes effect when publisherStyles is off
         publisherStyles = false,
         lineHeight = lineSpacing.toDouble().takeIf { lineSpacing != FormattingPreferences.DEFAULT_LINE_SPACING },

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/FormattingPreferencesMapper.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/FormattingPreferencesMapper.kt
@@ -53,7 +53,9 @@ fun FormattingPreferences.toEpubPreferences(
             ReaderFontFamily.Merriweather -> FontFamily("Merriweather")
             ReaderFontFamily.OpenDyslexic -> FontFamily("OpenDyslexic")
         },
-        textAlign = if (justifyText) TextAlign.JUSTIFY else null,
+        // TextAlign.START (not null) when justify is off: explicitly overrides any EPUB-level
+        // text-align:justify so the result matches Continuous mode's text-align:left!important.
+        textAlign = if (justifyText) TextAlign.JUSTIFY else TextAlign.START,
         // lineHeight only takes effect when publisherStyles is off
         publisherStyles = false,
         lineHeight = lineSpacing.toDouble().takeIf { lineSpacing != FormattingPreferences.DEFAULT_LINE_SPACING },

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/FormattingPreferencesMapper.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/FormattingPreferencesMapper.kt
@@ -25,7 +25,7 @@ fun FormattingPreferences.toEpubPreferences(
     isLandscape: Boolean = false,
     isFixedLayout: Boolean = false,
 ): EpubPreferences {
-    val isDoublePage = orientation != ReaderOrientation.Vertical && doublePageSpread && isLandscape
+    val isDoublePage = orientation == ReaderOrientation.Horizontal && doublePageSpread && isLandscape
     return EpubPreferences(
         fontSize = fontSize.toDouble(),
         theme = when (theme) {
@@ -58,7 +58,7 @@ fun FormattingPreferences.toEpubPreferences(
         publisherStyles = false,
         lineHeight = lineSpacing.toDouble().takeIf { lineSpacing != FormattingPreferences.DEFAULT_LINE_SPACING },
         pageMargins = margins.toDouble(),
-        scroll = orientation == ReaderOrientation.Vertical,
+        scroll = orientation != ReaderOrientation.Horizontal,
         // Fixed-layout: spread controls two-page side-by-side rendering.
         // Reflowable: column count is set via RS properties in toFragmentConfiguration().
         spread = if (isFixedLayout) (if (isDoublePage) Spread.ALWAYS else Spread.NEVER) else null,
@@ -74,7 +74,7 @@ fun FormattingPreferences.toFragmentConfiguration(
     // --RS__colWidth must be "auto" to remove the default 45em minimum which would otherwise
     // prevent two columns from fitting in a phone-width viewport.
     val isDoublePage = !isFixedLayout &&
-        orientation != ReaderOrientation.Vertical &&
+        orientation == ReaderOrientation.Horizontal &&
         doublePageSpread &&
         isLandscape
     return EpubNavigatorFragment.Configuration(
@@ -100,7 +100,7 @@ fun FormattingPreferences.toFragmentConfiguration(
             // default so a phone-width viewport rendered TWO columns — and its decoration renderer
             // mispositions the readaloud highlight in a multi-column layout, so the synced highlight
             // silently vanished. (Landscape double-page still uses TWO columns above, by design.)
-            !isFixedLayout && orientation != ReaderOrientation.Vertical ->
+            !isFixedLayout && orientation == ReaderOrientation.Horizontal ->
                 RsProperties(colCount = ColCount.ONE)
             // Scroll mode and fixed-layout: column count doesn't apply.
             else -> RsProperties()

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderSettingsControls.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderSettingsControls.kt
@@ -168,6 +168,19 @@ internal fun OrientationIcon(orientation: ReaderOrientation) {
                 }
             }
         }
+        ReaderOrientation.Continuous -> {
+            // Two stacked rectangles with a gap between them — multi-chapter scroll.
+            Canvas(modifier = Modifier.size(18.dp)) {
+                val w = size.width * 0.82f
+                val h = size.height * 0.32f
+                val gap = size.height * 0.12f
+                val leftX = (size.width - w) / 2f
+                val totalH = h * 2 + gap
+                val startY = (size.height - totalH) / 2f
+                drawRect(color, topLeft = Offset(leftX, startY), size = Size(w, h))
+                drawRect(color, topLeft = Offset(leftX, startY + h + gap), size = Size(w, h))
+            }
+        }
     }
 }
 

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderSettingsSummaries.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderSettingsSummaries.kt
@@ -47,7 +47,11 @@ fun formattingSummary(prefs: FormattingPreferences): String =
     "${prefs.fontFamily.label()} · ${(prefs.fontSize * 100).roundToInt()}% · ${marginsWord(prefs.margins)} margins"
 
 fun displaySummary(prefs: FormattingPreferences): String {
-    val mode = if (prefs.orientation == ReaderOrientation.Horizontal) "Paginated" else "Scroll"
+    val mode = when (prefs.orientation) {
+        ReaderOrientation.Horizontal -> "Paginated"
+        ReaderOrientation.Vertical -> "Scroll"
+        ReaderOrientation.Continuous -> "Continuous"
+    }
     val map = if (prefs.showChapterMap) "map on" else "map off"
     return "${prefs.theme.label()} · $mode · $map"
 }

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousPositionTrackerTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousPositionTrackerTest.kt
@@ -1,0 +1,91 @@
+package com.riffle.app.feature.reader
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class ContinuousPositionTrackerTest {
+
+    // Window: chapter A = height 1000, top 0; chapter B = height 500, top 1000
+    private val window = listOf(
+        ContinuousPositionTracker.ChapterSlot("A.xhtml", top = 0, height = 1000),
+        ContinuousPositionTracker.ChapterSlot("B.xhtml", top = 1000, height = 500),
+    )
+
+    @Test
+    fun `scrollY 0 with viewport 800 — midY 400 is in chapter A, progression 0_4`() {
+        val (href, prog) = ContinuousPositionTracker.locatorAt(
+            scrollY = 0, viewportHeight = 800, window = window
+        )
+        assertEquals("A.xhtml", href)
+        assertEquals(0.4f, prog, 0.001f)
+    }
+
+    @Test
+    fun `scrollY 1000 with viewport 800 — midY 1400 is in chapter B, progression 0_8`() {
+        val (href, prog) = ContinuousPositionTracker.locatorAt(
+            scrollY = 1000, viewportHeight = 800, window = window
+        )
+        assertEquals("B.xhtml", href)
+        assertEquals(0.8f, prog, 0.001f)
+    }
+
+    @Test
+    fun `scrollY past all chapters — clamps to last chapter`() {
+        val (href, prog) = ContinuousPositionTracker.locatorAt(
+            scrollY = 5000, viewportHeight = 800, window = window
+        )
+        assertEquals("B.xhtml", href)
+        assertEquals(1.0f, prog.coerceAtMost(1.0f), 0.001f)
+    }
+
+    @Test
+    fun `scrollOffsetFor returns correct offset for chapter B at progression 0_5`() {
+        val offset = ContinuousPositionTracker.scrollOffsetFor(
+            href = "B.xhtml", progression = 0.5f, window = window
+        )
+        // top=1000 + 0.5*500 = 1250
+        assertEquals(1250, offset)
+    }
+
+    @Test
+    fun `scrollOffsetFor returns null when chapter not in window`() {
+        val offset = ContinuousPositionTracker.scrollOffsetFor(
+            href = "C.xhtml", progression = 0.0f, window = window
+        )
+        assertNull(offset)
+    }
+
+    @Test
+    fun `shiftNeeded — current index below topIndex triggers backward shift`() {
+        // window covers chapters [2,3,4], topIndex=2
+        assertEquals(
+            ContinuousPositionTracker.ShiftDirection.BACKWARD,
+            ContinuousPositionTracker.shiftNeeded(currentChapterIndex = 1, topIndex = 2, readingOrderSize = 5)
+        )
+    }
+
+    @Test
+    fun `shiftNeeded — current index above topIndex+2 triggers forward shift`() {
+        assertEquals(
+            ContinuousPositionTracker.ShiftDirection.FORWARD,
+            ContinuousPositionTracker.shiftNeeded(currentChapterIndex = 3, topIndex = 0, readingOrderSize = 5)
+        )
+    }
+
+    @Test
+    fun `shiftNeeded — current within window returns NONE`() {
+        assertEquals(
+            ContinuousPositionTracker.ShiftDirection.NONE,
+            ContinuousPositionTracker.shiftNeeded(currentChapterIndex = 3, topIndex = 2, readingOrderSize = 5)
+        )
+    }
+
+    @Test
+    fun `shiftNeeded NONE when at first chapter and cannot go backward`() {
+        assertEquals(
+            ContinuousPositionTracker.ShiftDirection.NONE,
+            ContinuousPositionTracker.shiftNeeded(currentChapterIndex = 0, topIndex = 0, readingOrderSize = 3)
+        )
+    }
+}

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousPositionTrackerTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousPositionTrackerTest.kt
@@ -60,43 +60,52 @@ class ContinuousPositionTrackerTest {
 
     // ── forwardShiftNeeded ────────────────────────────────────────────────────
 
+    // Window of 5: 1 behind + current + 3 ahead (chaptersBehind = 1).
+
     @Test
-    fun `forwardShiftNeeded — viewport bottom in last chapter triggers FORWARD`() {
-        // window [0,1,2], viewport bottom just entered ch2 (last chapter)
+    fun `forwardShiftNeeded — midpoint past the behind budget triggers FORWARD`() {
+        // window [0..4], chaptersBehind=1; midpoint in ch2 is >1 slot past top → shift
         assertTrue(ContinuousPositionTracker.forwardShiftNeeded(
-            viewportBottomChapterIndex = 2, topIndex = 0, readingOrderSize = 5
+            viewportChapterIndex = 2, topIndex = 0, loadedChapterCount = 5,
+            readingOrderSize = 20, chaptersBehind = 1,
         ))
     }
 
     @Test
-    fun `forwardShiftNeeded — viewport bottom in middle chapter returns false`() {
-        // window [0,1,2], viewport bottom in ch1 (middle)
+    fun `forwardShiftNeeded — midpoint within the behind budget returns false`() {
+        // window [0..4], midpoint in ch1 == topIndex+chaptersBehind → no shift yet
         assertFalse(ContinuousPositionTracker.forwardShiftNeeded(
-            viewportBottomChapterIndex = 1, topIndex = 0, readingOrderSize = 5
+            viewportChapterIndex = 1, topIndex = 0, loadedChapterCount = 5,
+            readingOrderSize = 20, chaptersBehind = 1,
         ))
     }
 
     @Test
     fun `forwardShiftNeeded — no more chapters beyond window returns false`() {
-        // window [3,4,5] with readingOrderSize=6 — ch6 doesn't exist
+        // window covers [15..19], readingOrderSize=20 — nothing left to append
         assertFalse(ContinuousPositionTracker.forwardShiftNeeded(
-            viewportBottomChapterIndex = 5, topIndex = 3, readingOrderSize = 6
+            viewportChapterIndex = 18, topIndex = 15, loadedChapterCount = 5,
+            readingOrderSize = 20, chaptersBehind = 1,
         ))
     }
 
     @Test
-    fun `forwardShiftNeeded — viewport bottom already past last chapter (short chapter)`() {
-        // window [0,1,2], viewport bottom resolves to ch2 even when viewport is larger than ch2
+    fun `forwardShiftNeeded — after FORWARD shift midpoint sits at behind budget so false`() {
+        // After a shift topIndex advances by 1 but the midpoint chapter is unchanged, so the
+        // midpoint is back at topIndex+chaptersBehind → condition clears (no oscillation).
+        assertFalse(ContinuousPositionTracker.forwardShiftNeeded(
+            viewportChapterIndex = 2, topIndex = 1, loadedChapterCount = 5,
+            readingOrderSize = 20, chaptersBehind = 1,
+        ))
+    }
+
+    @Test
+    fun `forwardShiftNeeded — fires while several chapters remain loaded ahead (lead time)`() {
+        // window [0..4], midpoint in ch2 → shift fires even though ch3,ch4 are still loaded
+        // ahead. This is the look-ahead lead time that prevents blank gaps at chapter seams.
         assertTrue(ContinuousPositionTracker.forwardShiftNeeded(
-            viewportBottomChapterIndex = 2, topIndex = 0, readingOrderSize = 10
-        ))
-    }
-
-    @Test
-    fun `forwardShiftNeeded — after FORWARD shift viewport bottom in new middle chapter is false`() {
-        // After FORWARD shift topIdx=0→1; window=[ch1,ch2,ch3]; viewport bottom in ch2 (middle)
-        assertFalse(ContinuousPositionTracker.forwardShiftNeeded(
-            viewportBottomChapterIndex = 2, topIndex = 1, readingOrderSize = 10
+            viewportChapterIndex = 2, topIndex = 0, loadedChapterCount = 5,
+            readingOrderSize = 20, chaptersBehind = 1,
         ))
     }
 }

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousPositionTrackerTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousPositionTrackerTest.kt
@@ -1,7 +1,9 @@
 package com.riffle.app.feature.reader
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class ContinuousPositionTrackerTest {
@@ -56,36 +58,45 @@ class ContinuousPositionTrackerTest {
         assertNull(offset)
     }
 
+    // ── forwardShiftNeeded ────────────────────────────────────────────────────
+
     @Test
-    fun `shiftNeeded — current index below topIndex triggers backward shift`() {
-        // window covers chapters [2,3,4], topIndex=2
-        assertEquals(
-            ContinuousPositionTracker.ShiftDirection.BACKWARD,
-            ContinuousPositionTracker.shiftNeeded(currentChapterIndex = 1, topIndex = 2, readingOrderSize = 5)
-        )
+    fun `forwardShiftNeeded — viewport bottom in last chapter triggers FORWARD`() {
+        // window [0,1,2], viewport bottom just entered ch2 (last chapter)
+        assertTrue(ContinuousPositionTracker.forwardShiftNeeded(
+            viewportBottomChapterIndex = 2, topIndex = 0, readingOrderSize = 5
+        ))
     }
 
     @Test
-    fun `shiftNeeded — current index above topIndex+2 triggers forward shift`() {
-        assertEquals(
-            ContinuousPositionTracker.ShiftDirection.FORWARD,
-            ContinuousPositionTracker.shiftNeeded(currentChapterIndex = 3, topIndex = 0, readingOrderSize = 5)
-        )
+    fun `forwardShiftNeeded — viewport bottom in middle chapter returns false`() {
+        // window [0,1,2], viewport bottom in ch1 (middle)
+        assertFalse(ContinuousPositionTracker.forwardShiftNeeded(
+            viewportBottomChapterIndex = 1, topIndex = 0, readingOrderSize = 5
+        ))
     }
 
     @Test
-    fun `shiftNeeded — current within window returns NONE`() {
-        assertEquals(
-            ContinuousPositionTracker.ShiftDirection.NONE,
-            ContinuousPositionTracker.shiftNeeded(currentChapterIndex = 3, topIndex = 2, readingOrderSize = 5)
-        )
+    fun `forwardShiftNeeded — no more chapters beyond window returns false`() {
+        // window [3,4,5] with readingOrderSize=6 — ch6 doesn't exist
+        assertFalse(ContinuousPositionTracker.forwardShiftNeeded(
+            viewportBottomChapterIndex = 5, topIndex = 3, readingOrderSize = 6
+        ))
     }
 
     @Test
-    fun `shiftNeeded NONE when at first chapter and cannot go backward`() {
-        assertEquals(
-            ContinuousPositionTracker.ShiftDirection.NONE,
-            ContinuousPositionTracker.shiftNeeded(currentChapterIndex = 0, topIndex = 0, readingOrderSize = 3)
-        )
+    fun `forwardShiftNeeded — viewport bottom already past last chapter (short chapter)`() {
+        // window [0,1,2], viewport bottom resolves to ch2 even when viewport is larger than ch2
+        assertTrue(ContinuousPositionTracker.forwardShiftNeeded(
+            viewportBottomChapterIndex = 2, topIndex = 0, readingOrderSize = 10
+        ))
+    }
+
+    @Test
+    fun `forwardShiftNeeded — after FORWARD shift viewport bottom in new middle chapter is false`() {
+        // After FORWARD shift topIdx=0→1; window=[ch1,ch2,ch3]; viewport bottom in ch2 (middle)
+        assertFalse(ContinuousPositionTracker.forwardShiftNeeded(
+            viewportBottomChapterIndex = 2, topIndex = 1, readingOrderSize = 10
+        ))
     }
 }

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousPositionTrackerTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousPositionTrackerTest.kt
@@ -164,4 +164,32 @@ class ContinuousPositionTrackerTest {
         assertEquals(0, ContinuousPositionTracker.pageScrollDelta(0))
         assertEquals(0, ContinuousPositionTracker.pageScrollDelta(-5))
     }
+
+    // ── sentenceIdForSelection (Play from here) ───────────────────────────────
+
+    private val quoteTexts = mapOf(
+        "c1-s1" to "It was a bright cold day in April.",
+        "c1-s2" to "The clocks were striking thirteen.",
+        "c1-s3" to "Winston Smith slipped quickly through the glass doors.",
+    )
+
+    @Test
+    fun `sentenceIdForSelection finds the sentence containing the full selection`() {
+        assertEquals("c1-s2", ContinuousPositionTracker.sentenceIdForSelection("clocks were striking", quoteTexts))
+    }
+
+    @Test
+    fun `sentenceIdForSelection falls back to the leading chunk of a partial selection`() {
+        // Selection runs past the sentence end; the leading chunk still pins it.
+        assertEquals(
+            "c1-s3",
+            ContinuousPositionTracker.sentenceIdForSelection("Winston Smith slipped quickly and then more text", quoteTexts),
+        )
+    }
+
+    @Test
+    fun `sentenceIdForSelection returns null for blank or unmatched selection`() {
+        assertNull(ContinuousPositionTracker.sentenceIdForSelection("   ", quoteTexts))
+        assertNull(ContinuousPositionTracker.sentenceIdForSelection("nothing like this exists here", quoteTexts))
+    }
 }

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousPositionTrackerTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousPositionTrackerTest.kt
@@ -108,4 +108,60 @@ class ContinuousPositionTrackerTest {
             readingOrderSize = 20, chaptersBehind = 1,
         ))
     }
+
+    // ── internalLinkHref ──────────────────────────────────────────────────────
+
+    @Test
+    fun `internalLinkHref extracts the resource path for an in-book url`() {
+        assertEquals(
+            "text/ch5.xhtml",
+            ContinuousPositionTracker.internalLinkHref("https://readium_package/text/ch5.xhtml"),
+        )
+    }
+
+    @Test
+    fun `internalLinkHref keeps the fragment`() {
+        assertEquals(
+            "text/ch5.xhtml#note3",
+            ContinuousPositionTracker.internalLinkHref("https://readium_package/text/ch5.xhtml#note3"),
+        )
+    }
+
+    @Test
+    fun `internalLinkHref returns null for an external url`() {
+        assertNull(ContinuousPositionTracker.internalLinkHref("https://example.com/page"))
+        assertNull(ContinuousPositionTracker.internalLinkHref("mailto:a@b.com"))
+    }
+
+    // ── chapterIndexForHref ───────────────────────────────────────────────────
+
+    private val order = listOf("text/ch1.xhtml", "text/ch2.xhtml", "text/ch3.xhtml")
+
+    @Test
+    fun `chapterIndexForHref matches exact href`() {
+        assertEquals(1, ContinuousPositionTracker.chapterIndexForHref(order, "text/ch2.xhtml"))
+    }
+
+    @Test
+    fun `chapterIndexForHref matches ignoring a fragment on the target`() {
+        assertEquals(2, ContinuousPositionTracker.chapterIndexForHref(order, "text/ch3.xhtml#figure-4-1"))
+    }
+
+    @Test
+    fun `chapterIndexForHref returns -1 when not found`() {
+        assertEquals(-1, ContinuousPositionTracker.chapterIndexForHref(order, "text/missing.xhtml"))
+    }
+
+    // ── pageScrollDelta ───────────────────────────────────────────────────────
+
+    @Test
+    fun `pageScrollDelta is a viewport minus a small overlap`() {
+        assertEquals(900, ContinuousPositionTracker.pageScrollDelta(1000))
+    }
+
+    @Test
+    fun `pageScrollDelta is zero for a non-positive viewport`() {
+        assertEquals(0, ContinuousPositionTracker.pageScrollDelta(0))
+        assertEquals(0, ContinuousPositionTracker.pageScrollDelta(-5))
+    }
 }

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousPositionTrackerTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousPositionTrackerTest.kt
@@ -36,7 +36,7 @@ class ContinuousPositionTrackerTest {
             scrollY = 5000, viewportHeight = 800, window = window
         )
         assertEquals("B.xhtml", href)
-        assertEquals(1.0f, prog.coerceAtMost(1.0f), 0.001f)
+        assertEquals(1.0f, prog, 0.001f)
     }
 
     @Test

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousPositionTrackerTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousPositionTrackerTest.kt
@@ -50,6 +50,33 @@ class ContinuousPositionTrackerTest {
         assertEquals(1250, offset)
     }
 
+    // ── scrollYForProgression (resume round-trip — inverse of locatorAt) ───────
+
+    @Test
+    fun `scrollYForProgression round-trips locatorAt so a resumed position does not drift`() {
+        val viewport = 800
+        // Sweep scroll offsets whose viewport midpoint sits comfortably inside a chapter (not on a
+        // boundary, not past the last chapter — those clamp and can't round-trip). Each must survive
+        // save (locatorAt) + restore unchanged.
+        for (scrollY in listOf(200, 400, 700, 900)) {
+            val (href, prog) = ContinuousPositionTracker.locatorAt(scrollY, viewport, window)
+            val slot = window.first { it.href == href }
+            val restored = ContinuousPositionTracker.scrollYForProgression(
+                slot.top, slot.height, prog, viewport,
+            )
+            // Within rounding (progression is a float, scrollY/2 is integer-divided).
+            assertEquals("scrollY=$scrollY", scrollY.toFloat(), restored.toFloat(), 2f)
+        }
+    }
+
+    @Test
+    fun `scrollYForProgression top-aligns a chapter start and never goes negative`() {
+        // progression 0 → top of the chapter (no half-viewport shift up into the previous chapter).
+        assertEquals(1000, ContinuousPositionTracker.scrollYForProgression(1000, 500, 0f, 800))
+        // a tiny progression near a chapter start would compute negative — clamps to 0.
+        assertEquals(0, ContinuousPositionTracker.scrollYForProgression(0, 500, 0.1f, 800))
+    }
+
     @Test
     fun `scrollOffsetFor returns null when chapter not in window`() {
         val offset = ContinuousPositionTracker.scrollOffsetFor(

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjectorTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjectorTest.kt
@@ -66,25 +66,52 @@ class ContinuousStyleInjectorTest {
     }
 
     @Test
-    fun `Serif font family — injects Georgia serif stack`() {
+    fun `Serif uses generic serif — matches Readium null mapping`() {
         val js = css(FormattingPreferences(fontFamily = ReaderFontFamily.Serif))
-        // Without ReadiumCSS the WebView default is sans-serif, so Serif must actively apply
-        // a system serif stack rather than falling back to the EPUB's own (often sans-serif) font.
-        assertTrue("Serif injects Georgia", js.contains("Georgia"))
-        assertTrue("serif fallback present", js.contains("serif"))
+        // FormattingPreferencesMapper maps Serif → null (Readium default = system serif).
+        // Continuous mode must use the same generic so both modes pick the same system font.
+        assertTrue("generic serif keyword present", js.contains("font-family:serif"))
+        assertFalse("no Georgia override", js.contains("Georgia"))
     }
 
     @Test
-    fun `SansSerif sets Arial stack`() {
+    fun `SansSerif uses generic sans-serif — matches Readium mapping`() {
         val js = css(FormattingPreferences(fontFamily = ReaderFontFamily.SansSerif))
-        assertTrue(js.contains("font-family:Arial"))
+        assertTrue(js.contains("font-family:sans-serif"))
     }
 
     @Test
-    fun `Monospace sets Courier stack`() {
+    fun `Monospace uses generic monospace — matches Readium mapping`() {
         val js = css(FormattingPreferences(fontFamily = ReaderFontFamily.Monospace))
-        assertTrue(js.contains("font-family:"))
-        assertTrue(js.contains("Courier"))
+        assertTrue(js.contains("font-family:monospace"))
+        assertFalse("no Courier override", js.contains("Courier"))
+    }
+
+    @Test
+    fun `Literata injects font-face and uses Literata family`() {
+        val js = css(FormattingPreferences(fontFamily = ReaderFontFamily.Literata))
+        assertTrue("@font-face for Literata", js.contains("font-family:Literata"))
+        assertTrue("ttf url present", js.contains("Literata-Regular.ttf"))
+    }
+
+    @Test
+    fun `Merriweather injects font-face and uses Merriweather family`() {
+        val js = css(FormattingPreferences(fontFamily = ReaderFontFamily.Merriweather))
+        assertTrue("@font-face for Merriweather", js.contains("font-family:Merriweather"))
+        assertTrue("ttf url present", js.contains("Merriweather-Regular.ttf"))
+    }
+
+    @Test
+    fun `OpenDyslexic injects font-face and uses OpenDyslexic family`() {
+        val js = css(FormattingPreferences(fontFamily = ReaderFontFamily.OpenDyslexic))
+        assertTrue("@font-face for OpenDyslexic", js.contains("font-family:OpenDyslexic"))
+        assertTrue("otf url present", js.contains("OpenDyslexic-Regular.otf"))
+    }
+
+    @Test
+    fun `Serif does not inject font-face declarations`() {
+        val js = css(FormattingPreferences(fontFamily = ReaderFontFamily.Serif))
+        assertFalse("no @font-face for Serif", js.contains("@font-face"))
     }
 
     @Test

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjectorTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjectorTest.kt
@@ -9,103 +9,107 @@ import org.junit.Test
 
 class ContinuousStyleInjectorTest {
 
+    private fun css(prefs: FormattingPreferences): String =
+        ContinuousStyleInjector.buildStyleInjectionJs(prefs)
+
     @Test
-    fun `default prefs — fontSize 1rem, pageMargins 1, no lineHeight variable`() {
-        val js = ContinuousStyleInjector.buildVariableInjectionJs(FormattingPreferences())
-        assertTrue("fontSize", js.contains("--USER__fontSize', '1.0rem'"))
-        assertTrue("pageMargins", js.contains("--USER__pageMargins', '1.0'"))
-        // lineSpacing == DEFAULT (1.2f) → variable must NOT be set
-        assertFalse("lineHeight not set on default", js.contains("setProperty('--USER__lineHeight'"))
-        assertTrue("lineHeight removed on default", js.contains("removeProperty('--USER__lineHeight'"))
+    fun `output injects a style element with id _riffle_user`() {
+        val js = css(FormattingPreferences())
+        assertTrue(js.contains("_riffle_user"))
+        assertTrue(js.contains("createElement('style')"))
+        assertTrue(js.contains("s.textContent"))
     }
 
     @Test
-    fun `non-default lineSpacing sets --USER__lineHeight`() {
-        val js = ContinuousStyleInjector.buildVariableInjectionJs(
-            FormattingPreferences(lineSpacing = 1.6f)
-        )
-        assertTrue(js.contains("setProperty('--USER__lineHeight', '1.6'"))
+    fun `default prefs — font-size 1rem on html`() {
+        val js = css(FormattingPreferences())
+        assertTrue("fontSize 1.0rem", js.contains("font-size:1.0rem!important"))
     }
 
     @Test
-    fun `justifyText sets --USER__textAlign to justify`() {
-        val js = ContinuousStyleInjector.buildVariableInjectionJs(
-            FormattingPreferences(justifyText = true)
-        )
-        assertTrue(js.contains("setProperty('--USER__textAlign', 'justify'"))
+    fun `non-default fontSize reflected in CSS`() {
+        val js = css(FormattingPreferences(fontSize = 1.5f))
+        assertTrue(js.contains("font-size:1.5rem!important"))
     }
 
     @Test
-    fun `non-justify removes --USER__textAlign`() {
-        val js = ContinuousStyleInjector.buildVariableInjectionJs(
-            FormattingPreferences(justifyText = false)
-        )
-        assertTrue(js.contains("removeProperty('--USER__textAlign'"))
+    fun `default lineSpacing applied to body and paragraph elements`() {
+        val js = css(FormattingPreferences())
+        assertTrue("line-height on body", js.contains("line-height:1.2!important"))
     }
 
     @Test
-    fun `Serif font family (default) — no fontFamily variable set`() {
-        val js = ContinuousStyleInjector.buildVariableInjectionJs(
-            FormattingPreferences(fontFamily = ReaderFontFamily.Serif)
-        )
-        assertFalse(js.contains("setProperty('--USER__fontFamily'"))
-        assertTrue(js.contains("removeProperty('--USER__fontFamily'"))
+    fun `non-default lineSpacing set`() {
+        val js = css(FormattingPreferences(lineSpacing = 1.6f))
+        assertTrue(js.contains("line-height:1.6!important"))
     }
 
     @Test
-    fun `SansSerif family sets sans-serif`() {
-        val js = ContinuousStyleInjector.buildVariableInjectionJs(
-            FormattingPreferences(fontFamily = ReaderFontFamily.SansSerif)
-        )
-        assertTrue(js.contains("setProperty('--USER__fontFamily', 'sans-serif'"))
+    fun `justifyText true — text-align justify`() {
+        val js = css(FormattingPreferences(justifyText = true))
+        assertTrue(js.contains("text-align:justify!important"))
+        assertFalse(js.contains("text-align:left!important"))
     }
 
     @Test
-    fun `Dark theme — textColor NOT set (DarkDim only)`() {
-        val js = ContinuousStyleInjector.buildVariableInjectionJs(
-            FormattingPreferences(theme = ReaderTheme.Dark)
-        )
-        assertFalse(js.contains("setProperty('--USER__textColor'"))
+    fun `justifyText false (default) — text-align left overrides EPUB justify`() {
+        val js = css(FormattingPreferences(justifyText = false))
+        assertTrue(js.contains("text-align:left!important"))
     }
 
     @Test
-    fun `DarkDim theme — textColor set to AAAAAA`() {
-        val js = ContinuousStyleInjector.buildVariableInjectionJs(
-            FormattingPreferences(theme = ReaderTheme.DarkDim)
-        )
-        assertTrue(js.contains("setProperty('--USER__textColor', '#AAAAAA'"))
+    fun `default margins — padding applied`() {
+        val js = css(FormattingPreferences())
+        // margins=1.0 → paddingPct = (1.0*6).toInt() = 6
+        assertTrue(js.contains("padding-left:6%!important"))
+        assertTrue(js.contains("padding-right:6%!important"))
     }
 
     @Test
-    fun `Dark theme — backgroundColor set to black`() {
-        val js = ContinuousStyleInjector.buildVariableInjectionJs(
-            FormattingPreferences(theme = ReaderTheme.Dark)
-        )
-        assertTrue(js.contains("setProperty('--USER__backgroundColor', '#000000'"))
+    fun `Serif font family (default) — no font-family override`() {
+        val js = css(FormattingPreferences(fontFamily = ReaderFontFamily.Serif))
+        assertFalse("Serif keeps EPUB font", js.contains("font-family:"))
     }
 
     @Test
-    fun `DarkDim theme — backgroundColor set to black`() {
-        val js = ContinuousStyleInjector.buildVariableInjectionJs(
-            FormattingPreferences(theme = ReaderTheme.DarkDim)
-        )
-        assertTrue(js.contains("setProperty('--USER__backgroundColor', '#000000'"))
+    fun `SansSerif sets Arial stack`() {
+        val js = css(FormattingPreferences(fontFamily = ReaderFontFamily.SansSerif))
+        assertTrue(js.contains("font-family:Arial"))
     }
 
     @Test
-    fun `Sepia theme — backgroundColor set`() {
-        val js = ContinuousStyleInjector.buildVariableInjectionJs(
-            FormattingPreferences(theme = ReaderTheme.Sepia)
-        )
-        assertTrue(js.contains("setProperty('--USER__backgroundColor', '#FAF4E8'"))
+    fun `Monospace sets Courier stack`() {
+        val js = css(FormattingPreferences(fontFamily = ReaderFontFamily.Monospace))
+        assertTrue(js.contains("font-family:"))
+        assertTrue(js.contains("Courier"))
     }
 
     @Test
-    fun `Light theme — backgroundColor removed`() {
-        val js = ContinuousStyleInjector.buildVariableInjectionJs(
-            FormattingPreferences(theme = ReaderTheme.Light)
-        )
-        assertTrue(js.contains("removeProperty('--USER__backgroundColor'"))
+    fun `Dark theme — black background and white text`() {
+        val js = css(FormattingPreferences(theme = ReaderTheme.Dark))
+        assertTrue(js.contains("background-color:#000000!important"))
+        assertTrue(js.contains("color:#FEFEFE!important"))
+    }
+
+    @Test
+    fun `DarkDim theme — black background and dim grey text`() {
+        val js = css(FormattingPreferences(theme = ReaderTheme.DarkDim))
+        assertTrue(js.contains("background-color:#000000!important"))
+        assertTrue(js.contains("color:#AAAAAA!important"))
+    }
+
+    @Test
+    fun `Sepia theme — sepia background and dark text`() {
+        val js = css(FormattingPreferences(theme = ReaderTheme.Sepia))
+        assertTrue(js.contains("background-color:#FAF4E8!important"))
+        assertTrue(js.contains("color:#121212!important"))
+    }
+
+    @Test
+    fun `Light theme — no background or text colour override`() {
+        val js = css(FormattingPreferences(theme = ReaderTheme.Light))
+        assertFalse("no bg override on Light", js.contains("background-color:"))
+        assertFalse("no fg override on Light", js.contains("color:#"))
     }
 
     @Test

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjectorTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjectorTest.kt
@@ -66,9 +66,12 @@ class ContinuousStyleInjectorTest {
     }
 
     @Test
-    fun `Serif font family (default) — no font-family override`() {
+    fun `Serif font family — injects Georgia serif stack`() {
         val js = css(FormattingPreferences(fontFamily = ReaderFontFamily.Serif))
-        assertFalse("Serif keeps EPUB font", js.contains("font-family:"))
+        // Without ReadiumCSS the WebView default is sans-serif, so Serif must actively apply
+        // a system serif stack rather than falling back to the EPUB's own (often sans-serif) font.
+        assertTrue("Serif injects Georgia", js.contains("Georgia"))
+        assertTrue("serif fallback present", js.contains("serif"))
     }
 
     @Test

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjectorTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjectorTest.kt
@@ -81,11 +81,13 @@ class ContinuousStyleInjectorTest {
     }
 
     @Test
-    fun `Serif uses generic serif — matches Readium null mapping`() {
+    fun `Serif (default) emits no font-family override — matches Readium null mapping`() {
         val js = css(FormattingPreferences(fontFamily = ReaderFontFamily.Serif))
-        // FormattingPreferencesMapper maps Serif → null (Readium default = system serif).
-        // Continuous mode must use the same generic so both modes pick the same system font.
-        assertTrue("generic serif keyword present", js.contains("font-family:serif"))
+        // FormattingPreferencesMapper maps Serif → null: Readium leaves --USER__fontFamily unset,
+        // so the publisher's own font (or the system serif fallback) renders. Continuous mode must
+        // likewise NOT force a font for Serif, or it would override the EPUB's font and diverge
+        // from Scroll/Paginated mode (the "fonts differ between views" bug).
+        assertFalse("no font-family override on Serif", js.contains("font-family:"))
         assertFalse("no Georgia override", js.contains("Georgia"))
     }
 

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjectorTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjectorTest.kt
@@ -1,0 +1,78 @@
+package com.riffle.app.feature.reader
+
+import com.riffle.core.domain.FormattingPreferences
+import com.riffle.core.domain.ReaderFontFamily
+import com.riffle.core.domain.ReaderTheme
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ContinuousStyleInjectorTest {
+
+    @Test
+    fun `default prefs — fontSize 1rem, pageMargins 1, no lineHeight variable`() {
+        val js = ContinuousStyleInjector.buildVariableInjectionJs(FormattingPreferences())
+        assertTrue("fontSize", js.contains("--USER__fontSize', '1.0rem'"))
+        assertTrue("pageMargins", js.contains("--USER__pageMargins', '1.0'"))
+        // lineSpacing == DEFAULT (1.2f) → variable must NOT be set
+        assertFalse("lineHeight not set on default", js.contains("setProperty('--USER__lineHeight'"))
+        assertTrue("lineHeight removed on default", js.contains("removeProperty('--USER__lineHeight'"))
+    }
+
+    @Test
+    fun `non-default lineSpacing sets --USER__lineHeight`() {
+        val js = ContinuousStyleInjector.buildVariableInjectionJs(
+            FormattingPreferences(lineSpacing = 1.6f)
+        )
+        assertTrue(js.contains("setProperty('--USER__lineHeight', '1.6'"))
+    }
+
+    @Test
+    fun `justifyText sets --USER__textAlign to justify`() {
+        val js = ContinuousStyleInjector.buildVariableInjectionJs(
+            FormattingPreferences(justifyText = true)
+        )
+        assertTrue(js.contains("setProperty('--USER__textAlign', 'justify'"))
+    }
+
+    @Test
+    fun `non-justify removes --USER__textAlign`() {
+        val js = ContinuousStyleInjector.buildVariableInjectionJs(
+            FormattingPreferences(justifyText = false)
+        )
+        assertTrue(js.contains("removeProperty('--USER__textAlign'"))
+    }
+
+    @Test
+    fun `Serif font family (default) — no fontFamily variable set`() {
+        val js = ContinuousStyleInjector.buildVariableInjectionJs(
+            FormattingPreferences(fontFamily = ReaderFontFamily.Serif)
+        )
+        assertFalse(js.contains("setProperty('--USER__fontFamily'"))
+        assertTrue(js.contains("removeProperty('--USER__fontFamily'"))
+    }
+
+    @Test
+    fun `SansSerif family sets sans-serif`() {
+        val js = ContinuousStyleInjector.buildVariableInjectionJs(
+            FormattingPreferences(fontFamily = ReaderFontFamily.SansSerif)
+        )
+        assertTrue(js.contains("setProperty('--USER__fontFamily', 'sans-serif'"))
+    }
+
+    @Test
+    fun `Dark theme — textColor NOT set (DarkDim only)`() {
+        val js = ContinuousStyleInjector.buildVariableInjectionJs(
+            FormattingPreferences(theme = ReaderTheme.Dark)
+        )
+        assertFalse(js.contains("setProperty('--USER__textColor'"))
+    }
+
+    @Test
+    fun `DarkDim theme — textColor set to AAAAAA`() {
+        val js = ContinuousStyleInjector.buildVariableInjectionJs(
+            FormattingPreferences(theme = ReaderTheme.DarkDim)
+        )
+        assertTrue(js.contains("setProperty('--USER__textColor', '#AAAAAA'"))
+    }
+}

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjectorTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjectorTest.kt
@@ -77,9 +77,48 @@ class ContinuousStyleInjectorTest {
     }
 
     @Test
+    fun `Dark theme — backgroundColor set to black`() {
+        val js = ContinuousStyleInjector.buildVariableInjectionJs(
+            FormattingPreferences(theme = ReaderTheme.Dark)
+        )
+        assertTrue(js.contains("setProperty('--USER__backgroundColor', '#000000'"))
+    }
+
+    @Test
+    fun `DarkDim theme — backgroundColor set to black`() {
+        val js = ContinuousStyleInjector.buildVariableInjectionJs(
+            FormattingPreferences(theme = ReaderTheme.DarkDim)
+        )
+        assertTrue(js.contains("setProperty('--USER__backgroundColor', '#000000'"))
+    }
+
+    @Test
+    fun `Sepia theme — backgroundColor set`() {
+        val js = ContinuousStyleInjector.buildVariableInjectionJs(
+            FormattingPreferences(theme = ReaderTheme.Sepia)
+        )
+        assertTrue(js.contains("setProperty('--USER__backgroundColor', '#FAF4E8'"))
+    }
+
+    @Test
+    fun `Light theme — backgroundColor removed`() {
+        val js = ContinuousStyleInjector.buildVariableInjectionJs(
+            FormattingPreferences(theme = ReaderTheme.Light)
+        )
+        assertTrue(js.contains("removeProperty('--USER__backgroundColor'"))
+    }
+
+    @Test
     fun `highlightTextJs escapes single quotes in text`() {
         val js = ContinuousStyleInjector.highlightTextJs("it's a test")
         assertTrue(js.contains("it\\'s a test"))
         assertFalse(js.contains("it's a test"))
+    }
+
+    @Test
+    fun `highlightTextJs escapes newlines in text`() {
+        val js = ContinuousStyleInjector.highlightTextJs("line one\nline two")
+        assertTrue(js.contains("\\n"))
+        assertFalse(js.contains("line one\nline two"))
     }
 }

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjectorTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjectorTest.kt
@@ -66,6 +66,21 @@ class ContinuousStyleInjectorTest {
     }
 
     @Test
+    fun `text-size-adjust 100 percent — prevents Chrome font inflation`() {
+        val js = css(FormattingPreferences())
+        assertTrue(js.contains("-webkit-text-size-adjust:100%!important"))
+        assertTrue(js.contains("text-size-adjust:100%!important"))
+    }
+
+    @Test
+    fun `paragraph elements reset to 1rem to strip EPUB per-element font-size overrides`() {
+        val js = css(FormattingPreferences())
+        // Mirrors ReadiumCSS advanced-mode: p,li,dd,div{font-size:1rem!important}
+        assertTrue("p,li,dd,div block present", js.contains("p,li,dd,div{"))
+        assertTrue("1rem reset present", js.contains("font-size:1rem!important"))
+    }
+
+    @Test
     fun `Serif uses generic serif — matches Readium null mapping`() {
         val js = css(FormattingPreferences(fontFamily = ReaderFontFamily.Serif))
         // FormattingPreferencesMapper maps Serif → null (Readium default = system serif).

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjectorTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjectorTest.kt
@@ -75,4 +75,11 @@ class ContinuousStyleInjectorTest {
         )
         assertTrue(js.contains("setProperty('--USER__textColor', '#AAAAAA'"))
     }
+
+    @Test
+    fun `highlightTextJs escapes single quotes in text`() {
+        val js = ContinuousStyleInjector.highlightTextJs("it's a test")
+        assertTrue(js.contains("it\\'s a test"))
+        assertFalse(js.contains("it's a test"))
+    }
 }

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjectorTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjectorTest.kt
@@ -7,157 +7,178 @@ import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
+/**
+ * Continuous mode injects the SAME ReadiumCSS Scroll/Paginated mode uses, driven by the
+ * `--USER__*` settings attribute on `<html>`. These tests pin the attribute that
+ * [FormattingPreferencesMapper] -> Readium's UserProperties would produce for the same prefs, plus
+ * the stylesheet-link injection structure.
+ */
 class ContinuousStyleInjectorTest {
 
-    private fun css(prefs: FormattingPreferences): String =
-        ContinuousStyleInjector.buildStyleInjectionJs(prefs)
+    private fun attr(prefs: FormattingPreferences): String =
+        ContinuousStyleInjector.buildHtmlStyleAttr(prefs)
+
+    // ── html style attribute (--USER__*) ────────────────────────────────────────
 
     @Test
-    fun `output injects a style element with id _riffle_user`() {
-        val js = css(FormattingPreferences())
-        assertTrue(js.contains("_riffle_user"))
-        assertTrue(js.contains("createElement('style')"))
-        assertTrue(js.contains("s.textContent"))
+    fun `always scrolled and advanced (publisher styles off)`() {
+        val s = attr(FormattingPreferences())
+        assertTrue(s.contains("--USER__view: readium-scroll-on !important;"))
+        assertTrue(s.contains("--USER__advancedSettings: readium-advanced-on !important;"))
     }
 
     @Test
-    fun `default prefs — font-size 1rem on html`() {
-        val js = css(FormattingPreferences())
-        assertTrue("fontSize 1.0rem", js.contains("font-size:1.0rem!important"))
+    fun `default font size is 100 percent`() {
+        assertTrue(attr(FormattingPreferences()).contains("--USER__fontSize: 100% !important;"))
     }
 
     @Test
-    fun `non-default fontSize reflected in CSS`() {
-        val js = css(FormattingPreferences(fontSize = 1.5f))
-        assertTrue(js.contains("font-size:1.5rem!important"))
+    fun `non-default font size in percent`() {
+        assertTrue(attr(FormattingPreferences(fontSize = 1.5f)).contains("--USER__fontSize: 150% !important;"))
     }
 
     @Test
-    fun `default lineSpacing applied to body and paragraph elements`() {
-        val js = css(FormattingPreferences())
-        assertTrue("line-height on body", js.contains("line-height:1.2!important"))
+    fun `default page margins emitted as readium double`() {
+        assertTrue(attr(FormattingPreferences()).contains("--USER__pageMargins: 1.0 !important;"))
     }
 
     @Test
-    fun `non-default lineSpacing set`() {
-        val js = css(FormattingPreferences(lineSpacing = 1.6f))
-        assertTrue(js.contains("line-height:1.6!important"))
+    fun `justify on maps to textAlign justify`() {
+        val s = attr(FormattingPreferences(justifyText = true))
+        assertTrue(s.contains("--USER__textAlign: justify !important;"))
     }
 
     @Test
-    fun `justifyText true — text-align justify`() {
-        val js = css(FormattingPreferences(justifyText = true))
-        assertTrue(js.contains("text-align:justify!important"))
-        assertFalse(js.contains("text-align:left!important"))
+    fun `justify off maps to textAlign start (matches Readium default)`() {
+        val s = attr(FormattingPreferences(justifyText = false))
+        assertTrue(s.contains("--USER__textAlign: start !important;"))
     }
 
     @Test
-    fun `justifyText false (default) — text-align left overrides EPUB justify`() {
-        val js = css(FormattingPreferences(justifyText = false))
-        assertTrue(js.contains("text-align:left!important"))
+    fun `default line height is omitted (null-gated like the mapper)`() {
+        assertFalse(attr(FormattingPreferences()).contains("--USER__lineHeight"))
     }
 
     @Test
-    fun `default margins — padding applied`() {
-        val js = css(FormattingPreferences())
-        // margins=1.0 → paddingPct = (1.0*6).toInt() = 6
-        assertTrue(js.contains("padding-left:6%!important"))
-        assertTrue(js.contains("padding-right:6%!important"))
+    fun `non-default line height emitted`() {
+        // Float→Double widening (1.6f.toDouble()) yields 1.6000000238…, exactly as Readium's
+        // Scroll mode emits it (same mapper path), so match on the 1.6 prefix.
+        assertTrue(attr(FormattingPreferences(lineSpacing = 1.6f)).contains("--USER__lineHeight: 1.6"))
+    }
+
+    // ── font family ──────────────────────────────────────────────────────────────
+
+    @Test
+    fun `Serif (default) emits no font override — publisher font, matching Readium null mapping`() {
+        val s = attr(FormattingPreferences(fontFamily = ReaderFontFamily.Serif))
+        assertFalse("no font override", s.contains("--USER__fontOverride"))
+        assertFalse("no font family", s.contains("--USER__fontFamily"))
     }
 
     @Test
-    fun `text-size-adjust 100 percent — prevents Chrome font inflation`() {
-        val js = css(FormattingPreferences())
-        assertTrue(js.contains("-webkit-text-size-adjust:100%!important"))
-        assertTrue(js.contains("text-size-adjust:100%!important"))
+    fun `SansSerif sets fontOverride and quoted family`() {
+        val s = attr(FormattingPreferences(fontFamily = ReaderFontFamily.SansSerif))
+        assertTrue(s.contains("--USER__fontOverride: readium-font-on !important;"))
+        assertTrue(s.contains("--USER__fontFamily: \"sans-serif\" !important;"))
     }
 
     @Test
-    fun `paragraph elements reset to 1rem to strip EPUB per-element font-size overrides`() {
-        val js = css(FormattingPreferences())
-        // Mirrors ReadiumCSS advanced-mode: p,li,dd,div{font-size:1rem!important}
-        assertTrue("p,li,dd,div block present", js.contains("p,li,dd,div{"))
-        assertTrue("1rem reset present", js.contains("font-size:1rem!important"))
+    fun `Monospace sets quoted family`() {
+        assertTrue(attr(FormattingPreferences(fontFamily = ReaderFontFamily.Monospace))
+            .contains("--USER__fontFamily: \"monospace\" !important;"))
     }
 
     @Test
-    fun `Serif (default) emits no font-family override — matches Readium null mapping`() {
-        val js = css(FormattingPreferences(fontFamily = ReaderFontFamily.Serif))
-        // FormattingPreferencesMapper maps Serif → null: Readium leaves --USER__fontFamily unset,
-        // so the publisher's own font (or the system serif fallback) renders. Continuous mode must
-        // likewise NOT force a font for Serif, or it would override the EPUB's font and diverge
-        // from Scroll/Paginated mode (the "fonts differ between views" bug).
-        assertFalse("no font-family override on Serif", js.contains("font-family:"))
-        assertFalse("no Georgia override", js.contains("Georgia"))
+    fun `Literata sets quoted family`() {
+        assertTrue(attr(FormattingPreferences(fontFamily = ReaderFontFamily.Literata))
+            .contains("--USER__fontFamily: \"Literata\" !important;"))
+    }
+
+    // ── theme / appearance ─────────────────────────────────────────────────────────
+
+    @Test
+    fun `Light theme — no appearance flag`() {
+        assertFalse(attr(FormattingPreferences(theme = ReaderTheme.Light)).contains("--USER__appearance"))
     }
 
     @Test
-    fun `SansSerif uses generic sans-serif — matches Readium mapping`() {
-        val js = css(FormattingPreferences(fontFamily = ReaderFontFamily.SansSerif))
-        assertTrue(js.contains("font-family:sans-serif"))
+    fun `Dark theme — night appearance, no explicit text colour`() {
+        val s = attr(FormattingPreferences(theme = ReaderTheme.Dark))
+        assertTrue(s.contains("--USER__appearance: readium-night-on !important;"))
+        assertFalse(s.contains("--USER__textColor"))
     }
 
     @Test
-    fun `Monospace uses generic monospace — matches Readium mapping`() {
-        val js = css(FormattingPreferences(fontFamily = ReaderFontFamily.Monospace))
-        assertTrue(js.contains("font-family:monospace"))
-        assertFalse("no Courier override", js.contains("Courier"))
+    fun `DarkDim theme — night appearance plus dim grey text colour`() {
+        val s = attr(FormattingPreferences(theme = ReaderTheme.DarkDim))
+        assertTrue(s.contains("--USER__appearance: readium-night-on !important;"))
+        assertTrue(s.contains("--USER__textColor: #AAAAAA !important;"))
     }
 
     @Test
-    fun `Literata injects font-face and uses Literata family`() {
-        val js = css(FormattingPreferences(fontFamily = ReaderFontFamily.Literata))
-        assertTrue("@font-face for Literata", js.contains("font-family:Literata"))
-        assertTrue("ttf url present", js.contains("Literata-Regular.ttf"))
+    fun `Sepia theme — sepia appearance`() {
+        assertTrue(attr(FormattingPreferences(theme = ReaderTheme.Sepia))
+            .contains("--USER__appearance: readium-sepia-on !important;"))
+    }
+
+    // ── HTML injection structure ────────────────────────────────────────────────
+
+    private val sampleHtml =
+        "<html xmlns=\"http://www.w3.org/1999/xhtml\"><head><title>t</title></head><body><p>hi</p></body></html>"
+
+    @Test
+    fun `injectInto adds before and after ReadiumCSS links`() {
+        val out = ContinuousStyleInjector.injectInto(sampleHtml, FormattingPreferences())
+        assertTrue(out.contains("readium/readium-css/ReadiumCSS-before.css"))
+        assertTrue(out.contains("readium/readium-css/ReadiumCSS-after.css"))
     }
 
     @Test
-    fun `Merriweather injects font-face and uses Merriweather family`() {
-        val js = css(FormattingPreferences(fontFamily = ReaderFontFamily.Merriweather))
-        assertTrue("@font-face for Merriweather", js.contains("font-family:Merriweather"))
-        assertTrue("ttf url present", js.contains("Merriweather-Regular.ttf"))
+    fun `injectInto puts before-css after head open and after-css before head close`() {
+        val out = ContinuousStyleInjector.injectInto(sampleHtml, FormattingPreferences())
+        val before = out.indexOf("ReadiumCSS-before.css")
+        val after = out.indexOf("ReadiumCSS-after.css")
+        val headClose = out.indexOf("</head>")
+        assertTrue("before precedes after", before < after)
+        assertTrue("after precedes </head>", after < headClose)
     }
 
     @Test
-    fun `OpenDyslexic injects font-face and uses OpenDyslexic family`() {
-        val js = css(FormattingPreferences(fontFamily = ReaderFontFamily.OpenDyslexic))
-        assertTrue("@font-face for OpenDyslexic", js.contains("font-family:OpenDyslexic"))
-        assertTrue("otf url present", js.contains("OpenDyslexic-Regular.otf"))
+    fun `injectInto adds the user style attribute onto html`() {
+        val out = ContinuousStyleInjector.injectInto(sampleHtml, FormattingPreferences(fontSize = 1.5f))
+        assertTrue(out.contains("<html"))
+        assertTrue(out.contains("style="))
+        assertTrue(out.contains("--USER__fontSize: 150% !important;"))
     }
 
     @Test
-    fun `Serif does not inject font-face declarations`() {
-        val js = css(FormattingPreferences(fontFamily = ReaderFontFamily.Serif))
-        assertFalse("no @font-face for Serif", js.contains("@font-face"))
+    fun `injectInto includes bundled font-face declarations`() {
+        val out = ContinuousStyleInjector.injectInto(sampleHtml, FormattingPreferences())
+        assertTrue(out.contains("@font-face"))
+        assertTrue(out.contains("Literata-Regular.ttf"))
+        assertTrue(out.contains("OpenDyslexic-Regular.otf"))
     }
 
     @Test
-    fun `Dark theme — black background and white text`() {
-        val js = css(FormattingPreferences(theme = ReaderTheme.Dark))
-        assertTrue(js.contains("background-color:#000000!important"))
-        assertTrue(js.contains("color:#FEFEFE!important"))
+    fun `injectInto adds default-css only when chapter has no author styles`() {
+        val withStyles = "<html><head><style>p{}</style></head><body></body></html>"
+        val without = "<html><head><title>t</title></head><body></body></html>"
+        assertFalse(ContinuousStyleInjector.injectInto(withStyles, FormattingPreferences())
+            .contains("ReadiumCSS-default.css"))
+        assertTrue(ContinuousStyleInjector.injectInto(without, FormattingPreferences())
+            .contains("ReadiumCSS-default.css"))
     }
 
-    @Test
-    fun `DarkDim theme — black background and dim grey text`() {
-        val js = css(FormattingPreferences(theme = ReaderTheme.DarkDim))
-        assertTrue(js.contains("background-color:#000000!important"))
-        assertTrue(js.contains("color:#AAAAAA!important"))
-    }
+    // ── live preference-change JS ───────────────────────────────────────────────
 
     @Test
-    fun `Sepia theme — sepia background and dark text`() {
-        val js = css(FormattingPreferences(theme = ReaderTheme.Sepia))
-        assertTrue(js.contains("background-color:#FAF4E8!important"))
-        assertTrue(js.contains("color:#121212!important"))
+    fun `buildStyleInjectionJs sets the documentElement style attribute`() {
+        val js = ContinuousStyleInjector.buildStyleInjectionJs(FormattingPreferences(fontSize = 1.5f))
+        assertTrue(js.contains("document.documentElement.setAttribute('style'"))
+        assertTrue(js.contains("--USER__fontSize: 150% !important;"))
     }
 
-    @Test
-    fun `Light theme — no background or text colour override`() {
-        val js = css(FormattingPreferences(theme = ReaderTheme.Light))
-        assertFalse("no bg override on Light", js.contains("background-color:"))
-        assertFalse("no fg override on Light", js.contains("color:#"))
-    }
+    // ── highlight helpers (unchanged) ───────────────────────────────────────────
 
     @Test
     fun `highlightTextJs escapes single quotes in text`() {

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/FormattingPreferences.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/FormattingPreferences.kt
@@ -35,7 +35,7 @@ data class FormattingPreferences(
 
 enum class ReaderTheme { Light, Dark, DarkDim, Sepia, Auto }
 enum class ReaderFontFamily { Serif, SansSerif, Monospace, Literata, Merriweather, OpenDyslexic }
-enum class ReaderOrientation { Horizontal, Vertical }
+enum class ReaderOrientation { Horizontal, Vertical, Continuous }
 
 data class ThemeSchedule(
     val dayStart: LocalTime = DEFAULT_DAY_START,

--- a/docs/adr/0032-continuous-scroll-mode.md
+++ b/docs/adr/0032-continuous-scroll-mode.md
@@ -1,0 +1,40 @@
+# ADR 0032 — Continuous scroll mode: self-managed fixed-height WebViews in a NestedScrollView
+
+**Status:** Accepted
+
+## Context
+
+The existing Scroll orientation loads one chapter at a time in Readium's `EpubNavigatorFragment`. Chapter transitions require a deliberate 160 dp pull gesture, which triggers `goForward()`/`go(locator)` — a discrete jump with a brief visual flash masked by a loading cover. This model makes chapter boundaries perceptible and interrupts reading flow.
+
+The desired behaviour is a third orientation — **Continuous** — where the book reads as a single endless scroll: the end of one chapter and the start of the next are simultaneously visible on screen, with no gesture threshold and no transition moment.
+
+`EpubNavigatorFragment` renders exactly one resource at a time and exposes no API for showing adjacent resources simultaneously. Extending it to support this is not feasible without forking Readium.
+
+## Decision
+
+Add `Continuous` as a third value in `ReaderOrientation`. When active, `EpubNavigatorFragment` is replaced by a new `ContinuousReaderView` — a `NestedScrollView` subclass that stacks `ChapterWebView` instances vertically and is the sole scrollable container.
+
+**ChapterWebViews** are thin `WebView` wrappers with internal scrolling disabled (`isScrollContainer = false`) and height fixed to their content height. Chapter URLs are loaded from Readium's already-running local HTTP server — the same URLs the navigator fragment uses; no new serving infrastructure is needed. At any time exactly three `ChapterWebView`s are live (previous, current, next); as the user crosses a chapter boundary the trailing one is destroyed and a new one is appended at the advancing end.
+
+**Height measurement** occurs in three stages after each page loads: inject styles → await `document.fonts.ready` → `requestAnimationFrame` → read `document.body.scrollHeight`. A placeholder of 3× screen height reserves space until the real height is known. On a formatting-preference change all live `ChapterWebView`s re-inject and re-measure.
+
+**Style injection** (`ContinuousStyleInjector`) replicates everything `EpubNavigatorFragment` injects into its managed WebView: the full ReadiumCSS stylesheet stack (base, default, and user layers) plus CSS custom property overrides derived from `FormattingPreferences` → `EpubPreferences` → `--USER__*` variables. Publisher CSS is served by Readium's HTTP server as part of the EPUB resources and requires no additional handling. The injector is derived by auditing `EpubNavigatorFragment`'s `WebViewClient` and `evaluateJavascript` calls to ensure rendering is identical to Scroll mode.
+
+**Position tracking** uses the outer `NestedScrollView`'s `scrollY`. Current chapter = whichever `ChapterWebView` contains `scrollY + viewportHeight / 2`; progression = `(scrollY − chapterTop) / chapterHeight`. Saved locators are progression-based — the same shape as the existing Scroll mode — so `ProgressSweep` and ABS sync need no changes.
+
+**Readaloud highlight sync**: auto-follow JS is routed to the `ChapterWebView` matching the current audio locator. When audio crosses a chapter boundary the highlight moves with it. If the audio position falls outside the ±1 window (audio raced ahead of the reading position), the highlight is suppressed rather than shifting the reading window.
+
+**Search navigation**: `ContinuousReaderView` loads the target chapter into the window, scrolls to position, and highlights the matched term via `window.find()` — bypassing Readium's decoration API, which assumes a single navigator WebView.
+
+## Consequences
+
+- True simultaneous chapter visibility: the chapter boundary is a point in a continuous scroll, not a navigation event.
+- Self-managed WebViews mean the app owns the style injection layer. Any ReadiumCSS update or new `FormattingPreferences` entry must be reflected in `ContinuousStyleInjector` as well as `FormattingPreferencesMapper`.
+- Text selection across a chapter boundary is not supported (requires merging selection context across two independent WebView instances).
+- Custom app-asset fonts are not injected in Continuous mode (v1); the EPUB's own declared fonts are used.
+- Existing Paged and Scroll modes are unaffected.
+
+## Alternatives considered
+
+- **DOM-append: inject the next chapter's HTML into the current WebView.** Avoids multiple WebViews but breaks relative URLs (images, CSS) that resolve against the current chapter's base URL; drops each chapter's `<head>`; grows memory unboundedly. Rejected as too fragile.
+- **Velocity handoff between three full Readium WebViews.** Each WebView scrolls normally within itself; remaining scroll velocity is passed to the adjacent WebView at the boundary. Does not achieve true simultaneous visibility — there is always a gap between the two WebViews' content at the transition point. Rejected because it doesn't meet the requirement.

--- a/docs/superpowers/plans/2026-06-15-continuous-scroll.md
+++ b/docs/superpowers/plans/2026-06-15-continuous-scroll.md
@@ -1,0 +1,1304 @@
+# Continuous Scroll Mode Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a "Continuous" reading orientation where the full book renders as a single endless scroll, with multiple chapters simultaneously visible on screen.
+
+**Architecture:** A new `ContinuousReaderView` (`NestedScrollView` subclass) stacks up to 3 `ChapterWebView` instances (fixed height, internal scrolling disabled) loaded from Readium's already-running HTTP server. An invisible zero-height `EpubNavigatorFragment` stays alive to keep the HTTP server running and provide the base URL. A `ContinuousStyleInjector` replicates what Readium's fragment injects on page load (CSS variables + TypographyOverride). Position is tracked as `scrollY → chapterHref + progression` and emitted to the existing `EpubReaderViewModel.onPositionChanged` pipeline.
+
+**Tech Stack:** Kotlin, Android WebView (`addJavascriptInterface`, `evaluateJavascript`), Android `NestedScrollView`, Readium Kotlin SDK (`EpubNavigatorFragment`, `Publication.readingOrder`), Jetpack Compose `AndroidView`, Coroutines, JUnit 4 (project standard)
+
+---
+
+## File Map
+
+**New files:**
+- `app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjector.kt` — CSS variable + TypographyOverride JS injection for self-managed WebViews; pure, unit-testable
+- `app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousPositionTracker.kt` — maps `scrollY + chapter heights` to `href + progression` and vice versa; pure math, unit-testable
+- `app/src/main/kotlin/com/riffle/app/feature/reader/ChapterWebView.kt` — thin `WebView` wrapper: disabled internal scroll, JS-driven height measurement via `JavascriptInterface`, placeholder height until measured
+- `app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt` — `NestedScrollView` that owns a windowed pool of 3 `ChapterWebView`s; handles window shifting, position emission, TOC navigation, search navigation, and readaloud highlight routing
+- `app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjectorTest.kt`
+- `app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousPositionTrackerTest.kt`
+
+**Modified files:**
+- `core/domain/src/main/kotlin/com/riffle/core/domain/FormattingPreferences.kt` — add `Continuous` to `ReaderOrientation`
+- `app/src/main/kotlin/com/riffle/app/feature/reader/FormattingPanel.kt` — add "Continuous" chip to the orientation row
+- `app/src/main/kotlin/com/riffle/app/feature/reader/FormattingPreferencesMapper.kt` — handle `Continuous` in `toEpubPreferences` and `toFragmentConfiguration`
+- `app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt` — branch on `Continuous`: keep invisible fragment, extract base URL, show `ContinuousReaderView`, wire readaloud + search
+
+---
+
+## Task 1: Add `Continuous` to `ReaderOrientation` and update the formatting panel + mapper
+
+**Files:**
+- Modify: `core/domain/src/main/kotlin/com/riffle/core/domain/FormattingPreferences.kt`
+- Modify: `app/src/main/kotlin/com/riffle/app/feature/reader/FormattingPanel.kt`
+- Modify: `app/src/main/kotlin/com/riffle/app/feature/reader/FormattingPreferencesMapper.kt`
+
+- [ ] **Step 1: Add `Continuous` to the enum**
+
+In `core/domain/src/main/kotlin/com/riffle/core/domain/FormattingPreferences.kt`, line 36:
+
+```kotlin
+enum class ReaderOrientation { Horizontal, Vertical, Continuous }
+```
+
+- [ ] **Step 2: Add "Continuous" chip to the formatting panel**
+
+In `app/src/main/kotlin/com/riffle/app/feature/reader/FormattingPanel.kt`, find the `when (orientation)` label map inside the `ReaderOrientation.entries.forEach` loop (around line 270) and add the new case:
+
+```kotlin
+val label = when (orientation) {
+    ReaderOrientation.Horizontal -> "Paginated"
+    ReaderOrientation.Vertical -> "Scroll"
+    ReaderOrientation.Continuous -> "Continuous"
+}
+```
+
+- [ ] **Step 3: Update `toEpubPreferences` — treat Continuous like Vertical for the hidden fragment**
+
+In `FormattingPreferencesMapper.kt`, the invisible fragment we keep alive in Continuous mode needs valid scroll-mode preferences. Change line 27 and 60:
+
+```kotlin
+// Line 27 — isDoublePage guard
+val isDoublePage = orientation == ReaderOrientation.Horizontal && doublePageSpread && isLandscape
+
+// Line 60 — scroll flag
+scroll = orientation != ReaderOrientation.Horizontal,
+```
+
+- [ ] **Step 4: Update `toFragmentConfiguration` — Continuous uses no column layout**
+
+In `FormattingPreferencesMapper.kt` around line 96, the `when` in `readiumCssRsProperties` currently branches on `orientation != ReaderOrientation.Vertical`. Change it to also exclude `Continuous`:
+
+```kotlin
+readiumCssRsProperties = when {
+    isDoublePage -> RsProperties(
+        colCount = ColCount.TWO,
+        overrides = mapOf("--RS__colWidth" to "auto"),
+    )
+    !isFixedLayout && orientation == ReaderOrientation.Horizontal ->
+        RsProperties(colCount = ColCount.ONE)
+    else -> RsProperties()
+},
+```
+
+- [ ] **Step 5: Build to verify no exhaustive-`when` compile errors**
+
+```bash
+export JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"
+./gradlew :app:assembleDebug 2>&1 | grep -E "error:|warning:|BUILD"
+```
+
+Expected: `BUILD SUCCESSFUL` — no unresolved `when` branches.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add core/domain/src/main/kotlin/com/riffle/core/domain/FormattingPreferences.kt \
+        app/src/main/kotlin/com/riffle/app/feature/reader/FormattingPanel.kt \
+        app/src/main/kotlin/com/riffle/app/feature/reader/FormattingPreferencesMapper.kt
+git commit -m "feat(reader): add Continuous to ReaderOrientation enum, panel, and mapper"
+```
+
+---
+
+## Task 2: `ContinuousStyleInjector` — replicate Readium's page-load injections
+
+**Files:**
+- Create: `app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjector.kt`
+- Create: `app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjectorTest.kt`
+
+- [ ] **Step 1: Audit what Readium's fragment sets on page load**
+
+Before writing any code, open the app in Scroll mode on the Harness AVD or your device. Open WebView DevTools (`adb forward tcp:9222 localabstract:chrome_devtools_remote`, then `chrome://inspect`). In the console of a loaded chapter, run:
+
+```js
+// What CSS vars are set on :root?
+JSON.stringify(
+  Array.from({ length: document.documentElement.style.length }, (_, i) =>
+    document.documentElement.style.item(i)
+  ).map(p => [p, document.documentElement.style.getPropertyValue(p)])
+)
+// What classes does <html> have?
+document.documentElement.getAttribute('class')
+```
+
+Record the output — this is exactly what `ContinuousStyleInjector.buildVariableInjectionJs()` must reproduce for a given `FormattingPreferences`. Also check if ReadiumCSS `<link>` tags are present:
+
+```js
+[...document.querySelectorAll('link[rel=stylesheet]')].map(l => l.href)
+```
+
+If ReadiumCSS stylesheets appear in this list, the HTTP server is already injecting them — our injector only needs to set variables (the common case). If not, add a step to inject them as `<style>` blocks from Readium's assets.
+
+- [ ] **Step 2: Write the failing test**
+
+Create `app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjectorTest.kt`:
+
+```kotlin
+package com.riffle.app.feature.reader
+
+import com.riffle.core.domain.FormattingPreferences
+import com.riffle.core.domain.ReaderFontFamily
+import com.riffle.core.domain.ReaderTheme
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ContinuousStyleInjectorTest {
+
+    @Test
+    fun `default prefs — fontSize 1rem, pageMargins 1, no lineHeight variable`() {
+        val js = ContinuousStyleInjector.buildVariableInjectionJs(FormattingPreferences())
+        assertTrue("fontSize", js.contains("--USER__fontSize', '1.0rem'"))
+        assertTrue("pageMargins", js.contains("--USER__pageMargins', '1.0'"))
+        // lineSpacing == DEFAULT (1.2f) → variable must NOT be set
+        assertFalse("lineHeight not set on default", js.contains("setProperty('--USER__lineHeight'"))
+        assertTrue("lineHeight removed on default", js.contains("removeProperty('--USER__lineHeight'"))
+    }
+
+    @Test
+    fun `non-default lineSpacing sets --USER__lineHeight`() {
+        val js = ContinuousStyleInjector.buildVariableInjectionJs(
+            FormattingPreferences(lineSpacing = 1.6f)
+        )
+        assertTrue(js.contains("setProperty('--USER__lineHeight', '1.6'"))
+    }
+
+    @Test
+    fun `justifyText sets --USER__textAlign to justify`() {
+        val js = ContinuousStyleInjector.buildVariableInjectionJs(
+            FormattingPreferences(justifyText = true)
+        )
+        assertTrue(js.contains("setProperty('--USER__textAlign', 'justify'"))
+    }
+
+    @Test
+    fun `non-justify removes --USER__textAlign`() {
+        val js = ContinuousStyleInjector.buildVariableInjectionJs(
+            FormattingPreferences(justifyText = false)
+        )
+        assertTrue(js.contains("removeProperty('--USER__textAlign'"))
+    }
+
+    @Test
+    fun `Serif font family (default) — no fontFamily variable set`() {
+        val js = ContinuousStyleInjector.buildVariableInjectionJs(
+            FormattingPreferences(fontFamily = ReaderFontFamily.Serif)
+        )
+        assertFalse(js.contains("setProperty('--USER__fontFamily'"))
+        assertTrue(js.contains("removeProperty('--USER__fontFamily'"))
+    }
+
+    @Test
+    fun `SansSerif family sets sans-serif`() {
+        val js = ContinuousStyleInjector.buildVariableInjectionJs(
+            FormattingPreferences(fontFamily = ReaderFontFamily.SansSerif)
+        )
+        assertTrue(js.contains("setProperty('--USER__fontFamily', 'sans-serif'"))
+    }
+
+    @Test
+    fun `Dark theme — textColor NOT set (DarkDim only)`() {
+        val js = ContinuousStyleInjector.buildVariableInjectionJs(
+            FormattingPreferences(theme = ReaderTheme.Dark)
+        )
+        assertFalse(js.contains("setProperty('--USER__textColor'"))
+    }
+
+    @Test
+    fun `DarkDim theme — textColor set to AAAAAA`() {
+        val js = ContinuousStyleInjector.buildVariableInjectionJs(
+            FormattingPreferences(theme = ReaderTheme.DarkDim)
+        )
+        assertTrue(js.contains("setProperty('--USER__textColor', '#AAAAAA'"))
+    }
+}
+```
+
+- [ ] **Step 3: Run test to confirm it fails**
+
+```bash
+export JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"
+./gradlew :app:testDebugUnitTest --tests "com.riffle.app.feature.reader.ContinuousStyleInjectorTest" 2>&1 | tail -10
+```
+
+Expected: `FAILED` — `ContinuousStyleInjector` doesn't exist yet.
+
+- [ ] **Step 4: Implement `ContinuousStyleInjector`**
+
+Create `app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjector.kt`:
+
+```kotlin
+package com.riffle.app.feature.reader
+
+import com.riffle.core.domain.FormattingPreferences
+import com.riffle.core.domain.ReaderFontFamily
+import com.riffle.core.domain.ReaderTheme
+
+internal object ContinuousStyleInjector {
+
+    /**
+     * Produces JS that sets the same `--USER__*` CSS custom properties on `:root` that
+     * Readium's `EpubNavigatorFragment` sets via `submitPreferences()`. The null-gating
+     * logic mirrors [FormattingPreferencesMapper.toEpubPreferences]: when a value equals
+     * the default, Readium passes null — leaving the variable unset so publisher defaults
+     * are preserved. We match that behaviour with `removeProperty`.
+     *
+     * NOTE: verify after any Readium SDK upgrade that the variable names and value formats
+     * still match. Run DevTools on a Scroll-mode chapter and compare with the output of
+     * this function for the same [FormattingPreferences].
+     */
+    fun buildVariableInjectionJs(prefs: FormattingPreferences): String {
+        val lines = mutableListOf<String>()
+        val r = "document.documentElement.style"
+
+        // fontSize — always set (Readium always passes it as a Double)
+        lines += "$r.setProperty('--USER__fontSize', '${prefs.fontSize}rem');"
+
+        // lineHeight — null-gated (matches FormattingPreferencesMapper: null when == default)
+        if (prefs.lineSpacing != FormattingPreferences.DEFAULT_LINE_SPACING) {
+            lines += "$r.setProperty('--USER__lineHeight', '${prefs.lineSpacing}');"
+        } else {
+            lines += "$r.removeProperty('--USER__lineHeight');"
+        }
+
+        // pageMargins — always set
+        lines += "$r.setProperty('--USER__pageMargins', '${prefs.margins}');"
+
+        // textAlign — null-gated
+        if (prefs.justifyText) {
+            lines += "$r.setProperty('--USER__textAlign', 'justify');"
+        } else {
+            lines += "$r.removeProperty('--USER__textAlign');"
+        }
+
+        // fontFamily — null-gated (Serif is default → no variable, matching mapper)
+        val fontFamilyValue = when (prefs.fontFamily) {
+            ReaderFontFamily.Serif -> null
+            ReaderFontFamily.SansSerif -> "sans-serif"
+            ReaderFontFamily.Monospace -> "monospace"
+            ReaderFontFamily.Literata -> "Literata"
+            ReaderFontFamily.Merriweather -> "Merriweather"
+            ReaderFontFamily.OpenDyslexic -> "OpenDyslexic"
+        }
+        if (fontFamilyValue != null) {
+            lines += "$r.setProperty('--USER__fontFamily', '$fontFamilyValue');"
+        } else {
+            lines += "$r.removeProperty('--USER__fontFamily');"
+        }
+
+        // textColor — DarkDim only. 0xFFAAAAAA = ReaderThemePalette.DARK_DIM_TEXT
+        if (prefs.theme == ReaderTheme.DarkDim) {
+            lines += "$r.setProperty('--USER__textColor', '#AAAAAA');"
+        } else {
+            lines += "$r.removeProperty('--USER__textColor');"
+        }
+
+        return lines.joinToString("\n")
+    }
+
+    /**
+     * JS that fires after fonts load + one rAF and calls `window.RiffleChapter.onHeightMeasured`
+     * with `document.body.scrollHeight`. Requires the calling [ChapterWebView] to have
+     * registered a `JavascriptInterface` named `RiffleChapter`.
+     */
+    const val HEIGHT_MEASUREMENT_JS = """
+        document.fonts.ready.then(function() {
+            requestAnimationFrame(function() {
+                window.RiffleChapter.onHeightMeasured(document.body.scrollHeight);
+            });
+        });
+    """
+
+    /**
+     * JS that highlights [escapedText] via `window.find` + DOM `<mark>` injection, replacing
+     * any existing mark with id `_riffle_hl`. Pass an empty string to clear.
+     */
+    fun highlightTextJs(escapedText: String): String {
+        if (escapedText.isBlank()) return CLEAR_HIGHLIGHT_JS
+        return """
+            (function() {
+                var existing = document.getElementById('_riffle_hl');
+                if (existing) { existing.outerHTML = existing.innerHTML; }
+                if (!window.find('$escapedText', false, false, false, false, false, false)) return;
+                var sel = window.getSelection();
+                if (!sel || sel.rangeCount === 0) return;
+                var range = sel.getRangeAt(0);
+                var mark = document.createElement('mark');
+                mark.id = '_riffle_hl';
+                mark.style.cssText = 'background:#7DD3FC;color:inherit;';
+                try { range.surroundContents(mark); } catch(e) {}
+                sel.removeAllRanges();
+            })();
+        """.trimIndent()
+    }
+
+    const val CLEAR_HIGHLIGHT_JS = """
+        (function() {
+            var m = document.getElementById('_riffle_hl');
+            if (m) m.outerHTML = m.innerHTML;
+        })();
+    """
+}
+```
+
+- [ ] **Step 5: Run tests to confirm they pass**
+
+```bash
+export JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"
+./gradlew :app:testDebugUnitTest --tests "com.riffle.app.feature.reader.ContinuousStyleInjectorTest" 2>&1 | tail -10
+```
+
+Expected: `BUILD SUCCESSFUL`, all tests `PASSED`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjector.kt \
+        app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjectorTest.kt
+git commit -m "feat(reader): add ContinuousStyleInjector for CSS variable injection in self-managed WebViews"
+```
+
+---
+
+## Task 3: `ContinuousPositionTracker` — pure position math
+
+**Files:**
+- Create: `app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousPositionTracker.kt`
+- Create: `app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousPositionTrackerTest.kt`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousPositionTrackerTest.kt`:
+
+```kotlin
+package com.riffle.app.feature.reader
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class ContinuousPositionTrackerTest {
+
+    // Window: chapter A = height 1000, top 0; chapter B = height 500, top 1000
+    private val window = listOf(
+        ContinuousPositionTracker.ChapterSlot("A.xhtml", top = 0, height = 1000),
+        ContinuousPositionTracker.ChapterSlot("B.xhtml", top = 1000, height = 500),
+    )
+
+    @Test
+    fun `scrollY 0 with viewport 800 — midY 400 is in chapter A, progression 0_4`() {
+        val (href, prog) = ContinuousPositionTracker.locatorAt(
+            scrollY = 0, viewportHeight = 800, window = window
+        )
+        assertEquals("A.xhtml", href)
+        assertEquals(0.4f, prog, 0.001f)
+    }
+
+    @Test
+    fun `scrollY 1000 with viewport 800 — midY 1400 is in chapter B, progression 0_8`() {
+        val (href, prog) = ContinuousPositionTracker.locatorAt(
+            scrollY = 1000, viewportHeight = 800, window = window
+        )
+        assertEquals("B.xhtml", href)
+        assertEquals(0.8f, prog, 0.001f)
+    }
+
+    @Test
+    fun `scrollY past all chapters — clamps to last chapter`() {
+        val (href, prog) = ContinuousPositionTracker.locatorAt(
+            scrollY = 5000, viewportHeight = 800, window = window
+        )
+        assertEquals("B.xhtml", href)
+        assertEquals(1.0f, prog.coerceAtMost(1.0f), 0.001f)
+    }
+
+    @Test
+    fun `scrollOffsetFor returns correct offset for chapter B at progression 0_5`() {
+        val offset = ContinuousPositionTracker.scrollOffsetFor(
+            href = "B.xhtml", progression = 0.5f, window = window
+        )
+        // top=1000 + 0.5*500 = 1250; then subtract half viewport so it centres — but this
+        // function returns raw content offset (caller subtracts viewport/2 if desired)
+        assertEquals(1250, offset)
+    }
+
+    @Test
+    fun `scrollOffsetFor returns null when chapter not in window`() {
+        val offset = ContinuousPositionTracker.scrollOffsetFor(
+            href = "C.xhtml", progression = 0.0f, window = window
+        )
+        assertNull(offset)
+    }
+
+    @Test
+    fun `windowShiftNeeded — current index below topIndex triggers backward shift`() {
+        // window covers chapters [2,3,4], topIndex=2
+        assertEquals(
+            ContinuousPositionTracker.ShiftDirection.BACKWARD,
+            ContinuousPositionTracker.shiftNeeded(currentChapterIndex = 1, topIndex = 2, readingOrderSize = 5)
+        )
+    }
+
+    @Test
+    fun `windowShiftNeeded — current index above topIndex+2 triggers forward shift`() {
+        assertEquals(
+            ContinuousPositionTracker.ShiftDirection.FORWARD,
+            ContinuousPositionTracker.shiftNeeded(currentChapterIndex = 3, topIndex = 2, readingOrderSize = 5)
+        )
+    }
+
+    @Test
+    fun `windowShiftNeeded — current within window, no shift`() {
+        assertEquals(
+            ContinuousPositionTracker.ShiftDirection.NONE,
+            ContinuousPositionTracker.shiftNeeded(currentChapterIndex = 3, topIndex = 2, readingOrderSize = 5)
+        ).also { }
+        // Actually currentChapterIndex=3, topIndex=2 → covers [2,3,4], index 3 is inside → NONE
+    }
+
+    @Test
+    fun `shiftNeeded NONE when at first chapter and cannot go backward`() {
+        assertEquals(
+            ContinuousPositionTracker.ShiftDirection.NONE,
+            ContinuousPositionTracker.shiftNeeded(currentChapterIndex = 0, topIndex = 0, readingOrderSize = 3)
+        )
+    }
+}
+```
+
+> Note: fix the `windowShiftNeeded NONE` test assertion — it has a doubled `also {}`. Remove the spurious block:
+> ```kotlin
+> assertEquals(NONE, shiftNeeded(3, 2, 5))
+> ```
+
+- [ ] **Step 2: Run test to confirm failure**
+
+```bash
+export JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"
+./gradlew :app:testDebugUnitTest --tests "com.riffle.app.feature.reader.ContinuousPositionTrackerTest" 2>&1 | tail -10
+```
+
+Expected: `FAILED`.
+
+- [ ] **Step 3: Implement `ContinuousPositionTracker`**
+
+Create `app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousPositionTracker.kt`:
+
+```kotlin
+package com.riffle.app.feature.reader
+
+internal object ContinuousPositionTracker {
+
+    data class ChapterSlot(val href: String, val top: Int, val height: Int)
+
+    enum class ShiftDirection { NONE, FORWARD, BACKWARD }
+
+    /**
+     * Returns the chapter href and within-chapter progression (0..1) at the viewport midpoint.
+     * Falls back to the last slot if [scrollY] is past all content.
+     */
+    fun locatorAt(scrollY: Int, viewportHeight: Int, window: List<ChapterSlot>): Pair<String, Float> {
+        val midY = scrollY + viewportHeight / 2
+        val slot = window.lastOrNull { midY >= it.top } ?: window.first()
+        val progression = if (slot.height > 0) {
+            ((midY - slot.top).toFloat() / slot.height).coerceIn(0f, 1f)
+        } else {
+            0f
+        }
+        return slot.href to progression
+    }
+
+    /**
+     * Returns the content offset (from the top of the scroll view) for a given
+     * chapter + progression. Returns null if [href] is not in [window].
+     */
+    fun scrollOffsetFor(href: String, progression: Float, window: List<ChapterSlot>): Int? {
+        val slot = window.firstOrNull { it.href == href } ?: return null
+        return (slot.top + progression * slot.height).toInt()
+    }
+
+    /**
+     * Indicates whether the window (3 chapters: [topIndex, topIndex+2]) needs to shift
+     * because [currentChapterIndex] has moved outside it.
+     */
+    fun shiftNeeded(currentChapterIndex: Int, topIndex: Int, readingOrderSize: Int): ShiftDirection {
+        return when {
+            currentChapterIndex < topIndex && topIndex > 0 -> ShiftDirection.BACKWARD
+            currentChapterIndex > topIndex + 2 && topIndex + 3 < readingOrderSize -> ShiftDirection.FORWARD
+            else -> ShiftDirection.NONE
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Fix the test — remove spurious `also {}`**
+
+In `ContinuousPositionTrackerTest`, replace:
+
+```kotlin
+    @Test
+    fun `windowShiftNeeded — current within window, no shift`() {
+        assertEquals(
+            ContinuousPositionTracker.ShiftDirection.NONE,
+            ContinuousPositionTracker.shiftNeeded(currentChapterIndex = 3, topIndex = 2, readingOrderSize = 5)
+        ).also { }
+        // Actually currentChapterIndex=3, topIndex=2 → covers [2,3,4], index 3 is inside → NONE
+    }
+```
+
+with:
+
+```kotlin
+    @Test
+    fun `shiftNeeded — current within window returns NONE`() {
+        assertEquals(
+            ContinuousPositionTracker.ShiftDirection.NONE,
+            ContinuousPositionTracker.shiftNeeded(currentChapterIndex = 3, topIndex = 2, readingOrderSize = 5)
+        )
+    }
+```
+
+- [ ] **Step 5: Run tests to confirm they pass**
+
+```bash
+export JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"
+./gradlew :app:testDebugUnitTest --tests "com.riffle.app.feature.reader.ContinuousPositionTrackerTest" 2>&1 | tail -10
+```
+
+Expected: `BUILD SUCCESSFUL`, all tests `PASSED`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousPositionTracker.kt \
+        app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousPositionTrackerTest.kt
+git commit -m "feat(reader): add ContinuousPositionTracker for scrollY ↔ chapter+progression math"
+```
+
+---
+
+## Task 4: `ChapterWebView` — WebView wrapper with disabled scroll and JS height measurement
+
+**Files:**
+- Create: `app/src/main/kotlin/com/riffle/app/feature/reader/ChapterWebView.kt`
+
+No unit tests — `WebView` is not usable in JVM tests. Tested as part of integration via Task 5 and device testing.
+
+- [ ] **Step 1: Implement `ChapterWebView`**
+
+Create `app/src/main/kotlin/com/riffle/app/feature/reader/ChapterWebView.kt`:
+
+```kotlin
+package com.riffle.app.feature.reader
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.webkit.JavascriptInterface
+import android.webkit.WebView
+import android.webkit.WebViewClient
+
+/**
+ * A [WebView] that:
+ * - Has internal scrolling disabled so the parent [ContinuousReaderView] owns all scroll.
+ * - Measures its content height via a [JavascriptInterface] callback after fonts load.
+ * - Injects CSS variables and the TypographyOverride stylesheet on page load.
+ *
+ * Set [onHeightMeasured] before calling [loadChapter]. Height arrives asynchronously on
+ * the main thread after [ContinuousStyleInjector.HEIGHT_MEASUREMENT_JS] fires.
+ */
+@SuppressLint("SetJavaScriptEnabled")
+internal class ChapterWebView(context: Context) : WebView(context) {
+
+    /** Called on the main thread once the content height is known. */
+    var onHeightMeasured: ((heightPx: Int) -> Unit)? = null
+
+    /** Called on the main thread once the page finishes loading (before height is known). */
+    var onPageFinished: (() -> Unit)? = null
+
+    /** The chapter href this view is currently loading (e.g. `"EPUB/chapter01.xhtml"`). */
+    var chapterHref: String = ""
+        private set
+
+    init {
+        isScrollContainer = false
+        isVerticalScrollBarEnabled = false
+        isHorizontalScrollBarEnabled = false
+        settings.javaScriptEnabled = true
+        addJavascriptInterface(HeightBridge(), "RiffleChapter")
+        webViewClient = object : WebViewClient() {
+            override fun onPageFinished(view: WebView?, url: String?) {
+                this@ChapterWebView.onPageFinished?.invoke()
+            }
+        }
+    }
+
+    /**
+     * Load [chapterUrl] (absolute URL from Readium's HTTP server) for chapter at [href].
+     */
+    fun loadChapter(href: String, chapterUrl: String) {
+        chapterHref = href
+        loadUrl(chapterUrl)
+    }
+
+    /**
+     * Inject style variables + TypographyOverride + trigger height measurement.
+     * Call this from [onPageFinished] after Readium's server has served the page.
+     *
+     * @param variableJs output of [ContinuousStyleInjector.buildVariableInjectionJs]
+     */
+    fun injectStylesAndMeasure(variableJs: String) {
+        evaluateJavascript(variableJs, null)
+        evaluateJavascript(typographyOverrideInjectionJs(), null)
+        evaluateJavascript(ContinuousStyleInjector.HEIGHT_MEASUREMENT_JS, null)
+    }
+
+    /** Re-measure after a preference change. Call [injectStylesAndMeasure] with updated vars. */
+    fun reinjectAndRemeasure(variableJs: String) = injectStylesAndMeasure(variableJs)
+
+    private inner class HeightBridge {
+        @JavascriptInterface
+        fun onHeightMeasured(height: Int) {
+            post { this@ChapterWebView.onHeightMeasured?.invoke(height) }
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Build to confirm it compiles**
+
+```bash
+export JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"
+./gradlew :app:assembleDebug 2>&1 | grep -E "error:|BUILD"
+```
+
+Expected: `BUILD SUCCESSFUL`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/src/main/kotlin/com/riffle/app/feature/reader/ChapterWebView.kt
+git commit -m "feat(reader): add ChapterWebView with disabled scroll and JS height measurement bridge"
+```
+
+---
+
+## Task 5: `ContinuousReaderView` — windowed NestedScrollView
+
+**Files:**
+- Create: `app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt`
+
+- [ ] **Step 1: Implement `ContinuousReaderView`**
+
+Create `app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt`:
+
+```kotlin
+package com.riffle.app.feature.reader
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.ViewGroup.LayoutParams.MATCH_PARENT
+import android.view.ViewGroup.LayoutParams.WRAP_CONTENT
+import android.widget.LinearLayout
+import androidx.core.widget.NestedScrollView
+import com.riffle.core.domain.FormattingPreferences
+import org.readium.r2.shared.publication.Link
+
+/**
+ * Renders the entire book as a single vertical scroll by stacking a sliding window of 3
+ * [ChapterWebView]s (previous, current, next) inside a [LinearLayout].
+ *
+ * Scrolling is owned entirely by this [NestedScrollView]; each [ChapterWebView] has its
+ * internal scrolling disabled and its height fixed to its measured content height.
+ *
+ * Window shifting: when [currentChapterIndex] advances past the bottom chapter or retreats
+ * past the top chapter, the far end is destroyed and a new chapter is added at the other end.
+ * Adding a chapter at the TOP adjusts [scrollY] by the new chapter's height to keep the
+ * visible content stable.
+ */
+internal class ContinuousReaderView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+) : NestedScrollView(context, attrs) {
+
+    data class ChapterEntry(val link: Link, val url: String)
+
+    /** Called on main thread when position changes; supplies `href` and `progression`. */
+    var onPositionChanged: ((href: String, progression: Float) -> Unit)? = null
+
+    private val container = LinearLayout(context).apply {
+        orientation = LinearLayout.VERTICAL
+    }
+
+    /** All chapters in reading order. Set once via [initialize]. */
+    private var allChapters: List<ChapterEntry> = emptyList()
+
+    /** Current formatting preferences for CSS injection. */
+    private var formattingPrefs: FormattingPreferences = FormattingPreferences()
+
+    /**
+     * Index into [allChapters] of the topmost loaded chapter.
+     * The window covers [topIndex, topIndex+1, topIndex+2] (clamped to list bounds).
+     */
+    private var topIndex: Int = 0
+
+    /** Parallel list to the loaded WebViews; index i matches container.getChildAt(i). */
+    private val webViews = mutableListOf<ChapterWebView>()
+
+    /** Measured content heights for each WebView in the current window. */
+    private val measuredHeights = mutableListOf<Int>()
+
+    /** Placeholder height (3× screen height) used before real measurement arrives. */
+    private val placeholderHeight: Int get() = resources.displayMetrics.heightPixels * 3
+
+    init {
+        addView(container, LayoutParams(MATCH_PARENT, WRAP_CONTENT))
+        setOnScrollChangeListener { _, _, scrollY, _, _ ->
+            handleScrollChange(scrollY)
+        }
+    }
+
+    /**
+     * Initialize the view at [initialHref] + [initialProgression].
+     * Call once after attaching to the window.
+     */
+    fun initialize(
+        chapters: List<ChapterEntry>,
+        prefs: FormattingPreferences,
+        initialHref: String,
+        initialProgression: Float,
+    ) {
+        allChapters = chapters
+        formattingPrefs = prefs
+        val centerIndex = chapters.indexOfFirst { it.link.href.toString() == initialHref }
+            .coerceAtLeast(0)
+        topIndex = (centerIndex - 1).coerceAtLeast(0)
+        val windowSize = minOf(3, chapters.size - topIndex)
+        repeat(windowSize) { i -> appendChapter(topIndex + i) }
+        // Scroll to initial position after the first height measurement settles.
+        // We post to let the first layout pass happen.
+        post {
+            val window = buildWindow()
+            val offset = ContinuousPositionTracker.scrollOffsetFor(initialHref, initialProgression, window)
+            if (offset != null) scrollTo(0, (offset - height / 2).coerceAtLeast(0))
+        }
+    }
+
+    /** Update preferences and re-inject styles + remeasure all loaded chapters. */
+    fun updatePreferences(prefs: FormattingPreferences) {
+        formattingPrefs = prefs
+        val variableJs = ContinuousStyleInjector.buildVariableInjectionJs(prefs)
+        webViews.forEachIndexed { i, wv ->
+            wv.reinjectAndRemeasure(variableJs)
+        }
+    }
+
+    /** Scroll to [href] at [progression]. Loads the chapter into the window if needed. */
+    fun navigateTo(href: String, progression: Float) {
+        val targetIndex = allChapters.indexOfFirst { it.link.href.toString() == href }
+        if (targetIndex < 0) return
+        // Shift window so target is in range
+        if (targetIndex < topIndex || targetIndex > topIndex + 2) {
+            rebuildWindowAround(targetIndex)
+        }
+        post {
+            val window = buildWindow()
+            val offset = ContinuousPositionTracker.scrollOffsetFor(href, progression, window)
+            if (offset != null) smoothScrollTo(0, (offset - height / 2).coerceAtLeast(0))
+        }
+    }
+
+    /** Inject a highlight for [escapedText] in the chapter matching [href]. Clear if blank. */
+    fun highlightInChapter(href: String, escapedText: String) {
+        val i = webViewIndexFor(href) ?: return
+        webViews[i].evaluateJavascript(ContinuousStyleInjector.highlightTextJs(escapedText), null)
+    }
+
+    /** Clear any active highlight in the chapter at [href]. */
+    fun clearHighlightInChapter(href: String) {
+        val i = webViewIndexFor(href) ?: return
+        webViews[i].evaluateJavascript(ContinuousStyleInjector.CLEAR_HIGHLIGHT_JS, null)
+    }
+
+    // ── private ────────────────────────────────────────────────────────────────
+
+    private fun appendChapter(index: Int) {
+        val entry = allChapters[index]
+        val wv = ChapterWebView(context)
+        val placeholder = placeholderHeight
+        wv.onHeightMeasured = { measuredPx ->
+            val i = webViews.indexOf(wv)
+            if (i >= 0) {
+                val wasPlaceholder = measuredHeights[i] == placeholder
+                val delta = measuredPx - measuredHeights[i]
+                measuredHeights[i] = measuredPx
+                wv.layoutParams = wv.layoutParams.also { it.height = measuredPx }
+                if (wasPlaceholder && i == 0 && scrollY > 0) {
+                    // Chapter was prepended above the viewport — adjust scroll to keep visible
+                    // content in place. (Real height differs from placeholder.)
+                    scrollBy(0, delta)
+                }
+            }
+        }
+        wv.onPageFinished = {
+            val variableJs = ContinuousStyleInjector.buildVariableInjectionJs(formattingPrefs)
+            wv.injectStylesAndMeasure(variableJs)
+        }
+        webViews.add(wv)
+        measuredHeights.add(placeholder)
+        container.addView(wv, LinearLayout.LayoutParams(MATCH_PARENT, placeholder))
+        wv.loadChapter(entry.link.href.toString(), entry.url)
+    }
+
+    private fun prependChapter(index: Int) {
+        val entry = allChapters[index]
+        val wv = ChapterWebView(context)
+        val placeholder = placeholderHeight
+        wv.onHeightMeasured = { measuredPx ->
+            val i = webViews.indexOf(wv)
+            if (i >= 0) {
+                val delta = measuredPx - measuredHeights[i]
+                measuredHeights[i] = measuredPx
+                wv.layoutParams = wv.layoutParams.also { it.height = measuredPx }
+                // Always adjust scroll when prepending — this chapter is above the viewport.
+                scrollBy(0, delta)
+            }
+        }
+        wv.onPageFinished = {
+            val variableJs = ContinuousStyleInjector.buildVariableInjectionJs(formattingPrefs)
+            wv.injectStylesAndMeasure(variableJs)
+        }
+        webViews.add(0, wv)
+        measuredHeights.add(0, placeholder)
+        container.addView(wv, 0, LinearLayout.LayoutParams(MATCH_PARENT, placeholder))
+        // Compensate scroll immediately for the placeholder height so visible content doesn't jump.
+        scrollBy(0, placeholder)
+        wv.loadChapter(entry.link.href.toString(), entry.url)
+    }
+
+    private fun removeTop() {
+        if (webViews.isEmpty()) return
+        val h = measuredHeights.removeAt(0)
+        val wv = webViews.removeAt(0)
+        container.removeView(wv)
+        wv.destroy()
+        scrollBy(0, -h)
+        topIndex++
+    }
+
+    private fun removeBottom() {
+        if (webViews.isEmpty()) return
+        measuredHeights.removeAt(measuredHeights.lastIndex)
+        val wv = webViews.removeAt(webViews.lastIndex)
+        container.removeView(wv)
+        wv.destroy()
+    }
+
+    private fun handleScrollChange(scrollY: Int) {
+        val window = buildWindow()
+        val (href, progression) = ContinuousPositionTracker.locatorAt(scrollY, height, window)
+        onPositionChanged?.invoke(href, progression)
+
+        val currentChapterIndex = allChapters.indexOfFirst { it.link.href.toString() == href }
+        when (ContinuousPositionTracker.shiftNeeded(currentChapterIndex, topIndex, allChapters.size)) {
+            ContinuousPositionTracker.ShiftDirection.FORWARD -> {
+                removeTop()
+                val nextIndex = topIndex + 2 // topIndex already incremented in removeTop()
+                if (nextIndex < allChapters.size) appendChapter(nextIndex)
+            }
+            ContinuousPositionTracker.ShiftDirection.BACKWARD -> {
+                removeBottom()
+                val prevIndex = topIndex - 1
+                if (prevIndex >= 0) {
+                    topIndex--
+                    prependChapter(prevIndex)
+                }
+            }
+            ContinuousPositionTracker.ShiftDirection.NONE -> Unit
+        }
+    }
+
+    private fun rebuildWindowAround(centerIndex: Int) {
+        // Destroy all current WebViews
+        webViews.forEach { it.destroy() }
+        webViews.clear()
+        measuredHeights.clear()
+        container.removeAllViews()
+        topIndex = (centerIndex - 1).coerceAtLeast(0)
+        val windowSize = minOf(3, allChapters.size - topIndex)
+        repeat(windowSize) { i -> appendChapter(topIndex + i) }
+    }
+
+    private fun buildWindow(): List<ContinuousPositionTracker.ChapterSlot> {
+        var top = 0
+        return webViews.mapIndexed { i, wv ->
+            val h = measuredHeights[i]
+            ContinuousPositionTracker.ChapterSlot(wv.chapterHref, top, h).also { top += h }
+        }
+    }
+
+    private fun webViewIndexFor(href: String): Int? {
+        val i = webViews.indexOfFirst { it.chapterHref == href }
+        return if (i >= 0) i else null
+    }
+}
+```
+
+- [ ] **Step 2: Build to confirm it compiles**
+
+```bash
+export JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"
+./gradlew :app:assembleDebug 2>&1 | grep -E "error:|BUILD"
+```
+
+Expected: `BUILD SUCCESSFUL`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
+git commit -m "feat(reader): add ContinuousReaderView with windowed ChapterWebView pool"
+```
+
+---
+
+## Task 6: Wire `ContinuousReaderView` into `EpubReaderScreen`
+
+This is the largest single change: branch on `Continuous` orientation in the screen, keep an invisible fragment as the HTTP server, extract its base URL, mount `ContinuousReaderView`, and hook up position callbacks.
+
+**Files:**
+- Modify: `app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt`
+
+- [ ] **Step 1: Add a `continuousViewRef` and `serverBaseUrl` state alongside the existing `fragmentRef`**
+
+Near the top of the composable that contains the reader `AndroidView` (around line 155, with the other `remember` values), add:
+
+```kotlin
+val continuousViewRef = remember { mutableStateOf<ContinuousReaderView?>(null) }
+val serverBaseUrl = remember { mutableStateOf<String?>(null) }
+val isContinuous = formattingPrefs.orientation == ReaderOrientation.Continuous
+```
+
+- [ ] **Step 2: Extract base URL from the invisible fragment's first page load**
+
+After the existing `LaunchedEffect` that collects `fragment.currentLocator` (around line ~900), add:
+
+```kotlin
+// In Continuous mode, the fragment is zero-height (HTTP server keeper only).
+// Once it loads its first page, extract the HTTP server base URL so ContinuousReaderView
+// can construct chapter URLs without going through the Readium navigator.
+LaunchedEffect(fragmentRef.value, isContinuous) {
+    if (!isContinuous) return@LaunchedEffect
+    val fragment = fragmentRef.value ?: return@LaunchedEffect
+    fragment.currentLocator.collect { locator ->
+        if (serverBaseUrl.value != null) return@collect
+        val absoluteUrl = fragment.evaluateJavascript("window.location.href") ?: return@collect
+        val relHref = locator.href.toString().trimStart('/')
+        // absoluteUrl = "http://127.0.0.1:PORT/PUB_HASH/EPUB/chapter.xhtml"
+        // relHref     = "EPUB/chapter.xhtml"
+        // base        = "http://127.0.0.1:PORT/PUB_HASH"
+        val base = absoluteUrl.trim('"').removeSuffix("/$relHref")
+        serverBaseUrl.value = base
+    }
+}
+```
+
+- [ ] **Step 3: Suppress scroll-boundary polling in Continuous mode**
+
+The existing `LaunchedEffect` that polls JS boundaries every 120 ms (around line 1480) currently guards on `orientation != ReaderOrientation.Vertical`. Extend the guard:
+
+```kotlin
+LaunchedEffect(fragmentRef.value, currentFormattingPrefs.orientation) {
+    val fragment = fragmentRef.value ?: return@LaunchedEffect
+    if (currentFormattingPrefs.orientation != ReaderOrientation.Vertical) return@LaunchedEffect
+    // ... existing polling loop unchanged ...
+}
+```
+
+- [ ] **Step 4: Make the fragment container zero-height in Continuous mode**
+
+The `AndroidView` factory creates a `ScrollBoundaryNavigationContainer`. In the `update` lambda, conditionally collapse it:
+
+```kotlin
+update = { container ->
+    container.layoutParams = container.layoutParams.apply {
+        height = if (isContinuous) 0 else MATCH_PARENT
+    }
+    container.visibility = if (isContinuous) View.INVISIBLE else View.VISIBLE
+    // ... rest of existing update logic unchanged ...
+},
+```
+
+- [ ] **Step 5: Mount `ContinuousReaderView` alongside the existing `AndroidView`**
+
+After the existing `AndroidView(...)` block (which now collapses to zero when Continuous), add:
+
+```kotlin
+val base = serverBaseUrl.value
+if (isContinuous && base != null && state is ReaderState.Ready) {
+    val chapters = state.publication.readingOrder.map { link ->
+        ContinuousReaderView.ChapterEntry(link, "$base/${link.href.toString().trimStart('/')}")
+    }
+    AndroidView(
+        factory = { ctx ->
+            ContinuousReaderView(ctx).also { view ->
+                continuousViewRef.value = view
+                view.onPositionChanged = { href, progression ->
+                    val locator = Locator(
+                        href = Href(href),
+                        mediaType = MediaType.XHTML,
+                        locations = Locator.Locations(progression = progression.toDouble()),
+                    )
+                    viewModel.onPositionChanged(locator)
+                }
+            }
+        },
+        update = { _ -> /* ContinuousReaderView state is driven by LaunchedEffect below, not update */ },
+        modifier = readerModifier,
+    )
+    // Initialize once after factory runs.
+    LaunchedEffect(base, state.publication) {
+        val view = continuousViewRef.value ?: return@LaunchedEffect
+        val initialLocator = latestLocator() ?: state.initialLocator
+        view.initialize(
+            chapters = chapters,
+            prefs = formattingPrefs,
+            initialHref = initialLocator.href.toString(),
+            initialProgression = initialLocator.locations.progression?.toFloat() ?: 0f,
+        )
+    }
+}
+```
+
+- [ ] **Step 6: Propagate preference changes to `ContinuousReaderView`**
+
+Find the existing `LaunchedEffect` that calls `fragment.submitPreferences(...)` (search for `submitPreferences`). After that line, also update the continuous view if present:
+
+```kotlin
+continuousViewRef.value?.updatePreferences(formattingPrefs)
+```
+
+- [ ] **Step 7: Build**
+
+```bash
+export JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"
+./gradlew :app:assembleDebug 2>&1 | grep -E "error:|BUILD"
+```
+
+Expected: `BUILD SUCCESSFUL`.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+git commit -m "feat(reader): wire ContinuousReaderView into EpubReaderScreen with invisible fragment server keeper"
+```
+
+---
+
+## Task 7: Readaloud highlight routing in Continuous mode
+
+When readaloud is active, `activeFragmentRef` contains the current sentence's chapter href + span id. In Continuous mode, route the highlight to the correct `ChapterWebView` using `ContinuousReaderView.highlightInChapter`.
+
+**Files:**
+- Modify: `app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt`
+
+- [ ] **Step 1: Short-circuit the existing Readium decoration `LaunchedEffect` in Continuous mode**
+
+The `LaunchedEffect` around line 1278 calls `fragment.applyDecorations(...)`. Readium's API only works on its own managed WebView. Wrap the entire body with an early-return when `isContinuous`:
+
+```kotlin
+LaunchedEffect(activeFragmentRef, reflowGeneration, pageLoadGeneration.value, sentenceQuotes) {
+    if (isContinuous) return@LaunchedEffect  // handled separately below
+    // ... existing applyDecorations body unchanged ...
+}
+```
+
+- [ ] **Step 2: Add a new `LaunchedEffect` that routes highlights to `ContinuousReaderView` in Continuous mode**
+
+After the block above, add:
+
+```kotlin
+val prevHighlightHref = remember { mutableStateOf<String?>(null) }
+
+LaunchedEffect(activeFragmentRef, isContinuous, sentenceQuotes) {
+    if (!isContinuous) return@LaunchedEffect
+    val view = continuousViewRef.value ?: return@LaunchedEffect
+    val ref = activeFragmentRef
+    if (ref == null) {
+        // Readaloud stopped — clear the last known chapter's highlight
+        prevHighlightHref.value?.let { view.clearHighlightInChapter(it) }
+        prevHighlightHref.value = null
+        return@LaunchedEffect
+    }
+    val chapterHref = ref.substringBefore('#')
+    val sid = ref.substringAfter('#', "")
+    val quote = sentenceQuotes[sid]
+    val highlightText = quote?.highlight?.take(12) ?: return@LaunchedEffect
+    // If the chapter changed, clear the previous chapter's mark first
+    val prev = prevHighlightHref.value
+    if (prev != null && prev != chapterHref) view.clearHighlightInChapter(prev)
+    prevHighlightHref.value = chapterHref
+    // Use 12-char prefix — same heuristic as autoFollowSnapJs — so window.find matches reliably
+    view.highlightInChapter(chapterHref, highlightText.replace("'", "\\'"))
+}
+```
+
+- [ ] **Step 3: Short-circuit the auto-follow `LaunchedEffect` in Continuous mode**
+
+Around line 1363, the `LaunchedEffect` calls `ColumnSnap.followNarratedSentence(fragment, ...)`. In Continuous mode, the `ContinuousReaderView` already keeps the current position in view via its scroll position — no auto-scroll needed from this effect. Add at its top:
+
+```kotlin
+if (isContinuous) return@LaunchedEffect
+```
+
+- [ ] **Step 4: Build**
+
+```bash
+export JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"
+./gradlew :app:assembleDebug 2>&1 | grep -E "error:|BUILD"
+```
+
+Expected: `BUILD SUCCESSFUL`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+git commit -m "feat(reader): route readaloud highlight to ContinuousReaderView in Continuous mode"
+```
+
+---
+
+## Task 8: Search navigation in Continuous mode
+
+In Continuous mode, `goAndSnapWithCover` calls `ColumnSnap.goAndSnap(fragment, ...)` which requires Readium's fragment WebView. Replace the search navigation flow with `ContinuousReaderView.navigateTo` for Continuous mode.
+
+**Files:**
+- Modify: `app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt`
+
+- [ ] **Step 1: Branch `searchNavigationEvents` collection on `isContinuous`**
+
+Find the existing `LaunchedEffect(searchNavigationEvents)` around line 1179:
+
+```kotlin
+LaunchedEffect(searchNavigationEvents) {
+    searchNavigationEvents.collect { goAndSnapWithCover(it) }
+}
+```
+
+Replace with:
+
+```kotlin
+LaunchedEffect(searchNavigationEvents, isContinuous) {
+    searchNavigationEvents.collect { locator ->
+        if (isContinuous) {
+            val view = continuousViewRef.value ?: return@collect
+            val href = locator.href.toString()
+            val progression = locator.locations.progression?.toFloat() ?: 0f
+            val highlightText = locator.text.highlight?.take(40)?.replace("'", "\\'") ?: ""
+            view.navigateTo(href, progression)
+            // Clear previous search highlight then apply new one
+            view.highlightInChapter(href, highlightText)
+        } else {
+            goAndSnapWithCover(locator)
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Suppress Readium `applyDecorations` for search in Continuous mode**
+
+The `LaunchedEffect(searchResults, currentSearchIndex, ...)` around line 1217 calls `fragment.applyDecorations(...)` for search highlights. Add an early return at its top:
+
+```kotlin
+LaunchedEffect(searchResults, currentSearchIndex, reflowGeneration, pageLoadGeneration.value) {
+    if (isContinuous) return@LaunchedEffect  // ContinuousReaderView uses window.find instead
+    // ... existing applyDecorations logic unchanged ...
+}
+```
+
+- [ ] **Step 3: Build**
+
+```bash
+export JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"
+./gradlew :app:assembleDebug 2>&1 | grep -E "error:|BUILD"
+```
+
+Expected: `BUILD SUCCESSFUL`.
+
+- [ ] **Step 4: Run all reader JVM tests to confirm no regressions**
+
+```bash
+export JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"
+./gradlew test 2>&1 | tail -20
+```
+
+Expected: `BUILD SUCCESSFUL`, no test failures.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+git commit -m "feat(reader): route search navigation to ContinuousReaderView; suppress fragment decorations in Continuous mode"
+```
+
+---
+
+## Task 9: Style injection verification + final cleanup
+
+Before declaring done, verify that the CSS variables set by `ContinuousStyleInjector` actually match what Readium's own fragment sets. Then run the full test suite.
+
+**Files:**
+- Possibly modify: `app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjector.kt` (if audit reveals mismatches)
+
+- [ ] **Step 1: Install a Continuous-mode build on the Harness AVD and open a book**
+
+```bash
+export JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"
+./gradlew :app:assembleDebug
+adb -s <HARNESS_SERIAL> install -r app/build/outputs/apk/debug/app-debug.apk
+```
+
+Open a multi-chapter book, switch to Continuous mode. Scroll across two chapter boundaries. Verify:
+- Chapter transition is seamless (both chapters visible simultaneously, no gap)
+- Chapter below loads while still scrolling through current chapter
+- Progress indicator advances as you cross chapters
+
+- [ ] **Step 2: DevTools CSS variable audit**
+
+With the app open in Continuous mode, open WebView DevTools for a `ChapterWebView`:
+
+```bash
+adb forward tcp:9222 localabstract:chrome_devtools_remote
+```
+
+Open `chrome://inspect`, select a chapter tab and run:
+
+```js
+JSON.stringify(
+  Array.from({ length: document.documentElement.style.length }, (_, i) =>
+    document.documentElement.style.item(i)
+  ).map(p => [p, document.documentElement.style.getPropertyValue(p)])
+)
+```
+
+Then switch the book to **Scroll mode** and run the same query in the Readium fragment's tab. Compare both outputs. Any variables present in Scroll but missing in Continuous mode must be added to `ContinuousStyleInjector.buildVariableInjectionJs`.
+
+- [ ] **Step 3: Run full test suite**
+
+```bash
+export JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"
+./gradlew test 2>&1 | tail -20
+```
+
+Expected: `BUILD SUCCESSFUL`, zero failures.
+
+- [ ] **Step 4: Final commit**
+
+```bash
+git add -p  # stage only the style-injector changes, if any
+git commit -m "fix(reader): align ContinuousStyleInjector CSS variables with Readium fragment audit"
+```

--- a/docs/superpowers/specs/2026-06-14-continuous-scroll-design.md
+++ b/docs/superpowers/specs/2026-06-14-continuous-scroll-design.md
@@ -1,0 +1,134 @@
+# Continuous Scroll Mode — Design Spec
+
+**Date:** 2026-06-14  
+**Branch:** pkmetski/minnetonka-v1  
+**Status:** Approved
+
+---
+
+## Overview
+
+Add a third reading orientation — **Continuous** — where the entire book renders as a single endless scroll. Both the end of one chapter and the start of the next are simultaneously visible on screen as the user crosses the boundary. This is distinct from the existing Scroll mode (which uses a pull gesture to navigate between discrete chapter WebViews).
+
+---
+
+## Architecture
+
+### Mode switching
+
+`ReaderOrientation` gains a third enum value: `Continuous`.
+
+`FormattingPreferences.orientation` stores the selected mode. When `Continuous` is active:
+- `EpubNavigatorFragment` is removed from the layout entirely
+- A new `ContinuousReaderView` (a `NestedScrollView`-based custom view) takes its place in `EpubReaderScreen`
+- Switching away from Continuous saves the current locator and re-creates `EpubNavigatorFragment` at that position
+
+The existing Paged and Scroll modes are unchanged.
+
+### ContinuousReaderView
+
+A custom `NestedScrollView` subclass that stacks `ChapterWebView` items vertically. It is the sole scrollable container — no nested scrolling occurs.
+
+At any time it holds a windowed pool of **3 `ChapterWebView`s**: the chapter before the current, the current chapter, and the chapter after. As the user scrolls past a chapter boundary:
+- The far end `ChapterWebView` is detached and recycled
+- A new `ChapterWebView` is created and appended at the advancing end
+
+Chapter URLs are loaded from Readium's already-running local HTTP server — the same URLs `EpubNavigatorFragment` uses. No new serving infrastructure is required.
+
+### ChapterWebView
+
+A thin `WebView` wrapper with:
+- `isScrollContainer = false` — internal scrolling disabled
+- `layoutParams.height` set to its measured content height (see below)
+- A loading placeholder of `3 × screen height` shown until height is known
+
+### Height measurement
+
+After each `ChapterWebView` page loads:
+1. Inject ReadiumCSS + user preference CSS variables (see Style Injection below)
+2. Wait for fonts: `document.fonts.ready`
+3. Fire `requestAnimationFrame`, then read `document.body.scrollHeight`
+4. Set `layoutParams.height` to the measured value and trigger a layout pass
+
+When a formatting preference changes while in Continuous mode, all loaded `ChapterWebView`s re-inject styles and re-measure height.
+
+---
+
+## Style Injection
+
+A new `ContinuousStyleInjector` is responsible for making each `ChapterWebView` render identically to the same chapter in Scroll mode.
+
+### What gets injected
+
+1. **ReadiumCSS stylesheets** — the base, default, and user layers that `EpubNavigatorFragment` injects. These are injected by auditing `EpubNavigatorFragment`'s `WebViewClient` and `evaluateJavascript` calls and mirroring them exactly. They may be injected as `<link>` tags pointing to Readium's HTTP server URLs or inlined as `<style>` blocks.
+
+2. **CSS custom property overrides** — user formatting preferences mapped from `FormattingPreferences` → `EpubPreferences` → ReadiumCSS CSS variables (`--USER__fontSize`, `--USER__lineHeight`, etc.), applied via `evaluateJavascript`:
+   ```js
+   document.documentElement.style.setProperty('--USER__fontSize', '...');
+   ```
+
+   `ContinuousStyleInjector` mirrors `FormattingPreferencesMapper`: every preference the mapper sends to `EpubPreferences` gets a corresponding CSS variable entry here. Publisher CSS is served by Readium's HTTP server as part of the EPUB content and is automatically present — the ReadiumCSS layer mediates between publisher CSS and user preferences exactly as it does in Scroll/Paged mode.
+
+**Out of scope v1:** custom app-asset fonts (complex to serve into self-managed WebViews, low relative impact).
+
+---
+
+## Position Tracking
+
+The outer `NestedScrollView`'s `scrollY` is the source of truth. Each loaded `ChapterWebView` knows its `top` offset in the container and its measured `height`.
+
+- **Current chapter**: whichever `ChapterWebView` contains `scrollY + viewportHeight / 2`
+- **Progression within chapter**: `(scrollY - chapterTop) / chapterHeight`
+- **Saved locator**: progression-based, same shape as the existing Scroll mode — no changes needed in `ProgressSweep` or ABS sync
+
+On opening a book in Continuous mode, the saved locator's chapter is loaded as the center WebView of the initial pool, scrolled to `chapterTop + progression × chapterHeight`. The previous and next chapters are loaded above and below.
+
+---
+
+## UI Integration
+
+### Settings
+
+"Continuous" appears as a third chip/option in the orientation selector in the reader formatting panel, alongside "Paged" and "Scroll".
+
+### TOC navigation
+
+Jump to the target chapter's `ChapterWebView` (loading it into the window if needed), then scroll to `chapterTop + progression × chapterHeight`.
+
+### Reader chrome
+
+Top/bottom bars, the formatting sheet, and the progress bar observe the same state shape as today — no changes needed.
+
+---
+
+## Readaloud Highlight Sync
+
+The existing auto-follow JS is routed to whichever `ChapterWebView` corresponds to the current audio position:
+
+- The audio locator carries chapter href + progression
+- `ContinuousReaderView` routes highlight injection to the matching `ChapterWebView`
+- When readaloud crosses a chapter boundary, the highlight is cleared from the departing `ChapterWebView` and re-injected into the arriving one
+- The chapter must be in the current window (within ±1 of current) — if it isn't, the window shifts to include it
+
+### Search result navigation
+
+Search returns a locator (chapter + progression). `ContinuousReaderView`:
+1. Loads the target chapter into the window
+2. Scrolls to `chapterTop + progression × chapterHeight`
+3. Highlights the matched term via `window.find()` injected as JS — bypassing Readium's decoration API, which assumes a single navigator WebView
+
+---
+
+## Out of Scope (v1)
+
+- Text selection across a chapter boundary — requires merging content across two separate WebView contexts; not feasible without a custom selection protocol
+- Custom app-asset font injection into self-managed WebViews
+
+---
+
+## Testing
+
+- Unit tests for `ContinuousStyleInjector`: given `FormattingPreferences`, assert correct CSS variable output
+- Unit tests for position math: `scrollY` → chapter index + progression, and the reverse (open-at-locator scroll offset)
+- Unit tests for window shift logic: scrolling past a boundary drops the far chapter and loads the next
+- Harness test (scroll mode): open a multi-chapter book in Continuous mode, scroll past two chapter boundaries, verify no gap/flash and that the progress indicator advances correctly

--- a/docs/superpowers/specs/2026-06-14-continuous-scroll-design.md
+++ b/docs/superpowers/specs/2026-06-14-continuous-scroll-design.md
@@ -1,7 +1,7 @@
 # Continuous Scroll Mode — Design Spec
 
 **Date:** 2026-06-14  
-**Branch:** pkmetski/minnetonka-v1  
+**Branch:** pkmetski/endless-scroll-chapters  
 **Status:** Approved
 
 ---
@@ -30,7 +30,7 @@ The existing Paged and Scroll modes are unchanged.
 A custom `NestedScrollView` subclass that stacks `ChapterWebView` items vertically. It is the sole scrollable container — no nested scrolling occurs.
 
 At any time it holds a windowed pool of **3 `ChapterWebView`s**: the chapter before the current, the current chapter, and the chapter after. As the user scrolls past a chapter boundary:
-- The far end `ChapterWebView` is detached and recycled
+- The far end `ChapterWebView` is detached and destroyed (WebViews are not pooled — the cost of creating a new one is acceptable given the 3-item window)
 - A new `ChapterWebView` is created and appended at the advancing end
 
 Chapter URLs are loaded from Readium's already-running local HTTP server — the same URLs `EpubNavigatorFragment` uses. No new serving infrastructure is required.
@@ -108,7 +108,7 @@ The existing auto-follow JS is routed to whichever `ChapterWebView` corresponds 
 - The audio locator carries chapter href + progression
 - `ContinuousReaderView` routes highlight injection to the matching `ChapterWebView`
 - When readaloud crosses a chapter boundary, the highlight is cleared from the departing `ChapterWebView` and re-injected into the arriving one
-- The chapter must be in the current window (within ±1 of current) — if it isn't, the window shifts to include it
+- The chapter must be in the current window (within ±1 of current) — if it isn't (e.g. audio has raced ahead of the reading position), the highlight is suppressed rather than shifting the reading window, to avoid disrupting the user's scroll position
 
 ### Search result navigation
 


### PR DESCRIPTION
## What

Adds a third reading mode — **Continuous** (endless vertical scroll across the whole book) — alongside the existing **Paginated** (`Horizontal`) and **Scroll** (`Vertical`) modes. Continuous renders each chapter in its own `ChapterWebView` (internal scroll disabled, fixed to measured content height), stacked in a sliding window inside a parent `NestedScrollView` (`ContinuousReaderView`). Chapters are styled with the exact same ReadiumCSS + bundled fonts Readium injects, so type, headings, margins, and theme match Scroll mode by construction.

## Architecture / isolation

New, self-contained classes (continuous-only, never instantiated in the other modes):
- `ContinuousReaderView` — windowed stack + scroll ownership + position tracking
- `ChapterWebView` — per-chapter WebView (XHTML serving, height measurement, selection menu, footnotes)
- `ContinuousStyleInjector` — ReadiumCSS + `--USER__*` injection
- `ContinuousPositionTracker` — pure scroll↔(chapter, progression) math (unit-tested)

The mode is gated everywhere by `isContinuous = orientation == ReaderOrientation.Continuous`. In `EpubReaderScreen`, every navigation/decoration effect early-returns or branches on `isContinuous`, leaving the Paginated/Scroll paths byte-identical. The boolean rewrites (`!= Vertical` → `== Horizontal`, `== Vertical` → `!= Horizontal`) preserve both existing enum values exactly — only the new `Continuous` value resolves differently. The Readium fragment is kept alive but collapsed to a zero-height, invisible server-keeper in Continuous mode.

## Notable fixes in this branch

- Chapter-height measurement uses true content extent (body bottom + `:root` padding), not viewport-clamped `documentElement.scrollHeight` — fixes large blank gaps after short/divider chapters.
- Fling velocity capped to 60% of platform max to keep per-frame raster-tile demand within Chromium's tile budget (the `tile memory limits exceeded` blank-page class).
- Far TOC/chapter-map jumps land via the same slot-based math as in-window jumps (accurate landing), with a fallback so the initial scroll can never hang on async measurements.
- Saved position no longer drifts on reopen: restore is now the exact inverse of `locatorAt` (midpoint-based), unit-tested for round-trip.
- Footnote popups, selection toolbar anchoring, internal-link handling (no immersive flip), and readaloud "Play from here" (chapter-scoped) all wired for Continuous mode.
- **Reverted** a cross-mode `textAlign` change (justify-off → `START`) back to `null` so Paginated/Scroll keep preserving publisher text-align — Continuous sets its own text-align independently.

## Testing

- `./gradlew test` — green (unit + integration, all modules)
- `./gradlew lint` — green
- `make harness-test` — 209 instrumented tests, 0 failed (5 skipped)
- `make harness-test-tablet` — 5 `@TabletLayout` tests, 0 failed
- New unit tests: `ContinuousPositionTrackerTest` (incl. resume round-trip / no-drift), `ContinuousStyleInjectorTest`

The harness suite caught a regression mid-finalize (`justifyTextFalseMapsToNullTextAlign`); fixed by the `textAlign` revert above and re-run green.
