### PR TITLE
fix(reader): prevent forward→backward oscillation in continuous mode for short chapters

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
@@ -152,6 +152,26 @@ internal class ContinuousReaderView @JvmOverloads constructor(
      */
     private var shiftPending = false
 
+    /**
+     * Set after a forward shift so the very next [maybeShift] cycle suppresses the backward-shift
+     * check. Without this guard, a short first chapter (shorter than the viewport) triggers an
+     * immediate backward shift in the next cycle after every forward shift:
+     *
+     *   - Forward shift fires (midpoint crosses into ch[N+1]).
+     *   - [removeTop] compensates: scrollY -= ch[N-1].height → new scrollY ≈ ch[N].height − viewport/2.
+     *   - When ch[N] is shorter than the viewport (e.g. a "CHILDREN OF DUNE" divider page of ~1050 px
+     *     on a 2048 px screen), new scrollY ≈ 26 px, which is < ch[N].height/2 = 525 px.
+     *   - The next maybeShift sees sY < firstChapterHeight/2 → backward shift fires.
+     *   - Backward shift: prepend ch[N-1], scrollBy(+placeholder) → scrollY rebounds to ~827 px.
+     *   - That change triggers another maybeShift → forward shift fires again → oscillation.
+     *
+     * Suppressing the backward check for ONE cycle absorbs the reactive scrollBy from [removeTop]
+     * without affecting deliberate backward scrolling: any subsequent maybeShift is triggered by
+     * real user input (the fling continued or the user started a new gesture), at which point scrollY
+     * has moved past the threshold or the user genuinely wants to go back.
+     */
+    private var justShiftedForward = false
+
     /** True while rebuilding the window after a WebView renderer-process death (debounces the
      * per-WebView onRenderProcessGone events that all fire at once). */
     private var rendererRecovering = false
@@ -844,7 +864,11 @@ internal class ContinuousReaderView @JvmOverloads constructor(
         // of the reader (see ContinuousPositionTracker.forwardShiftNeeded).
         val firstChapterHeight = window.firstOrNull()?.height ?: 0
         val viewportMidIndex = allChapters.indexOfFirst { it.link.href.toString() == href }
-        val shouldShiftBackward = sY < firstChapterHeight / 2 && topIndex > 0
+        // Consume the justShiftedForward guard before evaluating either direction so it clears
+        // regardless of which branch (or neither) fires this cycle.
+        val skipBackward = justShiftedForward
+        justShiftedForward = false
+        val shouldShiftBackward = !skipBackward && sY < firstChapterHeight / 2 && topIndex > 0
         val shouldShiftForward = ContinuousPositionTracker.forwardShiftNeeded(
             viewportChapterIndex = viewportMidIndex,
             topIndex = topIndex,
@@ -868,6 +892,9 @@ internal class ContinuousReaderView @JvmOverloads constructor(
                 val nextIndex = topIndex + webViews.size
                 if (nextIndex < allChapters.size) appendChapter(nextIndex)
                 shiftInProgress = false
+                // Guard the very next maybeShift cycle against an immediate backward-shift
+                // reaction. See [justShiftedForward] for the full explanation.
+                justShiftedForward = true
             }
         }
     }

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousPositionTrackerTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousPositionTrackerTest.kt
@@ -136,6 +136,88 @@ class ContinuousPositionTrackerTest {
         ))
     }
 
+    // ── forward→backward oscillation — the "Children of Dune / Introduction" bug ──────────
+    //
+    // A short chapter (height < viewport) as the new first slot after a forward shift causes the
+    // post-shift scrollY to satisfy the backward-shift condition (sY < firstChapterHeight/2),
+    // creating an infinite loop. ContinuousReaderView.maybeShift() guards against this with the
+    // justShiftedForward flag that suppresses the backward check for exactly one cycle.
+    // These tests pin the mathematical invariant that makes that guard necessary.
+
+    @Test
+    fun `short new-first chapter — post-forward-shift scrollY always satisfies backward-shift condition`() {
+        // Scenario: user scrolls forward through a short "CHILDREN OF DUNE" divider page (ch_N,
+        // height H1 = 1050 device-px on a 2048-px screen) into the following "Introduction" chapter.
+        // The forward shift removes ch_N-1 (H0) and adjusts scrollY = old_scrollY - H0.
+        // The minimum old_scrollY that triggers the forward shift is H0 + H1 - viewport/2,
+        // so the post-shift scrollY_min = H1 - viewport/2.
+        //
+        // Backward-shift condition: scrollY < firstChapterHeight/2.
+        // For H1 < viewport: H1 - viewport/2 < H1/2, so the condition is always satisfied —
+        // i.e. a backward shift fires in the very next cycle without the justShiftedForward guard.
+        val viewport = 2048
+        val H0 = 30_000   // large chapter removed by the forward shift
+        val H1 = 1_050    // short divider page — height < viewport
+
+        // Post-shift scrollY: after removeTop subtracts H0 from the minimum trigger scrollY.
+        val postShiftScrollY = (H0 + H1 - viewport / 2) - H0
+        assertEquals("post-shift scrollY = H1 - viewport/2", H1 - viewport / 2, postShiftScrollY)
+
+        // Backward-shift threshold for the new first chapter (H1):
+        val backwardThreshold = H1 / 2
+        assertTrue(
+            "Without justShiftedForward, a backward shift fires: scrollY=$postShiftScrollY < threshold=$backwardThreshold",
+            postShiftScrollY < backwardThreshold,
+        )
+    }
+
+    @Test
+    fun `tall new-first chapter — post-forward-shift scrollY does NOT satisfy backward-shift condition`() {
+        // A tall chapter (height >> viewport) as the new first slot is the normal case: the
+        // post-shift scrollY lands deep inside it, well above firstChapterHeight/2, so no
+        // spurious backward shift fires and no guard is needed for this path.
+        val viewport = 2048
+        val H0 = 30_000   // large chapter removed by the forward shift
+        val H1 = 50_000   // tall new first chapter (normal body chapter)
+
+        val postShiftScrollY = (H0 + H1 - viewport / 2) - H0
+        val backwardThreshold = H1 / 2
+        assertFalse(
+            "Tall chapter: scrollY=$postShiftScrollY must NOT be < threshold=$backwardThreshold",
+            postShiftScrollY < backwardThreshold,
+        )
+    }
+
+    @Test
+    fun `oscillation threshold — any chapter shorter than viewport triggers the bug`() {
+        // The backward shift fires when: postShiftScrollY = H1 - viewport/2 < H1/2
+        // This simplifies to: H1 < viewport. Verify for a range of short-chapter heights.
+        val viewport = 2048
+        for (H1 in listOf(200, 400, 800, 1000, 1050, 1500, 1999)) {
+            val postShiftScrollY = H1 - viewport / 2
+            val backwardThreshold = H1 / 2
+            assertTrue(
+                "Chapter of $H1 px (< viewport $viewport) must trigger oscillation without guard: " +
+                    "postShiftScrollY=$postShiftScrollY, threshold=$backwardThreshold",
+                postShiftScrollY < backwardThreshold,
+            )
+        }
+    }
+
+    @Test
+    fun `oscillation threshold — chapters at least as tall as viewport do not trigger the bug`() {
+        val viewport = 2048
+        for (H1 in listOf(2048, 3000, 5000, 10_000, 50_000)) {
+            val postShiftScrollY = H1 - viewport / 2
+            val backwardThreshold = H1 / 2
+            assertFalse(
+                "Chapter of $H1 px (>= viewport $viewport) must NOT trigger oscillation: " +
+                    "postShiftScrollY=$postShiftScrollY, threshold=$backwardThreshold",
+                postShiftScrollY < backwardThreshold,
+            )
+        }
+    }
+
     // ── internalLinkHref ──────────────────────────────────────────────────────
 
     @Test

