### PR TITLE
feat(player): speed control — bottom sheet with +/− and presets

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/audio/PlaybackSpeedControl.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audio/PlaybackSpeedControl.kt
@@ -1,17 +1,20 @@
 package com.riffle.app.feature.audio
 
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Slider
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -21,40 +24,28 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.unit.IntOffset
-import androidx.compose.ui.unit.IntRect
-import androidx.compose.ui.unit.IntSize
-import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.window.Popup
-import androidx.compose.ui.window.PopupPositionProvider
 
 /**
  * The granular playback-speed range shared by the Read Aloud mini-player and the full-screen
- * Audiobook player: any [STEP] multiple in [[MIN], [MAX]] (so 1.4× is reachable), with the same
- * quick-preset chips and detent legend. Both players talk to the same ABS audio file, so keeping one
- * range/snap rule here means they behave identically.
+ * Audiobook player: any [STEP] multiple in [[MIN], [MAX]] (so 1.4× is reachable). Both players
+ * talk to the same ABS audio file, so keeping one range/snap rule here means they behave identically.
  */
 object PlaybackSpeed {
     const val MIN = 0.5f
     const val MAX = 3.0f
     const val STEP = 0.05f
 
-    /** Quick-jump presets surfaced as chips in the sheet (the familiar tap-cycle set). */
+    /** Quick-jump presets surfaced as options in Settings and the sheet. */
     val PRESETS = listOf(0.75f, 1f, 1.25f, 1.5f, 2f)
-
-    /** Detent labels printed under the slider track — a rough scale legend, not pixel-aligned. */
-    val DETENTS = listOf("0.5×", "1×", "2×", "3×")
 
     /** Clamps to [[MIN], [MAX]] and snaps to the nearest [STEP], free of float drift. */
     fun snap(raw: Float): Float = (Math.round(raw / STEP) * STEP).coerceIn(MIN, MAX)
 
     /** Formats the speed as 1×, 1.25×, 1.4×, 0.75× … (rounded to 0.05, trailing zeros trimmed). */
     fun label(speed: Float): String {
-        // Round to 2 decimals first so 0.05-step floats (e.g. 1.35000002) print cleanly.
         val rounded = Math.round(speed * 100.0) / 100.0
         val s = if (rounded % 1.0 == 0.0) rounded.toInt().toString()
         else rounded.toString().trimEnd('0').trimEnd('.')
@@ -62,13 +53,14 @@ object PlaybackSpeed {
     }
 }
 
+private val SHEET_PRESETS = listOf(0.75f, 1f, 1.25f, 1.5f, 2f, 3f)
+
 /**
- * The granular speed control: a caller-supplied [anchor] that, when tapped, opens a [SpeedSliderSheet]
- * floating **above** it in an overlay [Popup] (so nothing underneath reflows). The two players style
- * their own anchor (a compact chip vs. a labelled pill) but share the sheet and the popup mechanics.
+ * The speed control: a caller-supplied [anchor] that, when tapped, opens a [SpeedSheet]
+ * (ModalBottomSheet) with +/− nudge buttons and preset options, matching the sleep timer's
+ * presentation pattern.
  *
- * [tagPrefix] namespaces the test tags (`<prefix>_speed_slider`, `<prefix>_speed_preset_<label>`, …)
- * so each player's instrumentation stays distinct.
+ * [tagPrefix] namespaces the test tags so each player's instrumentation stays distinct.
  */
 @Composable
 fun PlaybackSpeedControl(
@@ -78,136 +70,133 @@ fun PlaybackSpeedControl(
     modifier: Modifier = Modifier,
     anchor: @Composable (onClick: () -> Unit) -> Unit,
 ) {
-    val density = LocalDensity.current
     var sheetOpen by remember { mutableStateOf(false) }
 
     Box(modifier = modifier) {
-        anchor { sheetOpen = !sheetOpen }
-
-        if (sheetOpen) {
-            val gapPx = with(density) { 8.dp.roundToPx() }
-            Popup(
-                popupPositionProvider = remember(gapPx) { AboveAnchorPositionProvider(gapPx) },
-                onDismissRequest = { sheetOpen = false },
-            ) {
-                SpeedSliderSheet(speed = speed, onSpeedChange = onSpeedChange, tagPrefix = tagPrefix)
-            }
-        }
+        anchor { sheetOpen = true }
     }
-}
 
-/**
- * The card that floats above the anchor while adjusting speed: a big readout, a 0.05-step slider with
- * a detent legend, and quick-preset chips.
- */
-@Composable
-private fun SpeedSliderSheet(
-    speed: Float,
-    onSpeedChange: (Float) -> Unit,
-    tagPrefix: String,
-) {
-    // One discrete stop per STEP between the endpoints (Slider snaps onValueChange to them).
-    val stepCount = Math.round((PlaybackSpeed.MAX - PlaybackSpeed.MIN) / PlaybackSpeed.STEP) - 1
-    Surface(
-        shape = MaterialTheme.shapes.large,
-        tonalElevation = 3.dp,
-        shadowElevation = 6.dp,
-        modifier = Modifier
-            .width(320.dp)
-            .testTag("${tagPrefix}_speed_slider_card"),
-    ) {
-        Column(
-            modifier = Modifier.padding(horizontal = 16.dp, vertical = 14.dp),
-            horizontalAlignment = Alignment.CenterHorizontally,
-        ) {
-            Text(
-                PlaybackSpeed.label(speed),
-                style = MaterialTheme.typography.headlineMedium,
-                fontWeight = FontWeight.Bold,
-                color = MaterialTheme.colorScheme.primary,
-            )
-            Spacer(modifier = Modifier.height(8.dp))
-            Slider(
-                value = speed.coerceIn(PlaybackSpeed.MIN, PlaybackSpeed.MAX),
-                onValueChange = { onSpeedChange(PlaybackSpeed.snap(it)) },
-                valueRange = PlaybackSpeed.MIN..PlaybackSpeed.MAX,
-                steps = stepCount,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .testTag("${tagPrefix}_speed_slider"),
-            )
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceBetween,
-            ) {
-                PlaybackSpeed.DETENTS.forEach { detent ->
-                    Text(
-                        detent,
-                        style = MaterialTheme.typography.labelSmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                }
-            }
-            Spacer(modifier = Modifier.height(12.dp))
-            Row(
-                horizontalArrangement = Arrangement.spacedBy(6.dp, Alignment.CenterHorizontally),
-                modifier = Modifier.fillMaxWidth(),
-            ) {
-                PlaybackSpeed.PRESETS.forEach { preset ->
-                    SpeedPresetChip(
-                        label = PlaybackSpeed.label(preset),
-                        selected = Math.abs(preset - speed) < 0.001f,
-                        onClick = { onSpeedChange(preset) },
-                        tagPrefix = tagPrefix,
-                    )
-                }
-            }
-        }
-    }
-}
-
-/** A compact pill preset (lighter than a Material FilterChip so all five fit one row). */
-@Composable
-private fun SpeedPresetChip(
-    label: String,
-    selected: Boolean,
-    onClick: () -> Unit,
-    tagPrefix: String,
-) {
-    Surface(
-        onClick = onClick,
-        shape = RoundedCornerShape(percent = 50),
-        color = if (selected) MaterialTheme.colorScheme.secondaryContainer
-        else MaterialTheme.colorScheme.surfaceVariant,
-        contentColor = if (selected) MaterialTheme.colorScheme.onSecondaryContainer
-        else MaterialTheme.colorScheme.onSurfaceVariant,
-        modifier = Modifier.testTag("${tagPrefix}_speed_preset_$label"),
-    ) {
-        Text(
-            label,
-            style = MaterialTheme.typography.labelLarge,
-            fontWeight = if (selected) FontWeight.SemiBold else FontWeight.Medium,
-            modifier = Modifier.padding(horizontal = 10.dp, vertical = 6.dp),
+    if (sheetOpen) {
+        SpeedSheet(
+            speed = speed,
+            onSpeedChange = onSpeedChange,
+            tagPrefix = tagPrefix,
+            onDismiss = { sheetOpen = false },
         )
     }
 }
 
-/**
- * Positions the speed sheet centred horizontally in the WINDOW (not over its anchor — the anchor can
- * sit at the far edge of a bar, so anchoring there would shove the sheet against the screen edge),
- * floating just above the anchor row.
- */
-private class AboveAnchorPositionProvider(private val gapPx: Int) : PopupPositionProvider {
-    override fun calculatePosition(
-        anchorBounds: IntRect,
-        windowSize: IntSize,
-        layoutDirection: LayoutDirection,
-        popupContentSize: IntSize,
-    ): IntOffset {
-        val x = ((windowSize.width - popupContentSize.width) / 2)
-            .coerceIn(0, (windowSize.width - popupContentSize.width).coerceAtLeast(0))
-        // Float above the anchor, but never let the top clip off-screen on a short viewport.
-        val y = (anchorBounds.top - popupContentSize.height - gapPx).coerceAtLeast(0)
-        return IntOffset(x, y)
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun SpeedSheet(
+    speed: Float,
+    onSpeedChange: (Float) -> Unit,
+    tagPrefix: String,
+    onDismiss: () -> Unit,
+) {
+    ModalBottomSheet(onDismissRequest = onDismiss) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp)
+                .padding(bottom = 24.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Text("Playback Speed", style = MaterialTheme.typography.titleMedium)
+
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(16.dp),
+            ) {
+                Surface(
+                    onClick = { onSpeedChange(PlaybackSpeed.snap(speed - PlaybackSpeed.STEP)) },
+                    shape = CircleShape,
+                    color = MaterialTheme.colorScheme.secondaryContainer,
+                    contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+                    modifier = Modifier.size(48.dp).testTag("${tagPrefix}_speed_minus"),
+                ) {
+                    Box(contentAlignment = Alignment.Center) {
+                        Text("−", style = MaterialTheme.typography.headlineSmall, fontWeight = FontWeight.Light)
+                    }
+                }
+                Text(
+                    PlaybackSpeed.label(speed),
+                    style = MaterialTheme.typography.headlineMedium,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.testTag("${tagPrefix}_speed_display"),
+                )
+                Surface(
+                    onClick = { onSpeedChange(PlaybackSpeed.snap(speed + PlaybackSpeed.STEP)) },
+                    shape = CircleShape,
+                    color = MaterialTheme.colorScheme.secondaryContainer,
+                    contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+                    modifier = Modifier.size(48.dp).testTag("${tagPrefix}_speed_plus"),
+                ) {
+                    Box(contentAlignment = Alignment.Center) {
+                        Text("+", style = MaterialTheme.typography.headlineSmall, fontWeight = FontWeight.Light)
+                    }
+                }
+            }
+
+            val row1 = SHEET_PRESETS.take(3)
+            val row2 = SHEET_PRESETS.drop(3)
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                row1.forEach { preset ->
+                    SpeedPresetButton(
+                        label = PlaybackSpeed.label(preset),
+                        selected = Math.abs(preset - speed) < 0.001f,
+                        onClick = { onSpeedChange(preset) },
+                        tagPrefix = tagPrefix,
+                        modifier = Modifier.weight(1f),
+                    )
+                }
+            }
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                row2.forEach { preset ->
+                    SpeedPresetButton(
+                        label = PlaybackSpeed.label(preset),
+                        selected = Math.abs(preset - speed) < 0.001f,
+                        onClick = { onSpeedChange(preset) },
+                        tagPrefix = tagPrefix,
+                        modifier = Modifier.weight(1f),
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun SpeedPresetButton(
+    label: String,
+    selected: Boolean,
+    onClick: () -> Unit,
+    tagPrefix: String,
+    modifier: Modifier = Modifier,
+) {
+    OutlinedButton(
+        onClick = onClick,
+        modifier = modifier.testTag("${tagPrefix}_speed_preset_$label"),
+        shape = RoundedCornerShape(50),
+        border = if (selected) BorderStroke(1.5.dp, MaterialTheme.colorScheme.primary)
+                 else ButtonDefaults.outlinedButtonBorder(enabled = true),
+        colors = if (selected) ButtonDefaults.outlinedButtonColors(contentColor = MaterialTheme.colorScheme.primary)
+                 else ButtonDefaults.outlinedButtonColors(),
+    ) {
+        Text(
+            label,
+            style = MaterialTheme.typography.labelLarge,
+            fontWeight = if (selected) FontWeight.SemiBold else FontWeight.Normal,
+        )
     }
 }

--- a/app/src/test/kotlin/com/riffle/app/feature/audio/PlaybackSpeedTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/audio/PlaybackSpeedTest.kt
@@ -1,0 +1,62 @@
+package com.riffle.app.feature.audio
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class PlaybackSpeedTest {
+
+    // ── snap ─────────────────────────────────────────────────────────────────
+
+    @Test fun snap_clampsAtMin() {
+        assertEquals(PlaybackSpeed.MIN, PlaybackSpeed.snap(PlaybackSpeed.MIN - PlaybackSpeed.STEP), 0.001f)
+    }
+
+    @Test fun snap_clampsAtMax() {
+        assertEquals(PlaybackSpeed.MAX, PlaybackSpeed.snap(PlaybackSpeed.MAX + PlaybackSpeed.STEP), 0.001f)
+    }
+
+    @Test fun snap_returnsExactStepValue() {
+        assertEquals(1.25f, PlaybackSpeed.snap(1.25f), 0.001f)
+    }
+
+    @Test fun snap_roundsToNearestStep() {
+        // 1.27 is closer to 1.25 than 1.30
+        assertEquals(1.25f, PlaybackSpeed.snap(1.27f), 0.001f)
+        // 1.28 is closer to 1.30
+        assertEquals(1.30f, PlaybackSpeed.snap(1.28f), 0.001f)
+    }
+
+    @Test fun snap_handlesFloatDriftFromRepeatedNudges() {
+        // Simulate 5 nudges up from 1.0 — floating-point addition can drift.
+        var v = 1.0f
+        repeat(5) { v = PlaybackSpeed.snap(v + PlaybackSpeed.STEP) }
+        assertEquals(1.25f, v, 0.001f)
+    }
+
+    @Test fun snap_nudgeBelowMinClampsToMin() {
+        assertEquals(PlaybackSpeed.MIN, PlaybackSpeed.snap(0.0f), 0.001f)
+    }
+
+    // ── label ─────────────────────────────────────────────────────────────────
+
+    @Test fun label_wholeNumberOmitsDecimal() {
+        assertEquals("1×", PlaybackSpeed.label(1.0f))
+        assertEquals("2×", PlaybackSpeed.label(2.0f))
+        assertEquals("3×", PlaybackSpeed.label(3.0f))
+    }
+
+    @Test fun label_trimsTrailingZeros() {
+        assertEquals("1.25×", PlaybackSpeed.label(1.25f))
+        assertEquals("0.75×", PlaybackSpeed.label(0.75f))
+        assertEquals("1.5×", PlaybackSpeed.label(1.5f))
+    }
+
+    @Test fun label_handlesMin() {
+        assertEquals("0.5×", PlaybackSpeed.label(PlaybackSpeed.MIN))
+    }
+
+    @Test fun label_handlesDriftedFloat() {
+        // 1.35000002 (common float drift) should print as "1.35×"
+        assertEquals("1.35×", PlaybackSpeed.label(1.3500001f))
+    }
+}


### PR DESCRIPTION
## Summary

- Replaces the floating popup card (slider + preset chips) that appeared above the speed pill with a `ModalBottomSheet`, matching the sleep timer's presentation pattern
- Sheet contains a `−` / speed display / `+` row for 0.05× nudging, and a 3×2 grid of `OutlinedButton` presets (0.75×, 1×, 1.25×, 1.5×, 2×, 3×)
- Sheet stays open on preset tap so the user can keep nudging after a jump
- Applies to both the audiobook player and the readaloud mini-player (shared `PlaybackSpeedControl` composable)
- `PlaybackSpeed.DETENTS` (unused outside the removed slider) deleted; `PRESETS` unchanged (still drives Settings)

## Test plan

- [ ] Unit: `PlaybackSpeedTest` — `snap` (clamp, rounding, float-drift) and `label` (formatting) — new, all green
- [ ] `./gradlew test` — full JVM suite green
- [ ] `./gradlew lint` — clean
- [ ] Harness: skipped per request — UI behaviour (sheet open/dismiss, preset selection, nudge) is covered by the interactive prototype session