### PR TITLE
fix(reader): close two holes that let book-open rest off the column grid

### DIFF
--- a/app/src/androidTest/kotlin/com/riffle/app/feature/reader/SettleSnapInstallTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/reader/SettleSnapInstallTest.kt
@@ -75,6 +75,59 @@ class SettleSnapInstallTest {
         }
     }
 
+    // The install-time fallback is what catches a programmatic landing that fires no scroll event
+    // (Readium's resume go() on book open). It must (a) not disturb an aligned page or a scroll-mode
+    // page, and (b) skip itself entirely when a navigation snap has bumped __riffleSnapGen since install
+    // — the rAF tracker owns the grid math while it's active.
+
+    @Test
+    fun installTimeFallbackDoesNotDisturbAlignedPage() {
+        withSizedWebViewFixture(shortFixture, widthPx = 1080, heightPx = 1600) { webView ->
+            webView.awaitInnerHeight()
+            webView.evalSync(ColumnSnap.SETTLE_SNAP_INSTALL_JS)
+            // Wait past the ~200ms install-time fallback delay without firing any scroll event.
+            Thread.sleep(350)
+            assertEquals("aligned page must not be moved by the install-time fallback", 0, webView.scrollX())
+        }
+    }
+
+    @Test
+    fun installTimeFallbackLeavesVerticalScrollModeUntouched() {
+        withSizedWebViewFixture(tallFixture, widthPx = 1080, heightPx = 1600) { webView ->
+            webView.awaitInnerHeight()
+            webView.evalSync("window.scrollTo(0, 300)")
+            webView.evalSync(ColumnSnap.SETTLE_SNAP_INSTALL_JS)
+            Thread.sleep(350)
+            assertTrue(
+                "vertical scroll position must survive the install-time fallback",
+                Math.abs(webView.scrollY() - 300) <= 2,
+            )
+            assertEquals("scroll mode must never gain a horizontal offset", 0, webView.scrollX())
+        }
+    }
+
+    @Test
+    fun installTimeFallbackSkipsWhenSnapGenBumped() {
+        withSizedWebViewFixture(shortFixture, widthPx = 1080, heightPx = 1600) { webView ->
+            webView.awaitInnerHeight()
+            webView.evalSync(ColumnSnap.SETTLE_SNAP_INSTALL_JS)
+            // Simulate a navigation snap kicking in immediately after install: bump __riffleSnapGen,
+            // the same handshake [snapToTargetColumnJs] / [snapToEndColumnJs] use. The install-time
+            // fallback must observe the bump and skip rather than fight the in-flight tracker.
+            webView.evalSync("window.__riffleSnapGen = (window.__riffleSnapGen||0) + 1")
+            Thread.sleep(350)
+            // No assertion on scrollX (page is already aligned anyway); the contract is that the
+            // fallback didn't fire — verified by the snap-gen guard. Re-installing must still be a
+            // no-op (guarded by __riffleSettleSnapInstalled).
+            webView.evalSync(ColumnSnap.SETTLE_SNAP_INSTALL_JS)
+            assertEquals(
+                "install flag must remain set after the skipped fallback",
+                "true",
+                webView.evalSync("window.__riffleSettleSnapInstalled").trim('"'),
+            )
+        }
+    }
+
     private fun WebView.scrollX(): Int = evalSync("window.scrollX").trim('"').toDouble().toInt()
     private fun WebView.scrollY(): Int = evalSync("window.scrollY").trim('"').toDouble().toInt()
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ColumnSnap.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ColumnSnap.kt
@@ -394,6 +394,12 @@ internal object ColumnSnap {
     // settles, re-arming this debounce, so it never fires mid-track; once a tracker finishes it has left the
     // page on the grid, so the debounce then rounds a no-op. Vertical (scroll) mode is skipped. Re-setting
     // scrollLeft re-fires 'scroll', but the next settle finds the page on-grid → one harmless no-op, no loop.
+    //
+    // ALSO schedules a one-shot install-time fallback: a programmatic landing (Readium's resume `go()` on
+    // book open) doesn't fire a scroll event, so if the listener were the only line of defence the page
+    // could rest off-grid for the entire session — the "page slightly turned to next" book-open bug. The
+    // fallback fires once ~200ms after install and only if `__riffleSnapGen` is unchanged (i.e. no
+    // navigation snap took over) — so it can't clobber an in-flight [snapToTargetColumnJs] tracker.
     internal val SETTLE_SNAP_INSTALL_JS: String =
         """
         (function(){
@@ -411,6 +417,14 @@ internal object ColumnSnap {
             if(t) clearTimeout(t);
             t=setTimeout(settle, 120);
           }, true);
+          // Install-time fallback for programmatic landings that fire no scroll event (Readium's resume
+          // go() on book open). Skip if a navigation snap has run/started since install — its rAF tracker
+          // owns the grid math while it's active, and will leave the page flush on exit.
+          var installGen=(window.__riffleSnapGen||0);
+          setTimeout(function(){
+            if((window.__riffleSnapGen||0) !== installGen) return;
+            settle();
+          }, 200);
         })()
         """.trimIndent()
 

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -1480,10 +1480,19 @@ private fun EpubNavigatorView(
     // mid-reading would be jarring. The background sync carries a within-chapter progression but
     // no DOM fragment, so landAtStartWhenNoTarget=false preserves where go() landed instead of
     // snapping to the chapter top.
+    //
+    // Awaits the fragment via snapshotFlow before snapping — same race as [goAndSnapWithCover]. On a
+    // cold open the resume locator is emitted on Activity ON_START (EpubReaderViewModel.onReaderResumed),
+    // which fires BEFORE the AndroidView composition has assigned fragmentRef. A bare `?.let` here
+    // silently drops the snap, leaving the page wherever Readium's initialLocator landing rested — which
+    // can be off-grid (the "page slightly turned to next" bug on book open). The at-rest backstop
+    // [SETTLE_SNAP_INSTALL_JS] doesn't rescue it: it arms on a scroll event, and Readium's programmatic
+    // initial landing never fires one.
     val serverLocatorTarget: NavigationTarget = remember(isContinuous) {
         if (isContinuous) ContinuousNavigationTarget { continuousViewRef.value }
         else ReadiumNavigationTarget { locator ->
-            fragmentRef.value?.let { ColumnSnap.goAndSnap(it, locator, landAtStartWhenNoTarget = false) }
+            val fragment = snapshotFlow { fragmentRef.value }.filterNotNull().first()
+            ColumnSnap.goAndSnap(fragment, locator, landAtStartWhenNoTarget = false)
         }
     }
 


### PR DESCRIPTION
## Summary

Reported regression: on book open in paginated mode the page sometimes rests slightly past a column boundary (next page not visible, just a margin shift) — the "partially turned page" state the ColumnSnap consolidation (#121) was supposed to make architecturally impossible.

Two independent failures conspired on the resume path:

1. **`serverLocatorTarget` silently dropped the resume snap.** Used `fragmentRef.value?.let { ColumnSnap.goAndSnap(...) }`. On cold open, `EpubReaderViewModel.onReaderResumed` emits the resume locator on Activity `ON_START` — which fires BEFORE the AndroidView composition assigns `fragmentRef`. The `?.let` no-op'd, so Readium's `initialLocator` landing was never rounded to the grid. The sibling `goAndSnapWithCover` path already guards this race with `snapshotFlow { fragmentRef.value }.filterNotNull().first()`; this PR mirrors that.

2. **`SETTLE_SNAP_INSTALL_JS` armed only on scroll events.** Readium's programmatic initial `go()` doesn't fire one, so a page that rested off-grid stayed there for the session. Added a one-shot install-time fallback that runs ~200ms after install and rounds `scrollLeft` — guarded by `__riffleSnapGen` so it cannot fight an in-flight `snapToTargetColumnJs` tracker.

Two fixes for one bug because (1) closes the specific race and (2) closes the *class*: any future programmatic landing that fires no scroll event now also gets rescued instead of resting off-grid for the session.

## Test plan

- [x] Three new `SettleSnapInstallTest` cases: aligned-page no-disturbance, scroll-mode no-disturbance, snap-gen skip path.
- [x] `:app:compileDebugKotlin :app:compileDebugAndroidTestKotlin` clean.
- [ ] Device verification on AVD: open a book that reproduces the off-grid rest, confirm the page lands flush in paged mode. (The off-grid → on-grid rounding itself can't be exercised on the API-25 WebView's synthetic fixtures — see the existing class comment.)