### PR TITLE
fix(harness): ephemeral AVD per run — clone, test, delete

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,6 +105,8 @@ define run_harness_tests
 	BRANCH=$$(git rev-parse --abbrev-ref HEAD 2>/dev/null | tr -cs '[:alnum:]' '-' | sed 's/-*$$//'); \
 	AVD_NAME="Harness_$${BRANCH}_$$$$"; \
 	AVD_DIR="$$HOME/.android/avd/$$AVD_NAME.avd"; \
+	EMU_PID=""; SERIAL=""; \
+	trap 'adb -s "$$SERIAL" emu kill 2>/dev/null || true; wait $$EMU_PID 2>/dev/null || true; kill -9 $$EMU_PID 2>/dev/null || true; rm -rf "$$AVD_DIR" "$$HOME/.android/avd/$$AVD_NAME.ini" 2>/dev/null || true' EXIT INT TERM; \
 	echo "Cloning $$AVD_BASE → $$AVD_NAME..."; \
 	cp -c -R "$$HOME/.android/avd/$$AVD_BASE.avd" "$$AVD_DIR"; \
 	sed "s|/$$AVD_BASE\.avd|/$$AVD_NAME.avd|g; s|$$AVD_BASE\.avd|$$AVD_NAME.avd|g" \
@@ -116,7 +118,7 @@ define run_harness_tests
 		"$$AVD_DIR/snapshot.trace" "$$AVD_DIR/read-snapshot.txt" 2>/dev/null || true; \
 	echo "Starting emulator '$$AVD_NAME'..."; \
 	emulator -avd "$$AVD_NAME" -no-window -no-audio -no-boot-anim -no-snapshot-load -no-snapshot-save \
-		&> /tmp/riffle-emulator.log & \
+		&> "/tmp/riffle-emulator-$$AVD_NAME.log" & \
 	EMU_PID=$$!; \
 	echo "Waiting for emulator to boot (pid $$EMU_PID)..."; \
 	SERIAL=""; \

--- a/Makefile
+++ b/Makefile
@@ -126,6 +126,9 @@ define run_harness_tests
 		done); \
 	done; \
 	until [ "$$(adb -s $$SERIAL shell getprop sys.boot_completed 2>/dev/null | tr -d '\r')" = "1" ]; do sleep 2; done; \
+	adb -s $$SERIAL shell input keyevent KEYCODE_WAKEUP; \
+	adb -s $$SERIAL shell wm dismiss-keyguard; \
+	adb -s $$SERIAL shell svc power stayon true; \
 	echo "Running harness tests on $$SERIAL..."; \
 	adb -s $$SERIAL shell pm clear com.riffle.app 2>/dev/null || true; \
 	ANDROID_SERIAL=$$SERIAL ./gradlew :app:connectedDebugAndroidTest $(2); \

--- a/Makefile
+++ b/Makefile
@@ -93,27 +93,28 @@ clean: ## Clean build outputs
 install: wrapper fonts ## Build debug APK and install on connected device
 	./gradlew :app:installDebug
 
-PHONE_AVD := Harness_Medium_Phone
-TABLET_AVD := Harness_Medium_Tablet
+PHONE_AVD_BASE := Harness_Medium_Phone_2
+TABLET_AVD_BASE := Harness_Medium_Tablet
 TABLET_ANNOTATION := com.riffle.app.harness.TabletLayout
 
-# $(1) = AVD name, $(2) = extra gradle args (annotation include/exclude filter)
+# $(1) = base AVD to clone (must be API 25 / Android 7.1.1), $(2) = extra gradle args
+# Each invocation clones a fresh ephemeral AVD from the base, runs tests, then deletes it.
+# Using a unique name (PID) avoids any interference from parallel workspace runs.
 define run_harness_tests
