### PR TITLE
feat(annotations): note glyph in highlight margin with read-first popup

### DIFF
--- a/app/src/androidTest/kotlin/com/riffle/app/feature/reader/HighlightActionsPopupTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/reader/HighlightActionsPopupTest.kt
@@ -22,6 +22,7 @@ class HighlightActionsPopupTest {
 
     private fun showPopup(
         note: String? = null,
+        noteOnly: Boolean = false,
         onOpenNoteEditor: () -> Unit = {},
         onDismiss: () -> Unit = {},
     ) {
@@ -34,6 +35,7 @@ class HighlightActionsPopupTest {
                 onDelete = {},
                 onOpenNoteEditor = onOpenNoteEditor,
                 onDismiss = onDismiss,
+                noteOnly = noteOnly,
             )
         }
     }
@@ -69,5 +71,24 @@ class HighlightActionsPopupTest {
         composeTestRule.onNodeWithText("Note").performClick()   // expand
         composeTestRule.onNodeWithText("Edit").performClick()   // open editor
         assertTrue("tapping Edit in expanded state must call onOpenNoteEditor", called)
+    }
+
+    @Test
+    fun noteOnly_hidesColorRowAndShowsNoteDirectly() {
+        showPopup(note = "My note", noteOnly = true)
+        composeTestRule.onNodeWithText("Note").assertIsDisplayed()
+        composeTestRule.onNodeWithText("My note").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Edit").assertIsDisplayed()
+        // Colour swatches and delete must not be visible in note-only mode
+        composeTestRule.onNodeWithContentDescription("Delete highlight").assertDoesNotExist()
+        composeTestRule.onNodeWithContentDescription("Yellow highlight, selected").assertDoesNotExist()
+    }
+
+    @Test
+    fun noteOnly_tapEditButton_callsOnOpenNoteEditor() {
+        var called = false
+        showPopup(note = "My note", noteOnly = true, onOpenNoteEditor = { called = true })
+        composeTestRule.onNodeWithText("Edit").performClick()
+        assertTrue("Edit in note-only mode must call onOpenNoteEditor", called)
     }
 }

--- a/app/src/androidTest/kotlin/com/riffle/app/feature/reader/HighlightActionsPopupTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/reader/HighlightActionsPopupTest.kt
@@ -91,4 +91,13 @@ class HighlightActionsPopupTest {
         composeTestRule.onNodeWithText("Edit").performClick()
         assertTrue("Edit in note-only mode must call onOpenNoteEditor", called)
     }
+
+    @Test
+    fun noteOnly_nullNote_showsLabelButNoEditButton() {
+        // Race: glyph decoration still visible in WebView while note was just deleted in Kotlin state.
+        // The popup must not render an orphaned "Edit" button with no note content.
+        showPopup(note = null, noteOnly = true)
+        composeTestRule.onNodeWithText("Note").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Edit").assertDoesNotExist()
+    }
 }

--- a/app/src/androidTest/kotlin/com/riffle/app/feature/reader/HighlightActionsPopupTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/reader/HighlightActionsPopupTest.kt
@@ -1,0 +1,73 @@
+package com.riffle.app.feature.reader
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.unit.IntRect
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.riffle.core.domain.HighlightColor
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class HighlightActionsPopupTest {
+
+    @get:Rule val composeTestRule = createComposeRule()
+
+    private val stubRect = IntRect(100, 200, 300, 220)
+
+    private fun showPopup(
+        note: String? = null,
+        onOpenNoteEditor: () -> Unit = {},
+        onDismiss: () -> Unit = {},
+    ) {
+        composeTestRule.setContent {
+            HighlightActionsPopup(
+                anchorRect = stubRect,
+                selected = HighlightColor.YELLOW,
+                note = note,
+                onPick = {},
+                onDelete = {},
+                onOpenNoteEditor = onOpenNoteEditor,
+                onDismiss = onDismiss,
+            )
+        }
+    }
+
+    @Test
+    fun noNote_tapNoteRow_callsOnOpenNoteEditor() {
+        var called = false
+        showPopup(note = null, onOpenNoteEditor = { called = true })
+        composeTestRule.onNodeWithText("Add note").performClick()
+        assertTrue("onOpenNoteEditor must be called directly when there is no note", called)
+    }
+
+    @Test
+    fun existingNote_initialState_showsPreviewAndExpandIcon() {
+        showPopup(note = "My detailed note text here")
+        composeTestRule.onNodeWithText("Note").assertIsDisplayed()
+        composeTestRule.onNodeWithText("My detailed note text here").assertIsDisplayed()
+        composeTestRule.onNodeWithContentDescription("Expand note").assertIsDisplayed()
+    }
+
+    @Test
+    fun existingNote_tapRow_expandsToFullTextAndEditButton() {
+        showPopup(note = "My detailed note text here")
+        composeTestRule.onNodeWithText("Note").performClick()
+        composeTestRule.onNodeWithText("Edit").assertIsDisplayed()
+        composeTestRule.onNodeWithContentDescription("Collapse note").assertIsDisplayed()
+    }
+
+    @Test
+    fun existingNote_expanded_tapEditButton_callsOnOpenNoteEditor() {
+        var called = false
+        showPopup(note = "Some note", onOpenNoteEditor = { called = true })
+        composeTestRule.onNodeWithText("Note").performClick()   // expand
+        composeTestRule.onNodeWithText("Edit").performClick()   // open editor
+        assertTrue("tapping Edit in expanded state must call onOpenNoteEditor", called)
+    }
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -1667,9 +1667,7 @@ private fun EpubNavigatorView(
             Decoration(
                 id = h.id,
                 locator = h.locator,
-                style = Decoration.Style.Underline(
-                    tint = HighlightColor.fromToken(h.color).readerTint(formattingPrefs.theme),
-                ),
+                style = NoteGlyphStyle(),
             )
         }
         withContext(Dispatchers.Main) {
@@ -1694,6 +1692,26 @@ private fun EpubNavigatorView(
             }
         }
         fragment?.addDecorationListener("annotations", listener)
+        onDispose { fragment?.removeDecorationListener(listener) }
+    }
+
+    // ---- Decoration tap listener (annotation-notes) ----------------------------------------
+    // Tapping the margin note glyph opens the same highlight-actions popup as tapping the
+    // highlight text. The glyph lives in the left gutter (outside the text hit area), so the
+    // "annotations" listener above does NOT fire for it — this dedicated listener is required.
+    DisposableEffect(fragmentRef.value) {
+        val fragment = fragmentRef.value as? DecorableNavigator
+        val listener = object : DecorableNavigator.Listener {
+            override fun onDecorationActivated(event: DecorableNavigator.OnActivatedEvent): Boolean {
+                if (event.group != "annotation-notes") return false
+                val container = containerRef.value ?: return false
+                val rawRect = event.rect ?: return false
+                val rect = rawRect.toWindowIntRect(container)
+                currentOnOpenHighlightActions(event.decoration.id, rect)
+                return true
+            }
+        }
+        fragment?.addDecorationListener("annotation-notes", listener)
         onDispose { fragment?.removeDecorationListener(listener) }
     }
 

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -1646,11 +1646,10 @@ private fun EpubNavigatorView(
         hasHighlightDecorations.value = true
     }
 
-    // ---- Note underline decorations (annotation-notes) -------------------------------------
-    // Draws a subtle underline under every noted highlight so the reader can see a note is
+    // ---- Note glyph decorations (annotation-notes) -----------------------------------------
+    // Renders a small margin note icon next to every highlighted range that has a note
     // attached. Uses its own group so it can be cleared/re-applied independently of the fill.
