### PR TITLE
fix(reader): drive continuous-mode totalProgression from spine positions

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousModeUtils.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousModeUtils.kt
@@ -4,25 +4,37 @@ import org.json.JSONObject
 import org.readium.r2.shared.publication.Locator
 
 /**
- * Computes a book-wide [0, 1] progression for continuous scroll mode using the same
- * per-chapter weights the chapter rail draws from (derived from Readium position counts).
+ * Computes a book-wide [0, 1] progression for continuous scroll mode from the spine's per-resource
+ * position counts (the same data Readium uses to derive `totalProgression` in paginated/vertical
+ * modes), given the current spine resource [href] and within-resource [progression] (0..1 across
+ * the loaded resource's pixel height).
  *
- * Returns null when [segments] is empty, total weight is zero, or [href] has no matching
- * segment.
+ * Why spine-based, not rail-segment-based: a single rail segment can map to several spine
+ * resources when a TOC entry is the sole entry for its file and the next TOC entry lives in a
+ * later file (e.g. "Chapter 20" → SOL 376, SOL 380, SOL 384 in The Martian). The continuous
+ * reader reports `progression` per-RESOURCE, but a segment-based formula would multiply it by the
+ * segment's full weight — making the cursor and time estimates advance ~N× too fast inside the
+ * first resource of an N-resource segment, then jamming for the remaining resources (whose href
+ * doesn't match any segment at all and returns null). Spine positions are the right grain.
+ *
+ * Returns null when [spineHrefs] / [positionCounts] are empty/zero or [href] is not in the spine.
  */
 fun computeTotalProgression(
     href: String,
     progression: Float,
-    segments: List<RailSegment>,
+    spineHrefs: List<String>,
+    positionCounts: List<Int>,
 ): Float? {
     val hrefBase = href.substringBefore('#')
-    val idx = segments.indexOfFirst { it.href.substringBefore('#') == hrefBase }
+    val idx = spineHrefs.indexOfFirst { it.substringBefore('#') == hrefBase }
     if (idx < 0) return null
-    val totalWeight = segments.sumOf { it.weight.toDouble() }.toFloat()
-    if (totalWeight == 0f) return null
-    val cumulativeWeight = segments.take(idx).sumOf { it.weight.toDouble() }.toFloat()
-    val chapterWeight = segments[idx].weight
-    return (cumulativeWeight + chapterWeight * progression) / totalWeight
+    val total = positionCounts.sumOf { it.toLong() }
+    if (total <= 0L) return null
+    var before = 0L
+    for (i in 0 until idx) before += positionCounts.getOrElse(i) { 0 }.toLong()
+    val resourcePositions = positionCounts.getOrElse(idx) { 0 }.toFloat()
+    val clamped = progression.coerceIn(0f, 1f)
+    return ((before + resourcePositions * clamped) / total.toFloat()).coerceIn(0f, 1f)
 }
 
 /**
@@ -30,10 +42,10 @@ fun computeTotalProgression(
  *
  * Paginated and vertical modes receive a fully-populated [Locator] (including
  * [Locator.Locations.totalProgression]) from Readium automatically. Continuous mode only knows
- * the spine [href] and within-chapter [progression], so this function derives
- * `totalProgression` from the rail segment weights and embeds it in the JSON — giving the
- * ViewModel the same input for the chapter-map rail cursor and reading-time estimates as the
- * other two modes.
+ * the spine [href] and within-resource [progression], so this function derives `totalProgression`
+ * from the spine's per-resource position counts and embeds it in the JSON — giving the ViewModel
+ * the same input for the chapter-map rail cursor and reading-time estimates as the other two
+ * modes.
  *
  * Separated from [buildContinuousLocator] so the JSON output is testable without
  * [android.net.Uri] (which [Locator.fromJSON] needs and JVM tests cannot provide).
@@ -41,9 +53,10 @@ fun computeTotalProgression(
 fun buildContinuousLocatorJson(
     href: String,
     progression: Float,
-    segments: List<RailSegment>,
+    spineHrefs: List<String>,
+    positionCounts: List<Int>,
 ): JSONObject {
-    val totalProg = computeTotalProgression(href, progression, segments)
+    val totalProg = computeTotalProgression(href, progression, spineHrefs, positionCounts)
     val locations = JSONObject().put("progression", progression.toDouble())
     if (totalProg != null) locations.put("totalProgression", totalProg.toDouble())
     return JSONObject()
@@ -59,5 +72,6 @@ fun buildContinuousLocatorJson(
 fun buildContinuousLocator(
     href: String,
     progression: Float,
-    segments: List<RailSegment>,
-): Locator? = Locator.fromJSON(buildContinuousLocatorJson(href, progression, segments))
+    spineHrefs: List<String>,
+    positionCounts: List<Int>,
+): Locator? = Locator.fromJSON(buildContinuousLocatorJson(href, progression, spineHrefs, positionCounts))

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderCoordinator.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderCoordinator.kt
@@ -27,7 +27,7 @@ import org.readium.r2.shared.publication.Publication
  */
 internal class ContinuousReaderCoordinator(
     private val publication: Publication,
-    private val railSegmentsProvider: () -> List<RailSegment>,
+    private val spinePositionsProvider: () -> Pair<List<String>, List<Int>>,
     private val onLocator: (Locator) -> Unit,
     private val onTap: () -> Unit,
     private val latestLocator: () -> Locator?,
@@ -61,7 +61,8 @@ internal class ContinuousReaderCoordinator(
         viewFlow.value = view
 
         view.onRawPosition = { href, progression ->
-            val locator = buildContinuousLocator(href, progression, railSegmentsProvider())
+            val (spineHrefs, counts) = spinePositionsProvider()
+            val locator = buildContinuousLocator(href, progression, spineHrefs, counts)
             if (locator != null) onLocator(locator)
         }
 

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -356,10 +356,12 @@ fun EpubReaderScreen(
                         if (tocVisible || showFormattingPanel) viewModel.closeSearch()
                         viewModel.onPanelStateChanged(tocVisible || showFormattingPanel)
                     }
+                    val spinePositions by viewModel.spinePositionCounts.collectAsState()
                     EpubNavigatorView(
                         state = s,
                         formattingPrefs = formattingPrefs,
                         railSegments = railSegments,
+                        spinePositions = spinePositions,
                         // Use formattingPreferences (= _formattingPreferences, set synchronously by
                         // loadFormattingPreferences()) rather than effectiveFormattingPreferences.
                         // effectiveFormattingPreferences propagates through a combine→stateIn chain
@@ -1013,6 +1015,7 @@ private fun EpubNavigatorView(
     state: ReaderState.Ready,
     formattingPrefs: FormattingPreferences,
     railSegments: List<RailSegment>,
+    spinePositions: Pair<List<String>, List<Int>>,
     formattingPrefsProvider: () -> FormattingPreferences,
     onPositionChanged: (Locator) -> Unit,
     onNavigationEvents: Flow<Link>,
@@ -1114,17 +1117,17 @@ private fun EpubNavigatorView(
     // freshly loaded page re-applies the current value.
     val currentReadaloudReservePx by rememberUpdatedState(readaloudReservePx)
     val currentPublication by rememberUpdatedState(state.publication)
-    // rememberUpdatedState: railSegments arrives asynchronously (Readium computes positions after
-    // publication load). The AndroidView factory captures this reference so the continuous
-    // onPositionChanged lambda always reads the latest list.
-    val currentRailSegments by rememberUpdatedState(railSegments)
+    // rememberUpdatedState: spinePositions arrives asynchronously (Readium computes positions
+    // after publication load). The AndroidView factory captures this reference so the continuous
+    // onPositionChanged lambda always reads the latest pair when building the locator.
+    val currentSpinePositions by rememberUpdatedState(spinePositions)
 
     // Coordinator created once; lambdas close over rememberUpdatedState delegates so each
     // invocation always reads the latest value, not the value at remember time.
     val coordinator = remember(state.publication) {
         ContinuousReaderCoordinator(
             publication = state.publication,
-            railSegmentsProvider = { currentRailSegments },
+            spinePositionsProvider = { currentSpinePositions },
             onLocator = onPositionChanged,
             onTap = { currentOnTap() },
             latestLocator = { currentLatestLocator() },

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -1125,11 +1125,13 @@ class EpubReaderViewModel @Inject constructor(
         val cp = locator.locations.progression?.toFloat()
         _currentLocatorProgression.value = cp
         // Prefer totalProgression from the locator (Readium sets it in paginated/vertical modes).
-        // In continuous mode the locator is built by buildContinuousLocator which computes it from
-        // railSegments; if segments are empty at scroll time the field is absent. Fall back to an
-        // inline computation so the value is always populated when segments are already available.
+        // In continuous mode the locator is built by buildContinuousLocator which derives it from
+        // the spine's per-resource position counts; if counts are empty at scroll time the field
+        // is absent. Fall back to an inline computation so the value is always populated when
+        // position counts are already available.
+        val (spineHrefs, counts) = spinePositionCounts.value
         val tp = locator.locations.totalProgression?.toFloat()
-            ?: cp?.let { computeTotalProgression(locator.href.toString(), it, railSegments.value) }
+            ?: cp?.let { computeTotalProgression(locator.href.toString(), it, spineHrefs, counts) }
         tp?.let { _currentLocatorTotalProgression.value = it }
         // Leaving the page readaloud stopped on ends the "park": the position is now genuine reading,
         // so reading→audiobook resumes its normal page-top tracking (ADR 0031).
@@ -1649,10 +1651,15 @@ class EpubReaderViewModel @Inject constructor(
         .map { (it as? ReaderState.Ready)?.publication?.tableOfContents?.toTocEntries() ?: emptyList() }
         .stateIn(viewModelScope, SharingStarted.Eagerly, emptyList())
 
-    val railSegments: StateFlow<List<RailSegment>> = state
+    /**
+     * Per-spine-resource position counts (Readium-computed), paired with their spine hrefs.
+     * Drives book-wide totalProgression in continuous mode (see [computeTotalProgression]) and
+     * feeds [railSegments] weighting. Exposed so the continuous reader can build correctly
+     * scaled locators when a rail segment spans multiple spine resources.
+     */
+    val spinePositionCounts: StateFlow<Pair<List<String>, List<Int>>> = state
         .map { s ->
-            val ready = s as? ReaderState.Ready ?: return@map emptyList()
-            val base = buildRailSegments(ready.publication.tableOfContents.toTocEntries(), ready.title)
+            val ready = s as? ReaderState.Ready ?: return@map emptyList<String>() to emptyList<Int>()
             val pub = ready.publication
             val positions: List<List<Locator>> = try {
                 pub.positionsByReadingOrder()
@@ -1660,25 +1667,33 @@ class EpubReaderViewModel @Inject constructor(
                 emptyList()
             }
             val spineHrefs = pub.readingOrder.map { it.url().toString() }
-            val positionCounts = positions.map { it.size }
-            val weighted = weightSegmentsByChapterLength(base, spineHrefs, positionCounts)
-            weighted
+            val counts = positions.map { it.size }
+            spineHrefs to counts
         }
+        .stateIn(viewModelScope, SharingStarted.Eagerly, emptyList<String>() to emptyList<Int>())
+
+    val railSegments: StateFlow<List<RailSegment>> = combine(state, spinePositionCounts) { s, (spineHrefs, counts) ->
+        val ready = s as? ReaderState.Ready ?: return@combine emptyList()
+        val base = buildRailSegments(ready.publication.tableOfContents.toTocEntries(), ready.title)
+        weightSegmentsByChapterLength(base, spineHrefs, counts)
+    }
         .stateIn(viewModelScope, SharingStarted.Eagerly, emptyList())
 
-    // Back-fill totalProgression when railSegments arrives after the first position event.
-    // In continuous mode the initial scroll may fire before segments load, leaving
-    // _currentLocatorTotalProgression null. When segments become non-empty, recompute from the
-    // last known href + chapter progression so time-remaining and rail cursor update immediately.
-    // Placed after railSegments declaration so the Dispatchers.Main.immediate coroutine start
-    // does not access the field while it is still null during class initialization.
+    // Back-fill totalProgression when spine position counts arrive after the first position event.
+    // In continuous mode the initial scroll may fire before positions load, leaving
+    // _currentLocatorTotalProgression null. When counts become non-empty, recompute from the
+    // last known href + within-resource progression so time-remaining and rail cursor update
+    // immediately. Placed after spinePositionCounts declaration so the Dispatchers.Main.immediate
+    // coroutine start does not access the field while it is still null during class initialization.
     init {
         viewModelScope.launch {
-            railSegments.collect { segs ->
-                if (segs.isEmpty() || _currentLocatorTotalProgression.value != null) return@collect
+            spinePositionCounts.collect { (spineHrefs, counts) ->
+                if (counts.isEmpty() || _currentLocatorTotalProgression.value != null) return@collect
                 val href = _currentLocatorHref.value ?: return@collect
                 val cp = _currentLocatorProgression.value ?: return@collect
-                computeTotalProgression(href, cp, segs)?.let { _currentLocatorTotalProgression.value = it }
+                computeTotalProgression(href, cp, spineHrefs, counts)?.let {
+                    _currentLocatorTotalProgression.value = it
+                }
             }
         }
     }

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ComputeTotalProgressionTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ComputeTotalProgressionTest.kt
@@ -6,79 +6,100 @@ import org.junit.Test
 
 class ComputeTotalProgressionTest {
 
-    private fun seg(href: String, weight: Float) = RailSegment(title = href, href = href, weight = weight)
-
     @Test
-    fun `returns null for empty segments`() {
-        assertNull(computeTotalProgression("ch1.xhtml", 0.5f, emptyList()))
+    fun `returns null for empty spine`() {
+        assertNull(computeTotalProgression("ch1.xhtml", 0.5f, emptyList(), emptyList()))
     }
 
     @Test
-    fun `returns null when href not in segments`() {
-        val segments = listOf(seg("ch1.xhtml", 1f), seg("ch2.xhtml", 1f))
-        assertNull(computeTotalProgression("ch3.xhtml", 0.5f, segments))
+    fun `returns null when href not in spine`() {
+        val spine = listOf("ch1.xhtml", "ch2.xhtml")
+        val counts = listOf(100, 100)
+        assertNull(computeTotalProgression("ch3.xhtml", 0.5f, spine, counts))
     }
 
     @Test
-    fun `returns null when total weight is zero`() {
-        val segments = listOf(seg("ch1.xhtml", 0f), seg("ch2.xhtml", 0f))
-        assertNull(computeTotalProgression("ch1.xhtml", 0.5f, segments))
+    fun `returns null when total positions is zero`() {
+        val spine = listOf("ch1.xhtml", "ch2.xhtml")
+        assertNull(computeTotalProgression("ch1.xhtml", 0.5f, spine, listOf(0, 0)))
     }
 
     @Test
     fun `first chapter at start`() {
-        val segments = listOf(seg("ch1.xhtml", 1f), seg("ch2.xhtml", 1f))
-        assertEquals(0f, computeTotalProgression("ch1.xhtml", 0f, segments)!!, 0.001f)
+        val spine = listOf("ch1.xhtml", "ch2.xhtml")
+        val counts = listOf(100, 100)
+        assertEquals(0f, computeTotalProgression("ch1.xhtml", 0f, spine, counts)!!, 0.001f)
     }
 
     @Test
     fun `first chapter at end`() {
-        val segments = listOf(seg("ch1.xhtml", 1f), seg("ch2.xhtml", 1f))
-        assertEquals(0.5f, computeTotalProgression("ch1.xhtml", 1f, segments)!!, 0.001f)
+        val spine = listOf("ch1.xhtml", "ch2.xhtml")
+        val counts = listOf(100, 100)
+        assertEquals(0.5f, computeTotalProgression("ch1.xhtml", 1f, spine, counts)!!, 0.001f)
     }
 
     @Test
     fun `last chapter at start`() {
-        val segments = listOf(seg("ch1.xhtml", 1f), seg("ch2.xhtml", 1f))
-        assertEquals(0.5f, computeTotalProgression("ch2.xhtml", 0f, segments)!!, 0.001f)
+        val spine = listOf("ch1.xhtml", "ch2.xhtml")
+        val counts = listOf(100, 100)
+        assertEquals(0.5f, computeTotalProgression("ch2.xhtml", 0f, spine, counts)!!, 0.001f)
     }
 
     @Test
     fun `last chapter at end`() {
-        val segments = listOf(seg("ch1.xhtml", 1f), seg("ch2.xhtml", 1f))
-        assertEquals(1f, computeTotalProgression("ch2.xhtml", 1f, segments)!!, 0.001f)
+        val spine = listOf("ch1.xhtml", "ch2.xhtml")
+        val counts = listOf(100, 100)
+        assertEquals(1f, computeTotalProgression("ch2.xhtml", 1f, spine, counts)!!, 0.001f)
     }
 
     @Test
     fun `mid-chapter of three equal-weight chapters`() {
-        val segments = listOf(seg("a.xhtml", 1f), seg("b.xhtml", 1f), seg("c.xhtml", 1f))
-        // b at 50% → (1 + 1*0.5) / 3 = 0.5
-        assertEquals(0.5f, computeTotalProgression("b.xhtml", 0.5f, segments)!!, 0.001f)
+        val spine = listOf("a.xhtml", "b.xhtml", "c.xhtml")
+        val counts = listOf(100, 100, 100)
+        // b at 50% → (100 + 100*0.5) / 300 = 0.5
+        assertEquals(0.5f, computeTotalProgression("b.xhtml", 0.5f, spine, counts)!!, 0.001f)
     }
 
     @Test
     fun `weighted chapters — heavy first chapter`() {
-        // ch1 weight=3, ch2 weight=1, total=4
-        // ch2 at 0% → cumulativeWeight=3, result = 3/4 = 0.75
-        val segments = listOf(seg("ch1.xhtml", 3f), seg("ch2.xhtml", 1f))
-        assertEquals(0.75f, computeTotalProgression("ch2.xhtml", 0f, segments)!!, 0.001f)
+        // ch1=300 positions, ch2=100, total=400
+        // ch2 at 0% → 300/400 = 0.75
+        val spine = listOf("ch1.xhtml", "ch2.xhtml")
+        val counts = listOf(300, 100)
+        assertEquals(0.75f, computeTotalProgression("ch2.xhtml", 0f, spine, counts)!!, 0.001f)
     }
 
     @Test
-    fun `single chapter at 50%`() {
-        val segments = listOf(seg("only.xhtml", 2f))
-        assertEquals(0.5f, computeTotalProgression("only.xhtml", 0.5f, segments)!!, 0.001f)
+    fun `single chapter at half`() {
+        val spine = listOf("only.xhtml")
+        val counts = listOf(200)
+        assertEquals(0.5f, computeTotalProgression("only.xhtml", 0.5f, spine, counts)!!, 0.001f)
     }
 
     @Test
-    fun `matches segment whose href has fragment when caller passes bare path`() {
-        // TOC entries often store hrefs with #fragment (e.g. "ch1.xhtml#intro"),
-        // while ContinuousReaderView reports the spine href without fragment.
-        val segments = listOf(
-            RailSegment(title = "ch1", href = "ch1.xhtml#intro", weight = 1f),
-            RailSegment(title = "ch2", href = "ch2.xhtml#start", weight = 1f),
+    fun `matches spine entry on base path when href carries a fragment`() {
+        val spine = listOf("ch1.xhtml", "ch2.xhtml")
+        val counts = listOf(100, 100)
+        assertEquals(
+            0.5f,
+            computeTotalProgression("ch2.xhtml#start", 0f, spine, counts)!!,
+            0.001f,
         )
-        // bare "ch2.xhtml" should match "ch2.xhtml#start"
-        assertEquals(0.5f, computeTotalProgression("ch2.xhtml", 0f, segments)!!, 0.001f)
+    }
+
+    // The bug this fix closes: a "Chapter 20" rail segment spanning 3 spine resources used to
+    // multiply the within-RESOURCE progression by the whole segment's weight, advancing the
+    // chapter map ~3× too fast across the first resource and jamming (null) for the rest.
+    // Per-spine-position math makes each resource contribute exactly its share.
+    @Test
+    fun `multi-resource chapter advances proportionally across all resources`() {
+        val spine = listOf("ch20-a.xhtml", "ch20-b.xhtml", "ch20-c.xhtml")
+        val counts = listOf(100, 100, 100)
+
+        // 50% through resource A = 50/300 of the book (NOT 50% of "chapter 20" = 150/300).
+        assertEquals(50f / 300f, computeTotalProgression("ch20-a.xhtml", 0.5f, spine, counts)!!, 0.001f)
+        // The middle resource keeps progressing (used to return null, freezing the cursor).
+        assertEquals(150f / 300f, computeTotalProgression("ch20-b.xhtml", 0.5f, spine, counts)!!, 0.001f)
+        assertEquals(250f / 300f, computeTotalProgression("ch20-c.xhtml", 0.5f, spine, counts)!!, 0.001f)
     }
 }

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousModeLocatorTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousModeLocatorTest.kt
@@ -20,81 +20,120 @@ import org.junit.Test
  */
 class ContinuousModeLocatorTest {
 
-    private fun seg(href: String, weight: Float) = RailSegment(title = href, href = href, weight = weight)
-
     // ── JSON structure ───────────────────────────────────────────────────────
 
     @Test
     fun `json carries href`() {
-        val json = buildContinuousLocatorJson("Text/ch1.xhtml", 0.5f, emptyList())
+        val json = buildContinuousLocatorJson("Text/ch1.xhtml", 0.5f, emptyList(), emptyList())
         assertEquals("Text/ch1.xhtml", json.getString("href"))
     }
 
     @Test
-    fun `json always carries within-chapter progression`() {
-        val json = buildContinuousLocatorJson("ch1.xhtml", 0.75f, emptyList())
+    fun `json always carries within-resource progression`() {
+        val json = buildContinuousLocatorJson("ch1.xhtml", 0.75f, emptyList(), emptyList())
         assertEquals(0.75, json.getJSONObject("locations").getDouble("progression"), 0.001)
     }
 
     // ── totalProgression: drives both chapter map and time estimates ─────────
 
     @Test
-    fun `totalProgression present when segments match — chapter map and time estimates update`() {
-        val segments = listOf(seg("ch1.xhtml", 1f), seg("ch2.xhtml", 1f))
-        val json = buildContinuousLocatorJson("ch2.xhtml", 0f, segments)
+    fun `totalProgression present when href is in spine — chapter map and time estimates update`() {
+        val spineHrefs = listOf("ch1.xhtml", "ch2.xhtml")
+        val counts = listOf(100, 100)
+        val json = buildContinuousLocatorJson("ch2.xhtml", 0f, spineHrefs, counts)
         val locations = json.getJSONObject("locations")
-        assertTrue("totalProgression must be present so railCursorPosition and time estimates update",
-            locations.has("totalProgression"))
-        // ch2 at 0 % = 50 % through book (two equal-weight chapters)
+        assertTrue(
+            "totalProgression must be present so railCursorPosition and time estimates update",
+            locations.has("totalProgression"),
+        )
+        // ch2 at 0 % = 50 % through book (two equal-weight resources)
         assertEquals(0.5, locations.getDouble("totalProgression"), 0.001)
     }
 
     @Test
-    fun `totalProgression absent when segments are empty (positions not yet computed)`() {
-        // Readium hasn't computed position counts yet — segments arrive later via StateFlow.
+    fun `totalProgression absent when position counts not yet computed`() {
+        // Readium hasn't computed position counts yet — counts arrive later via StateFlow.
         // The JSON is still valid for href/progression; totalProgression arrives on the next
-        // position update once segments populate.
-        val json = buildContinuousLocatorJson("ch1.xhtml", 0.5f, emptyList())
-        assertFalse("totalProgression must be absent when segments are empty",
-            json.getJSONObject("locations").has("totalProgression"))
+        // position update once counts populate.
+        val json = buildContinuousLocatorJson("ch1.xhtml", 0.5f, listOf("ch1.xhtml"), emptyList())
+        assertFalse(
+            "totalProgression must be absent when position counts are empty",
+            json.getJSONObject("locations").has("totalProgression"),
+        )
     }
 
     @Test
-    fun `totalProgression absent when href matches no segment`() {
-        val segments = listOf(seg("ch1.xhtml", 1f))
-        val json = buildContinuousLocatorJson("front-matter.xhtml", 0.5f, segments)
+    fun `totalProgression absent when href is not in spine`() {
+        val json = buildContinuousLocatorJson(
+            "front-matter.xhtml", 0.5f, listOf("ch1.xhtml"), listOf(100),
+        )
         assertFalse(json.getJSONObject("locations").has("totalProgression"))
     }
 
     @Test
-    fun `TOC fragment href in segment matches bare spine href from continuous reader`() {
-        // TOC-derived segments often store hrefs with #fragment (e.g. "ch2.xhtml#section1"),
-        // while ContinuousReaderView reports the spine resource without fragment.
-        // This was the original root cause: exact matching always returned null.
-        val segments = listOf(
-            RailSegment(title = "ch1", href = "ch1.xhtml#intro", weight = 1f),
-            RailSegment(title = "ch2", href = "ch2.xhtml#start", weight = 3f),
-        )
-        val json = buildContinuousLocatorJson("ch2.xhtml", 0f, segments)
+    fun `fragment hrefs match on the base path`() {
+        // ContinuousReaderView reports the spine resource without fragment, but URL inputs may
+        // carry one; both sides strip to the base path before matching.
+        val spineHrefs = listOf("ch1.xhtml", "ch2.xhtml")
+        val counts = listOf(100, 300)
+        val json = buildContinuousLocatorJson("ch2.xhtml#start", 0f, spineHrefs, counts)
         val locations = json.getJSONObject("locations")
-        assertTrue("fragment-bearing segment must match bare spine href",
-            locations.has("totalProgression"))
-        // ch2 starts at cumulativeWeight(1) / total(4) = 0.25
+        assertTrue("fragment-bearing href must match on base path", locations.has("totalProgression"))
         assertEquals(0.25, locations.getDouble("totalProgression"), 0.001)
     }
 
     @Test
     fun `totalProgression at book start is 0`() {
-        val segments = listOf(seg("ch1.xhtml", 10f), seg("ch2.xhtml", 30f), seg("ch3.xhtml", 60f))
-        val json = buildContinuousLocatorJson("ch1.xhtml", 0f, segments)
+        val spineHrefs = listOf("ch1.xhtml", "ch2.xhtml", "ch3.xhtml")
+        val counts = listOf(10, 30, 60)
+        val json = buildContinuousLocatorJson("ch1.xhtml", 0f, spineHrefs, counts)
         assertEquals(0.0, json.getJSONObject("locations").getDouble("totalProgression"), 0.001)
     }
 
     @Test
     fun `totalProgression at book end is 1`() {
-        val segments = listOf(seg("ch1.xhtml", 10f), seg("ch2.xhtml", 30f), seg("ch3.xhtml", 60f))
-        val json = buildContinuousLocatorJson("ch3.xhtml", 1f, segments)
+        val spineHrefs = listOf("ch1.xhtml", "ch2.xhtml", "ch3.xhtml")
+        val counts = listOf(10, 30, 60)
+        val json = buildContinuousLocatorJson("ch3.xhtml", 1f, spineHrefs, counts)
         assertEquals(1.0, json.getJSONObject("locations").getDouble("totalProgression"), 0.001)
+    }
+
+    // ── Multi-resource rail segments (the bug this fix closes) ───────────────
+    //
+    // When a TOC entry is the sole entry for its file and the next TOC entry lives in a later
+    // file, `weightSegmentsByChapterLength` collapses the run into one rail segment whose weight
+    // covers ALL the spine resources between them (e.g. "Chapter 20" → SOL 376, SOL 380, SOL 384
+    // in The Martian). The continuous reader still reports `progression` per-RESOURCE. The fix
+    // is to compute totalProgression from the spine's position counts, not the segment weights,
+    // so each resource only contributes its own share.
+
+    @Test
+    fun `multi-resource chapter — first resource advances proportionally, not segment-wide`() {
+        // Three equal-size resources comprise "Chapter 20"; spine has nothing else.
+        val spineHrefs = listOf("ch20-a.xhtml", "ch20-b.xhtml", "ch20-c.xhtml")
+        val counts = listOf(100, 100, 100)
+
+        // Halfway through the FIRST resource of the 3-resource chapter is 1/6 of the book,
+        // NOT halfway through the chapter (= 1/2 of the book) — the bug before this fix.
+        val totalProg = buildContinuousLocatorJson("ch20-a.xhtml", 0.5f, spineHrefs, counts)
+            .getJSONObject("locations").getDouble("totalProgression").toFloat()
+        assertEquals(50f / 300f, totalProg, 0.001f)
+    }
+
+    @Test
+    fun `multi-resource chapter — middle resource progresses (does not jam)`() {
+        // The pre-fix code would return null here (href didn't match any rail segment), freezing
+        // the chapter map and time estimates for the entire middle resource of a chapter run.
+        val spineHrefs = listOf("ch20-a.xhtml", "ch20-b.xhtml", "ch20-c.xhtml")
+        val counts = listOf(100, 100, 100)
+        val json = buildContinuousLocatorJson("ch20-b.xhtml", 0.5f, spineHrefs, counts)
+        val locations = json.getJSONObject("locations")
+        assertTrue(
+            "middle resource of a multi-resource chapter must still produce totalProgression",
+            locations.has("totalProgression"),
+        )
+        // Halfway through the 2nd of 3 equal resources = 150/300.
+        assertEquals(150.0 / 300.0, locations.getDouble("totalProgression"), 0.001)
     }
 
     // ── Chapter-map cursor position driven by totalProgression ───────────────
@@ -110,12 +149,14 @@ class ContinuousModeLocatorTest {
 
     @Test
     fun `chapter-map cursor lands inside the active segment when reader is in continuous mode`() {
+        val spineHrefs = listOf("a.xhtml", "b.xhtml", "c.xhtml")
+        val counts = listOf(10, 30, 60)
         val segments = listOf(
             RailSegment("A", "a.xhtml", 10f),
             RailSegment("B", "b.xhtml", 30f),
             RailSegment("C", "c.xhtml", 60f),
         )
-        val totalProg = buildContinuousLocatorJson("b.xhtml", 0.5f, segments)
+        val totalProg = buildContinuousLocatorJson("b.xhtml", 0.5f, spineHrefs, counts)
             .getJSONObject("locations").getDouble("totalProgression").toFloat()
 
         // totalProg = (10 + 30*0.5) / 100 = 25/100 = 0.25
@@ -133,10 +174,12 @@ class ContinuousModeLocatorTest {
     }
 
     @Test
-    fun `chapter-map cursor is 0 when no segments available (initial state, not a freeze)`() {
-        // No segments → no totalProgression → railCursorPosition returns 0f by ViewModel contract.
-        val json = buildContinuousLocatorJson("ch1.xhtml", 0.9f, emptyList())
-        assertFalse("no totalProgression means railCursorPosition resets to 0 — expected initial state",
-            json.getJSONObject("locations").has("totalProgression"))
+    fun `chapter-map cursor is 0 when position counts unavailable (initial state, not a freeze)`() {
+        // No counts → no totalProgression → railCursorPosition returns 0f by ViewModel contract.
+        val json = buildContinuousLocatorJson("ch1.xhtml", 0.9f, emptyList(), emptyList())
+        assertFalse(
+            "no totalProgression means railCursorPosition resets to 0 — expected initial state",
+            json.getJSONObject("locations").has("totalProgression"),
+        )
     }
 }

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/EpubReaderViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/EpubReaderViewModelTest.kt
@@ -859,10 +859,9 @@ class ReadingProgressLabelSourceTest {
  */
 class TotalProgressionFallbackTest {
 
-    private fun seg(href: String, weight: Float) = RailSegment(title = href, href = href, weight = weight)
-
     private class Source {
-        var segments: List<RailSegment> = emptyList()
+        var spineHrefs: List<String> = emptyList()
+        var positionCounts: List<Int> = emptyList()
         private var lastHref: String? = null
         private var lastCp: Float? = null
         val totalProgression = MutableStateFlow<Float?>(null)
@@ -870,62 +869,68 @@ class TotalProgressionFallbackTest {
         fun onPositionChanged(href: String, progression: Float?, total: Float?) {
             lastHref = href
             lastCp = progression
-            val tp = total ?: progression?.let { computeTotalProgression(href, it, segments) }
+            val tp = total ?: progression?.let {
+                computeTotalProgression(href, it, spineHrefs, positionCounts)
+            }
             tp?.let { totalProgression.value = it }
         }
 
-        fun onSegmentsChanged(newSegments: List<RailSegment>) {
-            segments = newSegments
-            if (newSegments.isEmpty() || totalProgression.value != null) return
+        fun onSpinePositionsChanged(spine: List<String>, counts: List<Int>) {
+            spineHrefs = spine
+            positionCounts = counts
+            if (counts.isEmpty() || totalProgression.value != null) return
             val href = lastHref ?: return
             val cp = lastCp ?: return
-            computeTotalProgression(href, cp, newSegments)?.let { totalProgression.value = it }
+            computeTotalProgression(href, cp, spine, counts)?.let { totalProgression.value = it }
         }
     }
 
     @Test
     fun `when locator has totalProgression it is used directly`() {
         val s = Source()
-        s.segments = listOf(seg("ch1.xhtml", 1f), seg("ch2.xhtml", 1f))
+        s.spineHrefs = listOf("ch1.xhtml", "ch2.xhtml")
+        s.positionCounts = listOf(100, 100)
         s.onPositionChanged("ch1.xhtml", progression = 0.5f, total = 0.25f)
         assertEquals(0.25f, s.totalProgression.value!!, 0.001f)
     }
 
     @Test
-    fun `when locator has no totalProgression and segments available, falls back to computeTotalProgression`() {
+    fun `when locator has no totalProgression and counts available, falls back to computeTotalProgression`() {
         val s = Source()
-        s.segments = listOf(seg("ch1.xhtml", 1f), seg("ch2.xhtml", 1f))
-        // Continuous-mode locator: totalProgression absent, segments already loaded.
+        s.spineHrefs = listOf("ch1.xhtml", "ch2.xhtml")
+        s.positionCounts = listOf(100, 100)
+        // Continuous-mode locator: totalProgression absent, position counts already loaded.
         s.onPositionChanged("ch2.xhtml", progression = 0f, total = null)
-        // ch2 at 0% through the chapter = 50% through the book.
+        // ch2 at 0% through the resource = 50% through the book.
         assertEquals(0.5f, s.totalProgression.value!!, 0.001f)
     }
 
     @Test
-    fun `when locator has no totalProgression and segments are empty, value stays null`() {
+    fun `when locator has no totalProgression and counts are empty, value stays null`() {
         val s = Source()
         s.onPositionChanged("ch1.xhtml", progression = 0.5f, total = null)
         assertNull(s.totalProgression.value)
     }
 
     @Test
-    fun `when segments arrive after first scroll, totalProgression is back-filled`() {
+    fun `when counts arrive after first scroll, totalProgression is back-filled`() {
         val s = Source()
         s.onPositionChanged("ch2.xhtml", progression = 0f, total = null)
-        assertNull("no segments yet — should stay null", s.totalProgression.value)
+        assertNull("no counts yet — should stay null", s.totalProgression.value)
 
-        s.onSegmentsChanged(listOf(seg("ch1.xhtml", 1f), seg("ch2.xhtml", 1f)))
+        s.onSpinePositionsChanged(listOf("ch1.xhtml", "ch2.xhtml"), listOf(100, 100))
         assertEquals(0.5f, s.totalProgression.value!!, 0.001f)
     }
 
     @Test
     fun `backfill does not overwrite a totalProgression already set from a locator`() {
         val s = Source()
-        s.segments = listOf(seg("ch1.xhtml", 1f), seg("ch2.xhtml", 1f))
+        s.spineHrefs = listOf("ch1.xhtml", "ch2.xhtml")
+        s.positionCounts = listOf(100, 100)
         s.onPositionChanged("ch2.xhtml", progression = 0f, total = 0.6f)
 
-        // Segments reload / re-emit — backfill guard must skip because value is already non-null.
-        s.onSegmentsChanged(s.segments)
+        // Counts reload / re-emit — backfill guard must skip because value is already non-null.
+        s.onSpinePositionsChanged(s.spineHrefs, s.positionCounts)
         assertEquals(0.6f, s.totalProgression.value!!, 0.001f)
     }
 }


### PR DESCRIPTION
## Summary

In continuous mode, reading-time estimates dropped by ~a minute for small
scrolls and the chapter-map cursor reached "end of chapter" before the
actual chapter end (reported on book `471ab948-4af2-41cc-b125-1b87998536df`).

**Root cause.** The continuous reader reports `progression` as a fraction
**within the current spine resource** (0..1 across the loaded resource's
pixel height). `computeTotalProgression` treated it as **within the active
rail segment**, multiplying by the segment's full weight. That's correct
only when each rail segment maps to exactly one spine resource. When
`weightSegmentsByChapterLength` collapses a multi-resource run into one
segment (e.g. The Martian's "Chapter 20" → SOL 376 + SOL 380 + SOL 384),
two failure modes appear:

- Inside the **first** resource of an N-resource chapter, the cursor and
  time-remaining advance ~N× too fast — the "lose a minute for a small
  scroll" symptom.
- For the **2nd…Nth** resources, the bare href doesn't match any rail
  segment, so the function returned `null` and the cursor jammed.

**Fix.** Compute book-wide progression from the spine's per-resource
position counts — the same data Readium uses in paginated/vertical modes:

```
(positionsBefore(spineIdx) + positionCounts[spineIdx] * progression) / totalPositions
```

- `ContinuousModeUtils.kt`: new signature `(href, progression, spineHrefs, positionCounts)`.
- `EpubReaderViewModel.kt`: exposes `spinePositionCounts`; `railSegments`
  combines off it; locator-emit fallback and late-arrival backfill use it.
- `ContinuousReaderCoordinator.kt`: takes `spinePositionsProvider`.
- `EpubReaderScreen.kt`: wires it through.

## Test plan

- [x] `ComputeTotalProgressionTest` — new regression covering multi-resource
      chapters (first resource advances proportionally; middle resource
      keeps progressing instead of jamming).
- [x] `ContinuousModeLocatorTest` — same coverage at the
      `buildContinuousLocatorJson` boundary.
- [x] `TotalProgressionFallbackTest` — fallback + backfill updated to the
      new spine-positions wiring.
- [x] `./gradlew :app:testDebugUnitTest` — all green.
- [ ] Device verification on book `471ab948` — open in continuous mode,
      confirm time-remaining decreases at a steady pace as you scroll
      through a multi-resource chapter, and the chapter-map cursor reaches
      the right edge of the segment only when the actual chapter ends.