### PR TITLE
fix(reader): pin bookmark ribbon at screen top, never moves

### DIFF
--- a/app/src/androidTest/kotlin/com/riffle/app/feature/reader/CornerBookmarkIndicatorTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/reader/CornerBookmarkIndicatorTest.kt
@@ -67,6 +67,20 @@ class CornerBookmarkIndicatorTest {
     }
 
     @Test
+    fun tap_bookmarked_firesToggleCallback() {
+        var toggled = false
+        composeTestRule.setContent {
+            CornerBookmarkIndicator(
+                isBookmarked = true,
+                isVisible = true,
+                onToggle = { toggled = true },
+            )
+        }
+        composeTestRule.onNodeWithContentDescription("Remove bookmark").performClick()
+        assertTrue("tapping the ribbon while bookmarked must call onToggle", toggled)
+    }
+
+    @Test
     fun customContentDescription_overridesDefault() {
         composeTestRule.setContent {
             CornerBookmarkIndicator(

--- a/app/src/androidTest/kotlin/com/riffle/app/feature/reader/CornerBookmarkIndicatorTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/reader/CornerBookmarkIndicatorTest.kt
@@ -1,0 +1,81 @@
+package com.riffle.app.feature.reader
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class CornerBookmarkIndicatorTest {
+
+    @get:Rule val composeTestRule = createComposeRule()
+
+    @Test
+    fun notVisible_rendersNothing() {
+        composeTestRule.setContent {
+            CornerBookmarkIndicator(
+                isBookmarked = false,
+                isVisible = false,
+                onToggle = {},
+            )
+        }
+        composeTestRule.onNodeWithContentDescription("Bookmark this page").assertDoesNotExist()
+        composeTestRule.onNodeWithContentDescription("Remove bookmark").assertDoesNotExist()
+    }
+
+    @Test
+    fun visible_notBookmarked_showsBookmarkPrompt() {
+        composeTestRule.setContent {
+            CornerBookmarkIndicator(
+                isBookmarked = false,
+                isVisible = true,
+                onToggle = {},
+            )
+        }
+        composeTestRule.onNodeWithContentDescription("Bookmark this page").assertIsDisplayed()
+    }
+
+    @Test
+    fun visible_bookmarked_showsRemovePrompt() {
+        composeTestRule.setContent {
+            CornerBookmarkIndicator(
+                isBookmarked = true,
+                isVisible = true,
+                onToggle = {},
+            )
+        }
+        composeTestRule.onNodeWithContentDescription("Remove bookmark").assertIsDisplayed()
+    }
+
+    @Test
+    fun tap_firesToggleCallback() {
+        var toggled = false
+        composeTestRule.setContent {
+            CornerBookmarkIndicator(
+                isBookmarked = false,
+                isVisible = true,
+                onToggle = { toggled = true },
+            )
+        }
+        composeTestRule.onNodeWithContentDescription("Bookmark this page").performClick()
+        assertTrue("tapping the ribbon must call onToggle", toggled)
+    }
+
+    @Test
+    fun customContentDescription_overridesDefault() {
+        composeTestRule.setContent {
+            CornerBookmarkIndicator(
+                isBookmarked = false,
+                isVisible = true,
+                onToggle = {},
+                contentDescription = "Custom description",
+            )
+        }
+        composeTestRule.onNodeWithContentDescription("Custom description").assertIsDisplayed()
+    }
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -288,9 +288,6 @@ fun EpubReaderScreen(
     // reserve, preventing Readium from paginating text behind the overlay in paged mode.
     var railOverlayHeightPx by remember { mutableStateOf(0) }
     val density = LocalDensity.current
-    // Latch the top-bar's full measured height so the bookmark can sit permanently below it.
-    // Max-only updates mean it never shrinks during the slide-out animation.
-    var topBarStableHeightPx by remember { mutableStateOf(0) }
     val paginated = formattingPrefs.orientation != ReaderOrientation.Vertical
     val railReserveCssPx: Int = if (paginated) {
         (railOverlayHeightPx / density.density).roundToInt()
@@ -428,10 +425,7 @@ fun EpubReaderScreen(
                         onToggle = viewModel::toggleBookmark,
                         modifier = Modifier
                             .align(Alignment.TopEnd)
-                            .padding(
-                                top = with(density) { topBarStableHeightPx.toDp() },
-                                end = 12.dp,
-                            ),
+                            .padding(end = 12.dp),
                     )
                 }
                 is ReaderState.Error -> {
@@ -536,9 +530,6 @@ fun EpubReaderScreen(
             visible = !immersiveState.isImmersive,
             enter = slideInVertically(initialOffsetY = { -it }) + expandVertically(expandFrom = Alignment.Top),
             exit = slideOutVertically(targetOffsetY = { -it }) + shrinkVertically(shrinkTowards = Alignment.Top),
-            modifier = Modifier.onSizeChanged { size ->
-                if (size.height > topBarStableHeightPx) topBarStableHeightPx = size.height
-            },
         ) {
             if (isSearchActive) {
                 SearchTopBar(


### PR DESCRIPTION
## Summary

- Removes the `topBarStableHeightPx` latch that was offsetting the bookmark ribbon below the top bar's full height (status bar + app bar), leaving it "parked" below the top-bar footprint even when the bar was hidden.
- The ribbon now sits at `Alignment.TopEnd` with only `end = 12.dp` padding — y=0 always. In edge-to-edge mode the transparent status bar overlays the ribbon when it appears, so the ribbon is visually static regardless of immersive-mode state.
- Removes the `onSizeChanged` listener on the `AnimatedVisibility` wrapper that was tracking the top-bar height.
- Adds `CornerBookmarkIndicatorTest` (6 tests) covering visibility, content-description state for both bookmark states, toggle callback for both states, and custom description override.

## Test plan

- [x] `./gradlew test` — JVM unit tests green
- [x] `./gradlew lint` — clean
- [x] Phone harness (222 tests, `notAnnotation=TabletLayout`) — green; `CornerBookmarkIndicatorTest` 6/6 pass
- [x] Tablet harness (5 tests, `annotation=TabletLayout`) — green