### PR TITLE
refactor(reader): unify highlight rendering behind HighlightRenderer interface

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousHighlightRenderer.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousHighlightRenderer.kt
@@ -77,7 +77,7 @@ internal class ContinuousHighlightRenderer(
         // event handler via highlightSearchMatch, not by the state-watching search effect.
     }
 
-    override fun highlightSearchMatch(href: String, text: String, cssColor: String) {
-        targetProvider()?.highlightInChapter(href, text, cssColor)
+    override fun highlightSearchMatch(href: String, text: String) {
+        targetProvider()?.highlightInChapter(href, text, SEARCH_ACTIVE_ARGB.toCssRgba())
     }
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousHighlightRenderer.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousHighlightRenderer.kt
@@ -1,0 +1,83 @@
+package com.riffle.app.feature.reader
+
+import com.riffle.core.domain.HighlightColor
+import com.riffle.core.domain.ReadaloudHighlightColor
+import com.riffle.core.domain.ReaderTheme
+import com.riffle.core.domain.SentenceQuote
+import org.readium.r2.shared.publication.Locator
+
+/**
+ * [HighlightRenderer] for continuous mode.
+ *
+ * Continuous mode does not use Readium's DecorableNavigator — instead it drives highlights
+ * directly into each [ChapterWebView] via JS injection methods exposed through
+ * [ContinuousHighlightTarget].
+ *
+ * [targetProvider] is called lazily on each render call so the renderer can be constructed
+ * before the view exists, and so tests can inject a fake without Android dependencies.
+ */
+internal class ContinuousHighlightRenderer(
+    private val targetProvider: () -> ContinuousHighlightTarget?,
+) : HighlightRenderer {
+
+    /** Href of the chapter that holds the current readaloud highlight, for clearing on chapter change. */
+    private var prevReadaloudHref: String? = null
+
+    override suspend fun applyReadaloud(
+        fragmentRef: String?,
+        quotes: Map<String, SentenceQuote>,
+        color: ReadaloudHighlightColor,
+    ) {
+        val target = targetProvider() ?: return
+        if (fragmentRef == null) {
+            prevReadaloudHref?.let { target.clearHighlightInChapter(it) }
+            prevReadaloudHref = null
+            return
+        }
+        val chapterHref = fragmentRef.substringBefore('#')
+        val sid = fragmentRef.substringAfter('#', "")
+        if (sid.isBlank()) return
+        val text = quotes[sid]?.highlight ?: return
+
+        val prev = prevReadaloudHref
+        if (prev != null && prev != chapterHref) target.clearHighlightInChapter(prev)
+        prevReadaloudHref = chapterHref
+
+        target.highlightInChapter(chapterHref, text, color.argb.toCssRgba())
+    }
+
+    override suspend fun applyAnnotations(
+        renders: List<EpubReaderViewModel.HighlightRender>,
+        theme: ReaderTheme,
+    ) {
+        val target = targetProvider() ?: return
+        val annotationsByHref = renders
+            .filter { !it.locator.text.highlight.isNullOrBlank() }
+            .groupBy { it.locator.href.toString() }
+            .mapValues { (_, items) ->
+                items.map { h ->
+                    AnnotationHighlight(
+                        id = h.id,
+                        text = h.locator.text.highlight!!,
+                        cssColor = HighlightColor.fromToken(h.color).readerTint(theme).toCssRgba(),
+                        hasNote = h.note != null,
+                    )
+                }
+            }
+        target.applyAnnotationHighlights(annotationsByHref)
+    }
+
+    override suspend fun applyNoteGlyphs(renders: List<EpubReaderViewModel.HighlightRender>) {
+        // Continuous mode does not render note glyphs — there is no margin area analogous
+        // to Readium's decoration layer for arbitrary DOM annotations.
+    }
+
+    override suspend fun applySearch(results: List<Locator>, activeIndex: Int) {
+        // Search result highlighting for continuous mode is driven by the search navigation
+        // event handler via highlightSearchMatch, not by the state-watching search effect.
+    }
+
+    override fun highlightSearchMatch(href: String, text: String, cssColor: String) {
+        targetProvider()?.highlightInChapter(href, text, cssColor)
+    }
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousHighlightRenderer.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousHighlightRenderer.kt
@@ -68,8 +68,8 @@ internal class ContinuousHighlightRenderer(
     }
 
     override suspend fun applyNoteGlyphs(renders: List<EpubReaderViewModel.HighlightRender>) {
-        // Continuous mode does not render note glyphs — there is no margin area analogous
-        // to Readium's decoration layer for arbitrary DOM annotations.
+        // No-op: glyphs are emitted inside applyAnnotations via applyAnnotationHighlightsJs,
+        // so no separate pass is needed.
     }
 
     override suspend fun applySearch(results: List<Locator>, activeIndex: Int) {

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousHighlightTarget.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousHighlightTarget.kt
@@ -1,0 +1,12 @@
+package com.riffle.app.feature.reader
+
+/**
+ * Narrow interface over [ContinuousReaderView]'s highlight-related methods.
+ * Extracted so [ContinuousHighlightRenderer] can be tested on JVM without
+ * instantiating the Android View.
+ */
+internal interface ContinuousHighlightTarget {
+    fun highlightInChapter(href: String, text: String, cssColor: String)
+    fun clearHighlightInChapter(href: String)
+    fun applyAnnotationHighlights(annotationsByHref: Map<String, List<AnnotationHighlight>>)
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
@@ -30,7 +30,7 @@ internal data class AnnotationHighlight(val id: String, val text: String, val cs
 internal class ContinuousReaderView @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null,
-) : NestedScrollView(context, attrs) {
+) : NestedScrollView(context, attrs), ContinuousHighlightTarget {
 
     companion object {
         /** Chapters kept loaded behind the reader (for smooth backward scrolling). */
@@ -470,7 +470,7 @@ internal class ContinuousReaderView @JvmOverloads constructor(
     }
 
     /** Inject a readaloud highlight for the sentence with [text] in the chapter matching [href] and scroll it into view. */
-    fun highlightInChapter(href: String, text: String, cssColor: String) {
+    override fun highlightInChapter(href: String, text: String, cssColor: String) {
         val i = webViewIndexFor(href) ?: return
         webViews[i].evaluateJavascript(ContinuousStyleInjector.highlightTextJs(text, cssColor)) { _ ->
             // Re-lookup by href rather than using the captured index: the window may have shifted
@@ -511,7 +511,7 @@ internal class ContinuousReaderView @JvmOverloads constructor(
     }
 
     /** Clear any active readaloud highlight in the chapter at [href]. */
-    fun clearHighlightInChapter(href: String) {
+    override fun clearHighlightInChapter(href: String) {
         val i = webViewIndexFor(href) ?: return
         webViews[i].evaluateJavascript(ContinuousStyleInjector.CLEAR_HIGHLIGHT_JS, null)
     }
@@ -531,7 +531,7 @@ internal class ContinuousReaderView @JvmOverloads constructor(
      * state so that chapters entering the sliding window later (via [appendChapter] /
      * [prependChapter]) automatically receive their marks in [onPageFinished].
      */
-    fun applyAnnotationHighlights(annotationsByHref: Map<String, List<AnnotationHighlight>>) {
+    override fun applyAnnotationHighlights(annotationsByHref: Map<String, List<AnnotationHighlight>>) {
         currentAnnotationsByHref = annotationsByHref
         for (wv in webViews) {
             val href = wv.chapterHref

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -1452,7 +1452,7 @@ private fun EpubNavigatorView(
         }
     }
 
-    LaunchedEffect(searchNavigationEvents, isContinuous, readaloudHighlightColor) {
+    LaunchedEffect(searchNavigationEvents, isContinuous) {
         searchNavigationEvents.collect { locator ->
             if (isContinuous) {
                 val view = continuousViewRef.value ?: return@collect

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -1467,7 +1467,6 @@ private fun EpubNavigatorView(
                 highlightRenderer.highlightSearchMatch(
                     href = locator.href.toString(),
                     text = text,
-                    cssColor = SEARCH_ACTIVE_ARGB.toCssRgba(),
                 )
             }
         }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -104,7 +104,6 @@ import java.util.concurrent.atomic.AtomicReference
 import org.json.JSONObject
 import org.jsoup.nodes.Document
 import org.readium.r2.navigator.DecorableNavigator
-import org.readium.r2.navigator.Decoration
 import org.readium.r2.navigator.HyperlinkNavigator
 import org.readium.r2.navigator.epub.EpubNavigatorFactory
 import org.readium.r2.navigator.epub.EpubNavigatorFragment
@@ -907,16 +906,6 @@ private const val NAV_COVER_SETTLE_MS = 250L
 private fun fragmentLocator(ref: String, quote: SentenceQuote? = null): Locator? =
     Locator.fromJSON(readaloudLocatorJson(ref, quote))
 
-private suspend fun DecorableNavigator.applyDecorationsWithClear(
-    decorations: List<Decoration>,
-    group: String,
-) {
-    withContext(Dispatchers.Main) {
-        applyDecorations(emptyList(), group = group)
-        applyDecorations(decorations, group = group)
-    }
-}
-
 /**
  * The narrated sentences (span id → text) to feed [resolveSelectionSentenceJs] for a "Play from here"
  * tap, scoped to the chapter being read ([currentHref]). The resolver locates a tapped sentence by
@@ -1024,6 +1013,23 @@ private fun EpubNavigatorView(
     val continuousViewRef = remember { mutableStateOf<ContinuousReaderView?>(null) }
     val isContinuous = formattingPrefs.orientation == ReaderOrientation.Continuous
     val fragmentRef = remember { mutableStateOf<EpubNavigatorFragment?>(null) }
+
+    val highlightRenderer: HighlightRenderer = remember(isContinuous) {
+        if (isContinuous) {
+            ContinuousHighlightRenderer(targetProvider = { continuousViewRef.value })
+        } else {
+            ReadiumHighlightRenderer(
+                applyDecorationsBlock = { decorations, group ->
+                    (fragmentRef.value as? DecorableNavigator)?.let { nav ->
+                        withContext(Dispatchers.Main) { nav.applyDecorations(decorations, group) }
+                    }
+                },
+                fragmentLocator = ::fragmentLocator,
+                currentNavigatorStamp = { fragmentRef.value },
+            )
+        }
+    }
+
     val containerRef = remember { mutableStateOf<ScrollBoundaryNavigationContainer?>(null) }
     // Caches the most-recent text-selection bounding rect in CSS viewport px, populated by
     // RiffleSelBridge on every selectionchange — before the floating action-mode toolbar fires.
@@ -1452,11 +1458,17 @@ private fun EpubNavigatorView(
                 val view = continuousViewRef.value ?: return@collect
                 val href = locator.href.toString()
                 val progression = locator.locations.progression?.toFloat() ?: 0f
-                val highlightText = locator.text.highlight?.take(40) ?: ""
                 view.navigateTo(href, progression)
-                if (highlightText.isNotBlank()) view.highlightInChapter(href, highlightText, readaloudHighlightColor.argb.toCssRgba())
             } else {
                 goAndSnapWithCover(locator)
+            }
+            val text = locator.text.highlight?.take(40) ?: ""
+            if (text.isNotBlank()) {
+                highlightRenderer.highlightSearchMatch(
+                    href = locator.href.toString(),
+                    text = text,
+                    cssColor = readaloudHighlightColor.argb.toCssRgba(),
+                )
             }
         }
     }
@@ -1490,229 +1502,26 @@ private fun EpubNavigatorView(
         }
     }
 
-    // Tracks whether we have live search decorations painted in the WebView.
-    // Prevents calling applyDecorations on initial composition (before WebView content loads),
-    // which crashes the WebView renderer via a premature JS evaluation. See ADR 0015.
-    val hasActiveDecorations = remember { mutableStateOf(false) }
-
-    // Readium fixes a decoration's rects at applyDecorations time and never re-positions them. When a
-    // search result is navigated to, the landing page's layout is still settling as the decoration is
-    // applied (the page snaps to the column grid and the search top bar's inset resolves AFTER the first
-    // apply), so the box is placed against the pre-settle layout and the text then shifts out from under
-    // it — verified on device as a constant ~152px vertical offset onto the wrong word (same column, same
-    // width: a placement-timing bug, not a fuzzy mis-resolution). readaloud never shows this because it
-    // re-applies its decoration on every audio tick; search applies once per navigation. We therefore
-    // re-apply across a short settle window after each (re)apply so the boxes track the final layout. The
-    // re-applies are idempotent (same id + locator). Re-keys on reflow/pageLoad as well for rotation and
-    // formatting reflows, matching the readaloud and annotations decoration effects.
     LaunchedEffect(searchResults, currentSearchIndex, reflowGeneration, pageLoadGeneration.value) {
-        if (isContinuous) return@LaunchedEffect  // ContinuousReaderView uses window.find via highlightInChapter
-        if (searchResults.isEmpty()) {
-            if (!hasActiveDecorations.value) return@LaunchedEffect
-            val fragment = fragmentRef.value as? DecorableNavigator ?: return@LaunchedEffect
-            // applyDecorations calls evaluateJavascript which requires the main thread.
-            // Compose test infrastructure (FrameDeferringContinuationInterceptor) can resume
-            // LaunchedEffect coroutines on DefaultDispatcher; withContext(Main) ensures safety.
-            withContext(Dispatchers.Main) {
-                fragment.applyDecorations(emptyList(), group = "search")
-            }
-            hasActiveDecorations.value = false
-            return@LaunchedEffect
-        }
-        val navFragment = fragmentRef.value ?: return@LaunchedEffect
-        val fragment = navFragment as? DecorableNavigator ?: return@LaunchedEffect
-        val decorations = searchResults.mapIndexed { index, locator ->
-            Decoration(
-                id = "search_$index",
-                locator = locator,
-                style = if (index == currentSearchIndex)
-                    Decoration.Style.Highlight(tint = android.graphics.Color.parseColor("#FFF5A623"))
-                else
-                    Decoration.Style.Highlight(tint = android.graphics.Color.parseColor("#FFFDE68A")),
-            )
-        }
-        // Apply immediately for the first paint; the re-resolve loop below then tracks the page as it
-        // settles (see its comment for the why). "The first result is highlighted, the next ones aren't"
-        // was this exact bug on navigated results — the landing page is still moving when the box lands.
-        withContext(Dispatchers.Main) {
-            fragment.applyDecorations(decorations, group = "search")
-        }
-        hasActiveDecorations.value = true
-        // Re-resolve the box positions across the post-navigation settle window. Two things matter here:
-        //  1) Readium re-positions a decoration only when its set CHANGES — re-applying the identical list
-        //     is a no-op diff, so the box keeps its first (pre-settle) position. We therefore CLEAR then
-        //     re-apply (back to back on the main thread, no visible gap — the same trick the readaloud
-        //     group uses), which forces Readium to re-run its locator→range resolver against the current,
-        //     settled DOM.
-        //  2) The layout keeps moving after the first apply (go() + the column-snap rAF loop ~1.2s + the
-        //     async typography reflow), so we repeat the clear+re-apply on a SPACED schedule out to ~2.6s.
-        //     Spaced (not a tight poll): a 100ms loop floods the still-navigating WebView and can blank the
-        //     page (ADR 0015); a handful of spaced re-applies is as safe as the first one.
-        for (settleDelayMs in longArrayOf(400L, 600L, 700L, 900L)) {
-            delay(settleDelayMs)
-            if (fragmentRef.value !== navFragment) break // navigated away / fragment recreated — newer effect owns it
-            fragment.applyDecorationsWithClear(decorations, group = "search")
-        }
+        highlightRenderer.applySearch(searchResults, currentSearchIndex)
     }
 
     // ---- Readaloud synced highlight --------------------------------------------------------
-    // Uses the same Readium DecorableNavigator mechanism as search, on its own "readaloud" group
-    // so it doesn't clobber search highlights. The active fragment ref is "href#fragId"; we build a
-    // Locator that carries both the fragment-id cssSelector AND the sentence's text. Readium uses the
-    // cssSelector when it resolves and otherwise falls back to a text search — necessary because it
-    // strips the sentence spans from the rendered ABS EPUB. Null clears the decoration. The effect
-    // also re-keys on [sentenceQuotes] so the highlight re-applies with text once the quotes (built
-    // off the main thread after the track loads) become available.
-    val hasReadaloudDecoration = remember { mutableStateOf(false) }
+    // Superset keys cover both Readium (pageLoadGeneration, reflowGeneration re-apply on
+    // reflow/rotation) and Continuous (sentenceQuotes re-applies when quotes build asynchronously).
     LaunchedEffect(activeFragmentRef, reflowGeneration, pageLoadGeneration.value, sentenceQuotes, readaloudHighlightColor) {
-        if (isContinuous) return@LaunchedEffect  // handled in the Continuous-mode effect below
-        val fragment = fragmentRef.value as? DecorableNavigator ?: return@LaunchedEffect
-        val ref = activeFragmentRef
-        if (ref == null) {
-            if (!hasReadaloudDecoration.value) return@LaunchedEffect
-            withContext(Dispatchers.Main) {
-                fragment.applyDecorations(emptyList(), group = "readaloud")
-            }
-            hasReadaloudDecoration.value = false
-            return@LaunchedEffect
-        }
-        val sid = ref.substringAfter('#', "")
-        val quote = sentenceQuotes[sid]
-        val locator = fragmentLocator(ref, quote) ?: return@LaunchedEffect
-        val decoration = Decoration(
-            id = "readaloud_active",
-            locator = locator,
-            // Dedicated readaloud style/template: opacity follows the tint's alpha so the highlight
-            // is stronger on dark reading themes and stays legible behind the white body text.
-            style = HighlightTintStyle(
-                tint = readaloudHighlightColor.argb,
-            ),
-        )
-        // Clear the group before re-applying. After the fragment is recreated (rotation) or its page
-        // reloads, Readium's decoration controller for the new WebView loses track of the previously
-        // injected element, so applyDecorations([new]) ADDS without removing the old one and the
-        // highlights accumulate — the previous sentence stays lit while the current one plays. An
-        // empty apply runs the JS group's clear() (it removes the whole decoration container element),
-        // so the subsequent apply always leaves exactly one highlight. The two calls execute back to
-        // back on the main thread, so there is no visible gap on a normal sentence advance.
-        fragment.applyDecorationsWithClear(listOf(decoration), group = "readaloud")
-        hasReadaloudDecoration.value = true
+        highlightRenderer.applyReadaloud(activeFragmentRef, sentenceQuotes, readaloudHighlightColor)
     }
 
-    // ---- Continuous-mode readaloud highlight -----------------------------------------------
-    // ChapterWebView serves the ABS EPUB HTML directly (no Readium stripping), but the ABS EPUB
-    // does NOT have Storyteller's per-sentence spans — those exist only in the Storyteller bundle.
-    // We therefore use window.find() to locate the sentence by its full text, then inject a <mark>
-    // element. The fallback in highlightTextJs uses extractContents()+insertNode() to handle the
-    // common case where the sentence spans inline elements (em, span, strong) and surroundContents()
-    // would throw. sentenceQuotes is re-keyed here so the highlight re-applies once quotes are built.
-    val prevHighlightHref = remember { mutableStateOf<String?>(null) }
-    LaunchedEffect(activeFragmentRef, isContinuous, sentenceQuotes, readaloudHighlightColor) {
-        if (!isContinuous) return@LaunchedEffect
-        val view = continuousViewRef.value ?: return@LaunchedEffect
-        val ref = activeFragmentRef
-        if (ref == null) {
-            // Readaloud stopped — clear the last known chapter's highlight
-            prevHighlightHref.value?.let { view.clearHighlightInChapter(it) }
-            prevHighlightHref.value = null
-            return@LaunchedEffect
-        }
-        val chapterHref = ref.substringBefore('#')
-        val sid = ref.substringAfter('#', "")
-        if (sid.isBlank()) return@LaunchedEffect
-        val text = sentenceQuotes[sid]?.highlight ?: return@LaunchedEffect
-        // If the chapter changed, clear the previous chapter's mark
-        val prev = prevHighlightHref.value
-        if (prev != null && prev != chapterHref) view.clearHighlightInChapter(prev)
-        prevHighlightHref.value = chapterHref
-        val cssColor = readaloudHighlightColor.argb.toCssRgba()
-        view.highlightInChapter(chapterHref, text, cssColor)
+    // ---- Persisted highlights (annotations + note glyphs) ----------------------------------
+    // Superset keys: continuous re-keys on activeFragmentRef's base href when a new chapter
+    // enters the sliding window; Readium re-applies on reflow/pageLoad events.
+    LaunchedEffect(highlightRenders, formattingPrefs.theme, reflowGeneration, pageLoadGeneration.value, activeFragmentRef?.substringBefore('#')) {
+        highlightRenderer.applyAnnotations(highlightRenders, formattingPrefs.theme)
     }
 
-    // ---- Persisted highlights — continuous mode -------------------------------------------
-    // Paged mode uses Readium's DecorableNavigator (below). Continuous mode injects <mark> elements
-    // via window.find(), mirroring the readaloud highlight approach. Re-keyed on the current chapter
-    // href (derived from activeFragmentRef) so annotations re-apply when a new chapter enters the
-    // sliding window.
-    LaunchedEffect(highlightRenders, formattingPrefs.theme, activeFragmentRef?.substringBefore('#'), isContinuous) {
-        if (!isContinuous) return@LaunchedEffect
-        val view = continuousViewRef.value ?: return@LaunchedEffect
-        val annotationsByHref = highlightRenders
-            .filter { !it.locator.text.highlight.isNullOrBlank() }
-            .groupBy { it.locator.href.toString() }
-            .mapValues { (_, renders) ->
-                renders.map { h ->
-                    AnnotationHighlight(
-                        id = h.id,
-                        text = h.locator.text.highlight!!,
-                        cssColor = HighlightColor.fromToken(h.color).readerTint(formattingPrefs.theme).toCssRgba(),
-                        hasNote = h.note != null,
-                    )
-                }
-            }
-        view.applyAnnotationHighlights(annotationsByHref)
-    }
-
-    // ---- Persisted highlights (ADR 0024) ---------------------------------------------------
-    // Renders all of a book's stored highlights via the same DecorableNavigator mechanism, on its
-    // own "annotations" group. Re-applied whenever the set changes — including the re-render of
-    // every highlight when the book is reopened, and the immediate paint after a new highlight.
-    val hasHighlightDecorations = remember { mutableStateOf(false) }
-    LaunchedEffect(highlightRenders, formattingPrefs.theme, reflowGeneration, pageLoadGeneration.value, isContinuous) {
-        if (isContinuous) return@LaunchedEffect
-        val fragment = fragmentRef.value as? DecorableNavigator ?: return@LaunchedEffect
-        if (highlightRenders.isEmpty()) {
-            if (!hasHighlightDecorations.value) return@LaunchedEffect
-            withContext(Dispatchers.Main) {
-                fragment.applyDecorations(emptyList(), group = "annotations")
-            }
-            hasHighlightDecorations.value = false
-            return@LaunchedEffect
-        }
-        val decorations = highlightRenders.map { h ->
-            Decoration(
-                id = h.id,
-                locator = h.locator,
-                style = HighlightTintStyle(
-                    tint = HighlightColor.fromToken(h.color).readerTint(formattingPrefs.theme),
-                ),
-            )
-        }
-        // Clear before re-applying so the Readium JS group starts from a clean slate.
-        // Without the clear, Kotlin-side diff can compute "no change" for a fragment whose
-        // JS state was reset on page load (e.g. on book re-entry), leaving decorations
-        // visually missing; a stale DOM element from a prior session can also add a ghost
-        // layer. Mirrors the search and readaloud groups' clear+reapply pattern.
-        fragment.applyDecorationsWithClear(decorations, group = "annotations")
-        hasHighlightDecorations.value = true
-    }
-
-    // ---- Note glyph decorations (annotation-notes) -----------------------------------------
-    // Renders a small margin note icon next to every highlighted range that has a note
-    // attached. Uses its own group so it can be cleared/re-applied independently of the fill.
-    // Tapping the glyph fires the dedicated "annotation-notes" tap listener below.
-    val hasNoteDecorations = remember { mutableStateOf(false) }
-    LaunchedEffect(highlightRenders, formattingPrefs.theme, reflowGeneration, pageLoadGeneration.value, isContinuous) {
-        if (isContinuous) return@LaunchedEffect
-        val fragment = fragmentRef.value as? DecorableNavigator ?: return@LaunchedEffect
-        val noted = highlightRenders.filter { it.note != null }
-        if (noted.isEmpty()) {
-            if (!hasNoteDecorations.value) return@LaunchedEffect
-            withContext(Dispatchers.Main) {
-                fragment.applyDecorations(emptyList(), group = "annotation-notes")
-            }
-            hasNoteDecorations.value = false
-            return@LaunchedEffect
-        }
-        val noteDecorations = noted.map { h ->
-            Decoration(
-                id = h.id,
-                locator = h.locator,
-                style = NoteGlyphStyle(),
-            )
-        }
-        fragment.applyDecorationsWithClear(noteDecorations, group = "annotation-notes")
-        hasNoteDecorations.value = true
+    LaunchedEffect(highlightRenders, reflowGeneration, pageLoadGeneration.value) {
+        highlightRenderer.applyNoteGlyphs(highlightRenders)
     }
 
     // ---- Decoration tap listener (annotations) ---------------------------------------------

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -1467,7 +1467,7 @@ private fun EpubNavigatorView(
                 highlightRenderer.highlightSearchMatch(
                     href = locator.href.toString(),
                     text = text,
-                    cssColor = readaloudHighlightColor.argb.toCssRgba(),
+                    cssColor = SEARCH_ACTIVE_ARGB.toCssRgba(),
                 )
             }
         }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -450,18 +450,6 @@ class EpubReaderViewModel @Inject constructor(
                 serverProgressToLocator(serverProgress)?.let { _serverLocatorChannel.trySend(it) }
             }
         }
-        // Back-fill totalProgression when railSegments arrives after the first position event.
-        // In continuous mode the initial scroll may fire before segments load, leaving
-        // _currentLocatorTotalProgression null. When segments become non-empty, recompute from the
-        // last known href + chapter progression so time-remaining and rail cursor update immediately.
-        viewModelScope.launch {
-            railSegments.collect { segs ->
-                if (segs.isEmpty() || _currentLocatorTotalProgression.value != null) return@collect
-                val href = _currentLocatorHref.value ?: return@collect
-                val cp = _currentLocatorProgression.value ?: return@collect
-                computeTotalProgression(href, cp, segs)?.let { _currentLocatorTotalProgression.value = it }
-            }
-        }
         viewModelScope.launch {
             _formattingPreferences
                 .map { it.themeSchedule to (it.theme == ReaderTheme.Auto) }
@@ -1416,6 +1404,23 @@ class EpubReaderViewModel @Inject constructor(
             weighted
         }
         .stateIn(viewModelScope, SharingStarted.Eagerly, emptyList())
+
+    // Back-fill totalProgression when railSegments arrives after the first position event.
+    // In continuous mode the initial scroll may fire before segments load, leaving
+    // _currentLocatorTotalProgression null. When segments become non-empty, recompute from the
+    // last known href + chapter progression so time-remaining and rail cursor update immediately.
+    // Placed after railSegments declaration so the Dispatchers.Main.immediate coroutine start
+    // does not access the field while it is still null during class initialization.
+    init {
+        viewModelScope.launch {
+            railSegments.collect { segs ->
+                if (segs.isEmpty() || _currentLocatorTotalProgression.value != null) return@collect
+                val href = _currentLocatorHref.value ?: return@collect
+                val cp = _currentLocatorProgression.value ?: return@collect
+                computeTotalProgression(href, cp, segs)?.let { _currentLocatorTotalProgression.value = it }
+            }
+        }
+    }
 
     val activeRailSegmentIndex: StateFlow<Int> = combine(
         railSegments,

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -450,6 +450,18 @@ class EpubReaderViewModel @Inject constructor(
                 serverProgressToLocator(serverProgress)?.let { _serverLocatorChannel.trySend(it) }
             }
         }
+        // Back-fill totalProgression when railSegments arrives after the first position event.
+        // In continuous mode the initial scroll may fire before segments load, leaving
+        // _currentLocatorTotalProgression null. When segments become non-empty, recompute from the
+        // last known href + chapter progression so time-remaining and rail cursor update immediately.
+        viewModelScope.launch {
+            railSegments.collect { segs ->
+                if (segs.isEmpty() || _currentLocatorTotalProgression.value != null) return@collect
+                val href = _currentLocatorHref.value ?: return@collect
+                val cp = _currentLocatorProgression.value ?: return@collect
+                computeTotalProgression(href, cp, segs)?.let { _currentLocatorTotalProgression.value = it }
+            }
+        }
         viewModelScope.launch {
             _formattingPreferences
                 .map { it.themeSchedule to (it.theme == ReaderTheme.Auto) }
@@ -932,8 +944,15 @@ class EpubReaderViewModel @Inject constructor(
     fun onPositionChanged(locator: Locator) {
         lastLocator = locator
         _currentLocatorHref.value = locator.href.toString()
-        _currentLocatorProgression.value = locator.locations.progression?.toFloat()
-        locator.locations.totalProgression?.toFloat()?.let { _currentLocatorTotalProgression.value = it }
+        val cp = locator.locations.progression?.toFloat()
+        _currentLocatorProgression.value = cp
+        // Prefer totalProgression from the locator (Readium sets it in paginated/vertical modes).
+        // In continuous mode the locator is built by buildContinuousLocator which computes it from
+        // railSegments; if segments are empty at scroll time the field is absent. Fall back to an
+        // inline computation so the value is always populated when segments are already available.
+        val tp = locator.locations.totalProgression?.toFloat()
+            ?: cp?.let { computeTotalProgression(locator.href.toString(), it, railSegments.value) }
+        tp?.let { _currentLocatorTotalProgression.value = it }
         // Leaving the page readaloud stopped on ends the "park": the position is now genuine reading,
         // so reading→audiobook resumes its normal page-top tracking (ADR 0031).
         if (parkedFragmentRef != null) {

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/HighlightRenderer.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/HighlightRenderer.kt
@@ -1,9 +1,18 @@
 package com.riffle.app.feature.reader
 
+import androidx.annotation.ColorInt
 import com.riffle.core.domain.ReadaloudHighlightColor
 import com.riffle.core.domain.ReaderTheme
 import com.riffle.core.domain.SentenceQuote
 import org.readium.r2.shared.publication.Locator
+
+/** ARGB color used for the active (current) search result highlight — warm orange. */
+@ColorInt
+internal val SEARCH_ACTIVE_ARGB: Int = 0xFFF5A623.toInt()
+
+/** ARGB color used for inactive (non-current) search result highlights — pale yellow. */
+@ColorInt
+internal val SEARCH_INACTIVE_ARGB: Int = 0xFFFDE68A.toInt()
 
 /**
  * Abstracts the two rendering pipelines for reader highlights:
@@ -37,7 +46,8 @@ internal interface HighlightRenderer {
     /**
      * Applies or clears note glyph decorations for annotations that have a note.
      * Empty or all-without-notes [renders] clears the group.
-     * Continuous implementation is a no-op (note glyphs are Readium-only).
+     * Continuous implementation is a no-op — glyphs are emitted inside [applyAnnotations]
+     * via [ContinuousStyleInjector.applyAnnotationHighlightsJs], so no separate pass is needed.
      */
     suspend fun applyNoteGlyphs(
         renders: List<EpubReaderViewModel.HighlightRender>,

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/HighlightRenderer.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/HighlightRenderer.kt
@@ -1,0 +1,65 @@
+package com.riffle.app.feature.reader
+
+import com.riffle.core.domain.ReadaloudHighlightColor
+import com.riffle.core.domain.ReaderTheme
+import com.riffle.core.domain.SentenceQuote
+import org.readium.r2.shared.publication.Locator
+
+/**
+ * Abstracts the two rendering pipelines for reader highlights:
+ *  - [ReadiumHighlightRenderer]: paginated and scroll modes via DecorableNavigator
+ *  - [ContinuousHighlightRenderer]: continuous mode via ChapterWebView JS injection
+ *
+ * All suspend methods are called from LaunchedEffect coroutines and must be idempotent —
+ * they may be invoked with the same arguments on reflow/pageLoad events.
+ */
+internal interface HighlightRenderer {
+
+    /**
+     * Applies or clears the readaloud sentence highlight.
+     * [fragmentRef] is "href#spanId" when active, null to clear.
+     */
+    suspend fun applyReadaloud(
+        fragmentRef: String?,
+        quotes: Map<String, SentenceQuote>,
+        color: ReadaloudHighlightColor,
+    )
+
+    /**
+     * Applies or clears persisted annotation highlight decorations.
+     * Empty [renders] clears the group.
+     */
+    suspend fun applyAnnotations(
+        renders: List<EpubReaderViewModel.HighlightRender>,
+        theme: ReaderTheme,
+    )
+
+    /**
+     * Applies or clears note glyph decorations for annotations that have a note.
+     * Empty or all-without-notes [renders] clears the group.
+     * Continuous implementation is a no-op (note glyphs are Readium-only).
+     */
+    suspend fun applyNoteGlyphs(
+        renders: List<EpubReaderViewModel.HighlightRender>,
+    )
+
+    /**
+     * Applies or clears search result decorations for ALL results at once.
+     * Readium implementation renders [Decoration] objects for each locator and
+     * runs a post-navigation settle loop to reposition boxes after layout settles.
+     * Continuous implementation is a no-op — search match highlighting is done
+     * via [highlightSearchMatch] from the navigation event handler.
+     * Empty [results] clears the group.
+     */
+    suspend fun applySearch(
+        results: List<Locator>,
+        activeIndex: Int,
+    )
+
+    /**
+     * Highlights a single navigated-to search match.
+     * Readium implementation is a no-op (DecorableNavigator handles all matches).
+     * Continuous implementation calls [ContinuousHighlightTarget.highlightInChapter].
+     */
+    fun highlightSearchMatch(href: String, text: String, cssColor: String)
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/HighlightRenderer.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/HighlightRenderer.kt
@@ -67,9 +67,9 @@ internal interface HighlightRenderer {
     )
 
     /**
-     * Highlights a single navigated-to search match.
-     * Readium implementation is a no-op (DecorableNavigator handles all matches).
-     * Continuous implementation calls [ContinuousHighlightTarget.highlightInChapter].
+     * Highlights a single navigated-to search match using [SEARCH_ACTIVE_ARGB].
+     * Readium implementation is a no-op (DecorableNavigator handles all matches via applySearch).
+     * Continuous implementation injects a mark into the chapter WebView.
      */
-    fun highlightSearchMatch(href: String, text: String, cssColor: String)
+    fun highlightSearchMatch(href: String, text: String)
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ReadiumHighlightRenderer.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ReadiumHighlightRenderer.kt
@@ -124,7 +124,7 @@ internal class ReadiumHighlightRenderer(
         }
     }
 
-    override fun highlightSearchMatch(href: String, text: String, cssColor: String) {
+    override fun highlightSearchMatch(href: String, text: String) {
         // Readium shows all search results via DecorableNavigator; per-match highlighting is
         // not needed — the active result is distinguished by color in applySearch.
     }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ReadiumHighlightRenderer.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ReadiumHighlightRenderer.kt
@@ -106,9 +106,9 @@ internal class ReadiumHighlightRenderer(
                 id = "search_$index",
                 locator = locator,
                 style = if (index == activeIndex)
-                    Decoration.Style.Highlight(tint = 0xFFF5A623.toInt())
+                    Decoration.Style.Highlight(tint = SEARCH_ACTIVE_ARGB)
                 else
-                    Decoration.Style.Highlight(tint = 0xFFFDE68A.toInt()),
+                    Decoration.Style.Highlight(tint = SEARCH_INACTIVE_ARGB),
             )
         }
         applyDecorationsBlock(decorations, "search")

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ReadiumHighlightRenderer.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ReadiumHighlightRenderer.kt
@@ -1,0 +1,136 @@
+package com.riffle.app.feature.reader
+
+import com.riffle.core.domain.HighlightColor
+import com.riffle.core.domain.ReadaloudHighlightColor
+import com.riffle.core.domain.ReaderTheme
+import com.riffle.core.domain.SentenceQuote
+import kotlinx.coroutines.delay
+import org.readium.r2.navigator.Decoration
+import org.readium.r2.shared.publication.Locator
+
+internal class ReadiumHighlightRenderer(
+    /**
+     * Calls [DecorableNavigator.applyDecorations] on the current fragment, dispatching to
+     * [Dispatchers.Main]. May be a no-op if the navigator is not yet available (returns without
+     * calling the block in that case). The Screen provides this.
+     */
+    private val applyDecorationsBlock: suspend (decorations: List<Decoration>, group: String) -> Unit,
+    /**
+     * Builds a Readium [Locator] from a "href#spanId" ref and an optional sentence quote.
+     * Mirrors the Screen-level [fragmentLocator] function.
+     */
+    private val fragmentLocator: (ref: String, quote: SentenceQuote?) -> Locator?,
+    /**
+     * Returns a stable identity token for the current navigator instance. Used by the
+     * search settle loop to abort when the fragment has been replaced (page navigation,
+     * rotation). In tests, always returns the same value to let the loop run to completion.
+     */
+    private val currentNavigatorStamp: () -> Any? = { null },
+) : HighlightRenderer {
+
+    private var hasReadaloudDecoration = false
+    private var hasAnnotationDecorations = false
+    private var hasNoteGlyphDecorations = false
+    private var hasSearchDecorations = false
+
+    override suspend fun applyReadaloud(
+        fragmentRef: String?,
+        quotes: Map<String, SentenceQuote>,
+        color: ReadaloudHighlightColor,
+    ) {
+        if (fragmentRef == null) {
+            if (!hasReadaloudDecoration) return
+            applyDecorationsBlock(emptyList(), "readaloud")
+            hasReadaloudDecoration = false
+            return
+        }
+        val sid = fragmentRef.substringAfter('#', "")
+        val quote = quotes[sid]
+        val locator = fragmentLocator(fragmentRef, quote) ?: return
+        val decoration = Decoration(
+            id = "readaloud_active",
+            locator = locator,
+            style = HighlightTintStyle(tint = color.argb),
+        )
+        applyDecorationsWithClear(listOf(decoration), "readaloud")
+        hasReadaloudDecoration = true
+    }
+
+    override suspend fun applyAnnotations(
+        renders: List<EpubReaderViewModel.HighlightRender>,
+        theme: ReaderTheme,
+    ) {
+        if (renders.isEmpty()) {
+            if (!hasAnnotationDecorations) return
+            applyDecorationsBlock(emptyList(), "annotations")
+            hasAnnotationDecorations = false
+            return
+        }
+        val decorations = renders.map { h ->
+            Decoration(
+                id = h.id,
+                locator = h.locator,
+                style = HighlightTintStyle(tint = HighlightColor.fromToken(h.color).readerTint(theme)),
+            )
+        }
+        applyDecorationsWithClear(decorations, "annotations")
+        hasAnnotationDecorations = true
+    }
+
+    override suspend fun applyNoteGlyphs(
+        renders: List<EpubReaderViewModel.HighlightRender>,
+    ) {
+        val noted = renders.filter { it.note != null }
+        if (noted.isEmpty()) {
+            if (!hasNoteGlyphDecorations) return
+            applyDecorationsBlock(emptyList(), "annotation-notes")
+            hasNoteGlyphDecorations = false
+            return
+        }
+        val noteDecorations = noted.map { h ->
+            Decoration(id = h.id, locator = h.locator, style = NoteGlyphStyle())
+        }
+        applyDecorationsWithClear(noteDecorations, "annotation-notes")
+        hasNoteGlyphDecorations = true
+    }
+
+    override suspend fun applySearch(results: List<Locator>, activeIndex: Int) {
+        if (results.isEmpty()) {
+            if (!hasSearchDecorations) return
+            applyDecorationsBlock(emptyList(), "search")
+            hasSearchDecorations = false
+            return
+        }
+        val decorations = results.mapIndexed { index, locator ->
+            Decoration(
+                id = "search_$index",
+                locator = locator,
+                style = if (index == activeIndex)
+                    Decoration.Style.Highlight(tint = 0xFFF5A623.toInt())
+                else
+                    Decoration.Style.Highlight(tint = 0xFFFDE68A.toInt()),
+            )
+        }
+        applyDecorationsBlock(decorations, "search")
+        hasSearchDecorations = true
+        // Re-apply across a post-navigation settle window so decoration boxes track the final
+        // layout (Readium fixes rects at applyDecorations time). See the comment at the original
+        // search LaunchedEffect in EpubReaderScreen for full rationale.
+        val stamp = currentNavigatorStamp()
+        for (settleDelayMs in longArrayOf(400L, 600L, 700L, 900L)) {
+            delay(settleDelayMs)
+            if (currentNavigatorStamp() !== stamp) break
+            applyDecorationsWithClear(decorations, "search")
+        }
+    }
+
+    override fun highlightSearchMatch(href: String, text: String, cssColor: String) {
+        // Readium shows all search results via DecorableNavigator; per-match highlighting is
+        // not needed — the active result is distinguished by color in applySearch.
+    }
+
+    private suspend fun applyDecorationsWithClear(decorations: List<Decoration>, group: String) {
+        applyDecorationsBlock(emptyList(), group)
+        applyDecorationsBlock(decorations, group)
+    }
+}

--- a/app/src/test/java/android/net/FakeUri.java
+++ b/app/src/test/java/android/net/FakeUri.java
@@ -1,0 +1,137 @@
+package android.net;
+
+/**
+ * Concrete {@link Uri} subclass for use in JVM unit tests.
+ *
+ * {@link Uri} has a package-private constructor, so it can only be subclassed from within
+ * {@code android.net}. Placing this file under {@code src/test/java/android/net/} lets it
+ * participate in the package while remaining test-only.
+ *
+ * Only {@link #toString()} is meaningful — all other abstract methods throw
+ * {@link UnsupportedOperationException} so tests fail loudly if they accidentally invoke them.
+ */
+public class FakeUri extends Uri {
+
+    private final String uriString;
+
+    public FakeUri(String uriString) {
+        this.uriString = uriString;
+    }
+
+    @Override
+    public String toString() {
+        return uriString;
+    }
+
+    @Override
+    public boolean isHierarchical() {
+        return true;
+    }
+
+    @Override
+    public boolean isRelative() {
+        return false;
+    }
+
+    @Override
+    public String getScheme() {
+        int colon = uriString.indexOf(':');
+        return colon < 0 ? null : uriString.substring(0, colon);
+    }
+
+    @Override
+    public String getSchemeSpecificPart() {
+        throw new UnsupportedOperationException("FakeUri stub");
+    }
+
+    @Override
+    public String getEncodedSchemeSpecificPart() {
+        throw new UnsupportedOperationException("FakeUri stub");
+    }
+
+    @Override
+    public String getAuthority() {
+        return null;
+    }
+
+    @Override
+    public String getEncodedAuthority() {
+        return null;
+    }
+
+    @Override
+    public String getUserInfo() {
+        return null;
+    }
+
+    @Override
+    public String getEncodedUserInfo() {
+        return null;
+    }
+
+    @Override
+    public String getHost() {
+        return null;
+    }
+
+    @Override
+    public int getPort() {
+        return -1;
+    }
+
+    @Override
+    public String getPath() {
+        throw new UnsupportedOperationException("FakeUri stub");
+    }
+
+    @Override
+    public String getEncodedPath() {
+        throw new UnsupportedOperationException("FakeUri stub");
+    }
+
+    @Override
+    public java.util.List<String> getPathSegments() {
+        return java.util.Collections.emptyList();
+    }
+
+    @Override
+    public String getLastPathSegment() {
+        int slash = uriString.lastIndexOf('/');
+        return slash < 0 ? uriString : uriString.substring(slash + 1);
+    }
+
+    @Override
+    public String getQuery() {
+        return null;
+    }
+
+    @Override
+    public String getEncodedQuery() {
+        return null;
+    }
+
+    @Override
+    public String getFragment() {
+        return null;
+    }
+
+    @Override
+    public String getEncodedFragment() {
+        return null;
+    }
+
+    @Override
+    public Uri.Builder buildUpon() {
+        throw new UnsupportedOperationException("FakeUri stub");
+    }
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    @Override
+    public void writeToParcel(android.os.Parcel dest, int flags) {
+        throw new UnsupportedOperationException("FakeUri stub");
+    }
+}

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousHighlightRendererTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousHighlightRendererTest.kt
@@ -208,9 +208,10 @@ class ContinuousHighlightRendererTest {
 
     @Test
     fun `highlightSearchMatch delegates to target`() {
-        renderer.highlightSearchMatch("ch1.xhtml", "search term", "rgba(255,165,0,0.3)")
+        renderer.highlightSearchMatch("ch1.xhtml", "search term")
         assertEquals(1, fakeTarget.highlighted.size)
         assertEquals("ch1.xhtml", fakeTarget.highlighted[0].first)
         assertEquals("search term", fakeTarget.highlighted[0].second)
+        assertEquals(SEARCH_ACTIVE_ARGB.toCssRgba(), fakeTarget.highlighted[0].third)
     }
 }

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousHighlightRendererTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousHighlightRendererTest.kt
@@ -1,0 +1,216 @@
+package com.riffle.app.feature.reader
+
+import android.net.FakeUri
+import com.riffle.core.domain.ReadaloudHighlightColor
+import com.riffle.core.domain.ReaderTheme
+import com.riffle.core.domain.SentenceQuote
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.readium.r2.shared.publication.Locator
+import org.readium.r2.shared.util.AbsoluteUrl
+import org.readium.r2.shared.util.mediatype.MediaType
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ContinuousHighlightRendererTest {
+
+    // Fake target records every call for assertion.
+    internal class FakeTarget : ContinuousHighlightTarget {
+        val highlighted = mutableListOf<Triple<String, String, String>>() // href, text, color
+        val cleared = mutableListOf<String>() // href
+        val appliedAnnotations = mutableListOf<Map<String, List<AnnotationHighlight>>>()
+
+        override fun highlightInChapter(href: String, text: String, cssColor: String) {
+            highlighted.add(Triple(href, text, cssColor))
+        }
+        override fun clearHighlightInChapter(href: String) { cleared.add(href) }
+        override fun applyAnnotationHighlights(annotationsByHref: Map<String, List<AnnotationHighlight>>) {
+            appliedAnnotations.add(annotationsByHref)
+        }
+    }
+
+    private val fakeTarget = FakeTarget()
+    private val renderer = ContinuousHighlightRenderer(targetProvider = { fakeTarget })
+
+    @Before
+    fun setUp() {
+        fakeTarget.highlighted.clear()
+        fakeTarget.cleared.clear()
+        fakeTarget.appliedAnnotations.clear()
+    }
+
+    // ---- Helpers -------------------------------------------------------------
+
+    /**
+     * Creates an [AbsoluteUrl] backed by [urlString] without going through [android.net.Uri.parse],
+     * which is unavailable in JVM unit tests.
+     *
+     * Uses [sun.misc.Unsafe] to allocate [AbsoluteUrl] without calling its private constructor,
+     * then injects a [FakeUri] (our test-only [android.net.Uri] concrete subclass) via reflection.
+     * [FakeUri] is in the [android.net] package so it can subclass the package-private [Uri] ctor.
+     */
+    @Suppress("UNCHECKED_CAST")
+    private fun makeAbsoluteUrl(urlString: String): AbsoluteUrl {
+        val unsafe = Class.forName("sun.misc.Unsafe")
+            .getDeclaredField("theUnsafe")
+            .also { it.isAccessible = true }
+            .get(null) as sun.misc.Unsafe
+        val instance = unsafe.allocateInstance(AbsoluteUrl::class.java) as AbsoluteUrl
+        val uriField = AbsoluteUrl::class.java.getDeclaredField("uri")
+            .also { it.isAccessible = true }
+        uriField.set(instance, FakeUri(urlString))
+        return instance
+    }
+
+    /**
+     * Creates a [Locator] with a meaningful href and text highlight for use in
+     * [applyAnnotations] tests.
+     */
+    private fun makeRender(
+        id: String,
+        href: String,
+        text: String,
+        color: String = "yellow",
+        note: String? = null,
+    ) = EpubReaderViewModel.HighlightRender(
+        id = id,
+        locator = Locator(
+            href = makeAbsoluteUrl("https://example.com/$href"),
+            mediaType = MediaType.XHTML,
+            text = Locator.Text(highlight = text),
+        ),
+        color = color,
+        note = note,
+    )
+
+    /**
+     * Creates a minimal [Locator] stub (no meaningful fields) for tests that don't inspect
+     * the locator content (e.g. [applySearch]).
+     */
+    @Suppress("UNCHECKED_CAST")
+    private fun minimalLocator(@Suppress("UNUSED_PARAMETER") href: String): Locator {
+        val unsafe = Class.forName("sun.misc.Unsafe")
+            .getDeclaredField("theUnsafe")
+            .also { it.isAccessible = true }
+            .get(null) as sun.misc.Unsafe
+        return unsafe.allocateInstance(Locator::class.java) as Locator
+    }
+
+    // ---- applyReadaloud -------------------------------------------------------
+
+    @Test
+    fun `applyReadaloud highlights the sentence text in the correct chapter`() = runTest {
+        renderer.applyReadaloud(
+            fragmentRef = "chapter1.xhtml#s42",
+            quotes = mapOf("s42" to SentenceQuote(before = "", highlight = "To be or not to be", after = "")),
+            color = ReadaloudHighlightColor.BLUE,
+        )
+        assertEquals(1, fakeTarget.highlighted.size)
+        assertEquals("chapter1.xhtml", fakeTarget.highlighted[0].first)
+        assertEquals("To be or not to be", fakeTarget.highlighted[0].second)
+    }
+
+    @Test
+    fun `applyReadaloud clears previous chapter when chapter changes`() = runTest {
+        renderer.applyReadaloud(
+            fragmentRef = "ch1.xhtml#s1",
+            quotes = mapOf("s1" to SentenceQuote(before = "", highlight = "First sentence", after = "")),
+            color = ReadaloudHighlightColor.BLUE,
+        )
+        renderer.applyReadaloud(
+            fragmentRef = "ch2.xhtml#s2",
+            quotes = mapOf("s2" to SentenceQuote(before = "", highlight = "Second chapter", after = "")),
+            color = ReadaloudHighlightColor.BLUE,
+        )
+        // ch1 should have been cleared when ch2 was highlighted
+        assertTrue("ch1 should be cleared", fakeTarget.cleared.contains("ch1.xhtml"))
+        val lastHighlight = fakeTarget.highlighted.last()
+        assertEquals("ch2.xhtml", lastHighlight.first)
+    }
+
+    @Test
+    fun `applyReadaloud with null ref clears previous chapter`() = runTest {
+        renderer.applyReadaloud(
+            fragmentRef = "ch1.xhtml#s1",
+            quotes = mapOf("s1" to SentenceQuote(before = "", highlight = "A sentence", after = "")),
+            color = ReadaloudHighlightColor.BLUE,
+        )
+        renderer.applyReadaloud(null, emptyMap(), ReadaloudHighlightColor.BLUE)
+        assertTrue(fakeTarget.cleared.contains("ch1.xhtml"))
+    }
+
+    @Test
+    fun `applyReadaloud does nothing when sid not in quotes`() = runTest {
+        renderer.applyReadaloud(
+            fragmentRef = "ch1.xhtml#unknown",
+            quotes = emptyMap(),
+            color = ReadaloudHighlightColor.BLUE,
+        )
+        assertEquals(0, fakeTarget.highlighted.size)
+    }
+
+    // ---- applyAnnotations ----------------------------------------------------
+
+    @Test
+    fun `applyAnnotations groups renders by href and maps color to CSS`() = runTest {
+        val renders = listOf(
+            makeRender("h1", "ch1.xhtml", "text one", color = "yellow"),
+            makeRender("h2", "ch1.xhtml", "text two", color = "green"),
+            makeRender("h3", "ch2.xhtml", "text three", color = "blue"),
+        )
+        renderer.applyAnnotations(renders, ReaderTheme.Light)
+
+        assertEquals(1, fakeTarget.appliedAnnotations.size)
+        val byHref = fakeTarget.appliedAnnotations[0]
+        assertEquals(2, byHref["https://example.com/ch1.xhtml"]?.size)
+        assertEquals(1, byHref["https://example.com/ch2.xhtml"]?.size)
+    }
+
+    @Test
+    fun `applyAnnotations skips renders whose locator has no highlight text`() = runTest {
+        // A render whose locator.text.highlight is null should be filtered out.
+        // (In production, the Screen always stores text in the locator, but guard anyway.)
+        val renders = listOf(makeRender("h1", "ch1.xhtml", "some text"))
+        renderer.applyAnnotations(renders, ReaderTheme.Light)
+        // applyAnnotationHighlights should still be called (with filtered content)
+        assertEquals(1, fakeTarget.appliedAnnotations.size)
+    }
+
+    @Test
+    fun `applyAnnotations with empty renders calls applyAnnotationHighlights with empty map`() = runTest {
+        renderer.applyAnnotations(emptyList(), ReaderTheme.Light)
+        assertEquals(1, fakeTarget.appliedAnnotations.size)
+        assertTrue(fakeTarget.appliedAnnotations[0].isEmpty())
+    }
+
+    // ---- applyNoteGlyphs (no-op) --------------------------------------------
+
+    @Test
+    fun `applyNoteGlyphs is a no-op in continuous mode`() = runTest {
+        renderer.applyNoteGlyphs(listOf(makeRender("h1", "ch1.xhtml", "text", note = "my note")))
+        assertEquals(0, fakeTarget.highlighted.size)
+        assertEquals(0, fakeTarget.cleared.size)
+        assertEquals(0, fakeTarget.appliedAnnotations.size)
+    }
+
+    // ---- applySearch (no-op) ------------------------------------------------
+
+    @Test
+    fun `applySearch is a no-op in continuous mode`() = runTest {
+        renderer.applySearch(listOf(minimalLocator("c.xhtml")), activeIndex = 0)
+        assertEquals(0, fakeTarget.highlighted.size)
+    }
+
+    // ---- highlightSearchMatch -----------------------------------------------
+
+    @Test
+    fun `highlightSearchMatch delegates to target`() {
+        renderer.highlightSearchMatch("ch1.xhtml", "search term", "rgba(255,165,0,0.3)")
+        assertEquals(1, fakeTarget.highlighted.size)
+        assertEquals("ch1.xhtml", fakeTarget.highlighted[0].first)
+        assertEquals("search term", fakeTarget.highlighted[0].second)
+    }
+}

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/EpubReaderViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/EpubReaderViewModelTest.kt
@@ -769,6 +769,95 @@ class ReadingProgressLabelSourceTest {
 }
 
 /**
+ * Regression for "remaining time barely refreshes, if ever, in continuous mode."
+ *
+ * In continuous mode, buildContinuousLocator may produce a Locator without totalProgression when
+ * railSegments have not yet loaded (the positions API call is still in-flight). Two fixes:
+ *
+ *  1. onPositionChanged now falls back to computeTotalProgression when the locator's field is
+ *     absent but segments are already available.
+ *  2. A second init block (placed after the railSegments declaration to avoid a Kotlin class-init
+ *     NPE) back-fills _currentLocatorTotalProgression the moment segments arrive if no real value
+ *     was ever set from a locator.
+ *
+ * EpubReaderViewModel cannot be constructed in a JVM test (Readium needs android.net.Uri), so the
+ * fake below mirrors the exact production control flow from onPositionChanged and the backfill init
+ * block; a regression here maps directly to the ViewModel.
+ */
+class TotalProgressionFallbackTest {
+
+    private fun seg(href: String, weight: Float) = RailSegment(title = href, href = href, weight = weight)
+
+    private class Source {
+        var segments: List<RailSegment> = emptyList()
+        private var lastHref: String? = null
+        private var lastCp: Float? = null
+        val totalProgression = MutableStateFlow<Float?>(null)
+
+        fun onPositionChanged(href: String, progression: Float?, total: Float?) {
+            lastHref = href
+            lastCp = progression
+            val tp = total ?: progression?.let { computeTotalProgression(href, it, segments) }
+            tp?.let { totalProgression.value = it }
+        }
+
+        fun onSegmentsChanged(newSegments: List<RailSegment>) {
+            segments = newSegments
+            if (newSegments.isEmpty() || totalProgression.value != null) return
+            val href = lastHref ?: return
+            val cp = lastCp ?: return
+            computeTotalProgression(href, cp, newSegments)?.let { totalProgression.value = it }
+        }
+    }
+
+    @Test
+    fun `when locator has totalProgression it is used directly`() {
+        val s = Source()
+        s.segments = listOf(seg("ch1.xhtml", 1f), seg("ch2.xhtml", 1f))
+        s.onPositionChanged("ch1.xhtml", progression = 0.5f, total = 0.25f)
+        assertEquals(0.25f, s.totalProgression.value!!, 0.001f)
+    }
+
+    @Test
+    fun `when locator has no totalProgression and segments available, falls back to computeTotalProgression`() {
+        val s = Source()
+        s.segments = listOf(seg("ch1.xhtml", 1f), seg("ch2.xhtml", 1f))
+        // Continuous-mode locator: totalProgression absent, segments already loaded.
+        s.onPositionChanged("ch2.xhtml", progression = 0f, total = null)
+        // ch2 at 0% through the chapter = 50% through the book.
+        assertEquals(0.5f, s.totalProgression.value!!, 0.001f)
+    }
+
+    @Test
+    fun `when locator has no totalProgression and segments are empty, value stays null`() {
+        val s = Source()
+        s.onPositionChanged("ch1.xhtml", progression = 0.5f, total = null)
+        assertNull(s.totalProgression.value)
+    }
+
+    @Test
+    fun `when segments arrive after first scroll, totalProgression is back-filled`() {
+        val s = Source()
+        s.onPositionChanged("ch2.xhtml", progression = 0f, total = null)
+        assertNull("no segments yet — should stay null", s.totalProgression.value)
+
+        s.onSegmentsChanged(listOf(seg("ch1.xhtml", 1f), seg("ch2.xhtml", 1f)))
+        assertEquals(0.5f, s.totalProgression.value!!, 0.001f)
+    }
+
+    @Test
+    fun `backfill does not overwrite a totalProgression already set from a locator`() {
+        val s = Source()
+        s.segments = listOf(seg("ch1.xhtml", 1f), seg("ch2.xhtml", 1f))
+        s.onPositionChanged("ch2.xhtml", progression = 0f, total = 0.6f)
+
+        // Segments reload / re-emit — backfill guard must skip because value is already non-null.
+        s.onSegmentsChanged(s.segments)
+        assertEquals(0.6f, s.totalProgression.value!!, 0.001f)
+    }
+}
+
+/**
  * Unit tests for the the canonical reconciliation cycle invariants that live in EpubReaderViewModel's
  * onPositionChanged / push / readaloud-start control flow. The ViewModel itself can't be constructed
  * in a JVM test (Readium needs android.net.Uri — see the file header), so each fake mirrors the exact

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ReadiumHighlightRendererTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ReadiumHighlightRendererTest.kt
@@ -198,7 +198,7 @@ class ReadiumHighlightRendererTest {
 
     @Test
     fun `highlightSearchMatch is a no-op`() {
-        renderer.highlightSearchMatch("c.xhtml", "some text", "rgba(255,0,0,0.3)")
+        renderer.highlightSearchMatch("c.xhtml", "some text")
         assertEquals(0, applied.size)
     }
 }

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ReadiumHighlightRendererTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ReadiumHighlightRendererTest.kt
@@ -1,0 +1,204 @@
+@file:OptIn(org.readium.r2.shared.ExperimentalReadiumApi::class)
+
+package com.riffle.app.feature.reader
+
+import com.riffle.core.domain.HighlightColor
+import com.riffle.core.domain.ReadaloudHighlightColor
+import com.riffle.core.domain.ReaderTheme
+import com.riffle.core.domain.SentenceQuote
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.readium.r2.navigator.Decoration
+import org.readium.r2.shared.publication.Locator
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ReadiumHighlightRendererTest {
+
+    private val applied = mutableListOf<Pair<List<Decoration>, String>>()
+    private var navigatorStamp: Any? = Any()
+
+    private val renderer = ReadiumHighlightRenderer(
+        applyDecorationsBlock = { decorations, group -> applied.add(decorations to group) },
+        fragmentLocator = { ref, _ ->
+            // Return a minimal locator for any non-blank ref
+            if (ref.isNotBlank()) minimalLocator(ref.substringBefore('#')) else null
+        },
+        currentNavigatorStamp = { navigatorStamp },
+    )
+
+    @Before
+    fun setUp() {
+        applied.clear()
+        navigatorStamp = Any()
+    }
+
+    private fun minimalLocator(@Suppress("UNUSED_PARAMETER") href: String): Locator {
+        // Locator(Url, MediaType, ...) requires android.net.Uri which is not available in JVM
+        // unit tests. Allocate a Locator stub via Unsafe — the resulting instance has all fields
+        // null/zero but is a real Locator that can be stored in HighlightRender and Decoration.
+        // Our assertions only care about decoration.id and group names, not the locator content.
+        @Suppress("UNCHECKED_CAST")
+        val unsafe = Class.forName("sun.misc.Unsafe")
+            .getDeclaredField("theUnsafe")
+            .also { it.isAccessible = true }
+            .get(null) as sun.misc.Unsafe
+        return unsafe.allocateInstance(Locator::class.java) as Locator
+    }
+
+    private fun makeRender(
+        id: String,
+        href: String,
+        color: String = "yellow",
+        note: String? = null,
+    ) = EpubReaderViewModel.HighlightRender(
+        id = id,
+        locator = minimalLocator(href),
+        color = color,
+        note = note,
+    )
+
+    // ---- applyReadaloud -------------------------------------------------------
+
+    @Test
+    fun `applyReadaloud with non-null ref applies readaloud group`() = runTest {
+        renderer.applyReadaloud(
+            fragmentRef = "chapter1.xhtml#s1",
+            quotes = mapOf("s1" to SentenceQuote(before = "", highlight = "Hello world", after = "")),
+            color = ReadaloudHighlightColor.BLUE,
+        )
+        val readaloudCalls = applied.filter { it.second == "readaloud" }
+        assertEquals(2, readaloudCalls.size) // applyDecorationsWithClear: clear then apply
+        assertEquals(emptyList<Decoration>(), readaloudCalls[0].first)
+        assertEquals(1, readaloudCalls[1].first.size)
+        assertEquals("readaloud_active", readaloudCalls[1].first[0].id)
+    }
+
+    @Test
+    fun `applyReadaloud with null ref clears group and does not re-clear if already clear`() = runTest {
+        // First call: nothing to clear → no dispatch
+        renderer.applyReadaloud(null, emptyMap(), ReadaloudHighlightColor.BLUE)
+        assertEquals(0, applied.size)
+
+        // Apply one, then clear
+        renderer.applyReadaloud("c.xhtml#s1", emptyMap(), ReadaloudHighlightColor.BLUE)
+        applied.clear()
+        renderer.applyReadaloud(null, emptyMap(), ReadaloudHighlightColor.BLUE)
+        assertEquals(1, applied.size)
+        assertEquals(emptyList<Decoration>(), applied[0].first)
+        assertEquals("readaloud", applied[0].second)
+    }
+
+    // ---- applyAnnotations ----------------------------------------------------
+
+    @Test
+    fun `applyAnnotations with renders produces one decoration per render`() = runTest {
+        val renders = listOf(
+            makeRender("h1", "c1.xhtml", color = "yellow"),
+            makeRender("h2", "c1.xhtml", color = "green"),
+        )
+        renderer.applyAnnotations(renders, ReaderTheme.Light)
+        // applyDecorationsWithClear = clear + apply → 2 calls to the block
+        val decorationCall = applied.last()
+        assertEquals("annotations", decorationCall.second)
+        assertEquals(2, decorationCall.first.size)
+        assertEquals("h1", decorationCall.first[0].id)
+        assertEquals("h2", decorationCall.first[1].id)
+    }
+
+    @Test
+    fun `applyAnnotations with empty list clears group`() = runTest {
+        // Apply something first so hasAnnotationDecorations = true
+        renderer.applyAnnotations(listOf(makeRender("h1", "c1.xhtml")), ReaderTheme.Light)
+        applied.clear()
+
+        renderer.applyAnnotations(emptyList(), ReaderTheme.Light)
+        assertEquals(1, applied.size)
+        assertEquals(emptyList<Decoration>(), applied[0].first)
+        assertEquals("annotations", applied[0].second)
+    }
+
+    @Test
+    fun `applyAnnotations empty list is no-op when no decorations active`() = runTest {
+        renderer.applyAnnotations(emptyList(), ReaderTheme.Light)
+        assertEquals(0, applied.size)
+    }
+
+    // ---- applyNoteGlyphs ----------------------------------------------------
+
+    @Test
+    fun `applyNoteGlyphs only decorates renders that have a note`() = runTest {
+        val renders = listOf(
+            makeRender("h1", "c.xhtml", note = "My note"),
+            makeRender("h2", "c.xhtml", note = null),
+        )
+        renderer.applyNoteGlyphs(renders)
+        val decorationCall = applied.last()
+        assertEquals("annotation-notes", decorationCall.second)
+        assertEquals(1, decorationCall.first.size)
+        assertEquals("h1", decorationCall.first[0].id)
+    }
+
+    @Test
+    fun `applyNoteGlyphs clears group when no noted renders`() = runTest {
+        // Apply one first
+        renderer.applyNoteGlyphs(listOf(makeRender("h1", "c.xhtml", note = "note")))
+        applied.clear()
+
+        renderer.applyNoteGlyphs(listOf(makeRender("h2", "c.xhtml", note = null)))
+        assertEquals(1, applied.size)
+        assertEquals(emptyList<Decoration>(), applied[0].first)
+        assertEquals("annotation-notes", applied[0].second)
+    }
+
+    // ---- applySearch ---------------------------------------------------------
+
+    @Test
+    fun `applySearch with results applies search group`() = runTest {
+        val results = listOf(minimalLocator("c.xhtml"), minimalLocator("c.xhtml"))
+        renderer.applySearch(results, activeIndex = 0)
+        // First call is the immediate apply; settle loop adds more (but UnconfinedTestDispatcher
+        // will advance through delays).
+        val searchCalls = applied.filter { it.second == "search" }
+        assertTrue(searchCalls.isNotEmpty())
+        assertEquals(2, searchCalls.first().first.size)
+    }
+
+    @Test
+    fun `applySearch with empty results clears group`() = runTest {
+        // Apply first so sentinel = true
+        renderer.applySearch(listOf(minimalLocator("c.xhtml")), 0)
+        applied.clear()
+
+        renderer.applySearch(emptyList(), 0)
+        val clearCall = applied.firstOrNull { it.second == "search" }
+        assertEquals(emptyList<Decoration>(), clearCall?.first)
+    }
+
+    @Test
+    fun `applySearch settle loop aborts when navigator stamp changes`() = runTest {
+        val recorder = mutableListOf<Pair<List<Decoration>, String>>()
+        val abortingRenderer = ReadiumHighlightRenderer(
+            applyDecorationsBlock = { decorations, group -> recorder.add(decorations to group) },
+            fragmentLocator = { ref, _ -> if (ref.isNotBlank()) minimalLocator(ref.substringBefore('#')) else null },
+            currentNavigatorStamp = { Any() }, // new object every call → stamp always changes
+        )
+        abortingRenderer.applySearch(listOf(minimalLocator("c.xhtml")), activeIndex = 0)
+        val searchCalls = recorder.filter { it.second == "search" }
+        // Only the initial apply fires; settle loop aborts on first resume because stamp changed
+        assertEquals(1, searchCalls.size)
+        assertEquals(1, searchCalls[0].first.size)
+    }
+
+    // ---- highlightSearchMatch ------------------------------------------------
+
+    @Test
+    fun `highlightSearchMatch is a no-op`() {
+        renderer.highlightSearchMatch("c.xhtml", "some text", "rgba(255,0,0,0.3)")
+        assertEquals(0, applied.size)
+    }
+}


### PR DESCRIPTION
## Summary

- Extracts 8 parallel \`LaunchedEffect\` bodies from \`EpubReaderScreen\` (4 concerns × 2 modes) behind a \`HighlightRenderer\` interface with two concrete adapters
- \`ReadiumHighlightRenderer\` handles paginated and scroll modes via \`DecorableNavigator\`; \`ContinuousHighlightRenderer\` handles continuous mode via ChapterWebView JS injection
- Removes 5 boolean sentinel states (\`hasReadaloudDecoration\`, \`hasHighlightDecorations\`, \`hasNoteDecorations\`, \`hasActiveDecorations\`, \`prevHighlightHref\`) and the private \`applyDecorationsWithClear\` extension from the screen
- Net −191 lines in \`EpubReaderScreen.kt\`; 26 new JVM tests cover both adapters and the ViewModel fixes
- Unifies search highlight color: \`SEARCH_ACTIVE_ARGB\`/\`SEARCH_INACTIVE_ARGB\` constants defined once in \`HighlightRenderer.kt\` — continuous mode previously used \`readaloudHighlightColor\` for search highlights by mistake
- Fixes continuous-mode remaining-time stalling: \`onPositionChanged\` now falls back to \`computeTotalProgression\` when the locator has no \`totalProgression\` field, and a second \`init\` block backfills the value when \`railSegments\` arrives late (placed after the \`railSegments\` declaration to avoid a Kotlin class-init NPE from \`Dispatchers.Main.immediate\`)
- Removes stale \`readaloudHighlightColor\` key from the \`searchNavigationEvents\` LaunchedEffect (it was never read by the body; keeping it restarted the collector unnecessarily on color changes)

## Test plan

- [x] \`./gradlew test\` — all JVM suites green (26 new tests: \`ReadiumHighlightRendererTest\` × 11, \`ContinuousHighlightRendererTest\` × 10, \`TotalProgressionFallbackTest\` × 5)
- [x] \`./gradlew lint\` — clean
- [x] \`make harness-test\` — 237 tests, 0 failures, 5 pre-existing skips
- [x] \`make harness-test-tablet\` — 5 tests, 0 failures
- [x] Continuous-mode remaining time verified updating on device (scrolling through Children of Dune: \`~6min chapter / ~6h 49min total\` → \`~5min chapter / ~6h 48min total\`)
- [ ] Paginated search: orange highlights visible, counter 1→2 of N navigation works
- [ ] Scroll search: orange highlights visible, counter 1→2 of N navigation works
- [ ] Continuous search: orange \`<mark>\` highlight (matches paginated/scroll color), counter 1→2 of N navigation works
- [ ] Readaloud highlight: applies and clears correctly in all three modes
- [ ] Annotation highlights: visible in all three modes on a book with saved highlights
- [ ] Note glyphs: margin icon appears next to annotated passages with notes in all three modes