### PR TITLE
fix(server-settings): span WebDAV sync banner full content width on tablets

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/server/AddServerScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/server/AddServerScreen.kt
@@ -246,7 +246,10 @@ private fun WebdavStatusCard(banner: WebdavBanner) {
             Icons.Default.Warning,
         )
     }
-    Card(colors = CardDefaults.cardColors(containerColor = container)) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = container),
+    ) {
         Column(
             modifier = Modifier.padding(16.dp),
             verticalArrangement = Arrangement.spacedBy(8.dp),


### PR DESCRIPTION
## Summary
- `WebdavStatusCard` had no `fillMaxWidth` modifier, so the Card wrapped to its content text — visibly short on tablets, where `TabletContentWidthContainer` gives the form a wider column than on phones.
- Added `Modifier.fillMaxWidth()` so the banner matches the rest of the form (every field below already sets `fillMaxWidth`).

## Test plan
- [ ] Open Settings → Add/Edit WebDAV on a tablet AVD and confirm the sync status banner now fills the form column.
- [ ] Confirm phone layout is unchanged.