### PR TITLE
refactor(reader): route navigation through ReadiumPresenter (#300 step 3)

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -47,6 +47,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
+import com.riffle.app.feature.reader.presenter.PageDirection
 import com.riffle.app.feature.reader.presenter.ReadiumPresenter
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -1515,7 +1516,7 @@ private fun EpubNavigatorView(
                 return@collect
             }
             // Wait for the fragment to be ready — same timing concern as the continuous case above.
-            val fragment = snapshotFlow { fragmentRef.value }.filterNotNull().first()
+            snapshotFlow { fragmentRef.value }.filterNotNull().first()
             // Cover only a cross-resource jump (where the load flash happens); a same-chapter jump
             // is instant and needs no mask.
             val cover = link.href.toString().substringBefore('#') !=
@@ -1524,7 +1525,7 @@ private fun EpubNavigatorView(
             try {
                 // Navigate and snap onto the target's column, tracked through the new chapter's async
                 // typography reflow (ColumnSnap owns the grid math). The cover is just cosmetic now.
-                ColumnSnap.goAndSnap(fragment, link)
+                readiumPresenter?.navigateToLink(link)
                 if (cover) delay(NAV_COVER_SETTLE_MS)
             } finally {
                 navigating = false
@@ -1544,11 +1545,11 @@ private fun EpubNavigatorView(
     // can be off-grid (the "page slightly turned to next" bug on book open). The at-rest backstop
     // [SETTLE_SNAP_INSTALL_JS] doesn't rescue it: it arms on a scroll event, and Readium's programmatic
     // initial landing never fires one.
-    val serverLocatorTarget: NavigationTarget = remember(isContinuous) {
+    val serverLocatorTarget: NavigationTarget = remember(isContinuous, readiumPresenter) {
         if (isContinuous) ContinuousNavigationTarget { continuousViewRef.value }
         else ReadiumNavigationTarget { locator ->
-            val fragment = snapshotFlow { fragmentRef.value }.filterNotNull().first()
-            ColumnSnap.goAndSnap(fragment, locator, landAtStartWhenNoTarget = false)
+            snapshotFlow { fragmentRef.value }.filterNotNull().first()
+            readiumPresenter?.navigateToLocator(locator, landAtStartWhenNoTarget = false)
         }
     }
 
@@ -1568,12 +1569,12 @@ private fun EpubNavigatorView(
         // silently drop the snap when this fires before the fragment is created — which is the
         // openAtCfi-from-library path: openBook emits the annotation-nav event before the AndroidView
         // factory has built the fragment, so the column-snap never ran and the page rested off-grid.
-        val fragment = snapshotFlow { fragmentRef.value }.filterNotNull().first()
+        snapshotFlow { fragmentRef.value }.filterNotNull().first()
         val cover = locator.href.toString().substringBefore('#') !=
             currentHrefHolder[0]?.substringBefore('#')
         navigating = cover
         try {
-            ColumnSnap.goAndSnap(fragment, locator, landAtStartWhenNoTarget = false)
+            readiumPresenter?.navigateToLocator(locator, landAtStartWhenNoTarget = false)
             if (cover) delay(NAV_COVER_SETTLE_MS)
         } finally {
             navigating = false
@@ -1581,15 +1582,15 @@ private fun EpubNavigatorView(
     }
 
     // Navigate in vertical (scroll) mode: use Readium's go() without column snapping.
-    // Vertical mode uses native scroll, not column pagination, so ColumnSnap.goAndSnap doesn't apply.
+    // Vertical mode uses native scroll, not column pagination, so the snap call is a no-op there.
     val goInScrollMode: suspend (Locator) -> Unit = goInScrollMode@{ locator ->
         // Same wait-for-fragment as [goAndSnapWithCover] above.
-        val fragment = snapshotFlow { fragmentRef.value }.filterNotNull().first()
+        snapshotFlow { fragmentRef.value }.filterNotNull().first()
         val cover = locator.href.toString().substringBefore('#') !=
             currentHrefHolder[0]?.substringBefore('#')
         navigating = cover
         try {
-            fragment.go(locator, animated = true)
+            readiumPresenter?.navigateToLocator(locator, snap = false)
             if (cover) delay(NAV_COVER_SETTLE_MS)
         } finally {
             navigating = false
@@ -1747,7 +1748,7 @@ private fun EpubNavigatorView(
         // (another chapter), where we fall back to a text-anchored go() to load it.
         val where = ColumnSnap.followNarratedSentence(fragment, quote.highlight)
         if (where != "off") return@LaunchedEffect
-        fragmentLocator(ref, quote)?.let { fragment.go(it, animated = false) }
+        fragmentLocator(ref, quote)?.let { readiumPresenter?.navigateToLocator(it, snap = false, animated = false) }
     }
 
     // INTRA-sentence page follow (paginated): the effect above snaps to the column holding the
@@ -1810,8 +1811,8 @@ private fun EpubNavigatorView(
                 }
             } else {
                 when (event) {
-                    VolumeNavEvent.Forward -> fragment.goForward(animated = false)
-                    VolumeNavEvent.Backward -> fragment.goBackward(animated = false)
+                    VolumeNavEvent.Forward -> readiumPresenter?.pageBy(PageDirection.Forward)
+                    VolumeNavEvent.Backward -> readiumPresenter?.pageBy(PageDirection.Backward)
                 }
             }
         }
@@ -2134,12 +2135,12 @@ private fun EpubNavigatorView(
                     }
                 }
 
-                fragmentRef.value?.let { fragment ->
+                fragmentRef.value?.let { _ ->
                     container.onNavigateForward = navigateForward@{
                         val idx = state.publication.readingOrder
                             .indexOfFirst { it.href.toString() == currentHrefHolder[0] }
                         if (idx < 0 || idx >= state.publication.readingOrder.size - 1) return@navigateForward
-                        fragment.goForward(animated = false)
+                        coroutineScope.launch { readiumPresenter?.pageBy(PageDirection.Forward) }
                     }
                     container.onNavigateBackward = navigateBackward@{
                         val idx = state.publication.readingOrder
@@ -2153,7 +2154,7 @@ private fun EpubNavigatorView(
                                 .put("locations", JSONObject().put("progression", 1.0))
                         ) ?: return@navigateBackward
                         coroutineScope.launch {
-                            fragment.go(locator, animated = false)
+                            readiumPresenter?.navigateToLocator(locator, snap = false, animated = false)
                         }
                     }
                 }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/presenter/ReadiumPresenter.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/presenter/ReadiumPresenter.kt
@@ -1,5 +1,6 @@
 package com.riffle.app.feature.reader.presenter
 
+import com.riffle.app.feature.reader.ColumnSnap
 import com.riffle.app.feature.reader.typographyOverrideInjectionJs
 import com.riffle.core.domain.FormattingPreferences
 import kotlinx.coroutines.CoroutineScope
@@ -166,6 +167,43 @@ internal class ReadiumPresenter(
      * settle loops break out when the stamp changes mid-iteration.
      */
     fun attachmentStamp(): Any? = fragment
+
+    // ----- Readium-typed navigation (#300 step 3) -------------------------------------------
+    //
+    // The screen still constructs Readium Locator/Link from TOC entries, search results, and
+    // server progress; these convenience overloads keep the type-conversion at the cutover
+    // boundary instead of forcing every caller to round-trip through JSON. They will collapse
+    // into [navigateTo] once the view-model owns navigation entirely (a later issue's job).
+
+    /**
+     * Navigate to [locator] and snap to the column it landed in. Replaces the screen-level
+     * `ColumnSnap.goAndSnap` and `fragment.go` calls. In vertical (scroll) mode the snap JS is a
+     * no-op, so passing `snap = true` is safe for both orientations; pass `snap = false` to skip
+     * the snap entirely when the caller knows the page must not be rounded (e.g. the readaloud
+     * `play-from-here` resume which already lands precisely).
+     */
+    suspend fun navigateToLocator(
+        locator: Locator,
+        landAtStartWhenNoTarget: Boolean = true,
+        snap: Boolean = true,
+        animated: Boolean = true,
+    ) {
+        val fragment = fragment ?: return
+        if (snap) {
+            ColumnSnap.goAndSnap(fragment, locator, landAtStartWhenNoTarget)
+        } else {
+            fragment.go(locator, animated = animated)
+        }
+    }
+
+    /**
+     * Navigate to [link] (TOC tap, internal cross-resource link) and snap to the column it
+     * landed in. Replaces the screen-level `ColumnSnap.goAndSnap(fragment, link)`.
+     */
+    suspend fun navigateToLink(link: Link) {
+        val fragment = fragment ?: return
+        ColumnSnap.goAndSnap(fragment, link)
+    }
 
     override suspend fun pageBy(direction: PageDirection) {
         val fragment = fragment ?: return


### PR DESCRIPTION
Step 3 of 7 for issue #300. **Stacked on #305 → #304.**

## What's in

- \`ReadiumPresenter\` gains \`navigateToLocator\` and \`navigateToLink\` Readium-typed convenience methods (kept off the abstract interface; they collapse into \`navigateTo(NavigationTarget)\` once the VM owns navigation).
- Every \`fragment.go\` / \`fragment.goForward\` / \`fragment.goBackward\` / \`ColumnSnap.goAndSnap(fragment, …)\` call site in \`EpubReaderScreen\` is replaced with a presenter delegation. The screen keeps the \`navigating\` cover-mask state and the \`snapshotFlow { fragmentRef.value }.filterNotNull()\` await — both are screen concerns, not renderer concerns.
- ScrollBoundaryNavigationContainer callbacks (non-suspend lambdas) wrap presenter calls in \`coroutineScope.launch\` to match the original \`fragment.goForward\` shape.

## What's still in the screen

- Continuous mode keeps its own navigation path (\`ContinuousReaderCoordinator.onTocNavigation\`, \`ContinuousNavigationTarget\`). \`ContinuousPresenter\` lands in step 5.
- Readium listener installation (\`fragmentListener\`, \`paginationListener\`) is unchanged. Step 5/6 route them through the presenter's \`feed*\` methods.
- Typography injection in \`paginationListener.onPageLoaded\` stays put. Step 4 routes typography through the presenter.

## Verification

- \`./gradlew test\` green.
- Harness coverage: existing navigation, search, annotation, volume-key tests cover the path end-to-end.
- AVD smoke owed: TOC nav, internal link, search match, resume position, volume key (paginated + vertical).

## Risk

Navigation is the highest-traffic surface in the reader. The behavior should be byte-identical because the presenter methods are 1:1 wrappers — they just relocate the \`fragment.X\` call from the screen lambda into the adapter. The only structural change is the \`coroutineScope.launch\` wrap inside the container callbacks, which preserves the call's fire-and-forget shape.

## Stack

\`\`\`
main
 └─ #304 (step 1: seam)
     └─ #305 (step 2: decoration cutover)
         └─ #THIS (step 3: navigation cutover)
\`\`\`

## Test plan

- [x] JVM tests green
- [ ] Harness phone + tablet (CI)
- [ ] AVD smoke (paginated + vertical): TOC, internal link, search hit, resume position, volume key forward/backward, footnote, return-card