### PR TITLE
refactor(data): scope library_items queries by serverId end-to-end (#301)

### DIFF
--- a/core/data/src/main/kotlin/com/riffle/core/data/LibraryRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/LibraryRepositoryImpl.kt
@@ -33,7 +33,6 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
@@ -70,24 +69,6 @@ class LibraryRepositoryImpl @Inject constructor(
     override fun observeLibraries(serverId: String): Flow<List<Library>> =
         libraryDao.observeByServerId(serverId).map { list -> list.map { it.toDomain() } }
 
-    override fun observeLibraryItems(libraryId: String): Flow<List<LibraryItem>> =
-        libraryItemDao.observeByLibraryId(libraryId).scopedToActiveServer()
-
-    override fun observeUngroupedLibraryItems(libraryId: String): Flow<List<LibraryItem>> =
-        libraryItemDao.observeUngroupedByLibraryId(libraryId).scopedToActiveServer()
-
-    override fun observeInProgressItems(libraryId: String): Flow<List<LibraryItem>> =
-        libraryItemDao.observeInProgress(libraryId).scopedToActiveServer()
-
-    override fun observeFinishedItems(libraryId: String): Flow<List<LibraryItem>> =
-        libraryItemDao.observeFinished(libraryId).scopedToActiveServer()
-
-    override fun observeRecentlyAddedItems(libraryId: String): Flow<List<LibraryItem>> =
-        libraryItemDao.observeRecentlyAdded(libraryId).scopedToActiveServer()
-
-    override fun observeAllBooks(libraryId: String): Flow<List<LibraryItem>> =
-        libraryItemDao.observeAllBooks(libraryId).scopedToActiveServer()
-
     // Id of the Server whose libraries the user is currently browsing. The nav drawer only ever
     // lists the active Server's libraries, so the visible library always belongs to it.
     private val activeServerId: Flow<String?> =
@@ -95,18 +76,36 @@ class LibraryRepositoryImpl @Inject constructor(
             .map { servers -> servers.firstOrNull { it.isActive }?.id }
             .distinctUntilChanged()
 
-    // Two Servers pointing at the same Audiobookshelf instance emit identical library and item ids
-    // (issue #113), so the libraryId-keyed item-shelf queries return a row per Server. Keep only the
-    // active Server's copy — the one book detail reads and markAsRead/the reader write. Without this,
-    // an inactive duplicate's stale progress keeps a finished book pinned to In Progress even though
-    // detail shows 100%. No active Server → pass rows through (nothing is being browsed anyway), still
-    // collapsing any duplicate ids. Mirrors how observeLibraries/getLibrary/getItem scope by Server.
-    private fun Flow<List<LibraryItemEntity>>.scopedToActiveServer(): Flow<List<LibraryItem>> =
-        combine(activeServerId) { list, serverId ->
-            list.filter { serverId == null || it.serverId == serverId }
-                .distinctBy { it.id }
-                .map { it.toDomain() }
+    // Library-scoped item flows resolve the active Server's id and pass it as the DAO's primary
+    // scope. library_items is keyed by (serverId, id) (ADR 0025), so the query itself enforces
+    // server isolation — no post-query filter required. With no active Server the screen has
+    // nothing to show, so we emit an empty list rather than mixing data across Servers.
+    @OptIn(ExperimentalCoroutinesApi::class)
+    private fun scopedItemFlow(
+        query: (String) -> Flow<List<LibraryItemEntity>>,
+    ): Flow<List<LibraryItem>> =
+        activeServerId.flatMapLatest { serverId ->
+            if (serverId == null) flowOf(emptyList())
+            else query(serverId).map { list -> list.map { it.toDomain() } }
         }
+
+    override fun observeLibraryItems(libraryId: String): Flow<List<LibraryItem>> =
+        scopedItemFlow { serverId -> libraryItemDao.observeByLibraryId(serverId, libraryId) }
+
+    override fun observeUngroupedLibraryItems(libraryId: String): Flow<List<LibraryItem>> =
+        scopedItemFlow { serverId -> libraryItemDao.observeUngroupedByLibraryId(serverId, libraryId) }
+
+    override fun observeInProgressItems(libraryId: String): Flow<List<LibraryItem>> =
+        scopedItemFlow { serverId -> libraryItemDao.observeInProgress(serverId, libraryId) }
+
+    override fun observeFinishedItems(libraryId: String): Flow<List<LibraryItem>> =
+        scopedItemFlow { serverId -> libraryItemDao.observeFinished(serverId, libraryId) }
+
+    override fun observeRecentlyAddedItems(libraryId: String): Flow<List<LibraryItem>> =
+        scopedItemFlow { serverId -> libraryItemDao.observeRecentlyAdded(serverId, libraryId) }
+
+    override fun observeAllBooks(libraryId: String): Flow<List<LibraryItem>> =
+        scopedItemFlow { serverId -> libraryItemDao.observeAllBooks(serverId, libraryId) }
 
     override fun observeSeries(libraryId: String): Flow<List<Series>> =
         seriesDao.observeByLibraryId(libraryId).map { list -> list.map { it.toDomain() } }
@@ -115,13 +114,13 @@ class LibraryRepositoryImpl @Inject constructor(
         collectionDao.observeByLibraryId(libraryId).map { list -> list.map { it.toDomain() } }
 
     override fun observeSeriesItems(seriesId: String): Flow<List<LibraryItem>> =
-        seriesDao.observeItemsBySeriesId(seriesId).scopedToActiveServer()
+        scopedItemFlow { serverId -> seriesDao.observeItemsBySeriesId(serverId, seriesId) }
 
     override fun observeContinueSeriesItems(libraryId: String): Flow<List<LibraryItem>> =
-        seriesDao.observeContinueSeriesItems(libraryId).scopedToActiveServer()
+        scopedItemFlow { serverId -> seriesDao.observeContinueSeriesItems(serverId, libraryId) }
 
     override fun observeCollectionItems(collectionId: String): Flow<List<LibraryItem>> =
-        collectionDao.observeItemsByCollectionId(collectionId).scopedToActiveServer()
+        scopedItemFlow { serverId -> collectionDao.observeItemsByCollectionId(serverId, collectionId) }
 
     // Item ids are only unique within a Server (ADR 0025); reads/writes here target the active
     // Server's copy, mirroring how reading positions are keyed. No active Server → nothing to do.
@@ -197,7 +196,7 @@ class LibraryRepositoryImpl @Inject constructor(
             }
             when (val result = itemsDeferred.await()) {
                 is NetworkLibraryItemsResult.Success -> {
-                    val lastOpenedAtMap = libraryItemDao.getLastOpenedAtMap(libraryId).associate { it.id to it.lastOpenedAt }
+                    val lastOpenedAtMap = libraryItemDao.getLastOpenedAtMap(server.id, libraryId).associate { it.id to it.lastOpenedAt }
                     val entities = result.items
                         .sortedByDescending { it.isSupported }
                         .distinctBy { it.title.trim().lowercase() }
@@ -239,7 +238,7 @@ class LibraryRepositoryImpl @Inject constructor(
                                 finishedAt = serverProgress?.finishedAt,
                             )
                         }
-                    libraryItemDao.replaceAllForLibrary(libraryId, entities)
+                    libraryItemDao.replaceAllForLibrary(server.id, libraryId, entities)
                     val isUnsupported = entities.isNotEmpty() && entities.none { it.ebookFormat != EbookFormat.Unsupported.toStorageString() }
                     libraryDao.setUnsupported(server.id, libraryId, isUnsupported)
                     // syncStale and reconcileLinks are not on the critical path — fire them on a

--- a/core/data/src/main/kotlin/com/riffle/core/data/ServerRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/ServerRepositoryImpl.kt
@@ -189,7 +189,7 @@ class ServerRepositoryImpl @Inject constructor(
         // For Storyteller servers this purges the synthetic Readaloud library and its books;
         // for ABS servers it cleans up real libraries and their items. ReadaloudLinks cross-server
         // cleanup belongs to #36 (matching slice) — until that lands the count of links is 0.
-        libraryDao.libraryIdsForServer(serverId).forEach { libraryItemDao.deleteByLibraryId(it) }
+        libraryDao.libraryIdsForServer(serverId).forEach { libraryItemDao.deleteByLibraryId(serverId, it) }
         libraryDao.deleteByServerId(serverId)
         dao.deleteById(serverId)
         tokenStorage.deleteToken(serverId)

--- a/core/data/src/main/kotlin/com/riffle/core/data/StorytellerReadaloudSyncer.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/StorytellerReadaloudSyncer.kt
@@ -89,8 +89,8 @@ open class StorytellerReadaloudSyncer(
         val libraryId = ServerRepositoryImpl.readaloudLibraryId(server.id)
         return when (val r = storytellerApi.listReadalouds(server.url.value, token, server.insecureConnectionAllowed)) {
             is NetworkStorytellerBooksResult.Success -> {
-                val lastOpenedAtMap = libraryItemDao.getLastOpenedAtMap(libraryId).associate { it.id to it.lastOpenedAt }
-                val progressMap = libraryItemDao.getReadingProgressMap(libraryId).associate { it.id to it.readingProgress }
+                val lastOpenedAtMap = libraryItemDao.getLastOpenedAtMap(server.id, libraryId).associate { it.id to it.lastOpenedAt }
+                val progressMap = libraryItemDao.getReadingProgressMap(server.id, libraryId).associate { it.id to it.readingProgress }
                 val entities = storytellerBooksToEntities(
                     books = r.books,
                     serverId = server.id,
@@ -99,7 +99,7 @@ open class StorytellerReadaloudSyncer(
                     lastOpenedAtMap = lastOpenedAtMap,
                     progressMap = progressMap,
                 )
-                libraryItemDao.replaceAllForLibrary(libraryId, entities)
+                libraryItemDao.replaceAllForLibrary(server.id, libraryId, entities)
                 true
             }
             is NetworkStorytellerBooksResult.NetworkError -> false

--- a/core/data/src/test/kotlin/com/riffle/core/data/FakeLibraryItemDao.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/FakeLibraryItemDao.kt
@@ -16,23 +16,26 @@ internal class FakeLibraryItemDao : LibraryItemDao {
     fun itemsFor(libraryId: String): List<LibraryItemEntity> =
         roomData[libraryId]?.value ?: emptyList()
 
-    override fun observeByLibraryId(libraryId: String): Flow<List<LibraryItemEntity>> =
-        roomData.getOrPut(libraryId) { MutableStateFlow(emptyList()) }
+    private fun scoped(serverId: String, libraryId: String): List<LibraryItemEntity> =
+        roomData[libraryId]?.value?.filter { it.serverId == serverId }.orEmpty()
 
-    override fun observeUngroupedByLibraryId(libraryId: String): Flow<List<LibraryItemEntity>> =
-        roomData.getOrPut(libraryId) { MutableStateFlow(emptyList()) }
+    override fun observeByLibraryId(serverId: String, libraryId: String): Flow<List<LibraryItemEntity>> =
+        MutableStateFlow(scoped(serverId, libraryId))
 
-    override fun observeInProgress(libraryId: String): Flow<List<LibraryItemEntity>> =
-        MutableStateFlow(roomData[libraryId]?.value?.filter { it.readingProgress > 0f && it.readingProgress < 1f } ?: emptyList())
+    override fun observeUngroupedByLibraryId(serverId: String, libraryId: String): Flow<List<LibraryItemEntity>> =
+        MutableStateFlow(scoped(serverId, libraryId))
 
-    override fun observeFinished(libraryId: String): Flow<List<LibraryItemEntity>> =
-        MutableStateFlow(roomData[libraryId]?.value?.filter { it.readingProgress == 1f } ?: emptyList())
+    override fun observeInProgress(serverId: String, libraryId: String): Flow<List<LibraryItemEntity>> =
+        MutableStateFlow(scoped(serverId, libraryId).filter { it.readingProgress > 0f && it.readingProgress < 1f })
 
-    override fun observeRecentlyAdded(libraryId: String): Flow<List<LibraryItemEntity>> =
-        MutableStateFlow(roomData[libraryId]?.value?.sortedByDescending { it.addedAt } ?: emptyList())
+    override fun observeFinished(serverId: String, libraryId: String): Flow<List<LibraryItemEntity>> =
+        MutableStateFlow(scoped(serverId, libraryId).filter { it.readingProgress == 1f })
 
-    override fun observeAllBooks(libraryId: String): Flow<List<LibraryItemEntity>> =
-        roomData.getOrPut(libraryId) { MutableStateFlow(emptyList()) }
+    override fun observeRecentlyAdded(serverId: String, libraryId: String): Flow<List<LibraryItemEntity>> =
+        MutableStateFlow(scoped(serverId, libraryId).sortedByDescending { it.addedAt })
+
+    override fun observeAllBooks(serverId: String, libraryId: String): Flow<List<LibraryItemEntity>> =
+        MutableStateFlow(scoped(serverId, libraryId))
 
     override suspend fun upsertAll(items: List<LibraryItemEntity>) {
         upserted.addAll(items)
@@ -101,23 +104,22 @@ internal class FakeLibraryItemDao : LibraryItemDao {
     override suspend fun findServerIdForItem(itemId: String): String? =
         roomData.values.flatMap { it.value }.firstOrNull { it.id == itemId }?.serverId
 
-    override suspend fun deleteByLibraryId(libraryId: String) {
-        roomData[libraryId]?.value = emptyList()
+    override suspend fun deleteByLibraryId(serverId: String, libraryId: String) {
+        val current = roomData[libraryId]?.value ?: return
+        roomData[libraryId]!!.value = current.filterNot { it.serverId == serverId }
     }
 
     override suspend fun updateLastOpenedAt(serverId: String, itemId: String, timestamp: Long) {}
 
-    override suspend fun getLastOpenedAtMap(libraryId: String): List<LastOpenedAtRow> =
-        roomData[libraryId]?.value
-            ?.filter { it.lastOpenedAt != null }
-            ?.map { LastOpenedAtRow(it.id, it.lastOpenedAt!!) }
-            ?: emptyList()
+    override suspend fun getLastOpenedAtMap(serverId: String, libraryId: String): List<LastOpenedAtRow> =
+        scoped(serverId, libraryId)
+            .filter { it.lastOpenedAt != null }
+            .map { LastOpenedAtRow(it.id, it.lastOpenedAt!!) }
 
-    override suspend fun getReadingProgressMap(libraryId: String): List<ReadingProgressRow> =
-        roomData[libraryId]?.value
-            ?.filter { it.readingProgress > 0f }
-            ?.map { ReadingProgressRow(it.id, it.readingProgress) }
-            ?: emptyList()
+    override suspend fun getReadingProgressMap(serverId: String, libraryId: String): List<ReadingProgressRow> =
+        scoped(serverId, libraryId)
+            .filter { it.readingProgress > 0f }
+            .map { ReadingProgressRow(it.id, it.readingProgress) }
 
     override suspend fun updateReadingProgress(serverId: String, itemId: String, progress: Float) {}
 

--- a/core/data/src/test/kotlin/com/riffle/core/data/LibraryRepositoryTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/LibraryRepositoryTest.kt
@@ -47,9 +47,13 @@ import java.io.IOException
 class LibraryRepositoryTest {
 
     private val fakeServerRepository = object : ServerRepository {
-        var activeServer: Server? = null
-        override fun observeAll() = MutableStateFlow(listOfNotNull(activeServer))
-        override suspend fun getActive() = activeServer
+        private val backing = MutableStateFlow<List<Server>>(emptyList())
+        var activeServer: Server?
+            get() = backing.value.firstOrNull { it.isActive }
+            set(value) { backing.value = listOfNotNull(value) }
+        fun setServers(servers: List<Server>) { backing.value = servers }
+        override fun observeAll() = backing
+        override suspend fun getActive() = backing.value.firstOrNull { it.isActive }
         override suspend fun authenticate(url: ServerUrl, username: String, password: String, insecureAllowed: Boolean, serverType: com.riffle.core.domain.ServerType): AuthenticateResult =
             AuthenticateResult.NetworkError(IOException())
         override suspend fun commit(pending: PendingServer, hiddenLibraryIds: Set<String>): CommitServerResult =
@@ -109,14 +113,14 @@ class LibraryRepositoryTest {
         override fun observeByLibraryId(libraryId: String): Flow<List<SeriesEntity>> =
             seriesData.getOrPut(libraryId) { MutableStateFlow(emptyList()) }
 
-        override fun observeItemsBySeriesId(seriesId: String): Flow<List<LibraryItemEntity>> =
+        override fun observeItemsBySeriesId(serverId: String, seriesId: String): Flow<List<LibraryItemEntity>> =
             itemData.getOrPut(seriesId) { MutableStateFlow(emptyList()) }
 
         override suspend fun findSeriesIdForItem(serverId: String, itemId: String): String? = null
 
         private val continueSeriesData = mutableMapOf<String, MutableStateFlow<List<LibraryItemEntity>>>()
 
-        override fun observeContinueSeriesItems(libraryId: String): Flow<List<LibraryItemEntity>> =
+        override fun observeContinueSeriesItems(serverId: String, libraryId: String): Flow<List<LibraryItemEntity>> =
             continueSeriesData.getOrPut(libraryId) { MutableStateFlow(emptyList()) }
 
         fun seedContinueSeriesItems(libraryId: String, items: List<LibraryItemEntity>) {
@@ -154,7 +158,7 @@ class LibraryRepositoryTest {
         override fun observeByLibraryId(libraryId: String): Flow<List<CollectionEntity>> =
             collectionData.getOrPut(libraryId) { MutableStateFlow(emptyList()) }
 
-        override fun observeItemsByCollectionId(collectionId: String): Flow<List<LibraryItemEntity>> =
+        override fun observeItemsByCollectionId(serverId: String, collectionId: String): Flow<List<LibraryItemEntity>> =
             itemData.getOrPut(collectionId) { MutableStateFlow(emptyList()) }
 
         override suspend fun upsertAll(collections: List<CollectionEntity>) {
@@ -625,6 +629,7 @@ class LibraryRepositoryTest {
 
     @Test
     fun `observeRecentlyAddedItems emits items from DAO ordered by addedAt`() = runTest {
+        fakeServerRepository.activeServer = activeServer()
         val dao = FakeLibraryItemDao()
         dao.upsertAll(listOf(
             LibraryItemEntity("s1", "item-1", "lib-1", "Older Book", "Author", null, 0f, addedAt = 1_000L),
@@ -677,6 +682,7 @@ class LibraryRepositoryTest {
 
     @Test
     fun `hasAudio maps from entity to domain`() = runTest {
+        fakeServerRepository.activeServer = activeServer()
         val dao = FakeLibraryItemDao()
         dao.upsertAll(listOf(LibraryItemEntity("s1", "item-1", "lib-1", "Audiobook", "Author", null, 0f, hasAudio = true)))
         val item = makeRepo(libraryItemDao = dao).observeLibraryItems("lib-1").first()[0]
@@ -687,6 +693,7 @@ class LibraryRepositoryTest {
 
     @Test
     fun `observeLibraryItems emits from Room`() = runTest {
+        fakeServerRepository.activeServer = activeServer()
         val dao = FakeLibraryItemDao()
         dao.upsertAll(listOf(LibraryItemEntity("s1", "item-1", "lib-1", "My Book", "Author A", null, 0.5f)))
         val result = makeRepo(libraryItemDao = dao).observeLibraryItems("lib-1").first()
@@ -720,6 +727,30 @@ class LibraryRepositoryTest {
     }
 
     @Test
+    fun `library shelves re-resolve when active server changes`() = runTest {
+        // ADR 0025: library-item flows resolve activeServerId via flatMapLatest, so when the user
+        // switches Servers, subsequent emissions come only from the new Server's DAO scope —
+        // never a stale snapshot of the previous Server's rows.
+        fakeServerRepository.activeServer = activeServer(id = "s1")
+        val dao = FakeLibraryItemDao()
+        dao.upsertAll(listOf(
+            LibraryItemEntity("s1", "item-1", "lib-shared", "S1 Book", "Author", null, 0.5f),
+            LibraryItemEntity("s2", "item-1", "lib-shared", "S2 Book", "Author", null, 0.2f),
+            LibraryItemEntity("s2", "item-99", "lib-shared", "S2 Other", "Author", null, 0.1f),
+        ))
+        val repo = makeRepo(libraryItemDao = dao)
+
+        val initial = repo.observeLibraryItems("lib-shared").first()
+        assertEquals(listOf("item-1"), initial.map { it.id })
+        assertEquals(0.5f, initial[0].readingProgress, 0.001f)
+
+        fakeServerRepository.activeServer = activeServer(id = "s2")
+        val afterSwitch = repo.observeLibraryItems("lib-shared").first()
+        assertEquals(setOf("item-1", "item-99"), afterSwitch.map { it.id }.toSet())
+        assertEquals(0.2f, afterSwitch.first { it.id == "item-1" }.readingProgress, 0.001f)
+    }
+
+    @Test
     fun `library shelves exclude rows owned by inactive duplicate servers`() = runTest {
         // The active Server (s1) has the in-progress copy; an inactive duplicate (s2) carries a
         // different fraction for the same id. Every shelf must show only the active Server's row.
@@ -744,6 +775,7 @@ class LibraryRepositoryTest {
 
     @Test
     fun `epub ebookFormat maps to isReadable true`() = runTest {
+        fakeServerRepository.activeServer = activeServer()
         val dao = FakeLibraryItemDao()
         dao.upsertAll(listOf(LibraryItemEntity("s1", "item-1", "lib-1", "Dune", "Herbert", null, 0f, ebookFormat = "epub")))
         val item = makeRepo(libraryItemDao = dao).observeLibraryItems("lib-1").first()[0]
@@ -753,6 +785,7 @@ class LibraryRepositoryTest {
 
     @Test
     fun `pdf ebookFormat maps to isReadable true`() = runTest {
+        fakeServerRepository.activeServer = activeServer()
         val dao = FakeLibraryItemDao()
         dao.upsertAll(listOf(LibraryItemEntity("s1", "item-1", "lib-1", "Dune", "Herbert", null, 0f, ebookFormat = "pdf")))
         val item = makeRepo(libraryItemDao = dao).observeLibraryItems("lib-1").first()[0]
@@ -762,6 +795,7 @@ class LibraryRepositoryTest {
 
     @Test
     fun `unsupported ebookFormat maps to isReadable false`() = runTest {
+        fakeServerRepository.activeServer = activeServer()
         val dao = FakeLibraryItemDao()
         dao.upsertAll(listOf(LibraryItemEntity("s1", "item-1", "lib-1", "Dune", "Herbert", null, 0f, ebookFormat = "unsupported")))
         val item = makeRepo(libraryItemDao = dao).observeLibraryItems("lib-1").first()[0]
@@ -771,6 +805,7 @@ class LibraryRepositoryTest {
 
     @Test
     fun `unknown ebookFormat string maps to isReadable false`() = runTest {
+        fakeServerRepository.activeServer = activeServer()
         val dao = FakeLibraryItemDao()
         dao.upsertAll(listOf(LibraryItemEntity("s1", "item-1", "lib-1", "Comic", "Author", null, 0f, ebookFormat = "cbz")))
         val item = makeRepo(libraryItemDao = dao).observeLibraryItems("lib-1").first()[0]
@@ -1005,6 +1040,7 @@ class LibraryRepositoryTest {
 
     @Test
     fun `observeSeriesItems emits items from Room in series order`() = runTest {
+        fakeServerRepository.activeServer = activeServer()
         val dao = FakeSeriesDao()
         val item1 = LibraryItemEntity("s1", "item-1", "lib-1", "WoK", "Sanderson", null, 0.5f)
         val item2 = LibraryItemEntity("s1", "item-2", "lib-1", "WoR", "Sanderson", null, 0f)
@@ -1019,6 +1055,7 @@ class LibraryRepositoryTest {
 
     @Test
     fun `observeContinueSeriesItems maps entities from DAO`() = runTest {
+        fakeServerRepository.activeServer = activeServer()
         val dao = FakeSeriesDao()
         val repo = makeRepo(seriesDao = dao)
         dao.seedContinueSeriesItems("lib-1", listOf(
@@ -1047,6 +1084,7 @@ class LibraryRepositoryTest {
 
     @Test
     fun `observeCollectionItems emits items from Room`() = runTest {
+        fakeServerRepository.activeServer = activeServer()
         val dao = FakeCollectionDao()
         val item1 = LibraryItemEntity("s1", "item-1", "lib-1", "Book A", "Author", null, 0f)
         dao.seedItems("col-1", listOf(item1))

--- a/core/data/src/test/kotlin/com/riffle/core/data/NoopLibraryDaos.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/NoopLibraryDaos.kt
@@ -13,25 +13,25 @@ import kotlinx.coroutines.flow.flowOf
 
 /** Empty [LibraryItemDao] for tests that never touch metadata resolution. */
 internal object ThrowingLibraryItemDao : LibraryItemDao {
-    override fun observeByLibraryId(libraryId: String): Flow<List<LibraryItemEntity>> = flowOf(emptyList())
-    override fun observeUngroupedByLibraryId(libraryId: String): Flow<List<LibraryItemEntity>> = flowOf(emptyList())
-    override fun observeInProgress(libraryId: String): Flow<List<LibraryItemEntity>> = flowOf(emptyList())
-    override fun observeFinished(libraryId: String): Flow<List<LibraryItemEntity>> = flowOf(emptyList())
-    override fun observeRecentlyAdded(libraryId: String): Flow<List<LibraryItemEntity>> = flowOf(emptyList())
-    override fun observeAllBooks(libraryId: String): Flow<List<LibraryItemEntity>> = flowOf(emptyList())
+    override fun observeByLibraryId(serverId: String, libraryId: String): Flow<List<LibraryItemEntity>> = flowOf(emptyList())
+    override fun observeUngroupedByLibraryId(serverId: String, libraryId: String): Flow<List<LibraryItemEntity>> = flowOf(emptyList())
+    override fun observeInProgress(serverId: String, libraryId: String): Flow<List<LibraryItemEntity>> = flowOf(emptyList())
+    override fun observeFinished(serverId: String, libraryId: String): Flow<List<LibraryItemEntity>> = flowOf(emptyList())
+    override fun observeRecentlyAdded(serverId: String, libraryId: String): Flow<List<LibraryItemEntity>> = flowOf(emptyList())
+    override fun observeAllBooks(serverId: String, libraryId: String): Flow<List<LibraryItemEntity>> = flowOf(emptyList())
     override suspend fun upsertAll(items: List<LibraryItemEntity>) = Unit
     override suspend fun insertOrIgnore(items: List<LibraryItemEntity>) = Unit
     override suspend fun updateMetadata(metadata: LibraryItemMetadata) = Unit
     override suspend fun getById(serverId: String, itemId: String): LibraryItemEntity? = null
     override fun observeById(serverId: String, itemId: String): Flow<LibraryItemEntity?> = flowOf(null)
     override suspend fun findServerIdForItem(itemId: String): String? = null
-    override suspend fun deleteByLibraryId(libraryId: String) = Unit
+    override suspend fun deleteByLibraryId(serverId: String, libraryId: String) = Unit
     override suspend fun deleteRemovedFromLibrary(serverId: String, libraryId: String, serverItemIds: List<String>) = Unit
     override suspend fun updateLastOpenedAt(serverId: String, itemId: String, timestamp: Long) = Unit
     override suspend fun updateReadingProgress(serverId: String, itemId: String, progress: Float) = Unit
     override suspend fun updateFinishedAt(serverId: String, itemId: String, finishedAt: Long?) = Unit
-    override suspend fun getLastOpenedAtMap(libraryId: String): List<LastOpenedAtRow> = emptyList()
-    override suspend fun getReadingProgressMap(libraryId: String): List<ReadingProgressRow> = emptyList()
+    override suspend fun getLastOpenedAtMap(serverId: String, libraryId: String): List<LastOpenedAtRow> = emptyList()
+    override suspend fun getReadingProgressMap(serverId: String, libraryId: String): List<ReadingProgressRow> = emptyList()
     override suspend fun listMatchableByServerType(serverType: String): List<MatchableItemRow> = emptyList()
 }
 

--- a/core/data/src/test/kotlin/com/riffle/core/data/ReadaloudMatchingServiceTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/ReadaloudMatchingServiceTest.kt
@@ -378,25 +378,25 @@ class ReadaloudMatchingServiceTest {
             "AUDIOBOOKSHELF" -> abs
             else -> emptyList()
         }
-        override fun observeByLibraryId(libraryId: String): Flow<List<LibraryItemEntity>> = flowOf(emptyList())
-        override fun observeUngroupedByLibraryId(libraryId: String): Flow<List<LibraryItemEntity>> = flowOf(emptyList())
-        override fun observeInProgress(libraryId: String): Flow<List<LibraryItemEntity>> = flowOf(emptyList())
-        override fun observeFinished(libraryId: String): Flow<List<LibraryItemEntity>> = flowOf(emptyList())
-        override fun observeRecentlyAdded(libraryId: String): Flow<List<LibraryItemEntity>> = flowOf(emptyList())
-        override fun observeAllBooks(libraryId: String): Flow<List<LibraryItemEntity>> = flowOf(emptyList())
+        override fun observeByLibraryId(serverId: String, libraryId: String): Flow<List<LibraryItemEntity>> = flowOf(emptyList())
+        override fun observeUngroupedByLibraryId(serverId: String, libraryId: String): Flow<List<LibraryItemEntity>> = flowOf(emptyList())
+        override fun observeInProgress(serverId: String, libraryId: String): Flow<List<LibraryItemEntity>> = flowOf(emptyList())
+        override fun observeFinished(serverId: String, libraryId: String): Flow<List<LibraryItemEntity>> = flowOf(emptyList())
+        override fun observeRecentlyAdded(serverId: String, libraryId: String): Flow<List<LibraryItemEntity>> = flowOf(emptyList())
+        override fun observeAllBooks(serverId: String, libraryId: String): Flow<List<LibraryItemEntity>> = flowOf(emptyList())
         override suspend fun upsertAll(items: List<LibraryItemEntity>) = Unit
         override suspend fun insertOrIgnore(items: List<LibraryItemEntity>) = Unit
         override suspend fun updateMetadata(metadata: com.riffle.core.database.LibraryItemMetadata) = Unit
         override suspend fun getById(serverId: String, itemId: String): LibraryItemEntity? = byId[itemId]
         override fun observeById(serverId: String, itemId: String): Flow<LibraryItemEntity?> = flowOf(byId[itemId])
         override suspend fun findServerIdForItem(itemId: String): String? = byId[itemId]?.serverId
-        override suspend fun deleteByLibraryId(libraryId: String) = Unit
+        override suspend fun deleteByLibraryId(serverId: String, libraryId: String) = Unit
         override suspend fun deleteRemovedFromLibrary(serverId: String, libraryId: String, serverItemIds: List<String>) = Unit
         override suspend fun updateLastOpenedAt(serverId: String, itemId: String, timestamp: Long) = Unit
         override suspend fun updateReadingProgress(serverId: String, itemId: String, progress: Float) = Unit
         override suspend fun updateFinishedAt(serverId: String, itemId: String, finishedAt: Long?) = Unit
-        override suspend fun getLastOpenedAtMap(libraryId: String): List<LastOpenedAtRow> = emptyList()
-        override suspend fun getReadingProgressMap(libraryId: String): List<ReadingProgressRow> = emptyList()
+        override suspend fun getLastOpenedAtMap(serverId: String, libraryId: String): List<LastOpenedAtRow> = emptyList()
+        override suspend fun getReadingProgressMap(serverId: String, libraryId: String): List<ReadingProgressRow> = emptyList()
     }
 
     private class RecordingReadaloudLinkDao : ReadaloudLinkDao {

--- a/core/data/src/test/kotlin/com/riffle/core/data/SeriesIntegrationTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/SeriesIntegrationTest.kt
@@ -87,10 +87,10 @@ class SeriesIntegrationTest {
         private val itemData = mutableMapOf<String, MutableStateFlow<List<LibraryItemEntity>>>()
         override fun observeByLibraryId(libraryId: String): Flow<List<SeriesEntity>> =
             seriesData.getOrPut(libraryId) { MutableStateFlow(emptyList()) }
-        override fun observeItemsBySeriesId(seriesId: String): Flow<List<LibraryItemEntity>> =
+        override fun observeItemsBySeriesId(serverId: String, seriesId: String): Flow<List<LibraryItemEntity>> =
             itemData.getOrPut(seriesId) { MutableStateFlow(emptyList()) }
         override suspend fun findSeriesIdForItem(serverId: String, itemId: String): String? = null
-        override fun observeContinueSeriesItems(libraryId: String): Flow<List<LibraryItemEntity>> = MutableStateFlow(emptyList())
+        override fun observeContinueSeriesItems(serverId: String, libraryId: String): Flow<List<LibraryItemEntity>> = MutableStateFlow(emptyList())
         override suspend fun upsertAll(series: List<SeriesEntity>) { upsertedSeries.addAll(series) }
         override suspend fun upsertAllItems(items: List<SeriesItemEntity>) { upsertedItems.addAll(items) }
         override suspend fun deleteByLibraryId(libraryId: String) {}
@@ -107,23 +107,23 @@ class SeriesIntegrationTest {
     }
 
     private class FakeLibraryItemDao : LibraryItemDao {
-        override fun observeByLibraryId(libraryId: String): Flow<List<LibraryItemEntity>> = MutableStateFlow(emptyList())
-        override fun observeUngroupedByLibraryId(libraryId: String): Flow<List<LibraryItemEntity>> = MutableStateFlow(emptyList())
-        override fun observeInProgress(libraryId: String): Flow<List<LibraryItemEntity>> = MutableStateFlow(emptyList())
-        override fun observeFinished(libraryId: String): Flow<List<LibraryItemEntity>> = MutableStateFlow(emptyList())
-        override fun observeRecentlyAdded(libraryId: String): Flow<List<LibraryItemEntity>> = MutableStateFlow(emptyList())
-        override fun observeAllBooks(libraryId: String): Flow<List<LibraryItemEntity>> = MutableStateFlow(emptyList())
+        override fun observeByLibraryId(serverId: String, libraryId: String): Flow<List<LibraryItemEntity>> = MutableStateFlow(emptyList())
+        override fun observeUngroupedByLibraryId(serverId: String, libraryId: String): Flow<List<LibraryItemEntity>> = MutableStateFlow(emptyList())
+        override fun observeInProgress(serverId: String, libraryId: String): Flow<List<LibraryItemEntity>> = MutableStateFlow(emptyList())
+        override fun observeFinished(serverId: String, libraryId: String): Flow<List<LibraryItemEntity>> = MutableStateFlow(emptyList())
+        override fun observeRecentlyAdded(serverId: String, libraryId: String): Flow<List<LibraryItemEntity>> = MutableStateFlow(emptyList())
+        override fun observeAllBooks(serverId: String, libraryId: String): Flow<List<LibraryItemEntity>> = MutableStateFlow(emptyList())
         override suspend fun getById(serverId: String, itemId: String): LibraryItemEntity? = null
         override fun observeById(serverId: String, itemId: String): Flow<LibraryItemEntity?> = MutableStateFlow(null)
         override suspend fun findServerIdForItem(itemId: String): String? = null
         override suspend fun upsertAll(items: List<LibraryItemEntity>) {}
         override suspend fun insertOrIgnore(items: List<LibraryItemEntity>) {}
         override suspend fun updateMetadata(metadata: com.riffle.core.database.LibraryItemMetadata) {}
-        override suspend fun deleteByLibraryId(libraryId: String) {}
+        override suspend fun deleteByLibraryId(serverId: String, libraryId: String) {}
         override suspend fun deleteRemovedFromLibrary(serverId: String, libraryId: String, serverItemIds: List<String>) {}
         override suspend fun updateLastOpenedAt(serverId: String, itemId: String, timestamp: Long) {}
-        override suspend fun getLastOpenedAtMap(libraryId: String): List<LastOpenedAtRow> = emptyList()
-        override suspend fun getReadingProgressMap(libraryId: String): List<ReadingProgressRow> = emptyList()
+        override suspend fun getLastOpenedAtMap(serverId: String, libraryId: String): List<LastOpenedAtRow> = emptyList()
+        override suspend fun getReadingProgressMap(serverId: String, libraryId: String): List<ReadingProgressRow> = emptyList()
         override suspend fun updateReadingProgress(serverId: String, itemId: String, progress: Float) {}
         override suspend fun updateFinishedAt(serverId: String, itemId: String, finishedAt: Long?) {}
         override suspend fun listMatchableByServerType(serverType: String): List<com.riffle.core.database.MatchableItemRow> = emptyList()
@@ -131,7 +131,7 @@ class SeriesIntegrationTest {
 
     private class FakeCollectionDao : CollectionDao {
         override fun observeByLibraryId(libraryId: String): Flow<List<CollectionEntity>> = MutableStateFlow(emptyList())
-        override fun observeItemsByCollectionId(collectionId: String): Flow<List<LibraryItemEntity>> = MutableStateFlow(emptyList())
+        override fun observeItemsByCollectionId(serverId: String, collectionId: String): Flow<List<LibraryItemEntity>> = MutableStateFlow(emptyList())
         override suspend fun upsertAll(collections: List<CollectionEntity>) {}
         override suspend fun upsertAllItems(items: List<CollectionItemEntity>) {}
         override suspend fun deleteByLibraryId(libraryId: String) {}

--- a/core/data/src/test/kotlin/com/riffle/core/data/ServerRepositoryTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/ServerRepositoryTest.kt
@@ -139,14 +139,14 @@ class ServerRepositoryTest {
             rows[libraryId] = items.toMutableList()
         }
         fun itemsFor(libraryId: String): List<com.riffle.core.database.LibraryItemEntity> = rows[libraryId].orEmpty()
-        override fun observeByLibraryId(libraryId: String) =
-            flowOf(rows[libraryId].orEmpty().toList())
-        override fun observeUngroupedByLibraryId(libraryId: String) =
-            flowOf(rows[libraryId].orEmpty().toList())
-        override fun observeInProgress(libraryId: String) = flowOf(emptyList<com.riffle.core.database.LibraryItemEntity>())
-        override fun observeFinished(libraryId: String) = flowOf(emptyList<com.riffle.core.database.LibraryItemEntity>())
-        override fun observeRecentlyAdded(libraryId: String) = flowOf(emptyList<com.riffle.core.database.LibraryItemEntity>())
-        override fun observeAllBooks(libraryId: String) = flowOf(emptyList<com.riffle.core.database.LibraryItemEntity>())
+        override fun observeByLibraryId(serverId: String, libraryId: String) =
+            flowOf(rows[libraryId].orEmpty().filter { it.serverId == serverId }.toList())
+        override fun observeUngroupedByLibraryId(serverId: String, libraryId: String) =
+            flowOf(rows[libraryId].orEmpty().filter { it.serverId == serverId }.toList())
+        override fun observeInProgress(serverId: String, libraryId: String) = flowOf(emptyList<com.riffle.core.database.LibraryItemEntity>())
+        override fun observeFinished(serverId: String, libraryId: String) = flowOf(emptyList<com.riffle.core.database.LibraryItemEntity>())
+        override fun observeRecentlyAdded(serverId: String, libraryId: String) = flowOf(emptyList<com.riffle.core.database.LibraryItemEntity>())
+        override fun observeAllBooks(serverId: String, libraryId: String) = flowOf(emptyList<com.riffle.core.database.LibraryItemEntity>())
         override suspend fun getById(serverId: String, itemId: String) = rows.values.flatten().firstOrNull { it.id == itemId }
         override fun observeById(serverId: String, itemId: String) = flowOf(rows.values.flatten().firstOrNull { it.id == itemId })
         override suspend fun findServerIdForItem(itemId: String): String? = rows.values.flatten().firstOrNull { it.id == itemId }?.serverId
@@ -157,14 +157,15 @@ class ServerRepositoryTest {
         }
         override suspend fun insertOrIgnore(items: List<com.riffle.core.database.LibraryItemEntity>) = Unit
         override suspend fun updateMetadata(metadata: com.riffle.core.database.LibraryItemMetadata) = Unit
-        override suspend fun deleteByLibraryId(libraryId: String) {
+        override suspend fun deleteByLibraryId(serverId: String, libraryId: String) {
             deletedLibraryIds += libraryId
-            rows.remove(libraryId)
+            rows[libraryId]?.removeAll { it.serverId == serverId }
+            if (rows[libraryId]?.isEmpty() == true) rows.remove(libraryId)
         }
         override suspend fun deleteRemovedFromLibrary(serverId: String, libraryId: String, serverItemIds: List<String>) = Unit
         override suspend fun updateLastOpenedAt(serverId: String, itemId: String, timestamp: Long) {}
-        override suspend fun getLastOpenedAtMap(libraryId: String) = emptyList<com.riffle.core.database.LastOpenedAtRow>()
-        override suspend fun getReadingProgressMap(libraryId: String) = emptyList<com.riffle.core.database.ReadingProgressRow>()
+        override suspend fun getLastOpenedAtMap(serverId: String, libraryId: String) = emptyList<com.riffle.core.database.LastOpenedAtRow>()
+        override suspend fun getReadingProgressMap(serverId: String, libraryId: String) = emptyList<com.riffle.core.database.ReadingProgressRow>()
         override suspend fun updateReadingProgress(serverId: String, itemId: String, progress: Float) {}
         override suspend fun updateFinishedAt(serverId: String, itemId: String, finishedAt: Long?) {}
         override suspend fun listMatchableByServerType(serverType: String) = emptyList<com.riffle.core.database.MatchableItemRow>()

--- a/core/database/src/androidTest/kotlin/com/riffle/core/database/CollectionDaoTest.kt
+++ b/core/database/src/androidTest/kotlin/com/riffle/core/database/CollectionDaoTest.kt
@@ -85,7 +85,7 @@ class CollectionDaoTest {
             CollectionItemEntity("c1", serverId = "s1", itemId = "item-m"),
         ))
 
-        val result = dao.observeItemsByCollectionId("c1").first()
+        val result = dao.observeItemsByCollectionId("s1", "c1").first()
 
         assertEquals(listOf("item-a", "item-m", "item-z"), result.map { it.id })
     }

--- a/core/database/src/androidTest/kotlin/com/riffle/core/database/LibraryItemDaoTest.kt
+++ b/core/database/src/androidTest/kotlin/com/riffle/core/database/LibraryItemDaoTest.kt
@@ -68,7 +68,7 @@ class LibraryItemDaoTest {
             item("finished", readingProgress = 1.0f),
         ))
 
-        val result = dao.observeInProgress("lib1").first()
+        val result = dao.observeInProgress("s1", "lib1").first()
 
         assertEquals(1, result.size)
         assertEquals("in-progress", result[0].id)
@@ -84,7 +84,7 @@ class LibraryItemDaoTest {
             item("null-ts",  readingProgress = 0.5f, lastOpenedAt = null),
         ))
 
-        val ids = dao.observeInProgress("lib1").first().map { it.id }
+        val ids = dao.observeInProgress("s1", "lib1").first().map { it.id }
 
         assertEquals(listOf("newest", "middle", "oldest", "null-ts"), ids)
     }
@@ -98,7 +98,7 @@ class LibraryItemDaoTest {
             item("finished",    readingProgress = 1.0f),
         ))
 
-        val result = dao.observeFinished("lib1").first()
+        val result = dao.observeFinished("s1", "lib1").first()
 
         assertEquals(1, result.size)
         assertEquals("finished", result[0].id)
@@ -113,7 +113,7 @@ class LibraryItemDaoTest {
             item("finished",    readingProgress = 1.0f),
         ))
 
-        val result = dao.observeAllBooks("lib1").first()
+        val result = dao.observeAllBooks("s1", "lib1").first()
 
         assertEquals(3, result.size)
     }
@@ -123,9 +123,9 @@ class LibraryItemDaoTest {
     fun notStartedItem_appearsOnlyInAllBooks() = runTest {
         dao.upsertAll(listOf(item("not-started", readingProgress = 0.0f)))
 
-        val inProgress = dao.observeInProgress("lib1").first()
-        val finished   = dao.observeFinished("lib1").first()
-        val allBooks   = dao.observeAllBooks("lib1").first()
+        val inProgress = dao.observeInProgress("s1", "lib1").first()
+        val finished   = dao.observeFinished("s1", "lib1").first()
+        val allBooks   = dao.observeAllBooks("s1", "lib1").first()
 
         assertEquals(0, inProgress.size)
         assertEquals(0, finished.size)
@@ -169,6 +169,23 @@ class LibraryItemDaoTest {
         assertEquals("each item must appear once, not duplicated by the library-id JOIN", keys.toSet().size, keys.size)
     }
 
+    // A0c — library-scoped queries (ADR 0025) must isolate by serverId. Two Servers sharing
+    // a library id with overlapping item ids must each see only their own rows.
+    @Test
+    fun observeByLibraryId_scopesByServerId() = runTest {
+        dao.upsertAll(listOf(
+            item("1", readingProgress = 0.3f, serverId = "s1").copy(libraryId = "shared-lib", title = "S1 Book 1"),
+            item("2", readingProgress = 0.7f, serverId = "s1").copy(libraryId = "shared-lib", title = "S1 Book 2"),
+            item("1", readingProgress = 0.4f, serverId = "s2").copy(libraryId = "shared-lib", title = "S2 Book 1"),
+        ))
+
+        val s1 = dao.observeByLibraryId("s1", "shared-lib").first().map { it.serverId to it.id }
+        val s2 = dao.observeByLibraryId("s2", "shared-lib").first().map { it.serverId to it.id }
+
+        assertEquals(setOf("s1" to "1", "s1" to "2"), s1.toSet())
+        assertEquals(setOf("s2" to "1"), s2.toSet())
+    }
+
     // A6 — replaceAllForLibrary must never expose an empty intermediate state to observers.
     // If @Transaction is removed the delete emits before the insert, causing a visible flicker.
     @Test
@@ -179,11 +196,11 @@ class LibraryItemDaoTest {
         // emissions deterministically (with a timeout) rather than racing them with yield().
         val emittedStates = CopyOnWriteArrayList<List<LibraryItemEntity>>()
         val collectJob = launch(Dispatchers.IO) {
-            dao.observeAllBooks("lib1").collect { emittedStates.add(it.toList()) }
+            dao.observeAllBooks("s1", "lib1").collect { emittedStates.add(it.toList()) }
         }
         withTimeout(5_000) { while (emittedStates.isEmpty()) delay(10) }
 
-        dao.replaceAllForLibrary("lib1", listOf(item("c", 0f), item("d", 0.5f), item("e", 1f)))
+        dao.replaceAllForLibrary("s1", "lib1", listOf(item("c", 0f), item("d", 0.5f), item("e", 1f)))
         withTimeout(5_000) {
             while (emittedStates.last().map { it.id }.toSet() != setOf("c", "d", "e")) delay(10)
         }

--- a/core/database/src/androidTest/kotlin/com/riffle/core/database/SeriesDaoTest.kt
+++ b/core/database/src/androidTest/kotlin/com/riffle/core/database/SeriesDaoTest.kt
@@ -86,7 +86,7 @@ class SeriesDaoTest {
             SeriesItemEntity("s1", serverId = "s1", itemId = "item-2", sequenceOrder = 3f),
         ))
 
-        val result = dao.observeItemsBySeriesId("s1").first()
+        val result = dao.observeItemsBySeriesId("s1", "s1").first()
 
         assertEquals(listOf("item-3", "item-1", "item-2"), result.map { it.id })
     }
@@ -110,7 +110,7 @@ class SeriesDaoTest {
             SeriesItemEntity("series-B", serverId = "s1", itemId = "item-3", sequenceOrder = 1f),
         ))
 
-        val result = dao.observeContinueSeriesItems("lib1").first()
+        val result = dao.observeContinueSeriesItems("s1", "lib1").first()
 
         assertEquals(listOf("item-2"), result.map { it.id })
     }
@@ -132,7 +132,7 @@ class SeriesDaoTest {
         ))
 
         // item-2 is in progress → the whole series is excluded
-        val result = dao.observeContinueSeriesItems("lib1").first()
+        val result = dao.observeContinueSeriesItems("s1", "lib1").first()
 
         assertEquals(emptyList<String>(), result.map { it.id })
     }
@@ -154,7 +154,7 @@ class SeriesDaoTest {
         ))
 
         // item-2 is barely opened (1% < 5% threshold) → must NOT block the series; item-2 is next
-        val result = dao.observeContinueSeriesItems("lib1").first()
+        val result = dao.observeContinueSeriesItems("s1", "lib1").first()
 
         assertEquals(listOf("item-2"), result.map { it.id })
     }
@@ -178,7 +178,7 @@ class SeriesDaoTest {
             SeriesItemEntity("series-new", serverId = "s1", itemId = "new-next", sequenceOrder = 2f),
         ))
 
-        val result = dao.observeContinueSeriesItems("lib1").first()
+        val result = dao.observeContinueSeriesItems("s1", "lib1").first()
 
         // series-new finished more recently → new-next must come first
         assertEquals(listOf("new-next", "old-next"), result.map { it.id })
@@ -203,7 +203,7 @@ class SeriesDaoTest {
             SeriesItemEntity("series-null", serverId = "s1", itemId = "null-next", sequenceOrder = 2f),
         ))
 
-        val result = dao.observeContinueSeriesItems("lib1").first()
+        val result = dao.observeContinueSeriesItems("s1", "lib1").first()
 
         // Both series appear; series-ts (real timestamp) before series-null (null → COALESCE 0)
         assertEquals(listOf("ts-next", "null-next"), result.map { it.id })
@@ -226,7 +226,7 @@ class SeriesDaoTest {
             SeriesItemEntity("series-B", serverId = "s1", itemId = "shared-next", sequenceOrder = 2f),
         ))
 
-        val result = dao.observeContinueSeriesItems("lib1").first()
+        val result = dao.observeContinueSeriesItems("s1", "lib1").first()
 
         // shared-next qualifies via both series but must only appear once
         assertEquals(listOf("shared-next"), result.map { it.id })

--- a/core/database/src/main/kotlin/com/riffle/core/database/CollectionDao.kt
+++ b/core/database/src/main/kotlin/com/riffle/core/database/CollectionDao.kt
@@ -16,10 +16,10 @@ interface CollectionDao {
     @Query("""
         SELECT li.* FROM library_items li
         INNER JOIN collection_items ci ON li.serverId = ci.serverId AND li.id = ci.itemId
-        WHERE ci.collectionId = :collectionId
+        WHERE ci.serverId = :serverId AND ci.collectionId = :collectionId
         ORDER BY li.title ASC
     """)
-    fun observeItemsByCollectionId(collectionId: String): Flow<List<LibraryItemEntity>>
+    fun observeItemsByCollectionId(serverId: String, collectionId: String): Flow<List<LibraryItemEntity>>
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun upsertAll(collections: List<CollectionEntity>)

--- a/core/database/src/main/kotlin/com/riffle/core/database/LibraryItemDao.kt
+++ b/core/database/src/main/kotlin/com/riffle/core/database/LibraryItemDao.kt
@@ -11,23 +11,25 @@ import kotlinx.coroutines.flow.Flow
 @Dao
 interface LibraryItemDao {
 
-    @Query("SELECT * FROM library_items WHERE libraryId = :libraryId ORDER BY title ASC")
-    fun observeByLibraryId(libraryId: String): Flow<List<LibraryItemEntity>>
+    @Query("SELECT * FROM library_items WHERE serverId = :serverId AND libraryId = :libraryId ORDER BY title ASC")
+    fun observeByLibraryId(serverId: String, libraryId: String): Flow<List<LibraryItemEntity>>
 
     @Query("""
         SELECT * FROM library_items
-        WHERE libraryId = :libraryId
+        WHERE serverId = :serverId AND libraryId = :libraryId
         AND id NOT IN (
             SELECT itemId FROM series_items
-            WHERE seriesId IN (SELECT id FROM series WHERE libraryId = :libraryId)
+            WHERE serverId = :serverId
+              AND seriesId IN (SELECT id FROM series WHERE libraryId = :libraryId)
         )
         AND id NOT IN (
             SELECT itemId FROM collection_items
-            WHERE collectionId IN (SELECT id FROM collections WHERE libraryId = :libraryId)
+            WHERE serverId = :serverId
+              AND collectionId IN (SELECT id FROM collections WHERE libraryId = :libraryId)
         )
         ORDER BY title ASC
     """)
-    fun observeUngroupedByLibraryId(libraryId: String): Flow<List<LibraryItemEntity>>
+    fun observeUngroupedByLibraryId(serverId: String, libraryId: String): Flow<List<LibraryItemEntity>>
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun upsertAll(items: List<LibraryItemEntity>)
@@ -63,17 +65,17 @@ interface LibraryItemDao {
     @Query("SELECT serverId FROM library_items WHERE id = :itemId LIMIT 1")
     suspend fun findServerIdForItem(itemId: String): String?
 
-    @Query("DELETE FROM library_items WHERE libraryId = :libraryId")
-    suspend fun deleteByLibraryId(libraryId: String)
+    @Query("DELETE FROM library_items WHERE serverId = :serverId AND libraryId = :libraryId")
+    suspend fun deleteByLibraryId(serverId: String, libraryId: String)
 
     @Transaction
-    suspend fun replaceAllForLibrary(libraryId: String, items: List<LibraryItemEntity>) {
+    suspend fun replaceAllForLibrary(serverId: String, libraryId: String, items: List<LibraryItemEntity>) {
         if (items.isEmpty()) {
-            deleteByLibraryId(libraryId)
+            deleteByLibraryId(serverId, libraryId)
             return
         }
         // Remove items no longer present on the server.
-        deleteRemovedFromLibrary(items.first().serverId, libraryId, items.map { it.id })
+        deleteRemovedFromLibrary(serverId, libraryId, items.map { it.id })
         // Insert truly new items — they get the server's readingProgress as the initial seed.
         insertOrIgnore(items)
         // Update metadata for all items, preserving each row's local readingProgress.
@@ -82,21 +84,21 @@ interface LibraryItemDao {
 
     @Query("""
         SELECT * FROM library_items
-        WHERE libraryId = :libraryId
+        WHERE serverId = :serverId AND libraryId = :libraryId
           AND readingProgress > 0.0
           AND readingProgress < 0.99
         ORDER BY lastOpenedAt IS NULL ASC, lastOpenedAt DESC
     """)
-    fun observeInProgress(libraryId: String): Flow<List<LibraryItemEntity>>
+    fun observeInProgress(serverId: String, libraryId: String): Flow<List<LibraryItemEntity>>
 
-    @Query("SELECT * FROM library_items WHERE libraryId = :libraryId AND readingProgress >= 0.99 ORDER BY COALESCE(finishedAt, lastOpenedAt) IS NULL ASC, COALESCE(finishedAt, lastOpenedAt) DESC")
-    fun observeFinished(libraryId: String): Flow<List<LibraryItemEntity>>
+    @Query("SELECT * FROM library_items WHERE serverId = :serverId AND libraryId = :libraryId AND readingProgress >= 0.99 ORDER BY COALESCE(finishedAt, lastOpenedAt) IS NULL ASC, COALESCE(finishedAt, lastOpenedAt) DESC")
+    fun observeFinished(serverId: String, libraryId: String): Flow<List<LibraryItemEntity>>
 
-    @Query("SELECT * FROM library_items WHERE libraryId = :libraryId ORDER BY addedAt IS NULL ASC, addedAt DESC")
-    fun observeRecentlyAdded(libraryId: String): Flow<List<LibraryItemEntity>>
+    @Query("SELECT * FROM library_items WHERE serverId = :serverId AND libraryId = :libraryId ORDER BY addedAt IS NULL ASC, addedAt DESC")
+    fun observeRecentlyAdded(serverId: String, libraryId: String): Flow<List<LibraryItemEntity>>
 
-    @Query("SELECT * FROM library_items WHERE libraryId = :libraryId ORDER BY title ASC")
-    fun observeAllBooks(libraryId: String): Flow<List<LibraryItemEntity>>
+    @Query("SELECT * FROM library_items WHERE serverId = :serverId AND libraryId = :libraryId ORDER BY title ASC")
+    fun observeAllBooks(serverId: String, libraryId: String): Flow<List<LibraryItemEntity>>
 
     @Query("UPDATE library_items SET lastOpenedAt = :timestamp WHERE serverId = :serverId AND id = :itemId")
     suspend fun updateLastOpenedAt(serverId: String, itemId: String, timestamp: Long)
@@ -107,11 +109,11 @@ interface LibraryItemDao {
     @Query("UPDATE library_items SET finishedAt = :finishedAt WHERE serverId = :serverId AND id = :itemId")
     suspend fun updateFinishedAt(serverId: String, itemId: String, finishedAt: Long?)
 
-    @Query("SELECT id, lastOpenedAt FROM library_items WHERE libraryId = :libraryId AND lastOpenedAt IS NOT NULL")
-    suspend fun getLastOpenedAtMap(libraryId: String): List<LastOpenedAtRow>
+    @Query("SELECT id, lastOpenedAt FROM library_items WHERE serverId = :serverId AND libraryId = :libraryId AND lastOpenedAt IS NOT NULL")
+    suspend fun getLastOpenedAtMap(serverId: String, libraryId: String): List<LastOpenedAtRow>
 
-    @Query("SELECT id, readingProgress FROM library_items WHERE libraryId = :libraryId AND readingProgress > 0.0")
-    suspend fun getReadingProgressMap(libraryId: String): List<ReadingProgressRow>
+    @Query("SELECT id, readingProgress FROM library_items WHERE serverId = :serverId AND libraryId = :libraryId AND readingProgress > 0.0")
+    suspend fun getReadingProgressMap(serverId: String, libraryId: String): List<ReadingProgressRow>
 
     /**
      * All library items whose owning Server is of the given [serverType]. Used by the

--- a/core/database/src/main/kotlin/com/riffle/core/database/SeriesDao.kt
+++ b/core/database/src/main/kotlin/com/riffle/core/database/SeriesDao.kt
@@ -16,14 +16,14 @@ interface SeriesDao {
     @Query("""
         SELECT li.* FROM library_items li
         INNER JOIN series_items si ON li.serverId = si.serverId AND li.id = si.itemId
-        WHERE si.seriesId = :seriesId
+        WHERE si.serverId = :serverId AND si.seriesId = :seriesId
         ORDER BY si.sequenceOrder ASC
     """)
-    fun observeItemsBySeriesId(seriesId: String): Flow<List<LibraryItemEntity>>
+    fun observeItemsBySeriesId(serverId: String, seriesId: String): Flow<List<LibraryItemEntity>>
 
     @Query("""
         SELECT li.* FROM library_items li
-        WHERE li.libraryId = :libraryId
+        WHERE li.serverId = :serverId AND li.libraryId = :libraryId
           AND li.readingProgress < 0.99
           AND EXISTS (
               SELECT 1 FROM series_items si
@@ -33,13 +33,13 @@ interface SeriesDao {
                     SELECT DISTINCT si2.seriesId
                     FROM series_items si2
                     INNER JOIN library_items li2 ON li2.serverId = si2.serverId AND li2.id = si2.itemId
-                    WHERE li2.libraryId = :libraryId AND li2.readingProgress >= 0.99
+                    WHERE li2.serverId = :serverId AND li2.libraryId = :libraryId AND li2.readingProgress >= 0.99
                 )
                 AND si.seriesId NOT IN (
                     SELECT DISTINCT si5.seriesId
                     FROM series_items si5
                     INNER JOIN library_items li5 ON li5.serverId = si5.serverId AND li5.id = si5.itemId
-                    WHERE li5.libraryId = :libraryId
+                    WHERE li5.serverId = :serverId AND li5.libraryId = :libraryId
                       AND li5.readingProgress >= 0.05
                       AND li5.readingProgress < 0.99
                 )
@@ -48,7 +48,7 @@ interface SeriesDao {
                     FROM series_items si3
                     INNER JOIN library_items li3 ON li3.serverId = si3.serverId AND li3.id = si3.itemId
                     WHERE si3.seriesId = si.seriesId
-                      AND li3.libraryId = :libraryId
+                      AND li3.serverId = :serverId AND li3.libraryId = :libraryId
                       AND li3.readingProgress < 0.99
                 )
           )
@@ -61,12 +61,12 @@ interface SeriesDao {
                     SELECT si_self.seriesId FROM series_items si_self
                     WHERE si_self.serverId = li.serverId AND si_self.itemId = li.id
                 )
-                  AND li4.libraryId = :libraryId
+                  AND li4.serverId = :serverId AND li4.libraryId = :libraryId
                   AND li4.readingProgress >= 0.99
             ), 0
         ) DESC
     """)
-    fun observeContinueSeriesItems(libraryId: String): Flow<List<LibraryItemEntity>>
+    fun observeContinueSeriesItems(serverId: String, libraryId: String): Flow<List<LibraryItemEntity>>
 
     /**
      * The id of the series an item belongs to, if any. Used by the Library Item Detail Screen to


### PR DESCRIPTION
## Summary

Closes #301 — executes ADR-0025 at the query layer.

The schema already keys `library_items` by `(serverId, id)`, but `LibraryItemDao` still exposed library-scoped queries that took only `libraryId`. `LibraryRepositoryImpl` compensated client-side via a private `.scopedToActiveServer()` filter — a convention, not a guarantee.

This PR pushes the invariant into the queries:

- `LibraryItemDao` library-scoped queries (`observeByLibraryId`, `observeUngroupedByLibraryId`, `observeInProgress`, `observeFinished`, `observeRecentlyAdded`, `observeAllBooks`, `getLastOpenedAtMap`, `getReadingProgressMap`, `deleteByLibraryId`, `replaceAllForLibrary`) now take `serverId`.
- `SeriesDao.observeItemsBySeriesId` / `observeContinueSeriesItems` and `CollectionDao.observeItemsByCollectionId` take `serverId`; joins through `series_items` / `collection_items` enforce it.
- `LibraryRepositoryImpl` exposes a shared `scopedItemFlow` helper that resolves `activeServerId` via `flatMapLatest` before each DAO call; no active Server → empty list. `scopedToActiveServer()` is gone (grep returns zero).
- Threaded `serverId` through `StorytellerReadaloudSyncer` and `ServerRepositoryImpl.remove()`.

## Deletion test

```
$ grep -rn "scopedToActiveServer" --include="*.kt" .
(no hits)
```

## Tests

- `LibraryItemDaoTest.observeByLibraryId_scopesByServerId` — cross-server isolation invariant: two items with the same `itemId` on different `serverId` coexist and only the queried Server's row is returned.
- `LibraryRepositoryTest.library shelves re-resolve when active server changes` — switching active Server while a flow is collected emits only the new Server's items via the `flatMapLatest` re-emission contract.
- All existing fakes (`FakeLibraryItemDao`, `NoopLibraryDaos`, inline test doubles in `ReadaloudMatchingServiceTest`, `ServerRepositoryTest`, `LibraryRepositoryTest`, `SeriesIntegrationTest`) updated to the new signatures.

## Test plan

- [x] `./gradlew test` green
- [ ] `make harness-test` (instrumentation: DAO tests on Harness AVD)
- [ ] `make harness-test-tablet`