### PR TITLE
feat(reader): annotation highlights + note glyphs in continuous mode

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ChapterWebView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ChapterWebView.kt
@@ -90,11 +90,12 @@ internal class ChapterWebView(context: Context) : WebView(context) {
     var annotationsAvailable: Boolean = false
 
     /**
-     * Called on the main thread with the selected text and its within-chapter progression (0..1)
-     * when the user taps "Highlight". The progression is computed from the selection's position
-     * in the chapter document so [createHighlight] can build a correctly-anchored CFI range.
+     * Called on the main thread with the selected text, its within-chapter progression (0..1),
+     * and its bounding rect in device pixels relative to this WebView's top-left corner.
+     * The progression lets [createHighlight] build a correctly-anchored CFI range; the rect
+     * lets the host position the highlight-actions popup next to the selected text.
      */
-    var onHighlight: ((selectedText: String, progression: Double) -> Unit)? = null
+    var onHighlight: ((selectedText: String, progression: Double, rect: android.graphics.Rect) -> Unit)? = null
 
     /**
      * Called on the main thread when the user taps an injected annotation mark (`<mark
@@ -362,7 +363,7 @@ internal class ChapterWebView(context: Context) : WebView(context) {
             override fun onActionItemClicked(mode: android.view.ActionMode, item: android.view.MenuItem): Boolean {
                 when (item.itemId) {
                     MENU_COPY -> withSelectionText { copyToClipboard(it) }
-                    MENU_HIGHLIGHT -> withSelectionTextAndProgression { text, prog -> onHighlight?.invoke(text, prog) }
+                    MENU_HIGHLIGHT -> withSelectionTextAndProgression { text, prog, rect -> onHighlight?.invoke(text, prog, rect) }
                     MENU_SEARCH -> withSelectionText { webSearch(it) }
                     MENU_SHARE -> withSelectionText { shareText(it) }
                     MENU_PLAY -> withSelectionText { onPlayFromHere?.invoke(it) }
@@ -387,40 +388,51 @@ internal class ChapterWebView(context: Context) : WebView(context) {
     }
 
     /**
-     * Read the current selection's plain text AND its within-document progression (0..1), then
-     * run [block]. The progression is `selectionTop / documentHeight` — correct in Continuous mode
-     * because the WebView never scrolls (pageYOffset=0), so getBoundingClientRect().top equals the
-     * absolute document position. Used when creating a highlight so [buildHighlightCfiRangeForSelection]
-     * receives a real startProgression instead of 0.0, placing the CFI at the actual text location.
+     * Read the current selection's plain text, its within-document progression (0..1), and the
+     * selection's bounding rect in device pixels relative to this WebView, then run [block].
+     *
+     * progression = selectionTop / documentHeight — correct in Continuous mode because the WebView
+     * never scrolls (pageYOffset=0), so getBoundingClientRect().top equals the absolute document
+     * position. The rect is CSS px × devicePixelRatio so it composes with [getLocationOnScreen].
      */
-    private fun withSelectionTextAndProgression(block: (text: String, progression: Double) -> Unit) {
+    private fun withSelectionTextAndProgression(block: (text: String, progression: Double, rect: android.graphics.Rect) -> Unit) {
         val js = """(function() {
             var sel = window.getSelection ? window.getSelection() : null;
             var text = sel ? sel.toString() : '';
             var prog = 0.0;
+            var l = 0, t = 0, r = 0, b = 0;
             if (sel && sel.rangeCount > 0) {
-                var r = sel.getRangeAt(0).getBoundingClientRect();
+                var rect = sel.getRangeAt(0).getBoundingClientRect();
                 var docH = Math.max(
                     document.documentElement ? document.documentElement.offsetHeight : 0,
                     document.body ? document.body.offsetHeight : 0,
                     1
                 );
-                prog = Math.max(0, Math.min(1, r.top / docH));
+                prog = Math.max(0, Math.min(1, rect.top / docH));
+                l = rect.left; t = rect.top; r = rect.right; b = rect.bottom;
             }
-            return JSON.stringify({t: text, p: prog});
+            return JSON.stringify({text: text, p: prog, l: l, t: t, r: r, b: b});
         })()"""
         evaluateJavascript(js) { raw ->
             val jsonStr = decodeJsString(raw)
             val text: String
             val prog: Double
+            val rect: android.graphics.Rect
             try {
                 val obj = org.json.JSONObject(jsonStr)
-                text = obj.optString("t", "")
+                text = obj.optString("text", "")
                 prog = obj.optDouble("p", 0.0)
+                val dpr = resources.displayMetrics.density
+                rect = android.graphics.Rect(
+                    (obj.optDouble("l", 0.0) * dpr).toInt(),
+                    (obj.optDouble("t", 0.0) * dpr).toInt(),
+                    (obj.optDouble("r", 0.0) * dpr).toInt(),
+                    (obj.optDouble("b", 0.0) * dpr).toInt(),
+                )
             } catch (_: Exception) {
                 return@evaluateJavascript
             }
-            if (text.isNotBlank()) block(text, prog)
+            if (text.isNotBlank()) block(text, prog, rect)
             evaluateJavascript("window.getSelection && window.getSelection().removeAllRanges()", null)
         }
     }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ChapterWebView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ChapterWebView.kt
@@ -89,8 +89,12 @@ internal class ChapterWebView(context: Context) : WebView(context) {
     /** When true, the text-selection menu offers "Highlight" (books with annotations UI). */
     var annotationsAvailable: Boolean = false
 
-    /** Called on the main thread with the selected text when the user taps "Highlight". */
-    var onHighlight: ((selectedText: String) -> Unit)? = null
+    /**
+     * Called on the main thread with the selected text and its within-chapter progression (0..1)
+     * when the user taps "Highlight". The progression is computed from the selection's position
+     * in the chapter document so [createHighlight] can build a correctly-anchored CFI range.
+     */
+    var onHighlight: ((selectedText: String, progression: Double) -> Unit)? = null
 
     /**
      * Called on the main thread when the user taps an injected annotation mark (`<mark
@@ -358,7 +362,7 @@ internal class ChapterWebView(context: Context) : WebView(context) {
             override fun onActionItemClicked(mode: android.view.ActionMode, item: android.view.MenuItem): Boolean {
                 when (item.itemId) {
                     MENU_COPY -> withSelectionText { copyToClipboard(it) }
-                    MENU_HIGHLIGHT -> withSelectionText { onHighlight?.invoke(it) }
+                    MENU_HIGHLIGHT -> withSelectionTextAndProgression { text, prog -> onHighlight?.invoke(text, prog) }
                     MENU_SEARCH -> withSelectionText { webSearch(it) }
                     MENU_SHARE -> withSelectionText { shareText(it) }
                     MENU_PLAY -> withSelectionText { onPlayFromHere?.invoke(it) }
@@ -378,6 +382,45 @@ internal class ChapterWebView(context: Context) : WebView(context) {
         evaluateJavascript("(window.getSelection ? window.getSelection().toString() : '')") { raw ->
             val text = decodeJsString(raw)
             if (text.isNotBlank()) block(text)
+            evaluateJavascript("window.getSelection && window.getSelection().removeAllRanges()", null)
+        }
+    }
+
+    /**
+     * Read the current selection's plain text AND its within-document progression (0..1), then
+     * run [block]. The progression is `selectionTop / documentHeight` — correct in Continuous mode
+     * because the WebView never scrolls (pageYOffset=0), so getBoundingClientRect().top equals the
+     * absolute document position. Used when creating a highlight so [buildHighlightCfiRangeForSelection]
+     * receives a real startProgression instead of 0.0, placing the CFI at the actual text location.
+     */
+    private fun withSelectionTextAndProgression(block: (text: String, progression: Double) -> Unit) {
+        val js = """(function() {
+            var sel = window.getSelection ? window.getSelection() : null;
+            var text = sel ? sel.toString() : '';
+            var prog = 0.0;
+            if (sel && sel.rangeCount > 0) {
+                var r = sel.getRangeAt(0).getBoundingClientRect();
+                var docH = Math.max(
+                    document.documentElement ? document.documentElement.offsetHeight : 0,
+                    document.body ? document.body.offsetHeight : 0,
+                    1
+                );
+                prog = Math.max(0, Math.min(1, r.top / docH));
+            }
+            return JSON.stringify({t: text, p: prog});
+        })()"""
+        evaluateJavascript(js) { raw ->
+            val jsonStr = decodeJsString(raw)
+            val text: String
+            val prog: Double
+            try {
+                val obj = org.json.JSONObject(jsonStr)
+                text = obj.optString("t", "")
+                prog = obj.optDouble("p", 0.0)
+            } catch (_: Exception) {
+                return@evaluateJavascript
+            }
+            if (text.isNotBlank()) block(text, prog)
             evaluateJavascript("window.getSelection && window.getSelection().removeAllRanges()", null)
         }
     }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ChapterWebView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ChapterWebView.kt
@@ -98,6 +98,12 @@ internal class ChapterWebView(context: Context) : WebView(context) {
      */
     var onAnnotationTap: ((id: String, rect: android.graphics.Rect) -> Unit)? = null
 
+    /**
+     * Called on the main thread when the user taps the note glyph (`<span data-riffle-note-glyph>`)
+     * next to an annotation that has a note. [rect] is in device pixels relative to this WebView.
+     */
+    var onAnnotationNoteTap: ((id: String, rect: android.graphics.Rect) -> Unit)? = null
+
     /** When true, the text-selection menu offers "Play" (readaloud books only). */
     var readaloudAvailable: Boolean = false
 
@@ -431,6 +437,20 @@ internal class ChapterWebView(context: Context) : WebView(context) {
                     (cssBottom * dpr).toInt(),
                 )
                 this@ChapterWebView.onAnnotationTap?.invoke(id, rect)
+            }
+        }
+
+        @JavascriptInterface
+        fun onAnnotationNoteTap(id: String, cssLeft: Float, cssTop: Float, cssRight: Float, cssBottom: Float) {
+            post {
+                val dpr = resources.displayMetrics.density
+                val rect = android.graphics.Rect(
+                    (cssLeft * dpr).toInt(),
+                    (cssTop * dpr).toInt(),
+                    (cssRight * dpr).toInt(),
+                    (cssBottom * dpr).toInt(),
+                )
+                this@ChapterWebView.onAnnotationNoteTap?.invoke(id, rect)
             }
         }
 

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ChapterWebView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ChapterWebView.kt
@@ -92,6 +92,12 @@ internal class ChapterWebView(context: Context) : WebView(context) {
     /** Called on the main thread with the selected text when the user taps "Highlight". */
     var onHighlight: ((selectedText: String) -> Unit)? = null
 
+    /**
+     * Called on the main thread when the user taps an injected annotation mark (`<mark
+     * data-riffle-ann>`). [rect] is in device pixels relative to this WebView's top-left corner.
+     */
+    var onAnnotationTap: ((id: String, rect: android.graphics.Rect) -> Unit)? = null
+
     /** When true, the text-selection menu offers "Play" (readaloud books only). */
     var readaloudAvailable: Boolean = false
 
@@ -412,6 +418,20 @@ internal class ChapterWebView(context: Context) : WebView(context) {
         @JavascriptInterface
         fun onTap() {
             post { this@ChapterWebView.onTap?.invoke() }
+        }
+
+        @JavascriptInterface
+        fun onAnnotationTap(id: String, cssLeft: Float, cssTop: Float, cssRight: Float, cssBottom: Float) {
+            post {
+                val dpr = resources.displayMetrics.density
+                val rect = android.graphics.Rect(
+                    (cssLeft * dpr).toInt(),
+                    (cssTop * dpr).toInt(),
+                    (cssRight * dpr).toInt(),
+                    (cssBottom * dpr).toInt(),
+                )
+                this@ChapterWebView.onAnnotationTap?.invoke(id, rect)
+            }
         }
 
         /**

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
@@ -515,12 +515,17 @@ internal class ContinuousReaderView @JvmOverloads constructor(
     /** Called on the main thread when the user taps an annotation highlight mark in any chapter. */
     var onAnnotationTap: ((href: String, id: String, screenRect: android.graphics.Rect) -> Unit)? = null
 
+    // Annotation state persisted so onPageFinished can re-apply marks when a chapter loads or
+    // the sliding window cycles in a new chapter without the LaunchedEffect re-running.
+    private var currentAnnotationsByHref: Map<String, List<AnnotationHighlight>> = emptyMap()
+
     /**
-     * Apply persisted annotation highlights to all currently loaded chapters.
-     * [annotationsByHref] maps each chapter href to the annotations that belong to it.
-     * Chapters in the window that have no entry are cleared of any stale marks.
+     * Apply persisted annotation highlights to all currently loaded chapters and remember the
+     * state so that chapters entering the sliding window later (via [appendChapter] /
+     * [prependChapter]) automatically receive their marks in [onPageFinished].
      */
     fun applyAnnotationHighlights(annotationsByHref: Map<String, List<AnnotationHighlight>>) {
+        currentAnnotationsByHref = annotationsByHref
         for (wv in webViews) {
             val href = wv.chapterHref
             if (href.isEmpty()) continue
@@ -616,6 +621,10 @@ internal class ContinuousReaderView @JvmOverloads constructor(
         wv.onPageFinished = {
             val styleJs = ContinuousStyleInjector.buildStyleInjectionJs(formattingPrefs)
             wv.injectStylesAndMeasure(styleJs)
+            val annotations = currentAnnotationsByHref[wv.chapterHref]
+            if (!annotations.isNullOrEmpty()) {
+                wv.evaluateJavascript(ContinuousStyleInjector.applyAnnotationHighlightsJs(annotations), null)
+            }
         }
         webViews.add(wv)
         measuredHeights.add(placeholder)
@@ -658,6 +667,10 @@ internal class ContinuousReaderView @JvmOverloads constructor(
         wv.onPageFinished = {
             val styleJs = ContinuousStyleInjector.buildStyleInjectionJs(formattingPrefs)
             wv.injectStylesAndMeasure(styleJs)
+            val annotations = currentAnnotationsByHref[wv.chapterHref]
+            if (!annotations.isNullOrEmpty()) {
+                wv.evaluateJavascript(ContinuousStyleInjector.applyAnnotationHighlightsJs(annotations), null)
+            }
         }
         webViews.add(0, wv)
         measuredHeights.add(0, placeholder)

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
@@ -463,9 +463,9 @@ internal class ContinuousReaderView @JvmOverloads constructor(
     }
 
     /** Inject a readaloud highlight for the sentence with [text] in the chapter matching [href] and scroll it into view. */
-    fun highlightInChapter(href: String, text: String) {
+    fun highlightInChapter(href: String, text: String, cssColor: String) {
         val i = webViewIndexFor(href) ?: return
-        webViews[i].evaluateJavascript(ContinuousStyleInjector.highlightTextJs(text)) { _ ->
+        webViews[i].evaluateJavascript(ContinuousStyleInjector.highlightTextJs(text, cssColor)) { _ ->
             // Re-lookup by href rather than using the captured index: the window may have shifted
             // between the evaluateJavascript call and this callback, making i stale.
             scrollToHighlight(href)

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
@@ -88,11 +88,12 @@ internal class ContinuousReaderView @JvmOverloads constructor(
         }
 
     /**
-     * Called on the main thread with (chapter href, selected text, within-chapter progression)
-     * when the user taps "Highlight". The progression comes from the selection's document position
-     * so the host can build a correctly-anchored CFI range.
+     * Called on the main thread with (chapter href, selected text, within-chapter progression,
+     * screen rect of the selection in device pixels) when the user taps "Highlight".
+     * The progression lets the host build a correctly-anchored CFI range; the rect positions
+     * the highlight-actions popup next to the selected text.
      */
-    var onHighlightSelection: ((href: String, selectedText: String, progression: Double) -> Unit)? = null
+    var onHighlightSelection: ((href: String, selectedText: String, progression: Double, screenRect: android.graphics.Rect) -> Unit)? = null
 
     /** Whether the text-selection menu should offer "Play" (readaloud books only). */
     var readaloudAvailable: Boolean = false
@@ -554,7 +555,12 @@ internal class ContinuousReaderView @JvmOverloads constructor(
         wv.onInternalLink = { onInternalLinkTapped?.invoke(it) }
         wv.onExternalLink = { onExternalLinkTapped?.invoke(it) }
         wv.annotationsAvailable = annotationsAvailable
-        wv.onHighlight = { text, prog -> onHighlightSelection?.invoke(wv.chapterHref, text, prog) }
+        wv.onHighlight = { text, prog, rect ->
+            val loc = IntArray(2)
+            wv.getLocationOnScreen(loc)
+            val screenRect = android.graphics.Rect(loc[0] + rect.left, loc[1] + rect.top, loc[0] + rect.right, loc[1] + rect.bottom)
+            onHighlightSelection?.invoke(wv.chapterHref, text, prog, screenRect)
+        }
         wv.onAnnotationTap = { id, rect ->
             val loc = IntArray(2)
             wv.getLocationOnScreen(loc)
@@ -652,7 +658,12 @@ internal class ContinuousReaderView @JvmOverloads constructor(
         wv.onInternalLink = { onInternalLinkTapped?.invoke(it) }
         wv.onExternalLink = { onExternalLinkTapped?.invoke(it) }
         wv.annotationsAvailable = annotationsAvailable
-        wv.onHighlight = { text, prog -> onHighlightSelection?.invoke(wv.chapterHref, text, prog) }
+        wv.onHighlight = { text, prog, rect ->
+            val loc = IntArray(2)
+            wv.getLocationOnScreen(loc)
+            val screenRect = android.graphics.Rect(loc[0] + rect.left, loc[1] + rect.top, loc[0] + rect.right, loc[1] + rect.bottom)
+            onHighlightSelection?.invoke(wv.chapterHref, text, prog, screenRect)
+        }
         wv.onAnnotationTap = { id, rect ->
             val loc = IntArray(2)
             wv.getLocationOnScreen(loc)

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
@@ -25,7 +25,7 @@ import kotlin.math.abs
  * Adding a chapter at the TOP adjusts [scrollY] by the new chapter's height to keep the
  * visible content stable.
  */
-internal data class AnnotationHighlight(val id: String, val text: String, val cssColor: String)
+internal data class AnnotationHighlight(val id: String, val text: String, val cssColor: String, val hasNote: Boolean = false)
 
 internal class ContinuousReaderView @JvmOverloads constructor(
     context: Context,
@@ -206,6 +206,7 @@ internal class ContinuousReaderView @JvmOverloads constructor(
         wv.onExternalLink = null
         wv.onHighlight = null
         wv.onAnnotationTap = null
+        wv.onAnnotationNoteTap = null
         wv.onPlayFromHere = null
         wv.onFootnoteContent = null
         if (recycledViews.size < WINDOW_SIZE) recycledViews.addLast(wv) else wv.destroy()
@@ -515,6 +516,9 @@ internal class ContinuousReaderView @JvmOverloads constructor(
     /** Called on the main thread when the user taps an annotation highlight mark in any chapter. */
     var onAnnotationTap: ((href: String, id: String, screenRect: android.graphics.Rect) -> Unit)? = null
 
+    /** Called on the main thread when the user taps a note glyph next to an annotation mark. */
+    var onAnnotationNoteTap: ((href: String, id: String, screenRect: android.graphics.Rect) -> Unit)? = null
+
     // Annotation state persisted so onPageFinished can re-apply marks when a chapter loads or
     // the sliding window cycles in a new chapter without the LaunchedEffect re-running.
     private var currentAnnotationsByHref: Map<String, List<AnnotationHighlight>> = emptyMap()
@@ -555,6 +559,12 @@ internal class ContinuousReaderView @JvmOverloads constructor(
             wv.getLocationOnScreen(loc)
             val screenRect = android.graphics.Rect(loc[0] + rect.left, loc[1] + rect.top, loc[0] + rect.right, loc[1] + rect.bottom)
             onAnnotationTap?.invoke(wv.chapterHref, id, screenRect)
+        }
+        wv.onAnnotationNoteTap = { id, rect ->
+            val loc = IntArray(2)
+            wv.getLocationOnScreen(loc)
+            val screenRect = android.graphics.Rect(loc[0] + rect.left, loc[1] + rect.top, loc[0] + rect.right, loc[1] + rect.bottom)
+            onAnnotationNoteTap?.invoke(wv.chapterHref, id, screenRect)
         }
         wv.readaloudAvailable = readaloudAvailable
         wv.onPlayFromHere = { text -> onPlayFromHereSelection?.invoke(wv.chapterHref, text) }
@@ -647,6 +657,12 @@ internal class ContinuousReaderView @JvmOverloads constructor(
             wv.getLocationOnScreen(loc)
             val screenRect = android.graphics.Rect(loc[0] + rect.left, loc[1] + rect.top, loc[0] + rect.right, loc[1] + rect.bottom)
             onAnnotationTap?.invoke(wv.chapterHref, id, screenRect)
+        }
+        wv.onAnnotationNoteTap = { id, rect ->
+            val loc = IntArray(2)
+            wv.getLocationOnScreen(loc)
+            val screenRect = android.graphics.Rect(loc[0] + rect.left, loc[1] + rect.top, loc[0] + rect.right, loc[1] + rect.bottom)
+            onAnnotationNoteTap?.invoke(wv.chapterHref, id, screenRect)
         }
         wv.readaloudAvailable = readaloudAvailable
         wv.onPlayFromHere = { text -> onPlayFromHereSelection?.invoke(wv.chapterHref, text) }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
@@ -466,12 +466,15 @@ internal class ContinuousReaderView @JvmOverloads constructor(
     fun highlightInChapter(href: String, text: String) {
         val i = webViewIndexFor(href) ?: return
         webViews[i].evaluateJavascript(ContinuousStyleInjector.highlightTextJs(text)) { _ ->
-            scrollToHighlight(i)
+            // Re-lookup by href rather than using the captured index: the window may have shifted
+            // between the evaluateJavascript call and this callback, making i stale.
+            scrollToHighlight(href)
         }
     }
 
-    private fun scrollToHighlight(webViewIndex: Int) {
-        val wv = webViews.getOrNull(webViewIndex) ?: return
+    private fun scrollToHighlight(href: String) {
+        val i = webViewIndexFor(href) ?: return
+        val wv = webViews[i]
         // getBoundingClientRect().top is in CSS pixels; multiply by devicePixelRatio to get device
         // pixels so the result is in the same coordinate space as slot.top and scrollY.
         wv.evaluateJavascript(
@@ -485,12 +488,17 @@ internal class ContinuousReaderView @JvmOverloads constructor(
         ) { result ->
             val elementTop = result?.toFloatOrNull()?.toInt() ?: return@evaluateJavascript
             if (elementTop < 0) return@evaluateJavascript
-            val slot = buildWindow().getOrNull(webViewIndex) ?: return@evaluateJavascript
+            // Re-lookup window state fresh — a shift between the two evaluateJavascript calls
+            // would have changed slot positions.
+            val freshI = webViewIndexFor(href) ?: return@evaluateJavascript
+            val slot = buildWindow().getOrNull(freshI) ?: return@evaluateJavascript
             val absoluteY = slot.top + elementTop
-            // Only scroll if the highlight is outside the middle two-thirds of the viewport.
-            val margin = height / 4
-            if (absoluteY < scrollY + margin || absoluteY > scrollY + height - margin) {
-                smoothScrollTo(0, (absoluteY - height / 3).coerceAtLeast(0))
+            val targetScrollY = (absoluteY - height / 3).coerceAtLeast(0)
+            // Scroll whenever the current position is more than height/8 away from the target.
+            // Using abs() avoids the previous bug where absoluteY just inside the top of the
+            // viewport triggered a backward scroll (absoluteY < scrollY+margin → target < scrollY).
+            if (abs(targetScrollY - scrollY) > height / 8) {
+                smoothScrollTo(0, targetScrollY)
             }
         }
     }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
@@ -88,10 +88,11 @@ internal class ContinuousReaderView @JvmOverloads constructor(
         }
 
     /**
-     * Called on the main thread with (chapter href, selected text) when the user taps "Highlight".
-     * The host builds a Locator and persists the highlight.
+     * Called on the main thread with (chapter href, selected text, within-chapter progression)
+     * when the user taps "Highlight". The progression comes from the selection's document position
+     * so the host can build a correctly-anchored CFI range.
      */
-    var onHighlightSelection: ((href: String, selectedText: String) -> Unit)? = null
+    var onHighlightSelection: ((href: String, selectedText: String, progression: Double) -> Unit)? = null
 
     /** Whether the text-selection menu should offer "Play" (readaloud books only). */
     var readaloudAvailable: Boolean = false
@@ -553,7 +554,7 @@ internal class ContinuousReaderView @JvmOverloads constructor(
         wv.onInternalLink = { onInternalLinkTapped?.invoke(it) }
         wv.onExternalLink = { onExternalLinkTapped?.invoke(it) }
         wv.annotationsAvailable = annotationsAvailable
-        wv.onHighlight = { text -> onHighlightSelection?.invoke(wv.chapterHref, text) }
+        wv.onHighlight = { text, prog -> onHighlightSelection?.invoke(wv.chapterHref, text, prog) }
         wv.onAnnotationTap = { id, rect ->
             val loc = IntArray(2)
             wv.getLocationOnScreen(loc)
@@ -651,7 +652,7 @@ internal class ContinuousReaderView @JvmOverloads constructor(
         wv.onInternalLink = { onInternalLinkTapped?.invoke(it) }
         wv.onExternalLink = { onExternalLinkTapped?.invoke(it) }
         wv.annotationsAvailable = annotationsAvailable
-        wv.onHighlight = { text -> onHighlightSelection?.invoke(wv.chapterHref, text) }
+        wv.onHighlight = { text, prog -> onHighlightSelection?.invoke(wv.chapterHref, text, prog) }
         wv.onAnnotationTap = { id, rect ->
             val loc = IntArray(2)
             wv.getLocationOnScreen(loc)

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
@@ -462,13 +462,13 @@ internal class ContinuousReaderView @JvmOverloads constructor(
         smoothScrollBy(0, if (forward) delta else -delta)
     }
 
-    /** Inject a highlight for [text] in the chapter matching [href]. Clear if blank. */
+    /** Inject a readaloud highlight for the sentence with [text] in the chapter matching [href]. */
     fun highlightInChapter(href: String, text: String) {
         val i = webViewIndexFor(href) ?: return
         webViews[i].evaluateJavascript(ContinuousStyleInjector.highlightTextJs(text), null)
     }
 
-    /** Clear any active highlight in the chapter at [href]. */
+    /** Clear any active readaloud highlight in the chapter at [href]. */
     fun clearHighlightInChapter(href: String) {
         val i = webViewIndexFor(href) ?: return
         webViews[i].evaluateJavascript(ContinuousStyleInjector.CLEAR_HIGHLIGHT_JS, null)

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
@@ -546,15 +546,12 @@ internal class ContinuousReaderView @JvmOverloads constructor(
 
     // ── private ────────────────────────────────────────────────────────────────
 
-    private fun appendChapter(index: Int) {
-        val entry = allChapters[index]
-        val wv = obtainWebView()
-        publication?.let { wv.setPublication(it) }
-        wv.onTap = { onTap?.invoke() }
-        wv.onRenderGone = { recoverFromRendererGone() }
-        wv.onInternalLink = { onInternalLinkTapped?.invoke(it) }
-        wv.onExternalLink = { onExternalLinkTapped?.invoke(it) }
-        wv.annotationsAvailable = annotationsAvailable
+    /**
+     * Wire all annotation-related callbacks on [wv]. The coordinate transform is done at event
+     * time (not at wiring time) so it always reflects the WebView's current screen position.
+     * Extracted to avoid duplication between [appendChapter] and [prependChapter].
+     */
+    private fun wireAnnotationCallbacks(wv: ChapterWebView) {
         wv.onHighlight = { text, prog, rect ->
             val loc = IntArray(2)
             wv.getLocationOnScreen(loc)
@@ -573,6 +570,18 @@ internal class ContinuousReaderView @JvmOverloads constructor(
             val screenRect = android.graphics.Rect(loc[0] + rect.left, loc[1] + rect.top, loc[0] + rect.right, loc[1] + rect.bottom)
             onAnnotationNoteTap?.invoke(wv.chapterHref, id, screenRect)
         }
+    }
+
+    private fun appendChapter(index: Int) {
+        val entry = allChapters[index]
+        val wv = obtainWebView()
+        publication?.let { wv.setPublication(it) }
+        wv.onTap = { onTap?.invoke() }
+        wv.onRenderGone = { recoverFromRendererGone() }
+        wv.onInternalLink = { onInternalLinkTapped?.invoke(it) }
+        wv.onExternalLink = { onExternalLinkTapped?.invoke(it) }
+        wv.annotationsAvailable = annotationsAvailable
+        wireAnnotationCallbacks(wv)
         wv.readaloudAvailable = readaloudAvailable
         wv.onPlayFromHere = { text -> onPlayFromHereSelection?.invoke(wv.chapterHref, text) }
         wv.onFootnoteContent = { onFootnoteContent?.invoke(it) }
@@ -658,24 +667,7 @@ internal class ContinuousReaderView @JvmOverloads constructor(
         wv.onInternalLink = { onInternalLinkTapped?.invoke(it) }
         wv.onExternalLink = { onExternalLinkTapped?.invoke(it) }
         wv.annotationsAvailable = annotationsAvailable
-        wv.onHighlight = { text, prog, rect ->
-            val loc = IntArray(2)
-            wv.getLocationOnScreen(loc)
-            val screenRect = android.graphics.Rect(loc[0] + rect.left, loc[1] + rect.top, loc[0] + rect.right, loc[1] + rect.bottom)
-            onHighlightSelection?.invoke(wv.chapterHref, text, prog, screenRect)
-        }
-        wv.onAnnotationTap = { id, rect ->
-            val loc = IntArray(2)
-            wv.getLocationOnScreen(loc)
-            val screenRect = android.graphics.Rect(loc[0] + rect.left, loc[1] + rect.top, loc[0] + rect.right, loc[1] + rect.bottom)
-            onAnnotationTap?.invoke(wv.chapterHref, id, screenRect)
-        }
-        wv.onAnnotationNoteTap = { id, rect ->
-            val loc = IntArray(2)
-            wv.getLocationOnScreen(loc)
-            val screenRect = android.graphics.Rect(loc[0] + rect.left, loc[1] + rect.top, loc[0] + rect.right, loc[1] + rect.bottom)
-            onAnnotationNoteTap?.invoke(wv.chapterHref, id, screenRect)
-        }
+        wireAnnotationCallbacks(wv)
         wv.readaloudAvailable = readaloudAvailable
         wv.onPlayFromHere = { text -> onPlayFromHereSelection?.invoke(wv.chapterHref, text) }
         wv.onFootnoteContent = { onFootnoteContent?.invoke(it) }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
@@ -25,6 +25,8 @@ import kotlin.math.abs
  * Adding a chapter at the TOP adjusts [scrollY] by the new chapter's height to keep the
  * visible content stable.
  */
+internal data class AnnotationHighlight(val id: String, val text: String, val cssColor: String)
+
 internal class ContinuousReaderView @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null,
@@ -507,6 +509,24 @@ internal class ContinuousReaderView @JvmOverloads constructor(
     fun clearHighlightInChapter(href: String) {
         val i = webViewIndexFor(href) ?: return
         webViews[i].evaluateJavascript(ContinuousStyleInjector.CLEAR_HIGHLIGHT_JS, null)
+    }
+
+    /**
+     * Apply persisted annotation highlights to all currently loaded chapters.
+     * [annotationsByHref] maps each chapter href to the annotations that belong to it.
+     * Chapters in the window that have no entry are cleared of any stale marks.
+     */
+    fun applyAnnotationHighlights(annotationsByHref: Map<String, List<AnnotationHighlight>>) {
+        for (wv in webViews) {
+            val href = wv.chapterHref
+            if (href.isEmpty()) continue
+            val annotations = annotationsByHref[href]
+            if (annotations.isNullOrEmpty()) {
+                wv.evaluateJavascript(ContinuousStyleInjector.CLEAR_ANNOTATION_HIGHLIGHTS_JS, null)
+            } else {
+                wv.evaluateJavascript(ContinuousStyleInjector.applyAnnotationHighlightsJs(annotations), null)
+            }
+        }
     }
 
     // ── private ────────────────────────────────────────────────────────────────

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
@@ -205,6 +205,7 @@ internal class ContinuousReaderView @JvmOverloads constructor(
         wv.onInternalLink = null
         wv.onExternalLink = null
         wv.onHighlight = null
+        wv.onAnnotationTap = null
         wv.onPlayFromHere = null
         wv.onFootnoteContent = null
         if (recycledViews.size < WINDOW_SIZE) recycledViews.addLast(wv) else wv.destroy()
@@ -511,6 +512,9 @@ internal class ContinuousReaderView @JvmOverloads constructor(
         webViews[i].evaluateJavascript(ContinuousStyleInjector.CLEAR_HIGHLIGHT_JS, null)
     }
 
+    /** Called on the main thread when the user taps an annotation highlight mark in any chapter. */
+    var onAnnotationTap: ((href: String, id: String, screenRect: android.graphics.Rect) -> Unit)? = null
+
     /**
      * Apply persisted annotation highlights to all currently loaded chapters.
      * [annotationsByHref] maps each chapter href to the annotations that belong to it.
@@ -541,6 +545,12 @@ internal class ContinuousReaderView @JvmOverloads constructor(
         wv.onExternalLink = { onExternalLinkTapped?.invoke(it) }
         wv.annotationsAvailable = annotationsAvailable
         wv.onHighlight = { text -> onHighlightSelection?.invoke(wv.chapterHref, text) }
+        wv.onAnnotationTap = { id, rect ->
+            val loc = IntArray(2)
+            wv.getLocationOnScreen(loc)
+            val screenRect = android.graphics.Rect(loc[0] + rect.left, loc[1] + rect.top, loc[0] + rect.right, loc[1] + rect.bottom)
+            onAnnotationTap?.invoke(wv.chapterHref, id, screenRect)
+        }
         wv.readaloudAvailable = readaloudAvailable
         wv.onPlayFromHere = { text -> onPlayFromHereSelection?.invoke(wv.chapterHref, text) }
         wv.onFootnoteContent = { onFootnoteContent?.invoke(it) }
@@ -623,6 +633,12 @@ internal class ContinuousReaderView @JvmOverloads constructor(
         wv.onExternalLink = { onExternalLinkTapped?.invoke(it) }
         wv.annotationsAvailable = annotationsAvailable
         wv.onHighlight = { text -> onHighlightSelection?.invoke(wv.chapterHref, text) }
+        wv.onAnnotationTap = { id, rect ->
+            val loc = IntArray(2)
+            wv.getLocationOnScreen(loc)
+            val screenRect = android.graphics.Rect(loc[0] + rect.left, loc[1] + rect.top, loc[0] + rect.right, loc[1] + rect.bottom)
+            onAnnotationTap?.invoke(wv.chapterHref, id, screenRect)
+        }
         wv.readaloudAvailable = readaloudAvailable
         wv.onPlayFromHere = { text -> onPlayFromHereSelection?.invoke(wv.chapterHref, text) }
         wv.onFootnoteContent = { onFootnoteContent?.invoke(it) }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
@@ -462,10 +462,29 @@ internal class ContinuousReaderView @JvmOverloads constructor(
         smoothScrollBy(0, if (forward) delta else -delta)
     }
 
-    /** Inject a readaloud highlight for the sentence with [text] in the chapter matching [href]. */
+    /** Inject a readaloud highlight for the sentence with [text] in the chapter matching [href] and scroll it into view. */
     fun highlightInChapter(href: String, text: String) {
         val i = webViewIndexFor(href) ?: return
-        webViews[i].evaluateJavascript(ContinuousStyleInjector.highlightTextJs(text), null)
+        webViews[i].evaluateJavascript(ContinuousStyleInjector.highlightTextJs(text)) { _ ->
+            scrollToHighlight(i)
+        }
+    }
+
+    private fun scrollToHighlight(webViewIndex: Int) {
+        val wv = webViews.getOrNull(webViewIndex) ?: return
+        wv.evaluateJavascript(
+            "(function(){var el=document.getElementById('_riffle_hl');return el?el.getBoundingClientRect().top:-1;})()"
+        ) { result ->
+            val elementTop = result?.toFloatOrNull()?.toInt() ?: return@evaluateJavascript
+            if (elementTop < 0) return@evaluateJavascript
+            val slot = buildWindow().getOrNull(webViewIndex) ?: return@evaluateJavascript
+            val absoluteY = slot.top + elementTop
+            // Only scroll if the highlight is outside the middle two-thirds of the viewport.
+            val margin = height / 4
+            if (absoluteY < scrollY + margin || absoluteY > scrollY + height - margin) {
+                smoothScrollTo(0, (absoluteY - height / 3).coerceAtLeast(0))
+            }
+        }
     }
 
     /** Clear any active readaloud highlight in the chapter at [href]. */

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
@@ -472,8 +472,16 @@ internal class ContinuousReaderView @JvmOverloads constructor(
 
     private fun scrollToHighlight(webViewIndex: Int) {
         val wv = webViews.getOrNull(webViewIndex) ?: return
+        // getBoundingClientRect().top is in CSS pixels; multiply by devicePixelRatio to get device
+        // pixels so the result is in the same coordinate space as slot.top and scrollY.
         wv.evaluateJavascript(
-            "(function(){var el=document.getElementById('_riffle_hl');return el?el.getBoundingClientRect().top:-1;})()"
+            """(function(){
+                var el=document.getElementById('_riffle_hl');
+                if(!el) return -1;
+                var r=el.getBoundingClientRect();
+                var y=r.top+(window.pageYOffset||document.documentElement.scrollTop||0);
+                return Math.max(0,Math.round(y*(window.devicePixelRatio||1)));
+            })()"""
         ) { result ->
             val elementTop = result?.toFloatOrNull()?.toInt() ?: return@evaluateJavascript
             if (elementTop < 0) return@evaluateJavascript

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjector.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjector.kt
@@ -374,8 +374,43 @@ internal object ContinuousStyleInjector {
             }
             append(']')
         }
+        // Single quotes inside the SVG percent-encoded URI must be escaped for JS string embedding.
+        val safeSvgUri = NOTE_GLYPH_SVG_DATA_URI.replace("'", "\\'")
         return """
             (function(anns) {
+                var SVG_URI = '$safeSvgUri';
+                // makeGlyph: positions the NoteAlt icon 28px to the left of anchorEl's first line,
+                // matching the paged-mode NoteGlyphStyle margin position.
+                var makeGlyph = function(id, anchorEl) {
+                    // Walk up to the nearest block ancestor so we can position within its coordinate space.
+                    var blockEl = document.body || document.documentElement;
+                    var p = anchorEl.parentNode;
+                    while (p && p.nodeType === 1 && p !== document.documentElement) {
+                        var d = window.getComputedStyle(p).display;
+                        if (d === 'block' || d === 'list-item') { blockEl = p; break; }
+                        p = p.parentNode;
+                    }
+                    if (window.getComputedStyle(blockEl).position === 'static') {
+                        blockEl.style.position = 'relative';
+                    }
+                    var markRect = anchorEl.getBoundingClientRect();
+                    var blockRect = blockEl.getBoundingClientRect();
+                    var relTop = Math.max(0, markRect.top - blockRect.top + 2);
+                    var s = document.createElement('span');
+                    s.setAttribute('data-riffle-note-glyph', id);
+                    s.style.cssText = 'position:absolute;left:-28px;top:' + relTop + 'px;' +
+                        'width:28px;height:28px;cursor:pointer;opacity:0.40;' +
+                        '-webkit-mask-image:url("' + SVG_URI + '");' +
+                        '-webkit-mask-size:contain;-webkit-mask-repeat:no-repeat;' +
+                        'background-color:currentColor;' +
+                        '-webkit-user-select:none;user-select:none;';
+                    s.addEventListener('click', function(e) {
+                        e.stopPropagation();
+                        var r = s.getBoundingClientRect();
+                        window.RiffleChapter.onAnnotationNoteTap(id, r.left, r.top, r.right, r.bottom);
+                    });
+                    blockEl.appendChild(s);
+                };
                 // Remove marks/glyphs for annotations no longer in the list.
                 var validIds = {};
                 anns.forEach(function(a) { validIds[a.id] = true; });
@@ -394,7 +429,7 @@ internal object ContinuousStyleInjector {
                         existing.style.background = ann.c;
                         var eg = document.querySelector('[data-riffle-note-glyph="' + ann.id + '"]');
                         if (ann.n && !eg) {
-                            existing.insertAdjacentElement('afterend', makeGlyph(ann.id));
+                            makeGlyph(ann.id, existing);
                         } else if (!ann.n && eg) {
                             eg.remove();
                         }
@@ -423,21 +458,9 @@ internal object ContinuousStyleInjector {
                             window.RiffleChapter.onAnnotationTap(annId, r.left, r.top, r.right, r.bottom);
                         });
                     })(mark, ann.id);
-                    if (ann.n) mark.insertAdjacentElement('afterend', makeGlyph(ann.id));
+                    if (ann.n) makeGlyph(ann.id, mark);
                 });
                 if (sel) sel.removeAllRanges();
-                function makeGlyph(id) {
-                    var s = document.createElement('span');
-                    s.setAttribute('data-riffle-note-glyph', id);
-                    s.textContent = '◆';
-                    s.style.cssText = 'display:inline;position:relative;top:-0.4em;font-size:0.5em;cursor:pointer;opacity:0.8;margin-left:1px;-webkit-user-select:none;user-select:none;';
-                    s.addEventListener('click', function(e) {
-                        e.stopPropagation();
-                        var r = s.getBoundingClientRect();
-                        window.RiffleChapter.onAnnotationNoteTap(id, r.left, r.top, r.right, r.bottom);
-                    });
-                    return s;
-                }
             })($json);
         """.trimIndent()
     }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjector.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjector.kt
@@ -370,6 +370,7 @@ internal object ContinuousStyleInjector {
                 if (i > 0) append(',')
                 val safeId = ann.id.replace("\\", "\\\\").replace("'", "\\'")
                 val safeText = ann.text.replace("\\", "\\\\").replace("'", "\\'").replace("\n", "\\n").replace("\r", "\\r")
+                // cssColor is machine-generated (e.g. "rgba(56,189,248,0.50)") — no quote escaping needed.
                 append("{id:'$safeId',t:'$safeText',c:'${ann.cssColor}',n:${if (ann.hasNote) 1 else 0}}")
             }
             append(']')
@@ -439,7 +440,7 @@ internal object ContinuousStyleInjector {
                         return;
                     }
                     // New annotation — locate via window.find() on the unmodified DOM.
-                    sel.removeAllRanges();
+                    if (sel) sel.removeAllRanges();
                     if (!window.find(ann.t, false, false, false, false, false, false)) return;
                     sel = window.getSelection();
                     if (!sel || sel.rangeCount === 0) return;

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjector.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjector.kt
@@ -351,7 +351,7 @@ internal object ContinuousStyleInjector {
      * (e.g. `<em>`, `<span class="smallcaps">`). The fallback uses `extractContents()` +
      * `insertNode()` which handles multi-node ranges correctly.
      */
-    fun highlightTextJs(text: String): String {
+    fun highlightTextJs(text: String, cssColor: String): String {
         if (text.isBlank()) return CLEAR_HIGHLIGHT_JS
         val safe = text.replace("\\", "\\\\").replace("'", "\\'").replace("\n", "\\n").replace("\r", "\\r")
         return """
@@ -364,7 +364,7 @@ internal object ContinuousStyleInjector {
                 var range = sel.getRangeAt(0);
                 var mark = document.createElement('mark');
                 mark.id = '_riffle_hl';
-                mark.style.cssText = 'background:#7DD3FC;color:inherit;';
+                mark.style.cssText = 'background:$cssColor;color:inherit;';
                 try {
                     range.surroundContents(mark);
                 } catch(e) {

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjector.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjector.kt
@@ -344,16 +344,24 @@ internal object ContinuousStyleInjector {
 
     val CLEAR_ANNOTATION_HIGHLIGHTS_JS = """
         (function() {
+            document.querySelectorAll('[data-riffle-note-glyph]').forEach(function(s) { s.remove(); });
             document.querySelectorAll('[data-riffle-ann]').forEach(function(m) { m.outerHTML = m.innerHTML; });
         })();
     """.trimIndent()
 
     /**
-     * JS that applies [annotations] as `<mark>` elements, keyed by their ID via `data-riffle-ann`.
-     * Clears any existing annotation marks first. Uses the same window.find() + surroundContents()
-     * approach as [highlightTextJs], with the extractContents() fallback for inline-spanning ranges.
-     * Selection is reset to the document start before each find so consecutive searches don't
-     * accumulate position.
+     * JS that applies [annotations] as `<mark>` elements (keyed by `data-riffle-ann`) and optional
+     * note-glyph `<span>` elements (keyed by `data-riffle-note-glyph`).
+     *
+     * Smart DOM diffing avoids the clear-and-reapply pattern: existing marks are updated in-place
+     * (colour only, no DOM structure change), marks for deleted annotations are removed, and only
+     * newly-added annotations go through `window.find()`. This prevents the race where clearing
+     * existing marks via `outerHTML = innerHTML` modifies the DOM just before `window.find()` is
+     * called — Chrome won't reliably find text in a DOM it just mutated synchronously — so a new
+     * highlight appears immediately without requiring a page reload.
+     *
+     * For annotations with notes a small ◆ glyph span is injected after the mark. Tapping it calls
+     * `window.RiffleChapter.onAnnotationNoteTap` so the host can open the note reader.
      */
     fun applyAnnotationHighlightsJs(annotations: List<AnnotationHighlight>): String {
         val json = buildString {
@@ -362,15 +370,37 @@ internal object ContinuousStyleInjector {
                 if (i > 0) append(',')
                 val safeId = ann.id.replace("\\", "\\\\").replace("'", "\\'")
                 val safeText = ann.text.replace("\\", "\\\\").replace("'", "\\'").replace("\n", "\\n").replace("\r", "\\r")
-                append("{id:'$safeId',t:'$safeText',c:'${ann.cssColor}'}")
+                append("{id:'$safeId',t:'$safeText',c:'${ann.cssColor}',n:${if (ann.hasNote) 1 else 0}}")
             }
             append(']')
         }
         return """
             (function(anns) {
-                document.querySelectorAll('[data-riffle-ann]').forEach(function(m) { m.outerHTML = m.innerHTML; });
+                // Remove marks/glyphs for annotations no longer in the list.
+                var validIds = {};
+                anns.forEach(function(a) { validIds[a.id] = true; });
+                document.querySelectorAll('[data-riffle-ann]').forEach(function(m) {
+                    if (!validIds[m.getAttribute('data-riffle-ann')]) {
+                        var g = document.querySelector('[data-riffle-note-glyph="' + m.getAttribute('data-riffle-ann') + '"]');
+                        if (g) g.remove();
+                        m.outerHTML = m.innerHTML;
+                    }
+                });
                 var sel = window.getSelection();
                 anns.forEach(function(ann) {
+                    var existing = document.querySelector('[data-riffle-ann="' + ann.id + '"]');
+                    if (existing) {
+                        // Update colour in-place — no window.find() needed, no DOM structure change.
+                        existing.style.background = ann.c;
+                        var eg = document.querySelector('[data-riffle-note-glyph="' + ann.id + '"]');
+                        if (ann.n && !eg) {
+                            existing.insertAdjacentElement('afterend', makeGlyph(ann.id));
+                        } else if (!ann.n && eg) {
+                            eg.remove();
+                        }
+                        return;
+                    }
+                    // New annotation — locate via window.find() on the unmodified DOM.
                     sel.removeAllRanges();
                     if (!window.find(ann.t, false, false, false, false, false, false)) return;
                     sel = window.getSelection();
@@ -386,7 +416,6 @@ internal object ContinuousStyleInjector {
                         mark.appendChild(frag);
                         range.insertNode(mark);
                     }
-                    // Capture mark + id in an IIFE so the click listener closes over the correct values.
                     (function(markEl, annId) {
                         markEl.addEventListener('click', function(e) {
                             e.stopPropagation();
@@ -394,8 +423,21 @@ internal object ContinuousStyleInjector {
                             window.RiffleChapter.onAnnotationTap(annId, r.left, r.top, r.right, r.bottom);
                         });
                     })(mark, ann.id);
+                    if (ann.n) mark.insertAdjacentElement('afterend', makeGlyph(ann.id));
                 });
                 if (sel) sel.removeAllRanges();
+                function makeGlyph(id) {
+                    var s = document.createElement('span');
+                    s.setAttribute('data-riffle-note-glyph', id);
+                    s.textContent = '◆';
+                    s.style.cssText = 'display:inline-block;vertical-align:super;font-size:0.55em;cursor:pointer;opacity:0.75;margin-left:2px;-webkit-user-select:none;user-select:none;';
+                    s.addEventListener('click', function(e) {
+                        e.stopPropagation();
+                        var r = s.getBoundingClientRect();
+                        window.RiffleChapter.onAnnotationNoteTap(id, r.left, r.top, r.right, r.bottom);
+                    });
+                    return s;
+                }
             })($json);
         """.trimIndent()
     }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjector.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjector.kt
@@ -386,6 +386,14 @@ internal object ContinuousStyleInjector {
                         mark.appendChild(frag);
                         range.insertNode(mark);
                     }
+                    // Capture mark + id in an IIFE so the click listener closes over the correct values.
+                    (function(markEl, annId) {
+                        markEl.addEventListener('click', function(e) {
+                            e.stopPropagation();
+                            var r = markEl.getBoundingClientRect();
+                            window.RiffleChapter.onAnnotationTap(annId, r.left, r.top, r.right, r.bottom);
+                        });
+                    })(mark, ann.id);
                 });
                 if (sel) sel.removeAllRanges();
             })($json);

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjector.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjector.kt
@@ -346,6 +346,10 @@ internal object ContinuousStyleInjector {
      * JS that highlights [text] via `window.find` + DOM `<mark>` injection, replacing
      * any existing mark with id `_riffle_hl`. Pass an empty string to clear.
      * Single quotes and backslashes in [text] are escaped before embedding in JS.
+     *
+     * `surroundContents()` throws when the selection range crosses an inline element boundary
+     * (e.g. `<em>`, `<span class="smallcaps">`). The fallback uses `extractContents()` +
+     * `insertNode()` which handles multi-node ranges correctly.
      */
     fun highlightTextJs(text: String): String {
         if (text.isBlank()) return CLEAR_HIGHLIGHT_JS
@@ -361,7 +365,14 @@ internal object ContinuousStyleInjector {
                 var mark = document.createElement('mark');
                 mark.id = '_riffle_hl';
                 mark.style.cssText = 'background:#7DD3FC;color:inherit;';
-                try { range.surroundContents(mark); } catch(e) {}
+                try {
+                    range.surroundContents(mark);
+                } catch(e) {
+                    // Range crosses an inline element boundary — extract contents into mark instead.
+                    var frag = range.extractContents();
+                    mark.appendChild(frag);
+                    range.insertNode(mark);
+                }
                 sel.removeAllRanges();
             })();
         """.trimIndent()

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjector.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjector.kt
@@ -396,9 +396,12 @@ internal object ContinuousStyleInjector {
                     var markRect = anchorEl.getBoundingClientRect();
                     var blockRect = blockEl.getBoundingClientRect();
                     var relTop = Math.max(0, markRect.top - blockRect.top + 2);
+                    // Mirror paged-mode NoteGlyphStyle: position 28px to the LEFT of the mark's
+                    // first-line left edge (not the block's left edge, which is the page margin).
+                    var relLeft = markRect.left - blockRect.left - 28;
                     var s = document.createElement('span');
                     s.setAttribute('data-riffle-note-glyph', id);
-                    s.style.cssText = 'position:absolute;left:-28px;top:' + relTop + 'px;' +
+                    s.style.cssText = 'position:absolute;left:' + relLeft + 'px;top:' + relTop + 'px;' +
                         'width:28px;height:28px;cursor:pointer;opacity:0.40;' +
                         '-webkit-mask-image:url("' + SVG_URI + '");' +
                         '-webkit-mask-size:contain;-webkit-mask-repeat:no-repeat;' +

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjector.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjector.kt
@@ -342,6 +342,56 @@ internal object ContinuousStyleInjector {
         })();
     """.trimIndent()
 
+    val CLEAR_ANNOTATION_HIGHLIGHTS_JS = """
+        (function() {
+            document.querySelectorAll('[data-riffle-ann]').forEach(function(m) { m.outerHTML = m.innerHTML; });
+        })();
+    """.trimIndent()
+
+    /**
+     * JS that applies [annotations] as `<mark>` elements, keyed by their ID via `data-riffle-ann`.
+     * Clears any existing annotation marks first. Uses the same window.find() + surroundContents()
+     * approach as [highlightTextJs], with the extractContents() fallback for inline-spanning ranges.
+     * Selection is reset to the document start before each find so consecutive searches don't
+     * accumulate position.
+     */
+    fun applyAnnotationHighlightsJs(annotations: List<AnnotationHighlight>): String {
+        val json = buildString {
+            append('[')
+            annotations.forEachIndexed { i, ann ->
+                if (i > 0) append(',')
+                val safeId = ann.id.replace("\\", "\\\\").replace("'", "\\'")
+                val safeText = ann.text.replace("\\", "\\\\").replace("'", "\\'").replace("\n", "\\n").replace("\r", "\\r")
+                append("{id:'$safeId',t:'$safeText',c:'${ann.cssColor}'}")
+            }
+            append(']')
+        }
+        return """
+            (function(anns) {
+                document.querySelectorAll('[data-riffle-ann]').forEach(function(m) { m.outerHTML = m.innerHTML; });
+                var sel = window.getSelection();
+                anns.forEach(function(ann) {
+                    sel.removeAllRanges();
+                    if (!window.find(ann.t, false, false, false, false, false, false)) return;
+                    sel = window.getSelection();
+                    if (!sel || sel.rangeCount === 0) return;
+                    var range = sel.getRangeAt(0);
+                    var mark = document.createElement('mark');
+                    mark.setAttribute('data-riffle-ann', ann.id);
+                    mark.style.cssText = 'background:' + ann.c + ';color:inherit;';
+                    try {
+                        range.surroundContents(mark);
+                    } catch(e) {
+                        var frag = range.extractContents();
+                        mark.appendChild(frag);
+                        range.insertNode(mark);
+                    }
+                });
+                if (sel) sel.removeAllRanges();
+            })($json);
+        """.trimIndent()
+    }
+
     /**
      * JS that highlights [text] via `window.find` + DOM `<mark>` injection, replacing
      * any existing mark with id `_riffle_hl`. Pass an empty string to clear.

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjector.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjector.kt
@@ -430,7 +430,7 @@ internal object ContinuousStyleInjector {
                     var s = document.createElement('span');
                     s.setAttribute('data-riffle-note-glyph', id);
                     s.textContent = '◆';
-                    s.style.cssText = 'display:inline-block;vertical-align:super;font-size:0.55em;cursor:pointer;opacity:0.75;margin-left:2px;-webkit-user-select:none;user-select:none;';
+                    s.style.cssText = 'display:inline;position:relative;top:-0.4em;font-size:0.5em;cursor:pointer;opacity:0.8;margin-left:1px;-webkit-user-select:none;user-select:none;';
                     s.addEventListener('click', function(e) {
                         e.stopPropagation();
                         var r = s.getBoundingClientRect();

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -1594,10 +1594,12 @@ private fun EpubNavigatorView(
     }
 
     // ---- Continuous-mode readaloud highlight -----------------------------------------------
-    // In Continuous mode, decoration APIs are not used. Instead we call ContinuousReaderView's
-    // highlightInChapter / clearHighlightInChapter directly, keyed by the 12-char text prefix
-    // (same heuristic as autoFollowSnapJs). prevHighlightHref tracks the chapter that currently
-    // carries the mark so we can clear it if the narrated chapter changes or playback stops.
+    // ChapterWebView serves the ABS EPUB HTML directly (no Readium stripping), but the ABS EPUB
+    // does NOT have Storyteller's per-sentence spans — those exist only in the Storyteller bundle.
+    // We therefore use window.find() to locate the sentence by its full text, then inject a <mark>
+    // element. The fallback in highlightTextJs uses extractContents()+insertNode() to handle the
+    // common case where the sentence spans inline elements (em, span, strong) and surroundContents()
+    // would throw. sentenceQuotes is re-keyed here so the highlight re-applies once quotes are built.
     val prevHighlightHref = remember { mutableStateOf<String?>(null) }
     LaunchedEffect(activeFragmentRef, isContinuous, sentenceQuotes) {
         if (!isContinuous) return@LaunchedEffect
@@ -1611,13 +1613,13 @@ private fun EpubNavigatorView(
         }
         val chapterHref = ref.substringBefore('#')
         val sid = ref.substringAfter('#', "")
-        val quote = sentenceQuotes[sid]
-        val highlightText = quote?.highlight?.take(12) ?: return@LaunchedEffect
+        if (sid.isBlank()) return@LaunchedEffect
+        val text = sentenceQuotes[sid]?.highlight ?: return@LaunchedEffect
         // If the chapter changed, clear the previous chapter's mark
         val prev = prevHighlightHref.value
         if (prev != null && prev != chapterHref) view.clearHighlightInChapter(prev)
         prevHighlightHref.value = chapterHref
-        view.highlightInChapter(chapterHref, highlightText)
+        view.highlightInChapter(chapterHref, text)
     }
 
     // ---- Persisted highlights (ADR 0024) ---------------------------------------------------

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -1651,7 +1651,8 @@ private fun EpubNavigatorView(
     // own "annotations" group. Re-applied whenever the set changes — including the re-render of
     // every highlight when the book is reopened, and the immediate paint after a new highlight.
     val hasHighlightDecorations = remember { mutableStateOf(false) }
-    LaunchedEffect(highlightRenders, formattingPrefs.theme, reflowGeneration, pageLoadGeneration.value) {
+    LaunchedEffect(highlightRenders, formattingPrefs.theme, reflowGeneration, pageLoadGeneration.value, isContinuous) {
+        if (isContinuous) return@LaunchedEffect
         val fragment = fragmentRef.value as? DecorableNavigator ?: return@LaunchedEffect
         if (highlightRenders.isEmpty()) {
             if (!hasHighlightDecorations.value) return@LaunchedEffect
@@ -1687,7 +1688,8 @@ private fun EpubNavigatorView(
     // attached. Uses its own group so it can be cleared/re-applied independently of the fill.
     // Tapping the glyph fires the dedicated "annotation-notes" tap listener below.
     val hasNoteDecorations = remember { mutableStateOf(false) }
-    LaunchedEffect(highlightRenders, formattingPrefs.theme, reflowGeneration, pageLoadGeneration.value) {
+    LaunchedEffect(highlightRenders, formattingPrefs.theme, reflowGeneration, pageLoadGeneration.value, isContinuous) {
+        if (isContinuous) return@LaunchedEffect
         val fragment = fragmentRef.value as? DecorableNavigator ?: return@LaunchedEffect
         val noted = highlightRenders.filter { it.note != null }
         if (noted.isEmpty()) {
@@ -2161,6 +2163,10 @@ private fun EpubNavigatorView(
                         }
                         view.onFootnoteContent = { content -> currentOnFootnoteTapped(content) }
                         view.annotationsAvailable = currentAnnotationsAvailable
+                        view.onAnnotationTap = { _, id, androidRect ->
+                            val rect = androidx.compose.ui.unit.IntRect(androidRect.left, androidRect.top, androidRect.right, androidRect.bottom)
+                            currentOnOpenHighlightActions(id, rect)
+                        }
                         view.onHighlightSelection = { chapterHref, selectedText ->
                             val locator = org.readium.r2.shared.publication.Locator.fromJSON(
                                 org.json.JSONObject()

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -1439,7 +1439,7 @@ private fun EpubNavigatorView(
                 val progression = locator.locations.progression?.toFloat() ?: 0f
                 val highlightText = locator.text.highlight?.take(40) ?: ""
                 view.navigateTo(href, progression)
-                if (highlightText.isNotBlank()) view.highlightInChapter(href, highlightText)
+                if (highlightText.isNotBlank()) view.highlightInChapter(href, highlightText, "#FDE68A")
             } else {
                 goAndSnapWithCover(locator)
             }
@@ -1601,7 +1601,7 @@ private fun EpubNavigatorView(
     // common case where the sentence spans inline elements (em, span, strong) and surroundContents()
     // would throw. sentenceQuotes is re-keyed here so the highlight re-applies once quotes are built.
     val prevHighlightHref = remember { mutableStateOf<String?>(null) }
-    LaunchedEffect(activeFragmentRef, isContinuous, sentenceQuotes) {
+    LaunchedEffect(activeFragmentRef, isContinuous, sentenceQuotes, readaloudHighlightColor, formattingPrefs.theme) {
         if (!isContinuous) return@LaunchedEffect
         val view = continuousViewRef.value ?: return@LaunchedEffect
         val ref = activeFragmentRef
@@ -1619,7 +1619,8 @@ private fun EpubNavigatorView(
         val prev = prevHighlightHref.value
         if (prev != null && prev != chapterHref) view.clearHighlightInChapter(prev)
         prevHighlightHref.value = chapterHref
-        view.highlightInChapter(chapterHref, text)
+        val cssColor = readaloudHighlightColor.readerTint(formattingPrefs.theme).toCssRgba()
+        view.highlightInChapter(chapterHref, text, cssColor)
     }
 
     // ---- Persisted highlights (ADR 0024) ---------------------------------------------------

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -1640,6 +1640,7 @@ private fun EpubNavigatorView(
                         id = h.id,
                         text = h.locator.text.highlight!!,
                         cssColor = HighlightColor.fromToken(h.color).readerTint(formattingPrefs.theme).toCssRgba(),
+                        hasNote = h.note != null,
                     )
                 }
             }
@@ -2166,6 +2167,10 @@ private fun EpubNavigatorView(
                         view.onAnnotationTap = { _, id, androidRect ->
                             val rect = androidx.compose.ui.unit.IntRect(androidRect.left, androidRect.top, androidRect.right, androidRect.bottom)
                             currentOnOpenHighlightActions(id, rect)
+                        }
+                        view.onAnnotationNoteTap = { _, id, androidRect ->
+                            val rect = androidx.compose.ui.unit.IntRect(androidRect.left, androidRect.top, androidRect.right, androidRect.bottom)
+                            currentOnOpenNoteReader(id, rect)
                         }
                         view.onHighlightSelection = { chapterHref, selectedText ->
                             val locator = org.readium.r2.shared.publication.Locator.fromJSON(

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -1623,6 +1623,29 @@ private fun EpubNavigatorView(
         view.highlightInChapter(chapterHref, text, cssColor)
     }
 
+    // ---- Persisted highlights — continuous mode -------------------------------------------
+    // Paged mode uses Readium's DecorableNavigator (below). Continuous mode injects <mark> elements
+    // via window.find(), mirroring the readaloud highlight approach. Re-keyed on the current chapter
+    // href (derived from activeFragmentRef) so annotations re-apply when a new chapter enters the
+    // sliding window.
+    LaunchedEffect(highlightRenders, formattingPrefs.theme, activeFragmentRef?.substringBefore('#'), isContinuous) {
+        if (!isContinuous) return@LaunchedEffect
+        val view = continuousViewRef.value ?: return@LaunchedEffect
+        val annotationsByHref = highlightRenders
+            .filter { !it.locator.text.highlight.isNullOrBlank() }
+            .groupBy { it.locator.href.toString() }
+            .mapValues { (_, renders) ->
+                renders.map { h ->
+                    AnnotationHighlight(
+                        id = h.id,
+                        text = h.locator.text.highlight!!,
+                        cssColor = HighlightColor.fromToken(h.color).readerTint(formattingPrefs.theme).toCssRgba(),
+                    )
+                }
+            }
+        view.applyAnnotationHighlights(annotationsByHref)
+    }
+
     // ---- Persisted highlights (ADR 0024) ---------------------------------------------------
     // Renders all of a book's stored highlights via the same DecorableNavigator mechanism, on its
     // own "annotations" group. Re-applied whenever the set changes — including the re-render of

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -2172,11 +2172,12 @@ private fun EpubNavigatorView(
                             val rect = androidx.compose.ui.unit.IntRect(androidRect.left, androidRect.top, androidRect.right, androidRect.bottom)
                             currentOnOpenNoteReader(id, rect)
                         }
-                        view.onHighlightSelection = { chapterHref, selectedText ->
+                        view.onHighlightSelection = { chapterHref, selectedText, progression ->
                             val locator = org.readium.r2.shared.publication.Locator.fromJSON(
                                 org.json.JSONObject()
                                     .put("href", chapterHref)
                                     .put("type", "application/xhtml+xml")
+                                    .put("locations", org.json.JSONObject().put("progression", progression))
                                     .put("text", org.json.JSONObject().put("highlight", selectedText))
                             )
                             // No WebView rect available in this path; popup falls back to top-left.

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -1431,7 +1431,7 @@ private fun EpubNavigatorView(
         }
     }
 
-    LaunchedEffect(searchNavigationEvents, isContinuous) {
+    LaunchedEffect(searchNavigationEvents, isContinuous, readaloudHighlightColor, formattingPrefs.theme) {
         searchNavigationEvents.collect { locator ->
             if (isContinuous) {
                 val view = continuousViewRef.value ?: return@collect
@@ -1439,7 +1439,7 @@ private fun EpubNavigatorView(
                 val progression = locator.locations.progression?.toFloat() ?: 0f
                 val highlightText = locator.text.highlight?.take(40) ?: ""
                 view.navigateTo(href, progression)
-                if (highlightText.isNotBlank()) view.highlightInChapter(href, highlightText, "#FDE68A")
+                if (highlightText.isNotBlank()) view.highlightInChapter(href, highlightText, readaloudHighlightColor.readerTint(formattingPrefs.theme).toCssRgba())
             } else {
                 goAndSnapWithCover(locator)
             }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -2172,7 +2172,7 @@ private fun EpubNavigatorView(
                             val rect = androidx.compose.ui.unit.IntRect(androidRect.left, androidRect.top, androidRect.right, androidRect.bottom)
                             currentOnOpenNoteReader(id, rect)
                         }
-                        view.onHighlightSelection = { chapterHref, selectedText, progression ->
+                        view.onHighlightSelection = { chapterHref, selectedText, progression, selectionScreenRect ->
                             val locator = org.readium.r2.shared.publication.Locator.fromJSON(
                                 org.json.JSONObject()
                                     .put("href", chapterHref)
@@ -2180,8 +2180,10 @@ private fun EpubNavigatorView(
                                     .put("locations", org.json.JSONObject().put("progression", progression))
                                     .put("text", org.json.JSONObject().put("highlight", selectedText))
                             )
-                            // No WebView rect available in this path; popup falls back to top-left.
-                            if (locator != null) currentOnHighlight(locator, androidx.compose.ui.unit.IntRect(0, 0, 0, 0))
+                            if (locator != null) {
+                                val rect = androidx.compose.ui.unit.IntRect(selectionScreenRect.left, selectionScreenRect.top, selectionScreenRect.right, selectionScreenRect.bottom)
+                                currentOnHighlight(locator, rect)
+                            }
                         }
                         view.readaloudAvailable = currentReadaloudAvailable
                         view.onPlayFromHereSelection = { chapterHref, selectedText ->

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -1431,7 +1431,7 @@ private fun EpubNavigatorView(
         }
     }
 
-    LaunchedEffect(searchNavigationEvents, isContinuous, readaloudHighlightColor, formattingPrefs.theme) {
+    LaunchedEffect(searchNavigationEvents, isContinuous, readaloudHighlightColor) {
         searchNavigationEvents.collect { locator ->
             if (isContinuous) {
                 val view = continuousViewRef.value ?: return@collect
@@ -1439,7 +1439,7 @@ private fun EpubNavigatorView(
                 val progression = locator.locations.progression?.toFloat() ?: 0f
                 val highlightText = locator.text.highlight?.take(40) ?: ""
                 view.navigateTo(href, progression)
-                if (highlightText.isNotBlank()) view.highlightInChapter(href, highlightText, readaloudHighlightColor.readerTint(formattingPrefs.theme).toCssRgba())
+                if (highlightText.isNotBlank()) view.highlightInChapter(href, highlightText, readaloudHighlightColor.argb.toCssRgba())
             } else {
                 goAndSnapWithCover(locator)
             }
@@ -1555,7 +1555,7 @@ private fun EpubNavigatorView(
     // also re-keys on [sentenceQuotes] so the highlight re-applies with text once the quotes (built
     // off the main thread after the track loads) become available.
     val hasReadaloudDecoration = remember { mutableStateOf(false) }
-    LaunchedEffect(activeFragmentRef, reflowGeneration, pageLoadGeneration.value, sentenceQuotes, readaloudHighlightColor, formattingPrefs.theme) {
+    LaunchedEffect(activeFragmentRef, reflowGeneration, pageLoadGeneration.value, sentenceQuotes, readaloudHighlightColor) {
         if (isContinuous) return@LaunchedEffect  // handled in the Continuous-mode effect below
         val fragment = fragmentRef.value as? DecorableNavigator ?: return@LaunchedEffect
         val ref = activeFragmentRef
@@ -1576,7 +1576,7 @@ private fun EpubNavigatorView(
             // Dedicated readaloud style/template: opacity follows the tint's alpha so the highlight
             // is stronger on dark reading themes and stays legible behind the white body text.
             style = HighlightTintStyle(
-                tint = readaloudHighlightColor.readerTint(formattingPrefs.theme),
+                tint = readaloudHighlightColor.argb,
             ),
         )
         // Clear the group before re-applying. After the fragment is recreated (rotation) or its page
@@ -1601,7 +1601,7 @@ private fun EpubNavigatorView(
     // common case where the sentence spans inline elements (em, span, strong) and surroundContents()
     // would throw. sentenceQuotes is re-keyed here so the highlight re-applies once quotes are built.
     val prevHighlightHref = remember { mutableStateOf<String?>(null) }
-    LaunchedEffect(activeFragmentRef, isContinuous, sentenceQuotes, readaloudHighlightColor, formattingPrefs.theme) {
+    LaunchedEffect(activeFragmentRef, isContinuous, sentenceQuotes, readaloudHighlightColor) {
         if (!isContinuous) return@LaunchedEffect
         val view = continuousViewRef.value ?: return@LaunchedEffect
         val ref = activeFragmentRef
@@ -1619,7 +1619,7 @@ private fun EpubNavigatorView(
         val prev = prevHighlightHref.value
         if (prev != null && prev != chapterHref) view.clearHighlightInChapter(prev)
         prevHighlightHref.value = chapterHref
-        val cssColor = readaloudHighlightColor.readerTint(formattingPrefs.theme).toCssRgba()
+        val cssColor = readaloudHighlightColor.argb.toCssRgba()
         view.highlightInChapter(chapterHref, text, cssColor)
     }
 

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/HighlightDecoration.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/HighlightDecoration.kt
@@ -95,3 +95,12 @@ fun HighlightColor.readerTint(theme: ReaderTheme): Int = tintForTheme(argb, them
 /** The tint to paint the readaloud "now speaking" highlight with on the given reading [theme]. */
 @ColorInt
 fun ReadaloudHighlightColor.readerTint(theme: ReaderTheme): Int = tintForTheme(argb, theme)
+
+/** Convert an ARGB color int to a CSS rgba() string for injection into WebView JS. */
+fun @receiver:ColorInt Int.toCssRgba(): String {
+    val a = (this ushr 24 and 0xFF) / 255.0
+    val r = this ushr 16 and 0xFF
+    val g = this ushr 8 and 0xFF
+    val b = this and 0xFF
+    return "rgba($r,$g,$b,${"%.2f".format(a)})"
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/HighlightDecoration.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/HighlightDecoration.kt
@@ -92,10 +92,6 @@ fun tintForTheme(@ColorInt argb: Int, theme: ReaderTheme): Int {
 @ColorInt
 fun HighlightColor.readerTint(theme: ReaderTheme): Int = tintForTheme(argb, theme)
 
-/** The tint to paint the readaloud "now speaking" highlight with on the given reading [theme]. */
-@ColorInt
-fun ReadaloudHighlightColor.readerTint(theme: ReaderTheme): Int = tintForTheme(argb, theme)
-
 /** Convert an ARGB color int to a CSS rgba() string for injection into WebView JS. */
 fun @receiver:ColorInt Int.toCssRgba(): String {
     val a = (this ushr 24 and 0xFF) / 255.0

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsScreen.kt
@@ -63,8 +63,9 @@ import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
-import com.riffle.app.feature.reader.HIGHLIGHT_ALPHA_LIGHT
 import com.riffle.app.feature.reader.behaviorSummary
+import com.riffle.app.feature.reader.tintForTheme
+import com.riffle.core.domain.ReaderTheme
 import com.riffle.app.feature.reader.displaySummary
 import com.riffle.app.feature.reader.formattingSummary
 import com.riffle.app.ui.TabletContentWidthContainer
@@ -292,7 +293,7 @@ fun SettingsScreen(
                         Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                             ReadaloudHighlightColor.entries.forEach { color ->
                                 val isSelected = readaloudPreferences.highlightColor == color
-                                val swatchColor = Color(color.argb).copy(alpha = HIGHLIGHT_ALPHA_LIGHT / 255f)
+                                val swatchColor = Color(tintForTheme(color.argb, ReaderTheme.Light))
                                 // Selected swatch reads clearly in both themes: an offset ring
                                 // (onSurface ring at the outer edge, separated from the swatch by a
                                 // transparent gap) plus a centred checkmark. The swatch keeps a

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsScreen.kt
@@ -64,8 +64,6 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.riffle.app.feature.reader.behaviorSummary
-import com.riffle.app.feature.reader.tintForTheme
-import com.riffle.core.domain.ReaderTheme
 import com.riffle.app.feature.reader.displaySummary
 import com.riffle.app.feature.reader.formattingSummary
 import com.riffle.app.ui.TabletContentWidthContainer
@@ -293,7 +291,7 @@ fun SettingsScreen(
                         Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                             ReadaloudHighlightColor.entries.forEach { color ->
                                 val isSelected = readaloudPreferences.highlightColor == color
-                                val swatchColor = Color(tintForTheme(color.argb, ReaderTheme.Light))
+                                val swatchColor = Color(color.argb.toLong() and 0xFFFFFFFFL)
                                 // Selected swatch reads clearly in both themes: an offset ring
                                 // (onSurface ring at the outer edge, separated from the swatch by a
                                 // transparent gap) plus a centred checkmark. The swatch keeps a

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsScreen.kt
@@ -63,6 +63,7 @@ import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.riffle.app.feature.reader.HIGHLIGHT_ALPHA_LIGHT
 import com.riffle.app.feature.reader.behaviorSummary
 import com.riffle.app.feature.reader.displaySummary
 import com.riffle.app.feature.reader.formattingSummary
@@ -291,7 +292,7 @@ fun SettingsScreen(
                         Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                             ReadaloudHighlightColor.entries.forEach { color ->
                                 val isSelected = readaloudPreferences.highlightColor == color
-                                val swatchColor = Color(color.argb.toLong() and 0xFFFFFFFFL)
+                                val swatchColor = Color(color.argb).copy(alpha = HIGHLIGHT_ALPHA_LIGHT / 255f)
                                 // Selected swatch reads clearly in both themes: an offset ring
                                 // (onSurface ring at the outer edge, separated from the swatch by a
                                 // transparent gap) plus a centred checkmark. The swatch keeps a

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjectorTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjectorTest.kt
@@ -183,14 +183,14 @@ class ContinuousStyleInjectorTest {
 
     @Test
     fun `highlightTextJs escapes single quotes in text`() {
-        val js = ContinuousStyleInjector.highlightTextJs("it's a test")
+        val js = ContinuousStyleInjector.highlightTextJs("it's a test", "rgba(56,189,248,0.30)")
         assertTrue(js.contains("it\\'s a test"))
         assertFalse(js.contains("it's a test"))
     }
 
     @Test
     fun `highlightTextJs escapes newlines in text`() {
-        val js = ContinuousStyleInjector.highlightTextJs("line one\nline two")
+        val js = ContinuousStyleInjector.highlightTextJs("line one\nline two", "rgba(56,189,248,0.30)")
         assertTrue(js.contains("\\n"))
         assertFalse(js.contains("line one\nline two"))
     }

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjectorTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjectorTest.kt
@@ -3,6 +3,7 @@ package com.riffle.app.feature.reader
 import com.riffle.core.domain.FormattingPreferences
 import com.riffle.core.domain.ReaderFontFamily
 import com.riffle.core.domain.ReaderTheme
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -193,5 +194,212 @@ class ContinuousStyleInjectorTest {
         val js = ContinuousStyleInjector.highlightTextJs("line one\nline two", "rgba(56,189,248,0.30)")
         assertTrue(js.contains("\\n"))
         assertFalse(js.contains("line one\nline two"))
+    }
+
+    // ── CLEAR_ANNOTATION_HIGHLIGHTS_JS ─────────────────────────────────────────
+
+    @Test
+    fun `CLEAR removes note-glyph spans before unwrapping marks`() {
+        val js = ContinuousStyleInjector.CLEAR_ANNOTATION_HIGHLIGHTS_JS
+        val glyphIdx = js.indexOf("data-riffle-note-glyph")
+        val markIdx = js.indexOf("data-riffle-ann")
+        assertTrue("glyph selector present", glyphIdx >= 0)
+        assertTrue("mark selector present", markIdx >= 0)
+        assertTrue("glyphs removed before marks (child must go before parent)", glyphIdx < markIdx)
+    }
+
+    @Test
+    fun `CLEAR uses outerHTML replacement to unwrap marks`() {
+        assertTrue(ContinuousStyleInjector.CLEAR_ANNOTATION_HIGHLIGHTS_JS.contains("outerHTML = m.innerHTML"))
+    }
+
+    // ── applyAnnotationHighlightsJs — JSON payload ───────────────────────────
+
+    private fun applyJs(vararg annotations: AnnotationHighlight) =
+        ContinuousStyleInjector.applyAnnotationHighlightsJs(annotations.toList())
+
+    @Test
+    fun `empty list produces empty JSON array`() {
+        val js = ContinuousStyleInjector.applyAnnotationHighlightsJs(emptyList())
+        assertTrue(js.contains("([])"))
+    }
+
+    @Test
+    fun `annotation without note emits n colon 0`() {
+        val js = applyJs(AnnotationHighlight("ann1", "hello", "#ff0000", hasNote = false))
+        assertTrue(js.contains("n:0"))
+        assertFalse(js.contains("n:1"))
+    }
+
+    @Test
+    fun `annotation with note emits n colon 1`() {
+        val js = applyJs(AnnotationHighlight("ann1", "hello", "#ff0000", hasNote = true))
+        assertTrue(js.contains("n:1"))
+    }
+
+    @Test
+    fun `each annotation is emitted with id text color and note fields`() {
+        val js = applyJs(AnnotationHighlight("myId", "my text", "#abc123", hasNote = false))
+        assertTrue("id field", js.contains("id:'myId'"))
+        assertTrue("text field", js.contains("t:'my text'"))
+        assertTrue("color field", js.contains("c:'#abc123'"))
+        assertTrue("note field", js.contains("n:0"))
+    }
+
+    @Test
+    fun `multiple annotations are comma-separated in JSON`() {
+        val js = applyJs(
+            AnnotationHighlight("a1", "first", "#111", hasNote = false),
+            AnnotationHighlight("a2", "second", "#222", hasNote = true),
+        )
+        assertTrue("first id present", js.contains("id:'a1'"))
+        assertTrue("second id present", js.contains("id:'a2'"))
+        assertTrue("first text present", js.contains("t:'first'"))
+        assertTrue("second text present", js.contains("t:'second'"))
+        assertTrue("first has n:0", js.contains("n:0"))
+        assertTrue("second has n:1", js.contains("n:1"))
+    }
+
+    @Test
+    fun `single quotes in annotation id are escaped`() {
+        val js = applyJs(AnnotationHighlight("it's-id", "text", "#000"))
+        assertTrue(js.contains("id:'it\\'s-id'"))
+        assertFalse("raw single quote must not appear in id", js.contains("id:'it's-id'"))
+    }
+
+    @Test
+    fun `single quotes in annotation text are escaped`() {
+        val js = applyJs(AnnotationHighlight("ann1", "don't stop", "#000"))
+        assertTrue(js.contains("t:'don\\'t stop'"))
+        assertFalse("raw single quote must not appear in text", js.contains("t:'don't stop'"))
+    }
+
+    @Test
+    fun `backslashes in text are escaped`() {
+        val js = applyJs(AnnotationHighlight("ann1", "back\\slash", "#000"))
+        assertTrue(js.contains("back\\\\slash"))
+    }
+
+    @Test
+    fun `newlines in text are escaped as backslash-n`() {
+        val js = applyJs(AnnotationHighlight("ann1", "line1\nline2", "#000"))
+        assertTrue(js.contains("\\n"))
+        assertFalse("literal newline must not appear in JS string", js.contains("line1\nline2"))
+    }
+
+    @Test
+    fun `carriage returns in text are escaped as backslash-r`() {
+        val js = applyJs(AnnotationHighlight("ann1", "cr\rtext", "#000"))
+        assertTrue(js.contains("\\r"))
+    }
+
+    // ── applyAnnotationHighlightsJs — DOM logic ──────────────────────────────
+
+    @Test
+    fun `JS sets data-riffle-ann attribute on injected mark`() {
+        val js = applyJs(AnnotationHighlight("ann42", "some text", "#ff0"))
+        assertTrue(js.contains("data-riffle-ann"))
+    }
+
+    @Test
+    fun `JS sets data-riffle-note-glyph attribute on injected glyph`() {
+        val js = applyJs(AnnotationHighlight("ann42", "text", "#ff0", hasNote = true))
+        assertTrue(js.contains("data-riffle-note-glyph"))
+    }
+
+    @Test
+    fun `existing mark is updated in-place via style-background — no window-find`() {
+        val js = applyJs(AnnotationHighlight("ann1", "text", "#abc"))
+        // The in-place update path sets style.background on the existing mark.
+        assertTrue(js.contains("existing.style.background"))
+        // And it calls window.find() only for NEW annotations (after the in-place branch returns).
+        assertTrue(js.contains("window.find("))
+    }
+
+    @Test
+    fun `stale marks are removed when their id is no longer in the annotation list`() {
+        val js = applyJs(AnnotationHighlight("ann1", "text", "#abc"))
+        // validIds is the guard that removes marks whose id is absent from the current list.
+        assertTrue(js.contains("validIds"))
+        assertTrue(js.contains("outerHTML = m.innerHTML"))
+    }
+
+    @Test
+    fun `glyph is added when annotation gains a note`() {
+        val js = applyJs(AnnotationHighlight("ann1", "text", "#abc", hasNote = true))
+        // The branch: if ann.n && !eg → makeGlyph
+        assertTrue(js.contains("ann.n && !eg"))
+        assertTrue(js.contains("makeGlyph"))
+    }
+
+    @Test
+    fun `glyph is removed when annotation loses its note`() {
+        val js = applyJs(AnnotationHighlight("ann1", "text", "#abc", hasNote = false))
+        // The branch: !ann.n && eg → eg.remove()
+        assertTrue(js.contains("!ann.n && eg"))
+        assertTrue(js.contains("eg.remove()"))
+    }
+
+    @Test
+    fun `glyph is positioned 28px to the left of the mark edge not the block edge`() {
+        val js = applyJs(AnnotationHighlight("ann1", "text", "#abc", hasNote = true))
+        // relLeft = markRect.left - blockRect.left - 28 (28px left of mark, not block left)
+        assertTrue(js.contains("markRect.left - blockRect.left - 28"))
+    }
+
+    @Test
+    fun `glyph click calls onAnnotationNoteTap bridge method`() {
+        val js = applyJs(AnnotationHighlight("ann1", "text", "#abc", hasNote = true))
+        assertTrue(js.contains("onAnnotationNoteTap"))
+    }
+
+    @Test
+    fun `mark click calls onAnnotationTap bridge method`() {
+        val js = applyJs(AnnotationHighlight("ann1", "text", "#abc"))
+        assertTrue(js.contains("onAnnotationTap"))
+    }
+
+    @Test
+    fun `selection is cleared after applying annotations`() {
+        val js = applyJs(AnnotationHighlight("ann1", "text", "#abc"))
+        assertTrue(js.contains("removeAllRanges"))
+    }
+
+    // ── applyAnnotationHighlightsJs — note-glyph SVG ────────────────────────
+
+    @Test
+    fun `NoteAlt SVG data-URI is embedded in the JS`() {
+        val js = applyJs(AnnotationHighlight("ann1", "text", "#abc", hasNote = true))
+        // The SVG URI contains the document-page path.
+        assertTrue(js.contains("data:image/svg+xml,"))
+        // webkit-mask-image is used to render the icon (inherits currentColor).
+        assertTrue(js.contains("-webkit-mask-image"))
+    }
+
+    @Test
+    fun `single quotes in SVG URI are escaped for JS embedding`() {
+        // NOTE_GLYPH_SVG_DATA_URI contains literal single quotes (e.g. xmlns='...').
+        // The injector must escape them so the SVG_URI string assignment is syntactically valid JS.
+        assertTrue("SVG constant has single quotes to escape", NOTE_GLYPH_SVG_DATA_URI.contains("'"))
+        val js = applyJs(AnnotationHighlight("ann1", "text", "#abc", hasNote = true))
+        // After escaping, xmlns=' becomes xmlns=\' — the raw xmlns=' must not appear in the JS.
+        assertFalse("raw xmlns=' must be escaped in the JS", js.contains("xmlns='"))
+        // The escaped form IS present.
+        assertTrue("escaped xmlns=\\' must appear in the JS", js.contains("xmlns=\\'"))
+    }
+
+    // ── AnnotationHighlight data class ───────────────────────────────────────
+
+    @Test
+    fun `AnnotationHighlight hasNote defaults to false`() {
+        val ann = AnnotationHighlight("id", "text", "#000")
+        assertFalse(ann.hasNote)
+    }
+
+    @Test
+    fun `AnnotationHighlight equality and copy`() {
+        val ann = AnnotationHighlight("id", "text", "#000", hasNote = true)
+        assertEquals(ann, AnnotationHighlight("id", "text", "#000", hasNote = true))
+        assertFalse(ann == ann.copy(hasNote = false))
     }
 }

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ReadaloudHighlightDecorationTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ReadaloudHighlightDecorationTest.kt
@@ -6,6 +6,7 @@ import com.riffle.core.domain.FormattingPreferences
 import com.riffle.core.domain.ReadaloudHighlightColor
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.readium.r2.navigator.Decoration
 
@@ -16,9 +17,10 @@ class ReadaloudHighlightDecorationTest {
     @Test
     fun allColorsHaveAlphaBakedIn() {
         // argb is the final rendered color used by both the swatch and the reader — no runtime
-        // transformation applied. Verify every entry has the expected translucent alpha.
+        // transformation applied. Verify every entry is translucent (not fully opaque).
         for (color in ReadaloudHighlightColor.entries) {
-            assertEquals("alpha for ${color.name}", HIGHLIGHT_ALPHA_LIGHT, alpha(color.argb))
+            val a = alpha(color.argb)
+            assertTrue("${color.name} alpha $a should be translucent", a in 1..254)
         }
     }
 

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ReadaloudHighlightDecorationTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ReadaloudHighlightDecorationTest.kt
@@ -4,7 +4,6 @@ package com.riffle.app.feature.reader
 
 import com.riffle.core.domain.FormattingPreferences
 import com.riffle.core.domain.ReadaloudHighlightColor
-import com.riffle.core.domain.ReaderTheme
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Test
@@ -13,24 +12,13 @@ import org.readium.r2.navigator.Decoration
 class ReadaloudHighlightDecorationTest {
 
     private fun alpha(argb: Int): Int = (argb ushr 24) and 0xFF
-    private fun rgb(argb: Int): Int = argb and 0x00FFFFFF
 
     @Test
-    fun darkThemesUseStrongerAlpha() {
-        for (theme in listOf(ReaderTheme.Dark, ReaderTheme.DarkDim)) {
-            val tint = ReadaloudHighlightColor.BLUE.readerTint(theme)
-            assertEquals("alpha for $theme", HIGHLIGHT_ALPHA_DARK, alpha(tint))
-            // The hue itself is preserved; only the alpha byte changes.
-            assertEquals(rgb(ReadaloudHighlightColor.BLUE.argb), rgb(tint))
-        }
-    }
-
-    @Test
-    fun lightThemesUseDefaultAlpha() {
-        for (theme in listOf(ReaderTheme.Light, ReaderTheme.Sepia, ReaderTheme.Auto)) {
-            val tint = ReadaloudHighlightColor.GREEN.readerTint(theme)
-            assertEquals("alpha for $theme", HIGHLIGHT_ALPHA_LIGHT, alpha(tint))
-            assertEquals(rgb(ReadaloudHighlightColor.GREEN.argb), rgb(tint))
+    fun allColorsHaveAlphaBakedIn() {
+        // argb is the final rendered color used by both the swatch and the reader — no runtime
+        // transformation applied. Verify every entry has the expected translucent alpha.
+        for (color in ReadaloudHighlightColor.entries) {
+            assertEquals("alpha for ${color.name}", HIGHLIGHT_ALPHA_LIGHT, alpha(color.argb))
         }
     }
 

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/ReadaloudPreferences.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/ReadaloudPreferences.kt
@@ -2,16 +2,16 @@ package com.riffle.core.domain
 
 import kotlinx.coroutines.flow.Flow
 
-// Medium-saturation (Tailwind ~400-level) hues at ~30% opacity. `argb` is the final rendered color
+// Medium-saturation (Tailwind ~400-level) hues at ~50% opacity. `argb` is the final rendered color
 // used by both the settings swatch and the reader — no further transformation applied. The alpha
 // is pre-baked so text remains legible through the highlight. Enum names are unchanged so persisted
 // preferences keep resolving without a migration.
 enum class ReadaloudHighlightColor(val argb: Int) {
-    BLUE(0x4D38BDF8),
-    YELLOW(0x4DFBBF24),
-    GREEN(0x4D34D399),
-    PINK(0x4DFB7185),
-    PURPLE(0x4DA78BFA),
+    BLUE(0x8038BDF8.toInt()),
+    YELLOW(0x80FBBF24.toInt()),
+    GREEN(0x8034D399.toInt()),
+    PINK(0x80FB7185.toInt()),
+    PURPLE(0x80A78BFA.toInt()),
 }
 
 data class ReadaloudPreferences(

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/ReadaloudPreferences.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/ReadaloudPreferences.kt
@@ -2,17 +2,16 @@ package com.riffle.core.domain
 
 import kotlinx.coroutines.flow.Flow
 
-// Medium-saturation (Tailwind ~400-level) hues: vivid enough to tell apart in the picker and to
-// read clearly behind text, without being neon. `argb` carries the full-opacity base color used
-// for the settings swatch; the reader applies a theme-dependent alpha (see readerTint()).
-// Enum names are intentionally unchanged from the original pastels so persisted preferences (which
-// store the name string) keep resolving without a migration.
+// Medium-saturation (Tailwind ~400-level) hues at ~30% opacity. `argb` is the final rendered color
+// used by both the settings swatch and the reader — no further transformation applied. The alpha
+// is pre-baked so text remains legible through the highlight. Enum names are unchanged so persisted
+// preferences keep resolving without a migration.
 enum class ReadaloudHighlightColor(val argb: Int) {
-    BLUE(0xFF38BDF8.toInt()),
-    YELLOW(0xFFFBBF24.toInt()),
-    GREEN(0xFF34D399.toInt()),
-    PINK(0xFFFB7185.toInt()),
-    PURPLE(0xFFA78BFA.toInt()),
+    BLUE(0x4D38BDF8),
+    YELLOW(0x4DFBBF24),
+    GREEN(0x4D34D399),
+    PINK(0x4DFB7185),
+    PURPLE(0x4DA78BFA),
 }
 
 data class ReadaloudPreferences(


### PR DESCRIPTION
## Summary

- **Annotation highlights in continuous mode**: `applyAnnotationHighlightsJs` injects `<mark data-riffle-ann>` elements via `window.find()` + smart DOM diffing. Existing marks are updated in-place (no DOM mutation before `window.find()`), stale marks removed selectively, new marks added only for newly-created annotations — fixing the Chrome race that prevented new highlights from appearing without a mode cycle.
- **Note glyphs in continuous mode**: `makeGlyph` injects the NoteAlt SVG icon 28 px to the left of the mark's first-line edge via `-webkit-mask-image`, matching paged mode's `NoteGlyphStyle` exactly. Tapping calls `onAnnotationNoteTap`.
- **CFI progression fix**: `withSelectionTextAndProgression` computes `progression = selectionTop / documentHeight` in JS (valid in continuous mode where `pageYOffset = 0`) and threads it through the callback chain. Previously all continuous-mode highlights stored progression 0.0, causing navigation to land at the chapter top.
- **Highlight popup anchor fix**: the selection's `getBoundingClientRect()` is captured at highlight-creation time, converted to screen coordinates via `getLocationOnScreen()`, and passed to `currentOnHighlight` — replacing the dead `IntRect(0, 0, 0, 0)` placeholder.
- **Color plumbing**: `ReadaloudHighlightColor.argb` now carries a pre-baked ~50% alpha; `toCssRgba()` converts any ARGB int to a CSS `rgba()` string for WebView injection; highlight color re-keys the readaloud `LaunchedEffect` so color changes apply immediately.
- **`wireAnnotationCallbacks`**: extracted from the identical duplication in `appendChapter` / `prependChapter`.

## Test plan

- `./gradlew test` — green (50 `ContinuousStyleInjectorTest` + full suite)
- `./gradlew lint` — green
- Harness skipped per finalize args; features are JS/view-layer and require a device to verify end-to-end
- New unit tests cover: `CLEAR_ANNOTATION_HIGHLIGHTS_JS` order, `applyAnnotationHighlightsJs` JSON payload & escape paths, smart DOM diffing logic (in-place update, stale removal, glyph add/remove), glyph positioning formula, bridge method wiring, NoteAlt SVG embedding & quote escaping, `AnnotationHighlight` defaults and equality