### PR TITLE
refactor(infra): introduce Clock + DispatcherProvider seams (#338)

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/FileCrashReportSender.kt
+++ b/app/src/main/kotlin/com/riffle/app/FileCrashReportSender.kt
@@ -1,6 +1,8 @@
 package com.riffle.app
 
 import android.content.Context
+import com.riffle.core.domain.Clock
+import com.riffle.core.domain.SystemClock
 import org.acra.ReportField
 import org.acra.config.CoreConfiguration
 import org.acra.data.CrashReportData
@@ -16,12 +18,15 @@ import java.io.File
  * files; ACRA's LimiterConfiguration also bounds the upstream queue, but this is a
  * second guard so a flapping bug can't fill the disk between launches.
  */
-class FileCrashReportSender(private val reportDir: File) : ReportSender {
+class FileCrashReportSender(
+    private val reportDir: File,
+    private val clock: Clock = SystemClock,
+) : ReportSender {
 
     override fun send(context: Context, errorContent: CrashReportData) {
         if (!reportDir.exists()) reportDir.mkdirs()
         val content = buildContent(errorContent)
-        val name = "${System.currentTimeMillis()}-${"%08x".format(content.hashCode())}.txt"
+        val name = "${clock.nowMs()}-${"%08x".format(content.hashCode())}.txt"
         File(reportDir, name).writeText(content)
         pruneToMax()
     }

--- a/app/src/main/kotlin/com/riffle/app/di/AppModule.kt
+++ b/app/src/main/kotlin/com/riffle/app/di/AppModule.kt
@@ -7,7 +7,11 @@ import com.riffle.app.feature.reader.EbookCfiTranslatorFactoryImpl
 import com.riffle.app.feature.reader.SystemTimeProvider
 import com.riffle.app.feature.reader.TimeProvider
 import com.riffle.core.domain.ApplicationScope
+import com.riffle.core.domain.Clock
+import com.riffle.core.domain.DefaultDispatcherProvider
+import com.riffle.core.domain.DispatcherProvider
 import com.riffle.core.domain.EbookCfiTranslatorFactory
+import com.riffle.core.domain.SystemClock
 import dagger.Binds
 import dagger.Module
 import dagger.Provides
@@ -15,7 +19,6 @@ import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import org.readium.adapter.pdfium.document.PdfiumDocumentFactory
 import org.readium.r2.shared.util.asset.AssetRetriever
@@ -49,12 +52,22 @@ object AppModule {
     @Provides
     @Singleton
     @DownloadScope
-    fun provideDownloadScope(): CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    fun provideDownloadScope(dispatchers: DispatcherProvider): CoroutineScope =
+        CoroutineScope(SupervisorJob() + dispatchers.io)
 
     @Provides
     @Singleton
     @ApplicationCoroutineScope
-    fun provideApplicationCoroutineScope(): CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    fun provideApplicationCoroutineScope(dispatchers: DispatcherProvider): CoroutineScope =
+        CoroutineScope(SupervisorJob() + dispatchers.io)
+
+    @Provides
+    @Singleton
+    fun provideClock(): Clock = SystemClock
+
+    @Provides
+    @Singleton
+    fun provideDispatcherProvider(): DispatcherProvider = DefaultDispatcherProvider
 
     @Provides
     @Singleton

--- a/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookController.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookController.kt
@@ -13,6 +13,8 @@ import com.riffle.app.feature.reader.readaloud.SharedBundle
 import com.riffle.core.domain.ApplicationScope
 import com.riffle.core.domain.AudiobookTrackSpan
 import com.riffle.core.domain.AudiobookTracks
+import com.riffle.core.domain.Clock
+import com.riffle.core.domain.SystemClock
 import com.riffle.core.logging.LogChannel
 import com.riffle.core.logging.Logger
 import com.riffle.core.logging.RecordingLogger
@@ -50,11 +52,12 @@ open class AudiobookController @Inject constructor(
     @ApplicationContext private val context: Context?,
     applicationScope: ApplicationScope?,
     private val logger: Logger,
+    private val clock: Clock,
 ) {
     // Test seam: a subclass that overrides every member the player touches needs no real Context (it's
     // only consulted in [ensureConnected], which fakes never reach). Keeps the controller unit-fakeable
     // without Robolectric.
-    protected constructor() : this(null, null, RecordingLogger())
+    protected constructor() : this(null, null, RecordingLogger(), SystemClock)
 
     data class PlaybackState(
         val connected: Boolean = false,
@@ -127,7 +130,7 @@ open class AudiobookController @Inject constructor(
         coverUri: String? = null,
     ) {
         logger.d(LogChannel.Handoff) { "AB.prepare start (controller already connected=${controller != null})" }
-        val t0 = System.currentTimeMillis()
+        val t0 = clock.nowMs()
         this.spans = spans
         this.durationSec = durationSec
         SharedAudiobookContext.spans = spans
@@ -138,7 +141,7 @@ open class AudiobookController @Inject constructor(
         ownsSharedBundle = localZipFile != null
         if (localZipFile != null) SharedBundle.current = localZipFile
         val c = ensureConnected() ?: return
-        logger.d(LogChannel.Handoff) { "AB.prepare ensureConnected +${System.currentTimeMillis() - t0}ms" }
+        logger.d(LogChannel.Handoff) { "AB.prepare ensureConnected +${clock.nowMs() - t0}ms" }
         val metadata = androidx.media3.common.MediaMetadata.Builder()
             .apply { if (coverUri != null) setArtworkUri(android.net.Uri.parse(coverUri)) }
             .build()
@@ -151,7 +154,7 @@ open class AudiobookController @Inject constructor(
         val start = AudiobookTracks.startPositionFor(startAtSec, durationSec, spans)
         c.setMediaItems(items, start.trackIndex, start.offsetMs)
         c.prepare()
-        logger.d(LogChannel.Handoff) { "AB.prepare setMediaItems+prepare +${System.currentTimeMillis() - t0}ms" }
+        logger.d(LogChannel.Handoff) { "AB.prepare setMediaItems+prepare +${clock.nowMs() - t0}ms" }
         prepared = true
         // If the user pressed play before preparation finished, honour it now — but only once the
         // player is ready (see [ResumePlaybackGate]); otherwise the listener starts it on STATE_READY.

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -18,6 +18,7 @@ import com.riffle.core.data.StorytellerPositionSyncController
 import com.riffle.core.data.StorytellerSyncOutcome
 import com.riffle.core.domain.Annotation
 import com.riffle.core.domain.AnnotationStore
+import com.riffle.core.domain.Clock
 import com.riffle.core.domain.AudioIdentity
 import com.riffle.core.domain.AudioIdentityResolver
 import com.riffle.core.domain.AudioPlaybackPreferencesStore
@@ -172,6 +173,7 @@ class EpubReaderViewModel @Inject constructor(
     private val annotationSessionFactory: com.riffle.app.feature.reader.session.AnnotationSession.Factory,
     private val readaloudSessionFactory: com.riffle.app.feature.reader.session.ReadaloudSession.Factory,
     private val logger: Logger,
+    private val clock: Clock,
 ) : AndroidViewModel(application) {
 
     // Formatting/typography/auto-scroll orchestrator — constructed with viewModelScope so
@@ -901,7 +903,7 @@ class EpubReaderViewModel @Inject constructor(
         closeSyncDone = false
         position.resetInitialLocatorSeen()
         sessionStartProgression = currentLocatorTotalProgression.value
-        sessionStartMs = System.currentTimeMillis()
+        sessionStartMs = clock.nowMs()
         if (_state.value is ReaderState.Ready) {
             syncCurrentPosition()
             startPeriodicSync()
@@ -1352,7 +1354,7 @@ class EpubReaderViewModel @Inject constructor(
     private fun flushReadingSession() {
         val startProg = sessionStartProgression ?: return
         sessionStartProgression = null
-        val timeDeltaSec = (System.currentTimeMillis() - sessionStartMs) / 1000.0
+        val timeDeltaSec = (clock.nowMs() - sessionStartMs) / 1000.0
         val totalProg = currentLocatorTotalProgression.value ?: return
         val progressDelta = totalProg - startProg
         val totalPos = railSegments.value.fold(0f) { acc, seg -> acc + seg.weight }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/autoscroll/AutoScrollController.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/autoscroll/AutoScrollController.kt
@@ -1,5 +1,7 @@
 package com.riffle.app.feature.reader.autoscroll
 
+import com.riffle.core.domain.Clock
+import com.riffle.core.domain.SystemClock
 import com.riffle.core.domain.autoscroll.AutoScrollEvent
 import com.riffle.core.domain.autoscroll.AutoScrollSpeed
 import com.riffle.core.domain.autoscroll.AutoScrollState
@@ -35,8 +37,9 @@ import javax.inject.Singleton
 @Singleton
 open class AutoScrollController internal constructor(
     dispatcher: CoroutineDispatcher,
+    private var clock: Clock = SystemClock,
 ) {
-    @Inject constructor() : this(Dispatchers.Main.immediate)
+    @Inject constructor() : this(Dispatchers.Main.immediate, SystemClock)
 
     private val scope = CoroutineScope(SupervisorJob() + dispatcher)
     private val _state = MutableStateFlow<AutoScrollState>(AutoScrollState.Idle)
@@ -53,7 +56,6 @@ open class AutoScrollController internal constructor(
     // [setLayoutContext] so the live pace stays correct when the user bumps font size or rotates.
     private var layoutContext: () -> LayoutContext =
         { LayoutContext(wordsPerLine = 9f, lineHeightPx = 66f) }
-    private var now: () -> Long = { System.nanoTime() }
 
     private val accumulator = ScrollDeltaAccumulator()
     private var tickerJob: Job? = null
@@ -66,8 +68,8 @@ open class AutoScrollController internal constructor(
         layoutContext = supplier
     }
 
-    internal fun setClock(clock: () -> Long) {
-        now = clock
+    internal fun setClock(clock: Clock) {
+        this.clock = clock
     }
 
     fun dispatch(event: AutoScrollEvent) {
@@ -85,10 +87,10 @@ open class AutoScrollController internal constructor(
     private fun startTicker() {
         accumulator.reset()
         tickerJob = scope.launch {
-            var lastNanos = now()
+            var lastNanos = clock.nowNs()
             while (isActive) {
                 delay(FRAME_INTERVAL_MS)
-                val n = now()
+                val n = clock.nowNs()
                 val dtSec = ((n - lastNanos).coerceAtLeast(0L)) / 1_000_000_000f
                 lastNanos = n
                 val speed = _state.value.speedOrNull ?: continue

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/ReadaloudController.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/ReadaloudController.kt
@@ -9,7 +9,9 @@ import androidx.media3.common.Player
 import androidx.media3.session.MediaController
 import androidx.media3.session.SessionToken
 import com.riffle.core.domain.ApplicationScope
+import com.riffle.core.domain.Clock
 import com.riffle.core.domain.ReadaloudTrack
+import com.riffle.core.domain.SystemClock
 import com.riffle.core.logging.LogChannel
 import com.riffle.core.logging.Logger
 import com.riffle.core.logging.RecordingLogger
@@ -42,10 +44,11 @@ open class ReadaloudController @Inject constructor(
     @ApplicationContext private val context: Context?,
     applicationScope: ApplicationScope?,
     private val logger: Logger,
+    private val clock: Clock,
 ) {
     // Test seam: subclasses that override the pre-warm methods need no real Context (only consulted in
     // [ensureConnected], which fakes never reach). Keeps the controller unit-fakeable without Robolectric.
-    protected constructor() : this(null, null, RecordingLogger())
+    protected constructor() : this(null, null, RecordingLogger(), SystemClock)
     data class PlaybackState(
         val connected: Boolean = false,
         val isPlaying: Boolean = false,
@@ -104,10 +107,10 @@ open class ReadaloudController @Inject constructor(
         logger.d(LogChannel.Handoff) { "RA.prepare start (controller already connected=${controller != null})" }
         this.track = track
         SharedBundle.current = bundle
-        val t0 = System.currentTimeMillis()
+        val t0 = clock.nowMs()
         SharedBundle.streaming = null
         val c = ensureConnected() ?: return
-        logger.d(LogChannel.Handoff) { "RA.prepare ensureConnected +${System.currentTimeMillis() - t0}ms" }
+        logger.d(LogChannel.Handoff) { "RA.prepare ensureConnected +${clock.nowMs() - t0}ms" }
 
         audioIndex.clear()
         val items = ArrayList<MediaItem>()
@@ -120,7 +123,7 @@ open class ReadaloudController @Inject constructor(
         }
         c.setMediaItems(items)
         c.prepare()
-        logger.d(LogChannel.Handoff) { "RA.prepare setMediaItems+prepare +${System.currentTimeMillis() - t0}ms" }
+        logger.d(LogChannel.Handoff) { "RA.prepare setMediaItems+prepare +${clock.nowMs() - t0}ms" }
         pushState()
     }
 

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/autoscroll/AutoScrollControllerTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/autoscroll/AutoScrollControllerTest.kt
@@ -68,7 +68,10 @@ class AutoScrollControllerTest {
         // Big lineHeight makes px/s sizable enough to emit a whole pixel each ~16ms tick.
         controller.setLayoutContext { LayoutContext(wordsPerLine = 1f, lineHeightPx = 100f) }
         // Inject a deterministic clock tied to virtual time so dt is predictable.
-        controller.setClock { testScheduler.currentTime * 1_000_000L }
+        controller.setClock(object : com.riffle.core.domain.Clock {
+            override fun nowMs(): Long = testScheduler.currentTime
+            override fun nowNs(): Long = testScheduler.currentTime * 1_000_000L
+        })
         controller.dispatch(AutoScrollEvent.Start)
 
         // Bounded collection: take first N emissions, then stop. Avoids `toList` on a
@@ -88,7 +91,10 @@ class AutoScrollControllerTest {
     fun `ticker stops emitting after Stop is dispatched`() = runTest {
         val controller = AutoScrollController.forTest(StandardTestDispatcher(testScheduler))
         controller.setLayoutContext { LayoutContext(wordsPerLine = 1f, lineHeightPx = 100f) }
-        controller.setClock { testScheduler.currentTime * 1_000_000L }
+        controller.setClock(object : com.riffle.core.domain.Clock {
+            override fun nowMs(): Long = testScheduler.currentTime
+            override fun nowNs(): Long = testScheduler.currentTime * 1_000_000L
+        })
         controller.dispatch(AutoScrollEvent.Start)
         // Drain one emission to confirm the ticker is alive.
         withTimeout(5_000L) { controller.scrollDeltas.first() }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -48,9 +48,116 @@ tasks.register("checkRiffleLogTags") {
     }
 }
 
+// Enforces that direct `System.currentTimeMillis()` / `System.nanoTime()` and `Dispatchers.IO/Main/Default`
+// calls route through the Clock + DispatcherProvider seams (#338). Existing sites are grandfathered via
+// the allowlist below; new sites — anywhere else — fail the build. Drop entries as bulk-sweep follow-up
+// PRs migrate each file.
+tasks.register("checkRiffleInfraSeams") {
+    group = "verification"
+    description = "Fails if Clock / DispatcherProvider are bypassed (System.currentTimeMillis / Dispatchers.[IMD]) outside the allowlist."
+    notCompatibleWithConfigurationCache("reading the file system at execution time")
+
+    doLast {
+        val clockPattern = Regex("""\bSystem\.(currentTimeMillis|nanoTime)\(\)""")
+        // Match Dispatchers.IO / .Main / .Main.immediate / .Default — but not Dispatchers.Unconfined and
+        // not type references like `kotlinx.coroutines.Dispatchers` inside KDoc/imports. Word-boundary
+        // before `Dispatchers` excludes nothing real and keeps regex simple.
+        val dispatcherPattern = Regex("""\bDispatchers\.(IO|Main|Default)\b""")
+
+        // Files allowed to mention the literals — seams + grandfathered sites pending follow-up PRs.
+        val allowlist = setOf(
+            // Seam interfaces + impls.
+            "core/domain/src/main/kotlin/com/riffle/core/domain/Clock.kt",
+            "core/domain/src/main/kotlin/com/riffle/core/domain/DispatcherProvider.kt",
+            "core/domain/src/main/kotlin/com/riffle/core/domain/SystemClock.kt",
+            "core/domain/src/main/kotlin/com/riffle/core/domain/DefaultDispatcherProvider.kt",
+            // ---- Grandfathered — Clock sweep follow-up.
+            "core/data/src/main/kotlin/com/riffle/core/data/AnnotationStoreImpl.kt",
+            "core/data/src/main/kotlin/com/riffle/core/data/LibraryRepositoryImpl.kt",
+            "core/data/src/main/kotlin/com/riffle/core/data/ReadaloudResumeStoreImpl.kt",
+            "core/data/src/main/kotlin/com/riffle/core/data/ReadingSessionRepositoryImpl.kt",
+            "core/data/src/main/kotlin/com/riffle/core/data/TimestampedPositionStore.kt",
+            "app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModel.kt",
+            "app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsViewModel.kt",
+            "app/src/main/kotlin/com/riffle/app/feature/server/AddServerViewModel.kt",
+            // ---- Grandfathered — DispatcherProvider sweep follow-up (core/network).
+            "core/network/src/main/kotlin/com/riffle/core/network/AbsApiClient.kt",
+            "core/network/src/main/kotlin/com/riffle/core/network/AudiobookBundleApi.kt",
+            "core/network/src/main/kotlin/com/riffle/core/network/GitHubReleaseApi.kt",
+            "core/network/src/main/kotlin/com/riffle/core/network/StorytellerApiClient.kt",
+            "core/network/src/main/kotlin/com/riffle/core/network/StorytellerBundleApi.kt",
+            "core/network/src/main/kotlin/com/riffle/core/network/StorytellerPositionApi.kt",
+            // ---- Grandfathered — DispatcherProvider sweep follow-up (core/data).
+            "core/data/src/main/kotlin/com/riffle/core/data/AppUpdateRepositoryImpl.kt",
+            "core/data/src/main/kotlin/com/riffle/core/data/AudiobookBundleDownloader.kt",
+            "core/data/src/main/kotlin/com/riffle/core/data/AudiobookDownloadRepositoryImpl.kt",
+            "core/data/src/main/kotlin/com/riffle/core/data/KeystoreTokenStorage.kt",
+            "core/data/src/main/kotlin/com/riffle/core/data/LocalStoreImpl.kt",
+            "core/data/src/main/kotlin/com/riffle/core/data/LocalStoreMigrator.kt",
+            "core/data/src/main/kotlin/com/riffle/core/data/ReadaloudAudioRepositoryImpl.kt",
+            "core/data/src/main/kotlin/com/riffle/core/data/ServerFilesCleanerImpl.kt",
+            "core/data/src/main/kotlin/com/riffle/core/data/StorytellerSidecarFetcher.kt",
+            "core/data/src/main/kotlin/com/riffle/core/data/WebDavAnnotationSyncTarget.kt",
+            "core/data/src/main/kotlin/com/riffle/core/data/di/DataModule.kt",
+            // ---- Grandfathered — DispatcherProvider sweep follow-up (app/feature).
+            "app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookController.kt",
+            "app/src/main/kotlin/com/riffle/app/feature/navigation/HomeScreen.kt",
+            "app/src/main/kotlin/com/riffle/app/feature/navigation/HomeViewModel.kt",
+            "app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt",
+            "app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt",
+            "app/src/main/kotlin/com/riffle/app/feature/reader/autoscroll/AutoScrollController.kt",
+            "app/src/main/kotlin/com/riffle/app/feature/reader/controllers/SearchController.kt",
+            "app/src/main/kotlin/com/riffle/app/feature/reader/presenter/ReadiumPresenter.kt",
+            "app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/PlayerCoordinator.kt",
+            "app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/ReadaloudController.kt",
+            "app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/ReadaloudStreamingSessionFactory.kt",
+            "app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/StreamingAudioDownloader.kt",
+            "app/src/main/kotlin/com/riffle/app/feature/reader/session/ReadaloudSession.kt",
+        )
+
+        val scanRoots = listOf(
+            layout.projectDirectory.dir("app/src/main").asFile,
+            layout.projectDirectory.dir("core").asFile,
+        ).filter { it.exists() }
+
+        val offenders = mutableListOf<String>()
+        scanRoots
+            .flatMap { it.walkTopDown().toList() }
+            .filter { it.isFile && it.extension == "kt" }
+            // Only enforce on production source — tests legitimately reference the literals in fakes.
+            .filterNot { it.absolutePath.contains("/src/test/") || it.absolutePath.contains("/src/androidTest/") }
+            .forEach { f ->
+                val rel = f.relativeTo(layout.projectDirectory.asFile).path
+                if (rel in allowlist) return@forEach
+                f.useLines { lines ->
+                    lines.forEachIndexed { idx, line ->
+                        // Skip comment-only lines so doc-comments mentioning the literals don't trip.
+                        val trimmed = line.trimStart()
+                        if (trimmed.startsWith("//") || trimmed.startsWith("*") || trimmed.startsWith("/*")) return@forEachIndexed
+                        if (clockPattern.containsMatchIn(line)) {
+                            offenders += "$rel:${idx + 1} — System.currentTimeMillis/nanoTime: route through Clock"
+                        }
+                        if (dispatcherPattern.containsMatchIn(line)) {
+                            offenders += "$rel:${idx + 1} — Dispatchers.[IMD]: route through DispatcherProvider"
+                        }
+                    }
+                }
+            }
+        if (offenders.isNotEmpty()) {
+            throw GradleException(
+                "Direct time/dispatcher access bypasses the Clock + DispatcherProvider seams (#338).\n" +
+                    "Inject `Clock` and use `clock.nowMs()` / `clock.nowNs()` instead of `System.currentTimeMillis()` / `System.nanoTime()`.\n" +
+                    "Inject `DispatcherProvider` and use `dispatchers.io` / `.main` / `.default` instead of `Dispatchers.IO` / `.Main` / `.Default`.\n" +
+                    offenders.joinToString("\n"),
+            )
+        }
+    }
+}
+
 // Make it part of the normal `./gradlew check` run.
 allprojects {
     tasks.matching { it.name == "check" }.configureEach {
         dependsOn(rootProject.tasks.named("checkRiffleLogTags"))
+        dependsOn(rootProject.tasks.named("checkRiffleInfraSeams"))
     }
 }

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/Clock.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/Clock.kt
@@ -1,0 +1,18 @@
+package com.riffle.core.domain
+
+/**
+ * Typed seam for "what time is it now?" — replaces direct [System.currentTimeMillis] / [System.nanoTime]
+ * calls so session-duration, handoff-trace, autoscroll-tick and similar timing logic become
+ * deterministic in tests.
+ *
+ * Production binding is [SystemClock]; tests inject a controllable fake (`TestClock`) from
+ * `core/domain` test source. The contract is intentionally narrow — only the `now()` family. For
+ * hour-of-day scheduling (ADR 0022) see `TimeProvider`, which delegates to this seam for millis.
+ */
+interface Clock {
+    /** Wall-clock millis since epoch — for session timestamps, ages, scheduling deadlines. */
+    fun nowMs(): Long
+
+    /** Monotonic nanos — for sub-ms handoff traces (ADR 0032) and short performance probes. */
+    fun nowNs(): Long
+}

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/DefaultDispatcherProvider.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/DefaultDispatcherProvider.kt
@@ -1,0 +1,12 @@
+package com.riffle.core.domain
+
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+
+/** Production [DispatcherProvider] — delegates straight to `kotlinx.coroutines.Dispatchers`. Bound in `AppModule`. */
+object DefaultDispatcherProvider : DispatcherProvider {
+    override val main: CoroutineDispatcher get() = Dispatchers.Main
+    override val mainImmediate: CoroutineDispatcher get() = Dispatchers.Main.immediate
+    override val io: CoroutineDispatcher get() = Dispatchers.IO
+    override val default: CoroutineDispatcher get() = Dispatchers.Default
+}

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/DispatcherProvider.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/DispatcherProvider.kt
@@ -1,0 +1,30 @@
+package com.riffle.core.domain
+
+import kotlinx.coroutines.CoroutineDispatcher
+
+/**
+ * Typed seam for coroutine dispatchers — replaces direct [kotlinx.coroutines.Dispatchers.IO] /
+ * `Main` / `Default` references so tests can swap in a `StandardTestDispatcher` (or any test
+ * dispatcher) without resorting to `Dispatchers.setMain` / global hacks.
+ *
+ * Production binding is [DefaultDispatcherProvider]; tests inject a `TestDispatcherProvider`
+ * backed by `kotlinx-coroutines-test` dispatchers. The four properties exhaust the dispatcher
+ * surface this codebase uses; if a fifth is ever needed (e.g. a custom limited-parallelism
+ * dispatcher), add it here rather than reintroducing direct `Dispatchers.X` literals.
+ */
+interface DispatcherProvider {
+    /** UI thread — default-binds to `Dispatchers.Main`. */
+    val main: CoroutineDispatcher
+
+    /**
+     * Immediate-mode UI dispatcher — default-binds to `Dispatchers.Main.immediate`. Use for sites
+     * that must avoid the post-to-main hop (Media3 controller construction, JS message receivers).
+     */
+    val mainImmediate: CoroutineDispatcher
+
+    /** IO-bound work (disk, network, DataStore) — default-binds to `Dispatchers.IO`. */
+    val io: CoroutineDispatcher
+
+    /** CPU-bound work — default-binds to `Dispatchers.Default`. */
+    val default: CoroutineDispatcher
+}

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/SystemClock.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/SystemClock.kt
@@ -1,0 +1,7 @@
+package com.riffle.core.domain
+
+/** Production [Clock] — delegates straight to the JVM system clock. Bound in `AppModule`. */
+object SystemClock : Clock {
+    override fun nowMs(): Long = System.currentTimeMillis()
+    override fun nowNs(): Long = System.nanoTime()
+}

--- a/core/domain/src/test/kotlin/com/riffle/core/domain/ClockTest.kt
+++ b/core/domain/src/test/kotlin/com/riffle/core/domain/ClockTest.kt
@@ -1,0 +1,35 @@
+package com.riffle.core.domain
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ClockTest {
+
+    @Test
+    fun `TestClock returns the initial value and advances by delta`() {
+        val clock = TestClock(initialMs = 1_000L)
+
+        assertEquals(1_000L, clock.nowMs())
+        assertEquals(1_000_000_000L, clock.nowNs())
+
+        clock.advance(500L)
+        assertEquals(1_500L, clock.nowMs())
+        assertEquals(1_500_000_000L, clock.nowNs())
+    }
+
+    @Test
+    fun `TestClock setNowMs jumps to absolute instant`() {
+        val clock = TestClock()
+        clock.setNowMs(42L)
+        assertEquals(42L, clock.nowMs())
+        assertEquals(42_000_000L, clock.nowNs())
+    }
+
+    @Test
+    fun `SystemClock returns monotonically non-decreasing nanos`() {
+        val first = SystemClock.nowNs()
+        val second = SystemClock.nowNs()
+        // nanoTime is monotonic; same-tick reads tie, never regress.
+        assert(second >= first) { "expected monotonic nanos, got first=$first second=$second" }
+    }
+}

--- a/core/domain/src/test/kotlin/com/riffle/core/domain/TestClock.kt
+++ b/core/domain/src/test/kotlin/com/riffle/core/domain/TestClock.kt
@@ -1,0 +1,15 @@
+package com.riffle.core.domain
+
+/**
+ * Controllable [Clock] for tests — start at any epoch instant, advance by [advance] or set
+ * absolutely via [setNowMs]. `nowNs()` advances in lock-step with millis (1ms = 1_000_000ns).
+ */
+class TestClock(initialMs: Long = 0L) : Clock {
+    private var ms: Long = initialMs
+
+    override fun nowMs(): Long = ms
+    override fun nowNs(): Long = ms * 1_000_000L
+
+    fun setNowMs(ms: Long) { this.ms = ms }
+    fun advance(ms: Long) { this.ms += ms }
+}

--- a/core/domain/src/test/kotlin/com/riffle/core/domain/TestDispatcherProvider.kt
+++ b/core/domain/src/test/kotlin/com/riffle/core/domain/TestDispatcherProvider.kt
@@ -1,0 +1,21 @@
+package com.riffle.core.domain
+
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestDispatcher
+
+/**
+ * Test [DispatcherProvider] — every dispatcher routes through the same [TestDispatcher] so a
+ * `TestScope`'s scheduler controls all four. Pass `runTest`'s `testScheduler` via
+ * `StandardTestDispatcher(testScheduler)` for full determinism.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class TestDispatcherProvider(
+    private val dispatcher: TestDispatcher = StandardTestDispatcher(),
+) : DispatcherProvider {
+    override val main: CoroutineDispatcher get() = dispatcher
+    override val mainImmediate: CoroutineDispatcher get() = dispatcher
+    override val io: CoroutineDispatcher get() = dispatcher
+    override val default: CoroutineDispatcher get() = dispatcher
+}


### PR DESCRIPTION
## Summary

Introduces two paired infra seams so timing and threading become substitutable
in tests. Follows the same shape as #346 (ApplicationScope) and #348 (Logger):
ship the abstraction + lint + a handful of tracer migrations, leaving the bulk
sweep for focused follow-up PRs.

- `Clock` (`nowMs()` / `nowNs()`) — production `SystemClock`, fake `TestClock`.
- `DispatcherProvider` (`main` / `mainImmediate` / `io` / `default`) —
  production `DefaultDispatcherProvider`, fake `TestDispatcherProvider`.
- Hilt bindings in `AppModule`; the survivable scopes (`@DownloadScope`,
  `@ApplicationCoroutineScope`) now consume `dispatchers.io` instead of
  `Dispatchers.IO`.
- Tracer migrations of every call site the issue explicitly names:
  `FileCrashReportSender`, `AutoScrollController` (the nanoTime ticker),
  `EpubReaderViewModel` (session-start / session-end), `AudiobookController` +
  `ReadaloudController` (ADR 0032 handoff traces).
- New `checkRiffleInfraSeams` Gradle task wired into `check`. Existing
  direct-call sites are grandfathered via a path-based allowlist so this PR
  stays reviewable. New sites — anywhere else — fail the build. Allowlist
  entries get retired one cluster at a time in the follow-up PRs below.

The strict acceptance criterion in #338 ("no production code calls
System.currentTimeMillis / Dispatchers.[IMD] directly") becomes the lint
target as each follow-up lands; the allowlist is the work-list.

## Follow-ups (to file)

- core/network Dispatcher sweep (6 files, 25+ sites in `AbsApiClient` alone)
- core/data Clock sweep (5 files)
- core/data Dispatcher sweep (11 files, incl. `WebDavAnnotationSyncTarget`)
- app/feature/reader Dispatcher sweep (Compose sites need a `CompositionLocal`
  or VM-threading design decision)
- DataModule.kt: convert the 3 inline `SupervisorJob + Dispatchers.IO`
  scope providers to consume `DispatcherProvider`
- Audiobook+Library+AddServer ViewModel Clock injection

## Test plan

- [x] `./gradlew :core:domain:test` green (includes new `ClockTest`)
- [x] `./gradlew :app:testDebugUnitTest` green
- [x] `./gradlew test` green (all JVM module suites)
- [x] `./gradlew checkRiffleInfraSeams` green
- [ ] Device verification not applicable — pure-JVM seam introduction; no Readium/WebView code path touched

Closes #338