### PR TITLE
fix(audiobook): close player and return to detail view on end-of-book

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookController.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookController.kt
@@ -67,7 +67,11 @@ open class AudiobookController @Inject constructor(
     private val _sleepTimer = MutableStateFlow<SleepTimerMode>(SleepTimerMode.None)
     open val sleepTimer: StateFlow<SleepTimerMode> = _sleepTimer.asStateFlow()
 
-    private val _playbackEnded = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
+    // replay=1 so a STATE_ENDED that fires while no collector is attached — e.g. across an Activity
+    // recreation (rotation, theme change) right at end-of-book — is still delivered to the next
+    // collector. The VM acts on it by stopping the controller (releasing the session), so a re-emit
+    // after that point can't re-trigger; idempotent.
+    private val _playbackEnded = MutableSharedFlow<Unit>(replay = 1, extraBufferCapacity = 1)
     open val playbackEnded: SharedFlow<Unit> = _playbackEnded.asSharedFlow()
     private var timerJob: Job? = null
 
@@ -254,6 +258,9 @@ open class AudiobookController @Inject constructor(
         cancelSleepTimer()
         pollJob?.cancel()
         pollJob = null
+        // Drop any cached end-of-book event so the next book opened on this singleton controller
+        // doesn't inherit the previous book's Finished signal at first-subscribe.
+        _playbackEnded.resetReplayCache()
         controller?.run {
             stop()
             clearMediaItems()

--- a/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookController.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookController.kt
@@ -20,8 +20,11 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
@@ -63,6 +66,9 @@ open class AudiobookController @Inject constructor(
 
     private val _sleepTimer = MutableStateFlow<SleepTimerMode>(SleepTimerMode.None)
     open val sleepTimer: StateFlow<SleepTimerMode> = _sleepTimer.asStateFlow()
+
+    private val _playbackEnded = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
+    open val playbackEnded: SharedFlow<Unit> = _playbackEnded.asSharedFlow()
     private var timerJob: Job? = null
 
     private var controller: MediaController? = null
@@ -81,6 +87,10 @@ open class AudiobookController @Inject constructor(
         override fun onEvents(player: Player, events: Player.Events) {
             if (events.containsAny(Player.EVENT_PLAYBACK_STATE_CHANGED, Player.EVENT_IS_PLAYING_CHANGED)) {
                 Log.d(HANDOFF, "AB.onPlaybackStateChanged state=${player.playbackState} isPlaying=${player.isPlaying}")
+            }
+            if (events.contains(Player.EVENT_PLAYBACK_STATE_CHANGED)
+                && player.playbackState == Player.STATE_ENDED) {
+                _playbackEnded.tryEmit(Unit)
             }
             maybeStart(player)
             pushState()

--- a/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.windowsizeclass.WindowHeightSizeClass
 import androidx.compose.material3.windowsizeclass.WindowSizeClass
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -132,6 +133,17 @@ fun AudiobookPlayerScreen(
     viewModel: AudiobookPlayerViewModel = hiltViewModel(),
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
+    // When the book ends naturally (last track played through to STATE_ENDED), close the player —
+    // pop back to the audiobook detail view. The VM's onCleared() then stops the MediaSession, which
+    // clears the foreground notification.
+    val latestOnNavigateBack = rememberUpdatedState(onNavigateBack)
+    LaunchedEffect(Unit) {
+        viewModel.events.collect { event ->
+            when (event) {
+                AudiobookPlayerEvent.Finished -> latestOnNavigateBack.value()
+            }
+        }
+    }
     // Any short (Compact-height) window — i.e. a phone in landscape — is too short for the vertical
     // layout (the square cover pushes the controls off-screen), so split into cover+details / controls.
     val twoColumn = windowSizeClass.heightSizeClass == WindowHeightSizeClass.Compact

--- a/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModel.kt
@@ -674,15 +674,14 @@ class AudiobookPlayerViewModel(
         // We can't rely solely on onCleared() to tear the player down: by the time the screen pops
         // and the VM is cleared, the player has been sitting in STATE_ENDED with media items still
         // in the queue, and the [AudioPlayerService] foreground notification stays put for the user
-        // to see. Flush final progress, clear the MediaSession queue, and release the controller
-        // here — that drops the foreground notification right away. onCleared() still runs its own
-        // teardown shortly after; the second calls are safe no-ops (controller is already null).
+        // to see. Tear down here so the foreground notification drops right away; onCleared() runs
+        // the same teardown shortly after, idempotently (controller is already null on the second
+        // pass).
         viewModelScope.launch {
             controller.playbackEnded.collect {
-                pushProgressOnStop()
                 flushPendingSpeed()
-                controller.stop()
-                nowPlayingStore.clearIf { it is com.riffle.app.playback.NowPlaying.Audiobook && it.itemId == itemId }
+                pushProgressAndStopPlayer()
+                clearAudiobookNowPlaying()
                 _events.tryEmit(AudiobookPlayerEvent.Finished)
             }
         }
@@ -1008,6 +1007,21 @@ class AudiobookPlayerViewModel(
         viewModelScope.launch { audiobookRepository.saveProgress(serverId, itemId, pos, dur) }
     }
 
+    /**
+     * Flush the just-ended position to ABS / the local position store, then tear down the
+     * MediaSession queue and release the [AudiobookController] (which dismisses the foreground
+     * notification). Idempotent: the controller's own stop() guards against a re-stop after release.
+     */
+    private fun pushProgressAndStopPlayer() {
+        pushProgressOnStop()
+        controller.stop()
+    }
+
+    /** Clear THIS book from the now-playing store so the mini-bar doesn't linger after the session ends. */
+    private fun clearAudiobookNowPlaying() {
+        nowPlayingStore.clearIf { it is com.riffle.app.playback.NowPlaying.Audiobook && it.itemId == itemId }
+    }
+
     override fun onCleared() {
         followJob?.cancel()
         // Release this book to the durable sweep again (ADR 0030).
@@ -1022,12 +1036,9 @@ class AudiobookPlayerViewModel(
         flushPendingSpeed()
         // On a readaloud handoff the progress was already pushed and the handle released without
         // stopping the shared player (readaloud now owns it) — stopping here would pause readaloud.
-        if (!handingOffToReadaloud) {
-            pushProgressOnStop()
-            controller.stop()
-        }
+        if (!handingOffToReadaloud) pushProgressAndStopPlayer()
         // Leaving the player stops playback (no mini-bar), so this session is no longer playing.
-        nowPlayingStore.clearIf { it is com.riffle.app.playback.NowPlaying.Audiobook && it.itemId == itemId }
+        clearAudiobookNowPlaying()
         super.onCleared()
     }
 

--- a/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModel.kt
@@ -18,8 +18,11 @@ import com.riffle.core.domain.LibraryRepository
 import com.riffle.core.domain.ServerRepository
 import com.riffle.core.domain.TokenStorage
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
@@ -99,6 +102,12 @@ internal fun buildAudiobookFacts(durationSec: Double, genres: List<String>): Str
     }
     // "Audiobook" alone is just the medium label with no real facts — not worth a line.
     return if (parts.size > 1) parts.joinToString(" · ") else null
+}
+
+/** One-shot UI events emitted by the [AudiobookPlayerViewModel] — collected by the screen. */
+sealed interface AudiobookPlayerEvent {
+    /** Playback finished naturally (last track ended); the screen should close the player. */
+    data object Finished : AudiobookPlayerEvent
 }
 
 /** UI state for the full-screen [Audiobook Player] (ADR 0029). */
@@ -358,6 +367,9 @@ class AudiobookPlayerViewModel(
     private val rewindOnResumeSec: StateFlow<Double> = listeningPreferencesStore.rewindOnResumeSeconds
         .map { it.toDouble() }
         .stateIn(viewModelScope, SharingStarted.Eagerly, ListeningPreferencesStore.DEFAULT_REWIND_ON_RESUME_SECONDS.toDouble())
+
+    private val _events = MutableSharedFlow<AudiobookPlayerEvent>(extraBufferCapacity = 1)
+    val events: SharedFlow<AudiobookPlayerEvent> = _events.asSharedFlow()
 
     val uiState: StateFlow<AudiobookPlayerUiState> =
         combine(meta, controller.state, controller.sleepTimer) { m, playback, timer ->
@@ -654,6 +666,25 @@ class AudiobookPlayerViewModel(
                     followJob = null
                     controller.pause()
                 }
+        }
+
+        // End-of-book: when the player reports STATE_ENDED (last track played through), close the
+        // android-level player immediately and tell the screen to pop back to the detail view.
+        //
+        // We can't rely solely on onCleared() to tear the player down: by the time the screen pops
+        // and the VM is cleared, the player has been sitting in STATE_ENDED with media items still
+        // in the queue, and the [AudioPlayerService] foreground notification stays put for the user
+        // to see. Flush final progress, clear the MediaSession queue, and release the controller
+        // here — that drops the foreground notification right away. onCleared() still runs its own
+        // teardown shortly after; the second calls are safe no-ops (controller is already null).
+        viewModelScope.launch {
+            controller.playbackEnded.collect {
+                pushProgressOnStop()
+                flushPendingSpeed()
+                controller.stop()
+                nowPlayingStore.clearIf { it is com.riffle.app.playback.NowPlaying.Audiobook && it.itemId == itemId }
+                _events.tryEmit(AudiobookPlayerEvent.Finished)
+            }
         }
 
         // End-of-chapter sleep timer: fire when chapter index advances while EoC mode is active.

--- a/app/src/test/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModelBookmarkTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModelBookmarkTest.kt
@@ -52,6 +52,10 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.resetMain
@@ -93,6 +97,9 @@ class AudiobookPlayerViewModelBookmarkTest {
         val seeks = mutableListOf<Double>()
         var preparedStartAtSec: Double? = null
         override val state = MutableStateFlow(PlaybackState())
+        private val ended = kotlinx.coroutines.flow.MutableSharedFlow<Unit>(extraBufferCapacity = 1)
+        override val playbackEnded: kotlinx.coroutines.flow.SharedFlow<Unit> = ended.asSharedFlow()
+        fun emitEnded() { ended.tryEmit(Unit) }
         override suspend fun prepare(
             trackUrls: List<String>,
             spans: List<com.riffle.core.domain.AudiobookTrackSpan>,
@@ -251,6 +258,24 @@ class AudiobookPlayerViewModelBookmarkTest {
         runCurrent()
 
         assertEquals(listOf(123.0), controller.seeks)
+        vm.clearForTest()
+    }
+
+    @Test
+    fun `controller playbackEnded emits a Finished UI event so the screen can close the player`() = runTest(testDispatcher) {
+        val controller = FakeController(position = 0.0)
+        val vm = buildViewModel(controller, FakeBookmarkStore())
+        runCurrent()
+
+        val collected = mutableListOf<AudiobookPlayerEvent>()
+        val job = launch { vm.events.take(1).toList(collected) }
+        runCurrent()
+
+        controller.emitEnded()
+        runCurrent()
+        job.join()
+
+        assertEquals(listOf(AudiobookPlayerEvent.Finished), collected)
         vm.clearForTest()
     }
 


### PR DESCRIPTION
## Summary

When the last track plays through to `STATE_ENDED`, the audiobook player now closes the foreground MediaSession player and pops back to the audiobook detail view. Previously the screen and the Android player notification both stayed put until the user manually navigated away.

- `AudiobookController` exposes a `playbackEnded: SharedFlow<Unit>` emitted from the `Player.Listener` on `STATE_ENDED`. `replay=1` so a STATE_ENDED that fires across an Activity recreation (e.g. rotation right at end-of-book) still reaches the next subscriber; `stop()` resets the replay cache so the next book opened on the singleton controller doesn't inherit it.
- `AudiobookPlayerViewModel` exposes a one-shot `events` flow with `Finished`. The end-of-book collector flushes the final position, stops the MediaSession (dismissing the foreground notification), clears the now-playing store, and emits `Finished`. Shared with `onCleared()` via two small helpers (`pushProgressAndStopPlayer` / `clearAudiobookNowPlaying`).
- `AudiobookPlayerScreen` collects `events` and calls the existing `onNavigateBack` on `Finished` (`popBackStack()` returns to the library item detail screen).

## Test plan
- [x] JVM: `:app:testDebugUnitTest` for `com.riffle.app.feature.audiobook.*` green, incl. new regression test `controller playbackEnded emits a Finished UI event so the screen can close the player`.
- [ ] Device: let an audiobook play out (or seek to last few seconds and let it finish) — confirm the player screen pops to the detail view AND the system media notification dismisses.
- [ ] Device: rotate the phone during the final seconds of playback — confirm the navigation+notification dismissal still fires after the rotation.