-	AVD_NAME="$(1)"; \
-	AVD_CONFIG=$$HOME/.android/avd/$$AVD_NAME.avd/config.ini; \
-	echo "Ensuring AVD heap is 1024 MB (was: $$(grep vm.heapSize $$AVD_CONFIG))..."; \
-	sed -i '' 's/^vm\.heapSize=.*/vm.heapSize=1024/' "$$AVD_CONFIG"; \
-	STALE=$$(for s in $$(adb devices 2>/dev/null | grep emulator | cut -f1); do \
-		name=$$(adb -s $$s emu avd name 2>/dev/null | head -1 | tr -d '\r'); \
-		[ "$$name" = "$$AVD_NAME" ] && echo $$s; \
-	done); \
-	if [ -n "$$STALE" ]; then \
-		echo "Killing stale emulator $$STALE..."; \
-		adb -s $$STALE emu kill 2>/dev/null || true; \
-		until ! adb devices 2>/dev/null | grep -q "$$STALE"; do sleep 2; done; \
-	fi; \
+	AVD_BASE="$(1)"; \
+	AVD_NAME="Harness_Temp_$$$$"; \
+	AVD_DIR="$$HOME/.android/avd/$$AVD_NAME.avd"; \
+	echo "Cloning $$AVD_BASE → $$AVD_NAME..."; \
+	cp -c -R "$$HOME/.android/avd/$$AVD_BASE.avd" "$$AVD_DIR"; \
+	sed "s|/$$AVD_BASE\.avd|/$$AVD_NAME.avd|g; s|$$AVD_BASE\.avd|$$AVD_NAME.avd|g" \
+		"$$HOME/.android/avd/$$AVD_BASE.ini" > "$$HOME/.android/avd/$$AVD_NAME.ini"; \
+	sed -i '' "s/^AvdId=.*/AvdId=$$AVD_NAME/" "$$AVD_DIR/config.ini"; \
+	sed -i '' "s/^avd.ini.displayname=.*/avd.ini.displayname=Harness Temp $$$$/" "$$AVD_DIR/config.ini"; \
+	sed -i '' 's/^vm\.heapSize=.*/vm.heapSize=1024/' "$$AVD_DIR/config.ini"; \
+	rm -rf "$$AVD_DIR/snapshots" "$$AVD_DIR"/*.lock \
+		"$$AVD_DIR/snapshot.trace" "$$AVD_DIR/read-snapshot.txt" 2>/dev/null || true; \
 	echo "Starting emulator '$$AVD_NAME'..."; \
-	emulator -avd "$$AVD_NAME" -no-window -no-audio -no-boot-anim -no-snapshot-load \
+	emulator -avd "$$AVD_NAME" -no-window -no-audio -no-boot-anim -no-snapshot-load -no-snapshot-save \
 		&> /tmp/riffle-emulator.log & \
 	EMU_PID=$$!; \
 	echo "Waiting for emulator to boot (pid $$EMU_PID)..."; \
@@ -137,17 +138,19 @@ define run_harness_tests
 	adb -s $$SERIAL emu kill; \
 	wait $$EMU_PID 2>/dev/null || true; \
 	kill -9 $$EMU_PID 2>/dev/null || true; \
+	echo "Deleting temp AVD $$AVD_NAME..."; \
+	rm -rf "$$AVD_DIR" "$$HOME/.android/avd/$$AVD_NAME.ini"; \
 	exit $$TEST_EXIT
 endef
 
 .PHONY: harness-test
-harness-test: wrapper fonts ## Boot "Harness Medium Phone" AVD, run non-tablet harness tests, then shut it down
-	@$(call run_harness_tests,$(PHONE_AVD),-Pandroid.testInstrumentationRunnerArguments.notAnnotation=$(TABLET_ANNOTATION))
+harness-test: wrapper fonts ## Clone a fresh API-25 phone AVD, run non-tablet harness tests, then delete it
+	@$(call run_harness_tests,$(PHONE_AVD_BASE),-Pandroid.testInstrumentationRunnerArguments.notAnnotation=$(TABLET_ANNOTATION))
 
 .PHONY: harness-test-tablet
-harness-test-tablet: wrapper fonts ## Boot "Harness Medium Tablet" AVD, run @TabletLayout tests only, then shut it down
-	@$(call run_harness_tests,$(TABLET_AVD),-Pandroid.testInstrumentationRunnerArguments.annotation=$(TABLET_ANNOTATION))
+harness-test-tablet: wrapper fonts ## Clone a fresh API-25 tablet AVD, run @TabletLayout tests only, then delete it
+	@$(call run_harness_tests,$(TABLET_AVD_BASE),-Pandroid.testInstrumentationRunnerArguments.annotation=$(TABLET_ANNOTATION))
 
 .PHONY: harness-test-class
-harness-test-class: wrapper fonts ## Boot the phone AVD and run a single test CLASS=<fqcn> (or pkg.Class#method), then shut it down
-	@$(call run_harness_tests,$(PHONE_AVD),-Pandroid.testInstrumentationRunnerArguments.class=$(CLASS))
+harness-test-class: wrapper fonts ## Clone a fresh API-25 phone AVD, run a single test CLASS=<fqcn> (or pkg.Class#method), then delete it
+	@$(call run_harness_tests,$(PHONE_AVD_BASE),-Pandroid.testInstrumentationRunnerArguments.class=$(CLASS))

--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ clean: ## Clean build outputs
 install: wrapper fonts ## Build debug APK and install on connected device
 	./gradlew :app:installDebug
 
-PHONE_AVD_BASE := Harness_Medium_Phone_2
+PHONE_AVD_BASE := Harness_Medium_Phone
 TABLET_AVD_BASE := Harness_Medium_Tablet
 TABLET_ANNOTATION := com.riffle.app.harness.TabletLayout
 
@@ -102,14 +102,15 @@ TABLET_ANNOTATION := com.riffle.app.harness.TabletLayout
 # Using a unique name (PID) avoids any interference from parallel workspace runs.
 define run_harness_tests
 	AVD_BASE="$(1)"; \
-	AVD_NAME="Harness_Temp_$$$$"; \
+	BRANCH=$$(git rev-parse --abbrev-ref HEAD 2>/dev/null | tr -cs '[:alnum:]' '-' | sed 's/-*$$//'); \
+	AVD_NAME="Harness_$${BRANCH}_$$$$"; \
 	AVD_DIR="$$HOME/.android/avd/$$AVD_NAME.avd"; \
 	echo "Cloning $$AVD_BASE → $$AVD_NAME..."; \
 	cp -c -R "$$HOME/.android/avd/$$AVD_BASE.avd" "$$AVD_DIR"; \
 	sed "s|/$$AVD_BASE\.avd|/$$AVD_NAME.avd|g; s|$$AVD_BASE\.avd|$$AVD_NAME.avd|g" \
 		"$$HOME/.android/avd/$$AVD_BASE.ini" > "$$HOME/.android/avd/$$AVD_NAME.ini"; \
 	sed -i '' "s/^AvdId=.*/AvdId=$$AVD_NAME/" "$$AVD_DIR/config.ini"; \
-	sed -i '' "s/^avd.ini.displayname=.*/avd.ini.displayname=Harness Temp $$$$/" "$$AVD_DIR/config.ini"; \
+	sed -i '' "s/^avd.ini.displayname=.*/avd.ini.displayname=Harness $${BRANCH} $$$$/" "$$AVD_DIR/config.ini"; \
 	sed -i '' 's/^vm\.heapSize=.*/vm.heapSize=1024/' "$$AVD_DIR/config.ini"; \
 	rm -rf "$$AVD_DIR/snapshots" "$$AVD_DIR"/*.lock \
 		"$$AVD_DIR/snapshot.trace" "$$AVD_DIR/read-snapshot.txt" 2>/dev/null || true; \


