### PR TITLE
fix(library): bust cover cache when server cover changes

### DIFF
--- a/core/data/src/main/kotlin/com/riffle/core/data/LibraryRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/LibraryRepositoryImpl.kt
@@ -194,8 +194,7 @@ class LibraryRepositoryImpl @Inject constructor(
                             libraryId = item.libraryId,
                             title = item.title,
                             author = item.author,
-                            coverUrl = "${server.url.value}/api/items/${item.id}/cover" +
-                                (item.updatedAt?.let { "?t=$it" } ?: ""),
+                            coverUrl = absCoverUrl(server.url.value, item.id, item.updatedAt),
                             // For an audiobook-only item the ABS user-progress fallback already maps
                             // its listen fraction into `ebookProgress` (AbsApiClient: ebookProgress ?:
                             // progress), so this single field is the unified "how far through this
@@ -246,8 +245,7 @@ class LibraryRepositoryImpl @Inject constructor(
                         libraryId = s.libraryId,
                         name = s.name,
                         coverUrl = s.items.firstOrNull()?.let { first ->
-                            "${server.url.value}/api/items/${first.id}/cover" +
-                                (first.updatedAt?.let { "?t=$it" } ?: "")
+                            absCoverUrl(server.url.value, first.id, first.updatedAt)
                         },
                         bookCount = s.bookCount,
                     )
@@ -336,6 +334,9 @@ class LibraryRepositoryImpl @Inject constructor(
         coverUrl = coverUrl,
         bookCount = bookCount,
     )
+
+    private fun absCoverUrl(baseUrl: String, itemId: String, updatedAt: Long?) =
+        "$baseUrl/api/items/$itemId/cover" + (updatedAt?.let { "?t=$it" } ?: "")
 
     private fun CollectionEntity.toDomain() = Collection(
         id = id,

--- a/core/data/src/main/kotlin/com/riffle/core/data/LibraryRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/LibraryRepositoryImpl.kt
@@ -194,7 +194,8 @@ class LibraryRepositoryImpl @Inject constructor(
                             libraryId = item.libraryId,
                             title = item.title,
                             author = item.author,
-                            coverUrl = "${server.url.value}/api/items/${item.id}/cover",
+                            coverUrl = "${server.url.value}/api/items/${item.id}/cover" +
+                                (item.updatedAt?.let { "?t=$it" } ?: ""),
                             // For an audiobook-only item the ABS user-progress fallback already maps
                             // its listen fraction into `ebookProgress` (AbsApiClient: ebookProgress ?:
                             // progress), so this single field is the unified "how far through this
@@ -244,7 +245,10 @@ class LibraryRepositoryImpl @Inject constructor(
                         id = s.id,
                         libraryId = s.libraryId,
                         name = s.name,
-                        coverUrl = s.items.firstOrNull()?.let { "${server.url.value}/api/items/${it.id}/cover" },
+                        coverUrl = s.items.firstOrNull()?.let { first ->
+                            "${server.url.value}/api/items/${first.id}/cover" +
+                                (first.updatedAt?.let { "?t=$it" } ?: "")
+                        },
                         bookCount = s.bookCount,
                     )
                 }

--- a/core/data/src/test/kotlin/com/riffle/core/data/LibraryRepositoryTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/LibraryRepositoryTest.kt
@@ -550,6 +550,54 @@ class LibraryRepositoryTest {
     }
 
     @Test
+    fun `refreshLibraryItems appends updatedAt as cache-buster to cover URL`() = runTest {
+        fakeServerRepository.activeServer = activeServer()
+        fakeTokenStorage.tokens["s1"] = "tok"
+        val dao = FakeLibraryItemDao()
+        val api = object : AbsLibraryApi {
+            override suspend fun getLibraries(baseUrl: String, token: String, insecureAllowed: Boolean) =
+                NetworkLibrariesResult.Success(emptyList())
+            override suspend fun getLibraryItems(baseUrl: String, libraryId: String, token: String, insecureAllowed: Boolean) =
+                NetworkLibraryItemsResult.Success(listOf(
+                    NetworkLibraryItem("item-1", "lib-1", "Dune", "Herbert", null, ebookFormat = EbookFormat.Epub, updatedAt = 1_762_902_014_957L)
+                ))
+            override suspend fun getSeries(baseUrl: String, libraryId: String, token: String, insecureAllowed: Boolean) =
+                NetworkSeriesResult.Success(emptyList())
+            override suspend fun getCollections(baseUrl: String, libraryId: String, token: String, insecureAllowed: Boolean) =
+                NetworkCollectionResult.Success(emptyList())
+        }
+        makeRepo(libraryItemDao = dao, api = api).refreshLibraryItems("lib-1")
+        assertEquals(
+            "https://abs.example.com/api/items/item-1/cover?t=1762902014957",
+            dao.itemsFor("lib-1").first().coverUrl,
+        )
+    }
+
+    @Test
+    fun `refreshLibraryItems uses plain cover URL when updatedAt is absent`() = runTest {
+        fakeServerRepository.activeServer = activeServer()
+        fakeTokenStorage.tokens["s1"] = "tok"
+        val dao = FakeLibraryItemDao()
+        val api = object : AbsLibraryApi {
+            override suspend fun getLibraries(baseUrl: String, token: String, insecureAllowed: Boolean) =
+                NetworkLibrariesResult.Success(emptyList())
+            override suspend fun getLibraryItems(baseUrl: String, libraryId: String, token: String, insecureAllowed: Boolean) =
+                NetworkLibraryItemsResult.Success(listOf(
+                    NetworkLibraryItem("item-1", "lib-1", "Dune", "Herbert", null, ebookFormat = EbookFormat.Epub, updatedAt = null)
+                ))
+            override suspend fun getSeries(baseUrl: String, libraryId: String, token: String, insecureAllowed: Boolean) =
+                NetworkSeriesResult.Success(emptyList())
+            override suspend fun getCollections(baseUrl: String, libraryId: String, token: String, insecureAllowed: Boolean) =
+                NetworkCollectionResult.Success(emptyList())
+        }
+        makeRepo(libraryItemDao = dao, api = api).refreshLibraryItems("lib-1")
+        assertEquals(
+            "https://abs.example.com/api/items/item-1/cover",
+            dao.itemsFor("lib-1").first().coverUrl,
+        )
+    }
+
+    @Test
     fun `observeRecentlyAddedItems emits items from DAO ordered by addedAt`() = runTest {
         val dao = FakeLibraryItemDao()
         dao.upsertAll(listOf(
@@ -801,6 +849,59 @@ class LibraryRepositoryTest {
         }
         val result = makeRepo(api = api).refreshSeries("lib-1")
         assertTrue(result is LibraryRefreshResult.NetworkError)
+    }
+
+    @Test
+    fun `refreshSeries uses first book updatedAt as cache-buster in cover URL`() = runTest {
+        fakeServerRepository.activeServer = activeServer()
+        fakeTokenStorage.tokens["s1"] = "tok"
+        val dao = FakeSeriesDao()
+        val api = object : AbsLibraryApi {
+            override suspend fun getLibraries(baseUrl: String, token: String, insecureAllowed: Boolean) =
+                NetworkLibrariesResult.Success(emptyList())
+            override suspend fun getLibraryItems(baseUrl: String, libraryId: String, token: String, insecureAllowed: Boolean) =
+                NetworkLibraryItemsResult.Success(emptyList())
+            override suspend fun getSeries(baseUrl: String, libraryId: String, token: String, insecureAllowed: Boolean) =
+                NetworkSeriesResult.Success(listOf(
+                    NetworkSeries("ser-1", "lib-1", "Stormlight", listOf(
+                        NetworkSeriesItem("item-1", "lib-1", "WoK", "Sanderson", "1", 0f, EbookFormat.Epub, updatedAt = 1_762_902_014_957L),
+                        NetworkSeriesItem("item-2", "lib-1", "WoR", "Sanderson", "2", 0f, EbookFormat.Epub, updatedAt = 1_762_000_000_000L),
+                    )),
+                ))
+            override suspend fun getCollections(baseUrl: String, libraryId: String, token: String, insecureAllowed: Boolean) =
+                NetworkCollectionResult.Success(emptyList())
+        }
+        makeRepo(seriesDao = dao, api = api).refreshSeries("lib-1")
+        assertEquals(
+            "https://abs.example.com/api/items/item-1/cover?t=1762902014957",
+            dao.upsertedSeries.first().coverUrl,
+        )
+    }
+
+    @Test
+    fun `refreshSeries uses plain cover URL when first book updatedAt is absent`() = runTest {
+        fakeServerRepository.activeServer = activeServer()
+        fakeTokenStorage.tokens["s1"] = "tok"
+        val dao = FakeSeriesDao()
+        val api = object : AbsLibraryApi {
+            override suspend fun getLibraries(baseUrl: String, token: String, insecureAllowed: Boolean) =
+                NetworkLibrariesResult.Success(emptyList())
+            override suspend fun getLibraryItems(baseUrl: String, libraryId: String, token: String, insecureAllowed: Boolean) =
+                NetworkLibraryItemsResult.Success(emptyList())
+            override suspend fun getSeries(baseUrl: String, libraryId: String, token: String, insecureAllowed: Boolean) =
+                NetworkSeriesResult.Success(listOf(
+                    NetworkSeries("ser-1", "lib-1", "Stormlight", listOf(
+                        NetworkSeriesItem("item-1", "lib-1", "WoK", "Sanderson", "1", 0f, EbookFormat.Epub, updatedAt = null),
+                    )),
+                ))
+            override suspend fun getCollections(baseUrl: String, libraryId: String, token: String, insecureAllowed: Boolean) =
+                NetworkCollectionResult.Success(emptyList())
+        }
+        makeRepo(seriesDao = dao, api = api).refreshSeries("lib-1")
+        assertEquals(
+            "https://abs.example.com/api/items/item-1/cover",
+            dao.upsertedSeries.first().coverUrl,
+        )
     }
 
     // ── observeSeries ─────────────────────────────────────────────────────────

--- a/core/network/src/main/kotlin/com/riffle/core/network/AbsApiClient.kt
+++ b/core/network/src/main/kotlin/com/riffle/core/network/AbsApiClient.kt
@@ -194,6 +194,7 @@ class AbsApiClient(private val httpClient: OkHttpClient) : AbsApi, AbsLibraryApi
                     publisher = dto.media.metadata.publisher,
                     language = dto.media.metadata.language,
                     addedAt = dto.addedAt,
+                    updatedAt = dto.updatedAt,
                     isbn = dto.media.metadata.isbn,
                     asin = dto.media.metadata.asin,
                 )
@@ -243,6 +244,7 @@ class AbsApiClient(private val httpClient: OkHttpClient) : AbsApi, AbsLibraryApi
                             publishedYear = book.media.metadata.publishedYear,
                             genres = book.media.metadata.genres,
                             publisher = book.media.metadata.publisher,
+                            updatedAt = book.updatedAt,
                         )
                     },
                 )

