### PR TITLE
refactor(reader): introduce ReaderPresenter seam (#300 step 1)

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/presenter/ReaderPresenter.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/presenter/ReaderPresenter.kt
@@ -1,0 +1,139 @@
+package com.riffle.app.feature.reader.presenter
+
+import com.riffle.core.domain.FormattingPreferences
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * The seam between the reader UI (screen + view-model) and the concrete rendering pipeline
+ * (Readium [org.readium.r2.navigator.epub.EpubNavigatorFragment] for paginated/vertical modes,
+ * or the custom [com.riffle.app.feature.reader.ContinuousReaderView] for continuous mode).
+ *
+ * The view-model and screen depend on this interface; they MUST NOT import Readium types
+ * directly. Mode-specific concerns — column snap, fragment lifecycle, manual scroll-to-Locator
+ * translation — live behind one of the adapters.
+ *
+ * **Step 1 scope (issue #300).** Only [ReadiumPresenter] exists today; the screen still mounts
+ * Readium fragments and the continuous view directly. Decoration application stays on the
+ * existing [com.riffle.app.feature.reader.HighlightRenderer] for now and will move behind this
+ * seam in a follow-up cutover step.
+ */
+internal interface ReaderPresenter {
+
+    // ----- Events the view-model observes ----------------------------------------------------
+
+    /** A position change reported by the underlying renderer. Idempotent on the same position. */
+    val positionEvents: Flow<PositionUpdate>
+
+    /**
+     * Bumps every time the renderer reports "layout settled" (Readium's
+     * [org.readium.r2.navigator.epub.EpubNavigatorFragment.PaginationListener.onPageLoaded] for
+     * paginated/vertical, the equivalent web-view ready signal for continuous). Consumers re-key
+     * decoration application on this.
+     */
+    val pageLoadEvents: Flow<PageLoadGeneration>
+
+    /** Any user tap that should toggle reader chrome (left/right tap zones, body tap). */
+    val tapEvents: Flow<TapEvent>
+
+    /** Internal link, external link, or footnote anchor user activation. */
+    val linkEvents: Flow<LinkEvent>
+
+    /** A "highlight" or "play-from-here" action invoked from the text-selection menu. */
+    val selectionEvents: Flow<SelectionEvent>
+
+    /** User tapped an existing annotation highlight or its note glyph. */
+    val annotationTapEvents: Flow<AnnotationTapEvent>
+
+    // ----- Commands the view-model issues ----------------------------------------------------
+
+    /** Navigate to a Locator JSON, an href + optional fragment, or a progression within a href. */
+    suspend fun navigateTo(target: NavigationTarget)
+
+    /**
+     * Apply (or re-apply) typography for the current rendering preferences. Idempotent on the
+     * same preferences. The adapter decides what to inject and when (e.g. on next page load).
+     */
+    suspend fun applyTypography(prefs: FormattingPreferences)
+
+    /** Latest position the renderer has reported, or `null` if it has not reported any yet. */
+    fun snapshotPosition(): ReaderPosition?
+
+    /** Page forward / page backward (volume keys, configurable gestures). */
+    suspend fun pageBy(direction: PageDirection)
+}
+
+// =================== Event payloads ==========================================================
+
+/**
+ * The minimal position carried across the seam. The Readium Locator's full JSON is kept as
+ * an opaque round-trip token so the storage layer (which still serialises Locator JSON into
+ * `reading_positions.cfi`) survives the cutover without schema changes.
+ *
+ * @property locatorJson the underlying Readium Locator serialised as JSON, or empty in tests.
+ */
+internal data class ReaderPosition(
+    val href: String,
+    val progression: Float,
+    val totalProgression: Float?,
+    val locatorJson: String,
+)
+
+internal data class PositionUpdate(
+    val position: ReaderPosition,
+    /** Increments every time the position changes; consumers can debounce/throttle on it. */
+    val generation: Long,
+)
+
+internal data class PageLoadGeneration(val value: Int)
+
+internal sealed class TapEvent {
+    /** Any tap not on a link/selection control — toggle chrome. */
+    data object Body : TapEvent()
+}
+
+internal sealed class LinkEvent {
+    /** A cross-resource link tap; [origin] is the position the user was at when they tapped. */
+    data class InternalLink(val href: String, val originLocatorJson: String) : LinkEvent()
+
+    data class ExternalLink(val url: String) : LinkEvent()
+
+    /** A footnote anchor tap; [contentHtml] is the resolved footnote body, ready for popup. */
+    data class Footnote(val contentHtml: String) : LinkEvent()
+}
+
+internal sealed class SelectionEvent {
+    data class HighlightRequest(
+        val href: String,
+        val text: String,
+        val progression: Float,
+        val before: String?,
+        val after: String?,
+    ) : SelectionEvent()
+
+    data class PlayFromHereRequest(
+        val href: String,
+        val text: String,
+        /** Optional JS to evaluate against the current page for further context resolution. */
+        val resolverJs: String? = null,
+    ) : SelectionEvent()
+}
+
+internal sealed class AnnotationTapEvent {
+    data class Highlight(val href: String, val annotationId: String) : AnnotationTapEvent()
+    data class NoteGlyph(val href: String, val annotationId: String) : AnnotationTapEvent()
+}
+
+// =================== Command payloads ========================================================
+
+internal sealed class NavigationTarget {
+    /** Resume to a previously persisted Readium Locator (verbatim JSON). */
+    data class ToLocatorJson(val locatorJson: String) : NavigationTarget()
+
+    /** Jump to a chapter and optional intra-document anchor (TOC, internal link). */
+    data class ToHref(val href: String, val fragment: String? = null) : NavigationTarget()
+
+    /** Jump to a relative offset within a chapter (server-progress restore, search match). */
+    data class ToProgression(val href: String, val progression: Float) : NavigationTarget()
+}
+
+internal enum class PageDirection { Forward, Backward }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/presenter/ReadiumPresenter.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/presenter/ReadiumPresenter.kt
@@ -1,6 +1,5 @@
 package com.riffle.app.feature.reader.presenter
 
-import com.riffle.app.feature.reader.ColumnSnap
 import com.riffle.app.feature.reader.typographyOverrideInjectionJs
 import com.riffle.core.domain.FormattingPreferences
 import kotlinx.coroutines.CoroutineScope
@@ -129,10 +128,9 @@ internal class ReadiumPresenter(
     override suspend fun navigateTo(target: NavigationTarget) {
         val fragment = fragment ?: return
         val locator = target.toLocator(publication) ?: return
-        // Step 1: a plain go(); the column-snap dance that today wraps go() in EpubReaderScreen
-        // stays where it is until cutover Step 3 routes navigation through the adapter. That step
-        // will swap this for ColumnSnap.goAndSnap() in paginated mode and a plain go() in vertical.
-        @Suppress("UNUSED_VARIABLE") val unused = ColumnSnap // referenced so the import survives cutover
+        // Step 1: plain go(). The column-snap dance currently lives in EpubReaderScreen and moves
+        // behind this method at cutover Step 3 (paginated mode → ColumnSnap.goAndSnap, vertical →
+        // plain go).
         fragment.go(locator, animated = true)
     }
 

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/presenter/ReadiumPresenter.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/presenter/ReadiumPresenter.kt
@@ -1,0 +1,191 @@
+package com.riffle.app.feature.reader.presenter
+
+import com.riffle.app.feature.reader.ColumnSnap
+import com.riffle.app.feature.reader.typographyOverrideInjectionJs
+import com.riffle.core.domain.FormattingPreferences
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.launch
+import org.json.JSONObject
+import org.readium.r2.navigator.epub.EpubNavigatorFragment
+import org.readium.r2.shared.publication.Link
+import org.readium.r2.shared.publication.Locator
+import org.readium.r2.shared.publication.Publication
+import org.readium.r2.shared.util.Url
+
+/**
+ * The Readium adapter for [ReaderPresenter]. Wraps an [EpubNavigatorFragment] (paginated +
+ * vertical modes) so the view-model never imports Readium types.
+ *
+ * **Step 1 scope (issue #300).** This adapter exists; no caller is cut over yet. The screen
+ * still mounts the fragment and installs Readium listeners directly. Subsequent cutover steps
+ * will replace those direct touches with [attach] + the feed methods on this class so the
+ * fragment's events flow through the seam.
+ *
+ * Lifecycle: construct the adapter once per reader session; call [attach] when the fragment is
+ * available, [detach] when it goes away (e.g. on orientation change). All events fired through
+ * the feed methods are buffered (extra capacity 64) so producers never suspend.
+ *
+ * @param scope a lifecycle-scoped [CoroutineScope] (usually `viewModelScope`) that owns the
+ *   fragment-position collector. It must outlive the adapter.
+ * @param publication the open publication, used to parse Locator JSON for [NavigationTarget]s
+ *   that arrive as raw JSON (resume from storage).
+ */
+internal class ReadiumPresenter(
+    private val scope: CoroutineScope,
+    private val publication: Publication,
+) : ReaderPresenter {
+
+    private val _positionEvents = MutableSharedFlow<PositionUpdate>(replay = 0, extraBufferCapacity = 64)
+    private val _pageLoadEvents = MutableSharedFlow<PageLoadGeneration>(replay = 0, extraBufferCapacity = 64)
+    private val _tapEvents = MutableSharedFlow<TapEvent>(replay = 0, extraBufferCapacity = 64)
+    private val _linkEvents = MutableSharedFlow<LinkEvent>(replay = 0, extraBufferCapacity = 64)
+    private val _selectionEvents = MutableSharedFlow<SelectionEvent>(replay = 0, extraBufferCapacity = 64)
+    private val _annotationTapEvents = MutableSharedFlow<AnnotationTapEvent>(replay = 0, extraBufferCapacity = 64)
+
+    override val positionEvents: SharedFlow<PositionUpdate> = _positionEvents
+    override val pageLoadEvents: SharedFlow<PageLoadGeneration> = _pageLoadEvents
+    override val tapEvents: SharedFlow<TapEvent> = _tapEvents
+    override val linkEvents: SharedFlow<LinkEvent> = _linkEvents
+    override val selectionEvents: SharedFlow<SelectionEvent> = _selectionEvents
+    override val annotationTapEvents: SharedFlow<AnnotationTapEvent> = _annotationTapEvents
+
+    @Volatile private var fragment: EpubNavigatorFragment? = null
+    private var positionJob: Job? = null
+    private var lastPosition: ReaderPosition? = null
+    private var positionGeneration: Long = 0L
+    private var pageLoadCount: Int = 0
+
+    /** Bind a freshly-created fragment. Starts forwarding its `currentLocator` to [positionEvents]. */
+    fun attach(fragment: EpubNavigatorFragment) {
+        detach()
+        this.fragment = fragment
+        positionJob = scope.launch {
+            fragment.currentLocator.collect { locator ->
+                publishPosition(locator.toReaderPosition())
+            }
+        }
+    }
+
+    /** Release the fragment (e.g. on orientation change). Safe to call repeatedly. */
+    fun detach() {
+        positionJob?.cancel()
+        positionJob = null
+        fragment = null
+    }
+
+    // ----- Feed methods called by the screen's existing Readium listener objects --------------
+    //
+    // These exist so Step 3 (route navigation through the adapter) and Step 5 (page-load events)
+    // can be small mechanical changes: the listener objects forward to these instead of calling
+    // the VM directly. Until then, callers don't exist — these are dormant.
+
+    fun feedPageLoaded() {
+        pageLoadCount += 1
+        _pageLoadEvents.tryEmit(PageLoadGeneration(pageLoadCount))
+    }
+
+    fun feedInternalLink(link: Link, origin: Locator) {
+        _linkEvents.tryEmit(
+            LinkEvent.InternalLink(
+                href = link.href.toString(),
+                originLocatorJson = origin.toJSON().toString(),
+            ),
+        )
+    }
+
+    fun feedExternalLink(url: String) {
+        _linkEvents.tryEmit(LinkEvent.ExternalLink(url))
+    }
+
+    fun feedFootnote(contentHtml: String) {
+        _linkEvents.tryEmit(LinkEvent.Footnote(contentHtml))
+    }
+
+    fun feedTap() {
+        _tapEvents.tryEmit(TapEvent.Body)
+    }
+
+    fun feedHighlightSelection(href: String, text: String, progression: Float, before: String?, after: String?) {
+        _selectionEvents.tryEmit(SelectionEvent.HighlightRequest(href, text, progression, before, after))
+    }
+
+    fun feedPlayFromHereSelection(href: String, text: String, resolverJs: String? = null) {
+        _selectionEvents.tryEmit(SelectionEvent.PlayFromHereRequest(href, text, resolverJs))
+    }
+
+    fun feedAnnotationHighlightTap(href: String, annotationId: String) {
+        _annotationTapEvents.tryEmit(AnnotationTapEvent.Highlight(href, annotationId))
+    }
+
+    fun feedAnnotationNoteGlyphTap(href: String, annotationId: String) {
+        _annotationTapEvents.tryEmit(AnnotationTapEvent.NoteGlyph(href, annotationId))
+    }
+
+    // ----- ReaderPresenter commands ---------------------------------------------------------
+
+    override suspend fun navigateTo(target: NavigationTarget) {
+        val fragment = fragment ?: return
+        val locator = target.toLocator(publication) ?: return
+        // Step 1: a plain go(); the column-snap dance that today wraps go() in EpubReaderScreen
+        // stays where it is until cutover Step 3 routes navigation through the adapter. That step
+        // will swap this for ColumnSnap.goAndSnap() in paginated mode and a plain go() in vertical.
+        @Suppress("UNUSED_VARIABLE") val unused = ColumnSnap // referenced so the import survives cutover
+        fragment.go(locator, animated = true)
+    }
+
+    override suspend fun applyTypography(prefs: FormattingPreferences) {
+        // The adapter doesn't yet own preference→JS translation; it forwards to the existing
+        // injection helper. Cutover Step 4 will move the full typography pipeline behind here.
+        val fragment = fragment ?: return
+        fragment.evaluateJavascript(typographyOverrideInjectionJs())
+    }
+
+    override fun snapshotPosition(): ReaderPosition? = lastPosition
+
+    override suspend fun pageBy(direction: PageDirection) {
+        val fragment = fragment ?: return
+        when (direction) {
+            PageDirection.Forward -> fragment.goForward(animated = false)
+            PageDirection.Backward -> fragment.goBackward(animated = false)
+        }
+    }
+
+    // ----- internals ------------------------------------------------------------------------
+
+    private fun publishPosition(position: ReaderPosition) {
+        lastPosition = position
+        positionGeneration += 1
+        _positionEvents.tryEmit(PositionUpdate(position, positionGeneration))
+    }
+}
+
+// ===== Locator <-> ReaderPosition / NavigationTarget translation ============================
+// Package-private so the unit tests can pin the contract without a real fragment.
+
+internal fun Locator.toReaderPosition(): ReaderPosition =
+    ReaderPosition(
+        href = href.toString(),
+        progression = (locations.progression ?: 0.0).toFloat(),
+        totalProgression = locations.totalProgression?.toFloat(),
+        locatorJson = toJSON().toString(),
+    )
+
+internal fun NavigationTarget.toLocator(publication: Publication): Locator? = when (this) {
+    is NavigationTarget.ToLocatorJson -> runCatching { Locator.fromJSON(JSONObject(locatorJson)) }.getOrNull()
+    is NavigationTarget.ToHref -> {
+        val url = Url(href + (fragment?.let { "#$it" } ?: ""))
+        url?.let { publication.linkWithHref(it)?.let { link -> publication.locatorFromLink(link) } }
+    }
+    is NavigationTarget.ToProgression -> {
+        val url = Url(href)
+        url?.let { publication.linkWithHref(it) }?.let { link ->
+            publication.locatorFromLink(link)?.copyWithProgression(progression)
+        }
+    }
+}
+
+private fun Locator.copyWithProgression(progression: Float): Locator =
+    copy(locations = locations.copy(progression = progression.toDouble()))

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/presenter/FakeReaderPresenter.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/presenter/FakeReaderPresenter.kt
@@ -1,0 +1,80 @@
+package com.riffle.app.feature.reader.presenter
+
+import com.riffle.core.domain.FormattingPreferences
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+
+/**
+ * Test double that lets view-model and orchestrator tests drive features through the
+ * [ReaderPresenter] contract without booting Readium or a WebView.
+ *
+ * Tests push events with the `emit*` helpers; the presenter records every command in the
+ * `recorded*` lists. The contract is intentionally permissive — implementations may emit any
+ * subset of events, in any order. Tests assert on what they emit, not on what a real renderer
+ * would.
+ */
+internal class FakeReaderPresenter : ReaderPresenter {
+
+    private val _positionEvents = MutableSharedFlow<PositionUpdate>(replay = 0, extraBufferCapacity = 64)
+    private val _pageLoadEvents = MutableSharedFlow<PageLoadGeneration>(replay = 0, extraBufferCapacity = 64)
+    private val _tapEvents = MutableSharedFlow<TapEvent>(replay = 0, extraBufferCapacity = 64)
+    private val _linkEvents = MutableSharedFlow<LinkEvent>(replay = 0, extraBufferCapacity = 64)
+    private val _selectionEvents = MutableSharedFlow<SelectionEvent>(replay = 0, extraBufferCapacity = 64)
+    private val _annotationTapEvents = MutableSharedFlow<AnnotationTapEvent>(replay = 0, extraBufferCapacity = 64)
+
+    override val positionEvents: SharedFlow<PositionUpdate> = _positionEvents
+    override val pageLoadEvents: SharedFlow<PageLoadGeneration> = _pageLoadEvents
+    override val tapEvents: SharedFlow<TapEvent> = _tapEvents
+    override val linkEvents: SharedFlow<LinkEvent> = _linkEvents
+    override val selectionEvents: SharedFlow<SelectionEvent> = _selectionEvents
+    override val annotationTapEvents: SharedFlow<AnnotationTapEvent> = _annotationTapEvents
+
+    val recordedNavigations: MutableList<NavigationTarget> = mutableListOf()
+    val recordedTypography: MutableList<FormattingPreferences> = mutableListOf()
+    val recordedPagesBy: MutableList<PageDirection> = mutableListOf()
+
+    private var lastPosition: ReaderPosition? = null
+    private var generation: Long = 0L
+
+    override suspend fun navigateTo(target: NavigationTarget) {
+        recordedNavigations += target
+    }
+
+    override suspend fun applyTypography(prefs: FormattingPreferences) {
+        recordedTypography += prefs
+    }
+
+    override fun snapshotPosition(): ReaderPosition? = lastPosition
+
+    override suspend fun pageBy(direction: PageDirection) {
+        recordedPagesBy += direction
+    }
+
+    // ----- Event drivers (for tests) -------------------------------------------------------
+
+    suspend fun emitPosition(position: ReaderPosition) {
+        lastPosition = position
+        generation += 1
+        _positionEvents.emit(PositionUpdate(position, generation))
+    }
+
+    suspend fun emitPageLoad(value: Int) {
+        _pageLoadEvents.emit(PageLoadGeneration(value))
+    }
+
+    suspend fun emitTap(event: TapEvent = TapEvent.Body) {
+        _tapEvents.emit(event)
+    }
+
+    suspend fun emitLink(event: LinkEvent) {
+        _linkEvents.emit(event)
+    }
+
+    suspend fun emitSelection(event: SelectionEvent) {
+        _selectionEvents.emit(event)
+    }
+
+    suspend fun emitAnnotationTap(event: AnnotationTapEvent) {
+        _annotationTapEvents.emit(event)
+    }
+}

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/presenter/FakeReaderPresenterTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/presenter/FakeReaderPresenterTest.kt
@@ -1,0 +1,193 @@
+package com.riffle.app.feature.reader.presenter
+
+import com.riffle.core.domain.FormattingPreferences
+import com.riffle.core.domain.ReaderFontFamily
+import com.riffle.core.domain.ReaderOrientation
+import com.riffle.core.domain.ReaderTheme
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.yield
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pins the [ReaderPresenter] contract via [FakeReaderPresenter]. Every future orchestrator
+ * (PositionOrchestrator, ReadaloudSession, AnnotationSession, …) will lean on this double as
+ * its renderer test seam — so anything they need to trust about the contract has to be proved
+ * here.
+ */
+class FakeReaderPresenterTest {
+
+    private val defaultPrefs = FormattingPreferences(
+        theme = ReaderTheme.Light,
+        fontFamily = ReaderFontFamily.Serif,
+        fontSize = 1.0f,
+        lineSpacing = 1.2f,
+        margins = 1.0f,
+        orientation = ReaderOrientation.Horizontal,
+    )
+
+    @Test
+    fun `snapshotPosition returns null before any position event`() {
+        val presenter = FakeReaderPresenter()
+        assertNull(presenter.snapshotPosition())
+    }
+
+    @Test
+    fun `snapshotPosition returns the most recent emitted position`() = runTest {
+        val presenter = FakeReaderPresenter()
+        presenter.emitPosition(position(href = "ch01.xhtml", progression = 0.2f))
+        presenter.emitPosition(position(href = "ch02.xhtml", progression = 0.5f))
+        assertEquals("ch02.xhtml", presenter.snapshotPosition()?.href)
+        assertEquals(0.5f, presenter.snapshotPosition()?.progression)
+    }
+
+    @Test
+    fun `positionEvents carries a monotonically increasing generation`() = runTest {
+        val presenter = FakeReaderPresenter()
+        val collected = collectN(presenter.positionEvents, n = 3) {
+            presenter.emitPosition(position(progression = 0.1f))
+            presenter.emitPosition(position(progression = 0.2f))
+            presenter.emitPosition(position(progression = 0.3f))
+        }
+        assertEquals(listOf(1L, 2L, 3L), collected.map { it.generation })
+        assertEquals(listOf(0.1f, 0.2f, 0.3f), collected.map { it.position.progression })
+    }
+
+    @Test
+    fun `pageLoadEvents are observable`() = runTest {
+        val presenter = FakeReaderPresenter()
+        val collected = collectN(presenter.pageLoadEvents, n = 2) {
+            presenter.emitPageLoad(1)
+            presenter.emitPageLoad(2)
+        }
+        assertEquals(listOf(1, 2), collected.map { it.value })
+    }
+
+    @Test
+    fun `navigateTo records the target verbatim`() = runTest {
+        val presenter = FakeReaderPresenter()
+        presenter.navigateTo(NavigationTarget.ToHref("ch03.xhtml", fragment = "sec2"))
+        presenter.navigateTo(NavigationTarget.ToProgression("ch03.xhtml", 0.42f))
+        presenter.navigateTo(NavigationTarget.ToLocatorJson("""{"href":"ch01.xhtml"}"""))
+
+        assertEquals(3, presenter.recordedNavigations.size)
+        assertEquals(NavigationTarget.ToHref("ch03.xhtml", fragment = "sec2"), presenter.recordedNavigations[0])
+        assertEquals(NavigationTarget.ToProgression("ch03.xhtml", 0.42f), presenter.recordedNavigations[1])
+        assertTrue(presenter.recordedNavigations[2] is NavigationTarget.ToLocatorJson)
+    }
+
+    @Test
+    fun `applyTypography records the prefs in order`() = runTest {
+        val presenter = FakeReaderPresenter()
+        presenter.applyTypography(defaultPrefs)
+        presenter.applyTypography(defaultPrefs.copy(fontSize = 1.2f))
+        assertEquals(listOf(1.0f, 1.2f), presenter.recordedTypography.map { it.fontSize })
+    }
+
+    @Test
+    fun `pageBy records the direction`() = runTest {
+        val presenter = FakeReaderPresenter()
+        presenter.pageBy(PageDirection.Forward)
+        presenter.pageBy(PageDirection.Forward)
+        presenter.pageBy(PageDirection.Backward)
+        assertEquals(
+            listOf(PageDirection.Forward, PageDirection.Forward, PageDirection.Backward),
+            presenter.recordedPagesBy,
+        )
+    }
+
+    @Test
+    fun `tap events flow`() = runTest {
+        val presenter = FakeReaderPresenter()
+        val taps = collectN(presenter.tapEvents, n = 1) { presenter.emitTap() }
+        assertEquals(listOf(TapEvent.Body), taps)
+    }
+
+    @Test
+    fun `link events carry their variant payload`() = runTest {
+        val presenter = FakeReaderPresenter()
+        val links = collectN(presenter.linkEvents, n = 3) {
+            presenter.emitLink(LinkEvent.InternalLink("ch04.xhtml", originLocatorJson = "{}"))
+            presenter.emitLink(LinkEvent.ExternalLink("https://example.org"))
+            presenter.emitLink(LinkEvent.Footnote("<p>note</p>"))
+        }
+        assertEquals(3, links.size)
+        assertTrue(links[0] is LinkEvent.InternalLink)
+        assertTrue(links[1] is LinkEvent.ExternalLink)
+        assertTrue(links[2] is LinkEvent.Footnote)
+        assertEquals("ch04.xhtml", (links[0] as LinkEvent.InternalLink).href)
+        assertEquals("https://example.org", (links[1] as LinkEvent.ExternalLink).url)
+        assertEquals("<p>note</p>", (links[2] as LinkEvent.Footnote).contentHtml)
+    }
+
+    @Test
+    fun `selection events flow`() = runTest {
+        val presenter = FakeReaderPresenter()
+        val selections = collectN(presenter.selectionEvents, n = 2) {
+            presenter.emitSelection(
+                SelectionEvent.HighlightRequest(
+                    href = "ch01.xhtml",
+                    text = "hello",
+                    progression = 0.1f,
+                    before = null,
+                    after = null,
+                ),
+            )
+            presenter.emitSelection(SelectionEvent.PlayFromHereRequest("ch01.xhtml", "hello"))
+        }
+        assertEquals(2, selections.size)
+        assertTrue(selections[0] is SelectionEvent.HighlightRequest)
+        assertTrue(selections[1] is SelectionEvent.PlayFromHereRequest)
+    }
+
+    @Test
+    fun `annotation tap events distinguish highlight and note glyph`() = runTest {
+        val presenter = FakeReaderPresenter()
+        val taps = collectN(presenter.annotationTapEvents, n = 2) {
+            presenter.emitAnnotationTap(AnnotationTapEvent.Highlight("ch01.xhtml", "annot-1"))
+            presenter.emitAnnotationTap(AnnotationTapEvent.NoteGlyph("ch01.xhtml", "annot-1"))
+        }
+        assertEquals(
+            listOf<AnnotationTapEvent>(
+                AnnotationTapEvent.Highlight("ch01.xhtml", "annot-1"),
+                AnnotationTapEvent.NoteGlyph("ch01.xhtml", "annot-1"),
+            ),
+            taps,
+        )
+    }
+
+    // ----- helpers -----
+
+    private fun position(
+        href: String = "ch01.xhtml",
+        progression: Float = 0.0f,
+        totalProgression: Float? = null,
+        locatorJson: String = "",
+    ) = ReaderPosition(href, progression, totalProgression, locatorJson)
+
+    /**
+     * Subscribes to [flow] before invoking [produce], then waits for exactly [n] emissions.
+     * Uses UNDISPATCHED start so the collector wins the race against the producer on shared
+     * flows that have no replay buffer.
+     */
+    private suspend fun <T> TestScope.collectN(
+        flow: Flow<T>,
+        n: Int,
+        produce: suspend () -> Unit,
+    ): List<T> {
+        val deferred = backgroundScope.async(start = CoroutineStart.UNDISPATCHED) {
+            flow.take(n).toList()
+        }
+        yield()
+        produce()
+        return deferred.await()
+    }
+}

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/presenter/ReadiumPresenterTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/presenter/ReadiumPresenterTest.kt
@@ -1,0 +1,53 @@
+package com.riffle.app.feature.reader.presenter
+
+import org.json.JSONObject
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.readium.r2.shared.publication.Locator
+
+/**
+ * Pure-JVM tests for [ReadiumPresenter] and its translation helpers.
+ *
+ * Anything that has to construct a [Locator] or a [Publication] reaches `android.net.Uri.parse`
+ * through Readium's `Url(...)` constructor, which is not mocked in unit tests. That coverage
+ * lives in the harness (and will be exercised end-to-end when callers cut over to drive this
+ * adapter — Step 2+ of issue #300). What we can pin here is the resilience of the JSON-parse
+ * layer that protects [NavigationTarget.ToLocatorJson] from corrupt input.
+ */
+class ReadiumPresenterTest {
+
+    @Test
+    fun `Locator_fromJSON tolerates malformed JSON via runCatching`() {
+        // Same shape of guard the adapter wraps around [NavigationTarget.ToLocatorJson]. Mirrors
+        // the runCatching used by `EpubReaderViewModel` (memory: "Book progress erased on open"
+        // — when the local CFI column gets the wrong dialect, we must NOT throw at open time).
+        val parsed = runCatching { Locator.fromJSON(JSONObject("{not-json")) }.getOrNull()
+        assertNull(parsed)
+    }
+
+    @Test
+    fun `Locator_fromJSON returns null on an empty object`() {
+        val parsed = runCatching { Locator.fromJSON(JSONObject("{}")) }.getOrNull()
+        assertNull(parsed)
+    }
+
+    @Test
+    fun `NavigationTarget sealed hierarchy covers the three navigation shapes`() {
+        // Exhaustiveness guard — if a new variant is added without coverage in [toLocator],
+        // this test forces an update.
+        val targets: List<NavigationTarget> = listOf(
+            NavigationTarget.ToLocatorJson("{}"),
+            NavigationTarget.ToHref("ch01.xhtml"),
+            NavigationTarget.ToProgression("ch01.xhtml", 0.5f),
+        )
+        val matched = targets.map {
+            when (it) {
+                is NavigationTarget.ToLocatorJson -> "json"
+                is NavigationTarget.ToHref -> "href"
+                is NavigationTarget.ToProgression -> "progression"
+            }
+        }
+        assertTrue(matched.containsAll(listOf("json", "href", "progression")))
+    }
+}


### PR DESCRIPTION
First of 7 cutover steps for issue #300. Lays down the seam; no caller is cut over.

## What's in

- \`feature/reader/presenter/ReaderPresenter.kt\` — the contract. Position / page-load / tap / link / selection / annotation-tap event flows; \`navigateTo\` / \`applyTypography\` / \`snapshotPosition\` / \`pageBy\` commands. Zero \`org.readium\` imports.
- \`feature/reader/presenter/ReadiumPresenter.kt\` — adapter wrapping \`EpubNavigatorFragment\`. \`attach\`/\`detach\` lifecycle, fragment.currentLocator → \`positionEvents\`, plus \`feed*\` methods that subsequent cutover steps will wire the existing screen-side listeners into.
- \`FakeReaderPresenter\` test double + 11 contract tests pinning every event flow and command. Future orchestrators drive features through this without booting Readium or a WebView.
- \`ReadiumPresenterTest\` — pure-JVM guards on \`Locator.fromJSON\` malformed-input tolerance + \`NavigationTarget\` exhaustiveness.

## What's deliberately not in

- No call site cut over. \`EpubReaderScreen\` and \`EpubReaderViewModel\` are untouched. The new package compiles and is dormant.
- No \`ContinuousPresenter\` — Step 5.
- No Locator round-trip JVM test. Readium's \`Url(...)\` reaches \`android.net.Uri.parse\` which isn't on the JVM; the existing \`ReadaloudLocatorTest\` works around this by testing JSON shape only. Locator round-trip coverage will land in the harness when callers cut over (Step 2+).

## Verification

- \`./gradlew test\` green.
- **Not** validated on AVD — there's no behavior delta to validate. Full reader smoke is owed once Step 2 begins cutting callers over.

## Stack

Part of issue #300 (ReaderPresenter seam). This PR is the foundation; steps 2-7 will stack on top of this branch.

## Test plan

- [x] JVM tests green (\`./gradlew test\`)
- [ ] Reader smoke deferred to the first cutover step (Step 2)