### PR TITLE
fix(reader): pin bookmark ribbon below top bar, never moves

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -19,7 +19,6 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.foundation.layout.Row
@@ -289,6 +288,9 @@ fun EpubReaderScreen(
     // reserve, preventing Readium from paginating text behind the overlay in paged mode.
     var railOverlayHeightPx by remember { mutableStateOf(0) }
     val density = LocalDensity.current
+    // Latch the top-bar's full measured height so the bookmark can sit permanently below it.
+    // Max-only updates mean it never shrinks during the slide-out animation.
+    var topBarStableHeightPx by remember { mutableStateOf(0) }
     val paginated = formattingPrefs.orientation != ReaderOrientation.Vertical
     val railReserveCssPx: Int = if (paginated) {
         (railOverlayHeightPx / density.density).roundToInt()
@@ -426,8 +428,10 @@ fun EpubReaderScreen(
                         onToggle = viewModel::toggleBookmark,
                         modifier = Modifier
                             .align(Alignment.TopEnd)
-                            .statusBarsPadding()
-                            .padding(end = 12.dp),
+                            .padding(
+                                top = with(density) { topBarStableHeightPx.toDp() },
+                                end = 12.dp,
+                            ),
                     )
                 }
                 is ReaderState.Error -> {
@@ -532,6 +536,9 @@ fun EpubReaderScreen(
             visible = !immersiveState.isImmersive,
             enter = slideInVertically(initialOffsetY = { -it }) + expandVertically(expandFrom = Alignment.Top),
             exit = slideOutVertically(targetOffsetY = { -it }) + shrinkVertically(shrinkTowards = Alignment.Top),
+            modifier = Modifier.onSizeChanged { size ->
+                if (size.height > topBarStableHeightPx) topBarStableHeightPx = size.height
+            },
         ) {
             if (isSearchActive) {
                 SearchTopBar(


### PR DESCRIPTION
## Summary

- `statusBarsPadding()` on `CornerBookmarkIndicator` tracked the animated system-bar inset, causing the ribbon to drift independently of the `AnimatedVisibility` slide driving the `TopAppBar` — the two animations ran on different timings, producing visible jitter.
- Replaced with a stable top offset latched from the top bar's maximum measured height via `onSizeChanged` on the `AnimatedVisibility`. Max-only updates (`size.height > topBarStableHeightPx`) mean the value is captured once at full extension and never decreases during slide-out, so the ribbon sits permanently just below the top bar in both immersive and non-immersive mode.

## Test plan

- [ ] Open a book with annotations available (ABS/Storyteller)
- [ ] Verify bookmark ribbon is visible just below the top bar
- [ ] Tap to enter immersive mode — ribbon should not move
- [ ] Tap to exit immersive mode — ribbon should not move
- [ ] Toggle bookmark via the ribbon and confirm active/idle states still animate correctly