### PR TITLE
refactor(reader): route continuous position events through presenter (#300 step 6)

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderCoordinator.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderCoordinator.kt
@@ -2,6 +2,7 @@ package com.riffle.app.feature.reader
 
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.unit.IntRect
+import com.riffle.app.feature.reader.presenter.ContinuousPresenter
 import com.riffle.core.domain.FormattingPreferences
 import com.riffle.core.domain.SentenceQuote
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -43,6 +44,16 @@ internal class ContinuousReaderCoordinator(
 ) {
     private var view: ContinuousReaderView? = null
 
+    /**
+     * Optional [ContinuousPresenter] hook for the seam (issue #300 step 6). When non-null,
+     * continuous-mode raw-position events also feed [ContinuousPresenter.feedPosition] so
+     * [ContinuousPresenter.positionEvents] becomes the canonical event source for any orchestrator
+     * built on top of [com.riffle.app.feature.reader.presenter.ReaderPresenter]. The existing
+     * [onLocator] callback path is unchanged in this step — full bypass deletion is the step 7
+     * cleanup pass.
+     */
+    var presenter: ContinuousPresenter? = null
+
     // Updated in attach() every time a new ContinuousReaderView is created (including after
     // Activity rotation, when Compose recreates the AndroidView and calls attach() again).
     // onTocNavigation awaits the first non-null emission to survive the race between the
@@ -63,7 +74,15 @@ internal class ContinuousReaderCoordinator(
         view.onRawPosition = { href, progression ->
             val (spineHrefs, counts) = spinePositionsProvider()
             val locator = buildContinuousLocator(href, progression, spineHrefs, counts)
-            if (locator != null) onLocator(locator)
+            if (locator != null) {
+                onLocator(locator)
+                presenter?.feedPosition(
+                    href = locator.href.toString(),
+                    progression = locator.locations.progression?.toFloat() ?: progression,
+                    totalProgression = locator.locations.totalProgression?.toFloat(),
+                    locatorJson = locator.toJSON().toString(),
+                )
+            }
         }
 
         view.onTap = { onTap() }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -2187,8 +2187,11 @@ private fun EpubNavigatorView(
                 factory = { ctx ->
                     ContinuousReaderView(ctx).also { view ->
                         continuousViewRef.value = view
-                        coordinator.attach(view)
+                        // Wire the presenter BEFORE attach so the coordinator's onRawPosition
+                        // handler routes raw-position events through it on the very first scroll.
+                        coordinator.presenter = continuousPresenter
                         continuousPresenter?.attach(view)
+                        coordinator.attach(view)
                         view.annotationsAvailable = currentAnnotationsAvailable
                         view.readaloudAvailable = currentReadaloudAvailable
                     }


### PR DESCRIPTION
Step 6 of 7 for issue #300. **Stacked on #308 → #307 → #306 → #305 → #304.**

## What's in

- \`ContinuousReaderCoordinator\` gains an optional \`presenter: ContinuousPresenter?\` property.
- Its existing \`view.onRawPosition\` handler also calls \`presenter.feedPosition(...)\` so \`ContinuousPresenter.positionEvents\` becomes the canonical seam-level position event source.
- \`EpubReaderScreen\` wires \`coordinator.presenter = continuousPresenter\` immediately before \`coordinator.attach(view)\` in the \`AndroidView\` factory.

## What's deliberately not removed

The legacy screen-level \`onPositionChanged\` lambda is intact for both modes (paginated reads \`fragment.currentLocator\` → \`onPositionChanged\`; continuous reads via coordinator's \`onLocator\` → \`onPositionChanged\`). The presenter is now a parallel emitter — orchestrators can switch to subscribing on \`presenter.positionEvents\` and the bypass deletion happens incrementally as they cut over.

The issue plan's "delete the bypass" target lives in step 7 cleanup (and the broader VM-split issue, where the screen's \`onPositionChanged\` parameter goes away entirely).

## Stack

\`\`\`
main
 └─ #304 (step 1: seam)
     └─ #305 (step 2: decoration)
         └─ #306 (step 3: navigation)
             └─ #307 (step 4: typography)
                 └─ #308 (step 5: ContinuousPresenter)
                     └─ #THIS (step 6: position events)
\`\`\`

## Test plan

- [x] JVM tests green
- [ ] Harness phone + tablet (CI)
- [ ] AVD smoke (continuous): scroll across chapters, verify progress sync to ABS still works, resume position survives reopen