### PR TITLE
fix(audiobook): show total book progress in OS media controls

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/audiobook/AbsolutePositionPlayer.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audiobook/AbsolutePositionPlayer.kt
@@ -1,0 +1,55 @@
+package com.riffle.app.feature.audiobook
+
+import androidx.annotation.OptIn
+import androidx.media3.common.ForwardingPlayer
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.exoplayer.ExoPlayer
+import com.riffle.core.domain.AudiobookTracks
+
+/**
+ * Wraps [ExoPlayer] and overrides the three position-related methods so that Android's OS media
+ * controls (notification, lock screen, Bluetooth) see book-absolute progress rather than
+ * per-track (per-chapter) progress.
+ *
+ * When no audiobook is active ([SharedAudiobookContext.spans] is empty) every call passes through
+ * to the delegate unchanged, so Readaloud playback is unaffected.
+ *
+ * The three overrides are mutually consistent:
+ * - [getCurrentPosition] → book-absolute milliseconds
+ * - [getDuration]        → total book duration in milliseconds
+ * - [seekTo] (single-arg) → resolves absolute ms → (track index, in-track offset) and delegates
+ *
+ * The two-argument [seekTo](mediaItemIndex, positionMs) is intentionally NOT overridden: the
+ * [AudiobookController] already resolves absolute positions to (index, offset) before calling it
+ * via the [MediaController] Binder, so it must reach [ExoPlayer] unchanged.
+ */
+@OptIn(UnstableApi::class)
+class AbsolutePositionPlayer(private val exoPlayer: ExoPlayer) : ForwardingPlayer(exoPlayer) {
+
+    override fun getCurrentPosition(): Long {
+        val spans = SharedAudiobookContext.spans
+        if (spans.isEmpty()) return exoPlayer.currentPosition
+        return (AudiobookTracks.absoluteSec(
+            exoPlayer.currentMediaItemIndex,
+            exoPlayer.currentPosition / 1000.0,
+            spans,
+        ) * 1000.0).toLong()
+    }
+
+    override fun getDuration(): Long {
+        val totalMs = SharedAudiobookContext.totalDurationMs
+        return if (totalMs > 0L) totalMs else exoPlayer.duration
+    }
+
+    override fun seekTo(positionMs: Long) {
+        val spans = SharedAudiobookContext.spans
+        if (spans.isEmpty()) {
+            exoPlayer.seekTo(positionMs)
+            return
+        }
+        val absoluteSec = positionMs / 1000.0
+        val trackIndex = AudiobookTracks.trackIndexAt(absoluteSec, spans)
+        val offsetMs = (AudiobookTracks.offsetInTrackSec(absoluteSec, spans) * 1000.0).toLong()
+        exoPlayer.seekTo(trackIndex, offsetMs)
+    }
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookController.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookController.kt
@@ -106,6 +106,8 @@ open class AudiobookController @Inject constructor(
         val t0 = System.currentTimeMillis()
         this.spans = spans
         this.durationSec = durationSec
+        SharedAudiobookContext.spans = spans
+        SharedAudiobookContext.totalDurationMs = (durationSec * 1000.0).toLong()
         // Bundle-backed audio: the track mediaIds are zip-entry paths the service reads from this file
         // via SharedBundle (the same channel Readaloud uses). Null for HTTP/file sessions, where the
         // service never consults SharedBundle (so we don't touch it and don't claim ownership).
@@ -253,6 +255,8 @@ open class AudiobookController @Inject constructor(
         // restores a zip URI after this.
         if (ownsSharedBundle) SharedBundle.current = null
         ownsSharedBundle = false
+        SharedAudiobookContext.spans = emptyList()
+        SharedAudiobookContext.totalDurationMs = 0L
         _state.value = PlaybackState()
     }
 
@@ -281,6 +285,8 @@ open class AudiobookController @Inject constructor(
         prepared = false
         wantsToPlay = false
         ownsSharedBundle = false
+        SharedAudiobookContext.spans = emptyList()
+        SharedAudiobookContext.totalDurationMs = 0L
         _state.value = PlaybackState()
     }
 

--- a/app/src/main/kotlin/com/riffle/app/feature/audiobook/SharedAudiobookContext.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audiobook/SharedAudiobookContext.kt
@@ -1,0 +1,17 @@
+package com.riffle.app.feature.audiobook
+
+import com.riffle.core.domain.AudiobookTrackSpan
+
+/**
+ * Process-scoped pointer to the active audiobook's track spans and total duration, set by
+ * [AudiobookController] before it queues tracks and cleared when the session ends.
+ *
+ * Mirrors the [com.riffle.app.feature.reader.readaloud.SharedBundle] pattern: the
+ * [com.riffle.app.feature.reader.readaloud.AudioPlayerService] is platform-constructed (no DI), so
+ * out-of-band state sharing is the only seam available. Used by [AbsolutePositionPlayer] to compute
+ * book-absolute position / total duration for the OS media controls.
+ */
+object SharedAudiobookContext {
+    @Volatile var spans: List<AudiobookTrackSpan> = emptyList()
+    @Volatile var totalDurationMs: Long = 0L
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/AudioPlayerService.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/AudioPlayerService.kt
@@ -25,6 +25,7 @@ import com.google.common.collect.ImmutableList
 import com.google.common.util.concurrent.Futures
 import com.google.common.util.concurrent.ListenableFuture
 import com.riffle.app.R
+import com.riffle.app.feature.audiobook.AbsolutePositionPlayer
 
 /**
  * Foreground [MediaSessionService] that plays Readaloud audio. Media3 supplies the media
@@ -52,7 +53,7 @@ class AudioPlayerService : MediaSessionService() {
                 .build()
                 .apply { setSmallIcon(R.drawable.ic_notification) },
         )
-        val player = ExoPlayer.Builder(this)
+        val exoPlayer = ExoPlayer.Builder(this)
             .setAudioAttributes(
                 AudioAttributes.Builder()
                     .setUsage(C.USAGE_MEDIA)
@@ -66,6 +67,9 @@ class AudioPlayerService : MediaSessionService() {
             // so their behaviour is unchanged.
             .setMediaSourceFactory(DefaultMediaSourceFactory(resolvingDataSourceFactory()))
             .build()
+        // Wraps ExoPlayer so the OS media controls (notification, lock screen, Bluetooth) see
+        // book-absolute position / total duration rather than per-track (per-chapter) values.
+        val player = AbsolutePositionPlayer(exoPlayer)
         mediaSession = MediaSession.Builder(this, player)
             .setCallback(MediaItemUriRestoringCallback)
             .setSessionActivity(openRiffleIntent())


### PR DESCRIPTION
## Summary

- Android's system media controls (notification, lock screen, Bluetooth) showed per-chapter progress because `AudioPlayerService` used a raw `ExoPlayer` with one `MediaItem` per audio track; the OS reads `player.currentPosition` / `player.duration` directly, which are per-track values
- Wraps `ExoPlayer` with `AbsolutePositionPlayer` (`ForwardingPlayer`) that overrides `getCurrentPosition()` → book-absolute ms, `getDuration()` → total book duration ms, and `seekTo(Long)` → resolves absolute ms back to `(trackIndex, offsetMs)` so notification rewind/forward buttons also seek correctly across track boundaries
- `SharedAudiobookContext` (following the `SharedBundle` pattern) carries `spans` and `totalDurationMs` from `AudiobookController.prepare()` into the platform-constructed `AudioPlayerService`; cleared in `stop()` and `releaseForHandoff()` so Readaloud playback is unaffected (`ForwardingPlayer` falls through to native `ExoPlayer` when `spans` is empty)

## Files changed

- `AbsolutePositionPlayer.kt` (new) — the `ForwardingPlayer` wrapper
- `SharedAudiobookContext.kt` (new) — process-scoped context shared between controller and service
- `AudiobookController.kt` — set/clear `SharedAudiobookContext` in `prepare()`, `stop()`, `releaseForHandoff()`
- `AudioPlayerService.kt` — wrap `ExoPlayer` with `AbsolutePositionPlayer`

## Test plan

- [ ] Play an audiobook with multiple chapters; notification and lock-screen player show total book elapsed / remaining (not chapter-level)
- [ ] Rewind/forward buttons in notification seek correctly across chapter boundaries
- [ ] Readaloud playback is unaffected (in-app readaloud progress and notification display unchanged)
- [ ] `./gradlew test` green