### PR TITLE
fix(reader): render persisted highlights & notes in continuous mode

### DIFF
--- a/app/src/androidTest/kotlin/com/riffle/app/feature/reader/ContinuousAnnotationHighlightsJsTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/reader/ContinuousAnnotationHighlightsJsTest.kt
@@ -1,0 +1,92 @@
+package com.riffle.app.feature.reader
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Diagnose continuous-mode annotation rendering: load a tiny EPUB-like body in a real WebView,
+ * run [ContinuousStyleInjector.applyAnnotationHighlightsJs] against it, and inspect the resulting
+ * DOM for the expected `<mark data-riffle-ann="...">` element.
+ */
+class ContinuousAnnotationHighlightsJsTest {
+
+    private val html = """
+        <!doctype html>
+        <html><head><meta charset="utf-8"></head>
+        <body>
+          <p id="p1">The quick brown fox jumps over the lazy dog.</p>
+          <p id="p2">Another paragraph with some more text in it for context.</p>
+        </body></html>
+    """.trimIndent()
+
+    @Test
+    fun applies_mark_to_simple_snippet() {
+        withWebViewFixture(html) { wv ->
+            val ann = AnnotationHighlight(
+                id = "ann-1",
+                text = "quick brown fox",
+                cssColor = "rgba(255,235,59,0.45)",
+                hasNote = false,
+                before = "The ",
+                after = " jumps",
+            )
+            val js = ContinuousStyleInjector.applyAnnotationHighlightsJs(listOf(ann))
+            wv.evalSync(js)
+            val count = wv.evalSync("document.querySelectorAll('[data-riffle-ann=\"ann-1\"]').length")
+            assertEquals("1", count.trim('"'))
+            val text = wv.evalSync("document.querySelector('[data-riffle-ann=\"ann-1\"]').textContent")
+            assertEquals("\"quick brown fox\"", text)
+        }
+    }
+
+    @Test
+    fun applies_mark_with_empty_before_after() {
+        withWebViewFixture(html) { wv ->
+            val ann = AnnotationHighlight(
+                id = "ann-2",
+                text = "Another paragraph",
+                cssColor = "rgba(76,175,80,0.45)",
+                hasNote = false,
+                before = "",
+                after = "",
+            )
+            val js = ContinuousStyleInjector.applyAnnotationHighlightsJs(listOf(ann))
+            wv.evalSync(js)
+            val count = wv.evalSync("document.querySelectorAll('[data-riffle-ann=\"ann-2\"]').length")
+            assertEquals("1", count.trim('"'))
+        }
+    }
+
+    @Test
+    fun emits_note_glyph_when_hasNote() {
+        withWebViewFixture(html) { wv ->
+            val ann = AnnotationHighlight(
+                id = "ann-3",
+                text = "lazy dog",
+                cssColor = "rgba(33,150,243,0.45)",
+                hasNote = true,
+                before = "the ",
+                after = ".",
+            )
+            val js = ContinuousStyleInjector.applyAnnotationHighlightsJs(listOf(ann))
+            wv.evalSync(js)
+            val glyph = wv.evalSync("document.querySelectorAll('[data-riffle-note-glyph=\"ann-3\"]').length")
+            assertEquals("1", glyph.trim('"'))
+        }
+    }
+
+    @Test
+    fun multiple_annotations_in_different_paragraphs_apply() {
+        withWebViewFixture(html) { wv ->
+            val a1 = AnnotationHighlight("a1", "quick brown fox", "rgba(255,235,59,0.45)", false, "The ", " jumps")
+            val a2 = AnnotationHighlight("a2", "Another paragraph", "rgba(76,175,80,0.45)", false, "", " with")
+            val js = ContinuousStyleInjector.applyAnnotationHighlightsJs(listOf(a1, a2))
+            wv.evalSync(js)
+            val c1 = wv.evalSync("document.querySelectorAll('[data-riffle-ann=\"a1\"]').length").trim('"')
+            val c2 = wv.evalSync("document.querySelectorAll('[data-riffle-ann=\"a2\"]').length").trim('"')
+            assertTrue("a1 present, got $c1", c1 == "1")
+            assertTrue("a2 present, got $c2", c2 == "1")
+        }
+    }
+}

