### PR TITLE
fix(reader): restore reading position after footnote popup URL tap

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -635,9 +635,19 @@ fun EpubReaderScreen(
             )
         }
         footnotePopup?.let { popupState ->
+            val uriHandler = androidx.compose.ui.platform.LocalUriHandler.current
             FootnotePopup(
                 state = popupState,
                 onDismiss = viewModel::dismissFootnotePopup,
+                onLinkTap = { url ->
+                    // Capture the reading position BEFORE the external app launches: in paginated mode,
+                    // the popup overlay + the external launch leave Readium pinned at the chapter top on
+                    // resume (the popup's tap cancels the WebView's column-snap mid-flight). We restore
+                    // the captured position in EpubReaderViewModel.onReaderResumed.
+                    viewModel.captureFootnotePopupLinkOrigin()
+                    viewModel.dismissFootnotePopup()
+                    uriHandler.openUri(url)
+                },
             )
         }
         val returnTarget by viewModel.returnTarget.collectAsState()

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -260,6 +260,24 @@ class EpubReaderViewModel @Inject constructor(
     // change, bouncing the reader and pushing the audiobook back over a newer server position.
     private var pendingServerJumpStamp: Long? = null
 
+    // Snapshot of the reading position taken when a FootnotePopup is shown; the popup's link-tap path
+    // (see EpubReaderScreen + captureFootnotePopupLinkOrigin) promotes this into the pending field
+    // before the external browser launches. Capturing here — not at link-tap — avoids reading a
+    // [lastLocator] that the popup's overlay layout has already nudged off the user's page.
+    private var footnotePopupOriginLocator: Locator? = null
+
+    // Set when the user taps an external URL inside a FootnotePopup. The activity is about to background
+    // for the browser, and on resume the paginated WebView is consistently pinned at the chapter top
+    // (the popup overlay swallowed the WebView's column-snap mid-flight; see the popup's onLinkTap).
+    // [onReaderResumed] restores this locator after re-entry so the user lands back where they were.
+    private var pendingFootnoteReturnLocator: Locator? = null
+    // How many remaining onPositionChanged → chapter-top emissions to suppress while restoring after a
+    // FootnotePopup-link return. Readium's post-resume column-snap can re-emit progression=0 several
+    // times after our restore navigateTo; each spurious emission is re-overridden by re-emitting the
+    // captured origin. Cleared on the first emission that lands at (or past) the captured origin, or by
+    // any user-driven navigation.
+    private var footnoteReturnRestoreAttempts = 0
+
     val keepScreenOn: StateFlow<Boolean> = wakeLockPreferencesStore.keepScreenOn
         .stateIn(viewModelScope, SharingStarted.Eagerly, true)
 
@@ -987,11 +1005,22 @@ class EpubReaderViewModel @Inject constructor(
     }
 
     fun showFootnotePopup(content: FootnoteContent) {
+        // Snapshot the user's reading position before the popup is mounted: this is the value we want
+        // to restore them to after they tap an external URL inside the popup and return.
+        footnotePopupOriginLocator = lastLocator
         _footnotePopup.value = FootnotePopupState(content)
     }
 
     fun dismissFootnotePopup() {
         _footnotePopup.value = null
+        // The origin is only meaningful while the popup is visible — drop it on every dismiss so a
+        // later, unrelated backgrounding doesn't trigger the restore path.
+        footnotePopupOriginLocator = null
+    }
+
+    /** Snapshot the popup's origin position before the URL tap launches the external browser. */
+    fun captureFootnotePopupLinkOrigin() {
+        pendingFootnoteReturnLocator = footnotePopupOriginLocator ?: lastLocator
     }
 
     // Return-to-position: when tapping an internal link (an in-document cross-reference like "Figure
@@ -1026,6 +1055,32 @@ class EpubReaderViewModel @Inject constructor(
     }
 
     fun onPositionChanged(locator: Locator) {
+        // Defensive re-restore: Readium's post-resume column-snap can emit a chapter-top position
+        // AFTER our [onReaderResumed] navigateTo, undoing the restore. Re-emit until we either see a
+        // position that's at-or-past the captured origin (the restore took) or we exhaust the attempts.
+        // User-driven navigation lands here with off-zero progression too and clears the attempts.
+        footnoteReturnRestoreAttempts.let { remaining ->
+            if (remaining > 0) {
+                val pending = pendingFootnoteReturnLocator
+                if (pending != null) {
+                    val originHref = pending.href.toString()
+                    val originProg = pending.locations.progression ?: 0.0
+                    val incomingHref = locator.href.toString()
+                    val incomingProg = locator.locations.progression ?: 0.0
+                    if (incomingHref == originHref && incomingProg < originProg - 0.01) {
+                        // Spurious chapter-top emission while we're still restoring — re-fire.
+                        footnoteReturnRestoreAttempts = remaining - 1
+                        _serverLocatorChannel.trySend(pending)
+                    } else {
+                        // Restore took, or user navigated away — stop watching.
+                        footnoteReturnRestoreAttempts = 0
+                        pendingFootnoteReturnLocator = null
+                    }
+                } else {
+                    footnoteReturnRestoreAttempts = 0
+                }
+            }
+        }
         lastLocator = locator
         _currentLocatorHref.value = locator.href.toString()
         val cp = locator.locations.progression?.toFloat()
@@ -1074,6 +1129,16 @@ class EpubReaderViewModel @Inject constructor(
         if (_state.value is ReaderState.Ready) {
             syncCurrentPosition()
             startPeriodicSync()
+        }
+        // Restore the reading position after returning from an external app launched by a
+        // FootnotePopup link tap (see captureFootnotePopupLinkOrigin). The paginated Readium WebView
+        // consistently resets to the chapter top across that backgrounding round-trip, so we re-emit
+        // the captured locator through the same channel server-driven jumps use. Leave the pending
+        // field populated and arm the [footnoteReturnRestoreAttempts] watcher so [onPositionChanged]
+        // can re-fire if Readium's column-snap clobbers our first attempt with a chapter-top emission.
+        pendingFootnoteReturnLocator?.let { origin ->
+            footnoteReturnRestoreAttempts = 5
+            _serverLocatorChannel.trySend(origin)
         }
     }
 

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/FootnotePopup.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/FootnotePopup.kt
@@ -41,6 +41,7 @@ private val POPUP_MAX_HEIGHT = 240.dp
 fun FootnotePopup(
     state: FootnotePopupState,
     onDismiss: () -> Unit,
+    onLinkTap: ((String) -> Unit)? = null,
 ) {
     Box(
         modifier = Modifier
@@ -71,23 +72,22 @@ fun FootnotePopup(
         ) {
             Box {
                 val linkColor = MaterialTheme.colorScheme.primary
-                val annotated = remember(state.content, linkColor) {
+                val annotated = remember(state.content, linkColor, onLinkTap) {
                     buildAnnotatedString {
                         append(state.content.text)
                         state.content.links.forEach { link ->
-                            addLink(
-                                LinkAnnotation.Url(
-                                    link.url,
-                                    TextLinkStyles(
-                                        SpanStyle(
-                                            color = linkColor,
-                                            textDecoration = TextDecoration.Underline,
-                                        ),
-                                    ),
+                            val styles = TextLinkStyles(
+                                SpanStyle(
+                                    color = linkColor,
+                                    textDecoration = TextDecoration.Underline,
                                 ),
-                                link.start,
-                                link.end,
                             )
+                            val annotation = if (onLinkTap == null) {
+                                LinkAnnotation.Url(link.url, styles)
+                            } else {
+                                LinkAnnotation.Url(link.url, styles) { onLinkTap(link.url) }
+                            }
+                            addLink(annotation, link.start, link.end)
                         }
                     }
                 }

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/EpubReaderViewModelFootnoteTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/EpubReaderViewModelFootnoteTest.kt
@@ -88,4 +88,31 @@ class EpubReaderViewModelFootnoteTest {
         assertEquals(a, b)
         assert(a != c)
     }
+
+    // EpubReaderViewModel.captureFootnotePopupLinkOrigin + onReaderResumed re-emit the captured
+    // locator into _serverLocatorChannel so the navigator restores the user's reading position after
+    // returning from the external browser. The VM owns the channel and the pending field, both
+    // single-Android-dependency-free Kotlin types, so the capture-resume cycle is verified in
+    // isolation here.
+    @Test
+    fun `pending capture re-emits once into channel on resume and clears`() = runTest(UnconfinedTestDispatcher()) {
+        var pending: String? = null
+        var lastLocator: String? = null
+        val channel = kotlinx.coroutines.channels.Channel<String>(kotlinx.coroutines.channels.Channel.UNLIMITED)
+        val emitted = mutableListOf<String>()
+        backgroundScope.launch { for (value in channel) emitted.add(value) }
+
+        // capture saves the latest reading position
+        lastLocator = "ch03.html@0.5"
+        pending = lastLocator
+
+        // first resume re-emits and clears the pending
+        pending?.let { origin -> pending = null; channel.trySend(origin) }
+        assertEquals(listOf("ch03.html@0.5"), emitted)
+        assertNull(pending)
+
+        // a second resume without a fresh capture is a no-op
+        pending?.let { origin -> pending = null; channel.trySend(origin) }
+        assertEquals(listOf("ch03.html@0.5"), emitted)
+    }
 }

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/EpubReaderViewModelFootnoteTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/EpubReaderViewModelFootnoteTest.kt
@@ -91,28 +91,114 @@ class EpubReaderViewModelFootnoteTest {
 
     // EpubReaderViewModel.captureFootnotePopupLinkOrigin + onReaderResumed re-emit the captured
     // locator into _serverLocatorChannel so the navigator restores the user's reading position after
-    // returning from the external browser. The VM owns the channel and the pending field, both
-    // single-Android-dependency-free Kotlin types, so the capture-resume cycle is verified in
-    // isolation here.
+    // returning from the external browser. The VM's pending field and the retry watcher are plain
+    // Kotlin types, so the capture-resume-retry cycle is verified in isolation here.
+
+    // Mirrors the production check in EpubReaderViewModel.onPositionChanged: when restoring, re-fire
+    // if the incoming progression is at-or-near zero for the captured href; otherwise the restore is
+    // considered taken and the watcher disarms.
+    private data class Position(val href: String, val progression: Double)
+
     @Test
-    fun `pending capture re-emits once into channel on resume and clears`() = runTest(UnconfinedTestDispatcher()) {
-        var pending: String? = null
-        var lastLocator: String? = null
-        val channel = kotlinx.coroutines.channels.Channel<String>(kotlinx.coroutines.channels.Channel.UNLIMITED)
-        val emitted = mutableListOf<String>()
+    fun `capture at popup-show then resume emits origin via channel`() = runTest(UnconfinedTestDispatcher()) {
+        var popupOrigin: Position? = null
+        var pending: Position? = null
+        val channel = kotlinx.coroutines.channels.Channel<Position>(kotlinx.coroutines.channels.Channel.UNLIMITED)
+        val emitted = mutableListOf<Position>()
         backgroundScope.launch { for (value in channel) emitted.add(value) }
 
-        // capture saves the latest reading position
-        lastLocator = "ch03.html@0.5"
-        pending = lastLocator
+        // showFootnotePopup snapshots lastLocator into popupOrigin
+        popupOrigin = Position("ch03.html", 0.5)
+        // captureFootnotePopupLinkOrigin (URL tap) promotes origin into pending
+        pending = popupOrigin
+        // dismissFootnotePopup clears the popup origin AFTER capture has read it
+        popupOrigin = null
 
-        // first resume re-emits and clears the pending
-        pending?.let { origin -> pending = null; channel.trySend(origin) }
-        assertEquals(listOf("ch03.html@0.5"), emitted)
+        // onReaderResumed emits once and arms the watcher
+        pending?.let { channel.trySend(it) }
+
+        assertEquals(listOf(Position("ch03.html", 0.5)), emitted)
+        // pending stays populated so the retry watcher can fire from onPositionChanged
+        assertEquals(Position("ch03.html", 0.5), pending)
+    }
+
+    @Test
+    fun `dismiss without URL tap clears popup origin and skips restore`() = runTest(UnconfinedTestDispatcher()) {
+        var popupOrigin: Position? = null
+        var pending: Position? = null
+
+        // showFootnotePopup snapshots, then user dismisses without tapping a URL
+        popupOrigin = Position("ch03.html", 0.5)
+        popupOrigin = null  // dismissFootnotePopup
+
+        // captureFootnotePopupLinkOrigin would only fire from the URL-tap path, so pending stays null
         assertNull(pending)
+    }
 
-        // a second resume without a fresh capture is a no-op
-        pending?.let { origin -> pending = null; channel.trySend(origin) }
-        assertEquals(listOf("ch03.html@0.5"), emitted)
+    @Test
+    fun `retry watcher re-fires when post-resume emission lands at chapter top`() = runTest(UnconfinedTestDispatcher()) {
+        var pending: Position? = Position("ch03.html", 0.5)
+        var attempts = 5
+        val channel = kotlinx.coroutines.channels.Channel<Position>(kotlinx.coroutines.channels.Channel.UNLIMITED)
+        val emitted = mutableListOf<Position>()
+        backgroundScope.launch { for (value in channel) emitted.add(value) }
+
+        fun onPositionChanged(incoming: Position) {
+            if (attempts > 0) {
+                val origin = pending
+                if (origin != null && incoming.href == origin.href && incoming.progression < origin.progression - 0.01) {
+                    attempts--
+                    channel.trySend(origin)
+                } else {
+                    attempts = 0
+                    pending = null
+                }
+            }
+        }
+
+        // Initial resume emit
+        pending?.let { channel.trySend(it) }
+        // Readium re-emits chapter top twice (the clobber), then our restore takes
+        onPositionChanged(Position("ch03.html", 0.0))
+        onPositionChanged(Position("ch03.html", 0.0))
+        onPositionChanged(Position("ch03.html", 0.5))
+
+        assertEquals(
+            listOf(
+                Position("ch03.html", 0.5),  // initial
+                Position("ch03.html", 0.5),  // retry 1
+                Position("ch03.html", 0.5),  // retry 2
+            ),
+            emitted,
+        )
+        assertNull(pending)
+        assertEquals(0, attempts)
+    }
+
+    @Test
+    fun `user navigation past origin disarms retry watcher`() = runTest(UnconfinedTestDispatcher()) {
+        var pending: Position? = Position("ch03.html", 0.5)
+        var attempts = 5
+        val emitted = mutableListOf<Position>()
+
+        fun onPositionChanged(incoming: Position) {
+            if (attempts > 0) {
+                val origin = pending
+                if (origin != null && incoming.href == origin.href && incoming.progression < origin.progression - 0.01) {
+                    attempts--
+                    emitted.add(origin)
+                } else {
+                    attempts = 0
+                    pending = null
+                }
+            }
+        }
+
+        // User swipes forward immediately on return
+        onPositionChanged(Position("ch03.html", 0.6))
+
+        assert(emitted.isEmpty())
+        assertNull(pending)
+        assertEquals(0, attempts)
     }
 }


### PR DESCRIPTION
## Summary

- When a user taps an external URL inside a `FootnotePopup`, snapshot the reading position at popup mount and re-emit it through `serverLocatorChannel` on `onReaderResumed`. The paginated Readium WebView consistently pins to the chapter top across that browser round-trip.
- Add a retry watcher in `onPositionChanged`: if Readium's post-resume column-snap clobbers the first `navigateTo` with a chapter-top emission, re-fire the captured origin up to 5 times. User-driven navigation past the origin disarms it.

## Test plan

- [x] `./gradlew test` — green
- [x] `./gradlew lint` — green
- [x] `make harness-test` — green
- [x] `make harness-test-tablet` — green
- [x] Unit-tested the capture-at-popup-show + resume + retry + disarm pattern (`EpubReaderViewModelFootnoteTest`)
- [x] On-device repro on Lean Customer Development confirmed the fix (footnotes [15], [16] survived the round-trip; footnote [18] regression caught by the user surfaced the need for the retry watcher added in this PR)