### PR TITLE
feat(annotations): floating highlight popup anchored near highlighted text (#204)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -171,7 +171,6 @@ dependencies {
     testImplementation(libs.junit)
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.json)
-    testImplementation("org.robolectric:robolectric:4.14.1")
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
     androidTestImplementation(composeBom)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -171,6 +171,7 @@ dependencies {
     testImplementation(libs.junit)
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.json)
+    testImplementation("org.robolectric:robolectric:4.14.1")
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
     androidTestImplementation(composeBom)

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -1112,7 +1112,8 @@ private fun EpubNavigatorView(
                         val container = containerRef.value ?: return false
                         coroutineScope.launch {
                             val selection = selectable.currentSelection() ?: return@launch
-                            val rawRect = selection.rect ?: return@launch
+                            val rawRect = selection.rect
+                                ?: run { selectable.clearSelection(); return@launch }
                             val rect = rawRect.toWindowIntRect(container)
                             currentOnHighlight(selection.locator, rect)
                             selectable.clearSelection()
@@ -2114,7 +2115,8 @@ private fun EpubNavigatorView(
                                     .put("type", "application/xhtml+xml")
                                     .put("text", org.json.JSONObject().put("highlight", selectedText))
                             )
-                            if (locator != null) currentOnHighlight(locator)
+                            // No WebView rect available in this path; popup falls back to top-left.
+                            if (locator != null) currentOnHighlight(locator, androidx.compose.ui.unit.IntRect(0, 0, 0, 0))
                         }
                         view.readaloudAvailable = currentReadaloudAvailable
                         view.onPlayFromHereSelection = { chapterHref, selectedText ->
@@ -2201,7 +2203,6 @@ private fun EpubNavigatorView(
                 note = current?.note,
                 onPick = { color -> onRecolorHighlight(editTarget.id, color) },
                 onDelete = { onDeleteHighlight(editTarget.id) },
-                onUpdateNote = { note -> onUpdateHighlightNote(editTarget.id, note) },
                 onOpenNoteEditor = {
                     noteEditorTarget = editTarget
                 },

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -1679,7 +1679,7 @@ private fun EpubNavigatorView(
     }
 
     // ---- Decoration tap listener (annotations) ---------------------------------------------
-    // Opens the highlight-actions sheet when the user taps an existing highlight decoration.
+    // Opens the highlight-actions popup when the user taps an existing highlight decoration.
     DisposableEffect(fragmentRef.value) {
         val fragment = fragmentRef.value as? DecorableNavigator
         val listener = object : DecorableNavigator.Listener {
@@ -2191,6 +2191,7 @@ private fun EpubNavigatorView(
         // Highlight actions sheet — opens when the user taps an existing highlight or immediately
         // after creating one. Floats as an overlay inside the reader so it has access to the
         // reader's BoxWithConstraints scope and sits above the reader content.
+        var noteEditorTarget by remember { mutableStateOf<EpubReaderViewModel.HighlightEditTarget?>(null) }
         val editTarget = highlightToEdit
         if (editTarget != null) {
             val current = highlightRenders.firstOrNull { it.id == editTarget.id }
@@ -2201,7 +2202,22 @@ private fun EpubNavigatorView(
                 onPick = { color -> onRecolorHighlight(editTarget.id, color) },
                 onDelete = { onDeleteHighlight(editTarget.id) },
                 onUpdateNote = { note -> onUpdateHighlightNote(editTarget.id, note) },
+                onOpenNoteEditor = {
+                    noteEditorTarget = editTarget
+                },
                 onDismiss = onDismissHighlightActions,
+            )
+        }
+        val noteTarget = noteEditorTarget
+        if (noteTarget != null) {
+            val current = highlightRenders.firstOrNull { it.id == noteTarget.id }
+            NoteEditorDialog(
+                initialNote = current?.note ?: "",
+                onConfirm = { text ->
+                    onUpdateHighlightNote(noteTarget.id, text.takeIf { it.isNotBlank() })
+                    noteEditorTarget = null
+                },
+                onDismiss = { noteEditorTarget = null },
             )
         }
     }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -993,9 +993,9 @@ private fun EpubNavigatorView(
     readaloudHighlightColor: ReadaloudHighlightColor,
     annotationsAvailable: Boolean,
     highlightRenders: List<EpubReaderViewModel.HighlightRender>,
-    onHighlight: (Locator) -> Unit,
-    highlightToEdit: String?,
-    onOpenHighlightActions: (String) -> Unit,
+    onHighlight: (Locator, androidx.compose.ui.unit.IntRect) -> Unit,
+    highlightToEdit: EpubReaderViewModel.HighlightEditTarget?,
+    onOpenHighlightActions: (String, androidx.compose.ui.unit.IntRect) -> Unit,
     onDismissHighlightActions: () -> Unit,
     onRecolorHighlight: (String, HighlightColor) -> Unit,
     onDeleteHighlight: (String) -> Unit,
@@ -1109,9 +1109,12 @@ private fun EpubNavigatorView(
                     highlightMenuId -> {
                         val selectable = fragmentRef.value as? org.readium.r2.navigator.SelectableNavigator
                             ?: return false
+                        val container = containerRef.value ?: return false
                         coroutineScope.launch {
                             val selection = selectable.currentSelection() ?: return@launch
-                            currentOnHighlight(selection.locator)
+                            val rawRect = selection.rect ?: return@launch
+                            val rect = rawRect.toWindowIntRect(container)
+                            currentOnHighlight(selection.locator, rect)
                             selectable.clearSelection()
                         }
                     }
@@ -1682,7 +1685,10 @@ private fun EpubNavigatorView(
         val listener = object : DecorableNavigator.Listener {
             override fun onDecorationActivated(event: DecorableNavigator.OnActivatedEvent): Boolean {
                 if (event.group != "annotations") return false
-                currentOnOpenHighlightActions(event.decoration.id)
+                val container = containerRef.value ?: return false
+                val rawRect = event.rect ?: return false
+                val rect = rawRect.toWindowIntRect(container)
+                currentOnOpenHighlightActions(event.decoration.id, rect)
                 return true
             }
         }
@@ -2185,15 +2191,16 @@ private fun EpubNavigatorView(
         // Highlight actions sheet — opens when the user taps an existing highlight or immediately
         // after creating one. Floats as an overlay inside the reader so it has access to the
         // reader's BoxWithConstraints scope and sits above the reader content.
-        val editId = highlightToEdit
-        if (editId != null) {
-            val current = highlightRenders.firstOrNull { it.id == editId }
-            HighlightActionsSheet(
+        val editTarget = highlightToEdit
+        if (editTarget != null) {
+            val current = highlightRenders.firstOrNull { it.id == editTarget.id }
+            HighlightActionsPopup(
+                anchorRect = editTarget.anchorRect,
                 selected = current?.let { HighlightColor.fromToken(it.color) },
                 note = current?.note,
-                onPick = { color -> onRecolorHighlight(editId, color) },
-                onDelete = { onDeleteHighlight(editId) },
-                onUpdateNote = { note -> onUpdateHighlightNote(editId, note) },
+                onPick = { color -> onRecolorHighlight(editTarget.id, color) },
+                onDelete = { onDeleteHighlight(editTarget.id) },
+                onUpdateNote = { note -> onUpdateHighlightNote(editTarget.id, note) },
                 onDismiss = onDismissHighlightActions,
             )
         }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -3,6 +3,7 @@
 package com.riffle.app.feature.reader
 
 import android.app.Application
+import androidx.compose.ui.unit.IntRect
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
@@ -328,11 +329,15 @@ class EpubReaderViewModel @Inject constructor(
 
     private val _bookmarkPositions = MutableStateFlow<List<BookmarkPosition>>(emptyList())
 
-    private val _highlightToEdit = MutableStateFlow<String?>(null)
-    /** Id of a highlight whose actions sheet should be open (just-created or tapped), else null. */
-    val highlightToEdit: StateFlow<String?> = _highlightToEdit
+    data class HighlightEditTarget(val id: String, val anchorRect: IntRect)
 
-    fun openHighlightActions(id: String) { _highlightToEdit.value = id }
+    private val _highlightToEdit = MutableStateFlow<HighlightEditTarget?>(null)
+    /** Highlight whose actions popup should be open (just-created or tapped), else null. */
+    val highlightToEdit: StateFlow<HighlightEditTarget?> = _highlightToEdit
+
+    fun openHighlightActions(id: String, anchorRect: IntRect) {
+        _highlightToEdit.value = HighlightEditTarget(id, anchorRect)
+    }
     fun dismissHighlightActions() { _highlightToEdit.value = null }
 
     private val _readaloudAvailable = MutableStateFlow(false)
@@ -1069,7 +1074,7 @@ class EpubReaderViewModel @Inject constructor(
     // the selection's start progression + selected text (ADR 0024), capturing the snippet + href.
     // Any existing highlights in the same chapter that overlap the new selection are deleted first —
     // a larger selection subsuming a previously highlighted word replaces that highlight.
-    fun createHighlight(selectionLocator: Locator) {
+    fun createHighlight(selectionLocator: Locator, anchorRect: IntRect) {
         val serverId = annotationServerId ?: return
         viewModelScope.launch {
             val pub = publication ?: return@launch
@@ -1108,7 +1113,7 @@ class EpubReaderViewModel @Inject constructor(
                 spineIndex = spineIndex,
                 progression = progression,
             )
-            _highlightToEdit.value = created.id
+            openHighlightActions(created.id, anchorRect)
             // observeHighlights re-emits → highlightRenders updates → the screen re-applies decorations.
         }
     }
@@ -1169,7 +1174,7 @@ class EpubReaderViewModel @Inject constructor(
     fun deleteHighlight(id: String) {
         viewModelScope.launch {
             annotationStore.delete(id)
-            if (_highlightToEdit.value == id) _highlightToEdit.value = null
+            if (_highlightToEdit.value?.id == id) _highlightToEdit.value = null
         }
     }
 

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -1197,7 +1197,7 @@ class EpubReaderViewModel @Inject constructor(
     fun deleteAnnotation(id: String) {
         viewModelScope.launch {
             annotationStore.delete(id)
-            if (_highlightToEdit.value == id) _highlightToEdit.value = null
+            if (_highlightToEdit.value?.id == id) _highlightToEdit.value = null
         }
     }
 

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/HighlightActionsSheet.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/HighlightActionsSheet.kt
@@ -12,19 +12,20 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.outlined.Edit
 import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -37,9 +38,14 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.IntRect
+import androidx.compose.ui.window.Popup
+import androidx.compose.ui.window.PopupProperties
 import com.riffle.core.domain.HighlightColor
 
 /**
@@ -88,9 +94,9 @@ fun HighlightSwatchRow(
     }
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun HighlightActionsSheet(
+fun HighlightActionsPopup(
+    anchorRect: IntRect,
     selected: HighlightColor?,
     note: String?,
     onPick: (HighlightColor) -> Unit,
@@ -99,61 +105,74 @@ fun HighlightActionsSheet(
     onDismiss: () -> Unit,
 ) {
     var noteEditorOpen by remember { mutableStateOf(false) }
+    val density = LocalDensity.current
+    val margin = with(density) { 8.dp.roundToPx() }
+    val provider = remember(anchorRect) { HighlightPopupPositionProvider(anchorRect, margin) }
 
-    ModalBottomSheet(onDismissRequest = onDismiss, dragHandle = null) {
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 24.dp)
-                .padding(vertical = 12.dp),
-            horizontalArrangement = Arrangement.SpaceBetween,
-            verticalAlignment = Alignment.CenterVertically,
+    Popup(
+        popupPositionProvider = provider,
+        onDismissRequest = onDismiss,
+        properties = PopupProperties(focusable = true),
+    ) {
+        Surface(
+            shape = RoundedCornerShape(12.dp),
+            shadowElevation = 4.dp,
+            tonalElevation = 0.dp,
         ) {
-            HighlightSwatchRow(selected = selected, onPick = onPick)
-            IconButton(onClick = onDelete) {
-                Icon(
-                    imageVector = Icons.Default.Delete,
-                    contentDescription = "Delete highlight",
-                    tint = MaterialTheme.colorScheme.error,
-                )
-            }
-        }
-
-        HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))
-
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .clickable { noteEditorOpen = true }
-                .padding(horizontal = 24.dp, vertical = 14.dp),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.SpaceBetween,
-        ) {
-            Column(modifier = Modifier.weight(1f)) {
-                Text(
-                    text = if (note != null) "Note" else "Add note",
-                    style = MaterialTheme.typography.bodyMedium,
-                )
-                if (note != null) {
-                    Spacer(Modifier.height(2.dp))
-                    Text(
-                        text = note,
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        maxLines = 2,
-                        overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis,
+            Column(modifier = Modifier.width(280.dp)) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 12.dp),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    HighlightSwatchRow(selected = selected, onPick = onPick)
+                    IconButton(onClick = onDelete) {
+                        Icon(
+                            imageVector = Icons.Default.Delete,
+                            contentDescription = "Delete highlight",
+                            tint = MaterialTheme.colorScheme.error,
+                        )
+                    }
+                }
+                HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clickable {
+                            onDismiss()
+                            noteEditorOpen = true
+                        }
+                        .padding(horizontal = 16.dp, vertical = 14.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                ) {
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(
+                            text = if (note != null) "Note" else "Add note",
+                            style = MaterialTheme.typography.bodyMedium,
+                        )
+                        if (note != null) {
+                            Spacer(Modifier.height(2.dp))
+                            Text(
+                                text = note,
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                maxLines = 2,
+                                overflow = TextOverflow.Ellipsis,
+                            )
+                        }
+                    }
+                    Icon(
+                        imageVector = Icons.Outlined.Edit,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.size(20.dp),
                     )
                 }
             }
-            Icon(
-                imageVector = Icons.Outlined.Edit,
-                contentDescription = null,
-                tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                modifier = Modifier.size(20.dp),
-            )
         }
-
-        Spacer(Modifier.height(8.dp))
     }
 
     if (noteEditorOpen) {

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/HighlightActionsSheet.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/HighlightActionsSheet.kt
@@ -101,7 +101,6 @@ fun HighlightActionsPopup(
     note: String?,
     onPick: (HighlightColor) -> Unit,
     onDelete: () -> Unit,
-    onUpdateNote: (String?) -> Unit,
     onOpenNoteEditor: () -> Unit,
     onDismiss: () -> Unit,
 ) {

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/HighlightActionsSheet.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/HighlightActionsSheet.kt
@@ -102,9 +102,9 @@ fun HighlightActionsPopup(
     onPick: (HighlightColor) -> Unit,
     onDelete: () -> Unit,
     onUpdateNote: (String?) -> Unit,
+    onOpenNoteEditor: () -> Unit,
     onDismiss: () -> Unit,
 ) {
-    var noteEditorOpen by remember { mutableStateOf(false) }
     val density = LocalDensity.current
     val margin = with(density) { 8.dp.roundToPx() }
     val provider = remember(anchorRect) { HighlightPopupPositionProvider(anchorRect, margin) }
@@ -142,7 +142,7 @@ fun HighlightActionsPopup(
                         .fillMaxWidth()
                         .clickable {
                             onDismiss()
-                            noteEditorOpen = true
+                            onOpenNoteEditor()
                         }
                         .padding(horizontal = 16.dp, vertical = 14.dp),
                     verticalAlignment = Alignment.CenterVertically,
@@ -174,21 +174,10 @@ fun HighlightActionsPopup(
             }
         }
     }
-
-    if (noteEditorOpen) {
-        NoteEditorDialog(
-            initialNote = note ?: "",
-            onConfirm = { text ->
-                onUpdateNote(text.takeIf { it.isNotBlank() })
-                noteEditorOpen = false
-            },
-            onDismiss = { noteEditorOpen = false },
-        )
-    }
 }
 
 @Composable
-private fun NoteEditorDialog(
+internal fun NoteEditorDialog(
     initialNote: String,
     onConfirm: (String) -> Unit,
     onDismiss: () -> Unit,

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderCoordinates.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderCoordinates.kt
@@ -9,18 +9,24 @@ import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.window.PopupPositionProvider
 import kotlin.math.roundToInt
 
-internal fun RectF.toWindowIntRect(viewLeft: Int, viewTop: Int): IntRect = IntRect(
-    left   = viewLeft + left.roundToInt(),
-    top    = viewTop  + top.roundToInt(),
-    right  = viewLeft + right.roundToInt(),
-    bottom = viewTop  + bottom.roundToInt(),
-)
+internal fun RectF.toWindowIntRect(viewLeft: Int, viewTop: Int): IntRect =
+    toWindowIntRect(left, top, right, bottom, viewLeft, viewTop)
 
 internal fun RectF.toWindowIntRect(view: View): IntRect {
     val loc = IntArray(2)
     view.getLocationOnScreen(loc)
     return toWindowIntRect(loc[0], loc[1])
 }
+
+internal fun toWindowIntRect(
+    rectLeft: Float, rectTop: Float, rectRight: Float, rectBottom: Float,
+    viewLeft: Int, viewTop: Int,
+): IntRect = IntRect(
+    left   = viewLeft + rectLeft.roundToInt(),
+    top    = viewTop  + rectTop.roundToInt(),
+    right  = viewLeft + rectRight.roundToInt(),
+    bottom = viewTop  + rectBottom.roundToInt(),
+)
 
 internal class HighlightPopupPositionProvider(
     private val anchorRect: IntRect,

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderCoordinates.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderCoordinates.kt
@@ -1,0 +1,44 @@
+package com.riffle.app.feature.reader
+
+import android.graphics.RectF
+import android.view.View
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntRect
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.window.PopupPositionProvider
+import kotlin.math.roundToInt
+
+internal fun RectF.toWindowIntRect(viewLeft: Int, viewTop: Int): IntRect = IntRect(
+    left   = viewLeft + left.roundToInt(),
+    top    = viewTop  + top.roundToInt(),
+    right  = viewLeft + right.roundToInt(),
+    bottom = viewTop  + bottom.roundToInt(),
+)
+
+internal fun RectF.toWindowIntRect(view: View): IntRect {
+    val loc = IntArray(2)
+    view.getLocationOnScreen(loc)
+    return toWindowIntRect(loc[0], loc[1])
+}
+
+internal class HighlightPopupPositionProvider(
+    private val anchorRect: IntRect,
+    private val margin: Int,
+) : PopupPositionProvider {
+    override fun calculatePosition(
+        anchorBounds: IntRect,
+        windowSize: IntSize,
+        layoutDirection: LayoutDirection,
+        popupContentSize: IntSize,
+    ): IntOffset {
+        // anchorBounds (Compose's composable anchor) is intentionally ignored — anchorRect is
+        // already mapped to window coordinates from the WebView's coordinate space.
+        val preferredTop = anchorRect.top - popupContentSize.height - margin
+        val top = if (preferredTop >= margin) preferredTop else anchorRect.bottom + margin
+        val centreX = anchorRect.center.x - popupContentSize.width / 2
+        val maxLeft = maxOf(margin, windowSize.width - popupContentSize.width - margin)
+        val left = centreX.coerceIn(margin, maxLeft)
+        return IntOffset(left, top)
+    }
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderCoordinates.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderCoordinates.kt
@@ -43,7 +43,7 @@ internal class HighlightPopupPositionProvider(
         val preferredTop = anchorRect.top - popupContentSize.height - margin
         val maxTop = windowSize.height - popupContentSize.height - margin
         val top = if (preferredTop >= margin) {
-            preferredTop
+            preferredTop.coerceAtMost(maxTop)
         } else {
             (anchorRect.bottom + margin).coerceAtMost(maxTop)
         }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderCoordinates.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderCoordinates.kt
@@ -41,7 +41,12 @@ internal class HighlightPopupPositionProvider(
         // anchorBounds (Compose's composable anchor) is intentionally ignored — anchorRect is
         // already mapped to window coordinates from the WebView's coordinate space.
         val preferredTop = anchorRect.top - popupContentSize.height - margin
-        val top = if (preferredTop >= margin) preferredTop else anchorRect.bottom + margin
+        val maxTop = windowSize.height - popupContentSize.height - margin
+        val top = if (preferredTop >= margin) {
+            preferredTop
+        } else {
+            (anchorRect.bottom + margin).coerceAtMost(maxTop)
+        }
         val centreX = anchorRect.center.x - popupContentSize.width / 2
         val maxLeft = maxOf(margin, windowSize.width - popupContentSize.width - margin)
         val left = centreX.coerceIn(margin, maxLeft)

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ReaderCoordinatesTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ReaderCoordinatesTest.kt
@@ -1,31 +1,31 @@
 package com.riffle.app.feature.reader
 
-import android.graphics.RectF
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntRect
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.LayoutDirection
 import org.junit.Assert.assertEquals
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
 class ReaderCoordinatesTest {
 
     // ── toWindowIntRect ──────────────────────────────────────────────────────
 
     @Test
     fun `toWindowIntRect adds view offset to rect coordinates`() {
-        val rect = RectF(10f, 20f, 50f, 60f)
-        val result = rect.toWindowIntRect(viewLeft = 100, viewTop = 200)
+        val result = toWindowIntRect(
+            rectLeft = 10f, rectTop = 20f, rectRight = 50f, rectBottom = 60f,
+            viewLeft = 100, viewTop = 200,
+        )
         assertEquals(IntRect(left = 110, top = 220, right = 150, bottom = 260), result)
     }
 
     @Test
     fun `toWindowIntRect rounds float coordinates`() {
-        val rect = RectF(10.4f, 20.6f, 50.3f, 60.7f)
-        val result = rect.toWindowIntRect(viewLeft = 0, viewTop = 0)
+        val result = toWindowIntRect(
+            rectLeft = 10.4f, rectTop = 20.6f, rectRight = 50.3f, rectBottom = 60.7f,
+            viewLeft = 0, viewTop = 0,
+        )
         assertEquals(IntRect(left = 10, top = 21, right = 50, bottom = 61), result)
     }
 

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ReaderCoordinatesTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ReaderCoordinatesTest.kt
@@ -93,4 +93,15 @@ class ReaderCoordinatesTest {
         val result = position(provider(anchor, margin = 8), IntSize(100, 800), IntSize(150, 100))
         assertEquals(8, result.x)
     }
+
+    @Test
+    fun `popup bottom-clamped when anchor near bottom and no space above`() {
+        // anchor spans nearly the full height → no space above, flip-below would overflow
+        // windowHeight=800, popupHeight=100, margin=8 → maxTop = 800-100-8 = 692
+        // anchorTop=10 → preferredTop = 10-100-8 = -98 < 8 → flip: anchorBottom+8 = 790+8=798
+        // 798.coerceAtMost(692) = 692
+        val anchor = IntRect(left = 100, top = 10, right = 200, bottom = 790)
+        val result = position(provider(anchor, margin = 8), IntSize(400, 800), IntSize(280, 100))
+        assertEquals(692, result.y)
+    }
 }

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ReaderCoordinatesTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ReaderCoordinatesTest.kt
@@ -1,0 +1,96 @@
+package com.riffle.app.feature.reader
+
+import android.graphics.RectF
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntRect
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.LayoutDirection
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class ReaderCoordinatesTest {
+
+    // ── toWindowIntRect ──────────────────────────────────────────────────────
+
+    @Test
+    fun `toWindowIntRect adds view offset to rect coordinates`() {
+        val rect = RectF(10f, 20f, 50f, 60f)
+        val result = rect.toWindowIntRect(viewLeft = 100, viewTop = 200)
+        assertEquals(IntRect(left = 110, top = 220, right = 150, bottom = 260), result)
+    }
+
+    @Test
+    fun `toWindowIntRect rounds float coordinates`() {
+        val rect = RectF(10.4f, 20.6f, 50.3f, 60.7f)
+        val result = rect.toWindowIntRect(viewLeft = 0, viewTop = 0)
+        assertEquals(IntRect(left = 10, top = 21, right = 50, bottom = 61), result)
+    }
+
+    // ── HighlightPopupPositionProvider ───────────────────────────────────────
+
+    private fun provider(anchorRect: IntRect, margin: Int = 8) =
+        HighlightPopupPositionProvider(anchorRect, margin)
+
+    private fun position(
+        provider: HighlightPopupPositionProvider,
+        windowSize: IntSize,
+        popupSize: IntSize,
+    ): IntOffset = provider.calculatePosition(
+        anchorBounds = IntRect.Zero,
+        windowSize = windowSize,
+        layoutDirection = LayoutDirection.Ltr,
+        popupContentSize = popupSize,
+    )
+
+    @Test
+    fun `popup positioned above anchor when space available`() {
+        // anchorTop=300, popupHeight=100, margin=8 → preferredTop = 300-100-8 = 192
+        val anchor = IntRect(left = 100, top = 300, right = 200, bottom = 320)
+        val result = position(provider(anchor), IntSize(400, 800), IntSize(280, 100))
+        assertEquals(192, result.y)
+    }
+
+    @Test
+    fun `popup flips below anchor when not enough space above`() {
+        // anchorTop=80, popupHeight=100, margin=8 → preferredTop = -28 < 8 → flip: 100+8=108
+        val anchor = IntRect(left = 100, top = 80, right = 200, bottom = 100)
+        val result = position(provider(anchor), IntSize(400, 800), IntSize(280, 100))
+        assertEquals(108, result.y)
+    }
+
+    @Test
+    fun `popup centred on anchor horizontally`() {
+        // anchorCentreX=150, popupWidth=100 → left = 150-50 = 100; within [8, 292] → 100
+        val anchor = IntRect(left = 100, top = 300, right = 200, bottom = 320)
+        val result = position(provider(anchor), IntSize(400, 800), IntSize(100, 100))
+        assertEquals(100, result.x)
+    }
+
+    @Test
+    fun `popup clamped to left margin when anchor is near left edge`() {
+        // anchorCentreX=10, popupWidth=200 → centreX = 10-100 = -90, clamped to 8
+        val anchor = IntRect(left = 5, top = 300, right = 15, bottom = 320)
+        val result = position(provider(anchor, margin = 8), IntSize(400, 800), IntSize(200, 100))
+        assertEquals(8, result.x)
+    }
+
+    @Test
+    fun `popup clamped to right margin when anchor is near right edge`() {
+        // anchorCentreX=395, popupWidth=200 → centreX=295, maxLeft=max(8,400-200-8)=192 → 192
+        val anchor = IntRect(left = 390, top = 300, right = 400, bottom = 320)
+        val result = position(provider(anchor, margin = 8), IntSize(400, 800), IntSize(200, 100))
+        assertEquals(192, result.x)
+    }
+
+    @Test
+    fun `popup max-left guard prevents crash on very narrow window`() {
+        // Window width 100, popup width 150, margin 8 → maxLeft = max(8, 100-150-8)=max(8,-58)=8
+        // centreX = 50-75 = -25, clamped to 8 (not crash from min>max)
+        val anchor = IntRect(left = 40, top = 300, right = 60, bottom = 320)
+        val result = position(provider(anchor, margin = 8), IntSize(100, 800), IntSize(150, 100))
+        assertEquals(8, result.x)
+    }
+}

--- a/docs/superpowers/plans/2026-06-18-floating-highlight-popup.md
+++ b/docs/superpowers/plans/2026-06-18-floating-highlight-popup.md
@@ -1,0 +1,739 @@
+# Floating Highlight Action Popup — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the `ModalBottomSheet` highlight actions UI with a small floating `Popup` card that appears anchored to the highlighted text.
+
+**Architecture:** The WebView-local `RectF` from both trigger paths (decoration tap + text selection) is mapped to window pixel coordinates using `View.getLocationOnScreen()`, stored in the ViewModel as `HighlightEditTarget(id, anchorRect)`, and consumed by a `PopupPositionProvider` that places the card above/below the anchor and clamps it to screen edges.
+
+**Tech Stack:** Kotlin, Jetpack Compose (`Popup`, `PopupPositionProvider`, `Surface`), Readium 3.3 (`DecorableNavigator.OnActivatedEvent`, `SelectableNavigator.currentSelection()`), Hilt, JUnit 4.
+
+## Global Constraints
+
+- No mocking libraries available — unit-test pure functions by extracting the Android-touching layer into a thin wrapper; pass `viewLeft`/`viewTop` ints to the pure logic.
+- `JAVA_HOME` must be set before running Gradle: `export JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"`
+- Run JVM tests with `./gradlew :app:testDebugUnitTest` (or `./gradlew test`).
+- Never call `./gradlew :app:connectedDebugAndroidTest` directly — use `make harness-test` for instrumented tests.
+- The `HighlightSwatchRow` and `NoteEditorDialog` composables are unchanged — reuse them verbatim.
+
+---
+
+### Task 1: Coordinate helper + position provider (with tests)
+
+**Files:**
+- Create: `app/src/main/kotlin/com/riffle/app/feature/reader/ReaderCoordinates.kt`
+- Create: `app/src/test/kotlin/com/riffle/app/feature/reader/ReaderCoordinatesTest.kt`
+
+**Interfaces:**
+- Produces:
+  - `internal fun RectF.toWindowIntRect(viewLeft: Int, viewTop: Int): IntRect` — pure arithmetic, testable
+  - `internal fun RectF.toWindowIntRect(view: View): IntRect` — Android wrapper, reads offset via `getLocationOnScreen`
+  - `internal class HighlightPopupPositionProvider(anchorRect: IntRect, margin: Int) : PopupPositionProvider`
+
+---
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `app/src/test/kotlin/com/riffle/app/feature/reader/ReaderCoordinatesTest.kt`:
+
+```kotlin
+package com.riffle.app.feature.reader
+
+import android.graphics.RectF
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntRect
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.LayoutDirection
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ReaderCoordinatesTest {
+
+    // ── toWindowIntRect ──────────────────────────────────────────────────────
+
+    @Test
+    fun `toWindowIntRect adds view offset to rect coordinates`() {
+        val rect = RectF(10f, 20f, 50f, 60f)
+        val result = rect.toWindowIntRect(viewLeft = 100, viewTop = 200)
+        assertEquals(IntRect(left = 110, top = 220, right = 150, bottom = 260), result)
+    }
+
+    @Test
+    fun `toWindowIntRect rounds float coordinates`() {
+        val rect = RectF(10.4f, 20.6f, 50.3f, 60.7f)
+        val result = rect.toWindowIntRect(viewLeft = 0, viewTop = 0)
+        assertEquals(IntRect(left = 10, top = 21, right = 50, bottom = 61), result)
+    }
+
+    // ── HighlightPopupPositionProvider ───────────────────────────────────────
+
+    private fun provider(anchorRect: IntRect, margin: Int = 8) =
+        HighlightPopupPositionProvider(anchorRect, margin)
+
+    private fun position(
+        provider: HighlightPopupPositionProvider,
+        windowSize: IntSize,
+        popupSize: IntSize,
+    ): IntOffset = provider.calculatePosition(
+        anchorBounds = IntRect.Zero,
+        windowSize = windowSize,
+        layoutDirection = LayoutDirection.Ltr,
+        popupContentSize = popupSize,
+    )
+
+    @Test
+    fun `popup positioned above anchor when space available`() {
+        // anchorTop=300, popupHeight=100, margin=8 → preferredTop = 300-100-8 = 192
+        val anchor = IntRect(left = 100, top = 300, right = 200, bottom = 320)
+        val result = position(provider(anchor), IntSize(400, 800), IntSize(280, 100))
+        assertEquals(192, result.y)
+    }
+
+    @Test
+    fun `popup flips below anchor when not enough space above`() {
+        // anchorTop=80, popupHeight=100, margin=8 → preferredTop = -28 < 8 → flip: 100+8=108
+        val anchor = IntRect(left = 100, top = 80, right = 200, bottom = 100)
+        val result = position(provider(anchor), IntSize(400, 800), IntSize(280, 100))
+        assertEquals(108, result.y)
+    }
+
+    @Test
+    fun `popup centred on anchor horizontally`() {
+        // anchorCentreX=150, popupWidth=100 → left = 150-50 = 100; within [8, 292] → 100
+        val anchor = IntRect(left = 100, top = 300, right = 200, bottom = 320)
+        val result = position(provider(anchor), IntSize(400, 800), IntSize(100, 100))
+        assertEquals(100, result.x)
+    }
+
+    @Test
+    fun `popup clamped to left margin when anchor is near left edge`() {
+        // anchorCentreX=10, popupWidth=200 → centreX = 10-100 = -90, clamped to 8
+        val anchor = IntRect(left = 5, top = 300, right = 15, bottom = 320)
+        val result = position(provider(anchor, margin = 8), IntSize(400, 800), IntSize(200, 100))
+        assertEquals(8, result.x)
+    }
+
+    @Test
+    fun `popup clamped to right margin when anchor is near right edge`() {
+        // anchorCentreX=395, popupWidth=200 → centreX=295, maxLeft=max(8,400-200-8)=192 → 192
+        val anchor = IntRect(left = 390, top = 300, right = 400, bottom = 320)
+        val result = position(provider(anchor, margin = 8), IntSize(400, 800), IntSize(200, 100))
+        assertEquals(192, result.x)
+    }
+
+    @Test
+    fun `popup max-left guard prevents crash on very narrow window`() {
+        // Window width 100, popup width 150, margin 8 → maxLeft = max(8, 100-150-8)=max(8,-58)=8
+        // centreX = 50-75 = -25, clamped to 8 (not crash from min>max)
+        val anchor = IntRect(left = 40, top = 300, right = 60, bottom = 320)
+        val result = position(provider(anchor, margin = 8), IntSize(100, 800), IntSize(150, 100))
+        assertEquals(8, result.x)
+    }
+}
+```
+
+- [ ] **Step 2: Run tests — expect compile failure (classes don't exist yet)**
+
+```bash
+export JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"
+./gradlew :app:testDebugUnitTest --tests "com.riffle.app.feature.reader.ReaderCoordinatesTest" 2>&1 | tail -20
+```
+
+Expected: compilation error — `toWindowIntRect` and `HighlightPopupPositionProvider` not found.
+
+- [ ] **Step 3: Create `ReaderCoordinates.kt`**
+
+```kotlin
+package com.riffle.app.feature.reader
+
+import android.graphics.RectF
+import android.view.View
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntRect
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.window.PopupPositionProvider
+import kotlin.math.roundToInt
+
+internal fun RectF.toWindowIntRect(viewLeft: Int, viewTop: Int): IntRect = IntRect(
+    left   = viewLeft + left.roundToInt(),
+    top    = viewTop  + top.roundToInt(),
+    right  = viewLeft + right.roundToInt(),
+    bottom = viewTop  + bottom.roundToInt(),
+)
+
+internal fun RectF.toWindowIntRect(view: View): IntRect {
+    val loc = IntArray(2)
+    view.getLocationOnScreen(loc)
+    return toWindowIntRect(loc[0], loc[1])
+}
+
+internal class HighlightPopupPositionProvider(
+    private val anchorRect: IntRect,
+    private val margin: Int,
+) : PopupPositionProvider {
+    override fun calculatePosition(
+        anchorBounds: IntRect,
+        windowSize: IntSize,
+        layoutDirection: LayoutDirection,
+        popupContentSize: IntSize,
+    ): IntOffset {
+        // anchorBounds (Compose's composable anchor) is intentionally ignored — anchorRect is
+        // already mapped to window coordinates from the WebView's coordinate space.
+        val preferredTop = anchorRect.top - popupContentSize.height - margin
+        val top = if (preferredTop >= margin) preferredTop else anchorRect.bottom + margin
+        val centreX = anchorRect.center.x - popupContentSize.width / 2
+        val maxLeft = maxOf(margin, windowSize.width - popupContentSize.width - margin)
+        val left = centreX.coerceIn(margin, maxLeft)
+        return IntOffset(left, top)
+    }
+}
+```
+
+- [ ] **Step 4: Run tests — expect all green**
+
+```bash
+export JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"
+./gradlew :app:testDebugUnitTest --tests "com.riffle.app.feature.reader.ReaderCoordinatesTest" 2>&1 | tail -20
+```
+
+Expected: `BUILD SUCCESSFUL` with 7 tests passing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/kotlin/com/riffle/app/feature/reader/ReaderCoordinates.kt \
+        app/src/test/kotlin/com/riffle/app/feature/reader/ReaderCoordinatesTest.kt
+git commit -m "feat(annotations): coordinate helper + popup position provider"
+```
+
+---
+
+### Task 2: ViewModel — `HighlightEditTarget` + updated signatures
+
+**Files:**
+- Modify: `app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt`
+
+**Interfaces:**
+- Consumes: `IntRect` from `androidx.compose.ui.unit`
+- Produces:
+  - `data class HighlightEditTarget(val id: String, val anchorRect: IntRect)` (nested in `EpubReaderViewModel`)
+  - `val highlightToEdit: StateFlow<HighlightEditTarget?>`
+  - `fun openHighlightActions(id: String, anchorRect: IntRect)`
+  - `fun createHighlight(selectionLocator: Locator, anchorRect: IntRect)`
+
+---
+
+- [ ] **Step 1: Add `IntRect` import to `EpubReaderViewModel.kt`**
+
+Open `app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt`. Add to the import block (keep alphabetical order):
+
+```kotlin
+import androidx.compose.ui.unit.IntRect
+```
+
+- [ ] **Step 2: Replace the `_highlightToEdit` block (lines ~330–335)**
+
+Find this block:
+
+```kotlin
+private val _highlightToEdit = MutableStateFlow<String?>(null)
+/** Id of a highlight whose actions sheet should be open (just-created or tapped), else null. */
+val highlightToEdit: StateFlow<String?> = _highlightToEdit
+
+fun openHighlightActions(id: String) { _highlightToEdit.value = id }
+fun dismissHighlightActions() { _highlightToEdit.value = null }
+```
+
+Replace with:
+
+```kotlin
+data class HighlightEditTarget(val id: String, val anchorRect: IntRect)
+
+private val _highlightToEdit = MutableStateFlow<HighlightEditTarget?>(null)
+/** Highlight whose actions popup should be open (just-created or tapped), else null. */
+val highlightToEdit: StateFlow<HighlightEditTarget?> = _highlightToEdit
+
+fun openHighlightActions(id: String, anchorRect: IntRect) {
+    _highlightToEdit.value = HighlightEditTarget(id, anchorRect)
+}
+fun dismissHighlightActions() { _highlightToEdit.value = null }
+```
+
+- [ ] **Step 3: Update `createHighlight` signature and its call to `openHighlightActions`**
+
+Find the function signature (line ~1049):
+
+```kotlin
+fun createHighlight(selectionLocator: Locator) {
+```
+
+Replace with:
+
+```kotlin
+fun createHighlight(selectionLocator: Locator, anchorRect: IntRect) {
+```
+
+Find (line ~1086):
+
+```kotlin
+_highlightToEdit.value = created.id
+```
+
+Replace with:
+
+```kotlin
+openHighlightActions(created.id, anchorRect)
+```
+
+- [ ] **Step 4: Run unit tests to verify no breakage**
+
+```bash
+export JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"
+./gradlew :app:testDebugUnitTest 2>&1 | tail -20
+```
+
+Expected: `BUILD SUCCESSFUL`. (The only compilation errors at this point are in `EpubReaderScreen.kt` where call sites pass the old signatures — those are fixed in Task 4.)
+
+Note: if the build fails due to `EpubReaderScreen.kt` call sites, that is expected and is not a problem — it will be resolved in Task 4. Focus on the ViewModel tests passing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+git commit -m "feat(annotations): HighlightEditTarget + updated openHighlightActions/createHighlight"
+```
+
+---
+
+### Task 3: Replace `HighlightActionsSheet` with `HighlightActionsPopup`
+
+**Files:**
+- Modify: `app/src/main/kotlin/com/riffle/app/feature/reader/HighlightActionsSheet.kt`
+
+**Interfaces:**
+- Consumes: `HighlightPopupPositionProvider` and `toWindowIntRect` from Task 1; `IntRect` from ViewModel (Task 2)
+- Produces: `@Composable fun HighlightActionsPopup(anchorRect: IntRect, selected, note, onPick, onDelete, onUpdateNote, onDismiss)`
+
+The `HighlightSwatchRow` and `NoteEditorDialog` composables are unchanged — keep them exactly as-is.
+
+---
+
+- [ ] **Step 1: Replace the import block in `HighlightActionsSheet.kt`**
+
+Replace the entire import section at the top of the file (everything after `package com.riffle.app.feature.reader` up to the first `/**` comment) with:
+
+```kotlin
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.outlined.Edit
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.IntRect
+import androidx.compose.ui.window.Popup
+import androidx.compose.ui.window.PopupProperties
+import com.riffle.core.domain.HighlightColor
+```
+
+- [ ] **Step 2: Replace `HighlightActionsSheet` with `HighlightActionsPopup`**
+
+Find and delete the entire `HighlightActionsSheet` composable (lines ~91–169):
+
+```kotlin
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun HighlightActionsSheet(
+    selected: HighlightColor?,
+    note: String?,
+    onPick: (HighlightColor) -> Unit,
+    onDelete: () -> Unit,
+    onUpdateNote: (String?) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    var noteEditorOpen by remember { mutableStateOf(false) }
+
+    ModalBottomSheet(onDismissRequest = onDismiss, dragHandle = null) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 24.dp)
+                .padding(vertical = 12.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            HighlightSwatchRow(selected = selected, onPick = onPick)
+            IconButton(onClick = onDelete) {
+                Icon(
+                    imageVector = Icons.Default.Delete,
+                    contentDescription = "Delete highlight",
+                    tint = MaterialTheme.colorScheme.error,
+                )
+            }
+        }
+
+        HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))
+
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clickable { noteEditorOpen = true }
+                .padding(horizontal = 24.dp, vertical = 14.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween,
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = if (note != null) "Note" else "Add note",
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+                if (note != null) {
+                    Spacer(Modifier.height(2.dp))
+                    Text(
+                        text = note,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        maxLines = 2,
+                        overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis,
+                    )
+                }
+            }
+            Icon(
+                imageVector = Icons.Outlined.Edit,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.size(20.dp),
+            )
+        }
+
+        Spacer(Modifier.height(8.dp))
+    }
+
+    if (noteEditorOpen) {
+        NoteEditorDialog(
+            initialNote = note ?: "",
+            onConfirm = { text ->
+                onUpdateNote(text.takeIf { it.isNotBlank() })
+                noteEditorOpen = false
+            },
+            onDismiss = { noteEditorOpen = false },
+        )
+    }
+}
+```
+
+Replace with:
+
+```kotlin
+@Composable
+fun HighlightActionsPopup(
+    anchorRect: IntRect,
+    selected: HighlightColor?,
+    note: String?,
+    onPick: (HighlightColor) -> Unit,
+    onDelete: () -> Unit,
+    onUpdateNote: (String?) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    var noteEditorOpen by remember { mutableStateOf(false) }
+    val density = LocalDensity.current
+    val margin = with(density) { 8.dp.roundToPx() }
+    val provider = remember(anchorRect) { HighlightPopupPositionProvider(anchorRect, margin) }
+
+    Popup(
+        popupPositionProvider = provider,
+        onDismissRequest = onDismiss,
+        properties = PopupProperties(focusable = true),
+    ) {
+        Surface(
+            shape = RoundedCornerShape(12.dp),
+            shadowElevation = 4.dp,
+            tonalElevation = 0.dp,
+        ) {
+            Column(modifier = Modifier.width(280.dp)) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 12.dp),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    HighlightSwatchRow(selected = selected, onPick = onPick)
+                    IconButton(onClick = onDelete) {
+                        Icon(
+                            imageVector = Icons.Default.Delete,
+                            contentDescription = "Delete highlight",
+                            tint = MaterialTheme.colorScheme.error,
+                        )
+                    }
+                }
+                HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clickable {
+                            onDismiss()
+                            noteEditorOpen = true
+                        }
+                        .padding(horizontal = 16.dp, vertical = 14.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                ) {
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(
+                            text = if (note != null) "Note" else "Add note",
+                            style = MaterialTheme.typography.bodyMedium,
+                        )
+                        if (note != null) {
+                            Spacer(Modifier.height(2.dp))
+                            Text(
+                                text = note,
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                maxLines = 2,
+                                overflow = TextOverflow.Ellipsis,
+                            )
+                        }
+                    }
+                    Icon(
+                        imageVector = Icons.Outlined.Edit,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.size(20.dp),
+                    )
+                }
+            }
+        }
+    }
+
+    if (noteEditorOpen) {
+        NoteEditorDialog(
+            initialNote = note ?: "",
+            onConfirm = { text ->
+                onUpdateNote(text.takeIf { it.isNotBlank() })
+                noteEditorOpen = false
+            },
+            onDismiss = { noteEditorOpen = false },
+        )
+    }
+}
+```
+
+- [ ] **Step 3: Commit (build will fail until Task 4 wires up the screen)**
+
+```bash
+git add app/src/main/kotlin/com/riffle/app/feature/reader/HighlightActionsSheet.kt
+git commit -m "feat(annotations): replace HighlightActionsSheet with HighlightActionsPopup"
+```
+
+---
+
+### Task 4: Wire up `EpubReaderScreen.kt`
+
+**Files:**
+- Modify: `app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt`
+
+**Interfaces:**
+- Consumes: `HighlightEditTarget` (Task 2), `toWindowIntRect(view: View)` (Task 1), `HighlightActionsPopup` (Task 3)
+
+This task makes the project compile and the feature work end-to-end.
+
+---
+
+- [ ] **Step 1: Update the top-level call site — `highlightToEdit` collect and `EpubNavigatorView` call**
+
+In the outer composable (around line 255), `highlightToEdit` now has type `EpubReaderViewModel.HighlightEditTarget?` — no code change needed, the type is inferred.
+
+At the `EpubNavigatorView` call site (around line 374–376), update two lines:
+
+Find:
+```kotlin
+                        onHighlight = viewModel::createHighlight,
+                        highlightToEdit = highlightToEdit,
+                        onOpenHighlightActions = viewModel::openHighlightActions,
+```
+
+Replace with (no change — method references still compile because signatures now match):
+```kotlin
+                        onHighlight = viewModel::createHighlight,
+                        highlightToEdit = highlightToEdit,
+                        onOpenHighlightActions = viewModel::openHighlightActions,
+```
+
+No change needed here — Kotlin method references adapt automatically to the new signatures.
+
+- [ ] **Step 2: Update `EpubNavigatorView` parameter declarations (around line 981–983)**
+
+Find:
+```kotlin
+    onHighlight: (Locator) -> Unit,
+    highlightToEdit: String?,
+    onOpenHighlightActions: (String) -> Unit,
+```
+
+Replace with:
+```kotlin
+    onHighlight: (Locator, androidx.compose.ui.unit.IntRect) -> Unit,
+    highlightToEdit: EpubReaderViewModel.HighlightEditTarget?,
+    onOpenHighlightActions: (String, androidx.compose.ui.unit.IntRect) -> Unit,
+```
+
+- [ ] **Step 3: Update `rememberUpdatedState` for `onHighlight` and `onOpenHighlightActions` (around line 1022–1023)**
+
+No change needed — `rememberUpdatedState` is generic and adapts to the new lambda types automatically.
+
+- [ ] **Step 4: Update the highlight menu handler to pass the rect (around line 1096–1103)**
+
+Find:
+```kotlin
+                    highlightMenuId -> {
+                        val selectable = fragmentRef.value as? org.readium.r2.navigator.SelectableNavigator
+                            ?: return false
+                        coroutineScope.launch {
+                            val selection = selectable.currentSelection() ?: return@launch
+                            currentOnHighlight(selection.locator)
+                            selectable.clearSelection()
+                        }
+                    }
+```
+
+Replace with:
+```kotlin
+                    highlightMenuId -> {
+                        val selectable = fragmentRef.value as? org.readium.r2.navigator.SelectableNavigator
+                            ?: return false
+                        val container = containerRef.value ?: return false
+                        coroutineScope.launch {
+                            val selection = selectable.currentSelection() ?: return@launch
+                            val rect = selection.rect.toWindowIntRect(container)
+                            currentOnHighlight(selection.locator, rect)
+                            selectable.clearSelection()
+                        }
+                    }
+```
+
+- [ ] **Step 5: Update the decoration tap listener to pass the rect (around line 1657–1660)**
+
+Find:
+```kotlin
+            override fun onDecorationActivated(event: DecorableNavigator.OnActivatedEvent): Boolean {
+                if (event.group != "annotations") return false
+                currentOnOpenHighlightActions(event.decoration.id)
+                return true
+            }
+```
+
+Replace with:
+```kotlin
+            override fun onDecorationActivated(event: DecorableNavigator.OnActivatedEvent): Boolean {
+                if (event.group != "annotations") return false
+                val container = containerRef.value ?: return false
+                val rect = event.rect.toWindowIntRect(container)
+                currentOnOpenHighlightActions(event.decoration.id, rect)
+                return true
+            }
+```
+
+- [ ] **Step 6: Update the call site that renders the popup (around line 2150–2161)**
+
+Find:
+```kotlin
+        val editId = highlightToEdit
+        if (editId != null) {
+            val current = highlightRenders.firstOrNull { it.id == editId }
+            HighlightActionsSheet(
+                selected = current?.let { HighlightColor.fromToken(it.color) },
+                note = current?.note,
+                onPick = { color -> onRecolorHighlight(editId, color) },
+                onDelete = { onDeleteHighlight(editId) },
+                onUpdateNote = { note -> onUpdateHighlightNote(editId, note) },
+                onDismiss = onDismissHighlightActions,
+            )
+        }
+```
+
+Replace with:
+```kotlin
+        val editTarget = highlightToEdit
+        if (editTarget != null) {
+            val current = highlightRenders.firstOrNull { it.id == editTarget.id }
+            HighlightActionsPopup(
+                anchorRect = editTarget.anchorRect,
+                selected = current?.let { HighlightColor.fromToken(it.color) },
+                note = current?.note,
+                onPick = { color -> onRecolorHighlight(editTarget.id, color) },
+                onDelete = { onDeleteHighlight(editTarget.id) },
+                onUpdateNote = { note -> onUpdateHighlightNote(editTarget.id, note) },
+                onDismiss = onDismissHighlightActions,
+            )
+        }
+```
+
+- [ ] **Step 7: Build and verify all unit tests pass**
+
+```bash
+export JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"
+./gradlew :app:testDebugUnitTest 2>&1 | tail -30
+```
+
+Expected: `BUILD SUCCESSFUL`.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+git commit -m "feat(annotations): wire floating highlight popup in EpubReaderScreen"
+```
+
+---
+
+## Done
+
+All four tasks complete. The project compiles, unit tests pass, and the floating popup replaces the bottom sheet.
+
+**Manual verification checklist:**
+- [ ] Tap existing highlight → popup appears near (above) the highlight text, never off-screen
+- [ ] Select text → highlight → popup appears near the selection
+- [ ] Tap a colour swatch → highlight recolours, popup stays open
+- [ ] Tap delete → highlight removed, popup dismissed
+- [ ] Tap "Add note" → popup dismisses, note dialog opens
+- [ ] Tap outside popup → dismissed
+- [ ] Highlight near top → popup appears below
+- [ ] Highlight near left/right edge → popup clamped to edge

--- a/docs/superpowers/specs/2026-06-18-floating-highlight-popup-design.md
+++ b/docs/superpowers/specs/2026-06-18-floating-highlight-popup-design.md
@@ -1,0 +1,148 @@
+# Floating Highlight Action Popup — Design
+
+**Issue:** #204  
+**Date:** 2026-06-18  
+**Branch:** pkmetski/brisbane
+
+## Problem
+
+The current `HighlightActionsSheet` is a `ModalBottomSheet` that slides up from the bottom edge, disconnected from where the highlight actually is on the page. The goal is to replace it with a small floating card that appears near the highlighted text — both when a new highlight is created and when an existing one is tapped.
+
+## Decisions
+
+| Question | Decision |
+|---|---|
+| Note row in popup? | Yes — same swatches + delete + note row as the current sheet |
+| Note editor interaction | Tapping the note row dismisses the popup, then opens the existing `NoteEditorDialog` (AlertDialog) |
+| Note reading (full text without edit mode) | Deferred to issue #206, which has been updated with this intent |
+| Anchor rect storage | Approach A — ViewModel holds `HighlightEditTarget(id, anchorRect: IntRect)` |
+| Popup dismissal on outside tap | `PopupProperties(focusable = true)` |
+
+## Design
+
+### 1. Data model
+
+```kotlin
+// In EpubReaderViewModel
+data class HighlightEditTarget(val id: String, val anchorRect: IntRect)
+
+private val _highlightToEdit = MutableStateFlow<HighlightEditTarget?>(null)
+val highlightToEdit: StateFlow<HighlightEditTarget?> = _highlightToEdit
+
+fun openHighlightActions(id: String, anchorRect: IntRect) {
+    _highlightToEdit.value = HighlightEditTarget(id, anchorRect)
+}
+fun dismissHighlightActions() { _highlightToEdit.value = null }
+```
+
+`IntRect` is `androidx.compose.ui.unit.IntRect` — window-pixel coordinates. The `HighlightEditTarget` type propagates through the composable parameter chain wherever `highlightToEdit: String?` appeared before.
+
+`createHighlight` gains an `anchorRect: IntRect` parameter and forwards it to `openHighlightActions`.
+
+### 2. Coordinate mapping
+
+A private top-level extension in `EpubReaderScreen.kt` converts a WebView-local `RectF` to window pixels using the `ScrollBoundaryNavigationContainer` as the reference view:
+
+```kotlin
+private fun RectF.toWindowIntRect(view: View): IntRect {
+    val loc = IntArray(2)
+    view.getLocationOnScreen(loc)
+    return IntRect(
+        left   = loc[0] + left.roundToInt(),
+        top    = loc[1] + top.roundToInt(),
+        right  = loc[0] + right.roundToInt(),
+        bottom = loc[1] + bottom.roundToInt(),
+    )
+}
+```
+
+**Tap existing highlight** — inside `onDecorationActivated`:
+```kotlin
+val rect = event.rect.toWindowIntRect(containerRef.value ?: return false)
+currentOnOpenHighlightActions(event.decoration.id, rect)
+```
+
+**New highlight** — after `selectable.currentSelection()`:
+```kotlin
+val rect = selection.rect.toWindowIntRect(containerRef.value ?: return@launch)
+currentOnHighlight(selection.locator, rect)
+```
+
+Note: after rotation the ViewModel survives with a stale `anchorRect`. The popup re-opens at approximately the correct position, which is acceptable.
+
+### 3. Popup card layout
+
+`HighlightActionsSheet` (the `ModalBottomSheet` composable) is replaced by `HighlightActionsPopup` in `HighlightActionsSheet.kt`. Card structure top-to-bottom:
+
+- `Row`: `HighlightSwatchRow` + delete `IconButton` — `padding(horizontal=16.dp, vertical=12.dp)`
+- `HorizontalDivider`
+- `Row`: note label + 2-line truncated preview if note exists + edit icon — `padding(horizontal=16.dp, vertical=14.dp)`, `clickable` → dismiss popup then open `NoteEditorDialog`
+
+Wrapped in:
+```kotlin
+Surface(
+    shape = RoundedCornerShape(12.dp),
+    shadowElevation = 4.dp,
+    tonalElevation = 0.dp,
+)
+```
+
+Fixed width: `280.dp`.
+
+### 4. PopupPositionProvider
+
+```kotlin
+private class HighlightPopupPositionProvider(
+    private val anchorRect: IntRect,
+    private val margin: Int,  // px
+) : PopupPositionProvider {
+    override fun calculatePosition(
+        anchorBounds: IntRect,
+        windowSize: IntSize,
+        layoutDirection: LayoutDirection,
+        popupContentSize: IntSize,
+    ): IntOffset {
+        val preferredTop = anchorRect.top - popupContentSize.height - margin
+        val top = if (preferredTop >= margin) {
+            preferredTop
+        } else {
+            anchorRect.bottom + margin  // flip below
+        }
+        val centreX = anchorRect.center.x - popupContentSize.width / 2
+        val left = centreX.coerceIn(margin, windowSize.width - popupContentSize.width - margin)
+        return IntOffset(left, top)
+    }
+}
+```
+
+Instantiated via `remember(anchorRect) { HighlightPopupPositionProvider(anchorRect, margin) }` where `margin` is `(8.dp).roundToPx()`.
+
+### 5. Note tap flow & dismissal
+
+- **Outside tap / back gesture:** `PopupProperties(focusable = true)` — Compose closes the popup before propagating the event to the reader.
+- **Note row tap:** calls `onDismissHighlightActions()` first, then sets `noteEditorOpen = true`. The popup is gone before the `NoteEditorDialog` appears — no layering issue.
+- **Color pick / delete:** unchanged — call through to existing ViewModel functions.
+
+### 6. Testing
+
+**Unit tests:**
+- `RectF.toWindowIntRect()` — mock `View.getLocationOnScreen()` returning known offsets; assert pixel arithmetic
+- `HighlightPopupPositionProvider.calculatePosition()` — pure function; test above/below flip threshold and left/right clamp boundary
+
+**Harness tests:**
+- `AnnotationReopenInstrumentedTest` covers the open/close lifecycle; verify it does not assert on `ModalBottomSheet`-specific semantics during implementation
+
+**Manual verification:** exact pixel position on a real device.
+
+## Files changed
+
+| File | Change |
+|---|---|
+| `EpubReaderViewModel.kt` | `HighlightEditTarget` data class; `_highlightToEdit` type; `openHighlightActions` signature; `createHighlight` signature |
+| `HighlightActionsSheet.kt` | Remove `HighlightActionsSheet`; add `HighlightActionsPopup` + `HighlightPopupPositionProvider` |
+| `EpubReaderScreen.kt` | `toWindowIntRect` helper; pass `anchorRect` in both trigger paths; update parameter types throughout |
+
+## Out of scope
+
+- Note reading without entering edit mode → issue #206
+- Rotation re-anchor (stale rect after config change is acceptable)

--- a/docs/superpowers/specs/2026-06-18-floating-highlight-popup-design.md
+++ b/docs/superpowers/specs/2026-06-18-floating-highlight-popup-design.md
@@ -108,8 +108,13 @@ private class HighlightPopupPositionProvider(
         } else {
             anchorRect.bottom + margin  // flip below
         }
+        // anchorBounds (the Compose anchor) is intentionally ignored — anchorRect carries
+        // the WebView-space rect already mapped to window coordinates.
         val centreX = anchorRect.center.x - popupContentSize.width / 2
-        val left = centreX.coerceIn(margin, windowSize.width - popupContentSize.width - margin)
+        // Guard: on a very narrow screen the max bound could be less than margin.
+        val minLeft = margin
+        val maxLeft = maxOf(margin, windowSize.width - popupContentSize.width - margin)
+        val left = centreX.coerceIn(minLeft, maxLeft)
         return IntOffset(left, top)
     }
 }


### PR DESCRIPTION
## Summary

- Replaces the `ModalBottomSheet` highlight actions UI with a small floating `Popup` card that appears near the highlighted text — both on new highlight creation and when tapping an existing one
- `HighlightEditTarget(id, anchorRect: IntRect)` replaces the bare `String?` in the ViewModel so the anchor rect travels with the edit state
- WebView-local `RectF` coordinates from Readium's `OnActivatedEvent.rect` and `SelectableNavigator.Selection.rect` are mapped to window pixels via `View.getLocationOnScreen()` on the `ScrollBoundaryNavigationContainer`
- `HighlightPopupPositionProvider` places the popup above the anchor (or flips below when near the top), centred and clamped within the screen margin
- Note editor state hoisted to `EpubNavigatorView` scope so `NoteEditorDialog` survives the popup being dismissed
- Coordinate arithmetic extracted to pure-JVM functions in `ReaderCoordinates.kt` (no Robolectric needed); 9 unit tests

Closes #204 

## Test plan

- `./gradlew test` — 780 JVM tests, 0 failures
- `./gradlew lint` — clean
- Harness tests running
- Manual verification on device needed to confirm popup position relative to highlighted text