### PR TITLE
fix(audiobook): align bookmark ribbon with ebook reader

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
@@ -24,10 +25,6 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.SnackbarDuration
-import androidx.compose.material3.SnackbarHost
-import androidx.compose.material3.SnackbarHostState
-import androidx.compose.material3.SnackbarResult
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.windowsizeclass.WindowHeightSizeClass
@@ -36,7 +33,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -53,7 +49,6 @@ import com.riffle.app.feature.audio.PlayerSurfaceState
 import com.riffle.app.feature.audio.formatHms
 import com.riffle.app.feature.reader.CornerBookmarkIndicator
 import com.riffle.core.domain.AudiobookBookmark
-import kotlinx.coroutines.launch
 
 /**
  * Full-screen [Audiobook Player] (ADR 0029): square cover, title/author, current-chapter label, a
@@ -149,9 +144,6 @@ fun AudiobookPlayerScreen(
     // they don't drift with the still-running playhead while the user edits (see [BookmarkDraft]).
     var createDraft by remember { mutableStateOf<BookmarkDraft?>(null) }
     var renaming by remember { mutableStateOf<AudiobookBookmark?>(null) }
-
-    val snackbarHostState = remember { SnackbarHostState() }
-    val scope = rememberCoroutineScope()
 
     val gradient = Brush.verticalGradient(
         listOf(
@@ -273,19 +265,25 @@ fun AudiobookPlayerScreen(
                 isVisible = true,
                 onToggle = {
                     val positionSec = viewModel.currentPositionSec()
-                    createDraft = BookmarkDraft(
-                        positionSec = positionSec,
-                        defaultTitle = viewModel.defaultBookmarkTitle(positionSec),
-                        chapterTitle = state.currentChapterTitle?.trim().orEmpty(),
-                    )
+                    val nearby = state.bookmarks
+                        .minByOrNull { kotlin.math.abs(it.positionSec - positionSec) }
+                        ?.takeIf { kotlin.math.abs(it.positionSec - positionSec) <= 3.0 }
+                    if (nearby != null) {
+                        viewModel.deleteBookmark(nearby.id)
+                    } else {
+                        createDraft = BookmarkDraft(
+                            positionSec = positionSec,
+                            defaultTitle = viewModel.defaultBookmarkTitle(positionSec),
+                            chapterTitle = state.currentChapterTitle?.trim().orEmpty(),
+                        )
+                    }
                 },
-                contentDescription = if (nearBookmark && createDraft == null) "Bookmark nearby" else "Add bookmark",
+                contentDescription = if (nearBookmark && createDraft == null) "Remove bookmark" else "Add bookmark",
                 modifier = Modifier
                     .align(Alignment.TopEnd)
-                    .safeDrawingPadding()
+                    .statusBarsPadding()
                     .padding(end = 12.dp),
             )
-            SnackbarHost(snackbarHostState, modifier = Modifier.align(Alignment.BottomCenter).navigationBarsPadding())
         }
     }
 
@@ -301,18 +299,6 @@ fun AudiobookPlayerScreen(
             onConfirm = { title ->
                 viewModel.addBookmark(title, draft.positionSec)
                 createDraft = null
-                scope.launch {
-                    val result = snackbarHostState.showSnackbar(
-                        message = "Bookmark saved",
-                        actionLabel = "Undo",
-                        duration = SnackbarDuration.Long,
-                    )
-                    if (result == SnackbarResult.ActionPerformed) {
-                        // The add is asynchronous; by the time Undo is tapped the id has been published
-                        // to uiState. Read it fresh from the ViewModel at click time.
-                        viewModel.uiState.value.lastCreatedBookmarkId?.let(viewModel::deleteBookmark)
-                    }
-                }
             },
             onDismiss = { createDraft = null },
         )

--- a/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerScreen.kt
@@ -13,7 +13,6 @@ import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
@@ -60,6 +59,7 @@ import com.riffle.core.domain.AudiobookBookmark
 // Minimum downward drag (px) on the player to trigger the switch to the readaloud reader — a
 // deliberate swipe, not an accidental nudge.
 private const val SWITCH_TO_READALOUD_THRESHOLD_PX = 160f
+private const val BOOKMARK_WINDOW_SEC = 3.0
 
 /** Which list the shared [PlayerListSheet] is showing (no tabs — one kind at a time). */
 private enum class SheetKind { Chapters, Bookmarks }
