### PR TITLE
fix(settings): simplify annotation-sync row label to "WebDAV"

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsScreen.kt
@@ -352,7 +352,7 @@ fun SettingsScreen(
                 val annotationSyncSummary by viewModel.annotationSyncSummary.collectAsState()
                 ListItem(
                     modifier = Modifier.clickable { onNavigateToAnnotationSync() },
-                    headlineContent = { Text("Annotation sync (WebDAV)") },
+                    headlineContent = { Text("WebDAV") },
                     supportingContent = {
                         Text(annotationSyncSummary ?: "Not configured · tap to set up a WebDAV server")
                     },


### PR DESCRIPTION
## Summary
- The Settings row under the "Annotations Sync" section header read "Annotation sync (WebDAV)", which duplicated the section label. Simplified to just "WebDAV".

## Test plan
- [ ] Open Settings → confirm the row under "Annotations Sync" now reads "WebDAV" with the same supporting summary text and tap target.