### PR TITLE
refactor(sync): rename SyncRemote → ProgressPeer with explicit WriteResult (#302)

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderSync.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderSync.kt
@@ -3,10 +3,11 @@ package com.riffle.app.feature.reader
 import com.riffle.core.domain.BookSyncState
 import com.riffle.core.domain.CanonicalReaderPosition
 import com.riffle.core.domain.LocalCanonical
+import com.riffle.core.domain.ProgressPeer
 import com.riffle.core.domain.ProgressSyncStrategy
 import com.riffle.core.domain.RemoteKind
 import com.riffle.core.domain.RemoteRead
-import com.riffle.core.domain.SyncRemote
+import com.riffle.core.domain.WriteResult
 import com.riffle.core.network.AbsSessionApi
 import com.riffle.core.network.NetworkAudiobookProgressPayload
 import com.riffle.core.network.NetworkEbookProgressPayload
@@ -22,7 +23,7 @@ data class AbsSyncEndpoint(val baseUrl: String, val token: String, val insecure:
 
 // A reachable peer that has no position yet: it never wins (timestamp 0) but is stale relative
 // to any local progress, so the cycle still pushes the reader's first position to it.
-internal val EMPTY_REMOTE_READ = RemoteRead(CanonicalReaderPosition(""), 0L)
+internal val EMPTY_PEER_READ = RemoteRead(CanonicalReaderPosition(""), 0L)
 
 // ABS's progress PATCH replies "OK" with no timestamp, so after a write we GET the record back to
 // learn the server time it was stored under. Callers record it as the local timestamp; without it a
@@ -39,12 +40,12 @@ internal suspend fun AbsSessionApi.writeAudiobookSeconds(ep: AbsSyncEndpoint, se
     return serverStamp(ep)
 }
 
-/** ABS ebook progress as a sync remote: an ebookLocation CFI on the ABS EPUB. */
-internal class AbsEbookSyncRemote(
+/** ABS ebook progress as a [ProgressPeer]: an ebookLocation CFI on the ABS EPUB. */
+internal class AbsEbookProgressPeer(
     private val api: AbsSessionApi,
     private val ep: AbsSyncEndpoint,
     private val bridge: ReaderPositionBridge,
-) : SyncRemote {
+) : ProgressPeer {
     override val id = RemoteKind.ABS_EBOOK.name
 
     override suspend fun tryGet(): RemoteRead? {
@@ -52,16 +53,19 @@ internal class AbsEbookSyncRemote(
         val p = (api.getProgress(ep.baseUrl, ep.itemId, ep.token, ep.insecure) as? NetworkGetProgressResult.Success)
             ?.progress ?: return null
         val cfi = p.ebookLocation.takeIf { it.startsWith("epubcfi(") }
-        if (p.lastUpdate <= 0L || cfi == null) return EMPTY_REMOTE_READ
-        val canonical = bridge.absCfiToCanonical(cfi) ?: return EMPTY_REMOTE_READ
+        if (p.lastUpdate <= 0L || cfi == null) return EMPTY_PEER_READ
+        val canonical = bridge.absCfiToCanonical(cfi) ?: return EMPTY_PEER_READ
         return RemoteRead(CanonicalReaderPosition(canonical), p.lastUpdate)
     }
 
-    override suspend fun tryPatch(canonical: CanonicalReaderPosition): Long? {
-        val cfi = bridge.canonicalToAbsCfi(canonical.value) ?: return null
+    override suspend fun tryPatch(canonical: CanonicalReaderPosition): WriteResult {
+        val cfi = bridge.canonicalToAbsCfi(canonical.value)
+            ?: return WriteResult.Skipped // canonical can't be placed in the ABS EPUB this cycle
         val payload = NetworkEbookProgressPayload(cfi, bridge.canonicalBookProgress(canonical.value))
-        if (api.syncEbookProgress(ep.baseUrl, ep.itemId, payload, ep.token, ep.insecure) !is NetworkSyncSessionResult.Success) return null
-        return api.serverStamp(ep)
+        if (api.syncEbookProgress(ep.baseUrl, ep.itemId, payload, ep.token, ep.insecure) !is NetworkSyncSessionResult.Success)
+            return WriteResult.Failed("ABS ebook PATCH network error")
+        val stamp = api.serverStamp(ep) ?: return WriteResult.Failed("ABS ebook stamp read-back failed")
+        return WriteResult.Ok(stamp)
     }
 }
 
@@ -77,43 +81,46 @@ internal class AbsEbookSyncRemote(
  * position — so a behind/early playback clock cannot drive the ebook. The feedback loop is closed by
  * adopting the server timestamp each write returns (the cycle / push records it as the local time).
  */
-internal class AbsAudiobookSyncRemote(
+internal class AbsAudiobookProgressPeer(
     private val api: AbsSessionApi,
     private val ep: AbsSyncEndpoint,
     private val bridge: ReaderPositionBridge,
-) : SyncRemote {
+) : ProgressPeer {
     override val id = RemoteKind.ABS_AUDIO.name
 
     override suspend fun tryGet(): RemoteRead? {
         val p = (api.getProgress(ep.baseUrl, ep.itemId, ep.token, ep.insecure) as? NetworkGetProgressResult.Success)
             ?.progress ?: return null
-        if (p.lastUpdate <= 0L || p.currentTime <= 0.0) return EMPTY_REMOTE_READ // no audiobook position yet
-        val canonical = bridge.audioSecondsToCanonical(p.currentTime) ?: return EMPTY_REMOTE_READ
+        if (p.lastUpdate <= 0L || p.currentTime <= 0.0) return EMPTY_PEER_READ // no audiobook position yet
+        val canonical = bridge.audioSecondsToCanonical(p.currentTime) ?: return EMPTY_PEER_READ
         return RemoteRead(CanonicalReaderPosition(canonical), p.lastUpdate)
     }
 
-    override suspend fun tryPatch(canonical: CanonicalReaderPosition): Long? {
-        val seconds = bridge.canonicalToAudioSeconds(canonical.value) ?: return null
-        return api.writeAudiobookSeconds(ep, seconds)
+    override suspend fun tryPatch(canonical: CanonicalReaderPosition): WriteResult {
+        val seconds = bridge.canonicalToAudioSeconds(canonical.value)
+            ?: return WriteResult.Skipped // canonical can't be placed on the audio timeline this cycle
+        val stamp = api.writeAudiobookSeconds(ep, seconds)
+            ?: return WriteResult.Failed("ABS audiobook PATCH or stamp read-back failed")
+        return WriteResult.Ok(stamp)
     }
 }
 
 /**
- * Wraps a remote so the cycle still READS it (a genuinely-newer remote still wins inbound) but never
+ * Wraps a peer so the cycle still READS it (a genuinely-newer remote still wins inbound) but never
  * PATCHes it. Used while the reader is parked on the sentence readaloud stopped on: readaloud already
  * wrote the precise audiobook position on close, so the cycle's page-derived outbound push must not
  * regress it to the page top (ADR 0031). Outbound resumes once the user navigates off that page.
  */
-private class InboundOnlyRemote(private val inner: SyncRemote) : SyncRemote {
+private class InboundOnlyPeer(private val inner: ProgressPeer) : ProgressPeer {
     override val id = inner.id
     override suspend fun tryGet(): RemoteRead? = inner.tryGet()
-    override suspend fun tryPatch(canonical: CanonicalReaderPosition): Long? = null
+    override suspend fun tryPatch(canonical: CanonicalReaderPosition): WriteResult = WriteResult.Skipped
 }
 
 /**
  * Drives one matched readaloud book's two-ABS-peer reconciliation (ADR 0019, as amended by ADR 0029
  * which dropped the Storyteller position peer). Builds the live
- * [SyncRemote]s for the applicable peer set and runs the unified [ProgressSyncStrategy] each
+ * [ProgressPeer]s for the applicable peer set and runs the unified [ProgressSyncStrategy] each
  * cycle. The canonical position is the displayed-EPUB Locator JSON; [runCycle] returns the
  * Locator JSON the reader should jump to, or `null` for no jump.
  *
@@ -151,12 +158,12 @@ class ReaderSyncCoordinator(
     suspend fun runCycle(displayedLocatorJson: String, localUpdatedAt: Long, pushAudio: Boolean = true): ReaderSyncCycleResult {
         val strategy = ProgressSyncStrategy { kind ->
             when (kind) {
-                RemoteKind.ABS_EBOOK -> absEbookEndpoint?.let { AbsEbookSyncRemote(absApi, it, bridge) }
+                RemoteKind.ABS_EBOOK -> absEbookEndpoint?.let { AbsEbookProgressPeer(absApi, it, bridge) }
                 RemoteKind.ABS_AUDIO -> absAudioEndpoint?.let {
-                    val remote = AbsAudiobookSyncRemote(absApi, it, bridge)
-                    if (pushAudio) remote else InboundOnlyRemote(remote)
+                    val peer = AbsAudiobookProgressPeer(absApi, it, bridge)
+                    if (pushAudio) peer else InboundOnlyPeer(peer)
                 }
-                // Bookmarks are not a position remote — they reconcile via the sweep, not this cycle.
+                // Bookmarks are not a position peer — they reconcile via the sweep, not this cycle.
                 RemoteKind.ABS_BOOKMARK -> null
             }
         }

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/AbsProgressPeerTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/AbsProgressPeerTest.kt
@@ -1,0 +1,127 @@
+package com.riffle.app.feature.reader
+
+import com.riffle.core.domain.CanonicalPositionTranslator
+import com.riffle.core.domain.CanonicalReaderPosition
+import com.riffle.core.domain.ChapterCharMap
+import com.riffle.core.domain.ChapterProgression
+import com.riffle.core.domain.CrossEpubIndex
+import com.riffle.core.domain.MediaOverlayClip
+import com.riffle.core.domain.WriteResult
+import com.riffle.core.network.AbsSessionApi
+import com.riffle.core.network.NetworkAudiobookProgressPayload
+import com.riffle.core.network.NetworkEbookProgressPayload
+import com.riffle.core.network.NetworkGetProgressResult
+import com.riffle.core.network.NetworkServerProgress
+import com.riffle.core.network.NetworkSyncSessionResult
+import kotlinx.coroutines.test.runTest
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.IOException
+
+/**
+ * Pins the new [WriteResult] contract on the ABS peer adapters (#302): a translator boundary that
+ * can't place the canonical position is a deliberate [WriteResult.Skipped], not a [WriteResult.Failed]
+ * — the row is left for a later cycle, never marked as a sync failure to act on. Network errors
+ * remain Failed.
+ */
+class AbsProgressPeerTest {
+
+    private val translator = CanonicalPositionTranslator(
+        smilClips = listOf(MediaOverlayClip("f1", "a.mp3", clipBeginSec = 5.0, clipEndSec = 10.0)),
+        index = CrossEpubIndex(listOf(ChapterCharMap(absChars = 100, storytellerChars = 100))),
+        fragmentProgressions = mapOf("f1" to ChapterProgression(0, 0.2)),
+    )
+    private val absHtml = "<html><body><p>${"x".repeat(100)}</p></body></html>"
+    private val bridge = ReaderPositionBridge(
+        absSpineHrefs = listOf("c1.xhtml"),
+        absChapterHtml = { if (it == 0) absHtml else null },
+        storytellerSpineHrefs = listOf("c1.xhtml"),
+        storytellerChapterHtml = { if (it == 0) absHtml else null },
+        translator = translator,
+    )
+    private val ep = AbsSyncEndpoint("http://abs", "t", false, "i", durationSec = 100.0)
+
+    private fun locator(href: String, progression: Double): String = JSONObject()
+        .put("href", href)
+        .put("locations", JSONObject().put("progression", progression))
+        .toString()
+
+    /** PATCH succeeds and the GET stamp read-back is what gets adopted by the cycle. */
+    private class OkAbs(private val stamp: Long) : AbsSessionApi {
+        override suspend fun syncEbookProgress(baseUrl: String, libraryItemId: String, payload: NetworkEbookProgressPayload, token: String, insecureAllowed: Boolean) =
+            NetworkSyncSessionResult.Success(stamp)
+        override suspend fun syncAudiobookProgress(baseUrl: String, libraryItemId: String, payload: NetworkAudiobookProgressPayload, token: String, insecureAllowed: Boolean) =
+            NetworkSyncSessionResult.Success(stamp)
+        override suspend fun getProgress(baseUrl: String, libraryItemId: String, token: String, insecureAllowed: Boolean) =
+            NetworkGetProgressResult.Success(NetworkServerProgress(ebookLocation = "", lastUpdate = stamp))
+    }
+
+    /** PATCH fails at the network. */
+    private class PatchFailAbs : AbsSessionApi {
+        override suspend fun syncEbookProgress(baseUrl: String, libraryItemId: String, payload: NetworkEbookProgressPayload, token: String, insecureAllowed: Boolean) =
+            NetworkSyncSessionResult.NetworkError(IOException("boom"))
+        override suspend fun syncAudiobookProgress(baseUrl: String, libraryItemId: String, payload: NetworkAudiobookProgressPayload, token: String, insecureAllowed: Boolean) =
+            NetworkSyncSessionResult.NetworkError(IOException("boom"))
+        override suspend fun getProgress(baseUrl: String, libraryItemId: String, token: String, insecureAllowed: Boolean) =
+            NetworkGetProgressResult.NetworkError(IOException("boom"))
+    }
+
+    /** PATCH OK but the follow-up GET (the stamp read-back) fails. */
+    private class StampReadbackFailAbs : AbsSessionApi {
+        override suspend fun syncEbookProgress(baseUrl: String, libraryItemId: String, payload: NetworkEbookProgressPayload, token: String, insecureAllowed: Boolean) =
+            NetworkSyncSessionResult.Success(0L)
+        override suspend fun syncAudiobookProgress(baseUrl: String, libraryItemId: String, payload: NetworkAudiobookProgressPayload, token: String, insecureAllowed: Boolean) =
+            NetworkSyncSessionResult.Success(0L)
+        override suspend fun getProgress(baseUrl: String, libraryItemId: String, token: String, insecureAllowed: Boolean) =
+            NetworkGetProgressResult.NetworkError(IOException("stamp read-back failed"))
+    }
+
+    @Test
+    fun `ebook peer Ok when network PATCH succeeds and stamp comes back`() = runTest {
+        val peer = AbsEbookProgressPeer(OkAbs(stamp = 1234L), ep, bridge)
+        val result = peer.tryPatch(CanonicalReaderPosition(locator("c1.xhtml", 0.5)))
+        assertEquals(WriteResult.Ok(1234L), result)
+    }
+
+    @Test
+    fun `ebook peer Skipped when canonical can't be translated to a CFI (deliberate no-op)`() = runTest {
+        // href not in the spine → bridge.canonicalToAbsCfi returns null → Skipped (not Failed): the
+        // peer made no network attempt; the row is not dirty, the cycle will retry next pass.
+        val peer = AbsEbookProgressPeer(OkAbs(stamp = 1234L), ep, bridge)
+        val result = peer.tryPatch(CanonicalReaderPosition(locator("nonexistent.xhtml", 0.5)))
+        assertEquals(WriteResult.Skipped, result)
+    }
+
+    @Test
+    fun `ebook peer Failed when ABS PATCH errors`() = runTest {
+        val peer = AbsEbookProgressPeer(PatchFailAbs(), ep, bridge)
+        val result = peer.tryPatch(CanonicalReaderPosition(locator("c1.xhtml", 0.5)))
+        assertTrue("expected Failed, was $result", result is WriteResult.Failed)
+    }
+
+    @Test
+    fun `ebook peer Failed when stamp read-back fails (PATCH stored, stamp unknown)`() = runTest {
+        // ABS itself returns Success with no stamp; the read-back GET fails. The cycle needs the stamp
+        // to break the feedback loop, so report Failed — not Ok with a fake stamp.
+        val peer = AbsEbookProgressPeer(StampReadbackFailAbs(), ep, bridge)
+        val result = peer.tryPatch(CanonicalReaderPosition(locator("c1.xhtml", 0.5)))
+        assertTrue("expected Failed, was $result", result is WriteResult.Failed)
+    }
+
+    @Test
+    fun `audiobook peer Ok when SMIL placement + PATCH + stamp succeed`() = runTest {
+        val peer = AbsAudiobookProgressPeer(OkAbs(stamp = 9000L), ep, bridge)
+        // progression 0.2 places inside the SMIL clip f1 (5–10s) — translates to a valid audio second
+        val result = peer.tryPatch(CanonicalReaderPosition(locator("c1.xhtml", 0.2)))
+        assertEquals(WriteResult.Ok(9000L), result)
+    }
+
+    @Test
+    fun `audiobook peer Failed when ABS PATCH errors`() = runTest {
+        val peer = AbsAudiobookProgressPeer(PatchFailAbs(), ep, bridge)
+        val result = peer.tryPatch(CanonicalReaderPosition(locator("c1.xhtml", 0.2)))
+        assertTrue("expected Failed, was $result", result is WriteResult.Failed)
+    }
+}

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/CanonicalSyncCycle.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/CanonicalSyncCycle.kt
@@ -54,22 +54,55 @@ data class LocalCanonical(val position: CanonicalReaderPosition, val lastUpdate:
 data class RemoteRead(val canonical: CanonicalReaderPosition, val lastUpdate: Long)
 
 /**
- * One reconcilable position holder (ABS ebook, ABS audiobook, or Storyteller). Both
- * operations are per-target isolated: [tryGet] returns `null` when the remote is
- * unreachable or its position cannot be translated to canonical (so it is left out of the
- * inbound comparison and not patched).
+ * The outcome of one [ProgressPeer.tryPatch] call. Explicit about the three things the cycle needs
+ * to distinguish:
  *
- * [tryPatch] returns the **server timestamp the write was stored under** (or `null` on
- * failure / a deliberate no-op). The cycle folds that timestamp into the canonical
- * `lastUpdate`: a remote that stamps the write later than the local clock (ABS stamps
- * server-side) would otherwise read back next cycle as a "newer" position and bounce the
- * reader to the very position it just wrote. Adopting the returned timestamp keeps local
- * the winner on the next tie. A remote that stores the timestamp we sent simply returns it.
+ *  - [Ok] — the peer stored the write and stamped it server-side at [serverStamp]. The cycle adds
+ *    the peer to `patched` and folds the stamp into the canonical `lastUpdate`, so the write
+ *    doesn't read back next cycle as a "newer remote" (ADR 0008).
+ *  - [Skipped] — the peer deliberately did not write (a translator boundary couldn't place the
+ *    canonical position, an inbound-only wrapper suppressed the outbound, etc.). Not a failure;
+ *    the row stays at its current state and the cycle does not retry.
+ *  - [Failed] — the write was attempted and failed (network, server error). The cycle leaves the
+ *    row dirty so a later sweep can retry; [retriable] is advisory for telemetry.
+ *
+ * The two non-Ok cases are observably identical in the live cycle (neither stamps, neither marks
+ * the peer patched), but the distinction makes the contract honest and gives the sweep / telemetry
+ * something to act on without sniffing nulls.
  */
-interface SyncRemote {
+sealed interface WriteResult {
+    data class Ok(val serverStamp: Long) : WriteResult
+    data object Skipped : WriteResult
+    data class Failed(val reason: String, val retriable: Boolean = true) : WriteResult
+}
+
+/**
+ * One reconcilable position holder for the live canonical cycle — today an ABS ebook peer and an
+ * ABS audiobook peer (ADR 0019, as amended by ADR 0029 which dropped the Storyteller position
+ * peer). Both operations are per-target isolated:
+ *
+ *  - [tryGet] returns `null` when the peer is unreachable or its position cannot be translated to
+ *    canonical (so it is left out of the inbound comparison and not patched).
+ *
+ *  - [tryPatch] returns a [WriteResult]: [WriteResult.Ok] with the server timestamp the write was
+ *    stored under, [WriteResult.Skipped] for a deliberate no-op (translator boundary, inbound-only
+ *    wrapper), or [WriteResult.Failed] when the write was attempted and failed. The cycle adopts
+ *    the [WriteResult.Ok.serverStamp] into the canonical `lastUpdate`; a peer that stamps later
+ *    than the local clock (ABS stamps server-side) would otherwise read back next cycle as a
+ *    "newer" position and bounce the reader to the very position it just wrote. A peer that stores
+ *    the timestamp we sent simply returns it.
+ *
+ * Note: the local Room store is **not** a `ProgressPeer` — it is the canonical authority the cycle
+ * is reconciling toward, and its write semantics are compare-and-swap (`ifLocalUpdatedAt` guarded
+ * via [SyncPositionStore]) rather than push-then-stamp. Storyteller is also not a peer: there is
+ * no progress-write endpoint on the Storyteller server. Both are intentionally absent; do not add
+ * a no-op peer to satisfy a symmetry that doesn't exist.
+ */
+interface ProgressPeer {
+    /** Stable identifier for logging, telemetry, and `SyncCycleResult.patched`. */
     val id: String
     suspend fun tryGet(): RemoteRead?
-    suspend fun tryPatch(canonical: CanonicalReaderPosition): Long?
+    suspend fun tryPatch(canonical: CanonicalReaderPosition): WriteResult
 }
 
 /** Outcome of one reconciliation cycle. */
@@ -86,15 +119,15 @@ data class SyncCycleResult(
  */
 object CanonicalSyncCycle {
 
-    suspend fun run(local: LocalCanonical, remotes: List<SyncRemote>): SyncCycleResult {
-        // GET each remote in parallel, isolating per-target failures (null = excluded).
+    suspend fun run(local: LocalCanonical, peers: List<ProgressPeer>): SyncCycleResult {
+        // GET each peer in parallel, isolating per-target failures (null = excluded).
         val reads = coroutineScope {
-            remotes.map { remote -> remote to async { remote.tryGet() } }
-                .map { (remote, deferred) -> remote to deferred.await() }
+            peers.map { peer -> peer to async { peer.tryGet() } }
+                .map { (peer, deferred) -> peer to deferred.await() }
         }
 
         // Inbound winner: the maximum lastUpdate among the local position and the
-        // successfully-read remotes. Local wins ties, so an in-sync remote never forces a jump.
+        // successfully-read peers. Local wins ties, so an in-sync peer never forces a jump.
         var winnerCanonical = local.position
         var canonicalLastUpdate = local.lastUpdate
         for ((_, read) in reads) {
@@ -106,19 +139,23 @@ object CanonicalSyncCycle {
 
         val jumpTo = if (winnerCanonical != local.position) winnerCanonical else null
 
-        // Outbound: patch every successfully-read remote that is now stale, all from the
-        // single canonical winner. Unreachable remotes (null read) are left untouched. Adopt the
+        // Outbound: patch every successfully-read peer that is now stale, all from the
+        // single canonical winner. Unreachable peers (null read) are left untouched. Adopt the
         // latest server timestamp any write was stored under, so a write the server stamps later
-        // than the local clock doesn't read back next cycle as a "newer" remote and bounce the
+        // than the local clock doesn't read back next cycle as a "newer" peer and bounce the
         // reader to the position it just wrote (the "server always overwrites local" bug).
         val patched = mutableSetOf<String>()
         var effectiveLastUpdate = canonicalLastUpdate
-        for ((remote, read) in reads) {
+        for ((peer, read) in reads) {
             if (read != null && read.lastUpdate < canonicalLastUpdate) {
-                val stamp = remote.tryPatch(winnerCanonical)
-                if (stamp != null) {
-                    patched += remote.id
-                    if (stamp > effectiveLastUpdate) effectiveLastUpdate = stamp
+                when (val outcome = peer.tryPatch(winnerCanonical)) {
+                    is WriteResult.Ok -> {
+                        patched += peer.id
+                        if (outcome.serverStamp > effectiveLastUpdate) effectiveLastUpdate = outcome.serverStamp
+                    }
+                    // Skipped/Failed: leave the peer out of `patched`; the cycle's other peers and
+                    // the durable sweep (ADR 0030) handle retry.
+                    WriteResult.Skipped, is WriteResult.Failed -> Unit
                 }
             }
         }

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/ProgressSyncStrategy.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/ProgressSyncStrategy.kt
@@ -7,15 +7,15 @@ package com.riffle.core.domain
  * strategy [ProgressSyncController] delegates to once it knows the book's [BookSyncState];
  * the open side feeds only into [applicableRemotes], never into the cycle itself.
  *
- * [remoteFor] constructs the live [SyncRemote] for a kind (wiring the network APIs and the
- * [CanonicalPositionTranslator]); it may return `null` when a remote cannot be built this
+ * [peerFor] constructs the live [ProgressPeer] for a kind (wiring the network APIs and the
+ * [CanonicalPositionTranslator]); it may return `null` when a peer cannot be built this
  * cycle (e.g. a prerequisite went missing), in which case that target is simply skipped.
  */
 class ProgressSyncStrategy(
-    private val remoteFor: (RemoteKind) -> SyncRemote?,
+    private val peerFor: (RemoteKind) -> ProgressPeer?,
 ) {
     suspend fun runCycle(state: BookSyncState, local: LocalCanonical): SyncCycleResult {
-        val remotes = applicableRemotes(state).mapNotNull { remoteFor(it) }
-        return CanonicalSyncCycle.run(local, remotes)
+        val peers = applicableRemotes(state).mapNotNull { peerFor(it) }
+        return CanonicalSyncCycle.run(local, peers)
     }
 }

--- a/core/domain/src/test/kotlin/com/riffle/core/domain/CanonicalSyncCycleTest.kt
+++ b/core/domain/src/test/kotlin/com/riffle/core/domain/CanonicalSyncCycleTest.kt
@@ -8,12 +8,12 @@ import org.junit.Test
 
 class CanonicalSyncCycleTest {
 
-    /** A fake remote with injectable GET result, recorded PATCH, and the timestamp the PATCH stores. */
-    private class FakeRemote(
+    /** A fake peer with injectable GET result, recorded PATCH, and the timestamp the PATCH stores. */
+    private class FakePeer(
         override val id: String,
         private val getResult: RemoteRead?,
         private val patchStamp: Long = 1L,
-    ) : SyncRemote {
+    ) : ProgressPeer {
         var patchedWith: CanonicalReaderPosition? = null
             private set
         var patchFails: Boolean = false
@@ -25,10 +25,10 @@ class CanonicalSyncCycleTest {
             return getResult
         }
 
-        override suspend fun tryPatch(canonical: CanonicalReaderPosition): Long? {
-            if (patchFails) return null
+        override suspend fun tryPatch(canonical: CanonicalReaderPosition): WriteResult {
+            if (patchFails) return WriteResult.Failed("test-induced failure")
             patchedWith = canonical
-            return patchStamp
+            return WriteResult.Ok(patchStamp)
         }
     }
 
@@ -37,9 +37,9 @@ class CanonicalSyncCycleTest {
     @Test
     fun `the newest remote wins, the reader jumps to it, and stale remotes are patched to it`() = runTest {
         val local = LocalCanonical(pos("L"), lastUpdate = 100)
-        val ebook = FakeRemote("ABS_EBOOK", RemoteRead(pos("A"), lastUpdate = 90))
-        val audio = FakeRemote("ABS_AUDIO", RemoteRead(pos("B"), lastUpdate = 80))
-        val storyteller = FakeRemote("STORYTELLER", RemoteRead(pos("S"), lastUpdate = 150))
+        val ebook = FakePeer("ABS_EBOOK", RemoteRead(pos("A"), lastUpdate = 90))
+        val audio = FakePeer("ABS_AUDIO", RemoteRead(pos("B"), lastUpdate = 80))
+        val storyteller = FakePeer("STORYTELLER", RemoteRead(pos("S"), lastUpdate = 150))
 
         val result = CanonicalSyncCycle.run(local, listOf(ebook, audio, storyteller))
 
@@ -56,8 +56,8 @@ class CanonicalSyncCycleTest {
     @Test
     fun `when local is newest there is no jump and every remote is patched to local`() = runTest {
         val local = LocalCanonical(pos("L"), lastUpdate = 200)
-        val ebook = FakeRemote("ABS_EBOOK", RemoteRead(pos("A"), lastUpdate = 90))
-        val storyteller = FakeRemote("STORYTELLER", RemoteRead(pos("S"), lastUpdate = 150))
+        val ebook = FakePeer("ABS_EBOOK", RemoteRead(pos("A"), lastUpdate = 90))
+        val storyteller = FakePeer("STORYTELLER", RemoteRead(pos("S"), lastUpdate = 150))
 
         val result = CanonicalSyncCycle.run(local, listOf(ebook, storyteller))
 
@@ -72,7 +72,7 @@ class CanonicalSyncCycleTest {
         // ABS stamps an ebook write with a server time later than the local clock. The cycle must
         // adopt it, so the write doesn't read back next cycle as a newer remote and bounce the reader.
         val local = LocalCanonical(pos("L"), lastUpdate = 200)
-        val ebook = FakeRemote("ABS_EBOOK", RemoteRead(pos("A"), lastUpdate = 90), patchStamp = 5_000)
+        val ebook = FakePeer("ABS_EBOOK", RemoteRead(pos("A"), lastUpdate = 90), patchStamp = 5_000)
 
         val result = CanonicalSyncCycle.run(local, listOf(ebook))
 
@@ -84,9 +84,9 @@ class CanonicalSyncCycleTest {
     @Test
     fun `a failed GET excludes that remote from comparison and from patching`() = runTest {
         val local = LocalCanonical(pos("L"), lastUpdate = 100)
-        val ebook = FakeRemote("ABS_EBOOK", RemoteRead(pos("A"), lastUpdate = 90))
-        val audio = FakeRemote("ABS_AUDIO", getResult = null) // unreachable
-        val storyteller = FakeRemote("STORYTELLER", RemoteRead(pos("S"), lastUpdate = 150))
+        val ebook = FakePeer("ABS_EBOOK", RemoteRead(pos("A"), lastUpdate = 90))
+        val audio = FakePeer("ABS_AUDIO", getResult = null) // unreachable
+        val storyteller = FakePeer("STORYTELLER", RemoteRead(pos("S"), lastUpdate = 150))
 
         val result = CanonicalSyncCycle.run(local, listOf(ebook, audio, storyteller))
 
@@ -99,12 +99,31 @@ class CanonicalSyncCycleTest {
     @Test
     fun `a failed PATCH leaves that remote out of the patched set but does not poison others`() = runTest {
         val local = LocalCanonical(pos("L"), lastUpdate = 200)
-        val ebook = FakeRemote("ABS_EBOOK", RemoteRead(pos("A"), lastUpdate = 90)).apply { patchFails = true }
-        val storyteller = FakeRemote("STORYTELLER", RemoteRead(pos("S"), lastUpdate = 150))
+        val ebook = FakePeer("ABS_EBOOK", RemoteRead(pos("A"), lastUpdate = 90)).apply { patchFails = true }
+        val storyteller = FakePeer("STORYTELLER", RemoteRead(pos("S"), lastUpdate = 150))
 
         val result = CanonicalSyncCycle.run(local, listOf(ebook, storyteller))
 
         assertEquals(setOf("STORYTELLER"), result.patched)
         assertEquals(pos("L"), storyteller.patchedWith)
+    }
+
+    @Test
+    fun `a peer that skips its PATCH is treated identically to one that fails`() = runTest {
+        // WriteResult.Skipped models a deliberate no-op (e.g. translator couldn't place the
+        // canonical position, or an inbound-only wrapper suppressed the outbound). The cycle must
+        // leave it out of `patched` and never adopt a stamp, exactly like Failed.
+        val local = LocalCanonical(pos("L"), lastUpdate = 200)
+        val skipping = object : ProgressPeer {
+            override val id = "SKIPPING"
+            override suspend fun tryGet() = RemoteRead(pos("X"), lastUpdate = 90)
+            override suspend fun tryPatch(canonical: CanonicalReaderPosition) = WriteResult.Skipped
+        }
+        val storyteller = FakePeer("STORYTELLER", RemoteRead(pos("S"), lastUpdate = 150))
+
+        val result = CanonicalSyncCycle.run(local, listOf(skipping, storyteller))
+
+        assertEquals(setOf("STORYTELLER"), result.patched)
+        assertEquals("the skipped peer's (non-existent) stamp must not be adopted", 200L, result.canonicalLastUpdate)
     }
 }

--- a/core/domain/src/test/kotlin/com/riffle/core/domain/ProgressSyncStrategyTest.kt
+++ b/core/domain/src/test/kotlin/com/riffle/core/domain/ProgressSyncStrategyTest.kt
@@ -8,12 +8,12 @@ import org.junit.Test
 
 class ProgressSyncStrategyTest {
 
-    private class FakeRemote(override val id: String) : SyncRemote {
+    private class FakePeer(override val id: String) : ProgressPeer {
         var patchedWith: CanonicalReaderPosition? = null
         override suspend fun tryGet(): RemoteRead? = null
-        override suspend fun tryPatch(canonical: CanonicalReaderPosition): Long? {
+        override suspend fun tryPatch(canonical: CanonicalReaderPosition): WriteResult {
             patchedWith = canonical
-            return 1L // non-null = stored; a fixed server timestamp
+            return WriteResult.Ok(serverStamp = 1L)
         }
     }
 
@@ -22,7 +22,7 @@ class ProgressSyncStrategyTest {
     @Test
     fun `a matched state reconciles the ebook and the audiobook`() = runTest {
         val built = mutableListOf<RemoteKind>()
-        val strategy = ProgressSyncStrategy { kind -> built += kind; FakeRemote(kind.name) }
+        val strategy = ProgressSyncStrategy { kind -> built += kind; FakePeer(kind.name) }
 
         val state = BookSyncState(
             isMatched = true,
@@ -41,7 +41,7 @@ class ProgressSyncStrategyTest {
     @Test
     fun `an ebook-only match reconciles the ebook only`() = runTest {
         val built = mutableListOf<RemoteKind>()
-        val strategy = ProgressSyncStrategy { kind -> built += kind; FakeRemote(kind.name) }
+        val strategy = ProgressSyncStrategy { kind -> built += kind; FakePeer(kind.name) }
 
         val state = BookSyncState(
             isMatched = true,
@@ -57,7 +57,7 @@ class ProgressSyncStrategyTest {
     @Test
     fun `an unmatched ABS-side book runs single-peer over ABS ebook only`() = runTest {
         val built = mutableListOf<RemoteKind>()
-        val strategy = ProgressSyncStrategy { kind -> built += kind; FakeRemote(kind.name) }
+        val strategy = ProgressSyncStrategy { kind -> built += kind; FakePeer(kind.name) }
 
         val state = BookSyncState(isMatched = false, hasAbsEbookTarget = true, hasAbsAudioTarget = false, prerequisitesCached = false)
         strategy.runCycle(state, local)
@@ -69,7 +69,7 @@ class ProgressSyncStrategyTest {
     fun `a remote the factory cannot build is skipped without poisoning the cycle`() = runTest {
         // Prerequisites cached but the audiobook remote can't be constructed (e.g. bundle gone).
         val strategy = ProgressSyncStrategy { kind ->
-            if (kind == RemoteKind.ABS_AUDIO) null else FakeRemote(kind.name)
+            if (kind == RemoteKind.ABS_AUDIO) null else FakePeer(kind.name)
         }
 
         val state = BookSyncState(isMatched = true, hasAbsEbookTarget = true, hasAbsAudioTarget = true, prerequisitesCached = true)


### PR DESCRIPTION
## Summary

Closes #302 in the form that actually fits the codebase. The architecture review that issue #302 was generated from (`/private/tmp/architecture-review-20260627.html`, Card 3) describes a `ProgressPeer` refactor as if Riffle has no unified canonical cycle today. In fact Riffle already has one: `CanonicalSyncCycle` runs ADR-0008 last-update-wins over a `List<SyncRemote>`, and `AbsEbookSyncRemote` / `AbsAudiobookSyncRemote` already act as adapters on the canonical-frame boundary. This PR is the part of #302 that is actually missing from that picture:

1. Adopt the issue's vocabulary. `SyncRemote` becomes `ProgressPeer`. The three ABS adapters rename to match.
2. Make the patch contract explicit. `tryPatch(canonical): Long?` becomes `tryPatch(canonical): WriteResult` with a sealed hierarchy:
   - `Ok(serverStamp)` — stored and stamped server-side.
   - `Skipped` — deliberate no-op (translator boundary couldn't place the canonical position, or `InboundOnlyPeer` wrapper suppressed the outbound).
   - `Failed(reason)` — attempted and failed; the durable sweep retries.
   The two non-Ok cases were both `null` before; the cycle still treats them identically, but telemetry / future sweep logic gets a real contract instead of a sniff.
3. Document what is intentionally NOT a `ProgressPeer`. The local Room store is the canonical authority with compare-and-swap (`SyncPositionStore.acceptServerPosition` / `confirmPushed`) semantics, not push-then-stamp — it can't fit a `tryPatch(canonical)` contract honestly. Storyteller has no progress-write endpoint, so the architecture review's `StorytellerPeer` would be a permanent no-op. The new KDoc on `ProgressPeer` says so explicitly to keep future agents from re-adding either.

### What the issue spec asked for vs. what's here

Cutover plan in the issue lists six steps. Mapped to the actual code:

- **Step 1** — define `ProgressPeer` + reconciler + fake-peer tests. Reconciler already existed (`CanonicalSyncCycle`) with fake-peer tests already passing. ✅ This PR upgrades the peer contract.
- **Step 2** — `LocalRoomPeer`. ❌ Skipped. The local store's compare-and-swap shape doesn't fit `tryPatch(canonical): WriteResult`. Forcing it would have been an LSP regression, not a fix.
- **Step 3** — `AbsPeer` + named-bug regression tests. ABS adapters are already in place; this PR renames them and pins the new `Skipped` case in `CanonicalSyncCycleTest`. The four named historical bugs were translator / payload bugs, not peer-orchestration bugs, and would not have been caught by a peer-interface change.
- **Step 4** — `StorytellerPeer`. ❌ Skipped. No such endpoint exists.
- **Step 5** — fold `ProgressFlushScope` into the reconciler. ❌ Skipped. `ProgressFlushScope` is a 6-line `scope.launch` shim already on the survivable app scope per ADR-0030; wrapping it in the reconciler would be motion, not progress.
- **Step 6** — audit / delete remaining direct peer calls. ❌ Already done — VMs already go through the repository layer; no direct peer calls remained to delete.

If the omitted steps end up wanted in a different form, opening a focused follow-up issue is the right shape — not a six-step rewrite of code that mostly already exists.

### Files changed

- `core/domain/CanonicalSyncCycle.kt` — `SyncRemote` → `ProgressPeer`, add `WriteResult`, peer KDoc explaining what's NOT a peer.
- `core/domain/ProgressSyncStrategy.kt` — rename `remoteFor` → `peerFor`.
- `app/.../reader/ReaderSync.kt` — three ABS adapter renames.
- Tests pinned, plus a new `Skipped`-case test.

## Test plan

- [x] `./gradlew test` — green (full JVM suite).
- [x] `./gradlew :core:domain:test :app:testDebugUnitTest` — green.
- [ ] Harness tests not run: pure JVM-domain rename, no Readium/WebView/UI surface touched. Behaviour preserved; CI will run the harness if it matters.