### PR TITLE
fix(reader): stop continuous-mode reopen drifting the chapter forward

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,10 @@ Do not `assembleDebug` (or any APK build) unless the user explicitly asks. Do no
 
 Always run harness tests via `make harness-test` (phone-form-factor tests) or `make harness-test-tablet` (tests annotated with `@TabletLayout`). Never call `./gradlew :app:connectedDebugAndroidTest` directly — it targets all connected devices and will interfere with the developer's physical device. Each target boots its dedicated AVD ("Harness Medium Phone" or "Harness Medium Tablet"), runs its filtered test subset against it exclusively, then shuts it down. The two subsets are mutually exclusive, so tests never double-run across targets.
 
+## Debugging on the developer's device
+
+When debugging with `[DEBUG-<tag>]` logs the user is reproducing for you, **fetch the logcat yourself** — don't ask the user to paste it. The user's device is connected via `adb`; run e.g. `adb logcat -d | grep DEBUG-<tag>` (use `-d` to dump and exit, not stream). Clear the buffer with `adb logcat -c` before they reproduce so the output isn't drowned in history. If multiple devices/emulators are connected, pick the right one with `-s <serial>` (`adb devices`). Trust the user when they say "reproduced" — go fetch.
+
 ## Reader mode changes
 
 The reader has three modes: **paginated**, **vertical**, and **continuous**.

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
@@ -248,6 +248,15 @@ internal class ContinuousReaderView @JvmOverloads constructor(
     private var landingHoldTargetY: Int = -1
     private var landingHoldUntilUptimeMs: Long = 0L
 
+    /** Disarm the landing hold so a deliberate programmatic scroll (volume-key page-turn,
+     *  readaloud highlight-follow, in-window TOC nav, post-annotation re-land, …) isn't reverted
+     *  to the initial-land target. The hold is meant to fight the framework's stale-state
+     *  smooth-scroll restoration, not legitimate scroll requests. */
+    private fun clearLandingHold() {
+        landingHoldTargetY = -1
+        landingHoldUntilUptimeMs = 0L
+    }
+
     /**
      * Placeholder height used before real measurement arrives. One screen height keeps the
      * forward-shift trigger working (the last chapter needs enough height to scroll into) while
@@ -799,6 +808,7 @@ internal class ContinuousReaderView @JvmOverloads constructor(
     private fun scrollToLoadedChapter(target: String, progression: Float, fragment: String, smooth: Boolean, alignToTop: Boolean = false) {
         val window = buildWindow()
         val slot = window.firstOrNull { it.href.substringBefore('#') == target } ?: return
+        clearLandingHold()
         fun go(y: Int) {
             val clamped = y.coerceAtLeast(0)
             if (smooth) smoothScrollTo(0, clamped) else scrollTo(0, clamped)
@@ -822,6 +832,7 @@ internal class ContinuousReaderView @JvmOverloads constructor(
     /** Scroll one viewport-page forward/backward (wired to the volume keys). */
     fun scrollByPage(forward: Boolean) {
         val delta = ContinuousPositionTracker.pageScrollDelta(height)
+        clearLandingHold()
         smoothScrollBy(0, if (forward) delta else -delta)
     }
 
@@ -861,6 +872,7 @@ internal class ContinuousReaderView @JvmOverloads constructor(
             // Using abs() avoids the previous bug where absoluteY just inside the top of the
             // viewport triggered a backward scroll (absoluteY < scrollY+margin → target < scrollY).
             if (abs(targetScrollY - scrollY) > height / 8) {
+                clearLandingHold()
                 smoothScrollTo(0, targetScrollY)
             }
         }
@@ -973,6 +985,10 @@ internal class ContinuousReaderView @JvmOverloads constructor(
             val i = pendingTargetHref?.let { webViewIndexFor(it) } ?: return@annotationOffsetTopDevicePx
             val slot = buildWindow().getOrNull(i) ?: return@annotationOffsetTopDevicePx
             val y = (slot.top + annOffset).coerceAtLeast(0)
+            // This is a deliberate precise re-land onto the freshly-decorated mark; the initial
+            // land's hold (which fights the framework's stale-state restoration) would otherwise
+            // revert this scrollTo on the next computeScroll tick. Clear so the precise mark Y wins.
+            clearLandingHold()
             post { scrollTo(0, y) }
             pendingFocusAnnotationId = null
         }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
@@ -74,6 +74,11 @@ internal class ContinuousReaderView @JvmOverloads constructor(
          * typically measure in <300ms), short enough that a stuck case recovers quickly.
          */
         private const val INITIAL_SCROLL_FALLBACK_MS = 700L
+
+        /** How long after the initial land to override framework smooth-scroll restoration of a
+         *  stale scrollY (NestedScrollView's mScroller resumes ~50ms after the land scrollTo and
+         *  drives the viewport off-target by hundreds of pixels). Cleared early on user touch. */
+        private const val LANDING_HOLD_MS = 600L
     }
 
     data class ChapterEntry(val link: Link, val url: String)
