### PR TITLE
fix(reader): inset reading-progress labels for rounded corners

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -884,7 +884,7 @@ private fun ReadingProgressLabels(
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(horizontal = 12.dp, vertical = 2.dp)
+            .padding(horizontal = 14.dp, vertical = 2.dp)
             .testTag("reading_progress_labels"),
         verticalAlignment = Alignment.CenterVertically,
     ) {


### PR DESCRIPTION
## Summary
Bump horizontal padding on the reading-progress label row from 12dp to 14dp so the chapter count, percent, and time-remaining labels sit slightly further from the screen edge and aren't clipped by rounded device corners. Both rows share the same `Row` padding so the time-remaining labels stay aligned with the reading-progress labels above them.

## Test plan
- [ ] Visual check on a rounded-corner device: time-remaining labels are no longer clipped at the corners
- [ ] Reading-progress labels (chapter count / %) remain aligned with the time labels below