### PR TITLE
refactor(reader): typed accessors on CanonicalReaderPosition

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderPositionBridge.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderPositionBridge.kt
@@ -1,6 +1,7 @@
 package com.riffle.app.feature.reader
 
 import com.riffle.core.domain.CanonicalPositionTranslator
+import com.riffle.core.domain.CanonicalReaderPosition
 import com.riffle.core.domain.ChapterProgression
 import org.json.JSONObject
 
@@ -91,10 +92,7 @@ class ReaderPositionBridge(
      * remote win to the ebook would write progress 0 and clear the server's progress bar.
      */
     fun canonicalBookProgress(locatorJson: String): Float {
-        val locations = runCatching { JSONObject(locatorJson).optJSONObject("locations") }.getOrNull()
-        if (locations != null && locations.has("totalProgression")) {
-            return locations.optDouble("totalProgression", 0.0).toFloat()
-        }
+        CanonicalReaderPosition(locatorJson).totalProgression?.let { return it.toFloat() }
         val p = canonicalToDisplayedProgression(locatorJson) ?: return 0f
         return (translator.absBookProgression(p) ?: p.progression).toFloat()
     }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderSync.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderSync.kt
@@ -232,12 +232,13 @@ class ReaderSyncCoordinator(
      */
     fun readaloudAnchorForAudioSeconds(seconds: Double): com.riffle.core.domain.ReadaloudResumePosition? {
         val canonicalJson = bridge.audioSecondsToCanonical(seconds) ?: return null
-        val fragmentRef = bridge.canonicalToFragmentRef(canonicalJson)
-        val locations = runCatching { org.json.JSONObject(canonicalJson) }.getOrNull()?.optJSONObject("locations")
-        val href = runCatching { org.json.JSONObject(canonicalJson) }.getOrNull()?.optString("href")
-            ?.takeIf { it.isNotEmpty() } ?: return null
-        val progression = locations?.takeIf { it.has("progression") }?.optDouble("progression")?.takeIf { !it.isNaN() }
-        return com.riffle.core.domain.ReadaloudResumePosition(href, progression, fragmentRef)
+        val pos = CanonicalReaderPosition(canonicalJson)
+        val href = pos.href ?: return null
+        return com.riffle.core.domain.ReadaloudResumePosition(
+            href = href,
+            progression = pos.chapterProgression,
+            fragmentRef = bridge.canonicalToFragmentRef(canonicalJson),
+        )
     }
 
     /**

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/CanonicalSyncCycle.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/CanonicalSyncCycle.kt
@@ -2,14 +2,52 @@ package com.riffle.core.domain
 
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.doubleOrNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 
 /**
  * A reader position expressed in the canonical coordinate system of the cycle — the
  * Readium Locator on the EPUB the reader currently displays (ADR 0019). Opaque to the
  * cycle, which only compares update times and routes the value to remotes; remotes
  * translate it to/from their native coordinates at their boundary.
+ *
+ * The wire form is the Locator JSON string; [href], [chapterProgression], and
+ * [totalProgression] are lazily-parsed read accessors so callers can pull fields
+ * without re-parsing the string at every site.
  */
-data class CanonicalReaderPosition(val value: String)
+data class CanonicalReaderPosition(val value: String) {
+    private val parsed: ParsedLocator? by lazy(LazyThreadSafetyMode.NONE) { ParsedLocator.parse(value) }
+
+    /** Spine href the locator points at, or `null` when the value isn't a parseable Locator JSON. */
+    val href: String? get() = parsed?.href
+
+    /** Within-chapter progression `[0..1]`, or `null` when absent / unparseable. */
+    val chapterProgression: Double? get() = parsed?.chapterProgression
+
+    /** Book-wide progression `[0..1]`. `null` for a canonical reconstructed from a remote
+     *  (audio / Storyteller) — the bridge then weights it from chapter character counts. */
+    val totalProgression: Double? get() = parsed?.totalProgression
+
+    private class ParsedLocator(val href: String?, val chapterProgression: Double?, val totalProgression: Double?) {
+        companion object {
+            fun parse(value: String): ParsedLocator? {
+                if (value.isEmpty()) return null
+                val element = runCatching { Json.parseToJsonElement(value) }.getOrNull() ?: return null
+                val root = element as? JsonObject ?: return null
+                val href = (root["href"] as? JsonPrimitive)?.contentOrNull?.takeIf { it.isNotEmpty() }
+                val locations = root["locations"] as? JsonObject
+                val cp = locations?.get("progression")?.let { it as? JsonPrimitive }?.doubleOrNull
+                val tp = locations?.get("totalProgression")?.let { it as? JsonPrimitive }?.doubleOrNull
+                return ParsedLocator(href, cp, tp)
+            }
+        }
+    }
+}
 
 /** The local reader position and the single `localUpdatedAt` it was last changed at. */
 data class LocalCanonical(val position: CanonicalReaderPosition, val lastUpdate: Long)

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/CanonicalSyncCycle.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/CanonicalSyncCycle.kt
@@ -7,8 +7,6 @@ import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.doubleOrNull
-import kotlinx.serialization.json.jsonObject
-import kotlinx.serialization.json.jsonPrimitive
 
 /**
  * A reader position expressed in the canonical coordinate system of the cycle — the
@@ -41,8 +39,8 @@ data class CanonicalReaderPosition(val value: String) {
                 val root = element as? JsonObject ?: return null
                 val href = (root["href"] as? JsonPrimitive)?.contentOrNull?.takeIf { it.isNotEmpty() }
                 val locations = root["locations"] as? JsonObject
-                val cp = locations?.get("progression")?.let { it as? JsonPrimitive }?.doubleOrNull
-                val tp = locations?.get("totalProgression")?.let { it as? JsonPrimitive }?.doubleOrNull
+                val cp = (locations?.get("progression") as? JsonPrimitive)?.doubleOrNull
+                val tp = (locations?.get("totalProgression") as? JsonPrimitive)?.doubleOrNull
                 return ParsedLocator(href, cp, tp)
             }
         }

--- a/core/domain/src/test/kotlin/com/riffle/core/domain/CanonicalReaderPositionTest.kt
+++ b/core/domain/src/test/kotlin/com/riffle/core/domain/CanonicalReaderPositionTest.kt
@@ -1,0 +1,87 @@
+package com.riffle.core.domain
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class CanonicalReaderPositionTest {
+
+    @Test fun parses_a_full_locator() {
+        val p = CanonicalReaderPosition(
+            """{"href":"ch5.xhtml","type":"application/xhtml+xml","locations":{"progression":0.42,"totalProgression":0.18}}"""
+        )
+        assertEquals("ch5.xhtml", p.href)
+        assertEquals(0.42, p.chapterProgression!!, 1e-9)
+        assertEquals(0.18, p.totalProgression!!, 1e-9)
+    }
+
+    /** A canonical reconstructed from a remote (audio / Storyteller) carries no book-wide
+     *  progression — the bridge then weights it from chapter character counts. The accessor
+     *  must surface that as `null` rather than 0 (which would clear the server's progress bar). */
+    @Test fun totalProgression_is_null_when_absent() {
+        val p = CanonicalReaderPosition(
+            """{"href":"ch5.xhtml","locations":{"progression":0.42}}"""
+        )
+        assertNull(p.totalProgression)
+        assertEquals(0.42, p.chapterProgression!!, 1e-9)
+        assertEquals("ch5.xhtml", p.href)
+    }
+
+    @Test fun chapterProgression_is_null_when_locations_is_missing() {
+        val p = CanonicalReaderPosition("""{"href":"ch5.xhtml"}""")
+        assertNull(p.chapterProgression)
+        assertNull(p.totalProgression)
+        assertEquals("ch5.xhtml", p.href)
+    }
+
+    @Test fun href_is_null_when_empty_string_value() {
+        val p = CanonicalReaderPosition("")
+        assertNull(p.href)
+        assertNull(p.chapterProgression)
+        assertNull(p.totalProgression)
+    }
+
+    @Test fun returns_null_on_malformed_json() {
+        val p = CanonicalReaderPosition("not json at all")
+        assertNull(p.href)
+        assertNull(p.chapterProgression)
+        assertNull(p.totalProgression)
+    }
+
+    @Test fun returns_null_when_root_is_not_an_object() {
+        val p = CanonicalReaderPosition("[1,2,3]")
+        assertNull(p.href)
+        assertNull(p.chapterProgression)
+    }
+
+    @Test fun returns_null_when_href_is_empty_string() {
+        val p = CanonicalReaderPosition("""{"href":"","locations":{"progression":0.5}}""")
+        assertNull(p.href)
+        assertEquals(0.5, p.chapterProgression!!, 1e-9)
+    }
+
+    /** Lazy parse: repeated reads of the same accessor don't re-parse the JSON. We can't
+     *  observe parser count directly; instead exercise the path many times to confirm no
+     *  exception escapes and the value is stable. */
+    @Test fun accessors_are_stable_across_repeated_reads() {
+        val p = CanonicalReaderPosition(
+            """{"href":"ch5.xhtml","locations":{"progression":0.42,"totalProgression":0.18}}"""
+        )
+        repeat(50) {
+            assertEquals("ch5.xhtml", p.href)
+            assertEquals(0.42, p.chapterProgression!!, 1e-9)
+            assertEquals(0.18, p.totalProgression!!, 1e-9)
+        }
+    }
+
+    /** Equality and hashCode are still defined solely by the wire value — the lazy field
+     *  must not leak into the data-class contract. Two equal-string positions stay equal. */
+    @Test fun equality_is_by_wire_value() {
+        val a = CanonicalReaderPosition("""{"href":"ch5.xhtml"}""")
+        val b = CanonicalReaderPosition("""{"href":"ch5.xhtml"}""")
+        // Touch the parsed field on one side only.
+        a.href
+        assertEquals(a, b)
+        assertEquals(a.hashCode(), b.hashCode())
+    }
+}


### PR DESCRIPTION
## Summary

- Add lazy-parsed `href` / `chapterProgression` / `totalProgression` accessors on the existing `CanonicalReaderPosition` data class — parsed once via `kotlinx.serialization`, wire format unchanged, equality / hashCode still by the wire string.
- Route the two duplicate-JSON-parse sites through them: `ReaderSyncCoordinator.readaloudAnchorForAudioSeconds` was re-parsing the same JSON twice in adjacent lines; `ReaderPositionBridge.canonicalBookProgress` was parsing partially.

## Why

The bridge already warns ([line](https://github.com/pkmetski/riffle/blob/main/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderPositionBridge.kt) 91) that a canonical reconstructed from a remote carries no `totalProgression` and writing 0 would clear the server's progress bar. Each scattered `JSONObject(...).optDouble("totalProgression", 0.0)` site is one bug-class instance waiting to happen. One typed accessor returning `null` (not `0`) collapses the class.

Architectural framing: this is the first slice of the [architecture review](#) candidate "make the canonical position a real type" — typed read accessors first, before any larger surface change to the bridge.

## Test plan

- [x] 8 new unit tests in `CanonicalReaderPositionTest` — full locator, missing `totalProgression` (the remote-reconstruction regression case), missing `locations`, empty value, malformed JSON, non-object root, empty href, repeat-read stability, equality-by-wire-value.
- [x] Full `./gradlew test` green locally.
- [ ] Existing `ReaderPositionBridgeTest.canonicalBookProgress` cases still cover both totalProgression-present and totalProgression-absent paths through the migrated code.