### PR TITLE
perf(library): eliminate UI stall on app resume and back-navigation

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsScreen.kt
@@ -181,7 +181,7 @@ fun LibraryItemsScreen(
                 // Re-check the server on every resume (e.g. wake from sleep) so a stale offline
                 // banner left by an earlier failed refresh clears immediately, rather than only
                 // when the periodic retry next fires.
-                viewModel.refresh()
+                viewModel.onScreenResumed()
             }
         }
         lifecycleOwner.lifecycle.addObserver(observer)

--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsViewModel.kt
@@ -318,6 +318,17 @@ class LibraryItemsViewModel @Inject constructor(
         savedStateHandle[KEY_SEARCH_QUERY] = query
     }
 
+    private var lastRefreshCompletedAt = 0L
+
+    /** Called from ON_RESUME. Skips if a refresh completed within the last 30s to avoid a
+     * redundant network round-trip when the library screen first enters RESUMED state immediately
+     * after init (which already launched its own refresh). */
+    fun onScreenResumed() {
+        if (System.currentTimeMillis() - lastRefreshCompletedAt > RESUME_REFRESH_DEBOUNCE_MS) {
+            refresh()
+        }
+    }
+
     fun refresh() {
         viewModelScope.launch { runRefresh() }
     }
@@ -331,6 +342,7 @@ class LibraryItemsViewModel @Inject constructor(
         val results = listOf(itemsDeferred.await(), seriesDeferred.await(), collectionsDeferred.await())
         toReadDeferred.await()
         _refreshFailed.value = results.any { it is LibraryRefreshResult.NetworkError }
+        lastRefreshCompletedAt = System.currentTimeMillis()
     }
 
     private fun filterCollectionsOffline(collections: List<Collection>, offline: Boolean): Flow<List<Collection>> {
@@ -354,5 +366,6 @@ class LibraryItemsViewModel @Inject constructor(
     private companion object {
         const val FAILED_REFRESH_RETRY_INTERVAL_MS = 10_000L
         const val KEY_SEARCH_QUERY = "searchQuery"
+        const val RESUME_REFRESH_DEBOUNCE_MS = 30_000L
     }
 }

--- a/core/data/src/main/kotlin/com/riffle/core/data/LibraryRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/LibraryRepositoryImpl.kt
@@ -27,6 +27,9 @@ import com.riffle.core.network.NetworkLibrariesResult
 import com.riffle.core.network.NetworkLibraryItemsResult
 import com.riffle.core.network.NetworkSeriesResult
 import com.riffle.core.network.NetworkUserProgressResult
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -176,61 +179,72 @@ class LibraryRepositoryImpl @Inject constructor(
     override suspend fun refreshLibraryItems(libraryId: String): LibraryRefreshResult {
         val server = serverRepository.getActive() ?: return LibraryRefreshResult.NoActiveServer
         val token = tokenStorage.getToken(server.id) ?: return LibraryRefreshResult.NoActiveServer
-        val serverProgressMap = when (val r = api.getUserProgress(server.url.value, token, server.insecureConnectionAllowed)) {
-            is NetworkUserProgressResult.Success -> r.byItemId
-            is NetworkUserProgressResult.NetworkError -> emptyMap()
-        }
-        return when (val result = api.getLibraryItems(server.url.value, libraryId, token, server.insecureConnectionAllowed)) {
-            is NetworkLibraryItemsResult.Success -> {
-                val lastOpenedAtMap = libraryItemDao.getLastOpenedAtMap(libraryId).associate { it.id to it.lastOpenedAt }
-                val entities = result.items
-                    .sortedByDescending { it.isSupported }
-                    .distinctBy { it.title.trim().lowercase() }
-                    .map { item ->
-                        val serverProgress = serverProgressMap[item.id]
-                        LibraryItemEntity(
-                            serverId = server.id,
-                            id = item.id,
-                            libraryId = item.libraryId,
-                            title = item.title,
-                            author = item.author,
-                            coverUrl = absCoverUrl(server.url.value, item.id, item.updatedAt),
-                            // For an audiobook-only item the ABS user-progress fallback already maps
-                            // its listen fraction into `ebookProgress` (AbsApiClient: ebookProgress ?:
-                            // progress), so this single field is the unified "how far through this
-                            // item" value that surfaces audiobooks in In Progress too (ADR 0029).
-                            // Note: for existing items the DAO's updateMetadata ignores this field and
-                            // preserves the locally-tracked value. It is only used when inserting a
-                            // new item for the first time.
-                            readingProgress = serverProgress?.ebookProgress ?: item.readingProgress ?: 0f,
-                            ebookFileIno = item.ebookFileIno,
-                            ebookFormat = item.ebookFormat.toStorageString(),
-                            hasAudio = item.hasAudio,
-                            audioDurationSec = item.audioDurationSec,
-                            description = item.description,
-                            seriesName = item.seriesName,
-                            publishedYear = item.publishedYear,
-                            genres = item.genres.joinToString(","),
-                            publisher = item.publisher,
-                            language = item.language,
-                            // Surface the most recent read activity across devices: pick whichever
-                            // of (local stamp, server's mediaProgress.lastUpdate) is later. Either
-                            // can lead — the local stamp wins between syncs on this device, the
-                            // server stamp wins once another device has read more recently.
-                            lastOpenedAt = mergeLastOpenedAt(lastOpenedAtMap[item.id], serverProgress?.lastUpdate),
-                            addedAt = item.addedAt,
-                            isbn = item.isbn,
-                            asin = item.asin,
-                        )
-                    }
-                libraryItemDao.replaceAllForLibrary(libraryId, entities)
-                val isUnsupported = entities.isNotEmpty() && entities.none { it.ebookFormat != EbookFormat.Unsupported.toStorageString() }
-                libraryDao.setUnsupported(server.id, libraryId, isUnsupported)
-                storytellerReadaloudSyncer.syncStale()
-                readaloudMatchingService.reconcileLinks()
-                LibraryRefreshResult.Success
+        return coroutineScope {
+            // Fire both calls simultaneously: user-progress and library items are independent
+            // requests. Total latency = max(getUserProgress, getLibraryItems) instead of their sum.
+            val progressDeferred = async { api.getUserProgress(server.url.value, token, server.insecureConnectionAllowed) }
+            val itemsDeferred = async { api.getLibraryItems(server.url.value, libraryId, token, server.insecureConnectionAllowed) }
+
+            val serverProgressMap = when (val r = progressDeferred.await()) {
+                is NetworkUserProgressResult.Success -> r.byItemId
+                is NetworkUserProgressResult.NetworkError -> emptyMap()
             }
-            is NetworkLibraryItemsResult.NetworkError -> LibraryRefreshResult.NetworkError(result.cause)
+            when (val result = itemsDeferred.await()) {
+                is NetworkLibraryItemsResult.Success -> {
+                    val lastOpenedAtMap = libraryItemDao.getLastOpenedAtMap(libraryId).associate { it.id to it.lastOpenedAt }
+                    val entities = result.items
+                        .sortedByDescending { it.isSupported }
+                        .distinctBy { it.title.trim().lowercase() }
+                        .map { item ->
+                            val serverProgress = serverProgressMap[item.id]
+                            LibraryItemEntity(
+                                serverId = server.id,
+                                id = item.id,
+                                libraryId = item.libraryId,
+                                title = item.title,
+                                author = item.author,
+                                coverUrl = absCoverUrl(server.url.value, item.id, item.updatedAt),
+                                // For an audiobook-only item the ABS user-progress fallback already maps
+                                // its listen fraction into `ebookProgress` (AbsApiClient: ebookProgress ?:
+                                // progress), so this single field is the unified "how far through this
+                                // item" value that surfaces audiobooks in In Progress too (ADR 0029).
+                                // Note: for existing items the DAO's updateMetadata ignores this field and
+                                // preserves the locally-tracked value. It is only used when inserting a
+                                // new item for the first time.
+                                readingProgress = serverProgress?.ebookProgress ?: item.readingProgress ?: 0f,
+                                ebookFileIno = item.ebookFileIno,
+                                ebookFormat = item.ebookFormat.toStorageString(),
+                                hasAudio = item.hasAudio,
+                                audioDurationSec = item.audioDurationSec,
+                                description = item.description,
+                                seriesName = item.seriesName,
+                                publishedYear = item.publishedYear,
+                                genres = item.genres.joinToString(","),
+                                publisher = item.publisher,
+                                language = item.language,
+                                // Surface the most recent read activity across devices: pick whichever
+                                // of (local stamp, server's mediaProgress.lastUpdate) is later. Either
+                                // can lead — the local stamp wins between syncs on this device, the
+                                // server stamp wins once another device has read more recently.
+                                lastOpenedAt = mergeLastOpenedAt(lastOpenedAtMap[item.id], serverProgress?.lastUpdate),
+                                addedAt = item.addedAt,
+                                isbn = item.isbn,
+                                asin = item.asin,
+                            )
+                        }
+                    libraryItemDao.replaceAllForLibrary(libraryId, entities)
+                    val isUnsupported = entities.isNotEmpty() && entities.none { it.ebookFormat != EbookFormat.Unsupported.toStorageString() }
+                    libraryDao.setUnsupported(server.id, libraryId, isUnsupported)
+                    // syncStale and reconcileLinks are not on the critical path — run them in the
+                    // background so the refresh result is available immediately to the caller.
+                    launch {
+                        storytellerReadaloudSyncer.syncStale()
+                        readaloudMatchingService.reconcileLinks()
+                    }
+                    LibraryRefreshResult.Success
+                }
+                is NetworkLibraryItemsResult.NetworkError -> LibraryRefreshResult.NetworkError(result.cause)
+            }
         }
     }
 

--- a/core/data/src/main/kotlin/com/riffle/core/data/LibraryRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/LibraryRepositoryImpl.kt
@@ -27,6 +27,8 @@ import com.riffle.core.network.NetworkLibrariesResult
 import com.riffle.core.network.NetworkLibraryItemsResult
 import com.riffle.core.network.NetworkSeriesResult
 import com.riffle.core.network.NetworkUserProgressResult
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
@@ -50,6 +52,10 @@ class LibraryRepositoryImpl @Inject constructor(
     private val readaloudMatchingService: ReadaloudMatchingService,
     private val storytellerReadaloudSyncer: StorytellerReadaloudSyncer,
 ) : LibraryRepository {
+
+    // Used to fire syncStale/reconcileLinks without blocking refreshLibraryItems.
+    // coroutineScope { launch {} } waits for all children, so background work needs its own scope.
+    private val backgroundScope = CoroutineScope(SupervisorJob())
 
     @OptIn(ExperimentalCoroutinesApi::class)
     override fun observeLibraries(): Flow<List<Library>> =
@@ -235,9 +241,11 @@ class LibraryRepositoryImpl @Inject constructor(
                     libraryItemDao.replaceAllForLibrary(libraryId, entities)
                     val isUnsupported = entities.isNotEmpty() && entities.none { it.ebookFormat != EbookFormat.Unsupported.toStorageString() }
                     libraryDao.setUnsupported(server.id, libraryId, isUnsupported)
-                    // syncStale and reconcileLinks are not on the critical path — run them in the
-                    // background so the refresh result is available immediately to the caller.
-                    launch {
+                    // syncStale and reconcileLinks are not on the critical path — fire them on a
+                    // detached background scope so refreshLibraryItems returns immediately after
+                    // the Room write. (launch {} inside coroutineScope {} would be a child and
+                    // would block the scope from returning.)
+                    backgroundScope.launch {
                         storytellerReadaloudSyncer.syncStale()
                         readaloudMatchingService.reconcileLinks()
                     }


### PR DESCRIPTION
## Problem

On app start and on returning to the library screen from item detail, the UI would stall for up to 5 seconds. Instrumented with wall-clock logging to identify three independent root causes.

## Root causes and fixes

### 1. Sequential `getUserProgress` → `getLibraryItems` (`LibraryRepositoryImpl`)
`getUserProgress` ran first (up to 10 s on a slow connection or on timeout), then `getLibraryItems` started only after it returned. Parallelised with `coroutineScope { async {} }` — both fire simultaneously; total latency = max(both) instead of their sum.

### 2. `syncStale` + `reconcileLinks` on the refresh critical path (`LibraryRepositoryImpl`)
After the Room write, Storyteller sync (~232 ms) and readaloud-link reconciliation (~92 ms) ran before `refreshLibraryItems` returned. Moved to a detached `backgroundScope.launch {}` so the caller gets `LibraryRefreshResult.Success` immediately after the DB write.

Note: `launch {}` inside `coroutineScope {}` creates a child — the scope waits for all children, so a bare `launch {}` would not have achieved background execution. A class-level `CoroutineScope(SupervisorJob())` is used instead.

### 3. Double-refresh on screen entry (`LibraryItemsViewModel` + `LibraryItemsScreen`)
`ON_RESUME` fired ~61 ms after `init` already launched its own refresh, triggering a second concurrent refresh. Added `onScreenResumed()` with a 30-second `lastRefreshCompletedAt` debounce. The `ON_RESUME` handler calls that instead of `refresh()` directly; manual refreshes (swipe-to-refresh) still call `refresh()` unconditionally.

## Measured improvement

On fast local network, observed round-trip went from ~831 ms → ~362 ms. On a slow/Tailscale server where `getUserProgress` timed out at 10 s, the stall was unchanged by fix 1 (timeout dominates) but fix 2 saves the additional ~324 ms that was previously added on top of the timeout.

## Testing

- All 907 JVM unit tests green
- Device-verified on emulator: library returns immediately on back-navigation from detail; no network activity fired on that resume (debounce working)