--- a/app/src/androidTest/kotlin/com/riffle/app/feature/reader/ContinuousAnnotationRenderHarnessTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/reader/ContinuousAnnotationRenderHarnessTest.kt
@@ -1,0 +1,223 @@
+package com.riffle.app.feature.reader
+
+import android.view.View
+import android.view.ViewGroup
+import android.webkit.WebView
+import androidx.compose.ui.test.hasSetTextAction
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onAllNodesWithContentDescription
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextReplacement
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.riffle.app.MainActivity
+import com.riffle.app.harness.ReaderSemanticMatchers
+import com.riffle.app.harness.StubAbsServer
+import com.riffle.core.data.di.EpubCacheStore
+import com.riffle.core.database.RiffleDatabase
+import com.riffle.core.domain.AnnotationStore
+import com.riffle.core.domain.FormattingPreferencesStore
+import com.riffle.core.domain.LocalStore
+import com.riffle.core.domain.ReaderOrientation
+import dagger.hilt.android.testing.HiltAndroidRule
+import dagger.hilt.android.testing.HiltAndroidTest
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.jsoup.Jsoup
+import org.junit.After
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import javax.inject.Inject
+
+/**
+ * Regression: in continuous mode, persisted highlights must render as `<mark data-riffle-ann>`
+ * elements in the chapter WebView's DOM. The user reported that they only appear in the
+ * annotations list, never on the page.
+ */
+@HiltAndroidTest
+@RunWith(AndroidJUnit4::class)
+class ContinuousAnnotationRenderHarnessTest {
+
+    @get:Rule(order = 0) val hiltRule = HiltAndroidRule(this)
+    @get:Rule(order = 1) val composeTestRule = createAndroidComposeRule<MainActivity>()
+
+    @Inject lateinit var database: RiffleDatabase
+    @EpubCacheStore @Inject lateinit var epubCacheStore: LocalStore
+    @Inject lateinit var annotationStore: AnnotationStore
+    @Inject lateinit var formattingPreferencesStore: FormattingPreferencesStore
+
+    private val stubServer = StubAbsServer()
+    private val targetPhrase = "Section 1.3: Development"
+
+    @Before
+    fun setUp() {
+        stubServer.start()
+        hiltRule.inject()
+        database.clearAllTables()
+        epubCacheStore.clear()
+        // Reset orientation so tests don't leak each other's state.
+        runBlocking {
+            val prefs = formattingPreferencesStore.preferences.first()
+            formattingPreferencesStore.update(prefs.copy(orientation = ReaderOrientation.Horizontal))
+        }
+    }
+
+    @After
+    fun tearDown() {
+        stubServer.shutdown()
+        composeTestRule.activityRule.scenario.close()
+        Runtime.getRuntime().gc()
+        Thread.sleep(400)
+        database.clearAllTables()
+    }
+
+    @Test
+    fun continuousMode_renderedHighlight_appearsAsMarkElement() {
+        runBlocking {
+            val prefs = formattingPreferencesStore.preferences.first()
+            formattingPreferencesStore.update(prefs.copy(orientation = ReaderOrientation.Continuous))
+        }
+        addServerAndBrowseLibrary()
+        seedDeepHighlight()
+        searchAndTapAnnotation()
+        composeTestRule.waitUntil(timeoutMillis = 20_000) {
+            composeTestRule.onAllNodesWithTag(ReaderSemanticMatchers.TAG_READER_READY)
+                .fetchSemanticsNodes().isNotEmpty()
+        }
+        Thread.sleep(6_000)
+        val webViews = allWebViews()
+        assertTrue("expected at least one WebView in hierarchy", webViews.isNotEmpty())
+        val perWebView = webViews.map { wv ->
+            val count = evalJs(wv, "document.querySelectorAll('[data-riffle-ann]').length").trim('"')
+            val href = evalJs(wv, "(window.location && window.location.pathname) || ''").trim('"').ifBlank { "<none>" }
+            "[href=$href marks=$count]"
+        }
+        val totalMarks = webViews.sumOf { wv ->
+            evalJs(wv, "document.querySelectorAll('[data-riffle-ann]').length").trim('"').toIntOrNull() ?: 0
+        }
+        assertTrue(
+            "expected at least one <mark data-riffle-ann> across ${webViews.size} WebViews; got: $perWebView",
+            totalMarks > 0,
+        )
+    }
+
+    private fun allWebViews(): List<WebView> {
+        val latch = CountDownLatch(1)
+        val out = mutableListOf<WebView>()
+        composeTestRule.activityRule.scenario.onActivity { activity ->
+            fun walk(v: View) {
+                if (v is WebView) out.add(v)
+                if (v is ViewGroup) for (i in 0 until v.childCount) walk(v.getChildAt(i))
+            }
+            walk(activity.window.decorView)
+            latch.countDown()
+        }
+        latch.await(5, TimeUnit.SECONDS)
+        return out
+    }
+
+    // ── helpers (copied from AnnotationFocusHarnessTest) ──────────────────────────
+
+    private fun seedDeepHighlight() = runBlocking {
+        val server = database.serverDao().getActive()
+            ?: error("no active server registered after browsing library")
+        val html = chapter1Html()
+        val progression = phraseProgression(html, targetPhrase)
+        val cfi = buildHighlightCfiRangeForSelection(
+            spineStep = 2,
+            html = html,
+            startProgression = progression,
+            selectedText = targetPhrase,
+        ) ?: error("failed to build highlight CFI for '$targetPhrase'")
+        annotationStore.createHighlight(
+            serverId = server.id,
+            itemId = StubAbsServer.TEST_STANDALONE_ITEM_ID,
+            cfi = cfi,
+            textSnippet = targetPhrase,
+            chapterHref = "chapter1.xhtml",
+        )
+    }
+
+    private fun chapter1Html(): String {
+        val ctx = InstrumentationRegistry.getInstrumentation().context
+        java.util.zip.ZipInputStream(ctx.assets.open("test.epub")).use { zis ->
+            var e = zis.nextEntry
+            while (e != null) {
+                if (e.name.endsWith("chapter1.xhtml")) return zis.readBytes().decodeToString()
+                e = zis.nextEntry
+            }
+        }
+        error("chapter1.xhtml not found in test.epub")
+    }
+
+    private fun phraseProgression(html: String, phrase: String): Double {
+        val body = Jsoup.parse(html).body().text()
+        val idx = body.indexOf(phrase)
+        require(idx >= 0) { "phrase '$phrase' not found in chapter body" }
+        return idx.toDouble() / body.length.toDouble()
+    }
+
+    private fun addServerAndBrowseLibrary() {
+        composeTestRule.waitUntil(timeoutMillis = 5_000) {
+            composeTestRule.onAllNodesWithText("Connect").fetchSemanticsNodes().isNotEmpty()
+        }
+        composeTestRule.onNode(hasSetTextAction() and hasText("Server URL")).performTextReplacement(stubServer.baseUrl)
+        composeTestRule.onNode(hasSetTextAction() and hasText("Username")).performTextReplacement("testuser")
+        composeTestRule.onNode(hasSetTextAction() and hasText("Password")).performTextReplacement("testpass")
+        composeTestRule.onNodeWithText("Connect").performClick()
+        composeTestRule.waitUntil(timeoutMillis = 15_000) {
+            composeTestRule.onAllNodesWithText("Connect anyway").fetchSemanticsNodes().isNotEmpty()
+        }
+        composeTestRule.onNodeWithText("Connect anyway").performClick()
+        composeTestRule.waitUntil(timeoutMillis = 10_000) {
+            composeTestRule.onAllNodesWithContentDescription("All Books").fetchSemanticsNodes().isNotEmpty()
+        }
+        composeTestRule.onNodeWithContentDescription("All Books").performClick()
+    }
+
+    private fun searchAndTapAnnotation() {
+        composeTestRule.waitUntil(timeoutMillis = 10_000) {
+            composeTestRule.onAllNodesWithText("Search").fetchSemanticsNodes().isNotEmpty()
+        }
+        composeTestRule.onNodeWithText("Search").performTextReplacement("Section 1.3")
+        composeTestRule.waitUntil(timeoutMillis = 8_000) {
+            composeTestRule.onAllNodesWithText(targetPhrase).fetchSemanticsNodes().isNotEmpty()
+        }
+        composeTestRule.onNodeWithText(targetPhrase).performClick()
+    }
+
+    private fun visibleWebViews(): List<WebView> {
+        val latch = CountDownLatch(1)
+        val out = mutableListOf<WebView>()
+        composeTestRule.activityRule.scenario.onActivity { activity ->
+            fun walk(v: View) {
+                if (v is WebView && v.width > 0 && v.height > 0 && v.isShown) out.add(v)
+                if (v is ViewGroup) for (i in 0 until v.childCount) walk(v.getChildAt(i))
+            }
+            walk(activity.window.decorView)
+            latch.countDown()
+        }
+        latch.await(5, TimeUnit.SECONDS)
+        return out
+    }
+
+    private fun evalJs(wv: WebView, js: String): String {
+        val latch = CountDownLatch(1)
+        val result = arrayOfNulls<String>(1)
+        composeTestRule.activityRule.scenario.onActivity {
+            wv.evaluateJavascript(js) { value -> result[0] = value; latch.countDown() }
+        }
+        if (!latch.await(5, TimeUnit.SECONDS)) return "NO_WEBVIEW"
+        return result[0] ?: "null"
+    }
+}

