### PR TITLE
fix(reader): align bookmark navigation to top in continuous mode

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
@@ -297,7 +297,7 @@ internal class ContinuousReaderView @JvmOverloads constructor(
      * Used for the first open, for a far TOC/link jump, and to recover after the WebView renderer
      * process is killed (see [onRenderProcessGone] wiring in [appendChapter]).
      */
-    private fun openWindowAt(initialHref: String, initialProgression: Float, anchorFragment: String = "") {
+    private fun openWindowAt(initialHref: String, initialProgression: Float, anchorFragment: String = "", alignToTop: Boolean = false) {
         val targetIndex = ContinuousPositionTracker
             .chapterIndexForHref(allChapters.map { it.link.href.toString() }, initialHref)
             .coerceAtLeast(0)
@@ -344,13 +344,17 @@ internal class ContinuousReaderView @JvmOverloads constructor(
                 } else {
                     // Restore at the viewport midpoint (inverse of locatorAt) so a resumed position
                     // doesn't drift forward half a screen on every reopen; a chapter start stays at
-                    // the top.
-                    scrollTo(
-                        0,
+                    // the top. When alignToTop is true (bookmark / external locator navigation) the
+                    // progression was measured at content top, not viewport midpoint, so skip the
+                    // half-viewport offset.
+                    val y = if (alignToTop) {
+                        (slot.top + (initialProgression * slot.height).toInt()).coerceAtLeast(0)
+                    } else {
                         ContinuousPositionTracker.scrollYForProgression(
                             slot.top, slot.height, initialProgression, height,
-                        ),
-                    )
+                        )
+                    }
+                    scrollTo(0, y)
                 }
             }
         }
@@ -408,8 +412,15 @@ internal class ContinuousReaderView @JvmOverloads constructor(
         webViews.forEach { wv -> wv.reinjectAndRemeasure(styleJs) }
     }
 
