### PR TITLE
fix(audiobook): bookmark snackbar covered by nav bar and never dismissed

### DIFF
--- a/app/src/androidTest/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerSnackbarTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerSnackbarTest.kt
@@ -33,11 +33,10 @@ class AudiobookPlayerSnackbarTest {
     @get:Rule val rule = createComposeRule()
 
     // Shared setup: show the "Bookmark saved" snackbar with the same parameters used in
-    // AudiobookPlayerScreen and advance the clock enough for it to appear.
+    // AudiobookPlayerScreen and wait for it to appear.
     // Returns the SnackbarHostState so individual tests can drive it further.
     private fun showBookmarkSavedSnackbar(): SnackbarHostState {
         val state = SnackbarHostState()
-        rule.mainClock.autoAdvance = false
 
         rule.setContent {
             Box(Modifier.fillMaxSize()) {
@@ -55,9 +54,6 @@ class AudiobookPlayerSnackbarTest {
             }
         }
 
-        // Allow the LaunchedEffect to start and the snackbar to appear.
-        rule.mainClock.advanceTimeBy(100L)
-        rule.waitForIdle()
         rule.onNodeWithText("Bookmark saved").assertIsDisplayed()
         return state
     }
@@ -89,6 +85,8 @@ class AudiobookPlayerSnackbarTest {
         // Perform the action — equivalent to tapping the Undo button.
         state.currentSnackbarData?.performAction()
 
+        // Advance the clock slightly so the coroutine resumption propagates.
+        rule.mainClock.advanceTimeBy(100L)
         rule.waitForIdle()
         rule.onNodeWithText("Bookmark saved").assertDoesNotExist()
     }

--- a/app/src/androidTest/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerSnackbarTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerSnackbarTest.kt
@@ -20,21 +20,22 @@ import org.junit.runner.RunWith
 /**
  * Guards against regressions in the "Bookmark saved" snackbar shown in
  * [AudiobookPlayerScreen] after the user confirms a new bookmark.
+ *
+ * Note: these tests exercise the snackbar mechanics in isolation (not the full screen) because
+ * wiring [AudiobookPlayerScreen] with a fake ViewModel requires disproportionate setup. They
+ * verify that the chosen parameters (SnackbarDuration.Long, actionLabel = "Undo") produce the
+ * right visible behaviour, but do not protect against accidentally reverting the duration back
+ * to Indefinite in the production call site.
  */
 @RunWith(AndroidJUnit4::class)
 class AudiobookPlayerSnackbarTest {
 
     @get:Rule val rule = createComposeRule()
 
-    /**
-     * The snackbar must auto-dismiss after the Long duration (~10 s).
-     *
-     * Before the fix it used SnackbarDuration.Indefinite (the Material3 default when
-     * actionLabel != null), so it never disappeared. This test would fail with Indefinite
-     * because assertDoesNotExist() would still find the node after 11 seconds.
-     */
-    @Test
-    fun bookmarkSavedSnackbarAutoDismissesAfterLongDuration() {
+    // Shared setup: show the "Bookmark saved" snackbar with the same parameters used in
+    // AudiobookPlayerScreen and advance the clock enough for it to appear.
+    // Returns the SnackbarHostState so individual tests can drive it further.
+    private fun showBookmarkSavedSnackbar(): SnackbarHostState {
         val state = SnackbarHostState()
         rule.mainClock.autoAdvance = false
 
@@ -58,6 +59,19 @@ class AudiobookPlayerSnackbarTest {
         rule.mainClock.advanceTimeBy(100L)
         rule.waitForIdle()
         rule.onNodeWithText("Bookmark saved").assertIsDisplayed()
+        return state
+    }
+
+    /**
+     * The snackbar must auto-dismiss after the Long duration (~10 s).
+     *
+     * Before the fix it used SnackbarDuration.Indefinite (the Material3 default when
+     * actionLabel != null), so it never disappeared. This test would fail with Indefinite
+     * because assertDoesNotExist() would still find the node after 11 seconds.
+     */
+    @Test
+    fun bookmarkSavedSnackbarAutoDismissesAfterLongDuration() {
+        showBookmarkSavedSnackbar()
 
         // Advance past SnackbarDuration.Long (10 000 ms).
         rule.mainClock.advanceTimeBy(11_000L)
@@ -70,28 +84,7 @@ class AudiobookPlayerSnackbarTest {
      */
     @Test
     fun bookmarkSavedSnackbarDismissesOnUndoTap() {
-        val state = SnackbarHostState()
-        rule.mainClock.autoAdvance = false
-
-        rule.setContent {
-            Box(Modifier.fillMaxSize()) {
-                SnackbarHost(
-                    state,
-                    modifier = Modifier.align(Alignment.BottomCenter).navigationBarsPadding(),
-                )
-            }
-            LaunchedEffect(Unit) {
-                state.showSnackbar(
-                    message = "Bookmark saved",
-                    actionLabel = "Undo",
-                    duration = SnackbarDuration.Long,
-                )
-            }
-        }
-
-        rule.mainClock.advanceTimeBy(100L)
-        rule.waitForIdle()
-        rule.onNodeWithText("Bookmark saved").assertIsDisplayed()
+        val state = showBookmarkSavedSnackbar()
 
         // Perform the action — equivalent to tapping the Undo button.
         state.currentSnackbarData?.performAction()

--- a/app/src/androidTest/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerSnackbarTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerSnackbarTest.kt
@@ -1,0 +1,102 @@
+package com.riffle.app.feature.audiobook
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.material3.SnackbarDuration
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Guards against regressions in the "Bookmark saved" snackbar shown in
+ * [AudiobookPlayerScreen] after the user confirms a new bookmark.
+ */
+@RunWith(AndroidJUnit4::class)
+class AudiobookPlayerSnackbarTest {
+
+    @get:Rule val rule = createComposeRule()
+
+    /**
+     * The snackbar must auto-dismiss after the Long duration (~10 s).
+     *
+     * Before the fix it used SnackbarDuration.Indefinite (the Material3 default when
+     * actionLabel != null), so it never disappeared. This test would fail with Indefinite
+     * because assertDoesNotExist() would still find the node after 11 seconds.
+     */
+    @Test
+    fun bookmarkSavedSnackbarAutoDismissesAfterLongDuration() {
+        val state = SnackbarHostState()
+        rule.mainClock.autoAdvance = false
+
+        rule.setContent {
+            Box(Modifier.fillMaxSize()) {
+                SnackbarHost(
+                    state,
+                    modifier = Modifier.align(Alignment.BottomCenter).navigationBarsPadding(),
+                )
+            }
+            LaunchedEffect(Unit) {
+                state.showSnackbar(
+                    message = "Bookmark saved",
+                    actionLabel = "Undo",
+                    duration = SnackbarDuration.Long,
+                )
+            }
+        }
+
+        // Allow the LaunchedEffect to start and the snackbar to appear.
+        rule.mainClock.advanceTimeBy(100L)
+        rule.waitForIdle()
+        rule.onNodeWithText("Bookmark saved").assertIsDisplayed()
+
+        // Advance past SnackbarDuration.Long (10 000 ms).
+        rule.mainClock.advanceTimeBy(11_000L)
+        rule.waitForIdle()
+        rule.onNodeWithText("Bookmark saved").assertDoesNotExist()
+    }
+
+    /**
+     * Tapping Undo dismisses the snackbar immediately without waiting for the timeout.
+     */
+    @Test
+    fun bookmarkSavedSnackbarDismissesOnUndoTap() {
+        val state = SnackbarHostState()
+        rule.mainClock.autoAdvance = false
+
+        rule.setContent {
+            Box(Modifier.fillMaxSize()) {
+                SnackbarHost(
+                    state,
+                    modifier = Modifier.align(Alignment.BottomCenter).navigationBarsPadding(),
+                )
+            }
+            LaunchedEffect(Unit) {
+                state.showSnackbar(
+                    message = "Bookmark saved",
+                    actionLabel = "Undo",
+                    duration = SnackbarDuration.Long,
+                )
+            }
+        }
+
+        rule.mainClock.advanceTimeBy(100L)
+        rule.waitForIdle()
+        rule.onNodeWithText("Bookmark saved").assertIsDisplayed()
+
+        // Perform the action — equivalent to tapping the Undo button.
+        state.currentSnackbarData?.performAction()
+
+        rule.waitForIdle()
+        rule.onNodeWithText("Bookmark saved").assertDoesNotExist()
+    }
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerScreen.kt
@@ -24,6 +24,7 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SnackbarDuration
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.SnackbarResult
@@ -284,7 +285,7 @@ fun AudiobookPlayerScreen(
                     .safeDrawingPadding()
                     .padding(end = 12.dp),
             )
-            SnackbarHost(snackbarHostState, modifier = Modifier.align(Alignment.BottomCenter))
+            SnackbarHost(snackbarHostState, modifier = Modifier.align(Alignment.BottomCenter).navigationBarsPadding())
         }
     }
 
@@ -304,6 +305,7 @@ fun AudiobookPlayerScreen(
                     val result = snackbarHostState.showSnackbar(
                         message = "Bookmark saved",
                         actionLabel = "Undo",
+                        duration = SnackbarDuration.Long,
                     )
                     if (result == SnackbarResult.ActionPerformed) {
                         // The add is asynchronous; by the time Undo is tapped the id has been published


### PR DESCRIPTION
## Summary

- `SnackbarHost` in `AudiobookPlayerScreen` lacked `navigationBarsPadding()`, causing the "Bookmark saved" snackbar to render behind the system navigation bar in edge-to-edge mode
- `showSnackbar` with `actionLabel = "Undo"` defaults to `SnackbarDuration.Indefinite` in Material3 (the snackbar never auto-dismissed); explicitly pass `SnackbarDuration.Long` (~10 s) instead

## Tests

Added `AudiobookPlayerSnackbarTest` (2 Compose UI tests):
- `bookmarkSavedSnackbarAutoDismissesAfterLongDuration` — advances the test clock 11 s past the Long duration and asserts the snackbar is gone; would fail with `Indefinite`
- `bookmarkSavedSnackbarDismissesOnUndoTap` — calls `performAction()` and asserts immediate dismissal

**Note:** tests exercise the snackbar mechanics in isolation (not the full screen), so they document and guard the timing/dismissal behaviour but don't prevent accidentally reverting the `duration = Long` parameter in the production call site.

## Test plan

- [x] `./gradlew test` — JVM unit tests green
- [x] `./gradlew lint` — clean
- [x] `make harness-test` — 223 phone tests, BUILD SUCCESSFUL
- [x] `make harness-test-tablet` — BUILD SUCCESSFUL