-    // Tapping the underlined range fires the existing "annotations" listener (both decorations
-    // overlap the same text, so the listener already registered above handles it).
+    // Tapping the glyph fires the dedicated "annotation-notes" tap listener below.
     val hasNoteDecorations = remember { mutableStateOf(false) }
     LaunchedEffect(highlightRenders, formattingPrefs.theme, reflowGeneration, pageLoadGeneration.value) {
         val fragment = fragmentRef.value as? DecorableNavigator ?: return@LaunchedEffect

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -373,6 +373,7 @@ fun EpubReaderScreen(
                         onHighlight = viewModel::createHighlight,
                         highlightToEdit = highlightToEdit,
                         onOpenHighlightActions = viewModel::openHighlightActions,
+                        onOpenNoteReader = viewModel::openNoteReader,
                         onDismissHighlightActions = viewModel::dismissHighlightActions,
                         onRecolorHighlight = viewModel::recolorHighlight,
                         onDeleteHighlight = viewModel::deleteHighlight,
@@ -996,6 +997,7 @@ private fun EpubNavigatorView(
     onHighlight: (Locator, androidx.compose.ui.unit.IntRect) -> Unit,
     highlightToEdit: EpubReaderViewModel.HighlightEditTarget?,
     onOpenHighlightActions: (String, androidx.compose.ui.unit.IntRect) -> Unit,
+    onOpenNoteReader: (String, androidx.compose.ui.unit.IntRect) -> Unit,
     onDismissHighlightActions: () -> Unit,
     onRecolorHighlight: (String, HighlightColor) -> Unit,
     onDeleteHighlight: (String) -> Unit,
@@ -1036,6 +1038,7 @@ private fun EpubNavigatorView(
     val currentSentenceChapters by rememberUpdatedState(sentenceChapters)
     val currentOnHighlight by rememberUpdatedState(onHighlight)
     val currentOnOpenHighlightActions by rememberUpdatedState(onOpenHighlightActions)
+    val currentOnOpenNoteReader by rememberUpdatedState(onOpenNoteReader)
     val currentOnUpdateHighlightNote by rememberUpdatedState(onUpdateHighlightNote)
     val currentAnnotationsAvailable by rememberUpdatedState(annotationsAvailable)
     val currentReadaloudAvailable by rememberUpdatedState(readaloudAvailable)
@@ -1706,7 +1709,7 @@ private fun EpubNavigatorView(
                 val container = containerRef.value ?: return false
                 val rawRect = event.rect ?: return false
                 val rect = rawRect.toWindowIntRect(container)
-                currentOnOpenHighlightActions(event.decoration.id, rect)
+                currentOnOpenNoteReader(event.decoration.id, rect)
                 return true
             }
         }
@@ -2224,6 +2227,7 @@ private fun EpubNavigatorView(
                     noteEditorTarget = editTarget
                 },
                 onDismiss = onDismissHighlightActions,
+                noteOnly = editTarget.noteOnly,
             )
         }
         val noteTarget = noteEditorTarget

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -329,7 +329,7 @@ class EpubReaderViewModel @Inject constructor(
 
     private val _bookmarkPositions = MutableStateFlow<List<BookmarkPosition>>(emptyList())
 
-    data class HighlightEditTarget(val id: String, val anchorRect: IntRect)
+    data class HighlightEditTarget(val id: String, val anchorRect: IntRect, val noteOnly: Boolean = false)
 
     private val _highlightToEdit = MutableStateFlow<HighlightEditTarget?>(null)
     /** Highlight whose actions popup should be open (just-created or tapped), else null. */
@@ -337,6 +337,10 @@ class EpubReaderViewModel @Inject constructor(
 
     fun openHighlightActions(id: String, anchorRect: IntRect) {
         _highlightToEdit.value = HighlightEditTarget(id, anchorRect)
+    }
+    /** Opens the popup in note-only read mode (no colour pickers, no delete). Used by the margin glyph. */
+    fun openNoteReader(id: String, anchorRect: IntRect) {
+        _highlightToEdit.value = HighlightEditTarget(id, anchorRect, noteOnly = true)
     }
     fun dismissHighlightActions() { _highlightToEdit.value = null }
 

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/FormattingPreferencesMapper.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/FormattingPreferencesMapper.kt
@@ -92,6 +92,7 @@ fun FormattingPreferences.toFragmentConfiguration(
         // so the synced highlight can be strengthened on dark reading themes (see readerTint()).
         decorationTemplates = HtmlDecorationTemplates.defaultTemplates().apply {
             set(HighlightTintStyle::class, highlightTintTemplate())
+            set(NoteGlyphStyle::class, noteGlyphTemplate())
         },
         readiumCssRsProperties = when {
             isDoublePage -> RsProperties(

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/HighlightActionsSheet.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/HighlightActionsSheet.kt
@@ -107,7 +107,6 @@ fun HighlightActionsPopup(
     onDismiss: () -> Unit,
     noteOnly: Boolean = false,
 ) {
-    var noteExpanded by remember(note) { mutableStateOf(false) }
     val density = LocalDensity.current
     val margin = with(density) { 8.dp.roundToPx() }
     val provider = remember(anchorRect) { HighlightPopupPositionProvider(anchorRect, margin) }
@@ -144,6 +143,8 @@ fun HighlightActionsPopup(
                 }
                 if (noteOnly) {
                     // Read-only note view: full text + Edit button. No colour pickers, no delete.
+                    // note==null is a transient race (glyph decorated before note deletion lands);
+                    // guard defensively rather than showing a broken "Edit" with no content.
                     Column(
                         modifier = Modifier
                             .fillMaxWidth()
@@ -160,15 +161,16 @@ fun HighlightActionsPopup(
                                 style = MaterialTheme.typography.bodyMedium,
                                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                             )
-                        }
-                        TextButton(
-                            onClick = { onDismiss(); onOpenNoteEditor() },
-                            modifier = Modifier.align(Alignment.End),
-                        ) {
-                            Text("Edit")
+                            TextButton(
+                                onClick = { onDismiss(); onOpenNoteEditor() },
+                                modifier = Modifier.align(Alignment.End),
+                            ) {
+                                Text("Edit")
+                            }
                         }
                     }
                 } else {
+                    var noteExpanded by remember(note) { mutableStateOf(false) }
                     Row(
                         modifier = Modifier
                             .fillMaxWidth()

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/HighlightActionsSheet.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/HighlightActionsSheet.kt
@@ -106,7 +106,7 @@ fun HighlightActionsPopup(
     onOpenNoteEditor: () -> Unit,
     onDismiss: () -> Unit,
 ) {
-    var noteExpanded by remember { mutableStateOf(false) }
+    var noteExpanded by remember(note) { mutableStateOf(false) }
     val density = LocalDensity.current
     val margin = with(density) { 8.dp.roundToPx() }
     val provider = remember(anchorRect) { HighlightPopupPositionProvider(anchorRect, margin) }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/HighlightActionsSheet.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/HighlightActionsSheet.kt
@@ -18,6 +18,8 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.KeyboardArrowUp
 import androidx.compose.material.icons.outlined.Edit
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.HorizontalDivider
@@ -104,6 +106,7 @@ fun HighlightActionsPopup(
     onOpenNoteEditor: () -> Unit,
     onDismiss: () -> Unit,
 ) {
+    var noteExpanded by remember { mutableStateOf(false) }
     val density = LocalDensity.current
     val margin = with(density) { 8.dp.roundToPx() }
     val provider = remember(anchorRect) { HighlightPopupPositionProvider(anchorRect, margin) }
@@ -140,8 +143,11 @@ fun HighlightActionsPopup(
                     modifier = Modifier
                         .fillMaxWidth()
                         .clickable {
-                            onDismiss()
-                            onOpenNoteEditor()
+                            when {
+                                note == null -> { onDismiss(); onOpenNoteEditor() }
+                                noteExpanded -> noteExpanded = false
+                                else -> noteExpanded = true
+                            }
                         }
                         .padding(horizontal = 16.dp, vertical = 14.dp),
                     verticalAlignment = Alignment.CenterVertically,
@@ -152,7 +158,7 @@ fun HighlightActionsPopup(
                             text = if (note != null) "Note" else "Add note",
                             style = MaterialTheme.typography.bodyMedium,
                         )
-                        if (note != null) {
+                        if (note != null && !noteExpanded) {
                             Spacer(Modifier.height(2.dp))
                             Text(
                                 text = note,
@@ -162,10 +168,31 @@ fun HighlightActionsPopup(
                                 overflow = TextOverflow.Ellipsis,
                             )
                         }
+                        if (note != null && noteExpanded) {
+                            Spacer(Modifier.height(4.dp))
+                            Text(
+                                text = note,
+                                style = MaterialTheme.typography.bodyMedium,
+                            )
+                            TextButton(
+                                onClick = { onDismiss(); onOpenNoteEditor() },
+                                modifier = Modifier.align(Alignment.End),
+                            ) {
+                                Text("Edit")
+                            }
+                        }
                     }
                     Icon(
-                        imageVector = Icons.Outlined.Edit,
-                        contentDescription = null,
+                        imageVector = when {
+                            note == null -> Icons.Outlined.Edit
+                            noteExpanded -> Icons.Filled.KeyboardArrowUp
+                            else -> Icons.Filled.KeyboardArrowDown
+                        },
+                        contentDescription = when {
+                            note == null -> null
+                            noteExpanded -> "Collapse note"
+                            else -> "Expand note"
+                        },
                         tint = MaterialTheme.colorScheme.onSurfaceVariant,
                         modifier = Modifier.size(20.dp),
                     )

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/HighlightActionsSheet.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/HighlightActionsSheet.kt
@@ -105,6 +105,7 @@ fun HighlightActionsPopup(
     onDelete: () -> Unit,
     onOpenNoteEditor: () -> Unit,
     onDismiss: () -> Unit,
+    noteOnly: Boolean = false,
 ) {
     var noteExpanded by remember(note) { mutableStateOf(false) }
     val density = LocalDensity.current
@@ -122,80 +123,110 @@ fun HighlightActionsPopup(
             tonalElevation = 0.dp,
         ) {
             Column(modifier = Modifier.width(280.dp)) {
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 16.dp, vertical = 12.dp),
-                    horizontalArrangement = Arrangement.SpaceBetween,
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    HighlightSwatchRow(selected = selected, onPick = onPick)
-                    IconButton(onClick = onDelete) {
-                        Icon(
-                            imageVector = Icons.Default.Delete,
-                            contentDescription = "Delete highlight",
-                            tint = MaterialTheme.colorScheme.error,
-                        )
-                    }
-                }
-                HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .clickable {
-                            when {
-                                note == null -> { onDismiss(); onOpenNoteEditor() }
-                                noteExpanded -> noteExpanded = false
-                                else -> noteExpanded = true
-                            }
-                        }
-                        .padding(horizontal = 16.dp, vertical = 14.dp),
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.SpaceBetween,
-                ) {
-                    Column(modifier = Modifier.weight(1f)) {
-                        Text(
-                            text = if (note != null) "Note" else "Add note",
-                            style = MaterialTheme.typography.bodyMedium,
-                        )
-                        if (note != null && !noteExpanded) {
-                            Spacer(Modifier.height(2.dp))
-                            Text(
-                                text = note,
-                                style = MaterialTheme.typography.bodySmall,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                maxLines = 2,
-                                overflow = TextOverflow.Ellipsis,
+                if (!noteOnly) {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 16.dp, vertical = 12.dp),
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        HighlightSwatchRow(selected = selected, onPick = onPick)
+                        IconButton(onClick = onDelete) {
+                            Icon(
+                                imageVector = Icons.Default.Delete,
+                                contentDescription = "Delete highlight",
+                                tint = MaterialTheme.colorScheme.error,
                             )
                         }
-                        if (note != null && noteExpanded) {
+                    }
+                    HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))
+                }
+                if (noteOnly) {
+                    // Read-only note view: full text + Edit button. No colour pickers, no delete.
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 16.dp, vertical = 14.dp),
+                    ) {
+                        Text(
+                            text = "Note",
+                            style = MaterialTheme.typography.bodyMedium,
+                        )
+                        if (note != null) {
                             Spacer(Modifier.height(4.dp))
                             Text(
                                 text = note,
                                 style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
                             )
-                            TextButton(
-                                onClick = { onDismiss(); onOpenNoteEditor() },
-                                modifier = Modifier.align(Alignment.End),
-                            ) {
-                                Text("Edit")
-                            }
+                        }
+                        TextButton(
+                            onClick = { onDismiss(); onOpenNoteEditor() },
+                            modifier = Modifier.align(Alignment.End),
+                        ) {
+                            Text("Edit")
                         }
                     }
-                    Icon(
-                        imageVector = when {
-                            note == null -> Icons.Outlined.Edit
-                            noteExpanded -> Icons.Filled.KeyboardArrowUp
-                            else -> Icons.Filled.KeyboardArrowDown
-                        },
-                        contentDescription = when {
-                            note == null -> null
-                            noteExpanded -> "Collapse note"
-                            else -> "Expand note"
-                        },
-                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                        modifier = Modifier.size(20.dp),
-                    )
+                } else {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clickable {
+                                when {
+                                    note == null -> { onDismiss(); onOpenNoteEditor() }
+                                    noteExpanded -> noteExpanded = false
+                                    else -> noteExpanded = true
+                                }
+                            }
+                            .padding(horizontal = 16.dp, vertical = 14.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                    ) {
+                        Column(modifier = Modifier.weight(1f)) {
+                            Text(
+                                text = if (note != null) "Note" else "Add note",
+                                style = MaterialTheme.typography.bodyMedium,
+                            )
+                            if (note != null && !noteExpanded) {
+                                Spacer(Modifier.height(2.dp))
+                                Text(
+                                    text = note,
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    maxLines = 2,
+                                    overflow = TextOverflow.Ellipsis,
+                                )
+                            }
+                            if (note != null && noteExpanded) {
+                                Spacer(Modifier.height(4.dp))
+                                Text(
+                                    text = note,
+                                    style = MaterialTheme.typography.bodyMedium,
+                                )
+                                TextButton(
+                                    onClick = { onDismiss(); onOpenNoteEditor() },
+                                    modifier = Modifier.align(Alignment.End),
+                                ) {
+                                    Text("Edit")
+                                }
+                            }
+                        }
+                        Icon(
+                            imageVector = when {
+                                note == null -> Icons.Outlined.Edit
+                                noteExpanded -> Icons.Filled.KeyboardArrowUp
+                                else -> Icons.Filled.KeyboardArrowDown
+                            },
+                            contentDescription = when {
+                                note == null -> null
+                                noteExpanded -> "Collapse note"
+                                else -> "Expand note"
+                            },
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier.size(20.dp),
+                        )
+                    }
                 }
             }
         }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/NoteGlyphDecoration.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/NoteGlyphDecoration.kt
@@ -21,6 +21,12 @@ internal const val NOTE_GLYPH_SVG_DATA_URI =
 private const val NOTE_GLYPH_CLASS = "riffle-note-glyph"
 private const val NOTE_GLYPH_ICON_CLASS = "riffle-note-glyph-icon"
 
+// data-activable="1" tells Readium to use THIS element's rect for hit-testing rather than
+// falling back to D.children (the outer BOUNDS div, which only covers the text selection).
+// Without it, taps on the gutter icon miss Readium's rect-based activation check.
+internal const val NOTE_GLYPH_ELEMENT_HTML =
+    """<div class="$NOTE_GLYPH_CLASS"><div class="$NOTE_GLYPH_ICON_CLASS" data-activable="1"></div></div>"""
+
 /**
  * Marker decoration style for noted highlights. No tint — the glyph is monochrome.
  * All noted highlights share the same icon regardless of highlight colour or theme.
@@ -56,9 +62,7 @@ class NoteGlyphStyle : Decoration.Style, Parcelable {
 fun noteGlyphTemplate(): HtmlDecorationTemplate =
     HtmlDecorationTemplate(
         layout = HtmlDecorationTemplate.Layout.BOUNDS,
-        element = { _ ->
-            """<div class="$NOTE_GLYPH_CLASS"><div class="$NOTE_GLYPH_ICON_CLASS"></div></div>"""
-        },
+        element = { _ -> NOTE_GLYPH_ELEMENT_HTML },
         stylesheet = """
             .$NOTE_GLYPH_CLASS {
                 background: none;
@@ -69,8 +73,8 @@ fun noteGlyphTemplate(): HtmlDecorationTemplate =
                 position: absolute;
                 left: -24px;
                 top: 2px;
-                width: 20px;
-                height: 20px;
+                width: 24px;
+                height: 24px;
                 -webkit-mask-image: url("$NOTE_GLYPH_SVG_DATA_URI");
                 -webkit-mask-size: contain;
                 -webkit-mask-repeat: no-repeat;

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/NoteGlyphDecoration.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/NoteGlyphDecoration.kt
@@ -49,6 +49,8 @@ class NoteGlyphStyle : Decoration.Style, Parcelable {
  * the selection; its ::before pseudo-element is absolutely positioned to the left of the
  * div (right: 100%), placing the note icon in the left gutter alongside the text.
  * overflow: visible on the host div prevents the gutter icon from being clipped.
+ * Uses CSS masking (`-webkit-mask-image`) so the icon inherits `currentColor` — readable
+ * on both light and dark reading themes.
  */
 fun noteGlyphTemplate(): HtmlDecorationTemplate =
     HtmlDecorationTemplate(
@@ -68,9 +70,10 @@ fun noteGlyphTemplate(): HtmlDecorationTemplate =
                 margin-right: 4px;
                 width: 16px;
                 height: 16px;
-                background-image: url("$NOTE_GLYPH_SVG_DATA_URI");
-                background-size: contain;
-                background-repeat: no-repeat;
+                -webkit-mask-image: url("$NOTE_GLYPH_SVG_DATA_URI");
+                -webkit-mask-size: contain;
+                -webkit-mask-repeat: no-repeat;
+                background-color: currentColor;
                 opacity: 0.55;
                 pointer-events: none;
             }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/NoteGlyphDecoration.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/NoteGlyphDecoration.kt
@@ -19,6 +19,7 @@ internal const val NOTE_GLYPH_SVG_DATA_URI =
     "%3C/svg%3E"
 
 private const val NOTE_GLYPH_CLASS = "riffle-note-glyph"
+private const val NOTE_GLYPH_ICON_CLASS = "riffle-note-glyph-icon"
 
 /**
  * Marker decoration style for noted highlights. No tint — the glyph is monochrome.
@@ -45,37 +46,36 @@ class NoteGlyphStyle : Decoration.Style, Parcelable {
 }
 
 /**
- * Decoration template for [NoteGlyphStyle]. A single transparent BOUNDS div sits over
- * the selection; its ::before pseudo-element is absolutely positioned to the left of the
- * div (right: 100%), placing the note icon in the left gutter alongside the text.
- * overflow: visible on the host div prevents the gutter icon from being clipped.
- * Uses CSS masking (`-webkit-mask-image`) so the icon inherits `currentColor` — readable
- * on both light and dark reading themes.
+ * Decoration template for [NoteGlyphStyle]. A transparent BOUNDS div covers the selection;
+ * an inner div child is absolutely positioned 24px to the left of the selection's left edge,
+ * landing in the left gutter. Using a real DOM child (not ::before) means tap events bubble
+ * up through the inner div → outer div → Readium's decoration listener, so glyph taps are
+ * reliably detected. Uses CSS masking so the icon inherits `currentColor` — readable on
+ * both light and dark reading themes.
  */
 fun noteGlyphTemplate(): HtmlDecorationTemplate =
     HtmlDecorationTemplate(
         layout = HtmlDecorationTemplate.Layout.BOUNDS,
-        element = { _ -> """<div class="$NOTE_GLYPH_CLASS"/>""" },
+        element = { _ ->
+            """<div class="$NOTE_GLYPH_CLASS"><div class="$NOTE_GLYPH_ICON_CLASS"></div></div>"""
+        },
         stylesheet = """
             .$NOTE_GLYPH_CLASS {
                 background: none;
                 overflow: visible;
                 position: relative;
             }
-            .$NOTE_GLYPH_CLASS::before {
-                content: "";
+            .$NOTE_GLYPH_ICON_CLASS {
                 position: absolute;
-                right: 100%;
-                top: 0;
-                margin-right: 4px;
-                width: 16px;
-                height: 16px;
+                left: -24px;
+                top: 2px;
+                width: 20px;
+                height: 20px;
                 -webkit-mask-image: url("$NOTE_GLYPH_SVG_DATA_URI");
                 -webkit-mask-size: contain;
                 -webkit-mask-repeat: no-repeat;
                 background-color: currentColor;
                 opacity: 0.55;
-                pointer-events: none;
             }
         """.trimIndent(),
     )

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/NoteGlyphDecoration.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/NoteGlyphDecoration.kt
@@ -1,0 +1,78 @@
+@file:OptIn(org.readium.r2.shared.ExperimentalReadiumApi::class)
+
+package com.riffle.app.feature.reader
+
+import android.os.Parcel
+import android.os.Parcelable
+import org.readium.r2.navigator.Decoration
+import org.readium.r2.navigator.html.HtmlDecorationTemplate
+
+// SVG path from Icons.AutoMirrored.Outlined.StickyNote2 (Apache 2.0).
+// Percent-encoded so it can be embedded directly in a CSS url() without base64.
+// %3C/%3E = < / >
+internal const val NOTE_GLYPH_SVG_DATA_URI =
+    "data:image/svg+xml," +
+    "%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E" +
+    "%3Cpath d='M19,5v9l-5,0,0,5H5V5H19M19,3H5C3.9,3,3,3.9,3,5v14" +
+    "c0,1.1,.9,2,2,2h10l6,-6V5C21,3.9,20.1,3,19,3Z" +
+    "M12,14H7v-2h5V14ZM17,10H7V8h10V10Z'/%3E" +
+    "%3C/svg%3E"
+
+private const val NOTE_GLYPH_CLASS = "riffle-note-glyph"
+
+/**
+ * Marker decoration style for noted highlights. No tint — the glyph is monochrome.
+ * All noted highlights share the same icon regardless of highlight colour or theme.
+ */
+class NoteGlyphStyle : Decoration.Style, Parcelable {
+
+    override fun describeContents(): Int = 0
+
+    override fun writeToParcel(dest: Parcel, flags: Int) = Unit
+
+    override fun equals(other: Any?): Boolean = other is NoteGlyphStyle
+
+    override fun hashCode(): Int = NoteGlyphStyle::class.hashCode()
+
+    companion object {
+        @JvmField
+        val CREATOR: Parcelable.Creator<NoteGlyphStyle> =
+            object : Parcelable.Creator<NoteGlyphStyle> {
+                override fun createFromParcel(source: Parcel) = NoteGlyphStyle()
+                override fun newArray(size: Int): Array<NoteGlyphStyle?> = arrayOfNulls(size)
+            }
+    }
+}
+
+/**
+ * Decoration template for [NoteGlyphStyle]. A single transparent BOUNDS div sits over
+ * the selection; its ::before pseudo-element is absolutely positioned to the left of the
+ * div (right: 100%), placing the note icon in the left gutter alongside the text.
+ * overflow: visible on the host div prevents the gutter icon from being clipped.
+ */
+fun noteGlyphTemplate(): HtmlDecorationTemplate =
+    HtmlDecorationTemplate(
+        layout = HtmlDecorationTemplate.Layout.BOUNDS,
+        element = { _ -> """<div class="$NOTE_GLYPH_CLASS"/>""" },
+        stylesheet = """
+            .$NOTE_GLYPH_CLASS {
+                background: none;
+                overflow: visible;
+                position: relative;
+            }
+            .$NOTE_GLYPH_CLASS::before {
+                content: "";
+                position: absolute;
+                right: 100%;
+                top: 0;
+                margin-right: 4px;
+                width: 16px;
+                height: 16px;
+                background-image: url("$NOTE_GLYPH_SVG_DATA_URI");
+                background-size: contain;
+                background-repeat: no-repeat;
+                opacity: 0.55;
+                pointer-events: none;
+            }
+        """.trimIndent(),
+    )

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/NoteGlyphDecoration.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/NoteGlyphDecoration.kt
@@ -7,15 +7,14 @@ import android.os.Parcelable
 import org.readium.r2.navigator.Decoration
 import org.readium.r2.navigator.html.HtmlDecorationTemplate
 
-// SVG path from Icons.AutoMirrored.Outlined.StickyNote2 (Apache 2.0).
+// SVG path from Icons.Outlined.NoteAlt (Apache 2.0): document page with ruled lines.
 // Percent-encoded so it can be embedded directly in a CSS url() without base64.
 // %3C/%3E = < / >
 internal const val NOTE_GLYPH_SVG_DATA_URI =
     "data:image/svg+xml," +
     "%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E" +
-    "%3Cpath d='M19,5v9l-5,0,0,5H5V5H19M19,3H5C3.9,3,3,3.9,3,5v14" +
-    "c0,1.1,.9,2,2,2h10l6,-6V5C21,3.9,20.1,3,19,3Z" +
-    "M12,14H7v-2h5V14ZM17,10H7V8h10V10Z'/%3E" +
+    "%3Cpath d='M22,10l-6,-6H4C2.9,4,2,4.9,2,6v12c0,1.1,0.9,2,2,2h16c1.1,0,2,-0.9,2,-2V10Z" +
+    "M16,4l4,4h-4V4ZM13,18H7v-2h6V18ZM17,14H7v-2h10V14ZM17,10H7V8h10V10Z'/%3E" +
     "%3C/svg%3E"
 
 private const val NOTE_GLYPH_CLASS = "riffle-note-glyph"
@@ -71,15 +70,15 @@ fun noteGlyphTemplate(): HtmlDecorationTemplate =
             }
             .$NOTE_GLYPH_ICON_CLASS {
                 position: absolute;
-                left: -24px;
+                left: -28px;
                 top: 2px;
-                width: 24px;
-                height: 24px;
+                width: 28px;
+                height: 28px;
                 -webkit-mask-image: url("$NOTE_GLYPH_SVG_DATA_URI");
                 -webkit-mask-size: contain;
                 -webkit-mask-repeat: no-repeat;
                 background-color: currentColor;
-                opacity: 0.55;
+                opacity: 0.40;
             }
         """.trimIndent(),
     )

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/NoteGlyphDecorationTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/NoteGlyphDecorationTest.kt
@@ -36,10 +36,14 @@ class NoteGlyphDecorationTest {
     }
 
     @Test
-    fun `noteGlyphTemplate stylesheet references the SVG data URI`() {
+    fun `noteGlyphTemplate stylesheet uses mask-image for theme-aware colouring`() {
         val stylesheet = noteGlyphTemplate().stylesheet ?: ""
-        assertTrue("stylesheet must include SVG data URI background-image",
+        assertTrue("stylesheet must use -webkit-mask-image so glyph inherits currentColor",
+            stylesheet.contains("-webkit-mask-image"))
+        assertTrue("mask image must reference the SVG data URI",
             stylesheet.contains("data:image/svg+xml"))
+        assertTrue("glyph must use currentColor background to be theme-aware",
+            stylesheet.contains("background-color: currentColor"))
     }
 
     // NOTE: Parcelable round-trip test is omitted here because android.os.Parcel is a JVM stub.

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/NoteGlyphDecorationTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/NoteGlyphDecorationTest.kt
@@ -1,0 +1,47 @@
+@file:OptIn(org.readium.r2.shared.ExperimentalReadiumApi::class)
+
+package com.riffle.app.feature.reader
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.readium.r2.navigator.html.HtmlDecorationTemplate
+
+class NoteGlyphDecorationTest {
+
+    @Test
+    fun `two NoteGlyphStyle instances are equal`() {
+        assertEquals(NoteGlyphStyle(), NoteGlyphStyle())
+    }
+
+    @Test
+    fun `NoteGlyphStyle is not equal to HighlightTintStyle`() {
+        assertNotEquals(NoteGlyphStyle(), HighlightTintStyle(0xFF000000.toInt()))
+    }
+
+    @Test
+    fun `noteGlyphTemplate uses BOUNDS layout`() {
+        val template = noteGlyphTemplate()
+        assertEquals(HtmlDecorationTemplate.Layout.BOUNDS, template.layout)
+    }
+
+    @Test
+    fun `noteGlyphTemplate stylesheet positions glyph in the left gutter`() {
+        // The ::before pseudo-element must be placed to the left of the bounding box.
+        val stylesheet = noteGlyphTemplate().stylesheet ?: ""
+        assertTrue("stylesheet must contain '::before'", stylesheet.contains("::before"))
+        assertTrue("stylesheet must position glyph left of bounds via 'right: 100%'",
+            stylesheet.contains("right: 100%"))
+    }
+
+    @Test
+    fun `noteGlyphTemplate stylesheet references the SVG data URI`() {
+        val stylesheet = noteGlyphTemplate().stylesheet ?: ""
+        assertTrue("stylesheet must include SVG data URI background-image",
+            stylesheet.contains("data:image/svg+xml"))
+    }
+
+    // NOTE: Parcelable round-trip test is omitted here because android.os.Parcel is a JVM stub.
+    // It will be added as an androidTest in Task 2's harness run (on-device verification).
+}

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/NoteGlyphDecorationTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/NoteGlyphDecorationTest.kt
@@ -27,12 +27,21 @@ class NoteGlyphDecorationTest {
     }
 
     @Test
-    fun `noteGlyphTemplate stylesheet positions glyph in the left gutter`() {
-        // The ::before pseudo-element must be placed to the left of the bounding box.
+    fun `noteGlyphTemplate stylesheet targets inner icon class for tap-bubbling element`() {
+        // The icon must be a real DOM child (not ::before) so taps bubble to Readium's listener.
+        // We verify by checking the stylesheet styles the inner icon class, not a pseudo-element.
         val stylesheet = noteGlyphTemplate().stylesheet ?: ""
-        assertTrue("stylesheet must contain '::before'", stylesheet.contains("::before"))
-        assertTrue("stylesheet must position glyph left of bounds via 'right: 100%'",
-            stylesheet.contains("right: 100%"))
+        assertTrue("stylesheet must style the inner icon div class",
+            stylesheet.contains("riffle-note-glyph-icon"))
+        assertTrue("stylesheet must not use ::before — taps on pseudo-elements fall outside the hit area",
+            !stylesheet.contains("::before"))
+    }
+
+    @Test
+    fun `noteGlyphTemplate stylesheet positions icon div in the left gutter`() {
+        val stylesheet = noteGlyphTemplate().stylesheet ?: ""
+        assertTrue("stylesheet must position icon left of selection bounds",
+            stylesheet.contains("left: -24px"))
     }
 
     @Test

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/NoteGlyphDecorationTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/NoteGlyphDecorationTest.kt
@@ -47,7 +47,7 @@ class NoteGlyphDecorationTest {
     fun `noteGlyphTemplate stylesheet positions icon div in the left gutter`() {
         val stylesheet = noteGlyphTemplate().stylesheet ?: ""
         assertTrue("stylesheet must position icon left of selection bounds",
-            stylesheet.contains("left: -24px"))
+            stylesheet.contains("left: -28px"))
     }
 
     @Test

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/NoteGlyphDecorationTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/NoteGlyphDecorationTest.kt
@@ -27,13 +27,19 @@ class NoteGlyphDecorationTest {
     }
 
     @Test
+    fun `noteGlyphTemplate element has data-activable on inner icon div`() {
+        // Readium hit-tests using data-activable='1' elements; without it, it falls back to
+        // D.children (the outer BOUNDS div covering the text selection), which misses the gutter.
+        assertTrue("inner icon div must carry data-activable='1' so Readium uses its gutter rect",
+            NOTE_GLYPH_ELEMENT_HTML.contains("data-activable=\"1\""))
+    }
+
+    @Test
     fun `noteGlyphTemplate stylesheet targets inner icon class for tap-bubbling element`() {
-        // The icon must be a real DOM child (not ::before) so taps bubble to Readium's listener.
-        // We verify by checking the stylesheet styles the inner icon class, not a pseudo-element.
         val stylesheet = noteGlyphTemplate().stylesheet ?: ""
         assertTrue("stylesheet must style the inner icon div class",
             stylesheet.contains("riffle-note-glyph-icon"))
-        assertTrue("stylesheet must not use ::before — taps on pseudo-elements fall outside the hit area",
+        assertTrue("stylesheet must not use ::before — pseudo-elements outside the hit area",
             !stylesheet.contains("::before"))
     }
 

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ReadaloudHighlightDecorationTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ReadaloudHighlightDecorationTest.kt
@@ -41,5 +41,7 @@ class ReadaloudHighlightDecorationTest {
         assertNotNull(templates[HighlightTintStyle::class])
         // ...without dropping the built-in highlight used by persisted + search highlights.
         assertNotNull(templates[Decoration.Style.Highlight::class])
+        // ...and the note-glyph style for annotation-notes group is also registered.
+        assertNotNull(templates[NoteGlyphStyle::class])
     }
 }

--- a/docs/superpowers/plans/2026-06-18-note-glyph.md
+++ b/docs/superpowers/plans/2026-06-18-note-glyph.md
@@ -1,0 +1,548 @@
+# Note Glyph in Highlight Margin — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the `"annotation-notes"` underline decoration with a margin note glyph, and make the highlight actions popup show a note read-first inline expansion.
+
+**Architecture:** A new `NoteGlyphStyle`/`noteGlyphTemplate()` pair (mirroring `HighlightTintStyle`/`highlightTintTemplate()`) registers a `BOUNDS`-layout decoration that places a `::before` SVG icon to the left of the highlighted text's bounding box. A dedicated `"annotation-notes"` tap listener routes glyph taps to `openHighlightActions`. The `HighlightActionsPopup` gains local `noteExpanded` state that shows the full note text inline before entering the editor.
+
+**Tech Stack:** Kotlin, Readium 3.3.0 `HtmlDecorationTemplate`, Compose, JUnit4
+
+## Global Constraints
+
+- Readium version: 3.3.0 — use only `HtmlDecorationTemplate.Layout.BOUNDS` or `BOXES`; no `userScripts` field exists on `EpubNavigatorFragment.Configuration`
+- minSdk = 24 — avoid `java.util.Base64` (API 26+); use inline percent-encoded SVG data URI instead
+- All new Kotlin goes in package `com.riffle.app.feature.reader`
+- Run JVM tests with `export JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home" && ./gradlew :app:testDebugUnitTest`
+- Never call `./gradlew :app:connectedDebugAndroidTest` directly — use `make harness-test`
+- No `Co-Authored-By: Claude` in commits
+
+---
+
+### Task 1: `NoteGlyphStyle` + `noteGlyphTemplate()` + unit tests
+
+**Files:**
+- Create: `app/src/main/kotlin/com/riffle/app/feature/reader/NoteGlyphDecoration.kt`
+- Create: `app/src/test/kotlin/com/riffle/app/feature/reader/NoteGlyphDecorationTest.kt`
+
+**Interfaces:**
+- Produces: `class NoteGlyphStyle : Decoration.Style, Parcelable` — marker style, no fields
+- Produces: `fun noteGlyphTemplate(): HtmlDecorationTemplate` — BOUNDS layout, SVG `::before` in gutter
+- Produces: `internal const val NOTE_GLYPH_SVG_DATA_URI: String` — percent-encoded SVG data URI
+
+---
+
+- [ ] **Step 1.1: Write the failing tests**
+
+Create `app/src/test/kotlin/com/riffle/app/feature/reader/NoteGlyphDecorationTest.kt`:
+
+```kotlin
+@file:OptIn(org.readium.r2.shared.ExperimentalReadiumApi::class)
+
+package com.riffle.app.feature.reader
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.readium.r2.navigator.html.HtmlDecorationTemplate
+
+class NoteGlyphDecorationTest {
+
+    @Test
+    fun `two NoteGlyphStyle instances are equal`() {
+        assertEquals(NoteGlyphStyle(), NoteGlyphStyle())
+    }
+
+    @Test
+    fun `NoteGlyphStyle is not equal to HighlightTintStyle`() {
+        assertNotEquals(NoteGlyphStyle(), HighlightTintStyle(0xFF000000.toInt()))
+    }
+
+    @Test
+    fun `noteGlyphTemplate uses BOUNDS layout`() {
+        val template = noteGlyphTemplate()
+        assertEquals(HtmlDecorationTemplate.Layout.BOUNDS, template.layout)
+    }
+
+    @Test
+    fun `noteGlyphTemplate stylesheet positions glyph in the left gutter`() {
+        // The ::before pseudo-element must be placed to the left of the bounding box.
+        val stylesheet = noteGlyphTemplate().stylesheet ?: ""
+        assertTrue("stylesheet must contain '::before'", stylesheet.contains("::before"))
+        assertTrue("stylesheet must position glyph left of bounds via 'right: 100%'",
+            stylesheet.contains("right: 100%"))
+    }
+
+    @Test
+    fun `noteGlyphTemplate stylesheet references the SVG data URI`() {
+        val stylesheet = noteGlyphTemplate().stylesheet ?: ""
+        assertTrue("stylesheet must include SVG data URI background-image",
+            stylesheet.contains("data:image/svg+xml"))
+    }
+
+    @Test
+    fun `NoteGlyphStyle survives Parcelable round-trip`() {
+        val original = NoteGlyphStyle()
+        val parcel = android.os.Parcel.obtain()
+        original.writeToParcel(parcel, 0)
+        parcel.setDataPosition(0)
+        val restored = NoteGlyphStyle.CREATOR.createFromParcel(parcel)
+        parcel.recycle()
+        assertEquals(original, restored)
+    }
+}
+```
+
+- [ ] **Step 1.2: Run tests to confirm they fail**
+
+```
+export JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"
+./gradlew :app:testDebugUnitTest --tests "*.NoteGlyphDecorationTest"
+```
+
+Expected: FAIL — `NoteGlyphStyle`, `noteGlyphTemplate`, `NOTE_GLYPH_SVG_DATA_URI` not defined.
+
+- [ ] **Step 1.3: Implement `NoteGlyphDecoration.kt`**
+
+Create `app/src/main/kotlin/com/riffle/app/feature/reader/NoteGlyphDecoration.kt`:
+
+```kotlin
+package com.riffle.app.feature.reader
+
+import android.os.Parcel
+import android.os.Parcelable
+import org.readium.r2.navigator.Decoration
+import org.readium.r2.navigator.html.HtmlDecorationTemplate
+
+// SVG path from Icons.AutoMirrored.Outlined.StickyNote2 (Apache 2.0).
+// Percent-encoded so it can be embedded directly in a CSS url() without base64.
+// %3C/%3E = < / >
+internal const val NOTE_GLYPH_SVG_DATA_URI =
+    "data:image/svg+xml," +
+    "%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E" +
+    "%3Cpath d='M19,5v9l-5,0,0,5H5V5H19M19,3H5C3.9,3,3,3.9,3,5v14" +
+    "c0,1.1,.9,2,2,2h10l6,-6V5C21,3.9,20.1,3,19,3Z" +
+    "M12,14H7v-2h5V14ZM17,10H7V8h10V10Z'/%3E" +
+    "%3C/svg%3E"
+
+private const val NOTE_GLYPH_CLASS = "riffle-note-glyph"
+
+/**
+ * Marker decoration style for noted highlights. No tint — the glyph is monochrome.
+ * All noted highlights share the same icon regardless of highlight colour or theme.
+ */
+class NoteGlyphStyle : Decoration.Style, Parcelable {
+
+    override fun describeContents(): Int = 0
+
+    override fun writeToParcel(dest: Parcel, flags: Int) = Unit
+
+    override fun equals(other: Any?): Boolean = other is NoteGlyphStyle
+
+    override fun hashCode(): Int = NoteGlyphStyle::class.hashCode()
+
+    companion object {
+        @JvmField
+        val CREATOR: Parcelable.Creator<NoteGlyphStyle> =
+            object : Parcelable.Creator<NoteGlyphStyle> {
+                override fun createFromParcel(source: Parcel) = NoteGlyphStyle()
+                override fun newArray(size: Int): Array<NoteGlyphStyle?> = arrayOfNulls(size)
+            }
+    }
+}
+
+/**
+ * Decoration template for [NoteGlyphStyle]. A single transparent BOUNDS div sits over
+ * the selection; its ::before pseudo-element is absolutely positioned to the left of the
+ * div (right: 100%), placing the note icon in the left gutter alongside the text.
+ * overflow: visible on the host div prevents the gutter icon from being clipped.
+ */
+fun noteGlyphTemplate(): HtmlDecorationTemplate =
+    HtmlDecorationTemplate(
+        layout = HtmlDecorationTemplate.Layout.BOUNDS,
+        element = { _ -> """<div class="$NOTE_GLYPH_CLASS"/>""" },
+        stylesheet = """
+            .$NOTE_GLYPH_CLASS {
+                background: none;
+                overflow: visible;
+                position: relative;
+            }
+            .$NOTE_GLYPH_CLASS::before {
+                content: "";
+                position: absolute;
+                right: 100%;
+                top: 0;
+                margin-right: 4px;
+                width: 16px;
+                height: 16px;
+                background-image: url("$NOTE_GLYPH_SVG_DATA_URI");
+                background-size: contain;
+                background-repeat: no-repeat;
+                opacity: 0.55;
+                pointer-events: none;
+            }
+        """.trimIndent(),
+    )
+```
+
+- [ ] **Step 1.4: Run tests again — all should pass**
+
+```
+export JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"
+./gradlew :app:testDebugUnitTest --tests "*.NoteGlyphDecorationTest"
+```
+
+Expected: all 6 tests PASS.
+
+Note: the Parcelable round-trip test requires the Android runtime — if it fails with `RuntimeException: Stub!`, remove it from this task and re-add it as an androidTest in Task 2.
+
+- [ ] **Step 1.5: Commit**
+
+```bash
+git add app/src/main/kotlin/com/riffle/app/feature/reader/NoteGlyphDecoration.kt \
+        app/src/test/kotlin/com/riffle/app/feature/reader/NoteGlyphDecorationTest.kt
+git commit -m "feat(annotations): NoteGlyphStyle + noteGlyphTemplate for margin note icon"
+```
+
+---
+
+### Task 2: Wire the decoration — register template, swap Underline, add tap listener
+
+**Files:**
+- Modify: `app/src/main/kotlin/com/riffle/app/feature/reader/FormattingPreferencesMapper.kt`
+- Modify: `app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt` (lines ~1649–1698)
+- Modify: `app/src/test/kotlin/com/riffle/app/feature/reader/ReadaloudHighlightDecorationTest.kt`
+
+**Interfaces:**
+- Consumes: `NoteGlyphStyle` and `noteGlyphTemplate()` from Task 1
+- Produces: `NoteGlyphStyle` template registered in `FormattingPreferencesMapper`; `"annotation-notes"` group uses `NoteGlyphStyle()`; dedicated tap listener routes glyph taps to `openHighlightActions`
+
+---
+
+- [ ] **Step 2.1: Extend the existing template-registration test**
+
+In `app/src/test/kotlin/com/riffle/app/feature/reader/ReadaloudHighlightDecorationTest.kt`, extend `fragmentConfigurationRegistersHighlightTemplateAlongsideDefaults`:
+
+```kotlin
+@Test
+fun fragmentConfigurationRegistersHighlightTemplateAlongsideDefaults() {
+    val templates = FormattingPreferences().toFragmentConfiguration().decorationTemplates
+    assertNotNull(templates[HighlightTintStyle::class])
+    assertNotNull(templates[Decoration.Style.Highlight::class])
+    assertNotNull(templates[NoteGlyphStyle::class])   // ← add this line
+}
+```
+
+Run to confirm it fails:
+```
+export JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"
+./gradlew :app:testDebugUnitTest --tests "*.ReadaloudHighlightDecorationTest"
+```
+
+Expected: FAIL — `NoteGlyphStyle` template not yet registered.
+
+- [ ] **Step 2.2: Register `NoteGlyphStyle` template in `FormattingPreferencesMapper.kt`**
+
+In `toFragmentConfiguration()`, the `decorationTemplates` block currently reads:
+
+```kotlin
+decorationTemplates = HtmlDecorationTemplates.defaultTemplates().apply {
+    set(HighlightTintStyle::class, highlightTintTemplate())
+},
+```
+
+Add one line:
+
+```kotlin
+decorationTemplates = HtmlDecorationTemplates.defaultTemplates().apply {
+    set(HighlightTintStyle::class, highlightTintTemplate())
+    set(NoteGlyphStyle::class, noteGlyphTemplate())
+},
+```
+
+Run the test again — it should now pass:
+```
+export JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"
+./gradlew :app:testDebugUnitTest --tests "*.ReadaloudHighlightDecorationTest"
+```
+
+Expected: PASS.
+
+- [ ] **Step 2.3: Swap `Decoration.Style.Underline` → `NoteGlyphStyle()` in `EpubReaderScreen.kt`**
+
+Find the `"annotation-notes"` LaunchedEffect (around line 1666–1674). Replace the `Decoration` construction:
+
+**Before:**
+```kotlin
+val noteDecorations = noted.map { h ->
+    Decoration(
+        id = h.id,
+        locator = h.locator,
+        style = Decoration.Style.Underline(
+            tint = HighlightColor.fromToken(h.color).readerTint(formattingPrefs.theme),
+        ),
+    )
+}
+```
+
+**After:**
+```kotlin
+val noteDecorations = noted.map { h ->
+    Decoration(
+        id = h.id,
+        locator = h.locator,
+        style = NoteGlyphStyle(),
+    )
+}
+```
+
+- [ ] **Step 2.4: Add the `"annotation-notes"` decoration tap listener in `EpubReaderScreen.kt`**
+
+After the existing `"annotations"` `DisposableEffect` (around line 1698), add:
+
+```kotlin
+// ---- Decoration tap listener (annotation-notes) ----------------------------------------
+// Tapping the margin note glyph opens the same highlight-actions popup as tapping the
+// highlight text. The glyph lives in the left gutter (outside the text hit area), so the
+// "annotations" listener above does NOT fire for it — this dedicated listener is required.
+DisposableEffect(fragmentRef.value) {
+    val fragment = fragmentRef.value as? DecorableNavigator
+    val listener = object : DecorableNavigator.Listener {
+        override fun onDecorationActivated(event: DecorableNavigator.OnActivatedEvent): Boolean {
+            if (event.group != "annotation-notes") return false
+            val container = containerRef.value ?: return false
+            val rawRect = event.rect ?: return false
+            val rect = rawRect.toWindowIntRect(container)
+            currentOnOpenHighlightActions(event.decoration.id, rect)
+            return true
+        }
+    }
+    fragment?.addDecorationListener("annotation-notes", listener)
+    onDispose { fragment?.removeDecorationListener(listener) }
+}
+```
+
+- [ ] **Step 2.5: Run the full JVM test suite**
+
+```
+export JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"
+./gradlew test
+```
+
+Expected: all tests pass (the suite includes `NoteGlyphDecorationTest` and `ReadaloudHighlightDecorationTest`).
+
+- [ ] **Step 2.6: Commit**
+
+```bash
+git add app/src/main/kotlin/com/riffle/app/feature/reader/FormattingPreferencesMapper.kt \
+        app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt \
+        app/src/test/kotlin/com/riffle/app/feature/reader/ReadaloudHighlightDecorationTest.kt
+git commit -m "feat(annotations): wire NoteGlyphStyle decoration and annotation-notes tap listener"
+```
+
+---
+
+### Task 3: Read-first inline note expansion in `HighlightActionsPopup` + Compose tests
+
+**Files:**
+- Modify: `app/src/main/kotlin/com/riffle/app/feature/reader/HighlightActionsSheet.kt`
+- Create: `app/src/androidTest/kotlin/com/riffle/app/feature/reader/HighlightActionsPopupTest.kt`
+
+**Interfaces:**
+- Consumes: `HighlightActionsPopup(anchorRect, selected, note, onPick, onDelete, onOpenNoteEditor, onDismiss)` — signature unchanged
+- Produces: when `note != null`, tapping the note row expands it inline (no immediate editor); "Edit" button then calls `onOpenNoteEditor`
+
+---
+
+- [ ] **Step 3.1: Write the failing Compose tests**
+
+Create `app/src/androidTest/kotlin/com/riffle/app/feature/reader/HighlightActionsPopupTest.kt`:
+
+```kotlin
+package com.riffle.app.feature.reader
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.unit.IntRect
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.riffle.core.domain.HighlightColor
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class HighlightActionsPopupTest {
+
+    @get:Rule val composeTestRule = createComposeRule()
+
+    private val stubRect = IntRect(100, 200, 300, 220)
+
+    private fun showPopup(
+        note: String? = null,
+        onOpenNoteEditor: () -> Unit = {},
+        onDismiss: () -> Unit = {},
+    ) {
+        composeTestRule.setContent {
+            HighlightActionsPopup(
+                anchorRect = stubRect,
+                selected = HighlightColor.YELLOW,
+                note = note,
+                onPick = {},
+                onDelete = {},
+                onOpenNoteEditor = onOpenNoteEditor,
+                onDismiss = onDismiss,
+            )
+        }
+    }
+
+    @Test
+    fun noNote_tapNoteRow_callsOnOpenNoteEditor() {
+        var called = false
+        showPopup(note = null, onOpenNoteEditor = { called = true })
+        composeTestRule.onNodeWithText("Add note").performClick()
+        assertTrue("onOpenNoteEditor must be called directly when there is no note", called)
+    }
+
+    @Test
+    fun existingNote_initialState_showsPreviewAndExpandIcon() {
+        showPopup(note = "My detailed note text here")
+        composeTestRule.onNodeWithText("Note").assertIsDisplayed()
+        composeTestRule.onNodeWithText("My detailed note text here").assertIsDisplayed()
+        composeTestRule.onNodeWithContentDescription("Expand note").assertIsDisplayed()
+    }
+
+    @Test
+    fun existingNote_tapRow_expandsToFullTextAndEditButton() {
+        showPopup(note = "My detailed note text here")
+        composeTestRule.onNodeWithText("Note").performClick()
+        composeTestRule.onNodeWithText("Edit").assertIsDisplayed()
+        composeTestRule.onNodeWithContentDescription("Collapse note").assertIsDisplayed()
+    }
+
+    @Test
+    fun existingNote_expanded_tapEditButton_callsOnOpenNoteEditor() {
+        var called = false
+        showPopup(note = "Some note", onOpenNoteEditor = { called = true })
+        composeTestRule.onNodeWithText("Note").performClick()   // expand
+        composeTestRule.onNodeWithText("Edit").performClick()   // open editor
+        assertTrue("tapping Edit in expanded state must call onOpenNoteEditor", called)
+    }
+}
+```
+
+- [ ] **Step 3.2: Run to confirm they fail**
+
+```
+make harness-test
+```
+
+(These are in `androidTest` — they run on the harness AVD via `make harness-test`.)
+
+Expected: FAIL — `Expand note` / `Collapse note` content descriptions not present yet.
+
+- [ ] **Step 3.3: Update `HighlightActionsPopup` in `HighlightActionsSheet.kt`**
+
+Add `var noteExpanded by remember { mutableStateOf(false) }` at the top of the composable body (before the `Popup` call), and add the missing import `androidx.compose.runtime.getValue`, `androidx.compose.runtime.setValue`.
+
+Replace the note row (the `Row` from line ~139 to ~173) with:
+
+```kotlin
+HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))
+Row(
+    modifier = Modifier
+        .fillMaxWidth()
+        .clickable {
+            when {
+                note == null -> { onDismiss(); onOpenNoteEditor() }
+                noteExpanded -> noteExpanded = false
+                else -> noteExpanded = true
+            }
+        }
+        .padding(horizontal = 16.dp, vertical = 14.dp),
+    verticalAlignment = Alignment.CenterVertically,
+    horizontalArrangement = Arrangement.SpaceBetween,
+) {
+    Column(modifier = Modifier.weight(1f)) {
+        Text(
+            text = if (note != null) "Note" else "Add note",
+            style = MaterialTheme.typography.bodyMedium,
+        )
+        if (note != null && !noteExpanded) {
+            Spacer(Modifier.height(2.dp))
+            Text(
+                text = note,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+        if (note != null && noteExpanded) {
+            Spacer(Modifier.height(4.dp))
+            Text(
+                text = note,
+                style = MaterialTheme.typography.bodyMedium,
+            )
+            TextButton(
+                onClick = { onDismiss(); onOpenNoteEditor() },
+                modifier = Modifier.align(Alignment.End),
+            ) {
+                Text("Edit")
+            }
+        }
+    }
+    Icon(
+        imageVector = when {
+            note == null -> Icons.Outlined.Edit
+            noteExpanded -> Icons.Filled.KeyboardArrowUp
+            else -> Icons.Filled.KeyboardArrowDown
+        },
+        contentDescription = when {
+            note == null -> null
+            noteExpanded -> "Collapse note"
+            else -> "Expand note"
+        },
+        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = Modifier.size(20.dp),
+    )
+}
+```
+
+Add missing imports at the top of the file:
+
+```kotlin
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.KeyboardArrowUp
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
+```
+
+- [ ] **Step 3.4: Run the full JVM suite to catch any regressions**
+
+```
+export JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"
+./gradlew test
+```
+
+Expected: all JVM tests pass.
+
+- [ ] **Step 3.5: Run the Compose tests on the harness AVD**
+
+```
+make harness-test
+```
+
+Expected: `HighlightActionsPopupTest` — all 4 tests PASS.
+
+- [ ] **Step 3.6: Commit**
+
+```bash
+git add app/src/main/kotlin/com/riffle/app/feature/reader/HighlightActionsSheet.kt \
+        app/src/androidTest/kotlin/com/riffle/app/feature/reader/HighlightActionsPopupTest.kt
+git commit -m "feat(annotations): read-first inline note expansion in highlight actions popup"
+```

--- a/docs/superpowers/specs/2026-06-18-note-glyph-design.md
+++ b/docs/superpowers/specs/2026-06-18-note-glyph-design.md
@@ -1,0 +1,197 @@
+# Note glyph in highlight margin — design spec
+
+**Issue:** #206
+**Date:** 2026-06-18
+**Status:** approved
+
+## Problem
+
+Noted highlights currently show a subtle `Decoration.Style.Underline` in the `"annotation-notes"` group. The underline is easy to miss and conflates the note affordance with the highlight fill. Additionally, tapping the note row in the highlight actions popup opens `NoteEditorDialog` immediately, forcing the user into edit mode even when they only want to read the note.
+
+## Goals
+
+1. Replace the underline with a small semi-transparent note icon rendered in the left gutter next to any highlight that carries a note.
+2. Tapping the glyph opens the highlight actions popup (same as tapping the highlight text).
+3. Reading a note does not require entering edit mode — a read-first expand-in-place flow precedes the editor.
+
+## Non-goals
+
+- Changing the note data model or sync behaviour.
+- Supporting RTL gutter placement (deferred).
+- Animating the popup expansion.
+
+---
+
+## Section 1: Decoration system changes
+
+### `NoteGlyphStyle`
+
+New file: `app/src/main/kotlin/com/riffle/app/feature/reader/NoteGlyphDecoration.kt`
+
+```kotlin
+class NoteGlyphStyle : Decoration.Style, Parcelable {
+    override fun describeContents() = 0
+    override fun writeToParcel(dest: Parcel, flags: Int) = Unit
+    override fun equals(other: Any?) = other is NoteGlyphStyle
+    override fun hashCode() = NoteGlyphStyle::class.hashCode()
+    companion object {
+        @JvmField val CREATOR: Parcelable.Creator<NoteGlyphStyle> = ...
+    }
+}
+```
+
+A marker style — no tint or data fields. Value equality is trivially true between instances (all noted highlights get the same icon).
+
+### `noteGlyphTemplate()`
+
+Lives in `NoteGlyphDecoration.kt`.
+
+```kotlin
+fun noteGlyphTemplate(): HtmlDecorationTemplate = HtmlDecorationTemplate(
+    layout = HtmlDecorationTemplate.Layout.BOUNDS,
+    element = { _ -> """<div class="$NOTE_GLYPH_CLASS"/>""" },
+    stylesheet = """
+        .$NOTE_GLYPH_CLASS {
+            background: none;
+            overflow: visible;
+            position: relative;
+        }
+        .$NOTE_GLYPH_CLASS::before {
+            content: "";
+            position: absolute;
+            right: 100%;
+            top: 0;
+            margin-right: 4px;
+            width: 16px;
+            height: 16px;
+            background-image: url("data:image/svg+xml,..."); /* Material StickyNote2 */
+            background-size: contain;
+            background-repeat: no-repeat;
+            opacity: 0.55;
+        }
+    """.trimIndent(),
+)
+```
+
+`Layout.BOUNDS` renders one transparent `div` spanning the entire selection bounding box. The `::before` pseudo-element is positioned `right: 100%; top: 0` — it exits the div to the left and sits in the gutter, aligned with the top of the first text line. `overflow: visible` on the host div prevents clipping at the column edge.
+
+The SVG data URI embeds the Material `StickyNote2` outlined icon at 16×16, monochrome (`currentColor` or explicit `#000`). Opacity 0.55 gives the semi-transparent look in both light and dark themes.
+
+### `FormattingPreferencesMapper.kt`
+
+Add one line in `toFragmentConfiguration()`:
+
+```kotlin
+decorationTemplates = HtmlDecorationTemplates.defaultTemplates().apply {
+    set(HighlightTintStyle::class, highlightTintTemplate())
+    set(NoteGlyphStyle::class, noteGlyphTemplate())   // ← new
+},
+```
+
+### `EpubReaderScreen.kt` — `"annotation-notes"` LaunchedEffect
+
+Replace `Decoration.Style.Underline(tint = ...)` with `NoteGlyphStyle()`. The tint parameter is no longer needed since the icon is monochrome + opacity-based.
+
+```kotlin
+val noteDecorations = noted.map { h ->
+    Decoration(
+        id = h.id,
+        locator = h.locator,
+        style = NoteGlyphStyle(),
+    )
+}
+```
+
+### New `"annotation-notes"` decoration tap listener
+
+Add a `DisposableEffect` parallel to the existing `"annotations"` listener:
+
+```kotlin
+DisposableEffect(fragmentRef.value) {
+    val fragment = fragmentRef.value as? DecorableNavigator
+    val listener = object : DecorableNavigator.Listener {
+        override fun onDecorationActivated(event: DecorableNavigator.OnActivatedEvent): Boolean {
+            if (event.group != "annotation-notes") return false
+            val container = containerRef.value ?: return false
+            val rawRect = event.rect ?: return false
+            val rect = rawRect.toWindowIntRect(container)
+            currentOnOpenHighlightActions(event.decoration.id, rect)
+            return true
+        }
+    }
+    fragment?.addDecorationListener("annotation-notes", listener)
+    onDispose { fragment?.removeDecorationListener(listener) }
+}
+```
+
+The underline's implicit tap fallthrough to the `"annotations"` listener is removed (the glyph is in the margin, outside the text hit area), so this dedicated listener is required.
+
+---
+
+## Section 2: Read-first note flow
+
+### `HighlightActionsPopup`
+
+Add local state:
+
+```kotlin
+var noteExpanded by remember { mutableStateOf(false) }
+```
+
+#### Note row — no note ("Add note")
+Behaviour unchanged: tapping calls `onDismiss(); onOpenNoteEditor()`.
+
+#### Note row — has note, not expanded
+- Label: "Note"
+- 2-line ellipsised preview (unchanged)
+- Trailing icon: `Icons.Filled.KeyboardArrowDown` (replaces `Icons.Outlined.Edit`)
+- Tapping: `noteExpanded = true`
+
+#### Note row — has note, expanded
+The Column in the row grows to show:
+1. Row header: "Note" label + `Icons.Filled.KeyboardArrowUp` trailing icon (tapping collapses)
+2. `Text(text = note, style = bodyMedium)` — non-editable, no max lines
+3. `TextButton("Edit")` aligned end — tapping calls `onDismiss(); onOpenNoteEditor()`
+
+`NoteEditorDialog` is unchanged — the edit path is identical to today, just gated behind the expand step when a note exists.
+
+---
+
+## Section 3: Testing
+
+### Unit tests (`app/src/test/`)
+
+- `NoteGlyphStyleTest`: equality (two instances equal, unequal to `HighlightTintStyle`), `Parcelable` round-trip.
+- `NoteGlyphDecorationTest`: snapshot assert that `noteGlyphTemplate()` HTML contains `::before`, `right: 100%`, and the SVG data URI prefix `data:image/svg+xml`.
+
+### Compose tests (`app/src/androidTest/` or Robolectric in `app/src/test/`)
+
+Extend or create `HighlightActionsSheetTest`:
+
+| # | Scenario | Assert |
+|---|----------|--------|
+| 1 | Popup with existing note, not expanded | Chevron-down visible, "Edit" icon absent, preview text shown (max 2 lines) |
+| 2 | Tap note row with existing note | Chevron-up visible, full note text visible, "Edit" button visible |
+| 3 | Tap "Edit" in expanded state | `onOpenNoteEditor` lambda invoked |
+| 4 | Tap "Add note" (no note) | `onOpenNoteEditor` lambda invoked immediately (no expand step) |
+
+### Harness test (`make harness-test`)
+
+One `@Test` in the annotation harness class:
+- Load a book with a noted highlight.
+- Assert `"annotation-notes"` decoration group is non-empty.
+- Tap the glyph area (margin-left of the highlight's bounding rect).
+- Assert highlight actions popup appears.
+
+---
+
+## Affected files
+
+| File | Change |
+|------|--------|
+| `app/.../reader/NoteGlyphDecoration.kt` | New — `NoteGlyphStyle` + `noteGlyphTemplate()` |
+| `app/.../reader/FormattingPreferencesMapper.kt` | Register `NoteGlyphStyle` template |
+| `app/.../reader/EpubReaderScreen.kt` | Swap `Underline` → `NoteGlyphStyle`; add `"annotation-notes"` listener |
+| `app/.../reader/HighlightActionsSheet.kt` | Inline-expand note row |
+| `app/src/test/.../NoteGlyphDecorationTest.kt` | New unit tests |
+| `app/src/test/.../HighlightActionsSheetTest.kt` | New/extended Compose tests |

--- a/docs/superpowers/specs/2026-06-18-note-glyph-design.md
+++ b/docs/superpowers/specs/2026-06-18-note-glyph-design.md
@@ -35,7 +35,11 @@ class NoteGlyphStyle : Decoration.Style, Parcelable {
     override fun equals(other: Any?) = other is NoteGlyphStyle
     override fun hashCode() = NoteGlyphStyle::class.hashCode()
     companion object {
-        @JvmField val CREATOR: Parcelable.Creator<NoteGlyphStyle> = ...
+        @JvmField val CREATOR: Parcelable.Creator<NoteGlyphStyle> =
+            object : Parcelable.Creator<NoteGlyphStyle> {
+                override fun createFromParcel(source: Parcel) = NoteGlyphStyle()
+                override fun newArray(size: Int): Array<NoteGlyphStyle?> = arrayOfNulls(size)
+            }
     }
 }
 ```


### PR DESCRIPTION
## Summary

- Adds a monochrome **NoteAlt glyph** (28 px, opacity 0.40) in the left gutter for every highlight that carries a note. The icon uses `-webkit-mask-image` + `background-color: currentColor` so it is theme-aware (light/dark/sepia).
- Tapping the **glyph** opens a **note-only read popup** (no colour pickers, no delete) showing the full note text and an Edit button.
- Tapping the **highlighted text** continues to open the full highlight-actions popup (colour swatches + delete + inline note expansion) unchanged.
- The glyph uses `data-activable="1"` on its inner div so Readium's JS hit-tester uses the gutter rect rather than falling back to the text-selection rect.
- Existing highlights without notes show no glyph; the `annotation-notes` Readium group is cleared on every update.

## Changes

| File | What |
|---|---|
| `NoteGlyphDecoration.kt` | `NoteGlyphStyle` marker + `noteGlyphTemplate()` (BOUNDS layout, NoteAlt SVG, CSS mask) |
| `FormattingPreferencesMapper.kt` | registers `NoteGlyphStyle::class → noteGlyphTemplate()` |
| `EpubReaderScreen.kt` | `annotation-notes` LaunchedEffect + dedicated tap listener (`openNoteReader`) |
| `EpubReaderViewModel.kt` | `HighlightEditTarget.noteOnly`, `openNoteReader()` |
| `HighlightActionsSheet.kt` | `noteOnly` branch in `HighlightActionsPopup` (note-only read view, null guard) |

## Test plan

- [x] `NoteGlyphDecorationTest` (7 JVM tests) — layout, `data-activable`, mask CSS, gutter offset
- [x] `HighlightActionsPopupTest` (8 Compose androidTests) — note-only mode, null note guard, expand/collapse, Edit callback
- [x] `ReadaloudHighlightDecorationTest` — `NoteGlyphStyle` registered alongside existing templates
- [x] `./gradlew test` — green
- [x] `./gradlew lint` — green
- [x] Phone harness (221 tests, Harness_Medium_Phone_2) — green
- [x] Tablet harness (5 tests, Harness_Medium_Tablet) — green
- [x] Device-verified on API-25 emulator: glyph visible, glyph tap → note-only popup, highlight tap → full popup

Closes #206