### PR TITLE
refactor(reader): document the completed presenter seam (#300 step 7)

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/presenter/ContinuousPresenter.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/presenter/ContinuousPresenter.kt
@@ -10,10 +10,11 @@ import kotlinx.coroutines.flow.SharedFlow
  * endless-scroll renderer used in [com.riffle.core.domain.ReaderOrientation.Continuous] mode)
  * so the view-model never imports continuous-rendering types.
  *
- * **Step 5 scope (issue #300).** The class exists, owns its event flows, and exposes
- * [attach]/[detach] + the basic command set ([applyTypography], [pageBy], [navigateTo]).
- * Position events still flow through the existing screen-level `onPositionChanged` lambda;
- * step 6 routes that through [positionEvents].
+ * Issue #300 cuts over: volume-key paging ([pageBy]), and position events
+ * ([positionEvents] — fed from [ContinuousReaderCoordinator]'s `view.onRawPosition` handler).
+ * Decoration application via [ContinuousHighlightRenderer] still goes through the existing
+ * `targetProvider` lambda; that path collapses when the view-model owns decoration
+ * orchestration (out of this issue's scope).
  *
  * Lifecycle parallels [ReadiumPresenter]: construct once per reader session in continuous mode,
  * call [attach] when the view is created, [detach] when the view goes away.
@@ -47,11 +48,11 @@ internal class ContinuousPresenter : ReaderPresenter {
         this.view = null
     }
 
-    // ----- Feed methods called by the screen's existing continuous-view callback wiring ------
+    // ----- Feed methods called by the coordinator and (future) the screen's callbacks --------
     //
-    // The view exposes nine plain-Kotlin callbacks (onRawPosition, onTap, onInternalLinkTapped,
-    // etc.). Step 6 will route them through these feeders so [positionEvents], [tapEvents], and
-    // friends become the canonical paths. Until then, dormant.
+    // [feedPosition] is wired today via [ContinuousReaderCoordinator]. The remaining feeders
+    // exist so future orchestrators can subscribe to [tapEvents] / [linkEvents] / etc. without
+    // touching ContinuousReaderView callbacks directly.
 
     fun feedPosition(href: String, progression: Float, totalProgression: Float?, locatorJson: String) {
         val position = ReaderPosition(href, progression, totalProgression, locatorJson)
@@ -99,10 +100,11 @@ internal class ContinuousPresenter : ReaderPresenter {
                 alignToTop = false,
             )
             is NavigationTarget.ToLocatorJson -> {
-                // Continuous-mode resume reads (href, progression) out of the Locator JSON. The
-                // existing ContinuousReaderCoordinator does the parse; until step 6 lets it call
-                // back through here, decline to handle Locator-JSON navigation in the presenter
-                // and let the coordinator continue to drive resume.
+                // Continuous-mode resume reads (href, progression) out of the Locator JSON.
+                // ContinuousReaderCoordinator owns the parse + landing today (it has the spine
+                // hrefs + chapter counts the math needs); routing resume through here would
+                // require relocating that machinery to the presenter, which is the job of the
+                // view-model split, not this seam.
             }
         }
     }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/presenter/ReaderPresenter.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/presenter/ReaderPresenter.kt
@@ -4,18 +4,18 @@ import com.riffle.core.domain.FormattingPreferences
 import kotlinx.coroutines.flow.Flow
 
 /**
- * The seam between the reader UI (screen + view-model) and the concrete rendering pipeline
- * (Readium [org.readium.r2.navigator.epub.EpubNavigatorFragment] for paginated/vertical modes,
- * or the custom [com.riffle.app.feature.reader.ContinuousReaderView] for continuous mode).
+ * The seam between the reader UI (screen + view-model) and the concrete rendering pipeline.
+ * Two adapters today: [ReadiumPresenter] (paginated + vertical via Readium's
+ * [org.readium.r2.navigator.epub.EpubNavigatorFragment]) and [ContinuousPresenter] (the custom
+ * endless-scroll renderer). Both implement this interface; the view-model and any future
+ * orchestrators depend only on the interface — they MUST NOT import Readium or
+ * [com.riffle.app.feature.reader.ContinuousReaderView] types directly.
  *
- * The view-model and screen depend on this interface; they MUST NOT import Readium types
- * directly. Mode-specific concerns — column snap, fragment lifecycle, manual scroll-to-Locator
- * translation — live behind one of the adapters.
- *
- * **Step 1 scope (issue #300).** Only [ReadiumPresenter] exists today; the screen still mounts
- * Readium fragments and the continuous view directly. Decoration application stays on the
- * existing [com.riffle.app.feature.reader.HighlightRenderer] for now and will move behind this
- * seam in a follow-up cutover step.
+ * Mode-specific concerns (column snap, fragment lifecycle, sliding-window position translation)
+ * live behind the adapters. Issue #300 routes decoration application, navigation, typography,
+ * volume-key paging, and continuous-mode position events through this seam. Higher-level
+ * concerns — three-peer progress sync, readaloud highlight orchestration, annotation merge —
+ * sit upstream of the seam in orchestrators that subscribe to its event flows.
  */
 internal interface ReaderPresenter {
 

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/presenter/ReadiumPresenter.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/presenter/ReadiumPresenter.kt
@@ -24,14 +24,16 @@ import org.readium.r2.shared.util.Url
  * The Readium adapter for [ReaderPresenter]. Wraps an [EpubNavigatorFragment] (paginated +
  * vertical modes) so the view-model never imports Readium types.
  *
- * **Step 1 scope (issue #300).** This adapter exists; no caller is cut over yet. The screen
- * still mounts the fragment and installs Readium listeners directly. Subsequent cutover steps
- * will replace those direct touches with [attach] + the feed methods on this class so the
- * fragment's events flow through the seam.
+ * Lifecycle: construct once per reader session (the screen does so when not in continuous mode),
+ * call [attach] when the fragment is available, [detach] when it goes away (e.g. orientation
+ * change). All events fired through the feed methods are buffered (extra capacity 64) so
+ * producers never suspend.
  *
- * Lifecycle: construct the adapter once per reader session; call [attach] when the fragment is
- * available, [detach] when it goes away (e.g. on orientation change). All events fired through
- * the feed methods are buffered (extra capacity 64) so producers never suspend.
+ * Issue #300 cuts over: decoration application ([applyDecorations]), navigation
+ * ([navigateToLocator], [navigateToLink], [pageBy]), typography ([applyTypography] +
+ * [updateLayoutContext]). Fragment-listener events (`feedPageLoaded`,
+ * `feedInternalLink`, …) exist for future orchestrators; the screen still installs the
+ * Readium listeners directly today.
  *
  * @param scope a lifecycle-scoped [CoroutineScope] (usually `viewModelScope`) that owns the
  *   fragment-position collector. It must outlive the adapter.
@@ -97,9 +99,11 @@ internal class ReadiumPresenter(
 
     // ----- Feed methods called by the screen's existing Readium listener objects --------------
     //
-    // These exist so Step 3 (route navigation through the adapter) and Step 5 (page-load events)
-    // can be small mechanical changes: the listener objects forward to these instead of calling
-    // the VM directly. Until then, callers don't exist — these are dormant.
+    // [PaginationListener.onPageLoaded], [EpubNavigatorFragment.Listener.shouldFollowInternalLink],
+    // tap zones, selection, and annotation-tap callbacks forward to these so [pageLoadEvents],
+    // [linkEvents], [tapEvents], [selectionEvents], and [annotationTapEvents] become the
+    // canonical paths for future orchestrators. The screen still installs the listeners and
+    // wires them up; the view-model split is what removes that intermediate.
 
     fun feedPageLoaded() {
         pageLoadCount += 1
@@ -148,9 +152,10 @@ internal class ReadiumPresenter(
     override suspend fun navigateTo(target: NavigationTarget) {
         val fragment = fragment ?: return
         val locator = target.toLocator(publication) ?: return
-        // Step 1: plain go(). The column-snap dance currently lives in EpubReaderScreen and moves
-        // behind this method at cutover Step 3 (paginated mode → ColumnSnap.goAndSnap, vertical →
-        // plain go).
+        // The Readium-typed convenience overloads ([navigateToLocator], [navigateToLink]) own
+        // the column-snap dance. This abstract entry point — used by future orchestrators that
+        // only know the abstract [NavigationTarget] shape — issues a plain go(); the snap
+        // backstop on PaginationListener.onPageLoaded rounds the page if needed.
         fragment.go(locator, animated = true)
     }
 
@@ -161,9 +166,9 @@ internal class ReadiumPresenter(
         // the layout context (orientation + fixed-layout flag) on the presenter rather than
         // forcing every caller to thread it through.
         fragment.submitPreferences(prefs.toEpubPreferences(isLandscape, isFixedLayout))
-        // The injected CSS overrides (font family, custom margins) are still applied on each
-        // onPageLoaded by the existing PaginationListener. Step 5 will move that into the
-        // presenter once page-load events flow through this seam.
+        // The injected CSS overrides (font family, custom margins) are also re-applied on each
+        // onPageLoaded by PaginationListener; doing it here too means a live preferences change
+        // takes effect immediately without waiting for the next page turn.
         fragment.evaluateJavascript(typographyOverrideInjectionJs())
     }
 
@@ -174,8 +179,8 @@ internal class ReadiumPresenter(
      * no fragment is attached or the fragment is not a [DecorableNavigator] — exactly mirrors the
      * original screen-level `applyDecorationsBlock` lambda this method replaces.
      *
-     * Cutover Step 2 (issue #300): callers in the screen pass through here instead of capturing
-     * `fragmentRef.value as? DecorableNavigator` directly.
+     * Called from [com.riffle.app.feature.reader.ReadiumHighlightRenderer] via the screen's
+     * `applyDecorationsBlock` lambda.
      */
     suspend fun applyDecorations(decorations: List<Decoration>, group: String) {
         val nav = fragment as? DecorableNavigator ?: return
@@ -189,12 +194,12 @@ internal class ReadiumPresenter(
      */
     fun attachmentStamp(): Any? = fragment
 
-    // ----- Readium-typed navigation (#300 step 3) -------------------------------------------
+    // ----- Readium-typed navigation ---------------------------------------------------------
     //
     // The screen still constructs Readium Locator/Link from TOC entries, search results, and
-    // server progress; these convenience overloads keep the type-conversion at the cutover
-    // boundary instead of forcing every caller to round-trip through JSON. They will collapse
-    // into [navigateTo] once the view-model owns navigation entirely (a later issue's job).
+    // server progress; these convenience overloads keep the type-conversion at the boundary
+    // instead of forcing every caller to round-trip through JSON. They collapse into
+    // [navigateTo] once the view-model owns navigation entirely (out of this issue's scope).
 
     /**
      * Navigate to [locator] and snap to the column it landed in. Replaces the screen-level


### PR DESCRIPTION
Step 7 of 7 for issue #300 — the final cleanup pass. **Stacked on #309 → #308 → #307 → #306 → #305 → #304.**

## What's in

- Doc cleanup across \`ReaderPresenter.kt\`, \`ReadiumPresenter.kt\`, \`ContinuousPresenter.kt\`. Inline "step N will move this" notes become accurate descriptions of the current responsibility.
- The interface doc enumerates both adapters and clarifies what's behind the seam today vs what stays upstream.

## What's deliberately not in

\`ReaderPositionBridge\` is untouched. It is already pure translation — a sync-layer helper used by \`ReaderSync\`, not the rendering pipeline. Its callers belong to issue #302's ProgressPeer refactor, not this seam.

The screen's legacy \`onPositionChanged\` lambda is still wired for both modes (paginated via fragment.currentLocator, continuous via coordinator's onLocator). The presenter is now a parallel emitter; full bypass deletion happens incrementally as orchestrators subscribe to \`presenter.positionEvents\` (the view-model split issue).

## Seam status at end of #300

| Concern | Status |
|---|---|
| Decoration application (paged/vertical) | through \`ReadiumPresenter.applyDecorations\` |
| Decoration application (continuous) | still via \`ContinuousHighlightRenderer.targetProvider\` |
| Navigation (paged/vertical) | through \`ReadiumPresenter.navigateToLocator\` / \`navigateToLink\` / \`pageBy\` |
| Navigation (continuous) | volume-key paging through \`ContinuousPresenter.pageBy\`; TOC + resume still via coordinator |
| Typography (paged/vertical) | through \`ReadiumPresenter.applyTypography\` + \`updateLayoutContext\` |
| Typography (continuous) | through coordinator (proxies to view.updatePreferences) |
| Position events (paged/vertical) | screen reads \`fragment.currentLocator\` directly |
| Position events (continuous) | coordinator feeds \`ContinuousPresenter.positionEvents\` as a parallel emitter |
| Listener events (taps, links, footnotes, selections, annotation taps) | feed methods exist; screen still installs listeners directly |

## Stack

\`\`\`
main
 └─ #304 (step 1: seam)
     └─ #305 (step 2: decoration)
         └─ #306 (step 3: navigation)
             └─ #307 (step 4: typography)
                 └─ #308 (step 5: ContinuousPresenter)
                     └─ #309 (step 6: continuous position events)
                         └─ #THIS (step 7: docs cleanup)
\`\`\`

## Test plan

- [x] JVM tests green (no behavior change — docs only)
- [ ] Harness phone + tablet (CI)