### PR TITLE
refactor(infra): introduce ApplicationScope seam for survivable writes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,10 @@ When adding a new Room migration:
      - Cursor assertions verifying new columns have correct default values and all pre-existing data is preserved
    - Add the new migration to the `migrateFullChain` test's `runMigrationsAndValidate` call.
 
+## Reference the source issue in the PR
+
+When the work originated from a GitHub Issue (e.g. the user asked you to "do #123"), the PR body must include a `Closes #N` line so the merge auto-closes the issue. One line per issue if the PR spans several. Put it near the top of the body, above the change summary.
+
 ## Tests are required before opening a PR
 
 Do not open a PR without tests that cover the fix or new functionality. Every bug fix needs a regression test that fails before the change and passes after; every new feature needs unit and/or integration coverage for its behaviour. "Manually verified" is not a substitute for an automated test.

--- a/app/src/androidTest/kotlin/com/riffle/app/feature/reader/readaloud/ReadaloudStreamingSessionFactoryAndroidTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/reader/readaloud/ReadaloudStreamingSessionFactoryAndroidTest.kt
@@ -22,8 +22,10 @@ import com.riffle.core.domain.TokenStorage
 import com.riffle.core.network.AbsApiClient
 import com.riffle.core.network.StorytellerApiClient
 import com.riffle.core.network.StorytellerBundleApiImpl
+import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import okhttp3.OkHttpClient
 import okhttp3.mockwebserver.Dispatcher
