### PR TITLE
refactor(reader): route typography through ReadiumPresenter (#300 step 4)

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -1820,8 +1820,9 @@ private fun EpubNavigatorView(
 
     // fragmentRef.value is a key so the effect re-fires when the fragment becomes available
     // after rotation (isLandscape changes while fragmentRef is null, so the call would be lost).
-    LaunchedEffect(formattingPrefs, isLandscape, fragmentRef.value) {
-        fragmentRef.value?.submitPreferences(formattingPrefs.toEpubPreferences(isLandscape, isFixedLayout))
+    LaunchedEffect(formattingPrefs, isLandscape, fragmentRef.value, readiumPresenter) {
+        readiumPresenter?.updateLayoutContext(isLandscape = isLandscape, isFixedLayout = isFixedLayout)
+        readiumPresenter?.applyTypography(formattingPrefs)
         coordinator.onPreferencesChanged(formattingPrefs)
     }
 

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/presenter/ReadiumPresenter.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/presenter/ReadiumPresenter.kt
@@ -1,6 +1,7 @@
 package com.riffle.app.feature.reader.presenter
 
 import com.riffle.app.feature.reader.ColumnSnap
+import com.riffle.app.feature.reader.toEpubPreferences
 import com.riffle.app.feature.reader.typographyOverrideInjectionJs
 import com.riffle.core.domain.FormattingPreferences
 import kotlinx.coroutines.CoroutineScope
@@ -61,6 +62,20 @@ internal class ReadiumPresenter(
     private var lastPosition: ReaderPosition? = null
     private var positionGeneration: Long = 0L
     private var pageLoadCount: Int = 0
+
+    /**
+     * Layout state the screen owns (device rotation, EPUB layout type). The Readium
+     * [submitPreferences] call needs both to derive RS column count and the fixed-layout flag;
+     * the screen pushes them in via [updateLayoutContext] whenever they change.
+     */
+    @Volatile private var isLandscape: Boolean = false
+    @Volatile private var isFixedLayout: Boolean = false
+
+    /** Push the current device/EPUB layout into the presenter before [applyTypography] runs. */
+    fun updateLayoutContext(isLandscape: Boolean, isFixedLayout: Boolean) {
+        this.isLandscape = isLandscape
+        this.isFixedLayout = isFixedLayout
+    }
 
     /** Bind a freshly-created fragment. Starts forwarding its `currentLocator` to [positionEvents]. */
     fun attach(fragment: EpubNavigatorFragment) {
@@ -140,9 +155,15 @@ internal class ReadiumPresenter(
     }
 
     override suspend fun applyTypography(prefs: FormattingPreferences) {
-        // The adapter doesn't yet own preference→JS translation; it forwards to the existing
-        // injection helper. Cutover Step 4 will move the full typography pipeline behind here.
         val fragment = fragment ?: return
+        // Live-update Readium's typography for the attached fragment. The screen previously
+        // called `fragmentRef.value?.submitPreferences(...)` directly; routing through here keeps
+        // the layout context (orientation + fixed-layout flag) on the presenter rather than
+        // forcing every caller to thread it through.
+        fragment.submitPreferences(prefs.toEpubPreferences(isLandscape, isFixedLayout))
+        // The injected CSS overrides (font family, custom margins) are still applied on each
+        // onPageLoaded by the existing PaginationListener. Step 5 will move that into the
+        // presenter once page-load events flow through this seam.
         fragment.evaluateJavascript(typographyOverrideInjectionJs())
     }
 


### PR DESCRIPTION
Step 4 of 7 for issue #300. **Stacked on #306 → #305 → #304.**

## What's in

- \`ReadiumPresenter\` gains \`updateLayoutContext(isLandscape, isFixedLayout)\` so the screen can push device + EPUB layout state in.
- \`ReadiumPresenter.applyTypography(prefs)\` calls \`fragment.submitPreferences(prefs.toEpubPreferences(isLandscape, isFixedLayout))\` and the existing typography override JS injection.
- \`EpubReaderScreen\` no longer calls \`fragmentRef.value?.submitPreferences\` directly. The typography \`LaunchedEffect\` drives the presenter instead.

## What's still in the screen

- The \`PaginationListener.onPageLoaded\` JS injection of \`typographyOverrideInjectionJs()\` stays put. It moves behind the presenter when page-load events flow through the seam in step 5/6.
- The initial fragment-construction \`initialPreferences = formattingPrefs.toEpubPreferences(...)\` in the AndroidView factory stays put — that's a creation-time concern, not a runtime command.

## Stack

\`\`\`
main
 └─ #304 (step 1: seam)
     └─ #305 (step 2: decoration)
         └─ #306 (step 3: navigation)
             └─ #THIS (step 4: typography)
\`\`\`

## Test plan

- [x] JVM tests green
- [ ] Harness phone + tablet (CI)
- [ ] AVD smoke (paginated + vertical): font size, line spacing, margins, theme switch, font family swap, orientation rotate