### PR TITLE
fix(readaloud): scope match set per ABS server+login

### DIFF
--- a/core/data/src/main/kotlin/com/riffle/core/data/ReadaloudMatchingService.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/ReadaloudMatchingService.kt
@@ -74,11 +74,9 @@ open class ReadaloudMatchingService(
             // Sticky is per-ABS-server: a user-confirmed link on Server A leaves Server A alone
             // but doesn't suppress auto-matching on Server B. Keep user slots fresh so the
             // stale sweep doesn't delete them.
-            val userConfirmedAbsServers = existingLinks.asSequence()
-                .filter { it.userConfirmed }
-                .onEach { freshAutoSlots += it.absServerId to it.absLibraryItemId }
-                .map { it.absServerId }
-                .toSet()
+            val userConfirmedLinks = existingLinks.filter { it.userConfirmed }
+            userConfirmedLinks.forEach { freshAutoSlots += it.absServerId to it.absLibraryItemId }
+            val userConfirmedAbsServers = userConfirmedLinks.map { it.absServerId }.toSet()
 
             val dismissedPairs = readaloudDismissalDao
                 .findByStorytellerBook(book.serverId, book.itemId)

--- a/core/data/src/main/kotlin/com/riffle/core/data/ReadaloudMatchingService.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/ReadaloudMatchingService.kt
@@ -52,7 +52,14 @@ open class ReadaloudMatchingService(
         val storytellerBooks = libraryItemDao.listMatchableByServerType(ServerType.STORYTELLER.name)
         val absItems = libraryItemDao.listMatchableByServerType(ServerType.AUDIOBOOKSHELF.name)
 
-        val candidates = absItems.map { it.toAbsCandidate() }
+        // Match each ABS server (= one user login on one ABS instance) independently: a
+        // Storyteller readaloud is evaluated against each ABS server's library set on its own.
+        // Without per-server scoping, two ABS logins exposing the same title in both ebook +
+        // audiobook form would each emit Confirmed links, surfacing 2 ebook + 2 audiobook rows
+        // per match on the Matches screen instead of one set per server.
+        val candidatesByAbsServer: Map<String, List<MatchableAbsItem>> = absItems
+            .groupBy { it.serverId }
+            .mapValues { (_, rows) -> rows.map { it.toAbsCandidate() } }
         val now = clock()
         // Track every ABS PK the current pass auto-Confirmed (or a sticky user slot), to sweep
         // stale rows. Fresh Pending-Review candidate rows are collected then written wholesale.
@@ -60,64 +67,70 @@ open class ReadaloudMatchingService(
         val freshCandidates = mutableListOf<ReadaloudCandidateEntity>()
 
         for (book in storytellerBooks) {
-            val existingLinks = readaloudLinkDao.findByStorytellerBook(book.serverId, book.itemId)
-            // Sticky: a user-Confirmed readaloud is left untouched — no re-match, no candidates.
-            // Keep its slots fresh so the stale sweep below doesn't delete them.
-            if (existingLinks.any { it.userConfirmed }) {
-                existingLinks.filter { it.userConfirmed }
-                    .forEach { freshAutoSlots += it.absServerId to it.absLibraryItemId }
-                continue
-            }
-            // Sticky: "No match — don't ask again" keeps the book Unmatched forever.
+            // Sticky: "No match — don't ask again" keeps the book Unmatched on every ABS server.
             if (readaloudDismissalDao.isBookDismissed(book.serverId, book.itemId)) continue
 
-            when (val outcome = ReadaloudMatcher.match(book.toStorytellerBook(), candidates)) {
-                is MatchOutcome.Confirmed -> outcome.links.forEach { match ->
-                    val slot = match.absServerUuid to match.absLibraryItemId
-                    val existing = readaloudLinkDao.findByAbsItem(match.absServerUuid, match.absLibraryItemId)
-                    if (existing?.userConfirmed == true) {
-                        // The user owns this ABS slot; never overwrite it. Only mark it fresh when
-                        // it already points at this book, so an unrelated user choice isn't swept.
-                        if (existing.storytellerServerId == book.serverId && existing.storytellerBookId == book.itemId) {
-                            freshAutoSlots += slot
-                        }
-                        return@forEach
-                    }
-                    readaloudLinkDao.upsert(
-                        ReadaloudLinkEntity(
-                            absServerId = match.absServerUuid,
-                            absLibraryItemId = match.absLibraryItemId,
-                            storytellerServerId = book.serverId,
-                            storytellerBookId = book.itemId,
-                            state = ReadaloudLinkEntity.STATE_CONFIRMED,
-                            userConfirmed = false,
-                            createdAt = existing?.createdAt ?: now,
-                            updatedAt = now,
-                        )
-                    )
-                    freshAutoSlots += slot
-                }
+            val existingLinks = readaloudLinkDao.findByStorytellerBook(book.serverId, book.itemId)
+            // Sticky is per-ABS-server: a user-confirmed link on Server A leaves Server A alone
+            // but doesn't suppress auto-matching on Server B. Keep user slots fresh so the
+            // stale sweep doesn't delete them.
+            val userConfirmedAbsServers = existingLinks.asSequence()
+                .filter { it.userConfirmed }
+                .onEach { freshAutoSlots += it.absServerId to it.absLibraryItemId }
+                .map { it.absServerId }
+                .toSet()
 
-                is MatchOutcome.PendingReview -> {
-                    val dismissedPairs = readaloudDismissalDao
-                        .findByStorytellerBook(book.serverId, book.itemId)
-                        .filter { it.scope == ReadaloudDismissalEntity.SCOPE_CANDIDATE }
-                        .map { it.absServerId to it.absLibraryItemId }
-                        .toSet()
-                    outcome.candidates
-                        .filter { (it.absServerUuid to it.absLibraryItemId) !in dismissedPairs }
-                        .forEach {
-                            freshCandidates += ReadaloudCandidateEntity(
+            val dismissedPairs = readaloudDismissalDao
+                .findByStorytellerBook(book.serverId, book.itemId)
+                .filter { it.scope == ReadaloudDismissalEntity.SCOPE_CANDIDATE }
+                .map { it.absServerId to it.absLibraryItemId }
+                .toSet()
+
+            for ((absServerId, serverCandidates) in candidatesByAbsServer) {
+                if (absServerId in userConfirmedAbsServers) continue
+                when (val outcome = ReadaloudMatcher.match(book.toStorytellerBook(), serverCandidates)) {
+                    is MatchOutcome.Confirmed -> outcome.links.forEach { match ->
+                        val slot = match.absServerUuid to match.absLibraryItemId
+                        val existing = readaloudLinkDao.findByAbsItem(match.absServerUuid, match.absLibraryItemId)
+                        if (existing?.userConfirmed == true) {
+                            // The user owns this ABS slot; never overwrite it. Only mark it fresh when
+                            // it already points at this book, so an unrelated user choice isn't swept.
+                            if (existing.storytellerServerId == book.serverId && existing.storytellerBookId == book.itemId) {
+                                freshAutoSlots += slot
+                            }
+                            return@forEach
+                        }
+                        readaloudLinkDao.upsert(
+                            ReadaloudLinkEntity(
+                                absServerId = match.absServerUuid,
+                                absLibraryItemId = match.absLibraryItemId,
                                 storytellerServerId = book.serverId,
                                 storytellerBookId = book.itemId,
-                                absServerId = it.absServerUuid,
-                                absLibraryItemId = it.absLibraryItemId,
-                                score = it.score,
+                                state = ReadaloudLinkEntity.STATE_CONFIRMED,
+                                userConfirmed = false,
+                                createdAt = existing?.createdAt ?: now,
+                                updatedAt = now,
                             )
-                        }
-                }
+                        )
+                        freshAutoSlots += slot
+                    }
 
-                MatchOutcome.Unmatched -> Unit
+                    is MatchOutcome.PendingReview -> {
+                        outcome.candidates
+                            .filter { (it.absServerUuid to it.absLibraryItemId) !in dismissedPairs }
+                            .forEach {
+                                freshCandidates += ReadaloudCandidateEntity(
+                                    storytellerServerId = book.serverId,
+                                    storytellerBookId = book.itemId,
+                                    absServerId = it.absServerUuid,
+                                    absLibraryItemId = it.absLibraryItemId,
+                                    score = it.score,
+                                )
+                            }
+                    }
+
+                    MatchOutcome.Unmatched -> Unit
+                }
             }
         }
 

--- a/core/data/src/main/kotlin/com/riffle/core/data/ReadaloudReviewRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/ReadaloudReviewRepositoryImpl.kt
@@ -62,12 +62,17 @@ class ReadaloudReviewRepositoryImpl(
             linkDao.observeAll(),
             candidateDao.observeForStorytellerServer(storytellerServerId),
         ) { links, candidates ->
-            // When the screen scopes to one ABS Server, filter candidate suggestions to that
-            // server here. Confirmed links stay unscoped so existing matches on the other ABS
-            // accounts remain visible and unlinkable.
+            // When the screen scopes to one ABS Server, both confirmed links and pending
+            // candidates are filtered to that server so each ABS account (= one server+login)
+            // shows its own self-contained match set. Without this, a readaloud auto-matched
+            // against the same title on two ABS accounts piles their links into one card
+            // ("2 ebook + 2 audiobook" per match). Switching the active ABS account flips the
+            // visible set; nothing is permanently hidden.
+            val scopedLinks = if (absServerId == null) links
+                else links.filter { it.absServerId == absServerId }
             val scopedCandidates = if (absServerId == null) candidates
                 else candidates.filter { it.absServerId == absServerId }
-            buildReview(storytellerServerId, links, scopedCandidates)
+            buildReview(storytellerServerId, scopedLinks, scopedCandidates)
         }
 
     private suspend fun buildReview(

--- a/core/data/src/test/kotlin/com/riffle/core/data/ReadaloudMatchingServiceTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/ReadaloudMatchingServiceTest.kt
@@ -66,6 +66,61 @@ class ReadaloudMatchingServiceTest {
     }
 
     @Test
+    fun `matching is scoped per ABS server so the same title across two servers doesn't double-count`() = runTest {
+        // Two ABS logins, each with a Books library + an Audiobooks library containing the
+        // same title. With per-server scoping we get one ebook + one audiobook link per
+        // server (4 rows across 2 servers), NOT 4 rows on each server.
+        val items = StubLibraryItemDao(
+            storyteller = listOf(row("st-1", "42", title = "The Martian: A Novel", author = "Andy Weir")),
+            abs = listOf(
+                row("abs-A", "A-ebook", title = "The Martian", author = "Andy Weir"),
+                row("abs-A", "A-audio", title = "The Martian", author = "Andy Weir"),
+                row("abs-B", "B-ebook", title = "The Martian", author = "Andy Weir"),
+                row("abs-B", "B-audio", title = "The Martian", author = "Andy Weir"),
+            ),
+        )
+        val links = RecordingReadaloudLinkDao()
+
+        service(items, links).reconcileLinks()
+
+        val keys = links.upserts.map { it.absServerId to it.absLibraryItemId }.toSet()
+        assertEquals(
+            setOf("abs-A" to "A-ebook", "abs-A" to "A-audio", "abs-B" to "B-ebook", "abs-B" to "B-audio"),
+            keys,
+        )
+        // Each (server, item) is upserted exactly once — no cross-server duplication.
+        assertEquals(4, links.upserts.size)
+    }
+
+    @Test
+    fun `user-confirmed link on one ABS server doesn't suppress auto-matching on another`() = runTest {
+        val items = StubLibraryItemDao(
+            storyteller = listOf(row("st-1", "42", isbn = "9780261103573")),
+            abs = listOf(row("abs-B", "B-ebook", isbn = "9780261103573")),
+        )
+        val links = RecordingReadaloudLinkDao().apply {
+            // User already locked in a slot on server A for this readaloud.
+            seed(
+                ReadaloudLinkEntity(
+                    absServerId = "abs-A",
+                    absLibraryItemId = "A-user-pick",
+                    storytellerServerId = "st-1",
+                    storytellerBookId = "42",
+                    state = ReadaloudLinkEntity.STATE_CONFIRMED,
+                    userConfirmed = true,
+                    createdAt = 1L, updatedAt = 1L,
+                ),
+            )
+        }
+
+        service(items, links).reconcileLinks()
+
+        val newLinks = links.upserts.map { it.absServerId to it.absLibraryItemId }
+        assertEquals(listOf("abs-B" to "B-ebook"), newLinks)
+        assertTrue("server A user pick must not be swept", links.deletions.none { it == "abs-A" to "A-user-pick" })
+    }
+
+    @Test
     fun `userConfirmed row in an ABS slot is never overwritten by the auto-matcher`() = runTest {
         val items = StubLibraryItemDao(
             storyteller = listOf(row("st-1", "42", isbn = "9780261103573")),

--- a/core/data/src/test/kotlin/com/riffle/core/data/ReadaloudReviewRepositoryTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/ReadaloudReviewRepositoryTest.kt
@@ -347,10 +347,11 @@ class ReadaloudReviewRepositoryTest {
     }
 
     @Test
-    fun `observeReview confirmed targets stay visible across all ABS Servers even when scoped`() = runTest {
-        // Symmetric to the pending scoping: existing confirmed links across other ABS accounts
-        // MUST stay visible so the user can see and unlink them. Otherwise scoping to one ABS
-        // account would hide the cross-account history and feel destructive.
+    fun `observeReview confirmed targets are scoped to the chosen ABS Server`() = runTest {
+        // Each ABS account (= one server+login) shows its own self-contained match set so a
+        // readaloud auto-matched against the same title on two ABS accounts doesn't pile their
+        // links into one card ("2 ebook + 2 audiobook" per match). Switching the active ABS
+        // account flips the visible set; the sibling account's links remain in the DB.
         val items = MatchableLibraryItemDao(
             listOf(
                 absCombined("X").copy(serverId = "abs-A"),
@@ -368,7 +369,7 @@ class ReadaloudReviewRepositoryTest {
 
         val confirmed = repo.observeReview("st", absServerId = "abs-A").first().confirmed.single()
 
-        assertEquals(setOf("abs-A", "abs-B"), confirmed.targets.map { it.absServerId }.toSet())
+        assertEquals(setOf("abs-A"), confirmed.targets.map { it.absServerId }.toSet())
     }
 
     private fun absSearchDao() = MatchableLibraryItemDao(


### PR DESCRIPTION
## Summary

The readaloud Matches screen lumped confirmed links from every ABS account into one card. With two ABS accounts containing the same title in both ebook + audiobook form, each match surfaced as **2 ebook + 2 audiobook** rows instead of one self-contained set per account.

This scopes the display by the active ABS server so each account (= one server+login) shows its own match set. While there, the auto-matcher is also scoped per ABS server so a user-confirmed link on Server A no longer suppresses auto-matching on Server B.

- `ReadaloudReviewRepositoryImpl.observeReview()` — confirmed links are now filtered by the active `absServerId` the same way candidates already were.
- `ReadaloudMatchingService.reconcileLinks()` — groups ABS items by `serverId` and runs `ReadaloudMatcher.match` per server. Sticky user-Confirmed becomes per-server. Per-candidate dismissal lookup hoisted once per book.

No DB migration: existing installs keep their rows; the screen just filters per active ABS server on display. Switching the active account in the main app flips the visible set.

## Test plan

- [x] `./gradlew :core:data:testDebugUnitTest --tests 'com.riffle.core.data.ReadaloudMatchingServiceTest' --tests 'com.riffle.core.data.ReadaloudReviewRepositoryTest'` — green.
- [x] New `ReadaloudMatchingServiceTest` cases:
  - per-ABS-server matching: the same title across two servers produces 1 ebook + 1 audio per server (4 rows, not 8).
  - user-confirmed slot on Server A doesn't block auto-matching on Server B and isn't swept.
- [x] Existing `ReadaloudReviewRepositoryTest` updated: confirmed targets are now scoped to the chosen ABS server.
- [ ] Not device-verified — pure JVM-layer change; no Readium/WebView touched.