### PR TITLE
fix(reader): hold reading position across background resume

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -267,17 +267,20 @@ class EpubReaderViewModel @Inject constructor(
     // [lastLocator] that the popup's overlay layout has already nudged off the user's page.
     private var footnotePopupOriginLocator: Locator? = null
 
-    // Set when the user taps an external URL inside a FootnotePopup. The activity is about to background
-    // for the browser, and on resume the paginated WebView is consistently pinned at the chapter top
-    // (the popup overlay swallowed the WebView's column-snap mid-flight; see the popup's onLinkTap).
-    // [onReaderResumed] restores this locator after re-entry so the user lands back where they were.
-    private var pendingFootnoteReturnLocator: Locator? = null
+    // The locator to restore on [onReaderResumed]. Readium's WebView (all three modes) consistently
+    // resets to the chapter top across the backgrounding round-trip (originally observed via a
+    // FootnotePopup URL tap launching an external browser, but the same applies to any
+    // home-button / app-switcher backgrounding). Armed in [onReaderClosed] from [lastLocator]; the
+    // footnote-popup URL-tap path pre-arms it earlier via [captureFootnotePopupLinkOrigin] so the
+    // pre-popup origin (not the popup-nudged lastLocator) is what restores. [onReaderResumed]
+    // re-emits this through the same channel server-driven jumps use.
+    private var pendingReturnLocator: Locator? = null
     // How many remaining onPositionChanged → chapter-top emissions to suppress while restoring after a
-    // FootnotePopup-link return. Readium's post-resume column-snap can re-emit progression=0 several
-    // times after our restore navigateTo; each spurious emission is re-overridden by re-emitting the
+    // background return. Readium's post-resume column-snap can re-emit progression=0 several times
+    // after our restore navigateTo; each spurious emission is re-overridden by re-emitting the
     // captured origin. Cleared on the first emission that lands at (or past) the captured origin, or by
     // any user-driven navigation.
-    private var footnoteReturnRestoreAttempts = 0
+    private var returnRestoreAttempts = 0
 
     val keepScreenOn: StateFlow<Boolean> = wakeLockPreferencesStore.keepScreenOn
         .stateIn(viewModelScope, SharingStarted.Eagerly, true)
@@ -1023,7 +1026,7 @@ class EpubReaderViewModel @Inject constructor(
 
     /** Snapshot the popup's origin position before the URL tap launches the external browser. */
     fun captureFootnotePopupLinkOrigin() {
-        pendingFootnoteReturnLocator = footnotePopupOriginLocator ?: lastLocator
+        pendingReturnLocator = footnotePopupOriginLocator ?: lastLocator
     }
 
     // Return-to-position: when tapping an internal link (an in-document cross-reference like "Figure
@@ -1062,9 +1065,9 @@ class EpubReaderViewModel @Inject constructor(
         // AFTER our [onReaderResumed] navigateTo, undoing the restore. Re-emit until we either see a
         // position that's at-or-past the captured origin (the restore took) or we exhaust the attempts.
         // User-driven navigation lands here with off-zero progression too and clears the attempts.
-        footnoteReturnRestoreAttempts.let { remaining ->
+        returnRestoreAttempts.let { remaining ->
             if (remaining > 0) {
-                val pending = pendingFootnoteReturnLocator
+                val pending = pendingReturnLocator
                 if (pending != null) {
                     val originHref = pending.href.toString()
                     val originProg = pending.locations.progression ?: 0.0
@@ -1072,15 +1075,15 @@ class EpubReaderViewModel @Inject constructor(
                     val incomingProg = locator.locations.progression ?: 0.0
                     if (incomingHref == originHref && incomingProg < originProg - 0.01) {
                         // Spurious chapter-top emission while we're still restoring — re-fire.
-                        footnoteReturnRestoreAttempts = remaining - 1
+                        returnRestoreAttempts = remaining - 1
                         _serverLocatorChannel.trySend(pending)
                     } else {
                         // Restore took, or user navigated away — stop watching.
-                        footnoteReturnRestoreAttempts = 0
-                        pendingFootnoteReturnLocator = null
+                        returnRestoreAttempts = 0
+                        pendingReturnLocator = null
                     }
                 } else {
-                    footnoteReturnRestoreAttempts = 0
+                    returnRestoreAttempts = 0
                 }
             }
         }
@@ -1133,14 +1136,16 @@ class EpubReaderViewModel @Inject constructor(
             syncCurrentPosition()
             startPeriodicSync()
         }
-        // Restore the reading position after returning from an external app launched by a
-        // FootnotePopup link tap (see captureFootnotePopupLinkOrigin). The paginated Readium WebView
-        // consistently resets to the chapter top across that backgrounding round-trip, so we re-emit
-        // the captured locator through the same channel server-driven jumps use. Leave the pending
-        // field populated and arm the [footnoteReturnRestoreAttempts] watcher so [onPositionChanged]
-        // can re-fire if Readium's column-snap clobbers our first attempt with a chapter-top emission.
-        pendingFootnoteReturnLocator?.let { origin ->
-            footnoteReturnRestoreAttempts = 5
+        // Restore the reading position after returning from background. Readium's WebView (all three
+        // modes) consistently resets to the chapter top across the backgrounding round-trip —
+        // originally observed via a FootnotePopup URL tap that backgrounded the activity for the
+        // external browser, but the same applies to any home-button / app-switcher backgrounding.
+        // [onReaderClosed] captures [lastLocator] into [pendingReturnLocator] on every ON_STOP so this
+        // re-emit can fire for both paths. Leave the pending field populated and arm the
+        // [returnRestoreAttempts] watcher so [onPositionChanged] can re-fire if Readium's column-snap
+        // clobbers our first attempt with a chapter-top emission.
+        pendingReturnLocator?.let { origin ->
+            returnRestoreAttempts = 5
             _serverLocatorChannel.trySend(origin)
         }
     }
@@ -1152,6 +1157,10 @@ class EpubReaderViewModel @Inject constructor(
         readerStateHolder.isAudioPlaying = false
         syncJob?.cancel()
         storytellerSyncJob?.cancel()
+        // Arm the resume-restore for the next ON_START. The footnote-popup URL-tap path may have
+        // pre-armed this with the pre-popup origin (see captureFootnotePopupLinkOrigin); don't
+        // overwrite that with the popup-nudged lastLocator. See [pendingReturnLocator].
+        if (pendingReturnLocator == null) pendingReturnLocator = lastLocator
         if (closeSyncDone) return
         closeSyncDone = true
         // Leaving the book without first pressing X: persist the sentence narrating now so re-entry

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -1062,9 +1062,12 @@ class EpubReaderViewModel @Inject constructor(
 
     fun onPositionChanged(locator: Locator) {
         // Defensive re-restore: Readium's post-resume column-snap can emit a chapter-top position
-        // AFTER our [onReaderResumed] navigateTo, undoing the restore. Re-emit until we either see a
-        // position that's at-or-past the captured origin (the restore took) or we exhaust the attempts.
-        // User-driven navigation lands here with off-zero progression too and clears the attempts.
+        // AFTER our [onReaderResumed] navigateTo, sometimes more than once — including a delayed
+        // clobber that arrives AFTER a first emission has already landed at the captured origin.
+        // Stay armed (within the attempt budget) as long as we're parked at-or-near the origin;
+        // only disarm when the user clearly navigates AWAY (different href, or progression past
+        // origin). An emission AT origin means this round took, not that future emissions can't
+        // re-clobber us, so don't clear pending on equality.
         returnRestoreAttempts.let { remaining ->
             if (remaining > 0) {
                 val pending = pendingReturnLocator
@@ -1073,14 +1076,19 @@ class EpubReaderViewModel @Inject constructor(
                     val originProg = pending.locations.progression ?: 0.0
                     val incomingHref = locator.href.toString()
                     val incomingProg = locator.locations.progression ?: 0.0
-                    if (incomingHref == originHref && incomingProg < originProg - 0.01) {
-                        // Spurious chapter-top emission while we're still restoring — re-fire.
-                        returnRestoreAttempts = remaining - 1
-                        _serverLocatorChannel.trySend(pending)
-                    } else {
-                        // Restore took, or user navigated away — stop watching.
-                        returnRestoreAttempts = 0
-                        pendingReturnLocator = null
+                    when {
+                        incomingHref == originHref && incomingProg < originProg - 0.01 -> {
+                            // Spurious chapter-top emission while we're still restoring — re-fire.
+                            returnRestoreAttempts = remaining - 1
+                            _serverLocatorChannel.trySend(pending)
+                        }
+                        incomingHref != originHref || incomingProg > originProg + 0.01 -> {
+                            // User navigated away — stop watching.
+                            returnRestoreAttempts = 0
+                            pendingReturnLocator = null
+                        }
+                        // else: incoming ≈ origin — restore took this round; stay armed in case
+                        // a delayed column-snap re-clobbers before the budget is exhausted.
                     }
                 } else {
                     returnRestoreAttempts = 0

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/EpubReaderViewModelFootnoteTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/EpubReaderViewModelFootnoteTest.kt
@@ -135,6 +135,34 @@ class EpubReaderViewModelFootnoteTest {
         assertNull(pending)
     }
 
+    private fun watcher(
+        getPending: () -> Position?,
+        setPending: (Position?) -> Unit,
+        getAttempts: () -> Int,
+        setAttempts: (Int) -> Unit,
+        channel: kotlinx.coroutines.channels.Channel<Position>,
+    ): (Position) -> Unit = { incoming ->
+        val remaining = getAttempts()
+        if (remaining > 0) {
+            val origin = getPending()
+            if (origin != null) {
+                when {
+                    incoming.href == origin.href && incoming.progression < origin.progression - 0.01 -> {
+                        setAttempts(remaining - 1)
+                        channel.trySend(origin)
+                    }
+                    incoming.href != origin.href || incoming.progression > origin.progression + 0.01 -> {
+                        setAttempts(0)
+                        setPending(null)
+                    }
+                    // incoming ≈ origin: stay armed.
+                }
+            } else {
+                setAttempts(0)
+            }
+        }
+    }
+
     @Test
     fun `retry watcher re-fires when post-resume emission lands at chapter top`() = runTest(UnconfinedTestDispatcher()) {
         var pending: Position? = Position("ch03.html", 0.5)
@@ -142,19 +170,7 @@ class EpubReaderViewModelFootnoteTest {
         val channel = kotlinx.coroutines.channels.Channel<Position>(kotlinx.coroutines.channels.Channel.UNLIMITED)
         val emitted = mutableListOf<Position>()
         backgroundScope.launch { for (value in channel) emitted.add(value) }
-
-        fun onPositionChanged(incoming: Position) {
-            if (attempts > 0) {
-                val origin = pending
-                if (origin != null && incoming.href == origin.href && incoming.progression < origin.progression - 0.01) {
-                    attempts--
-                    channel.trySend(origin)
-                } else {
-                    attempts = 0
-                    pending = null
-                }
-            }
-        }
+        val onPositionChanged = watcher({ pending }, { pending = it }, { attempts }, { attempts = it }, channel)
 
         // Initial resume emit
         pending?.let { channel.trySend(it) }
@@ -171,8 +187,37 @@ class EpubReaderViewModelFootnoteTest {
             ),
             emitted,
         )
-        assertNull(pending)
-        assertEquals(0, attempts)
+        // Equality keeps the watcher armed for a possible delayed clobber.
+        assertEquals(Position("ch03.html", 0.5), pending)
+        assertEquals(3, attempts)
+    }
+
+    // The bug from the screen recording: Readium lands at the captured origin first (the restore
+    // appears to take), then a DELAYED column-snap re-emits the chapter top. The watcher must stay
+    // armed across the equality emission so the delayed clobber is also re-restored.
+    @Test
+    fun `retry watcher re-fires after a delayed chapter-top clobber following a successful land`() = runTest(UnconfinedTestDispatcher()) {
+        var pending: Position? = Position("ch03.html", 0.9)
+        var attempts = 5
+        val channel = kotlinx.coroutines.channels.Channel<Position>(kotlinx.coroutines.channels.Channel.UNLIMITED)
+        val emitted = mutableListOf<Position>()
+        backgroundScope.launch { for (value in channel) emitted.add(value) }
+        val onPositionChanged = watcher({ pending }, { pending = it }, { attempts }, { attempts = it }, channel)
+
+        // Initial resume emit, restore lands at origin, THEN a delayed chapter-top clobber arrives.
+        pending?.let { channel.trySend(it) }
+        onPositionChanged(Position("ch03.html", 0.9))  // restore took
+        onPositionChanged(Position("ch03.html", 0.0))  // delayed clobber
+
+        assertEquals(
+            listOf(
+                Position("ch03.html", 0.9),  // initial
+                Position("ch03.html", 0.9),  // retry after delayed clobber
+            ),
+            emitted,
+        )
+        assertEquals(Position("ch03.html", 0.9), pending)
+        assertEquals(4, attempts)
     }
 
     // Mirrors the production behaviour added for plain home-button / app-switcher backgrounding:
@@ -227,25 +272,28 @@ class EpubReaderViewModelFootnoteTest {
     fun `user navigation past origin disarms retry watcher`() = runTest(UnconfinedTestDispatcher()) {
         var pending: Position? = Position("ch03.html", 0.5)
         var attempts = 5
+        val channel = kotlinx.coroutines.channels.Channel<Position>(kotlinx.coroutines.channels.Channel.UNLIMITED)
         val emitted = mutableListOf<Position>()
-
-        fun onPositionChanged(incoming: Position) {
-            if (attempts > 0) {
-                val origin = pending
-                if (origin != null && incoming.href == origin.href && incoming.progression < origin.progression - 0.01) {
-                    attempts--
-                    emitted.add(origin)
-                } else {
-                    attempts = 0
-                    pending = null
-                }
-            }
-        }
+        backgroundScope.launch { for (value in channel) emitted.add(value) }
+        val onPositionChanged = watcher({ pending }, { pending = it }, { attempts }, { attempts = it }, channel)
 
         // User swipes forward immediately on return
         onPositionChanged(Position("ch03.html", 0.6))
 
         assert(emitted.isEmpty())
+        assertNull(pending)
+        assertEquals(0, attempts)
+    }
+
+    @Test
+    fun `navigating to a different chapter disarms retry watcher`() = runTest(UnconfinedTestDispatcher()) {
+        var pending: Position? = Position("ch03.html", 0.5)
+        var attempts = 5
+        val channel = kotlinx.coroutines.channels.Channel<Position>(kotlinx.coroutines.channels.Channel.UNLIMITED)
+        val onPositionChanged = watcher({ pending }, { pending = it }, { attempts }, { attempts = it }, channel)
+
+        onPositionChanged(Position("ch04.html", 0.0))
+
         assertNull(pending)
         assertEquals(0, attempts)
     }

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/EpubReaderViewModelFootnoteTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/EpubReaderViewModelFootnoteTest.kt
@@ -175,6 +175,54 @@ class EpubReaderViewModelFootnoteTest {
         assertEquals(0, attempts)
     }
 
+    // Mirrors the production behaviour added for plain home-button / app-switcher backgrounding:
+    // onReaderClosed arms pendingReturnLocator from lastLocator (unless it was pre-armed by the
+    // footnote-popup URL-tap path), and onReaderResumed re-emits it through the server-locator
+    // channel so Readium's chapter-top reset on resume is overridden. Without onReaderClosed
+    // capturing, ordinary backgrounding leaves pending=null and the reader lands at the chapter top.
+    @Test
+    fun `ordinary background then resume re-emits last position`() = runTest(UnconfinedTestDispatcher()) {
+        var lastLocator: Position? = null
+        var pending: Position? = null
+        var attempts = 0
+        val channel = kotlinx.coroutines.channels.Channel<Position>(kotlinx.coroutines.channels.Channel.UNLIMITED)
+        val emitted = mutableListOf<Position>()
+        backgroundScope.launch { for (value in channel) emitted.add(value) }
+
+        // User reads to the middle of chapter 3
+        lastLocator = Position("ch03.html", 0.5)
+
+        // ON_STOP: app goes to background — onReaderClosed captures lastLocator into pending
+        if (pending == null) pending = lastLocator
+
+        // ON_START: app returns — onReaderResumed re-emits pending and arms the retry watcher
+        pending?.let {
+            attempts = 5
+            channel.trySend(it)
+        }
+
+        assertEquals(listOf(Position("ch03.html", 0.5)), emitted)
+        assertEquals(Position("ch03.html", 0.5), pending)
+        assertEquals(5, attempts)
+    }
+
+    // Pre-arming from the footnote-popup URL-tap path must take precedence: onReaderClosed
+    // must NOT overwrite a pendingReturnLocator that was already captured (the popup overlay had
+    // already nudged lastLocator off the user's page, so lastLocator at ON_STOP is stale).
+    @Test
+    fun `onReaderClosed does not overwrite pre-armed pendingReturnLocator`() = runTest(UnconfinedTestDispatcher()) {
+        // captureFootnotePopupLinkOrigin pre-arms with the popup-time origin (0.5)
+        var pending: Position? = Position("ch03.html", 0.5)
+        // The popup overlay then nudges lastLocator to a different progression (the popup's layout)
+        val lastLocator: Position = Position("ch03.html", 0.95)
+
+        // ON_STOP: onReaderClosed runs the new capture-only-if-null line
+        if (pending == null) pending = lastLocator
+
+        // Pre-armed origin survives — restore on resume lands the user at 0.5, not 0.95
+        assertEquals(Position("ch03.html", 0.5), pending)
+    }
+
     @Test
     fun `user navigation past origin disarms retry watcher`() = runTest(UnconfinedTestDispatcher()) {
         var pending: Position? = Position("ch03.html", 0.5)


### PR DESCRIPTION
## Summary

A first fix (d40f2df0) restored the reading position after backgrounding by re-emitting `pendingReturnLocator` on `onReaderResumed` and re-firing it for chapter-top column-snap clobbers. In practice that watcher disarmed as soon as one emission matched the captured origin — but Readium can emit *another* chapter-top *after* the first successful land, which then got saved as the new reading position. Visible symptom: the reader briefly showed the correct page on return, then jumped to the chapter top.

This change keeps the watcher armed (within the 5-attempt budget) on the equality emission. It only disarms when the user clearly navigates away — a different href or a progression past the origin. Net effect: a delayed column-snap clobber is re-restored too, instead of becoming the saved position.

## Test plan

- [x] `./gradlew test` — green
- [x] `./gradlew lint` — green
- [x] AVD repro: opened *Lean Customer Development* (the bug-report book), paged ~10 turns into Chapter 4 to "ARE INTERVIEWS NECESSARY?", pressed Home, relaunched. Position held at 2s and 6s after resume — no chapter-top jump. With the prior fix alone, the same sequence jumped to the chapter top.
- [x] New unit test covers the delayed-clobber-after-successful-land scenario; existing retry tests updated for the new "stay armed on equality" semantics.