### PR TITLE
fix(covers): keep cached covers visible in offline mode

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/RiffleApplication.kt
+++ b/app/src/main/kotlin/com/riffle/app/RiffleApplication.kt
@@ -122,14 +122,15 @@ class RiffleApplication : Application(), ImageLoaderFactory {
 internal const val IMAGE_DISK_CACHE_MAX_BYTES = 100L * 1024 * 1024
 
 /**
- * Serves cached covers instantly and revalidates silently after a day; stale copies are acceptable
- * for up to 7 days (covers rarely change). Coil's DiskCache reads these response headers to decide
- * freshness, so the policy applies without an OkHttp disk cache.
+ * Treats covers as immutable so Coil's DiskCache serves them without ever needing the network —
+ * critical for offline mode, where any revalidation would fail and leave cells blank. Safe because
+ * cover URLs embed the item's `updatedAt` as `?t=…` (see `LibraryRepositoryImpl.absCoverUrl`): a
+ * real cover change in ABS bumps `updatedAt`, producing a new URL and a fresh Coil cache key.
  */
 internal val coverCacheControlInterceptor = Interceptor { chain ->
     chain.proceed(chain.request())
         .newBuilder()
-        .header("Cache-Control", "max-age=86400, stale-while-revalidate=604800")
+        .header("Cache-Control", "max-age=31536000, immutable")
         .build()
 }
 

--- a/app/src/test/kotlin/com/riffle/app/RiffleImageLoaderTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/RiffleImageLoaderTest.kt
@@ -41,20 +41,23 @@ class RiffleImageLoaderTest {
     }
 
     @Test
-    fun `revalidation interceptor rewrites Cache-Control so Coil can cache and revalidate covers`() {
+    fun `cover interceptor marks responses immutable so offline cells keep rendering past one day`() {
+        // Covers must be served from Coil's DiskCache without revalidation — otherwise offline
+        // mode blanks out every cell whose cache entry has aged past Cache-Control max-age.
+        // Cover URLs embed the ABS item updatedAt as ?t=… so a real cover change produces a new
+        // URL (and a fresh cache key), making `immutable` safe.
         val request = Request.Builder().url("https://abs.example/cover.jpg").build()
         val upstream = Response.Builder()
             .request(request)
             .protocol(Protocol.HTTP_1_1)
             .code(200)
             .message("OK")
-            // Server sends no caching headers — without the interceptor covers wouldn't cache.
             .body("img".toResponseBody(null))
             .build()
 
         val result = coverCacheControlInterceptor.intercept(FakeChain(request, upstream))
 
-        assertEquals("max-age=86400, stale-while-revalidate=604800", result.header("Cache-Control"))
+        assertEquals("max-age=31536000, immutable", result.header("Cache-Control"))
     }
 
     /** Minimal [Interceptor.Chain] that returns a canned response for the request. */


### PR DESCRIPTION
## Summary

Switch the cover `Cache-Control` interceptor from `max-age=86400, stale-while-revalidate=604800` to `max-age=31536000, immutable`. Past the previous 1-day freshness window, Coil's `DiskCache` triggered a network revalidation per cover; offline that revalidation fails and `AsyncImage` falls back to the placeholder, blanking every previously-loaded cover.

## Why this is safe

Cover URLs already embed the ABS item's `updatedAt` as `?t=…` (introduced by PR #211 in `LibraryRepositoryImpl.absCoverUrl`). Coil keys its DiskCache by full URL, so any real ABS-side cover change rotates the URL and produces a fresh cache key on the next library sync — `immutable` does not block cover refreshes, it just removes the redundant 1-day revalidation that was breaking offline.

## Test plan

- [x] `RiffleImageLoaderTest` updated and green (`./gradlew :app:testDebugUnitTest --tests "com.riffle.app.RiffleImageLoaderTest"`)
- [ ] Manual: open the app online so covers populate, toggle offline mode, confirm covers still render in library/home grids