### PR TITLE
style(settings): bold section titles and add missing dividers

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsScreen.kt
@@ -61,6 +61,7 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.platform.ClipEntry
 import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.riffle.app.feature.reader.behaviorSummary
@@ -139,9 +140,12 @@ fun SettingsScreen(
                     .fillMaxSize()
                     .verticalScroll(rememberScrollState()),
             ) {
+                HorizontalDivider()
+
                 Text(
                     text = "Servers",
                     style = MaterialTheme.typography.titleSmall,
+                    fontWeight = FontWeight.Bold,
                     modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
                 )
                 HorizontalDivider()
@@ -224,6 +228,7 @@ fun SettingsScreen(
                 Text(
                     text = "Appearance",
                     style = MaterialTheme.typography.titleSmall,
+                    fontWeight = FontWeight.Bold,
                     modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
                 )
                 HorizontalDivider()
@@ -236,6 +241,7 @@ fun SettingsScreen(
                 Text(
                     text = "Reading",
                     style = MaterialTheme.typography.titleSmall,
+                    fontWeight = FontWeight.Bold,
                     modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
                 )
                 HorizontalDivider()
@@ -263,9 +269,12 @@ fun SettingsScreen(
                         TextButton(onClick = { showBehaviorPanel = true }) { Text("Edit") }
                     },
                 )
+                HorizontalDivider()
+
                 Text(
                     text = "Listening",
                     style = MaterialTheme.typography.titleSmall,
+                    fontWeight = FontWeight.Bold,
                     modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
                 )
                 HorizontalDivider()
@@ -282,6 +291,7 @@ fun SettingsScreen(
                 Text(
                     text = "Readaloud",
                     style = MaterialTheme.typography.titleSmall,
+                    fontWeight = FontWeight.Bold,
                     modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
                 )
                 HorizontalDivider()
@@ -334,6 +344,7 @@ fun SettingsScreen(
                 Text(
                     text = "Crash reports",
                     style = MaterialTheme.typography.titleSmall,
+                    fontWeight = FontWeight.Bold,
                     modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
                 )
                 HorizontalDivider()
@@ -380,6 +391,7 @@ fun SettingsScreen(
                 Text(
                     text = "App version",
                     style = MaterialTheme.typography.titleSmall,
+                    fontWeight = FontWeight.Bold,
                     modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
                 )
                 HorizontalDivider()


### PR DESCRIPTION
## Summary

- Add `HorizontalDivider` above the **Servers** section (top of the list was missing an opening rule)
- Add `HorizontalDivider` above the **Listening** section (which was missing the separator that all other sections had between them)
- Apply `FontWeight.Bold` to all six section title `Text` composables: Servers, Appearance, Reading, Listening, Readaloud, Crash reports, App version

## Test plan

- Visual check: Settings screen shows bold section titles with consistent dividers above each section