@@ -155,7 +157,19 @@ class ReadaloudStreamingSessionFactoryAndroidTest {
     private fun factory(): ReadaloudStreamingSessionFactory {
         val repo = StubServerRepository(mapOf(ABS_SERVER to baseUrl, ST_SERVER to baseUrl))
         val fetcher = StorytellerSidecarFetcher(StorytellerBundleApiImpl(OkHttpClient()))
-        sidecarStore = ReadaloudSidecarStore(ctx, fetcher, repo, StubTokenStorage)
+        val sidecarScope = kotlinx.coroutines.CoroutineScope(
+            kotlinx.coroutines.SupervisorJob() + kotlinx.coroutines.Dispatchers.IO,
+        )
+        sidecarStore = ReadaloudSidecarStore(
+            ctx, fetcher, repo, StubTokenStorage,
+            object : com.riffle.core.domain.ApplicationScope {
+                override val coroutineScope = sidecarScope
+                override fun launchSurvivable(block: suspend kotlinx.coroutines.CoroutineScope.() -> Unit) =
+                    sidecarScope.launch(block = block)
+                override suspend fun <T> withSurvivable(block: suspend kotlinx.coroutines.CoroutineScope.() -> T): T =
+                    sidecarScope.async(block = block).await()
+            },
+        )
         return ReadaloudStreamingSessionFactory(
             context = ctx,
             audioIdentityResolver = AudioIdentityResolverImpl(db.readaloudLinkDao(), db.libraryItemDao()),

--- a/app/src/main/kotlin/com/riffle/app/RiffleApplication.kt
+++ b/app/src/main/kotlin/com/riffle/app/RiffleApplication.kt
@@ -6,15 +6,12 @@ import coil.ImageLoader
 import coil.ImageLoaderFactory
 import coil.disk.DiskCache
 import com.riffle.core.data.LocalStoreMigrator
+import com.riffle.core.domain.ApplicationScope
 import dagger.hilt.EntryPoint
 import dagger.hilt.InstallIn
 import dagger.hilt.android.EntryPointAccessors
 import dagger.hilt.android.HiltAndroidApp
 import dagger.hilt.components.SingletonComponent
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.launch
 import okhttp3.Interceptor
 import okhttp3.OkHttpClient
 import org.acra.ReportField
@@ -32,6 +29,7 @@ class RiffleApplication : Application(), ImageLoaderFactory {
         fun localStoreMigrator(): LocalStoreMigrator
         fun connectivityObserver(): com.riffle.core.domain.ConnectivityObserver
         fun appUpdateRepository(): com.riffle.core.domain.AppUpdateRepository
+        fun applicationScope(): ApplicationScope
     }
 
     override fun attachBaseContext(base: Context) {
@@ -67,17 +65,20 @@ class RiffleApplication : Application(), ImageLoaderFactory {
 
     override fun onCreate() {
         super.onCreate()
+        val entryPoint = EntryPointAccessors.fromApplication(this, MigratorEntryPoint::class.java)
+        val applicationScope = entryPoint.applicationScope()
+
         // One-time relocation of legacy flat cache/download files into per-Server dirs (ADR 0025).
         // Idempotent and best-effort; runs off the main thread and never blocks startup.
-        val migrator = EntryPointAccessors.fromApplication(this, MigratorEntryPoint::class.java).localStoreMigrator()
-        CoroutineScope(SupervisorJob() + Dispatchers.IO).launch {
+        val migrator = entryPoint.localStoreMigrator()
+        applicationScope.launchSurvivable {
             runCatching { migrator.migrate() }
         }
 
         // Reclaim any update APK left behind by a previous self-update: a successful install restarts
         // the app before the download flow can delete it, so we sweep the update cache on launch.
-        val appUpdate = EntryPointAccessors.fromApplication(this, MigratorEntryPoint::class.java).appUpdateRepository()
-        CoroutineScope(SupervisorJob() + Dispatchers.IO).launch {
+        val appUpdate = entryPoint.appUpdateRepository()
+        applicationScope.launchSurvivable {
             runCatching { appUpdate.sweepStaleApks() }
         }
 
@@ -93,8 +94,8 @@ class RiffleApplication : Application(), ImageLoaderFactory {
         // Flush promptly when connectivity returns mid-session (offline edits made while the app kept
         // running would otherwise wait for the periodic sweep). Skip the initial value; sweep on each
         // false→true transition.
-        val connectivity = EntryPointAccessors.fromApplication(this, MigratorEntryPoint::class.java).connectivityObserver()
-        CoroutineScope(SupervisorJob() + Dispatchers.IO).launch {
+        val connectivity = entryPoint.connectivityObserver()
+        applicationScope.launchSurvivable {
             var wasOnline = connectivity.isOnline.value
             connectivity.isOnline.collect { online ->
                 if (online && !wasOnline) {

--- a/app/src/main/kotlin/com/riffle/app/di/AppModule.kt
+++ b/app/src/main/kotlin/com/riffle/app/di/AppModule.kt
@@ -6,6 +6,7 @@ import android.content.Context
 import com.riffle.app.feature.reader.EbookCfiTranslatorFactoryImpl
 import com.riffle.app.feature.reader.SystemTimeProvider
 import com.riffle.app.feature.reader.TimeProvider
+import com.riffle.core.domain.ApplicationScope
 import com.riffle.core.domain.EbookCfiTranslatorFactory
 import dagger.Binds
 import dagger.Module
@@ -34,14 +35,12 @@ import javax.inject.Singleton
 annotation class DownloadScope
 
 /**
- * Application-lifetime [CoroutineScope] for terminal progress writes (the close / pause flush) that
- * must survive the screen's ViewModel being cleared — see `ProgressFlushScope`. Without it, a flush
- * launched on `viewModelScope` is cancelled mid-PATCH when the user leaves the screen right after
- * triggering it.
+ * Backing [CoroutineScope] for [ApplicationScope] — survives the entire process; cancels only on
+ * process death. Tests rebind this qualifier with a `TestScope`-backed scope.
  */
 @Qualifier
 @Retention(AnnotationRetention.BINARY)
-annotation class ProgressFlush
+annotation class ApplicationCoroutineScope
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -54,8 +53,8 @@ object AppModule {
 
     @Provides
     @Singleton
-    @ProgressFlush
-    fun provideProgressFlushScope(): CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    @ApplicationCoroutineScope
+    fun provideApplicationCoroutineScope(): CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
     @Provides
     @Singleton
@@ -104,4 +103,11 @@ object AppModule {
 abstract class AnnotationSyncModule {
     @Binds
     abstract fun bindAnnotationSweepEnqueuer(impl: com.riffle.app.sync.AnnotationSweepEnqueuerImpl): com.riffle.core.domain.AnnotationSweepEnqueuer
+}
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class ApplicationScopeModule {
+    @Binds
+    abstract fun bindApplicationScope(impl: DefaultApplicationScope): ApplicationScope
 }

--- a/app/src/main/kotlin/com/riffle/app/di/DefaultApplicationScope.kt
+++ b/app/src/main/kotlin/com/riffle/app/di/DefaultApplicationScope.kt
@@ -1,0 +1,31 @@
+package com.riffle.app.di
+
+import com.riffle.core.domain.ApplicationScope
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.async
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Survivable backing scope is injected via [@ApplicationCoroutineScope] so tests can supply a
+ * `TestScope`-backed scope; production binds [Dispatchers.IO] + a [SupervisorJob] in `AppModule`.
+ *
+ * [withSurvivable] uses `async { ... }.await()` on the backing scope so the actual work runs on
+ * the survivable scope (and completes even if the caller cancels mid-await), while only the await
+ * itself is cancellation-aware in the caller.
+ */
+@Singleton
+class DefaultApplicationScope @Inject constructor(
+    @ApplicationCoroutineScope private val scope: CoroutineScope,
+) : ApplicationScope {
+
+    override val coroutineScope: CoroutineScope = scope
+
+    override fun launchSurvivable(block: suspend CoroutineScope.() -> Unit): Job =
+        scope.launch(block = block)
+
+    override suspend fun <T> withSurvivable(block: suspend CoroutineScope.() -> T): T =
+        scope.async(block = block).await()
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookController.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookController.kt
@@ -19,6 +19,7 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -63,10 +64,11 @@ open class AudiobookController @Inject constructor(
 
     // Main.immediate is required for Media3 MediaController calls; the survivable Job tree comes from
     // ApplicationScope so we don't allocate a sibling SupervisorJob. In tests, subclasses override every
-    // method that launches on this scope, so [applicationScope] is permitted to be null.
-    private val scope: CoroutineScope = applicationScope?.let {
-        CoroutineScope(it.coroutineScope.coroutineContext + Dispatchers.Main.immediate)
-    } ?: CoroutineScope(Dispatchers.Main.immediate)
+    // method that launches on this scope, so [applicationScope] is permitted to be null — the fallback
+    // mirrors the production SupervisorJob semantics so a future partial-override test fake doesn't get
+    // surprised by sibling-cancel behaviour.
+    private val scope: CoroutineScope = applicationScope?.scopeOn(Dispatchers.Main.immediate)
+        ?: CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
     private val _state = MutableStateFlow(PlaybackState())
     open val state: StateFlow<PlaybackState> = _state.asStateFlow()
 

--- a/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookController.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookController.kt
@@ -12,13 +12,13 @@ import androidx.media3.session.SessionToken
 import com.riffle.app.feature.reader.readaloud.AudioPlayerService
 import com.riffle.app.feature.reader.readaloud.ReadaloudController.Companion.HANDOFF
 import com.riffle.app.feature.reader.readaloud.SharedBundle
+import com.riffle.core.domain.ApplicationScope
 import com.riffle.core.domain.AudiobookTrackSpan
 import com.riffle.core.domain.AudiobookTracks
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -46,11 +46,12 @@ import kotlin.coroutines.resume
 @Singleton
 open class AudiobookController @Inject constructor(
     @ApplicationContext private val context: Context?,
+    applicationScope: ApplicationScope?,
 ) {
     // Test seam: a subclass that overrides every member the player touches needs no real Context (it's
     // only consulted in [ensureConnected], which fakes never reach). Keeps the controller unit-fakeable
     // without Robolectric.
-    protected constructor() : this(null)
+    protected constructor() : this(null, null)
 
     data class PlaybackState(
         val connected: Boolean = false,
@@ -60,7 +61,12 @@ open class AudiobookController @Inject constructor(
         val durationSec: Double = 0.0,
     )
 
-    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+    // Main.immediate is required for Media3 MediaController calls; the survivable Job tree comes from
+    // ApplicationScope so we don't allocate a sibling SupervisorJob. In tests, subclasses override every
+    // method that launches on this scope, so [applicationScope] is permitted to be null.
+    private val scope: CoroutineScope = applicationScope?.let {
+        CoroutineScope(it.coroutineScope.coroutineContext + Dispatchers.Main.immediate)
+    } ?: CoroutineScope(Dispatchers.Main.immediate)
     private val _state = MutableStateFlow(PlaybackState())
     open val state: StateFlow<PlaybackState> = _state.asStateFlow()
 

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ProgressFlushScope.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ProgressFlushScope.kt
@@ -1,9 +1,7 @@
 package com.riffle.app.feature.reader
 
-import com.riffle.app.di.ProgressFlush
-import kotlinx.coroutines.CoroutineScope
+import com.riffle.core.domain.ApplicationScope
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.launch
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -11,19 +9,21 @@ import javax.inject.Singleton
  * Runs a final progress write (the close / pause flush) on an application-lifetime scope so it isn't
  * cancelled mid-network-write when the user leaves the screen the instant they trigger it.
  *
+ * Now a thin adapter over [ApplicationScope] — the seam every "must outlive teardown" write should
+ * route through. Existing callers keep using `flush { ... }`; new code can take [ApplicationScope]
+ * directly and call [ApplicationScope.launchSurvivable] / [ApplicationScope.withSurvivable].
+ *
  * The hazard this exists for: a reader / audiobook ViewModel launching its close flush on
  * `viewModelScope` loses the in-flight ABS PATCH the moment the ViewModel is cleared — which on the
  * audiobook player's `onCleared` is *always* (the scope is already cancelled by then), and on the
  * reader's readaloud-close is a race lost whenever the user backs out of the book before the PATCH
  * round-trip finishes ("close, then leave right away"). In-session periodic syncs stay on
  * `viewModelScope` — they *should* stop when the screen goes away; only the terminal flush comes here.
- *
- * Mirrors the existing [ProgressFlush]/download scope rationale in `AppModule`.
  */
 @Singleton
 class ProgressFlushScope @Inject constructor(
-    @ProgressFlush private val scope: CoroutineScope,
+    private val applicationScope: ApplicationScope,
 ) {
     /** Launch [write] on the survivable scope; returns its [Job] (for tests / awaiting if needed). */
-    fun flush(write: suspend () -> Unit): Job = scope.launch { write() }
+    fun flush(write: suspend () -> Unit): Job = applicationScope.launchSurvivable { write() }
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/ReadaloudController.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/ReadaloudController.kt
@@ -15,6 +15,7 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -57,10 +58,11 @@ open class ReadaloudController @Inject constructor(
 
     // Main.immediate is required for Media3 MediaController calls; the survivable Job tree comes from
     // ApplicationScope. Tests use the protected no-arg constructor and subclasses override every method
-    // that launches on this scope, so [applicationScope] is permitted to be null.
-    private val scope: CoroutineScope = applicationScope?.let {
-        CoroutineScope(it.coroutineScope.coroutineContext + Dispatchers.Main.immediate)
-    } ?: CoroutineScope(Dispatchers.Main.immediate)
+    // that launches on this scope, so [applicationScope] is permitted to be null — the fallback mirrors
+    // the production SupervisorJob semantics so a future partial-override test fake doesn't get
+    // surprised by sibling-cancel behaviour.
+    private val scope: CoroutineScope = applicationScope?.scopeOn(Dispatchers.Main.immediate)
+        ?: CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
     private val _state = MutableStateFlow(PlaybackState())
     val state: StateFlow<PlaybackState> = _state.asStateFlow()
 

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/ReadaloudController.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/ReadaloudController.kt
@@ -9,12 +9,12 @@ import androidx.media3.common.PlaybackException
 import androidx.media3.common.Player
 import androidx.media3.session.MediaController
 import androidx.media3.session.SessionToken
+import com.riffle.core.domain.ApplicationScope
 import com.riffle.core.domain.ReadaloudTrack
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -37,10 +37,11 @@ import kotlin.coroutines.resume
 @Singleton
 open class ReadaloudController @Inject constructor(
     @ApplicationContext private val context: Context?,
+    applicationScope: ApplicationScope?,
 ) {
     // Test seam: subclasses that override the pre-warm methods need no real Context (only consulted in
     // [ensureConnected], which fakes never reach). Keeps the controller unit-fakeable without Robolectric.
-    protected constructor() : this(null)
+    protected constructor() : this(null, null)
     data class PlaybackState(
         val connected: Boolean = false,
         val isPlaying: Boolean = false,
@@ -54,7 +55,12 @@ open class ReadaloudController @Inject constructor(
         val chapterCount: Int = 0,
     )
 
-    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+    // Main.immediate is required for Media3 MediaController calls; the survivable Job tree comes from
+    // ApplicationScope. Tests use the protected no-arg constructor and subclasses override every method
+    // that launches on this scope, so [applicationScope] is permitted to be null.
+    private val scope: CoroutineScope = applicationScope?.let {
+        CoroutineScope(it.coroutineScope.coroutineContext + Dispatchers.Main.immediate)
+    } ?: CoroutineScope(Dispatchers.Main.immediate)
     private val _state = MutableStateFlow(PlaybackState())
     val state: StateFlow<PlaybackState> = _state.asStateFlow()
 

--- a/app/src/test/kotlin/com/riffle/app/di/DefaultApplicationScopeTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/di/DefaultApplicationScopeTest.kt
@@ -1,0 +1,83 @@
+package com.riffle.app.di
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class DefaultApplicationScopeTest {
+
+    @Test
+    fun `launchSurvivable completes even if a per-screen scope is cancelled mid-write`() = runTest {
+        val survivable = CoroutineScope(StandardTestDispatcher(testScheduler) + SupervisorJob())
+        val applicationScope = DefaultApplicationScope(survivable)
+
+        var completed = false
+
+        // A reader/player viewModelScope kicks off a terminal write through applicationScope and is
+        // then torn down before the write finishes. The write must still complete.
+        val viewModelScope = CoroutineScope(StandardTestDispatcher(testScheduler) + Job())
+        viewModelScope.launch {
+            applicationScope.launchSurvivable {
+                delay(100)
+                completed = true
+            }
+        }
+        advanceTimeBy(10)
+        viewModelScope.cancel()
+
+        advanceUntilIdle()
+        assertTrue("the survivable launch must outlive caller teardown", completed)
+    }
+
+    @Test
+    fun `withSurvivable runs the work to completion even when the caller cancels mid-await`() = runTest {
+        val survivable = CoroutineScope(StandardTestDispatcher(testScheduler) + SupervisorJob())
+        val applicationScope = DefaultApplicationScope(survivable)
+
+        var completed = false
+
+        val callerScope = CoroutineScope(StandardTestDispatcher(testScheduler) + Job())
+        callerScope.launch {
+            applicationScope.withSurvivable {
+                delay(100)
+                completed = true
+            }
+        }
+        advanceTimeBy(10)
+        callerScope.cancel()
+
+        advanceUntilIdle()
+        assertTrue("the survivable work proceeds to completion when the caller cancels", completed)
+    }
+
+    @Test
+    fun `withSurvivable returns the value to a caller that does not cancel`() = runTest {
+        val survivable = CoroutineScope(StandardTestDispatcher(testScheduler) + SupervisorJob())
+        val applicationScope = DefaultApplicationScope(survivable)
+
+        var result: Int? = null
+
+        val callerScope = CoroutineScope(StandardTestDispatcher(testScheduler) + Job())
+        callerScope.launch {
+            result = applicationScope.withSurvivable {
+                delay(50)
+                42
+            }
+        }
+
+        advanceUntilIdle()
+        assertEquals(42, result)
+    }
+}

--- a/app/src/test/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModelBookmarkTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModelBookmarkTest.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import com.riffle.app.feature.reader.ReaderSyncCoordinator
 import com.riffle.app.feature.reader.ReaderSyncFactory
 import com.riffle.app.feature.reader.ProgressFlushScope
+import com.riffle.app.testing.TestApplicationScope
 import com.riffle.app.feature.reader.AudiobookFollow
 import com.riffle.app.playback.NowPlayingStore
 import com.riffle.core.data.CrossEpubIndexBuildTrigger
@@ -164,7 +165,7 @@ class AudiobookPlayerViewModelBookmarkTest {
             audioSyncStore = FakeSyncStoreDouble(),
             readaloudResumeStore = FakeResumeStore,
             openReconcileTargets = OpenReconcileTargets(),
-            progressFlushScope = ProgressFlushScope(CoroutineScope(testDispatcher)),
+            progressFlushScope = ProgressFlushScope(TestApplicationScope(CoroutineScope(testDispatcher))),
             bookmarkStore = bookmarkStore,
             connectivityObserver = connectivity,
             audiobookHandoffState = AudiobookHandoffState(),

--- a/app/src/test/kotlin/com/riffle/app/feature/audiobook/SleepTimerTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/audiobook/SleepTimerTest.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import com.riffle.app.feature.reader.AudiobookFollow
 import com.riffle.app.feature.reader.ProgressFlushScope
+import com.riffle.app.testing.TestApplicationScope
 import com.riffle.app.feature.reader.ReaderSyncCoordinator
 import com.riffle.app.feature.reader.ReaderSyncFactory
 import com.riffle.app.playback.NowPlayingStore
@@ -207,7 +208,7 @@ class SleepTimerTest {
             audioSyncStore = FakeSyncStoreDouble(),
             readaloudResumeStore = FakeResumeStore,
             openReconcileTargets = OpenReconcileTargets(),
-            progressFlushScope = ProgressFlushScope(CoroutineScope(testDispatcher)),
+            progressFlushScope = ProgressFlushScope(TestApplicationScope(CoroutineScope(testDispatcher))),
             bookmarkStore = bookmarkStore,
             connectivityObserver = connectivity,
             audiobookHandoffState = AudiobookHandoffState(),

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ProgressFlushScopeTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ProgressFlushScopeTest.kt
@@ -1,5 +1,6 @@
 package com.riffle.app.feature.reader
 
+import com.riffle.app.testing.TestApplicationScope
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
@@ -23,7 +24,7 @@ class ProgressFlushScopeTest {
     // case where the in-flight ABS PATCH was being cancelled mid-network-write.
     @Test
     fun `a flush completes even when the caller's scope is cancelled immediately after submitting`() = runTest {
-        val flusher = ProgressFlushScope(CoroutineScope(StandardTestDispatcher(testScheduler) + SupervisorJob()))
+        val flusher = ProgressFlushScope(TestApplicationScope(CoroutineScope(StandardTestDispatcher(testScheduler) + SupervisorJob())))
         var completed = false
 
         // Model the screen's viewModelScope: the user submits a close flush from it, then leaves the

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ReaderSyncCoordinatorTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ReaderSyncCoordinatorTest.kt
@@ -1,5 +1,6 @@
 package com.riffle.app.feature.reader
 
+import com.riffle.app.testing.TestApplicationScope
 import com.riffle.core.domain.BookSyncState
 import com.riffle.core.domain.CanonicalPositionTranslator
 import com.riffle.core.domain.ChapterCharMap
@@ -289,7 +290,7 @@ class ReaderSyncCoordinatorTest {
     fun `closing readaloud flushes the exact narrated sentence to ABS even when the reader is torn down at once`() = runTest {
         val abs = FakeAbs(NetworkServerProgress(ebookLocation = "", lastUpdate = 0L))
         val coordinator = coordinator(abs)
-        val flusher = ProgressFlushScope(CoroutineScope(StandardTestDispatcher(testScheduler) + SupervisorJob()))
+        val flusher = ProgressFlushScope(TestApplicationScope(CoroutineScope(StandardTestDispatcher(testScheduler) + SupervisorJob())))
 
         // closeReadaloud(): fire the precise audiobook push (narrated fragment f9 → 90s) on the flush
         // scope, then the user immediately leaves the book — cancelling the reader's viewModelScope.
@@ -307,7 +308,7 @@ class ReaderSyncCoordinatorTest {
     fun `the audiobook player's stop flush reaches ABS through the survivable scope after onCleared`() = runTest {
         val abs = FakeAbs(NetworkServerProgress(ebookLocation = "", lastUpdate = 0L))
         val coordinator = coordinator(abs)
-        val flusher = ProgressFlushScope(CoroutineScope(StandardTestDispatcher(testScheduler) + SupervisorJob()))
+        val flusher = ProgressFlushScope(TestApplicationScope(CoroutineScope(StandardTestDispatcher(testScheduler) + SupervisorJob())))
 
         // The audiobook player's pushProgressOnStop runs an audio-led cycle (listen at 90s). On the
         // player's onCleared the viewModelScope is already cancelled, so it must run on the flush scope.

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/session/AnnotationSessionTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/session/AnnotationSessionTest.kt
@@ -3,6 +3,7 @@ package com.riffle.app.feature.reader.session
 import android.net.FakeUri
 import com.riffle.app.feature.reader.EpubReaderViewModel
 import com.riffle.app.feature.reader.ProgressFlushScope
+import com.riffle.app.testing.TestApplicationScope
 import com.riffle.core.data.AnnotationSyncStatusStore
 import com.riffle.core.data.CycleOutcome
 import com.riffle.core.domain.Annotation
@@ -170,7 +171,7 @@ class AnnotationSessionTest {
         scope: CoroutineScope,
         statusStore: AnnotationSyncStatusStore = AnnotationSyncStatusStore(),
         flushScope: ProgressFlushScope = ProgressFlushScope(
-            CoroutineScope(UnconfinedTestDispatcher() + SupervisorJob())
+            TestApplicationScope(CoroutineScope(UnconfinedTestDispatcher() + SupervisorJob()))
         ),
     ) = AnnotationSession(
         scope = scope,
@@ -404,7 +405,7 @@ class AnnotationSessionTest {
         val syncOps = FakeSyncOps()
         // Use a real ProgressFlushScope backed by a test dispatcher
         val flushScope = ProgressFlushScope(
-            CoroutineScope(UnconfinedTestDispatcher() + SupervisorJob())
+            TestApplicationScope(CoroutineScope(UnconfinedTestDispatcher() + SupervisorJob()))
         )
         val session = makeSession(syncOps = syncOps, scope = sessionScope, flushScope = flushScope)
 

--- a/app/src/test/kotlin/com/riffle/app/testing/TestApplicationScope.kt
+++ b/app/src/test/kotlin/com/riffle/app/testing/TestApplicationScope.kt
@@ -1,0 +1,24 @@
+package com.riffle.app.testing
+
+import com.riffle.core.domain.ApplicationScope
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.async
+import kotlinx.coroutines.launch
+
+/**
+ * Test [ApplicationScope] that runs on whatever [CoroutineScope] the test wires up — typically a
+ * `TestScope` (`StandardTestDispatcher`) so launches are deterministic via `advanceUntilIdle()`.
+ *
+ * Mirrors `DefaultApplicationScope` in production: [withSurvivable] uses `async { }.await()` so the
+ * work continues on the survivable scope even when the caller cancels.
+ */
+class TestApplicationScope(private val scope: CoroutineScope) : ApplicationScope {
+    override val coroutineScope: CoroutineScope = scope
+
+    override fun launchSurvivable(block: suspend CoroutineScope.() -> Unit): Job =
+        scope.launch(block = block)
+
+    override suspend fun <T> withSurvivable(block: suspend CoroutineScope.() -> T): T =
+        scope.async(block = block).await()
+}

--- a/core/data/src/main/kotlin/com/riffle/core/data/ConnectivityObserverImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/ConnectivityObserverImpl.kt
@@ -5,10 +5,9 @@ import android.net.ConnectivityManager
 import android.net.Network
 import android.net.NetworkCapabilities
 import android.net.NetworkRequest
+import com.riffle.core.domain.ApplicationScope
 import com.riffle.core.domain.ConnectivityObserver
 import dagger.hilt.android.qualifiers.ApplicationContext
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -21,12 +20,13 @@ import javax.inject.Singleton
 @Singleton
 class ConnectivityObserverImpl @Inject constructor(
     @ApplicationContext context: Context,
+    applicationScope: ApplicationScope,
 ) : ConnectivityObserver {
 
     private val connectivityManager =
         context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
 
-    private val scope = CoroutineScope(SupervisorJob())
+    private val scope = applicationScope.coroutineScope
 
     override val isOnline: StateFlow<Boolean> = callbackFlow {
         // Online-state is derived from callback events rather than re-queried on each transition.

--- a/core/data/src/main/kotlin/com/riffle/core/data/CrossEpubIndexBuilderService.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/CrossEpubIndexBuilderService.kt
@@ -2,6 +2,7 @@ package com.riffle.core.data
 
 import com.riffle.core.data.di.EpubCacheStore
 import com.riffle.core.data.di.EpubDownloadsStore
+import com.riffle.core.domain.ApplicationScope
 import com.riffle.core.domain.CrossEpubBuildInputs
 import com.riffle.core.domain.CrossEpubIndexBuildOutcome
 import com.riffle.core.domain.CrossEpubIndexService
@@ -16,9 +17,6 @@ import com.riffle.core.domain.TokenStorage
 import com.riffle.core.network.AbsLibraryApi
 import com.riffle.core.network.NetworkEpubDownloadResult
 import com.riffle.core.network.NetworkItemEbookInoResult
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import java.io.File
 import java.util.Collections
@@ -52,6 +50,7 @@ class CrossEpubIndexBuilderService(
     private val store: CrossEpubIndexStore,
     private val sidecarStore: ReadaloudSidecarStore,
     private val clock: () -> Long,
+    applicationScope: ApplicationScope,
 ) : CrossEpubIndexBuildTrigger {
     @Inject constructor(
         serverRepository: ServerRepository,
@@ -61,9 +60,10 @@ class CrossEpubIndexBuilderService(
         @EpubDownloadsStore downloadsStore: LocalStore,
         store: CrossEpubIndexStore,
         sidecarStore: ReadaloudSidecarStore,
-    ) : this(serverRepository, tokenStorage, absApi, cacheStore, downloadsStore, store, sidecarStore, System::currentTimeMillis)
+        applicationScope: ApplicationScope,
+    ) : this(serverRepository, tokenStorage, absApi, cacheStore, downloadsStore, store, sidecarStore, System::currentTimeMillis, applicationScope)
 
-    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val scope = applicationScope.coroutineScope
     private val inFlight = Collections.synchronizedSet(mutableSetOf<Pair<String, String>>())
 
     private val service = CrossEpubIndexService(

--- a/core/data/src/main/kotlin/com/riffle/core/data/LibraryRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/LibraryRepositoryImpl.kt
@@ -11,6 +11,7 @@ import com.riffle.core.database.LibraryItemEntity
 import com.riffle.core.database.SeriesDao
 import com.riffle.core.database.SeriesEntity
 import com.riffle.core.database.SeriesItemEntity
+import com.riffle.core.domain.ApplicationScope
 import com.riffle.core.domain.Collection
 import com.riffle.core.domain.EbookFormat
 import com.riffle.core.domain.Library
@@ -27,8 +28,6 @@ import com.riffle.core.network.NetworkLibrariesResult
 import com.riffle.core.network.NetworkLibraryItemsResult
 import com.riffle.core.network.NetworkSeriesResult
 import com.riffle.core.network.NetworkUserProgressResult
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
@@ -50,11 +49,12 @@ class LibraryRepositoryImpl @Inject constructor(
     private val readingSessionRepository: ReadingSessionRepository,
     private val readaloudMatchingService: ReadaloudMatchingService,
     private val storytellerReadaloudSyncer: StorytellerReadaloudSyncer,
+    applicationScope: ApplicationScope,
 ) : LibraryRepository {
 
     // Used to fire syncStale/reconcileLinks without blocking refreshLibraryItems.
     // coroutineScope { launch {} } waits for all children, so background work needs its own scope.
-    private val backgroundScope = CoroutineScope(SupervisorJob())
+    private val backgroundScope = applicationScope.coroutineScope
 
     @OptIn(ExperimentalCoroutinesApi::class)
     override fun observeLibraries(): Flow<List<Library>> =

--- a/core/data/src/main/kotlin/com/riffle/core/data/ReadaloudSidecarStore.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/ReadaloudSidecarStore.kt
@@ -1,14 +1,13 @@
 package com.riffle.core.data
 
 import android.content.Context
+import com.riffle.core.domain.ApplicationScope
 import com.riffle.core.domain.ReadaloudSidecarCache
 import com.riffle.core.domain.ServerRepository
 import com.riffle.core.domain.TokenStorage
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -57,12 +56,13 @@ class ReadaloudSidecarStore private constructor(
         fetcher: StorytellerSidecarFetcher,
         serverRepository: ServerRepository,
         tokenStorage: TokenStorage,
+        applicationScope: ApplicationScope,
     ) : this(
         cacheRootDir = { context.cacheDir },
         fetcher = fetcher,
         serverRepository = serverRepository,
         tokenStorage = tokenStorage,
-        scope = CoroutineScope(SupervisorJob() + Dispatchers.IO),
+        scope = applicationScope.coroutineScope,
     )
 
     internal constructor(

--- a/core/data/src/test/kotlin/com/riffle/core/data/LibraryRepositoryTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/LibraryRepositoryTest.kt
@@ -207,6 +207,7 @@ class LibraryRepositoryTest {
         api, libraryDao, libraryItemDao, seriesDao, collectionDao,
         fakeServerRepository, fakeTokenStorage, readingSessionRepository, readaloudMatchingService,
         storytellerReadaloudSyncer,
+        com.riffle.core.data.testing.TestApplicationScope(),
     )
 
     private fun noopMatchingService(itemDao: FakeLibraryItemDao): ReadaloudMatchingService =

--- a/core/data/src/test/kotlin/com/riffle/core/data/SeriesIntegrationTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/SeriesIntegrationTest.kt
@@ -163,6 +163,7 @@ class SeriesIntegrationTest {
                 },
                 itemDao, { 0L },
             ),
+            applicationScope = com.riffle.core.data.testing.TestApplicationScope(),
         )
     }
 

--- a/core/data/src/test/kotlin/com/riffle/core/data/testing/TestApplicationScope.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/testing/TestApplicationScope.kt
@@ -1,0 +1,22 @@
+package com.riffle.core.data.testing
+
+import com.riffle.core.domain.ApplicationScope
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.async
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class TestApplicationScope(
+    private val scope: CoroutineScope = CoroutineScope(UnconfinedTestDispatcher()),
+) : ApplicationScope {
+    override val coroutineScope: CoroutineScope = scope
+
+    override fun launchSurvivable(block: suspend CoroutineScope.() -> Unit): Job =
+        scope.launch(block = block)
+
+    override suspend fun <T> withSurvivable(block: suspend CoroutineScope.() -> T): T =
+        scope.async(block = block).await()
+}

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/ApplicationScope.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/ApplicationScope.kt
@@ -1,0 +1,39 @@
+package com.riffle.core.domain
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+
+/**
+ * Application-lifetime coroutine seam for work that must outlive any caller's scope — terminal
+ * progress flushes, close-path PATCHes, one-shot migrations kicked off in `Application.onCreate`.
+ *
+ * The hazard: launching a final write on `viewModelScope` (or any per-screen scope) loses it the
+ * instant the screen goes away; the user closes the player, navigates back, and the in-flight
+ * `viewModelScope` is cancelled before the PATCH round-trip completes. ProgressFlushScope was the
+ * tactical fix for the audiobook close-path; this seam generalises the contract so every "must
+ * survive teardown" write routes through one named owner.
+ *
+ * Scope lifetime: cancels only on process death.
+ */
+interface ApplicationScope {
+    /**
+     * Raw survivable [CoroutineScope] handle — for sites that need to pass a scope into a
+     * scope-consuming API (`stateIn`, `shareIn`, a worker class that takes a `CoroutineScope`
+     * constructor param). Prefer [launchSurvivable] / [withSurvivable] for one-shot work.
+     *
+     * Never call `.cancel()` on this — it would tear down every survivable launch in the app.
+     * Per-component cancellable scopes belong on their own [Job], not here (the "in-screen work"
+     * exclusion in the seam's contract).
+     */
+    val coroutineScope: CoroutineScope
+
+    /** Launch [block] on the survivable scope; returns the [Job] for callers that want to await it. */
+    fun launchSurvivable(block: suspend CoroutineScope.() -> Unit): Job
+
+    /**
+     * Run [block] on the survivable scope and return its result. The work proceeds to completion
+     * even if the caller's coroutine is cancelled — useful for a UI scope that wants to await a
+     * terminal write before navigating, without losing the write if the user backs out mid-await.
+     */
+    suspend fun <T> withSurvivable(block: suspend CoroutineScope.() -> T): T
+}

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/ApplicationScope.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/ApplicationScope.kt
@@ -1,5 +1,6 @@
 package com.riffle.core.domain
 
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 
@@ -36,4 +37,14 @@ interface ApplicationScope {
      * terminal write before navigating, without losing the write if the user backs out mid-await.
      */
     suspend fun <T> withSurvivable(block: suspend CoroutineScope.() -> T): T
+
+    /**
+     * Survivable [CoroutineScope] whose dispatcher is [dispatcher] but whose [Job] is the same
+     * SupervisorJob as [coroutineScope] — for components that need a specific dispatcher (e.g.
+     * Media3 controllers require [kotlinx.coroutines.Dispatchers.Main.immediate]) but should still
+     * sit inside the app's survivable job tree. Use instead of `CoroutineScope(SupervisorJob() +
+     * dispatcher)`, which would allocate a sibling root job outside this seam.
+     */
+    fun scopeOn(dispatcher: CoroutineDispatcher): CoroutineScope =
+        CoroutineScope(coroutineScope.coroutineContext + dispatcher)
 }


### PR DESCRIPTION
Closes #336.

## Summary

Lift the "must outlive teardown" coroutine pattern into one named seam (`ApplicationScope`) so close-path writes, app-startup work, and process-lifetime singletons all route through one owner instead of each allocating its own `CoroutineScope(SupervisorJob() + Dispatchers.IO)`.

### What changed

- **New `ApplicationScope` interface** in `core/domain` with `launchSurvivable`, `withSurvivable`, a `coroutineScope` handle for sites that need to pass a scope into `stateIn` / a worker, and a `scopeOn(dispatcher)` helper for components that need a specific dispatcher (e.g. Media3 controllers need `Dispatchers.Main.immediate`) but should still sit in the survivable Job tree.
- **`DefaultApplicationScope` + Hilt binding** in `app/di`; backed by `@ApplicationCoroutineScope`-qualified `CoroutineScope(SupervisorJob() + Dispatchers.IO)`. Replaces the `@ProgressFlush` qualifier.
- **`ProgressFlushScope` now an adapter** that delegates `.flush { }` to `applicationScope.launchSurvivable { }`. Existing close-path callers unchanged.
- **`RiffleApplication` migrator + APK sweep + connectivity collector** migrated from three anonymous `CoroutineScope(...)` allocations to `applicationScope.launchSurvivable { }`.
- **6 survivable singletons migrated**: `ConnectivityObserverImpl`, `ReadaloudSidecarStore`, `LibraryRepositoryImpl`, `CrossEpubIndexBuilderService`, `AudiobookController`, `ReadaloudController`. The two Media3 controllers use `applicationScope.scopeOn(Dispatchers.Main.immediate)` so callbacks stay on the main thread while the Job tree stays survivable.
- **Out of scope**: `PlayerCoordinator` and `AutoScrollController` keep their own cancellable scopes — they call `scope.cancel()` on lifecycle exit, the "in-screen work" pattern the seam explicitly excludes (per the issue's "Out of scope" line).

### Tests

- New `DefaultApplicationScopeTest` covers survivable-launch and survivable-await semantics across caller cancellation.
- Shared `TestApplicationScope` in `app/testing` and `core/data/testing` for the existing call sites that construct `ProgressFlushScope` / `LibraryRepositoryImpl` / `ReadaloudSidecarStore` in unit tests.
- All existing JVM tests pass; `./gradlew test` green; `./gradlew :app:compileDebugAndroidTestKotlin` green.

### Device smoke test

Built debug APK, installed on a freshly-cloned session AVD (API 25), exercised:

- **Cold start** — Hilt graph builds, all 3 migrated `RiffleApplication` sites run, `ProgressSyncWorker` + `AnnotationSyncWorker` both SUCCESS, MainActivity displayed in 865ms, no exceptions.
- **Audiobook playback** — ABS session resolved (821ms), `MediaController` connected via the composed `applicationScope.scopeOn(Dispatchers.Main.immediate)`, playback cycled BUFFERING↔READY with `isPlaying=true` — audio streamed and played. This is the riskiest piece (Media3 absolutely requires `Dispatchers.Main`).
- **Close path** — back twice → IDLE cleanly, no exceptions on the `ProgressFlushScope.flush` → `ApplicationScope.launchSurvivable` path.

### Behaviour change worth noting

`LibraryRepositoryImpl.backgroundScope`'s dispatcher shifted from `Dispatchers.Default` (the old fresh `CoroutineScope(SupervisorJob())` had no dispatcher) to `Dispatchers.IO` (inherited from ApplicationScope). The work is DB+network so IO is arguably more correct, but it does mean library background work now competes for slots with other survivable IO workloads on the same pool.

### Follow-ups (not done in this PR)

- Slice 5 of the issue (lint rule banning new `CoroutineScope(SupervisorJob()` allocations outside the binding module) — separate PR.
- `TestApplicationScope` is duplicated across `app/test` and `core/data/test` plus inlined as an anonymous object in one androidTest — could be consolidated by moving the helper into `core/domain` main under a `testing` subpackage, or by introducing `testFixtures`. Out of scope for this PR.

## Test plan

- [x] `./gradlew test` green across app, core:data, core:network, core:domain
- [x] `./gradlew :app:compileDebugAndroidTestKotlin` green
- [x] Cold start on AVD — no crashes, sweeps SUCCESS
- [x] Audiobook playback on AVD — streams + plays
- [x] Close-path flush on AVD — clean teardown
- [ ] CI to confirm