### PR DESCRIPTION
## Summary

- **Ephemeral AVD cloning**: each `make harness-test` / `make harness-test-tablet` invocation now clones a fresh API-25 AVD from the permanent base (`Harness_Medium_Phone` / `Harness_Medium_Tablet`), runs tests against it exclusively, then deletes it — eliminating cross-workspace/cross-session interference that was causing hangs and crashes.
- **Branch-tagged AVD name**: ephemeral clones are named `Harness_<branch>_<PID>` (e.g. `Harness_pkmetski-harness-avd-crash-debug_12345`), making it immediately obvious which workspace/branch owns a running emulator.
- **Screen wake/unlock before tests**: adds `KEYCODE_WAKEUP` + `wm dismiss-keyguard` + `svc power stayon true` after boot — without these, Compose touch injection fails on a locked screen.
- **EXIT/INT/TERM trap**: registers a cleanup trap before any side-effects so the temp AVD is always deleted even on Ctrl-C or early failure.
- **Per-run emulator log**: moves the log from the shared `/tmp/riffle-emulator.log` to `/tmp/riffle-emulator-<AVD_NAME>.log` so concurrent runs don't clobber each other's logs.
- **`-no-snapshot-save` flag**: prevents SIGABRT on exit from a cloned AVD that has no valid snapshot state.

## Test plan

- `./gradlew test` — green
- `./gradlew lint` — green (run in isolation; concurrent test+lint hits KSP corruption, pre-existing toolchain issue)
- `make harness-test` — 221 tests, 0 failed, ephemeral AVD cloned and deleted cleanly
- `make harness-test-tablet` — 5 tests, 0 failed, ephemeral AVD cloned and deleted cleanly