### PR TITLE
fix(reader): ignore horizontal swipes for scroll-mode chapter pull

### DIFF
--- a/app/src/androidTest/kotlin/com/riffle/app/feature/reader/ScrollBoundaryNavigationContainerTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/reader/ScrollBoundaryNavigationContainerTest.kt
@@ -238,6 +238,54 @@ class ScrollBoundaryNavigationContainerTest {
         assertFalse(invoked)
     }
 
+    @Test
+    fun leftwardSwipeAtForwardBoundaryDoesNotArmPull() {
+        // Regression: a leftward swipe at a forward boundary with per-MOVE y jitter that
+        // exceeds MOVEMENT_SLOP_PX (real fingers, especially on a phone, never produce a
+        // perfectly horizontal trace) must not arm the pull. Gating on |totalDx| > |totalDy|
+        // since ACTION_DOWN prevents this — only predominantly-vertical gestures arm.
+        var navigated = false
+        var pillShown = false
+        val c = container(atForwardBoundary = true)
+        c.onNavigateForward = { navigated = true }
+        c.onPullStarted = { pillShown = true }
+        // 600 px leftward, 30 px cumulative upward (1.5 px per step would pass slop=2; use 3 px
+        // to be unambiguously above slop). dx (600) >>> dy (60) → gate must suppress.
+        val perMoveDx = 30f
+        val perMoveDy = 3f
+        val steps = 20
+        onMain { dispatchDown(c, 700f, 1000f) }
+        for (i in 1..steps) {
+            Thread.sleep(50)
+            onMain { dispatchMove(c, 700f - i * perMoveDx, 1000f - i * perMoveDy) }
+        }
+        onMain { dispatchUp(c, 700f - steps * perMoveDx, 1000f - steps * perMoveDy) }
+        onMain {}
+        assertFalse(pillShown)
+        assertFalse(navigated)
+    }
+
+    @Test
+    fun rightwardSwipeAtBackwardBoundaryDoesNotArmPull() {
+        var navigated = false
+        var pillShown = false
+        val c = container(atBackwardBoundary = true)
+        c.onNavigateBackward = { navigated = true }
+        c.onPullStarted = { pillShown = true }
+        val perMoveDx = 30f
+        val perMoveDy = 3f
+        val steps = 20
+        onMain { dispatchDown(c, 100f, 200f) }
+        for (i in 1..steps) {
+            Thread.sleep(50)
+            onMain { dispatchMove(c, 100f + i * perMoveDx, 200f + i * perMoveDy) }
+        }
+        onMain { dispatchUp(c, 100f + steps * perMoveDx, 200f + steps * perMoveDy) }
+        onMain {}
+        assertFalse(pillShown)
+        assertFalse(navigated)
+    }
+
     // -- Chapter-nav suppression on ACTION_UP --
     //
     // The container lets MOVE events pass through to the WebView so vertical scrolling and

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ScrollBoundaryNavigationContainer.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ScrollBoundaryNavigationContainer.kt
@@ -37,6 +37,8 @@ class ScrollBoundaryNavigationContainer(context: Context) : FrameLayout(context)
     private var lastNavigationMs = 0L
     private var lastVolumeNavMs = 0L
     private var lastTouchY = 0f
+    private var downX = 0f
+    private var downY = 0f
     private var lastMoveTimeMs = 0L
     private var pullDirection = 0 // 1 = forward pull, -1 = backward pull, 0 = inactive
     private var pullDistancePx = 0f
@@ -126,16 +128,18 @@ class ScrollBoundaryNavigationContainer(context: Context) : FrameLayout(context)
             when (ev.actionMasked) {
                 MotionEvent.ACTION_DOWN -> {
                     lastTouchY = ev.y
+                    downX = ev.x
+                    downY = ev.y
                     resetPull()
                 }
-                MotionEvent.ACTION_MOVE -> handlePullMove(ev.y)
+                MotionEvent.ACTION_MOVE -> handlePullMove(ev.x, ev.y)
                 MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL -> resetPull()
             }
         }
         return super.dispatchTouchEvent(ev)
     }
 
-    private fun handlePullMove(y: Float) {
+    private fun handlePullMove(x: Float, y: Float) {
         val dy = y - lastTouchY
         lastTouchY = y
         val now = SystemClock.elapsedRealtime()
@@ -159,7 +163,13 @@ class ScrollBoundaryNavigationContainer(context: Context) : FrameLayout(context)
             resetPull(); return
         }
 
-        // Start a new pull only when finger moves in the correct direction at a boundary.
+        // Start a new pull only when finger moves in the correct direction at a boundary AND
+        // the gesture is predominantly vertical. A horizontal swipe has tiny y jitter that
+        // easily passes MOVEMENT_SLOP_PX, which previously armed the pull on left/right swipes
+        // at a boundary — only up/down pulls should trigger chapter navigation in scroll mode.
+        val totalDx = x - downX
+        val totalDy = y - downY
+        if (pullDirection == 0 && abs(totalDx) >= abs(totalDy)) return
         if (pullDirection == 0) {
             when {
                 dy < -MOVEMENT_SLOP_PX && atForwardBoundary && canNavigateForward -> {


### PR DESCRIPTION
## Summary

In scroll/vertical mode, a left or right swipe at a chapter boundary was triggering the pull-to-next-chapter pill. Only up/down pulls should navigate chapters.

**Root cause:** `ScrollBoundaryNavigationContainer.handlePullMove` armed the pull whenever per-MOVE `|dy| > MOVEMENT_SLOP_PX (2px)` and at-boundary. Real horizontal swipes have y-jitter that easily exceeds 2 px per move, so left/right swipes at a chapter boundary armed the pill.

**Fix:** Before arming, require the cumulative gesture since `ACTION_DOWN` to be predominantly vertical (`|Δy| > |Δx|`). Once armed, existing logic runs unchanged.

## Test plan

- [x] New regression tests: `leftwardSwipeAtForwardBoundaryDoesNotArmPull`, `rightwardSwipeAtBackwardBoundaryDoesNotArmPull` (3 px/move y-jitter — above slop=2 — with dx ≫ dy)
- [x] Existing pull/nav tests still pass under compile
- [ ] Manually reproduce the original gesture in a live AVD