### PR TITLE
fix(readaloud): streaming play pauses, errors, or starts at book beginning

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -2176,8 +2176,19 @@ class EpubReaderViewModel @Inject constructor(
                 // it asks the WebView for the first narrated sentence whose start is on the page and
                 // replies via onPageTopResolved(), which starts playback there. Falls back to plain play
                 // only when there is no reader page at all.
+                //
+                // For the streaming path (sidecar just became ready), the sentence-quote map may still
+                // be building when the probe fires, so the WebView returns null → onPageTopResolved with
+                // null fragmentId → resolveStartClip with href only. Skip the probe in that case and
+                // call playFromReaderPosition directly: it uses the sameChapter() tolerance to find the
+                // chapter's first clip even when ABS and Storyteller hrefs differ by an OEBPS prefix,
+                // giving a chapter-top start rather than leaving the player paused.
                 if (loc != null) {
-                    _pageTopProbeChannel.trySend(loc.href.toString())
+                    if (_sentenceQuotes.value.isNotEmpty()) {
+                        _pageTopProbeChannel.trySend(loc.href.toString())
+                    } else {
+                        playerCoordinator.playFromReaderPosition(loc.href.toString(), null)
+                    }
                 } else {
                     playerCoordinator.play()
                 }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderSyncFactory.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderSyncFactory.kt
@@ -4,7 +4,6 @@ import com.riffle.core.data.CrossEpubIndexBuildTrigger
 import com.riffle.core.data.di.EpubCacheStore
 import com.riffle.core.data.di.EpubDownloadsStore
 import com.riffle.core.domain.BookSyncState
-import com.riffle.core.domain.ReadaloudSidecarCache
 import com.riffle.core.domain.CanonicalPositionTranslator
 import com.riffle.core.domain.CrossEpubIndexStore
 import com.riffle.core.domain.EpubChecksum
@@ -13,6 +12,7 @@ import com.riffle.core.domain.ExtractedEpub
 import com.riffle.core.domain.LibraryRepository
 import com.riffle.core.domain.LocalStore
 import com.riffle.core.domain.ReadaloudLinkRepository
+import com.riffle.core.domain.ReadaloudSidecarCache
 import com.riffle.core.domain.ServerRepository
 import com.riffle.core.domain.StorytellerFragmentIndexBuilder
 import com.riffle.core.domain.TokenStorage

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderSyncFactory.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderSyncFactory.kt
@@ -4,6 +4,7 @@ import com.riffle.core.data.CrossEpubIndexBuildTrigger
 import com.riffle.core.data.di.EpubCacheStore
 import com.riffle.core.data.di.EpubDownloadsStore
 import com.riffle.core.domain.BookSyncState
+import com.riffle.core.domain.ReadaloudSidecarCache
 import com.riffle.core.domain.CanonicalPositionTranslator
 import com.riffle.core.domain.CrossEpubIndexStore
 import com.riffle.core.domain.EpubChecksum
@@ -35,6 +36,7 @@ open class ReaderSyncFactory @Inject constructor(
     @EpubCacheStore private val cacheStore: LocalStore,
     @EpubDownloadsStore private val downloadsStore: LocalStore,
     private val crossEpubIndexBuildTrigger: CrossEpubIndexBuildTrigger,
+    private val sidecarCache: ReadaloudSidecarCache,
 ) {
     /**
      * @param itemId the ABS Library Item id the reader opened. A book is always read from the ABS
@@ -129,7 +131,14 @@ open class ReaderSyncFactory @Inject constructor(
         }
         val targets = resolveAbsTargets(itemId, linkedMedia)
         val audioTarget = targets.audio ?: return null
-        val storytellerFile = cachedFile(openedLink.storytellerServerId, openedLink.storytellerBookId) ?: return null
+        // For the streaming path (ADR 0028) the sidecar stands in for the full bundle: it carries the
+        // SMIL clips and chapter HTML needed by CanonicalPositionTranslator and ReadaloudTextQuotes, so
+        // AudiobookFollow can be built without a downloaded bundle. createIfApplicable() still requires
+        // the full bundle (for cross-EPUB index checksums), so the coordinator stays on the sidecar-only
+        // path until the bundle is downloaded.
+        val storytellerFile = cachedFile(openedLink.storytellerServerId, openedLink.storytellerBookId)
+            ?: sidecarCache.cachedFile(openedLink.storytellerServerId, openedLink.storytellerBookId)
+            ?: return null
         val storytellerExtract = EpubContentExtractor.extract(storytellerFile) ?: return null
         val durationSec = linkedMedia.firstOrNull { it.link.absLibraryItemId == audioTarget.absLibraryItemId }?.audioDurationSec ?: 0.0
         val endpoint = absEndpointFor(audioTarget.absServerId, audioTarget.absLibraryItemId, durationSec) ?: return null

--- a/app/src/test/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModelBookmarkTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModelBookmarkTest.kt
@@ -674,6 +674,7 @@ class AudiobookPlayerViewModelBookmarkTest {
         StubLocalStore,
         StubLocalStore,
         StubBuildTrigger,
+        sidecarCache = { _, _ -> null },
     ) {
         override suspend fun createIfApplicable(itemId: String): ReaderSyncCoordinator? = null
         override suspend fun createAudiobookFollowIfApplicable(itemId: String): AudiobookFollow? = null

--- a/app/src/test/kotlin/com/riffle/app/feature/audiobook/SleepTimerTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/audiobook/SleepTimerTest.kt
@@ -535,6 +535,7 @@ class SleepTimerTest {
         StubLocalStore,
         StubLocalStore,
         StubBuildTrigger,
+        sidecarCache = { _, _ -> null },
     ) {
         override suspend fun createIfApplicable(itemId: String): ReaderSyncCoordinator? = null
         override suspend fun createAudiobookFollowIfApplicable(itemId: String): AudiobookFollow? = null

--- a/core/data/src/main/kotlin/com/riffle/core/data/ReadaloudSidecarStore.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/ReadaloudSidecarStore.kt
@@ -1,6 +1,7 @@
 package com.riffle.core.data
 
 import android.content.Context
+import com.riffle.core.domain.ReadaloudSidecarCache
 import com.riffle.core.domain.ServerRepository
 import com.riffle.core.domain.TokenStorage
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -46,7 +47,7 @@ class ReadaloudSidecarStore @Inject constructor(
     private val fetcher: StorytellerSidecarFetcher,
     private val serverRepository: ServerRepository,
     private val tokenStorage: TokenStorage,
-) : ReadaloudSidecarPrefetcher {
+) : ReadaloudSidecarPrefetcher, ReadaloudSidecarCache {
     enum class State { Preparing, Ready, Failed }
 
     // App-scoped: a prepare started on the details screen must survive into the reader (and vice versa),
@@ -65,7 +66,7 @@ class ReadaloudSidecarStore @Inject constructor(
     private fun fileFor(serverId: String, bookId: String) = File(dir(), "${key(serverId, bookId)}.epub")
 
     /** The cached sidecar if it's already on disk — never triggers a fetch. */
-    fun cachedFile(storytellerServerId: String, storytellerBookId: String): File? =
+    override fun cachedFile(storytellerServerId: String, storytellerBookId: String): File? =
         fileFor(storytellerServerId, storytellerBookId).takeIf { it.exists() && it.length() > 0 }
 
     /** State for the bar/UX: Ready when cached, else the in-flight/last prepare outcome. */

--- a/core/data/src/main/kotlin/com/riffle/core/data/di/DataModule.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/di/DataModule.kt
@@ -511,6 +511,11 @@ abstract class DataModule {
 
         @Provides
         @Singleton
+        fun provideReadaloudSidecarCache(store: com.riffle.core.data.ReadaloudSidecarStore): com.riffle.core.domain.ReadaloudSidecarCache =
+            store
+
+        @Provides
+        @Singleton
         fun provideAudiobookBundleApi(okHttpClient: OkHttpClient): AudiobookBundleApiImpl =
             AudiobookBundleApiImpl(okHttpClient)
 

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/ReadaloudSidecarCache.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/ReadaloudSidecarCache.kt
@@ -1,0 +1,8 @@
+package com.riffle.core.domain
+
+import java.io.File
+
+/** Read-only view of the sidecar cache: is a book's sidecar on disk? */
+fun interface ReadaloudSidecarCache {
+    fun cachedFile(storytellerServerId: String, storytellerBookId: String): File?
+}

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/ReadaloudTrack.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/ReadaloudTrack.kt
@@ -170,6 +170,12 @@ class ReadaloudTrack(val clips: List<MediaOverlayClip>) {
         }
         fun chapterHref(clip: MediaOverlayClip) = clip.textFragmentRef.substringBefore('#').trimStart('/')
         clips.firstOrNull { chapterHref(it) == target }?.let { return it }
+        // Same tolerance as the fragment-id path: ABS and Storyteller EPUBs can carry the same chapter
+        // under different href prefixes (e.g. "Text/ch01.xhtml" vs "OEBPS/Text/ch01.xhtml"). Without
+        // this, a streaming play with no sentence-quote map yet (quotes build races playback startup)
+        // sends a null fragmentId here and the lexicographic ">= target" fallback picks the wrong clip
+        // or returns null when Storyteller hrefs are lexicographically less than the ABS href.
+        clips.firstOrNull { sameChapter(it, target) }?.let { return it }
         return clips.firstOrNull { chapterHref(it) >= target }
     }
 

--- a/core/domain/src/test/kotlin/com/riffle/core/domain/ReadaloudTrackTest.kt
+++ b/core/domain/src/test/kotlin/com/riffle/core/domain/ReadaloudTrackTest.kt
@@ -155,6 +155,25 @@ class ReadaloudTrackTest {
         assertEquals(null, splitTrack.resolveStartClip("text/part0099_split_000.html", null))
     }
 
+    // Streaming-path regression: the sentence-quote map may not be built yet when the page-top probe
+    // fires, so fragmentId is null. ABS (the rendered EPUB) and Storyteller (the SMIL source) can
+    // carry the same chapter under different href prefixes — e.g. "Text/ch01.xhtml" vs
+    // "OEBPS/Text/ch01.xhtml". The lexicographic ">= target" fallback silently picks the wrong clip
+    // or returns null when the Storyteller hrefs are lex-less than the ABS href. sameChapter()
+    // tolerance was added before the fallback to handle this case.
+    private val oebpsClips = listOf(
+        MediaOverlayClip("OEBPS/Text/ch01.xhtml#s1", "c1.mp3", 0.0, 2.0),
+        MediaOverlayClip("OEBPS/Text/ch01.xhtml#s2", "c1.mp3", 2.0, 5.0),
+        MediaOverlayClip("OEBPS/Text/ch02.xhtml#s1", "c2.mp3", 0.0, 4.0),
+    )
+    private val oebpsTrack = ReadaloudTrack(oebpsClips)
+
+    @Test
+    fun `resolveStartClip with null fragment tolerates OEBPS prefix difference between ABS and Storyteller hrefs`() {
+        assertEquals(oebpsClips[0], oebpsTrack.resolveStartClip("Text/ch01.xhtml", null))
+        assertEquals(oebpsClips[2], oebpsTrack.resolveStartClip("Text/ch02.xhtml", null))
+    }
+
     // ── skip + chapter math (rewind/forward, prev/next chapter) ──
 
     // Two chapters across two files. Global timeline: c1 -> [0,9), c2 -> [9,13).


### PR DESCRIPTION
## Problem

Starting readaloud via streaming (no downloaded bundle) had three distinct failure modes:

1. **Paused player**: `resolveStartClip(href, null)` returned `null` when ABS and Storyteller EPUBs carry the same chapter under different href prefixes (`Text/ch01.xhtml` vs `OEBPS/Text/ch01.xhtml`). The lexicographic `>= target` fallback silently picked the wrong clip or returned null, leaving the player in a paused state.

2. **Starts at beginning**: When `autoPlayWhenPrepared` fires (sidecar just became ready), the sentence-quote map may still be building. The page-top WebView probe fires, returns `null` (no quotes yet), and `resolveStartClip(href, null)` hits failure mode 1 above.

3. **AudiobookFollow not built**: `ReaderSyncFactory.createAudiobookFollowIfApplicable()` only searched the full-bundle stores (`cacheDir/epubs/`, `filesDir/downloads/epubs/`), never finding the sidecar at `cacheDir/readaloud-sidecars/`. Without `AudiobookFollow`, reader↔audio sync is broken.

## Fixes

**`ReadaloudTrack.resolveStartClip`** (`core/domain`): Added a `sameChapter()` tolerance step between the exact-match and the lex fallback in the null-fragment path. `sameChapter()` already handles OEBPS-prefix differences for the fragment-id path; this extends the same logic to the chapter-top case.

**`EpubReaderViewModel.ensurePreparedAndPlay`** (`app`): Before sending to the page-top probe, check `_sentenceQuotes.value.isNotEmpty()`. If quotes aren't ready yet, skip the probe and call `playFromReaderPosition(href, null)` directly — Fix 1 then resolves the chapter correctly. Result: chapter-top start rather than stuck-paused.

**`ReaderSyncFactory`** (`app`): Inject `ReadaloudSidecarCache` (new minimal `fun interface` in `:core:domain`) and fall back to `sidecarCache.cachedFile()` when no full bundle is present. `ReadaloudSidecarStore` implements the new interface; `DataModule` provides the binding.

## Testing

- **Unit tests**: `ReadaloudTrackTest` — added regression test for the OEBPS-prefix / null-fragment case.
- **JVM suite**: `./gradlew test` — BUILD SUCCESSFUL.
- **Lint**: `./gradlew lint` — clean.
- **Phone harness**: 242 tests, 0 failed (run against `Harness_Medium_Phone_2` clone).
- **Tablet harness**: 5 tests, 0 failed (`make harness-test-tablet`).
- **Device-verified on AVD**: Cloned API-33 AVD, cleared sidecar cache, opened The Martian, tapped Readaloud. Observed `Preparing narration…` → `Pause` (playing) at Chapter 15 across 14 consecutive 5-second polls. All three failure modes eliminated.