@@ -208,6 +213,13 @@ internal class ContinuousReaderView @JvmOverloads constructor(
     /** Window index of the chapter the initial scroll lands on (set in [openWindowAt]). */
     private var pendingTargetWindowIndex: Int = -1
 
+    /** Href of the chapter the initial scroll lands on. Stable across window shifts — used to
+     *  re-resolve the current window slot at scrollTo time so a forward/backward shift between
+     *  [pendingInitialScroll] firing and the deferred [post] draining doesn't lock in pre-shift
+     *  coordinates (was: a shift made [pendingTargetWindowIndex] point at the next chapter and
+     *  the saved-position restore landed one chapter forward). */
+    private var pendingTargetHref: String? = null
+
     /**
      * The initial-scroll closure, retained when the safety-net fallback fires it BEFORE the target
      * chapter measured (so it may have landed short against a placeholder height). Re-invoked once
@@ -226,6 +238,15 @@ internal class ContinuousReaderView @JvmOverloads constructor(
      *  chain has been disarmed (touch event during boot, mark created after height stabilised, etc).
      *  Cleared on first manual touch and on rebuilds. */
     private var pendingFocusAnnotationId: String? = null
+
+    /** The scrollY of the most recent initial land, and the deadline (uptime ms) until which any
+     *  off-target scroll movement should be reverted. The framework restarts [NestedScrollView]'s
+     *  [OverScroller] after the land (a smooth-scroll restoration of a stale scroll-position from
+     *  saved view state — drives the user's content off the saved position by hundreds of pixels);
+     *  computeScroll() aborts that scroller and snaps back to the target while the window is open.
+     *  Cleared on first user touch and on a fresh window open. */
+    private var landingHoldTargetY: Int = -1
+    private var landingHoldUntilUptimeMs: Long = 0L
 
     /**
      * Placeholder height used before real measurement arrives. One screen height keeps the
@@ -398,6 +419,24 @@ internal class ContinuousReaderView @JvmOverloads constructor(
         super.scrollBy(x, y)
     }
 
+    override fun computeScroll() {
+        super.computeScroll()
+        // Hold the post-land target against framework smooth-scroll restoration of a stale scroll
+        // position. NestedScrollView's mScroller resumes ~50ms after the initial-land scrollTo and
+        // drives scrollY hundreds of pixels off-target (finalY = a stale scroll position from view-
+        // state save). The drifted value would then be persisted, and the next reopen would land
+        // even further off — pushing the chapter forward on every reopen. Window is open until
+        // LANDING_HOLD_MS elapses or the user touches the screen.
+        if (landingHoldTargetY >= 0) {
+            if (android.os.SystemClock.uptimeMillis() > landingHoldUntilUptimeMs) {
+                landingHoldTargetY = -1
+            } else if (scrollY != landingHoldTargetY) {
+                abortFling()
+                super.scrollTo(0, landingHoldTargetY)
+            }
+        }
+    }
+
     /**
      * Block all scroll-into-view requests bubbling up from a child [ChapterWebView].
      *
@@ -456,6 +495,8 @@ internal class ContinuousReaderView @JvmOverloads constructor(
                 // out from under a manual scroll.
                 reapplyLandingAfterFallback = null
                 pendingFocusAnnotationId = null
+                landingHoldTargetY = -1
+                landingHoldUntilUptimeMs = 0L
             }
             MotionEvent.ACTION_MOVE ->
                 if (abs(ev.y - interceptDownY) > touchSlop / 2f) return true
@@ -559,6 +600,7 @@ internal class ContinuousReaderView @JvmOverloads constructor(
         topIndex = initial.topIndex
         val targetWindowIndex = initial.targetWindowIndex
         pendingTargetWindowIndex = targetWindowIndex
+        pendingTargetHref = initialHref
         reapplyLandingAfterFallback = null
         reapplyTargetLastHeight = -1
         pendingFocusAnnotationId = focusAnnotationId
@@ -567,60 +609,69 @@ internal class ContinuousReaderView @JvmOverloads constructor(
         // so the target's slot.top (the sum of the heights before it) is exact.
         pendingInitialMeasureIndices.clear()
         pendingInitialMeasureIndices.addAll(0..targetWindowIndex)
+        val targetHref = initialHref
         pendingInitialScroll = {
-            val slot = buildWindow().getOrNull(targetWindowIndex)
-            val targetWv = webViews.getOrNull(targetWindowIndex)
-            if (slot != null) {
-                // Three landing strategies in priority order:
-                //  1) annotation-decoration anchor: the `<mark data-riffle-ann="<id>">` exists only
-                //     after applyAnnotationHighlightsJs has run inside onPageFinished (post-style-
-                //     injection / post-reflow), so its rect reflects the FINAL layout. Exact landing.
-                //  2) element-id anchor (#fragment): for TOC/cross-ref targets that point at a real
-                //     DOM element. Same recipe but the element is created by the chapter itself.
-                //  3) progression × slot.height: char-fraction × measured-WebView-height — works
-                //     for the resource-top / resume case but lands inexactly when the highlight sits
-                //     in dense text (heading-vs-paragraph density mismatch).
-                //
-                // The reflow-tracking re-land (see [appendChapter]'s onHeightMeasured) re-fires this
-                // closure on every target remeasure, so a cold start where (1) returns null on the
-                // first fire (mark not yet decorated) falls back to (2)/(3), and the NEXT remeasure
-                // — which is virtually always after applyAnnotationHighlightsJs has run — re-fires
-                // and snaps onto the precise mark Y.
-                fun landViaProgression(): Int {
-                    return if (alignToTop) {
-                        (slot.top + (initialProgression * slot.height).toInt()).coerceAtLeast(0)
-                    } else {
-                        ContinuousPositionTracker.scrollYForProgression(
+            // Three landing strategies in priority order:
+            //  1) annotation-decoration anchor: the `<mark data-riffle-ann="<id>">` exists only
+            //     after applyAnnotationHighlightsJs has run inside onPageFinished (post-style-
+            //     injection / post-reflow), so its rect reflects the FINAL layout. Exact landing.
+            //  2) element-id anchor (#fragment): for TOC/cross-ref targets that point at a real
+            //     DOM element. Same recipe but the element is created by the chapter itself.
+            //  3) progression × slot.height: char-fraction × measured-WebView-height — works
+            //     for the resource-top / resume case but lands inexactly when the highlight sits
+            //     in dense text (heading-vs-paragraph density mismatch).
+            //
+            // The reflow-tracking re-land (see [appendChapter]'s onHeightMeasured) re-fires this
+            // closure on every target remeasure, so a cold start where (1) returns null on the
+            // first fire (mark not yet decorated) falls back to (2)/(3), and the NEXT remeasure
+            // — which is virtually always after applyAnnotationHighlightsJs has run — re-fires
+            // and snaps onto the precise mark Y.
+            //
+            // slot / target WebView are resolved by href INSIDE the deferred [post]: a forward or
+            // backward shift can fire between closure invocation and the scrollTo draining (the
+            // closure clears [pendingInitialScroll] before posting, so [maybeShift] is no longer
+            // gated; a previously-queued scroll handler can trigger a shift via [handleScrollChange]).
+            // A captured pre-shift [pendingTargetWindowIndex] would then point at the NEXT chapter,
+            // landing the user one chapter forward. Looking up by href is shift-stable.
+            fun postLandAt(offsetWithinTargetPx: Int?) {
+                post {
+                    val i = webViewIndexFor(targetHref) ?: return@post
+                    val slot = buildWindow().getOrNull(i) ?: return@post
+                    val y = when {
+                        offsetWithinTargetPx != null -> (slot.top + offsetWithinTargetPx).coerceAtLeast(0)
+                        alignToTop -> (slot.top + (initialProgression * slot.height).toInt()).coerceAtLeast(0)
+                        else -> ContinuousPositionTracker.scrollYForProgression(
                             slot.top, slot.height, initialProgression, height,
                         )
                     }
+                    abortFling()
+                    scrollTo(0, y)
+                    // Hold the landing target against framework smooth-scroll restoration of a
+                    // stale scrollY from view-state. Without this, NestedScrollView's mScroller
+                    // resumes ~50ms after this scrollTo and drives the viewport hundreds of pixels
+                    // toward an old saved position — pushing the reader past the actual saved
+                    // position on every reopen.
+                    landingHoldTargetY = y
+                    landingHoldUntilUptimeMs = android.os.SystemClock.uptimeMillis() + LANDING_HOLD_MS
                 }
-                fun landViaAnchor(onMiss: () -> Unit) {
-                    if (anchorFragment.isNotEmpty() && targetWv != null) {
-                        targetWv.anchorOffsetTopDevicePx(anchorFragment) { anchorOffset ->
-                            if (anchorOffset != null) post { scrollTo(0, (slot.top + anchorOffset).coerceAtLeast(0)) }
-                            else onMiss()
-                        }
-                    } else {
-                        onMiss()
-                    }
-                }
-                // post the scrollTo so the pending requestLayout from onHeightMeasured's
-                // layoutParams update has a chance to run BEFORE NestedScrollView clamps the target
-                // against the child's measured height. Without this, on first measurement the WV's
-                // layout is still at the pre-reflow size (~2274px) and scrollTo(0, 8544) clamps to
-                // (childMeasured - viewHeight), stranding the reader well short of the annotation.
-                if (focusAnnotationId != null && targetWv != null) {
-                    targetWv.annotationOffsetTopDevicePx(focusAnnotationId) { annOffset ->
-                        if (annOffset != null) {
-                            post { scrollTo(0, (slot.top + annOffset).coerceAtLeast(0)) }
-                        } else {
-                            landViaAnchor { post { scrollTo(0, landViaProgression()) } }
-                        }
+            }
+            val targetWv = webViewIndexFor(targetHref)?.let { webViews.getOrNull(it) }
+            fun resolveAnchorThenLand() {
+                if (anchorFragment.isNotEmpty() && targetWv != null) {
+                    targetWv.anchorOffsetTopDevicePx(anchorFragment) { anchorOffset ->
+                        postLandAt(anchorOffset)
                     }
                 } else {
-                    landViaAnchor { post { scrollTo(0, landViaProgression()) } }
+                    postLandAt(null)
                 }
+            }
+            if (focusAnnotationId != null && targetWv != null) {
+                targetWv.annotationOffsetTopDevicePx(focusAnnotationId) { annOffset ->
+                    if (annOffset != null) postLandAt(annOffset)
+                    else resolveAnchorThenLand()
+                }
+            } else {
+                resolveAnchorThenLand()
             }
         }
 
@@ -888,7 +939,7 @@ internal class ContinuousReaderView @JvmOverloads constructor(
      * call sites just invoke this and don't need to repeat the index check.
      */
     private fun onAnnotationHighlightsApplied(wv: ChapterWebView) {
-        if (webViews.indexOf(wv) != pendingTargetWindowIndex) return
+        if (wv.chapterHref != pendingTargetHref) return
         reapplyLandingAfterFallback?.invoke()
         scrollToPendingFocusAnnotation(wv)
     }
@@ -901,7 +952,10 @@ internal class ContinuousReaderView @JvmOverloads constructor(
         val id = pendingFocusAnnotationId ?: return
         wv.annotationOffsetTopDevicePx(id) { annOffset ->
             if (annOffset == null) return@annotationOffsetTopDevicePx
-            val slot = buildWindow().getOrNull(pendingTargetWindowIndex) ?: return@annotationOffsetTopDevicePx
+            // Resolve by href, not by index — a window shift between the JS in-flight and this
+            // callback would otherwise look up the wrong slot.
+            val i = pendingTargetHref?.let { webViewIndexFor(it) } ?: return@annotationOffsetTopDevicePx
+            val slot = buildWindow().getOrNull(i) ?: return@annotationOffsetTopDevicePx
             val y = (slot.top + annOffset).coerceAtLeast(0)
             post { scrollTo(0, y) }
             pendingFocusAnnotationId = null
@@ -1011,8 +1065,10 @@ internal class ContinuousReaderView @JvmOverloads constructor(
                     // a re-land that tracks the target chapter's height until it stabilises so the
                     // landing follows the reflow. Disarmed on the first manual touch.
                     reapplyLandingAfterFallback = scroll
-                    reapplyTargetLastHeight = measuredHeights.getOrElse(pendingTargetWindowIndex) { measuredPx }
-                } else if (i == pendingTargetWindowIndex && reapplyLandingAfterFallback != null &&
+                    val targetIdx = pendingTargetHref?.let { webViewIndexFor(it) } ?: -1
+                    reapplyTargetLastHeight = measuredHeights.getOrElse(targetIdx) { measuredPx }
+                } else if (webViews.getOrNull(i)?.chapterHref == pendingTargetHref &&
+                    reapplyLandingAfterFallback != null &&
                     measuredPx != reapplyTargetLastHeight
                 ) {
                     // Re-land on EACH target remeasure — the chapter keeps growing as typography

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
@@ -210,13 +210,10 @@ internal class ContinuousReaderView @JvmOverloads constructor(
      *  it fires against the new window's [pendingInitialScroll]. */
     private var pendingFallbackRunnable: Runnable? = null
 
-    /** Window index of the chapter the initial scroll lands on (set in [openWindowAt]). */
-    private var pendingTargetWindowIndex: Int = -1
-
     /** Href of the chapter the initial scroll lands on. Stable across window shifts — used to
      *  re-resolve the current window slot at scrollTo time so a forward/backward shift between
      *  [pendingInitialScroll] firing and the deferred [post] draining doesn't lock in pre-shift
-     *  coordinates (was: a shift made [pendingTargetWindowIndex] point at the next chapter and
+     *  coordinates (was: a shift made the captured window index point at the next chapter and
      *  the saved-position restore landed one chapter forward). */
     private var pendingTargetHref: String? = null
 
@@ -614,7 +611,6 @@ internal class ContinuousReaderView @JvmOverloads constructor(
         )
         topIndex = initial.topIndex
         val targetWindowIndex = initial.targetWindowIndex
-        pendingTargetWindowIndex = targetWindowIndex
         pendingTargetHref = initialHref
         reapplyLandingAfterFallback = null
         reapplyTargetLastHeight = -1
@@ -646,8 +642,8 @@ internal class ContinuousReaderView @JvmOverloads constructor(
             // backward shift can fire between closure invocation and the scrollTo draining (the
             // closure clears [pendingInitialScroll] before posting, so [maybeShift] is no longer
             // gated; a previously-queued scroll handler can trigger a shift via [handleScrollChange]).
-            // A captured pre-shift [pendingTargetWindowIndex] would then point at the NEXT chapter,
-            // landing the user one chapter forward. Looking up by href is shift-stable.
+            // A captured pre-shift window index would then point at the NEXT chapter, landing the
+            // user one chapter forward. Looking up by href is shift-stable.
             fun postLandAt(offsetWithinTargetPx: Int?) {
                 post {
                     val i = webViewIndexFor(targetHref)

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
@@ -574,6 +574,12 @@ internal class ContinuousReaderView @JvmOverloads constructor(
         // Clear the oscillation guard so a stale forward-shift flag from the previous position
         // doesn't suppress the first backward check after the window is rebuilt here.
         windowManager.reset()
+        // Hide the chapter stack until the initial scroll lands. While chapters mount with
+        // placeholder heights and then shrink to their real sizes, NestedScrollView re-clamps
+        // scrollY in big visible jumps (e.g. 0 → 460 → 5396) — the user sees the wrong content
+        // sliding past before the land snaps to the right spot. Held invisible until [postLandAt]
+        // runs the deferred scrollTo and the target slot.height has stabilised.
+        container.visibility = android.view.View.INVISIBLE
 
         val targetIndex = ContinuousPositionTracker
             .chapterIndexForHref(allChapters.map { it.link.href.toString() }, initialHref)
@@ -635,8 +641,14 @@ internal class ContinuousReaderView @JvmOverloads constructor(
             // landing the user one chapter forward. Looking up by href is shift-stable.
             fun postLandAt(offsetWithinTargetPx: Int?) {
                 post {
-                    val i = webViewIndexFor(targetHref) ?: return@post
-                    val slot = buildWindow().getOrNull(i) ?: return@post
+                    val i = webViewIndexFor(targetHref)
+                    val slot = i?.let { buildWindow().getOrNull(it) }
+                    if (i == null || slot == null) {
+                        // Target dropped out of the window before this fired — reveal anyway so
+                        // the user isn't stuck staring at a blank page.
+                        container.visibility = android.view.View.VISIBLE
+                        return@post
+                    }
                     val y = when {
                         offsetWithinTargetPx != null -> (slot.top + offsetWithinTargetPx).coerceAtLeast(0)
                         alignToTop -> (slot.top + (initialProgression * slot.height).toInt()).coerceAtLeast(0)
@@ -653,6 +665,10 @@ internal class ContinuousReaderView @JvmOverloads constructor(
                     // position on every reopen.
                     landingHoldTargetY = y
                     landingHoldUntilUptimeMs = android.os.SystemClock.uptimeMillis() + LANDING_HOLD_MS
+                    // Reveal the chapter stack on the next frame so the first paint after the
+                    // visibility change happens against the post-scrollTo position, not the
+                    // pre-scrollTo one — eliminates the "page slides into place" flash.
+                    postOnAnimation { container.visibility = android.view.View.VISIBLE }
                 }
             }
             val targetWv = webViewIndexFor(targetHref)?.let { webViews.getOrNull(it) }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
@@ -681,10 +681,17 @@ internal class ContinuousReaderView @JvmOverloads constructor(
                 }
             }
             val targetWv = webViewIndexFor(targetHref)?.let { webViews.getOrNull(it) }
+            // The offset returned by the async JS query is only trustworthy if [targetWv] is still
+            // serving the target chapter. A window shift between the JS dispatch and its callback
+            // can recycle [targetWv] to a different chapter (the closure cleared
+            // [pendingInitialScroll], unblocking [maybeShift]), in which case the JS resolved
+            // against the wrong DOM. Treat that case as a miss and fall back to progression.
+            fun ChapterWebView.offsetIfStillTarget(offset: Int?): Int? =
+                if (offset != null && chapterHref == targetHref) offset else null
             fun resolveAnchorThenLand() {
                 if (anchorFragment.isNotEmpty() && targetWv != null) {
                     targetWv.anchorOffsetTopDevicePx(anchorFragment) { anchorOffset ->
-                        postLandAt(anchorOffset)
+                        postLandAt(targetWv.offsetIfStillTarget(anchorOffset))
                     }
                 } else {
                     postLandAt(null)
@@ -692,7 +699,8 @@ internal class ContinuousReaderView @JvmOverloads constructor(
             }
             if (focusAnnotationId != null && targetWv != null) {
                 targetWv.annotationOffsetTopDevicePx(focusAnnotationId) { annOffset ->
-                    if (annOffset != null) postLandAt(annOffset)
+                    val validated = targetWv.offsetIfStillTarget(annOffset)
+                    if (validated != null) postLandAt(validated)
                     else resolveAnchorThenLand()
                 }
             } else {

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -1778,6 +1778,30 @@ private fun EpubNavigatorView(
         if (isContinuous) navigating = false
     }
 
+    // Sync the Readium fragment to the continuous reader's position when the user switches
+    // FROM Continuous to a Readium-driven mode. In continuous mode the fragment is held alive
+    // for its HTTP server only — invisible, height=0 — and TOC/scroll navigation steers
+    // ContinuousReaderView via [ContinuousNavigationTarget], leaving the fragment parked at
+    // wherever the book first opened. Without this, mode-switching showed the user the original
+    // book-open chapter instead of the chapter they were actually reading in continuous mode.
+    //
+    // Suppress the first composition so a fresh open (already initialised with the same
+    // locator) doesn't fire a redundant nav. wasContinuous tracks the previous value via
+    // rememberSaveable so a config change can't fire a spurious sync.
+    var wasContinuous by rememberSaveable { mutableStateOf(isContinuous) }
+    LaunchedEffect(isContinuous) {
+        val transitionedFromContinuous = wasContinuous && !isContinuous
+        wasContinuous = isContinuous
+        if (!transitionedFromContinuous) return@LaunchedEffect
+        val locator = currentLatestLocator() ?: return@LaunchedEffect
+        // Wait for the fragment to be present AND for the AndroidView update block to have
+        // flipped its container visibility (mode change → recomposition → update runs). The
+        // navigator's WebView only completes go() once visible, so navigating it while still
+        // height=0 would suspend forever (the same gotcha called out in onNavigationEvents).
+        val fragment = snapshotFlow { fragmentRef.value }.filterNotNull().first()
+        fragment.go(locator, animated = false)
+    }
+
     DisposableEffect(tapListener) {
         onDispose { fragmentRef.value?.removeInputListener(tapListener) }
     }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -2026,7 +2026,19 @@ private fun EpubNavigatorView(
                     coroutineScope.launch {
                         fragment.currentLocator.collect { locator ->
                             currentHrefHolder[0] = locator.href.toString()
-                            onPositionChanged(locator)
+                            // In Continuous mode the EpubNavigatorFragment is held alive only to keep
+                            // Readium's HTTP server up (see the height=0 / INVISIBLE collapse above).
+                            // Its currentLocator still emits its content-top "initial locator"
+                            // (progression=0 with the chapter title) shortly after WebView load —
+                            // typically AFTER ContinuousReaderView has already persisted a real
+                            // midpoint-derived position via [onRawPosition]. Without this guard, that
+                            // delayed Readium emission overwrites the saved position with prog=0,
+                            // and the next reopen lands viewport-top at the chapter top instead of
+                            // the user's actual reading spot. ContinuousReaderView owns position
+                            // tracking in this mode.
+                            if (formattingPrefsProvider().orientation != ReaderOrientation.Continuous) {
+                                onPositionChanged(locator)
+                            }
                             val key = locator.href.removeFragment().toString()
                             if (key.isNotEmpty() && !footnoteDocCache.containsKey(key)) {
                                 launch(Dispatchers.IO) {
@@ -2130,6 +2142,13 @@ private fun EpubNavigatorView(
                     initialHref = initialHref,
                     initialProgression = initialLocator?.locations?.progression?.toFloat() ?: 0f,
                     publication = state.publication,
+                    // Saved reading positions come from locatorAt, which measures progression at the
+                    // viewport midpoint. The inverse — scrollYForProgression — places mid-chapter
+                    // progressions back at the midpoint. Top-aligning instead drifts the view
+                    // forward by half a viewport on every reopen. Annotation-tap opens still land
+                    // precisely via the focusAnnotationId mark-anchor path in openWindowAt, which
+                    // takes priority over the progression fallback.
+                    alignToTop = false,
                     focusAnnotationId = focusId,
                 )
             }

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousPositionTrackerTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousPositionTrackerTest.kt
@@ -70,6 +70,23 @@ class ContinuousPositionTrackerTest {
     }
 
     @Test
+    fun `top-aligning a midpoint-saved progression drifts forward by half a viewport — do not use for resume`() {
+        // Pins the failure mode behind the resume-overshoot bug: the call site that opens at a saved
+        // position must invoke scrollYForProgression (midpoint inverse), NOT the slot.top + p*height
+        // top-alignment used for TOC/bookmark jumps. Using top-alignment on a locatorAt-derived
+        // progression lands the view exactly viewport/2 past the original scrollY on every reopen.
+        val viewport = 800
+        for (scrollY in listOf(200, 400, 700, 900)) {
+            val (href, prog) = ContinuousPositionTracker.locatorAt(scrollY, viewport, window)
+            val slot = window.first { it.href == href }
+            val topAligned = (slot.top + (prog * slot.height).toInt()).coerceAtLeast(0)
+            assertEquals(
+                "scrollY=$scrollY", (scrollY + viewport / 2).toFloat(), topAligned.toFloat(), 2f,
+            )
+        }
+    }
+
+    @Test
     fun `scrollYForProgression top-aligns a chapter start and never goes negative`() {
         // progression 0 → top of the chapter (no half-viewport shift up into the previous chapter).
         assertEquals(1000, ContinuousPositionTracker.scrollYForProgression(1000, 500, 0f, 800))


### PR DESCRIPTION
## Summary

Continuous-mode reading position was pushed forward by one chapter on every reopen. After a few sessions the user could no longer reach where they actually stopped reading — the reader would land deep in a later chapter every time.

Root cause was four interacting bugs in the reopen path:

1. **Resume restored progression with the wrong inverse.** `locatorAt` saves progression at the viewport midpoint; the resume path top-aligned it instead, drifting forward by half a viewport on every reopen — and by entire chapter slots when chapters are shorter than the viewport. Resume now passes `alignToTop = false` so the midpoint-aware `scrollYForProgression` is used (TOC/bookmark jumps still top-align).
2. **The deferred landing scroll captured a stale slot.** The closure built `slot` from a window index then `post {}`-ed the actual `scrollTo`; a forward window shift between fire and drain moved every chapter's index by −1, but the captured slot pointed at the old position. Slot is now resolved by stable href inside the deferred block.
3. **NestedScrollView's `mScroller` resumed a smooth-scroll restoration of a stale scroll position from view-state** ~50ms after the land, driving `scrollY` hundreds of pixels off-target via `computeScroll`+`overScrollBy` (bypassing `scrollTo`/`scrollBy` overrides). Short landing-hold window holds the target; cleared on user touch and on intentional programmatic scrolls.
4. **In continuous mode the hidden `EpubNavigatorFragment`** (kept alive only for its HTTP server) still emitted its content-top initial locator into `onPositionChanged`, clobbering the midpoint-derived position written by `ContinuousReaderView`. Now gated on `orientation != Continuous`.

Additional adjacent fixes from the same investigation:

- Hide the chapter stack until the initial scroll lands — kills the "page slides into place" flash caused by placeholder-height shrink + NestedScrollView re-clamping.
- Sync the Readium fragment to the continuous reader's position when switching from Continuous to Scroll/Paginated — fragment was parked at the original open chapter and ignored continuous-mode TOC navigations.

Three follow-up fixes from ultracode review:
- Clear the landing-hold on intentional programmatic scrolls (volume keys, readaloud highlight follow, in-window TOC, post-annotation re-land) — was reverting all of them within 600ms of the land.
- Drop the initial-land offset if the `targetWv` was recycled to a different chapter while the JS offset query was in flight.
- Delete `pendingTargetWindowIndex` — became write-only after the href migration and was an attractive nuisance for re-introducing the shift-staleness bug.

## Test plan
- [x] Regression test in `ContinuousPositionTrackerTest` pinning the failure mode (top-aligning a midpoint-saved progression drifts exactly viewport/2 forward)
- [ ] Verified on device: open book, exit, reopen — lands at exact saved position; repeated reopens stay stable
- [ ] Verified on device: open book, TOC-jump to a different chapter in continuous mode, switch to Scroll — fragment is at the navigated chapter, not the original open
- [ ] Verified on device: open book, immediately press volume key — page advances and stays advanced (not snapped back to land)