### PR TITLE
fix(reader): keep bookmark ribbon visible over Readium's WebView

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -450,13 +450,18 @@ fun EpubReaderScreen(
                     // all touches before Compose's outer-box elements ever see them.
                     // `isVisible = annotationsAvailable` omits the `state is ReaderState.Ready`
                     // guard deliberately — we're already inside that branch, so it's implicit.
+                    // `graphicsLayer { }` forces the ribbon into its own GPU layer so it composites
+                    // above Readium's hardware-accelerated WebView surface — Compose Box child
+                    // order alone doesn't beat the WebView, which paints from its own RenderNode
+                    // and otherwise hides the ribbon once the page settles.
                     CornerBookmarkIndicator(
                         isBookmarked = isCurrentPageBookmarked,
                         isVisible = annotationsAvailable,
                         onToggle = viewModel::toggleBookmark,
                         modifier = Modifier
                             .align(Alignment.TopEnd)
-                            .padding(end = 12.dp),
+                            .padding(end = 12.dp)
+                            .graphicsLayer { },
                     )
                 }
                 is ReaderState.Error -> {


### PR DESCRIPTION
## Summary
- After #263, the bookmark indicator's predicate worked correctly across sessions — accessibility on the bookmarked page reads "Remove bookmark" — but the dark-brown ribbon was invisible in steady state on real devices.
- The `CornerBookmarkIndicator` lives in the same Compose `Box` as `EpubNavigatorView` and is the last child, so plain Compose Z-ordering claims it draws on top. On hardware-accelerated devices that's not enough: the WebView wrapped by the `AndroidView` composites from its own RenderNode and paints over later siblings, hiding the ribbon once the page renders. Tested `zIndex(1f)` on the indicator first — still hidden. `Modifier.graphicsLayer { }` pushes the ribbon into its own GPU layer, which Compose then composites above the WebView surface.

## Test plan
- [x] Reproduced the user's flow on book `0807f241…` (same one cited in #263) on a Harness AVD bridged to the live ABS server. Without the fix: corner crop is all-white text from the WebView with no ribbon, even though `content-desc="Remove bookmark"` (predicate true). With the fix: filled dark-brown ribbon visible in steady state on the bookmarked page.
- [x] Verified in **paginated** mode (exit book → reopen → ribbon brown on resume page).
- [x] Verified in **continuous** mode (switch via Format → Behavior → Continuous → exit → reopen → navigate via annotations panel to bookmark → ribbon brown).
- [x] Idle state still renders (light-pink ribbon visible on a non-bookmarked page).