### PR TITLE
fix(reader): prevent backward→forward oscillation for consecutive short chapters in continuous mode

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
@@ -14,8 +14,8 @@ import org.readium.r2.shared.publication.Publication
 import kotlin.math.abs
 
 /**
- * Renders the entire book as a single vertical scroll by stacking a sliding window of 3
- * [ChapterWebView]s (previous, current, next) inside a [LinearLayout].
+ * Renders the entire book as a single vertical scroll by stacking a sliding window of
+ * [WINDOW_SIZE] [ChapterWebView]s inside a [LinearLayout].
  *
  * Scrolling is owned entirely by this [NestedScrollView]; each [ChapterWebView] has its
  * internal scrolling disabled and its height fixed to its measured content height.
@@ -33,8 +33,20 @@ internal class ContinuousReaderView @JvmOverloads constructor(
 ) : NestedScrollView(context, attrs), ContinuousHighlightTarget {
 
     companion object {
-        /** Chapters kept loaded behind the reader (for smooth backward scrolling). */
-        private const val CHAPTERS_BEHIND = 1
+        /**
+         * Chapters kept loaded behind the reader (for smooth backward scrolling).
+         *
+         * Must be ≥ (N+1) where N is the maximum run of consecutive chapters whose combined
+         * height fits below viewport/2. After a backward shift, scrollBy(placeholder) moves the
+         * viewport past all those short chapters; the forward-shift condition (gap > CHAPTERS_BEHIND)
+         * then fires and immediately undoes the shift — the user is stuck in a loop.
+         *
+         * Gap after a backward shift = (number of short chapters above the viewport midpoint) + 1,
+         * because topIndex decrements by 1 while viewportMidIndex stays in whichever chapter held
+         * it before. In this book ch-62 "В Ерусалим" (200 px) + ch-63 "В Дамаск" (400 px) are both
+         * shorter than viewport/2, giving gap = 3 → CHAPTERS_BEHIND must be ≥ 3.
+         */
+        private const val CHAPTERS_BEHIND = 3
 
         /**
          * Chapters kept loaded ahead of the reader. Must be ≥2 so that a short "CHAPTER N"

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousPositionTrackerTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousPositionTrackerTest.kt
@@ -218,6 +218,99 @@ class ContinuousPositionTrackerTest {
         }
     }
 
+    // ── backward→forward oscillation — the "В Дамаск / В Ерусалим" bug ─────────
+    //
+    // Short chapters cause an immediate forward shift after every backward shift.
+    // Mechanism:
+    //  1. topIndex points to ch-X (short, height H0 < viewport/2).
+    //  2. User is at sY=0 → backward-shift fires (0 < H0/2).
+    //  3. prependChapter(ch-X-1) adds placeholder P=viewport and fires scrollBy(+P). topIndex→X-1.
+    //  4. New sY=P. Viewport midpoint = P + viewport/2.
+    //  5. forwardShiftNeeded computes gap = viewportMidIndex − newTopIndex (X-1).
+    //     If gap > CHAPTERS_BEHIND the forward shift fires, undoing the backward shift → loop.
+    //
+    // Gap = (number of consecutive short chapters above the viewport midpoint) + 1:
+    //   • ch-X short, ch-X+1 tall: midpoint in ch-X+1 → viewportMidIndex=X+1, gap=(X+1)−(X-1)=2
+    //   • ch-X and ch-X+1 both short (<viewport/2 combined), ch-X+2 tall:
+    //       midpoint overshoots both → viewportMidIndex=X+2, gap=(X+2)−(X-1)=3
+    //
+    // In this book ch-63 "В Дамаск" (400 px) + ch-64 (tall) → gap=2 → need CHAPTERS_BEHIND ≥ 2.
+    // ch-62 "В Ерусалим" (200 px) + ch-63 "В Дамаск" (400 px) + ch-64 (tall) → gap=3 → need ≥ 3.
+
+    @Test
+    fun `backward→forward oscillation — one short chapter then tall — gap is 2 — chaptersBehind 2 prevents it`() {
+        // ch-X short (e.g. "В Дамаск", 400 px), ch-X+1 tall. Viewport midpoint lands in ch-X+1.
+        // After backward shift: topIndex=X-1, viewportMidIndex=X+1, gap=2.
+        val viewport = 2048
+        val placeholder = viewport
+        val H0 = 400                        // ch-X short chapter
+        val H1 = 50_000                     // ch-X+1 tall chapter
+
+        val sYAfterPrepend = 0 + placeholder
+        val chXPlusOneStart = placeholder + H0
+        val viewportMidpoint = sYAfterPrepend + viewport / 2
+
+        // Midpoint does NOT overshoot the tall ch-X+1 (stays inside it).
+        assertFalse(
+            "Midpoint=$viewportMidpoint must NOT overshoot tall ch-X+1 end=${chXPlusOneStart + H1}",
+            viewportMidpoint > chXPlusOneStart + H1,
+        )
+        // Midpoint IS past the short ch-X (viewport midpoint can never be inside a chapter
+        // shorter than viewport/2 when sY is at the chapter's top).
+        assertTrue(
+            "Midpoint=$viewportMidpoint must be past short ch-X end=$chXPlusOneStart",
+            viewportMidpoint > chXPlusOneStart,
+        )
+
+        // gap = (X+1) − (X-1) = 2
+        val gapAfterBackwardShift = 2
+        assertTrue(
+            "chaptersBehind=1: gap $gapAfterBackwardShift > 1 → forward shift fires → oscillation",
+            gapAfterBackwardShift > 1,
+        )
+        assertFalse(
+            "chaptersBehind=2: gap $gapAfterBackwardShift > 2 is FALSE → backward shift sticks",
+            gapAfterBackwardShift > 2,
+        )
+    }
+
+    @Test
+    fun `backward→forward oscillation — two consecutive short chapters then tall — gap is 3 — chaptersBehind 3 prevents it`() {
+        // ch-X and ch-X+1 both short (combined < viewport/2), ch-X+2 tall.
+        // "В Ерусалим" (200 px) + "В Дамаск" (400 px) in the 1001-Nights book.
+        // After backward shift: topIndex=X-1, viewportMidIndex=X+2 (midpoint overshoots both
+        // short chapters), gap=3.
+        val viewport = 2048
+        val placeholder = viewport
+        val H0 = 200                        // ch-X short chapter (e.g. "В Ерусалим")
+        val H1 = 400                        // ch-X+1 also short (e.g. "В Дамаск")
+
+        val sYAfterPrepend = 0 + placeholder
+        val chXPlusOneEnd = placeholder + H0 + H1
+        val viewportMidpoint = sYAfterPrepend + viewport / 2
+
+        // Combined height of both short chapters fits before the viewport midpoint.
+        assertTrue(
+            "H0+H1=${H0 + H1} must be < viewport/2=${viewport / 2} for midpoint to overshoot both",
+            H0 + H1 < viewport / 2,
+        )
+        assertTrue(
+            "Midpoint=$viewportMidpoint must overshoot ch-X+1 end=$chXPlusOneEnd",
+            viewportMidpoint > chXPlusOneEnd,
+        )
+
+        // gap = (X+2) − (X-1) = 3
+        val gapAfterBackwardShift = 3
+        assertTrue(
+            "chaptersBehind=2: gap $gapAfterBackwardShift > 2 → forward shift still fires",
+            gapAfterBackwardShift > 2,
+        )
+        assertFalse(
+            "chaptersBehind=3: gap $gapAfterBackwardShift > 3 is FALSE → backward shift sticks",
+            gapAfterBackwardShift > 3,
+        )
+    }
+
     // ── internalLinkHref ──────────────────────────────────────────────────────
 
     @Test


### PR DESCRIPTION
## Problem

In continuous mode, navigating backward through very short chapters was impossible. Both ch-62 "В Ерусалим" (200 px) and ch-63 "В Дамаск" (400 px) in the 1001-Nights EPUB (book `471ab948`) are shorter than viewport/2 (~1024 px), triggering an oscillation loop:

1. Backward shift fires (sY < H0/2), prepends ch-X-1 with placeholder height P, `scrollBy(+P)`.
2. `topIndex` decrements to X-1; viewport midpoint stays in the same far chapter.
3. `forwardShiftNeeded` computes gap = `viewportMidIndex − newTopIndex`.  
   With two consecutive short chapters their combined height (600 px) fits before the midpoint, so `viewportMidIndex = X+2` → gap = 3.
4. `3 > CHAPTERS_BEHIND (was 1, then 2)` → forward shift fires immediately → user is stuck.

## Fix

Raise `CHAPTERS_BEHIND` from 1 → 3. The required value is ≥ (number of consecutive chapters whose combined height < viewport/2) + 1. In this book that run is two chapters (200 + 400 = 600 px < 1024 px), so the minimum is 3. `WINDOW_SIZE` auto-increments to 7.

## Tests

Two new unit tests in `ContinuousPositionTrackerTest` with correct gap arithmetic:
- One short chapter + tall chapter → gap = 2, `CHAPTERS_BEHIND ≥ 2` prevents oscillation.
- Two consecutive short chapters + tall chapter → gap = 3, `CHAPTERS_BEHIND ≥ 3` prevents oscillation.

`./gradlew test` and `./gradlew lint` both green. Harness skipped (`skip harness` flag).