### PR TITLE
fix(annotation-sync): retry transient WebDAV failures so connectivity-regain re-fires sync

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/sync/AnnotationSyncWorker.kt
+++ b/app/src/main/kotlin/com/riffle/app/sync/AnnotationSyncWorker.kt
@@ -2,8 +2,10 @@ package com.riffle.app.sync
 
 import android.content.Context
 import androidx.work.CoroutineWorker
+import androidx.work.ListenableWorker
 import androidx.work.WorkerParameters
 import com.riffle.core.data.AnnotationSweep
+import com.riffle.core.data.CycleOutcome
 import dagger.hilt.EntryPoint
 import dagger.hilt.InstallIn
 import dagger.hilt.android.EntryPointAccessors
@@ -11,9 +13,14 @@ import dagger.hilt.components.SingletonComponent
 import kotlinx.coroutines.CancellationException
 
 /**
- * Thin WorkManager shell over [AnnotationSweep] (ADR 0036). Mirrors [ProgressSyncWorker]:
- * dependencies via a Hilt EntryPoint (no @HiltWorker / custom factory). A transient failure
- * inside the sweep leaves rows dirty, so Result.retry is safe and idempotent.
+ * Thin WorkManager shell over [AnnotationSweep] (ADR 0036). Dependencies via a Hilt EntryPoint
+ * (no @HiltWorker / custom factory).
+ *
+ * Maps the sweep's [CycleOutcome] to a [Result] so WorkManager's exponential backoff actually
+ * re-fires after transient failures — and so the retry job carries the CONNECTED constraint that
+ * makes "go back online → sync resumes" a property of the system, not of the foreground app.
+ * The previous shape unconditionally returned [Result.success], which is why a stale "will retry
+ * automatically" banner could sit there until the periodic 1-hour tick.
  */
 class AnnotationSyncWorker(
     appContext: Context,
@@ -28,16 +35,32 @@ class AnnotationSyncWorker(
 
     override suspend fun doWork(): Result =
         try {
-            EntryPointAccessors.fromApplication(applicationContext, SweepEntryPoint::class.java)
+            val outcome = EntryPointAccessors
+                .fromApplication(applicationContext, SweepEntryPoint::class.java)
                 .annotationSweep()
                 .run()
-            Result.success()
+            outcomeToResult(outcome)
         } catch (e: CancellationException) {
             throw e
         } catch (_: Exception) {
             // Anything reaching here is a programming error — AnnotationSweep absorbs all transport
-            // failures itself. Don't retry; report a permanent failure so WorkManager stops
-            // scheduling backoff retries.
+            // failures itself. Don't retry.
             Result.failure()
         }
+}
+
+/**
+ * Translate a [CycleOutcome] into a WorkManager [Result]. Transient transport failures retry so
+ * WorkManager's CONNECTED-constrained backoff re-fires when the network returns; credential/TLS
+ * failures need user action and exit the queue.
+ */
+internal fun outcomeToResult(outcome: CycleOutcome?): ListenableWorker.Result = when (outcome) {
+    null, // unconfigured target: nothing to do
+    is CycleOutcome.NeverRun, // unreachable from the sweep, defensive
+    is CycleOutcome.Success -> ListenableWorker.Result.success()
+    is CycleOutcome.Failed.Network,
+    is CycleOutcome.Failed.Server,
+    is CycleOutcome.Failed.Unknown -> ListenableWorker.Result.retry()
+    is CycleOutcome.Failed.Auth,
+    is CycleOutcome.Failed.Tls -> ListenableWorker.Result.failure()
 }

--- a/app/src/test/kotlin/com/riffle/app/sync/AnnotationSyncWorkerOutcomeMappingTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/sync/AnnotationSyncWorkerOutcomeMappingTest.kt
@@ -1,0 +1,72 @@
+package com.riffle.app.sync
+
+import androidx.work.ListenableWorker
+import com.riffle.core.data.CycleOutcome
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Regression: when [com.riffle.core.data.AnnotationSweep] reports a transient transport failure
+ * (network/server/unknown), the worker must return [ListenableWorker.Result.retry] so WorkManager
+ * schedules an exponential-backoff retry. That retry job carries the CONNECTED constraint, which
+ * is what re-fires sync the moment the device comes back online. The previous shape returned
+ * `success()` unconditionally, which left the in-memory status badge saying "will retry
+ * automatically" while no retry was actually queued — sync would only resume on the next 1-hour
+ * periodic tick or a foreground connectivity-regain kick (and the kick uses KEEP, so it can't
+ * unblock anything either).
+ */
+class AnnotationSyncWorkerOutcomeMappingTest {
+
+    @Test
+    fun `unconfigured target maps to success`() {
+        assertEquals(ListenableWorker.Result.success(), outcomeToResult(null))
+    }
+
+    @Test
+    fun `success maps to success`() {
+        assertEquals(
+            ListenableWorker.Result.success(),
+            outcomeToResult(CycleOutcome.Success(atMs = 1L)),
+        )
+    }
+
+    @Test
+    fun `network failure maps to retry`() {
+        assertEquals(
+            ListenableWorker.Result.retry(),
+            outcomeToResult(CycleOutcome.Failed.Network(atMs = 1L, message = "eof")),
+        )
+    }
+
+    @Test
+    fun `server failure maps to retry`() {
+        assertEquals(
+            ListenableWorker.Result.retry(),
+            outcomeToResult(CycleOutcome.Failed.Server(atMs = 1L, code = 503)),
+        )
+    }
+
+    @Test
+    fun `unknown failure maps to retry`() {
+        assertEquals(
+            ListenableWorker.Result.retry(),
+            outcomeToResult(CycleOutcome.Failed.Unknown(atMs = 1L, message = "boom")),
+        )
+    }
+
+    @Test
+    fun `auth failure maps to permanent failure`() {
+        assertEquals(
+            ListenableWorker.Result.failure(),
+            outcomeToResult(CycleOutcome.Failed.Auth(atMs = 1L, code = 401)),
+        )
+    }
+
+    @Test
+    fun `tls failure maps to permanent failure`() {
+        assertEquals(
+            ListenableWorker.Result.failure(),
+            outcomeToResult(CycleOutcome.Failed.Tls(atMs = 1L, message = "bad cert")),
+        )
+    }
+}

--- a/core/data/src/main/kotlin/com/riffle/core/data/AnnotationSweep.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/AnnotationSweep.kt
@@ -37,14 +37,21 @@ class AnnotationSweep(
     private val nowIso: () -> String = { Instant.now().toString() },
     private val clock: () -> Long = System::currentTimeMillis,
 ) {
-    suspend fun run() {
-        val target = targetProvider() ?: return
+    /**
+     * Runs one push cycle. Returns the [CycleOutcome] reported to the status store, or `null` when
+     * the sync target is unconfigured (silent no-op — see class kdoc). The worker maps the outcome
+     * to a [androidx.work.ListenableWorker.Result] so transient failures get WorkManager's
+     * exponential-backoff retry, which is also what re-fires the work the moment connectivity
+     * returns (CONNECTED constraint on the retried JobInfo).
+     */
+    suspend fun run(): CycleOutcome? {
+        val target = targetProvider() ?: return null
 
         // Sentinels are written once per unique namespace touched this cycle. Skip pull-only
         // sweeps with nothing dirty — the live controller refreshes sentinels on its own paths
         // and writing here would require iterating every known namespace.
         val sentinelTargets = mutableSetOf<Pair<String, String>>()
-        try {
+        val outcome: CycleOutcome = try {
             val deviceId = deviceIdStore.getOrCreate()
             for ((serverId, itemId) in annotationDao.dirtyServerItems()) {
                 val namespace = serverRepository.ensureAbsUserId(serverId) ?: continue
@@ -52,13 +59,15 @@ class AnnotationSweep(
                 pushBook(target, serverId, namespace, itemId, deviceId, bookTitle)
                 sentinelTargets += serverId to namespace
             }
-            statusStore.report(CycleOutcome.Success(clock()))
             for ((serverId, namespace) in sentinelTargets) {
                 writeDeviceMetaQuietly(target, deviceId, namespace, serverId)
             }
+            CycleOutcome.Success(clock())
         } catch (e: Exception) {
-            statusStore.report(e.toFailedCycleOutcome(clock()))
+            e.toFailedCycleOutcome(clock())
         }
+        statusStore.report(outcome)
+        return outcome
     }
 
     /**

--- a/core/data/src/test/kotlin/com/riffle/core/data/AnnotationSweepTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/AnnotationSweepTest.kt
@@ -39,10 +39,13 @@ class AnnotationSweepTest {
             clock = { 1000L },
         )
 
-        sweep.run()
+        val outcome = sweep.run()
 
         assertEquals(CycleOutcome.NeverRun, status.lastCycleOutcome.value)
         assertEquals(0, dao.markSyncedCalls)
+        // Unconfigured target returns null so the worker treats it as success — there's nothing
+        // to retry until the user configures a target.
+        assertEquals(null, outcome)
     }
 
     @Test
@@ -73,7 +76,8 @@ class AnnotationSweepTest {
             clock = { now },
         )
 
-        sweep.run()
+        val returned = sweep.run()
+        assertTrue("run() must return the reported outcome", returned is CycleOutcome.Success)
 
         assertEquals(1, target.writes.size)
         val write = target.writes.single()
@@ -133,13 +137,15 @@ class AnnotationSweepTest {
             clock = { 9_000L },
         )
 
-        sweep.run()
+        val returned = sweep.run()
 
         assertEquals(0, dao.markSyncedCalls)
         val outcome = status.lastCycleOutcome.value
         assertTrue(outcome is CycleOutcome.Failed.Auth)
         assertEquals(9_000L, (outcome as CycleOutcome.Failed.Auth).atMs)
         assertEquals(401, outcome.code)
+        // run() returns the same outcome so the worker can map Failed.Auth → Result.failure().
+        assertEquals(outcome, returned)
     }
 
     @Test
@@ -169,12 +175,15 @@ class AnnotationSweepTest {
             clock = { 1L },
         )
 
-        sweep.run()
+        val returned = sweep.run()
 
         // First book attempted, failed; second book never attempted.
         assertEquals(1, target.writes.size)
         assertEquals(0, dao.markSyncedCalls)
         assertTrue(status.lastCycleOutcome.value is CycleOutcome.Failed.Network)
+        // run() returns Failed.Network so the worker maps it to Result.retry() — that's the queue
+        // entry whose CONNECTED constraint re-fires when the device comes back online.
+        assertTrue("run() must return Failed.Network", returned is CycleOutcome.Failed.Network)
     }
 
     @Test


### PR DESCRIPTION
## Summary

- `AnnotationSweep.run()` was catching every transport exception itself, so `AnnotationSyncWorker.doWork()` always returned `Result.success()` — WorkManager never scheduled a retry for a failed cycle.
- This left the status banner saying "will retry automatically" with no retry actually queued. Coming back online didn't help (nothing to fire), and the only thing that re-tried sync was the 1-hour periodic.
- Fix: `AnnotationSweep.run()` now returns its `CycleOutcome`, and the worker maps it: `Failed.Network/Server/Unknown` → `Result.retry()` (carries the existing 30s exponential backoff and CONNECTED constraint, so JobScheduler fires it when the device comes back online); `Failed.Auth/Tls` → `Result.failure()` (need user action).

`ProgressSyncWorker` already had this shape (rethrows + `Result.retry()` in `catch`), so no change there.

## Test plan

- [x] `:core:data:testDebugUnitTest --tests AnnotationSweepTest` — green; updated 4 tests to assert `run()` now returns the reported outcome.
- [x] `:app:testDebugUnitTest --tests AnnotationSyncWorkerOutcomeMappingTest` — new, 7 cases pinning each outcome → Result mapping.
- [ ] Smoke on the Asus device: with sync misconfigured to fail (e.g. wrong WebDAV password temporarily), confirm WorkManager schedules a retry (`adb shell dumpsys jobscheduler | grep -A 20 riffle` shows a TIMING_DELAY + CONNECTIVITY-constrained job after a failed cycle, not nothing).