### PR TITLE
fix(reader): reading estimates and chapter map not updating in continuous mode

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,3 +21,20 @@ When adding a new Room migration:
      - `helper.runMigrationsAndValidate(TEST_DB, N+1, true, RiffleDatabase.MIGRATION_N_(N+1))`
      - Cursor assertions verifying new columns have correct default values and all pre-existing data is preserved
    - Add the new migration to the `migrateFullChain` test's `runMigrationsAndValidate` call.
+
+## Reader mode changes
+
+The reader has three modes: paginated, vertical, and continuous.
+
+Paginated and vertical both use Readium's EpubNavigatorFragment (scroll=false vs
+scroll=true). Readium drives navigation, emits position updates, and populates Locator
+fields automatically.
+
+Continuous uses a custom ContinuousReaderView with a fully manual position pipeline.
+Anything Readium provides for free to paginated/vertical must be explicitly computed
+and threaded through the continuous onPositionChanged lambda in EpubReaderScreen.kt.
+
+Any change that touches the reader — position tracking, navigation events, new ViewModel
+state, UI driven by the current locator — must be verified to work in all three modes,
+with particular attention to continuous: if paginated/vertical get something from Readium,
+ask whether continuous needs to compute an equivalent.

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousModeUtils.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousModeUtils.kt
@@ -1,5 +1,8 @@
 package com.riffle.app.feature.reader
 
