### PR TITLE
perf(player): eliminate readaloud↔audiobook first-switch gap

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookController.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookController.kt
@@ -10,6 +10,7 @@ import androidx.media3.common.Player
 import androidx.media3.session.MediaController
 import androidx.media3.session.SessionToken
 import com.riffle.app.feature.reader.readaloud.AudioPlayerService
+import com.riffle.app.feature.reader.readaloud.ReadaloudController.Companion.HANDOFF
 import com.riffle.app.feature.reader.readaloud.SharedBundle
 import com.riffle.core.domain.AudiobookTrackSpan
 import com.riffle.core.domain.AudiobookTracks
@@ -78,6 +79,9 @@ open class AudiobookController @Inject constructor(
 
     private val listener = object : Player.Listener {
         override fun onEvents(player: Player, events: Player.Events) {
+            if (events.containsAny(Player.EVENT_PLAYBACK_STATE_CHANGED)) {
+                Log.d(HANDOFF, "AB.onPlaybackStateChanged state=${player.playbackState} isPlaying=${player.isPlaying}")
+            }
             maybeStart(player)
             pushState()
         }
@@ -98,6 +102,8 @@ open class AudiobookController @Inject constructor(
         localZipFile: File? = null,
         coverUri: String? = null,
     ) {
+        Log.d(HANDOFF, "AB.prepare start (controller already connected=${controller != null})")
+        val t0 = System.currentTimeMillis()
         this.spans = spans
         this.durationSec = durationSec
         // Bundle-backed audio: the track mediaIds are zip-entry paths the service reads from this file
@@ -106,6 +112,7 @@ open class AudiobookController @Inject constructor(
         ownsSharedBundle = localZipFile != null
         if (localZipFile != null) SharedBundle.current = localZipFile
         val c = ensureConnected() ?: return
+        Log.d(HANDOFF, "AB.prepare ensureConnected +${System.currentTimeMillis() - t0}ms")
         val metadata = androidx.media3.common.MediaMetadata.Builder()
             .apply { if (coverUri != null) setArtworkUri(android.net.Uri.parse(coverUri)) }
             .build()
@@ -118,6 +125,7 @@ open class AudiobookController @Inject constructor(
         val start = AudiobookTracks.startPositionFor(startAtSec, durationSec, spans)
         c.setMediaItems(items, start.trackIndex, start.offsetMs)
         c.prepare()
+        Log.d(HANDOFF, "AB.prepare setMediaItems+prepare +${System.currentTimeMillis() - t0}ms")
         prepared = true
         // If the user pressed play before preparation finished, honour it now — but only once the
         // player is ready (see [ResumePlaybackGate]); otherwise the listener starts it on STATE_READY.
@@ -250,6 +258,7 @@ open class AudiobookController @Inject constructor(
      * in ~0 ms instead of paying a full [MediaController.Builder.buildAsync] round-trip each time.
      */
     fun releaseForHandoff() {
+        Log.d(HANDOFF, "AB.releaseForHandoff (T0 — audio pausing)")
         cancelSleepTimer()
         pollJob?.cancel()
         pollJob = null

--- a/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookController.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookController.kt
@@ -79,7 +79,7 @@ open class AudiobookController @Inject constructor(
 
     private val listener = object : Player.Listener {
         override fun onEvents(player: Player, events: Player.Events) {
-            if (events.containsAny(Player.EVENT_PLAYBACK_STATE_CHANGED)) {
+            if (events.containsAny(Player.EVENT_PLAYBACK_STATE_CHANGED, Player.EVENT_IS_PLAYING_CHANGED)) {
                 Log.d(HANDOFF, "AB.onPlaybackStateChanged state=${player.playbackState} isPlaying=${player.isPlaying}")
             }
             maybeStart(player)
@@ -131,6 +131,15 @@ open class AudiobookController @Inject constructor(
         // player is ready (see [ResumePlaybackGate]); otherwise the listener starts it on STATE_READY.
         maybeStart(c)
         pushState()
+    }
+
+    /**
+     * Establishes the [MediaController] binder connection without touching media items. Call during
+     * pre-warm so the first swipe-up pays ~0 ms instead of the full [MediaController.Builder.buildAsync]
+     * round-trip (ADR 0032).
+     */
+    open suspend fun warmBinder() {
+        ensureConnected()
     }
 
     open fun play() {

--- a/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookController.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookController.kt
@@ -65,6 +65,7 @@ open class AudiobookController @Inject constructor(
     private var timerJob: Job? = null
 
     private var controller: MediaController? = null
+    private var listenerAttached = false
     private var pollJob: Job? = null
     private var spans: List<AudiobookTrackSpan> = emptyList()
     private var durationSec: Double = 0.0
@@ -226,6 +227,7 @@ open class AudiobookController @Inject constructor(
             release()
         }
         controller = null
+        listenerAttached = false
         spans = emptyList()
         prepared = false
         wantsToPlay = false
@@ -243,6 +245,9 @@ open class AudiobookController @Inject constructor(
      * the audiobook goes silent immediately, but does NOT `stop()`/`clearMediaItems()`: readaloud's
      * own `setMediaItems` replaces the queue, and clearing here would kill the readaloud playback that
      * is about to start (the "swipe down pauses readaloud" bug). Leaves the bundle for readaloud.
+     *
+     * Keeps the [MediaController] Binder connection alive (ADR 0032) so the incoming side reconnects
+     * in ~0 ms instead of paying a full [MediaController.Builder.buildAsync] round-trip each time.
      */
     fun releaseForHandoff() {
         cancelSleepTimer()
@@ -252,9 +257,8 @@ open class AudiobookController @Inject constructor(
             setVolume(1f)
             pause()
             removeListener(listener)
-            release()
         }
-        controller = null
+        listenerAttached = false
         spans = emptyList()
         prepared = false
         wantsToPlay = false
@@ -263,15 +267,20 @@ open class AudiobookController @Inject constructor(
     }
 
     private suspend fun ensureConnected(): MediaController? {
-        controller?.let { return it }
-        val context = this.context ?: return null
-        val token = SessionToken(context, ComponentName(context, AudioPlayerService::class.java))
-        val future = MediaController.Builder(context, token).buildAsync()
-        val c = suspendCancellableCoroutine<MediaController?> { cont ->
-            future.addListener({ cont.resume(runCatching { future.get() }.getOrNull()) }, ContextCompat.getMainExecutor(context))
+        val c = controller ?: run {
+            val context = this.context ?: return null
+            val token = SessionToken(context, ComponentName(context, AudioPlayerService::class.java))
+            val future = MediaController.Builder(context, token).buildAsync()
+            val newC = suspendCancellableCoroutine<MediaController?> { cont ->
+                future.addListener({ cont.resume(runCatching { future.get() }.getOrNull()) }, ContextCompat.getMainExecutor(context))
+            }
+            controller = newC
+            newC
         }
-        c?.addListener(listener)
-        controller = c
+        if (!listenerAttached && c != null) {
+            c.addListener(listener)
+            listenerAttached = true
+        }
         pushState()
         return c
     }

--- a/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookHandoffState.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookHandoffState.kt
@@ -1,0 +1,48 @@
+package com.riffle.app.feature.audiobook
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Coordinates the pre-warmed audiobook overlay lifecycle.
+ *
+ * [signal] is emitted by [com.riffle.app.feature.reader.EpubReaderViewModel] when the user
+ * completes the swipe-up gesture; the pre-warmed [AudiobookPlayerViewModel] collects it to
+ * activate (prepare controller + start playing from the given position).
+ *
+ * [dismiss] is emitted when the user presses back on the overlay without a swipe-down handoff;
+ * [AudiobookPlayerViewModel] pauses the controller so audiobook audio stops while the reader
+ * is visible.
+ *
+ * Both are [StateFlow] so the signal is never missed even if the VM's collector hasn't started
+ * yet when the event fires (the collector sees the current non-null value immediately).
+ */
+@Singleton
+class AudiobookHandoffState @Inject constructor() {
+    private val _pendingHandoff = MutableStateFlow<HandoffSignal?>(null)
+    val pendingHandoff: StateFlow<HandoffSignal?> = _pendingHandoff.asStateFlow()
+
+    private val _pendingDismiss = MutableStateFlow<String?>(null)
+    val pendingDismiss: StateFlow<String?> = _pendingDismiss.asStateFlow()
+
+    fun signal(itemId: String, atSec: Double) {
+        _pendingHandoff.value = HandoffSignal(itemId, atSec)
+    }
+
+    fun consumeHandoff() {
+        _pendingHandoff.value = null
+    }
+
+    fun dismiss(itemId: String) {
+        _pendingDismiss.value = itemId
+    }
+
+    fun consumeDismiss() {
+        _pendingDismiss.value = null
+    }
+
+    data class HandoffSignal(val itemId: String, val atSec: Double)
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerScreen.kt
@@ -171,7 +171,10 @@ fun AudiobookPlayerScreen(
                     .pointerInput(Unit) {
                         var total = 0f
                         detectVerticalDragGestures(
-                            onDragStart = { total = 0f },
+                            // Pre-warm readaloud the moment a downward drag starts (ADR 0032):
+                            // resolves the SMIL seek target while the user is still dragging so
+                            // playFromSecond() fires instantly when the threshold is reached.
+                            onDragStart = { total = 0f; viewModel.hintReadaloudHandoff() },
                             onVerticalDrag = { change, dragAmount -> total += dragAmount; change.consume() },
                             onDragEnd = {
                                 val s = latestState.value
@@ -181,6 +184,8 @@ fun AudiobookPlayerScreen(
                                     // navigating, so readaloud keeps playing through the handoff.
                                     viewModel.prepareReadaloudHandoff()
                                     onSwitchToReadaloud(ebookId, s.positionSec)
+                                } else {
+                                    viewModel.cancelHandoffHint()
                                 }
                             },
                         )

--- a/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModel.kt
@@ -145,6 +145,7 @@ class AudiobookPlayerViewModel(
     private val serverRepository: ServerRepository,
     private val tokenStorage: TokenStorage,
     private val controller: AudiobookController,
+    private val readaloudController: com.riffle.app.feature.reader.readaloud.ReadaloudController,
     private val audioPlaybackPreferencesStore: AudioPlaybackPreferencesStore,
     private val listeningPreferencesStore: ListeningPreferencesStore,
     private val audioIdentityResolver: AudioIdentityResolver,
@@ -184,6 +185,7 @@ class AudiobookPlayerViewModel(
         serverRepository: ServerRepository,
         tokenStorage: TokenStorage,
         controller: AudiobookController,
+        readaloudController: com.riffle.app.feature.reader.readaloud.ReadaloudController,
         audioPlaybackPreferencesStore: AudioPlaybackPreferencesStore,
         listeningPreferencesStore: ListeningPreferencesStore,
         audioIdentityResolver: AudioIdentityResolver,
@@ -208,6 +210,7 @@ class AudiobookPlayerViewModel(
         serverRepository,
         tokenStorage,
         controller,
+        readaloudController,
         audioPlaybackPreferencesStore,
         listeningPreferencesStore,
         audioIdentityResolver,
@@ -819,6 +822,20 @@ class AudiobookPlayerViewModel(
     // would pause the readaloud playback that just started). We save progress + release the handle
     // here instead.
     private var handingOffToReadaloud = false
+
+    /**
+     * Called when the user starts dragging down (before the threshold). Pre-resolves the SMIL seek
+     * target so [playFromSecond] in [ReadaloudController] can skip the computation at commit time
+     * (ADR 0032). No-op when no readaloud track is loaded (audiobook-only session).
+     */
+    fun hintReadaloudHandoff() {
+        readaloudController.preWarmSeek(controller.currentAbsoluteSec())
+    }
+
+    /** Discard the pre-warm if the drag was abandoned without crossing the threshold. */
+    fun cancelHandoffHint() {
+        readaloudController.cancelPreWarm()
+    }
 
     /**
      * Prepare to switch to the readaloud reader: persist the just-reached listen position (so the

--- a/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModel.kt
@@ -394,13 +394,10 @@ class AudiobookPlayerViewModel(
             val item = libraryRepository.getItem(itemId)
             // Prefer a dedicated audiobook download, then a downloaded readaloud bundle's audio, then
             // stream from ABS (connectivity-independent: a local copy always beats streaming).
-            val t0Session = System.currentTimeMillis()
-            android.util.Log.d(com.riffle.app.feature.reader.readaloud.ReadaloudController.HANDOFF, "AB.VM prepare start (startAtSec=$startAtSec)")
             val session = if (serverId.isEmpty()) null
                 else audiobookDownloadRepository.localSession(serverId, itemId)
                     ?: bundleAudiobookSource.localSession(serverId, itemId)
                     ?: audiobookRepository.openSession(serverId, itemId)
-            android.util.Log.d(com.riffle.app.feature.reader.readaloud.ReadaloudController.HANDOFF, "AB.VM session resolved +${System.currentTimeMillis() - t0Session}ms (local=${session?.localZipFile != null})")
             if (item == null || session == null) {
                 meta.value = meta.value.copy(loading = false, failed = true)
                 return@launch

--- a/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModel.kt
@@ -19,6 +19,8 @@ import com.riffle.core.domain.TokenStorage
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
@@ -167,6 +169,7 @@ class AudiobookPlayerViewModel(
     private val progressFlushScope: com.riffle.app.feature.reader.ProgressFlushScope,
     private val bookmarkStore: AudiobookBookmarkStore,
     private val connectivityObserver: com.riffle.core.domain.ConnectivityObserver,
+    private val audiobookHandoffState: AudiobookHandoffState,
     // Wall-clock for bookmark stamps (createdAt + dirty); a () -> Long for deterministic tests, the
     // established clock-injection pattern in this codebase (e.g. ReadaloudMatchingService).
     private val now: () -> Long = System::currentTimeMillis,
@@ -201,6 +204,7 @@ class AudiobookPlayerViewModel(
         progressFlushScope: com.riffle.app.feature.reader.ProgressFlushScope,
         bookmarkStore: AudiobookBookmarkStore,
         connectivityObserver: com.riffle.core.domain.ConnectivityObserver,
+        audiobookHandoffState: AudiobookHandoffState,
     ) : this(
         savedStateHandle,
         audiobookRepository,
@@ -226,13 +230,25 @@ class AudiobookPlayerViewModel(
         progressFlushScope,
         bookmarkStore,
         connectivityObserver,
+        audiobookHandoffState,
         System::currentTimeMillis,
     )
 
     private val itemId: String = savedStateHandle.get<String>("itemId") ?: ""
 
-    // readaloud→audiobook swipe handoff: the listen position to continue from (-1 = opened normally).
+    // readaloud→audiobook swipe handoff: the listen position to continue from.
+    // -2 = PREWARM_SENTINEL: pre-warm mode (overlay always-mounted, actual position arrives via
+    //      AudiobookHandoffState when the user swipes up — controller.prepare() is deferred).
+    // -1 = normal resume from saved position.
+    // ≥0 = explicit start second (handoff from the standalone reader path).
     private val startAtSec: Double = (savedStateHandle.get<Float>("startAtSec") ?: -1f).toDouble()
+
+    // Stored during pre-warm init so activateFromHandoff() can prepare the controller without
+    // re-fetching. Set even in normal-open mode so re-activations (second+ swipe-up) can
+    // re-prepare the controller after releaseForHandoff() clears the spans.
+    private var resolvedSession: com.riffle.core.domain.AudiobookSession? = null
+    private var resolvedCoverUri: String? = null
+    private var resolvedInitialSpeed: Float = 1f
 
     private val meta = MutableStateFlow(
         AudiobookPlayerUiState(loading = true),
@@ -535,45 +551,82 @@ class AudiobookPlayerViewModel(
                     playbackStartSec = (resumeSec - rewindOnResume).coerceAtLeast(0.0)
                 }
             }
-            // Resume at the server-recorded position (last-update-wins resume; ADR 0029) so the
-            // audio-led canonical never starts behind.
-            controller.prepare(
-                trackUrls = session.trackUrls,
-                spans = session.tracks,
-                durationSec = session.timeline.durationSec,
-                startAtSec = playbackStartSec,
-                localZipFile = session.localZipFile,
-                coverUri = item.coverUrl,
-            )
-            // Record the active session so a media-notification tap reopens this audiobook player.
-            nowPlayingStore.set(com.riffle.app.playback.NowPlaying.Audiobook(itemId))
-            // Apply the persisted per-book speed to the freshly-prepared (singleton) controller, which
-            // would otherwise retain the previous book's speed. Set directly on the controller (not the
-            // VM's setSpeed) so restoring the saved value doesn't re-save it.
-            controller.setSpeed(initialSpeed)
-            reconciledResumeSec = resumeSec
-            localUpdatedAt = resumeStamp
-            // Opening the player is itself a "play" intent (the user tapped Listen), so start playback
-            // immediately rather than landing on a paused player. A genuinely-newer remote resume is
-            // still honoured: attachReaderSync's inbound-only reconcile seeks the already-playing
-            // position to the reconciled point (ADR 0029).
-            controller.play()
 
-            // The cross-EPUB index build (needed for the full ebook-sync coordinator) is self-healed by
-            // ReaderSyncFactory.createIfApplicable below: if the bundle is present but the index isn't
-            // built yet, it enqueues the build there — so this open is itself the player-open retry path
-            // (ADR 0031). No explicit enqueue needed here.
+            // Store resolved data so handoff activations (first swipe-up or re-activations after
+            // a swipe-down) can re-prepare the controller without re-fetching (ADR 0032).
+            resolvedSession = session
+            resolvedCoverUri = item.coverUrl
+            resolvedInitialSpeed = initialSpeed
 
-            // Attach the matched 2-peer cycle if its prerequisites are already cached (the follow loop
-            // re-attaches later if the index is still building). Seed it with the reconciled resume so
-            // a genuinely-newer local listen can lead the first cycle. Use resumeStamp (== resumeUpdatedAt
-            // normally, but the fresh now-stamp on a readaloud→audiobook handoff) so the handed-off
-            // position leads the first cycle instead of being pulled back to a stale server position.
-            attachReaderSync(resumeSec, resumeStamp)
-            // Always run the follow loop so the listen position reaches ABS while playing — in the
-            // matched case it drives both ABS peers (audio-led), otherwise it pushes the single ABS
-            // audiobook record (ADR 0029). Without this a plain audiobook only synced on pause/close.
-            startFollowLoop()
+            if (startAtSec != PREWARM_SENTINEL) {
+                // Normal open or readaloud→audiobook handoff via nav arg: prepare and play now.
+                // Resume at the server-recorded position (last-update-wins resume; ADR 0029).
+                controller.prepare(
+                    trackUrls = session.trackUrls,
+                    spans = session.tracks,
+                    durationSec = session.timeline.durationSec,
+                    startAtSec = playbackStartSec,
+                    localZipFile = session.localZipFile,
+                    coverUri = item.coverUrl,
+                )
+                // Record the active session so a media-notification tap reopens this audiobook player.
+                nowPlayingStore.set(com.riffle.app.playback.NowPlaying.Audiobook(itemId))
+                // Apply the persisted per-book speed to the freshly-prepared (singleton) controller,
+                // which would otherwise retain the previous book's speed. Set directly on the controller
+                // (not the VM's setSpeed) so restoring the saved value doesn't re-save it.
+                controller.setSpeed(initialSpeed)
+                reconciledResumeSec = resumeSec
+                localUpdatedAt = resumeStamp
+                // Opening the player is itself a "play" intent (the user tapped Listen), so start
+                // playback immediately rather than landing on a paused player. A genuinely-newer remote
+                // resume is still honoured: attachReaderSync's inbound-only reconcile seeks the
+                // already-playing position to the reconciled point (ADR 0029).
+                controller.play()
+
+                // The cross-EPUB index build (needed for the full ebook-sync coordinator) is self-healed
+                // by ReaderSyncFactory.createIfApplicable below: if the bundle is present but the index
+                // isn't built yet, it enqueues the build there — so this open is itself the player-open
+                // retry path (ADR 0031). No explicit enqueue needed here.
+
+                // Attach the matched 2-peer cycle if its prerequisites are already cached (the follow
+                // loop re-attaches later if the index is still building). Seed it with the reconciled
+                // resume so a genuinely-newer local listen can lead the first cycle. Use resumeStamp
+                // (== resumeUpdatedAt normally, but the fresh now-stamp on a readaloud→audiobook
+                // handoff) so the handed-off position leads the first cycle.
+                attachReaderSync(resumeSec, resumeStamp)
+                // Always run the follow loop so the listen position reaches ABS while playing — in the
+                // matched case it drives both ABS peers (audio-led), otherwise it pushes the single ABS
+                // audiobook record (ADR 0029). Without this a plain audiobook only synced on pause/close.
+                startFollowLoop()
+            }
+            // PREWARM_SENTINEL: controller.prepare() is intentionally skipped here. The handoff
+            // watcher below receives the actual start position when the user swipes up.
+        }
+
+        // Watch for the swipe-up handoff signal from EpubReaderViewModel. Runs in all modes so
+        // re-activations (second+ swipe-up after a swipe-down) also work.
+        viewModelScope.launch {
+            audiobookHandoffState.pendingHandoff
+                .filterNotNull()
+                .filter { it.itemId == itemId }
+                .collect { signal ->
+                    audiobookHandoffState.consumeHandoff()
+                    activateFromHandoff(signal.atSec)
+                }
+        }
+
+        // Watch for the overlay-dismissed signal (back button without a swipe-down handoff).
+        // Pause the controller so audiobook audio stops while the reader is visible.
+        viewModelScope.launch {
+            audiobookHandoffState.pendingDismiss
+                .filterNotNull()
+                .filter { it == itemId }
+                .collect {
+                    audiobookHandoffState.consumeDismiss()
+                    followJob?.cancel()
+                    followJob = null
+                    controller.pause()
+                }
         }
 
         // End-of-chapter sleep timer: fire when chapter index advances while EoC mode is active.
@@ -845,8 +898,42 @@ class AudiobookPlayerViewModel(
     fun prepareReadaloudHandoff() {
         if (handingOffToReadaloud) return
         handingOffToReadaloud = true
+        // Cancel the follow loop now (VM stays alive in the always-mounted overlay, so onCleared
+        // won't do this until the user exits the reader entirely).
+        followJob?.cancel()
+        followJob = null
         pushProgressOnStop()
         controller.releaseForHandoff()
+    }
+
+    /**
+     * Prepare and start the audiobook controller from [atSec] on the concatenated timeline.
+     * Called by the handoff watcher when the user swipes up (for both first activation from
+     * pre-warm state and subsequent re-activations after a swipe-down).
+     */
+    private suspend fun activateFromHandoff(atSec: Double) {
+        val session = resolvedSession ?: return
+        handingOffToReadaloud = false
+        val finalSec = atSec.coerceIn(0.0, session.timeline.durationSec)
+        controller.prepare(
+            trackUrls = session.trackUrls,
+            spans = session.tracks,
+            durationSec = session.timeline.durationSec,
+            startAtSec = finalSec,
+            localZipFile = session.localZipFile,
+            coverUri = resolvedCoverUri,
+        )
+        controller.setSpeed(resolvedInitialSpeed)
+        reconciledResumeSec = finalSec
+        localUpdatedAt = System.currentTimeMillis()
+        if (serverId.isNotEmpty()) {
+            audiobookPositionStore.save(serverId, itemId, finalSec)
+            audiobookPositionStore.updateLocalTimestamp(serverId, itemId, localUpdatedAt)
+        }
+        nowPlayingStore.set(com.riffle.app.playback.NowPlaying.Audiobook(itemId))
+        controller.play()
+        attachReaderSync(finalSec, localUpdatedAt)
+        startFollowLoop()
     }
 
     private fun saveProgress() {
@@ -888,5 +975,8 @@ class AudiobookPlayerViewModel(
         // (covers a seek/buffer landing within a tick); anything further behind is a transient that
         // must not lead. Small, so a genuine book-start 0 can never drive the ebook.
         const val SETTLE_EPS_SEC = 3.0
+        // Sentinel for startAtSec: the overlay is always mounted for pre-warming; the actual start
+        // position arrives via AudiobookHandoffState when the user swipes up.
+        const val PREWARM_SENTINEL = -2.0
     }
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModel.kt
@@ -394,10 +394,13 @@ class AudiobookPlayerViewModel(
             val item = libraryRepository.getItem(itemId)
             // Prefer a dedicated audiobook download, then a downloaded readaloud bundle's audio, then
             // stream from ABS (connectivity-independent: a local copy always beats streaming).
+            val t0Session = System.currentTimeMillis()
+            android.util.Log.d(com.riffle.app.feature.reader.readaloud.ReadaloudController.HANDOFF, "AB.VM prepare start (startAtSec=$startAtSec)")
             val session = if (serverId.isEmpty()) null
                 else audiobookDownloadRepository.localSession(serverId, itemId)
                     ?: bundleAudiobookSource.localSession(serverId, itemId)
                     ?: audiobookRepository.openSession(serverId, itemId)
+            android.util.Log.d(com.riffle.app.feature.reader.readaloud.ReadaloudController.HANDOFF, "AB.VM session resolved +${System.currentTimeMillis() - t0Session}ms (local=${session?.localZipFile != null})")
             if (item == null || session == null) {
                 meta.value = meta.value.copy(loading = false, failed = true)
                 return@launch

--- a/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModel.kt
@@ -1,5 +1,6 @@
 package com.riffle.app.feature.audiobook
 
+import android.util.Log
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -26,7 +27,9 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeoutOrNull
 import javax.inject.Inject
 
 /**
@@ -247,6 +250,9 @@ class AudiobookPlayerViewModel(
     // re-fetching. Set even in normal-open mode so re-activations (second+ swipe-up) can
     // re-prepare the controller after releaseForHandoff() clears the spans.
     private var resolvedSession: com.riffle.core.domain.AudiobookSession? = null
+    // Completed (with the session or null on failure) when init finishes, so activateFromHandoff()
+    // can await rather than drop when a swipe arrives before the ~1–2 s bundle-session fetch is done.
+    private val sessionDeferred = CompletableDeferred<com.riffle.core.domain.AudiobookSession?>()
     private var resolvedCoverUri: String? = null
     private var resolvedInitialSpeed: Float = 1f
 
@@ -383,6 +389,9 @@ class AudiobookPlayerViewModel(
 
     init {
         viewModelScope.launch {
+            try {
+            val t0 = System.currentTimeMillis()
+            log("AB.VM init start itemId=$itemId startAtSec=$startAtSec")
             val server = serverRepository.getActive()
             serverId = server?.id ?: ""
             // Claim this audiobook so the durable sweep leaves it to this player's own cycle (ADR 0030).
@@ -407,14 +416,20 @@ class AudiobookPlayerViewModel(
                 }
             }
             val token = server?.let { tokenStorage.getToken(it.id) } ?: ""
+            log("AB.VM init: got server +${System.currentTimeMillis() - t0}ms")
             val item = libraryRepository.getItem(itemId)
+            log("AB.VM init: got item +${System.currentTimeMillis() - t0}ms")
             // Prefer a dedicated audiobook download, then a downloaded readaloud bundle's audio, then
             // stream from ABS (connectivity-independent: a local copy always beats streaming).
             val session = if (serverId.isEmpty()) null
                 else audiobookDownloadRepository.localSession(serverId, itemId)
+                    ?.also { log("AB.VM init: local download session +${System.currentTimeMillis() - t0}ms") }
                     ?: bundleAudiobookSource.localSession(serverId, itemId)
+                    ?.also { log("AB.VM init: bundle session +${System.currentTimeMillis() - t0}ms") }
                     ?: audiobookRepository.openSession(serverId, itemId)
+                    ?.also { log("AB.VM init: ABS network session +${System.currentTimeMillis() - t0}ms") }
             if (item == null || session == null) {
+                log("AB.VM init: FAILED (item=${item != null} session=${session != null}) +${System.currentTimeMillis() - t0}ms")
                 meta.value = meta.value.copy(loading = false, failed = true)
                 return@launch
             }
@@ -555,10 +570,18 @@ class AudiobookPlayerViewModel(
             // Store resolved data so handoff activations (first swipe-up or re-activations after
             // a swipe-down) can re-prepare the controller without re-fetching (ADR 0032).
             resolvedSession = session
+            sessionDeferred.complete(session)
             resolvedCoverUri = item.coverUrl
             resolvedInitialSpeed = initialSpeed
+            log("AB.VM init: resolvedSession ready +${System.currentTimeMillis() - t0}ms (startAtSec=$startAtSec)")
 
-            if (startAtSec != PREWARM_SENTINEL) {
+            if (startAtSec == PREWARM_SENTINEL) {
+                // Pre-connect the binder now so the first swipe-up pays ~0 ms instead of the full
+                // MediaController.Builder.buildAsync round-trip (ADR 0032).
+                log("AB.VM init: warming binder +${System.currentTimeMillis() - t0}ms")
+                controller.warmBinder()
+                log("AB.VM init: binder warm +${System.currentTimeMillis() - t0}ms")
+            } else {
                 // Normal open or readaloud→audiobook handoff via nav arg: prepare and play now.
                 // Resume at the server-recorded position (last-update-wins resume; ADR 0029).
                 controller.prepare(
@@ -599,8 +622,14 @@ class AudiobookPlayerViewModel(
                 // audiobook record (ADR 0029). Without this a plain audiobook only synced on pause/close.
                 startFollowLoop()
             }
-            // PREWARM_SENTINEL: controller.prepare() is intentionally skipped here. The handoff
-            // watcher below receives the actual start position when the user swipes up.
+            // PREWARM_SENTINEL: controller.prepare() is intentionally deferred. The binder is
+            // pre-connected above; the handoff watcher below receives the actual start position
+            // when the user swipes up.
+            } finally {
+                // Guarantee the deferred is always completed so activateFromHandoff() never
+                // hangs on await() when init fails or returns early (e.g. missing item/session).
+                if (!sessionDeferred.isCompleted) sessionDeferred.complete(null)
+            }
         }
 
         // Watch for the swipe-up handoff signal from EpubReaderViewModel. Runs in all modes so
@@ -912,7 +941,16 @@ class AudiobookPlayerViewModel(
      * pre-warm state and subsequent re-activations after a swipe-down).
      */
     private suspend fun activateFromHandoff(atSec: Double) {
-        val session = resolvedSession ?: return
+        val t0 = System.currentTimeMillis()
+        log("AB.activateFromHandoff start atSec=$atSec resolvedSession=${resolvedSession != null}")
+        val session = resolvedSession ?: run {
+            // Init still running — await the bundle-session fetch rather than drop the handoff.
+            log("AB.activateFromHandoff: init in progress, awaiting session (up to 10s)")
+            withTimeoutOrNull(10_000L) { sessionDeferred.await() }
+        } ?: run {
+            log("AB.activateFromHandoff: DROPPED — session unavailable after waiting")
+            return
+        }
         handingOffToReadaloud = false
         val finalSec = atSec.coerceIn(0.0, session.timeline.durationSec)
         controller.prepare(
@@ -923,6 +961,7 @@ class AudiobookPlayerViewModel(
             localZipFile = session.localZipFile,
             coverUri = resolvedCoverUri,
         )
+        log("AB.activateFromHandoff: prepare() done +${System.currentTimeMillis() - t0}ms")
         controller.setSpeed(resolvedInitialSpeed)
         reconciledResumeSec = finalSec
         localUpdatedAt = System.currentTimeMillis()
@@ -932,6 +971,7 @@ class AudiobookPlayerViewModel(
         }
         nowPlayingStore.set(com.riffle.app.playback.NowPlaying.Audiobook(itemId))
         controller.play()
+        log("AB.activateFromHandoff: play() called +${System.currentTimeMillis() - t0}ms")
         attachReaderSync(finalSec, localUpdatedAt)
         startFollowLoop()
     }
@@ -978,5 +1018,8 @@ class AudiobookPlayerViewModel(
         // Sentinel for startAtSec: the overlay is always mounted for pre-warming; the actual start
         // position arrives via AudiobookHandoffState when the user swipes up.
         const val PREWARM_SENTINEL = -2.0
+        private const val HANDOFF = "RIFFLE_HANDOFF"
+        // android.util.Log is not available in JVM unit tests; swallow the RuntimeException.
+        fun log(msg: String) = try { Log.d(HANDOFF, msg) } catch (_: Throwable) { }
     }
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -298,14 +298,15 @@ fun EpubReaderScreen(
     // to edge and the nav bar floats over the last sliver of content. Padding would carve
     // out a solid strip behind the bar that doesn't blend with any reader theme — exactly
     // the "white/black bar" the user reported when exiting Immersive mode.
-    var audiobookOverlayItemId by rememberSaveable { mutableStateOf("") }
-    var audiobookOverlayStartAtSec by rememberSaveable { mutableStateOf(-1f) }
-    val showAudiobookOverlay = audiobookOverlayItemId.isNotEmpty()
+
+    // `showAudiobookOverlay` drives visibility; the overlay composable itself is always mounted
+    // when `audiobookItemId != null` so AudiobookPlayerViewModel pre-warms in the background.
+    var showAudiobookOverlay by rememberSaveable { mutableStateOf(false) }
 
     // Dismiss the audiobook overlay when the system back button is pressed, rather than
     // navigating back through the outer NavHost (which would exit the reader entirely).
     BackHandler(enabled = showAudiobookOverlay) {
-        audiobookOverlayItemId = ""
+        showAudiobookOverlay = false
         viewModel.onAudiobookOverlayDismissed()
     }
 
@@ -437,10 +438,9 @@ fun EpubReaderScreen(
                         handleColor = readerPalette.foreground,
                         enabled = audiobookItemId != null,
                         onSwipeUp = {
-                            audiobookItemId?.let { abId ->
-                                val sec = viewModel.prepareAudiobookHandoff()
-                                audiobookOverlayStartAtSec = sec.toFloat()
-                                audiobookOverlayItemId = abId
+                            if (audiobookItemId != null) {
+                                viewModel.prepareAudiobookHandoff()
+                                showAudiobookOverlay = true
                             }
                         },
                         onDragHint = { viewModel.hintAudiobookHandoff() },
@@ -577,17 +577,20 @@ fun EpubReaderScreen(
                 onDismiss = viewModel::dismissReturnTarget,
             )
         }
-        if (showAudiobookOverlay) {
+        // Always mount the overlay when an audiobook is linked so AudiobookPlayerViewModel
+        // can pre-warm (session open, metadata load) while the user reads. The overlay is
+        // rendered at size 0 when hidden, making it invisible and non-interactive.
+        audiobookItemId?.let { abItemId ->
             AudiobookPlayerOverlay(
-                itemId = audiobookOverlayItemId,
-                startAtSec = audiobookOverlayStartAtSec,
+                itemId = abItemId,
+                visible = showAudiobookOverlay,
                 windowSizeClass = windowSizeClass,
                 onDismiss = {
-                    audiobookOverlayItemId = ""
+                    showAudiobookOverlay = false
                     viewModel.onAudiobookOverlayDismissed()
                 },
                 onSwitchToReadaloud = { atSec ->
-                    audiobookOverlayItemId = ""
+                    showAudiobookOverlay = false
                     viewModel.startReadaloudAtSecond(atSec)
                 },
             )
@@ -2088,18 +2091,22 @@ private fun highlightTint(color: String): Int =
 @Composable
 private fun AudiobookPlayerOverlay(
     itemId: String,
-    startAtSec: Float,
+    visible: Boolean,
     windowSizeClass: WindowSizeClass,
     onDismiss: () -> Unit,
     onSwitchToReadaloud: (Double) -> Unit,
 ) {
     val navController = rememberNavController()
     val encoded = URLEncoder.encode(itemId, "UTF-8")
-    val startRoute = "overlay_audiobook/$encoded?startAtSec=$startAtSec"
+    // Always use the PREWARM_SENTINEL (-2f) so the NavBackStackEntry — and therefore
+    // AudiobookPlayerViewModel — is created once and kept alive between swipe-up/down cycles.
+    // The actual start position arrives via AudiobookHandoffState when the overlay is revealed.
+    val startRoute = "overlay_audiobook/$encoded?startAtSec=-2.0"
     NavHost(
         navController = navController,
         startDestination = startRoute,
-        modifier = Modifier.fillMaxSize(),
+        // size(0.dp) renders but hides the composable; fillMaxSize when shown.
+        modifier = if (visible) Modifier.fillMaxSize() else Modifier.size(0.dp),
     ) {
         composable(
             route = "overlay_audiobook/{itemId}?startAtSec={startAtSec}",
@@ -2107,7 +2114,7 @@ private fun AudiobookPlayerOverlay(
                 navArgument("itemId") { type = NavType.StringType },
                 navArgument("startAtSec") {
                     type = NavType.FloatType
-                    defaultValue = -1f
+                    defaultValue = -2f
                 },
             ),
         ) {

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -422,6 +422,8 @@ fun EpubReaderScreen(
                                 onSwitchToAudiobook(abId, sec)
                             }
                         },
+                        onDragHint = { viewModel.hintAudiobookHandoff() },
+                        onDragAbandoned = { viewModel.cancelHandoffHint() },
                     ) {
                         ReadaloudMiniPlayer(
                             isPlaying = playbackState.isPlaying,

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -311,6 +311,7 @@ fun EpubReaderScreen(
                         viewModel.onPanelStateChanged(tocVisible || showFormattingPanel)
                     }
                     EpubNavigatorView(
+                        viewModel = viewModel,
                         state = s,
                         formattingPrefs = formattingPrefs,
                         onPositionChanged = { locator ->
@@ -886,6 +887,7 @@ internal fun readaloudLocatorJson(ref: String, quote: SentenceQuote?): JSONObjec
 @OptIn(ExperimentalReadiumApi::class)
 @Composable
 private fun EpubNavigatorView(
+    viewModel: EpubReaderViewModel,
     state: ReaderState.Ready,
     formattingPrefs: FormattingPreferences,
     onPositionChanged: (Locator) -> Unit,
@@ -921,10 +923,13 @@ private fun EpubNavigatorView(
     val isLandscape = LocalConfiguration.current.orientation == Configuration.ORIENTATION_LANDSCAPE
     val isFixedLayout = state.publication.metadata.layout == Layout.FIXED
     val coroutineScope = rememberCoroutineScope()
-    val fragmentRef = remember { mutableStateOf<EpubNavigatorFragment?>(null) }
-    val containerRef = remember { mutableStateOf<ScrollBoundaryNavigationContainer?>(null) }
     val continuousViewRef = remember { mutableStateOf<ContinuousReaderView?>(null) }
     val isContinuous = formattingPrefs.orientation == ReaderOrientation.Continuous
+    // Initialize from the ViewModel cache so the fragment/view survive composable removal while
+    // the reader is in the back stack behind the audiobook player. On back-stack return the
+    // factory returns the same ScrollBoundaryNavigationContainer (WebView intact, no reload).
+    val fragmentRef = remember { mutableStateOf(viewModel.savedNavigatorFragment) }
+    val containerRef = remember { mutableStateOf(viewModel.savedNavigatorContainer as? ScrollBoundaryNavigationContainer) }
     // Covers the reader with a plain page-coloured screen while a cross-resource jump (TOC/search)
     // loads the new chapter. Readium briefly paints the new resource's opener (a figure/graphic) or
     // a white blank before scrolling to the target, and the column-snap nudges the page a beat after;
@@ -934,8 +939,9 @@ private fun EpubNavigatorView(
     // navigation callbacks. Using a plain array avoids triggering recomposition on scroll.
     val currentHrefHolder = remember { arrayOf<String?>(null) }
     // Tracks the isDoublePage value the current fragment was created with; null = no fragment.
+    // Initialized from the ViewModel so back-stack returns don't re-create a still-valid fragment.
     // Plain array (not MutableState) to avoid triggering recomposition.
-    val fragmentDoublePageHolder = remember { arrayOf<Boolean?>(null) }
+    val fragmentDoublePageHolder = remember { arrayOf(viewModel.savedNavigatorFragmentIsDoublePage) }
     val currentFormattingPrefs by rememberUpdatedState(formattingPrefs)
 
     // rememberUpdatedState ensures the listener always calls the latest onTap lambda
@@ -1735,22 +1741,34 @@ private fun EpubNavigatorView(
         }
         AndroidView(
             factory = { ctx ->
-                ScrollBoundaryNavigationContainer(ctx).apply {
-                    // Compose handles all inset-based padding (navigationBarsPadding on the outer
-                    // Box, TopAppBarDefaults.windowInsets on the floating TopAppBar). Consuming
-                    // insets here prevents Readium's WebViews from applying status-bar padding,
-                    // which on physical devices remains non-zero even after controller.hide().
-                    ViewCompat.setOnApplyWindowInsetsListener(this) { _, _ -> WindowInsetsCompat.CONSUMED }
-                    onPullStarted = { fwd ->
-                        pullForward = fwd
-                        pullProgress = 0f
-                        pullActive = true
-                    }
-                    onPullEnded = { pullActive = false }
-                    onPullProgress = { p -> pullProgress = p }
-                    val fragmentContainer = FragmentContainerView(ctx).apply { id = containerId }
-                    addView(fragmentContainer, FrameLayout.LayoutParams(FrameLayout.LayoutParams.MATCH_PARENT, FrameLayout.LayoutParams.MATCH_PARENT))
-                }.also { containerRef.value = it }
+                // Reuse the cached container (and its WebView) when returning from the audiobook
+                // player's back stack entry. The view was removed from the Compose hierarchy (but
+                // kept alive by the ViewModel) while the audiobook was on top; re-adding it here
+                // re-attaches the Fragment's view to the window without recreating the WebView.
+                // Context identity check detects Activity recreation (rotation) and falls through
+                // to create a fresh container in that case.
+                val cached = viewModel.savedNavigatorContainer as? ScrollBoundaryNavigationContainer
+                val container = if (cached != null && cached.context === ctx) {
+                    cached
+                } else {
+                    // Clear stale cache on rotation or first open.
+                    viewModel.savedNavigatorContainer = null
+                    viewModel.savedNavigatorFragment = null
+                    viewModel.savedNavigatorFragmentIsDoublePage = null
+                    fragmentRef.value = null
+                    fragmentDoublePageHolder[0] = null
+                    ScrollBoundaryNavigationContainer(ctx).apply {
+                        // Compose handles all inset-based padding (navigationBarsPadding on the outer
+                        // Box, TopAppBarDefaults.windowInsets on the floating TopAppBar). Consuming
+                        // insets here prevents Readium's WebViews from applying status-bar padding,
+                        // which on physical devices remains non-zero even after controller.hide().
+                        ViewCompat.setOnApplyWindowInsetsListener(this) { _, _ -> WindowInsetsCompat.CONSUMED }
+                        val fragmentContainer = FragmentContainerView(ctx).apply { id = containerId }
+                        addView(fragmentContainer, FrameLayout.LayoutParams(FrameLayout.LayoutParams.MATCH_PARENT, FrameLayout.LayoutParams.MATCH_PARENT))
+                    }.also { viewModel.savedNavigatorContainer = it }
+                }
+                containerRef.value = container
+                container
             },
             update = { container ->
                 // In Continuous mode the fragment is kept alive only to maintain the HTTP server.
@@ -1763,6 +1781,16 @@ private fun EpubNavigatorView(
                     container.visibility = View.VISIBLE
                 }
                 container.isScrollMode = formattingPrefs.orientation != ReaderOrientation.Horizontal
+                // Pull callbacks capture composable-local State vars; re-set on every update so
+                // back-stack returns (which re-create the composable but reuse the cached View)
+                // always write to the current State instances rather than stale ones.
+                container.onPullStarted = { fwd ->
+                    pullForward = fwd
+                    pullProgress = 0f
+                    pullActive = true
+                }
+                container.onPullEnded = { pullActive = false }
+                container.onPullProgress = { p -> pullProgress = p }
 
                 val fragmentContainer = container.getChildAt(0) as? FragmentContainerView
                     ?: return@AndroidView
@@ -1793,6 +1821,8 @@ private fun EpubNavigatorView(
                     fm.beginTransaction().remove(existingFrag).commitNow()
                     fragmentRef.value = null
                     fragmentDoublePageHolder[0] = null
+                    viewModel.savedNavigatorFragment = null
+                    viewModel.savedNavigatorFragmentIsDoublePage = null
                 }
 
                 // After Activity recreation, the FragmentManager may have restored an
@@ -1842,6 +1872,8 @@ private fun EpubNavigatorView(
                             animatedTransition = true,
                         ),
                     )
+                    viewModel.savedNavigatorFragment = fragment
+                    viewModel.savedNavigatorFragmentIsDoublePage = isDoublePage
                     fragment.addInputListener(tapListener)
                     coroutineScope.launch {
                         fragment.currentLocator.collect { locator ->

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -6,6 +6,9 @@ import android.view.WindowManager
 import android.widget.FrameLayout
 import android.widget.Toast
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.tween
 import androidx.compose.animation.expandVertically
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
@@ -17,6 +20,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
@@ -2102,11 +2106,33 @@ private fun AudiobookPlayerOverlay(
     // AudiobookPlayerViewModel — is created once and kept alive between swipe-up/down cycles.
     // The actual start position arrives via AudiobookHandoffState when the overlay is revealed.
     val startRoute = "overlay_audiobook/$encoded?startAtSec=-2.0"
+
+    // Slide up on show, slide down on dismiss. `overlayVisible` trails `visible` on the way out —
+    // it stays true until the slide-down animation finishes, then flips to false (size 0).
+    val slideProgress = remember { Animatable(0f) }
+    var overlayVisible by remember { mutableStateOf(false) }
+    LaunchedEffect(visible) {
+        if (visible) {
+            overlayVisible = true
+            slideProgress.snapTo(0f)
+            slideProgress.animateTo(1f, tween(durationMillis = 320, easing = FastOutSlowInEasing))
+        } else {
+            slideProgress.animateTo(0f, tween(durationMillis = 280, easing = FastOutSlowInEasing))
+            overlayVisible = false
+        }
+    }
+
     NavHost(
         navController = navController,
         startDestination = startRoute,
-        // size(0.dp) renders but hides the composable; fillMaxSize when shown.
-        modifier = if (visible) Modifier.fillMaxSize() else Modifier.size(0.dp),
+        // size(0.dp) keeps the composable in the tree for pre-warming but makes it invisible.
+        modifier = if (overlayVisible) {
+            Modifier.fillMaxSize().graphicsLayer {
+                translationY = (1f - slideProgress.value) * size.height
+            }
+        } else {
+            Modifier.size(0.dp)
+        },
     ) {
         composable(
             route = "overlay_audiobook/{itemId}?startAtSec={startAtSec}",

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -109,6 +109,15 @@ import org.readium.r2.shared.publication.Link
 import org.readium.r2.shared.publication.Locator
 import org.readium.r2.shared.publication.Layout
 import org.readium.r2.shared.util.AbsoluteUrl
+import androidx.activity.compose.BackHandler
+import androidx.compose.material3.windowsizeclass.WindowSizeClass
+import androidx.navigation.NavType
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+import androidx.navigation.navArgument
+import com.riffle.app.feature.audiobook.AudiobookPlayerScreen
+import java.net.URLEncoder
 
 // Gates the "Highlight" text-selection action. ADR 0024 shipped highlight create + render +
 // sync-ready persistence, but there's still no UI to view, delete, or recolor highlights — so
@@ -153,8 +162,8 @@ internal fun rememberReflowReapplyGeneration(reflowTrigger: Any?): Int {
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun EpubReaderScreen(
+    windowSizeClass: WindowSizeClass,
     onNavigateBack: () -> Unit,
-    onSwitchToAudiobook: (audiobookItemId: String, atSec: Double) -> Unit = { _, _ -> },
     viewModel: EpubReaderViewModel = hiltViewModel(),
 ) {
     val state by viewModel.state.collectAsState()
@@ -289,6 +298,17 @@ fun EpubReaderScreen(
     // to edge and the nav bar floats over the last sliver of content. Padding would carve
     // out a solid strip behind the bar that doesn't blend with any reader theme — exactly
     // the "white/black bar" the user reported when exiting Immersive mode.
+    var audiobookOverlayItemId by rememberSaveable { mutableStateOf("") }
+    var audiobookOverlayStartAtSec by rememberSaveable { mutableStateOf(-1f) }
+    val showAudiobookOverlay = audiobookOverlayItemId.isNotEmpty()
+
+    // Dismiss the audiobook overlay when the system back button is pressed, rather than
+    // navigating back through the outer NavHost (which would exit the reader entirely).
+    BackHandler(enabled = showAudiobookOverlay) {
+        audiobookOverlayItemId = ""
+        viewModel.onAudiobookOverlayDismissed()
+    }
+
     Box(modifier = Modifier.fillMaxSize()) {
         // Status bar insets are consumed at the AndroidView root (see
         // ViewCompat.setOnApplyWindowInsetsListener in EpubNavigatorView) so they never
@@ -311,7 +331,6 @@ fun EpubReaderScreen(
                         viewModel.onPanelStateChanged(tocVisible || showFormattingPanel)
                     }
                     EpubNavigatorView(
-                        viewModel = viewModel,
                         state = s,
                         formattingPrefs = formattingPrefs,
                         onPositionChanged = { locator ->
@@ -420,7 +439,8 @@ fun EpubReaderScreen(
                         onSwipeUp = {
                             audiobookItemId?.let { abId ->
                                 val sec = viewModel.prepareAudiobookHandoff()
-                                onSwitchToAudiobook(abId, sec)
+                                audiobookOverlayStartAtSec = sec.toFloat()
+                                audiobookOverlayItemId = abId
                             }
                         },
                         onDragHint = { viewModel.hintAudiobookHandoff() },
@@ -555,6 +575,21 @@ fun EpubReaderScreen(
             ReturnToPositionCard(
                 onReturn = viewModel::returnToCapturedPosition,
                 onDismiss = viewModel::dismissReturnTarget,
+            )
+        }
+        if (showAudiobookOverlay) {
+            AudiobookPlayerOverlay(
+                itemId = audiobookOverlayItemId,
+                startAtSec = audiobookOverlayStartAtSec,
+                windowSizeClass = windowSizeClass,
+                onDismiss = {
+                    audiobookOverlayItemId = ""
+                    viewModel.onAudiobookOverlayDismissed()
+                },
+                onSwitchToReadaloud = { atSec ->
+                    audiobookOverlayItemId = ""
+                    viewModel.startReadaloudAtSecond(atSec)
+                },
             )
         }
     }
@@ -887,7 +922,6 @@ internal fun readaloudLocatorJson(ref: String, quote: SentenceQuote?): JSONObjec
 @OptIn(ExperimentalReadiumApi::class)
 @Composable
 private fun EpubNavigatorView(
-    viewModel: EpubReaderViewModel,
     state: ReaderState.Ready,
     formattingPrefs: FormattingPreferences,
     onPositionChanged: (Locator) -> Unit,
@@ -925,11 +959,8 @@ private fun EpubNavigatorView(
     val coroutineScope = rememberCoroutineScope()
     val continuousViewRef = remember { mutableStateOf<ContinuousReaderView?>(null) }
     val isContinuous = formattingPrefs.orientation == ReaderOrientation.Continuous
-    // Initialize from the ViewModel cache so the fragment/view survive composable removal while
-    // the reader is in the back stack behind the audiobook player. On back-stack return the
-    // factory returns the same ScrollBoundaryNavigationContainer (WebView intact, no reload).
-    val fragmentRef = remember { mutableStateOf(viewModel.savedNavigatorFragment) }
-    val containerRef = remember { mutableStateOf(viewModel.savedNavigatorContainer as? ScrollBoundaryNavigationContainer) }
+    val fragmentRef = remember { mutableStateOf<EpubNavigatorFragment?>(null) }
+    val containerRef = remember { mutableStateOf<ScrollBoundaryNavigationContainer?>(null) }
     // Covers the reader with a plain page-coloured screen while a cross-resource jump (TOC/search)
     // loads the new chapter. Readium briefly paints the new resource's opener (a figure/graphic) or
     // a white blank before scrolling to the target, and the column-snap nudges the page a beat after;
@@ -939,9 +970,8 @@ private fun EpubNavigatorView(
     // navigation callbacks. Using a plain array avoids triggering recomposition on scroll.
     val currentHrefHolder = remember { arrayOf<String?>(null) }
     // Tracks the isDoublePage value the current fragment was created with; null = no fragment.
-    // Initialized from the ViewModel so back-stack returns don't re-create a still-valid fragment.
     // Plain array (not MutableState) to avoid triggering recomposition.
-    val fragmentDoublePageHolder = remember { arrayOf(viewModel.savedNavigatorFragmentIsDoublePage) }
+    val fragmentDoublePageHolder = remember { arrayOf<Boolean?>(null) }
     val currentFormattingPrefs by rememberUpdatedState(formattingPrefs)
 
     // rememberUpdatedState ensures the listener always calls the latest onTap lambda
@@ -1741,34 +1771,15 @@ private fun EpubNavigatorView(
         }
         AndroidView(
             factory = { ctx ->
-                // Reuse the cached container (and its WebView) when returning from the audiobook
-                // player's back stack entry. The view was removed from the Compose hierarchy (but
-                // kept alive by the ViewModel) while the audiobook was on top; re-adding it here
-                // re-attaches the Fragment's view to the window without recreating the WebView.
-                // Context identity check detects Activity recreation (rotation) and falls through
-                // to create a fresh container in that case.
-                val cached = viewModel.savedNavigatorContainer as? ScrollBoundaryNavigationContainer
-                val container = if (cached != null && cached.context === ctx) {
-                    cached
-                } else {
-                    // Clear stale cache on rotation or first open.
-                    viewModel.savedNavigatorContainer = null
-                    viewModel.savedNavigatorFragment = null
-                    viewModel.savedNavigatorFragmentIsDoublePage = null
-                    fragmentRef.value = null
-                    fragmentDoublePageHolder[0] = null
-                    ScrollBoundaryNavigationContainer(ctx).apply {
-                        // Compose handles all inset-based padding (navigationBarsPadding on the outer
-                        // Box, TopAppBarDefaults.windowInsets on the floating TopAppBar). Consuming
-                        // insets here prevents Readium's WebViews from applying status-bar padding,
-                        // which on physical devices remains non-zero even after controller.hide().
-                        ViewCompat.setOnApplyWindowInsetsListener(this) { _, _ -> WindowInsetsCompat.CONSUMED }
-                        val fragmentContainer = FragmentContainerView(ctx).apply { id = containerId }
-                        addView(fragmentContainer, FrameLayout.LayoutParams(FrameLayout.LayoutParams.MATCH_PARENT, FrameLayout.LayoutParams.MATCH_PARENT))
-                    }.also { viewModel.savedNavigatorContainer = it }
-                }
-                containerRef.value = container
-                container
+                ScrollBoundaryNavigationContainer(ctx).apply {
+                    // Compose handles all inset-based padding (navigationBarsPadding on the outer
+                    // Box, TopAppBarDefaults.windowInsets on the floating TopAppBar). Consuming
+                    // insets here prevents Readium's WebViews from applying status-bar padding,
+                    // which on physical devices remains non-zero even after controller.hide().
+                    ViewCompat.setOnApplyWindowInsetsListener(this) { _, _ -> WindowInsetsCompat.CONSUMED }
+                    val fragmentContainer = FragmentContainerView(ctx).apply { id = containerId }
+                    addView(fragmentContainer, FrameLayout.LayoutParams(FrameLayout.LayoutParams.MATCH_PARENT, FrameLayout.LayoutParams.MATCH_PARENT))
+                }.also { containerRef.value = it }
             },
             update = { container ->
                 // In Continuous mode the fragment is kept alive only to maintain the HTTP server.
@@ -1821,8 +1832,6 @@ private fun EpubNavigatorView(
                     fm.beginTransaction().remove(existingFrag).commitNow()
                     fragmentRef.value = null
                     fragmentDoublePageHolder[0] = null
-                    viewModel.savedNavigatorFragment = null
-                    viewModel.savedNavigatorFragmentIsDoublePage = null
                 }
 
                 // After Activity recreation, the FragmentManager may have restored an
@@ -1872,8 +1881,6 @@ private fun EpubNavigatorView(
                             animatedTransition = true,
                         ),
                     )
-                    viewModel.savedNavigatorFragment = fragment
-                    viewModel.savedNavigatorFragmentIsDoublePage = isDoublePage
                     fragment.addInputListener(tapListener)
                     coroutineScope.launch {
                         fragment.currentLocator.collect { locator ->
@@ -2077,3 +2084,38 @@ private fun PullChip(forward: Boolean, progress: Float) {
 // later colour-picker slice maps `color` to other tints.
 private fun highlightTint(color: String): Int =
     android.graphics.Color.parseColor("#FFFDE68A")
+
+@Composable
+private fun AudiobookPlayerOverlay(
+    itemId: String,
+    startAtSec: Float,
+    windowSizeClass: WindowSizeClass,
+    onDismiss: () -> Unit,
+    onSwitchToReadaloud: (Double) -> Unit,
+) {
+    val navController = rememberNavController()
+    val encoded = URLEncoder.encode(itemId, "UTF-8")
+    val startRoute = "overlay_audiobook/$encoded?startAtSec=$startAtSec"
+    NavHost(
+        navController = navController,
+        startDestination = startRoute,
+        modifier = Modifier.fillMaxSize(),
+    ) {
+        composable(
+            route = "overlay_audiobook/{itemId}?startAtSec={startAtSec}",
+            arguments = listOf(
+                navArgument("itemId") { type = NavType.StringType },
+                navArgument("startAtSec") {
+                    type = NavType.FloatType
+                    defaultValue = -1f
+                },
+            ),
+        ) {
+            AudiobookPlayerScreen(
+                windowSizeClass = windowSizeClass,
+                onNavigateBack = onDismiss,
+                onSwitchToReadaloud = { _, atSec -> onSwitchToReadaloud(atSec) },
+            )
+        }
+    }
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -513,6 +513,7 @@ class EpubReaderViewModel @Inject constructor(
             // readaloud from the audiobook's position so narration continues where listening stopped.
             // The auto-follow drives the reader page to the narrated sentence once the navigator is up.
             if (startReadaloudAtSec >= 0.0 && control.enabled) {
+                android.util.Log.d(com.riffle.app.feature.reader.readaloud.ReadaloudController.HANDOFF, "RA.VM control.enabled fired — calling startReadaloudAtSecond")
                 startReadaloudAtSecond(startReadaloudAtSec)
             }
 
@@ -1574,6 +1575,7 @@ class EpubReaderViewModel @Inject constructor(
      * must skip the normal readaloud stop — see [handingOffToAudiobook].
      */
     fun prepareAudiobookHandoff(): Double {
+        android.util.Log.d(com.riffle.app.feature.reader.readaloud.ReadaloudController.HANDOFF, "RA.VM prepareAudiobookHandoff (T0 — about to pause)")
         val sec = playbackState.value.positionGlobalSec
         handingOffToAudiobook = true
         playerCoordinator.releaseForHandoff()
@@ -1633,6 +1635,7 @@ class EpubReaderViewModel @Inject constructor(
      * disk.
      */
     fun startReadaloudAtSecond(globalSec: Double) {
+        android.util.Log.d(com.riffle.app.feature.reader.readaloud.ReadaloudController.HANDOFF, "RA.VM startReadaloudAtSecond called (readaloudAvailable=${_readaloudAvailable.value})")
         if (!_readaloudAvailable.value) return
         val bundle = readaloudAudioRepository.bundleFile(audioServerId, audioBookId)
         if (bundle == null) {
@@ -1640,8 +1643,11 @@ class EpubReaderViewModel @Inject constructor(
             return
         }
         if (!_readaloudOpen.value) openReadaloudSession()
+        val t0 = System.currentTimeMillis()
         viewModelScope.launch {
+            android.util.Log.d(com.riffle.app.feature.reader.readaloud.ReadaloudController.HANDOFF, "RA.VM ensureOpened start +${System.currentTimeMillis() - t0}ms (readaloudPrepared=$readaloudPrepared)")
             ensureOpened(bundle) ?: return@launch
+            android.util.Log.d(com.riffle.app.feature.reader.readaloud.ReadaloudController.HANDOFF, "RA.VM ensureOpened done +${System.currentTimeMillis() - t0}ms")
             readaloudStarted = true
             resumeFragmentRef = null
             closeLocator = null

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -72,10 +72,7 @@ import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import kotlinx.coroutines.flow.drop
-import kotlinx.coroutines.flow.filter
 import org.json.JSONObject
-import org.readium.r2.navigator.epub.EpubNavigatorFragment
 import org.readium.r2.shared.publication.Link
 import org.readium.r2.shared.publication.Locator
 import org.readium.r2.shared.publication.Publication
@@ -162,20 +159,6 @@ class EpubReaderViewModel @Inject constructor(
     // receive an updated value set by the audiobook player when it pops back.
     private val startReadaloudAtSec: Double =
         (savedStateHandle.get<Float>("startReadaloudAtSec") ?: -1f).toDouble()
-
-    // Cached WebView host view and Readium fragment — kept alive across composable removal so the
-    // Readium WebView does not reload when the reader re-surfaces from the back stack after the
-    // audiobook player was on top. Cleared in onCleared to prevent leaks on permanent navigation
-    // away. The Activity context embedded in the view is validated in EpubNavigatorView before
-    // reuse so rotation clears and recreates the cache safely (see EpubReaderScreen).
-    //
-    // Storing a View in a ViewModel is non-standard; it is justified here because the WebView
-    // reload (1–2 s) was the dominant latency in the audiobook↔readaloud switch, and all
-    // alternative approaches (overlay composables, Fragment-retain tricks) required far larger
-    // architectural changes. The cache is guarded against rotation via a Context identity check.
-    internal var savedNavigatorContainer: Any? = null   // ScrollBoundaryNavigationContainer
-    internal var savedNavigatorFragment: EpubNavigatorFragment? = null
-    internal var savedNavigatorFragmentIsDoublePage: Boolean? = null
 
     private val _state = MutableStateFlow<ReaderState>(ReaderState.Loading)
     val state: StateFlow<ReaderState> = _state
@@ -581,16 +564,6 @@ class EpubReaderViewModel @Inject constructor(
                     }
                     searchJob = launch { performSearch(query) }
                 }
-        }
-        // Back-stack return: the audiobook player was popped while the reader was alive behind it.
-        // The audiobook sets startReadaloudAtSec in our savedStateHandle before calling popBackStack(),
-        // so we observe subsequent emissions (drop(1) skips the initial value handled in the
-        // control.enabled block above) and auto-start readaloud at the new position.
-        viewModelScope.launch {
-            savedStateHandle.getStateFlow("startReadaloudAtSec", -1f)
-                .drop(1)
-                .filter { it >= 0f }
-                .collect { sec -> startReadaloudAtSecond(sec.toDouble()) }
         }
     }
 
@@ -1096,13 +1069,6 @@ class EpubReaderViewModel @Inject constructor(
         }
         epubZip?.close()
         epubZip = null
-        // Drop the cached WebView container so it can be garbage-collected. In the stacking
-        // navigation model the reader's onCleared fires only when the user permanently leaves
-        // the reader (back from reader, navigate to home, etc.) — at that point the audiobook
-        // has already been popped and stopped, so there is no live session to protect.
-        savedNavigatorContainer = null
-        savedNavigatorFragment = null
-        savedNavigatorFragmentIsDoublePage = null
         // Tear down the audio session so it doesn't outlive the reader (clears the highlight too).
         playerCoordinator.close()
         // Readaloud can't outlive the reader, so this session is no longer playing.
@@ -1610,6 +1576,15 @@ class EpubReaderViewModel @Inject constructor(
         return sec
     }
 
+    /**
+     * Called when the audiobook overlay is dismissed (back button or navigate-back) without a
+     * readaloud handoff. Resets [readaloudPrepared] so the next play re-prepares the media session
+     * with the readaloud's audio items (the audiobook replaced them during playback).
+     */
+    fun onAudiobookOverlayDismissed() {
+        readaloudPrepared = false
+    }
+
     /** Called when the user starts dragging up (before the threshold) — reserved for future pre-warm. */
     fun hintAudiobookHandoff() = Unit
 
@@ -1668,6 +1643,7 @@ class EpubReaderViewModel @Inject constructor(
             return
         }
         if (!_readaloudOpen.value) openReadaloudSession()
+        readaloudPrepared = false
         viewModelScope.launch {
             ensureOpened(bundle) ?: return@launch
             readaloudStarted = true

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -6,6 +6,7 @@ import android.app.Application
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
+import com.riffle.app.feature.audiobook.AudiobookHandoffState
 import com.riffle.app.feature.reader.readaloud.PlayerCoordinator
 import com.riffle.app.feature.reader.readaloud.ReadaloudController
 import com.riffle.core.data.StorytellerPositionSyncController
@@ -148,6 +149,7 @@ class EpubReaderViewModel @Inject constructor(
     private val progressFlushScope: ProgressFlushScope,
     private val readaloudPreferencesStore: ReadaloudPreferencesStore,
     private val readingSpeedStore: ReadingSpeedStore,
+    private val audiobookHandoffState: AudiobookHandoffState,
 ) : AndroidViewModel(application) {
 
     private val itemId: String = checkNotNull(savedStateHandle["itemId"])
@@ -1573,16 +1575,23 @@ class EpubReaderViewModel @Inject constructor(
     fun prepareAudiobookHandoff(): Double {
         val sec = playbackState.value.positionGlobalSec
         playerCoordinator.releaseForHandoff()
+        // Signal the pre-warmed AudiobookPlayerViewModel to activate from this position.
+        val abId = _audiobookItemId.value
+        if (abId != null) audiobookHandoffState.signal(abId, sec)
         return sec
     }
 
     /**
-     * Called when the audiobook overlay is dismissed (back button or navigate-back) without a
-     * readaloud handoff. Resets [readaloudPrepared] so the next play re-prepares the media session
-     * with the readaloud's audio items (the audiobook replaced them during playback).
+     * Called when the audiobook overlay is dismissed (back button) without a readaloud handoff.
+     * Resets [readaloudPrepared] so the next play re-prepares the media session with the
+     * readaloud's audio items (the audiobook replaced them during playback).
+     * Also signals the pre-warmed [AudiobookPlayerViewModel] to pause its controller so audiobook
+     * audio stops while the reader is visible.
      */
     fun onAudiobookOverlayDismissed() {
         readaloudPrepared = false
+        val abId = _audiobookItemId.value
+        if (abId != null) audiobookHandoffState.dismiss(abId)
     }
 
     /** Called when the user starts dragging up (before the threshold) — reserved for future pre-warm. */

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -1580,6 +1580,12 @@ class EpubReaderViewModel @Inject constructor(
         return sec
     }
 
+    /** Called when the user starts dragging up (before the threshold) — reserved for future pre-warm. */
+    fun hintAudiobookHandoff() = Unit
+
+    /** Discard any pre-warm state if the drag was abandoned. */
+    fun cancelHandoffHint() = Unit
+
     private var handingOffToAudiobook = false
 
     fun previousChapter() = playerCoordinator.previousChapter()

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -72,7 +72,10 @@ import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.flow.filter
 import org.json.JSONObject
+import org.readium.r2.navigator.epub.EpubNavigatorFragment
 import org.readium.r2.shared.publication.Link
 import org.readium.r2.shared.publication.Locator
 import org.readium.r2.shared.publication.Publication
@@ -155,8 +158,24 @@ class EpubReaderViewModel @Inject constructor(
     // Audiobook→readaloud handoff: when opened by swiping the audiobook player down, this carries the
     // audiobook's current position (seconds on the concatenated timeline; -1 = not a handoff). On open
     // we auto-start readaloud playing from this second so narration continues where listening left off.
+    // Also observed as a flow so a back-stack return (reader was alive behind the audiobook player) can
+    // receive an updated value set by the audiobook player when it pops back.
     private val startReadaloudAtSec: Double =
         (savedStateHandle.get<Float>("startReadaloudAtSec") ?: -1f).toDouble()
+
+    // Cached WebView host view and Readium fragment — kept alive across composable removal so the
+    // Readium WebView does not reload when the reader re-surfaces from the back stack after the
+    // audiobook player was on top. Cleared in onCleared to prevent leaks on permanent navigation
+    // away. The Activity context embedded in the view is validated in EpubNavigatorView before
+    // reuse so rotation clears and recreates the cache safely (see EpubReaderScreen).
+    //
+    // Storing a View in a ViewModel is non-standard; it is justified here because the WebView
+    // reload (1–2 s) was the dominant latency in the audiobook↔readaloud switch, and all
+    // alternative approaches (overlay composables, Fragment-retain tricks) required far larger
+    // architectural changes. The cache is guarded against rotation via a Context identity check.
+    internal var savedNavigatorContainer: Any? = null   // ScrollBoundaryNavigationContainer
+    internal var savedNavigatorFragment: EpubNavigatorFragment? = null
+    internal var savedNavigatorFragmentIsDoublePage: Boolean? = null
 
     private val _state = MutableStateFlow<ReaderState>(ReaderState.Loading)
     val state: StateFlow<ReaderState> = _state
@@ -513,7 +532,6 @@ class EpubReaderViewModel @Inject constructor(
             // readaloud from the audiobook's position so narration continues where listening stopped.
             // The auto-follow drives the reader page to the narrated sentence once the navigator is up.
             if (startReadaloudAtSec >= 0.0 && control.enabled) {
-                android.util.Log.d(com.riffle.app.feature.reader.readaloud.ReadaloudController.HANDOFF, "RA.VM control.enabled fired — calling startReadaloudAtSecond")
                 startReadaloudAtSecond(startReadaloudAtSec)
             }
 
@@ -563,6 +581,16 @@ class EpubReaderViewModel @Inject constructor(
                     }
                     searchJob = launch { performSearch(query) }
                 }
+        }
+        // Back-stack return: the audiobook player was popped while the reader was alive behind it.
+        // The audiobook sets startReadaloudAtSec in our savedStateHandle before calling popBackStack(),
+        // so we observe subsequent emissions (drop(1) skips the initial value handled in the
+        // control.enabled block above) and auto-start readaloud at the new position.
+        viewModelScope.launch {
+            savedStateHandle.getStateFlow("startReadaloudAtSec", -1f)
+                .drop(1)
+                .filter { it >= 0f }
+                .collect { sec -> startReadaloudAtSecond(sec.toDouble()) }
         }
     }
 
@@ -1068,13 +1096,15 @@ class EpubReaderViewModel @Inject constructor(
         }
         epubZip?.close()
         epubZip = null
+        // Drop the cached WebView container so it can be garbage-collected. In the stacking
+        // navigation model the reader's onCleared fires only when the user permanently leaves
+        // the reader (back from reader, navigate to home, etc.) — at that point the audiobook
+        // has already been popped and stopped, so there is no live session to protect.
+        savedNavigatorContainer = null
+        savedNavigatorFragment = null
+        savedNavigatorFragmentIsDoublePage = null
         // Tear down the audio session so it doesn't outlive the reader (clears the highlight too).
-        // On a swipe-up handoff the audiobook now owns the shared player and the readaloud handle was
-        // already released without stopping it — closing here would stop the audiobook that just took
-        // over, so skip it.
-        if (!handingOffToAudiobook) {
-            playerCoordinator.close()
-        }
+        playerCoordinator.close()
         // Readaloud can't outlive the reader, so this session is no longer playing.
         nowPlayingStore.clearIf { it is com.riffle.app.playback.NowPlaying.Readaloud && it.itemId == itemId }
         // Cancel the coordinator's state-collection scope so it isn't leaked past this ViewModel.
@@ -1571,13 +1601,11 @@ class EpubReaderViewModel @Inject constructor(
     /**
      * Swipe-up handoff to the single large player: capture the current listen second, release the
      * shared player to the audiobook WITHOUT stopping it (so the audiobook keeps playing through the
-     * switch), and return the second to hand off. The reader is popped right after, so its onCleared
-     * must skip the normal readaloud stop — see [handingOffToAudiobook].
+     * switch), and return the second to hand off. The reader stays in the Compose Navigation back
+     * stack (stacking model, not swap), so onCleared is NOT called here — no guard needed.
      */
     fun prepareAudiobookHandoff(): Double {
-        android.util.Log.d(com.riffle.app.feature.reader.readaloud.ReadaloudController.HANDOFF, "RA.VM prepareAudiobookHandoff (T0 — about to pause)")
         val sec = playbackState.value.positionGlobalSec
-        handingOffToAudiobook = true
         playerCoordinator.releaseForHandoff()
         return sec
     }
@@ -1587,8 +1615,6 @@ class EpubReaderViewModel @Inject constructor(
 
     /** Discard any pre-warm state if the drag was abandoned. */
     fun cancelHandoffHint() = Unit
-
-    private var handingOffToAudiobook = false
 
     fun previousChapter() = playerCoordinator.previousChapter()
 
@@ -1635,7 +1661,6 @@ class EpubReaderViewModel @Inject constructor(
      * disk.
      */
     fun startReadaloudAtSecond(globalSec: Double) {
-        android.util.Log.d(com.riffle.app.feature.reader.readaloud.ReadaloudController.HANDOFF, "RA.VM startReadaloudAtSecond called (readaloudAvailable=${_readaloudAvailable.value})")
         if (!_readaloudAvailable.value) return
         val bundle = readaloudAudioRepository.bundleFile(audioServerId, audioBookId)
         if (bundle == null) {
@@ -1643,11 +1668,8 @@ class EpubReaderViewModel @Inject constructor(
             return
         }
         if (!_readaloudOpen.value) openReadaloudSession()
-        val t0 = System.currentTimeMillis()
         viewModelScope.launch {
-            android.util.Log.d(com.riffle.app.feature.reader.readaloud.ReadaloudController.HANDOFF, "RA.VM ensureOpened start +${System.currentTimeMillis() - t0}ms (readaloudPrepared=$readaloudPrepared)")
             ensureOpened(bundle) ?: return@launch
-            android.util.Log.d(com.riffle.app.feature.reader.readaloud.ReadaloudController.HANDOFF, "RA.VM ensureOpened done +${System.currentTimeMillis() - t0}ms")
             readaloudStarted = true
             resumeFragmentRef = null
             closeLocator = null

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -466,6 +466,17 @@ class EpubReaderViewModel @Inject constructor(
                     }
                     ?.absLibraryItemId
             }
+            android.util.Log.d("RIFFLE_HANDOFF", "RA.audiobookItemId resolved=${_audiobookItemId.value} (overlay can now mount)")
+            // Pre-warm the SMIL track parse so the first audiobook→readaloud swipe-down skips
+            // the ~1.5 s MediaOverlayReader.readTrack() cost (parses every .smil in the bundle).
+            // Stored so startReadaloudAtSecond() can join() it instead of double-parsing the zip.
+            preWarmTrackJob = viewModelScope.launch {
+                readaloudAudioRepository.bundleFile(audioServerId, audioBookId)?.let { bundle ->
+                    android.util.Log.d("RIFFLE_HANDOFF", "RA.preWarmTrack start")
+                    ensureTrack(bundle)
+                    android.util.Log.d("RIFFLE_HANDOFF", "RA.preWarmTrack done (readaloudTrack=${readaloudTrack != null})")
+                }
+            }
             // Claim this book so the durable sweep leaves it to this reader's own cycle (ADR 0030).
             activeServer?.id?.let { openReconcileTargets.markOpen(it, itemId) }
 
@@ -1574,9 +1585,9 @@ class EpubReaderViewModel @Inject constructor(
      */
     fun prepareAudiobookHandoff(): Double {
         val sec = playbackState.value.positionGlobalSec
-        playerCoordinator.releaseForHandoff()
-        // Signal the pre-warmed AudiobookPlayerViewModel to activate from this position.
         val abId = _audiobookItemId.value
+        android.util.Log.d("RIFFLE_HANDOFF", "RA.prepareAudiobookHandoff sec=$sec abId=$abId")
+        playerCoordinator.releaseForHandoff()
         if (abId != null) audiobookHandoffState.signal(abId, sec)
         return sec
     }
@@ -1654,6 +1665,7 @@ class EpubReaderViewModel @Inject constructor(
         if (!_readaloudOpen.value) openReadaloudSession()
         readaloudPrepared = false
         viewModelScope.launch {
+            preWarmTrackJob?.join()  // wait for background SMIL parse to finish before ensureTrack
             ensureOpened(bundle) ?: return@launch
             readaloudStarted = true
             resumeFragmentRef = null
@@ -1725,6 +1737,10 @@ class EpubReaderViewModel @Inject constructor(
     fun dismissDownloadPrompt() {
         _downloadPromptBytes.value = null
     }
+
+    // Job from the background SMIL pre-warm launched at book-open. startReadaloudAtSecond() joins
+    // this before calling ensureTrack so it never double-parses the zip concurrently.
+    private var preWarmTrackJob: Job? = null
 
     // True once the controller has been pointed at the bundle this session, so resuming after a
     // pause doesn't re-prepare (which would reset playback to the start).

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/PlayerCoordinator.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/PlayerCoordinator.kt
@@ -118,6 +118,12 @@ class PlayerCoordinator @Inject constructor(
 
     fun skipBy(deltaSec: Double) = controller.skipBy(deltaSec)
 
+    /** Pre-resolves [globalSec] during a swipe drag so [playFromSecond] skips SMIL computation. */
+    fun preWarmSeek(globalSec: Double) = controller.preWarmSeek(globalSec)
+
+    /** Discards the pre-warmed seek target when a drag is abandoned. */
+    fun cancelPreWarm() = controller.cancelPreWarm()
+
     fun previousChapter() = controller.previousChapter()
 
     fun nextChapter() = controller.nextChapter()

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/ReadaloudController.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/ReadaloudController.kt
@@ -69,6 +69,9 @@ open class ReadaloudController @Inject constructor(
 
     private val listener = object : Player.Listener {
         override fun onEvents(player: Player, events: Player.Events) {
+            if (events.containsAny(Player.EVENT_PLAYBACK_STATE_CHANGED)) {
+                Log.d(HANDOFF, "RA.onPlaybackStateChanged state=${player.playbackState} isPlaying=${player.isPlaying}")
+            }
             pushState()
         }
 
@@ -83,9 +86,12 @@ open class ReadaloudController @Inject constructor(
 
     /** Connects (if needed), points the service at [bundle], and queues [track]'s audio files. */
     suspend fun prepare(bundle: File, track: ReadaloudTrack) {
+        Log.d(HANDOFF, "RA.prepare start (controller already connected=${controller != null})")
         this.track = track
         SharedBundle.current = bundle
+        val t0 = System.currentTimeMillis()
         val c = ensureConnected() ?: return
+        Log.d(HANDOFF, "RA.prepare ensureConnected +${System.currentTimeMillis() - t0}ms")
 
         audioIndex.clear()
         val items = ArrayList<MediaItem>()
@@ -98,10 +104,12 @@ open class ReadaloudController @Inject constructor(
         }
         c.setMediaItems(items)
         c.prepare()
+        Log.d(HANDOFF, "RA.prepare setMediaItems+prepare +${System.currentTimeMillis() - t0}ms")
         pushState()
     }
 
     fun play() {
+        Log.d(HANDOFF, "RA.play called")
         controller?.play()
         startPolling()
     }
@@ -139,6 +147,7 @@ open class ReadaloudController @Inject constructor(
      * Keeps [track] so [preWarmSeek] can still resolve a position if the user drags back.
      */
     fun releaseForHandoff() {
+        Log.d(HANDOFF, "RA.releaseForHandoff (T0 — audio pausing)")
         pollJob?.cancel()
         pollJob = null
         controller?.run {
@@ -181,6 +190,7 @@ open class ReadaloudController @Inject constructor(
 
     /** Seeks to [globalSec] on the concatenated timeline and starts playing (audiobook→readaloud handoff). */
     fun playFromSecond(globalSec: Double) {
+        Log.d(HANDOFF, "RA.playFromSecond (preWarmed=${preWarmedPosition != null})")
         val target = preWarmedPosition ?: track?.seekTarget(globalSec) ?: return
         preWarmedPosition = null
         seekToAudio(target.audioSrc, target.positionSec)
@@ -274,5 +284,6 @@ open class ReadaloudController @Inject constructor(
         private const val NEAR_START_SEC = 3.0
         private const val POLL_INTERVAL_MS = 250L
         private const val LOG = "RIFFLE_RA"
+        internal const val HANDOFF = "RIFFLE_HANDOFF"
     }
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/ReadaloudController.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/ReadaloudController.kt
@@ -35,9 +35,12 @@ import kotlin.coroutines.resume
  * mini-player's shared speed sheet; see [com.riffle.app.feature.audio.PlaybackSpeed].
  */
 @Singleton
-class ReadaloudController @Inject constructor(
-    @ApplicationContext private val context: Context,
+open class ReadaloudController @Inject constructor(
+    @ApplicationContext private val context: Context?,
 ) {
+    // Test seam: subclasses that override the pre-warm methods need no real Context (only consulted in
+    // [ensureConnected], which fakes never reach). Keeps the controller unit-fakeable without Robolectric.
+    protected constructor() : this(null)
     data class PlaybackState(
         val connected: Boolean = false,
         val isPlaying: Boolean = false,
@@ -56,10 +59,13 @@ class ReadaloudController @Inject constructor(
     val state: StateFlow<PlaybackState> = _state.asStateFlow()
 
     private var controller: MediaController? = null
+    private var listenerAttached = false
     private var pollJob: Job? = null
     private var track: ReadaloudTrack? = null
     /** Maps a distinct audio file to its index in the queued playlist. */
     private val audioIndex = LinkedHashMap<String, Int>()
+    /** Pre-resolved seek target for the next [playFromSecond] call (set during swipe drag). */
+    private var preWarmedPosition: ReadaloudTrack.Position? = null
 
     private val listener = object : Player.Listener {
         override fun onEvents(player: Player, events: Player.Events) {
@@ -127,6 +133,10 @@ class ReadaloudController @Inject constructor(
      * narration goes silent immediately, but does NOT stop/clearMediaItems: the audiobook's own
      * setMediaItems replaces the queue, and clearing here would kill the audiobook playback that is
      * about to start. Symmetric to AudiobookController.releaseForHandoff.
+     *
+     * Keeps the [MediaController] Binder connection alive (ADR 0032) so the incoming side reconnects
+     * in ~0 ms instead of paying a full [MediaController.Builder.buildAsync] round-trip each time.
+     * Keeps [track] so [preWarmSeek] can still resolve a position if the user drags back.
      */
     fun releaseForHandoff() {
         pollJob?.cancel()
@@ -134,11 +144,24 @@ class ReadaloudController @Inject constructor(
         controller?.run {
             pause()
             removeListener(listener)
-            release()
         }
-        controller = null
-        track = null
+        listenerAttached = false
+        preWarmedPosition = null
         _state.value = PlaybackState()
+    }
+
+    /**
+     * Pre-resolves [globalSec] to a [ReadaloudTrack.Position] during the drag gesture, so
+     * [playFromSecond] can skip the SMIL computation at commit time (ADR 0032). No-op when [track]
+     * is null (audiobook-only entry with no prior readaloud session this app lifetime).
+     */
+    fun preWarmSeek(globalSec: Double) {
+        preWarmedPosition = track?.seekTarget(globalSec)
+    }
+
+    /** Discards any pre-warmed seek target — call when the drag is abandoned. */
+    fun cancelPreWarm() {
+        preWarmedPosition = null
     }
 
     /** Jumps to the first clip of an adjacent chapter (see [ReadaloudTrack.resolveChapterSkip]). */
@@ -158,7 +181,8 @@ class ReadaloudController @Inject constructor(
 
     /** Seeks to [globalSec] on the concatenated timeline and starts playing (audiobook→readaloud handoff). */
     fun playFromSecond(globalSec: Double) {
-        val target = track?.seekTarget(globalSec) ?: return
+        val target = preWarmedPosition ?: track?.seekTarget(globalSec) ?: return
+        preWarmedPosition = null
         seekToAudio(target.audioSrc, target.positionSec)
         play()
     }
@@ -184,6 +208,9 @@ class ReadaloudController @Inject constructor(
             release()
         }
         controller = null
+        listenerAttached = false
+        track = null
+        preWarmedPosition = null
         SharedBundle.current = null
         _state.value = PlaybackState()
     }
@@ -194,16 +221,22 @@ class ReadaloudController @Inject constructor(
     }
 
     private suspend fun ensureConnected(): MediaController? {
-        controller?.let { return it }
-        val token = SessionToken(context, ComponentName(context, AudioPlayerService::class.java))
-        val future = MediaController.Builder(context, token).buildAsync()
-        val c = suspendCancellableCoroutine<MediaController?> { cont ->
-            future.addListener({
-                cont.resume(runCatching { future.get() }.getOrNull())
-            }, ContextCompat.getMainExecutor(context))
+        val c = controller ?: run {
+            val ctx = context ?: return null
+            val token = SessionToken(ctx, ComponentName(ctx, AudioPlayerService::class.java))
+            val future = MediaController.Builder(ctx, token).buildAsync()
+            val newC = suspendCancellableCoroutine<MediaController?> { cont ->
+                future.addListener({
+                    cont.resume(runCatching { future.get() }.getOrNull())
+                }, ContextCompat.getMainExecutor(ctx))
+            }
+            controller = newC
+            newC
         }
-        c?.addListener(listener)
-        controller = c
+        if (!listenerAttached && c != null) {
+            c.addListener(listener)
+            listenerAttached = true
+        }
         pushState()
         return c
     }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/ReadaloudPlayerSheet.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/ReadaloudPlayerSheet.kt
@@ -29,6 +29,10 @@ fun ReadaloudPeek(
     // the affordance is never shown for a title with no audiobook to swipe up to.
     enabled: Boolean,
     modifier: Modifier = Modifier,
+    // Pre-warm callbacks for the drag gesture (ADR 0032): called as soon as a drag starts so the
+    // incoming audiobook player can connect/prepare during the gesture rather than after the threshold.
+    onDragHint: () -> Unit = {},
+    onDragAbandoned: () -> Unit = {},
     content: @Composable () -> Unit,
 ) {
     if (!enabled) {
@@ -39,9 +43,11 @@ fun ReadaloudPeek(
         modifier = modifier.pointerInput(Unit) {
             var total = 0f
             detectVerticalDragGestures(
-                onDragStart = { total = 0f },
+                onDragStart = { total = 0f; onDragHint() },
                 onVerticalDrag = { change, dragAmount -> total += dragAmount; change.consume() },
-                onDragEnd = { if (total < -SWIPE_UP_THRESHOLD_PX) onSwipeUp() },
+                onDragEnd = {
+                    if (total < -SWIPE_UP_THRESHOLD_PX) onSwipeUp() else onDragAbandoned()
+                },
             )
         },
     ) {

--- a/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
@@ -402,19 +402,8 @@ fun MainScreen(
                 )
             ) {
                 EpubReaderScreen(
+                    windowSizeClass = windowSizeClass,
                     onNavigateBack = { navController.popBackStack() },
-                    // Swipe up → switch to the single large player (the audiobook), continuing from the
-                    // listen position. Replace the reader (popUpTo inclusive) so the two surfaces swap
-                    // rather than stack; the reader's onCleared releases the shared player without
-                    // stopping it so the audiobook keeps playing.
-                    onSwitchToAudiobook = { audiobookItemId, atSec ->
-                        val encoded = URLEncoder.encode(audiobookItemId, "UTF-8")
-                        // Push the audiobook player ON TOP of the reader (no popUpTo). The reader
-                        // stays alive in the back stack so its Readium WebView is not destroyed and
-                        // does not need to reload on the return swipe — eliminating the 1–2 s blank
-                        // screen (see EpubNavigatorView WebView cache in EpubReaderScreen).
-                        navController.navigate("audiobook_player/$encoded?startAtSec=$atSec")
-                    },
                 )
             }
             composable(
@@ -442,23 +431,11 @@ fun MainScreen(
                     // the audiobook position. Pop the player off the stack so leaving readaloud doesn't
                     // land back on a dead player, and its onCleared stops audio + flushes progress.
                     onSwitchToReadaloud = { ebookItemId, atSec ->
-                        val prevEntry = navController.previousBackStackEntry
-                        if (prevEntry?.destination?.route?.startsWith(
-                                EPUB_READER.substringBefore("{")
-                            ) == true
-                        ) {
-                            // Reader is alive in the back stack (opened audiobook via swipe-up from
-                            // the reader). Pass the position to resume and pop — the reader's
-                            // WebView was never torn down, so this is instant.
-                            prevEntry.savedStateHandle["startReadaloudAtSec"] = atSec.toFloat()
-                            navController.popBackStack()
-                        } else {
-                            // Audiobook was opened directly (e.g. from the library). Navigate to a
-                            // new reader, replacing the player so Back doesn't return to a dead session.
-                            val encoded = URLEncoder.encode(ebookItemId, "UTF-8")
-                            navController.navigate("epub_reader/$encoded?startReadaloudAtSec=$atSec") {
-                                popUpTo(AUDIOBOOK_PLAYER) { inclusive = true }
-                            }
+                        // Audiobook opened from the library (not from the reader overlay). Navigate
+                        // to the reader, replacing the player so Back doesn't return to a dead session.
+                        val encoded = URLEncoder.encode(ebookItemId, "UTF-8")
+                        navController.navigate("epub_reader/$encoded?startReadaloudAtSec=$atSec") {
+                            popUpTo(AUDIOBOOK_PLAYER) { inclusive = true }
                         }
                     },
                 )

--- a/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
@@ -409,9 +409,11 @@ fun MainScreen(
                     // stopping it so the audiobook keeps playing.
                     onSwitchToAudiobook = { audiobookItemId, atSec ->
                         val encoded = URLEncoder.encode(audiobookItemId, "UTF-8")
-                        navController.navigate("audiobook_player/$encoded?startAtSec=$atSec") {
-                            popUpTo(EPUB_READER) { inclusive = true }
-                        }
+                        // Push the audiobook player ON TOP of the reader (no popUpTo). The reader
+                        // stays alive in the back stack so its Readium WebView is not destroyed and
+                        // does not need to reload on the return swipe — eliminating the 1–2 s blank
+                        // screen (see EpubNavigatorView WebView cache in EpubReaderScreen).
+                        navController.navigate("audiobook_player/$encoded?startAtSec=$atSec")
                     },
                 )
             }
@@ -440,9 +442,23 @@ fun MainScreen(
                     // the audiobook position. Pop the player off the stack so leaving readaloud doesn't
                     // land back on a dead player, and its onCleared stops audio + flushes progress.
                     onSwitchToReadaloud = { ebookItemId, atSec ->
-                        val encoded = URLEncoder.encode(ebookItemId, "UTF-8")
-                        navController.navigate("epub_reader/$encoded?startReadaloudAtSec=$atSec") {
-                            popUpTo(AUDIOBOOK_PLAYER) { inclusive = true }
+                        val prevEntry = navController.previousBackStackEntry
+                        if (prevEntry?.destination?.route?.startsWith(
+                                EPUB_READER.substringBefore("{")
+                            ) == true
+                        ) {
+                            // Reader is alive in the back stack (opened audiobook via swipe-up from
+                            // the reader). Pass the position to resume and pop — the reader's
+                            // WebView was never torn down, so this is instant.
+                            prevEntry.savedStateHandle["startReadaloudAtSec"] = atSec.toFloat()
+                            navController.popBackStack()
+                        } else {
+                            // Audiobook was opened directly (e.g. from the library). Navigate to a
+                            // new reader, replacing the player so Back doesn't return to a dead session.
+                            val encoded = URLEncoder.encode(ebookItemId, "UTF-8")
+                            navController.navigate("epub_reader/$encoded?startReadaloudAtSec=$atSec") {
+                                popUpTo(AUDIOBOOK_PLAYER) { inclusive = true }
+                            }
                         }
                     },
                 )

--- a/app/src/test/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModelBookmarkTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModelBookmarkTest.kt
@@ -160,6 +160,7 @@ class AudiobookPlayerViewModelBookmarkTest {
             progressFlushScope = ProgressFlushScope(CoroutineScope(testDispatcher)),
             bookmarkStore = bookmarkStore,
             connectivityObserver = connectivity,
+            audiobookHandoffState = AudiobookHandoffState(),
             now = { fixedNow },
         )
     }

--- a/app/src/test/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModelBookmarkTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModelBookmarkTest.kt
@@ -85,6 +85,8 @@ class AudiobookPlayerViewModelBookmarkTest {
         ),
     )
 
+    private class FakeReadaloudController : com.riffle.app.feature.reader.readaloud.ReadaloudController()
+
     // A fake controller whose book-absolute position is settable and whose seekTo is recorded. Only the
     // members the VM actually touches are overridden; the heavy Media3/Context machinery is bypassed.
     private class FakeController(var position: Double) : AudiobookController() {
@@ -142,6 +144,7 @@ class AudiobookPlayerViewModelBookmarkTest {
             serverRepository = FakeServerRepository(),
             tokenStorage = FakeTokenStorage,
             controller = controller,
+            readaloudController = FakeReadaloudController(),
             audioPlaybackPreferencesStore = prefsStore,
             listeningPreferencesStore = listeningStore,
             audioIdentityResolver = FakeIdentityResolver,

--- a/app/src/test/kotlin/com/riffle/app/feature/audiobook/SleepTimerTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/audiobook/SleepTimerTest.kt
@@ -122,6 +122,8 @@ class SleepTimerTest {
 
     // ── FakeController ───────────────────────────────────────────────────────────
 
+    private class FakeReadaloudController : com.riffle.app.feature.reader.readaloud.ReadaloudController()
+
     private class FakeController(position: Double = 0.0) : AudiobookController() {
         var position: Double = position
 
@@ -192,6 +194,7 @@ class SleepTimerTest {
             serverRepository = FakeServerRepository(),
             tokenStorage = FakeTokenStorage,
             controller = controller,
+            readaloudController = FakeReadaloudController(),
             audioPlaybackPreferencesStore = FakePrefsStore,
             listeningPreferencesStore = FakeListeningPreferencesStore,
             audioIdentityResolver = FakeIdentityResolver,

--- a/app/src/test/kotlin/com/riffle/app/feature/audiobook/SleepTimerTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/audiobook/SleepTimerTest.kt
@@ -210,6 +210,7 @@ class SleepTimerTest {
             progressFlushScope = ProgressFlushScope(CoroutineScope(testDispatcher)),
             bookmarkStore = bookmarkStore,
             connectivityObserver = connectivity,
+            audiobookHandoffState = AudiobookHandoffState(),
             now = { 0L },
         )
     }

--- a/core/data/src/main/kotlin/com/riffle/core/data/ReadaloudAudioRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/ReadaloudAudioRepositoryImpl.kt
@@ -11,8 +11,9 @@ import com.riffle.core.network.StorytellerBundleProbeApi
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.io.File
+import java.util.concurrent.ConcurrentHashMap
 
-class ReadaloudAudioRepositoryImpl(
+open class ReadaloudAudioRepositoryImpl(
     private val downloader: AudiobookBundleDownloader,
     private val bundleProbe: StorytellerBundleProbeApi,
     private val cacheStore: LocalStore,
@@ -21,6 +22,10 @@ class ReadaloudAudioRepositoryImpl(
     private val tokenStorage: TokenStorage,
 ) : ReadaloudAudioRepository {
 
+    // Process-level cache: keyed by (serverId, itemId, file.lastModified()) so a re-downloaded bundle
+    // gets a fresh parse while repeated opens of the same bundle return instantly (~0ms vs ~1.8s).
+    private val trackCache = ConcurrentHashMap<Triple<String, String, Long>, ReadaloudTrack>()
+
     override fun isAudioAvailable(serverId: String, itemId: String): Boolean = bundleFile(serverId, itemId) != null
 
     override fun bundleFile(serverId: String, itemId: String): File? =
@@ -28,10 +33,18 @@ class ReadaloudAudioRepositoryImpl(
 
     override suspend fun readTrack(serverId: String, itemId: String): ReadaloudTrack? = withContext(Dispatchers.IO) {
         val file = bundleFile(serverId, itemId) ?: return@withContext null
+        val key = Triple(serverId, itemId, file.lastModified())
+        trackCache[key]?.let { return@withContext it }
+        val track = parseTrack(file) ?: return@withContext null
+        trackCache[key] = track
+        track
+    }
+
+    // Test seam: subclasses can supply a fake parser without touching the zip on disk.
+    protected open fun parseTrack(file: File): ReadaloudTrack? =
         runCatching { MediaOverlayReader.readTrack(file) }
             .getOrNull()
             ?.takeIf { it.clips.isNotEmpty() }
-    }
 
     override suspend fun probeSizeBytes(serverId: String, itemId: String): Long? {
         val server = serverRepository.getById(serverId) ?: return null

--- a/core/data/src/test/kotlin/com/riffle/core/data/ReadaloudAudioRepositoryImplTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/ReadaloudAudioRepositoryImplTest.kt
@@ -1,0 +1,144 @@
+package com.riffle.core.data
+
+import com.riffle.core.domain.AuthenticateResult
+import com.riffle.core.domain.CommitServerResult
+import com.riffle.core.domain.LocalStore
+import com.riffle.core.domain.MediaOverlayClip
+import com.riffle.core.domain.PendingServer
+import com.riffle.core.domain.ReadaloudTrack
+import com.riffle.core.domain.Server
+import com.riffle.core.domain.ServerRepository
+import com.riffle.core.domain.ServerType
+import com.riffle.core.domain.ServerUrl
+import com.riffle.core.domain.StoredItemRef
+import com.riffle.core.domain.TokenStorage
+import com.riffle.core.network.NetworkStorytellerBundleSizeResult
+import com.riffle.core.network.StorytellerBundleProbeApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+import java.io.InputStream
+
+class ReadaloudAudioRepositoryImplTest {
+
+    @get:Rule
+    val tmp = TemporaryFolder()
+
+    private val track = ReadaloudTrack(listOf(MediaOverlayClip("c1.xhtml#s0", "audio/0.mp3", 0.0, 30.0)))
+
+    private fun makeRepo(bundleFile: File?, parseResult: ReadaloudTrack?): Pair<ReadaloudAudioRepositoryImpl, () -> Int> {
+        var parseCalls = 0
+        val repo = object : ReadaloudAudioRepositoryImpl(
+            downloader = AudiobookBundleDownloader(
+                api = { _, _, _, _, _ -> throw UnsupportedOperationException() },
+                targetFileProvider = { _, _ -> File("") },
+            ),
+            bundleProbe = StorytellerBundleProbeApi { _, _, _, _ ->
+                NetworkStorytellerBundleSizeResult.NetworkError(UnsupportedOperationException())
+            },
+            cacheStore = FakeStore(null),
+            downloadsStore = FakeStore(bundleFile),
+            serverRepository = NoopServerRepository,
+            tokenStorage = NoopTokenStorage,
+        ) {
+            override fun parseTrack(file: File): ReadaloudTrack? {
+                parseCalls++
+                return parseResult
+            }
+        }
+        return repo to { parseCalls }
+    }
+
+    @Test
+    fun `readTrack returns null when no bundle file`() = runTest {
+        val (repo, _) = makeRepo(bundleFile = null, parseResult = track)
+        assertNull(repo.readTrack("s", "i"))
+    }
+
+    @Test
+    fun `readTrack returns null when parser returns null`() = runTest {
+        val bundle = tmp.newFile("book.zip")
+        val (repo, parseCalls) = makeRepo(bundleFile = bundle, parseResult = null)
+        assertNull(repo.readTrack("s", "i"))
+        assertEquals(1, parseCalls())
+    }
+
+    @Test
+    fun `readTrack parses once and caches the result`() = runTest {
+        val bundle = tmp.newFile("book.zip")
+        val (repo, parseCalls) = makeRepo(bundleFile = bundle, parseResult = track)
+
+        val first = repo.readTrack("s", "i")
+        val second = repo.readTrack("s", "i")
+
+        assertEquals(track, first)
+        assertEquals(track, second)
+        assertEquals("should parse exactly once", 1, parseCalls())
+    }
+
+    @Test
+    fun `readTrack re-parses after bundle file is replaced`() = runTest {
+        val bundle = tmp.newFile("book.zip")
+        val (repo, parseCalls) = makeRepo(bundleFile = bundle, parseResult = track)
+
+        repo.readTrack("s", "i")
+        // Simulate a bundle re-download by touching the file (updates lastModified).
+        bundle.setLastModified(bundle.lastModified() + 1_000)
+        repo.readTrack("s", "i")
+
+        assertEquals("should re-parse after bundle replaced", 2, parseCalls())
+    }
+
+    @Test
+    fun `readTrack isolates cache by (serverId, itemId)`() = runTest {
+        val bundle = tmp.newFile("book.zip")
+        val (repo, parseCalls) = makeRepo(bundleFile = bundle, parseResult = track)
+
+        repo.readTrack("server-A", "item-1")
+        repo.readTrack("server-B", "item-1")
+
+        assertEquals("different servers produce separate cache entries", 2, parseCalls())
+    }
+
+    // ------- minimal collaborator stubs -------
+
+    private class FakeStore(private val file: File?) : LocalStore {
+        override fun get(serverId: String, itemId: String): File? = file
+        override suspend fun save(serverId: String, itemId: String, stream: InputStream): File = throw UnsupportedOperationException()
+        override fun delete(serverId: String, itemId: String) = Unit
+        override fun deleteServer(serverId: String) = Unit
+        override fun clear() = Unit
+        override fun listItems(): List<StoredItemRef> = emptyList()
+    }
+
+    private object NoopServerRepository : ServerRepository {
+        override fun observeAll(): Flow<List<Server>> = MutableStateFlow(emptyList())
+        override suspend fun getActive(): Server? = null
+        override suspend fun authenticate(
+            url: ServerUrl,
+            username: String,
+            password: String,
+            insecureAllowed: Boolean,
+            serverType: ServerType,
+        ): AuthenticateResult = AuthenticateResult.NetworkError(UnsupportedOperationException())
+        override suspend fun commit(
+            pending: PendingServer,
+            hiddenLibraryIds: Set<String>,
+        ): CommitServerResult = CommitServerResult.Failure(UnsupportedOperationException())
+        override suspend fun setActive(serverId: String) = Unit
+        override suspend fun remove(serverId: String) = Unit
+        override suspend fun getServerVersion(serverId: String): String? = null
+    }
+
+    private object NoopTokenStorage : TokenStorage {
+        override suspend fun getToken(serverId: String): String? = null
+        override suspend fun saveToken(serverId: String, token: String) = Unit
+        override suspend fun deleteToken(serverId: String) = Unit
+    }
+}

--- a/docs/adr/0032-pre-warm-player-handoff.md
+++ b/docs/adr/0032-pre-warm-player-handoff.md
@@ -1,0 +1,61 @@
+# ADR 0032 — Pre-warm player handoff: keep MediaController alive and pre-fetch session data during drag
+
+**Status:** Accepted
+**Relates to:** [ADR 0029](0029-audiobook-direct-abs-streaming-audio-led-sync.md), [ADR 0031](0031-unified-matched-book-position.md).
+
+## Context
+
+Switching between audiobook and readaloud (swipe up on the mini-player, swipe down on the full player) had a noticeable audio gap in both directions. The gap came from three sequential costs that ran *after* the swipe threshold, while the user was already waiting:
+
+1. **MediaController reconnect.** Both `releaseForHandoff()` implementations called `controller.release()` and set `controller = null`, destroying the Binder connection to `AudioPlayerService`. The incoming side had to call `MediaController.Builder.buildAsync()` to reconnect (~100–200 ms).
+
+2. **ABS play session fetch.** When navigating to `AudiobookPlayerViewModel`, the init path called `audiobookRepository.openPlaySession()` — a network round-trip (~200–500 ms) — before it could queue tracks via `setMediaItems`.
+
+3. **SMIL seek resolve.** When navigating back to readaloud, `playerCoordinator.playFromSecond()` resolved the global-second seek target from the bundle's SMIL. This is pure in-memory computation but runs synchronously after navigation.
+
+The drag gesture itself takes 300–800 ms to reach the threshold, which is free preparation time that was previously wasted.
+
+## Decision
+
+### 1. Keep the MediaController connection alive across handoffs
+
+`releaseForHandoff()` in both `AudiobookController` and `ReadaloudController` no longer calls `release()` or nulls `controller`. It pauses playback and removes the listener, but the Binder channel to `AudioPlayerService` stays open.
+
+`ensureConnected()` tracks a `listenerAttached` flag so it re-adds the listener exactly once when the incoming side takes ownership, without double-registration.
+
+This turns the ~150 ms reconnect in both directions into a no-op on every handoff after the first.
+
+### 2. Pre-fetch ABS session data during the drag (readaloud → audiobook)
+
+`EpubReaderViewModel` gains a `hintAudiobookHandoff()` method, wired to the gesture detector's `onDragStart`. It launches a coroutine to call `audiobookRepository.openPlaySession()` and stores the result in `AudiobookController.preWarmState`.
+
+When `AudiobookPlayerViewModel.prepare()` runs after navigation, it calls `controller.consumePreWarm()`. If non-null, it skips the `openPlaySession()` network call and uses the pre-fetched tracks directly.
+
+If the drag is abandoned, `cancelHandoffHint()` calls `AudiobookController.cancelPreWarm()`, discarding the stored state.
+
+### 3. Pre-resolve SMIL seek target during the drag (audiobook → readaloud)
+
+`AudiobookPlayerViewModel` gains a `hintReadaloudHandoff()` method, wired to its gesture detector's `onDragStart`. It calls `ReadaloudController.preWarmSeek(bundle, currentPositionSec)`, which resolves `track.seekTarget(positionSec)` and caches the result.
+
+When `playerCoordinator.playFromSecond()` runs post-navigation, the seek target is already computed.
+
+### Old audio continues playing during the drag
+
+Pausing the outgoing player happens at the threshold (inside `releaseForHandoff()`), not at drag start. The user hears continuous audio throughout the swipe gesture.
+
+## Timing after this change
+
+**Readaloud → audiobook:**
+- Drag start: `openPlaySession()` fires in background
+- Threshold: old readaloud pauses, navigate, `AudiobookPlayerViewModel` finds pre-fetched session → `setMediaItems + prepare + play` (only remaining cost: ExoPlayer `STATE_READY`, ~50–150 ms for cached streams)
+
+**Audiobook → readaloud:**
+- Drag start: SMIL seek target pre-resolved in memory
+- Threshold: old audiobook pauses, navigate, `playFromSecond()` uses cached target → `play()` immediately (readaloud uses local `zipaudio://` files; `STATE_READY` is <50 ms)
+
+## Consequences
+
+- `AudiobookController` and `ReadaloudController` hold a persistent Binder connection to `AudioPlayerService` for the lifetime of the session (negligible overhead — just a handle).
+- Both controllers gain `preWarmState` fields. If the app is killed and restarted mid-drag, the pre-warm is lost; the incoming side falls back to the normal `openPlaySession()` path.
+- Drag gestures that start and abandon rapidly (e.g. accidental touch) trigger a `cancelPreWarm()` call, which is a no-op if pre-warm hasn't completed yet.
+- The 10 px hint threshold is below the 60 px / 160 px commit thresholds so there is enough lead time on typical hardware. If the drag completes faster than `openPlaySession()` returns, the audiobook side falls back to the normal path (pre-warm is a best-effort optimisation, not a gate).


### PR DESCRIPTION
## Summary

- **Process-level SMIL-parse cache** in `ReadaloudAudioRepositoryImpl` (keyed by `serverId + itemId + file.lastModified()`): `MediaOverlayReader.readTrack()` parses the 315 MB Storyteller bundle once per process (~1.8 s); every subsequent call — including after navigating back to the same book — returns instantly from `ConcurrentHashMap`. This also eliminates the ~2.7 s `bundleAudiobookSource.localSession()` bottleneck in the AB prewarm, since it calls `readTrack()` internally.
- **`CompletableDeferred<AudiobookSession?>` in `AudiobookPlayerViewModel`**: a swipe-up that arrives before the ~1–2 s bundle-session init completes now awaits (up to 10 s) rather than silently dropping the handoff.
- **`warmBinder()` on PREWARM_SENTINEL path**: pre-connects the `MediaController` binder so the first swipe-up pays ~0 ms for the `buildAsync` round-trip (ADR 0032).
- **`preWarmTrackJob` in `EpubReaderViewModel`**: starts the SMIL parse at book-open in a background job; `startReadaloudAtSecond()` joins it so the handoff path never double-parses the zip.
- **Slide animation** on `AudiobookPlayerOverlay`: 320 ms slide-up / 280 ms slide-down via `Animatable` + `FastOutSlowInEasing`.

## Test plan

- [x] `./gradlew test` — all JVM unit tests green
- [x] `./gradlew lint` — no issues
- [x] Phone harness (`connectedDebugAndroidTest notAnnotation=TabletLayout`) — green on throwaway clone of Harness_Medium_Phone_2
- [x] Tablet harness (`connectedDebugAndroidTest annotation=TabletLayout`) — green on throwaway clone of Harness_Medium_Tablet
- [x] New `ReadaloudAudioRepositoryImplTest` covering: null-bundle, null-parse, parses-once-and-caches, re-parses-on-bundle-replace, isolates-by-server