### PR TITLE
fix(theming): keep system nav-bar icons light over the dark scrim

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/MainActivity.kt
+++ b/app/src/main/kotlin/com/riffle/app/MainActivity.kt
@@ -93,14 +93,17 @@ class MainActivity : FragmentActivity() {
         setContent {
             val theme by appTheme.collectAsState()
             val isDark = theme.isDark(isSystemInDarkTheme())
-            // Keep the transparent system-bar icon contrast in step with the chosen chrome theme,
+            // Keep the transparent status-bar icon contrast in step with the chosen chrome theme,
             // overriding the system-driven default from enableEdgeToEdge above (otherwise a forced
             // Dark theme under a Light OS would render dark icons on the dark top app bar).
+            // The navigation bar always sits over our dark BottomNavBarScrim, so its icons must
+            // stay light regardless of theme — otherwise light-mode renders dark-on-dark and the
+            // gesture pill / 3-button nav vanishes.
             val view = LocalView.current
             SideEffect {
                 WindowCompat.getInsetsController(window, view).run {
                     isAppearanceLightStatusBars = !isDark
-                    isAppearanceLightNavigationBars = !isDark
+                    isAppearanceLightNavigationBars = false
                 }
             }
             RiffleTheme(darkTheme = isDark) {

--- a/app/src/test/kotlin/com/riffle/app/ui/SystemBarScrimTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/ui/SystemBarScrimTest.kt
@@ -1,0 +1,24 @@
+package com.riffle.app.ui
+
+import androidx.compose.ui.graphics.luminance
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SystemBarScrimTest {
+    // Guards the invariant behind MainActivity pinning `isAppearanceLightNavigationBars = false`:
+    // the nav-bar inset is always painted by BottomNavBarScrim, so if the scrim ever stops being
+    // dark, the system nav-button tint decision in MainActivity needs to be revisited. Without
+    // that pin, light-mode renders dark glyphs on this dark scrim and the gesture pill / 3-button
+    // nav vanishes on API 26+ (observed on Android 13).
+    @Test
+    fun navBarScrimRendersDarkSoSystemGlyphsMustStayLight() {
+        val scrim = bottomBarScrimColor()
+        // Compose's perceptual luminance: 0 = black, 1 = white. Anything under ~0.5 is "dark".
+        // The scrim is Color.Black at 0.6 alpha; alpha doesn't affect luminance() but the RGB
+        // channels do — this fails the moment someone swaps the base color for a light tone.
+        assertTrue(
+            "BottomNavBarScrim must stay dark or MainActivity.isAppearanceLightNavigationBars needs re-evaluating",
+            scrim.luminance() < 0.5f,
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- On API 26+ in light mode, the system navigation buttons (back / home / recents on 3-button nav, the gesture pill) were invisible: `MainActivity` set `isAppearanceLightNavigationBars = !isDark`, which asks the OS to draw dark glyphs — but the nav-bar inset is always painted by `BottomNavBarScrim`'s translucent-black fill. Dark glyphs on a dark scrim ⇒ vanishes. Observed on a real Android 13 device; not reproducible on the API 25 harness AVD because the flag has no effect there.
- Pin `isAppearanceLightNavigationBars = false`; leave the status-bar flag theme-driven (status bar is not always scrimmed).
- Add a JVM unit test that locks the underlying invariant — if anyone changes `bottomBarScrimColor()` to something light, the test fails and prompts re-evaluating the nav-bar appearance pin.

## Test plan
- [x] `./gradlew :app:testDebugUnitTest --tests com.riffle.app.ui.SystemBarScrimTest` — green
- [ ] Visual check on real Android 13 device in light mode: system nav buttons visible over the app's bottom scrim