### PR TITLE
fix(audiobook): seek bar stops jumping past the book end while scrubbing

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/audio/PlayerSurface.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audio/PlayerSurface.kt
@@ -431,6 +431,12 @@ private fun ChapterSeekBar(
     // Bookmark ticks read over both the filled and unfilled track; onSurfaceVariant contrasts with
     // the accent fill and the muted base track alike.
     val bookmarkTickColor = MaterialTheme.colorScheme.onSurfaceVariant
+    // While the user is actively dragging, render the bar from the finger position instead of the
+    // polled `positionSec`. Seeks round-trip through the MediaController binder on a ~250 ms poll, so
+    // mid-drag the polled value lags multiple seeks behind the finger and the bar visibly snaps back
+    // to stale positions. Seeks still fire on every drag delta so audio scrubs along; we just stop
+    // letting their echoes drive the visual until the user lifts.
+    var dragSec by remember { mutableStateOf<Double?>(null) }
     Box(
         modifier = modifier
             .height(24.dp)
@@ -438,8 +444,22 @@ private fun ChapterSeekBar(
                 detectTapGestures { offset -> if (durationSec > 0) onSeek(durationSec * (offset.x / size.width).coerceIn(0f, 1f)) }
             }
             .pointerInput(durationSec) {
-                detectHorizontalDragGestures { change, _ ->
-                    if (durationSec > 0) onSeek(durationSec * (change.position.x / size.width).coerceIn(0f, 1f))
+                detectHorizontalDragGestures(
+                    onDragStart = { offset ->
+                        if (durationSec > 0) {
+                            val target = durationSec * (offset.x / size.width).coerceIn(0f, 1f)
+                            dragSec = target
+                            onSeek(target)
+                        }
+                    },
+                    onDragEnd = { dragSec = null },
+                    onDragCancel = { dragSec = null },
+                ) { change, _ ->
+                    if (durationSec > 0) {
+                        val target = durationSec * (change.position.x / size.width).coerceIn(0f, 1f)
+                        dragSec = target
+                        onSeek(target)
+                    }
                 }
             },
         contentAlignment = Alignment.Center,
@@ -447,7 +467,8 @@ private fun ChapterSeekBar(
         Canvas(modifier = Modifier.fillMaxWidth().height(9.dp)) {
             val w = size.width
             val h = size.height
-            val frac = if (durationSec > 0) (positionSec / durationSec).coerceIn(0.0, 1.0).toFloat() else 0f
+            val displayedSec = dragSec ?: positionSec
+            val frac = if (durationSec > 0) (displayedSec / durationSec).coerceIn(0.0, 1.0).toFloat() else 0f
             // base track
             drawRoundRect(color = track, size = size, cornerRadius = CornerRadius(h / 2, h / 2))
             // filled portion

--- a/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookController.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookController.kt
@@ -230,9 +230,14 @@ open class AudiobookController @Inject constructor(
     fun rewind() = skipBy(-REWIND_SEC)
     fun forward() = skipBy(FORWARD_SEC)
 
+    // The service wraps ExoPlayer in [AbsolutePositionPlayer], whose `getCurrentPosition` override
+    // already projects ExoPlayer's per-track ms into book-absolute ms via [SharedAudiobookContext].
+    // That value is what the MediaController reports back here, so this side must NOT add the
+    // current track's startOffset again — doing so double-counts every time playback advances past
+    // track 0 and inflates the displayed position past durationSec (e.g. 19:56 books reading 27:50+).
     open fun currentAbsoluteSec(): Double {
         val c = controller ?: return 0.0
-        return AudiobookTracks.absoluteSec(c.currentMediaItemIndex, c.currentPosition / 1000.0, spans)
+        return c.currentPosition / 1000.0
     }
 
     fun stop() {


### PR DESCRIPTION
## Summary
- Stop double-counting the track offset in `AudiobookController.currentAbsoluteSec()`. `AbsolutePositionPlayer` already projects ExoPlayer's per-track position into book-absolute ms before it reaches the MediaController, so adding `spans[currentMediaItemIndex].startOffsetSec` was a second offset on an already-absolute value. Invisible while playback was on track 0; the moment ExoPlayer advanced into the next ABS audio file the displayed position inflated past `durationSec` (e.g. a 19:56:30 audiobook scrubbed to `27:50:02` with remaining pinned to `-0:00`, chapter label stuck on the final chapter).
- Render the audiobook seek bar from a local `dragSec` while a horizontal drag is in flight. The bar was previously redrawn purely from `state.positionSec`, sourced from a ~250 ms poll of `MediaController.currentPosition`; mid-drag that polled value lagged several seeks behind the finger and the bar bounced backward to stale positions. Seeks still fire on every drag delta so audio keeps scrubbing; `dragSec` clears on `onDragEnd`/`onDragCancel` so the polled state takes over after release.

## Test plan
- [ ] Open an audiobook split into two ABS audio files (e.g. The Fellowship of the Ring) and scrub forward past the first file boundary — total stays at the real duration, position never exceeds it, chapter label tracks correctly.
- [ ] Drag rapidly across the scrubber — the bar fill and playhead follow the finger continuously, no snap-backs to earlier positions while the finger is down.
- [ ] Release the drag — the bar settles on the released position (no visible jump from drag value to polled value).