### PR TITLE
feat(library-search): search annotations and audiobook bookmarks in library

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/library/AnnotationSearch.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/AnnotationSearch.kt
@@ -1,0 +1,36 @@
+package com.riffle.app.feature.library
+
+import com.riffle.core.domain.Annotation
+import com.riffle.core.domain.LibraryItem
+
+/** One annotation match in a [LibraryItemsViewModel] search, carrying its owning book's display fields. */
+data class AnnotationSearchResult(
+    val annotation: Annotation,
+    val bookTitle: String,
+    val bookCoverUrl: String?,
+)
+
+/**
+ * Filter [annotations] to those whose note text, highlighted snippet, or bookmark title contains
+ * [query] (case-insensitive), scoped to the books in [libraryItems], and pair each with its book's
+ * title + cover. Returns empty for a blank query. Order follows [annotations] (caller decides sort).
+ */
+fun searchAnnotations(
+    annotations: List<Annotation>,
+    libraryItems: List<LibraryItem>,
+    query: String,
+): List<AnnotationSearchResult> {
+    val q = query.trim()
+    if (q.isEmpty()) return emptyList()
+    val byId = libraryItems.associateBy { it.id }
+    return annotations.mapNotNull { a ->
+        val item = byId[a.itemId] ?: return@mapNotNull null // scope to this library's items
+        if (!annotationMatches(a, q)) return@mapNotNull null
+        AnnotationSearchResult(annotation = a, bookTitle = item.title, bookCoverUrl = item.coverUrl)
+    }
+}
+
+private fun annotationMatches(a: Annotation, query: String): Boolean =
+    a.note?.contains(query, ignoreCase = true) == true ||
+        a.textSnippet.contains(query, ignoreCase = true) ||
+        a.bookmarkTitle.contains(query, ignoreCase = true)

--- a/app/src/main/kotlin/com/riffle/app/feature/library/AnnotationSearch.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/AnnotationSearch.kt
@@ -1,11 +1,19 @@
 package com.riffle.app.feature.library
 
 import com.riffle.core.domain.Annotation
+import com.riffle.core.domain.AudiobookBookmark
 import com.riffle.core.domain.LibraryItem
 
 /** One annotation match in a [LibraryItemsViewModel] search, carrying its owning book's display fields. */
 data class AnnotationSearchResult(
     val annotation: Annotation,
+    val bookTitle: String,
+    val bookCoverUrl: String?,
+)
+
+/** One audiobook-bookmark match in a library search, carrying its owning book's display fields. */
+data class AudiobookBookmarkSearchResult(
+    val bookmark: AudiobookBookmark,
     val bookTitle: String,
     val bookCoverUrl: String?,
 )
@@ -34,3 +42,23 @@ private fun annotationMatches(a: Annotation, query: String): Boolean =
     a.note?.contains(query, ignoreCase = true) == true ||
         a.textSnippet.contains(query, ignoreCase = true) ||
         a.bookmarkTitle.contains(query, ignoreCase = true)