--- a/app/src/androidTest/kotlin/com/riffle/app/feature/reader/ContinuousAnnotationRenderHarnessTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/reader/ContinuousAnnotationRenderHarnessTest.kt
@@ -79,6 +79,12 @@ class ContinuousAnnotationRenderHarnessTest {
         Runtime.getRuntime().gc()
         Thread.sleep(400)
         database.clearAllTables()
+        // Reset orientation so subsequent tests on the shared APK install start in Horizontal —
+        // leaving it in Continuous breaks any test that asserts column-pagination scrollLeft.
+        runBlocking {
+            val prefs = formattingPreferencesStore.preferences.first()
+            formattingPreferencesStore.update(prefs.copy(orientation = ReaderOrientation.Horizontal))
+        }
     }
 
     @Test

--- a/app/src/androidTest/kotlin/com/riffle/app/feature/reader/ContinuousAnnotationRenderHarnessTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/reader/ContinuousAnnotationRenderHarnessTest.kt
@@ -196,21 +196,6 @@ class ContinuousAnnotationRenderHarnessTest {
         composeTestRule.onNodeWithText(targetPhrase).performClick()
     }
 
-    private fun visibleWebViews(): List<WebView> {
-        val latch = CountDownLatch(1)
-        val out = mutableListOf<WebView>()
-        composeTestRule.activityRule.scenario.onActivity { activity ->
-            fun walk(v: View) {
-                if (v is WebView && v.width > 0 && v.height > 0 && v.isShown) out.add(v)
-                if (v is ViewGroup) for (i in 0 until v.childCount) walk(v.getChildAt(i))
-            }
-            walk(activity.window.decorView)
-            latch.countDown()
-        }
-        latch.await(5, TimeUnit.SECONDS)
-        return out
-    }
-
     private fun evalJs(wv: WebView, js: String): String {
         val latch = CountDownLatch(1)
         val result = arrayOfNulls<String>(1)

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -1594,30 +1594,31 @@ private fun EpubNavigatorView(
         }
     }
 
