### PR TITLE
fix(annotation-sync): label header timestamp as "Last synced"

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/settings/annotationsync/AnnotationSyncMaintenanceViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/annotationsync/AnnotationSyncMaintenanceViewModel.kt
@@ -277,7 +277,7 @@ class AnnotationSyncMaintenanceViewModel @Inject constructor(
         metadata?.lastSeenAt
             ?.takeIf { it.isNotBlank() }
             ?.let { humanizeLastSeen(it) }
-            ?.let { parts += "Last seen $it" }
+            ?.let { parts += "Last synced $it" }
         return MaintenanceDeviceRowUiState(
             deviceId = deviceId,
             namespace = namespace,

--- a/app/src/test/kotlin/com/riffle/app/feature/settings/annotationsync/AnnotationSyncMaintenanceViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/settings/annotationsync/AnnotationSyncMaintenanceViewModelTest.kt
@@ -56,6 +56,40 @@ class AnnotationSyncMaintenanceViewModelTest {
     @After fun tearDown() { Dispatchers.resetMain() }
 
     @Test
+    fun `device row labels the header timestamp as Last synced not Last seen`() = runTest {
+        val activeNs = "alice-userid"
+        val header = AnnotationFileHeaderCodec.buildFileBody(
+            AnnotationFileHeader(
+                deviceId = "this-device",
+                label = "Alice's Pixel",
+                lastSeenAt = "2026-06-25T12:00:00Z",
+                username = "alice",
+                bookTitle = "Project Hail Mary",
+            ),
+            annotationJsonStrings = emptyList(),
+        )
+        val target = InMemoryTarget(
+            files = mutableMapOf(
+                FileKey(activeNs, "i1", "annotations-this-device.jsonld") to header,
+            ),
+        )
+
+        val vm = vmWith(target, activeNs = activeNs)
+        advanceUntilIdle()
+
+        val rows = (vm.state.value.devices as MaintenanceScreenUiState.Loaded).devices
+        val secondary = rows.single().secondary
+        assertTrue(
+            "secondary line must use \"Last synced\" — \"Last seen\" reads as nonsense for the current device; got: $secondary",
+            secondary.contains("Last synced"),
+        )
+        assertTrue(
+            "stale \"Last seen\" label must not resurface; got: $secondary",
+            !secondary.contains("Last seen"),
+        )
+    }
+
+    @Test
     fun `foreign namespace shows up as Other Users group labelled by username from header`() = runTest {
         val activeNs = "alice-userid"
         val foreignNs = "bob-userid"

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/AnnotationFileHeader.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/AnnotationFileHeader.kt
@@ -19,7 +19,7 @@ import kotlinx.serialization.Serializable
  * @property label Human-friendly device name shown to the user. Source order: user override on
  *     this device > `Settings.Global.DEVICE_NAME` (API 25+) > `Build.MANUFACTURER + " " + Build.MODEL`
  *     (manufacturer dropped when MODEL already starts with it). Always non-blank on a real device.
- * @property lastSeenAt ISO 8601 timestamp of the publishing push. Drives the "Last seen …"
+ * @property lastSeenAt ISO 8601 timestamp of the publishing push. Drives the "Last synced …"
  *     hint in the Maintenance list so the user can pick the dead device to Forget.
  * @property username The account username that owned this push (i.e. the login used by the
  *     writing device). Read on Maintenance to label a *foreign* user's group of files — the


### PR DESCRIPTION
## Summary

The WebDAV Maintenance device list rendered the per-file header timestamp as **"Last seen …"**. That label reads as nonsense for the current device (you can't last-see yourself) — it's actually the timestamp written at push time, i.e. the last *sync*.

Renames the user-facing label to **"Last synced …"** in `AnnotationSyncMaintenanceViewModel.toUiRow`. The JSON wire key (`lastSeenAt`) stays as-is to keep header compatibility with any device still on the old build.

Also adds a unit test that pins the new label and guards against the old one resurfacing.

## Test plan

- [x] `:app:testDebugUnitTest --tests AnnotationSyncMaintenanceViewModelTest` passes locally