### PR TITLE
fix(annotation-sync): split device meta into a sentinel for honest Last synced

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/settings/annotationsync/AnnotationSyncMaintenanceScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/annotationsync/AnnotationSyncMaintenanceScreen.kt
@@ -442,16 +442,14 @@ private fun MaintenanceSnackBanner(snack: MaintenanceSnack, onDismiss: () -> Uni
             val parts = mutableListOf<String>()
             parts += "Forgot \"${snack.label}\""
             parts += "${snack.files} file(s) removed"
-            if (snack.legacySidecarDeleted) parts += "legacy sidecar removed"
             if (snack.failures > 0) parts += "${snack.failures} failure(s)"
             parts.joinToString(" · ") to (snack.failures > 0)
         }
         is MaintenanceSnack.Renamed -> {
-            val parts = mutableListOf<String>()
-            parts += "Device renamed"
-            parts += "${snack.rewritten} file(s) updated"
-            if (snack.failures > 0) parts += "${snack.failures} failure(s)"
-            parts.joinToString(" · ") to (snack.failures > 0)
+            // The sentinel is a single file; reporting a count would always say "1 file(s) updated"
+            // on success, which carries no information. Surface only success vs. failure.
+            val text = if (snack.failures > 0) "Device rename failed" else "Device renamed"
+            text to (snack.failures > 0)
         }
         is MaintenanceSnack.ForgotUser ->
             "Forgot \"${snack.userLabel}\" · ${snack.files} file(s) removed" to false

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/annotationsync/AnnotationSyncMaintenanceViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/annotationsync/AnnotationSyncMaintenanceViewModel.kt
@@ -3,6 +3,8 @@ package com.riffle.app.feature.settings.annotationsync
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.riffle.core.data.AnnotationSyncMaintenance
+import com.riffle.core.data.AnnotationSyncStatusStore
+import com.riffle.core.data.CycleOutcome
 import com.riffle.core.domain.DeviceIdStore
 import com.riffle.core.domain.DeviceLabelResolver
 import com.riffle.core.domain.DeviceLabelStore
