### PR TITLE
fix(reader): persist bookmark indicator across sessions

### DIFF
--- a/app/src/androidTest/kotlin/com/riffle/app/feature/reader/BookmarkIndicatorReopenInstrumentedTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/reader/BookmarkIndicatorReopenInstrumentedTest.kt
@@ -1,0 +1,161 @@
+package com.riffle.app.feature.reader
+
+import androidx.room.Room
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.riffle.core.data.AnnotationStoreImpl
+import com.riffle.core.database.RiffleDatabase
+import com.riffle.core.database.ServerEntity
+import com.riffle.core.domain.DeviceIdStore
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Regression test for the cross-session bookmark indicator.
+ *
+ * The reader's CornerBookmarkIndicator is driven by [com.riffle.app.feature.reader.EpubReaderViewModel.isCurrentPageBookmarked],
+ * which compares the live navigator's locator href against the stored chapterHref. Readium serves
+ * the EPUB via a localhost HTTP server with a port chosen per session, so a raw `==` comparison
+ * silently misses a bookmark created in a prior session even though the chapter path is identical.
+ *
+ * The fix normalizes both sides via [normalizeEpubHref]; this test pins that behaviour using
+ * AnnotationStoreImpl against a real Room database, then replays the actual matching predicate the
+ * ViewModel uses. Works the same in paginated, vertical, and continuous modes because all three
+ * funnel through the same predicate.
+ */
+@RunWith(AndroidJUnit4::class)
+class BookmarkIndicatorReopenInstrumentedTest {
+
+    private lateinit var db: RiffleDatabase
+    private lateinit var store: AnnotationStoreImpl
+
+    private class FixedDeviceIdStore : DeviceIdStore {
+        override suspend fun getOrCreate(): String = "device-test"
+    }
+
+    @Before
+    fun setUp() {
+        db = Room.inMemoryDatabaseBuilder(
+            InstrumentationRegistry.getInstrumentation().targetContext,
+            RiffleDatabase::class.java,
+        ).allowMainThreadQueries().build()
+        store = AnnotationStoreImpl(
+            dao = db.annotationDao(),
+            deviceIdStore = FixedDeviceIdStore(),
+            clock = { 1_000L },
+            idGenerator = { "uuid-1" },
+        )
+        runBlocking {
+            db.serverDao().upsert(
+                ServerEntity("abs1", "http://abs1", isActive = true, insecureConnectionAllowed = false, username = "u"),
+            )
+        }
+    }
+
+    @After
+    fun tearDown() {
+        db.close()
+    }
+
+    @Test
+    fun bookmark_lights_up_on_reopen_when_localhost_port_differs() = runTest {
+        // Session A: bookmark stored against this session's Readium localhost URL.
+        val sessionAHref = "http://localhost:41234/OEBPS/chapter1.xhtml"
+        store.createBookmark(
+            serverId = "abs1",
+            itemId = "item-1",
+            cfi = "epubcfi(/6/2!/4/2/1:0)",
+            textSnippet = "",
+            chapterHref = sessionAHref,
+            spineIndex = 0,
+            progression = 0.30,
+            bookmarkTitle = "Test",
+        )
+
+        // Session B: same chapter, different port.
+        val reopened = store.observeBookmarks("abs1", "item-1").first()
+        assertEquals(1, reopened.size)
+        val positions = reopened.map {
+            BookmarkPosition(it.id, normalizeEpubHref(it.chapterHref), it.progression)
+        }
+
+        val sessionBHref = "http://localhost:58901/OEBPS/chapter1.xhtml"
+        assertTrue(
+            "Same-chapter bookmark must light up across sessions despite differing localhost ports",
+            indicatorFires(positions, sessionBHref, currentProgression = 0.31f),
+        )
+    }
+
+    @Test
+    fun bookmark_does_not_light_up_on_different_chapter() = runTest {
+        val sessionAHref = "http://localhost:41234/OEBPS/chapter1.xhtml"
+        store.createBookmark(
+            serverId = "abs1",
+            itemId = "item-1",
+            cfi = "epubcfi(/6/2!/4/2/1:0)",
+            textSnippet = "",
+            chapterHref = sessionAHref,
+            spineIndex = 0,
+            progression = 0.30,
+            bookmarkTitle = "Test",
+        )
+
+        val reopened = store.observeBookmarks("abs1", "item-1").first()
+        val positions = reopened.map {
+            BookmarkPosition(it.id, normalizeEpubHref(it.chapterHref), it.progression)
+        }
+
+        val differentChapterHref = "http://localhost:58901/OEBPS/chapter2.xhtml"
+        assertFalse(
+            "Indicator must not fire on a different chapter even with matching progression",
+            indicatorFires(positions, differentChapterHref, currentProgression = 0.30f),
+        )
+    }
+
+    @Test
+    fun bookmark_does_not_light_up_outside_progression_window() = runTest {
+        store.createBookmark(
+            serverId = "abs1",
+            itemId = "item-1",
+            cfi = "epubcfi(/6/2!/4/2/1:0)",
+            textSnippet = "",
+            chapterHref = "http://localhost:41234/OEBPS/chapter1.xhtml",
+            spineIndex = 0,
+            progression = 0.10,
+            bookmarkTitle = "Test",
+        )
+
+        val reopened = store.observeBookmarks("abs1", "item-1").first()
+        val positions = reopened.map {
+            BookmarkPosition(it.id, normalizeEpubHref(it.chapterHref), it.progression)
+        }
+
+        // Outside ±5% window.
+        assertFalse(
+            indicatorFires(positions, "http://localhost:58901/OEBPS/chapter1.xhtml", currentProgression = 0.30f),
+        )
+    }
+
+    private data class BookmarkPosition(val id: String, val chapterHref: String, val progression: Double)
+
+    // Mirrors EpubReaderViewModel.isCurrentPageBookmarked's predicate.
+    private fun indicatorFires(
+        positions: List<BookmarkPosition>,
+        currentHref: String,
+        currentProgression: Float?,
+    ): Boolean {
+        val hrefNorm = normalizeEpubHref(currentHref)
+        return positions.any { bm ->
+            bm.chapterHref == hrefNorm &&
+                (currentProgression == null || kotlin.math.abs(bm.progression - currentProgression) < 0.05)
+        }
+    }
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -1289,7 +1289,7 @@ class EpubReaderViewModel @Inject constructor(
             ) { annotations, st -> annotations to (st is ReaderState.Ready) }
                 .collect { (annotations, ready) ->
                     _bookmarkPositions.value =
-                        if (!ready) emptyList() else annotations.mapNotNull { annotationToBookmarkPosition(it) }
+                        if (!ready) emptyList() else annotations.map { annotationToBookmarkPosition(it) }
                 }
         }
     }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -1306,13 +1306,10 @@ class EpubReaderViewModel @Inject constructor(
         }
     }
 
