### PR TITLE
feat(annotations): notes on highlights

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -1621,22 +1621,32 @@ private fun EpubNavigatorView(
     // attached. Uses its own group so it can be cleared/re-applied independently of the fill.
     // Tapping the underlined range fires the existing "annotations" listener (both decorations
     // overlap the same text, so the listener already registered above handles it).
-    LaunchedEffect(highlightRenders, reflowGeneration, pageLoadGeneration.value) {
+    val hasNoteDecorations = remember { mutableStateOf(false) }
+    LaunchedEffect(highlightRenders, formattingPrefs.theme, reflowGeneration, pageLoadGeneration.value) {
         val fragment = fragmentRef.value as? DecorableNavigator ?: return@LaunchedEffect
         val noted = highlightRenders.filter { it.note != null }
+        if (noted.isEmpty()) {
+            if (!hasNoteDecorations.value) return@LaunchedEffect
+            withContext(Dispatchers.Main) {
+                fragment.applyDecorations(emptyList(), group = "annotation-notes")
+            }
+            hasNoteDecorations.value = false
+            return@LaunchedEffect
+        }
         val noteDecorations = noted.map { h ->
             Decoration(
                 id = h.id,
                 locator = h.locator,
-                style = Decoration.Style.Underline(tint = android.graphics.Color.argb(180, 80, 80, 80)),
+                style = Decoration.Style.Underline(
+                    tint = HighlightColor.fromToken(h.color).readerTint(formattingPrefs.theme),
+                ),
             )
         }
         withContext(Dispatchers.Main) {
             fragment.applyDecorations(emptyList(), group = "annotation-notes")
-            if (noteDecorations.isNotEmpty()) {
-                fragment.applyDecorations(noteDecorations, group = "annotation-notes")
-            }
+            fragment.applyDecorations(noteDecorations, group = "annotation-notes")
         }
+        hasNoteDecorations.value = true
     }
 
     // ---- Decoration tap listener (annotations) ---------------------------------------------

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -377,6 +377,7 @@ fun EpubReaderScreen(
                         onDismissHighlightActions = viewModel::dismissHighlightActions,
                         onRecolorHighlight = viewModel::recolorHighlight,
                         onDeleteHighlight = viewModel::deleteHighlight,
+                        onUpdateHighlightNote = viewModel::updateHighlightNote,
                         modifier = Modifier
                             .fillMaxSize()
                             .testTag("reader_ready")
@@ -983,6 +984,7 @@ private fun EpubNavigatorView(
     onDismissHighlightActions: () -> Unit,
     onRecolorHighlight: (String, HighlightColor) -> Unit,
     onDeleteHighlight: (String) -> Unit,
+    onUpdateHighlightNote: (String, String?) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val context = LocalContext.current
@@ -1019,6 +1021,7 @@ private fun EpubNavigatorView(
     val currentSentenceChapters by rememberUpdatedState(sentenceChapters)
     val currentOnHighlight by rememberUpdatedState(onHighlight)
     val currentOnOpenHighlightActions by rememberUpdatedState(onOpenHighlightActions)
+    val currentOnUpdateHighlightNote by rememberUpdatedState(onUpdateHighlightNote)
     val currentAnnotationsAvailable by rememberUpdatedState(annotationsAvailable)
     val currentReadaloudAvailable by rememberUpdatedState(readaloudAvailable)
     // Latest readaloud bottom reserve, read inside the (remembered-once) pagination listener so each
@@ -1613,6 +1616,29 @@ private fun EpubNavigatorView(
         hasHighlightDecorations.value = true
     }
 
+    // ---- Note underline decorations (annotation-notes) -------------------------------------
+    // Draws a subtle underline under every noted highlight so the reader can see a note is
+    // attached. Uses its own group so it can be cleared/re-applied independently of the fill.
+    // Tapping the underlined range fires the existing "annotations" listener (both decorations
+    // overlap the same text, so the listener already registered above handles it).
+    LaunchedEffect(highlightRenders, reflowGeneration, pageLoadGeneration.value) {
+        val fragment = fragmentRef.value as? DecorableNavigator ?: return@LaunchedEffect
+        val noted = highlightRenders.filter { it.note != null }
+        val noteDecorations = noted.map { h ->
+            Decoration(
+                id = h.id,
+                locator = h.locator,
+                style = Decoration.Style.Underline(tint = android.graphics.Color.argb(180, 80, 80, 80)),
+            )
+        }
+        withContext(Dispatchers.Main) {
+            fragment.applyDecorations(emptyList(), group = "annotation-notes")
+            if (noteDecorations.isNotEmpty()) {
+                fragment.applyDecorations(noteDecorations, group = "annotation-notes")
+            }
+        }
+    }
+
     // ---- Decoration tap listener (annotations) ---------------------------------------------
     // Opens the highlight-actions sheet when the user taps an existing highlight decoration.
     DisposableEffect(fragmentRef.value) {
@@ -2116,8 +2142,10 @@ private fun EpubNavigatorView(
             val current = highlightRenders.firstOrNull { it.id == editId }
             HighlightActionsSheet(
                 selected = current?.let { HighlightColor.fromToken(it.color) },
+                note = current?.note,
                 onPick = { color -> onRecolorHighlight(editId, color) },
                 onDelete = { onDeleteHighlight(editId) },
+                onUpdateNote = { note -> onUpdateHighlightNote(editId, note) },
                 onDismiss = onDismissHighlightActions,
             )
         }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -316,8 +316,8 @@ class EpubReaderViewModel @Inject constructor(
     private val _annotationsAvailable = MutableStateFlow(false)
     val annotationsAvailable: StateFlow<Boolean> = _annotationsAvailable
 
-    /** A persisted highlight reconstructed into a renderable Readium locator + colour token. */
-    data class HighlightRender(val id: String, val locator: Locator, val color: String)
+    /** A persisted highlight reconstructed into a renderable Readium locator + colour token + optional note. */
+    data class HighlightRender(val id: String, val locator: Locator, val color: String, val note: String?)
 
     private val _highlightRenders = MutableStateFlow<List<HighlightRender>>(emptyList())
     val highlightRenders: StateFlow<List<HighlightRender>> = _highlightRenders
@@ -1131,6 +1131,11 @@ class EpubReaderViewModel @Inject constructor(
         }
     }
 
+    /** Save (or clear) the note on a highlight; blank text is treated as null (removes the note). */
+    fun updateHighlightNote(id: String, note: String?) {
+        viewModelScope.launch { annotationStore.updateNote(id, note?.takeIf { it.isNotBlank() }) }
+    }
+
     // Reconstruct a persisted highlight into a renderable Readium locator. The CFI start re-anchors
     // the within-chapter position; the text snippet lets Readium's decorator locate the range.
     private suspend fun annotationToRender(a: Annotation): HighlightRender? {
@@ -1153,7 +1158,7 @@ class EpubReaderViewModel @Inject constructor(
         } catch (_: Exception) {
             null
         } ?: return null
-        return HighlightRender(a.id, locator, a.color)
+        return HighlightRender(a.id, locator, a.color, a.note)
     }
 
     private suspend fun readChapterHtml(spineIndex: Int): String? {

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/HighlightActionsSheet.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/HighlightActionsSheet.kt
@@ -5,20 +5,33 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.outlined.Edit
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -78,10 +91,14 @@ fun HighlightSwatchRow(
 @Composable
 fun HighlightActionsSheet(
     selected: HighlightColor?,
+    note: String?,
     onPick: (HighlightColor) -> Unit,
     onDelete: () -> Unit,
+    onUpdateNote: (String?) -> Unit,
     onDismiss: () -> Unit,
 ) {
+    var noteEditorOpen by rememberSaveable { mutableStateOf(false) }
+
     ModalBottomSheet(onDismissRequest = onDismiss, dragHandle = null) {
         Row(
             modifier = Modifier
@@ -100,5 +117,87 @@ fun HighlightActionsSheet(
                 )
             }
         }
+
+        HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))
+
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clickable { noteEditorOpen = true }
+                .padding(horizontal = 24.dp, vertical = 14.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween,
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = if (note != null) "Note" else "Add note",
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+                if (note != null) {
+                    Spacer(Modifier.height(2.dp))
+                    Text(
+                        text = note,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        maxLines = 2,
+                        overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis,
+                    )
+                }
+            }
+            Icon(
+                imageVector = Icons.Outlined.Edit,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.size(20.dp),
+            )
+        }
+
+        Spacer(Modifier.height(8.dp))
     }
+
+    if (noteEditorOpen) {
+        NoteEditorDialog(
+            initialNote = note ?: "",
+            onConfirm = { text ->
+                onUpdateNote(text.takeIf { it.isNotBlank() })
+                noteEditorOpen = false
+            },
+            onDismiss = { noteEditorOpen = false },
+        )
+    }
+}
+
+@Composable
+private fun NoteEditorDialog(
+    initialNote: String,
+    onConfirm: (String) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    var text by rememberSaveable(initialNote) { mutableStateOf(initialNote) }
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Note") },
+        text = {
+            OutlinedTextField(
+                value = text,
+                onValueChange = { text = it },
+                placeholder = { Text("Add a note…") },
+                minLines = 3,
+                maxLines = 6,
+                modifier = Modifier.fillMaxWidth(),
+            )
+        },
+        confirmButton = {
+            TextButton(onClick = { onConfirm(text) }) { Text("Save") }
+        },
+        dismissButton = {
+            if (initialNote.isNotBlank()) {
+                TextButton(onClick = { onConfirm("") }) {
+                    Text("Remove", color = MaterialTheme.colorScheme.error)
+                }
+            } else {
+                TextButton(onClick = onDismiss) { Text("Cancel") }
+            }
+        },
+    )
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/HighlightActionsSheet.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/HighlightActionsSheet.kt
@@ -30,6 +30,7 @@ import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -97,7 +98,7 @@ fun HighlightActionsSheet(
     onUpdateNote: (String?) -> Unit,
     onDismiss: () -> Unit,
 ) {
-    var noteEditorOpen by rememberSaveable { mutableStateOf(false) }
+    var noteEditorOpen by remember { mutableStateOf(false) }
 
     ModalBottomSheet(onDismissRequest = onDismiss, dragHandle = null) {
         Row(

--- a/core/data/src/main/kotlin/com/riffle/core/data/AnnotationStoreImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/AnnotationStoreImpl.kt
@@ -105,6 +105,10 @@ class AnnotationStoreImpl(
     override suspend fun recolor(id: String, color: String) {
         dao.recolor(id, color = color, updatedAt = clock(), deviceId = deviceIdStore.getOrCreate())
     }
+
+    override suspend fun updateNote(id: String, note: String?) {
+        dao.updateNote(id, note = note, updatedAt = clock(), deviceId = deviceIdStore.getOrCreate())
+    }
 }
 
 private fun AnnotationEntity.toDomain() = Annotation(

--- a/core/data/src/test/kotlin/com/riffle/core/data/AnnotationStoreImplTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/AnnotationStoreImplTest.kt
@@ -40,6 +40,12 @@ class AnnotationStoreImplTest {
                 if (it.id == id) it.copy(color = color, updatedAt = updatedAt, lastModifiedByDeviceId = deviceId) else it
             }
         }
+
+        override suspend fun updateNote(id: String, note: String?, updatedAt: Long, deviceId: String) {
+            rows.value = rows.value.map {
+                if (it.id == id) it.copy(note = note, updatedAt = updatedAt, lastModifiedByDeviceId = deviceId) else it
+            }
+        }
     }
 
     private val deviceIdStore = object : DeviceIdStore {
@@ -77,6 +83,47 @@ class AnnotationStoreImplTest {
         assertEquals("blue", row?.color)
         assertEquals(5000L, row?.updatedAt)
         assertEquals("device-X", row?.lastModifiedByDeviceId)
+    }
+
+    @Test
+    fun `updateNote adds a note and bumps updatedAt and device`() = runTest {
+        val s = store()
+        val created = s.createHighlight("abs1", "item1", "epubcfi(/6/4!/4/2,/1:0,/1:10)", "t", "c.xhtml")
+        now = 7000L
+
+        s.updateNote(created.id, "My note")
+
+        val row = dao.getById(created.id)
+        assertEquals("My note", row?.note)
+        assertEquals(7000L, row?.updatedAt)
+        assertEquals("device-X", row?.lastModifiedByDeviceId)
+    }
+
+    @Test
+    fun `updateNote edits an existing note`() = runTest {
+        val s = store()
+        val created = s.createHighlight("abs1", "item1", "epubcfi(/6/4!/4/2,/1:0,/1:10)", "t", "c.xhtml")
+        s.updateNote(created.id, "First")
+        now = 8000L
+
+        s.updateNote(created.id, "Revised")
+
+        assertEquals("Revised", dao.getById(created.id)?.note)
+        assertEquals(8000L, dao.getById(created.id)?.updatedAt)
+    }
+
+    @Test
+    fun `updateNote with null clears the note and leaves the highlight intact`() = runTest {
+        val s = store()
+        val created = s.createHighlight("abs1", "item1", "epubcfi(/6/4!/4/2,/1:0,/1:10)", "t", "c.xhtml")
+        s.updateNote(created.id, "To be removed")
+
+        s.updateNote(created.id, null)
+
+        val row = dao.getById(created.id)
+        assertEquals(null, row?.note)
+        assertEquals(false, row?.deleted)
+        assertEquals("t", row?.textSnippet)
     }
 
     @Test

--- a/core/data/src/test/kotlin/com/riffle/core/data/AnnotationStoreTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/AnnotationStoreTest.kt
@@ -40,6 +40,11 @@ class AnnotationStoreTest {
                 if (it.id == id) it.copy(color = color, updatedAt = updatedAt, lastModifiedByDeviceId = deviceId) else it
             }
         }
+        override suspend fun updateNote(id: String, note: String?, updatedAt: Long, deviceId: String) {
+            rows.value = rows.value.map {
+                if (it.id == id) it.copy(note = note, updatedAt = updatedAt, lastModifiedByDeviceId = deviceId) else it
+            }
+        }
     }
 
     private class FakeDeviceIdStore(private val id: String) : DeviceIdStore {

--- a/core/database/src/main/kotlin/com/riffle/core/database/AnnotationDao.kt
+++ b/core/database/src/main/kotlin/com/riffle/core/database/AnnotationDao.kt
@@ -36,4 +36,8 @@ interface AnnotationDao {
     /** Recolour an annotation in place, bumping updatedAt + provenance so the change can propagate. */
     @Query("UPDATE annotations SET color = :color, updatedAt = :updatedAt, lastModifiedByDeviceId = :deviceId WHERE id = :id")
     suspend fun recolor(id: String, color: String, updatedAt: Long, deviceId: String)
+
+    /** Set (or clear) the note on a highlight in place, bumping updatedAt + provenance. */
+    @Query("UPDATE annotations SET note = :note, updatedAt = :updatedAt, lastModifiedByDeviceId = :deviceId WHERE id = :id")
+    suspend fun updateNote(id: String, note: String?, updatedAt: Long, deviceId: String)
 }

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/AnnotationStore.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/AnnotationStore.kt
@@ -47,6 +47,9 @@ interface AnnotationStore {
     /** Recolour an existing highlight in place, bumping its updatedAt. */
     suspend fun recolor(id: String, color: String)
 
+    /** Set (or clear) the note on an existing highlight, bumping its updatedAt. Null removes the note. */
+    suspend fun updateNote(id: String, note: String?)
+
     companion object {
         const val DEFAULT_COLOR = "yellow"
     }


### PR DESCRIPTION
## What

Lets the reader attach optional text notes to highlights (Closes #71). Noted highlights get a subtle underline so the reader can see at a glance that a note is present.

## Changes

- **`AnnotationDao`** — new `updateNote` targeted UPDATE (bumps `updatedAt` + `lastModifiedByDeviceId`, no migration needed — `note` column already existed from #69)
- **`AnnotationStore` / `AnnotationStoreImpl`** — `updateNote(id, note)` implementation
- **`HighlightRender`** — gains `note: String?` field
- **`EpubReaderViewModel`** — `updateHighlightNote(id, note)` public function; blank strings coerced to null before persistence
- **`HighlightActionsSheet`** — note row below the colour swatches (shows "Add note" or the note preview); tapping opens `NoteEditorDialog`
- **`NoteEditorDialog`** (new private composable) — `AlertDialog` with a multiline `OutlinedTextField`; Save / Remove (error colour, only when a note exists) / Cancel
- **`EpubReaderScreen`** — `annotation-notes` decoration group applies `Decoration.Style.Underline` keyed on the highlight's own `readerTint` (adapts to light/dark/sepia themes); guarded by `hasNoteDecorations` flag to avoid spurious empty calls

## Tests

- `AnnotationStoreImplTest`: 3 new unit tests — add note, edit note, clear note (null)
- All existing `AnnotationStoreTest` tests pass (fake DAO updated)

## Related

Closes #71. The "note glyph in the margin" variant (Readium `Decoration.Style.Other` + JS user script) is tracked separately in #206.