### PR TITLE
fix(reader): wrong word highlighted in continuous mode readaloud

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjector.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjector.kt
@@ -477,6 +477,14 @@ internal object ContinuousStyleInjector {
      * `surroundContents()` throws when the selection range crosses an inline element boundary
      * (e.g. `<em>`, `<span class="smallcaps">`). The fallback uses `extractContents()` +
      * `insertNode()` which handles multi-node ranges correctly.
+     *
+     * The sentinel trick: before removing the old mark we insert a temporary empty `<span>`
+     * immediately after it. `outerHTML = innerHTML` removes the mark but leaves the sentinel
+     * in place. We then collapse the selection to right after the sentinel and remove it.
+     * This makes `window.find()` search forward from the end of the previous sentence rather
+     * than from the document start (the unpredictable position the DOM mutation leaves the
+     * selection at), so consecutive sentences that share a repeated word/phrase always resolve
+     * to the next occurrence in reading order instead of the first one in the document.
      */
     fun highlightTextJs(text: String, cssColor: String): String {
         if (text.isBlank()) return CLEAR_HIGHLIGHT_JS
@@ -484,9 +492,25 @@ internal object ContinuousStyleInjector {
         return """
             (function() {
                 var existing = document.getElementById('_riffle_hl');
-                if (existing) { existing.outerHTML = existing.innerHTML; }
+                var sentinel = null;
+                if (existing && existing.parentNode) {
+                    sentinel = document.createElement('span');
+                    existing.parentNode.insertBefore(sentinel, existing.nextSibling);
+                    existing.outerHTML = existing.innerHTML;
+                }
+                var sel = window.getSelection ? window.getSelection() : null;
+                if (sel) sel.removeAllRanges();
+                if (sentinel && sentinel.parentNode) {
+                    try {
+                        var r = document.createRange();
+                        r.setStartAfter(sentinel);
+                        r.collapse(true);
+                        if (sel) sel.addRange(r);
+                    } catch(e) {}
+                    sentinel.parentNode.removeChild(sentinel);
+                }
                 if (!window.find('$safe', false, false, false, false, false, false)) return;
-                var sel = window.getSelection();
+                sel = window.getSelection();
                 if (!sel || sel.rangeCount === 0) return;
                 var range = sel.getRangeAt(0);
                 var mark = document.createElement('mark');

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjectorTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjectorTest.kt
@@ -196,6 +196,26 @@ class ContinuousStyleInjectorTest {
         assertFalse(js.contains("line one\nline two"))
     }
 
+    @Test
+    fun `highlightTextJs uses sentinel to preserve search position after clearing old mark`() {
+        // The sentinel trick: a temporary span is inserted AFTER the existing _riffle_hl mark
+        // before the outerHTML mutation, so window.find() starts from the end of the previous
+        // sentence rather than from the document start (which would find the first occurrence
+        // and misplace the highlight when the same word/phrase recurs earlier in the chapter).
+        val js = ContinuousStyleInjector.highlightTextJs("test sentence", "rgba(56,189,248,0.30)")
+        assertTrue("inserts sentinel after existing mark", js.contains("insertBefore(sentinel, existing.nextSibling)"))
+        assertTrue("removes sentinel before searching", js.contains("removeChild(sentinel)"))
+        assertTrue("collapses selection after sentinel", js.contains("setStartAfter(sentinel)"))
+        // Sentinel must be inserted BEFORE the outerHTML mutation (not after).
+        val insertIdx = js.indexOf("insertBefore(sentinel")
+        val outerHtmlIdx = js.indexOf("outerHTML = existing.innerHTML")
+        assertTrue("sentinel inserted before outerHTML mutation", insertIdx < outerHtmlIdx)
+        // And the sentinel must be removed BEFORE window.find() is called.
+        val removeIdx = js.indexOf("removeChild(sentinel)")
+        val findIdx = js.indexOf("window.find(")
+        assertTrue("sentinel removed before window.find()", removeIdx < findIdx)
+    }
+
     // ── CLEAR_ANNOTATION_HIGHLIGHTS_JS ─────────────────────────────────────────
 
     @Test


### PR DESCRIPTION
## Summary

- `window.find()` in `highlightTextJs` was starting from an unpredictable position after the previous `<mark id="_riffle_hl">` was cleared via `outerHTML = innerHTML`. The DOM mutation resets the selection, and `window.find()` would then search from the document start — finding the **first** occurrence of the sentence text in the chapter instead of the correct next one in reading order.
- When a short word or phrase (e.g. "original") appears earlier in the same chapter (in a different sentence), the wrong occurrence gets highlighted.
- Fix: insert a temporary empty `<span>` (sentinel) immediately after the existing mark before the `outerHTML` mutation. The sentinel survives the mutation and marks the position right after the cleared sentence. We collapse the selection there, remove the sentinel, then call `window.find()` — which now searches forward from the end of the previous sentence.

## Test plan

- [x] `ContinuousStyleInjectorTest` — new test verifies sentinel is inserted before the `outerHTML` mutation and removed before `window.find()` is called
- [x] `./gradlew test` — all JVM tests green
- [x] `./gradlew lint` — clean
- [ ] Device verification: book with a repeated word/phrase at different chapter positions in continuous mode; confirmed readaloud highlight lands on the correct occurrence