### PR TITLE
fix(reader): search highlights in continuous mode — all instances + color parity

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousHighlightRenderer.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousHighlightRenderer.kt
@@ -74,11 +74,11 @@ internal class ContinuousHighlightRenderer(
 
     override suspend fun applySearch(results: List<Locator>, activeIndex: Int) {
         val target = targetProvider() ?: return
-        if (results.isEmpty() || activeIndex < 0) {
+        if (results.isEmpty() || activeIndex < 0 || activeIndex >= results.size) {
             target.applySearchHighlights(null)
             return
         }
-        val activeLocator = results.getOrNull(activeIndex) ?: return
+        val activeLocator = results[activeIndex]
         val activeText = activeLocator.text.highlight?.take(40) ?: return
         if (activeText.isBlank()) return
 

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousHighlightRenderer.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousHighlightRenderer.kt
@@ -73,11 +73,41 @@ internal class ContinuousHighlightRenderer(
     }
 
     override suspend fun applySearch(results: List<Locator>, activeIndex: Int) {
-        // Search result highlighting for continuous mode is driven by the search navigation
-        // event handler via highlightSearchMatch, not by the state-watching search effect.
+        val target = targetProvider() ?: return
+        if (results.isEmpty() || activeIndex < 0) {
+            target.applySearchHighlights(null)
+            return
+        }
+        val activeLocator = results.getOrNull(activeIndex) ?: return
+        val activeText = activeLocator.text.highlight?.take(40) ?: return
+        if (activeText.isBlank()) return
+
+        val activeHref = activeLocator.href.toString()
+        val activeProgression = activeLocator.locations.progression?.toFloat() ?: 0f
+
+        val resultsByHref = results
+            .groupBy { it.href.toString() }
+            .mapValues { (_, locators) ->
+                locators.mapNotNull { it.text.highlight?.take(40)?.takeIf { t -> t.isNotBlank() } }
+                    .distinct()
+            }
+            .filterValues { it.isNotEmpty() }
+
+        target.applySearchHighlights(
+            SearchHighlightsState(
+                resultsByHref = resultsByHref,
+                activeHref = activeHref,
+                activeText = activeText,
+                activeProgression = activeProgression,
+                activeCssColor = SEARCH_ACTIVE_ARGB.toCssRgbaWithAlpha(SEARCH_DECORATION_ALPHA),
+                inactiveCssColor = SEARCH_INACTIVE_ARGB.toCssRgbaWithAlpha(SEARCH_DECORATION_ALPHA),
+            )
+        )
     }
 
     override fun highlightSearchMatch(href: String, text: String) {
-        targetProvider()?.highlightInChapter(href, text, SEARCH_ACTIVE_ARGB.toCssRgba())
+        // Highlights for all results (inactive) and the active match are applied via applySearch,
+        // which fires from the LaunchedEffect on currentSearchIndex change. No separate per-match
+        // call is needed in continuous mode.
     }
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousHighlightTarget.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousHighlightTarget.kt
@@ -9,4 +9,27 @@ internal interface ContinuousHighlightTarget {
     fun highlightInChapter(href: String, text: String, cssColor: String)
     fun clearHighlightInChapter(href: String)
     fun applyAnnotationHighlights(annotationsByHref: Map<String, List<AnnotationHighlight>>)
+    /**
+     * Apply search highlights across all currently-loaded chapters. Persists the state so
+     * chapters entering the sliding window later (via onPageFinished) automatically receive
+     * their marks. Pass null to clear all search highlights.
+     */
+    fun applySearchHighlights(state: SearchHighlightsState?)
 }
+
+/**
+ * Full snapshot of the current search-highlight state.
+ *
+ * [resultsByHref] maps chapter hrefs to the unique highlighted-text snippets (up to 40 chars each)
+ * for all search results in that chapter.  All results are displayed with [inactiveCssColor]; the
+ * single active result ([activeHref] / [activeText] / [activeProgression]) is additionally
+ * distinguished with [activeCssColor].
+ */
+internal data class SearchHighlightsState(
+    val resultsByHref: Map<String, List<String>>,
+    val activeHref: String?,
+    val activeText: String?,
+    val activeProgression: Float,
+    val activeCssColor: String,
+    val inactiveCssColor: String,
+)

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
@@ -533,6 +533,42 @@ internal class ContinuousReaderView @JvmOverloads constructor(
         webViews[i].evaluateJavascript(ContinuousStyleInjector.CLEAR_HIGHLIGHT_JS, null)
     }
 
+    // Search highlight state — persisted across the window so onPageFinished can re-apply marks
+    // when a chapter enters the sliding window or when a chapter reloads after a far-jump.
+    private var currentSearchHighlights: SearchHighlightsState? = null
+
+    override fun applySearchHighlights(state: SearchHighlightsState?) {
+        currentSearchHighlights = state
+        if (state == null) {
+            for (wv in webViews) {
+                wv.evaluateJavascript(ContinuousStyleInjector.CLEAR_SEARCH_HIGHLIGHTS_JS, null)
+            }
+            return
+        }
+        for (wv in webViews) {
+            applySearchHighlightsToWebView(wv, state)
+        }
+    }
+
+    private fun applySearchHighlightsToWebView(wv: ChapterWebView, state: SearchHighlightsState) {
+        val href = wv.chapterHref
+        if (href.isEmpty()) return
+        val texts = state.resultsByHref[href] ?: return
+        val isActive = href == state.activeHref
+        val js = ContinuousStyleInjector.applySearchHighlightsJs(
+            inactiveTexts = texts,
+            inactiveCssColor = state.inactiveCssColor,
+            activeText = if (isActive) state.activeText else null,
+            activeProgression = if (isActive) state.activeProgression else -1f,
+            activeCssColor = state.activeCssColor,
+        )
+        // Clear first, then re-apply in callback: Chrome won't reliably find text in a DOM
+        // that was just mutated synchronously (see ContinuousStyleInjector.applyAnnotationHighlightsJs).
+        wv.evaluateJavascript(ContinuousStyleInjector.CLEAR_SEARCH_HIGHLIGHTS_JS) { _ ->
+            wv.evaluateJavascript(js, null)
+        }
+    }
+
     /** Called on the main thread when the user taps an annotation highlight mark in any chapter. */
     var onAnnotationTap: ((href: String, id: String, screenRect: android.graphics.Rect) -> Unit)? = null
 
@@ -670,6 +706,10 @@ internal class ContinuousReaderView @JvmOverloads constructor(
             if (!annotations.isNullOrEmpty()) {
                 wv.evaluateJavascript(ContinuousStyleInjector.applyAnnotationHighlightsJs(annotations), null)
             }
+            val searchState = currentSearchHighlights
+            if (searchState != null && searchState.resultsByHref.containsKey(wv.chapterHref)) {
+                applySearchHighlightsToWebView(wv, searchState)
+            }
         }
         webViews.add(wv)
         measuredHeights.add(placeholder)
@@ -710,6 +750,10 @@ internal class ContinuousReaderView @JvmOverloads constructor(
             val annotations = currentAnnotationsByHref[wv.chapterHref]
             if (!annotations.isNullOrEmpty()) {
                 wv.evaluateJavascript(ContinuousStyleInjector.applyAnnotationHighlightsJs(annotations), null)
+            }
+            val searchState = currentSearchHighlights
+            if (searchState != null && searchState.resultsByHref.containsKey(wv.chapterHref)) {
+                applySearchHighlightsToWebView(wv, searchState)
             }
         }
         webViews.add(0, wv)

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjector.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjector.kt
@@ -423,9 +423,9 @@ internal object ContinuousStyleInjector {
                         if (cont.nodeType !== 1) cont = cont.parentNode;
                         if (cont && cont.hasAttribute &&
                             (cont.hasAttribute('data-riffle-si') || cont.hasAttribute('data-riffle-sa'))) {
-                            var r2 = document.createRange();
-                            r2.setStartAfter(cont); r2.collapse(true);
-                            sel.removeAllRanges(); sel.addRange(r2);
+                            var skip = document.createRange();
+                            skip.setStartAfter(cont); skip.collapse(true);
+                            sel.removeAllRanges(); sel.addRange(skip);
                             continue;
                         }
                         var mark = document.createElement('mark');
@@ -433,9 +433,9 @@ internal object ContinuousStyleInjector {
                         mark.style.cssText = 'background:' + inactiveCss + ';color:inherit;';
                         try { range.surroundContents(mark); }
                         catch(e) { var frag = range.extractContents(); mark.appendChild(frag); range.insertNode(mark); }
-                        var r2 = document.createRange();
-                        r2.setStartAfter(mark); r2.collapse(true);
-                        sel.removeAllRanges(); sel.addRange(r2);
+                        var advance = document.createRange();
+                        advance.setStartAfter(mark); advance.collapse(true);
+                        sel.removeAllRanges(); sel.addRange(advance);
                     }
                 });
                 if (activeT && activeProg >= 0) {

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjector.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjector.kt
@@ -356,6 +356,113 @@ internal object ContinuousStyleInjector {
         })();
     """.trimIndent()
 
+    /** Removes all search inactive ([data-riffle-si]) and active ([data-riffle-sa]) marks. */
+    val CLEAR_SEARCH_HIGHLIGHTS_JS = """
+        (function() {
+            document.querySelectorAll('[data-riffle-si],[data-riffle-sa]').forEach(function(m) {
+                m.outerHTML = m.innerHTML;
+            });
+        })();
+    """.trimIndent()
+
+    /**
+     * JS that marks all occurrences of each text in [inactiveTexts] with `data-riffle-si` and
+     * [inactiveCssColor], then promotes the occurrence of [activeText] closest to [activeProgression]
+     * (a 0–1 document fraction) to `data-riffle-sa` with [activeCssColor].
+     *
+     * Call this ONLY after clearing existing marks via [CLEAR_SEARCH_HIGHLIGHTS_JS] (via a
+     * [WebView.evaluateJavascript] callback), because Chrome won't reliably find text in a DOM
+     * that was just mutated synchronously in the same JS block.
+     *
+     * Pass [activeText] as null (and [activeProgression] < 0) when this chapter has no active result.
+     */
+    fun applySearchHighlightsJs(
+        inactiveTexts: List<String>,
+        inactiveCssColor: String,
+        activeText: String?,
+        activeProgression: Float,
+        activeCssColor: String,
+    ): String {
+        val textsJson = buildString {
+            append('[')
+            inactiveTexts.forEachIndexed { i, text ->
+                if (i > 0) append(',')
+                val safe = text
+                    .replace("\\", "\\\\")
+                    .replace("'", "\\'")
+                    .replace("\n", "\\n")
+                    .replace("\r", "\\r")
+                append("'$safe'")
+            }
+            append(']')
+        }
+        val safeActive = activeText
+            ?.replace("\\", "\\\\")?.replace("'", "\\'")?.replace("\n", "\\n")?.replace("\r", "\\r")
+        val activeTextJs = if (safeActive != null) "'$safeActive'" else "null"
+        // Colors are machine-generated CSS rgba() strings — no quote escaping needed.
+        return """
+            (function(texts,inactiveCss,activeT,activeProg,activeCss) {
+                var sel = window.getSelection();
+                var seen = {};
+                texts.forEach(function(text) {
+                    if (!text || seen[text]) return;
+                    seen[text] = true;
+                    try {
+                        var r0 = document.createRange();
+                        r0.setStart(document.body || document.documentElement, 0);
+                        r0.collapse(true);
+                        if (sel) { sel.removeAllRanges(); sel.addRange(r0); }
+                    } catch(e) { return; }
+                    var limit = 500;
+                    while (limit-- > 0) {
+                        if (!window.find(text, false, false, false, false, false, false)) break;
+                        sel = window.getSelection();
+                        if (!sel || sel.rangeCount === 0) break;
+                        var range = sel.getRangeAt(0);
+                        var cont = range.commonAncestorContainer;
+                        if (cont.nodeType !== 1) cont = cont.parentNode;
+                        if (cont && cont.hasAttribute &&
+                            (cont.hasAttribute('data-riffle-si') || cont.hasAttribute('data-riffle-sa'))) {
+                            var r2 = document.createRange();
+                            r2.setStartAfter(cont); r2.collapse(true);
+                            sel.removeAllRanges(); sel.addRange(r2);
+                            continue;
+                        }
+                        var mark = document.createElement('mark');
+                        mark.setAttribute('data-riffle-si', '');
+                        mark.style.cssText = 'background:' + inactiveCss + ';color:inherit;';
+                        try { range.surroundContents(mark); }
+                        catch(e) { var frag = range.extractContents(); mark.appendChild(frag); range.insertNode(mark); }
+                        var r2 = document.createRange();
+                        r2.setStartAfter(mark); r2.collapse(true);
+                        sel.removeAllRanges(); sel.addRange(r2);
+                    }
+                });
+                if (activeT && activeProg >= 0) {
+                    var docH = Math.max(
+                        document.documentElement.scrollHeight,
+                        document.body ? document.body.scrollHeight : 0, 1
+                    );
+                    var targetY = activeProg * docH;
+                    var best = null, bestDist = Infinity;
+                    document.querySelectorAll('[data-riffle-si]').forEach(function(m) {
+                        if (m.textContent.toLowerCase().indexOf(activeT.toLowerCase()) < 0) return;
+                        var rect = m.getBoundingClientRect();
+                        var absY = rect.top + (window.pageYOffset || document.documentElement.scrollTop || 0);
+                        var dist = Math.abs(absY - targetY);
+                        if (dist < bestDist) { bestDist = dist; best = m; }
+                    });
+                    if (best) {
+                        best.setAttribute('data-riffle-sa', '');
+                        best.removeAttribute('data-riffle-si');
+                        best.style.background = activeCss;
+                    }
+                }
+                if (sel) sel.removeAllRanges();
+            })($textsJson,'$inactiveCssColor',$activeTextJs,${activeProgression},'$activeCssColor');
+        """.trimIndent()
+    }
+
     val CLEAR_ANNOTATION_HIGHLIGHTS_JS = """
         (function() {
             document.querySelectorAll('[data-riffle-note-glyph]').forEach(function(s) { s.remove(); });

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -300,7 +300,7 @@ class EpubReaderViewModel @Inject constructor(
     private val _currentSearchIndex = MutableStateFlow(-1)
     val currentSearchIndex: StateFlow<Int> = _currentSearchIndex
 
-    private val _searchNavigationChannel = Channel<Locator>(Channel.CONFLATED)
+    private val _searchNavigationChannel = Channel<Locator>(Channel.BUFFERED)
     val searchNavigationEvents: Flow<Locator> = _searchNavigationChannel.receiveAsFlow()
 
     private var searchJob: Job? = null
@@ -1596,6 +1596,9 @@ class EpubReaderViewModel @Inject constructor(
     }
 
     private suspend fun performSearch(query: String) {
+        // Drain any pending navigation events buffered from the previous search so they don't
+        // fire after the new results arrive.
+        while (_searchNavigationChannel.tryReceive().isSuccess) { /* drain */ }
         val pub = publication ?: return
         val service = pub.findService(SearchService::class)
         if (service == null) {

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/HighlightDecoration.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/HighlightDecoration.kt
@@ -100,3 +100,11 @@ fun @receiver:ColorInt Int.toCssRgba(): String {
     val b = this and 0xFF
     return "rgba($r,$g,$b,${"%.2f".format(a)})"
 }
+
+/** Convert an ARGB color int to a CSS rgba() string, overriding the alpha with [alpha] (0.0–1.0). */
+fun @receiver:ColorInt Int.toCssRgbaWithAlpha(alpha: Double): String {
+    val r = this ushr 16 and 0xFF
+    val g = this ushr 8 and 0xFF
+    val b = this and 0xFF
+    return "rgba($r,$g,$b,${"%.2f".format(alpha)})"
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/HighlightDecoration.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/HighlightDecoration.kt
@@ -8,6 +8,7 @@ import com.riffle.core.domain.HighlightColor
 import com.riffle.core.domain.ReaderTheme
 import com.riffle.core.domain.ReadaloudHighlightColor
 import org.readium.r2.navigator.Decoration
+import java.util.Locale
 import org.readium.r2.navigator.html.HtmlDecorationTemplate
 import org.readium.r2.navigator.html.toCss
 
@@ -98,7 +99,7 @@ fun @receiver:ColorInt Int.toCssRgba(): String {
     val r = this ushr 16 and 0xFF
     val g = this ushr 8 and 0xFF
     val b = this and 0xFF
-    return "rgba($r,$g,$b,${"%.2f".format(a)})"
+    return "rgba($r,$g,$b,${"%.2f".format(Locale.US, a)})"
 }
 
 /** Convert an ARGB color int to a CSS rgba() string, overriding the alpha with [alpha] (0.0–1.0). */
@@ -106,5 +107,5 @@ fun @receiver:ColorInt Int.toCssRgbaWithAlpha(alpha: Double): String {
     val r = this ushr 16 and 0xFF
     val g = this ushr 8 and 0xFF
     val b = this and 0xFF
-    return "rgba($r,$g,$b,${"%.2f".format(alpha)})"
+    return "rgba($r,$g,$b,${"%.2f".format(Locale.US, alpha)})"
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/HighlightRenderer.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/HighlightRenderer.kt
@@ -63,9 +63,9 @@ internal interface HighlightRenderer {
      * Applies or clears search result decorations for ALL results at once.
      * Readium implementation renders [Decoration] objects for each locator and
      * runs a post-navigation settle loop to reposition boxes after layout settles.
-     * Continuous implementation is a no-op — search match highlighting is done
-     * via [highlightSearchMatch] from the navigation event handler.
-     * Empty [results] clears the group.
+     * Continuous implementation groups all results by chapter href, builds a
+     * [SearchHighlightsState], and delegates to [ContinuousHighlightTarget.applySearchHighlights].
+     * Empty [results] or negative [activeIndex] clears all search highlights.
      */
     suspend fun applySearch(
         results: List<Locator>,

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/HighlightRenderer.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/HighlightRenderer.kt
@@ -15,6 +15,12 @@ internal val SEARCH_ACTIVE_ARGB: Int = 0xFFF5A623.toInt()
 internal val SEARCH_INACTIVE_ARGB: Int = 0xFFFDE68A.toInt()
 
 /**
+ * Alpha applied by Readium's [Decoration.Style.Highlight] for search results.
+ * The continuous renderer uses this constant so both pipelines render at the same opacity.
+ */
+internal const val SEARCH_DECORATION_ALPHA = 0.30
+
+/**
  * Abstracts the two rendering pipelines for reader highlights:
  *  - [ReadiumHighlightRenderer]: paginated and scroll modes via DecorableNavigator
  *  - [ContinuousHighlightRenderer]: continuous mode via ChapterWebView JS injection

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousHighlightRendererTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousHighlightRendererTest.kt
@@ -22,6 +22,8 @@ class ContinuousHighlightRendererTest {
         val highlighted = mutableListOf<Triple<String, String, String>>() // href, text, color
         val cleared = mutableListOf<String>() // href
         val appliedAnnotations = mutableListOf<Map<String, List<AnnotationHighlight>>>()
+        var searchHighlightsState: SearchHighlightsState? = null
+        var searchHighlightsCalls = 0
 
         override fun highlightInChapter(href: String, text: String, cssColor: String) {
             highlighted.add(Triple(href, text, cssColor))
@@ -29,6 +31,10 @@ class ContinuousHighlightRendererTest {
         override fun clearHighlightInChapter(href: String) { cleared.add(href) }
         override fun applyAnnotationHighlights(annotationsByHref: Map<String, List<AnnotationHighlight>>) {
             appliedAnnotations.add(annotationsByHref)
+        }
+        override fun applySearchHighlights(state: SearchHighlightsState?) {
+            searchHighlightsState = state
+            searchHighlightsCalls++
         }
     }
 
@@ -40,6 +46,8 @@ class ContinuousHighlightRendererTest {
         fakeTarget.highlighted.clear()
         fakeTarget.cleared.clear()
         fakeTarget.appliedAnnotations.clear()
+        fakeTarget.searchHighlightsState = null
+        fakeTarget.searchHighlightsCalls = 0
     }
 
     // ---- Helpers -------------------------------------------------------------
@@ -86,18 +94,12 @@ class ContinuousHighlightRendererTest {
         note = note,
     )
 
-    /**
-     * Creates a minimal [Locator] stub (no meaningful fields) for tests that don't inspect
-     * the locator content (e.g. [applySearch]).
-     */
-    @Suppress("UNCHECKED_CAST")
-    private fun minimalLocator(@Suppress("UNUSED_PARAMETER") href: String): Locator {
-        val unsafe = Class.forName("sun.misc.Unsafe")
-            .getDeclaredField("theUnsafe")
-            .also { it.isAccessible = true }
-            .get(null) as sun.misc.Unsafe
-        return unsafe.allocateInstance(Locator::class.java) as Locator
-    }
+    /** Creates a [Locator] with href and text highlight, suitable for search result tests. */
+    private fun makeSearchLocator(href: String, text: String): Locator = Locator(
+        href = makeAbsoluteUrl("https://example.com/$href"),
+        mediaType = MediaType.XHTML,
+        text = Locator.Text(highlight = text),
+    )
 
     // ---- applyReadaloud -------------------------------------------------------
 
@@ -196,22 +198,87 @@ class ContinuousHighlightRendererTest {
         assertEquals(0, fakeTarget.appliedAnnotations.size)
     }
 
-    // ---- applySearch (no-op) ------------------------------------------------
+    // ---- applySearch --------------------------------------------------------
 
     @Test
-    fun `applySearch is a no-op in continuous mode`() = runTest {
-        renderer.applySearch(listOf(minimalLocator("c.xhtml")), activeIndex = 0)
-        assertEquals(0, fakeTarget.highlighted.size)
+    fun `applySearch with active result calls applySearchHighlights with correct active fields`() = runTest {
+        val locator = makeSearchLocator("ch1.xhtml", "found text")
+        renderer.applySearch(listOf(locator), activeIndex = 0)
+        val state = fakeTarget.searchHighlightsState
+        assertTrue("state should not be null", state != null)
+        assertTrue("activeHref should end with ch1.xhtml", state!!.activeHref?.endsWith("ch1.xhtml") == true)
+        assertEquals("found text", state.activeText)
+        assertEquals(1, fakeTarget.searchHighlightsCalls)
+    }
+
+    @Test
+    fun `applySearch uses SEARCH_DECORATION_ALPHA for both active and inactive colors`() = runTest {
+        val locator = makeSearchLocator("ch1.xhtml", "text")
+        renderer.applySearch(listOf(locator), activeIndex = 0)
+        val state = fakeTarget.searchHighlightsState!!
+        assertEquals(SEARCH_ACTIVE_ARGB.toCssRgbaWithAlpha(SEARCH_DECORATION_ALPHA), state.activeCssColor)
+        assertEquals(SEARCH_INACTIVE_ARGB.toCssRgbaWithAlpha(SEARCH_DECORATION_ALPHA), state.inactiveCssColor)
+    }
+
+    @Test
+    fun `applySearch truncates active text to 40 chars`() = runTest {
+        val longText = "a".repeat(60)
+        val locator = makeSearchLocator("ch1.xhtml", longText)
+        renderer.applySearch(listOf(locator), activeIndex = 0)
+        assertEquals(40, fakeTarget.searchHighlightsState!!.activeText!!.length)
+    }
+
+    @Test
+    fun `applySearch groups results by href`() = runTest {
+        val results = listOf(
+            makeSearchLocator("ch1.xhtml", "word"),
+            makeSearchLocator("ch1.xhtml", "word"),
+            makeSearchLocator("ch2.xhtml", "word"),
+        )
+        renderer.applySearch(results, activeIndex = 0)
+        val byHref = fakeTarget.searchHighlightsState!!.resultsByHref
+        assertTrue(byHref.keys.any { it.endsWith("ch1.xhtml") })
+        assertTrue(byHref.keys.any { it.endsWith("ch2.xhtml") })
+    }
+
+    @Test
+    fun `applySearch deduplicates texts within a chapter`() = runTest {
+        val results = listOf(
+            makeSearchLocator("ch1.xhtml", "word"),
+            makeSearchLocator("ch1.xhtml", "word"),
+        )
+        renderer.applySearch(results, activeIndex = 0)
+        val ch1Key = fakeTarget.searchHighlightsState!!.resultsByHref.keys.first { it.endsWith("ch1.xhtml") }
+        assertEquals(1, fakeTarget.searchHighlightsState!!.resultsByHref[ch1Key]!!.size)
+    }
+
+    @Test
+    fun `applySearch with empty results clears highlights`() = runTest {
+        renderer.applySearch(emptyList(), activeIndex = -1)
+        assertEquals(1, fakeTarget.searchHighlightsCalls)
+        assertEquals(null, fakeTarget.searchHighlightsState)
+    }
+
+    @Test
+    fun `applySearch with negative index clears highlights`() = runTest {
+        val locator = makeSearchLocator("ch1.xhtml", "text")
+        renderer.applySearch(listOf(locator), activeIndex = -1)
+        assertEquals(1, fakeTarget.searchHighlightsCalls)
+        assertEquals(null, fakeTarget.searchHighlightsState)
+    }
+
+    @Test
+    fun `applySearch skips locators with blank text`() = runTest {
+        val locator = makeSearchLocator("ch1.xhtml", "   ")
+        renderer.applySearch(listOf(locator), activeIndex = 0)
+        assertEquals(0, fakeTarget.searchHighlightsCalls)
     }
 
     // ---- highlightSearchMatch -----------------------------------------------
 
     @Test
-    fun `highlightSearchMatch delegates to target`() {
+    fun `highlightSearchMatch is a no-op in continuous mode`() {
         renderer.highlightSearchMatch("ch1.xhtml", "search term")
-        assertEquals(1, fakeTarget.highlighted.size)
-        assertEquals("ch1.xhtml", fakeTarget.highlighted[0].first)
-        assertEquals("search term", fakeTarget.highlighted[0].second)
-        assertEquals(SEARCH_ACTIVE_ARGB.toCssRgba(), fakeTarget.highlighted[0].third)
+        assertEquals(0, fakeTarget.searchHighlightsCalls)
     }
 }

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjectorTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjectorTest.kt
@@ -436,4 +436,90 @@ class ContinuousStyleInjectorTest {
         assertEquals(ann, AnnotationHighlight("id", "text", "#000", hasNote = true))
         assertFalse(ann == ann.copy(hasNote = false))
     }
+
+    // ── applySearchHighlightsJs ───────────────────────────────────────────────
+
+    @Test
+    fun `applySearchHighlightsJs embeds inactive text array in JS output`() {
+        val js = ContinuousStyleInjector.applySearchHighlightsJs(
+            inactiveTexts = listOf("hello", "world"),
+            inactiveCssColor = "rgba(253,230,138,0.30)",
+            activeText = null,
+            activeProgression = -1f,
+            activeCssColor = "rgba(245,166,35,0.30)",
+        )
+        assertTrue("JS should contain 'hello'", js.contains("'hello'"))
+        assertTrue("JS should contain 'world'", js.contains("'world'"))
+    }
+
+    @Test
+    fun `applySearchHighlightsJs embeds colors in JS output`() {
+        val active = "rgba(245,166,35,0.30)"
+        val inactive = "rgba(253,230,138,0.30)"
+        val js = ContinuousStyleInjector.applySearchHighlightsJs(
+            inactiveTexts = listOf("text"),
+            inactiveCssColor = inactive,
+            activeText = "text",
+            activeProgression = 0.5f,
+            activeCssColor = active,
+        )
+        assertTrue(js.contains(active))
+        assertTrue(js.contains(inactive))
+    }
+
+    @Test
+    fun `applySearchHighlightsJs embeds active text and progression when provided`() {
+        val js = ContinuousStyleInjector.applySearchHighlightsJs(
+            inactiveTexts = listOf("Dune"),
+            inactiveCssColor = "rgba(253,230,138,0.30)",
+            activeText = "Dune",
+            activeProgression = 0.42f,
+            activeCssColor = "rgba(245,166,35,0.30)",
+        )
+        assertTrue("active text in output", js.contains("'Dune'"))
+        assertTrue("progression in output", js.contains("0.42"))
+    }
+
+    @Test
+    fun `applySearchHighlightsJs passes null active text when chapter has no active result`() {
+        val js = ContinuousStyleInjector.applySearchHighlightsJs(
+            inactiveTexts = listOf("word"),
+            inactiveCssColor = "rgba(253,230,138,0.30)",
+            activeText = null,
+            activeProgression = -1f,
+            activeCssColor = "rgba(245,166,35,0.30)",
+        )
+        assertTrue("null literal in output", js.contains(",null,"))
+    }
+
+    @Test
+    fun `applySearchHighlightsJs escapes single quotes in text`() {
+        val js = ContinuousStyleInjector.applySearchHighlightsJs(
+            inactiveTexts = listOf("it's"),
+            inactiveCssColor = "rgba(253,230,138,0.30)",
+            activeText = "it's",
+            activeProgression = 0.5f,
+            activeCssColor = "rgba(245,166,35,0.30)",
+        )
+        assertTrue("single quote escaped", js.contains("\\'"))
+    }
+
+    @Test
+    fun `applySearchHighlightsJs uses data-riffle-si for inactive and data-riffle-sa for active`() {
+        val js = ContinuousStyleInjector.applySearchHighlightsJs(
+            inactiveTexts = listOf("word"),
+            inactiveCssColor = "rgba(253,230,138,0.30)",
+            activeText = "word",
+            activeProgression = 0.5f,
+            activeCssColor = "rgba(245,166,35,0.30)",
+        )
+        assertTrue("inactive marker attribute present", js.contains("data-riffle-si"))
+        assertTrue("active marker attribute present", js.contains("data-riffle-sa"))
+    }
+
+    @Test
+    fun `CLEAR_SEARCH_HIGHLIGHTS_JS targets both data-riffle-si and data-riffle-sa`() {
+        assertTrue(ContinuousStyleInjector.CLEAR_SEARCH_HIGHLIGHTS_JS.contains("data-riffle-si"))
+        assertTrue(ContinuousStyleInjector.CLEAR_SEARCH_HIGHLIGHTS_JS.contains("data-riffle-sa"))
+    }
 }

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ReadaloudHighlightDecorationTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ReadaloudHighlightDecorationTest.kt
@@ -14,6 +14,36 @@ class ReadaloudHighlightDecorationTest {
 
     private fun alpha(argb: Int): Int = (argb ushr 24) and 0xFF
 
+    // ---- toCssRgbaWithAlpha --------------------------------------------------
+
+    @Test
+    fun `toCssRgbaWithAlpha extracts RGB from ARGB and uses provided alpha`() {
+        // 0xFFF5A623 = alpha=FF r=F5 g=A6 b=23 (SEARCH_ACTIVE_ARGB)
+        val color = 0xFFF5A623.toInt()
+        assertEquals("rgba(245,166,35,0.30)", color.toCssRgbaWithAlpha(0.30))
+    }
+
+    @Test
+    fun `toCssRgbaWithAlpha ignores the alpha channel of the ARGB int`() {
+        // Same RGB as above but with a different alpha in the ARGB value — output alpha must be the argument.
+        val fullyOpaque = 0xFFF5A623.toInt()
+        val semiTransparent = 0x80F5A623.toInt()
+        assertEquals(fullyOpaque.toCssRgbaWithAlpha(0.50), semiTransparent.toCssRgbaWithAlpha(0.50))
+    }
+
+    @Test
+    fun `toCssRgbaWithAlpha formats alpha to two decimal places`() {
+        val result = 0xFFFF0000.toInt().toCssRgbaWithAlpha(0.30)
+        assertTrue("expected '0.30' in '$result'", result.contains("0.30"))
+    }
+
+    @Test
+    fun `SEARCH_DECORATION_ALPHA matches Readium implicit highlight alpha`() {
+        // Readium's Decoration.Style.Highlight always renders at 0.30 opacity.
+        // Pin the constant so it never silently drifts.
+        assertEquals(0.30, SEARCH_DECORATION_ALPHA, 0.001)
+    }
+
     @Test
     fun allColorsHaveAlphaBakedIn() {
         // argb is the final rendered color used by both the swatch and the reader — no runtime


### PR DESCRIPTION
## Summary

- **All occurrences highlighted**: In continuous mode, every occurrence of each search result text in the loaded chapter is now marked with pale yellow (inactive), matching paginated mode's per-page all-instances decoration. The active result is promoted to orange.
- **Color parity**: Added `SEARCH_DECORATION_ALPHA = 0.30` constant (Readium's hardcoded opacity) and `toCssRgbaWithAlpha()` helper so both renderers use the same alpha from a single source — no copying.
- **Skip-button fix**: `Channel.CONFLATED` → `Channel.BUFFERED` for search navigation so rapid next/prev presses no longer silently skip intermediate results. Channel is drained at the start of each new search to prevent stale events.
- **Locale fix**: `toCssRgba()` and `toCssRgbaWithAlpha()` now use `Locale.US` so the decimal separator is always `.` regardless of JVM/device locale.

## Architecture

- `SearchHighlightsState` carries `resultsByHref: Map<String,List<String>>` + active chapter/text/progression + both CSS colors. It mirrors the `currentAnnotationsByHref` pattern so chapters entering the sliding window via `onPageFinished` automatically receive marks.
- `applySearchHighlightsJs` uses `window.find` loop to mark all occurrences of each unique text, then promotes the mark nearest `activeProgression * scrollHeight` to active color via `data-riffle-sa`. Clear-then-apply is split across two `evaluateJavascript` callbacks to avoid the Chrome "find on mutated DOM" race.
- `highlightSearchMatch` is now a no-op in continuous mode; all marking is driven by `applySearch`.

## Test plan

- [ ] Unit: `./gradlew test` — 86 tasks, 0 failures (incl. `ContinuousHighlightRendererTest`, `ContinuousStyleInjectorTest`, `ReadaloudHighlightDecorationTest`)
- [ ] Lint: `./gradlew lint` — clean
- [ ] Harness phone: 238 passed, 5 skipped, 0 failed
- [ ] Harness tablet: 5 passed, 0 failed