### PR TITLE
fix(reader): apply typography overrides in continuous mode

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjector.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjector.kt
@@ -158,11 +158,19 @@ internal object ContinuousStyleInjector {
             beforeBlock + out
         }
 
-        // 2. After-CSS + bundled @font-face before </head>.
+        // 2. After-CSS + bundled @font-face + typography overrides before </head>.
+        // The typography override CSS must come after ReadiumCSS-after.css because it needs to
+        // beat after.css's `text-align: inherit !important` rule (specificity 0,2,4) for justify.
+        // It uses the same gate selectors as the paginated-mode typographyOverrideInjectionJs()
+        // path, so toggling justify via buildStyleInjectionJs() (which updates --USER__textAlign
+        // on <html>) automatically activates/deactivates the override without reloading the page.
         val afterBlock = buildString {
             append("\n<link rel=\"stylesheet\" type=\"text/css\" href=\"$CSS_BASE/ReadiumCSS-after.css\"/>\n")
             append("<style type=\"text/css\">\n")
             append(bundledFontFaces())
+            append("</style>\n")
+            append("<style type=\"text/css\" id=\"riffle-typography-override\">\n")
+            append(typographyOverrideCss())
             append("</style>\n")
         }
         val headCloseIdx = out.indexOf("</head>", ignoreCase = true)

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjector.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjector.kt
@@ -37,6 +37,12 @@ internal object ContinuousStyleInjector {
     /** ReaderThemePalette.DARK_DIM_TEXT as a ReadiumCSS hex colour (matches FormattingPreferencesMapper). */
     private val DARK_DIM_TEXT_HEX: String = String.format("#%06X", 0xFFFFFF and DARK_DIM_TEXT.toArgb())
 
+    // Regex patterns used in injectInto() — hoisted so they are compiled once rather than on
+    // every chapter load (shouldInterceptRequest is on the WebCore hot path).
+    private val REGEX_STYLE_TAG = Regex("<style", RegexOption.IGNORE_CASE)
+    private val REGEX_HEAD_OPEN = Regex("<head[^>]*>", RegexOption.IGNORE_CASE)
+    private val REGEX_HTML_OPEN = Regex("<html[^>]*", RegexOption.IGNORE_CASE)
+
     /**
      * Builds the value of the `style` attribute injected onto `<html>` — the `--USER__*` CSS
      * variables plus `readium-*-on` flags. Mirrors Readium's `EpubSettings.update()` →
@@ -141,8 +147,8 @@ internal object ContinuousStyleInjector {
         // 1. Before-CSS (+ default-CSS when the chapter has no author styles) at <head> start.
         val hasAuthorStyles = html.contains("<link ", ignoreCase = true) ||
             html.contains(" style=", ignoreCase = true) ||
-            Regex("<style", RegexOption.IGNORE_CASE).containsMatchIn(html)
-        val headOpen = Regex("<head[^>]*>", RegexOption.IGNORE_CASE).find(out)
+            REGEX_STYLE_TAG.containsMatchIn(html)
+        val headOpen = REGEX_HEAD_OPEN.find(out)
         val beforeBlock = buildString {
             append("\n<link rel=\"stylesheet\" type=\"text/css\" href=\"$CSS_BASE/ReadiumCSS-before.css\"/>\n")
             // Match Readium's overflow fix so scroll layout behaves identically.
@@ -170,7 +176,7 @@ internal object ContinuousStyleInjector {
             append(bundledFontFaces())
             append("</style>\n")
             append("<style type=\"text/css\" id=\"riffle-typography-override\">\n")
-            append(typographyOverrideCss())
+            append(TYPOGRAPHY_OVERRIDE_CSS)
             append("</style>\n")
         }
         val headCloseIdx = out.indexOf("</head>", ignoreCase = true)
@@ -182,7 +188,7 @@ internal object ContinuousStyleInjector {
 
         // 3. The --USER__ style attribute on <html>.
         val styleAttr = buildHtmlStyleAttr(prefs).replace("\"", "&quot;")
-        val htmlTag = Regex("<html[^>]*", RegexOption.IGNORE_CASE).find(out)
+        val htmlTag = REGEX_HTML_OPEN.find(out)
         if (htmlTag != null) {
             val insertAt = htmlTag.range.last + 1
             out = out.substring(0, insertAt) + " style=\"$styleAttr\"" + out.substring(insertAt)

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/TypographyOverride.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/TypographyOverride.kt
@@ -123,16 +123,18 @@ internal fun typographyOverrideCss(): String =
         """.trimIndent()
     }
 
-/**
- * JavaScript that idempotently injects [typographyOverrideCss] into `document.head`.
- * Safe to evaluate multiple times — the stable id prevents duplicate `<style>` elements.
- */
-internal fun typographyOverrideInjectionJs(): String {
-    val css = typographyOverrideCss()
+// Cached because the output is fully determined by the compile-time TYPOGRAPHY_OVERRIDES
+// constant. Called on every chapter load (ContinuousStyleInjector.injectInto) and every page
+// load in paginated/scroll mode (typographyOverrideInjectionJs), so recomputing joinToString
+// and string splits on each call wastes allocations on the WebCore/UI thread hot paths.
+internal val TYPOGRAPHY_OVERRIDE_CSS: String = typographyOverrideCss()
+
+private val TYPOGRAPHY_OVERRIDE_INJECTION_JS: String = run {
+    val css = TYPOGRAPHY_OVERRIDE_CSS
         .replace("\\", "\\\\")
         .replace("`", "\\`")
         .replace("\$", "\\\$")
-    return """
+    """
         (function() {
           var id = 'riffle-typography-override';
           if (document.getElementById(id)) return;
@@ -143,3 +145,9 @@ internal fun typographyOverrideInjectionJs(): String {
         })();
     """.trimIndent()
 }
+
+/**
+ * JavaScript that idempotently injects [typographyOverrideCss] into `document.head`.
+ * Safe to evaluate multiple times — the stable id prevents duplicate `<style>` elements.
+ */
+internal fun typographyOverrideInjectionJs(): String = TYPOGRAPHY_OVERRIDE_INJECTION_JS

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjectorTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjectorTest.kt
@@ -161,6 +161,20 @@ class ContinuousStyleInjectorTest {
     }
 
     @Test
+    fun `injectInto embeds typography override CSS after ReadiumCSS-after to beat its text-align inherit rule`() {
+        val out = ContinuousStyleInjector.injectInto(sampleHtml, FormattingPreferences())
+        val afterIdx = out.indexOf("ReadiumCSS-after.css")
+        val overrideIdx = out.indexOf("riffle-typography-override")
+        val headCloseIdx = out.indexOf("</head>")
+        assertTrue("override style block present", overrideIdx >= 0)
+        assertTrue("override after ReadiumCSS-after", overrideIdx > afterIdx)
+        assertTrue("override before </head>", overrideIdx < headCloseIdx)
+        // Verify the justify gate uses 3 attribute-selector repetitions (specificity 0,3,2) to
+        // beat ReadiumCSS-after.css's text-align: inherit !important rule (specificity 0,2,4).
+        assertTrue("3x gate attr reps present", out.contains("[style*=\"--USER__textAlign\"][style*=\"--USER__textAlign\"][style*=\"--USER__textAlign\"]"))
+    }
+
+    @Test
     fun `injectInto adds default-css only when chapter has no author styles`() {
         val withStyles = "<html><head><style>p{}</style></head><body></body></html>"
         val without = "<html><head><title>t</title></head><body></body></html>"


### PR DESCRIPTION
## Summary

- **Bug:** In continuous mode, text justification (and to a lesser extent line-spacing and font-family) was ignored for books with high-specificity publisher CSS. Setting `--USER__textAlign: justify` on `<html>` was not enough — ReadiumCSS-after.css has a `text-align: inherit !important` rule at specificity `(0,2,4)` that won the cascade, causing paragraphs to inherit `text-align` from publisher divs (e.g. `#sbo-rt-content div { text-align: left }`).
- **Root cause:** `ContinuousStyleInjector.injectInto()` injected ReadiumCSS but never included the high-specificity typography override CSS that paginated/vertical mode injects via `typographyOverrideInjectionJs()` on every page load.
- **Fix:** Embed `typographyOverrideCss()` as a static `<style id="riffle-typography-override">` block in `injectInto()`, placed after `ReadiumCSS-after.css`. The gate selector (`:root[style*="--USER__textAlign"]…` × 3, giving specificity `(0,3,2)`) beats after.css and activates/deactivates automatically as `buildStyleInjectionJs()` toggles the CSS variable — no page reload needed.
- **Scope:** The fix covers all three typography overrides (`justifyText`, `lineSpacing`, `fontFamily`) since they all went through the same missing path.
- **Cleanup:** Cache `typographyOverrideCss()` and `typographyOverrideInjectionJs()` output as top-level vals (both are pure no-arg constants called on every chapter/page load). Hoist three `Regex(...)` constructions in `injectInto()` to object-level vals to avoid recompiling on every `shouldInterceptRequest` call.

## Test plan

- [ ] New unit test in `ContinuousStyleInjectorTest` verifies the override style block is present after `ReadiumCSS-after.css` and before `</head>`, with the 3× attribute-selector gate.
- [ ] `./gradlew test` — green
- [ ] `./gradlew lint` — green
- [ ] Harness tests skipped per branch instructions (no UI/layout change, pure CSS injection path)
- [ ] Manual: open book `00c67042-519f-49bb-993f-2d6ae20fd654` in continuous mode, enable justify — verify text is justified