### PR TITLE
fix(updater): skip releases without an APK asset

### DIFF
--- a/core/network/src/main/kotlin/com/riffle/core/network/GitHubReleaseApi.kt
+++ b/core/network/src/main/kotlin/com/riffle/core/network/GitHubReleaseApi.kt
@@ -22,10 +22,14 @@ class GitHubReleaseApi(
 
     private val json = Json { ignoreUnknownKeys = true }
 
-    /** Fetches the repo's latest (non-prerelease) release and its APK asset. */
+    /**
+     * Fetches the repo's most recent non-prerelease, non-draft release whose assets include an APK.
+     * Releases that exist but haven't finished their APK build yet are skipped so an in-flight release
+     * doesn't stall the updater.
+     */
     suspend fun latestRelease(repo: String): GitHubReleaseResult = withContext(Dispatchers.IO) {
         val request = Request.Builder()
-            .url("$apiBaseUrl/repos/$repo/releases/latest")
+            .url("$apiBaseUrl/repos/$repo/releases?per_page=10")
             .header("Accept", "application/vnd.github+json")
             .get()
             .build()
@@ -36,16 +40,21 @@ class GitHubReleaseApi(
                 }
                 val raw = response.body?.string()
                     ?: return@use GitHubReleaseResult.Failed("Empty response")
-                val parsed = json.decodeFromString<ReleaseResponse>(raw)
-                val apk = parsed.assets.firstOrNull { it.name.endsWith(".apk", ignoreCase = true) }
-                    ?: return@use GitHubReleaseResult.Failed("Release has no APK asset")
-                GitHubReleaseResult.Success(
-                    GitHubRelease(
-                        tagName = parsed.tagName,
-                        apkUrl = apk.downloadUrl,
-                        apkSizeBytes = apk.size,
+                val parsed = json.decodeFromString<List<ReleaseResponse>>(raw)
+                for (release in parsed) {
+                    if (release.draft || release.prerelease) continue
+                    val apk = release.assets.firstOrNull {
+                        it.name.endsWith(".apk", ignoreCase = true)
+                    } ?: continue
+                    return@use GitHubReleaseResult.Success(
+                        GitHubRelease(
+                            tagName = release.tagName,
+                            apkUrl = apk.downloadUrl,
+                            apkSizeBytes = apk.size,
+                        )
                     )
-                )
+                }
+                GitHubReleaseResult.Failed("No release with an APK asset")
             }
         } catch (e: IOException) {
             GitHubReleaseResult.Failed(e.message ?: "Network error")
@@ -110,6 +119,8 @@ data class GitHubRelease(
 @Serializable
 private data class ReleaseResponse(
     @SerialName("tag_name") val tagName: String,
+    val draft: Boolean = false,
+    val prerelease: Boolean = false,
     val assets: List<AssetResponse> = emptyList(),
 )
 

--- a/core/network/src/test/kotlin/com/riffle/core/network/GitHubReleaseApiTest.kt
+++ b/core/network/src/test/kotlin/com/riffle/core/network/GitHubReleaseApiTest.kt
@@ -35,13 +35,17 @@ class GitHubReleaseApiTest {
         server.enqueue(
             MockResponse().setBody(
                 """
-                {
-                  "tag_name": "v1.5.0",
-                  "assets": [
-                    { "name": "mapping.txt", "browser_download_url": "https://x/mapping.txt", "size": 10 },
-                    { "name": "riffle-1.5.0.apk", "browser_download_url": "https://x/riffle.apk", "size": 4200 }
-                  ]
-                }
+                [
+                  {
+                    "tag_name": "v1.5.0",
+                    "draft": false,
+                    "prerelease": false,
+                    "assets": [
+                      { "name": "mapping.txt", "browser_download_url": "https://x/mapping.txt", "size": 10 },
+                      { "name": "riffle-1.5.0.apk", "browser_download_url": "https://x/riffle.apk", "size": 4200 }
+                    ]
+                  }
+                ]
                 """.trimIndent()
             )
         )
@@ -56,10 +60,93 @@ class GitHubReleaseApiTest {
     }
 
     @Test
-    fun `latestRelease fails when no apk asset is present`() = runTest {
+    fun `latestRelease skips a still-building release and falls back to the prior apk release`() = runTest {
         server.enqueue(
             MockResponse().setBody(
-                """{ "tag_name": "v1.5.0", "assets": [ { "name": "notes.txt", "browser_download_url": "https://x/n", "size": 1 } ] }"""
+                """
+                [
+                  {
+                    "tag_name": "v1.6.0",
+                    "draft": false,
+                    "prerelease": false,
+                    "assets": []
+                  },
+                  {
+                    "tag_name": "v1.5.0",
+                    "draft": false,
+                    "prerelease": false,
+                    "assets": [
+                      { "name": "riffle-1.5.0.apk", "browser_download_url": "https://x/riffle.apk", "size": 4200 }
+                    ]
+                  }
+                ]
+                """.trimIndent()
+            )
+        )
+
+        val result = api.latestRelease("pkmetski/riffle")
+
+        assertTrue(result is GitHubReleaseResult.Success)
+        assertEquals("v1.5.0", (result as GitHubReleaseResult.Success).release.tagName)
+    }
+
+    @Test
+    fun `latestRelease ignores drafts and prereleases`() = runTest {
+        server.enqueue(
+            MockResponse().setBody(
+                """
+                [
+                  {
+                    "tag_name": "v2.0.0-rc1",
+                    "draft": false,
+                    "prerelease": true,
+                    "assets": [
+                      { "name": "riffle-2.0.0-rc1.apk", "browser_download_url": "https://x/rc.apk", "size": 1 }
+                    ]
+                  },
+                  {
+                    "tag_name": "v1.9.0-draft",
+                    "draft": true,
+                    "prerelease": false,
+                    "assets": [
+                      { "name": "riffle-1.9.0.apk", "browser_download_url": "https://x/draft.apk", "size": 1 }
+                    ]
+                  },
+                  {
+                    "tag_name": "v1.5.0",
+                    "draft": false,
+                    "prerelease": false,
+                    "assets": [
+                      { "name": "riffle-1.5.0.apk", "browser_download_url": "https://x/riffle.apk", "size": 4200 }
+                    ]
+                  }
+                ]
+                """.trimIndent()
+            )
+        )
+
+        val result = api.latestRelease("pkmetski/riffle")
+
+        assertTrue(result is GitHubReleaseResult.Success)
+        assertEquals("v1.5.0", (result as GitHubReleaseResult.Success).release.tagName)
+    }
+
+    @Test
+    fun `latestRelease fails when no release has an apk asset`() = runTest {
+        server.enqueue(
+            MockResponse().setBody(
+                """
+                [
+                  {
+                    "tag_name": "v1.5.0",
+                    "draft": false,
+                    "prerelease": false,
+                    "assets": [
+                      { "name": "notes.txt", "browser_download_url": "https://x/n", "size": 1 }
+                    ]
+                  }
+                ]
+                """.trimIndent()
             )
         )
 


### PR DESCRIPTION
## Summary

The updater surfaced "release has no APK asset" whenever the most recent stable release on GitHub hadn't finished its APK build yet (the release tag exists; the workflow that builds and attaches the APK is still running).

Now `GitHubReleaseApi.latestRelease` fetches `/releases?per_page=10` and walks the list, skipping drafts/prereleases (defensive) and any release whose assets don't yet include an APK, returning the most recent stable release that has one. The "no APK asset" failure now only fires when none of the recent stable releases has an APK.

## Test plan

- [x] `:core:network:test` — green, including new coverage for: still-building release with no APK falls back to the prior release; drafts/prereleases are ignored; failure only when no stable release has an APK.