### PR TITLE
fix(reader): preserve publisher text-align in continuous mode

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjector.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjector.kt
@@ -79,8 +79,13 @@ internal object ContinuousStyleInjector {
         // Advanced settings: Continuous always runs with publisherStyles off (advanced on).
         props["--USER__advancedSettings"] = "readium-advanced-on"
 
-        // Text alignment mirrors FormattingPreferencesMapper: justify, else start.
-        props["--USER__textAlign"] = if (prefs.justifyText) "justify" else "start"
+        // Text alignment: set only when justify is on. When off, omit --USER__textAlign entirely
+        // so the publisher's own text-align is preserved — matching FormattingPreferencesMapper's
+        // contract (null when justifyText=false) and the Scroll/Paginated mode behaviour where the
+        // variable is left unset and the publisher's alignment shows through.
+        if (prefs.justifyText) {
+            props["--USER__textAlign"] = "justify"
+        }
 
         // Line height only when the user moved it off the default (mirrors the mapper's null-gating).
         if (prefs.lineSpacing != FormattingPreferences.DEFAULT_LINE_SPACING) {

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjectorTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjectorTest.kt
@@ -49,9 +49,9 @@ class ContinuousStyleInjectorTest {
     }
 
     @Test
-    fun `justify off maps to textAlign start (matches Readium default)`() {
+    fun `justify off omits textAlign — publisher alignment preserved (mirrors Readium null contract)`() {
         val s = attr(FormattingPreferences(justifyText = false))
-        assertTrue(s.contains("--USER__textAlign: start !important;"))
+        assertFalse("--USER__textAlign must not be set when justifyText=false", s.contains("--USER__textAlign"))
     }
 
     @Test

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjectorTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjectorTest.kt
@@ -176,6 +176,7 @@ class ContinuousStyleInjectorTest {
         val js = ContinuousStyleInjector.buildStyleInjectionJs(FormattingPreferences(fontSize = 1.5f))
         assertTrue(js.contains("document.documentElement.setAttribute('style'"))
         assertTrue(js.contains("--USER__fontSize: 150% !important;"))
+        assertFalse("--USER__textAlign absent when justifyText=false", js.contains("--USER__textAlign"))
     }
 
     // ── highlight helpers (unchanged) ───────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Continuous mode was always emitting `--USER__textAlign: start !important` when the "Justify text" setting was off. ReadiumCSS's `[style*="--USER__textAlign"]` selector fires whenever the variable is present in the style attribute, forcing all paragraph text to left-align with `!important` — overriding publisher-justified text and making it appear visually less dense (seemingly "smaller font").
- Fix: omit `--USER__textAlign` entirely when `justifyText=false`, matching `FormattingPreferencesMapper`'s null contract for Paged/Scroll modes where the variable is left unset and the publisher's own `text-align` shows through.
- Updated the corresponding unit test (wrong expectation: `start`; correct: variable absent) and added an assertion to the `buildStyleInjectionJs` test to cover the live preference-update path.

## Test plan

- [ ] JVM unit tests (`./gradlew test`) — green
- [ ] Lint (`./gradlew lint`) — green
- [ ] Manual: open a book in Continuous mode with "Justify text" off → publisher-justified text remains justified (no longer forced left-aligned)