### PR TITLE
fix(reader): keep continuous-mode text selection anchored and on-screen

### DIFF
--- a/app/src/androidTest/kotlin/com/riffle/app/feature/reader/ContinuousReaderViewSelectionInterceptTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/reader/ContinuousReaderViewSelectionInterceptTest.kt
@@ -1,0 +1,158 @@
+package com.riffle.app.feature.reader
+
+import android.os.SystemClock
+import android.view.MotionEvent
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Regression: in continuous mode, dragging a text-selection handle made the page fling away,
+ * leaving the highlight broken. Root cause was the parent [ContinuousReaderView] (a
+ * NestedScrollView) intercepting vertical touch after half a touch-slop and refusing to honour
+ * the child WebView's `requestDisallowInterceptTouchEvent(true)`. The fix suppresses both while
+ * any child has an active text-selection action mode.
+ *
+ * Reaches into the view via the package-private `onChildSelectionActiveChanged` callback because
+ * spinning up a real WebView selection inside an instrumentation test is unwieldy — the field
+ * `selectionActiveCount` is what production code flips through exactly this hook.
+ */
+@RunWith(AndroidJUnit4::class)
+class ContinuousReaderViewSelectionInterceptTest {
+
+    private val instrumentation = InstrumentationRegistry.getInstrumentation()
+    private val context = instrumentation.targetContext
+
+    private fun onMain(block: () -> Unit) = instrumentation.runOnMainSync(block)
+
+    private fun view(): ContinuousReaderView {
+        var v: ContinuousReaderView? = null
+        onMain { v = ContinuousReaderView(context) }
+        return v!!
+    }
+
+    private fun down(v: ContinuousReaderView, x: Float, y: Float) {
+        val t = SystemClock.uptimeMillis()
+        val e = MotionEvent.obtain(t, t, MotionEvent.ACTION_DOWN, x, y, 0)
+        onMain { v.onInterceptTouchEvent(e) }
+        e.recycle()
+    }
+
+    private fun move(v: ContinuousReaderView, x: Float, y: Float): Boolean {
+        val t = SystemClock.uptimeMillis()
+        val e = MotionEvent.obtain(t, t, MotionEvent.ACTION_MOVE, x, y, 0)
+        var intercepted = false
+        onMain { intercepted = v.onInterceptTouchEvent(e) }
+        e.recycle()
+        return intercepted
+    }
+
+    @Test
+    fun normalReading_interceptsAsSoonAsHalfTouchSlopIsCrossed() {
+        val v = view()
+        down(v, 100f, 100f)
+        // 50dp vertical drift is well past any touch-slop on any density.
+        assertTrue("expected intercept during normal reading", move(v, 100f, 1000f))
+    }
+
+    @Test
+    fun activeSelection_doesNotIntercept_evenAfterLongVerticalDrag() {
+        val v = view()
+        onMain { v.onSelectionActiveForTest(true) }
+        down(v, 100f, 100f)
+        // The user is dragging a selection handle 900px down the page. Pre-fix this returned true
+        // and the NestedScrollView fling-scrolled away ("page jumps around while highlighting").
+        assertFalse("must NOT intercept while a selection is active", move(v, 100f, 1000f))
+    }
+
+    @Test
+    fun selectionDeactivated_restoresEarlyIntercept() {
+        val v = view()
+        onMain {
+            v.onSelectionActiveForTest(true)
+            v.onSelectionActiveForTest(false)
+        }
+        down(v, 100f, 100f)
+        assertTrue("intercept must resume after selection ends", move(v, 100f, 1000f))
+    }
+
+    @Test
+    fun overlappingSelections_decrementOnlyClearsWhenAllEnd() {
+        val v = view()
+        onMain {
+            // Window-shift recycle race: a new WebView's create fires before the recycled one's
+            // destroy. The counter must not flip back to "intercept" until BOTH end.
+            v.onSelectionActiveForTest(true)
+            v.onSelectionActiveForTest(true)
+            v.onSelectionActiveForTest(false)
+        }
+        down(v, 100f, 100f)
+        assertFalse("still one active selection — must not intercept", move(v, 100f, 1000f))
+        onMain { v.onSelectionActiveForTest(false) }
+        down(v, 100f, 100f)
+        assertTrue("all selections ended — intercept restored", move(v, 100f, 1000f))
+    }
+
+    @Test
+    fun requestChildFocus_doesNotCrashAndCancelsScroller() {
+        // Smoke test: NestedScrollView.requestChildFocus would queue a scroll-into-view via the
+        // private mScroller. Our override calls abortFling() after super to cancel that scroll.
+        // We can't easily prove the absence of scrolling on an unattached view, but we can prove
+        // the override doesn't crash and that the view doesn't end up in an inconsistent state.
+        val v = view()
+        val child = android.view.View(context)
+        onMain {
+            // No-op when focused is null and there's no focused child — exercises the call path.
+            v.requestChildFocus(child, child)
+        }
+    }
+
+    @Test
+    fun onStartNestedScroll_isAlwaysRefused() {
+        val v = view()
+        val child = android.view.View(context)
+        // The WebView dispatches nested scroll to keep its handle visible during selection drags.
+        // We must refuse to participate, otherwise the inherited NestedScrollView consumes the
+        // dispatch and scrolls — same "page jumps" symptom as the rectangle-on-screen path.
+        var accepted = true
+        onMain { accepted = v.onStartNestedScroll(child, child, androidx.core.view.ViewCompat.SCROLL_AXIS_VERTICAL) }
+        assertFalse("nested-scroll dispatch from child must be refused", accepted)
+    }
+
+    @Test
+    fun requestChildRectangleOnScreen_isAlwaysBlocked() {
+        val v = view()
+        val child = android.view.View(context)
+        val rect = android.graphics.Rect(0, 5000, 100, 5100)
+        // The WebView fires this BEFORE its selection action mode opens — so gating on
+        // "is selecting" would let the page jump on the very first selection. Continuous mode
+        // owns scroll positioning, so child rectangle-on-screen is always refused.
+        var outsideSelection = true
+        onMain { outsideSelection = v.requestChildRectangleOnScreen(child, rect, true) }
+        assertFalse("rectangle-on-screen must be refused even before selection action mode", outsideSelection)
+        onMain { v.onSelectionActiveForTest(true) }
+        var insideSelection = true
+        onMain { insideSelection = v.requestChildRectangleOnScreen(child, rect, true) }
+        assertFalse("rectangle-on-screen must also be refused during selection", insideSelection)
+    }
+
+    @Test
+    fun requestDisallowIntercept_honouredOnlyWhileSelecting() {
+        val v = view()
+        // Sanity: outside selection, disallow=true is ignored (production behaviour).
+        onMain { v.requestDisallowInterceptTouchEvent(true) }
+        // No exception; nothing to assert beyond no-crash.
+        // While selecting, the WebView's disallow request must be honoured so its handle drag
+        // keeps ownership of the gesture.
+        onMain {
+            v.onSelectionActiveForTest(true)
+            v.requestDisallowInterceptTouchEvent(true)
+        }
+        // Same dispatch path proves the gesture isn't stolen even when child has asked to keep it.
+        down(v, 100f, 100f)
+        assertFalse(move(v, 100f, 1000f))
+    }
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ChapterWebView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ChapterWebView.kt
@@ -86,6 +86,15 @@ internal class ChapterWebView(context: Context) : WebView(context) {
     @Volatile
     private var footnoteDoc: org.jsoup.nodes.Document? = null
 
+    /**
+     * Called on the main thread when a text-selection action mode opens (true) or closes (false).
+     * The parent [ContinuousReaderView] uses this to suppress its early scroll intercept while a
+     * selection handle is being dragged — otherwise its half-touch-slop intercept (see
+     * `onInterceptTouchEvent`) steals the gesture the moment the user drags vertically, scrolling
+     * the page mid-selection and breaking the highlight.
+     */
+    var onSelectionActiveChanged: ((active: Boolean) -> Unit)? = null
+
     /** When true, the text-selection menu offers "Highlight" (books with annotations UI). */
     var annotationsAvailable: Boolean = false
 
@@ -387,9 +396,36 @@ internal class ChapterWebView(context: Context) : WebView(context) {
                 } else {
                     super.onGetContentRect(mode, view, outRect)
                 }
+                // Clamp the rect to the WebView's WINDOW-visible portion (in view-local coords).
+                // Each ChapterWebView is laid out as tall as its entire chapter and on edge-to-edge
+                // displays its bottom can extend BELOW the app window's visible area into the
+                // gesture-bar / status-bar inset strips — pixels that are visually painted but lie
+                // outside `windowVisibleDisplayFrame`. If Chromium returns a selection rect inside
+                // that strip, the framework's FloatingToolbar maps it to a screen y that's below the
+                // viewport bottom; `availableHeightBelowContent` goes negative and the toolbar ends
+                // up just off-screen below. (Using `getGlobalVisibleRect` here doesn't help because
+                // it returns the WebView's bounds intersected with parent clipping but NOT clipped
+                // to the window's visible display frame — so the selection is "globally visible"
+                // even when it's painted under the gesture bar. Use windowVisibleDisplayFrame
+                // explicitly.) Clamping keeps the rect inside the actually-visible app-window band.
+                val wvdf = android.graphics.Rect()
+                getWindowVisibleDisplayFrame(wvdf)
+                val locWin = IntArray(2)
+                getLocationInWindow(locWin)
+                val clamped = clampSelectionYBandToWindow(
+                    rectTop = outRect.top,
+                    rectBottom = outRect.bottom,
+                    viewportTop = wvdf.top,
+                    viewportBottom = wvdf.bottom,
+                    viewLocationInWindowY = locWin[1],
+                    viewHeight = height,
+                )
+                outRect.top = clamped.first
+                outRect.bottom = clamped.second
             }
 
             override fun onCreateActionMode(mode: android.view.ActionMode, menu: android.view.Menu): Boolean {
+                onSelectionActiveChanged?.invoke(true)
                 menu.clear()
                 menu.add(0, MENU_COPY, 0, android.R.string.copy)
                 if (annotationsAvailable) {
@@ -423,6 +459,7 @@ internal class ChapterWebView(context: Context) : WebView(context) {
             }
 
             override fun onDestroyActionMode(mode: android.view.ActionMode) {
+                onSelectionActiveChanged?.invoke(false)
                 inner.onDestroyActionMode(mode)
             }
         }
@@ -601,6 +638,29 @@ internal class ChapterWebView(context: Context) : WebView(context) {
             return true
         }
     }
+}
+
+/**
+ * Computes the clamped (top, bottom) for a selection content rect so that, when forwarded to the
+ * floating ActionMode framework, it sits inside the host view's WINDOW-visible portion. The four
+ * y-axis inputs are in window coordinates; output is in view-local (matches what onGetContentRect
+ * is supposed to populate). When the WebView is fully outside the window viewport (or the rect was
+ * already inside the visible band), the original top/bottom pass through unchanged. See the
+ * call-site in [ChapterWebView.wrapSelectionCallback] for why this clamping is necessary on
+ * edge-to-edge displays.
+ */
+internal fun clampSelectionYBandToWindow(
+    rectTop: Int,
+    rectBottom: Int,
+    viewportTop: Int,
+    viewportBottom: Int,
+    viewLocationInWindowY: Int,
+    viewHeight: Int,
+): Pair<Int, Int> {
+    val topLocal = (viewportTop - viewLocationInWindowY).coerceAtLeast(0)
+    val bottomLocal = (viewportBottom - viewLocationInWindowY).coerceAtMost(viewHeight)
+    if (bottomLocal <= topLocal) return rectTop to rectBottom
+    return rectTop.coerceIn(topLocal, bottomLocal) to rectBottom.coerceIn(topLocal, bottomLocal)
 }
 
 private fun mimeTypeForPath(path: String): String = when {

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
@@ -266,6 +266,7 @@ internal class ContinuousReaderView @JvmOverloads constructor(
         wv.onAnnotationNoteTap = null
         wv.onPlayFromHere = null
         wv.onFootnoteContent = null
+        wv.onSelectionActiveChanged = null
         if (recycledViews.size < WINDOW_SIZE) recycledViews.addLast(wv) else wv.destroy()
     }
 
@@ -286,13 +287,152 @@ internal class ContinuousReaderView @JvmOverloads constructor(
         recycledViews.clear()
     }
 
+    /**
+     * Number of child [ChapterWebView]s currently showing a text-selection action mode. The reader
+     * suppresses both its early intercept and its disallow-intercept override while this is > 0,
+     * so dragging a selection handle vertically extends the selection instead of being stolen as a
+     * scroll — which previously fling-scrolled the page mid-selection and broke the highlight flow.
+     * Counter (not a flag) so two simultaneous selections — possible during a window-shift recycle
+     * race where an old menu's destroy fires after a new one's create — can't underflow the state.
+     */
+    private var selectionActiveCount = 0
+
+    private fun onChildSelectionActiveChanged(active: Boolean) {
+        if (active) selectionActiveCount++
+        else if (selectionActiveCount > 0) selectionActiveCount--
+    }
+
+    /** Test seam: drives the same counter the production [ChapterWebView] callback does, without
+     *  needing to spin up a real WebView selection. */
+    @androidx.annotation.VisibleForTesting
+    internal fun onSelectionActiveForTest(active: Boolean) = onChildSelectionActiveChanged(active)
+
+    /**
+     * Decline to be a nested-scrolling parent for child [ChapterWebView]s.
+     *
+     * Chromium's [android.webkit.WebView] implements [androidx.core.view.NestedScrollingChild3] and,
+     * when it wants to scroll itself (most relevantly: to keep the active text selection or its drag
+     * handle visible during a handle drag), calls [dispatchNestedPreScroll] / [dispatchNestedScroll]
+     * on its scrolling parent. The inherited [NestedScrollView] default consumes those and scrolls
+     * its own viewport — same end result as the rectangle-on-screen path: in continuous mode the
+     * page jumps to a far-off chapter in the middle of the user's selection because the WebView's
+     * scroll request is expressed in its huge child-content coordinates. Refusing to participate in
+     * nested scrolling at the start makes `dispatchNested…` return false in the child, so the
+     * WebView falls back to its own (disabled) internal scroll and the page stays put. Our own
+     * scroll positioning (window shifts, navigate-to) doesn't go through nested scrolling — it
+     * calls [scrollTo]/[scrollBy] directly — so this override doesn't affect normal reading.
+     */
+    override fun onStartNestedScroll(child: android.view.View, target: android.view.View, axes: Int): Boolean = false
+
+    /**
+     * Type-aware nested-scroll override. NestedScrollView's basic 3-arg [onStartNestedScroll]
+     * delegates to this 4-arg version with `type = TYPE_TOUCH`; the 4-arg version is also what
+     * gets called directly for `TYPE_NON_TOUCH` dispatches (programmatic / fling). Chromium's
+     * modern WebView routes its scroll-to-center-selection through nested scrolling with the
+     * non-touch type, so blocking only the 3-arg version still lets the page jump on long-press
+     * near an edge. Refuse both.
+     */
+    override fun onStartNestedScroll(child: android.view.View, target: android.view.View, axes: Int, type: Int): Boolean = false
+
+    /**
+     * Suppress NestedScrollView's "scroll the focused child into view" inside super.requestChildFocus.
+     *
+     * The actual mechanism behind the "long-press near the top sometimes makes the page jump to
+     * reposition the word closer to the middle" bug, identified via logcat stack traces during a
+     * live AVD repro on API 33 / Chromium WebView:
+     *
+     *   WebView.requestFocus (on long-press completing a selection)
+     *     → ContinuousReaderView.requestChildFocus
+     *       → super (NestedScrollView).requestChildFocus
+     *         → NestedScrollView.scrollToChild      ← synchronous
+     *           → scrollBy(0, scrollDelta)          ← the page jump (~233px observed)
+     *
+     * `scrollToChild` doesn't go through the scroller or smoothScroll — it calls `scrollBy`
+     * synchronously, INSIDE the super call. So [abortFling] AFTER super is too late, and blocking
+     * [onStartNestedScroll] / [requestChildRectangleOnScreen] doesn't help — this path uses neither.
+     *
+     * We can't override `scrollToChild` (package-private in androidx.core). Instead we set a flag
+     * for the duration of the super.requestChildFocus call and short-circuit [scrollBy] while it's
+     * set. Continuous mode's own scrolls call [scrollBy] from elsewhere (window-shift compensation,
+     * etc.) and never recurse through requestChildFocus, so they're unaffected.
+     */
+    private var inRequestChildFocus = false
+
+
+    /**
+     * Cancel the implicit "scroll focused child into view" that [NestedScrollView] queues here.
+     *
+     * `NestedScrollView.requestChildFocus(child, focused)` calls `scrollToChild(focused)`, which
+     * computes a scroll delta to bring the focused descendant into view and starts an internal
+     * [android.widget.OverScroller] animation. Then `super.requestChildFocus` propagates focus
+     * upward. The animation plays out across the next few frames via [computeScroll].
+     *
+     * Modern Chromium WebView calls [requestFocus] on itself when a long-press completes a
+     * selection. If the selection rect is close to a viewport edge (top/bottom), the queued
+     * scroll fires and shifts the page so the just-selected word ends up near the middle —
+     * which from the user's perspective is "long-press near the top sometimes makes the page
+     * jump to reposition the word." This was the residual mode left after blocking
+     * [requestChildRectangleOnScreen] and [onStartNestedScroll], because focus-induced scroll
+     * uses the scroller directly rather than either of those APIs.
+     *
+     * Fix: let super run (preserves focus bookkeeping AND any legitimate intra-frame state),
+     * then immediately [abortFling] to clear the scroller's pending animation. The next
+     * [computeScroll] reads `mScroller.isFinished() == true` and does not move. Continuous mode's
+     * own scrolls go through [scrollTo] / [scrollBy] / [smoothScrollBy] elsewhere (window
+     * shifting, initial-scroll, navigateTo) and are NOT queued via [scrollToChild], so this
+     * doesn't affect them.
+     */
+    override fun requestChildFocus(child: android.view.View?, focused: android.view.View?) {
+        inRequestChildFocus = true
+        try {
+            super.requestChildFocus(child, focused)
+        } finally {
+            inRequestChildFocus = false
+        }
+    }
+
+    override fun scrollBy(x: Int, y: Int) {
+        // Block the synchronous scrollBy that NestedScrollView.scrollToChild calls during
+        // super.requestChildFocus — the "scroll-to-center-selection" page jump on long-press.
+        if (inRequestChildFocus) return
+        super.scrollBy(x, y)
+    }
+
+    /**
+     * Block all scroll-into-view requests bubbling up from a child [ChapterWebView].
+     *
+     * Android's [android.webkit.WebView] aggressively keeps the active text selection (and its drag
+     * handle) visible by calling [requestRectangleOnScreen] with the current selection rect. That
+     * bubbles to the scrolling parent's [requestChildRectangleOnScreen], which here is the inherited
+     * [NestedScrollView] implementation that smooth-scrolls the rect into view. In continuous mode
+     * each child WebView is sized to its whole chapter — tens of thousands of px tall — so when the
+     * user long-presses a word or drags a selection handle, the WebView passes a rect whose top is
+     * far inside the chapter and the parent fling-scrolls there. From the user's perspective the
+     * page jumps to an unrelated location at the moment they select, and any in-progress drag is
+     * lost — the original "page jumps around while highlighting" bug.
+     *
+     * The scroll request runs BEFORE the action-mode callback fires (the WebView centres the
+     * selection in view, then opens the menu), so gating the override on "is a selection mode
+     * active" is too late to be useful; the page has already jumped by the time selectionActiveCount
+     * bumps. Continuous mode owns scroll positioning entirely — every legitimate scroll comes from
+     * the reader's own navigation/restore code, never from a WebView internal — so it's correct to
+     * unconditionally decline child rectangle-on-screen requests here.
+     */
+    override fun requestChildRectangleOnScreen(
+        child: android.view.View,
+        rectangle: android.graphics.Rect,
+        immediate: Boolean,
+    ): Boolean = false
+
     // ChapterWebViews detect vertical motion and call requestDisallowInterceptTouchEvent(true),
     // which would prevent NestedScrollView from intercepting and owning the scroll — exactly the
     // same bug ScrollBoundaryNavigationContainer solves for Readium WebViews. We are the scroll
-    // owner, so we never yield the right to intercept.
+    // owner during normal reading, so we never yield the right to intercept — EXCEPT while a child
+    // WebView is in text-selection action mode, when the WebView's own selection-handle drag logic
+    // must keep ownership of vertical movement (extending the selection, not scrolling the page).
     override fun requestDisallowInterceptTouchEvent(disallowIntercept: Boolean) {
-        if (disallowIntercept) return
-        super.requestDisallowInterceptTouchEvent(false)
+        if (disallowIntercept && selectionActiveCount == 0) return
+        super.requestDisallowInterceptTouchEvent(disallowIntercept)
     }
 
     // Intercept vertical movement as soon as it exceeds a minimal threshold (half the system
@@ -300,8 +440,15 @@ internal class ContinuousReaderView @JvmOverloads constructor(
     // intercepting, which leaves the WebView handling touch for long enough that the user
     // perceives scroll resistance ("fighting"). Intercepting earlier gives us scroll ownership
     // from the very first detectable movement, matching native smooth-scroll feel.
+    //
+    // Suppressed entirely while a text-selection action mode is active: any vertical movement
+    // is the user dragging a selection handle, and intercepting it scrolls the page mid-selection
+    // (the original "page jumps around while highlighting" bug). We return false directly instead
+    // of falling through to super, because super (NestedScrollView) also intercepts vertical
+    // drags past its own touch slop — calling super would still steal the handle drag.
     private var interceptDownY = 0f
     override fun onInterceptTouchEvent(ev: MotionEvent): Boolean {
+        if (selectionActiveCount > 0) return false
         when (ev.actionMasked) {
             MotionEvent.ACTION_DOWN -> {
                 interceptDownY = ev.y
@@ -793,6 +940,7 @@ internal class ContinuousReaderView @JvmOverloads constructor(
         wv.onInternalLink = { onInternalLinkTapped?.invoke(it) }
         wv.onExternalLink = { onExternalLinkTapped?.invoke(it) }
         wv.annotationsAvailable = annotationsAvailable
+        wv.onSelectionActiveChanged = ::onChildSelectionActiveChanged
         wireAnnotationCallbacks(wv)
         wv.readaloudAvailable = readaloudAvailable
         wv.onPlayFromHere = { text, evalJs -> onPlayFromHereSelection?.invoke(wv.chapterHref, text, evalJs) }
@@ -911,6 +1059,7 @@ internal class ContinuousReaderView @JvmOverloads constructor(
         wv.onInternalLink = { onInternalLinkTapped?.invoke(it) }
         wv.onExternalLink = { onExternalLinkTapped?.invoke(it) }
         wv.annotationsAvailable = annotationsAvailable
+        wv.onSelectionActiveChanged = ::onChildSelectionActiveChanged
         wireAnnotationCallbacks(wv)
         wv.readaloudAvailable = readaloudAvailable
         wv.onPlayFromHere = { text, evalJs -> onPlayFromHereSelection?.invoke(wv.chapterHref, text, evalJs) }

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ChapterWebViewSelectionClampTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ChapterWebViewSelectionClampTest.kt
@@ -1,0 +1,125 @@
+package com.riffle.app.feature.reader
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Regression for the bug where the floating selection toolbar landed off-screen below the
+ * selection in continuous mode.
+ *
+ * Root cause (captured from a real device log on a Pixel-class edge-to-edge phone): the
+ * ChapterWebView is laid out as tall as the full chapter, and the bottom of the WebView paints
+ * INTO the gesture-bar / system-inset strip — pixels that are visually visible but lie outside the
+ * window's visible display frame. Chromium reports a selection rect whose view-local y, once
+ * translated by view.getLocationInWindow, places the rect ENTIRELY below the window viewport
+ * bottom. The framework's FloatingActionMode then sees a content rect outside its viewport, the
+ * above/below room calculation goes negative, and the toolbar slips off-screen.
+ *
+ * Real numbers from device (RIFFLE_SEL log):
+ *   rect=(52, 1874-286, 1937)  locWin=(0,455)  viewWH=1080x1941  windowVisDisplay=(0,63-1080,2274)
+ * Selection screen y = 455+1874=2329 .. 455+1937=2392 — both below viewport.bottom=2274.
+ *
+ * [clampSelectionYBandToWindow] snaps the rect's y-band into the window-visible portion so the
+ * framework's geometry comparison happens against on-window coordinates.
+ */
+class ChapterWebViewSelectionClampTest {
+
+    @Test
+    fun `selection entirely below window viewport is clamped to viewport bottom`() {
+        // Real captured numbers — selection at view-local y 1874..1937, WebView at window y 455,
+        // viewport (0,63)..(_,2274), WebView 1941 tall.
+        val (top, bottom) = clampSelectionYBandToWindow(
+            rectTop = 1874,
+            rectBottom = 1937,
+            viewportTop = 63,
+            viewportBottom = 2274,
+            viewLocationInWindowY = 455,
+            viewHeight = 1941,
+        )
+        // Visible band in view-local: max(0, 63-455)=0 .. min(1941, 2274-455)=1819.
+        // Rect top 1874 > 1819 — clamped down to 1819. Same for bottom.
+        assertEquals(1819, top)
+        assertEquals(1819, bottom)
+    }
+
+    @Test
+    fun `selection fully inside window viewport is untouched`() {
+        // Selection near the middle of the visible band.
+        val (top, bottom) = clampSelectionYBandToWindow(
+            rectTop = 600,
+            rectBottom = 660,
+            viewportTop = 63,
+            viewportBottom = 2274,
+            viewLocationInWindowY = 455,
+            viewHeight = 1941,
+        )
+        assertEquals(600, top)
+        assertEquals(660, bottom)
+    }
+
+    @Test
+    fun `selection partially above window viewport has its top pushed down to the band`() {
+        // WebView scrolled so its top is above the window: locInWindow.y is negative.
+        // Visible band in view-local: max(0, 63-(-400))=463 .. min(2000, 2274-(-400))=2000.
+        val (top, bottom) = clampSelectionYBandToWindow(
+            rectTop = 100,
+            rectBottom = 500,
+            viewportTop = 63,
+            viewportBottom = 2274,
+            viewLocationInWindowY = -400,
+            viewHeight = 2000,
+        )
+        assertEquals(463, top)
+        assertEquals(500, bottom)
+    }
+
+    @Test
+    fun `selection partially below window viewport has its bottom pulled up to the band`() {
+        // Visible band in view-local: 0 .. 1819 (same as case 1). Rect straddles the bottom edge.
+        val (top, bottom) = clampSelectionYBandToWindow(
+            rectTop = 1800,
+            rectBottom = 1900,
+            viewportTop = 63,
+            viewportBottom = 2274,
+            viewLocationInWindowY = 455,
+            viewHeight = 1941,
+        )
+        assertEquals(1800, top)
+        assertEquals(1819, bottom)
+    }
+
+    @Test
+    fun `view completely outside the viewport returns rect unchanged`() {
+        // WebView's whole on-window range is above the viewport top. Visible band would be
+        // [topLocal=0, bottomLocal=min(1000, 63-(-5000))=1000] — actually that's a no-op band.
+        // To exercise the "view outside viewport" guard, place view BELOW the viewport entirely.
+        // View at window y=3000, viewport (0,63)..(_,2274): topLocal=max(0,63-3000)=0,
+        // bottomLocal=min(1000, 2274-3000)=min(1000,-726)=-726 -> bottomLocal<=topLocal -> no-op.
+        val (top, bottom) = clampSelectionYBandToWindow(
+            rectTop = 500,
+            rectBottom = 600,
+            viewportTop = 63,
+            viewportBottom = 2274,
+            viewLocationInWindowY = 3000,
+            viewHeight = 1000,
+        )
+        assertEquals(500, top)
+        assertEquals(600, bottom)
+    }
+
+    @Test
+    fun `view shorter than the viewport caps bottomLocal at view height`() {
+        // Short WebView (e.g. a tiny chapter), entirely inside the viewport. Visible band is the
+        // whole view: [0, viewHeight]. Rect that already fits stays as-is.
+        val (top, bottom) = clampSelectionYBandToWindow(
+            rectTop = 50,
+            rectBottom = 100,
+            viewportTop = 63,
+            viewportBottom = 2274,
+            viewLocationInWindowY = 800,
+            viewHeight = 300,
+        )
+        assertEquals(50, top)
+        assertEquals(100, bottom)
+    }
+}


### PR DESCRIPTION
## Summary

Two regressions when long-pressing text in continuous reader mode:

1. **Page jumped on selection.** Chromium's `requestFocus` ran through `super.requestChildFocus`, which called `NestedScrollView.scrollToChild` synchronously and produced a `scrollBy` that shifted the chapter half a viewport to centre the selection. The selection completed against the moved page (wrong word highlighted) and the parent's half-touch-slop intercept scrolled mid-handle-drag.
2. **Selection toolbar appeared off-screen** when the selection sat near the bottom of the visible page. On edge-to-edge displays the `ChapterWebView`'s bottom paints into the gesture-bar / system-inset strip — pixels that are visible but lie outside `windowVisibleDisplayFrame`. Chromium's rect in that strip mapped to a screen y past `viewport.bottom`, so `FloatingActionMode`'s above/below room calculation went negative and the toolbar slipped off-screen. From a real-device log: `rect=(52,1874-286,1937)` `locWin=(0,455)` `windowVisDisplay=(0,63-1080,2274)` — selection mapped to y=2329..2392 with viewport.bottom=2274.

## Changes

- `ContinuousReaderView` refuses the synchronous focus-driven `scrollBy` via an `inRequestChildFocus` guard around `super.requestChildFocus`, and gates its half-touch-slop intercept + `requestChildRectangleOnScreen` on an `onSelectionActiveChanged` count from each child WebView's action-mode lifecycle (overlap-safe counter, not a boolean, so a recycled WebView's stale destroy can't disable interception on a freshly opened one).
- `ChapterWebView.wrapSelectionCallback.onGetContentRect` clamps the rect to the host view's window-visible band before returning it, snapping out-of-viewport selections to the visible edge so the framework's geometry math is done against on-window coordinates. Extracted to a pure `clampSelectionYBandToWindow` helper.
- Tests: `ChapterWebViewSelectionClampTest` (JVM) covers the clamp helper across the diagnosed scenarios + the boundary cases. `ContinuousReaderViewSelectionInterceptTest` (instrumentation) covers the early-intercept gating.

## Known follow-up

Vertical (Readium) mode shows the same toolbar-off-screen symptom, but Readium 3.x's `selectionActionModeCallback` hook delegates `onGetContentRect` to Chromium's original Callback2 and never to ours, so the same clamp can't be applied without a different seam.

## Test plan

- [x] Reproduced both bugs on a real device (logged + screenshot-confirmed)
- [x] Verified fix on continuous mode against the original reproduction
- [x] `./gradlew test` green
- [x] `./gradlew lint` green
- [ ] Harness suites skipped at user request (`/finalize implement tests, skip harness`)