+
+/**
+ * Filter [bookmarks] to those whose title contains [query] (case-insensitive), scoped to the
+ * books in [libraryItems], and pair each with its book's title + cover. Returns empty for a
+ * blank query. Order follows [bookmarks] (earliest position first per DAO contract).
+ */
+fun searchAudiobookBookmarks(
+    bookmarks: List<AudiobookBookmark>,
+    libraryItems: List<LibraryItem>,
+    query: String,
+): List<AudiobookBookmarkSearchResult> {
+    val q = query.trim()
+    if (q.isEmpty()) return emptyList()
+    val byId = libraryItems.associateBy { it.id }
+    return bookmarks.mapNotNull { bm ->
+        val item = byId[bm.itemId] ?: return@mapNotNull null
+        if (!bm.title.contains(q, ignoreCase = true)) return@mapNotNull null
+        AudiobookBookmarkSearchResult(bookmark = bm, bookTitle = item.title, bookCoverUrl = item.coverUrl)
+    }
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/library/AnnotationSearchResultsScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/AnnotationSearchResultsScreen.kt
@@ -1,0 +1,74 @@
+package com.riffle.app.feature.library
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AnnotationSearchResultsScreen(
+    onNavigateBack: () -> Unit,
+    onAnnotationSelected: (AnnotationSearchResult) -> Unit,
+    viewModel: AnnotationSearchViewModel = hiltViewModel(),
+) {
+    val results by viewModel.results.collectAsState()
+    val token by viewModel.authToken.collectAsState()
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Annotations · '${viewModel.query}'") },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        if (results.isEmpty()) {
+            Box(
+                modifier = Modifier.fillMaxSize().padding(padding),
+                contentAlignment = Alignment.Center,
+            ) {
+                Text(
+                    "No annotations for '${viewModel.query}'",
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            return@Scaffold
+        }
+        LazyColumn(
+            modifier = Modifier.fillMaxSize().padding(padding),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+            contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
+        ) {
+            items(results, key = { it.annotation.id }) { result ->
+                AnnotationResultRow(
+                    result = result,
+                    token = token,
+                    onClick = { onAnnotationSelected(result) },
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/library/AnnotationSearchResultsScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/AnnotationSearchResultsScreen.kt
@@ -29,9 +29,11 @@ import androidx.hilt.navigation.compose.hiltViewModel
 fun AnnotationSearchResultsScreen(
     onNavigateBack: () -> Unit,
     onAnnotationSelected: (AnnotationSearchResult) -> Unit,
+    onAudiobookBookmarkSelected: (AudiobookBookmarkSearchResult) -> Unit,
     viewModel: AnnotationSearchViewModel = hiltViewModel(),
 ) {
     val results by viewModel.results.collectAsState()
+    val bookmarkResults by viewModel.bookmarkResults.collectAsState()
     val token by viewModel.authToken.collectAsState()
     Scaffold(
         topBar = {
@@ -45,7 +47,7 @@ fun AnnotationSearchResultsScreen(
             )
         },
     ) { padding ->
-        if (results.isEmpty()) {
+        if (results.isEmpty() && bookmarkResults.isEmpty()) {
             Box(
                 modifier = Modifier.fillMaxSize().padding(padding),
                 contentAlignment = Alignment.Center,
@@ -62,11 +64,18 @@ fun AnnotationSearchResultsScreen(
             verticalArrangement = Arrangement.spacedBy(8.dp),
             contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
         ) {
-            items(results, key = { it.annotation.id }) { result ->
+            items(results, key = { "anno_${it.annotation.id}" }) { result ->
                 AnnotationResultRow(
                     result = result,
                     token = token,
                     onClick = { onAnnotationSelected(result) },
+                )
+            }
+            items(bookmarkResults, key = { "abm_${it.bookmark.id}" }) { result ->
+                AudiobookBookmarkResultRow(
+                    result = result,
+                    token = token,
+                    onClick = { onAudiobookBookmarkSelected(result) },
                 )
             }
         }

--- a/app/src/main/kotlin/com/riffle/app/feature/library/AnnotationSearchViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/AnnotationSearchViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.riffle.core.domain.AnnotationStore
+import com.riffle.core.domain.AudiobookBookmarkStore
 import com.riffle.core.domain.LibraryRepository
 import com.riffle.core.domain.ServerRepository
 import com.riffle.core.domain.TokenStorage
@@ -27,6 +28,7 @@ class AnnotationSearchViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     libraryRepository: LibraryRepository,
     annotationStore: AnnotationStore,
+    audiobookBookmarkStore: AudiobookBookmarkStore,
     private val serverRepository: ServerRepository,
     private val tokenStorage: TokenStorage,
 ) : ViewModel() {
@@ -38,8 +40,10 @@ class AnnotationSearchViewModel @Inject constructor(
     private val _authToken = MutableStateFlow("")
     val authToken: StateFlow<String> = _authToken.asStateFlow()
 
+    private val libraryItems = libraryRepository.observeLibraryItems(libraryId)
+
     val results: StateFlow<List<AnnotationSearchResult>> =
-        libraryRepository.observeLibraryItems(libraryId)
+        libraryItems
             .flatMapLatest { items ->
                 val serverId = items.firstOrNull()?.serverId
                 if (query.isBlank() || serverId.isNullOrEmpty()) {
@@ -47,6 +51,19 @@ class AnnotationSearchViewModel @Inject constructor(
                 } else {
                     annotationStore.observeAnnotationsForServer(serverId)
                         .map { annotations -> searchAnnotations(annotations, items, query) }
+                }
+            }
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
+
+    val bookmarkResults: StateFlow<List<AudiobookBookmarkSearchResult>> =
+        libraryItems
+            .flatMapLatest { items ->
+                val serverId = items.firstOrNull()?.serverId
+                if (query.isBlank() || serverId.isNullOrEmpty()) {
+                    flowOf(emptyList())
+                } else {
+                    audiobookBookmarkStore.observeForServer(serverId)
+                        .map { bookmarks -> searchAudiobookBookmarks(bookmarks, items, query) }
                 }
             }
             .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())

--- a/app/src/main/kotlin/com/riffle/app/feature/library/AnnotationSearchViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/AnnotationSearchViewModel.kt
@@ -1,0 +1,60 @@
+package com.riffle.app.feature.library
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.riffle.core.domain.AnnotationStore
+import com.riffle.core.domain.LibraryRepository
+import com.riffle.core.domain.ServerRepository
+import com.riffle.core.domain.TokenStorage
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import java.net.URLDecoder
+import javax.inject.Inject
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@HiltViewModel
+class AnnotationSearchViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle,
+    libraryRepository: LibraryRepository,
+    annotationStore: AnnotationStore,
+    private val serverRepository: ServerRepository,
+    private val tokenStorage: TokenStorage,
+) : ViewModel() {
+
+    private val libraryId: String = savedStateHandle.get<String>("libraryId") ?: ""
+    val query: String = savedStateHandle.get<String>("query")
+        ?.let { URLDecoder.decode(it, "UTF-8") } ?: ""
+
+    private val _authToken = MutableStateFlow("")
+    val authToken: StateFlow<String> = _authToken.asStateFlow()
+
+    val results: StateFlow<List<AnnotationSearchResult>> =
+        libraryRepository.observeLibraryItems(libraryId)
+            .flatMapLatest { items ->
+                val serverId = items.firstOrNull()?.serverId
+                if (query.isBlank() || serverId.isNullOrEmpty()) {
+                    flowOf(emptyList())
+                } else {
+                    annotationStore.observeAnnotationsForServer(serverId)
+                        .map { annotations -> searchAnnotations(annotations, items, query) }
+                }
+            }
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
+
+    init {
+        viewModelScope.launch {
+            val server = serverRepository.getActive()
+            if (server != null) _authToken.value = tokenStorage.getToken(server.id) ?: ""
+        }
+    }
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsScreen.kt
@@ -102,6 +102,7 @@ import coil.compose.AsyncImage
 import coil.request.ImageRequest
 import com.riffle.app.R
 import com.riffle.core.domain.Collection
+import com.riffle.core.domain.HighlightColor
 import com.riffle.core.domain.LibraryItem
 import com.riffle.core.domain.Series
 import kotlin.math.floor
@@ -124,6 +125,8 @@ fun LibraryItemsScreen(
     onSeriesSelected: (Series) -> Unit,
     onCollectionSelected: (Collection) -> Unit,
     onItemSelected: (LibraryItem) -> Unit,
+    onAnnotationSelected: (AnnotationSearchResult) -> Unit,
+    onShowAllAnnotations: (query: String) -> Unit,
     onSectionSeeMore: (LibrarySectionType) -> Unit,
     // When the navigation drawer is open, its own BackHandler must take Back so it can close
     // itself. We disable our layered Back in that case (issue #60).
@@ -145,6 +148,7 @@ fun LibraryItemsScreen(
     val isLoading by viewModel.isLoading.collectAsState()
     val linkedItemIds by viewModel.linkedItemIds.collectAsState()
     val notStartedFilterActive by viewModel.notStartedFilterActive.collectAsState()
+    val annotationResults by viewModel.filteredAnnotations.collectAsState()
 
     val coversAreSquare by viewModel.coversAreSquare.collectAsState()
     var selectedTab by rememberSaveable { mutableIntStateOf(0) }
@@ -229,10 +233,13 @@ fun LibraryItemsScreen(
                     filteredSeries = series,
                     filteredCollections = collections,
                     filteredItems = filteredUngroupedItems,
+                    annotationResults = annotationResults,
                     token = viewModel.authToken,
                     onSeriesSelected = onSeriesSelected,
                     onCollectionSelected = onCollectionSelected,
                     onItemSelected = onItemSelected,
+                    onAnnotationSelected = onAnnotationSelected,
+                    onShowAllAnnotations = onShowAllAnnotations,
                     linkedItemIds = linkedItemIds,
                 )
             } else {
@@ -296,13 +303,17 @@ private fun SearchResultsContent(
     filteredSeries: List<Series>,
     filteredCollections: List<Collection>,
     filteredItems: List<LibraryItem>,
+    annotationResults: List<AnnotationSearchResult>,
     token: String,
     onSeriesSelected: (Series) -> Unit,
     onCollectionSelected: (Collection) -> Unit,
     onItemSelected: (LibraryItem) -> Unit,
+    onAnnotationSelected: (AnnotationSearchResult) -> Unit,
+    onShowAllAnnotations: (query: String) -> Unit,
     linkedItemIds: Set<String> = emptySet(),
 ) {
-    val allEmpty = filteredSeries.isEmpty() && filteredCollections.isEmpty() && filteredItems.isEmpty()
+    val allEmpty = filteredSeries.isEmpty() && filteredCollections.isEmpty() &&
+        filteredItems.isEmpty() && annotationResults.isEmpty()
     if (allEmpty) {
         Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
             Text("No results for '$query'")
@@ -337,8 +348,29 @@ private fun SearchResultsContent(
                 )
             }
         }
+        if (annotationResults.isNotEmpty()) {
+            item { SectionHeader("Annotations") }
+            val preview = annotationResults.take(ANNOTATION_PREVIEW_CAP)
+            items(preview, key = { "anno_${it.annotation.id}" }) { result ->
+                AnnotationResultRow(
+                    result = result,
+                    token = token,
+                    onClick = { onAnnotationSelected(result) },
+                )
+            }
+            if (annotationResults.size > ANNOTATION_PREVIEW_CAP) {
+                item(key = "anno_show_all") {
+                    ShowAllAnnotationsRow(
+                        count = annotationResults.size,
+                        onClick = { onShowAllAnnotations(query) },
+                    )
+                }
+            }
+        }
     }
 }
+
+private const val ANNOTATION_PREVIEW_CAP = 5
 
 // --- Section grids ---
 
@@ -769,6 +801,99 @@ private fun SearchCollectionRow(collection: Collection, onClick: () -> Unit) {
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
         }
+    }
+}
+
+@Composable
+internal fun AnnotationResultRow(
+    result: AnnotationSearchResult,
+    token: String,
+    onClick: () -> Unit,
+) {
+    val annotation = result.annotation
+    val isBookmark = annotation.type == "BOOKMARK"
+    Surface(
+        modifier = Modifier.fillMaxWidth().clickable(onClick = onClick),
+        shape = RoundedCornerShape(8.dp),
+        border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant),
+    ) {
+        Row(modifier = Modifier.padding(12.dp), verticalAlignment = Alignment.Top) {
+            // Leading: highlight colour bar, or a bookmark glyph.
+            Box(modifier = Modifier.size(width = 16.dp, height = 40.dp), contentAlignment = Alignment.Center) {
+                if (isBookmark) {
+                    Icon(
+                        Icons.Filled.Bookmark,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.size(18.dp),
+                    )
+                } else {
+                    val color = HighlightColor.fromToken(annotation.color)
+                    Surface(
+                        shape = RoundedCornerShape(2.dp),
+                        color = Color(color.argb.toLong() and 0xFFFFFFFFL),
+                        modifier = Modifier.size(width = 4.dp, height = 40.dp),
+                    ) {}
+                }
+            }
+            Spacer(Modifier.width(12.dp))
+            Column(modifier = Modifier.weight(1f)) {
+                val primary = if (isBookmark) annotation.bookmarkTitle.ifBlank { "Bookmark" } else annotation.textSnippet
+                Text(
+                    text = primary,
+                    style = MaterialTheme.typography.bodyMedium,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                val note = annotation.note
+                if (!isBookmark && !note.isNullOrBlank()) {
+                    Text(
+                        text = note,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
+                Spacer(Modifier.height(6.dp))
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    AsyncImage(
+                        model = ImageRequest.Builder(LocalContext.current)
+                            .data(result.bookCoverUrl)
+                            .addHeader("Authorization", "Bearer $token")
+                            .crossfade(true)
+                            .build(),
+                        placeholder = ColorPainter(MaterialTheme.colorScheme.surfaceVariant),
+                        contentDescription = null,
+                        contentScale = ContentScale.Crop,
+                        modifier = Modifier.size(width = 20.dp, height = 28.dp).clip(RoundedCornerShape(2.dp)),
+                    )
+                    Spacer(Modifier.width(8.dp))
+                    Text(
+                        text = result.bookTitle,
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ShowAllAnnotationsRow(count: Int, onClick: () -> Unit) {
+    Surface(
+        modifier = Modifier.fillMaxWidth().clickable(onClick = onClick),
+        shape = RoundedCornerShape(8.dp),
+    ) {
+        Text(
+            text = "Show all $count annotations",
+            style = MaterialTheme.typography.labelLarge,
+            color = MaterialTheme.colorScheme.primary,
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 14.dp),
+        )
     }
 }
 

--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsScreen.kt
@@ -126,6 +126,7 @@ fun LibraryItemsScreen(
     onCollectionSelected: (Collection) -> Unit,
     onItemSelected: (LibraryItem) -> Unit,
     onAnnotationSelected: (AnnotationSearchResult) -> Unit,
+    onAudiobookBookmarkSelected: (AudiobookBookmarkSearchResult) -> Unit,
     onShowAllAnnotations: (query: String) -> Unit,
     onSectionSeeMore: (LibrarySectionType) -> Unit,
     // When the navigation drawer is open, its own BackHandler must take Back so it can close
@@ -149,6 +150,7 @@ fun LibraryItemsScreen(
     val linkedItemIds by viewModel.linkedItemIds.collectAsState()
     val notStartedFilterActive by viewModel.notStartedFilterActive.collectAsState()
     val annotationResults by viewModel.filteredAnnotations.collectAsState()
+    val audiobookBookmarkResults by viewModel.filteredAudiobookBookmarks.collectAsState()
 
     val coversAreSquare by viewModel.coversAreSquare.collectAsState()
     var selectedTab by rememberSaveable { mutableIntStateOf(0) }
@@ -234,11 +236,13 @@ fun LibraryItemsScreen(
                     filteredCollections = collections,
                     filteredItems = filteredUngroupedItems,
                     annotationResults = annotationResults,
+                    audiobookBookmarkResults = audiobookBookmarkResults,
                     token = viewModel.authToken,
                     onSeriesSelected = onSeriesSelected,
                     onCollectionSelected = onCollectionSelected,
                     onItemSelected = onItemSelected,
                     onAnnotationSelected = onAnnotationSelected,
+                    onAudiobookBookmarkSelected = onAudiobookBookmarkSelected,
                     onShowAllAnnotations = onShowAllAnnotations,
                     linkedItemIds = linkedItemIds,
                 )
@@ -304,16 +308,18 @@ private fun SearchResultsContent(
     filteredCollections: List<Collection>,
     filteredItems: List<LibraryItem>,
     annotationResults: List<AnnotationSearchResult>,
+    audiobookBookmarkResults: List<AudiobookBookmarkSearchResult>,
     token: String,
     onSeriesSelected: (Series) -> Unit,
     onCollectionSelected: (Collection) -> Unit,
     onItemSelected: (LibraryItem) -> Unit,
     onAnnotationSelected: (AnnotationSearchResult) -> Unit,
+    onAudiobookBookmarkSelected: (AudiobookBookmarkSearchResult) -> Unit,
     onShowAllAnnotations: (query: String) -> Unit,
     linkedItemIds: Set<String> = emptySet(),
 ) {
     val allEmpty = filteredSeries.isEmpty() && filteredCollections.isEmpty() &&
-        filteredItems.isEmpty() && annotationResults.isEmpty()
+        filteredItems.isEmpty() && annotationResults.isEmpty() && audiobookBookmarkResults.isEmpty()
     if (allEmpty) {
         Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
             Text("No results for '$query'")
@@ -348,20 +354,30 @@ private fun SearchResultsContent(
                 )
             }
         }
-        if (annotationResults.isNotEmpty()) {
+        val hasAnnotations = annotationResults.isNotEmpty() || audiobookBookmarkResults.isNotEmpty()
+        if (hasAnnotations) {
             item { SectionHeader("Annotations") }
-            val preview = annotationResults.take(ANNOTATION_PREVIEW_CAP)
-            items(preview, key = { "anno_${it.annotation.id}" }) { result ->
+            val totalCount = annotationResults.size + audiobookBookmarkResults.size
+            val annoPreview = annotationResults.take(ANNOTATION_PREVIEW_CAP)
+            val bmPreview = audiobookBookmarkResults.take((ANNOTATION_PREVIEW_CAP - annoPreview.size).coerceAtLeast(0))
+            items(annoPreview, key = { "anno_${it.annotation.id}" }) { result ->
                 AnnotationResultRow(
                     result = result,
                     token = token,
                     onClick = { onAnnotationSelected(result) },
                 )
             }
-            if (annotationResults.size > ANNOTATION_PREVIEW_CAP) {
+            items(bmPreview, key = { "abm_${it.bookmark.id}" }) { result ->
+                AudiobookBookmarkResultRow(
+                    result = result,
+                    token = token,
+                    onClick = { onAudiobookBookmarkSelected(result) },
+                )
+            }
+            if (totalCount > ANNOTATION_PREVIEW_CAP) {
                 item(key = "anno_show_all") {
                     ShowAllAnnotationsRow(
-                        count = annotationResults.size,
+                        count = totalCount,
                         onClick = { onShowAllAnnotations(query) },
                     )
                 }
@@ -855,6 +871,61 @@ internal fun AnnotationResultRow(
                         overflow = TextOverflow.Ellipsis,
                     )
                 }
+                Spacer(Modifier.height(6.dp))
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    AsyncImage(
+                        model = ImageRequest.Builder(LocalContext.current)
+                            .data(result.bookCoverUrl)
+                            .addHeader("Authorization", "Bearer $token")
+                            .crossfade(true)
+                            .build(),
+                        placeholder = ColorPainter(MaterialTheme.colorScheme.surfaceVariant),
+                        contentDescription = null,
+                        contentScale = ContentScale.Crop,
+                        modifier = Modifier.size(width = 20.dp, height = 28.dp).clip(RoundedCornerShape(2.dp)),
+                    )
+                    Spacer(Modifier.width(8.dp))
+                    Text(
+                        text = result.bookTitle,
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+internal fun AudiobookBookmarkResultRow(
+    result: AudiobookBookmarkSearchResult,
+    token: String,
+    onClick: () -> Unit,
+) {
+    Surface(
+        modifier = Modifier.fillMaxWidth().clickable(onClick = onClick),
+        shape = RoundedCornerShape(8.dp),
+        border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant),
+    ) {
+        Row(modifier = Modifier.padding(12.dp), verticalAlignment = Alignment.Top) {
+            Box(modifier = Modifier.size(width = 16.dp, height = 40.dp), contentAlignment = Alignment.Center) {
+                Icon(
+                    Icons.Filled.Bookmark,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.size(18.dp),
+                )
+            }
+            Spacer(Modifier.width(12.dp))
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = result.bookmark.title.ifBlank { "Audiobook Bookmark" },
+                    style = MaterialTheme.typography.bodyMedium,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                )
                 Spacer(Modifier.height(6.dp))
                 Row(verticalAlignment = Alignment.CenterVertically) {
                     AsyncImage(

--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsScreen.kt
@@ -358,8 +358,11 @@ private fun SearchResultsContent(
         if (hasAnnotations) {
             item { SectionHeader("Annotations") }
             val totalCount = annotationResults.size + audiobookBookmarkResults.size
-            val annoPreview = annotationResults.take(ANNOTATION_PREVIEW_CAP)
-            val bmPreview = audiobookBookmarkResults.take((ANNOTATION_PREVIEW_CAP - annoPreview.size).coerceAtLeast(0))
+            // Split the preview cap fairly so neither type is starved when both are present.
+            // Each type gets at least ceil(cap/2) slots; unused slots from one side spill to the other.
+            val halfCap = (ANNOTATION_PREVIEW_CAP + 1) / 2
+            val annoPreview = annotationResults.take(if (audiobookBookmarkResults.isEmpty()) ANNOTATION_PREVIEW_CAP else halfCap)
+            val bmPreview = audiobookBookmarkResults.take(ANNOTATION_PREVIEW_CAP - annoPreview.size)
             items(annoPreview, key = { "anno_${it.annotation.id}" }) { result ->
                 AnnotationResultRow(
                     result = result,
@@ -387,6 +390,7 @@ private fun SearchResultsContent(
 }
 
 private const val ANNOTATION_PREVIEW_CAP = 5
+private const val ANNOTATION_TYPE_BOOKMARK = "BOOKMARK"
 
 // --- Section grids ---
 
@@ -827,7 +831,7 @@ internal fun AnnotationResultRow(
     onClick: () -> Unit,
 ) {
     val annotation = result.annotation
-    val isBookmark = annotation.type == "BOOKMARK"
+    val isBookmark = annotation.type == ANNOTATION_TYPE_BOOKMARK
     Surface(
         modifier = Modifier.fillMaxWidth().clickable(onClick = onClick),
         shape = RoundedCornerShape(8.dp),

--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsViewModel.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.setValue
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.riffle.core.domain.AnnotationStore
 import com.riffle.core.domain.Collection
 import com.riffle.core.domain.ConnectivityObserver
 import com.riffle.core.domain.LibraryItem
@@ -54,6 +55,7 @@ class LibraryItemsViewModel @Inject constructor(
     private val toReadRepository: ToReadRepository,
     private val readaloudLinkRepository: com.riffle.core.domain.ReadaloudLinkRepository,
     private val coverGridDensityStore: com.riffle.core.domain.CoverGridDensityStore,
+    private val annotationStore: AnnotationStore,
 ) : ViewModel() {
 
     val libraryId: String = savedStateHandle.get<String>("libraryId") ?: ""
@@ -183,6 +185,22 @@ class LibraryItemsViewModel @Inject constructor(
             else all.filter { it.title.contains(query, ignoreCase = true) || it.author.contains(query, ignoreCase = true) }
         if (offline) base.filter { offlineAvailability.isAvailableOffline(it) } else base
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
+
+    // Annotation search results, scoped to this library's items and matched on note text,
+    // highlighted snippet, or bookmark title. Independent of the Books section (a book is never
+    // promoted here because its annotations matched). Empty when the query is blank.
+    val filteredAnnotations: StateFlow<List<AnnotationSearchResult>> =
+        combine(allItems, searchQuery) { items, query -> items to query }
+            .flatMapLatest { (items, query) ->
+                val serverId = items.firstOrNull()?.serverId
+                if (query.isBlank() || serverId.isNullOrEmpty()) {
+                    flowOf(emptyList())
+                } else {
+                    annotationStore.observeAnnotationsForServer(serverId)
+                        .map { annotations -> searchAnnotations(annotations, items, query) }
+                }
+            }
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
 
     val filteredInProgress: StateFlow<List<LibraryItem>> = combine(inProgress, isOffline) { items, offline ->
         if (offline) items.filter { offlineAvailability.isAvailableOffline(it) } else items

--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsViewModel.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.riffle.core.domain.AnnotationStore
+import com.riffle.core.domain.AudiobookBookmarkStore
 import com.riffle.core.domain.Collection
 import com.riffle.core.domain.ConnectivityObserver
 import com.riffle.core.domain.LibraryItem
@@ -56,6 +57,7 @@ class LibraryItemsViewModel @Inject constructor(
     private val readaloudLinkRepository: com.riffle.core.domain.ReadaloudLinkRepository,
     private val coverGridDensityStore: com.riffle.core.domain.CoverGridDensityStore,
     private val annotationStore: AnnotationStore,
+    private val audiobookBookmarkStore: AudiobookBookmarkStore,
 ) : ViewModel() {
 
     val libraryId: String = savedStateHandle.get<String>("libraryId") ?: ""
@@ -198,6 +200,21 @@ class LibraryItemsViewModel @Inject constructor(
                 } else {
                     annotationStore.observeAnnotationsForServer(serverId)
                         .map { annotations -> searchAnnotations(annotations, items, query) }
+                }
+            }
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
+
+    // Audiobook bookmark search results, scoped to this library's items and matched on title.
+    // Shares the same Annotations section in the UI. Empty when the query is blank.
+    val filteredAudiobookBookmarks: StateFlow<List<AudiobookBookmarkSearchResult>> =
+        combine(allItems, searchQuery) { items, query -> items to query }
+            .flatMapLatest { (items, query) ->
+                val serverId = items.firstOrNull()?.serverId
+                if (query.isBlank() || serverId.isNullOrEmpty()) {
+                    flowOf(emptyList())
+                } else {
+                    audiobookBookmarkStore.observeForServer(serverId)
+                        .map { bookmarks -> searchAudiobookBookmarks(bookmarks, items, query) }
                 }
             }
             .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
@@ -288,7 +288,8 @@ internal class ContinuousReaderView @JvmOverloads constructor(
         allChapters = chapters
         formattingPrefs = prefs
         this.publication = publication
-        openWindowAt(initialHref, initialProgression)
+        val anchorFragment = initialHref.substringAfter('#', "")
+        openWindowAt(initialHref.substringBefore('#'), initialProgression, anchorFragment)
     }
 
     /**

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubCfiTranslator.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubCfiTranslator.kt
@@ -71,6 +71,17 @@ internal fun extractCfiElementIds(docPath: String): List<String> {
 internal fun hasElementWithId(html: String, id: String): Boolean =
     Jsoup.parse(html).getElementById(id) != null
 
+/**
+ * Returns the innermost element ID from the doc-path portion of [fullCfi] that actually
+ * exists in [html], or null when the CFI has no ID assertions or none match the DOM.
+ * Used by continuous-mode navigation to anchor on the exact element rather than a
+ * character-count progression approximation.
+ */
+internal fun extractAnchorFromCfi(fullCfi: String, html: String): String? {
+    val docPath = extractCfiDocPath(fullCfi) ?: return null
+    return extractCfiElementIds(docPath).firstOrNull { hasElementWithId(html, it) }
+}
+
 // ── CFI string parsing ────────────────────────────────────────────────────────
 
 internal data class ParsedCfiDocPath(val steps: List<Int>, val charOffset: Int)

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -1369,10 +1369,9 @@ private fun EpubNavigatorView(
     }
 
     val goToContinuous: suspend (Locator) -> Unit = { locator ->
-        continuousViewRef.value?.navigateTo(
-            locator.href.toString(),
-            locator.locations.progression?.toFloat() ?: 0f,
-        )
+        val anchor = locator.locations.fragments.firstOrNull()
+        val href = if (anchor != null) "${locator.href}#$anchor" else locator.href.toString()
+        continuousViewRef.value?.navigateTo(href, locator.locations.progression?.toFloat() ?: 0f)
     }
 
     LaunchedEffect(onNavigationEvents, isContinuous) {
@@ -2078,9 +2077,11 @@ private fun EpubNavigatorView(
             LaunchedEffect(continuousView) {
                 val view = continuousView ?: return@LaunchedEffect
                 val initialLocator = latestLocator() ?: state.initialLocator
-                val initialHref = initialLocator?.href?.toString()
+                val anchor = initialLocator?.locations?.fragments?.firstOrNull()
+                val rawHref = initialLocator?.href?.toString()
                     ?: chapters.firstOrNull()?.link?.href?.toString()
                     ?: return@LaunchedEffect
+                val initialHref = if (anchor != null) "$rawHref#$anchor" else rawHref
                 view.initialize(
                     chapters = chapters,
                     prefs = formattingPrefs,

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -174,6 +174,10 @@ class EpubReaderViewModel @Inject constructor(
     private val startReadaloudAtSec: Double =
         (savedStateHandle.get<Float>("startReadaloudAtSec") ?: -1f).toDouble()
 
+    // When opened from a library annotation search result, jump to this CFI instead of the saved
+    // reading position. Null/blank for a normal open. EPUB-only (annotations anchor on ABS-EPUB CFI).
+    private val openAtCfi: String? = savedStateHandle.get<String>("openAtCfi")
+
     private val _state = MutableStateFlow<ReaderState>(ReaderState.Loading)
     val state: StateFlow<ReaderState> = _state
 
@@ -681,10 +685,13 @@ class EpubReaderViewModel @Inject constructor(
                 // translation fix (< 2.6.x) may still hold a raw ABS `epubcfi(...)` — convert
                 // those on open so legacy progress isn't lost (one-time healing; new rows are
                 // always canonical Locator JSON). A genuinely unusable value falls back to null.
-                val locator = result.lastPosition?.takeIf { it.isNotBlank() }?.let { stored ->
-                    runCatching { Locator.fromJSON(JSONObject(stored)) }.getOrNull()
-                        ?: cfiStringToLocator(stored)
-                }
+                // A search-result open overrides the saved position; cfiStringToLocator needs `publication`,
+                // which is set by this point (same call used just below for legacy CFI healing).
+                val locator = openAtCfi?.takeIf { it.isNotBlank() }?.let { cfiStringToLocator(it) }
+                    ?: result.lastPosition?.takeIf { it.isNotBlank() }?.let { stored ->
+                        runCatching { Locator.fromJSON(JSONObject(stored)) }.getOrNull()
+                            ?: cfiStringToLocator(stored)
+                    }
                 _state.value = ReaderState.Ready(
                     publication = pub,
                     title = item.title,

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -1065,12 +1065,19 @@ class EpubReaderViewModel @Inject constructor(
             else -> null
         }
         if (link == null || chapterProgression == null) return null
+        // For continuous-mode navigation: if the CFI references a named DOM element, store its
+        // ID in locations.fragments so goToContinuous can anchor precisely on it rather than
+        // relying on character-count progression (which doesn't account for pixel height variation).
+        val anchorId = if (html != null && docPath != null) extractAnchorFromCfi(cfi, html) else null
         return try {
             Locator.fromJSON(
                 JSONObject()
                     .put("href", link.href.toString())
                     .put("type", "application/xhtml+xml")
-                    .put("locations", JSONObject().put("progression", chapterProgression))
+                    .put("locations", JSONObject()
+                        .put("progression", chapterProgression)
+                        .apply { if (anchorId != null) put("fragments", org.json.JSONArray().put(anchorId)) }
+                    )
             )
         } catch (_: Exception) { null }
     }

--- a/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
@@ -26,6 +26,7 @@ import com.riffle.app.feature.library.FilteredBooksScreen
 import com.riffle.app.feature.audiobook.AudiobookPlayerScreen
 import com.riffle.app.feature.library.LibraryItemDetailScreen
 import com.riffle.app.feature.library.AnnotationSearchResultsScreen
+import com.riffle.app.feature.library.AudiobookBookmarkSearchResult
 import com.riffle.app.feature.library.LibraryItemsScreen
 import com.riffle.app.feature.library.LibraryItemsViewModel
 import com.riffle.app.feature.library.LibrarySectionScreen
@@ -280,6 +281,10 @@ fun MainScreen(
                         val encodedCfi = URLEncoder.encode(result.annotation.cfi, "UTF-8")
                         navController.navigate("epub_reader/$encodedId?openAtCfi=$encodedCfi")
                     },
+                    onAudiobookBookmarkSelected = { result ->
+                        val encodedId = URLEncoder.encode(result.bookmark.itemId, "UTF-8")
+                        navController.navigate("audiobook_player/$encodedId?startAtSec=${result.bookmark.positionSec}")
+                    },
                     onShowAllAnnotations = { query ->
                         val encodedQuery = URLEncoder.encode(query, "UTF-8")
                         navController.navigate("annotation_search/$libraryId?query=$encodedQuery")
@@ -439,6 +444,10 @@ fun MainScreen(
                         val encodedId = URLEncoder.encode(result.annotation.itemId, "UTF-8")
                         val encodedCfi = URLEncoder.encode(result.annotation.cfi, "UTF-8")
                         navController.navigate("epub_reader/$encodedId?openAtCfi=$encodedCfi")
+                    },
+                    onAudiobookBookmarkSelected = { result ->
+                        val encodedId = URLEncoder.encode(result.bookmark.itemId, "UTF-8")
+                        navController.navigate("audiobook_player/$encodedId?startAtSec=${result.bookmark.positionSec}")
                     },
                 )
             }

--- a/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
@@ -25,6 +25,7 @@ import com.riffle.app.feature.library.FacetType
 import com.riffle.app.feature.library.FilteredBooksScreen
 import com.riffle.app.feature.audiobook.AudiobookPlayerScreen
 import com.riffle.app.feature.library.LibraryItemDetailScreen
+import com.riffle.app.feature.library.AnnotationSearchResultsScreen
 import com.riffle.app.feature.library.LibraryItemsScreen
 import com.riffle.app.feature.library.LibraryItemsViewModel
 import com.riffle.app.feature.library.LibrarySectionScreen
@@ -59,8 +60,9 @@ private const val SERIES_DETAIL = "series_detail/{libraryId}/{seriesId}/{seriesN
 private const val COLLECTION_DETAIL = "collection_detail/{libraryId}/{collectionId}/{collectionName}"
 private const val FILTERED_BOOKS = "filtered_books/{libraryId}/{facetType}/{facetValue}"
 private const val LIBRARY_ITEM_DETAIL = "library_item_detail/{itemId}"
-private const val EPUB_READER = "epub_reader/{itemId}?startReadaloudAtSec={startReadaloudAtSec}"
+private const val EPUB_READER = "epub_reader/{itemId}?startReadaloudAtSec={startReadaloudAtSec}&openAtCfi={openAtCfi}"
 private const val PDF_READER = "pdf_reader/{itemId}"
+private const val ANNOTATION_SEARCH = "annotation_search/{libraryId}?query={query}"
 private const val AUDIOBOOK_PLAYER = "audiobook_player/{itemId}?startAtSec={startAtSec}"
 
 @Composable
@@ -273,9 +275,15 @@ fun MainScreen(
                         val encodedId = URLEncoder.encode(item.id, "UTF-8")
                         navController.navigate("library_item_detail/$encodedId")
                     },
-                    // TODO(Task 6): wire real navigation for annotation results
-                    onAnnotationSelected = {},
-                    onShowAllAnnotations = {},
+                    onAnnotationSelected = { result ->
+                        val encodedId = URLEncoder.encode(result.annotation.itemId, "UTF-8")
+                        val encodedCfi = URLEncoder.encode(result.annotation.cfi, "UTF-8")
+                        navController.navigate("epub_reader/$encodedId?openAtCfi=$encodedCfi")
+                    },
+                    onShowAllAnnotations = { query ->
+                        val encodedQuery = URLEncoder.encode(query, "UTF-8")
+                        navController.navigate("annotation_search/$libraryId?query=$encodedQuery")
+                    },
                     onSectionSeeMore = { sectionType ->
                         val encodedName = URLEncoder.encode(libraryName, "UTF-8")
                         navController.navigate("library_section/$libraryId/$encodedName/${sectionType.name}")
@@ -402,11 +410,36 @@ fun MainScreen(
                         type = NavType.FloatType
                         defaultValue = -1f // -1 = opened normally, not an audiobook→readaloud handoff
                     },
+                    navArgument("openAtCfi") {
+                        type = NavType.StringType
+                        nullable = true
+                        defaultValue = null
+                    },
                 )
             ) {
                 EpubReaderScreen(
                     windowSizeClass = windowSizeClass,
                     onNavigateBack = { navController.popBackStack() },
+                )
+            }
+            composable(
+                route = ANNOTATION_SEARCH,
+                arguments = listOf(
+                    navArgument("libraryId") { type = NavType.StringType },
+                    navArgument("query") {
+                        type = NavType.StringType
+                        nullable = true
+                        defaultValue = null
+                    },
+                ),
+            ) {
+                AnnotationSearchResultsScreen(
+                    onNavigateBack = { navController.popBackStack() },
+                    onAnnotationSelected = { result ->
+                        val encodedId = URLEncoder.encode(result.annotation.itemId, "UTF-8")
+                        val encodedCfi = URLEncoder.encode(result.annotation.cfi, "UTF-8")
+                        navController.navigate("epub_reader/$encodedId?openAtCfi=$encodedCfi")
+                    },
                 )
             }
             composable(

--- a/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
@@ -273,6 +273,9 @@ fun MainScreen(
                         val encodedId = URLEncoder.encode(item.id, "UTF-8")
                         navController.navigate("library_item_detail/$encodedId")
                     },
+                    // TODO(Task 6): wire real navigation for annotation results
+                    onAnnotationSelected = {},
+                    onShowAllAnnotations = {},
                     onSectionSeeMore = { sectionType ->
                         val encodedName = URLEncoder.encode(libraryName, "UTF-8")
                         navController.navigate("library_section/$libraryId/$encodedName/${sectionType.name}")

--- a/app/src/test/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModelBookmarkTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModelBookmarkTest.kt
@@ -218,7 +218,7 @@ class AudiobookPlayerViewModelBookmarkTest {
         val vm = buildViewModel(controller, store)
         runCurrent()
 
-        val bookmark = AudiobookBookmark(id = "bm-1", positionSec = 42.0, title = "Saved", createdAt = fixedNow)
+        val bookmark = AudiobookBookmark(id = "bm-1", serverId = "srv-1", itemId = "item-1", positionSec = 42.0, title = "Saved", createdAt = fixedNow)
         store.flow.value = listOf(bookmark)
         runCurrent()
 
@@ -233,7 +233,7 @@ class AudiobookPlayerViewModelBookmarkTest {
         // Seed the store BEFORE the ViewModel is built, so the live collector observes it during init's
         // suspend points — before the success-path writes the resolved metadata. A success path that
         // builds a fresh state (rather than copy()) would wipe this; copy() carries it forward.
-        val bookmark = AudiobookBookmark(id = "bm-1", positionSec = 42.0, title = "Saved", createdAt = fixedNow)
+        val bookmark = AudiobookBookmark(id = "bm-1", serverId = "srv-1", itemId = "item-1", positionSec = 42.0, title = "Saved", createdAt = fixedNow)
         store.flow.value = listOf(bookmark)
 
         val vm = buildViewModel(controller, store)
@@ -456,6 +456,7 @@ class AudiobookPlayerViewModelBookmarkTest {
         var lastId: String = ""
         private var seq = 0
         override fun observe(serverId: String, itemId: String): Flow<List<AudiobookBookmark>> = flow
+        override fun observeForServer(serverId: String): Flow<List<AudiobookBookmark>> = flow
         override fun observeHasUnsynced(serverId: String, itemId: String): Flow<Boolean> = hasUnsynced
         override suspend fun add(serverId: String, itemId: String, positionSec: Double, title: String, now: Long): String {
             added.add(AddCall(serverId, itemId, positionSec, title, now))

--- a/app/src/test/kotlin/com/riffle/app/feature/audiobook/SleepTimerTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/audiobook/SleepTimerTest.kt
@@ -348,6 +348,7 @@ class SleepTimerTest {
         val flow = MutableStateFlow<List<AudiobookBookmark>>(emptyList())
         val hasUnsynced = MutableStateFlow(false)
         override fun observe(serverId: String, itemId: String): Flow<List<AudiobookBookmark>> = flow
+        override fun observeForServer(serverId: String): Flow<List<AudiobookBookmark>> = flow
         override fun observeHasUnsynced(serverId: String, itemId: String): Flow<Boolean> = hasUnsynced
         override suspend fun add(serverId: String, itemId: String, positionSec: Double, title: String, now: Long): String = "bm-0"
         override suspend fun rename(id: String, title: String, now: Long) {}

--- a/app/src/test/kotlin/com/riffle/app/feature/library/AnnotationSearchTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/AnnotationSearchTest.kt
@@ -1,0 +1,86 @@
+package com.riffle.app.feature.library
+
+import com.riffle.core.domain.Annotation
+import com.riffle.core.domain.LibraryItem
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class AnnotationSearchTest {
+
+    private fun item(id: String, title: String) = LibraryItem(
+        id = id,
+        libraryId = "lib1",
+        title = title,
+        author = "Author",
+        coverUrl = "https://cover/$id.jpg",
+        serverId = "srv1",
+        readingProgress = 0f,
+        isCached = false,
+        isDownloaded = false,
+        ebookFormat = com.riffle.core.domain.EbookFormat.Epub,
+    )
+
+    private fun annotation(
+        id: String,
+        itemId: String,
+        type: String = "HIGHLIGHT",
+        note: String? = null,
+        textSnippet: String = "",
+        bookmarkTitle: String = "",
+    ) = Annotation(
+        id = id,
+        serverId = "srv1",
+        itemId = itemId,
+        type = type,
+        cfi = "epubcfi(/6/4!/4)",
+        color = "yellow",
+        note = note,
+        textSnippet = textSnippet,
+        textBefore = "",
+        textAfter = "",
+        chapterHref = "ch.html",
+        spineIndex = 0,
+        progression = 0.0,
+        bookmarkTitle = bookmarkTitle,
+        createdAt = 0L,
+        updatedAt = 0L,
+    )
+
+    private val items = listOf(item("b1", "Children of Dune"), item("b2", "Dune Messiah"))
+
+    @Test
+    fun blankQueryReturnsNothing() {
+        val annos = listOf(annotation("a1", "b1", textSnippet = "conscience"))
+        assertEquals(emptyList<AnnotationSearchResult>(), searchAnnotations(annos, items, "   "))
+    }
+
+    @Test
+    fun matchesNoteSnippetAndBookmarkTitleCaseInsensitively() {
+        val annos = listOf(
+            annotation("a1", "b1", textSnippet = "The CONSCIENCE of the king"),
+            annotation("a2", "b1", note = "about conscience"),
+            annotation("a3", "b2", type = "BOOKMARK", bookmarkTitle = "Conscience chapter"),
+            annotation("a4", "b1", textSnippet = "unrelated passage"),
+        )
+        val result = searchAnnotations(annos, items, "conscience").map { it.annotation.id }
+        assertEquals(listOf("a1", "a2", "a3"), result)
+    }
+
+    @Test
+    fun scopesToLibraryItemsOnly() {
+        val annos = listOf(
+            annotation("a1", "b1", textSnippet = "conscience"),
+            annotation("aX", "OTHER_LIBRARY_ITEM", textSnippet = "conscience"),
+        )
+        val result = searchAnnotations(annos, items, "conscience").map { it.annotation.id }
+        assertEquals(listOf("a1"), result)
+    }
+
+    @Test
+    fun carriesBookTitleAndCover() {
+        val annos = listOf(annotation("a1", "b1", textSnippet = "conscience"))
+        val r = searchAnnotations(annos, items, "conscience").single()
+        assertEquals("Children of Dune", r.bookTitle)
+        assertEquals("https://cover/b1.jpg", r.bookCoverUrl)
+    }
+}

--- a/app/src/test/kotlin/com/riffle/app/feature/library/AnnotationSearchTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/AnnotationSearchTest.kt
@@ -1,6 +1,7 @@
 package com.riffle.app.feature.library
 
 import com.riffle.core.domain.Annotation
+import com.riffle.core.domain.AudiobookBookmark
 import com.riffle.core.domain.LibraryItem
 import org.junit.Assert.assertEquals
 import org.junit.Test
@@ -82,5 +83,54 @@ class AnnotationSearchTest {
         val r = searchAnnotations(annos, items, "conscience").single()
         assertEquals("Children of Dune", r.bookTitle)
         assertEquals("https://cover/b1.jpg", r.bookCoverUrl)
+    }
+
+    // --- audiobook bookmark search ---
+
+    private fun audiobookBookmark(id: String, itemId: String, title: String) =
+        AudiobookBookmark(id = id, serverId = "srv1", itemId = itemId, positionSec = 0.0, title = title, createdAt = 0L)
+
+    @Test
+    fun audiobookBookmarkBlankQueryReturnsNothing() {
+        val bms = listOf(audiobookBookmark("bm1", "b1", "The Battle of Winterfell"))
+        assertEquals(emptyList<AudiobookBookmarkSearchResult>(), searchAudiobookBookmarks(bms, items, "   "))
+    }
+
+    @Test
+    fun audiobookBookmarkMatchesTitleCaseInsensitively() {
+        val bms = listOf(
+            audiobookBookmark("bm1", "b1", "The BATTLE of Winterfell"),
+            audiobookBookmark("bm2", "b1", "Chapter Three"),
+        )
+        val result = searchAudiobookBookmarks(bms, items, "battle").map { it.bookmark.id }
+        assertEquals(listOf("bm1"), result)
+    }
+
+    @Test
+    fun audiobookBookmarkScopesToLibraryItems() {
+        val bms = listOf(
+            audiobookBookmark("bm1", "b1", "found"),
+            audiobookBookmark("bm2", "UNKNOWN_ITEM", "found"),
+        )
+        val result = searchAudiobookBookmarks(bms, items, "found").map { it.bookmark.id }
+        assertEquals(listOf("bm1"), result)
+    }
+
+    @Test
+    fun audiobookBookmarkCarriesBookTitleAndCover() {
+        val bms = listOf(audiobookBookmark("bm1", "b1", "My Marker"))
+        val r = searchAudiobookBookmarks(bms, items, "marker").single()
+        assertEquals("Children of Dune", r.bookTitle)
+        assertEquals("https://cover/b1.jpg", r.bookCoverUrl)
+    }
+
+    @Test
+    fun unnamedBookmarkFoundByTextSnippet() {
+        val annos = listOf(
+            annotation("bm1", "b1", type = "BOOKMARK", textSnippet = "the conscience of the king", bookmarkTitle = ""),
+            annotation("bm2", "b1", type = "BOOKMARK", textSnippet = "unrelated passage", bookmarkTitle = ""),
+        )
+        val result = searchAnnotations(annos, items, "conscience").map { it.annotation.id }
+        assertEquals(listOf("bm1"), result)
     }
 }

--- a/app/src/test/kotlin/com/riffle/app/feature/library/AnnotationSearchViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/AnnotationSearchViewModelTest.kt
@@ -86,6 +86,16 @@ class AnnotationSearchViewModelTest {
         override suspend fun renameBookmark(id: String, title: String) = error("unused")
     }
 
+    private fun fakeAudiobookBookmarkStore(): com.riffle.core.domain.AudiobookBookmarkStore =
+        object : com.riffle.core.domain.AudiobookBookmarkStore {
+            override fun observe(serverId: String, itemId: String) = MutableStateFlow(emptyList<com.riffle.core.domain.AudiobookBookmark>())
+            override fun observeForServer(serverId: String) = MutableStateFlow(emptyList<com.riffle.core.domain.AudiobookBookmark>())
+            override fun observeHasUnsynced(serverId: String, itemId: String) = MutableStateFlow(false)
+            override suspend fun add(serverId: String, itemId: String, positionSec: Double, title: String, now: Long) = error("unused")
+            override suspend fun rename(id: String, title: String, now: Long) = error("unused")
+            override suspend fun delete(id: String, now: Long) = error("unused")
+        }
+
     private fun fakeServerRepository(): ServerRepository = object : ServerRepository {
         override fun observeAll(): Flow<List<Server>> = MutableStateFlow(emptyList())
         override suspend fun getActive(): Server? =
@@ -145,7 +155,7 @@ class AnnotationSearchViewModelTest {
             annotation(id = "a2", serverId = "srv1", itemId = "b1", textSnippet = "other"),
         )
         val savedState = SavedStateHandle(mapOf("libraryId" to "lib1", "query" to "conscience"))
-        val vm = AnnotationSearchViewModel(savedState, fakeRepo(), fakeAnnotationStore(), fakeServerRepository(), fakeTokenStorage())
+        val vm = AnnotationSearchViewModel(savedState, fakeRepo(), fakeAnnotationStore(), fakeAudiobookBookmarkStore(), fakeServerRepository(), fakeTokenStorage())
 
         val results = vm.results.first { it.isNotEmpty() }
         assertEquals(listOf("a1"), results.map { it.annotation.id })

--- a/app/src/test/kotlin/com/riffle/app/feature/library/AnnotationSearchViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/AnnotationSearchViewModelTest.kt
@@ -1,0 +1,153 @@
+package com.riffle.app.feature.library
+
+import androidx.lifecycle.SavedStateHandle
+import com.riffle.core.domain.Annotation
+import com.riffle.core.domain.AnnotationStore
+import com.riffle.core.domain.Collection
+import com.riffle.core.domain.EbookFormat
+import com.riffle.core.domain.Library
+import com.riffle.core.domain.LibraryItem
+import com.riffle.core.domain.LibraryRefreshResult
+import com.riffle.core.domain.LibraryRepository
+import com.riffle.core.domain.PendingServer
+import com.riffle.core.domain.Series
+import com.riffle.core.domain.Server
+import com.riffle.core.domain.ServerRepository
+import com.riffle.core.domain.ServerType
+import com.riffle.core.domain.ServerUrl
+import com.riffle.core.domain.TokenStorage
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class AnnotationSearchViewModelTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+
+    @Before
+    fun setUp() { Dispatchers.setMain(testDispatcher) }
+
+    @After
+    fun tearDown() { Dispatchers.resetMain() }
+
+    private val allItemsFlow = MutableStateFlow<List<LibraryItem>>(emptyList())
+    private val annotationsFlow = MutableStateFlow<List<Annotation>>(emptyList())
+
+    private fun fakeRepo(): LibraryRepository = object : LibraryRepository {
+        override fun observeLibraries(): Flow<List<Library>> = MutableStateFlow(emptyList())
+        override fun observeLibraries(serverId: String): Flow<List<Library>> = MutableStateFlow(emptyList())
+        override fun observeLibraryItems(libraryId: String): Flow<List<LibraryItem>> = allItemsFlow
+        override fun observeUngroupedLibraryItems(libraryId: String): Flow<List<LibraryItem>> = MutableStateFlow(emptyList())
+        override fun observeInProgressItems(libraryId: String): Flow<List<LibraryItem>> = MutableStateFlow(emptyList())
+        override fun observeFinishedItems(libraryId: String): Flow<List<LibraryItem>> = MutableStateFlow(emptyList())
+        override fun observeRecentlyAddedItems(libraryId: String): Flow<List<LibraryItem>> = MutableStateFlow(emptyList())
+        override fun observeContinueSeriesItems(libraryId: String): Flow<List<LibraryItem>> = MutableStateFlow(emptyList())
+        override fun observeAllBooks(libraryId: String): Flow<List<LibraryItem>> = MutableStateFlow(emptyList())
+        override fun observeSeries(libraryId: String): Flow<List<Series>> = MutableStateFlow(emptyList())
+        override fun observeCollections(libraryId: String): Flow<List<Collection>> = MutableStateFlow(emptyList())
+        override fun observeSeriesItems(seriesId: String): Flow<List<LibraryItem>> = MutableStateFlow(emptyList())
+        override fun observeCollectionItems(collectionId: String): Flow<List<LibraryItem>> = MutableStateFlow(emptyList())
+        override suspend fun getItem(itemId: String): LibraryItem? = null
+        override fun observeItem(itemId: String): Flow<LibraryItem?> = MutableStateFlow(null)
+        override suspend fun getItem(serverId: String, itemId: String): LibraryItem? = null
+        override suspend fun getLibrary(libraryId: String): Library? = null
+        override suspend fun getSeriesIdForItem(serverId: String, itemId: String): String? = null
+        override suspend fun markItemOpened(itemId: String) {}
+        override suspend fun updateReadingProgress(itemId: String, progress: Float) {}
+        override suspend fun refreshLibraries() = LibraryRefreshResult.Success
+        override suspend fun refreshLibraryItems(libraryId: String) = LibraryRefreshResult.Success
+        override suspend fun refreshSeries(libraryId: String) = LibraryRefreshResult.Success
+        override suspend fun refreshCollections(libraryId: String) = LibraryRefreshResult.Success
+    }
+
+    private fun fakeAnnotationStore(): AnnotationStore = object : AnnotationStore {
+        override fun observeHighlights(serverId: String, itemId: String) = MutableStateFlow(emptyList<Annotation>())
+        override fun observeBookmarks(serverId: String, itemId: String) = MutableStateFlow(emptyList<Annotation>())
+        override fun observeAnnotations(serverId: String, itemId: String) = MutableStateFlow(emptyList<Annotation>())
+        override fun observeAnnotationsForServer(serverId: String) =
+            annotationsFlow.map { all -> all.filter { it.serverId == serverId } }
+        override suspend fun createHighlight(serverId: String, itemId: String, cfi: String, textSnippet: String, chapterHref: String, textBefore: String, textAfter: String, color: String, spineIndex: Int, progression: Double) = error("unused")
+        override suspend fun createBookmark(serverId: String, itemId: String, cfi: String, textSnippet: String, chapterHref: String, spineIndex: Int, progression: Double, bookmarkTitle: String) = error("unused")
+        override suspend fun delete(id: String) = error("unused")
+        override suspend fun recolor(id: String, color: String) = error("unused")
+        override suspend fun updateNote(id: String, note: String?) = error("unused")
+        override suspend fun renameBookmark(id: String, title: String) = error("unused")
+    }
+
+    private fun fakeServerRepository(): ServerRepository = object : ServerRepository {
+        override fun observeAll(): Flow<List<Server>> = MutableStateFlow(emptyList())
+        override suspend fun getActive(): Server? =
+            Server("srv1", ServerUrl.parse("http://localhost")!!, true, false, "test")
+        override suspend fun authenticate(url: ServerUrl, username: String, password: String, insecureAllowed: Boolean, serverType: ServerType) =
+            throw UnsupportedOperationException()
+        override suspend fun commit(pending: PendingServer, hiddenLibraryIds: Set<String>) =
+            throw UnsupportedOperationException()
+        override suspend fun setActive(serverId: String) {}
+        override suspend fun remove(serverId: String) {}
+        override suspend fun getServerVersion(serverId: String): String? = null
+    }
+
+    private fun fakeTokenStorage(): TokenStorage = object : TokenStorage {
+        override suspend fun saveToken(serverId: String, token: String) {}
+        override suspend fun getToken(serverId: String): String = "test-token"
+        override suspend fun deleteToken(serverId: String) {}
+    }
+
+    private fun annotation(
+        id: String,
+        serverId: String,
+        itemId: String,
+        textSnippet: String = "",
+        note: String? = null,
+        bookmarkTitle: String = "",
+    ) = Annotation(
+        id = id,
+        serverId = serverId,
+        itemId = itemId,
+        type = "highlight",
+        cfi = "",
+        color = "yellow",
+        note = note,
+        textSnippet = textSnippet,
+        textBefore = "",
+        textAfter = "",
+        chapterHref = "",
+        spineIndex = 0,
+        progression = 0.0,
+        bookmarkTitle = bookmarkTitle,
+        createdAt = 0L,
+        updatedAt = 0L,
+    )
+
+    @Test
+    fun results_matchQueryScopedToLibrary() = runTest {
+        allItemsFlow.value = listOf(
+            LibraryItem(
+                id = "b1", libraryId = "lib1", title = "Children of Dune", author = "Herbert",
+                coverUrl = null, readingProgress = 0f, isCached = false, isDownloaded = false,
+                ebookFormat = EbookFormat.Epub, serverId = "srv1",
+            ),
+        )
+        annotationsFlow.value = listOf(
+            annotation(id = "a1", serverId = "srv1", itemId = "b1", textSnippet = "conscience"),
+            annotation(id = "a2", serverId = "srv1", itemId = "b1", textSnippet = "other"),
+        )
+        val savedState = SavedStateHandle(mapOf("libraryId" to "lib1", "query" to "conscience"))
+        val vm = AnnotationSearchViewModel(savedState, fakeRepo(), fakeAnnotationStore(), fakeServerRepository(), fakeTokenStorage())
+
+        val results = vm.results.first { it.isNotEmpty() }
+        assertEquals(listOf("a1"), results.map { it.annotation.id })
+    }
+}

--- a/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemsViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemsViewModelTest.kt
@@ -30,6 +30,8 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.resetMain
@@ -65,6 +67,22 @@ class LibraryItemsViewModelTest {
     private val collectionItemsByCollectionId = mutableMapOf<String, MutableStateFlow<List<LibraryItem>>>()
     private val seriesItemsBySeriesId = mutableMapOf<String, MutableStateFlow<List<LibraryItem>>>()
     private val librariesFlow = MutableStateFlow<List<Library>>(emptyList())
+    private val annotationsFlow = MutableStateFlow<List<com.riffle.core.domain.Annotation>>(emptyList())
+
+    private fun fakeAnnotationStore(): com.riffle.core.domain.AnnotationStore =
+        object : com.riffle.core.domain.AnnotationStore {
+            override fun observeHighlights(serverId: String, itemId: String) = MutableStateFlow(emptyList<com.riffle.core.domain.Annotation>())
+            override fun observeBookmarks(serverId: String, itemId: String) = MutableStateFlow(emptyList<com.riffle.core.domain.Annotation>())
+            override fun observeAnnotations(serverId: String, itemId: String) = MutableStateFlow(emptyList<com.riffle.core.domain.Annotation>())
+            override fun observeAnnotationsForServer(serverId: String) =
+                annotationsFlow.map { all -> all.filter { it.serverId == serverId } }
+            override suspend fun createHighlight(serverId: String, itemId: String, cfi: String, textSnippet: String, chapterHref: String, textBefore: String, textAfter: String, color: String, spineIndex: Int, progression: Double) = error("unused")
+            override suspend fun createBookmark(serverId: String, itemId: String, cfi: String, textSnippet: String, chapterHref: String, spineIndex: Int, progression: Double, bookmarkTitle: String) = error("unused")
+            override suspend fun delete(id: String) = error("unused")
+            override suspend fun recolor(id: String, color: String) = error("unused")
+            override suspend fun updateNote(id: String, note: String?) = error("unused")
+            override suspend fun renameBookmark(id: String, title: String) = error("unused")
+        }
 
     private fun fakeRepo(): LibraryRepository = object : LibraryRepository {
         override fun observeLibraries(): Flow<List<Library>> = librariesFlow
@@ -180,6 +198,7 @@ class LibraryItemsViewModelTest {
             override val scale = kotlinx.coroutines.flow.flowOf(1f)
             override suspend fun setScale(value: Float) {}
         },
+        annotationStore: com.riffle.core.domain.AnnotationStore = fakeAnnotationStore(),
     ) = LibraryItemsViewModel(
         savedStateHandle,
         libraryRepository,
@@ -198,6 +217,7 @@ class LibraryItemsViewModelTest {
         toReadRepository,
         readaloudLinkRepository,
         coverGridDensityStore,
+        annotationStore,
     )
 
     private fun series(name: String) = Series("id-$name", "lib-1", name, null, 1)
@@ -1020,5 +1040,76 @@ class LibraryItemsViewModelTest {
         testDispatcher.scheduler.advanceUntilIdle()
 
         assertEquals(listOf(availableItem), vm.continueSeriesItems.value)
+    }
+
+    // --- filteredAnnotations ---
+
+    private fun annotation(
+        id: String,
+        serverId: String,
+        itemId: String,
+        textSnippet: String = "",
+        note: String? = null,
+        bookmarkTitle: String = "",
+    ) = com.riffle.core.domain.Annotation(
+        id = id,
+        serverId = serverId,
+        itemId = itemId,
+        type = "highlight",
+        cfi = "",
+        color = "yellow",
+        note = note,
+        textSnippet = textSnippet,
+        textBefore = "",
+        textAfter = "",
+        chapterHref = "",
+        spineIndex = 0,
+        progression = 0.0,
+        bookmarkTitle = bookmarkTitle,
+        createdAt = 0L,
+        updatedAt = 0L,
+    )
+
+    private fun itemWithServerId(id: String, title: String, serverId: String) = LibraryItem(
+        id = id,
+        libraryId = "lib1",
+        title = title,
+        author = "Author",
+        coverUrl = null,
+        readingProgress = 0f,
+        isCached = false,
+        isDownloaded = false,
+        ebookFormat = EbookFormat.Epub,
+        serverId = serverId,
+    )
+
+    @Test
+    fun `filteredAnnotations matches query scoped to library items`() = runTest {
+        val vm = makeViewModel()
+        backgroundScope.launch { vm.filteredAnnotations.collect {} }
+        allItemsFlow.value = listOf(itemWithServerId("b1", "Children of Dune", "srv1"))
+        annotationsFlow.value = listOf(
+            annotation(id = "a1", serverId = "srv1", itemId = "b1", textSnippet = "conscience is flexible"),
+            annotation(id = "a2", serverId = "srv1", itemId = "b1", textSnippet = "unrelated"),
+            annotation(id = "aX", serverId = "srv1", itemId = "NOT_IN_LIB", textSnippet = "conscience"),
+        )
+        vm.onSearchQueryChange("conscience")
+
+        val results = vm.filteredAnnotations.first { it.isNotEmpty() }
+        assertEquals(listOf("a1"), results.map { it.annotation.id })
+        assertEquals("Children of Dune", results.single().bookTitle)
+    }
+
+    @Test
+    fun `filteredAnnotations returns empty list when query is blank`() = runTest {
+        val vm = makeViewModel()
+        backgroundScope.launch { vm.filteredAnnotations.collect {} }
+        allItemsFlow.value = listOf(itemWithServerId("b1", "Dune", "srv1"))
+        annotationsFlow.value = listOf(
+            annotation(id = "a1", serverId = "srv1", itemId = "b1", textSnippet = "spice"),
+        )
+        // No query set — blank by default
+        testDispatcher.scheduler.advanceUntilIdle()
+        assertEquals(emptyList<AnnotationSearchResult>(), vm.filteredAnnotations.value)
     }
 }

--- a/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemsViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemsViewModelTest.kt
@@ -84,6 +84,16 @@ class LibraryItemsViewModelTest {
             override suspend fun renameBookmark(id: String, title: String) = error("unused")
         }
 
+    private fun fakeAudiobookBookmarkStore(): com.riffle.core.domain.AudiobookBookmarkStore =
+        object : com.riffle.core.domain.AudiobookBookmarkStore {
+            override fun observe(serverId: String, itemId: String) = MutableStateFlow(emptyList<com.riffle.core.domain.AudiobookBookmark>())
+            override fun observeForServer(serverId: String) = MutableStateFlow(emptyList<com.riffle.core.domain.AudiobookBookmark>())
+            override fun observeHasUnsynced(serverId: String, itemId: String) = MutableStateFlow(false)
+            override suspend fun add(serverId: String, itemId: String, positionSec: Double, title: String, now: Long) = error("unused")
+            override suspend fun rename(id: String, title: String, now: Long) = error("unused")
+            override suspend fun delete(id: String, now: Long) = error("unused")
+        }
+
     private fun fakeRepo(): LibraryRepository = object : LibraryRepository {
         override fun observeLibraries(): Flow<List<Library>> = librariesFlow
         override fun observeLibraries(serverId: String): Flow<List<Library>> = observeLibraries()
@@ -199,6 +209,7 @@ class LibraryItemsViewModelTest {
             override suspend fun setScale(value: Float) {}
         },
         annotationStore: com.riffle.core.domain.AnnotationStore = fakeAnnotationStore(),
+        audiobookBookmarkStore: com.riffle.core.domain.AudiobookBookmarkStore = fakeAudiobookBookmarkStore(),
     ) = LibraryItemsViewModel(
         savedStateHandle,
         libraryRepository,
@@ -218,6 +229,7 @@ class LibraryItemsViewModelTest {
         readaloudLinkRepository,
         coverGridDensityStore,
         annotationStore,
+        audiobookBookmarkStore,
     )
 
     private fun series(name: String) = Series("id-$name", "lib-1", name, null, 1)

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/EpubCfiTranslatorTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/EpubCfiTranslatorTest.kt
@@ -625,6 +625,41 @@ class EpubCfiTranslatorTest {
         assertTrue(!hasElementWithId(html, "shallow"))
     }
 
+    // ── extractAnchorFromCfi ─────────────────────────────────────────────────
+
+    @Test
+    fun `extractAnchorFromCfi returns innermost element id present in html`() {
+        val html = "<html><body><div id=\"outer\"><p id=\"inner\">Hello</p></div></body></html>"
+        val cfi = "epubcfi(/6/4!/4/2[outer]/2[inner]/1:5)"
+        assertEquals("inner", extractAnchorFromCfi(cfi, html))
+    }
+
+    @Test
+    fun `extractAnchorFromCfi falls back to next id when innermost is absent`() {
+        val html = "<html><body><div id=\"outer\"><p>Hello</p></div></body></html>"
+        val cfi = "epubcfi(/6/4!/4/2[outer]/2[missing]/1:5)"
+        assertEquals("outer", extractAnchorFromCfi(cfi, html))
+    }
+
+    @Test
+    fun `extractAnchorFromCfi returns null when no element ids in cfi`() {
+        val html = "<html><body><p>Hello</p></body></html>"
+        assertNull(extractAnchorFromCfi("epubcfi(/6/4!/4/2/1:5)", html))
+    }
+
+    @Test
+    fun `extractAnchorFromCfi returns null when no ids match html`() {
+        val html = "<html><body><p>Hello</p></body></html>"
+        assertNull(extractAnchorFromCfi("epubcfi(/6/4!/4/2[gone]/1:5)", html))
+    }
+
+    @Test
+    fun `extractAnchorFromCfi works with range cfi extracting id from base path`() {
+        val html = "<html><body><p id=\"p1\">Hello world</p></body></html>"
+        val cfi = "epubcfi(/6/4!/4/2[p1]/1,/1:0,/1:5)"
+        assertEquals("p1", extractAnchorFromCfi(cfi, html))
+    }
+
     // ── ID-anchored cfiDocPathToProgression ───────────────────────────────────
 
     @Test

--- a/core/data/src/main/kotlin/com/riffle/core/data/AnnotationStoreImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/AnnotationStoreImpl.kt
@@ -38,6 +38,9 @@ class AnnotationStoreImpl(
     override fun observeAnnotations(serverId: String, itemId: String): Flow<List<Annotation>> =
         dao.observeAnnotationsByPosition(serverId, itemId).map { rows -> rows.map { it.toDomain() } }
 
+    override fun observeAnnotationsForServer(serverId: String): Flow<List<Annotation>> =
+        dao.observeForServer(serverId).map { rows -> rows.map { it.toDomain() } }
+
     override suspend fun createHighlight(
         serverId: String,
         itemId: String,

--- a/core/data/src/main/kotlin/com/riffle/core/data/AudiobookBookmarkStoreImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/AudiobookBookmarkStoreImpl.kt
@@ -14,9 +14,13 @@ class AudiobookBookmarkStoreImpl @Inject constructor(
 ) : AudiobookBookmarkStore {
 
     override fun observe(serverId: String, itemId: String): Flow<List<AudiobookBookmark>> =
-        dao.observeForItem(serverId, itemId).map { rows ->
-            rows.map { AudiobookBookmark(it.id, it.positionSec, it.title, it.createdAt) }
-        }
+        dao.observeForItem(serverId, itemId).map { rows -> rows.map { it.toDomain() } }
+
+    override fun observeForServer(serverId: String): Flow<List<AudiobookBookmark>> =
+        dao.observeForServer(serverId).map { rows -> rows.map { it.toDomain() } }
+
+    private fun AudiobookBookmarkEntity.toDomain() =
+        AudiobookBookmark(id, serverId, itemId, positionSec, title, createdAt)
 
     override fun observeHasUnsynced(serverId: String, itemId: String): Flow<Boolean> =
         dao.observeDirtyCountForItem(serverId, itemId).map { it > 0 }

--- a/core/data/src/test/kotlin/com/riffle/core/data/AnnotationStoreImplTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/AnnotationStoreImplTest.kt
@@ -58,6 +58,9 @@ class AnnotationStoreImplTest {
                 if (it.id == id) it.copy(bookmarkTitle = title, updatedAt = updatedAt, lastModifiedByDeviceId = deviceId) else it
             }
         }
+
+        override fun observeForServer(serverId: String): Flow<List<AnnotationEntity>> =
+            rows.map { all -> all.filter { it.serverId == serverId && !it.deleted } }
     }
 
     private val deviceIdStore = object : DeviceIdStore {
@@ -210,5 +213,17 @@ class AnnotationStoreImplTest {
         s.delete(bm.id)
         val result = s.observeAnnotations("abs1", "item1").first()
         assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun observeAnnotationsForServerReturnsAllNonDeletedForServer() = runTest {
+        var idSeq = 0
+        val store = AnnotationStoreImpl(dao, deviceIdStore, clock = { 0L }, idGenerator = { "id-${idSeq++}" })
+        store.createHighlight("srv1", "b1", "epubcfi(/6/4!/4)", "snippet", "ch.html")
+        store.createBookmark("srv1", "b2", "epubcfi(/6/6!/2)", "top", "ch2.html", 1, 0.1, "mark")
+        store.createHighlight("srv2", "b9", "epubcfi(/6/4!/4)", "other server", "ch.html")
+
+        val forSrv1 = store.observeAnnotationsForServer("srv1").first()
+        assertEquals(setOf("b1", "b2"), forSrv1.map { it.itemId }.toSet())
     }
 }

--- a/core/data/src/test/kotlin/com/riffle/core/data/AnnotationStoreTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/AnnotationStoreTest.kt
@@ -57,6 +57,9 @@ class AnnotationStoreTest {
                 if (it.id == id) it.copy(bookmarkTitle = title, updatedAt = updatedAt, lastModifiedByDeviceId = deviceId) else it
             }
         }
+
+        override fun observeForServer(serverId: String): Flow<List<AnnotationEntity>> =
+            rows.map { all -> all.filter { it.serverId == serverId && !it.deleted } }
     }
 
     private class FakeDeviceIdStore(private val id: String) : DeviceIdStore {

--- a/core/data/src/test/kotlin/com/riffle/core/data/AudiobookBookmarkReconcilerTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/AudiobookBookmarkReconcilerTest.kt
@@ -33,6 +33,9 @@ class AudiobookBookmarkReconcilerTest {
                     .sortedBy { it.positionSec }
             }
 
+        override fun observeForServer(serverId: String): Flow<List<AudiobookBookmarkEntity>> =
+            rows.map { list -> list.filter { it.serverId == serverId && !it.deleted }.sortedBy { it.positionSec } }
+
         override suspend fun getById(id: String) = rows.value.firstOrNull { it.id == id }
 
         override suspend fun allForItem(serverId: String, itemId: String) =

--- a/core/data/src/test/kotlin/com/riffle/core/data/AudiobookBookmarkStoreImplTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/AudiobookBookmarkStoreImplTest.kt
@@ -20,6 +20,8 @@ class AudiobookBookmarkStoreImplTest {
         }
         override fun observeForItem(serverId: String, itemId: String): Flow<List<AudiobookBookmarkEntity>> =
             rows.map { list -> list.filter { it.serverId == serverId && it.itemId == itemId && !it.deleted }.sortedBy { it.positionSec } }
+        override fun observeForServer(serverId: String): Flow<List<AudiobookBookmarkEntity>> =
+            rows.map { list -> list.filter { it.serverId == serverId && !it.deleted }.sortedBy { it.positionSec } }
         override suspend fun getById(id: String) = rows.value.firstOrNull { it.id == id }
         override suspend fun allForItem(serverId: String, itemId: String) =
             rows.value.filter { it.serverId == serverId && it.itemId == itemId }

--- a/core/database/src/androidTest/kotlin/com/riffle/core/database/AnnotationDaoTest.kt
+++ b/core/database/src/androidTest/kotlin/com/riffle/core/database/AnnotationDaoTest.kt
@@ -30,6 +30,8 @@ class AnnotationDaoTest {
         val servers = db.serverDao()
         servers.upsert(ServerEntity("abs1", "http://abs1", isActive = true, insecureConnectionAllowed = false, username = "u"))
         servers.upsert(ServerEntity("abs2", "http://abs2", isActive = false, insecureConnectionAllowed = false, username = "u"))
+        servers.upsert(ServerEntity("srv1", "http://srv1", isActive = true, insecureConnectionAllowed = false, username = "u"))
+        servers.upsert(ServerEntity("srv2", "http://srv2", isActive = false, insecureConnectionAllowed = false, username = "u"))
     }
 
     @After
@@ -133,5 +135,17 @@ class AnnotationDaoTest {
         assertEquals("device-B", row?.lastModifiedByDeviceId)
         // The live query still returns it (recolour is not a delete).
         assertEquals(listOf("h1"), dao.observeForItem("abs1", "item1").first().map { it.id })
+    }
+
+    @Test
+    fun observeForServer_returnsAllNonDeletedAcrossItems_excludesOtherServers() = runBlocking {
+        dao.upsert(highlight("a1", serverId = "srv1", itemId = "b1"))
+        dao.upsert(highlight("a2", serverId = "srv1", itemId = "b2"))
+        dao.upsert(highlight("a3", serverId = "srv1", itemId = "b3", deleted = true))
+        dao.upsert(highlight("a4", serverId = "srv2", itemId = "b9"))
+
+        val result = dao.observeForServer("srv1").first()
+
+        assertEquals(listOf("a1", "a2"), result.map { it.id })
     }
 }

--- a/core/database/src/main/kotlin/com/riffle/core/database/AnnotationDao.kt
+++ b/core/database/src/main/kotlin/com/riffle/core/database/AnnotationDao.kt
@@ -16,6 +16,13 @@ interface AnnotationDao {
     )
     fun observeForItem(serverId: String, itemId: String): Flow<List<AnnotationEntity>>
 
+    /** Live, non-deleted annotations across every item for a server, oldest first. */
+    @Query(
+        "SELECT * FROM annotations WHERE serverId = :serverId AND deleted = 0 " +
+            "ORDER BY createdAt ASC"
+    )
+    fun observeForServer(serverId: String): Flow<List<AnnotationEntity>>
+
     /** One-shot read of non-deleted annotations for an ABS Library Item, oldest first. */
     @Query(
         "SELECT * FROM annotations WHERE serverId = :serverId AND itemId = :itemId AND deleted = 0 " +

--- a/core/database/src/main/kotlin/com/riffle/core/database/AudiobookBookmarkDao.kt
+++ b/core/database/src/main/kotlin/com/riffle/core/database/AudiobookBookmarkDao.kt
@@ -19,6 +19,10 @@ interface AudiobookBookmarkDao {
     )
     fun observeForItem(serverId: String, itemId: String): Flow<List<AudiobookBookmarkEntity>>
 
+    /** Live, non-deleted bookmarks across an entire server — for library-wide search. */
+    @Query("SELECT * FROM audiobook_bookmarks WHERE serverId = :serverId AND deleted = 0 ORDER BY positionSec ASC")
+    fun observeForServer(serverId: String): Flow<List<AudiobookBookmarkEntity>>
+
     @Query("SELECT * FROM audiobook_bookmarks WHERE id = :id LIMIT 1")
     suspend fun getById(id: String): AudiobookBookmarkEntity?
 

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/AnnotationStore.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/AnnotationStore.kt
@@ -13,6 +13,9 @@ interface AnnotationStore {
     /** Live, non-deleted highlights + bookmarks for an ABS Library Item, sorted by reading position. */
     fun observeAnnotations(serverId: String, itemId: String): Flow<List<Annotation>>
 
+    /** Live, non-deleted highlights + bookmarks across every item for a server, oldest first. */
+    fun observeAnnotationsForServer(serverId: String): Flow<List<Annotation>>
+
     suspend fun createHighlight(
         serverId: String,
         itemId: String,

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/AudiobookBookmark.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/AudiobookBookmark.kt
@@ -3,6 +3,8 @@ package com.riffle.core.domain
 /** A user bookmark in an audiobook: a titled book-absolute position. */
 data class AudiobookBookmark(
     val id: String,
+    val serverId: String,
+    val itemId: String,
     val positionSec: Double,
     val title: String,
     val createdAt: Long,

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/AudiobookBookmarkStore.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/AudiobookBookmarkStore.kt
@@ -6,6 +6,9 @@ import kotlinx.coroutines.flow.Flow
 interface AudiobookBookmarkStore {
     fun observe(serverId: String, itemId: String): Flow<List<AudiobookBookmark>>
 
+    /** Live stream of all non-deleted bookmarks for a server — for library-wide search. */
+    fun observeForServer(serverId: String): Flow<List<AudiobookBookmark>>
+
     /** Live: whether this item has unsynced (dirty) bookmarks pending a push to ABS. */
     fun observeHasUnsynced(serverId: String, itemId: String): Flow<Boolean>
 


### PR DESCRIPTION
## Summary

- Adds a live **Annotations section** to library search that matches EPUB highlights, bookmarks (by note text, snippet, or title), and **audiobook player bookmarks** (by title) across an entire server's library
- Tapping an EPUB annotation deep-links into the reader at the exact CFI; tapping an audiobook bookmark navigates to the player at the saved position
- A **full-screen Annotation Search Results** screen shows all matches for a query
- Fixes **continuous-mode CFI navigation precision**: the reader now anchors to the exact DOM element ID extracted from the CFI rather than relying on character-count progression, which could land several paragraphs away
- Preview in the inline Annotations section caps at 5 combined results, split fairly (ceil(cap/2) slots per type) so audiobook bookmarks are never starved by a large annotation set

## Changes

**Data layer**
- `AudiobookBookmark` gains `serverId` + `itemId` so bookmarks can be joined to library items
- `AudiobookBookmarkDao` / `AudiobookBookmarkStore` gain `observeForServer(serverId)` for library-wide streaming
- `AudiobookBookmarkStoreImpl` maps new fields via extracted `toDomain()` helper

**Search layer**
- `AnnotationSearch.kt`: `AudiobookBookmarkSearchResult` model + `searchAudiobookBookmarks()` function
- `LibraryItemsViewModel` + `AnnotationSearchViewModel` each expose a `filteredAudiobookBookmarks` / `bookmarkResults` StateFlow

**UI**
- Annotations section in library search renders EPUB annotations and audiobook bookmarks together with a fair preview split
- `AnnotationSearchResultsScreen` renders both result types side-by-side
- `MainScreen` wires audiobook bookmark taps to `audiobook_player/{itemId}?startAtSec={pos}`

**Reader (continuous mode)**
- `extractAnchorFromCfi()` reuses existing `extractCfiElementIds` + `hasElementWithId` to find the innermost DOM anchor from a CFI
- `goToContinuous` and `ContinuousReaderView.initialize()` pass `href#anchorId` when available

## Test plan

- [x] `./gradlew test` — 86 JVM tests, BUILD SUCCESSFUL
- [x] `./gradlew lint` — clean
- [x] `make harness-test` — 242 phone tests, 0 failed
- [x] `make harness-test-tablet` — 5 tablet tests, 0 failed
- [x] New unit tests: `searchAudiobookBookmarks` (4 cases), `extractAnchorFromCfi` (5 cases), `unnamedBookmarkFoundByTextSnippet`