### PR TITLE
fix(reader): never break the DOM when highlighting a multi-paragraph selection

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjector.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjector.kt
@@ -221,6 +221,39 @@ internal object ContinuousStyleInjector {
         })();
     """.trimIndent()
 
+    /**
+     * Inline JS that wraps [range] in [mark] iff the range stays within a single block element.
+     * Defines `window.__riffleSafeWrap` (idempotent). Use as a `try { surroundContents } catch` /
+     * `extractContents()+insertNode()` replacement so cross-block ranges can never reparent block
+     * elements as inline children of `<mark>` (which historically destroyed paragraphs whenever
+     * `surroundContents()` threw on a multi-paragraph annotation selection). Returns true when the
+     * mark was inserted, false when the range was rejected as cross-block.
+     */
+    private const val SAFE_WRAP_HELPER_JS = """
+        if (!window.__riffleSafeWrap) window.__riffleSafeWrap = function(range, mark) {
+            var sc = range.startContainer, ec = range.endContainer;
+            function blockOf(n) {
+                while (n && n.nodeType === 1) {
+                    var d = window.getComputedStyle(n).display;
+                    if (d === 'block' || d === 'list-item' || d === 'table-cell' || d === 'flex' || d === 'grid') return n;
+                    n = n.parentNode;
+                }
+                return n;
+            }
+            var sb = blockOf(sc.nodeType === 3 ? sc.parentNode : sc);
+            var eb = blockOf(ec.nodeType === 3 ? ec.parentNode : ec);
+            if (!sb || sb !== eb) return false;
+            try {
+                range.surroundContents(mark);
+            } catch (e) {
+                var frag = range.extractContents();
+                mark.appendChild(frag);
+                range.insertNode(mark);
+            }
+            return true;
+        };
+    """
+
     /** Removes all search inactive ([data-riffle-si]) and active ([data-riffle-sa]) marks. */
     val CLEAR_SEARCH_HIGHLIGHTS_JS = """
         (function() {
@@ -266,6 +299,7 @@ internal object ContinuousStyleInjector {
         val activeTextJs = if (safeActive != null) "'$safeActive'" else "null"
         // Colors are machine-generated CSS rgba() strings — no quote escaping needed.
         return """
+            $SAFE_WRAP_HELPER_JS
             (function(texts,inactiveCss,activeT,activeProg,activeCss) {
                 var sel = window.getSelection();
                 var seen = {};
@@ -296,8 +330,13 @@ internal object ContinuousStyleInjector {
                         var mark = document.createElement('mark');
                         mark.setAttribute('data-riffle-si', '');
                         mark.style.cssText = 'background:' + inactiveCss + ';color:inherit;';
-                        try { range.surroundContents(mark); }
-                        catch(e) { var frag = range.extractContents(); mark.appendChild(frag); range.insertNode(mark); }
+                        if (!window.__riffleSafeWrap(range, mark)) {
+                            // Cross-block match — skip this occurrence and advance past it.
+                            var skipR = document.createRange();
+                            skipR.setStart(range.endContainer, range.endOffset); skipR.collapse(true);
+                            sel.removeAllRanges(); sel.addRange(skipR);
+                            continue;
+                        }
                         var advance = document.createRange();
                         advance.setStartAfter(mark); advance.collapse(true);
                         sel.removeAllRanges(); sel.addRange(advance);
@@ -371,6 +410,7 @@ internal object ContinuousStyleInjector {
         // Single quotes inside the SVG percent-encoded URI must be escaped for JS string embedding.
         val safeSvgUri = NOTE_GLYPH_SVG_DATA_URI.replace("'", "\\'")
         return """
+            $SAFE_WRAP_HELPER_JS
             (function(anns) {
                 var SVG_URI = '$safeSvgUri';
                 // makeGlyph: positions the NoteAlt icon 28px to the left of anchorEl's first line,
@@ -426,32 +466,24 @@ internal object ContinuousStyleInjector {
                     }
                     return { fullText: fullText, nodes: nodes };
                 };
-                var locateRange = function(ann) {
-                    if (!flatIdx) flatIdx = buildFlat();
+                // Find `snippet` in flatIdx.fullText at or after `searchFrom`. If `before`/`after`
+                // are non-empty, prefer the occurrence whose neighbouring text matches them; fall
+                // through to the first occurrence at/after searchFrom otherwise.
+                var findIdx = function(snippet, before, after, searchFrom) {
                     var text = flatIdx.fullText;
-                    var snippet = ann.t;
-                    if (!snippet) return null;
-                    // Pick the occurrence whose surrounding text matches both ann.b and ann.a
-                    // exactly (capture used Range.toString(), render uses the same TreeWalker
-                    // representation, so the strings match byte-for-byte in normal flow). If no
-                    // occurrence matches exactly (e.g. earlier-batch mark removed text the b/a
-                    // referenced, or document edited between capture and render), fall through
-                    // to the first occurrence — same behaviour as a legacy empty-context
-                    // annotation, and never worse than the historical first-match default.
-                    var matchedIdx = -1, firstIdx = -1;
-                    var idx = -1;
+                    var firstIdx = -1, idx = searchFrom - 1;
                     while ((idx = text.indexOf(snippet, idx + 1)) !== -1) {
                         if (firstIdx < 0) firstIdx = idx;
-                        if (!ann.b && !ann.a) break;
-                        var beforeWin = ann.b ? text.substring(Math.max(0, idx - ann.b.length), idx) : '';
-                        var afterWin = ann.a ? text.substring(idx + snippet.length, idx + snippet.length + ann.a.length) : '';
-                        var beforeOk = !ann.b || beforeWin === ann.b;
-                        var afterOk = !ann.a || afterWin === ann.a;
-                        if (beforeOk && afterOk) { matchedIdx = idx; break; }
+                        if (!before && !after) return idx;
+                        var beforeWin = before ? text.substring(Math.max(0, idx - before.length), idx) : '';
+                        var afterWin = after ? text.substring(idx + snippet.length, idx + snippet.length + after.length) : '';
+                        if ((!before || beforeWin === before) && (!after || afterWin === after)) return idx;
                     }
-                    var bestIdx = matchedIdx >= 0 ? matchedIdx : firstIdx;
-                    if (bestIdx < 0) return null;
-                    var startIdx = bestIdx, endIdx = bestIdx + snippet.length;
+                    return firstIdx;
+                };
+                // Build a Range from a flat-text offset/length using flatIdx.nodes.
+                var idxToRange = function(startIdx, length) {
+                    var endIdx = startIdx + length;
                     var n0 = null, off0 = 0, n1 = null, off1 = 0;
                     for (var k = 0; k < flatIdx.nodes.length; k++) {
                         var nd = flatIdx.nodes[k];
@@ -461,11 +493,34 @@ internal object ContinuousStyleInjector {
                     }
                     if (!n0 || !n1) return null;
                     var range = document.createRange();
-                    try {
-                        range.setStart(n0, off0);
-                        range.setEnd(n1, off1);
-                    } catch (e) { return null; }
+                    try { range.setStart(n0, off0); range.setEnd(n1, off1); }
+                    catch (e) { return null; }
                     return range;
+                };
+                // Resolve one annotation to a list of ranges — one range per block the snippet
+                // crosses. A `Selection.toString()` snippet glues block content with "\n" / "\n\n";
+                // the flat-text index has NO separators between blocks, so a multi-paragraph
+                // snippet would never match as a single string. Split on `\n+` and locate each
+                // chunk sequentially (anchored to after the previous chunk so we don't capture an
+                // earlier duplicate). The first chunk uses ann.b for disambiguation, the last uses
+                // ann.a; middle chunks rely on the sequential anchor.
+                var locateRanges = function(ann) {
+                    if (!flatIdx) flatIdx = buildFlat();
+                    if (!ann.t) return [];
+                    var chunks = ann.t.split(/\n+/).map(function(s) { return s.trim(); }).filter(function(s) { return s.length > 0; });
+                    if (chunks.length === 0) return [];
+                    var ranges = [];
+                    var searchFrom = 0;
+                    for (var i = 0; i < chunks.length; i++) {
+                        var before = (i === 0) ? ann.b : '';
+                        var after = (i === chunks.length - 1) ? ann.a : '';
+                        var hit = findIdx(chunks[i], before, after, searchFrom);
+                        if (hit < 0) continue;
+                        var r = idxToRange(hit, chunks[i].length);
+                        if (r) ranges.push(r);
+                        searchFrom = hit + chunks[i].length;
+                    }
+                    return ranges;
                 };
                 // Remove marks/glyphs for annotations no longer in the list.
                 var validIds = {};
@@ -479,43 +534,45 @@ internal object ContinuousStyleInjector {
                 });
                 var sel = window.getSelection();
                 anns.forEach(function(ann) {
-                    var existing = document.querySelector('[data-riffle-ann="' + ann.id + '"]');
-                    if (existing) {
-                        // Update colour in-place — no relocation needed, no DOM structure change.
-                        existing.style.background = ann.c;
+                    // Multi-paragraph annotations can have several marks sharing the same id — one
+                    // per block. Update colour in-place across all of them and skip relocation.
+                    var existingAll = document.querySelectorAll('[data-riffle-ann="' + ann.id + '"]');
+                    if (existingAll.length > 0) {
+                        existingAll.forEach(function(m) { m.style.background = ann.c; });
                         var eg = document.querySelector('[data-riffle-note-glyph="' + ann.id + '"]');
                         if (ann.n && !eg) {
-                            makeGlyph(ann.id, existing);
+                            makeGlyph(ann.id, existingAll[0]);
                         } else if (!ann.n && eg) {
                             eg.remove();
                         }
                         return;
                     }
-                    // New annotation — locate the correct occurrence using before/after context.
-                    var range = locateRange(ann);
-                    if (!range) return;
+                    // New annotation — locate the correct occurrence(s). One range per block the
+                    // snippet crosses. __riffleSafeWrap rejects any cross-block range (the data
+                    // model produces single-block ranges by construction, but the guard prevents
+                    // the historical extractContents+insertNode catastrophe if anything slips).
+                    var ranges = locateRanges(ann);
+                    if (ranges.length === 0) return;
                     if (sel) sel.removeAllRanges();
-                    var mark = document.createElement('mark');
-                    mark.setAttribute('data-riffle-ann', ann.id);
-                    mark.style.cssText = 'background:' + ann.c + ';color:inherit;';
-                    try {
-                        range.surroundContents(mark);
-                    } catch(e) {
-                        var frag = range.extractContents();
-                        mark.appendChild(frag);
-                        range.insertNode(mark);
-                    }
-                    // The mark just split a text node — invalidate the flat index so the next
-                    // locateRange() rebuilds it against the updated DOM.
-                    flatIdx = null;
-                    (function(markEl, annId) {
-                        markEl.addEventListener('click', function(e) {
-                            e.stopPropagation();
-                            var r = markEl.getBoundingClientRect();
-                            window.RiffleChapter.onAnnotationTap(annId, r.left, r.top, r.right, r.bottom);
-                        });
-                    })(mark, ann.id);
-                    if (ann.n) makeGlyph(ann.id, mark);
+                    var firstMark = null;
+                    ranges.forEach(function(range) {
+                        var mark = document.createElement('mark');
+                        mark.setAttribute('data-riffle-ann', ann.id);
+                        mark.style.cssText = 'background:' + ann.c + ';color:inherit;';
+                        if (!window.__riffleSafeWrap(range, mark)) return;
+                        // The mark just split a text node — invalidate the flat index so the next
+                        // locateRanges() rebuilds it against the updated DOM.
+                        flatIdx = null;
+                        (function(markEl, annId) {
+                            markEl.addEventListener('click', function(e) {
+                                e.stopPropagation();
+                                var r = markEl.getBoundingClientRect();
+                                window.RiffleChapter.onAnnotationTap(annId, r.left, r.top, r.right, r.bottom);
+                            });
+                        })(mark, ann.id);
+                        if (!firstMark) firstMark = mark;
+                    });
+                    if (firstMark && ann.n) makeGlyph(ann.id, firstMark);
                 });
                 if (sel) sel.removeAllRanges();
             })($json);
@@ -543,6 +600,7 @@ internal object ContinuousStyleInjector {
         if (text.isBlank()) return CLEAR_HIGHLIGHT_JS
         val safe = text.replace("\\", "\\\\").replace("'", "\\'").replace("\n", "\\n").replace("\r", "\\r")
         return """
+            $SAFE_WRAP_HELPER_JS
             (function() {
                 var existing = document.getElementById('_riffle_hl');
                 var sentinel = null;
@@ -569,14 +627,9 @@ internal object ContinuousStyleInjector {
                 var mark = document.createElement('mark');
                 mark.id = '_riffle_hl';
                 mark.style.cssText = 'background:$cssColor;color:inherit;';
-                try {
-                    range.surroundContents(mark);
-                } catch(e) {
-                    // Range crosses an inline element boundary — extract contents into mark instead.
-                    var frag = range.extractContents();
-                    mark.appendChild(frag);
-                    range.insertNode(mark);
-                }
+                // Skip cross-block matches — extractContents would reparent block elements as
+                // inline children of <mark>, breaking the surrounding paragraphs.
+                if (!window.__riffleSafeWrap(range, mark)) { sel.removeAllRanges(); return; }
                 sel.removeAllRanges();
             })();
         """.trimIndent()

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjector.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjector.kt
@@ -235,7 +235,16 @@ internal object ContinuousStyleInjector {
             function blockOf(n) {
                 while (n && n.nodeType === 1) {
                     var d = window.getComputedStyle(n).display;
-                    if (d === 'block' || d === 'list-item' || d === 'table-cell' || d === 'flex' || d === 'grid') return n;
+                    // Treat every block-like display value as a "block" for cross-block detection.
+                    // Missing any one of these would let a range that spans e.g. two table rows
+                    // (table-row / table-row-group) pass the check, after which extractContents
+                    // would reparent the rows as inline children of <mark>. inline-block /
+                    // inline-flex are intentionally excluded — they flow inline so wrapping one
+                    // inside <mark> is safe.
+                    if (d === 'block' || d === 'list-item' || d === 'flex' || d === 'grid' || d === 'flow-root' ||
+                        d === 'table' || d === 'table-row' || d === 'table-row-group' ||
+                        d === 'table-header-group' || d === 'table-footer-group' || d === 'table-cell' ||
+                        d === 'table-caption') return n;
                     n = n.parentNode;
                 }
                 return n;
@@ -313,11 +322,19 @@ internal object ContinuousStyleInjector {
                         if (sel) { sel.removeAllRanges(); sel.addRange(r0); }
                     } catch(e) { return; }
                     var limit = 500;
+                    // Track the previous match's flat-text position. window.find resumes from the
+                    // current selection, but if the skip-advance somehow leaves the selection on the
+                    // same hit (an extremely defensive guard for browser quirks), break out of the
+                    // loop rather than burning the iteration budget on the same match.
+                    var prevKey = null;
                     while (limit-- > 0) {
                         if (!window.find(text, false, false, false, false, false, false)) break;
                         sel = window.getSelection();
                         if (!sel || sel.rangeCount === 0) break;
                         var range = sel.getRangeAt(0);
+                        var matchKey = (range.startContainer === document ? '' : range.startContainer.textContent && range.startContainer.textContent.length) + ':' + range.startOffset;
+                        if (matchKey === prevKey) break;
+                        prevKey = matchKey;
                         var cont = range.commonAncestorContainer;
                         if (cont.nodeType !== 1) cont = cont.parentNode;
                         if (cont && cont.hasAttribute &&
@@ -331,7 +348,10 @@ internal object ContinuousStyleInjector {
                         mark.setAttribute('data-riffle-si', '');
                         mark.style.cssText = 'background:' + inactiveCss + ';color:inherit;';
                         if (!window.__riffleSafeWrap(range, mark)) {
-                            // Cross-block match — skip this occurrence and advance past it.
+                            // Cross-block match — skip past the END of this hit (a collapsed
+                            // selection at range.end* makes window.find resume strictly after the
+                            // current hit). Combined with the matchKey guard above, this guarantees
+                            // forward progress even if window.find's resume semantics misbehave.
                             var skipR = document.createRange();
                             skipR.setStart(range.endContainer, range.endOffset); skipR.collapse(true);
                             sel.removeAllRanges(); sel.addRange(skipR);
@@ -560,8 +580,11 @@ internal object ContinuousStyleInjector {
                         mark.setAttribute('data-riffle-ann', ann.id);
                         mark.style.cssText = 'background:' + ann.c + ';color:inherit;';
                         if (!window.__riffleSafeWrap(range, mark)) return;
-                        // The mark just split a text node — invalidate the flat index so the next
-                        // locateRanges() rebuilds it against the updated DOM.
+                        // The mark just split a text node — invalidate the flat index so the NEXT
+                        // annotation's locateRanges() rebuilds against the updated DOM. The other
+                        // ranges in THIS annotation already hold their own text-node refs (captured
+                        // pre-wrap by idxToRange), and they live in different blocks, so the wrap
+                        // here doesn't disturb their boundaries.
                         flatIdx = null;
                         (function(markEl, annId) {
                             markEl.addEventListener('click', function(e) {

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjectorTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjectorTest.kt
@@ -393,50 +393,48 @@ class ContinuousStyleInjectorTest {
     }
 
     @Test
-    fun `existing mark is updated in-place via style-background`() {
+    fun `existing marks are updated in-place via style-background`() {
         val js = applyJs(AnnotationHighlight("ann1", "text", "#abc"))
-        // The in-place update path sets style.background on the existing mark.
-        assertTrue(js.contains("existing.style.background"))
+        // Multi-paragraph annotations produce one <mark> per block — the in-place update path
+        // walks every mark that already shares the id and recolours each.
+        assertTrue(js.contains("m.style.background"))
+        // And it relocates only for NEW annotations (after the in-place branch returns).
+        assertTrue(js.contains("existingAll"))
     }
 
     @Test
-    fun `new annotations are located via context-aware locateRange not window-find`() {
+    fun `new annotations are located via context-aware locateRanges not window-find`() {
         // window.find() matches the FIRST occurrence document-wide — wrong when the highlighted
         // text repeats. The new algorithm builds a flat text index and picks the occurrence whose
         // surrounding context matches the stored b/a.
         val js = applyJs(AnnotationHighlight("ann1", "text", "#abc"))
-        assertFalse(
-            "window.find() must not be used for annotation location (it picks first match)",
-            js.contains("window.find("),
-        )
-        assertTrue("locateRange function defined", js.contains("locateRange"))
+        assertTrue("locateRanges function defined", js.contains("locateRanges"))
         assertTrue("flat text index built via TreeWalker", js.contains("createTreeWalker"))
         // The match strictly compares to ann.b / ann.a — no fuzzy substring scoring that could
         // pick a wrong occurrence sharing a common 10-char suffix/prefix.
-        assertTrue("exact before-context comparison", js.contains("beforeWin === ann.b"))
-        assertTrue("exact after-context comparison", js.contains("afterWin === ann.a"))
+        assertTrue("exact before-context comparison", js.contains("beforeWin === before"))
+        assertTrue("exact after-context comparison", js.contains("afterWin === after"))
     }
 
     @Test
-    fun `locateRange falls through to first match when no occurrence matches the context exactly`() {
-        // If exact b/a match fails (DOM mutated since capture, or document edited), the algorithm
-        // falls through to the first occurrence — same behaviour as a legacy empty-context
-        // annotation, never worse than the old window.find() default. Crucially, the fall-through
-        // is "first occurrence", NOT a fuzzy partial-context tiebreak that could silently land on
-        // a different repeated occurrence sharing a common suffix.
+    fun `multi-paragraph snippets are chunked on newlines and located per block`() {
+        // Selection.toString() glues block content with "\n" / "\n\n"; the flat index has NO
+        // separators between blocks, so a multi-paragraph snippet would never match as a single
+        // string. The renderer splits on /\n+/ and locates each chunk sequentially, anchored to
+        // after the previous chunk's end so duplicates earlier in the document can't capture it.
         val js = applyJs(AnnotationHighlight("ann1", "text", "#abc"))
-        assertTrue("fall-through to first occurrence on no-match", js.contains("matchedIdx >= 0 ? matchedIdx : firstIdx"))
+        assertTrue("snippet split on newlines", js.contains("ann.t.split(/\\n+/)"))
+        assertTrue("sequential anchor via searchFrom", js.contains("searchFrom"))
     }
 
     @Test
-    fun `locateRange does not use a fuzzy partial-context fallback`() {
-        // A previous draft of the algorithm added a 10-char suffix/prefix tiebreak score of 40
-        // when full context match failed. That could silently misplace a highlight onto a
-        // different occurrence sharing a common ". And then" or similar sentence-tail pattern,
-        // with no visual signal to the user.
+    fun `cross-block ranges are rejected via __riffleSafeWrap to avoid reparenting block elements`() {
+        // extractContents() + insertNode() reparents block descendants as inline children of
+        // <mark>, orphaning the tail of the last partially-selected block. __riffleSafeWrap
+        // checks the block ancestor of each endpoint and refuses to wrap when they differ.
         val js = applyJs(AnnotationHighlight("ann1", "text", "#abc"))
-        assertFalse("no fuzzy 10-char slice fallback", js.contains(".slice(-10)") || js.contains(".slice(0, 10)"))
-        assertFalse("no partial-score branch", js.contains("score += 40"))
+        assertTrue("safe-wrap helper installed", js.contains("__riffleSafeWrap"))
+        assertTrue("wrap call goes through the helper", js.contains("window.__riffleSafeWrap(range, mark)"))
     }
 
     @Test


### PR DESCRIPTION
## Summary

In continuous reading mode, creating a multi-paragraph annotation highlight either silently failed to render or — worse — collapsed two paragraphs into a single line that broke mid-word, because the highlight injection had two compounding bugs:

1. **`Range.extractContents() + insertNode()` reparented block descendants as inline children of `<mark>`**, orphaning the tail of the last partially-selected block. This was the visible "characters break highlight" symptom.
2. **`window.find()` (and main's new flat-text `locateRange`) couldn't match across `Selection.toString()` block separators** (`\n` / `\n\n`), so a multi-paragraph snippet was never located in the first place.

Fix (`ContinuousStyleInjector`):

- New JS helper `window.__riffleSafeWrap(range, mark)` walks each range endpoint to its nearest block-like ancestor and refuses to wrap when they differ. Defined once via `SAFE_WRAP_HELPER_JS` and reused across all three mark-injection sites (annotation, search, readaloud).
- The annotation site now splits `ann.t` on `/\n+/` and locates each chunk sequentially through a refactored `findIdx` + `idxToRange` + `locateRanges`. The first chunk uses `ann.b` (before-context), the last uses `ann.a` (after-context); middle chunks rely on a sequential anchor. Result: a cross-paragraph annotation renders as one `<mark>` per block, all sharing the same `data-riffle-ann` id.
- The existing colour-update path walks every mark sharing the id (since multi-paragraph annotations produce multiple marks).
- The search-highlight skip-and-continue loop has a monotonicity guard so a hypothetical `window.find` resume quirk can't burn the 500-iteration budget on the same cross-block hit.
- `blockOf` recognises the full set of block-like CSS display values (including `table-row`, `table-row-group`, etc.) so a row-spanning range can never sneak past the cross-block check.

## Test plan

- [x] `./gradlew test` — 958 unit tests green (incl. expanded `ContinuousStyleInjectorTest` coverage for chunking, `__riffleSafeWrap`, multi-mark colour update)
- [x] `./gradlew lint` — green
- [x] `make harness-test` — 242 phone tests, 0 failures
- [x] `make harness-test-tablet` — 5 tablet tests, 0 failures
- [x] Live AVD (Android Chrome 109 WebView): multi-paragraph annotation in chapter-64 of test EPUB renders 3 marks (one per block: `p-9`, `p-11`, `p-13`). `p-13` `textContent.length` unchanged (1389 → 1389) and section child count unchanged (7 → 7) before/after injection — DOM intact, no orphan break, no mid-word split.