### PR TITLE
chore(deps): remove unused gradle dependencies

### DIFF
--- a/core/database/build.gradle.kts
+++ b/core/database/build.gradle.kts
@@ -36,7 +36,6 @@ dependencies {
     api(libs.androidx.room.runtime)
     api(libs.androidx.room.ktx)
     ksp(libs.androidx.room.compiler)
-    implementation(libs.kotlinx.coroutines.android)
 
     testImplementation(libs.junit)
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -53,7 +53,6 @@ androidx-test-runner = { group = "androidx.test", name = "runner", version.ref =
 androidx-datastore-preferences = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "datastore" }
 androidx-work-runtime-ktx = { group = "androidx.work", name = "work-runtime-ktx", version.ref = "workmanager" }
 okhttp = { group = "com.squareup.okhttp3", name = "okhttp", version.ref = "okhttp" }
-okhttp-logging = { group = "com.squareup.okhttp3", name = "logging-interceptor", version.ref = "okhttp" }
 okhttp-mockwebserver = { group = "com.squareup.okhttp3", name = "mockwebserver", version.ref = "okhttp" }
 androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigation" }
 hilt-navigation-compose = { group = "androidx.hilt", name = "hilt-navigation-compose", version.ref = "hiltNavigation" }


### PR DESCRIPTION
## Summary
- Drop `kotlinx-coroutines-android` from `core:database` — the module only uses `Dispatchers.IO` and `Flow`, both provided transitively by `room-ktx` via `kotlinx-coroutines-core`. No `Dispatchers.Main` usage anywhere in the module's main or test sources.
- Drop the unused `okhttp-logging` catalog entry from `gradle/libs.versions.toml` — not referenced by any module's `build.gradle.kts` and no `HttpLoggingInterceptor` imports in the codebase.

## Test plan
- [x] `./gradlew :core:database:compileDebugKotlin :core:database:compileDebugUnitTestKotlin` — passes
- [ ] CI green