--- a/core/data/src/test/kotlin/com/riffle/core/data/LibraryRepositoryTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/LibraryRepositoryTest.kt
@@ -32,6 +32,7 @@ import com.riffle.core.network.NetworkLibraryItemsResult
 import com.riffle.core.network.NetworkSeries
 import com.riffle.core.network.NetworkSeriesItem
 import com.riffle.core.network.NetworkSeriesResult
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
@@ -1063,11 +1064,14 @@ class LibraryRepositoryTest {
         fakeServerRepository.activeServer = activeServer()
         fakeTokenStorage.tokens["s1"] = "tok"
         val itemDao = FakeLibraryItemDao()
-        var synced = false
+        // syncStale() is called on a detached backgroundScope (Dispatchers.Default), so it races
+        // with the test assertion. Use CompletableDeferred to suspend until the call arrives
+        // rather than reading a boolean that may not yet be set.
+        val syncedDeferred = CompletableDeferred<Unit>()
         val spySyncer = object : StorytellerReadaloudSyncer(
             fakeServerRepository, fakeTokenStorage, storytellerApiReturning(emptyList()), itemDao, { 0L },
         ) {
-            override suspend fun syncStale() { synced = true }
+            override suspend fun syncStale() { syncedDeferred.complete(Unit) }
         }
         val api = object : AbsLibraryApi {
             override suspend fun getLibraries(baseUrl: String, token: String, insecureAllowed: Boolean) =
@@ -1084,6 +1088,6 @@ class LibraryRepositoryTest {
         val result = makeRepo(libraryItemDao = itemDao, api = api, storytellerReadaloudSyncer = spySyncer)
             .refreshLibraryItems("lib-1")
         assertTrue(result is LibraryRefreshResult.Success)
-        assertTrue("syncStale() should have been called during ABS library refresh", synced)
+        syncedDeferred.await() // suspends until the background scope calls syncStale()
     }
 }


### PR DESCRIPTION
## Summary

- **Root cause**: In `ContinuousReaderView.maybeShift()`, after a forward shift removes the old first chapter (height H0), the new `scrollY` is computed as `H0 + H1 - viewport/2 - H0 = H1 - viewport/2`. When H1 < viewport (e.g. a short divider chapter ~1050px on a 2048px screen), this is always less than `H1/2` — the backward-shift threshold — so a backward shift immediately fires, which triggers a forward shift, which triggers a backward shift, ad infinitum. Reproduced on "Children of Dune / Introduction" chapter boundary.
- **Fix**: Added a `justShiftedForward` boolean in `ContinuousReaderView`. It is set to `true` inside the forward-shift branch and consumed (and cleared to `false`) unconditionally at the top of the next `maybeShift()` call. When set, the backward-shift check is skipped for that one cycle, breaking the oscillation. The guard is minimal — it fires at most once per forward shift, and only suppresses a backward shift that would have occurred within the same scroll event cycle.
- **Pre-existing race fix**: `LibraryRepositoryTest` had a race between a `Dispatchers.Default` background scope calling `syncStale()` and the test assertion reading a `var synced: Boolean`. Fixed with `CompletableDeferred` so the test coroutine suspends until the background scope completes its call.

## What was tested

- `./gradlew test` — JVM unit + integration suites, all green
- `./gradlew lint` — no new lint errors
- `make harness-test` — 242 tests, 0 failures (phone AVD)
- `make harness-test-tablet` — 5 tests, 0 failures (tablet AVD)

New pure-JVM tests in `ContinuousPositionTrackerTest` prove the mathematical invariant that makes the oscillation inevitable: for any H1 < viewport, `H1 - viewport/2 < H1/2`.