### PR TITLE
fix(connectivity): emit offline immediately on airplane mode

### DIFF
--- a/core/data/src/main/kotlin/com/riffle/core/data/ConnectivityObserverImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/ConnectivityObserverImpl.kt
@@ -29,15 +29,21 @@ class ConnectivityObserverImpl @Inject constructor(
     private val scope = CoroutineScope(SupervisorJob())
 
     override val isOnline: StateFlow<Boolean> = callbackFlow {
+        // Online-state is derived from callback events rather than re-queried on each transition.
+        // Re-querying ConnectivityManager.activeNetwork inside onLost is racy: at the instant the
+        // callback fires, the just-lost network can still appear active and validated, which would
+        // emit `true` and — because our NetworkRequest filters on VALIDATED — never produce another
+        // event for that network. Result: airplane mode never flipped the offline banner.
+        val tracker = ValidatedNetworkTracker<Network>()
         trySend(currentOnline())
 
         val callback = object : ConnectivityManager.NetworkCallback() {
             override fun onAvailable(network: Network) {
-                trySend(true)
+                trySend(tracker.onAvailable(network))
             }
 
             override fun onLost(network: Network) {
-                trySend(currentOnline())
+                trySend(tracker.onLost(network))
             }
 
             override fun onCapabilitiesChanged(
@@ -46,7 +52,7 @@ class ConnectivityObserverImpl @Inject constructor(
             ) {
                 val hasInternet = capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET) &&
                     capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED)
-                trySend(hasInternet)
+                trySend(tracker.onCapabilitiesChanged(network, hasInternet))
             }
         }
 

--- a/core/data/src/main/kotlin/com/riffle/core/data/ValidatedNetworkTracker.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/ValidatedNetworkTracker.kt
@@ -1,0 +1,26 @@
+package com.riffle.core.data
+
+/**
+ * Bookkeeping for the set of currently-validated networks observed via a
+ * `ConnectivityManager.NetworkCallback`. Each event returns the up-to-date online state
+ * (`isNotEmpty()`), so the callback emits a value derived from the events it has already received
+ * rather than re-querying the system — which can lie at the exact instant a network is lost.
+ */
+internal class ValidatedNetworkTracker<K : Any> {
+    private val validated = mutableSetOf<K>()
+
+    fun onAvailable(network: K): Boolean {
+        validated += network
+        return validated.isNotEmpty()
+    }
+
+    fun onLost(network: K): Boolean {
+        validated -= network
+        return validated.isNotEmpty()
+    }
+
+    fun onCapabilitiesChanged(network: K, hasValidatedInternet: Boolean): Boolean {
+        if (hasValidatedInternet) validated += network else validated -= network
+        return validated.isNotEmpty()
+    }
+}

--- a/core/data/src/test/kotlin/com/riffle/core/data/ValidatedNetworkTrackerTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/ValidatedNetworkTrackerTest.kt
@@ -1,0 +1,62 @@
+package com.riffle.core.data
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ValidatedNetworkTrackerTest {
+
+    @Test
+    fun `onLost of the only validated network flips online to false`() {
+        // Regression for the airplane-mode bug: onLost previously re-queried
+        // ConnectivityManager.activeNetwork, which can still report the just-lost network as
+        // validated. Now online-state must be derived from the tracker's own bookkeeping.
+        val tracker = ValidatedNetworkTracker<String>()
+        assertTrue(tracker.onAvailable("wifi"))
+
+        assertFalse(tracker.onLost("wifi"))
+    }
+
+    @Test
+    fun `onLost keeps online true while another validated network remains`() {
+        val tracker = ValidatedNetworkTracker<String>()
+        tracker.onAvailable("wifi")
+        tracker.onAvailable("cellular")
+
+        assertTrue(tracker.onLost("wifi"))
+    }
+
+    @Test
+    fun `capabilities changed dropping validated removes the network`() {
+        val tracker = ValidatedNetworkTracker<String>()
+        tracker.onAvailable("wifi")
+
+        assertFalse(tracker.onCapabilitiesChanged("wifi", hasValidatedInternet = false))
+    }
+
+    @Test
+    fun `capabilities changed regaining validated restores the network`() {
+        val tracker = ValidatedNetworkTracker<String>()
+        tracker.onAvailable("wifi")
+        tracker.onCapabilitiesChanged("wifi", hasValidatedInternet = false)
+
+        assertTrue(tracker.onCapabilitiesChanged("wifi", hasValidatedInternet = true))
+    }
+
+    @Test
+    fun `duplicate onAvailable for the same network does not double-count`() {
+        val tracker = ValidatedNetworkTracker<String>()
+        tracker.onAvailable("wifi")
+        tracker.onAvailable("wifi")
+
+        assertFalse(tracker.onLost("wifi"))
+    }
+
+    @Test
+    fun `onLost for an unknown network is a no-op`() {
+        val tracker = ValidatedNetworkTracker<String>()
+        tracker.onAvailable("wifi")
+
+        assertTrue(tracker.onLost("cellular"))
+    }
+}


### PR DESCRIPTION
## Summary

`ConnectivityObserverImpl.onLost` re-queried `ConnectivityManager.activeNetwork`, which on Android 10+ can still report the just-lost network as `VALIDATED` for a beat. We re-sent `true`, `distinctUntilChanged` dropped it, and because the `NetworkRequest` filters on `VALIDATED` no follow-up event arrived for that network — so toggling airplane mode left the offline banner stuck on the library screen until the user navigated to another screen whose ViewModel re-ran `refresh()` and flipped `_refreshFailed`.

Derive online-state from callback events instead: track validated networks in a set updated by `onAvailable` / `onLost` / `onCapabilitiesChanged`, emit `set.isNotEmpty()`. The bookkeeping is extracted to a tiny `ValidatedNetworkTracker<K>` so it's unit-testable on the JVM without `ConnectivityManager`.

Latent on Android 7.1.1 (system cleared `activeNetwork` promptly), which is why PR #182 missed it.

## Test plan

- [x] `ValidatedNetworkTrackerTest` — 6 unit tests cover: `onLost` of the only validated network flips to false (regression), secondary-network retention, capability-change drops/restores, duplicate `onAvailable` idempotency, unknown-network `onLost` no-op.
- [ ] Manual: on the Android 13 device, toggle airplane mode on the library screen and confirm the offline banner appears within ~1 s, and disappears immediately when airplane mode is turned off.