@@ -40,7 +42,7 @@ sealed class MaintenanceScreenUiState {
 /** Banner shown after Forget/Compact completes. */
 sealed class MaintenanceSnack {
     object None : MaintenanceSnack()
-    data class Forgot(val label: String, val files: Int, val legacySidecarDeleted: Boolean, val failures: Int) : MaintenanceSnack()
+    data class Forgot(val label: String, val files: Int, val failures: Int) : MaintenanceSnack()
     data class ForgotUser(val userLabel: String, val files: Int) : MaintenanceSnack()
     data class Renamed(val rewritten: Int, val failures: Int) : MaintenanceSnack()
 }
@@ -81,6 +83,7 @@ class AnnotationSyncMaintenanceViewModel @Inject constructor(
     private val deviceLabelStore: DeviceLabelStore,
     private val deviceLabelResolver: DeviceLabelResolver,
     private val serverRepository: ServerRepository,
+    private val statusStore: AnnotationSyncStatusStore,
 ) : ViewModel() {
 
     private val _state = MutableStateFlow(AnnotationSyncMaintenanceUiState())
@@ -119,7 +122,6 @@ class AnnotationSyncMaintenanceViewModel @Inject constructor(
                 snack = MaintenanceSnack.Forgot(
                     label = row.label,
                     files = result.deletedAnnotationFiles,
-                    legacySidecarDeleted = result.deletedLegacySidecar,
                     failures = result.failures,
                 ),
             )
@@ -242,7 +244,7 @@ class AnnotationSyncMaintenanceViewModel @Inject constructor(
                         namespace = summary.namespace,
                         displayLabel = username,
                         devices = nestedRows.map { it.toUiRow(summary.namespace, myDeviceId = "", myLocalLabel = "") },
-                        totalFileCount = summary.annotationFileCount + summary.sidecarCount,
+                        totalFileCount = summary.annotationFileCount,
                     )
                 }
         } catch (_: Exception) {
@@ -260,6 +262,12 @@ class AnnotationSyncMaintenanceViewModel @Inject constructor(
      * "this device" treatment only applies when [myDeviceId] matches and the row is under the
      * **active** namespace — foreign-user groups should never carry the chip even if a deviceId
      * happens to collide.
+     *
+     * "Last synced" sources differ by row type. This device reads the in-memory cycle outcome
+     * (matches the AddServer banner) and so honours pull-only cycles even though they leave no
+     * trace in WebDAV. Foreign devices read their own sentinel (refreshed by them on every
+     * cycle), so a peer that hasn't run a cycle on the new client shows no "Last synced" — the
+     * honest signal that we have no recent evidence of them.
      */
     private fun AnnotationSyncMaintenance.DeviceRow.toUiRow(
         namespace: String,
@@ -274,10 +282,15 @@ class AnnotationSyncMaintenanceViewModel @Inject constructor(
         }
         val parts = mutableListOf<String>()
         parts += "$annotationFileCount annotation file" + if (annotationFileCount == 1) "" else "s"
-        metadata?.lastSeenAt
-            ?.takeIf { it.isNotBlank() }
-            ?.let { humanizeLastSeen(it) }
-            ?.let { parts += "Last synced $it" }
+        val lastSynced = when {
+            isMe -> (statusStore.lastCycleOutcome.value as? CycleOutcome.Success)
+                ?.atMs
+                ?.let { humanizeEpochMs(it) }
+            else -> metadata?.lastSyncedAt
+                ?.takeIf { it.isNotBlank() }
+                ?.let { humanizeIso(it) }
+        }
+        lastSynced?.let { parts += "Last synced $it" }
         return MaintenanceDeviceRowUiState(
             deviceId = deviceId,
             namespace = namespace,
@@ -287,8 +300,8 @@ class AnnotationSyncMaintenanceViewModel @Inject constructor(
         )
     }
 
-    /** Best-effort ISO-8601 → "yyyy-MM-dd HH:mm" formatter; returns the raw input on failure. */
-    private fun humanizeLastSeen(iso: String): String = try {
+    /** ISO-8601 → "yyyy-MM-dd HH:mm" in the device's timezone; returns the raw input on failure. */
+    private fun humanizeIso(iso: String): String = try {
         val instant = java.time.Instant.parse(iso)
         java.time.format.DateTimeFormatter
             .ofPattern("yyyy-MM-dd HH:mm")
@@ -297,6 +310,13 @@ class AnnotationSyncMaintenanceViewModel @Inject constructor(
     } catch (_: Exception) {
         iso
     }
+
+    /** Epoch millis → "yyyy-MM-dd HH:mm" in the device's timezone. */
+    private fun humanizeEpochMs(atMs: Long): String =
+        java.time.format.DateTimeFormatter
+            .ofPattern("yyyy-MM-dd HH:mm")
+            .withZone(java.time.ZoneId.systemDefault())
+            .format(java.time.Instant.ofEpochMilli(atMs))
 
     private suspend fun resolveNamespace(): String? {
         // Active server first (most relevant to the user), then any configured ABS server with a

--- a/app/src/test/kotlin/com/riffle/app/feature/settings/annotationsync/AnnotationSyncMaintenanceViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/settings/annotationsync/AnnotationSyncMaintenanceViewModelTest.kt
@@ -1,8 +1,10 @@
 package com.riffle.app.feature.settings.annotationsync
 
-import com.riffle.core.data.AnnotationFileHeaderCodec
+import com.riffle.core.data.AnnotationDeviceMetaCodec
 import com.riffle.core.data.AnnotationSyncMaintenance
-import com.riffle.core.domain.AnnotationFileHeader
+import com.riffle.core.data.AnnotationSyncStatusStore
+import com.riffle.core.data.CycleOutcome
+import com.riffle.core.domain.AnnotationDeviceMeta
 import com.riffle.core.domain.AnnotationFileRef
 import com.riffle.core.domain.AnnotationSyncConfig
 import com.riffle.core.domain.AnnotationSyncConfigStore
@@ -56,58 +58,65 @@ class AnnotationSyncMaintenanceViewModelTest {
     @After fun tearDown() { Dispatchers.resetMain() }
 
     @Test
-    fun `device row labels the header timestamp as Last synced not Last seen`() = runTest {
+    fun `this-device row reads Last synced from the in-memory status store, not from any file`() = runTest {
+        // The status store advances on every successful cycle (including pull-only), so this is
+        // the only honest source for the current device's "Last synced". The per-device sentinel
+        // on disk lags the cycle store by a network write, and per-file headers don't capture
+        // pull-only cycles at all.
         val activeNs = "alice-userid"
-        val header = AnnotationFileHeaderCodec.buildFileBody(
-            AnnotationFileHeader(
-                deviceId = "this-device",
-                label = "Alice's Pixel",
-                lastSeenAt = "2026-06-25T12:00:00Z",
-                username = "alice",
-                bookTitle = "Project Hail Mary",
-            ),
-            annotationJsonStrings = emptyList(),
-        )
-        val target = InMemoryTarget(
-            files = mutableMapOf(
-                FileKey(activeNs, "i1", "annotations-this-device.jsonld") to header,
-            ),
-        )
-
-        val vm = vmWith(target, activeNs = activeNs)
-        advanceUntilIdle()
-
-        val rows = (vm.state.value.devices as MaintenanceScreenUiState.Loaded).devices
-        val secondary = rows.single().secondary
-        assertTrue(
-            "secondary line must use \"Last synced\" — \"Last seen\" reads as nonsense for the current device; got: $secondary",
-            secondary.contains("Last synced"),
-        )
-        assertTrue(
-            "stale \"Last seen\" label must not resurface; got: $secondary",
-            !secondary.contains("Last seen"),
-        )
-    }
-
-    @Test
-    fun `foreign namespace shows up as Other Users group labelled by username from header`() = runTest {
-        val activeNs = "alice-userid"
-        val foreignNs = "bob-userid"
-        val foreignHeader = AnnotationFileHeaderCodec.buildFileBody(
-            AnnotationFileHeader(
-                deviceId = "bobs-phone",
-                label = "Bob's Pixel",
-                lastSeenAt = "2026-06-25T12:00:00Z",
-                username = "bob",
-                bookTitle = "Project Hail Mary",
-            ),
-            annotationJsonStrings = emptyList(),
-        )
         val target = InMemoryTarget(
             files = mutableMapOf(
                 FileKey(activeNs, "i1", "annotations-this-device.jsonld") to "[]",
-                FileKey(foreignNs, "i2", "annotations-bobs-phone.jsonld") to foreignHeader,
             ),
+        )
+        val statusStore = AnnotationSyncStatusStore().apply {
+            report(CycleOutcome.Success(atMs = 1_780_000_000_000L))
+        }
+
+        val vm = vmWith(target, activeNs = activeNs, statusStore = statusStore)
+        advanceUntilIdle()
+
+        val rows = (vm.state.value.devices as MaintenanceScreenUiState.Loaded).devices
+        val secondary = rows.single { it.isThisDevice }.secondary
+        assertTrue("got: $secondary", secondary.contains("Last synced"))
+        // No "Last seen" — the relabel and source change took effect together.
+        assertTrue("got: $secondary", !secondary.contains("Last seen"))
+    }
+
+    @Test
+    fun `this-device row shows no Last synced when the status store is NeverRun`() = runTest {
+        val activeNs = "alice-userid"
+        val target = InMemoryTarget(
+            files = mutableMapOf(
+                FileKey(activeNs, "i1", "annotations-this-device.jsonld") to "[]",
+            ),
+        )
+        // Default status store is NeverRun — fresh process, no cycle has fired yet.
+        val vm = vmWith(target, activeNs = activeNs, statusStore = AnnotationSyncStatusStore())
+        advanceUntilIdle()
+
+        val rows = (vm.state.value.devices as MaintenanceScreenUiState.Loaded).devices
+        val secondary = rows.single { it.isThisDevice }.secondary
+        assertTrue("got: $secondary", !secondary.contains("Last synced"))
+    }
+
+    @Test
+    fun `foreign namespace surfaces as Other Users group labelled by username from sentinel`() = runTest {
+        val activeNs = "alice-userid"
+        val foreignNs = "bob-userid"
+        val target = InMemoryTarget(
+            files = mutableMapOf(
+                FileKey(activeNs, "i1", "annotations-this-device.jsonld") to "[]",
+                FileKey(foreignNs, "i2", "annotations-bobs-phone.jsonld") to "[]",
+            ),
+        )
+        target.deviceMetaFiles[foreignNs to "bobs-phone"] = AnnotationDeviceMetaCodec.encode(
+            AnnotationDeviceMeta(
+                deviceId = "bobs-phone",
+                label = "Bob's Pixel",
+                lastSyncedAt = "2026-06-25T12:00:00Z",
+                username = "bob",
+            )
         )
 
         val vm = vmWith(target, activeNs = activeNs)
@@ -117,7 +126,6 @@ class AnnotationSyncMaintenanceViewModelTest {
         assertEquals(1, state.otherUsers.size)
         val group = state.otherUsers.single()
         assertEquals(foreignNs, group.namespace)
-        // Username from the header object surfaces as the group label — not the opaque user.id.
         assertEquals("bob", group.displayLabel)
         assertEquals(1, group.devices.size)
         assertEquals(foreignNs, group.devices.single().namespace)
@@ -130,14 +138,10 @@ class AnnotationSyncMaintenanceViewModelTest {
     fun `forget on a foreign-user device routes to the foreign namespace`() = runTest {
         val activeNs = "alice-userid"
         val foreignNs = "bob-userid"
-        val foreignHeader = AnnotationFileHeaderCodec.buildFileBody(
-            AnnotationFileHeader("bobs-phone", "Bob's Pixel", "2026-06-25T12:00:00Z", "bob"),
-            annotationJsonStrings = emptyList(),
-        )
         val target = InMemoryTarget(
             files = mutableMapOf(
                 FileKey(activeNs, "i1", "annotations-this-device.jsonld") to "[]",
-                FileKey(foreignNs, "i2", "annotations-bobs-phone.jsonld") to foreignHeader,
+                FileKey(foreignNs, "i2", "annotations-bobs-phone.jsonld") to "[]",
             ),
         )
 
@@ -158,10 +162,9 @@ class AnnotationSyncMaintenanceViewModelTest {
     }
 
     @Test
-    fun `legacy file with no username falls back to a null displayLabel`() = runTest {
+    fun `foreign namespace with no sentinel falls back to a null displayLabel`() = runTest {
         val activeNs = "alice-userid"
         val foreignNs = "old-userid"
-        // Header-less file (pre-embed-header refactor) → listDevices yields a row with null metadata.
         val target = InMemoryTarget(
             files = mutableMapOf(
                 FileKey(activeNs, "i1", "annotations-this-device.jsonld") to "[]",
@@ -173,7 +176,8 @@ class AnnotationSyncMaintenanceViewModelTest {
         advanceUntilIdle()
 
         val group = vm.state.value.otherUsers.single()
-        assertNull("no username in any header → group has no displayLabel", group.displayLabel)
+        assertNull("no sentinel for any device in this namespace → group has no displayLabel",
+            group.displayLabel)
     }
 
     // --- fakes ---
@@ -181,6 +185,7 @@ class AnnotationSyncMaintenanceViewModelTest {
     private fun vmWith(
         target: InMemoryTarget,
         activeNs: String,
+        statusStore: AnnotationSyncStatusStore = AnnotationSyncStatusStore(),
     ): AnnotationSyncMaintenanceViewModel {
         val maintenance = AnnotationSyncMaintenance(targetProvider = { target })
         return AnnotationSyncMaintenanceViewModel(
@@ -190,6 +195,7 @@ class AnnotationSyncMaintenanceViewModelTest {
             deviceLabelStore = FakeDeviceLabelStore(),
             deviceLabelResolver = FakeDeviceLabelResolver("This Device"),
             serverRepository = FakeServerRepository(activeAbsUserId = activeNs),
+            statusStore = statusStore,
         )
     }
 
@@ -210,7 +216,12 @@ class AnnotationSyncMaintenanceViewModelTest {
         override suspend fun delete(namespace: String, itemId: String, filename: String) {
             files.remove(FileKey(namespace, itemId, filename))
         }
-        override suspend fun deleteDeviceSidecar(namespace: String, deviceId: String) {}
+        val deviceMetaFiles: MutableMap<Pair<String, String>, String> = mutableMapOf()
+        override suspend fun readDeviceMeta(namespace: String, deviceId: String): String? =
+            deviceMetaFiles[namespace to deviceId]
+        override suspend fun writeDeviceMeta(namespace: String, deviceId: String, content: String) {
+            deviceMetaFiles[namespace to deviceId] = content
+        }
         override suspend fun enumerateDevices(namespace: String): NamespaceDeviceListing {
             val byDevice = files.keys
                 .filter { it.namespace == namespace }
@@ -219,7 +230,6 @@ class AnnotationSyncMaintenanceViewModelTest {
                 DeviceFileSummary(
                     deviceId = deviceId,
                     annotationFiles = byDevice[deviceId].orEmpty().map { AnnotationFileRef(it.itemId, it.filename) },
-                    hasLegacySidecar = false,
                 )
             }
             return NamespaceDeviceListing(rows)
@@ -227,7 +237,7 @@ class AnnotationSyncMaintenanceViewModelTest {
         override suspend fun enumerateNamespaces(): List<NamespaceSummary> {
             val byNs = files.keys.groupBy { it.namespace }.mapValues { it.value.size }
             return byNs.keys.toSortedSet().map { ns ->
-                NamespaceSummary(namespace = ns, annotationFileCount = byNs[ns] ?: 0, sidecarCount = 0)
+                NamespaceSummary(namespace = ns, annotationFileCount = byNs[ns] ?: 0)
             }
         }
         override suspend fun forgetNamespace(namespace: String): Int {

--- a/app/src/test/kotlin/com/riffle/app/feature/settings/annotationsync/AnnotationSyncMaintenanceViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/settings/annotationsync/AnnotationSyncMaintenanceViewModelTest.kt
@@ -222,6 +222,9 @@ class AnnotationSyncMaintenanceViewModelTest {
         override suspend fun writeDeviceMeta(namespace: String, deviceId: String, content: String) {
             deviceMetaFiles[namespace to deviceId] = content
         }
+        override suspend fun deleteDeviceMeta(namespace: String, deviceId: String) {
+            deviceMetaFiles.remove(namespace to deviceId)
+        }
         override suspend fun enumerateDevices(namespace: String): NamespaceDeviceListing {
             val byDevice = files.keys
                 .filter { it.namespace == namespace }

--- a/core/data/src/main/kotlin/com/riffle/core/data/AnnotationDeviceMetaCodec.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/AnnotationDeviceMetaCodec.kt
@@ -1,0 +1,49 @@
+package com.riffle.core.data
+
+import com.riffle.core.domain.AnnotationDeviceMeta
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+
+/**
+ * JSON codec for the per-device metadata sentinel ([AnnotationDeviceMeta]).
+ *
+ * The file body is a single JSON object:
+ * ```
+ * {"type":"riffle:DeviceSyncMeta","deviceId":"...","label":"...","lastSyncedAt":"...","username":"..."}
+ * ```
+ *
+ * Distinct `type` discriminator from the legacy `riffle:FileHeader` / `riffle:DeviceMeta`
+ * embedded annotation-file header so a future reader can tell at a glance what schema it's
+ * looking at and so the two never accidentally cross-parse.
+ */
+object AnnotationDeviceMetaCodec {
+
+    const val TYPE = "riffle:DeviceSyncMeta"
+
+    private val json = Json { ignoreUnknownKeys = true; prettyPrint = false }
+
+    /** Render an [AnnotationDeviceMeta] as the JSON object body for `device-meta-<deviceId>.json`. */
+    fun encode(meta: AnnotationDeviceMeta): String = buildJsonObject {
+        put("type", TYPE)
+        put("deviceId", meta.deviceId)
+        put("label", meta.label)
+        put("lastSyncedAt", meta.lastSyncedAt)
+        meta.username?.takeIf { it.isNotBlank() }?.let { put("username", it) }
+    }.toString()
+
+    /** Parse a sentinel-file body. Returns null when the body is malformed or carries the wrong type. */
+    fun decode(fileBody: String): AnnotationDeviceMeta? = try {
+        val obj = json.parseToJsonElement(fileBody) as? JsonObject ?: return null
+        if (obj["type"]?.jsonPrimitive?.content != TYPE) return null
+        val deviceId = obj["deviceId"]?.jsonPrimitive?.content ?: return null
+        val label = obj["label"]?.jsonPrimitive?.content ?: return null
+        val lastSyncedAt = obj["lastSyncedAt"]?.jsonPrimitive?.content ?: return null
+        val username = obj["username"]?.jsonPrimitive?.content?.takeIf { it.isNotBlank() }
+        AnnotationDeviceMeta(deviceId, label, lastSyncedAt, username)
+    } catch (_: Exception) {
+        null
+    }
+}

--- a/core/data/src/main/kotlin/com/riffle/core/data/AnnotationFileHeaderCodec.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/AnnotationFileHeaderCodec.kt
@@ -11,12 +11,12 @@ import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.put
 
 /**
- * JSON helpers for the [AnnotationFileHeader] embedded in each annotation file.
+ * JSON helpers for the book-scoped [AnnotationFileHeader] embedded in each annotation file.
  *
  * Each per-device annotation file is a JSON array whose first element is a header object:
  * ```
  * [
- *   {"type":"riffle:FileHeader","deviceId":"...","label":"...","lastSeenAt":"...","username":"..."},
+ *   {"type":"riffle:FileHeader","deviceId":"...","bookTitle":"..."},
  *   { ...annotation 1... },
  *   { ...annotation 2... }
  * ]
@@ -24,6 +24,11 @@ import kotlinx.serialization.json.put
  *
  * The W3C annotation parser drops entries that don't carry an `id`, so the header is
  * automatically excluded from merge and from older readers — backwards-compatible.
+ *
+ * Legacy headers from earlier builds also carried device-scoped fields (`label`, `lastSeenAt`,
+ * `username`). Those moved to the per-device sentinel ([AnnotationDeviceMetaCodec]) on this build;
+ * on read we ignore the legacy fields here, and on write we don't emit them, so the headers in the
+ * share converge on the slim shape after every device's next push.
  */
 object AnnotationFileHeaderCodec {
 
@@ -35,11 +40,6 @@ object AnnotationFileHeaderCodec {
      * AnnotationFileHeader rename still surface their metadata on Maintenance; write-side
      * never uses it. The transition is bounded — every push rewrites the file from scratch
      * with [HEADER_TYPE], so over time every file in the share converges on the new marker.
-     *
-     * TODO(annotation-sync): remove this legacy marker — and all references to it in
-     *  [recognisedHeaderTypes], [extractHeader], [replaceHeader], and any test fixtures —
-     *  once we're confident every install has rewritten its files at least once. Safe to
-     *  drop a few releases after the rename ships.
      */
     private const val LEGACY_HEADER_TYPE = "riffle:DeviceMeta"
 
@@ -51,9 +51,6 @@ object AnnotationFileHeaderCodec {
     fun encodeHeader(header: AnnotationFileHeader): String = buildJsonObject {
         put("type", HEADER_TYPE)
         put("deviceId", header.deviceId)
-        put("label", header.label)
-        put("lastSeenAt", header.lastSeenAt)
-        header.username?.takeIf { it.isNotBlank() }?.let { put("username", it) }
         header.bookTitle?.takeIf { it.isNotBlank() }?.let { put("bookTitle", it) }
     }.toString()
 
@@ -71,8 +68,9 @@ object AnnotationFileHeaderCodec {
     /**
      * Pull the [AnnotationFileHeader] out of a serialised annotation-file body, if present.
      * Accepts both the current and legacy header markers so files written by older builds
-     * still surface their metadata. Returns null when the body is malformed, isn't a JSON
-     * array, or carries no recognised header object.
+     * still surface their book title. Legacy device-scoped fields (label/lastSeenAt/username)
+     * are silently ignored — they live in the per-device sentinel now. Returns null when the
+     * body is malformed, isn't a JSON array, or carries no recognised header object.
      */
     fun extractHeader(fileBody: String): AnnotationFileHeader? = try {
         val root = json.parseToJsonElement(fileBody)
@@ -89,35 +87,9 @@ object AnnotationFileHeaderCodec {
         null
     }
 
-    /**
-     * Replace the existing header in [fileBody] with [header]. Used by "rename this device" to
-     * refresh the label across every annotation file owned by this device. Drops headers
-     * carrying either the current or legacy marker so renaming through the transition leaves a
-     * single clean header instead of stacking a new one on top of an old one. Returns the
-     * original body unchanged when parsing fails.
-     */
-    fun replaceHeader(fileBody: String, header: AnnotationFileHeader): String {
-        val root = try { json.parseToJsonElement(fileBody) } catch (_: Exception) { return fileBody }
-        val elements: List<JsonElement> = when (root) {
-            is JsonArray -> root.toList()
-            is JsonObject -> listOf(root)
-            else -> return fileBody
-        }
-        val annotationsOnly = elements
-            .filter { el ->
-                val obj = el as? JsonObject ?: return@filter true
-                (obj["type"]?.jsonPrimitive?.content ?: "") !in recognisedHeaderTypes
-            }
-            .map { it.toString() }
-        return buildFileBody(header, annotationsOnly)
-    }
-
     private fun headerObjectToHeader(obj: JsonObject): AnnotationFileHeader? {
         val deviceId = obj["deviceId"]?.jsonPrimitive?.content ?: return null
-        val label = obj["label"]?.jsonPrimitive?.content ?: return null
-        val lastSeenAt = obj["lastSeenAt"]?.jsonPrimitive?.content ?: return null
-        val username = obj["username"]?.jsonPrimitive?.content?.takeIf { it.isNotBlank() }
         val bookTitle = obj["bookTitle"]?.jsonPrimitive?.content?.takeIf { it.isNotBlank() }
-        return AnnotationFileHeader(deviceId, label, lastSeenAt, username, bookTitle)
+        return AnnotationFileHeader(deviceId, bookTitle)
     }
 }

--- a/core/data/src/main/kotlin/com/riffle/core/data/AnnotationSweep.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/AnnotationSweep.kt
@@ -1,6 +1,7 @@
 package com.riffle.core.data
 
 import com.riffle.core.database.AnnotationDao
+import com.riffle.core.domain.AnnotationDeviceMeta
 import com.riffle.core.domain.AnnotationSyncTarget
 import com.riffle.core.domain.DeviceIdStore
 import com.riffle.core.domain.DeviceLabelResolver
@@ -39,17 +40,49 @@ class AnnotationSweep(
     suspend fun run() {
         val target = targetProvider() ?: return
 
+        // Sentinels are written once per unique namespace touched this cycle. Skip pull-only
+        // sweeps with nothing dirty — the live controller refreshes sentinels on its own paths
+        // and writing here would require iterating every known namespace.
+        val sentinelTargets = mutableSetOf<Pair<String, String>>()
         try {
             val deviceId = deviceIdStore.getOrCreate()
             for ((serverId, itemId) in annotationDao.dirtyServerItems()) {
                 val namespace = serverRepository.ensureAbsUserId(serverId) ?: continue
-                val username = serverRepository.getById(serverId)?.username
                 val bookTitle = bookTitleProvider(serverId, itemId)
-                pushBook(target, serverId, namespace, itemId, deviceId, username, bookTitle)
+                pushBook(target, serverId, namespace, itemId, deviceId, bookTitle)
+                sentinelTargets += serverId to namespace
             }
             statusStore.report(CycleOutcome.Success(clock()))
+            for ((serverId, namespace) in sentinelTargets) {
+                writeDeviceMetaQuietly(target, deviceId, namespace, serverId)
+            }
         } catch (e: Exception) {
             statusStore.report(e.toFailedCycleOutcome(clock()))
+        }
+    }
+
+    /**
+     * Best-effort write of this device's metadata sentinel under [namespace]. See
+     * [AnnotationSyncController.writeDeviceMetaQuietly] for the rationale; same swallow behaviour.
+     */
+    private suspend fun writeDeviceMetaQuietly(
+        target: AnnotationSyncTarget,
+        deviceId: String,
+        namespace: String,
+        serverId: String,
+    ) {
+        try {
+            val body = AnnotationDeviceMetaCodec.encode(
+                AnnotationDeviceMeta(
+                    deviceId = deviceId,
+                    label = deviceLabelResolver.resolveLabel(deviceId),
+                    lastSyncedAt = nowIso(),
+                    username = serverRepository.getById(serverId)?.username,
+                )
+            )
+            target.writeDeviceMeta(namespace, deviceId, body)
+        } catch (_: Exception) {
+            // Swallowed — see [AnnotationSyncController.writeDeviceMetaQuietly].
         }
     }
 
@@ -59,22 +92,15 @@ class AnnotationSweep(
         namespace: String,
         itemId: String,
         deviceId: String,
-        username: String?,
         bookTitle: String?,
     ) {
         val rows = annotationDao.getAllForItemIncludingDeleted(serverId, itemId)
         if (rows.isEmpty()) return
         val jsonStrings = rows.map { AnnotationW3CCodec.annotationEntityToW3C(it) }
         // Mirror the header written by AnnotationSyncController.pushPending so files from the
-        // sweep and from the live controller are format-identical. Without this, the sweep would
-        // overwrite the header on every alternate push.
-        val header = AnnotationFileHeader(
-            deviceId = deviceId,
-            label = deviceLabelResolver.resolveLabel(deviceId),
-            lastSeenAt = nowIso(),
-            username = username,
-            bookTitle = bookTitle,
-        )
+        // sweep and from the live controller are format-identical. Device-scoped metadata
+        // lives in the per-device sentinel — see [AnnotationDeviceMeta].
+        val header = AnnotationFileHeader(deviceId = deviceId, bookTitle = bookTitle)
         val jsonArray = AnnotationFileHeaderCodec.buildFileBody(header, jsonStrings)
         target.write(namespace, itemId, "annotations-$deviceId.jsonld", jsonArray)
         annotationDao.markSynced(rows.map { it.id }, clock())

--- a/core/data/src/main/kotlin/com/riffle/core/data/AnnotationSyncController.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/AnnotationSyncController.kt
@@ -2,6 +2,7 @@ package com.riffle.core.data
 
 import com.riffle.core.database.AnnotationDao
 import com.riffle.core.database.AnnotationEntity
+import com.riffle.core.domain.AnnotationDeviceMeta
 import com.riffle.core.domain.AnnotationMergeService
 import com.riffle.core.domain.AnnotationSweepEnqueuer
 import com.riffle.core.domain.AnnotationSyncTarget
@@ -101,6 +102,33 @@ class AnnotationSyncController(
      * success or failure. Shared by [syncOnOpen] (which lists first) and [startLiveSync] (which
      * lists itself so it can short-circuit when no peer files exist).
      */
+    /**
+     * Best-effort write of this device's metadata sentinel under [namespace]. Called at the end
+     * of every successful sync cycle so peers see "Last synced …" advance on pull-only cycles too.
+     * Failure is swallowed — the next cycle will rewrite, and we don't want a transient WebDAV
+     * blip on the sentinel to flip a successful merge/push to Failed.
+     */
+    private suspend fun writeDeviceMetaQuietly(
+        target: AnnotationSyncTarget,
+        namespace: String,
+        serverId: String,
+    ) {
+        try {
+            val deviceId = deviceIdStore.getOrCreate()
+            val body = AnnotationDeviceMetaCodec.encode(
+                AnnotationDeviceMeta(
+                    deviceId = deviceId,
+                    label = deviceLabelResolver.resolveLabel(deviceId),
+                    lastSyncedAt = nowIso(),
+                    username = usernameProvider(serverId),
+                )
+            )
+            target.writeDeviceMeta(namespace, deviceId, body)
+        } catch (_: Exception) {
+            // Best-effort. See kdoc.
+        }
+    }
+
     private suspend fun runMergeFromListing(
         target: AnnotationSyncTarget,
         serverId: String,
@@ -171,6 +199,7 @@ class AnnotationSyncController(
                 annotationDao.upsert(entity)
             }
             statusStore.report(CycleOutcome.Success(clock()))
+            writeDeviceMetaQuietly(target, namespace, serverId)
         } catch (e: Exception) {
             statusStore.report(e.toFailedCycleOutcome(clock()))
         }
@@ -226,6 +255,7 @@ class AnnotationSyncController(
                     // Success so the status badge can recover from a prior Failed.* state without
                     // forcing a no-op merge that would only re-read our own file.
                     statusStore.report(CycleOutcome.Success(clock()))
+                    writeDeviceMetaQuietly(target, namespace, serverId)
                 }
             }
         }
@@ -288,12 +318,11 @@ class AnnotationSyncController(
                 AnnotationW3CCodec.annotationEntityToW3C(entity)
             }
             // Embed the file header at position 0 of the array. Old readers already drop entries
-            // with no `id`, so the header is invisible to merge.
+            // with no `id`, so the header is invisible to merge. Device-scoped metadata
+            // (label, lastSyncedAt, username) lives in the per-device sentinel — see
+            // [AnnotationDeviceMeta] — so this header carries only the book-scoped bookTitle.
             val header = AnnotationFileHeader(
                 deviceId = deviceId,
-                label = deviceLabelResolver.resolveLabel(deviceId),
-                lastSeenAt = nowIso(),
-                username = usernameProvider(serverId),
                 bookTitle = bookTitleProvider(serverId, itemId),
             )
             val jsonArray = AnnotationFileHeaderCodec.buildFileBody(header, jsonStrings)
@@ -302,6 +331,7 @@ class AnnotationSyncController(
             val now = clock()
             annotationDao.markSynced(localEntities.map { it.id }, now)
             statusStore.report(CycleOutcome.Success(now))
+            writeDeviceMetaQuietly(target, namespace, serverId)
         } catch (e: Exception) {
             statusStore.report(e.toFailedCycleOutcome(clock()))
             sweepEnqueuer.enqueue()

--- a/core/data/src/main/kotlin/com/riffle/core/data/AnnotationSyncController.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/AnnotationSyncController.kt
@@ -97,12 +97,6 @@ class AnnotationSyncController(
     }
 
     /**
-     * Merge the device files already listed in [filenames] into Room using the same [target]
-     * instance that produced the listing. Reports a [CycleOutcome] to the status store on
-     * success or failure. Shared by [syncOnOpen] (which lists first) and [startLiveSync] (which
-     * lists itself so it can short-circuit when no peer files exist).
-     */
-    /**
      * Best-effort write of this device's metadata sentinel under [namespace]. Called at the end
      * of every successful sync cycle so peers see "Last synced …" advance on pull-only cycles too.
      * Failure is swallowed — the next cycle will rewrite, and we don't want a transient WebDAV
@@ -129,6 +123,12 @@ class AnnotationSyncController(
         }
     }
 
+    /**
+     * Merge the device files already listed in [filenames] into Room using the same [target]
+     * instance that produced the listing. Reports a [CycleOutcome] to the status store on
+     * success or failure. Shared by [syncOnOpen] (which lists first) and [startLiveSync] (which
+     * lists itself so it can short-circuit when no peer files exist).
+     */
     private suspend fun runMergeFromListing(
         target: AnnotationSyncTarget,
         serverId: String,

--- a/core/data/src/main/kotlin/com/riffle/core/data/AnnotationSyncMaintenance.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/AnnotationSyncMaintenance.kt
@@ -120,7 +120,14 @@ class AnnotationSyncMaintenance(
         val failures: Int,
     )
 
-    /** Deletes every annotation file belonging to [deviceId] under [namespace]. */
+    /**
+     * Deletes every annotation file belonging to [deviceId] under [namespace], plus that device's
+     * metadata sentinel. The sentinel delete is best-effort — failures don't block reporting
+     * success on the annotation-file deletes, but they DO count against [ForgetResult.failures]
+     * so the user sees the partial outcome. Without the sentinel delete, a forgotten peer that
+     * later writes one annotation file would resurrect its row carrying the stale pre-forget
+     * label and lastSyncedAt.
+     */
     suspend fun forgetDevice(namespace: String, deviceId: String): ForgetResult {
         val target = targetProvider() ?: return ForgetResult(0, failures = 0)
         val listing = try {
@@ -140,6 +147,11 @@ class AnnotationSyncMaintenance(
             } catch (_: Exception) {
                 failures++
             }
+        }
+        try {
+            target.deleteDeviceMeta(namespace, deviceId)
+        } catch (_: Exception) {
+            failures++
         }
         return ForgetResult(deleted, failures)
     }

--- a/core/data/src/main/kotlin/com/riffle/core/data/AnnotationSyncMaintenance.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/AnnotationSyncMaintenance.kt
@@ -66,7 +66,7 @@ class AnnotationSyncMaintenance(
     data class DeviceRow(
         val deviceId: String,
         val annotationFileCount: Int,
-        val metadata: com.riffle.core.domain.AnnotationDeviceMeta?,
+        val metadata: AnnotationDeviceMeta?,
     )
 
     /** All namespaces discovered on the target, regardless of which is currently active. */

--- a/core/data/src/main/kotlin/com/riffle/core/data/AnnotationSyncMaintenance.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/AnnotationSyncMaintenance.kt
@@ -1,8 +1,8 @@
 package com.riffle.core.data
 
+import com.riffle.core.domain.AnnotationDeviceMeta
 import com.riffle.core.domain.AnnotationSyncTarget
 import com.riffle.core.domain.DeviceFileSummary
-import com.riffle.core.domain.AnnotationFileHeader
 import com.riffle.core.domain.NamespaceSummary
 import java.time.Instant
 
@@ -10,10 +10,9 @@ import java.time.Instant
  * Manual housekeeping for the per-device-file annotation-sync model (issue #78).
  *
  * Single user-initiated action: [forgetDevice] — DELETE every annotation file owned by a single
- * `deviceId` under one namespace, plus any legacy `device-<deviceId>.json` sidecar left over
- * from earlier builds. Safe under the all-mirrors-everything push model because each peer's
- * file already carries the same records; the only risk is data loss from devices that went
- * offline before any other device synced their last edits.
+ * `deviceId` under one namespace. Safe under the all-mirrors-everything push model because each
+ * peer's file already carries the same records; the only risk is data loss from devices that
+ * went offline before any other device synced their last edits.
  *
  * A tombstone-compaction action was prototyped and removed — see ADR 0025 for the rationale.
  * Operates against the controller's active target (gracefully no-ops when sync is disabled).
@@ -29,11 +28,11 @@ class AnnotationSyncMaintenance(
     )
 
     /**
-     * Refresh this device's [AnnotationFileHeader] header across every annotation file it owns under
-     * [namespace]. Used after a rename so peer devices see the new label without waiting for
-     * the next annotation push. Preserves each file's existing `lastSeenAt` so a rename does not
-     * masquerade as a fresh push — the hint stays a real signal of when this device last
-     * actually pushed. Returns counts so the caller can surface partial failure.
+     * Refresh this device's metadata sentinel under [namespace]. Used after a rename so peer
+     * devices see the new label without waiting for the next sync cycle. A rename does not
+     * masquerade as a fresh sync — the sentinel's `lastSyncedAt` is preserved when present so
+     * the visible "Last synced" timestamp stays a real signal of when this device last actually
+     * synced. Returns counts so the caller can surface success/failure.
      */
     suspend fun publishHeader(
         namespace: String,
@@ -42,51 +41,32 @@ class AnnotationSyncMaintenance(
         username: String?,
     ): PublishMetadataResult {
         val target = targetProvider() ?: return PublishMetadataResult(0, 0)
-        val listing = try {
-            target.enumerateDevices(namespace)
+        val existing = try {
+            target.readDeviceMeta(namespace, deviceId)?.let { AnnotationDeviceMetaCodec.decode(it) }
         } catch (_: Exception) {
-            return PublishMetadataResult(0, 1)
+            null
         }
-        val row = listing.devices.firstOrNull { it.deviceId == deviceId }
-            ?: return PublishMetadataResult(0, 0)
-
-        // Mint a single fallback timestamp for files that don't yet have a header. This only fires
-        // on legacy files written before the embed-header refactor; current files always have one.
-        val fallbackLastSeenAt = nowIso()
-        var rewritten = 0
-        var failures = 0
-        for (file in row.annotationFiles) {
-            try {
-                val body = target.read(namespace, file.itemId, file.filename) ?: continue
-                val existing = AnnotationFileHeaderCodec.extractHeader(body)
-                val header = AnnotationFileHeader(
-                    deviceId = deviceId,
-                    label = label,
-                    lastSeenAt = existing?.lastSeenAt ?: fallbackLastSeenAt,
-                    // Preserve any previously-recorded username when the caller didn't supply one
-                    // (e.g. rename triggered before the active user was resolved this session).
-                    username = username ?: existing?.username,
-                    // Rename doesn't know the book title (it iterates files, not catalog rows),
-                    // so keep whatever the previous push embedded — subsequent pushes refresh it.
-                    bookTitle = existing?.bookTitle,
-                )
-                val newBody = AnnotationFileHeaderCodec.replaceHeader(body, header)
-                if (newBody != body) {
-                    target.write(namespace, file.itemId, file.filename, newBody)
-                    rewritten++
-                }
-            } catch (_: Exception) {
-                failures++
-            }
+        val meta = AnnotationDeviceMeta(
+            deviceId = deviceId,
+            label = label,
+            // Rename must NOT bump the visible "Last synced" timestamp — keep whatever the last
+            // real cycle stamped (or, if none, the fallback minted by [nowIso]).
+            lastSyncedAt = existing?.lastSyncedAt ?: nowIso(),
+            username = username ?: existing?.username,
+        )
+        return try {
+            target.writeDeviceMeta(namespace, deviceId, AnnotationDeviceMetaCodec.encode(meta))
+            PublishMetadataResult(rewrittenFiles = 1, failures = 0)
+        } catch (_: Exception) {
+            PublishMetadataResult(rewrittenFiles = 0, failures = 1)
         }
-        return PublishMetadataResult(rewritten, failures)
     }
 
     /** A row in the Maintenance device-list, post header-hydration. */
     data class DeviceRow(
         val deviceId: String,
         val annotationFileCount: Int,
-        val metadata: AnnotationFileHeader?,
+        val metadata: com.riffle.core.domain.AnnotationDeviceMeta?,
     )
 
     /** All namespaces discovered on the target, regardless of which is currently active. */
@@ -117,15 +97,15 @@ class AnnotationSyncMaintenance(
         namespace: String,
         summary: DeviceFileSummary,
     ): DeviceRow {
-        // Read the header from the first available annotation file. Stop at the first parse — every
-        // file owned by this device carries the same metadata (refreshed atomically with each push).
-        val metadata = summary.annotationFiles.firstNotNullOfOrNull { ref ->
-            try {
-                target.read(namespace, ref.itemId, ref.filename)
-                    ?.let { AnnotationFileHeaderCodec.extractHeader(it) }
-            } catch (_: Exception) {
-                null
-            }
+        // Single source of truth: the per-device sentinel. No fallback to per-file headers —
+        // a device that hasn't run a sync cycle on the new client legitimately has no
+        // "Last synced" yet, and presenting per-file `lastSeenAt` would re-introduce the
+        // push-vs-pull dishonesty the sentinel was created to eliminate.
+        val metadata = try {
+            target.readDeviceMeta(namespace, summary.deviceId)
+                ?.let { AnnotationDeviceMetaCodec.decode(it) }
+        } catch (_: Exception) {
+            null
         }
         return DeviceRow(
             deviceId = summary.deviceId,
@@ -137,26 +117,19 @@ class AnnotationSyncMaintenance(
     /** Result of [forgetDevice]. Surfaces partial-success info to the UI. */
     data class ForgetResult(
         val deletedAnnotationFiles: Int,
-        val deletedLegacySidecar: Boolean,
         val failures: Int,
     )
 
-    /**
-     * Deletes every annotation file belonging to [deviceId] under [namespace], plus any legacy
-     * `device-<deviceId>.json` sidecar file from earlier builds. The legacy delete is
-     * opportunistic — current builds don't write sidecars, but older clients in the household
-     * may still publish them.
-     */
+    /** Deletes every annotation file belonging to [deviceId] under [namespace]. */
     suspend fun forgetDevice(namespace: String, deviceId: String): ForgetResult {
-        val target = targetProvider()
-            ?: return ForgetResult(0, deletedLegacySidecar = false, failures = 0)
+        val target = targetProvider() ?: return ForgetResult(0, failures = 0)
         val listing = try {
             target.enumerateDevices(namespace)
         } catch (_: Exception) {
-            return ForgetResult(0, deletedLegacySidecar = false, failures = 1)
+            return ForgetResult(0, failures = 1)
         }
         val row = listing.devices.firstOrNull { it.deviceId == deviceId }
-            ?: return ForgetResult(0, deletedLegacySidecar = false, failures = 0)
+            ?: return ForgetResult(0, failures = 0)
 
         var deleted = 0
         var failures = 0
@@ -168,16 +141,7 @@ class AnnotationSyncMaintenance(
                 failures++
             }
         }
-        var legacySidecarDeleted = false
-        if (row.hasLegacySidecar) {
-            try {
-                target.deleteDeviceSidecar(namespace, deviceId)
-                legacySidecarDeleted = true
-            } catch (_: Exception) {
-                failures++
-            }
-        }
-        return ForgetResult(deleted, legacySidecarDeleted, failures)
+        return ForgetResult(deleted, failures)
     }
 
 }

--- a/core/data/src/main/kotlin/com/riffle/core/data/LocalDirectoryTarget.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/LocalDirectoryTarget.kt
@@ -93,6 +93,15 @@ class LocalDirectoryTarget(private val context: Context) : AnnotationSyncTarget 
         }
     }
 
+    override suspend fun deleteDeviceMeta(namespace: String, deviceId: String) {
+        try {
+            val file = deviceMetaFile(namespace, deviceId)
+            if (file.exists()) file.delete()
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to delete device-meta $deviceId for $namespace", e)
+        }
+    }
+
     override suspend fun enumerateDevices(namespace: String): NamespaceDeviceListing {
         return try {
             val nsDir = namespaceDir(namespace)

--- a/core/data/src/main/kotlin/com/riffle/core/data/LocalDirectoryTarget.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/LocalDirectoryTarget.kt
@@ -15,7 +15,7 @@ import java.io.File
  * Stores per-device annotation files in the app's internal files directory:
  * ```
  * <filesDir>/annotation-sync/<namespace>/<itemId>/annotations-<deviceId>.jsonld
- * <filesDir>/annotation-sync/<namespace>/device-<deviceId>.json   (sidecar; no itemId)
+ * <filesDir>/annotation-sync/<namespace>/device-meta-<deviceId>.json   (sentinel; no itemId)
  * ```
  *
  * This is a test scaffold for issue #75. Issue #76 adds the first network backend
@@ -70,12 +70,26 @@ class LocalDirectoryTarget(private val context: Context) : AnnotationSyncTarget 
         }
     }
 
-    override suspend fun deleteDeviceSidecar(namespace: String, deviceId: String) {
-        try {
-            val file = sidecarFile(namespace, deviceId)
-            if (file.exists()) file.delete()
+    override suspend fun readDeviceMeta(namespace: String, deviceId: String): String? {
+        return try {
+            val file = deviceMetaFile(namespace, deviceId)
+            if (!file.exists()) null else file.readText()
         } catch (e: Exception) {
-            Log.e(TAG, "Failed to delete sidecar $deviceId for $namespace", e)
+            Log.e(TAG, "Failed to read device-meta $deviceId for $namespace", e)
+            null
+        }
+    }
+
+    override suspend fun writeDeviceMeta(namespace: String, deviceId: String, content: String) {
+        try {
+            val dir = namespaceDir(namespace)
+            if (!dir.exists() && !dir.mkdirs()) {
+                throw Exception("Failed to create directory: ${dir.absolutePath}")
+            }
+            deviceMetaFile(namespace, deviceId).writeText(content)
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to write device-meta $deviceId for $namespace", e)
+            throw Exception("Failed to write device-meta $deviceId: ${e.message}", e)
         }
     }
 
@@ -85,15 +99,6 @@ class LocalDirectoryTarget(private val context: Context) : AnnotationSyncTarget 
             if (!nsDir.exists()) return NamespaceDeviceListing(emptyList())
 
             val annotationFiles = mutableMapOf<String, MutableList<AnnotationFileRef>>()
-            val sidecarDeviceIds = mutableSetOf<String>()
-
-            // Sidecars sit at the namespace root.
-            nsDir.listFiles { f ->
-                f.isFile && f.name.startsWith(SIDECAR_NAME_PREFIX) && f.name.endsWith(JSON_SUFFIX)
-            }?.forEach { f ->
-                val deviceId = f.name.removePrefix(SIDECAR_NAME_PREFIX).removeSuffix(JSON_SUFFIX)
-                if (deviceId.isNotEmpty()) sidecarDeviceIds += deviceId
-            }
 
             // Annotation files live under <namespace>/<itemId>/.
             nsDir.listFiles { f -> f.isDirectory }?.forEach { itemDir ->
@@ -113,7 +118,6 @@ class LocalDirectoryTarget(private val context: Context) : AnnotationSyncTarget 
                 DeviceFileSummary(
                     deviceId = deviceId,
                     annotationFiles = annotationFiles[deviceId]?.toList().orEmpty(),
-                    hasLegacySidecar = deviceId in sidecarDeviceIds,
                 )
             }
             NamespaceDeviceListing(devices = rows)
@@ -129,10 +133,6 @@ class LocalDirectoryTarget(private val context: Context) : AnnotationSyncTarget 
             if (!root.exists()) return emptyList()
             root.listFiles { f -> f.isDirectory }?.map { nsDir ->
                 var annotations = 0
-                var sidecars = 0
-                nsDir.listFiles { f ->
-                    f.isFile && f.name.startsWith(SIDECAR_NAME_PREFIX) && f.name.endsWith(JSON_SUFFIX)
-                }?.let { sidecars = it.size }
                 nsDir.listFiles { f -> f.isDirectory }?.forEach { itemDir ->
                     itemDir.listFiles { f ->
                         f.isFile && f.name.startsWith(ANNOTATION_NAME_PREFIX) && f.name.endsWith(JSONLD_SUFFIX)
@@ -141,7 +141,6 @@ class LocalDirectoryTarget(private val context: Context) : AnnotationSyncTarget 
                 NamespaceSummary(
                     namespace = nsDir.name,
                     annotationFileCount = annotations,
-                    sidecarCount = sidecars,
                 )
             }.orEmpty().sortedBy { it.namespace }
         } catch (e: Exception) {
@@ -180,14 +179,14 @@ class LocalDirectoryTarget(private val context: Context) : AnnotationSyncTarget 
     private fun annotationFile(namespace: String, itemId: String, filename: String): File =
         File(bookDir(namespace, itemId), filename)
 
-    private fun sidecarFile(namespace: String, deviceId: String): File =
-        File(namespaceDir(namespace), "$SIDECAR_NAME_PREFIX$deviceId$JSON_SUFFIX")
+    private fun deviceMetaFile(namespace: String, deviceId: String): File =
+        File(namespaceDir(namespace), "$DEVICE_META_NAME_PREFIX$deviceId$JSON_SUFFIX")
 
     companion object {
         private const val TAG = "LocalDirectoryTarget"
         private const val ROOT = "annotation-sync"
         private const val ANNOTATION_NAME_PREFIX = "annotations-"
-        private const val SIDECAR_NAME_PREFIX = "device-"
+        private const val DEVICE_META_NAME_PREFIX = "device-meta-"
         private const val JSONLD_SUFFIX = ".jsonld"
         private const val JSON_SUFFIX = ".json"
     }

--- a/core/data/src/main/kotlin/com/riffle/core/data/WebDavAnnotationSyncTarget.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/WebDavAnnotationSyncTarget.kt
@@ -27,8 +27,6 @@ import javax.xml.parsers.SAXParserFactory
  * under `basePath` and carries the per-account+book scope in its name:
  *
  * - Annotation file: `<basePath>/<namespace>__<itemId>__annotations-<deviceId>.jsonld`
- * - Device sidecar: `<basePath>/<namespace>__device-<deviceId>.json` (no `itemId` segment —
- *   sidecars are global to a device, not per-book).
  *
  * `namespace` is the cross-device-stable ABS user id (`/api/me` → `user.id`, persisted on
  * [com.riffle.core.domain.Server.absUserId]). Using the local `servers.id` here would break
@@ -89,28 +87,24 @@ class WebDavAnnotationSyncTarget(
         deleteFile(annotationFileUrl(namespace, itemId, filename), "delete $filename")
     }
 
-    override suspend fun deleteDeviceSidecar(namespace: String, deviceId: String) {
-        deleteFile(sidecarFileUrl(namespace, deviceId), "delete sidecar $deviceId")
+    override suspend fun readDeviceMeta(namespace: String, deviceId: String): String? =
+        readFile(deviceMetaUrl(namespace, deviceId))
+
+    override suspend fun writeDeviceMeta(namespace: String, deviceId: String, content: String) {
+        withContext(Dispatchers.IO) {
+            putFile(deviceMetaUrl(namespace, deviceId), content, JSON_MEDIA, "write device-meta $deviceId")
+        }
     }
 
     override suspend fun enumerateDevices(namespace: String): NamespaceDeviceListing =
         withContext(Dispatchers.IO) {
             val all = propfindBaseFilenames()
             val annotationPrefix = "$namespace$NAMESPACE_SEPARATOR"
-            val sidecarPrefix = "$namespace$NAMESPACE_SEPARATOR$SIDECAR_NAME_PREFIX"
 
             val annotationFiles = mutableMapOf<String, MutableList<AnnotationFileRef>>()
-            val sidecarDeviceIds = mutableSetOf<String>()
 
             for (physicalName in all) {
                 if (!physicalName.startsWith(annotationPrefix)) continue
-                if (physicalName.startsWith(sidecarPrefix) && physicalName.endsWith(JSON_SUFFIX)) {
-                    val deviceId = physicalName
-                        .removePrefix(sidecarPrefix)
-                        .removeSuffix(JSON_SUFFIX)
-                    if (deviceId.isNotEmpty()) sidecarDeviceIds += deviceId
-                    continue
-                }
                 if (!physicalName.endsWith(JSONLD_SUFFIX)) continue
                 // <namespace>__<itemId>__annotations-<deviceId>.jsonld
                 val afterNamespace = physicalName.removePrefix(annotationPrefix)
@@ -128,14 +122,10 @@ class WebDavAnnotationSyncTarget(
                     .add(AnnotationFileRef(itemId = itemId, filename = filename))
             }
 
-            // Devices appear iff they own at least one annotation file. Legacy sidecars without
-            // matching annotation files are intentionally ignored — they're handled by the
-            // namespace-level cleanup (NamespaceSummary.sidecarCount + forgetNamespace).
             val rows = annotationFiles.keys.toSortedSet().map { deviceId ->
                 DeviceFileSummary(
                     deviceId = deviceId,
                     annotationFiles = annotationFiles[deviceId]?.toList().orEmpty(),
-                    hasLegacySidecar = deviceId in sidecarDeviceIds,
                 )
             }
             NamespaceDeviceListing(devices = rows)
@@ -145,25 +135,21 @@ class WebDavAnnotationSyncTarget(
         withContext(Dispatchers.IO) {
             val all = propfindBaseFilenames()
             val annotationByNs = mutableMapOf<String, Int>()
-            val sidecarByNs = mutableMapOf<String, Int>()
             for (physical in all) {
                 val sepIdx = physical.indexOf(NAMESPACE_SEPARATOR)
                 if (sepIdx <= 0) continue
                 val ns = physical.substring(0, sepIdx)
                 val tail = physical.substring(sepIdx + NAMESPACE_SEPARATOR.length)
                 when {
-                    tail.startsWith(SIDECAR_NAME_PREFIX) && tail.endsWith(JSON_SUFFIX) ->
-                        sidecarByNs[ns] = (sidecarByNs[ns] ?: 0) + 1
                     tail.endsWith(JSONLD_SUFFIX) ->
                         annotationByNs[ns] = (annotationByNs[ns] ?: 0) + 1
                     // else: unknown file under base — skip silently.
                 }
             }
-            (annotationByNs.keys + sidecarByNs.keys).toSortedSet().map { ns ->
+            annotationByNs.keys.toSortedSet().map { ns ->
                 NamespaceSummary(
                     namespace = ns,
                     annotationFileCount = annotationByNs[ns] ?: 0,
-                    sidecarCount = sidecarByNs[ns] ?: 0,
                 )
             }
         }
@@ -174,7 +160,7 @@ class WebDavAnnotationSyncTarget(
         var deleted = 0
         for (physical in all) {
             if (!physical.startsWith(prefix)) continue
-            // Use the physical filename as the URL segment directly. annotationFileUrl/sidecarFileUrl
+            // Use the physical filename as the URL segment directly. annotationFileUrl
             // would re-prefix and double-encode the namespace; just hit the literal name we saw.
             val url = basePath.newBuilder().addPathSegment(physical).build()
             try {
@@ -316,9 +302,9 @@ class WebDavAnnotationSyncTarget(
             .addPathSegment(annotationPrefix(namespace, itemId) + filename)
             .build()
 
-    private fun sidecarFileUrl(namespace: String, deviceId: String): HttpUrl =
+    private fun deviceMetaUrl(namespace: String, deviceId: String): HttpUrl =
         basePath.newBuilder()
-            .addPathSegment("$namespace$NAMESPACE_SEPARATOR$SIDECAR_NAME_PREFIX$deviceId$JSON_SUFFIX")
+            .addPathSegment("$namespace$NAMESPACE_SEPARATOR$DEVICE_META_NAME_PREFIX$deviceId$JSON_SUFFIX")
             .build()
 
     /** Composite filename prefix that emulates the per-book directory: `<namespace>__<itemId>__`. */
@@ -378,7 +364,7 @@ class WebDavAnnotationSyncTarget(
     companion object {
         private const val NAMESPACE_SEPARATOR = "__"
         private const val ANNOTATION_NAME_PREFIX = "annotations-"
-        private const val SIDECAR_NAME_PREFIX = "device-"
+        private const val DEVICE_META_NAME_PREFIX = "device-meta-"
         private const val JSONLD_SUFFIX = ".jsonld"
         private const val JSON_SUFFIX = ".json"
         // Matches macOS Finder's WebDAVFS — well-known by Synology and other DSM-style WebDAV
@@ -386,6 +372,7 @@ class WebDavAnnotationSyncTarget(
         private const val FINDER_USER_AGENT = "WebDAVFS/3.0.0 (03008000) Darwin/22.0.0 (x86_64)"
         private val XML_MEDIA = "application/xml; charset=utf-8".toMediaType()
         private val JSON_LD_MEDIA = "application/ld+json; charset=utf-8".toMediaType()
+        private val JSON_MEDIA = "application/json; charset=utf-8".toMediaType()
 
         // Minimal PROPFIND asking for resourcetype on each child resource.
         private const val PROPFIND_BODY =

--- a/core/data/src/main/kotlin/com/riffle/core/data/WebDavAnnotationSyncTarget.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/WebDavAnnotationSyncTarget.kt
@@ -96,6 +96,10 @@ class WebDavAnnotationSyncTarget(
         }
     }
 
+    override suspend fun deleteDeviceMeta(namespace: String, deviceId: String) {
+        deleteFile(deviceMetaUrl(namespace, deviceId), "delete device-meta $deviceId")
+    }
+
     override suspend fun enumerateDevices(namespace: String): NamespaceDeviceListing =
         withContext(Dispatchers.IO) {
             val all = propfindBaseFilenames()

--- a/core/data/src/test/kotlin/com/riffle/core/data/AnnotationDeviceMetaCodecTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/AnnotationDeviceMetaCodecTest.kt
@@ -1,0 +1,66 @@
+package com.riffle.core.data
+
+import com.riffle.core.domain.AnnotationDeviceMeta
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AnnotationDeviceMetaCodecTest {
+
+    @Test
+    fun `encode then decode round-trips every field`() {
+        val meta = AnnotationDeviceMeta(
+            deviceId = "dev-1",
+            label = "Phone A",
+            lastSyncedAt = "2026-06-27T12:00:00Z",
+            username = "alice",
+        )
+        val encoded = AnnotationDeviceMetaCodec.encode(meta)
+        assertEquals(meta, AnnotationDeviceMetaCodec.decode(encoded))
+    }
+
+    @Test
+    fun `username is omitted when null and parses back as null`() {
+        val meta = AnnotationDeviceMeta("dev-1", "Phone A", "2026-06-27T12:00:00Z", username = null)
+        val encoded = AnnotationDeviceMetaCodec.encode(meta)
+        assertTrue("username field must not appear in body when null", !encoded.contains("username"))
+        assertNull(AnnotationDeviceMetaCodec.decode(encoded)?.username)
+    }
+
+    @Test
+    fun `blank username is treated as absent`() {
+        val meta = AnnotationDeviceMeta("dev-1", "Phone A", "2026-06-27T12:00:00Z", username = "")
+        val encoded = AnnotationDeviceMetaCodec.encode(meta)
+        assertTrue(!encoded.contains("username"))
+        assertNull(AnnotationDeviceMetaCodec.decode(encoded)?.username)
+    }
+
+    @Test
+    fun `encode carries the discriminator type so the file is self-describing`() {
+        val meta = AnnotationDeviceMeta("dev-1", "Phone A", "2026-06-27T12:00:00Z")
+        assertTrue(AnnotationDeviceMetaCodec.encode(meta).contains("\"type\":\"riffle:DeviceSyncMeta\""))
+    }
+
+    @Test
+    fun `decode rejects bodies carrying a different type discriminator`() {
+        // A foreign-shape object — same field names but the type belongs to the per-file header.
+        // The codec must not return data here; cross-parsing would silently corrupt Maintenance.
+        val foreign = """{"type":"riffle:FileHeader","deviceId":"x","label":"y","lastSyncedAt":"z"}"""
+        assertNull(AnnotationDeviceMetaCodec.decode(foreign))
+    }
+
+    @Test
+    fun `decode returns null on malformed input`() {
+        assertNull(AnnotationDeviceMetaCodec.decode("not json {{"))
+    }
+
+    @Test
+    fun `decode tolerates unknown fields (forward-compat)`() {
+        val withExtra = """
+            {"type":"riffle:DeviceSyncMeta","deviceId":"dev-1","label":"Phone A","lastSyncedAt":"2026-06-27T12:00:00Z","futureField":42}
+        """.trimIndent()
+        val decoded = AnnotationDeviceMetaCodec.decode(withExtra)!!
+        assertEquals("dev-1", decoded.deviceId)
+    }
+}

--- a/core/data/src/test/kotlin/com/riffle/core/data/AnnotationFileHeaderCodecTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/AnnotationFileHeaderCodecTest.kt
@@ -8,11 +8,7 @@ import org.junit.Test
 
 class AnnotationFileHeaderCodecTest {
 
-    private val meta = AnnotationFileHeader(
-        deviceId = "dev-1",
-        label = "Phone A",
-        lastSeenAt = "2026-01-01T00:00:00Z",
-    )
+    private val meta = AnnotationFileHeader(deviceId = "dev-1")
 
     @Test
     fun `buildFileBody with no annotations renders just the header`() {
@@ -34,37 +30,14 @@ class AnnotationFileHeaderCodecTest {
     }
 
     @Test
-    fun `replaceHeader swaps the header without losing annotations`() {
-        val original = AnnotationFileHeaderCodec.buildFileBody(
-            meta,
-            annotationJsonStrings = listOf("""{"id":"x"}"""),
-        )
-        val newMeta = meta.copy(label = "Renamed", lastSeenAt = "2026-02-02T02:02:02Z")
-        val rewritten = AnnotationFileHeaderCodec.replaceHeader(original, newMeta)
-        val extracted = AnnotationFileHeaderCodec.extractHeader(rewritten)
-        assertEquals(newMeta, extracted)
-        assertTrue(rewritten.contains("\"id\":\"x\""))
-    }
-
-    @Test
     fun `extractHeader returns null for legacy header-less files`() {
         val legacy = """[{"id":"a"},{"id":"b"}]"""
         assertNull(AnnotationFileHeaderCodec.extractHeader(legacy))
     }
 
     @Test
-    fun `replaceHeader on a legacy file inserts a header`() {
-        val legacy = """[{"id":"a"}]"""
-        val rewritten = AnnotationFileHeaderCodec.replaceHeader(legacy, meta)
-        assertEquals(meta, AnnotationFileHeaderCodec.extractHeader(rewritten))
-        assertTrue(rewritten.contains("\"id\":\"a\""))
-    }
-
-    @Test
-    fun `malformed input is returned unchanged by replaceHeader and null by extractHeader`() {
-        val bogus = "not json {{"
-        assertNull(AnnotationFileHeaderCodec.extractHeader(bogus))
-        assertEquals(bogus, AnnotationFileHeaderCodec.replaceHeader(bogus, meta))
+    fun `extractHeader returns null on malformed input`() {
+        assertNull(AnnotationFileHeaderCodec.extractHeader("not json {{"))
     }
 
     @Test
@@ -76,19 +49,28 @@ class AnnotationFileHeaderCodecTest {
     }
 
     @Test
-    fun `username round-trips through encode and extract`() {
-        val withUser = meta.copy(username = "alice")
-        val body = AnnotationFileHeaderCodec.buildFileBody(withUser, annotationJsonStrings = emptyList())
-        assertTrue(body.contains("\"username\":\"alice\""))
-        assertEquals(withUser, AnnotationFileHeaderCodec.extractHeader(body))
+    fun `device-scoped fields are not emitted on encode`() {
+        // The slim file header carries only book-scoped data. label/lastSeenAt/username live in
+        // the per-device sentinel ([AnnotationDeviceMeta]); they must not be re-emitted here even
+        // by accident — duplicating them would re-introduce the inconsistency the split fixed.
+        val body = AnnotationFileHeaderCodec.buildFileBody(meta.copy(bookTitle = "Title"), emptyList())
+        assertTrue("no label", !body.contains("\"label\""))
+        assertTrue("no lastSeenAt", !body.contains("\"lastSeenAt\""))
+        assertTrue("no username", !body.contains("\"username\""))
     }
 
     @Test
-    fun `username is omitted when null and parses back as null`() {
-        val body = AnnotationFileHeaderCodec.buildFileBody(meta, annotationJsonStrings = emptyList())
-        assertTrue(!body.contains("username"))
-        val extracted = AnnotationFileHeaderCodec.extractHeader(body)
-        assertNull(extracted?.username)
+    fun `legacy header carrying device-scoped fields is read as the slim shape`() {
+        // Pre-split file: the embedded header still has label/lastSeenAt/username/bookTitle.
+        // extractHeader must ignore the device-scoped extras and surface only deviceId + bookTitle.
+        val legacyBody = """
+            [
+              {"type":"riffle:FileHeader","deviceId":"legacy-A","label":"Old","lastSeenAt":"2025-01-01T00:00:00Z","username":"alice","bookTitle":"Dune"},
+              {"id":"ann-1"}
+            ]
+        """.trimIndent()
+        val header = AnnotationFileHeaderCodec.extractHeader(legacyBody)
+        assertEquals(AnnotationFileHeader(deviceId = "legacy-A", bookTitle = "Dune"), header)
     }
 
     @Test
@@ -103,25 +85,6 @@ class AnnotationFileHeaderCodecTest {
             ]
         """.trimIndent()
         val header = AnnotationFileHeaderCodec.extractHeader(legacyBody)
-        assertEquals(AnnotationFileHeader("legacy-A", "Old", "2025-01-01T00:00:00Z", "alice"), header)
-    }
-
-    @Test
-    fun `replaceHeader on a legacy-marker file leaves a single new-marker header`() {
-        // Mid-transition: another device wrote the file with the old marker; we rename on this
-        // device and rewrite. The legacy header must be removed, not stacked alongside the new one.
-        val legacyBody = """[{"type":"riffle:DeviceMeta","deviceId":"A","label":"Old","lastSeenAt":"2025-01-01T00:00:00Z"},{"id":"x"}]"""
-        val rewritten = AnnotationFileHeaderCodec.replaceHeader(legacyBody, meta.copy(deviceId = "A"))
-        assertTrue("new marker must be present", rewritten.contains("riffle:FileHeader"))
-        assertTrue("legacy marker must be gone", !rewritten.contains("riffle:DeviceMeta"))
-        assertTrue("annotation records survive", rewritten.contains("\"id\":\"x\""))
-    }
-
-    @Test
-    fun `blank username is treated as absent on both sides`() {
-        val blank = meta.copy(username = "")
-        val body = AnnotationFileHeaderCodec.buildFileBody(blank, annotationJsonStrings = emptyList())
-        assertTrue(!body.contains("username"))
-        assertNull(AnnotationFileHeaderCodec.extractHeader(body)?.username)
+        assertEquals(AnnotationFileHeader(deviceId = "legacy-A"), header)
     }
 }

--- a/core/data/src/test/kotlin/com/riffle/core/data/AnnotationSweepTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/AnnotationSweepTest.kt
@@ -84,11 +84,12 @@ class AnnotationSweepTest {
         assertTrue(write.content.contains("ann-2"))
         // Verify the file body carries the file-header object written by AnnotationFileHeaderCodec.
         assertTrue("sweep output must contain riffle:FileHeader", write.content.contains("riffle:FileHeader"))
-        // Header carries the username so foreign-user groups on other devices' Maintenance
-        // screens can be labelled by name instead of by opaque user id.
-        assertTrue("sweep header must include username", write.content.contains("\"username\":\"alice\""))
-        // Header carries the catalog's book title so Maintenance can show recognisable names.
+        // The per-file header is book-scoped only: deviceId + bookTitle. Device-scoped fields
+        // (label/lastSyncedAt/username) live in the per-device sentinel — see below.
         assertTrue("sweep header must include bookTitle", write.content.contains("\"bookTitle\":\"Project Hail Mary\""))
+        assertTrue("no label in per-file header", !write.content.contains("\"label\""))
+        assertTrue("no lastSeenAt in per-file header", !write.content.contains("\"lastSeenAt\""))
+        assertTrue("no username in per-file header", !write.content.contains("\"username\""))
 
         assertEquals(listOf("ann-1", "ann-2"), dao.lastMarkSyncedIds)
         assertEquals(now, dao.lastMarkSyncedAt)
@@ -96,6 +97,17 @@ class AnnotationSweepTest {
         val outcome = status.lastCycleOutcome.value
         assertTrue(outcome is CycleOutcome.Success)
         assertEquals(now, (outcome as CycleOutcome.Success).atMs)
+
+        // One sentinel was written per unique namespace touched this cycle, carrying
+        // label/lastSyncedAt/username — peers read this to label the device and surface
+        // an honest "Last synced …" timestamp.
+        assertEquals(1, target.deviceMetaWrites.size)
+        val sentinel = target.deviceMetaWrites.single()
+        assertEquals("abs-user-A", sentinel.namespace)
+        assertEquals("dev-A", sentinel.deviceId)
+        val parsed = AnnotationDeviceMetaCodec.decode(sentinel.content)!!
+        assertEquals("test-label", parsed.label)
+        assertEquals("alice", parsed.username)
     }
 
     @Test
@@ -214,7 +226,9 @@ class AnnotationSweepTest {
 
     private class FakeTarget(private val writeException: Throwable? = null) : AnnotationSyncTarget {
         data class WriteCall(val namespace: String, val itemId: String, val filename: String, val content: String)
+        data class DeviceMetaWriteCall(val namespace: String, val deviceId: String, val content: String)
         val writes = mutableListOf<WriteCall>()
+        val deviceMetaWrites = mutableListOf<DeviceMetaWriteCall>()
         override suspend fun list(namespace: String, itemId: String): List<String> = emptyList()
         override suspend fun read(namespace: String, itemId: String, filename: String): String? = null
         override suspend fun write(namespace: String, itemId: String, filename: String, content: String) {
@@ -223,7 +237,11 @@ class AnnotationSweepTest {
             writeException?.let { throw it }
         }
         override suspend fun delete(namespace: String, itemId: String, filename: String) {}
-        override suspend fun deleteDeviceSidecar(namespace: String, deviceId: String) {}
+        override suspend fun readDeviceMeta(namespace: String, deviceId: String): String? = null
+        override suspend fun writeDeviceMeta(namespace: String, deviceId: String, content: String) {
+            deviceMetaWrites += DeviceMetaWriteCall(namespace, deviceId, content.take(1024))
+            writeException?.let { throw it }
+        }
         override suspend fun enumerateDevices(namespace: String): NamespaceDeviceListing = NamespaceDeviceListing(emptyList())
         override suspend fun enumerateNamespaces(): List<NamespaceSummary> = emptyList()
         override suspend fun forgetNamespace(namespace: String): Int = 0

--- a/core/data/src/test/kotlin/com/riffle/core/data/AnnotationSweepTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/AnnotationSweepTest.kt
@@ -242,6 +242,7 @@ class AnnotationSweepTest {
             deviceMetaWrites += DeviceMetaWriteCall(namespace, deviceId, content.take(1024))
             writeException?.let { throw it }
         }
+        override suspend fun deleteDeviceMeta(namespace: String, deviceId: String) {}
         override suspend fun enumerateDevices(namespace: String): NamespaceDeviceListing = NamespaceDeviceListing(emptyList())
         override suspend fun enumerateNamespaces(): List<NamespaceSummary> = emptyList()
         override suspend fun forgetNamespace(namespace: String): Int = 0

--- a/core/data/src/test/kotlin/com/riffle/core/data/AnnotationSyncControllerLifecycleTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/AnnotationSyncControllerLifecycleTest.kt
@@ -246,6 +246,39 @@ class AnnotationSyncControllerLifecycleTest {
         assertEquals(setOf("uuid-a", "uuid-b"), parsed.map { it.id }.toSet())
     }
 
+    @Test
+    fun `pushPending success writes the device-meta sentinel under the namespace`() = runTest {
+        // Sentinel write is the only way a peer's Maintenance screen ever advances "Last synced"
+        // for this device — without it, the cycle is invisible to other devices. The write is
+        // best-effort (failure is swallowed), but a successful push MUST emit one.
+        dao.localAnnotations += highlightEntity("uuid-a", updatedAt = 100L)
+
+        newController().syncOnClose(SRV, NS, ITEM)
+        advanceUntilIdle()
+
+        assertEquals(1, target.deviceMetaWrites.size)
+        val sentinel = target.deviceMetaWrites.single()
+        assertEquals(NS, sentinel.namespace)
+        assertEquals(DEVICE_ID, sentinel.deviceId)
+        val parsed = AnnotationDeviceMetaCodec.decode(sentinel.content)!!
+        assertEquals(DEVICE_ID, parsed.deviceId)
+        assertEquals("test-label", parsed.label)
+    }
+
+    @Test
+    fun `pushPending failure does NOT write a sentinel`() = runTest {
+        // The sentinel announces "this device just synced". A failed push has not synced, so the
+        // sentinel must not advance — peers would otherwise show a fresh "Last synced" timestamp
+        // for a device that never actually got its content through.
+        target.writeException = RuntimeException("simulated push failure")
+        dao.localAnnotations += highlightEntity("uuid-a", updatedAt = 100L)
+
+        newController().syncOnClose(SRV, NS, ITEM)
+        advanceUntilIdle()
+
+        assertTrue(target.deviceMetaWrites.isEmpty())
+    }
+
     // ===== Code review fixes =====
 
     @Test
@@ -617,12 +650,14 @@ class AnnotationSyncControllerLifecycleTest {
 private class LifecycleRecordingTarget : AnnotationSyncTarget {
     val files: MutableMap<String, String> = mutableMapOf()
     val writes: MutableList<Write> = mutableListOf()
+    val deviceMetaWrites: MutableList<DeviceMetaWrite> = mutableListOf()
     val listNamespaceArgs: MutableList<String> = mutableListOf()
     var listCalls = 0
     var failNextList: Boolean = false
     var writeException: Throwable? = null
 
     data class Write(val namespace: String, val itemId: String, val filename: String, val content: String)
+    data class DeviceMetaWrite(val namespace: String, val deviceId: String, val content: String)
 
     override suspend fun list(namespace: String, itemId: String): List<String> {
         listCalls++
@@ -645,7 +680,10 @@ private class LifecycleRecordingTarget : AnnotationSyncTarget {
     override suspend fun delete(namespace: String, itemId: String, filename: String) {
         files.remove(filename)
     }
-    override suspend fun deleteDeviceSidecar(namespace: String, deviceId: String) {}
+    override suspend fun readDeviceMeta(namespace: String, deviceId: String): String? = null
+    override suspend fun writeDeviceMeta(namespace: String, deviceId: String, content: String) {
+        deviceMetaWrites += DeviceMetaWrite(namespace, deviceId, content)
+    }
     override suspend fun enumerateDevices(namespace: String) = NamespaceDeviceListing(emptyList())
     override suspend fun enumerateNamespaces(): List<NamespaceSummary> = emptyList()
     override suspend fun forgetNamespace(namespace: String): Int = 0

--- a/core/data/src/test/kotlin/com/riffle/core/data/AnnotationSyncControllerLifecycleTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/AnnotationSyncControllerLifecycleTest.kt
@@ -684,6 +684,7 @@ private class LifecycleRecordingTarget : AnnotationSyncTarget {
     override suspend fun writeDeviceMeta(namespace: String, deviceId: String, content: String) {
         deviceMetaWrites += DeviceMetaWrite(namespace, deviceId, content)
     }
+    override suspend fun deleteDeviceMeta(namespace: String, deviceId: String) {}
     override suspend fun enumerateDevices(namespace: String) = NamespaceDeviceListing(emptyList())
     override suspend fun enumerateNamespaces(): List<NamespaceSummary> = emptyList()
     override suspend fun forgetNamespace(namespace: String): Int = 0

--- a/core/data/src/test/kotlin/com/riffle/core/data/AnnotationSyncControllerReactiveTargetTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/AnnotationSyncControllerReactiveTargetTest.kt
@@ -59,7 +59,8 @@ private class RecordingTarget : AnnotationSyncTarget {
     override suspend fun read(namespace: String, itemId: String, filename: String): String? = null
     override suspend fun write(namespace: String, itemId: String, filename: String, content: String) {}
     override suspend fun delete(namespace: String, itemId: String, filename: String) {}
-    override suspend fun deleteDeviceSidecar(namespace: String, deviceId: String) {}
+    override suspend fun readDeviceMeta(namespace: String, deviceId: String): String? = null
+    override suspend fun writeDeviceMeta(namespace: String, deviceId: String, content: String) {}
     override suspend fun enumerateDevices(namespace: String) = NamespaceDeviceListing(emptyList())
     override suspend fun enumerateNamespaces(): List<NamespaceSummary> = emptyList()
     override suspend fun forgetNamespace(namespace: String): Int = 0

--- a/core/data/src/test/kotlin/com/riffle/core/data/AnnotationSyncControllerReactiveTargetTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/AnnotationSyncControllerReactiveTargetTest.kt
@@ -61,6 +61,7 @@ private class RecordingTarget : AnnotationSyncTarget {
     override suspend fun delete(namespace: String, itemId: String, filename: String) {}
     override suspend fun readDeviceMeta(namespace: String, deviceId: String): String? = null
     override suspend fun writeDeviceMeta(namespace: String, deviceId: String, content: String) {}
+    override suspend fun deleteDeviceMeta(namespace: String, deviceId: String) {}
     override suspend fun enumerateDevices(namespace: String) = NamespaceDeviceListing(emptyList())
     override suspend fun enumerateNamespaces(): List<NamespaceSummary> = emptyList()
     override suspend fun forgetNamespace(namespace: String): Int = 0

--- a/core/data/src/test/kotlin/com/riffle/core/data/AnnotationSyncMaintenanceTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/AnnotationSyncMaintenanceTest.kt
@@ -1,15 +1,16 @@
 package com.riffle.core.data
 
+import com.riffle.core.domain.AnnotationDeviceMeta
 import com.riffle.core.domain.AnnotationFileRef
 import com.riffle.core.domain.AnnotationSyncTarget
 import com.riffle.core.domain.DeviceFileSummary
-import com.riffle.core.domain.AnnotationFileHeader
 import com.riffle.core.domain.NamespaceDeviceListing
 import com.riffle.core.domain.NamespaceSummary
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -26,108 +27,98 @@ class AnnotationSyncMaintenanceTest {
                 FileKey("ns", "item-2", "annotations-dev-A.jsonld") to "[]",
                 FileKey("ns", "item-1", "annotations-dev-B.jsonld") to "[]",
             ),
-            legacySidecars = mutableSetOf(),
         )
         val m = maintenanceFor(target)
         val result = m.forgetDevice("ns", "dev-A")
 
         assertEquals(2, result.deletedAnnotationFiles)
-        assertFalse(result.deletedLegacySidecar)
         assertEquals(0, result.failures)
         assertFalse(target.files.keys.any { it.deviceId == "dev-A" })
         assertTrue(target.files.containsKey(FileKey("ns", "item-1", "annotations-dev-B.jsonld")))
     }
 
     @Test
-    fun `forgetDevice also nukes a leftover legacy sidecar`() = runTest {
+    fun `listDevices reads the per-device sentinel for label and lastSyncedAt`() = runTest {
         val target = InMemoryMaintenanceTarget(
             files = mutableMapOf(
-                FileKey("ns", "item-1", "annotations-dev-A.jsonld") to "[]",
-            ),
-            legacySidecars = mutableSetOf("dev-A"),
-        )
-        val m = maintenanceFor(target)
-        val result = m.forgetDevice("ns", "dev-A")
-
-        assertEquals(1, result.deletedAnnotationFiles)
-        assertTrue(result.deletedLegacySidecar)
-        assertFalse(target.legacySidecars.contains("dev-A"))
-    }
-
-    @Test
-    fun `listDevices extracts the embedded metadata header from annotation files`() = runTest {
-        val headerA = AnnotationFileHeaderCodec.buildFileBody(
-            AnnotationFileHeader("A", "Phone A", "2026-01-01T00:00:00Z"),
-            annotationJsonStrings = emptyList(),
-        )
-        val target = InMemoryMaintenanceTarget(
-            files = mutableMapOf(
-                FileKey("ns", "i1", "annotations-A.jsonld") to headerA,
+                FileKey("ns", "i1", "annotations-A.jsonld") to "[]",
                 FileKey("ns", "i1", "annotations-B.jsonld") to "[]",
             ),
-            legacySidecars = mutableSetOf(),
         )
-        val m = maintenanceFor(target)
-        val rows = m.listDevices("ns")
+        target.deviceMetaFiles["ns" to "A"] = AnnotationDeviceMetaCodec.encode(
+            AnnotationDeviceMeta("A", "Phone A", "2026-01-01T00:00:00Z", username = "alice")
+        )
+
+        val rows = maintenanceFor(target).listDevices("ns")
 
         assertEquals(2, rows.size)
         val a = rows.first { it.deviceId == "A" }
         val b = rows.first { it.deviceId == "B" }
-        assertEquals(1, a.annotationFileCount)
         assertNotNull(a.metadata)
         assertEquals("Phone A", a.metadata!!.label)
-        assertEquals(1, b.annotationFileCount)
-        assertEquals(null, b.metadata)
+        assertEquals("2026-01-01T00:00:00Z", a.metadata!!.lastSyncedAt)
+        assertEquals("alice", a.metadata!!.username)
+        // No sentinel for B → no metadata. The Maintenance UI shows just the deviceId-derived
+        // label, which is the honest signal that we have no recent evidence of this peer.
+        assertNull(b.metadata)
     }
 
     @Test
-    fun `publishHeader rewrites every annotation file's header and preserves lastSeenAt`() = runTest {
-        val originalA = AnnotationFileHeaderCodec.buildFileBody(
-            AnnotationFileHeader("A", "Old Name", "2025-09-15T10:00:00Z"),
-            annotationJsonStrings = listOf("""{"id":"x"}"""),
-        )
-        val originalA2 = AnnotationFileHeaderCodec.buildFileBody(
-            AnnotationFileHeader("A", "Old Name", "2025-09-15T10:00:00Z"),
-            annotationJsonStrings = listOf("""{"id":"y"}"""),
-        )
-        val target = InMemoryMaintenanceTarget(
-            files = mutableMapOf(
-                FileKey("ns", "i1", "annotations-A.jsonld") to originalA,
-                FileKey("ns", "i2", "annotations-A.jsonld") to originalA2,
-            ),
-            legacySidecars = mutableSetOf(),
-        )
-        val m = maintenanceFor(target)
-        val result = m.publishHeader("ns", "A", "New Name", username = "alice")
-
-        assertEquals(2, result.rewrittenFiles)
-        assertEquals(0, result.failures)
-        target.files.values.forEach { body ->
-            val header = AnnotationFileHeaderCodec.extractHeader(body)!!
-            assertEquals("New Name", header.label)
-            // The original lastSeenAt is preserved — a rename must not masquerade as a fresh push.
-            assertEquals("2025-09-15T10:00:00Z", header.lastSeenAt)
-            // Rename refreshes the recorded ABS username too.
-            assertEquals("alice", header.username)
-        }
-        assertTrue(target.files.values.any { it.contains("\"id\":\"x\"") })
-        assertTrue(target.files.values.any { it.contains("\"id\":\"y\"") })
-    }
-
-    @Test
-    fun `publishHeader mints a fallback lastSeenAt for legacy header-less files`() = runTest {
-        // Legacy file from a build prior to the embed-header refactor: pure annotations, no header.
-        val legacy = """[{"id":"x"}]"""
+    fun `listDevices does NOT fall back to per-file headers when sentinel is missing`() = runTest {
+        // Old per-file header carrying device-scoped fields. Maintenance must NOT mine it for
+        // label/lastSyncedAt — that would reintroduce the push-vs-pull dishonesty.
+        val legacy = """
+            [
+              {"type":"riffle:FileHeader","deviceId":"A","label":"Old Per-File Label","lastSeenAt":"2024-01-01T00:00:00Z","username":"alice","bookTitle":"Dune"},
+              {"id":"x"}
+            ]
+        """.trimIndent()
         val target = InMemoryMaintenanceTarget(
             files = mutableMapOf(FileKey("ns", "i1", "annotations-A.jsonld") to legacy),
-            legacySidecars = mutableSetOf(),
         )
-        val m = maintenanceFor(target)
-        m.publishHeader("ns", "A", "New Name", username = "alice")
 
-        val header = AnnotationFileHeaderCodec.extractHeader(target.files.values.first())!!
-        assertEquals("New Name", header.label)
-        assertEquals("2026-02-02T02:02:02Z", header.lastSeenAt)
+        val rows = maintenanceFor(target).listDevices("ns")
+
+        assertEquals(1, rows.size)
+        assertNull(rows.single().metadata)
+    }
+
+    @Test
+    fun `publishHeader writes exactly one sentinel, with the new label`() = runTest {
+        val target = InMemoryMaintenanceTarget(
+            files = mutableMapOf(
+                FileKey("ns", "i1", "annotations-A.jsonld") to "[]",
+                FileKey("ns", "i2", "annotations-A.jsonld") to "[]",
+            ),
+        )
+        target.deviceMetaFiles["ns" to "A"] = AnnotationDeviceMetaCodec.encode(
+            AnnotationDeviceMeta("A", "Old Name", "2025-09-15T10:00:00Z")
+        )
+
+        val result = maintenanceFor(target).publishHeader("ns", "A", "New Name", username = "alice")
+
+        assertEquals(1, result.rewrittenFiles)
+        assertEquals(0, result.failures)
+        // No annotation files were rewritten — rename is a one-PUT operation now.
+        target.files.values.forEach { assertEquals("[]", it) }
+        val updated = AnnotationDeviceMetaCodec.decode(target.deviceMetaFiles["ns" to "A"]!!)!!
+        assertEquals("New Name", updated.label)
+        assertEquals("alice", updated.username)
+        // Rename does NOT bump the visible "Last synced" — preserves the prior sentinel value.
+        assertEquals("2025-09-15T10:00:00Z", updated.lastSyncedAt)
+    }
+
+    @Test
+    fun `publishHeader mints a fallback lastSyncedAt when no sentinel exists yet`() = runTest {
+        val target = InMemoryMaintenanceTarget(
+            files = mutableMapOf(FileKey("ns", "i1", "annotations-A.jsonld") to "[]"),
+        )
+
+        maintenanceFor(target).publishHeader("ns", "A", "New Name", username = "alice")
+
+        val written = AnnotationDeviceMetaCodec.decode(target.deviceMetaFiles["ns" to "A"]!!)!!
+        assertEquals("New Name", written.label)
+        assertEquals("2026-02-02T02:02:02Z", written.lastSyncedAt)
     }
 }
 
@@ -137,7 +128,6 @@ private data class FileKey(val namespace: String, val itemId: String, val filena
 
 private class InMemoryMaintenanceTarget(
     val files: MutableMap<FileKey, String>,
-    val legacySidecars: MutableSet<String>,
 ) : AnnotationSyncTarget {
     override suspend fun list(namespace: String, itemId: String): List<String> =
         files.keys.filter { it.namespace == namespace && it.itemId == itemId }.map { it.filename }
@@ -149,8 +139,11 @@ private class InMemoryMaintenanceTarget(
     override suspend fun delete(namespace: String, itemId: String, filename: String) {
         files.remove(FileKey(namespace, itemId, filename))
     }
-    override suspend fun deleteDeviceSidecar(namespace: String, deviceId: String) {
-        legacySidecars.remove(deviceId)
+    val deviceMetaFiles: MutableMap<Pair<String, String>, String> = mutableMapOf()
+    override suspend fun readDeviceMeta(namespace: String, deviceId: String): String? =
+        deviceMetaFiles[namespace to deviceId]
+    override suspend fun writeDeviceMeta(namespace: String, deviceId: String, content: String) {
+        deviceMetaFiles[namespace to deviceId] = content
     }
     override suspend fun enumerateDevices(namespace: String): NamespaceDeviceListing {
         val byDevice = files.keys
@@ -160,7 +153,6 @@ private class InMemoryMaintenanceTarget(
             DeviceFileSummary(
                 deviceId = deviceId,
                 annotationFiles = byDevice[deviceId].orEmpty().map { AnnotationFileRef(it.itemId, it.filename) },
-                hasLegacySidecar = legacySidecars.contains(deviceId),
             )
         }
         return NamespaceDeviceListing(rows)
@@ -172,7 +164,6 @@ private class InMemoryMaintenanceTarget(
             NamespaceSummary(
                 namespace = ns,
                 annotationFileCount = annotations[ns] ?: 0,
-                sidecarCount = if (ns == "ns") legacySidecars.size else 0,
             )
         }
     }
@@ -180,11 +171,6 @@ private class InMemoryMaintenanceTarget(
     override suspend fun forgetNamespace(namespace: String): Int {
         val keys = files.keys.filter { it.namespace == namespace }
         keys.forEach { files.remove(it) }
-        var deleted = keys.size
-        if (namespace == "ns") {
-            deleted += legacySidecars.size
-            legacySidecars.clear()
-        }
-        return deleted
+        return keys.size
     }
 }

--- a/core/data/src/test/kotlin/com/riffle/core/data/AnnotationSyncMaintenanceTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/AnnotationSyncMaintenanceTest.kt
@@ -38,6 +38,31 @@ class AnnotationSyncMaintenanceTest {
     }
 
     @Test
+    fun `forgetDevice also deletes the device's metadata sentinel`() = runTest {
+        // Without this, forgetting a peer would leave its sentinel orphan on the share — and the
+        // peer's row would resurrect carrying the pre-forget label/lastSyncedAt the next time
+        // that deviceId pushed even a single annotation file.
+        val target = InMemoryMaintenanceTarget(
+            files = mutableMapOf(
+                FileKey("ns", "item-1", "annotations-dev-A.jsonld") to "[]",
+                FileKey("ns", "item-1", "annotations-dev-B.jsonld") to "[]",
+            ),
+        )
+        target.deviceMetaFiles["ns" to "dev-A"] = AnnotationDeviceMetaCodec.encode(
+            AnnotationDeviceMeta("dev-A", "A's phone", "2026-06-01T00:00:00Z")
+        )
+        target.deviceMetaFiles["ns" to "dev-B"] = AnnotationDeviceMetaCodec.encode(
+            AnnotationDeviceMeta("dev-B", "B's phone", "2026-06-01T00:00:00Z")
+        )
+
+        maintenanceFor(target).forgetDevice("ns", "dev-A")
+
+        assertFalse(target.deviceMetaFiles.containsKey("ns" to "dev-A"))
+        // Other devices' sentinels are untouched.
+        assertTrue(target.deviceMetaFiles.containsKey("ns" to "dev-B"))
+    }
+
+    @Test
     fun `listDevices reads the per-device sentinel for label and lastSyncedAt`() = runTest {
         val target = InMemoryMaintenanceTarget(
             files = mutableMapOf(
@@ -144,6 +169,9 @@ private class InMemoryMaintenanceTarget(
         deviceMetaFiles[namespace to deviceId]
     override suspend fun writeDeviceMeta(namespace: String, deviceId: String, content: String) {
         deviceMetaFiles[namespace to deviceId] = content
+    }
+    override suspend fun deleteDeviceMeta(namespace: String, deviceId: String) {
+        deviceMetaFiles.remove(namespace to deviceId)
     }
     override suspend fun enumerateDevices(namespace: String): NamespaceDeviceListing {
         val byDevice = files.keys

--- a/core/data/src/test/kotlin/com/riffle/core/data/WebDavAnnotationSyncTargetTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/WebDavAnnotationSyncTargetTest.kt
@@ -368,18 +368,52 @@ class WebDavAnnotationSyncTargetTest {
     }
 
     @Test
-    fun `deleteDeviceSidecar targets the namespace-scoped sidecar path (no itemId)`() = runTest {
-        server.enqueue(MockResponse().setResponseCode(204))
+    fun `readDeviceMeta GETs the namespace-scoped sentinel path`() = runTest {
+        server.enqueue(MockResponse().setResponseCode(200).setBody("""{"type":"riffle:DeviceSyncMeta","deviceId":"dev-A","label":"L","lastSyncedAt":"2026-06-27T12:00:00Z"}"""))
 
-        newTarget().deleteDeviceSidecar("srv1", "dev-A")
+        val body = newTarget().readDeviceMeta("srv1", "dev-A")
 
+        assertNotNull(body)
+        assertTrue(body!!.contains("riffle:DeviceSyncMeta"))
         val req = server.takeRequest()
-        assertEquals("DELETE", req.method)
-        assertEquals("/annotations/srv1__device-dev-A.json", req.path)
+        assertEquals("GET", req.method)
+        assertEquals("/annotations/srv1__device-meta-dev-A.json", req.path)
     }
 
     @Test
-    fun `enumerateNamespaces groups files by namespace prefix and counts annotations vs sidecars`() = runTest {
+    fun `readDeviceMeta returns null on 404`() = runTest {
+        server.enqueue(MockResponse().setResponseCode(404))
+        assertNull(newTarget().readDeviceMeta("srv1", "dev-A"))
+    }
+
+    @Test
+    fun `writeDeviceMeta PUTs to the namespace-scoped sentinel path`() = runTest {
+        server.enqueue(MockResponse().setResponseCode(201))
+
+        newTarget().writeDeviceMeta("srv1", "dev-A", """{"type":"riffle:DeviceSyncMeta","deviceId":"dev-A","label":"L","lastSyncedAt":"now"}""")
+
+        val req = server.takeRequest()
+        assertEquals("PUT", req.method)
+        assertEquals("/annotations/srv1__device-meta-dev-A.json", req.path)
+        assertTrue(req.body.readUtf8().contains("riffle:DeviceSyncMeta"))
+    }
+
+    @Test
+    fun `enumerateDevices ignores device-meta files at the namespace root`() = runTest {
+        // PROPFIND surfaces device-meta files too; the device-listing must not invent a phantom
+        // device row from one, otherwise Maintenance would show duplicates.
+        server.enqueue(MockResponse().setResponseCode(207).setBody(PROPFIND_WITH_DEVICE_META_BODY))
+
+        val listing = newTarget().enumerateDevices("srv1")
+
+        // Only the real annotation file contributes a row — the device-meta-A.json sibling is
+        // not annotation content and must not surface as its own device.
+        assertEquals(1, listing.devices.size)
+        assertEquals("dev-A", listing.devices.single().deviceId)
+    }
+
+    @Test
+    fun `enumerateNamespaces groups files by namespace prefix and counts annotations`() = runTest {
         server.enqueue(MockResponse().setResponseCode(207).setBody(PROPFIND_MIXED_NAMESPACES_BODY))
 
         val result = newTarget().enumerateNamespaces()
@@ -387,10 +421,10 @@ class WebDavAnnotationSyncTargetTest {
         assertEquals(2, result.size)
         val ns1 = result.first { it.namespace == "ns-1" }
         val ns2 = result.first { it.namespace == "ns-2" }
+        // Only .jsonld files count; the legacy `ns-1__device-dev-a.json` sidecar in the fixture
+        // is an unknown-shape file under base and is skipped silently.
         assertEquals(2, ns1.annotationFileCount)
-        assertEquals(1, ns1.sidecarCount)
         assertEquals(1, ns2.annotationFileCount)
-        assertEquals(0, ns2.sidecarCount)
     }
 
     @Test
@@ -405,9 +439,10 @@ class WebDavAnnotationSyncTargetTest {
     }
 
     @Test
-    fun `forgetNamespace DELETEs every file matching the prefix, including the sidecar`() = runTest {
+    fun `forgetNamespace DELETEs every file matching the prefix`() = runTest {
         server.enqueue(MockResponse().setResponseCode(207).setBody(PROPFIND_MIXED_NAMESPACES_BODY))
-        // 3 files match ns-1 (2 jsonld + 1 sidecar); the 1 ns-2 file must NOT be DELETEd.
+        // 3 files match ns-1 (2 jsonld + 1 unknown-shape json the fixture happens to include);
+        // forgetNamespace deletes by prefix regardless of suffix. The 1 ns-2 file must NOT be DELETEd.
         repeat(3) { server.enqueue(MockResponse().setResponseCode(204)) }
 
         val deleted = newTarget().forgetNamespace("ns-1")
@@ -505,6 +540,29 @@ class WebDavAnnotationSyncTargetTest {
               </d:response>
               <d:response>
                 <d:href>/annotations/srv1__book2__annotations-device-A.jsonld</d:href>
+                <d:propstat><d:prop><d:resourcetype/></d:prop>
+                  <d:status>HTTP/1.1 200 OK</d:status></d:propstat>
+              </d:response>
+            </d:multistatus>
+        """.trimIndent()
+
+        // PROPFIND that includes one annotation file *and* its sibling per-device sentinel,
+        // both under `srv1`. enumerateDevices must surface only the annotation file's owner.
+        private val PROPFIND_WITH_DEVICE_META_BODY = """
+            <?xml version="1.0" encoding="utf-8"?>
+            <d:multistatus xmlns:d="DAV:">
+              <d:response>
+                <d:href>/annotations/</d:href>
+                <d:propstat><d:prop><d:resourcetype><d:collection/></d:resourcetype></d:prop>
+                  <d:status>HTTP/1.1 200 OK</d:status></d:propstat>
+              </d:response>
+              <d:response>
+                <d:href>/annotations/srv1__book1__annotations-dev-A.jsonld</d:href>
+                <d:propstat><d:prop><d:resourcetype/></d:prop>
+                  <d:status>HTTP/1.1 200 OK</d:status></d:propstat>
+              </d:response>
+              <d:response>
+                <d:href>/annotations/srv1__device-meta-dev-A.json</d:href>
                 <d:propstat><d:prop><d:resourcetype/></d:prop>
                   <d:status>HTTP/1.1 200 OK</d:status></d:propstat>
               </d:response>

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/AnnotationDeviceMeta.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/AnnotationDeviceMeta.kt
@@ -1,0 +1,35 @@
+package com.riffle.core.domain
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Per-device metadata sentinel — the single source of truth for a device's identity and last
+ * sync time, regardless of how many annotation files it owns.
+ *
+ * Stored at `<namespace>/device-meta-<deviceId>.json` (one file per device per namespace) and
+ * rewritten on every successful sync cycle, including pull-only cycles. This is what other
+ * devices read to answer "is this peer still syncing?"
+ *
+ * Split from the per-file annotation header so that:
+ *  - the per-file header can shrink to `deviceId + bookTitle` (book-scoped) — no duplicated
+ *    device label across every annotation file;
+ *  - device-label renames cost a single PUT instead of N;
+ *  - `lastSyncedAt` advances on pull-only cycles (the per-file header only ever advanced on push,
+ *    leaving silent pull-only devices looking dormant to peers).
+ *
+ * @property deviceId Same UUID embedded in `annotations-<deviceId>.jsonld`.
+ * @property label Human-friendly device name. Source order matches the per-file header: user
+ *     override > Settings.Global.DEVICE_NAME (API 25+) > `Build.MANUFACTURER + Build.MODEL`.
+ * @property lastSyncedAt ISO 8601 timestamp of the last successful sync cycle, push or pull-only.
+ *     Drives the "Last synced …" hint on the Maintenance list for foreign devices.
+ * @property username The ABS login that owned this device's last cycle. Lets Maintenance label
+ *     foreign-user groups by a recognisable name instead of the opaque user id. Null when the
+ *     device didn't have a credentialed server when it last synced.
+ */
+@Serializable
+data class AnnotationDeviceMeta(
+    val deviceId: String,
+    val label: String,
+    val lastSyncedAt: String,
+    val username: String? = null,
+)

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/AnnotationDeviceMeta.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/AnnotationDeviceMeta.kt
@@ -7,8 +7,12 @@ import kotlinx.serialization.Serializable
  * sync time, regardless of how many annotation files it owns.
  *
  * Stored at `<namespace>/device-meta-<deviceId>.json` (one file per device per namespace) and
- * rewritten on every successful sync cycle, including pull-only cycles. This is what other
- * devices read to answer "is this peer still syncing?"
+ * rewritten by every successful pass through the live controller (push, pull-merge, or
+ * solo-PROPFIND). The push-only [AnnotationSweep] additionally writes a sentinel for every
+ * namespace it touched on a cycle, but skips the sentinel write when nothing was dirty —
+ * pull-only sweeps don't refresh the sentinel because they don't represent a sync event the
+ * controller hasn't already advertised. This is what other devices read to answer "is this
+ * peer still syncing?"
  *
  * Split from the per-file annotation header so that:
  *  - the per-file header can shrink to `deviceId + bookTitle` (book-scoped) — no duplicated

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/AnnotationFileHeader.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/AnnotationFileHeader.kt
@@ -6,25 +6,15 @@ import kotlinx.serialization.Serializable
  * Header object embedded at the top of each annotation file.
  *
  * Each per-device annotation file is a JSON array whose first element is an
- * [AnnotationFileHeader] — `{type: "riffle:FileHeader", deviceId, label, lastSeenAt, username}`
- * — followed by the W3C annotation records. The annotation parser drops non-annotation
- * entries (records with no `id`), so the header is invisible to merge and older readers still
- * parse correctly.
+ * [AnnotationFileHeader] — `{type: "riffle:FileHeader", deviceId, bookTitle}` — followed by the
+ * W3C annotation records. The annotation parser drops non-annotation entries (records with no
+ * `id`), so the header is invisible to merge and older readers still parse correctly.
  *
- * The name reflects what the object actually is — the header of a per-device annotation file —
- * rather than calling it "device metadata", because it carries account context too, not just
- * device fields.
+ * Device-scoped metadata (label, lastSyncedAt, username) lives in the per-device sentinel
+ * [AnnotationDeviceMeta] instead — see its kdoc for the rationale. The per-file header is now
+ * book-scoped only.
  *
  * @property deviceId The device's UUID — same identifier embedded in `annotations-<deviceId>.jsonld`.
- * @property label Human-friendly device name shown to the user. Source order: user override on
- *     this device > `Settings.Global.DEVICE_NAME` (API 25+) > `Build.MANUFACTURER + " " + Build.MODEL`
- *     (manufacturer dropped when MODEL already starts with it). Always non-blank on a real device.
- * @property lastSeenAt ISO 8601 timestamp of the publishing push. Drives the "Last synced …"
- *     hint in the Maintenance list so the user can pick the dead device to Forget.
- * @property username The account username that owned this push (i.e. the login used by the
- *     writing device). Read on Maintenance to label a *foreign* user's group of files — the
- *     namespace itself is the opaque user id, which gives the user nothing to recognise.
- *     Null on legacy files written before the field existed; renderers fall back to the id.
  * @property bookTitle The local catalog's title for the book this file holds annotations for.
  *     Per-file, refreshed on every push, so re-tagged metadata propagates without explicit
  *     migration. Used on Maintenance to show "Project Hail Mary, Dune, …" instead of opaque
@@ -33,8 +23,5 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class AnnotationFileHeader(
     val deviceId: String,
-    val label: String,
-    val lastSeenAt: String,
-    val username: String? = null,
     val bookTitle: String? = null,
 )

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/AnnotationSyncTarget.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/AnnotationSyncTarget.kt
@@ -10,8 +10,7 @@ package com.riffle.core.domain
  *
  * Each per-device file is a JSON array whose first element is a [AnnotationFileHeader] header
  * (label / model / lastSeenAt) followed by the W3C annotation records — see [AnnotationFileHeader]
- * for the format rationale. There is no separate sidecar file; legacy `device-*.json` files
- * from earlier builds are cleaned up opportunistically by `forgetDevice`.
+ * for the format rationale.
  *
  * [namespace] is an opaque, **cross-device-stable** identity that scopes a sync target's view
  * of "the same account" — for ABS that is `/api/me` → `user.id`, persisted as
@@ -50,21 +49,25 @@ interface AnnotationSyncTarget {
     suspend fun delete(namespace: String, itemId: String, filename: String)
 
     /**
-     * Delete a device's legacy `device-<deviceId>.json` sidecar. No-op if absent. Kept on the
-     * interface so [com.riffle.core.data.AnnotationSyncMaintenance.forgetDevice] can clean up
-     * sidecars left behind by builds prior to the embedded-header migration. Current builds
-     * never write a sidecar.
+     * Read the per-device metadata sentinel for [deviceId] under [namespace]. Single JSON object,
+     * stored at the namespace root (no `itemId` segment). Returns null when the file does not
+     * exist — devices that haven't run a successful sync cycle on the new client never have one.
      */
-    suspend fun deleteDeviceSidecar(namespace: String, deviceId: String)
+    suspend fun readDeviceMeta(namespace: String, deviceId: String): String?
+
+    /**
+     * Write (overwrite) the per-device metadata sentinel for [deviceId] under [namespace].
+     * Called at the end of every successful sync cycle, push or pull-only — see
+     * [com.riffle.core.data.AnnotationDeviceMetaCodec] for the body shape.
+     */
+    suspend fun writeDeviceMeta(namespace: String, deviceId: String, content: String)
 
     /**
      * Enumerate every device that owns annotation files under [namespace], grouping by
-     * `deviceId`. Devices appear iff they own at least one annotation file; legacy sidecars
-     * are tracked separately via [hasLegacySidecar] so [forgetDevice] can clean them up.
+     * `deviceId`. Devices appear iff they own at least one annotation file.
      *
      * This drives the Maintenance UI (per-device row with file counts) and is the work-list
-     * for both forget-device (delete its files) and compact-tombstones (rewrite every
-     * annotation file).
+     * for forget-device (delete its files).
      */
     suspend fun enumerateDevices(namespace: String): NamespaceDeviceListing
 
@@ -72,13 +75,13 @@ interface AnnotationSyncTarget {
      * Enumerate every distinct namespace prefix found under the target's base. Used by the
      * Maintenance UI to surface namespaces other than the currently-active one — typically
      * orphans left behind by a previous namespacing scheme (see commit history around the
-     * absUserId migration). Returns counts of annotation files and sidecars per namespace.
+     * absUserId migration). Returns counts of annotation files per namespace.
      */
     suspend fun enumerateNamespaces(): List<NamespaceSummary>
 
     /**
-     * Delete every file (annotation + sidecar) under [namespace]. Used by the Maintenance
-     * "Forget orphan namespace" bulk action. Returns the number of files actually deleted.
+     * Delete every file under [namespace]. Used by the Maintenance "Forget orphan namespace"
+     * bulk action. Returns the number of files actually deleted.
      */
     suspend fun forgetNamespace(namespace: String): Int
 }
@@ -93,15 +96,11 @@ data class NamespaceDeviceListing(
  *
  * @property deviceId The opaque device identifier (UUID minted at install time on each device).
  * @property annotationFiles References to that device's per-book annotation files. Used as the
- *     work-list for "forget device" (delete each) and "compact tombstones" (rewrite each).
- * @property hasLegacySidecar Whether a legacy `device-<deviceId>.json` file (from builds prior
- *     to the embedded-header migration) is still present. Used by `forgetDevice` to clean it
- *     up alongside the annotation files. Not surfaced in the UI.
+ *     work-list for "forget device" (delete each).
  */
 data class DeviceFileSummary(
     val deviceId: String,
     val annotationFiles: List<AnnotationFileRef>,
-    val hasLegacySidecar: Boolean,
 )
 
 /** Reference to a single annotation file under a namespace. */
@@ -114,5 +113,4 @@ data class AnnotationFileRef(
 data class NamespaceSummary(
     val namespace: String,
     val annotationFileCount: Int,
-    val sidecarCount: Int,
 )

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/AnnotationSyncTarget.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/AnnotationSyncTarget.kt
@@ -63,6 +63,14 @@ interface AnnotationSyncTarget {
     suspend fun writeDeviceMeta(namespace: String, deviceId: String, content: String)
 
     /**
+     * Delete the per-device metadata sentinel for [deviceId] under [namespace]. No-op if absent.
+     * Called by `forgetDevice` so a forgotten peer leaves no orphan sentinel that could resurrect
+     * the row if the same deviceId ever writes another annotation file. Implementations MUST NOT
+     * throw on a 404-equivalent.
+     */
+    suspend fun deleteDeviceMeta(namespace: String, deviceId: String)
+
+    /**
      * Enumerate every device that owns annotation files under [namespace], grouping by
      * `deviceId`. Devices appear iff they own at least one annotation file.
      *


### PR DESCRIPTION
## Summary

Maintenance's "Last synced …" hint was sourced from the per-file annotation
header's `lastSeenAt`, which only advanced on push. A device that synced
(pulled) without writing any annotation file looked dormant to peers, and on
the current device the timestamp could disagree with the AddServer banner.

Split device-scoped metadata (label, lastSyncedAt, username) into a new
per-device sentinel file `<namespace>/device-meta-<deviceId>.json` rewritten
on every successful sync cycle through the live controller (push, pull-merge,
solo-PROPFIND). The per-file annotation header shrinks to `deviceId + bookTitle`;
the codec stays tolerant of legacy fields on read.

Maintenance now reads:

- the sentinel for foreign rows (honest "Last synced" per peer, no fallback)
- `AnnotationSyncStatusStore` for this-device (matches the AddServer banner)

`publishHeader` (rename) collapses to one sentinel write instead of N
annotation-file rewrites. Sentinel-write failure is swallowed so it can't flip
a successful cycle to Failed.

Also removes the legacy `device-<deviceId>.json` sidecar cleanup machinery —
the new sentinel uses a distinct `device-meta-` prefix and the old code path
hasn't been needed for several releases.

### Net cost
+1 small PUT per successful cycle through the live controller.

### Commits
1. `fix(annotation-sync): split device meta into a sentinel for honest Last synced` — main change.
2. `fix(annotation-sync): delete the device-meta sentinel on forgetDevice` — review fix; without it forgetting a peer leaked an orphan sentinel that could later resurrect a stale row.
3. `docs(annotation-sync): fix orphan kdoc, drop FQN, soften sentinel invariant` — review fixes; documentation accuracy.

## Test plan

- [x] `./gradlew test` is green across every module.
- [ ] Verify on an AVD: open Maintenance with foreign-device sentinels populated; rename this device; trigger a sync cycle (open a book in WebDAV-synced reader); confirm "Last synced …" advances for this-device on cycle completion (banner-matched) and for foreign rows when their sentinels arrive.
- [ ] Verify Forget on a foreign device row: row disappears, and a subsequent PROPFIND no longer shows `<ns>__device-meta-<peerId>.json`.