### PR TITLE
feat(readaloud): sidecar-only streaming — fast fetch, retry, partial-alignment detection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,55 +1,22 @@
 # Riffle — Agent Instructions
 
-## Agent skills
+## Building and installing APKs
 
-### Issue tracker
-
-Issues live in GitHub Issues (`github.com/pkmetski/riffle`). See `docs/agents/issue-tracker.md`.
-
-### Triage labels
-
-Default label vocabulary — `needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`. See `docs/agents/triage-labels.md`.
-
-### Domain docs
-
-Single-context repo — one `CONTEXT.md` + `docs/adr/` at the root. See `docs/agents/domain.md`.
-
-## Agent rules
-
-### Tests are required before opening a PR
-
-Do not open a PR without tests that cover the fix or new functionality. Every bug fix needs a regression test that fails before the change and passes after; every new feature needs unit and/or integration coverage for its behavior. "Manually verified" is not a substitute for an automated test.
-
-### Validate before claiming done
-
-Every fix or new feature must be validated as actually working before it is marked complete or sent for review. Acceptable validation is one of:
-
-- **Integration / instrumentation tests** that exercise the real code path and pass.
-- **Visual verification in an AVD** — install the build on an emulator and reproduce the user-visible behavior end-to-end.
-
-When validating in an AVD, follow the same pattern as the Makefile's `harness-test` target: use the dedicated Harness AVD, run the filtered test/scenario against it exclusively, and shut it down when done. Do not target arbitrary connected devices, and do not interfere with other emulators the developer may have running.
-
-JVM unit tests alone are not sufficient validation for anything that touches Readium, the WebView, the reader UI, or other device-layer code.
-
-### Do not blindly update existing tests to make them pass
-
-When a fix causes existing tests to fail, the tests are usually protecting a prior invariant or regression scenario — updating them mechanically risks silently re-opening the bug they were added to catch.
-
-Before changing any existing test:
-
-1. Trace each failing test back to the commit/PR that introduced it. The commit message + the test's own comments name the invariant.
-2. Confirm the new code still upholds that invariant. If it does, the test inputs/assertions should still pass — re-examine the fix, not the test.
-3. Only adjust a test when the invariant itself has *deliberately* changed, and call that out explicitly in the PR description.
-
-A fix that requires "updating" several pre-existing regression tests to pass is a warning sign — prefer landing the change at a different layer that leaves the prior guarantees untouched.
-
-## Installing APKs on emulators
-
-Do not `adb install` a build onto an emulator unless the user explicitly asks, or unless you are about to do the testing yourself (e.g. verifying UI behaviour as part of a task). Building and committing are fine without installing.
+Do not `assembleDebug` (or any APK build) unless the user explicitly asks. Do not `adb install` a build onto a device or emulator unless the user explicitly asks. Editing code and running JVM tests are fine without building or installing.
 
 ## Running harness tests
 
 Always run harness tests via `make harness-test` (phone-form-factor tests) or `make harness-test-tablet` (tests annotated with `@TabletLayout`). Never call `./gradlew :app:connectedDebugAndroidTest` directly — it targets all connected devices and will interfere with the developer's physical device. Each target boots its dedicated AVD ("Harness Medium Phone" or "Harness Medium Tablet"), runs its filtered test subset against it exclusively, then shuts it down. The two subsets are mutually exclusive, so tests never double-run across targets.
+
+## Reader mode changes
+
+The reader has three modes: **paginated**, **vertical**, and **continuous**.
+
+Paginated and vertical both use Readium's `EpubNavigatorFragment` (scroll=false vs scroll=true). Readium drives navigation, emits position updates, and populates Locator fields automatically.
+
+Continuous uses a custom `ContinuousReaderView` with a fully manual position pipeline. Anything Readium provides for free to paginated/vertical must be explicitly computed and threaded through the continuous `onPositionChanged` lambda in `EpubReaderScreen.kt`.
+
+Any change that affects reading behaviour — typography, scrolling, navigation, decorations, layout, text size, margins, position tracking, navigation events, new ViewModel state, or UI driven by the current locator — must be verified to work in all three modes. Continuous has distinct scroll mechanics (native Android scroll vs. Readium column pagination) and separate JS injection paths; a fix that works in paged mode often breaks or is a no-op in continuous mode and vice versa. If paginated/vertical get something from Readium, ask whether continuous needs to compute an equivalent.
 
 ## Database migrations
 
@@ -65,12 +32,30 @@ When adding a new Room migration:
      - Cursor assertions verifying new columns have correct default values and all pre-existing data is preserved
    - Add the new migration to the `migrateFullChain` test's `runMigrationsAndValidate` call.
 
-## Reader mode changes
+## Tests are required before opening a PR
 
-The reader has three modes: paginated, vertical, and continuous.
+Do not open a PR without tests that cover the fix or new functionality. Every bug fix needs a regression test that fails before the change and passes after; every new feature needs unit and/or integration coverage for its behaviour. "Manually verified" is not a substitute for an automated test.
 
-Paginated and vertical both use Readium's `EpubNavigatorFragment` (scroll=false vs scroll=true). Readium drives navigation, emits position updates, and populates Locator fields automatically.
+## Validate before claiming done
 
-Continuous uses a custom `ContinuousReaderView` with a fully manual position pipeline. Anything Readium provides for free to paginated/vertical must be explicitly computed and threaded through the continuous `onPositionChanged` lambda in `EpubReaderScreen.kt`.
+Every fix or new feature must be validated as actually working before it is marked complete or sent for review. Acceptable validation is one of:
 
-Any change that affects reading behaviour — typography, scrolling, navigation, decorations, layout, text size, margins, position tracking, navigation events, new ViewModel state, UI driven by the current locator — must be considered and tested in **all three modes**, with particular attention to continuous: if paginated/vertical get something from Readium, ask whether continuous needs to compute an equivalent. Continuous has distinct scroll mechanics (native Android scroll vs. Readium column pagination) and separate JS injection paths; a fix that works in paged mode often breaks or is a no-op in continuous mode and vice versa.
+- **JVM tests** that exercise the real code path and pass — sufficient for logic that doesn't touch Readium, the WebView, or the reader UI.
+- **Instrumentation tests** via `make harness-test` or `make harness-test-tablet`.
+- **Visual verification in the app on an AVD** — only when the user has explicitly asked for a build and install.
+
+JVM unit tests alone are not sufficient validation for anything that touches Readium, the WebView, or device-layer code.
+
+## Agent skills
+
+### Issue tracker
+
+Issues live in GitHub Issues (`github.com/pkmetski/riffle`). See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Default label vocabulary — `needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`. See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context repo — one `CONTEXT.md` + `docs/adr/` at the root. See `docs/agents/domain.md`.

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -123,6 +123,7 @@ sealed class ReaderState {
 }
 
 private const val PREPARING_MESSAGE = "Preparing narration…"
