### PR TITLE
fix(annotation-sync): banner reactive + anchor "Last sync" to actual success

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/server/AddServerScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/server/AddServerScreen.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.material3.windowsizeclass.WindowSizeClass
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -116,7 +117,10 @@ fun AddServerScreen(
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
                 }
-                viewModel.webdavBanner?.let { WebdavStatusCard(it) }
+                val webdavBanner by viewModel.webdavBanner.collectAsState()
+                if (backend == AddServerBackend.WEBDAV) {
+                    webdavBanner?.let { WebdavStatusCard(it) }
+                }
                 Row(verticalAlignment = Alignment.CenterVertically) {
                     var schemeExpanded by remember { mutableStateOf(false) }
                     Box {

--- a/app/src/main/kotlin/com/riffle/app/feature/server/AddServerViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/server/AddServerViewModel.kt
@@ -26,8 +26,12 @@ import com.riffle.core.domain.ServerUrl
 import com.riffle.core.domain.TokenStorage
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -70,8 +74,21 @@ class AddServerViewModel @Inject constructor(
     var password by mutableStateOf(BuildConfig.DEV_PASSWORD)
     var isLoading by mutableStateOf(false)
     var error by mutableStateOf<String?>(null)
-    var webdavBanner by mutableStateOf<WebdavBanner?>(null)
-        private set
+    /**
+     * Reactive banner state derived from the stored WebDAV config, the in-memory cycle outcome,
+     * and the last-success timestamp — so when the periodic sweep flips Failed.Network → Success
+     * in the background, the on-screen card updates without the screen being re-entered. Caller
+     * (the WebDAV screen) is responsible for only rendering this on the WebDAV backend; it stays
+     * non-null whenever a config exists, regardless of which backend the user is editing.
+     */
+    val webdavBanner: StateFlow<WebdavBanner?> = combine(
+        webdavConfigStore.observe(),
+        webdavStatusStore.lastCycleOutcome,
+        webdavStatusStore.lastSuccessAtMs,
+    ) { config, outcome, lastSuccessAtMs ->
+        config?.let { webdavBanner(it, outcome, lastSuccessAtMs) }
+    }.stateIn(viewModelScope, SharingStarted.Eagerly, null)
+
     var insecureWarning by mutableStateOf<InsecureConnectionType?>(null)
 
     private val _navigateToSelectLibraries = Channel<PendingServer>(Channel.CONFLATED)
@@ -102,7 +119,9 @@ class AddServerViewModel @Inject constructor(
                     applyUrl(existing.baseUrl)
                     username = existing.username
                     password = existing.password
-                    webdavBanner = webdavBanner(existing, webdavStatusStore.lastCycleOutcome.value)
+                    // Banner content is driven by the reactive `webdavBanner` StateFlow above —
+                    // intentionally no one-shot snapshot here, so the card refreshes when the
+                    // background sweep flips the outcome.
                 } else {
                     // Fresh WebDAV add — wipe ABS dev defaults so the form starts clean.
                     applyUrl("")
@@ -253,7 +272,11 @@ class AddServerViewModel @Inject constructor(
         }
     }
 
-    private fun webdavBanner(config: AnnotationSyncConfig, outcome: CycleOutcome): WebdavBanner {
+    private fun webdavBanner(
+        config: AnnotationSyncConfig,
+        outcome: CycleOutcome,
+        lastSuccessAtMs: Long?,
+    ): WebdavBanner {
         val (kind, prescription) = when (outcome) {
             is CycleOutcome.NeverRun -> WebdavBannerKind.Pending to null
             is CycleOutcome.Success -> WebdavBannerKind.Synced to null
@@ -274,18 +297,19 @@ class AddServerViewModel @Inject constructor(
             host = host,
             baseUrl = config.baseUrl,
             username = config.username,
-            lastSyncRelative = relativeTime(outcome),
+            lastSyncRelative = relativeSuccessTime(lastSuccessAtMs),
             prescription = prescription,
         )
     }
 
-    private fun relativeTime(outcome: CycleOutcome): String {
-        val atMs: Long = when (outcome) {
-            is CycleOutcome.NeverRun -> return "Never since app start"
-            is CycleOutcome.Success -> outcome.atMs
-            is CycleOutcome.Failed -> outcome.atMs
-        }
-        val elapsedSec = (System.currentTimeMillis() - atMs) / 1_000L
+    /**
+     * Renders "Last sync" as the elapsed time since the most recent *successful* push — not the
+     * most recent attempt. A failing retry every few minutes would otherwise slide this forward to
+     * "just now" while sync is in fact still broken.
+     */
+    private fun relativeSuccessTime(lastSuccessAtMs: Long?): String {
+        if (lastSuccessAtMs == null) return "Never"
+        val elapsedSec = (System.currentTimeMillis() - lastSuccessAtMs) / 1_000L
         return when {
             elapsedSec < 60 -> "just now"
             elapsedSec < 3_600 -> "${elapsedSec / 60} min ago"

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/annotationsync/AnnotationSyncMaintenanceViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/annotationsync/AnnotationSyncMaintenanceViewModel.kt
@@ -4,7 +4,6 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.riffle.core.data.AnnotationSyncMaintenance
 import com.riffle.core.data.AnnotationSyncStatusStore
-import com.riffle.core.data.CycleOutcome
 import com.riffle.core.domain.DeviceIdStore
 import com.riffle.core.domain.DeviceLabelResolver
 import com.riffle.core.domain.DeviceLabelStore
@@ -263,11 +262,13 @@ class AnnotationSyncMaintenanceViewModel @Inject constructor(
      * **active** namespace — foreign-user groups should never carry the chip even if a deviceId
      * happens to collide.
      *
-     * "Last synced" sources differ by row type. This device reads the in-memory cycle outcome
-     * (matches the AddServer banner) and so honours pull-only cycles even though they leave no
-     * trace in WebDAV. Foreign devices read their own sentinel (refreshed by them on every
-     * cycle), so a peer that hasn't run a cycle on the new client shows no "Last synced" — the
-     * honest signal that we have no recent evidence of them.
+     * "Last synced" sources differ by row type. This device reads the sticky last-success
+     * timestamp from the status store (matches the AddServer banner) and so honours pull-only
+     * cycles even though they leave no trace in WebDAV — and crucially survives subsequent
+     * failed retries instead of disappearing the moment we go offline. Foreign devices read
+     * their own sentinel (refreshed by them on every cycle), so a peer that hasn't run a cycle
+     * on the new client shows no "Last synced" — the honest signal that we have no recent
+     * evidence of them.
      */
     private fun AnnotationSyncMaintenance.DeviceRow.toUiRow(
         namespace: String,
@@ -283,9 +284,7 @@ class AnnotationSyncMaintenanceViewModel @Inject constructor(
         val parts = mutableListOf<String>()
         parts += "$annotationFileCount annotation file" + if (annotationFileCount == 1) "" else "s"
         val lastSynced = when {
-            isMe -> (statusStore.lastCycleOutcome.value as? CycleOutcome.Success)
-                ?.atMs
-                ?.let { humanizeEpochMs(it) }
+            isMe -> statusStore.lastSuccessAtMs.value?.let { humanizeEpochMs(it) }
             else -> metadata?.lastSyncedAt
                 ?.takeIf { it.isNotBlank() }
                 ?.let { humanizeIso(it) }

--- a/app/src/test/kotlin/com/riffle/app/feature/server/AddServerViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/server/AddServerViewModelTest.kt
@@ -2,6 +2,7 @@ package com.riffle.app.feature.server
 
 import androidx.lifecycle.SavedStateHandle
 import com.riffle.core.data.AnnotationSyncStatusStore
+import com.riffle.core.data.CycleOutcome
 import com.riffle.core.data.WebDavAnnotationSyncTargetFactory
 import com.riffle.core.domain.AnnotationSweepEnqueuer
 import com.riffle.core.domain.AnnotationSyncConfig
@@ -153,11 +154,12 @@ class AddServerViewModelTest {
         savedState: SavedStateHandle = SavedStateHandle(),
         configStore: AnnotationSyncConfigStore = NullConfigStore,
         tokenStorage: com.riffle.core.domain.TokenStorage = io.mockk.mockk(relaxed = true),
+        statusStore: AnnotationSyncStatusStore = AnnotationSyncStatusStore(),
     ): AddServerViewModel = AddServerViewModel(
         repository = repository,
         webdavConfigStore = configStore,
         webdavTargetFactory = WebDavAnnotationSyncTargetFactory(OkHttpClient()),
-        webdavStatusStore = AnnotationSyncStatusStore(),
+        webdavStatusStore = statusStore,
         sweepEnqueuer = AnnotationSweepEnqueuer { },
         storytellerSyncer = io.mockk.mockk(relaxed = true),
         readaloudMatcher = io.mockk.mockk(relaxed = true),
@@ -346,7 +348,7 @@ class AddServerViewModelTest {
         assertEquals("dav.example.com/store", vm.host)
         assertEquals("syncuser", vm.username)
         assertEquals("syncpass", vm.password)
-        assertNotNull(vm.webdavBanner)
+        assertNotNull(vm.webdavBanner.value)
     }
 
     @Test
@@ -364,7 +366,44 @@ class AddServerViewModelTest {
         assertEquals("", vm.host)
         assertEquals("", vm.username)
         assertEquals("", vm.password)
-        assertNull(vm.webdavBanner)
+        assertNull(vm.webdavBanner.value)
+    }
+
+    @Test
+    fun `webdavBanner re-evaluates when the status store reports a new outcome`() = runTest {
+        val existing = com.riffle.core.domain.AnnotationSyncConfig(
+            baseUrl = "https://dav.example.com/store",
+            username = "syncuser",
+            password = "syncpass",
+        )
+        val store = RecordingConfigStore(initial = existing)
+        val statusStore = AnnotationSyncStatusStore()
+        // Seed an offline failure — UI should land on Pending.
+        statusStore.report(CycleOutcome.Failed.Network(1_000L, "offline"))
+
+        val vm = makeVm(
+            fakeRepo(AuthenticateResult.WrongCredentials("x")),
+            savedState = SavedStateHandle(mapOf("type" to "webdav")),
+            configStore = store,
+            statusStore = statusStore,
+        )
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        val pending = vm.webdavBanner.value
+        assertNotNull(pending)
+        assertEquals(WebdavBannerKind.Pending, pending!!.kind)
+        // No successful sync yet → "Never", NOT "just now"/"1 d ago" derived from the failed attempt.
+        assertEquals("Never", pending.lastSyncRelative)
+
+        // Connectivity returns, sweep succeeds. Banner must flip Pending → Synced without the
+        // screen being re-entered.
+        statusStore.report(CycleOutcome.Success(System.currentTimeMillis()))
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        val synced = vm.webdavBanner.value
+        assertNotNull(synced)
+        assertEquals(WebdavBannerKind.Synced, synced!!.kind)
+        assertEquals("just now", synced.lastSyncRelative)
     }
 
     @Test

--- a/app/src/test/kotlin/com/riffle/app/feature/settings/annotationsync/AnnotationSyncMaintenanceViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/settings/annotationsync/AnnotationSyncMaintenanceViewModelTest.kt
@@ -84,6 +84,31 @@ class AnnotationSyncMaintenanceViewModelTest {
     }
 
     @Test
+    fun `this-device row keeps Last synced visible after a Success is followed by a Failed cycle`() = runTest {
+        // Regression for the bug where Maintenance hid "Last synced" the moment we went offline:
+        // it read lastCycleOutcome and pattern-matched Success, so a subsequent Failed.Network
+        // erased the timestamp even though sync had succeeded an hour earlier.
+        val activeNs = "alice-userid"
+        val target = InMemoryTarget(
+            files = mutableMapOf(
+                FileKey(activeNs, "i1", "annotations-this-device.jsonld") to "[]",
+            ),
+        )
+        val statusStore = AnnotationSyncStatusStore().apply {
+            report(CycleOutcome.Success(atMs = 1_780_000_000_000L))
+            // A later transient failure must not erase the sticky last-success timestamp.
+            report(CycleOutcome.Failed.Network(atMs = 1_780_000_060_000L, message = "offline"))
+        }
+
+        val vm = vmWith(target, activeNs = activeNs, statusStore = statusStore)
+        advanceUntilIdle()
+
+        val rows = (vm.state.value.devices as MaintenanceScreenUiState.Loaded).devices
+        val secondary = rows.single { it.isThisDevice }.secondary
+        assertTrue("got: $secondary", secondary.contains("Last synced"))
+    }
+
+    @Test
     fun `this-device row shows no Last synced when the status store is NeverRun`() = runTest {
         val activeNs = "alice-userid"
         val target = InMemoryTarget(

--- a/core/data/src/main/kotlin/com/riffle/core/data/AnnotationSyncStatusStore.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/AnnotationSyncStatusStore.kt
@@ -36,8 +36,17 @@ class AnnotationSyncStatusStore @Inject constructor() {
     private val _lastCycleOutcome = MutableStateFlow<CycleOutcome>(CycleOutcome.NeverRun)
     val lastCycleOutcome: StateFlow<CycleOutcome> = _lastCycleOutcome.asStateFlow()
 
+    private val _lastSuccessAtMs = MutableStateFlow<Long?>(null)
+    /**
+     * Timestamp of the last cycle that actually completed (push succeeded). Sticks across subsequent
+     * failures, which is what the UI's "Last sync" relative time needs — `lastCycleOutcome.atMs` is
+     * the time of the last *attempt* and would slide forward on every failed retry.
+     */
+    val lastSuccessAtMs: StateFlow<Long?> = _lastSuccessAtMs.asStateFlow()
+
     fun report(outcome: CycleOutcome) {
         _lastCycleOutcome.value = outcome
+        if (outcome is CycleOutcome.Success) _lastSuccessAtMs.value = outcome.atMs
     }
 }
 

--- a/core/data/src/test/kotlin/com/riffle/core/data/AnnotationSyncStatusStoreTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/AnnotationSyncStatusStoreTest.kt
@@ -39,4 +39,28 @@ class AnnotationSyncStatusStoreTest {
         store.report(CycleOutcome.Success(2L))
         assertTrue(store.lastCycleOutcome.value is CycleOutcome.Success)
     }
+
+    @Test
+    fun `lastSuccessAtMs starts null`() {
+        val store = AnnotationSyncStatusStore()
+        assertEquals(null, store.lastSuccessAtMs.value)
+    }
+
+    @Test
+    fun `reporting Success updates lastSuccessAtMs`() {
+        val store = AnnotationSyncStatusStore()
+        store.report(CycleOutcome.Success(1_234L))
+        assertEquals(1_234L, store.lastSuccessAtMs.value)
+    }
+
+    @Test
+    fun `reporting a Failed outcome does not touch lastSuccessAtMs`() {
+        val store = AnnotationSyncStatusStore()
+        store.report(CycleOutcome.Success(100L))
+        store.report(CycleOutcome.Failed.Network(200L, "timeout"))
+        assertEquals(
+            "a failed attempt must not overwrite the last successful sync timestamp",
+            100L, store.lastSuccessAtMs.value,
+        )
+    }
 }


### PR DESCRIPTION
## Summary

Two related bugs surfaced together as "Pending · Last sync: just now" sitting there forever on the Configure WebDAV screen after connectivity returned.

- **AddServerViewModel** read `lastCycleOutcome.value` exactly once in `initFromRoute` into a `mutableStateOf` and never re-read it. When the periodic worker later flipped Failed.Network → Success in the background, the on-screen card was a stale snapshot — you had to leave and re-enter the screen for the banner to update. Now `webdavBanner` is a `StateFlow` derived from `combine(config, lastCycleOutcome, lastSuccessAtMs).stateIn(..., Eagerly, null)`, and `AddServerScreen` `collectAsState()`s it.
- **`relativeTime`** read `outcome.atMs` regardless of variant — Success OR Failed. With PR #291's retry-on-transient-failure work, a failing network retry every minute slid the displayed time to "just now" while sync was still broken. `AnnotationSyncStatusStore` now exposes `lastSuccessAtMs: StateFlow<Long?>` (updated only on `Success`); `relativeSuccessTime` reads only that and shows "Never" until the first successful push.
- **Maintenance VM** had the same conceptual bug in a different form: it read `lastCycleOutcome as? CycleOutcome.Success`, so the "Last synced …" line for the "this device" row disappeared the moment we went offline, even when sync had succeeded an hour earlier. Switched to the sticky `lastSuccessAtMs`.

## Test plan

- [x] `:core:data:testDebugUnitTest` green — new `AnnotationSyncStatusStoreTest` cases verify `lastSuccessAtMs` starts null, updates on Success, and is untouched by Failed cycles.
- [x] `:app:testDebugUnitTest` green — new `AddServerViewModelTest.webdavBanner re-evaluates when the status store reports a new outcome` seeds a `Failed.Network`, asserts Pending + "Never", reports `Success(now)`, asserts Synced + "just now" without re-entering the screen. New `AnnotationSyncMaintenanceViewModelTest.this-device row keeps Last synced visible after a Success is followed by a Failed cycle` regression test.
- [ ] On-device: with `pkmetski/library-offline-banner-and-covers` merged (or the connectivity fix `3d586e2a9` cherry-picked), confirm airplane-mode toggle flips banner Pending → Synced without leaving the screen.