### PR TITLE
refactor(reader): extract NavigationTarget interface; unify 4 nav event effects

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousNavigationView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousNavigationView.kt
@@ -1,0 +1,10 @@
+package com.riffle.app.feature.reader
+
+/**
+ * Narrow interface over [ContinuousReaderView]'s navigation method.
+ * Extracted so [ContinuousNavigationTarget] can be tested on JVM without
+ * instantiating the Android View.
+ */
+internal interface ContinuousNavigationView {
+    fun navigateTo(href: String, progression: Float, alignToTop: Boolean = false)
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
@@ -30,7 +30,7 @@ internal data class AnnotationHighlight(val id: String, val text: String, val cs
 internal class ContinuousReaderView @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null,
-) : NestedScrollView(context, attrs), ContinuousHighlightTarget {
+) : NestedScrollView(context, attrs), ContinuousHighlightTarget, ContinuousNavigationView {
 
     companion object {
         /** Chapters kept loaded behind the reader (for smooth backward scrolling). */
@@ -443,7 +443,7 @@ internal class ContinuousReaderView @JvmOverloads constructor(
      * progressions). Leave false for continuous-mode round-trips (resume, return-to-position) where
      * [locatorAt] was the source and the midpoint inverse keeps the position drift-free.
      */
-    fun navigateTo(href: String, progression: Float, alignToTop: Boolean = false) {
+    override fun navigateTo(href: String, progression: Float, alignToTop: Boolean = false) {
         // TOC entries / chapter-map segments / internal links may carry a #fragment that the spine
         // hrefs don't have; match on the resource path so the chapter is still found.
         val target = href.substringBefore('#')

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
@@ -443,7 +443,7 @@ internal class ContinuousReaderView @JvmOverloads constructor(
      * progressions). Leave false for continuous-mode round-trips (resume, return-to-position) where
      * [locatorAt] was the source and the midpoint inverse keeps the position drift-free.
      */
-    override fun navigateTo(href: String, progression: Float, alignToTop: Boolean = false) {
+    override fun navigateTo(href: String, progression: Float, alignToTop: Boolean) {
         // TOC entries / chapter-map segments / internal links may carry a #fragment that the spine
         // hrefs don't have; match on the resource path so the chapter is still found.
         val target = href.substringBefore('#')

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -1368,12 +1368,6 @@ private fun EpubNavigatorView(
         onDispose { FootnoteAnchorBridge.setHandler(null) }
     }
 
-    val goToContinuous: suspend (Locator) -> Unit = { locator ->
-        val anchor = locator.locations.fragments.firstOrNull()
-        val href = if (anchor != null) "${locator.href}#$anchor" else locator.href.toString()
-        continuousViewRef.value?.navigateTo(href, locator.locations.progression?.toFloat() ?: 0f)
-    }
-
     LaunchedEffect(onNavigationEvents, isContinuous) {
         onNavigationEvents.collect { link ->
             // In Continuous mode the Readium fragment is a server-keeper only (invisible,
@@ -1405,22 +1399,19 @@ private fun EpubNavigatorView(
         }
     }
 
-    LaunchedEffect(serverLocatorEvents, isContinuous) {
-        serverLocatorEvents.collect { locator ->
-            // Background position sync (peer/resume/audiobook handoff): in Continuous mode the
-            // fragment is the invisible server-keeper, so route the jump to the continuous view.
-            if (isContinuous) {
-                goToContinuous(locator)
-                return@collect
-            }
-            // Paginated/scroll: navigate and snap onto the target's column, tracked through the new
-            // chapter's reflow, but never cover — a cover here would flash mid-reading.
-            val fragment = fragmentRef.value ?: return@collect
-            // A background sync (audiobook/peer) carries a within-chapter progression but no DOM
-            // fragment; preserve where go() landed (round to the column grid) instead of snapping to
-            // the chapter top, so the reader lands on the actual synced page.
-            ColumnSnap.goAndSnap(fragment, locator, landAtStartWhenNoTarget = false)
+    // Background position sync (peer/resume/audiobook handoff). Never covers — a flash
+    // mid-reading would be jarring. The background sync carries a within-chapter progression but
+    // no DOM fragment, so landAtStartWhenNoTarget=false preserves where go() landed instead of
+    // snapping to the chapter top.
+    val serverLocatorTarget: NavigationTarget = remember(isContinuous) {
+        if (isContinuous) ContinuousNavigationTarget { continuousViewRef.value }
+        else ReadiumNavigationTarget { locator ->
+            fragmentRef.value?.let { ColumnSnap.goAndSnap(it, locator, landAtStartWhenNoTarget = false) }
         }
+    }
+
+    LaunchedEffect(serverLocatorEvents, isContinuous) {
+        serverLocatorEvents.collect { serverLocatorTarget.navigateTo(it) }
     }
 
     // Navigate to a within-chapter [locator] and snap the page to the grid where go() landed
@@ -1441,26 +1432,18 @@ private fun EpubNavigatorView(
         }
     }
 
+    val navigationTarget: NavigationTarget = remember(isContinuous) {
+        if (isContinuous) ContinuousNavigationTarget { continuousViewRef.value }
+        else ReadiumNavigationTarget(goAndSnapWithCover)
+    }
+
     LaunchedEffect(returnNavEvents, isContinuous) {
-        returnNavEvents.collect { locator ->
-            if (isContinuous) {
-                goToContinuous(locator)
-            } else {
-                goAndSnapWithCover(locator)
-            }
-        }
+        returnNavEvents.collect { navigationTarget.navigateTo(it) }
     }
 
     LaunchedEffect(searchNavigationEvents, isContinuous) {
         searchNavigationEvents.collect { locator ->
-            if (isContinuous) {
-                val view = continuousViewRef.value ?: return@collect
-                val href = locator.href.toString()
-                val progression = locator.locations.progression?.toFloat() ?: 0f
-                view.navigateTo(href, progression)
-            } else {
-                goAndSnapWithCover(locator)
-            }
+            navigationTarget.navigateTo(locator)
             val text = locator.text.highlight?.take(40) ?: ""
             if (text.isNotBlank()) {
                 highlightRenderer.highlightSearchMatch(
@@ -1472,19 +1455,10 @@ private fun EpubNavigatorView(
     }
 
     LaunchedEffect(annotationNavigationEvents, isContinuous) {
-        annotationNavigationEvents.collect { locator ->
-            if (isContinuous) {
-                // Bookmark locators carry CFI-derived progressions measured at content top (not the
-                // viewport midpoint that locatorAt uses), so align to top rather than midpoint.
-                continuousViewRef.value?.navigateTo(
-                    locator.href.toString(),
-                    locator.locations.progression?.toFloat() ?: 0f,
-                    alignToTop = true,
-                )
-            } else {
-                goAndSnapWithCover(locator)
-            }
-        }
+        // Bookmark locators carry CFI-derived progressions measured at content top (not the
+        // viewport midpoint that locatorAt uses), so pass alignToTop=true for continuous mode.
+        // ReadiumNavigationTarget ignores this flag — Readium handles alignment internally.
+        annotationNavigationEvents.collect { navigationTarget.navigateTo(it, alignToTop = true) }
     }
 
     // Resolve "top of the current page" when readaloud reopens on a different page: ask the WebView

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/NavigationTarget.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/NavigationTarget.kt
@@ -9,22 +9,29 @@ import org.readium.r2.shared.publication.Locator
  *
  * Implementations are selected via `remember(isContinuous)` in [EpubReaderScreen] so that
  * all callers share a single `navigationTarget.navigateTo(locator)` call site.
+ *
+ * [alignToTop] is continuous-mode-only: set true when the locator's progression was measured at
+ * content top (e.g. CFI-derived bookmark positions) rather than the viewport midpoint.
  */
-internal fun interface NavigationTarget {
-    suspend fun navigateTo(locator: Locator)
+internal interface NavigationTarget {
+    suspend fun navigateTo(locator: Locator, alignToTop: Boolean = false)
 }
 
 /**
  * [NavigationTarget] for Continuous mode: delegates to [ContinuousNavigationView.navigateTo],
- * extracting href and progression from the [Locator]. A no-op when no view is available.
+ * extracting href (plus any fragment anchor) and progression from the [Locator]. A no-op when no
+ * view is available.
  */
 internal class ContinuousNavigationTarget(
     private val viewProvider: () -> ContinuousNavigationView?,
 ) : NavigationTarget {
-    override suspend fun navigateTo(locator: Locator) {
+    override suspend fun navigateTo(locator: Locator, alignToTop: Boolean) {
+        val anchor = locator.locations.fragments.firstOrNull()
+        val href = if (anchor != null) "${locator.href}#$anchor" else locator.href.toString()
         viewProvider()?.navigateTo(
-            locator.href.toString(),
+            href,
             locator.locations.progression?.toFloat() ?: 0f,
+            alignToTop,
         )
     }
 }
@@ -32,10 +39,11 @@ internal class ContinuousNavigationTarget(
 /**
  * [NavigationTarget] for paginated and scroll modes: delegates to a caller-supplied [go] lambda.
  * The lambda can be `goAndSnapWithCover` (return/search/annotation nav) or a bare
- * `ColumnSnap.goAndSnap` call (background server-locator sync).
+ * `ColumnSnap.goAndSnap` call (background server-locator sync). [alignToTop] is ignored — Readium
+ * handles column alignment internally.
  */
 internal class ReadiumNavigationTarget(
     private val go: suspend (Locator) -> Unit,
 ) : NavigationTarget {
-    override suspend fun navigateTo(locator: Locator) = go(locator)
+    override suspend fun navigateTo(locator: Locator, alignToTop: Boolean) = go(locator)
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/NavigationTarget.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/NavigationTarget.kt
@@ -1,0 +1,41 @@
+package com.riffle.app.feature.reader
+
+import org.readium.r2.shared.publication.Locator
+
+/**
+ * Abstracts the two navigation pipelines:
+ *  - [ContinuousNavigationTarget]: continuous mode via [ContinuousNavigationView.navigateTo]
+ *  - [ReadiumNavigationTarget]: paginated and scroll modes via a caller-supplied lambda
+ *
+ * Implementations are selected via `remember(isContinuous)` in [EpubReaderScreen] so that
+ * all callers share a single `navigationTarget.navigateTo(locator)` call site.
+ */
+internal fun interface NavigationTarget {
+    suspend fun navigateTo(locator: Locator)
+}
+
+/**
+ * [NavigationTarget] for Continuous mode: delegates to [ContinuousNavigationView.navigateTo],
+ * extracting href and progression from the [Locator]. A no-op when no view is available.
+ */
+internal class ContinuousNavigationTarget(
+    private val viewProvider: () -> ContinuousNavigationView?,
+) : NavigationTarget {
+    override suspend fun navigateTo(locator: Locator) {
+        viewProvider()?.navigateTo(
+            locator.href.toString(),
+            locator.locations.progression?.toFloat() ?: 0f,
+        )
+    }
+}
+
+/**
+ * [NavigationTarget] for paginated and scroll modes: delegates to a caller-supplied [go] lambda.
+ * The lambda can be `goAndSnapWithCover` (return/search/annotation nav) or a bare
+ * `ColumnSnap.goAndSnap` call (background server-locator sync).
+ */
+internal class ReadiumNavigationTarget(
+    private val go: suspend (Locator) -> Unit,
+) : NavigationTarget {
+    override suspend fun navigateTo(locator: Locator) = go(locator)
+}

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/NavigationTargetTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/NavigationTargetTest.kt
@@ -15,13 +15,13 @@ import org.readium.r2.shared.util.mediatype.MediaType
 @OptIn(ExperimentalCoroutinesApi::class)
 class NavigationTargetTest {
 
-    data class NavCall(val href: String, val progression: Float)
+    data class NavCall(val href: String, val progression: Float, val alignToTop: Boolean)
 
     private val calls = mutableListOf<NavCall>()
 
     private val fakeView = object : ContinuousNavigationView {
-        override fun navigateTo(href: String, progression: Float) {
-            calls.add(NavCall(href, progression))
+        override fun navigateTo(href: String, progression: Float, alignToTop: Boolean) {
+            calls.add(NavCall(href, progression, alignToTop))
         }
     }
 
@@ -53,10 +53,11 @@ class NavigationTargetTest {
     private fun makeLocator(
         urlString: String,
         progression: Double? = null,
+        fragments: List<String> = emptyList(),
     ) = Locator(
         href = makeAbsoluteUrl(urlString),
         mediaType = MediaType.XHTML,
-        locations = Locator.Locations(progression = progression),
+        locations = Locator.Locations(progression = progression, fragments = fragments),
     )
 
     /** Returns a Locator with all fields null/zero (sufficient for pass-through tests). */
@@ -81,6 +82,7 @@ class NavigationTargetTest {
         assertEquals(1, calls.size)
         assertEquals("https://example.com/ch1.xhtml", calls[0].href)
         assertEquals(0.75f, calls[0].progression, 0.001f)
+        assertEquals(false, calls[0].alignToTop)
     }
 
     @Test
@@ -92,6 +94,45 @@ class NavigationTargetTest {
 
         assertEquals(1, calls.size)
         assertEquals(0f, calls[0].progression, 0.001f)
+    }
+
+    @Test
+    fun `ContinuousNavigationTarget appends fragment anchor to href`() = runTest {
+        val target = ContinuousNavigationTarget { fakeView }
+        val locator = makeLocator(
+            "https://example.com/ch3.xhtml",
+            progression = 0.4,
+            fragments = listOf("section-2"),
+        )
+
+        target.navigateTo(locator)
+
+        assertEquals(1, calls.size)
+        assertEquals("https://example.com/ch3.xhtml#section-2", calls[0].href)
+    }
+
+    @Test
+    fun `ContinuousNavigationTarget uses first fragment only`() = runTest {
+        val target = ContinuousNavigationTarget { fakeView }
+        val locator = makeLocator(
+            "https://example.com/ch4.xhtml",
+            fragments = listOf("first", "second"),
+        )
+
+        target.navigateTo(locator)
+
+        assertEquals("https://example.com/ch4.xhtml#first", calls[0].href)
+    }
+
+    @Test
+    fun `ContinuousNavigationTarget forwards alignToTop to view`() = runTest {
+        val target = ContinuousNavigationTarget { fakeView }
+        val locator = makeLocator("https://example.com/ch5.xhtml", progression = 0.1)
+
+        target.navigateTo(locator, alignToTop = true)
+
+        assertEquals(1, calls.size)
+        assertEquals(true, calls[0].alignToTop)
     }
 
     @Test
@@ -140,5 +181,17 @@ class NavigationTargetTest {
         target.navigateTo(nullLocator())
 
         assertTrue(completed)
+    }
+
+    @Test
+    fun `ReadiumNavigationTarget ignores alignToTop`() = runTest {
+        val received = mutableListOf<Locator>()
+        val target = ReadiumNavigationTarget { locator -> received.add(locator) }
+        val locator = nullLocator()
+
+        target.navigateTo(locator, alignToTop = true)
+
+        assertEquals(1, received.size)
+        assertSame(locator, received[0])
     }
 }

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/NavigationTargetTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/NavigationTargetTest.kt
@@ -1,0 +1,144 @@
+package com.riffle.app.feature.reader
+
+import android.net.FakeUri
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.readium.r2.shared.publication.Locator
+import org.readium.r2.shared.util.AbsoluteUrl
+import org.readium.r2.shared.util.mediatype.MediaType
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class NavigationTargetTest {
+
+    data class NavCall(val href: String, val progression: Float)
+
+    private val calls = mutableListOf<NavCall>()
+
+    private val fakeView = object : ContinuousNavigationView {
+        override fun navigateTo(href: String, progression: Float) {
+            calls.add(NavCall(href, progression))
+        }
+    }
+
+    @Before
+    fun setUp() {
+        calls.clear()
+    }
+
+    // ---- helpers -------------------------------------------------------
+
+    /**
+     * Allocates an [AbsoluteUrl] without invoking its private constructor and injects a
+     * [FakeUri] so that [AbsoluteUrl.toString] returns [urlString]. See
+     * [ContinuousHighlightRendererTest.makeAbsoluteUrl] for rationale.
+     */
+    @Suppress("UNCHECKED_CAST")
+    private fun makeAbsoluteUrl(urlString: String): AbsoluteUrl {
+        val unsafe = Class.forName("sun.misc.Unsafe")
+            .getDeclaredField("theUnsafe")
+            .also { it.isAccessible = true }
+            .get(null) as sun.misc.Unsafe
+        val instance = unsafe.allocateInstance(AbsoluteUrl::class.java) as AbsoluteUrl
+        AbsoluteUrl::class.java.getDeclaredField("uri")
+            .also { it.isAccessible = true }
+            .set(instance, FakeUri(urlString))
+        return instance
+    }
+
+    private fun makeLocator(
+        urlString: String,
+        progression: Double? = null,
+    ) = Locator(
+        href = makeAbsoluteUrl(urlString),
+        mediaType = MediaType.XHTML,
+        locations = Locator.Locations(progression = progression),
+    )
+
+    /** Returns a Locator with all fields null/zero (sufficient for pass-through tests). */
+    @Suppress("UNCHECKED_CAST")
+    private fun nullLocator(): Locator {
+        val unsafe = Class.forName("sun.misc.Unsafe")
+            .getDeclaredField("theUnsafe")
+            .also { it.isAccessible = true }
+            .get(null) as sun.misc.Unsafe
+        return unsafe.allocateInstance(Locator::class.java) as Locator
+    }
+
+    // ---- ContinuousNavigationTarget ------------------------------------
+
+    @Test
+    fun `ContinuousNavigationTarget delegates href and progression to view`() = runTest {
+        val target = ContinuousNavigationTarget { fakeView }
+        val locator = makeLocator("https://example.com/ch1.xhtml", progression = 0.75)
+
+        target.navigateTo(locator)
+
+        assertEquals(1, calls.size)
+        assertEquals("https://example.com/ch1.xhtml", calls[0].href)
+        assertEquals(0.75f, calls[0].progression, 0.001f)
+    }
+
+    @Test
+    fun `ContinuousNavigationTarget uses zero progression when locator has none`() = runTest {
+        val target = ContinuousNavigationTarget { fakeView }
+        val locator = makeLocator("https://example.com/ch2.xhtml", progression = null)
+
+        target.navigateTo(locator)
+
+        assertEquals(1, calls.size)
+        assertEquals(0f, calls[0].progression, 0.001f)
+    }
+
+    @Test
+    fun `ContinuousNavigationTarget is a no-op when view is unavailable`() = runTest {
+        val target = ContinuousNavigationTarget { null }
+        val locator = makeLocator("https://example.com/ch3.xhtml", progression = 0.5)
+
+        target.navigateTo(locator)
+
+        assertEquals(0, calls.size)
+    }
+
+    // ---- ReadiumNavigationTarget ---------------------------------------
+
+    @Test
+    fun `ReadiumNavigationTarget delegates to go lambda`() = runTest {
+        var received: Locator? = null
+        val target = ReadiumNavigationTarget { locator -> received = locator }
+        val locator = nullLocator()
+
+        target.navigateTo(locator)
+
+        assertSame(locator, received)
+    }
+
+    @Test
+    fun `ReadiumNavigationTarget go lambda receives each navigateTo call`() = runTest {
+        val received = mutableListOf<Locator>()
+        val target = ReadiumNavigationTarget { locator -> received.add(locator) }
+        val a = nullLocator()
+        val b = nullLocator()
+
+        target.navigateTo(a)
+        target.navigateTo(b)
+
+        assertEquals(2, received.size)
+        assertSame(a, received[0])
+        assertSame(b, received[1])
+    }
+
+    @Test
+    fun `ReadiumNavigationTarget suspends until go completes`() = runTest {
+        var completed = false
+        val target = ReadiumNavigationTarget { kotlinx.coroutines.delay(1); completed = true }
+
+        target.navigateTo(nullLocator())
+
+        assertTrue(completed)
+    }
+}


### PR DESCRIPTION
## Summary

- Extracts a `NavigationTarget` interface with two implementations: `ContinuousNavigationTarget` (continuous mode) and `ReadiumNavigationTarget` (paginated/scroll modes via a caller-supplied lambda).
- Also extracts `ContinuousNavigationView` — a narrow interface over `ContinuousReaderView.navigateTo` for JVM testability.
- Unifies all four navigation `LaunchedEffect` blocks in `EpubNavigatorView` to single-line `navigationTarget.navigateTo(locator)` call sites, eliminating the `isContinuous` branch inside each effect and the `goToContinuous` lambda.
- `serverLocatorTarget` uses `ColumnSnap.goAndSnap(landAtStartWhenNoTarget=false)` (no cover animation) while `navigationTarget` uses `goAndSnapWithCover`; this distinction is preserved across both modes.

## What was tested

- **JVM:** `./gradlew test lint` — green (10 new `NavigationTargetTest` cases covering both implementations).
- **Harness:** `make harness-test` — 237 run, 5 skipped (pre-existing), 0 failed.
- **Device — paginated mode:** TOC nav, search nav, annotation (bookmark) nav, return-link nav verified on Harness API-25 AVD.
- **Device — scroll (vertical) mode:** same four nav types verified.
- **Device — continuous mode:** TOC nav (chapter changed), search nav (result counter advanced), annotation nav (bookmark returned to location) verified on API-33 AVD. Note: content rendering in continuous mode is broken on API 33 due to a pre-existing `net::ERR_NAME_NOT_RESOLVED` on the `readium_package` virtual hostname — confirmed by reproducing the same failure on `origin/main` (a24ff016); this PR does not touch that code path.

## Notes

A handoff doc for the pre-existing `readium_package` / API-33 continuous-mode rendering bug has been written to `/tmp/handoff-readium-package-continuous-mode.md`. The recommended fix is `WebViewAssetLoader`.