### PR TITLE
fix(sync): make position-store save timestamps monotonic per row

### DIFF
--- a/core/data/src/main/kotlin/com/riffle/core/data/TimestampedPositionStore.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/TimestampedPositionStore.kt
@@ -3,9 +3,19 @@ package com.riffle.core.data
 import com.riffle.core.domain.PositionStore
 
 /**
- * Shared policy for the per-medium position stores: [save] stamps the current wall clock;
+ * Shared policy for the per-medium position stores: [save] stamps a monotonically-non-decreasing
+ * timestamp (wall clock, or one millisecond past the stored value when the wall clock is behind);
  * [loadLocalUpdatedAt] defaults a missing row to 0L. Subclasses supply the per-table storage via the
  * four template methods (Room forbids a shared generic entity/DAO). [now] is overridable for tests.
+ *
+ * The monotonic guard exists because the live progress-sync cycle and the durable sweep order edits
+ * by comparing `localUpdatedAt` with the server's `lastUpdate`. ABS stamps PATCHes with its own wall
+ * clock; when that clock is ahead of the device's clock, the cycle adopts the server's future stamp
+ * into `localUpdatedAt` (so the write doesn't immediately read back as a "newer remote"). If the
+ * very next `save()` used a raw `now()`, it would silently regress `localUpdatedAt` below the adopted
+ * stamp, making every subsequent cycle conclude server-wins and yank the reader back to the older
+ * server position — the "periodic sync overwrites my position" bug. Saving `max(now, existing+1)`
+ * preserves user edits as strictly newer than any prior state, regardless of cross-machine clock skew.
  */
 abstract class TimestampedPositionStore<P> : PositionStore<P> {
 
@@ -16,8 +26,11 @@ abstract class TimestampedPositionStore<P> : PositionStore<P> {
     protected abstract suspend fun readUpdatedAt(serverId: String, itemId: String): Long?
     protected abstract suspend fun writeUpdatedAt(serverId: String, itemId: String, updatedAt: Long)
 
-    final override suspend fun save(serverId: String, itemId: String, payload: P) =
-        writePayload(serverId, itemId, payload, now())
+    final override suspend fun save(serverId: String, itemId: String, payload: P) {
+        val existing = readUpdatedAt(serverId, itemId) ?: 0L
+        val ts = maxOf(now(), existing + 1)
+        writePayload(serverId, itemId, payload, ts)
+    }
 
     final override suspend fun load(serverId: String, itemId: String): P? =
         readPayload(serverId, itemId)

--- a/core/data/src/test/kotlin/com/riffle/core/data/ReadingPositionStoreTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/ReadingPositionStoreTest.kt
@@ -107,6 +107,28 @@ class ReadingPositionStoreTest {
     }
 
     @Test
+    fun `save never regresses localUpdatedAt below an adopted future server stamp`() = runTest {
+        // Regression: when ABS's clock is ahead of the device, the sync cycle adopts a future server
+        // stamp as localUpdatedAt. A subsequent save() using raw now() would silently lower
+        // localUpdatedAt back under the server's last-known stamp, making every next cycle conclude
+        // server-wins and yank the reader to the older server position — the "periodic sync
+        // overwrites my position" bug. save() must always advance localUpdatedAt strictly past
+        // whatever's already stored.
+        val dao = FakeReadingPositionDao()
+        val store = ReadingPositionStoreImpl(dao)
+        val futureServerStamp = System.currentTimeMillis() + 120_000L // 2 minutes ahead
+        dao.seed(ReadingPositionEntity("server-A", "item-1", "old", futureServerStamp, futureServerStamp))
+
+        store.save("server-A", "item-1", "fresh")
+
+        val after = dao.store["server-A" to "item-1"]?.localUpdatedAt ?: 0L
+        assert(after > futureServerStamp) {
+            "save() must advance localUpdatedAt past the adopted server stamp; was $after, server stamp $futureServerStamp"
+        }
+        assertEquals("fresh", store.load("server-A", "item-1"))
+    }
+
+    @Test
     fun `load on a different server returns null even when itemId is saved elsewhere`() = runTest {
         val dao = FakeReadingPositionDao().also {
             it.seed(ReadingPositionEntity("server-A", "item-1", "epubcfi(/6/2!/4/1:42)"))


### PR DESCRIPTION
## Summary

- Periodic sync was overwriting the user's current reading position with an older one, both visibly while reading and on reopening the book.
- Root cause: ABS stamps every PATCH with its own wall clock. When that clock is ahead of the device's (common on emulators that drift after pause/snapshot or a sleeping Mac host, but possible in production whenever the server's clock is ahead), the live sync cycle correctly adopts the server's future-stamped time into `localUpdatedAt` — but the very next `TimestampedPositionStore.save()` used a raw `now()` and silently regressed `localUpdatedAt` back below the adopted server stamp. Every following cycle then concluded `SERVER_WINS` and yanked the reader to the older server position.
- Fix: `save()` now writes `max(now(), existing + 1)`, making `localUpdatedAt` monotonically non-decreasing per row. A local edit always presents as strictly newer than any prior state, regardless of cross-machine clock skew. Applies to both ebook and audiobook stores (shared base class).

## Test plan

- [x] Added unit test `save never regresses localUpdatedAt below an adopted future server stamp` in `ReadingPositionStoreTest`. Seeds a row with a 2-minute-future stamp (the adopted server time), saves, and asserts the new stamp is strictly past it. Fails before the change.
- [x] `./gradlew test` green.
- [x] Verified end-to-end on an emulator with ~10 min clock skew from the ABS server: with the fix installed, opening the book / reading / closing / reopening no longer regresses the position; without the fix the regression reproduces every cycle.