-    /** Scroll to [href] at [progression]. Loads the chapter into the window if needed. */
-    fun navigateTo(href: String, progression: Float) {
+    /**
+     * Scroll to [href] at [progression]. Loads the chapter into the window if needed.
+     *
+     * [alignToTop] must be true when [progression] was measured at content top rather than the
+     * viewport midpoint — i.e. for bookmarks and external locators (which use CFI-derived
+     * progressions). Leave false for continuous-mode round-trips (resume, return-to-position) where
+     * [locatorAt] was the source and the midpoint inverse keeps the position drift-free.
+     */
+    fun navigateTo(href: String, progression: Float, alignToTop: Boolean = false) {
         // TOC entries / chapter-map segments / internal links may carry a #fragment that the spine
         // hrefs don't have; match on the resource path so the chapter is still found.
         val target = href.substringBefore('#')
@@ -421,7 +432,7 @@ internal class ContinuousReaderView @JvmOverloads constructor(
         val inWindow = targetIndex in topIndex until (topIndex + webViews.size)
         if (inWindow) {
             // Already loaded and measured: scroll straight to it.
-            post { scrollToLoadedChapter(target, progression, fragment, smooth = true) }
+            post { scrollToLoadedChapter(target, progression, fragment, smooth = true, alignToTop = alignToTop) }
         } else {
             // Far jump (typical TOC / chapter-map tap): rebuild the window around the target and land
             // via the open path, which defers the scroll until the target's REAL height is known.
@@ -433,7 +444,7 @@ internal class ContinuousReaderView @JvmOverloads constructor(
             container.removeAllViews()
             recycledViews.forEach { it.destroy() }
             recycledViews.clear()
-            openWindowAt(target, progression, fragment)
+            openWindowAt(target, progression, fragment, alignToTop = alignToTop)
         }
     }
 
@@ -444,7 +455,7 @@ internal class ContinuousReaderView @JvmOverloads constructor(
      * previous chapter into the top half ("wrong page"); a mid-chapter position (search hit) is
      * centred so the hit is comfortably visible.
      */
-    private fun scrollToLoadedChapter(target: String, progression: Float, fragment: String, smooth: Boolean) {
+    private fun scrollToLoadedChapter(target: String, progression: Float, fragment: String, smooth: Boolean, alignToTop: Boolean = false) {
         val window = buildWindow()
         val slot = window.firstOrNull { it.href.substringBefore('#') == target } ?: return
         fun go(y: Int) {
@@ -459,7 +470,11 @@ internal class ContinuousReaderView @JvmOverloads constructor(
             }
         } else {
             // Top-align a chapter start; centre a mid-chapter target (inverse of locatorAt).
-            go(ContinuousPositionTracker.scrollYForProgression(slot.top, slot.height, progression, height))
+            // When alignToTop, skip the half-viewport offset — the progression is content-top-relative.
+            go(
+                if (alignToTop) slot.top + (progression * slot.height).toInt()
+                else ContinuousPositionTracker.scrollYForProgression(slot.top, slot.height, progression, height)
+            )
         }
     }
 

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
@@ -334,6 +334,8 @@ internal class ContinuousReaderView @JvmOverloads constructor(
                     targetWv.anchorOffsetTopDevicePx(anchorFragment) { anchorOffset ->
                         val y = if (anchorOffset != null) {
                             (slot.top + anchorOffset).coerceAtLeast(0)
+                        } else if (alignToTop) {
+                            (slot.top + (initialProgression * slot.height).toInt()).coerceAtLeast(0)
                         } else {
                             ContinuousPositionTracker.scrollYForProgression(
                                 slot.top, slot.height, initialProgression, height,

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -1475,7 +1475,13 @@ private fun EpubNavigatorView(
     LaunchedEffect(annotationNavigationEvents, isContinuous) {
         annotationNavigationEvents.collect { locator ->
             if (isContinuous) {
-                goToContinuous(locator)
+                // Bookmark locators carry CFI-derived progressions measured at content top (not the
+                // viewport midpoint that locatorAt uses), so align to top rather than midpoint.
+                continuousViewRef.value?.navigateTo(
+                    locator.href.toString(),
+                    locator.locations.progression?.toFloat() ?: 0f,
+                    alignToTop = true,
+                )
             } else {
                 goAndSnapWithCover(locator)
             }

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousPositionTrackerTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousPositionTrackerTest.kt
@@ -192,6 +192,52 @@ class ContinuousPositionTrackerTest {
         assertEquals(0, ContinuousPositionTracker.pageScrollDelta(-5))
     }
 
+    // ── Bookmark vs. continuous-resume alignment ──────────────────────────────
+    //
+    // scrollYForProgression is the midpoint-inverse of locatorAt: it's correct for continuous
+    // round-trips (save position → resume) but wrong for external locators (bookmark/CFI) whose
+    // progression was measured at content top rather than viewport midpoint. For those,
+    // scrollOffsetFor gives the top-aligned scrollY.
+
+    @Test
+    fun `scrollOffsetFor gives top-aligned scrollY for a bookmark locator — content at viewport top`() {
+        // Bookmark at progression 0·5 through chapter A (height 1000, top 0): content is at offset 500.
+        // Top-aligned: scrollY = 0 + 0.5 * 1000 = 500 → bookmarked line at viewport top.
+        val offset = ContinuousPositionTracker.scrollOffsetFor("A.xhtml", 0.5f, window)
+        assertEquals(500, offset)
+    }
+
+    @Test
+    fun `scrollYForProgression for the same bookmark progression places content at viewport midpoint`() {
+        // scrollYForProgression subtracts viewportHeight/2 (midpoint-inverse of locatorAt).
+        // For a progression measured at content top (bookmark), this scrolls viewportHeight/2 too
+        // high — the bug that alignToTop = true fixes.
+        val viewport = 800
+        val midpointAligned = ContinuousPositionTracker.scrollYForProgression(
+            slotTop = 0, slotHeight = 1000, progression = 0.5f, viewportHeight = viewport,
+        )
+        val topAligned = ContinuousPositionTracker.scrollOffsetFor("A.xhtml", 0.5f, window)!!
+
+        // midpoint-aligned = 500 - 400 = 100; top-aligned = 500. Difference = viewportHeight/2.
+        assertEquals(topAligned - viewport / 2, midpointAligned)
+        assertEquals(viewport / 2, topAligned - midpointAligned)
+    }
+
+    @Test
+    fun `top-aligned bookmark at chapter start lands at chapter top, not before it`() {
+        // progression 0 on chapter B (top=1000): both alignments agree — the chapter start is at 1000.
+        val topAligned = ContinuousPositionTracker.scrollOffsetFor("B.xhtml", 0f, window)
+        assertEquals(1000, topAligned)
+    }
+
+    @Test
+    fun `top-aligned bookmark at chapter end lands at the last content, not past it`() {
+        // progression 1.0 on chapter A (height 1000, top 0): scrollY = 0 + 1000 = 1000
+        // (the very bottom of chapter A, which is also where chapter B begins).
+        val topAligned = ContinuousPositionTracker.scrollOffsetFor("A.xhtml", 1.0f, window)
+        assertEquals(1000, topAligned)
+    }
+
     // ── sentenceIdForSelection (Play from here) ───────────────────────────────
 
     private val quoteTexts = mapOf(


### PR DESCRIPTION
## Problem

When a bookmark is created in paginated mode and then navigated to in continuous mode, the reader lands roughly half a viewport too early — showing text that appears before the bookmarked line.

**Root cause:** `scrollYForProgression` is designed as the exact inverse of `locatorAt()`, which measures position at the viewport _midpoint_. Bookmark locators are built via `cfiStringToLocator` (CFI → progression), which measures position from the content _top_. Feeding a content-top progression into the midpoint-inverse function subtracts `viewportHeight / 2` unnecessarily, undershooting by half a screen.

## Changes

- **`ContinuousReaderView`** — `navigateTo`, `openWindowAt`, and `scrollToLoadedChapter` each gain an `alignToTop: Boolean = false` parameter. When `true`, the scroll target is computed as `slot.top + progression * slot.height` (no viewport/2 offset). Also propagates the flag into the anchor-element-not-found fallback in `openWindowAt` so bookmark far-jumps with a fragment stay top-aligned even when the anchor can't resolve.
- **`EpubReaderScreen`** — the `annotationNavigationEvents` handler calls `navigateTo(..., alignToTop = true)` directly instead of `goToContinuous`. All other navigation paths (reading-position resume, return-to-position, server sync, search) keep their existing midpoint-inverse behaviour unchanged.

## Tests

Added four unit tests to `ContinuousPositionTrackerTest` documenting:
- `scrollOffsetFor` (top-aligned) gives the correct scrollY for a bookmark locator
- `scrollYForProgression` places content at viewport midpoint — exactly `viewportHeight/2` less than the top-aligned value (the bug)
- Chapter-start and chapter-end bookmarks are handled correctly with top alignment

## Test commands

- `./gradlew test` — all green
- `./gradlew lint` — clean