### PR TITLE
fix(library): keep home tab anchored to top while sections hydrate

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsScreen.kt
@@ -25,9 +25,11 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.interaction.DragInteraction
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.GridItemSpan
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
@@ -69,6 +71,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
@@ -105,6 +108,7 @@ import com.riffle.core.domain.Collection
 import com.riffle.core.domain.HighlightColor
 import com.riffle.core.domain.LibraryItem
 import com.riffle.core.domain.Series
+import kotlinx.coroutines.flow.filterIsInstance
 import kotlin.math.floor
 import kotlin.math.max
 
@@ -1210,6 +1214,19 @@ private fun LibraryTabBar(selectedTab: Int, onTabSelected: (Int) -> Unit) {
 
 // --- Tab content composables ---
 
+internal fun homeLeadingSectionKey(
+    inProgress: List<LibraryItem>,
+    continueSeries: List<LibraryItem>,
+    recentlyAdded: List<LibraryItem>,
+    finished: List<LibraryItem>,
+): String? = when {
+    inProgress.isNotEmpty() -> "in_progress"
+    continueSeries.isNotEmpty() -> "continue_series"
+    recentlyAdded.isNotEmpty() -> "recently_added"
+    finished.isNotEmpty() -> "finished"
+    else -> null
+}
+
 @Composable
 private fun HomeTabContent(
     inProgress: List<LibraryItem>,
@@ -1230,7 +1247,30 @@ private fun HomeTabContent(
         }
         return
     }
+    val listState = rememberLazyListState()
+    val leadingSectionKey = homeLeadingSectionKey(
+        inProgress = inProgress,
+        continueSeries = continueSeries,
+        recentlyAdded = recentlyAdded,
+        finished = finished,
+    )
+    val userHasScrolled = remember { mutableStateOf(false) }
+    LaunchedEffect(listState) {
+        listState.interactionSource.interactions
+            .filterIsInstance<DragInteraction.Start>()
+            .collect { userHasScrolled.value = true }
+    }
+    // Sections hydrate asynchronously; a late-arriving higher-priority section
+    // would be prepended above the user's view, leaving them parked on a lower
+    // section ("scrolled to the bottom"). While the user hasn't dragged, keep
+    // the column anchored at the top so prepends don't shove them down.
+    LaunchedEffect(leadingSectionKey, userHasScrolled.value) {
+        if (!userHasScrolled.value && leadingSectionKey != null) {
+            listState.scrollToItem(0)
+        }
+    }
     LazyColumn(
+        state = listState,
         modifier = Modifier
             .pinchCoverZoom(onCoverScaleChange)
             .fillMaxSize(),

--- a/app/src/test/kotlin/com/riffle/app/feature/library/HomeLeadingSectionKeyTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/HomeLeadingSectionKeyTest.kt
@@ -1,0 +1,103 @@
+package com.riffle.app.feature.library
+
+import com.riffle.core.domain.EbookFormat
+import com.riffle.core.domain.LibraryItem
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * The library home tab anchors to the first non-empty section in this priority order:
+ *   In Progress → Continue Series → Recently Added → Finished.
+ *
+ * The UI uses the returned key to detect when a higher-priority section arrives
+ * late (and would otherwise be prepended above the user's view, shoving them down
+ * to look "scrolled to the bottom"). On every key change while the user hasn't
+ * dragged, the column is re-snapped to the top.
+ */
+class HomeLeadingSectionKeyTest {
+
+    private fun item(title: String) = LibraryItem(
+        "id-$title", "lib-1", title, "Author", null, 0f, false, false, EbookFormat.Epub,
+    )
+
+    @Test
+    fun `returns null when all sections are empty`() {
+        assertNull(homeLeadingSectionKey(emptyList(), emptyList(), emptyList(), emptyList()))
+    }
+
+    @Test
+    fun `in_progress wins over every other section`() {
+        assertEquals(
+            "in_progress",
+            homeLeadingSectionKey(
+                inProgress = listOf(item("A")),
+                continueSeries = listOf(item("B")),
+                recentlyAdded = listOf(item("C")),
+                finished = listOf(item("D")),
+            ),
+        )
+    }
+
+    @Test
+    fun `continue_series wins when in_progress is empty`() {
+        assertEquals(
+            "continue_series",
+            homeLeadingSectionKey(
+                inProgress = emptyList(),
+                continueSeries = listOf(item("B")),
+                recentlyAdded = listOf(item("C")),
+                finished = listOf(item("D")),
+            ),
+        )
+    }
+
+    @Test
+    fun `recently_added wins when in_progress and continue_series are empty`() {
+        assertEquals(
+            "recently_added",
+            homeLeadingSectionKey(
+                inProgress = emptyList(),
+                continueSeries = emptyList(),
+                recentlyAdded = listOf(item("C")),
+                finished = listOf(item("D")),
+            ),
+        )
+    }
+
+    @Test
+    fun `finished is the fallback`() {
+        assertEquals(
+            "finished",
+            homeLeadingSectionKey(
+                inProgress = emptyList(),
+                continueSeries = emptyList(),
+                recentlyAdded = emptyList(),
+                finished = listOf(item("D")),
+            ),
+        )
+    }
+
+    /**
+     * Regression for "app opens scrolled to the bottom":
+     * Finished hydrates first from local cache, then In Progress arrives over the network.
+     * The key must change so the home tab knows to re-anchor to the top.
+     */
+    @Test
+    fun `key changes when a higher-priority section arrives after a lower one`() {
+        val onlyFinished = homeLeadingSectionKey(
+            inProgress = emptyList(),
+            continueSeries = emptyList(),
+            recentlyAdded = emptyList(),
+            finished = listOf(item("D")),
+        )
+        val laterWithInProgress = homeLeadingSectionKey(
+            inProgress = listOf(item("A")),
+            continueSeries = emptyList(),
+            recentlyAdded = emptyList(),
+            finished = listOf(item("D")),
+        )
+        assertEquals("finished", onlyFinished)
+        assertEquals("in_progress", laterWithInProgress)
+    }
+}


### PR DESCRIPTION
## Summary

The library home tab sometimes opened "scrolled to the bottom" on cold start. Root cause: the home tab's four sections (In Progress / Continue Series / Recently Added / Finished) come from independent flows. When a lower-priority section emitted first (e.g. Finished from local cache) and a higher-priority section arrived later (e.g. In Progress over the network), the LazyColumn anchored on the keyed item the user was viewing — so the prepend shoved their view down, leaving them looking at Finished.

Fix: hoist a `LazyListState` on `HomeTabContent`'s LazyColumn. A `LaunchedEffect` watches the leading non-empty section key, and as long as the user hasn't physically dragged the list (`DragInteraction.Start` flips a flag), each leading-section change re-snaps to index 0. Once the user drags, auto-snapping is disabled for the rest of the screen's lifetime so an intentional scroll isn't yanked back.

The priority logic is extracted as a small pure helper (`homeLeadingSectionKey`) so it's unit-testable on the JVM.

## Test plan

- [x] `:app:testDebugUnitTest --tests HomeLeadingSectionKeyTest` — 6 cases, all pass. Includes the regression case (Finished alone → In Progress arrives later → key flips, which is what triggers the snap).
- [ ] Cold-start the app on an AVD a few times and confirm Home lands at the top while sections fill in.
- [ ] Scroll down to Finished, switch tabs, return → still parked at Finished (auto-snap disabled after drag).