-    private suspend fun annotationToBookmarkPosition(a: Annotation): BookmarkPosition? {
-        val spineIndex = epubCfiToSpineIndex(a.cfi) ?: return null
-        val html = readChapterHtml(spineIndex) ?: return null
-        val docPath = extractCfiDocPath(a.cfi) ?: return null
-        val progression = cfiDocPathToProgression(docPath, html) ?: return null
-        return BookmarkPosition(a.id, a.chapterHref, progression)
-    }
+    private fun annotationToBookmarkPosition(a: Annotation): BookmarkPosition =
+        // chapterHref is normalized so cross-session URL prefix changes (Readium's per-session
+        // localhost port; file:// vs http://localhost) don't make the indicator miss its own page.
+        BookmarkPosition(a.id, normalizeEpubHref(a.chapterHref), a.progression)
 
     // Create a yellow highlight at the current text selection. Anchors on a CFI range built from
     // the selection's start progression + selected text (ADR 0024), capturing the snippet + href.
@@ -1373,9 +1370,10 @@ class EpubReaderViewModel @Inject constructor(
         viewModelScope.launch {
             val locator = lastLocator ?: return@launch
             val href = locator.href.toString()
+            val hrefNorm = normalizeEpubHref(href)
             val prog = locator.locations.progression ?: 0.0
             val existing = _bookmarkPositions.value.firstOrNull { bm ->
-                bm.chapterHref == href && kotlin.math.abs(bm.progression - prog) < BOOKMARK_PAGE_EPS
+                bm.chapterHref == hrefNorm && kotlin.math.abs(bm.progression - prog) < BOOKMARK_PAGE_EPS
             }
             if (existing != null) {
                 annotationStore.delete(existing.id)
@@ -1556,9 +1554,12 @@ class EpubReaderViewModel @Inject constructor(
         _currentLocatorProgression,
     ) { positions, href, prog ->
         if (href == null) false
-        else positions.any { bm ->
-            bm.chapterHref == href &&
-                (prog == null || kotlin.math.abs(bm.progression - prog) < BOOKMARK_PAGE_EPS)
+        else {
+            val hrefNorm = normalizeEpubHref(href)
+            positions.any { bm ->
+                bm.chapterHref == hrefNorm &&
+                    (prog == null || kotlin.math.abs(bm.progression - prog) < BOOKMARK_PAGE_EPS)
+            }
         }
     }.stateIn(viewModelScope, SharingStarted.Eagerly, false)
 

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/EpubReaderViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/EpubReaderViewModelTest.kt
@@ -1192,8 +1192,9 @@ class BookmarkIndicatorTest {
         progression: Float?,
     ): Boolean {
         if (href == null) return false
+        val hrefNorm = normalizeEpubHref(href)
         return positions.any { bm ->
-            bm.chapterHref == href &&
+            bm.chapterHref == hrefNorm &&
                 (progression == null || kotlin.math.abs(bm.progression - progression) < 0.05)
         }
     }
@@ -1241,5 +1242,23 @@ class BookmarkIndicatorTest {
         )
         // Near 0.10, not 0.50
         assertTrue(isCurrentPageBookmarked(bms, "ch1.xhtml", 0.11f))
+    }
+
+    @Test
+    fun `matches across sessions when Readium's localhost port differs`() {
+        // Stored chapterHref came from a prior session's Readium server (port 41234).
+        // Current session serves the same chapter from a different port (port 58901).
+        // The indicator must still light up on the bookmarked page.
+        val bm = BookmarkPosition("id", "OEBPS/chapter1.xhtml", 0.30)
+        val currentSessionHref = "http://localhost:58901/OEBPS/chapter1.xhtml"
+        assertTrue(isCurrentPageBookmarked(listOf(bm), currentSessionHref, 0.31f))
+    }
+
+    @Test
+    fun `matches across sessions when stored href has file scheme and current is localhost`() {
+        // Legacy stored chapterHref from file:// path; current session serves via http://localhost.
+        val bm = BookmarkPosition("id", "OEBPS/ch1.xhtml", 0.30)
+        val currentSessionHref = "http://localhost:58901/OEBPS/ch1.xhtml"
+        assertTrue(isCurrentPageBookmarked(listOf(bm), currentSessionHref, 0.31f))
     }
 }


### PR DESCRIPTION
## Summary
- Bookmarks created in one reader session no longer show the corner ribbon on reopen, even though they remain in the annotations list. Readium serves the EPUB via a per-session random `http://localhost:PORT/...` URL, so `bm.chapterHref == href` raw equality in `isCurrentPageBookmarked` and in `toggleBookmark`'s existing-bookmark lookup silently missed cross-session matches. The whole codebase otherwise compares hrefs through `normalizeEpubHref`; these were the only two raw `==` sites.
- Normalize both sides of the comparison via `normalizeEpubHref`, and drop the lossy CFI round-trip in `annotationToBookmarkPosition` — the persisted `chapterHref` + `progression` fields are already on the annotation row, and the round-trip was a silent drop path when html parsing failed.
- Same predicate serves paginated, vertical, and continuous modes — they all read `isCurrentPageBookmarked`.

## Test plan
- [x] `BookmarkIndicatorTest` (JVM unit) — added two cross-session cases (`localhost` port differs; legacy `file://` stored vs current `http://localhost`).
- [x] `BookmarkIndicatorReopenInstrumentedTest` (new, Android instrumented against Room) — light-up across sessions, no false positive on a different chapter, EPS still enforced. 3/3 green on Harness API 25 AVD.
- [ ] Manual: open a book in each of the three reader modes, set a bookmark, close the book, reopen, verify the ribbon is filled on the same page.