### PR TITLE
fix(reader): equalize row spacing in Behavior settings

### DIFF
--- a/app/src/androidTest/kotlin/com/riffle/app/feature/reader/BehaviorSectionRowHeightTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/reader/BehaviorSectionRowHeightTest.kt
@@ -1,0 +1,62 @@
+package com.riffle.app.feature.reader
+
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import kotlin.math.abs
+
+/**
+ * Regression: the three rows in [BehaviorSection] must have equal intrinsic
+ * height so the 4.dp spacers between them read as uniform vertical rhythm.
+ *
+ * The original bug: "Invert volume keys" used `clickable` on the Row plus a
+ * real `onCheckedChange` on the Switch, which made the Switch claim its 48dp
+ * minimum interactive size. Rows 1–2 passed `onCheckedChange = null`, so their
+ * Switch was just its visual height. Result: row 3 was taller than rows 1–2,
+ * making the gap below row 2 visually larger than the gap below row 1.
+ */
+@RunWith(AndroidJUnit4::class)
+class BehaviorSectionRowHeightTest {
+
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+    @Test
+    fun allThreeRowsHaveEqualHeight() {
+        composeTestRule.setContent {
+            BehaviorSection(
+                keepScreenOn = true,
+                onKeepScreenOnChange = {},
+                volumeKeyNavigationEnabled = true,
+                onVolumeKeyNavigationEnabledChange = {},
+                invertVolumeKeys = false,
+                onInvertVolumeKeysChange = {},
+            )
+        }
+
+        val keepScreen = composeTestRule.onNodeWithText("Keep screen on")
+            .fetchSemanticsNode().boundsInRoot
+        val volumeKeys = composeTestRule.onNodeWithText("Volume key navigation")
+            .fetchSemanticsNode().boundsInRoot
+        val invertKeys = composeTestRule.onNodeWithText("Invert volume keys")
+            .fetchSemanticsNode().boundsInRoot
+
+        // Each label sits in a Row whose height is dominated by the Switch's
+        // touch target. If row 3's Switch claims its 48dp minimum and rows 1–2
+        // don't, row 3's label sits higher within a taller row, so the gap
+        // from row 2's label-bottom to row 3's label-top grows. Assert the gap
+        // between consecutive labels is the same (within 1px tolerance).
+        val gap12 = volumeKeys.top - keepScreen.bottom
+        val gap23 = invertKeys.top - volumeKeys.bottom
+        assertEquals(
+            "Row gaps differ: row1→2 = $gap12, row2→3 = $gap23",
+            gap12, gap23, 1f,
+        )
+        assert(abs(gap12 - gap23) <= 1f)
+    }
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/BehaviorSection.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/BehaviorSection.kt
@@ -1,6 +1,5 @@
 package com.riffle.app.feature.reader
 
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -60,14 +59,19 @@ fun BehaviorSection(
         Row(
             verticalAlignment = Alignment.CenterVertically,
             modifier = Modifier.fillMaxWidth()
-                .clickable(enabled = volumeKeyNavigationEnabled) { onInvertVolumeKeysChange(!invertVolumeKeys) }
+                .toggleable(
+                    value = invertVolumeKeys,
+                    enabled = volumeKeyNavigationEnabled,
+                    role = Role.Switch,
+                    onValueChange = onInvertVolumeKeysChange,
+                )
                 .alpha(if (volumeKeyNavigationEnabled) 1f else 0.38f),
         ) {
             Column(modifier = Modifier.weight(1f)) {
                 Text("Invert volume keys", style = MaterialTheme.typography.bodyLarge)
                 Text("Applies to all books", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
             }
-            Switch(checked = invertVolumeKeys, onCheckedChange = onInvertVolumeKeysChange, enabled = volumeKeyNavigationEnabled)
+            Switch(checked = invertVolumeKeys, onCheckedChange = null, enabled = volumeKeyNavigationEnabled)
         }
     }
 }


### PR DESCRIPTION
## Summary
- The Invert volume keys row in Settings → Behavior (and the reader sheet's Behavior tab) used `clickable` on the Row plus a real `onCheckedChange` on the Switch. That made the Switch claim its 48dp minimum interactive size, so the row was taller than rows 1 and 2 — making the 4.dp spacer below "Volume key navigation" look larger than the one below "Keep screen on".
- Converted row 3 to the same `toggleable(... enabled = volumeKeyNavigationEnabled)` + `Switch(onCheckedChange = null)` pattern used by the first two rows. All three rows now have identical intrinsic height.
- Added a harness regression test that asserts the inter-label gap is equal across the three rows.

## Test plan
- [ ] `make harness-test` — verifies `BehaviorSectionRowHeightTest` and other phone harness tests pass.
- [ ] Open Settings → Reading → Behavior on a phone and confirm the three rows have visually identical vertical spacing whether Volume key navigation is on or off.