-    // Key on highlightRenderer + the continuous view ref so the effect re-fires when the
-    // orientation flips and a new renderer instance is bound — otherwise switching paged↔continuous
-    // mid-session leaves the new renderer un-invoked (none of the other keys naturally change on
-    // orientation flip; the renderer's targetProvider needs the view ref to be populated, which
-    // happens in the AndroidView factory's commit phase, so we re-fire on that too).
-    LaunchedEffect(highlightRenderer, continuousViewRef.value, fragmentRef.value, searchResults, currentSearchIndex, reflowGeneration, pageLoadGeneration.value) {
+    // Key on highlightRenderer so the effect re-fires when an orientation flip rebinds a fresh
+    // renderer instance (otherwise none of the other keys naturally change on the flip).
+    LaunchedEffect(highlightRenderer, searchResults, currentSearchIndex, reflowGeneration, pageLoadGeneration.value) {
         highlightRenderer.applySearch(searchResults, currentSearchIndex)
     }
 
     // ---- Readaloud synced highlight --------------------------------------------------------
     // Superset keys cover both Readium (pageLoadGeneration, reflowGeneration re-apply on
     // reflow/rotation) and Continuous (sentenceQuotes re-applies when quotes build asynchronously).
-    LaunchedEffect(highlightRenderer, continuousViewRef.value, fragmentRef.value, activeFragmentRef, reflowGeneration, pageLoadGeneration.value, sentenceQuotes, readaloudHighlightColor) {
+    LaunchedEffect(highlightRenderer, activeFragmentRef, reflowGeneration, pageLoadGeneration.value, sentenceQuotes, readaloudHighlightColor) {
         highlightRenderer.applyReadaloud(activeFragmentRef, sentenceQuotes, readaloudHighlightColor)
     }
 
     // ---- Persisted highlights (annotations + note glyphs) ----------------------------------
     // Superset keys: continuous re-keys on activeFragmentRef's base href when a new chapter
-    // enters the sliding window; Readium re-applies on reflow/pageLoad events.
-    LaunchedEffect(highlightRenderer, continuousViewRef.value, fragmentRef.value, highlightRenders, formattingPrefs.theme, reflowGeneration, pageLoadGeneration.value, activeFragmentRef?.substringBefore('#')) {
+    // enters the sliding window; Readium re-applies on reflow/pageLoad events. The
+    // continuousViewRef.value key is required because the ContinuousReaderView's
+    // targetProvider is null until the AndroidView factory commits, AFTER the
+    // initial fire — and unlike search/readaloud, there is no downstream data event
+    // (no user re-search, no playback frame) to re-trigger this apply.
+    LaunchedEffect(highlightRenderer, continuousViewRef.value, highlightRenders, formattingPrefs.theme, reflowGeneration, pageLoadGeneration.value, activeFragmentRef?.substringBefore('#')) {
         highlightRenderer.applyAnnotations(highlightRenders, formattingPrefs.theme)
     }
 
-    LaunchedEffect(highlightRenderer, continuousViewRef.value, fragmentRef.value, highlightRenders, reflowGeneration, pageLoadGeneration.value) {
+    LaunchedEffect(highlightRenderer, highlightRenders, reflowGeneration, pageLoadGeneration.value) {
         highlightRenderer.applyNoteGlyphs(highlightRenders)
     }
 

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -1594,31 +1594,29 @@ private fun EpubNavigatorView(
         }
     }
 
-    // Key on highlightRenderer so the effect re-fires when an orientation flip rebinds a fresh
-    // renderer instance (otherwise none of the other keys naturally change on the flip).
-    LaunchedEffect(highlightRenderer, searchResults, currentSearchIndex, reflowGeneration, pageLoadGeneration.value) {
+    LaunchedEffect(searchResults, currentSearchIndex, reflowGeneration, pageLoadGeneration.value) {
         highlightRenderer.applySearch(searchResults, currentSearchIndex)
     }
 
     // ---- Readaloud synced highlight --------------------------------------------------------
     // Superset keys cover both Readium (pageLoadGeneration, reflowGeneration re-apply on
     // reflow/rotation) and Continuous (sentenceQuotes re-applies when quotes build asynchronously).
-    LaunchedEffect(highlightRenderer, activeFragmentRef, reflowGeneration, pageLoadGeneration.value, sentenceQuotes, readaloudHighlightColor) {
+    LaunchedEffect(activeFragmentRef, reflowGeneration, pageLoadGeneration.value, sentenceQuotes, readaloudHighlightColor) {
         highlightRenderer.applyReadaloud(activeFragmentRef, sentenceQuotes, readaloudHighlightColor)
     }
 
     // ---- Persisted highlights (annotations + note glyphs) ----------------------------------
     // Superset keys: continuous re-keys on activeFragmentRef's base href when a new chapter
-    // enters the sliding window; Readium re-applies on reflow/pageLoad events. The
-    // continuousViewRef.value key is required because the ContinuousReaderView's
-    // targetProvider is null until the AndroidView factory commits, AFTER the
-    // initial fire — and unlike search/readaloud, there is no downstream data event
-    // (no user re-search, no playback frame) to re-trigger this apply.
-    LaunchedEffect(highlightRenderer, continuousViewRef.value, highlightRenders, formattingPrefs.theme, reflowGeneration, pageLoadGeneration.value, activeFragmentRef?.substringBefore('#')) {
+    // enters the sliding window; Readium re-applies on reflow/pageLoad events. Note: the
+    // initial bootstrap for continuous mode happens in the LaunchedEffect(continuousView)
+    // block below (around line 2110) — when the AndroidView factory binds the ref, this effect
+    // alone wouldn't re-fire (none of its keys change on orientation flip) and the new
+    // ContinuousHighlightRenderer would never be invoked, leaving annotations un-rendered.
+    LaunchedEffect(highlightRenders, formattingPrefs.theme, reflowGeneration, pageLoadGeneration.value, activeFragmentRef?.substringBefore('#')) {
         highlightRenderer.applyAnnotations(highlightRenders, formattingPrefs.theme)
     }
 
-    LaunchedEffect(highlightRenderer, highlightRenders, reflowGeneration, pageLoadGeneration.value) {
+    LaunchedEffect(highlightRenders, reflowGeneration, pageLoadGeneration.value) {
         highlightRenderer.applyNoteGlyphs(highlightRenders)
     }
 
@@ -2119,6 +2117,13 @@ private fun EpubNavigatorView(
                 val initialHref = if (anchor != null) "$rawHref#$anchor" else rawHref
                 val focusId = state.initialFocusAnnotationId?.takeIf { focusIsFresh }
                 focusIsFresh = false
+                // Bootstrap persisted highlights for this freshly-bound view BEFORE chapters load:
+                // the persisted-highlights LaunchedEffect above this block doesn't re-fire on the
+                // ref-null→view transition (its keys don't include continuousViewRef.value), so on
+                // a paged↔continuous orientation flip the new ContinuousHighlightRenderer would
+                // otherwise never be invoked and ContinuousReaderView.currentAnnotationsByHref
+                // would stay empty — onPageFinished would skip every chapter as it loaded.
+                highlightRenderer.applyAnnotations(highlightRenders, formattingPrefs.theme)
                 view.initialize(
                     chapters = chapters,
                     prefs = formattingPrefs,

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -1594,25 +1594,30 @@ private fun EpubNavigatorView(
         }
     }
 
-    LaunchedEffect(searchResults, currentSearchIndex, reflowGeneration, pageLoadGeneration.value) {
+    // Key on highlightRenderer + the continuous view ref so the effect re-fires when the
+    // orientation flips and a new renderer instance is bound — otherwise switching paged↔continuous
+    // mid-session leaves the new renderer un-invoked (none of the other keys naturally change on
+    // orientation flip; the renderer's targetProvider needs the view ref to be populated, which
+    // happens in the AndroidView factory's commit phase, so we re-fire on that too).
+    LaunchedEffect(highlightRenderer, continuousViewRef.value, fragmentRef.value, searchResults, currentSearchIndex, reflowGeneration, pageLoadGeneration.value) {
         highlightRenderer.applySearch(searchResults, currentSearchIndex)
     }
 
     // ---- Readaloud synced highlight --------------------------------------------------------
     // Superset keys cover both Readium (pageLoadGeneration, reflowGeneration re-apply on
     // reflow/rotation) and Continuous (sentenceQuotes re-applies when quotes build asynchronously).
-    LaunchedEffect(activeFragmentRef, reflowGeneration, pageLoadGeneration.value, sentenceQuotes, readaloudHighlightColor) {
+    LaunchedEffect(highlightRenderer, continuousViewRef.value, fragmentRef.value, activeFragmentRef, reflowGeneration, pageLoadGeneration.value, sentenceQuotes, readaloudHighlightColor) {
         highlightRenderer.applyReadaloud(activeFragmentRef, sentenceQuotes, readaloudHighlightColor)
     }
 
     // ---- Persisted highlights (annotations + note glyphs) ----------------------------------
     // Superset keys: continuous re-keys on activeFragmentRef's base href when a new chapter
     // enters the sliding window; Readium re-applies on reflow/pageLoad events.
-    LaunchedEffect(highlightRenders, formattingPrefs.theme, reflowGeneration, pageLoadGeneration.value, activeFragmentRef?.substringBefore('#')) {
+    LaunchedEffect(highlightRenderer, continuousViewRef.value, fragmentRef.value, highlightRenders, formattingPrefs.theme, reflowGeneration, pageLoadGeneration.value, activeFragmentRef?.substringBefore('#')) {
         highlightRenderer.applyAnnotations(highlightRenders, formattingPrefs.theme)
     }
 
-    LaunchedEffect(highlightRenders, reflowGeneration, pageLoadGeneration.value) {
+    LaunchedEffect(highlightRenderer, continuousViewRef.value, fragmentRef.value, highlightRenders, reflowGeneration, pageLoadGeneration.value) {
         highlightRenderer.applyNoteGlyphs(highlightRenders)
     }
 


### PR DESCRIPTION
## Summary

- Add `highlightRenderer`, `continuousViewRef.value`, and `fragmentRef.value` to the four highlight-related `LaunchedEffect` key lists in `EpubReaderView`. Without them, a paged↔continuous orientation flip rebuilt `ContinuousHighlightRenderer` via `remember(isContinuous)` but never invoked it — none of the existing keys changed — so `ContinuousReaderView.currentAnnotationsByHref` stayed empty and `onPageFinished` applied no marks. The user saw highlights only in the annotations list.
- Add `ContinuousAnnotationHighlightsJsTest` (4 cases) — proves `applyAnnotationHighlightsJs` actually injects `<mark data-riffle-ann>` + note glyphs in a real WebView (the existing `ContinuousStyleInjectorTest` only checks the JS string at JVM altitude).
- Add `ContinuousAnnotationRenderHarnessTest` — end-to-end regression that seeds a highlight, opens the book in continuous mode, walks the WebView hierarchy, and asserts the mark exists in the DOM.

## Test plan

- [x] `:app:connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=com.riffle.app.feature.reader.ContinuousAnnotationRenderHarnessTest,com.riffle.app.feature.reader.ContinuousAnnotationHighlightsJsTest` — 5/5 green on Harness AVD.
- [ ] Manual: open a book with paged-mode highlights, flip orientation to continuous in the in-reader settings sheet, verify highlights + note glyphs render on the page (the test harness's DataStore-driven orientation update doesn't propagate through `composeTestRule` in time, so the mid-session switch path is only covered by the code-path guarantee — the in-app `updateFormatting` path writes `_formattingPreferences` synchronously and exercises the same fixed code).