+import org.json.JSONObject
+import org.readium.r2.shared.publication.Locator
+
 /**
  * Computes a book-wide [0, 1] progression for continuous scroll mode using the same
  * per-chapter weights the chapter rail draws from (derived from Readium position counts).
@@ -21,3 +24,40 @@ fun computeTotalProgression(
     val chapterWeight = segments[idx].weight
     return (cumulativeWeight + chapterWeight * progression) / totalWeight
 }
+
+/**
+ * Builds the JSON object consumed by [Locator.fromJSON] for a continuous-mode position.
+ *
+ * Paginated and vertical modes receive a fully-populated [Locator] (including
+ * [Locator.Locations.totalProgression]) from Readium automatically. Continuous mode only knows
+ * the spine [href] and within-chapter [progression], so this function derives
+ * `totalProgression` from the rail segment weights and embeds it in the JSON — giving the
+ * ViewModel the same input for the chapter-map rail cursor and reading-time estimates as the
+ * other two modes.
+ *
+ * Separated from [buildContinuousLocator] so the JSON output is testable without
+ * [android.net.Uri] (which [Locator.fromJSON] needs and JVM tests cannot provide).
+ */
+fun buildContinuousLocatorJson(
+    href: String,
+    progression: Float,
+    segments: List<RailSegment>,
+): JSONObject {
+    val totalProg = computeTotalProgression(href, progression, segments)
+    val locations = JSONObject().put("progression", progression.toDouble())
+    if (totalProg != null) locations.put("totalProgression", totalProg.toDouble())
+    return JSONObject()
+        .put("href", href)
+        .put("type", "application/xhtml+xml")
+        .put("locations", locations)
+}
+
+/**
+ * Converts a raw continuous-mode position into a [Locator] that the ViewModel can consume.
+ * Thin wrapper over [buildContinuousLocatorJson] + [Locator.fromJSON].
+ */
+fun buildContinuousLocator(
+    href: String,
+    progression: Float,
+    segments: List<RailSegment>,
+): Locator? = Locator.fromJSON(buildContinuousLocatorJson(href, progression, segments))

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousModeUtils.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousModeUtils.kt
@@ -1,0 +1,22 @@
+package com.riffle.app.feature.reader
+
+/**
+ * Computes a book-wide [0, 1] progression for continuous scroll mode using the same
+ * per-chapter weights the chapter rail draws from (derived from Readium position counts).
+ *
+ * Returns null when [segments] is empty, total weight is zero, or [href] has no matching
+ * segment.
+ */
+fun computeTotalProgression(
+    href: String,
+    progression: Float,
+    segments: List<RailSegment>,
+): Float? {
+    val idx = segments.indexOfFirst { it.href == href }
+    if (idx < 0) return null
+    val totalWeight = segments.sumOf { it.weight.toDouble() }.toFloat()
+    if (totalWeight == 0f) return null
+    val cumulativeWeight = segments.take(idx).sumOf { it.weight.toDouble() }.toFloat()
+    val chapterWeight = segments[idx].weight
+    return (cumulativeWeight + chapterWeight * progression) / totalWeight
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousModeUtils.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousModeUtils.kt
@@ -12,7 +12,8 @@ fun computeTotalProgression(
     progression: Float,
     segments: List<RailSegment>,
 ): Float? {
-    val idx = segments.indexOfFirst { it.href == href }
+    val hrefBase = href.substringBefore('#')
+    val idx = segments.indexOfFirst { it.href.substringBefore('#') == hrefBase }
     if (idx < 0) return null
     val totalWeight = segments.sumOf { it.weight.toDouble() }.toFloat()
     if (totalWeight == 0f) return null

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -252,6 +252,7 @@ fun EpubReaderScreen(
     val isCurrentPageBookmarked by viewModel.isCurrentPageBookmarked.collectAsState()
     val highlightRenders by viewModel.highlightRenders.collectAsState()
     val highlightToEdit by viewModel.highlightToEdit.collectAsState()
+    val railSegments by viewModel.railSegments.collectAsState()
     val readaloudAvailable by viewModel.readaloudAvailable.collectAsState()
     val readaloudVisible by viewModel.readaloudVisible.collectAsState()
     val readaloudOpen by viewModel.readaloudOpen.collectAsState()
@@ -339,6 +340,7 @@ fun EpubReaderScreen(
                     EpubNavigatorView(
                         state = s,
                         formattingPrefs = formattingPrefs,
+                        railSegments = railSegments,
                         onPositionChanged = { locator ->
                             if (!isSearchActive) immersiveState.dismissOverlay()
                             viewModel.onPositionChanged(locator)
@@ -966,6 +968,7 @@ internal fun readaloudLocatorJson(ref: String, quote: SentenceQuote?): JSONObjec
 private fun EpubNavigatorView(
     state: ReaderState.Ready,
     formattingPrefs: FormattingPreferences,
+    railSegments: List<RailSegment>,
     onPositionChanged: (Locator) -> Unit,
     onNavigationEvents: Flow<Link>,
     serverLocatorEvents: Flow<Locator>,
@@ -1044,6 +1047,10 @@ private fun EpubNavigatorView(
     // freshly loaded page re-applies the current value.
     val currentReadaloudReservePx by rememberUpdatedState(readaloudReservePx)
     val currentPublication by rememberUpdatedState(state.publication)
+    // rememberUpdatedState: railSegments arrives asynchronously (Readium computes positions after
+    // publication load). The AndroidView factory captures this reference so the continuous
+    // onPositionChanged lambda always reads the latest list.
+    val currentRailSegments by rememberUpdatedState(railSegments)
 
     // The text-selection action bar is fully owned by this callback (Readium 3.0.0's
     // selectionActionModeCallback is the only supported hook, and it replaces the WebView's default
@@ -2121,11 +2128,14 @@ private fun EpubNavigatorView(
                     ContinuousReaderView(ctx).also { view ->
                         continuousViewRef.value = view
                         view.onPositionChanged = { href, progression ->
+                            val totalProg = computeTotalProgression(href, progression, currentRailSegments)
+                            val locations = org.json.JSONObject().put("progression", progression.toDouble())
+                            if (totalProg != null) locations.put("totalProgression", totalProg.toDouble())
                             val locator = Locator.fromJSON(
                                 org.json.JSONObject()
                                     .put("href", href)
                                     .put("type", "application/xhtml+xml")
-                                    .put("locations", org.json.JSONObject().put("progression", progression.toDouble()))
+                                    .put("locations", locations)
                             )
                             if (locator != null) onPositionChanged(locator)
                         }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -1346,6 +1346,13 @@ private fun EpubNavigatorView(
         onDispose { FootnoteAnchorBridge.setHandler(null) }
     }
 
+    val goToContinuous: suspend (Locator) -> Unit = { locator ->
+        continuousViewRef.value?.navigateTo(
+            locator.href.toString(),
+            locator.locations.progression?.toFloat() ?: 0f,
+        )
+    }
+
     LaunchedEffect(onNavigationEvents, isContinuous) {
         onNavigationEvents.collect { link ->
             // In Continuous mode the Readium fragment is a server-keeper only (invisible,
@@ -1382,10 +1389,7 @@ private fun EpubNavigatorView(
             // Background position sync (peer/resume/audiobook handoff): in Continuous mode the
             // fragment is the invisible server-keeper, so route the jump to the continuous view.
             if (isContinuous) {
-                continuousViewRef.value?.navigateTo(
-                    locator.href.toString(),
-                    locator.locations.progression?.toFloat() ?: 0f,
-                )
+                goToContinuous(locator)
                 return@collect
             }
             // Paginated/scroll: navigate and snap onto the target's column, tracked through the new
@@ -1419,10 +1423,7 @@ private fun EpubNavigatorView(
     LaunchedEffect(returnNavEvents, isContinuous) {
         returnNavEvents.collect { locator ->
             if (isContinuous) {
-                continuousViewRef.value?.navigateTo(
-                    locator.href.toString(),
-                    locator.locations.progression?.toFloat() ?: 0f,
-                )
+                goToContinuous(locator)
             } else {
                 goAndSnapWithCover(locator)
             }
@@ -1447,10 +1448,7 @@ private fun EpubNavigatorView(
     LaunchedEffect(annotationNavigationEvents, isContinuous) {
         annotationNavigationEvents.collect { locator ->
             if (isContinuous) {
-                continuousViewRef.value?.navigateTo(
-                    locator.href.toString(),
-                    locator.locations.progression?.toFloat() ?: 0f,
-                )
+                goToContinuous(locator)
             } else {
                 goAndSnapWithCover(locator)
             }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -906,6 +906,16 @@ private const val NAV_COVER_SETTLE_MS = 250L
 private fun fragmentLocator(ref: String, quote: SentenceQuote? = null): Locator? =
     Locator.fromJSON(readaloudLocatorJson(ref, quote))
 
+private suspend fun DecorableNavigator.applyDecorationsWithClear(
+    decorations: List<Decoration>,
+    group: String,
+) {
+    withContext(Dispatchers.Main) {
+        applyDecorations(emptyList(), group = group)
+        applyDecorations(decorations, group = group)
+    }
+}
+
 /**
  * The narrated sentences (span id → text) to feed [resolveSelectionSentenceJs] for a "Play from here"
  * tap, scoped to the chapter being read ([currentHref]). The resolver locates a tapped sentence by
@@ -1535,10 +1545,7 @@ private fun EpubNavigatorView(
         for (settleDelayMs in longArrayOf(400L, 600L, 700L, 900L)) {
             delay(settleDelayMs)
             if (fragmentRef.value !== navFragment) break // navigated away / fragment recreated — newer effect owns it
-            withContext(Dispatchers.Main) {
-                fragment.applyDecorations(emptyList(), group = "search")
-                fragment.applyDecorations(decorations, group = "search")
-            }
+            fragment.applyDecorationsWithClear(decorations, group = "search")
         }
     }
 
@@ -1582,10 +1589,7 @@ private fun EpubNavigatorView(
         // empty apply runs the JS group's clear() (it removes the whole decoration container element),
         // so the subsequent apply always leaves exactly one highlight. The two calls execute back to
         // back on the main thread, so there is no visible gap on a normal sentence advance.
-        withContext(Dispatchers.Main) {
-            fragment.applyDecorations(emptyList(), group = "readaloud")
-            fragment.applyDecorations(listOf(decoration), group = "readaloud")
-        }
+        fragment.applyDecorationsWithClear(listOf(decoration), group = "readaloud")
         hasReadaloudDecoration.value = true
     }
 
@@ -1668,15 +1672,12 @@ private fun EpubNavigatorView(
                 ),
             )
         }
-        withContext(Dispatchers.Main) {
-            // Clear before re-applying so the Readium JS group starts from a clean slate.
-            // Without the clear, Kotlin-side diff can compute "no change" for a fragment whose
-            // JS state was reset on page load (e.g. on book re-entry), leaving decorations
-            // visually missing; a stale DOM element from a prior session can also add a ghost
-            // layer. Mirrors the search and readaloud groups' clear+reapply pattern.
-            fragment.applyDecorations(emptyList(), group = "annotations")
-            fragment.applyDecorations(decorations, group = "annotations")
-        }
+        // Clear before re-applying so the Readium JS group starts from a clean slate.
+        // Without the clear, Kotlin-side diff can compute "no change" for a fragment whose
+        // JS state was reset on page load (e.g. on book re-entry), leaving decorations
+        // visually missing; a stale DOM element from a prior session can also add a ghost
+        // layer. Mirrors the search and readaloud groups' clear+reapply pattern.
+        fragment.applyDecorationsWithClear(decorations, group = "annotations")
         hasHighlightDecorations.value = true
     }
 
@@ -1704,10 +1705,7 @@ private fun EpubNavigatorView(
                 style = NoteGlyphStyle(),
             )
         }
-        withContext(Dispatchers.Main) {
-            fragment.applyDecorations(emptyList(), group = "annotation-notes")
-            fragment.applyDecorations(noteDecorations, group = "annotation-notes")
-        }
+        fragment.applyDecorationsWithClear(noteDecorations, group = "annotation-notes")
         hasNoteDecorations.value = true
     }
 

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -2124,15 +2124,7 @@ private fun EpubNavigatorView(
                     ContinuousReaderView(ctx).also { view ->
                         continuousViewRef.value = view
                         view.onPositionChanged = { href, progression ->
-                            val totalProg = computeTotalProgression(href, progression, currentRailSegments)
-                            val locations = org.json.JSONObject().put("progression", progression.toDouble())
-                            if (totalProg != null) locations.put("totalProgression", totalProg.toDouble())
-                            val locator = Locator.fromJSON(
-                                org.json.JSONObject()
-                                    .put("href", href)
-                                    .put("type", "application/xhtml+xml")
-                                    .put("locations", locations)
-                            )
+                            val locator = buildContinuousLocator(href, progression, currentRailSegments)
                             if (locator != null) onPositionChanged(locator)
                         }
                         view.onTap = currentOnTap

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ComputeTotalProgressionTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ComputeTotalProgressionTest.kt
@@ -69,4 +69,16 @@ class ComputeTotalProgressionTest {
         val segments = listOf(seg("only.xhtml", 2f))
         assertEquals(0.5f, computeTotalProgression("only.xhtml", 0.5f, segments)!!, 0.001f)
     }
+
+    @Test
+    fun `matches segment whose href has fragment when caller passes bare path`() {
+        // TOC entries often store hrefs with #fragment (e.g. "ch1.xhtml#intro"),
+        // while ContinuousReaderView reports the spine href without fragment.
+        val segments = listOf(
+            RailSegment(title = "ch1", href = "ch1.xhtml#intro", weight = 1f),
+            RailSegment(title = "ch2", href = "ch2.xhtml#start", weight = 1f),
+        )
+        // bare "ch2.xhtml" should match "ch2.xhtml#start"
+        assertEquals(0.5f, computeTotalProgression("ch2.xhtml", 0f, segments)!!, 0.001f)
+    }
 }

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ComputeTotalProgressionTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ComputeTotalProgressionTest.kt
@@ -1,0 +1,72 @@
+package com.riffle.app.feature.reader
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class ComputeTotalProgressionTest {
+
+    private fun seg(href: String, weight: Float) = RailSegment(title = href, href = href, weight = weight)
+
+    @Test
+    fun `returns null for empty segments`() {
+        assertNull(computeTotalProgression("ch1.xhtml", 0.5f, emptyList()))
+    }
+
+    @Test
+    fun `returns null when href not in segments`() {
+        val segments = listOf(seg("ch1.xhtml", 1f), seg("ch2.xhtml", 1f))
+        assertNull(computeTotalProgression("ch3.xhtml", 0.5f, segments))
+    }
+
+    @Test
+    fun `returns null when total weight is zero`() {
+        val segments = listOf(seg("ch1.xhtml", 0f), seg("ch2.xhtml", 0f))
+        assertNull(computeTotalProgression("ch1.xhtml", 0.5f, segments))
+    }
+
+    @Test
+    fun `first chapter at start`() {
+        val segments = listOf(seg("ch1.xhtml", 1f), seg("ch2.xhtml", 1f))
+        assertEquals(0f, computeTotalProgression("ch1.xhtml", 0f, segments)!!, 0.001f)
+    }
+
+    @Test
+    fun `first chapter at end`() {
+        val segments = listOf(seg("ch1.xhtml", 1f), seg("ch2.xhtml", 1f))
+        assertEquals(0.5f, computeTotalProgression("ch1.xhtml", 1f, segments)!!, 0.001f)
+    }
+
+    @Test
+    fun `last chapter at start`() {
+        val segments = listOf(seg("ch1.xhtml", 1f), seg("ch2.xhtml", 1f))
+        assertEquals(0.5f, computeTotalProgression("ch2.xhtml", 0f, segments)!!, 0.001f)
+    }
+
+    @Test
+    fun `last chapter at end`() {
+        val segments = listOf(seg("ch1.xhtml", 1f), seg("ch2.xhtml", 1f))
+        assertEquals(1f, computeTotalProgression("ch2.xhtml", 1f, segments)!!, 0.001f)
+    }
+
+    @Test
+    fun `mid-chapter of three equal-weight chapters`() {
+        val segments = listOf(seg("a.xhtml", 1f), seg("b.xhtml", 1f), seg("c.xhtml", 1f))
+        // b at 50% → (1 + 1*0.5) / 3 = 0.5
+        assertEquals(0.5f, computeTotalProgression("b.xhtml", 0.5f, segments)!!, 0.001f)
+    }
+
+    @Test
+    fun `weighted chapters — heavy first chapter`() {
+        // ch1 weight=3, ch2 weight=1, total=4
+        // ch2 at 0% → cumulativeWeight=3, result = 3/4 = 0.75
+        val segments = listOf(seg("ch1.xhtml", 3f), seg("ch2.xhtml", 1f))
+        assertEquals(0.75f, computeTotalProgression("ch2.xhtml", 0f, segments)!!, 0.001f)
+    }
+
+    @Test
+    fun `single chapter at 50%`() {
+        val segments = listOf(seg("only.xhtml", 2f))
+        assertEquals(0.5f, computeTotalProgression("only.xhtml", 0.5f, segments)!!, 0.001f)
+    }
+}

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousModeLocatorTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousModeLocatorTest.kt
@@ -1,0 +1,142 @@
+package com.riffle.app.feature.reader
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Tests for the continuous-mode position-update chain that drives the chapter-map rail cursor
+ * and reading-time estimates.
+ *
+ * Paginated and vertical modes receive a fully-populated Locator (including totalProgression)
+ * from Readium automatically. Continuous mode must construct the equivalent JSON via
+ * buildContinuousLocatorJson. If totalProgression is absent, EpubReaderViewModel's
+ * _currentLocatorTotalProgression never updates, leaving the chapter map frozen at 0 and
+ * reading-time estimates blank — the regression this file guards.
+ *
+ * buildContinuousLocator (the Locator-parsing wrapper) is not tested here because Locator.fromJSON
+ * calls android.net.Uri which cannot be mocked in JVM tests; only the JSON it receives is ours.
+ */
+class ContinuousModeLocatorTest {
+
+    private fun seg(href: String, weight: Float) = RailSegment(title = href, href = href, weight = weight)
+
+    // ── JSON structure ───────────────────────────────────────────────────────
+
+    @Test
+    fun `json carries href`() {
+        val json = buildContinuousLocatorJson("Text/ch1.xhtml", 0.5f, emptyList())
+        assertEquals("Text/ch1.xhtml", json.getString("href"))
+    }
+
+    @Test
+    fun `json always carries within-chapter progression`() {
+        val json = buildContinuousLocatorJson("ch1.xhtml", 0.75f, emptyList())
+        assertEquals(0.75, json.getJSONObject("locations").getDouble("progression"), 0.001)
+    }
+
+    // ── totalProgression: drives both chapter map and time estimates ─────────
+
+    @Test
+    fun `totalProgression present when segments match — chapter map and time estimates update`() {
+        val segments = listOf(seg("ch1.xhtml", 1f), seg("ch2.xhtml", 1f))
+        val json = buildContinuousLocatorJson("ch2.xhtml", 0f, segments)
+        val locations = json.getJSONObject("locations")
+        assertTrue("totalProgression must be present so railCursorPosition and time estimates update",
+            locations.has("totalProgression"))
+        // ch2 at 0 % = 50 % through book (two equal-weight chapters)
+        assertEquals(0.5, locations.getDouble("totalProgression"), 0.001)
+    }
+
+    @Test
+    fun `totalProgression absent when segments are empty (positions not yet computed)`() {
+        // Readium hasn't computed position counts yet — segments arrive later via StateFlow.
+        // The JSON is still valid for href/progression; totalProgression arrives on the next
+        // position update once segments populate.
+        val json = buildContinuousLocatorJson("ch1.xhtml", 0.5f, emptyList())
+        assertFalse("totalProgression must be absent when segments are empty",
+            json.getJSONObject("locations").has("totalProgression"))
+    }
+
+    @Test
+    fun `totalProgression absent when href matches no segment`() {
+        val segments = listOf(seg("ch1.xhtml", 1f))
+        val json = buildContinuousLocatorJson("front-matter.xhtml", 0.5f, segments)
+        assertFalse(json.getJSONObject("locations").has("totalProgression"))
+    }
+
+    @Test
+    fun `TOC fragment href in segment matches bare spine href from continuous reader`() {
+        // TOC-derived segments often store hrefs with #fragment (e.g. "ch2.xhtml#section1"),
+        // while ContinuousReaderView reports the spine resource without fragment.
+        // This was the original root cause: exact matching always returned null.
+        val segments = listOf(
+            RailSegment(title = "ch1", href = "ch1.xhtml#intro", weight = 1f),
+            RailSegment(title = "ch2", href = "ch2.xhtml#start", weight = 3f),
+        )
+        val json = buildContinuousLocatorJson("ch2.xhtml", 0f, segments)
+        val locations = json.getJSONObject("locations")
+        assertTrue("fragment-bearing segment must match bare spine href",
+            locations.has("totalProgression"))
+        // ch2 starts at cumulativeWeight(1) / total(4) = 0.25
+        assertEquals(0.25, locations.getDouble("totalProgression"), 0.001)
+    }
+
+    @Test
+    fun `totalProgression at book start is 0`() {
+        val segments = listOf(seg("ch1.xhtml", 10f), seg("ch2.xhtml", 30f), seg("ch3.xhtml", 60f))
+        val json = buildContinuousLocatorJson("ch1.xhtml", 0f, segments)
+        assertEquals(0.0, json.getJSONObject("locations").getDouble("totalProgression"), 0.001)
+    }
+
+    @Test
+    fun `totalProgression at book end is 1`() {
+        val segments = listOf(seg("ch1.xhtml", 10f), seg("ch2.xhtml", 30f), seg("ch3.xhtml", 60f))
+        val json = buildContinuousLocatorJson("ch3.xhtml", 1f, segments)
+        assertEquals(1.0, json.getJSONObject("locations").getDouble("totalProgression"), 0.001)
+    }
+
+    // ── Chapter-map cursor position driven by totalProgression ───────────────
+    //
+    // EpubReaderViewModel.railCursorPosition combines activeRailSegmentIndex, railSegments, and
+    // currentLocatorTotalProgression. The ViewModel can't be constructed in JVM tests (Readium
+    // needs android.net.Uri), so we verify the math chain:
+    //   buildContinuousLocatorJson → totalProgression → weightedRailCursorPosition
+    //
+    // weightedRailCursorPosition is already covered by RailSegmentGeneratorTest. These tests
+    // verify that continuous-mode positions produce the totalProgression that lands the cursor
+    // inside the correct segment's bounds.
+
+    @Test
+    fun `chapter-map cursor lands inside the active segment when reader is in continuous mode`() {
+        val segments = listOf(
+            RailSegment("A", "a.xhtml", 10f),
+            RailSegment("B", "b.xhtml", 30f),
+            RailSegment("C", "c.xhtml", 60f),
+        )
+        val totalProg = buildContinuousLocatorJson("b.xhtml", 0.5f, segments)
+            .getJSONObject("locations").getDouble("totalProgression").toFloat()
+
+        // totalProg = (10 + 30*0.5) / 100 = 25/100 = 0.25
+        assertEquals(0.25f, totalProg, 0.001f)
+
+        // Compute the rail cursor the same way EpubReaderViewModel.railCursorPosition does.
+        val totalWeight = 100f
+        val weightBefore = 10f   // weight of A
+        val segWeight = 30f      // weight of B
+        val withinSeg = ((totalProg * totalWeight - weightBefore) / segWeight).coerceIn(0f, 1f)
+        val cursor = weightedRailCursorPosition(1, segments, withinSeg)
+
+        // B covers [10/100, 40/100] = [0.1, 0.4]. At 50 % through B the cursor sits at 0.25.
+        assertEquals(0.25f, cursor, 0.001f)
+    }
+
+    @Test
+    fun `chapter-map cursor is 0 when no segments available (initial state, not a freeze)`() {
+        // No segments → no totalProgression → railCursorPosition returns 0f by ViewModel contract.
+        val json = buildContinuousLocatorJson("ch1.xhtml", 0.9f, emptyList())
+        assertFalse("no totalProgression means railCursorPosition resets to 0 — expected initial state",
+            json.getJSONObject("locations").has("totalProgression"))
+    }
+}

--- a/docs/superpowers/plans/2026-06-19-continuous-mode-reading-estimates.md
+++ b/docs/superpowers/plans/2026-06-19-continuous-mode-reading-estimates.md
@@ -1,0 +1,509 @@
+# Continuous Mode Reading Estimates Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix reading time estimates and the chapter-map rail cursor not updating in continuous scroll mode, add a CLAUDE.md guideline for three-mode awareness, and extract three repeated code patterns.
+
+**Architecture:** A pure `computeTotalProgression()` function converts `(href, withinChapterProgression, railSegments)` into a book-wide 0–1 fraction using the same weights the rail already draws from. It is called from the continuous `onPositionChanged` lambda in `EpubReaderScreen.kt`, which gains a `rememberUpdatedState` capture for `railSegments` so the lambda never reads a stale list. The ViewModel receives a complete `Locator` and needs no changes.
+
+**Tech Stack:** Kotlin, Jetpack Compose, Readium SDK (`Locator`, `DecorableNavigator`), JUnit 4
+
+## Global Constraints
+
+- Never call `./gradlew :app:connectedDebugAndroidTest` directly — use `make harness-test` for device tests.
+- Run JVM tests with `./gradlew test` (not `:testDebugUnitTest`).
+- `export JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"` before every Gradle invocation.
+- Do not push to remote without explicit user permission.
+- No `Co-Authored-By: Claude` trailers in commits.
+
+---
+
+### Task 1: `computeTotalProgression` — pure function + unit tests
+
+**Files:**
+- Create: `app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousModeUtils.kt`
+- Create: `app/src/test/kotlin/com/riffle/app/feature/reader/ComputeTotalProgressionTest.kt`
+
+**Interfaces:**
+- Produces: `fun computeTotalProgression(href: String, progression: Float, segments: List<RailSegment>): Float?`
+  - Returns `null` when `segments` is empty, total weight is 0, or `href` is not found in segments.
+  - Returns a value in `[0f, 1f]` otherwise.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `app/src/test/kotlin/com/riffle/app/feature/reader/ComputeTotalProgressionTest.kt`:
+
+```kotlin
+package com.riffle.app.feature.reader
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class ComputeTotalProgressionTest {
+
+    private fun seg(href: String, weight: Float) = RailSegment(title = href, href = href, weight = weight)
+
+    @Test
+    fun `returns null for empty segments`() {
+        assertNull(computeTotalProgression("ch1.xhtml", 0.5f, emptyList()))
+    }
+
+    @Test
+    fun `returns null when href not in segments`() {
+        val segments = listOf(seg("ch1.xhtml", 1f), seg("ch2.xhtml", 1f))
+        assertNull(computeTotalProgression("ch3.xhtml", 0.5f, segments))
+    }
+
+    @Test
+    fun `returns null when total weight is zero`() {
+        val segments = listOf(seg("ch1.xhtml", 0f), seg("ch2.xhtml", 0f))
+        assertNull(computeTotalProgression("ch1.xhtml", 0.5f, segments))
+    }
+
+    @Test
+    fun `first chapter at start`() {
+        val segments = listOf(seg("ch1.xhtml", 1f), seg("ch2.xhtml", 1f))
+        assertEquals(0f, computeTotalProgression("ch1.xhtml", 0f, segments)!!, 0.001f)
+    }
+
+    @Test
+    fun `first chapter at end`() {
+        val segments = listOf(seg("ch1.xhtml", 1f), seg("ch2.xhtml", 1f))
+        assertEquals(0.5f, computeTotalProgression("ch1.xhtml", 1f, segments)!!, 0.001f)
+    }
+
+    @Test
+    fun `last chapter at start`() {
+        val segments = listOf(seg("ch1.xhtml", 1f), seg("ch2.xhtml", 1f))
+        assertEquals(0.5f, computeTotalProgression("ch2.xhtml", 0f, segments)!!, 0.001f)
+    }
+
+    @Test
+    fun `last chapter at end`() {
+        val segments = listOf(seg("ch1.xhtml", 1f), seg("ch2.xhtml", 1f))
+        assertEquals(1f, computeTotalProgression("ch2.xhtml", 1f, segments)!!, 0.001f)
+    }
+
+    @Test
+    fun `mid-chapter of three equal-weight chapters`() {
+        val segments = listOf(seg("a.xhtml", 1f), seg("b.xhtml", 1f), seg("c.xhtml", 1f))
+        // b at 50% → (1 + 1*0.5) / 3 = 0.5
+        assertEquals(0.5f, computeTotalProgression("b.xhtml", 0.5f, segments)!!, 0.001f)
+    }
+
+    @Test
+    fun `weighted chapters — heavy first chapter`() {
+        // ch1 weight=3, ch2 weight=1, total=4
+        // ch2 at 0% → cumulativeWeight=3, result = 3/4 = 0.75
+        val segments = listOf(seg("ch1.xhtml", 3f), seg("ch2.xhtml", 1f))
+        assertEquals(0.75f, computeTotalProgression("ch2.xhtml", 0f, segments)!!, 0.001f)
+    }
+
+    @Test
+    fun `single chapter at 50%`() {
+        val segments = listOf(seg("only.xhtml", 2f))
+        assertEquals(0.5f, computeTotalProgression("only.xhtml", 0.5f, segments)!!, 0.001f)
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+export JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"
+./gradlew :app:test --tests "com.riffle.app.feature.reader.ComputeTotalProgressionTest" 2>&1 | tail -20
+```
+
+Expected: compilation failure — `computeTotalProgression` not defined.
+
+- [ ] **Step 3: Implement `computeTotalProgression`**
+
+Create `app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousModeUtils.kt`:
+
+```kotlin
+package com.riffle.app.feature.reader
+
+/**
+ * Computes a book-wide [0, 1] progression for continuous scroll mode using the same
+ * per-chapter weights the chapter rail draws from (derived from Readium position counts).
+ *
+ * Returns null when [segments] is empty, total weight is zero, or [href] has no matching
+ * segment.
+ */
+fun computeTotalProgression(
+    href: String,
+    progression: Float,
+    segments: List<RailSegment>,
+): Float? {
+    val idx = segments.indexOfFirst { it.href == href }
+    if (idx < 0) return null
+    val totalWeight = segments.sumOf { it.weight.toDouble() }.toFloat()
+    if (totalWeight == 0f) return null
+    val cumulativeWeight = segments.take(idx).sumOf { it.weight.toDouble() }.toFloat()
+    val chapterWeight = segments[idx].weight
+    return (cumulativeWeight + chapterWeight * progression) / totalWeight
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+export JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"
+./gradlew :app:test --tests "com.riffle.app.feature.reader.ComputeTotalProgressionTest" 2>&1 | tail -20
+```
+
+Expected: `BUILD SUCCESSFUL`, all 9 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousModeUtils.kt \
+        app/src/test/kotlin/com/riffle/app/feature/reader/ComputeTotalProgressionTest.kt
+git commit -m "feat(reader): computeTotalProgression for continuous mode"
+```
+
+---
+
+### Task 2: Wire `totalProgression` into the continuous `onPositionChanged` lambda
+
+**Files:**
+- Modify: `app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt`
+
+**Interfaces:**
+- Consumes: `computeTotalProgression(href, progression, segments)` from Task 1.
+- The continuous `onPositionChanged` lambda (line 2132) gains a `totalProgression` field in the `Locator` JSON it constructs.
+
+- [ ] **Step 1: Add `rememberUpdatedState` for `railSegments`**
+
+`railSegments` is collected at line 671:
+```kotlin
+val railSegments by viewModel.railSegments.collectAsState()
+```
+
+This is in the outer `EpubReaderBody` composable scope — the `AndroidView` factory captures values at creation time, so the lambda could read a stale empty list before positions load. Add a `rememberUpdatedState` capture alongside the other `currentXxx` vals (around line 1054):
+
+```kotlin
+val currentRailSegments by rememberUpdatedState(railSegments)
+```
+
+- [ ] **Step 2: Update the continuous `onPositionChanged` lambda**
+
+Find the factory block starting at line 2132. Replace:
+
+```kotlin
+view.onPositionChanged = { href, progression ->
+    val locator = Locator.fromJSON(
+        org.json.JSONObject()
+            .put("href", href)
+            .put("type", "application/xhtml+xml")
+            .put("locations", org.json.JSONObject().put("progression", progression.toDouble()))
+    )
+    if (locator != null) onPositionChanged(locator)
+}
+```
+
+With:
+
+```kotlin
+view.onPositionChanged = { href, progression ->
+    val totalProg = computeTotalProgression(href, progression, currentRailSegments)
+    val locations = org.json.JSONObject().put("progression", progression.toDouble())
+    if (totalProg != null) locations.put("totalProgression", totalProg.toDouble())
+    val locator = Locator.fromJSON(
+        org.json.JSONObject()
+            .put("href", href)
+            .put("type", "application/xhtml+xml")
+            .put("locations", locations)
+    )
+    if (locator != null) onPositionChanged(locator)
+}
+```
+
+- [ ] **Step 3: Build to confirm no compilation errors**
+
+```bash
+export JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"
+./gradlew :app:assembleDebug 2>&1 | tail -20
+```
+
+Expected: `BUILD SUCCESSFUL`.
+
+- [ ] **Step 4: Run full JVM test suite to confirm no regressions**
+
+```bash
+export JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"
+./gradlew test 2>&1 | tail -30
+```
+
+Expected: `BUILD SUCCESSFUL`, no new failures.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+git commit -m "fix(reader): compute totalProgression in continuous mode position callback"
+```
+
+---
+
+### Task 3: Add CLAUDE.md reader mode guideline
+
+**Files:**
+- Modify: `CLAUDE.md`
+
+- [ ] **Step 1: Append the guideline**
+
+Add the following section to the end of `CLAUDE.md`:
+
+```markdown
+## Reader mode changes
+
+The reader has three modes: paginated, vertical, and continuous.
+
+Paginated and vertical both use Readium's EpubNavigatorFragment (scroll=false vs
+scroll=true). Readium drives navigation, emits position updates, and populates Locator
+fields automatically.
+
+Continuous uses a custom ContinuousReaderView with a fully manual position pipeline.
+Anything Readium provides for free to paginated/vertical must be explicitly computed
+and threaded through the continuous onPositionChanged lambda in EpubReaderScreen.kt.
+
+Any change that touches the reader — position tracking, navigation events, new ViewModel
+state, UI driven by the current locator — must be verified to work in all three modes,
+with particular attention to continuous: if paginated/vertical get something from Readium,
+ask whether continuous needs to compute an equivalent.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs(reader): add three-mode awareness guideline to CLAUDE.md"
+```
+
+---
+
+### Task 4: Extract `goToContinuousLocator` helper
+
+**Files:**
+- Modify: `app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt`
+
+The block:
+```kotlin
+continuousViewRef.value?.navigateTo(
+    locator.href.toString(),
+    locator.locations.progression?.toFloat() ?: 0f,
+)
+return@collect
+```
+appears verbatim in three `LaunchedEffect` blocks: `serverLocatorEvents` (line 1387), `returnNavEvents` (line 1424), and `annotationNavigationEvents` (line 1452).
+
+**Interfaces:**
+- Produces local lambda: `val goToContinuous: suspend (Locator) -> Unit`  
+  Navigates the continuous view to the locator if the view reference is non-null. Keeping it as a local lambda gives access to `continuousViewRef` without threading it as a parameter.
+
+- [ ] **Step 1: Define the helper lambda**
+
+Add directly below the `goAndSnapWithCover` lambda (around line 1419):
+
+```kotlin
+val goToContinuous: suspend (Locator) -> Unit = { locator ->
+    continuousViewRef.value?.navigateTo(
+        locator.href.toString(),
+        locator.locations.progression?.toFloat() ?: 0f,
+    )
+}
+```
+
+- [ ] **Step 2: Replace all three occurrences**
+
+**`serverLocatorEvents` (around line 1386):**
+
+Replace:
+```kotlin
+if (isContinuous) {
+    continuousViewRef.value?.navigateTo(
+        locator.href.toString(),
+        locator.locations.progression?.toFloat() ?: 0f,
+    )
+    return@collect
+}
+```
+With:
+```kotlin
+if (isContinuous) {
+    goToContinuous(locator)
+    return@collect
+}
+```
+
+**`returnNavEvents` (around line 1423):**
+
+Replace:
+```kotlin
+if (isContinuous) {
+    continuousViewRef.value?.navigateTo(
+        locator.href.toString(),
+        locator.locations.progression?.toFloat() ?: 0f,
+    )
+} else {
+```
+With:
+```kotlin
+if (isContinuous) {
+    goToContinuous(locator)
+} else {
+```
+
+**`annotationNavigationEvents` (around line 1451):**
+
+Replace:
+```kotlin
+if (isContinuous) {
+    continuousViewRef.value?.navigateTo(
+        locator.href.toString(),
+        locator.locations.progression?.toFloat() ?: 0f,
+    )
+} else {
+```
+With:
+```kotlin
+if (isContinuous) {
+    goToContinuous(locator)
+} else {
+```
+
+- [ ] **Step 3: Build and test**
+
+```bash
+export JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"
+./gradlew :app:assembleDebug 2>&1 | tail -10
+./gradlew test 2>&1 | tail -20
+```
+
+Expected: `BUILD SUCCESSFUL` for both, no new failures.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+git commit -m "refactor(reader): extract goToContinuous helper for repeated continuous nav pattern"
+```
+
+---
+
+### Task 5: Extract `applyDecorationsWithClear` helper
+
+**Files:**
+- Modify: `app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt`
+
+The pattern:
+```kotlin
+withContext(Dispatchers.Main) {
+    fragment.applyDecorations(emptyList(), group = "<group>")
+    fragment.applyDecorations(<list>, group = "<group>")
+}
+```
+appears in four places:
+- Lines 1543–1544 (search, inside a loop)
+- Lines 1590–1591 (readaloud, single decoration)
+- Lines 1675–1682 (annotations)
+- Lines 1711–1713 (annotation-notes)
+
+**Interfaces:**
+- Produces top-level private suspend extension on `DecorableNavigator`:
+  `private suspend fun DecorableNavigator.applyDecorationsWithClear(decorations: List<Decoration>, group: String)`
+
+- [ ] **Step 1: Add the helper**
+
+Add as a private top-level function near the top of the file, alongside other private helpers (search for `private fun` or `private suspend fun` in `EpubReaderScreen.kt` to find a suitable location):
+
+```kotlin
+private suspend fun DecorableNavigator.applyDecorationsWithClear(
+    decorations: List<Decoration>,
+    group: String,
+) {
+    withContext(Dispatchers.Main) {
+        applyDecorations(emptyList(), group = group)
+        applyDecorations(decorations, group = group)
+    }
+}
+```
+
+- [ ] **Step 2: Replace all four occurrences**
+
+**Search effect — inside the settle loop (around line 1542):**
+
+Replace:
+```kotlin
+withContext(Dispatchers.Main) {
+    fragment.applyDecorations(emptyList(), group = "search")
+    fragment.applyDecorations(decorations, group = "search")
+}
+```
+With:
+```kotlin
+fragment.applyDecorationsWithClear(decorations, group = "search")
+```
+
+**Readaloud effect (around line 1590):**
+
+Replace:
+```kotlin
+withContext(Dispatchers.Main) {
+    fragment.applyDecorations(emptyList(), group = "readaloud")
+    fragment.applyDecorations(listOf(decoration), group = "readaloud")
+}
+```
+With:
+```kotlin
+fragment.applyDecorationsWithClear(listOf(decoration), group = "readaloud")
+```
+
+**Annotations effect (around line 1681):**
+
+Replace:
+```kotlin
+withContext(Dispatchers.Main) {
+    fragment.applyDecorations(emptyList(), group = "annotations")
+    fragment.applyDecorations(decorations, group = "annotations")
+}
+```
+With:
+```kotlin
+fragment.applyDecorationsWithClear(decorations, group = "annotations")
+```
+
+**Annotation-notes effect (around line 1711):**
+
+Replace:
+```kotlin
+withContext(Dispatchers.Main) {
+    fragment.applyDecorations(emptyList(), group = "annotation-notes")
+    fragment.applyDecorations(noteDecorations, group = "annotation-notes")
+}
+```
+With:
+```kotlin
+fragment.applyDecorationsWithClear(noteDecorations, group = "annotation-notes")
+```
+
+Note: the initial single-apply calls (lines 1525–1526 for search, 1564–1565 for readaloud clear-only) are NOT the clear+reapply pattern — leave those unchanged.
+
+- [ ] **Step 3: Build and test**
+
+```bash
+export JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"
+./gradlew :app:assembleDebug 2>&1 | tail -10
+./gradlew test 2>&1 | tail -20
+```
+
+Expected: `BUILD SUCCESSFUL` for both, no new failures.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+git commit -m "refactor(reader): extract applyDecorationsWithClear extension for repeated pattern"
+```

--- a/docs/superpowers/specs/2026-06-19-continuous-mode-reading-estimates-design.md
+++ b/docs/superpowers/specs/2026-06-19-continuous-mode-reading-estimates-design.md
@@ -1,0 +1,186 @@
+# Continuous Mode: Reading Estimates & Chapter Map Fix
+
+**Date:** 2026-06-19  
+**Branch:** pkmetski/surat-v1
+
+## Problem
+
+Reading time estimates and the chapter map rail cursor are not updated in continuous scroll
+mode. They work correctly in paginated and vertical modes.
+
+**Root cause:** Paginated and vertical modes use Readium's `EpubNavigatorFragment`, which
+emits `Locator` objects that include `totalProgression` (a book-wide 0.0–1.0 fraction).
+Continuous mode uses a custom `ContinuousReaderView` whose `onPositionChanged` callback
+only reports `(href, withinChapterProgression)` — `totalProgression` is never computed
+or included in the `Locator` passed to the ViewModel.
+
+`chapterTimeRemaining`, `bookTimeRemaining`, and `railCursorPosition` all return null /
+degenerate when `totalProgression` is absent.
+
+## Architecture context
+
+Three reading modes:
+
+| Mode       | Navigator                        | `totalProgression` source |
+|------------|----------------------------------|---------------------------|
+| Paginated  | Readium `EpubNavigatorFragment` (scroll=false) | Readium — automatic |
+| Vertical   | Readium `EpubNavigatorFragment` (scroll=true)  | Readium — automatic |
+| Continuous | Custom `ContinuousReaderView`    | **Missing — this fix**   |
+
+The ViewModel (`EpubReaderViewModel`) is mode-agnostic: it receives a `Locator` and reads
+`locator.locations.totalProgression`. It does not need to change.
+
+The adaptation boundary is `EpubReaderScreen.kt`, which already branches per-mode to wire
+up position callbacks.
+
+## Section 1 — Fix: compute `totalProgression` for continuous mode
+
+### Where
+
+In `EpubReaderScreen.kt`, inside the continuous-mode `onPositionChanged` lambda
+(currently around line 2132). This is the only place that constructs a `Locator` from raw
+`(href, progression)` values before forwarding to the ViewModel.
+
+### How
+
+Extract a pure function:
+
+```kotlin
+fun computeTotalProgression(
+    href: String,
+    progression: Float,
+    segments: List<RailSegment>,
+): Float? {
+    val idx = segments.indexOfFirst { it.href == href }
+    if (idx < 0) return null
+    val totalWeight = segments.sumOf { it.weight.toDouble() }.toFloat()
+    if (totalWeight == 0f) return null
+    val cumulativeWeight = segments.take(idx).sumOf { it.weight.toDouble() }.toFloat()
+    val chapterWeight = segments[idx].weight
+    return (cumulativeWeight + chapterWeight * progression) / totalWeight
+}
+```
+
+Use it in the lambda:
+
+```kotlin
+view.onPositionChanged = { href, progression ->
+    val totalProgression = computeTotalProgression(href, progression, railSegments)
+    val locator = Locator.fromJSON(
+        JSONObject()
+            .put("href", href)
+            .put("type", "application/xhtml+xml")
+            .put("locations", JSONObject()
+                .put("progression", progression.toDouble())
+                .apply { totalProgression?.let { put("totalProgression", it.toDouble()) } })
+    )
+    if (locator != null) onPositionChanged(locator)
+}
+```
+
+`railSegments` is a `StateFlow` whose values arrive asynchronously as Readium computes
+positions after publication load. The `onPositionChanged` callback is set inside
+`AndroidView`'s `factory` lambda, which runs once and captures values at creation time.
+To avoid a stale capture, use `rememberUpdatedState(railSegments)` in the composable so
+the lambda always reads the latest segment list:
+
+```kotlin
+val currentSegments by rememberUpdatedState(railSegments)
+// ... inside AndroidView factory:
+view.onPositionChanged = { href, progression ->
+    val totalProgression = computeTotalProgression(href, progression, currentSegments)
+    ...
+}
+```
+
+`computeTotalProgression` is a pure function with no side effects, so it is unit
+testable without any Android dependencies.
+
+The ViewModel receives a complete `Locator` and needs no changes. Paginated and vertical
+modes are unaffected (they never enter this lambda).
+
+### Accuracy
+
+`RailSegment.weight` values are derived from `publication.positionsByReadingOrder()` —
+the same position-count data Readium uses internally for its own `totalProgression`
+calculation. The continuous mode result will be consistent with how the chapter rail is
+drawn.
+
+## Section 2 — CLAUDE.md guideline
+
+Add to `CLAUDE.md`:
+
+```markdown
+## Reader mode changes
+
+The reader has three modes: paginated, vertical, and continuous.
+
+Paginated and vertical both use Readium's EpubNavigatorFragment (scroll=false vs
+scroll=true). Readium drives navigation, emits position updates, and populates Locator
+fields automatically.
+
+Continuous uses a custom ContinuousReaderView with a fully manual position pipeline.
+Anything Readium provides for free to paginated/vertical must be explicitly computed
+and threaded through the continuous onPositionChanged lambda in EpubReaderScreen.kt.
+
+Any change that touches the reader — position tracking, navigation events, new ViewModel
+state, UI driven by the current locator — must be verified to work in all three modes,
+with particular attention to continuous: if paginated/vertical get something from Readium,
+ask whether continuous needs to compute an equivalent.
+```
+
+## Section 3 — Code reuse
+
+Three mechanical extractions, all in `EpubReaderScreen.kt`:
+
+### 3a. `computeTotalProgression()` (new — part of the fix)
+
+Pure function described above. Lives as a top-level function alongside other reader
+utilities, or as a companion/object function where `RailSegment` is defined.
+
+### 3b. `goToContinuousLocator(view, locator)` (extraction)
+
+The following block appears verbatim in 5 separate `LaunchedEffect` blocks
+(`onNavigationEvents`, `serverLocatorEvents`, `returnNavEvents`,
+`searchNavigationEvents`, `annotationNavigationEvents`):
+
+```kotlin
+val view = continuousViewRef.value ?: return@collect
+view.navigateTo(
+    locator.href.toString(),
+    locator.locations.progression?.toFloat() ?: 0f,
+)
+return@collect
+```
+
+Extract to a local helper; replace all 5 occurrences.
+
+### 3c. `applyDecorationsWithClear(fragment, decorations, group)` (extraction)
+
+The clear-then-reapply pattern for Readium decorations appears 4+ times:
+
+```kotlin
+withContext(Dispatchers.Main) {
+    fragment.applyDecorations(emptyList(), group = "X")
+    fragment.applyDecorations(decorations, group = "X")
+}
+```
+
+Extract to a one-liner helper; replace all occurrences.
+
+## Out of scope
+
+- Unifying the Flow (paginated) vs callback (continuous) position-tracking idioms — higher
+  risk, no behaviour change, separate refactor.
+- JS boundary evaluation deduplication — touches volume key handling, separate concern.
+- Pixel-based `totalProgression` from `ContinuousPositionTracker` scroll heights — the
+  sliding window only holds ~3 chapters so accuracy would be worse than the weight-based
+  approach for out-of-window chapters.
+
+## Testing
+
+- `computeTotalProgression()`: unit tests covering first chapter, last chapter, mid-chapter,
+  href not found, empty segments, zero total weight.
+- Manual verification in continuous mode: chapter map cursor moves as you scroll, time
+  estimates update, switching between modes preserves the last known position.
+- Paginated and vertical modes: regression check that estimates and rail are unchanged.


### PR DESCRIPTION
## Summary

- **Root cause**: `ContinuousReaderView.onPositionChanged` only emitted `(href, withinChapterProgression)`. The ViewModel's chapter-map cursor (`railCursorPosition`) and reading-time estimates both require `totalProgression` (a book-wide 0–1 fraction), which Readium supplies automatically for paginated/vertical modes but had to be derived manually for continuous mode. `totalProgression` was never computed → both features were silently frozen.
- **Second cause**: The initial `computeTotalProgression` used exact href matching; TOC-derived `RailSegment.href` values often carry `#fragment` suffixes (`ch1.xhtml#intro`) while `ContinuousReaderView` reports bare spine hrefs (`ch1.xhtml`). Every lookup returned null. Fixed with `substringBefore('#')` matching, mirroring the existing `findActiveSegmentIndex` approach.
- **New `ContinuousModeUtils.kt`**: `computeTotalProgression`, `buildContinuousLocatorJson`, `buildContinuousLocator` — all pure functions, fully unit-tested.
- **Code reuse** (also requested): extracted `goToContinuous` helper (3 identical continuous-navigate blocks → 1) and `applyDecorationsWithClear` extension (4 identical clear+reapply blocks → 1).
- **CLAUDE.md**: Added three-mode awareness guideline so future reader changes don't re-introduce the same gap.

## What was tested

- `ComputeTotalProgressionTest` — 10 unit tests: boundaries, weights, fragment-href matching
- `ContinuousModeLocatorTest` — 11 unit tests: JSON structure, `totalProgression` presence/absence, the `#fragment` regression, end-to-end cursor-chain math (`buildContinuousLocatorJson → totalProgression → weightedRailCursorPosition`)
- `./gradlew test` — full JVM suite green
- `./gradlew lint` — clean