### PR TITLE
fix(reader): continuous play-from-here picks the selected sentence by geometry, not text match

### DIFF
--- a/app/src/androidTest/kotlin/com/riffle/app/feature/reader/ReaderWebViewScriptsTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/reader/ReaderWebViewScriptsTest.kt
@@ -297,6 +297,37 @@ class ReaderWebViewScriptsTest {
         }
     }
 
+    // ---- Continuous mode (tall document) ----
+    //
+    // In ContinuousReaderView each ChapterWebView is auto-sized to its content height, so
+    // window.innerHeight equals the chapter's full rendered height — potentially much larger than
+    // the visible viewport. Every sentence therefore passes the on-screen filter
+    // (r.top < window.innerHeight) and all are candidates. The resolver must still pick the sentence
+    // at the SELECTION POSITION, not the first occurrence in reading order.
+    //
+    // These tests verify that heightPx >> content height (the continuous mode shape) does not
+    // break position-based disambiguation. Reuses strippedFixture (its recurring "cat" word) with a
+    // 3000 device-px WebView — far taller than the few-line content, just as a chapter WebView is
+    // far taller than a typical screen in continuous mode.
+
+    @Test
+    fun resolveSelectionPicksCorrectSentenceInContinuousModeWhereAllSentencesPassTheOnScreenFilter() {
+        withSizedWebViewFixture(strippedFixture, widthPx = 1080, heightPx = 3000) { webView ->
+            webView.awaitInnerHeight()
+            webView.evalSync(SELECTION_SPAN_TRACKER_JS)
+            // "cat" occurs in s0, s1, s2. Text matching would always return s0 (first occurrence).
+            // With a 3000-device-px-tall WebView (all sentences well within window.innerHeight),
+            // geometry must still resolve to the sentence at the actual selection position.
+            webView.selectNthOccurrence("cat", 3)
+            assertTrue("tracker must stash a rect in a tall continuous-mode WebView", webView.awaitSelRect())
+            assertEquals(
+                "geometry resolves to the selected sentence when window.innerHeight exceeds content height",
+                "c1-s2",
+                webView.evalSync(resolveSelectionSentenceJs(strippedSentences)).trim('"'),
+            )
+        }
+    }
+
     // ---- helpers ----
 
     // Selects the [n]-th occurrence (1-based, document order) of [word], driving a real selection so the

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ChapterWebView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ChapterWebView.kt
@@ -113,10 +113,10 @@ internal class ChapterWebView(context: Context) : WebView(context) {
     var readaloudAvailable: Boolean = false
 
     /**
-     * Called on the main thread with the selected text when the user taps "Play".
-     * The host resolves it to a narrated sentence and starts playback there.
+     * Called on the main thread when the user taps "Play". Receives the selected text and this
+     * WebView's [evaluateJavascript] so the host can run geometry-based sentence resolution.
      */
-    var onPlayFromHere: ((selectedText: String) -> Unit)? = null
+    var onPlayFromHere: ((selectedText: String, evalJs: (String, (String?) -> Unit) -> Unit) -> Unit)? = null
 
     /** The chapter href this view is currently loading (e.g. `"EPUB/chapter01.xhtml"`). */
     var chapterHref: String = ""
@@ -383,7 +383,9 @@ internal class ChapterWebView(context: Context) : WebView(context) {
                     MENU_HIGHLIGHT -> withSelectionTextAndProgression { text, prog, rect -> onHighlight?.invoke(text, prog, rect) }
                     MENU_SEARCH -> withSelectionText { webSearch(it) }
                     MENU_SHARE -> withSelectionText { shareText(it) }
-                    MENU_PLAY -> withSelectionText { onPlayFromHere?.invoke(it) }
+                    MENU_PLAY -> withSelectionText { text ->
+                        onPlayFromHere?.invoke(text) { js, cb -> evaluateJavascript(js, cb) }
+                    }
                     else -> return inner.onActionItemClicked(mode, item)
                 }
                 mode.finish()

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
@@ -103,10 +103,11 @@ internal class ContinuousReaderView @JvmOverloads constructor(
         }
 
     /**
-     * Called on the main thread with (chapter href, selected text) when the user taps "Play".
-     * The host resolves the selection to a narrated sentence and starts playback.
+     * Called on the main thread with (chapter href, selected text, evalJs) when the user taps
+     * "Play". [evalJs] is the WebView's evaluateJavascript so the host can run geometry-based
+     * sentence resolution before falling back to text matching.
      */
-    var onPlayFromHereSelection: ((href: String, selectedText: String) -> Unit)? = null
+    var onPlayFromHereSelection: ((href: String, selectedText: String, evalJs: (String, (String?) -> Unit) -> Unit) -> Unit)? = null
 
     /**
      * Called on the main thread with the resolved footnote body when the user taps a footnote
@@ -583,7 +584,7 @@ internal class ContinuousReaderView @JvmOverloads constructor(
         wv.annotationsAvailable = annotationsAvailable
         wireAnnotationCallbacks(wv)
         wv.readaloudAvailable = readaloudAvailable
-        wv.onPlayFromHere = { text -> onPlayFromHereSelection?.invoke(wv.chapterHref, text) }
+        wv.onPlayFromHere = { text, evalJs -> onPlayFromHereSelection?.invoke(wv.chapterHref, text, evalJs) }
         wv.onFootnoteContent = { onFootnoteContent?.invoke(it) }
         val placeholder = placeholderHeight
         wv.onHeightMeasured = { measuredPx ->
@@ -647,6 +648,7 @@ internal class ContinuousReaderView @JvmOverloads constructor(
         wv.onPageFinished = {
             val styleJs = ContinuousStyleInjector.buildStyleInjectionJs(formattingPrefs)
             wv.injectStylesAndMeasure(styleJs)
+            wv.evaluateJavascript(SELECTION_SPAN_TRACKER_JS, null)
             val annotations = currentAnnotationsByHref[wv.chapterHref]
             if (!annotations.isNullOrEmpty()) {
                 wv.evaluateJavascript(ContinuousStyleInjector.applyAnnotationHighlightsJs(annotations), null)
@@ -669,7 +671,7 @@ internal class ContinuousReaderView @JvmOverloads constructor(
         wv.annotationsAvailable = annotationsAvailable
         wireAnnotationCallbacks(wv)
         wv.readaloudAvailable = readaloudAvailable
-        wv.onPlayFromHere = { text -> onPlayFromHereSelection?.invoke(wv.chapterHref, text) }
+        wv.onPlayFromHere = { text, evalJs -> onPlayFromHereSelection?.invoke(wv.chapterHref, text, evalJs) }
         wv.onFootnoteContent = { onFootnoteContent?.invoke(it) }
         val placeholder = placeholderHeight
         wv.onHeightMeasured = { measuredPx ->
@@ -687,6 +689,7 @@ internal class ContinuousReaderView @JvmOverloads constructor(
         wv.onPageFinished = {
             val styleJs = ContinuousStyleInjector.buildStyleInjectionJs(formattingPrefs)
             wv.injectStylesAndMeasure(styleJs)
+            wv.evaluateJavascript(SELECTION_SPAN_TRACKER_JS, null)
             val annotations = currentAnnotationsByHref[wv.chapterHref]
             if (!annotations.isNullOrEmpty()) {
                 wv.evaluateJavascript(ContinuousStyleInjector.applyAnnotationHighlightsJs(annotations), null)

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -2175,19 +2175,28 @@ private fun EpubNavigatorView(
                             }
                         }
                         view.readaloudAvailable = currentReadaloudAvailable
-                        view.onPlayFromHereSelection = { chapterHref, selectedText ->
-                            // Resolve the selection to a narrated sentence id and start playback there.
-                            // Scope the candidate sentences to the TAPPED chapter first (same as the
-                            // paged path): handed the whole book, a short selection can match a foreign
-                            // chapter's sentence whose text recurs in this one, so playback would jump to
-                            // a completely different sentence (and the highlight, keyed on this chapter,
-                            // would never appear). scopeSentencesToChapter removes the cross-chapter
-                            // candidates; within one chapter the text containment match is reliable.
+                        view.onPlayFromHereSelection = { chapterHref, selectedText, evalJs ->
+                            // Scope candidates to the tapped chapter first — same reason as the paged
+                            // path (cross-chapter text recurrence → wrong sentence).
                             val scoped = scopeSentencesToChapter(
                                 currentSentenceQuotes, currentSentenceChapters, chapterHref,
-                            ).toMap()
-                            val sid = ContinuousPositionTracker.sentenceIdForSelection(selectedText, scoped)
-                            if (sid != null) currentOnPlayFromHere("$chapterHref#$sid")
+                            )
+                            // Preferred: geometry-based resolution (same as paged mode). Reads
+                            // window.__riffleSelRect stashed by SELECTION_SPAN_TRACKER_JS on
+                            // selectionchange, then walks text nodes to find the sentence whose start
+                            // is latest-in-reading-order at-or-before the selection position. Immune
+                            // to duplicate words; returns "" when nothing resolves.
+                            //
+                            // Fallback: text-substring match — reliable only when the selected text
+                            // is unique within the chapter (the original approach), kept as safety net.
+                            evalJs(resolveSelectionSentenceJs(scoped)) { raw ->
+                                val geomId = raw?.trim('"')?.takeIf { it.isNotEmpty() }
+                                val sid = geomId
+                                    ?: ContinuousPositionTracker.sentenceIdForSelection(
+                                        selectedText, scoped.toMap(),
+                                    )
+                                if (sid != null) currentOnPlayFromHere("$chapterHref#$sid")
+                            }
                         }
                     }
                 },

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousPositionTrackerTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousPositionTrackerTest.kt
@@ -219,4 +219,21 @@ class ContinuousPositionTrackerTest {
         assertNull(ContinuousPositionTracker.sentenceIdForSelection("   ", quoteTexts))
         assertNull(ContinuousPositionTracker.sentenceIdForSelection("nothing like this exists here", quoteTexts))
     }
+
+    @Test
+    fun `sentenceIdForSelection returns the first matching sentence even when the word also appears later`() {
+        // Text matching always returns the FIRST sentence in the map whose text contains the
+        // selected word, regardless of which occurrence the user actually selected. This is the
+        // known limitation of the text-match path — why geometry-based resolution (via
+        // resolveSelectionSentenceJs) is the preferred primary path in continuous mode.
+        val duplicateWordQuotes = mapOf(
+            "c1-s1" to "The cat sat on the mat.",
+            "c1-s2" to "The cat ran away quickly.",
+        )
+        assertEquals(
+            "text-match picks the first sentence containing the word, not the selected position",
+            "c1-s1",
+            ContinuousPositionTracker.sentenceIdForSelection("cat", duplicateWordQuotes),
+        )
+    }
 }


### PR DESCRIPTION
## Problem

In continuous mode, tapping "Play from here" on a selection started playback at the wrong sentence whenever the selected word appeared elsewhere in the same chapter. Text-match (`sentenceIdForSelection`) always returns the _first_ sentence in reading order that contains the word, regardless of which occurrence the user actually selected.

## Root cause

Paged/vertical mode already uses geometry-based resolution: `resolveSelectionSentenceJs` reads `window.__riffleSelRect` (the selection's on-screen bounding rect, stashed by `SELECTION_SPAN_TRACKER_JS` at `selectionchange` time) and finds the sentence whose start is latest-in-reading-order at-or-before the selection position. This is immune to duplicate words.

Continuous mode was not wired up to this path — it used only the text-match fallback.

## Fix

- **`ContinuousReaderView`**: inject `SELECTION_SPAN_TRACKER_JS` in `onPageFinished` so `window.__riffleSelRect` is stashed when the user makes a selection.
- **`ChapterWebView`** → **`ContinuousReaderView`** → **`EpubReaderScreen`**: thread `WebView.evaluateJavascript` out through the callback chain so `EpubReaderScreen` can run `resolveSelectionSentenceJs` against the tapped chapter's WebView.
- **`EpubReaderScreen`**: try geometry first; fall back to text-match only when geometry returns nothing (e.g. `__riffleSelRect` not stashed yet).

## Tests

- `ContinuousPositionTrackerTest`: documents the text-match limitation — always returns the first sentence for a duplicate word, regardless of position (shows why geometry is the primary path).
- `ReaderWebViewScriptsTest`: asserts `resolveSelectionSentenceJs` resolves to the selected sentence even when `window.innerHeight` greatly exceeds the content height (the continuous-mode shape where all sentences pass the on-screen filter).