### PR TITLE
refactor(reader): route decoration application through ReadiumPresenter (#300 step 2)

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -47,6 +47,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
+import com.riffle.app.feature.reader.presenter.ReadiumPresenter
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -1104,18 +1105,28 @@ private fun EpubNavigatorView(
     val isContinuous = formattingPrefs.orientation == ReaderOrientation.Continuous
     val fragmentRef = remember { mutableStateOf<EpubNavigatorFragment?>(null) }
 
-    val highlightRenderer: HighlightRenderer = remember(isContinuous) {
+    // Per-publication ReadiumPresenter (#300 step 2). Owns the seam between paginated/vertical
+    // rendering and the rest of the reader. Step 2 routes decoration application through it; the
+    // remaining concerns (typography, navigation, page-load + position events) cut over in later
+    // steps. Continuous mode bypasses the presenter until step 5 introduces ContinuousPresenter.
+    val readiumPresenter: ReadiumPresenter? = remember(state.publication, isContinuous, coroutineScope) {
+        if (isContinuous) null else ReadiumPresenter(coroutineScope, state.publication)
+    }
+    DisposableEffect(readiumPresenter) {
+        onDispose { readiumPresenter?.detach() }
+    }
+
+    val highlightRenderer: HighlightRenderer = remember(isContinuous, readiumPresenter) {
         if (isContinuous) {
             ContinuousHighlightRenderer(targetProvider = { continuousViewRef.value })
         } else {
+            val presenter = readiumPresenter!! // by construction: non-null when !isContinuous
             ReadiumHighlightRenderer(
                 applyDecorationsBlock = { decorations, group ->
-                    (fragmentRef.value as? DecorableNavigator)?.let { nav ->
-                        withContext(Dispatchers.Main) { nav.applyDecorations(decorations, group) }
-                    }
+                    presenter.applyDecorations(decorations, group)
                 },
                 fragmentLocator = ::fragmentLocator,
-                currentNavigatorStamp = { fragmentRef.value },
+                currentNavigatorStamp = { presenter.attachmentStamp() },
             )
         }
     }
@@ -2034,6 +2045,7 @@ private fun EpubNavigatorView(
                 val existingFrag = fragmentRef.value
                 if (existingFrag != null && fragmentDoublePageHolder[0] != isDoublePage) {
                     fm.beginTransaction().remove(existingFrag).commitNow()
+                    readiumPresenter?.detach()
                     fragmentRef.value = null
                     fragmentDoublePageHolder[0] = null
                 }
@@ -2078,6 +2090,9 @@ private fun EpubNavigatorView(
                         ?: return@AndroidView
                     fragmentRef.value = fragment
                     fragmentDoublePageHolder[0] = isDoublePage
+                    // Attach to the ReaderPresenter seam (#300 step 2). Today only decoration
+                    // application flows through it; remaining concerns cut over in later steps.
+                    readiumPresenter?.attach(fragment)
                     // Readium's built-in ANIMATED page transition (Kotlin toolkit 3.2.0+): edge taps
                     // turn the page with a smooth slide instead of an instant jump. Added before
                     // tapListener so the adapter consumes horizontal edge taps and tapListener only

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/presenter/ReadiumPresenter.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/presenter/ReadiumPresenter.kt
@@ -3,11 +3,15 @@ package com.riffle.app.feature.reader.presenter
 import com.riffle.app.feature.reader.typographyOverrideInjectionJs
 import com.riffle.core.domain.FormattingPreferences
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.json.JSONObject
+import org.readium.r2.navigator.Decoration
+import org.readium.r2.navigator.DecorableNavigator
 import org.readium.r2.navigator.epub.EpubNavigatorFragment
 import org.readium.r2.shared.publication.Link
 import org.readium.r2.shared.publication.Locator
@@ -142,6 +146,26 @@ internal class ReadiumPresenter(
     }
 
     override fun snapshotPosition(): ReaderPosition? = lastPosition
+
+    /**
+     * Apply Readium decorations to the currently attached fragment for a given group. No-op when
+     * no fragment is attached or the fragment is not a [DecorableNavigator] — exactly mirrors the
+     * original screen-level `applyDecorationsBlock` lambda this method replaces.
+     *
+     * Cutover Step 2 (issue #300): callers in the screen pass through here instead of capturing
+     * `fragmentRef.value as? DecorableNavigator` directly.
+     */
+    suspend fun applyDecorations(decorations: List<Decoration>, group: String) {
+        val nav = fragment as? DecorableNavigator ?: return
+        withContext(Dispatchers.Main) { nav.applyDecorations(decorations, group) }
+    }
+
+    /**
+     * Stable token that changes whenever the attached fragment changes. Replaces the
+     * `currentNavigatorStamp` lambda the screen passes into the highlight renderer: search-result
+     * settle loops break out when the stamp changes mid-iteration.
+     */
+    fun attachmentStamp(): Any? = fragment
 
     override suspend fun pageBy(direction: PageDirection) {
         val fragment = fragment ?: return

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/presenter/ReadiumPresenterTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/presenter/ReadiumPresenterTest.kt
@@ -1,10 +1,12 @@
 package com.riffle.app.feature.reader.presenter
 
+import kotlinx.coroutines.test.runTest
 import org.json.JSONObject
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.readium.r2.shared.publication.Locator
+import org.readium.r2.shared.publication.Publication
 
 /**
  * Pure-JVM tests for [ReadiumPresenter] and its translation helpers.
@@ -33,6 +35,33 @@ class ReadiumPresenterTest {
     }
 
     @Test
+    fun `attachmentStamp returns null before attach (#300 step 2)`() = runTest {
+        // The Step 2 cutover replaces `currentNavigatorStamp = { fragmentRef.value }` in the
+        // screen with `currentNavigatorStamp = { presenter.attachmentStamp() }`. Both return
+        // null before a fragment is bound, which is what lets the search-decoration settle loop
+        // break out cleanly across detaches.
+        val presenter = ReadiumPresenter(
+            scope = kotlinx.coroutines.test.TestScope(),
+            publication = stubPublication(),
+        )
+        assertNull(presenter.attachmentStamp())
+    }
+
+    @Test
+    fun `applyDecorations no-ops before attach (#300 step 2)`() = runTest {
+        // Mirrors the original screen-level `(fragmentRef.value as? DecorableNavigator)?.let{...}`
+        // — silently skips when there is no fragment, so calls between detach/attach (orientation
+        // change, fragment recreation) never crash.
+        val presenter = ReadiumPresenter(
+            scope = kotlinx.coroutines.test.TestScope(),
+            publication = stubPublication(),
+        )
+        presenter.applyDecorations(emptyList(), "annotations")
+        // No exception means contract preserved.
+        assertTrue(true)
+    }
+
+    @Test
     fun `NavigationTarget sealed hierarchy covers the three navigation shapes`() {
         // Exhaustiveness guard — if a new variant is added without coverage in [toLocator],
         // this test forces an update.
@@ -49,5 +78,20 @@ class ReadiumPresenterTest {
             }
         }
         assertTrue(matched.containsAll(listOf("json", "href", "progression")))
+    }
+
+    /**
+     * Allocates an uninitialised [Publication]. Constructing one normally reaches
+     * `android.net.Uri.parse` (via Readium's `Url(...)`) which isn't on the JVM. The presenter
+     * methods exercised in this file (`attachmentStamp`, `applyDecorations`-without-fragment)
+     * never touch the publication, so an empty shell is fine. Same trick as
+     * [com.riffle.app.feature.reader.ReadiumHighlightRendererTest.minimalLocator].
+     */
+    private fun stubPublication(): Publication {
+        val unsafe = Class.forName("sun.misc.Unsafe")
+            .getDeclaredField("theUnsafe")
+            .also { it.isAccessible = true }
+            .get(null) as sun.misc.Unsafe
+        return unsafe.allocateInstance(Publication::class.java) as Publication
     }
 }


### PR DESCRIPTION
Step 2 of 7 for issue #300. **Stacked on #304** — review/merge #304 first.

## What's in

- \`ReadiumPresenter\` gains \`applyDecorations(decorations, group)\` and \`attachmentStamp()\` — verbatim replacements for the screen-level \`applyDecorationsBlock\` lambda and \`currentNavigatorStamp = { fragmentRef.value }\`.
- \`EpubReaderScreen\` constructs a \`ReadiumPresenter\` per publication when not in continuous mode, attaches it to the fragment on creation, detaches on recreation / disposal, and sources the two lambdas it passes to \`ReadiumHighlightRenderer\` through the presenter.
- New tests in \`ReadiumPresenterTest\` pin the no-fragment contract (stamp null, applyDecorations no-ops). Uses the existing \`sun.misc.Unsafe\` Publication-stub trick from \`ReadiumHighlightRendererTest\` to dodge the JVM's missing \`android.net.Uri\`.

## What's still bypassed

- Continuous mode (\`ContinuousHighlightRenderer\`) is unchanged. \`ContinuousPresenter\` lands in step 5.
- \`ReadiumHighlightRenderer\` constructor signature is unchanged. The existing \`ReadiumHighlightRendererTest\` remains the regression net for decoration semantics.

## Verification

- \`./gradlew test\` green.
- Harness coverage: existing reader tests cover the call path end-to-end; they exercise the new presenter wiring on the way through.
- AVD smoke owed — annotation create, search highlight, readaloud sentence highlight in paginated + vertical modes.

## Stack

\`\`\`
main
 └─ #304 (step 1: seam)
     └─ #THIS (step 2: decoration cutover)
\`\`\`

## Test plan

- [x] JVM tests green
- [ ] Harness phone + tablet (CI)
- [ ] AVD smoke: annotation, readaloud highlight, search match (paginated + vertical)