@@ -258,7 +258,7 @@ fun AudiobookPlayerScreen(
             // Corner bookmark ribbon — same shape/placement as the ebook reader. Filled when the
             // playhead is within ±3 s of an existing bookmark, or while the add-bookmark dialog is open.
             val nearBookmark = state.bookmarks.any { bm ->
-                kotlin.math.abs(bm.positionSec - state.positionSec) <= 3.0
+                kotlin.math.abs(bm.positionSec - state.positionSec) <= BOOKMARK_WINDOW_SEC
             }
             CornerBookmarkIndicator(
                 isBookmarked = createDraft != null || nearBookmark,
@@ -266,8 +266,8 @@ fun AudiobookPlayerScreen(
                 onToggle = {
                     val positionSec = viewModel.currentPositionSec()
                     val nearby = state.bookmarks
+                        .filter { kotlin.math.abs(it.positionSec - positionSec) <= BOOKMARK_WINDOW_SEC }
                         .minByOrNull { kotlin.math.abs(it.positionSec - positionSec) }
-                        ?.takeIf { kotlin.math.abs(it.positionSec - positionSec) <= 3.0 }
                     if (nearby != null) {
                         viewModel.deleteBookmark(nearby.id)
                     } else {
@@ -281,7 +281,7 @@ fun AudiobookPlayerScreen(
                 contentDescription = if (nearBookmark && createDraft == null) "Remove bookmark" else "Add bookmark",
                 modifier = Modifier
                     .align(Alignment.TopEnd)
-                    .statusBarsPadding()
+                    .safeDrawingPadding()
                     .padding(end = 12.dp),
             )
         }

--- a/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModel.kt
@@ -129,9 +129,6 @@ data class AudiobookPlayerUiState(
     val readaloudEbookItemId: String? = null,
     // User bookmarks for this audiobook, observed live from the store (ordered by position, earliest first).
     val bookmarks: List<AudiobookBookmark> = emptyList(),
-    // The id of the most recently added bookmark, so the UI can offer an Undo on the add. Null until
-    // an add succeeds this session.
-    val lastCreatedBookmarkId: String? = null,
     // True only when this item has unsynced (dirty) bookmarks AND the device is offline, so the
     // Bookmarks sheet can show a quiet "Offline — bookmarks will sync" note. Sync is otherwise silent.
     val bookmarksOffline: Boolean = false,
@@ -377,7 +374,6 @@ class AudiobookPlayerViewModel(
                 canPreviousChapter = timeline.canPreviousChapter,
                 canNextChapter = timeline.canNextChapter,
                 bookmarks = m.bookmarks,
-                lastCreatedBookmarkId = m.lastCreatedBookmarkId,
                 bookmarksOffline = m.bookmarksOffline,
                 sleepTimer = timer,
             )
@@ -809,16 +805,12 @@ class AudiobookPlayerViewModel(
 
     /**
      * Create a bookmark at [positionSec] (the position pinned when the dialog opened — NOT the live
-     * playhead, which may have drifted while the user typed). On success the new id is surfaced in
-     * [AudiobookPlayerUiState.lastCreatedBookmarkId] so the UI can offer an Undo; the new row arrives
-     * in [AudiobookPlayerUiState.bookmarks] via the store observation.
+     * playhead, which may have drifted while the user typed). The new row arrives in
+     * [AudiobookPlayerUiState.bookmarks] via the store observation.
      */
     fun addBookmark(title: String, positionSec: Double) {
         if (serverId.isEmpty()) return
-        viewModelScope.launch {
-            val id = bookmarkStore.add(serverId, itemId, positionSec, title, now())
-            meta.value = meta.value.copy(lastCreatedBookmarkId = id)
-        }
+        viewModelScope.launch { bookmarkStore.add(serverId, itemId, positionSec, title, now()) }
     }
 
     fun renameBookmark(id: String, title: String) {

--- a/app/src/test/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModelBookmarkTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModelBookmarkTest.kt
@@ -206,8 +206,6 @@ class AudiobookPlayerViewModelBookmarkTest {
             AddCall(serverId, itemId, 321.0, "My title", fixedNow),
             store.added.single(),
         )
-        // The new id is surfaced for an Undo.
-        assertEquals(store.lastId, vm.uiState.value.lastCreatedBookmarkId)
         vm.clearForTest()
     }
 


### PR DESCRIPTION
## Summary

- **Ribbon position**: Uses `safeDrawingPadding()` so the ribbon starts just below the status bar (non-immersive player) and clears side display cutouts in landscape — matching the visual intent without the cutout regression that `statusBarsPadding()` would introduce
- **Toggle removes bookmark**: Tapping the ribbon when the playhead is within ±3 s of an existing bookmark now deletes it, mirroring `EpubReaderViewModel.toggleBookmark()`; tapping elsewhere still opens the create dialog
- **No "Bookmark saved" popup**: Removed the snackbar and its Undo action
- **Cleanup**: Extracted `BOOKMARK_WINDOW_SEC = 3.0` constant (used by both the indicator and the toggle logic); replaced `minByOrNull+takeIf` double-evaluation with `filter+minByOrNull`; removed dead `lastCreatedBookmarkId` field from `AudiobookPlayerUiState` and its ViewModel update path

## Test plan

- [ ] Open audiobook player; ribbon appears flush below the status bar at top-right
- [ ] Tap ribbon → bookmark create dialog appears; confirm → ribbon fills; tap again → bookmark is deleted
- [ ] Tap ribbon when no nearby bookmark → create dialog; dismiss → ribbon unfills
- [ ] JVM unit tests: `./gradlew test` (includes `AudiobookPlayerViewModelBookmarkTest`)