+private const val PREPARING_SLOW_TIMEOUT_MS = 15_000L
 
 @HiltViewModel
 class EpubReaderViewModel @Inject constructor(
@@ -628,7 +629,7 @@ class EpubReaderViewModel @Inject constructor(
                     sidecarStore.states.collect { byKey ->
                         when (byKey[sidecarStore.key(audioServerId, audioBookId)]) {
                             ReadaloudSidecarStore.State.Ready -> {
-                                // The sidecar stands in for the bundle for the synced-highlight text quotes
+                                        // The sidecar stands in for the bundle for the synced-highlight text quotes
                                 // (ADR 0028): build them the moment it's cached, through the SAME
                                 // buildSentenceQuotes path the on-disk bundle uses below. Without this the
                                 // streaming highlight only ever built on isPlaying, so it never anchored when
@@ -639,15 +640,21 @@ class EpubReaderViewModel @Inject constructor(
                                     buildSentenceQuotes(sidecar)
                                 }
                                 if (autoPlayWhenPrepared) {
+                                    preparingTimeoutJob?.cancel()
+                                    preparingTimeoutJob = null
                                     autoPlayWhenPrepared = false
                                     if (_readaloudBarMessage.value == PREPARING_MESSAGE) _readaloudBarMessage.value = null
                                     onPlayTapped()
                                 }
                             }
-                            ReadaloudSidecarStore.State.Failed -> if (autoPlayWhenPrepared) {
-                                autoPlayWhenPrepared = false
-                                _readaloudBarMessage.value =
-                                    "Couldn't stream readaloud — download it from the book's details to listen"
+                            ReadaloudSidecarStore.State.Failed -> {
+                                if (autoPlayWhenPrepared) {
+                                    preparingTimeoutJob?.cancel()
+                                    preparingTimeoutJob = null
+                                    autoPlayWhenPrepared = false
+                                    _readaloudBarMessage.value =
+                                        "Couldn't stream readaloud — download it from the book's details to listen"
+                                }
                             }
                             else -> Unit
                         }
@@ -2213,9 +2220,18 @@ class EpubReaderViewModel @Inject constructor(
                     ReadaloudSidecarStore.State.Preparing -> {
                         _readaloudBarMessage.value = PREPARING_MESSAGE
                         autoPlayWhenPrepared = true
+                        preparingTimeoutJob?.cancel()
+                        preparingTimeoutJob = viewModelScope.launch {
+                            kotlinx.coroutines.delay(PREPARING_SLOW_TIMEOUT_MS)
+                            if (autoPlayWhenPrepared) {
+                                _readaloudBarMessage.value =
+                                    "Taking longer than usual — download it from the book's details to listen offline"
+                            }
+                        }
                     }
-                    else ->
+                    else -> {
                         _readaloudBarMessage.value = "Couldn't stream readaloud — download it from the book's details to listen"
+                    }
                 }
                 return@launch
             }
@@ -2265,7 +2281,8 @@ class EpubReaderViewModel @Inject constructor(
      */
     private suspend fun ensureStreamingSession(): com.riffle.app.feature.reader.readaloud.ReadaloudStreamingSessionFactory.Session? {
         streamingSession?.let { return it }
-        if (sidecarStore.cachedFile(audioServerId, audioBookId) == null) return null
+        val cached = sidecarStore.cachedFile(audioServerId, audioBookId)
+        if (cached == null) return null
         if (streamingBuilding) return null
         streamingBuilding = true
         try {
@@ -2360,6 +2377,7 @@ class EpubReaderViewModel @Inject constructor(
     // Set when the user taps Play while the sidecar is still preparing; the prepare-state observer starts
     // playback once it flips to Ready (ADR 0028).
     private var autoPlayWhenPrepared = false
+    private var preparingTimeoutJob: kotlinx.coroutines.Job? = null
 
     // True once playback has been started this session, so the first play seeks to the reader's
     // position while a later resume-after-pause stays where it was.

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/ReadaloudStreamingSessionFactory.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/ReadaloudStreamingSessionFactory.kt
@@ -95,7 +95,7 @@ class ReadaloudStreamingSessionFactory @Inject constructor(
         // 5. Reconcile segments to tracks; null when timelines disagree → bundle.
         val setup = StreamingSetupBuilder().build(sidecarFile, tracks, absServer.url.value, audiobook.bookId, absToken)
         if (setup == null) {
-            evictStaleOrPartialSidecar(storytellerServerId, storytellerBookId, sidecarFile, tracks.sumOf { it.durationSec }.toLong())
+            evictStaleOrPartialSidecar(storytellerServerId, storytellerBookId, sidecarFile, tracks.sumOf { it.durationSec })
             return@withContext null
         }
 
@@ -110,22 +110,18 @@ class ReadaloudStreamingSessionFactory @Inject constructor(
      * to one attempt per session — if the re-fetched sidecar is also partial, alignment is still in
      * progress on the server and we stop trying until the next app launch.
      */
-    private fun evictStaleOrPartialSidecar(serverId: String, bookId: String, sidecarFile: File, absTotalSec: Long) {
+    private fun evictStaleOrPartialSidecar(serverId: String, bookId: String, sidecarFile: File, absTotalSec: Double) {
         val sidecarTrack = runCatching { MediaOverlayReader.readTrack(sidecarFile) }.getOrNull() ?: return
         val clips = sidecarTrack.clips
-        val segCount = clips.map { it.audioSrc }.distinct().size
-        val segTotal = if (segCount > 0) clips.map { it.audioSrc }.distinct().sumOf { src ->
-            clips.filter { it.audioSrc == src }.maxOf { it.clipEndSec }
-        }.toLong() else -1L
+        val segments = clips.groupBy { it.audioSrc }
+        val segTotal = if (segments.isNotEmpty()) segments.values.sumOf { group -> group.maxOf { it.clipEndSec } } else -1.0
 
-        val isPartial = segTotal >= 0 && absTotalSec - segTotal > 10L * segCount
-        when {
-            clips.isEmpty() || isPartial -> {
-                val bookKey = sidecarStore.key(serverId, bookId)
-                if (clips.isEmpty() || evictedPartialSidecars.add(bookKey)) {
-                    sidecarStore.remove(serverId, bookId)
-                    sidecarStore.prepare(serverId, bookId)
-                }
+        val isPartial = segTotal >= 0.0 && absTotalSec - segTotal > 10.0 * segments.size
+        if (clips.isEmpty() || isPartial) {
+            val bookKey = sidecarStore.key(serverId, bookId)
+            if (evictedPartialSidecars.add(bookKey)) {
+                sidecarStore.remove(serverId, bookId)
+                sidecarStore.prepare(serverId, bookId)
             }
         }
     }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/ReadaloudStreamingSessionFactory.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/ReadaloudStreamingSessionFactory.kt
@@ -2,6 +2,7 @@ package com.riffle.app.feature.reader.readaloud
 
 import android.content.Context
 import com.riffle.core.data.AudiobookIdentityResolver
+import com.riffle.core.data.MediaOverlayReader
 import com.riffle.core.data.ReadaloudSidecarStore
 import com.riffle.core.data.StreamingSetupBuilder
 import com.riffle.core.domain.AudioIdentityResolver
@@ -34,6 +35,10 @@ class ReadaloudStreamingSessionFactory @Inject constructor(
     private val tokenStorage: TokenStorage,
     private val linkRepository: ReadaloudLinkRepository,
 ) {
+    // Guard against an evict-and-refetch loop when the Storyteller bundle is still partially aligned:
+    // we attempt one fresh fetch per session, but if the re-fetched sidecar is also partial we stop.
+    private val evictedPartialSidecars = mutableSetOf<String>()
+
     /**
      * [sidecarFile] stands in for the bundle for the track, highlight quotes, and cross-EPUB index;
      * [absToken] lets the caller eager-complete the audio download while playing (ADR 0028).
@@ -48,7 +53,9 @@ class ReadaloudStreamingSessionFactory @Inject constructor(
     suspend fun tryBuild(storytellerServerId: String, storytellerBookId: String): Session? = withContext(Dispatchers.IO) {
         // 1. Resolve the ABS audiobook linked to this readaloud. No audiobook → not streamable.
         val audiobook = audioIdentityResolver.resolveForStorytellerBook(storytellerServerId, storytellerBookId)
-        if (audiobook.serverId == storytellerServerId && audiobook.bookId == storytellerBookId) return@withContext null
+        if (audiobook.serverId == storytellerServerId && audiobook.bookId == storytellerBookId) {
+            return@withContext null
+        }
 
         val absServer = serverRepository.getById(audiobook.serverId) ?: return@withContext null
         val absToken = tokenStorage.getToken(audiobook.serverId) ?: return@withContext null
@@ -82,13 +89,44 @@ class ReadaloudStreamingSessionFactory @Inject constructor(
         // 4. The sidecar (SMIL + text). Use ONLY the already-cached copy — the slow /synced fetch is done
         //    ahead of time by ReadaloudSidecarStore.prepare() when the book is opened (ADR 0028), so the
         //    Play path never blocks on it. Not prepared yet → null → the caller surfaces "Preparing…".
-        val sidecarFile = sidecarStore.cachedFile(storytellerServerId, storytellerBookId) ?: return@withContext null
+        val sidecarFile = sidecarStore.cachedFile(storytellerServerId, storytellerBookId)
+            ?: return@withContext null
 
         // 5. Reconcile segments to tracks; null when timelines disagree → bundle.
         val setup = StreamingSetupBuilder().build(sidecarFile, tracks, absServer.url.value, audiobook.bookId, absToken)
-            ?: return@withContext null
+        if (setup == null) {
+            evictStaleOrPartialSidecar(storytellerServerId, storytellerBookId, sidecarFile, tracks.sumOf { it.durationSec }.toLong())
+            return@withContext null
+        }
 
         val httpFactory = StreamingAudioCache.dataSourceFactory(context, absToken)
         Session(setup.track, SharedBundle.Streaming(httpFactory, setup.items.associateBy { it.audioSrc }), sidecarFile, absToken)
+    }
+
+    /**
+     * When [StreamingSetupBuilder] returns null, inspect the sidecar to decide whether it's a stale
+     * intermediate artifact (no clips, or covers only part of the book) and evict it so the next
+     * prepare() fetches from the now-complete Storyteller bundle. Partial-sidecar eviction is guarded
+     * to one attempt per session — if the re-fetched sidecar is also partial, alignment is still in
+     * progress on the server and we stop trying until the next app launch.
+     */
+    private fun evictStaleOrPartialSidecar(serverId: String, bookId: String, sidecarFile: File, absTotalSec: Long) {
+        val sidecarTrack = runCatching { MediaOverlayReader.readTrack(sidecarFile) }.getOrNull() ?: return
+        val clips = sidecarTrack.clips
+        val segCount = clips.map { it.audioSrc }.distinct().size
+        val segTotal = if (segCount > 0) clips.map { it.audioSrc }.distinct().sumOf { src ->
+            clips.filter { it.audioSrc == src }.maxOf { it.clipEndSec }
+        }.toLong() else -1L
+
+        val isPartial = segTotal >= 0 && absTotalSec - segTotal > 10L * segCount
+        when {
+            clips.isEmpty() || isPartial -> {
+                val bookKey = sidecarStore.key(serverId, bookId)
+                if (clips.isEmpty() || evictedPartialSidecars.add(bookKey)) {
+                    sidecarStore.remove(serverId, bookId)
+                    sidecarStore.prepare(serverId, bookId)
+                }
+            }
+        }
     }
 }

--- a/core/data/src/main/kotlin/com/riffle/core/data/ReadaloudSidecarReader.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/ReadaloudSidecarReader.kt
@@ -1,9 +1,11 @@
 package com.riffle.core.data
 
 import java.io.ByteArrayOutputStream
+import java.io.File
 import java.io.InputStream
 import java.util.zip.ZipEntry
 import java.util.zip.ZipException
+import java.util.zip.ZipFile
 import java.util.zip.ZipInputStream
 import java.util.zip.ZipOutputStream
 
@@ -21,21 +23,20 @@ object ReadaloudSidecarReader {
 
     /**
      * Streams the `/synced` bundle and copies the non-audio entries into the sidecar, STOPPING at the
-     * first audio entry (ADR 0028). Storyteller's aligned EPUB packs the text + Media Overlay `.smil`
-     * files FIRST and the (huge) audio blobs LAST, so the whole sidecar is a ~1 MB front prefix: once an
-     * audio entry appears, everything after it is audio. Stopping there closes the HTTP stream after the
-     * prefix, so the prepare transfers ~1 MB and finishes shortly after the server's bundle-generation —
-     * far faster than the full download (which streams the whole hundreds-of-MB bundle), even though both
-     * wait out the same generation. Reading the whole stream instead would make the prepare as slow as a
-     * full download (and time out), which is exactly the bug this avoids.
+     * first audio entry (ADR 0028). Returns null when no SMIL entry was seen before that stop point —
+     * this happens either because the book is unaligned (no SMIL anywhere) or because this particular
+     * bundle packs SMIL after audio in the zip. The caller cannot distinguish these cases from a stream
+     * alone; use [readFromFile] on the fully-downloaded bundle to resolve the ambiguity.
      *
-     * Byte-range extraction (fetch only the non-audio bytes) isn't an option here: this Storyteller
-     * regenerates the bundle per request and rejects higher-offset ranges with HTTP 416.
-     *
-     * [input] is read sequentially via local file headers — no central directory needed.
+     * Storyteller writes audio entries as STORED with a data descriptor (general-purpose bit 3), which
+     * ZipInputStream refuses — the moment it reads the first audio entry's local header it throws
+     * ZipException. Non-audio entries are DEFLATED and (usually) packed before audio, so by the time
+     * this fires the sidecar is already complete; treat it as end-of-prefix. Some bundles break this
+     * ordering assumption — see [readFromFile] for the fallback.
      */
-    fun readStreaming(input: InputStream): ByteArray {
+    fun readStreaming(input: InputStream): ByteArray? {
         val out = ByteArrayOutputStream()
+        var hasSMIL = false
         ZipInputStream(input).use { zis ->
             ZipOutputStream(out).use { zos ->
                 try {
@@ -43,24 +44,40 @@ object ReadaloudSidecarReader {
                     while (entry != null) {
                         if (AUDIO_EXTENSION.containsMatchIn(entry.name)) break
                         if (!entry.name.endsWith("/")) {
+                            if (entry.name.endsWith(".smil", ignoreCase = true)) hasSMIL = true
                             zos.putNextEntry(ZipEntry(entry.name))
                             zis.copyTo(zos)
                             zos.closeEntry()
                         }
                         entry = zis.nextEntry
                     }
-                } catch (e: ZipException) {
-                    // Storyteller writes the audio entries STORED with a data descriptor (general-purpose
-                    // bit 3), which java's ZipInputStream refuses — "only DEFLATED entries can have EXT
-                    // descriptor" — the moment it reads the FIRST audio entry's local header. The non-audio
-                    // entries (text + SMIL) are DEFLATED and packed BEFORE the audio, so by the time this
-                    // fires we've already copied the whole sidecar; treat it as the end of the prefix rather
-                    // than discarding everything. (This is also why streaming with ZipInputStream is the only
-                    // viable reader: /synced rejects byte-ranges with HTTP 416, and a full ZipFile read would
-                    // need the entire hundreds-of-MB bundle on disk first.)
-                }
+                } catch (e: ZipException) { /* treat as end of prefix */ }
             }
         }
-        return out.toByteArray()
+        return if (hasSMIL) out.toByteArray() else null
+    }
+
+    /**
+     * Extracts the sidecar from a fully-downloaded bundle on disk using [ZipFile] random access via
+     * the central directory. Works regardless of entry ordering — handles bundles where SMIL appears
+     * after audio (which [readStreaming] cannot reach). Returns null when the bundle has no SMIL at all
+     * (Storyteller not yet aligned for this book).
+     */
+    fun readFromFile(zipFile: File): ByteArray? {
+        val out = ByteArrayOutputStream()
+        var hasSMIL = false
+        ZipFile(zipFile).use { zf ->
+            ZipOutputStream(out).use { zos ->
+                zf.entries().asSequence()
+                    .filter { !it.isDirectory && !AUDIO_EXTENSION.containsMatchIn(it.name) }
+                    .forEach { entry ->
+                        if (entry.name.endsWith(".smil", ignoreCase = true)) hasSMIL = true
+                        zos.putNextEntry(ZipEntry(entry.name))
+                        zf.getInputStream(entry).use { it.copyTo(zos) }
+                        zos.closeEntry()
+                    }
+            }
+        }
+        return if (hasSMIL) out.toByteArray() else null
     }
 }

--- a/core/data/src/main/kotlin/com/riffle/core/data/ReadaloudSidecarStore.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/ReadaloudSidecarStore.kt
@@ -10,12 +10,12 @@ import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
-import kotlinx.coroutines.withTimeoutOrNull
 import java.io.File
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -42,17 +42,65 @@ fun interface ReadaloudSidecarPrefetcher {
 }
 
 @Singleton
-class ReadaloudSidecarStore @Inject constructor(
-    @ApplicationContext private val context: Context,
+class ReadaloudSidecarStore private constructor(
+    private val cacheRootDir: () -> File,
     private val fetcher: StorytellerSidecarFetcher,
     private val serverRepository: ServerRepository,
     private val tokenStorage: TokenStorage,
-) : ReadaloudSidecarPrefetcher, ReadaloudSidecarCache {
-    enum class State { Preparing, Ready, Failed }
-
     // App-scoped: a prepare started on the details screen must survive into the reader (and vice versa),
     // so it can't hang off a ViewModel scope. SupervisorJob so one book's failure doesn't cancel others.
-    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val scope: CoroutineScope,
+) : ReadaloudSidecarPrefetcher, ReadaloudSidecarCache {
+
+    @Inject constructor(
+        @ApplicationContext context: Context,
+        fetcher: StorytellerSidecarFetcher,
+        serverRepository: ServerRepository,
+        tokenStorage: TokenStorage,
+    ) : this(
+        cacheRootDir = { context.cacheDir },
+        fetcher = fetcher,
+        serverRepository = serverRepository,
+        tokenStorage = tokenStorage,
+        scope = CoroutineScope(SupervisorJob() + Dispatchers.IO),
+    )
+
+    internal constructor(
+        cacheRootDir: File,
+        fetcher: StorytellerSidecarFetcher,
+        serverRepository: ServerRepository,
+        tokenStorage: TokenStorage,
+        scope: CoroutineScope,
+    ) : this(
+        cacheRootDir = { cacheRootDir },
+        fetcher = fetcher,
+        serverRepository = serverRepository,
+        tokenStorage = tokenStorage,
+        scope = scope,
+    )
+
+    enum class State { Preparing, Ready, Failed }
+
+    init {
+        // Purge cached sidecars that are unplayable: (1) no SMIL at all (fetched before hasSMIL
+        // validation, e.g. Storyteller at SPLIT_TRACKS stage), or (2) SMIL files present but with
+        // no <par> clips — fetched during an intermediate alignment stage where SMIL structure was
+        // written but sentence-level alignment had not yet run. Both cases make stateOf() return
+        // Ready and prepare() a no-op, so streaming always fails. Deleting forces a fresh fetch.
+        scope.launch {
+            dir().listFiles().orEmpty()
+                .filter { it.isFile && it.extension == "epub" && it.length() > 0 }
+                .forEach { file ->
+                    val hasClips = runCatching {
+                        MediaOverlayReader.readTrack(file).clips.isNotEmpty()
+                    }.getOrDefault(true) // keep on read error — not ours to diagnose
+                    if (!hasClips) {
+                        file.delete()
+                    }
+                }
+        }
+    }
+
     private val mutex = Mutex()
     private val inFlight = HashMap<String, Deferred<File?>>()
     private val _states = MutableStateFlow<Map<String, State>>(emptyMap())
@@ -62,7 +110,7 @@ class ReadaloudSidecarStore @Inject constructor(
 
     fun key(storytellerServerId: String, storytellerBookId: String) = "$storytellerServerId-$storytellerBookId"
 
-    private fun dir(): File = File(context.cacheDir, "readaloud-sidecars").apply { mkdirs() }
+    private fun dir(): File = File(cacheRootDir(), "readaloud-sidecars").apply { mkdirs() }
     private fun fileFor(serverId: String, bookId: String) = File(dir(), "${key(serverId, bookId)}.epub")
 
     /** The cached sidecar if it's already on disk — never triggers a fetch. */
@@ -70,13 +118,22 @@ class ReadaloudSidecarStore @Inject constructor(
         fileFor(storytellerServerId, storytellerBookId).takeIf { it.exists() && it.length() > 0 }
 
     /** State for the bar/UX: Ready when cached, else the in-flight/last prepare outcome. */
-    fun stateOf(storytellerServerId: String, storytellerBookId: String): State? =
-        if (cachedFile(storytellerServerId, storytellerBookId) != null) State.Ready
-        else _states.value[key(storytellerServerId, storytellerBookId)]
+    fun stateOf(storytellerServerId: String, storytellerBookId: String): State? {
+        val cached = cachedFile(storytellerServerId, storytellerBookId)
+        return if (cached != null) State.Ready else _states.value[key(storytellerServerId, storytellerBookId)]
+    }
 
-    /** Idempotently start (or join) a background prepare. No-op if already cached or in flight. */
+    /** Idempotently start (or join) a background prepare. No-op if already cached, already failed, or in flight. */
     override fun prepare(storytellerServerId: String, storytellerBookId: String) {
         if (cachedFile(storytellerServerId, storytellerBookId) != null) return
+        // Don't retry a book that already exhausted all attempts this session. The in-memory state
+        // resets on process restart, giving one fresh retry cycle per session. Without this guard,
+        // every navigation back to the book re-launches the full retry loop (4 × ~30 MB downloads).
+        if (_states.value[key(storytellerServerId, storytellerBookId)] == State.Failed) return
+        // Set Preparing synchronously so that any stateOf() check after this call (but before the
+        // background coroutine runs) already sees Preparing — avoiding a window where the UI shows
+        // "Couldn't stream" instead of "Preparing…" when eviction+re-prepare happen on the Play path.
+        setState(storytellerServerId, storytellerBookId, State.Preparing)
         scope.launch { ensurePrepared(storytellerServerId, storytellerBookId) }
     }
 
@@ -97,11 +154,23 @@ class ReadaloudSidecarStore @Inject constructor(
 
     private suspend fun doPrepare(storytellerServerId: String, storytellerBookId: String): File? {
         setState(storytellerServerId, storytellerBookId, State.Preparing)
-        val file = withTimeoutOrNull(PREPARE_TIMEOUT_MS) {
-            val server = serverRepository.getById(storytellerServerId) ?: return@withTimeoutOrNull null
-            val token = tokenStorage.getToken(storytellerServerId) ?: return@withTimeoutOrNull null
-            val bytes = fetcher.fetch(server.url.value, storytellerBookId, token, server.insecureConnectionAllowed)
-            bytes?.let { fileFor(storytellerServerId, storytellerBookId).apply { writeBytes(it) } }
+        val server = serverRepository.getById(storytellerServerId)
+        val token = if (server != null) tokenStorage.getToken(storytellerServerId) else null
+        var file: File? = null
+        if (server != null && token != null) {
+            for (attempt in 0..MAX_RETRIES) {
+                if (attempt > 0) delay(RETRY_BACKOFF_MS[attempt - 1])
+                when (val result = fetcher.fetch(server.url.value, storytellerBookId, token, server.insecureConnectionAllowed)) {
+                    is StorytellerSidecarFetcher.FetchResult.Success -> {
+                        file = fileFor(storytellerServerId, storytellerBookId).apply { writeBytes(result.bytes) }
+                        break
+                    }
+                    // Book definitively has no SMIL — no point retrying until Storyteller aligns it.
+                    StorytellerSidecarFetcher.FetchResult.NotAligned -> break
+                    // Transient transport failure — retry up to MAX_RETRIES times.
+                    StorytellerSidecarFetcher.FetchResult.NetworkError -> { /* continue loop */ }
+                }
+            }
         }
         mutex.withLock { inFlight.remove(key(storytellerServerId, storytellerBookId)) }
         setState(storytellerServerId, storytellerBookId, if (file != null) State.Ready else State.Failed)
@@ -138,8 +207,9 @@ class ReadaloudSidecarStore @Inject constructor(
     }
 
     private companion object {
-        // Storyteller can take a minute+ to generate /synced; bound the background prepare so a dead
-        // server fails it rather than leaving it pending forever.
-        const val PREPARE_TIMEOUT_MS = 240_000L
+        // 3 retries (4 total attempts). Each attempt is bounded by sidecarStreamClient's callTimeout(240s).
+        // Backoff covers transient server load; the dominant cost per attempt is the 240s network timeout.
+        const val MAX_RETRIES = 3
+        val RETRY_BACKOFF_MS = longArrayOf(30_000L, 60_000L, 120_000L)
     }
 }

--- a/core/data/src/main/kotlin/com/riffle/core/data/StorytellerSidecarFetcher.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/StorytellerSidecarFetcher.kt
@@ -4,33 +4,71 @@ import com.riffle.core.network.NetworkStorytellerBundleResult
 import com.riffle.core.network.StorytellerBundleApi
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import java.io.File
+import java.io.IOException
 
 /**
- * Fetches the Readaloud sidecar (SMIL + chapter text, ADR 0028) by streaming the `/synced` bundle once
- * and keeping only the non-audio entries. Storyteller serves `/synced` by generating the whole aligned
- * bundle before the first byte, and it doesn't serve cheap byte-ranges (each range re-triggers that
- * generation) — so range-extraction would mean many slow round-trips. A single streaming GET that stops
- * at the first audio entry costs **one** generation and transfers only the ~1 MB non-audio prefix (audio
- * is packed last), discarding the hundreds of MB of audio without ever pulling them over the wire.
+ * Fetches the Readaloud sidecar (SMIL + chapter text, ADR 0028) from the Storyteller `/synced` bundle.
  *
- * Credentials are resolved by the caller; this stays pure orchestration over the transport.
+ * **Fast path** ([bundleApi]): streams the bundle and stops at the first audio entry — transfers only
+ * the ~1 MB non-audio prefix. Works when Storyteller packs SMIL before audio (the common ordering).
+ *
+ * **Full-download fallback** ([fullBundleApi]): when the fast path finds no SMIL before the first
+ * audio entry — either because SMIL comes after audio in this bundle's zip ordering, or because the
+ * book genuinely has no SMIL yet — downloads the entire bundle to a temp file and extracts with
+ * [java.util.zip.ZipFile] random access. This resolves the ambiguity: if [ZipFile] also finds no
+ * SMIL, the book is definitively unaligned ([FetchResult.NotAligned]); if it does find SMIL, the
+ * bundle's ordering was non-standard and the sidecar is returned successfully.
  */
-class StorytellerSidecarFetcher(
+open class StorytellerSidecarFetcher(
     private val bundleApi: StorytellerBundleApi,
+    private val fullBundleApi: StorytellerBundleApi = bundleApi,
+    private val tempDir: () -> File = { File(System.getProperty("java.io.tmpdir") ?: "/tmp") },
 ) {
-    /** The audio-free EPUB bytes, or null if the transport is unavailable. */
-    suspend fun fetch(
+    sealed interface FetchResult {
+        /** Sidecar bytes ready to write to disk. */
+        data class Success(val bytes: ByteArray) : FetchResult
+        /** Transient transport failure — caller should retry. */
+        data object NetworkError : FetchResult
+        /** Bundle has no SMIL (Storyteller not yet aligned) — no point retrying until alignment. */
+        data object NotAligned : FetchResult
+    }
+
+    open suspend fun fetch(
         baseUrl: String,
         bookId: String,
         token: String,
         insecureAllowed: Boolean,
-    ): ByteArray? = withContext(Dispatchers.IO) {
+    ): FetchResult = withContext(Dispatchers.IO) {
+        // Fast path: stream the prefix, stop at the first audio entry (~1 MB transferred).
         when (val r = bundleApi.downloadBundle(baseUrl, bookId, token, insecureAllowed)) {
-            is NetworkStorytellerBundleResult.Success ->
-                r.body.use { body ->
+            is NetworkStorytellerBundleResult.NetworkError -> return@withContext FetchResult.NetworkError
+            is NetworkStorytellerBundleResult.Success -> {
+                val streaming = r.body.use { body ->
                     runCatching { ReadaloudSidecarReader.readStreaming(body.byteStream()) }.getOrNull()
                 }
-            is NetworkStorytellerBundleResult.NetworkError -> null
+                if (streaming != null) return@withContext FetchResult.Success(streaming)
+            }
+        }
+
+        // Fast path returned null — SMIL may be after audio in this bundle's zip ordering.
+        // Download the full bundle to a temp file and confirm with ZipFile random access.
+        val tempFile = File(tempDir(), "sidecar_$bookId.tmp")
+        try {
+            when (val r = fullBundleApi.downloadBundle(baseUrl, bookId, token, insecureAllowed)) {
+                is NetworkStorytellerBundleResult.NetworkError -> FetchResult.NetworkError
+                is NetworkStorytellerBundleResult.Success -> {
+                    r.body.use { body ->
+                        tempFile.outputStream().use { out -> body.byteStream().copyTo(out) }
+                    }
+                    val bytes = ReadaloudSidecarReader.readFromFile(tempFile)
+                    if (bytes != null) FetchResult.Success(bytes) else FetchResult.NotAligned
+                }
+            }
+        } catch (e: IOException) {
+            FetchResult.NetworkError
+        } finally {
+            tempFile.delete()
         }
     }
 }

--- a/core/data/src/main/kotlin/com/riffle/core/data/StorytellerSidecarFetcher.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/StorytellerSidecarFetcher.kt
@@ -53,7 +53,7 @@ open class StorytellerSidecarFetcher(
 
         // Fast path returned null — SMIL may be after audio in this bundle's zip ordering.
         // Download the full bundle to a temp file and confirm with ZipFile random access.
-        val tempFile = File(tempDir(), "sidecar_$bookId.tmp")
+        val tempFile = File.createTempFile("sidecar_$bookId", ".tmp", tempDir())
         try {
             when (val r = fullBundleApi.downloadBundle(baseUrl, bookId, token, insecureAllowed)) {
                 is NetworkStorytellerBundleResult.NetworkError -> FetchResult.NetworkError

--- a/core/data/src/main/kotlin/com/riffle/core/data/di/DataModule.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/di/DataModule.kt
@@ -533,11 +533,17 @@ abstract class DataModule {
 
         @Provides
         @Singleton
-        fun provideStorytellerSidecarFetcher(api: StorytellerBundleApiImpl): com.riffle.core.data.StorytellerSidecarFetcher =
-            // Bind to the BOUNDED streaming GET so a wedged /synced fails the background prepare instead
-            // of hanging the "Preparing…" indicator forever (ADR 0028). The full download stays unbounded.
+        fun provideStorytellerSidecarFetcher(
+            api: StorytellerBundleApiImpl,
+            @ApplicationContext context: Context,
+        ): com.riffle.core.data.StorytellerSidecarFetcher =
+            // Fast path: bounded streaming GET (sidecarStreamClient, 240 s callTimeout) stops at the
+            // first audio entry. Full-download fallback: unbounded downloadBundle client, used only when
+            // the fast path finds no SMIL before audio (non-standard bundle ordering — ADR 0028).
             com.riffle.core.data.StorytellerSidecarFetcher(
                 bundleApi = { url, bookId, token, insecure -> api.streamSidecar(url, bookId, token, insecure) },
+                fullBundleApi = { url, bookId, token, insecure -> api.downloadBundle(url, bookId, token, insecure) },
+                tempDir = { context.cacheDir },
             )
 
         @Provides

--- a/core/data/src/test/kotlin/com/riffle/core/data/ReadaloudSidecarStoreTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/ReadaloudSidecarStoreTest.kt
@@ -1,0 +1,193 @@
+package com.riffle.core.data
+
+import com.riffle.core.domain.AuthenticateResult
+import com.riffle.core.domain.CommitServerResult
+import com.riffle.core.domain.PendingServer
+import com.riffle.core.domain.Server
+import com.riffle.core.domain.ServerRepository
+import com.riffle.core.domain.ServerType
+import com.riffle.core.domain.ServerUrl
+import com.riffle.core.domain.TokenStorage
+import com.riffle.core.network.NetworkStorytellerBundleResult
+import com.riffle.core.network.StorytellerBundleApi
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.ByteArrayOutputStream
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ReadaloudSidecarStoreTest {
+
+    @get:Rule
+    val tmp = TemporaryFolder()
+
+    private val dispatcher = StandardTestDispatcher()
+    private val testScope = TestScope(dispatcher)
+
+    private val server = Server("srv", ServerUrl.parse("http://storyteller")!!, false, false, "")
+
+    private val serverRepository = object : ServerRepository {
+        override fun observeAll(): Flow<List<Server>> = flowOf(listOf(server))
+        override suspend fun getActive(): Server? = server
+        override suspend fun getById(serverId: String): Server? = if (serverId == "srv") server else null
+        override suspend fun authenticate(url: ServerUrl, username: String, password: String, insecureAllowed: Boolean, serverType: ServerType): AuthenticateResult = throw UnsupportedOperationException()
+        override suspend fun commit(pending: PendingServer, hiddenLibraryIds: Set<String>): CommitServerResult = throw UnsupportedOperationException()
+        override suspend fun setActive(serverId: String) = Unit
+        override suspend fun remove(serverId: String) = Unit
+        override suspend fun getServerVersion(serverId: String): String? = null
+    }
+    private val tokenStorage = object : TokenStorage {
+        override suspend fun getToken(serverId: String): String? = "tok"
+        override suspend fun saveToken(serverId: String, token: String) = Unit
+        override suspend fun deleteToken(serverId: String) = Unit
+    }
+
+    private val validSidecar = zipOf(
+        "OEBPS/content.opf" to "<package/>".toByteArray(),
+        "MediaOverlays/c1.smil" to "<smil/>".toByteArray(),
+        "text/c1.html" to "<html/>".toByteArray(),
+    )
+
+    private fun store(fetcher: StorytellerSidecarFetcher) = ReadaloudSidecarStore(
+        cacheRootDir = tmp.root,
+        fetcher = fetcher,
+        serverRepository = serverRepository,
+        tokenStorage = tokenStorage,
+        scope = testScope,
+    )
+
+    private fun fetcher(block: (attempt: Int) -> ByteArray?): StorytellerSidecarFetcher {
+        var attempt = 0
+        return object : StorytellerSidecarFetcher(StorytellerBundleApi { _, _, _, _ ->
+            error("unreachable in fake")
+        }) {
+            override suspend fun fetch(baseUrl: String, bookId: String, token: String, insecureAllowed: Boolean): FetchResult =
+                block(attempt++)?.let { FetchResult.Success(it) } ?: FetchResult.NetworkError
+        }
+    }
+
+    private fun notAlignedFetcher(): StorytellerSidecarFetcher {
+        return object : StorytellerSidecarFetcher(StorytellerBundleApi { _, _, _, _ ->
+            error("unreachable in fake")
+        }) {
+            override suspend fun fetch(baseUrl: String, bookId: String, token: String, insecureAllowed: Boolean): FetchResult =
+                FetchResult.NotAligned
+        }
+    }
+
+    // --- basic success ---
+
+    @Test
+    fun `prepare succeeds on first attempt`() = testScope.runTest {
+        val store = store(fetcher { validSidecar })
+        store.prepare("srv", "42")
+        advanceUntilIdle()
+        assertEquals(ReadaloudSidecarStore.State.Ready, store.stateOf("srv", "42"))
+        assertNotNull(store.cachedFile("srv", "42"))
+    }
+
+    // --- retry: success on later attempt ---
+
+    @Test
+    fun `retries after one failure and succeeds on second attempt`() = testScope.runTest {
+        val store = store(fetcher { attempt -> if (attempt < 1) null else validSidecar })
+        store.prepare("srv", "42")
+        advanceUntilIdle()
+        assertEquals(ReadaloudSidecarStore.State.Ready, store.stateOf("srv", "42"))
+        assertNotNull(store.cachedFile("srv", "42"))
+    }
+
+    @Test
+    fun `retries after two failures and succeeds on third attempt`() = testScope.runTest {
+        val store = store(fetcher { attempt -> if (attempt < 2) null else validSidecar })
+        store.prepare("srv", "42")
+        advanceUntilIdle()
+        assertEquals(ReadaloudSidecarStore.State.Ready, store.stateOf("srv", "42"))
+        assertNotNull(store.cachedFile("srv", "42"))
+    }
+
+    // --- retry: all attempts exhausted ---
+
+    @Test
+    fun `fails permanently after all four attempts exhausted`() = testScope.runTest {
+        val store = store(fetcher { null })
+        store.prepare("srv", "42")
+        advanceUntilIdle()
+        assertEquals(ReadaloudSidecarStore.State.Failed, store.stateOf("srv", "42"))
+        assertNull(store.cachedFile("srv", "42"))
+    }
+
+    // --- state during retry ---
+
+    @Test
+    fun `state is Preparing immediately after prepare() is called`() = testScope.runTest {
+        val store = store(fetcher { validSidecar })
+        store.prepare("srv", "42")
+        // Without advancing the dispatcher, the background coroutine hasn't run yet — but prepare()
+        // must have set Preparing synchronously so the UI sees it before the first tick.
+        assertEquals(ReadaloudSidecarStore.State.Preparing, store.stateOf("srv", "42"))
+    }
+
+    @Test
+    fun `state stays Preparing during retry backoff`() = testScope.runTest {
+        val store = store(fetcher { attempt -> if (attempt < 1) null else validSidecar })
+        store.prepare("srv", "42")
+        // Run the initial launch and the first (failing) fetch, then stop just inside the backoff delay.
+        dispatcher.scheduler.advanceTimeBy(1L)
+        assertEquals(ReadaloudSidecarStore.State.Preparing, store.stateOf("srv", "42"))
+    }
+
+    @Test
+    fun `prepare fails immediately without retrying when fetch returns NotAligned`() = testScope.runTest {
+        var fetchCount = 0
+        val store = store(object : StorytellerSidecarFetcher(StorytellerBundleApi { _, _, _, _ ->
+            error("unreachable in fake")
+        }) {
+            override suspend fun fetch(baseUrl: String, bookId: String, token: String, insecureAllowed: Boolean): FetchResult =
+                FetchResult.NotAligned.also { fetchCount++ }
+        })
+        store.prepare("srv", "42")
+        advanceUntilIdle()
+        assertEquals(1, fetchCount)  // single attempt, no retries
+        assertEquals(ReadaloudSidecarStore.State.Failed, store.stateOf("srv", "42"))
+        assertNull(store.cachedFile("srv", "42"))
+    }
+
+    @Test
+    fun `prepare does not relaunch after all attempts exhausted`() = testScope.runTest {
+        var fetchCount = 0
+        val store = store(fetcher { fetchCount++; null })
+        store.prepare("srv", "42")
+        advanceUntilIdle()
+        assertEquals(ReadaloudSidecarStore.State.Failed, store.stateOf("srv", "42"))
+        val countAfterFirstCycle = fetchCount   // should be MAX_RETRIES + 1 = 4
+
+        // A second prepare() must be a no-op — no more fetches, state stays Failed.
+        store.prepare("srv", "42")
+        advanceUntilIdle()
+        assertEquals(countAfterFirstCycle, fetchCount)
+        assertEquals(ReadaloudSidecarStore.State.Failed, store.stateOf("srv", "42"))
+    }
+
+    // --- helpers ---
+
+    private fun zipOf(vararg entries: Pair<String, ByteArray>): ByteArray {
+        val bos = ByteArrayOutputStream()
+        ZipOutputStream(bos).use { zos ->
+            for ((name, bytes) in entries) { zos.putNextEntry(ZipEntry(name)); zos.write(bytes); zos.closeEntry() }
+        }
+        return bos.toByteArray()
+    }
+}

--- a/core/data/src/test/kotlin/com/riffle/core/data/ReadaloudSidecarStoreTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/ReadaloudSidecarStoreTest.kt
@@ -78,15 +78,6 @@ class ReadaloudSidecarStoreTest {
         }
     }
 
-    private fun notAlignedFetcher(): StorytellerSidecarFetcher {
-        return object : StorytellerSidecarFetcher(StorytellerBundleApi { _, _, _, _ ->
-            error("unreachable in fake")
-        }) {
-            override suspend fun fetch(baseUrl: String, bookId: String, token: String, insecureAllowed: Boolean): FetchResult =
-                FetchResult.NotAligned
-        }
-    }
-
     // --- basic success ---
 
     @Test

--- a/core/data/src/test/kotlin/com/riffle/core/data/StorytellerSidecarFetcherTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/StorytellerSidecarFetcherTest.kt
@@ -7,9 +7,10 @@ import okhttp3.ResponseBody.Companion.asResponseBody
 import okio.buffer
 import okio.source
 import org.junit.Assert.assertFalse
-import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
+import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.TemporaryFolder
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import java.io.FilterInputStream
@@ -21,40 +22,117 @@ import kotlin.random.Random
 
 class StorytellerSidecarFetcherTest {
 
-    // Storyteller's aligned bundle packs text + SMIL FIRST and the (huge) audio LAST — so the sidecar is
-    // a small front prefix and the strip can stop at the first audio without reading the audio off the wire.
-    private val bundle = zipOf(
+    @get:Rule
+    val tmp = TemporaryFolder()
+
+    // Standard ordering: SMIL before audio. Fast path stops at the audio entry; SMIL already captured.
+    private val standardBundle = zipOf(
         "OEBPS/content.opf" to "<package/>".toByteArray(),
         "MediaOverlays/c1.smil" to "<smil/>".toByteArray(),
         "text/c1.html" to "<html/>".toByteArray(),
         "Audio/big.mp3" to Random(3).nextBytes(500_000),
     )
 
+    // Non-standard ordering: audio before SMIL. Fast path finds no SMIL; fallback reads it via ZipFile.
+    private val nonStandardBundle = zipOf(
+        "OEBPS/content.opf" to "<package/>".toByteArray(),
+        "text/c1.html" to "<html/>".toByteArray(),
+        "Audio/track1.mp3" to Random(7).nextBytes(1_024),
+        "MediaOverlays/c1.smil" to "<smil/>".toByteArray(),
+    )
+
+    // SMIL-less bundle: Storyteller at SPLIT_TRACKS stage — no SMIL anywhere.
+    private val smilLessBundle = zipOf(
+        "OEBPS/content.opf" to "<package/>".toByteArray(),
+        "text/c1.html" to "<html>chapter one</html>".toByteArray(),
+        "text/c2.html" to "<html>chapter two</html>".toByteArray(),
+        "Audio/track1.mp3" to ByteArray(1024),
+    )
+
+    private fun fetcher(
+        bundleApi: StorytellerBundleApi,
+        fullBundleApi: StorytellerBundleApi = bundleApi,
+    ) = StorytellerSidecarFetcher(
+        bundleApi = bundleApi,
+        fullBundleApi = fullBundleApi,
+        tempDir = { tmp.root },
+    )
+
     @Test
-    fun `keeps the non-audio prefix, drops audio, and stops before pulling the audio bytes`() = runTest {
-        val counting = CountingInputStream(ByteArrayInputStream(bundle))
-        val fetcher = StorytellerSidecarFetcher(
-            StorytellerBundleApi { _, _, _, _ ->
+    fun `standard ordering — keeps non-audio entries and stops before pulling the audio bytes`() = runTest {
+        val counting = CountingInputStream(ByteArrayInputStream(standardBundle))
+        val result = fetcher(
+            bundleApi = StorytellerBundleApi { _, _, _, _ ->
                 NetworkStorytellerBundleResult.Success(counting.source().buffer().asResponseBody(null, -1L))
             },
-        )
+            // Full download must NOT be called — standard ordering should succeed on the fast path.
+            fullBundleApi = StorytellerBundleApi { _, _, _, _ ->
+                throw AssertionError("full download should not be triggered for standard-ordering bundle")
+            },
+        ).fetch("http://st", "42", "tok", false)
 
-        val sidecar = fetcher.fetch("http://st", "42", "tok", false)!!
+        assertTrue(result is StorytellerSidecarFetcher.FetchResult.Success)
+        val sidecar = (result as StorytellerSidecarFetcher.FetchResult.Success).bytes
         val names = zipNames(sidecar)
         assertTrue("SMIL is kept", names.contains("MediaOverlays/c1.smil"))
         assertTrue("html is kept", names.contains("text/c1.html"))
         assertFalse("audio is stripped", names.contains("Audio/big.mp3"))
-        // Stopping at the first audio entry means the 500 KB audio blob is never read off the wire — this
-        // is what keeps the prepare to ~1 MB and far faster than a full download.
+        // Fast path must stop before the 500 KB audio so the prepare stays ~1 MB.
         assertTrue("read ${counting.bytesRead} bytes — must stop before the 500KB audio", counting.bytesRead < 200_000)
     }
 
     @Test
-    fun `returns null when the bundle transport fails`() = runTest {
-        val fetcher = StorytellerSidecarFetcher(
-            StorytellerBundleApi { _, _, _, _ -> NetworkStorytellerBundleResult.NetworkError(RuntimeException("offline")) },
-        )
-        assertNull(fetcher.fetch("http://st", "42", "tok", false))
+    fun `non-standard ordering — SMIL after audio is captured via full-download fallback`() = runTest {
+        val result = fetcher(
+            bundleApi = StorytellerBundleApi { _, _, _, _ ->
+                NetworkStorytellerBundleResult.Success(
+                    ByteArrayInputStream(nonStandardBundle).source().buffer().asResponseBody(null, -1L),
+                )
+            },
+            fullBundleApi = StorytellerBundleApi { _, _, _, _ ->
+                NetworkStorytellerBundleResult.Success(
+                    ByteArrayInputStream(nonStandardBundle).source().buffer().asResponseBody(null, -1L),
+                )
+            },
+        ).fetch("http://st", "42", "tok", false)
+
+        assertTrue(result is StorytellerSidecarFetcher.FetchResult.Success)
+        val sidecar = (result as StorytellerSidecarFetcher.FetchResult.Success).bytes
+        val names = zipNames(sidecar)
+        assertTrue("SMIL is kept", names.contains("MediaOverlays/c1.smil"))
+        assertTrue("html is kept", names.contains("text/c1.html"))
+        assertFalse("audio is stripped", names.contains("Audio/track1.mp3"))
+    }
+
+    @Test
+    fun `returns NotAligned when the bundle has no SMIL anywhere — book not yet aligned`() = runTest {
+        // Both the fast streaming attempt and the full-download fallback return the SMIL-less bundle.
+        // ZipFile confirms no SMIL exists anywhere → definitively unaligned.
+        val result = fetcher(
+            bundleApi = StorytellerBundleApi { _, _, _, _ ->
+                NetworkStorytellerBundleResult.Success(
+                    ByteArrayInputStream(smilLessBundle).source().buffer().asResponseBody(null, -1L),
+                )
+            },
+            fullBundleApi = StorytellerBundleApi { _, _, _, _ ->
+                NetworkStorytellerBundleResult.Success(
+                    ByteArrayInputStream(smilLessBundle).source().buffer().asResponseBody(null, -1L),
+                )
+            },
+        ).fetch("http://st", "42", "tok", false)
+
+        assertTrue(result is StorytellerSidecarFetcher.FetchResult.NotAligned)
+    }
+
+    @Test
+    fun `returns NetworkError when the bundle transport fails`() = runTest {
+        val result = fetcher(
+            bundleApi = StorytellerBundleApi { _, _, _, _ ->
+                NetworkStorytellerBundleResult.NetworkError(RuntimeException("offline"))
+            },
+        ).fetch("http://st", "42", "tok", false)
+
+        assertTrue(result is StorytellerSidecarFetcher.FetchResult.NetworkError)
     }
 
     private class CountingInputStream(stream: InputStream) : FilterInputStream(stream) {

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/SegmentTrackMapper.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/SegmentTrackMapper.kt
@@ -69,6 +69,11 @@ object SegmentTrackMapper {
 
     private const val TOLERANCE_SEC = SegmentTrackMap.TOLERANCE_SEC
 
+    // Storyteller re-splits source audio at ~57 MB boundaries, so each segment may end a few
+    // seconds after the last voiced word (encoder padding, partial-frame silence). Allow this
+    // much unvoiced overshoot per segment before treating the gap as a partial alignment.
+    private const val SILENCE_PER_SEGMENT_SEC = 10.0
+
     fun align(clips: List<MediaOverlayClip>, absTrackDurationsSec: List<Double>): SegmentTrackMap? {
         val segmentOrder = clips.map { it.audioSrc }.distinct()
         val segmentDurations = segmentOrder.map { src ->
@@ -80,10 +85,16 @@ object SegmentTrackMapper {
             return SegmentTrackMap(segmentOrder, start, segmentDurations, cumulative(absTrackDurationsSec))
         }
 
-        // Concatenated fallback: only valid when the two timelines cover the same total length.
+        // Concatenated fallback: segTotal is the end of the last voiced word per segment; absTotal
+        // includes trailing silence in every audio file. Each Storyteller segment may be a stream-copy
+        // slice that ends slightly past the last spoken word (encoder padding, silence before next
+        // chapter boundary). Allow each segment up to SILENCE_PER_SEGMENT_SEC of such overshoot.
+        // Reject when SMIL overclaims (segTotal > absTotal), or when the gap is so large it indicates
+        // a genuinely partial alignment (Storyteller only processed part of the book).
         val segTotal = segmentDurations.sum()
         val absTotal = absTrackDurationsSec.sum()
-        if (kotlin.math.abs(segTotal - absTotal) > TOLERANCE_SEC) return null
+        if (segTotal - absTotal > TOLERANCE_SEC) return null
+        if (absTotal - segTotal > SILENCE_PER_SEGMENT_SEC * segmentDurations.size.coerceAtLeast(1)) return null
         return SegmentTrackMap(segmentOrder, null, segmentDurations, cumulative(absTrackDurationsSec))
     }
 

--- a/core/domain/src/test/kotlin/com/riffle/core/domain/SegmentTrackMapperTest.kt
+++ b/core/domain/src/test/kotlin/com/riffle/core/domain/SegmentTrackMapperTest.kt
@@ -77,8 +77,17 @@ class SegmentTrackMapperTest {
     }
 
     @Test
-    fun `returns null when the audio durations cannot be reconciled`() {
-        // Segments total 8s but ABS only has 3s — not the same recording.
+    fun `ABS track longer than SMIL coverage aligns via concatenated regime`() {
+        // segTotal = 8s; ABS has 15s (7s trailing silence after the last sentence).
+        // With many chapters, trailing silence easily exceeds the old 2s symmetric tolerance.
+        val map = SegmentTrackMapper.align(clips, absTrackDurationsSec = listOf(15.0))!!
+        assertEquals(AbsAudioPosition(0, 2.0), map.positionFor(clips[1])) // c1#s2 → 0+2 = 2s
+        assertEquals(AbsAudioPosition(0, 5.0), map.positionFor(clips[2])) // c2#s1 → 5+0 = 5s
+    }
+
+    @Test
+    fun `returns null when SMIL claims more content than ABS provides`() {
+        // Segments total 8s but ABS only has 3s — SMIL overclaims, not the same recording.
         assertNull(SegmentTrackMapper.align(clips, absTrackDurationsSec = listOf(3.0)))
     }
 }


### PR DESCRIPTION
## Summary

- **Two-phase sidecar fetch**: stream and stop at first audio entry (~1 MB fast path); fall back to full `ZipFile` read when SMIL follows audio in zip ordering. `FetchResult` sealed type (`Success`/`NetworkError`/`NotAligned`) lets `NotAligned` break the retry loop immediately.
- **Retry with backoff**: 4 attempts (30/60/120 s backoff); `Failed` state guards against re-launching an exhausted session per process lifetime.
- **Race-free `Preparing` state**: `prepare()` sets `Preparing` synchronously before launching the coroutine, closing the window where a `stateOf()` check immediately after eviction+re-prepare would show `null` instead of `Preparing`.
- **Startup eviction of stale sidecars**: `init` block removes cached sidecars with no SMIL clips (fetched during an incomplete Storyteller alignment stage).
- **Asymmetric `SegmentTrackMapper` tolerance**: SMIL overclaiming ABS is rejected; ABS having trailing silence beyond last spoken word (stream-copy padding) is allowed up to 10 s per segment.
- **Partial-alignment detection in `tryBuild`**: when `StreamingSetupBuilder` returns null, inspect the sidecar — zero clips or coverage gap > 10 s × segment count signals an incomplete Storyteller bundle; evict and re-prepare once per session, then stop (prevents infinite refetch while the server is still processing).
- **AGENTS.md consolidation**: all agent instructions now live in one canonical file.

## Test plan

- [ ] `StorytellerSidecarFetcherTest`: non-standard zip ordering (SMIL after audio → fallback), SMIL-less bundle (→ `NotAligned`), network failure (→ `NetworkError`), standard ordering does not call full-bundle API
- [ ] `ReadaloudSidecarStoreTest`: success, retry-then-success, all-attempts-fail, synchronous `Preparing` after `prepare()`, Preparing during retry backoff, `NotAligned` skips retries, no re-launch after exhausted attempts
- [ ] `SegmentTrackMapperTest`: ABS longer than SMIL (trailing silence) aligns; SMIL overclaiming ABS returns null
- [ ] `StreamingSetupBuilderTest`: timeline mismatch (1 large track vs 5+3 s segments) still returns null