--- a/core/network/src/main/kotlin/com/riffle/core/network/NetworkLibraryItemsResult.kt
+++ b/core/network/src/main/kotlin/com/riffle/core/network/NetworkLibraryItemsResult.kt
@@ -19,6 +19,7 @@ data class NetworkLibraryItem(
     val publisher: String? = null,
     val language: String? = null,
     val addedAt: Long? = null,
+    val updatedAt: Long? = null,
     val isbn: String? = null,
     val asin: String? = null,
 ) {

--- a/core/network/src/main/kotlin/com/riffle/core/network/NetworkSeriesResult.kt
+++ b/core/network/src/main/kotlin/com/riffle/core/network/NetworkSeriesResult.kt
@@ -16,6 +16,7 @@ data class NetworkSeriesItem(
     val publishedYear: String? = null,
     val genres: List<String> = emptyList(),
     val publisher: String? = null,
+    val updatedAt: Long? = null,
 ) {
     val isSupported: Boolean get() = ebookFormat != EbookFormat.Unsupported
 }

--- a/core/network/src/main/kotlin/com/riffle/core/network/model/AbsLibraryItemsResponse.kt
+++ b/core/network/src/main/kotlin/com/riffle/core/network/model/AbsLibraryItemsResponse.kt
@@ -13,6 +13,7 @@ internal data class AbsLibraryItemsResponse(val results: List<AbsLibraryItemDto>
         val media: AbsMediaDto,
         val userMediaProgress: AbsProgressDto? = null,
         val addedAt: Long? = null,
+        val updatedAt: Long? = null,
     )
 
     @Serializable

--- a/core/network/src/main/kotlin/com/riffle/core/network/model/AbsSeriesResponse.kt
+++ b/core/network/src/main/kotlin/com/riffle/core/network/model/AbsSeriesResponse.kt
@@ -20,6 +20,7 @@ internal data class AbsSeriesResponse(val results: List<AbsSeriesDto>) {
         val seriesSequence: String? = null,
         val media: AbsSeriesMediaDto,
         val userMediaProgress: AbsSeriesProgressDto? = null,
+        val updatedAt: Long? = null,
     )
 
     @Serializable

--- a/core/network/src/test/kotlin/com/riffle/core/network/AbsApiClientLibraryTest.kt
+++ b/core/network/src/test/kotlin/com/riffle/core/network/AbsApiClientLibraryTest.kt
@@ -201,6 +201,32 @@ class AbsApiClientLibraryTest {
     }
 
     @Test
+    fun `getLibraryItems parses updatedAt timestamp`() = runTest {
+        server.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setBody("""{"results":[{"id":"item-1","libraryId":"lib-1","updatedAt":1719000000000,"media":{"metadata":{"title":"Dune","authorName":"Frank Herbert"},"ebookFormat":"epub"}}]}""")
+                .addHeader("Content-Type", "application/json")
+        )
+        val result = client.getLibraryItems(server.url("/").toString().trimEnd('/'), "lib-1", "token", false)
+        val success = result as NetworkLibraryItemsResult.Success
+        assertEquals(1719000000000L, success.items[0].updatedAt)
+    }
+
+    @Test
+    fun `getLibraryItems sets updatedAt to null when field is absent`() = runTest {
+        server.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setBody("""{"results":[{"id":"item-1","libraryId":"lib-1","media":{"metadata":{"title":"Dune","authorName":"Frank Herbert"},"ebookFormat":"epub"}}]}""")
+                .addHeader("Content-Type", "application/json")
+        )
+        val result = client.getLibraryItems(server.url("/").toString().trimEnd('/'), "lib-1", "token", false)
+        val success = result as NetworkLibraryItemsResult.Success
+        assertNull(success.items[0].updatedAt)
+    }
+
+    @Test
     fun `getLibraryItems sets addedAt to null when field is absent`() = runTest {
         server.enqueue(
             MockResponse()

--- a/core/network/src/test/kotlin/com/riffle/core/network/AbsApiClientSeriesCollectionTest.kt
+++ b/core/network/src/test/kotlin/com/riffle/core/network/AbsApiClientSeriesCollectionTest.kt
@@ -124,6 +124,30 @@ class AbsApiClientSeriesCollectionTest {
     }
 
     @Test
+    fun `getSeries parses updatedAt from book items`() = runTest {
+        server.enqueue(
+            MockResponse().setResponseCode(200)
+                .setBody("""{"results":[{"id":"ser-1","name":"Discworld","libraryId":"lib-1","books":[{"id":"item-1","libraryId":"lib-1","updatedAt":1762902014957,"media":{"metadata":{"title":"Colour of Magic","authorName":"Pratchett"},"ebookFormat":"epub"}}]}]}""")
+                .addHeader("Content-Type", "application/json")
+        )
+        val result = client.getSeries(server.url("/").toString().trimEnd('/'), "lib-1", "token", false)
+        val item = (result as NetworkSeriesResult.Success).series[0].items[0]
+        assertEquals(1762902014957L, item.updatedAt)
+    }
+
+    @Test
+    fun `getSeries sets book updatedAt to null when absent`() = runTest {
+        server.enqueue(
+            MockResponse().setResponseCode(200)
+                .setBody("""{"results":[{"id":"ser-1","name":"Discworld","libraryId":"lib-1","books":[{"id":"item-1","libraryId":"lib-1","media":{"metadata":{"title":"Colour of Magic","authorName":"Pratchett"},"ebookFormat":"epub"}}]}]}""")
+                .addHeader("Content-Type", "application/json")
+        )
+        val result = client.getSeries(server.url("/").toString().trimEnd('/'), "lib-1", "token", false)
+        val item = (result as NetworkSeriesResult.Success).series[0].items[0]
+        assertNull(item.updatedAt)
+    }
+
+    @Test
     fun `getSeries returns NetworkError on unreachable host`() = runTest {
         server.shutdown()
         val result = client.getSeries("http://127.0.0.1:1", "lib-1", "token", false)


### PR DESCRIPTION
## Summary

- Parses `updatedAt` from the ABS items and series-books API responses and appends `?t={updatedAt}` to cover URLs stored in the database
- Coil uses the full URL as its disk-cache key, so a cover change on the server (which bumps `updatedAt`) produces a new URL on the next library refresh → cache miss → fresh cover fetched immediately
- Applies to both individual item covers and series covers (which use the first book's `updatedAt`)
- Extracts a shared `absCoverUrl()` helper in `LibraryRepositoryImpl` to ensure both construction sites stay consistent

**Root cause:** The cover URL was always `{server}/api/items/{id}/cover` — static regardless of cover changes. The `coverCacheControlInterceptor` forces `max-age=86400, stale-while-revalidate=604800`, so Coil served stale covers for up to 7 days.

**One-time migration cost:** The first library refresh after this update re-fetches all covers (old cached URLs lacked `?t=`). Subsequent refreshes only re-fetch covers whose `updatedAt` changed.

## Test plan

- [ ] `getLibraryItems parses updatedAt timestamp` / `sets updatedAt to null when field is absent`
- [ ] `getSeries parses updatedAt from book items` / `sets book updatedAt to null when absent`
- [ ] `refreshLibraryItems appends updatedAt as cache-buster to cover URL` / `uses plain cover URL when updatedAt is absent`
- [ ] `refreshSeries uses first book updatedAt as cache-buster in cover URL` / `uses plain cover URL when first book updatedAt is absent`
- [ ] `./gradlew test` — green
- [ ] `./gradlew lint` — green