### PR TITLE
fix(reader): gate navigator construction until prefs propagate

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -178,6 +178,9 @@ fun EpubReaderScreen(
     // Resolved prefs — `theme` is always concrete. Feeds Readium, the chapter rail
     // backdrop, and any palette consumer.
     val formattingPrefs by viewModel.effectiveFormattingPreferences.collectAsState()
+    // False until the loaded prefs have propagated to effectiveFormattingPreferences. Gates
+    // navigator construction so first paint never uses the StateFlow's default.
+    val formattingPreferencesReady by viewModel.formattingPreferencesReady.collectAsState()
     val hasBookOverrides by viewModel.hasBookOverrides.collectAsState()
     val keepScreenOn by viewModel.keepScreenOn.collectAsState()
     val volumeKeyNavigationEnabled by viewModel.volumeKeyNavigationEnabled.collectAsState()
@@ -334,7 +337,19 @@ fun EpubReaderScreen(
                             .testTag("reader_loading"),
                     )
                 }
-                is ReaderState.Ready -> {
+                // Prefs haven't propagated to effectiveFormattingPreferences yet — keep
+                // the spinner up rather than constructing the Readium navigator with the
+                // StateFlow's FormattingPreferences() default. Without this gate, fast/cached
+                // opens occasionally rendered the first chapter with no typography overrides
+                // applied (tiny unstyled text at the top-left of the page), surviving until
+                // the user closed and reopened the book.
+                is ReaderState.Ready -> if (!formattingPreferencesReady) {
+                    CircularProgressIndicator(
+                        modifier = Modifier
+                            .align(Alignment.Center)
+                            .testTag("reader_loading"),
+                    )
+                } else {
                     val locatorHref by viewModel.currentLocatorHref.collectAsState()
                     val tocEntries by viewModel.tocEntries.collectAsState()
                     LaunchedEffect(tocVisible, showFormattingPanel) {

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -297,6 +297,15 @@ class EpubReaderViewModel @Inject constructor(
     private val _hasBookOverrides = MutableStateFlow(false)
     val hasBookOverrides: StateFlow<Boolean> = _hasBookOverrides
 
+    // False until loadFormattingPreferences() has both written the loaded value into
+    // _formattingPreferences AND that value has propagated through the combine→stateIn chain
+    // backing effectiveFormattingPreferences. The screen gates EpubNavigatorFragment /
+    // ContinuousReaderView construction on this so the first paint never uses the StateFlow's
+    // FormattingPreferences() default — which would otherwise produce an occasional unstyled
+    // render (no typography overrides applied) that survives until the user reopens the book.
+    private val _formattingPreferencesReady = MutableStateFlow(false)
+    val formattingPreferencesReady: StateFlow<Boolean> = _formattingPreferencesReady
+
     private val _isSearchActive = MutableStateFlow(false)
     val isSearchActive: StateFlow<Boolean> = _isSearchActive
 
@@ -667,8 +676,18 @@ class EpubReaderViewModel @Inject constructor(
         val overrides = bookFormattingPreferencesStore.load(itemId)
         val global = formattingPreferencesStore.preferences.first()
         _bookOverrides.value = overrides
-        _formattingPreferences.value = overrides.applyTo(global)
+        val effective = overrides.applyTo(global)
+        _formattingPreferences.value = effective
         _hasBookOverrides.value = !overrides.isEmpty
+        // Wait until the derived effectiveFormattingPreferences StateFlow actually reflects
+        // the loaded value before flipping the gate. The combine→stateIn chain has its own
+        // dispatch latency: writing _formattingPreferences.value does not synchronously
+        // update effectiveFormattingPreferences.value, and the screen reads the latter when
+        // constructing the Readium navigator. Without this wait, ReaderState.Ready can
+        // arrive while effectiveFormattingPreferences.value still holds FormattingPreferences().
+        val targetEffective = effective.withResolvedTheme(timeProvider.nowLocalTime())
+        effectiveFormattingPreferences.first { it == targetEffective }
+        _formattingPreferencesReady.value = true
     }
 
     private suspend fun openBook() {

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/EpubReaderViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/EpubReaderViewModelTest.kt
@@ -7,11 +7,19 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.Dispatchers
@@ -234,6 +242,71 @@ class EpubReaderViewModelTest {
         }
         advanceTimeBy(24 * 3600 * 1000L)
         assertEquals(0, tickCount)
+    }
+
+    // Regression: EpubReaderViewModel.effectiveFormattingPreferences is a
+    //     combine(_formattingPreferences, scheduleTicks).distinctUntilChanged()
+    //         .stateIn(viewModelScope, SharingStarted.Eagerly, FormattingPreferences())
+    // The stateIn default (FormattingPreferences()) seeds .value at construction. When the
+    // screen subscribes immediately after _formattingPreferences is set inside the same
+    // launch (loadFormattingPreferences() → openBook() → _state.value = Ready), the
+    // combine emission may not have propagated yet — collectAsState reads the stateIn
+    // default and the EpubNavigatorFragment is constructed with empty preferences,
+    // producing an unstyled first paint that survives until the user reopens the book.
+    //
+    // This pair replays that timing with the real combine/stateIn shape: the un-gated
+    // observer sees the default; the ready-gated observer doesn't.
+    @Test
+    fun `effective prefs StateFlow can expose stateIn default after upstream is updated`() = runTest {
+        val source = MutableStateFlow("default")
+        val ticks = MutableSharedFlow<Unit>(extraBufferCapacity = 1, replay = 1)
+            .apply { tryEmit(Unit) }
+
+        val effective: StateFlow<String> = combine(source, ticks) { v, _ -> v }
+            .distinctUntilChanged()
+            .stateIn(backgroundScope, SharingStarted.Eagerly, "default")
+
+        var snapshotAtReady: String? = null
+        backgroundScope.launch {
+            source.value = "stored"           // loadFormattingPreferences() — synchronous .value write
+            snapshotAtReady = effective.value // screen reads effectiveFormattingPreferences.value
+        }
+
+        // Do NOT advance virtual time past the writer's launch: the screen reads on the same
+        // dispatcher pulse as the writer, before the stateIn collector has been scheduled.
+        runCurrent()
+
+        // The race: the derived StateFlow still reports the stateIn default.
+        assertEquals("default", snapshotAtReady)
+    }
+
+    @Test
+    fun `ready gate blocks read of derived StateFlow until upstream has propagated`() = runTest {
+        val source = MutableStateFlow("default")
+        val ticks = MutableSharedFlow<Unit>(extraBufferCapacity = 1, replay = 1)
+            .apply { tryEmit(Unit) }
+        val ready = MutableStateFlow(false)
+
+        val effective: StateFlow<String> = combine(source, ticks) { v, _ -> v }
+            .distinctUntilChanged()
+            .stateIn(backgroundScope, SharingStarted.Eagerly, "default")
+
+        var snapshotAtReady: String? = null
+        backgroundScope.launch {
+            source.value = "stored"
+            // Wait for the derived StateFlow to actually reflect the upstream before flipping
+            // ready. This is the contract loadFormattingPreferences() must uphold.
+            effective.first { it == "stored" }
+            ready.value = true
+        }
+        backgroundScope.launch {
+            // The screen reads .value only after the gate opens.
+            ready.first { it }
+            snapshotAtReady = effective.value
+        }
+
+        runCurrent()
+        assertEquals("stored", snapshotAtReady)
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes an occasional unstyled first-paint when opening a book: tiny raw text crammed at the top-left, blank below, gone on close+reopen. Happens in all three reading modes.

**Root cause:** `EpubReaderViewModel.effectiveFormattingPreferences` is a `combine(_formattingPreferences, scheduleTicks).distinctUntilChanged().stateIn(viewModelScope, Eagerly, FormattingPreferences())`. On a fast/cached open, `ReaderState.Ready` arrives before the combine's first emission has propagated, so the screen's `collectAsState` snapshot still holds the `stateIn` default when `EpubNavigatorFactory.createFragmentFactory(initialPreferences = ...)` runs — Readium constructs the WebView with empty preferences and paints the chapter unstyled.

**Fix:** Add `formattingPreferencesReady: StateFlow<Boolean>` that flips true only after `loadFormattingPreferences()` has both written `_formattingPreferences.value` AND awaited the derived `effectiveFormattingPreferences` to reflect that value. The screen keeps the loading spinner up while `!ready`, so the navigator (paged, vertical, continuous) is never constructed with the default.

Two new JVM tests document the race shape (`stateIn` default leaks through on the same dispatcher pulse) and the gate contract (gated consumer sees the propagated value).

## Test plan

- [x] `./gradlew test` — green
- [x] `./gradlew lint` — green
- [ ] Harness tests skipped per request
- [ ] Device verification — the bug is intermittent and I couldn't reproduce it here; the fix is defensive against the known race in prefs propagation