### PR TITLE
refactor(library): collapse 11 filteredX flows behind LibraryFilterEngine

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryFilterEngine.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryFilterEngine.kt
@@ -1,0 +1,208 @@
+package com.riffle.app.feature.library
+
+import com.riffle.core.data.ToReadRepository
+import com.riffle.core.domain.AnnotationStore
+import com.riffle.core.domain.AudiobookBookmarkStore
+import com.riffle.core.domain.Collection
+import com.riffle.core.domain.LibraryItem
+import com.riffle.core.domain.LibraryItemOfflineAvailability
+import com.riffle.core.domain.LibraryRepository
+import com.riffle.core.domain.Series
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
+
+data class LibraryProjection(
+    val series: List<Series>,
+    val collections: List<Collection>,
+    val ungrouped: List<LibraryItem>,
+    val inProgress: List<LibraryItem>,
+    val finished: List<LibraryItem>,
+    val recentlyAdded: List<LibraryItem>,
+    val continueSeries: List<LibraryItem>,
+    val allBooks: List<LibraryItem>,
+    val toRead: List<LibraryItem>,
+    val annotations: List<AnnotationSearchResult>,
+    val audiobookBookmarks: List<AudiobookBookmarkSearchResult>,
+) {
+    companion object {
+        val Empty = LibraryProjection(
+            series = emptyList(),
+            collections = emptyList(),
+            ungrouped = emptyList(),
+            inProgress = emptyList(),
+            finished = emptyList(),
+            recentlyAdded = emptyList(),
+            continueSeries = emptyList(),
+            allBooks = emptyList(),
+            toRead = emptyList(),
+            annotations = emptyList(),
+            audiobookBookmarks = emptyList(),
+        )
+    }
+}
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class LibraryFilterEngine(
+    private val libraryRepository: LibraryRepository,
+    private val annotationStore: AnnotationStore,
+    private val audiobookBookmarkStore: AudiobookBookmarkStore,
+    private val toReadRepository: ToReadRepository,
+    private val offlineAvailability: LibraryItemOfflineAvailability,
+    private val libraryId: String,
+    private val isOffline: Flow<Boolean>,
+    private val searchQuery: Flow<String>,
+    private val notStartedFilterActive: Flow<Boolean>,
+) {
+
+    private val seriesSource: Flow<List<Series>> = libraryRepository.observeSeries(libraryId)
+    private val collectionsSource: Flow<List<Collection>> = libraryRepository.observeCollections(libraryId)
+    private val ungroupedSource: Flow<List<LibraryItem>> = libraryRepository.observeUngroupedLibraryItems(libraryId)
+    private val inProgressSource: Flow<List<LibraryItem>> = libraryRepository.observeInProgressItems(libraryId)
+    private val finishedSource: Flow<List<LibraryItem>> = libraryRepository.observeFinishedItems(libraryId)
+    private val recentlyAddedSource: Flow<List<LibraryItem>> = libraryRepository.observeRecentlyAddedItems(libraryId)
+    private val continueSeriesSource: Flow<List<LibraryItem>> = libraryRepository.observeContinueSeriesItems(libraryId)
+    private val allBooksSource: Flow<List<LibraryItem>> = libraryRepository.observeAllBooks(libraryId)
+    private val allItemsSource: Flow<List<LibraryItem>> = libraryRepository.observeLibraryItems(libraryId)
+    private val toReadIdsSource: Flow<Set<String>> = toReadRepository.observeToReadItemIds(libraryId)
+
+    private val seriesProjection: Flow<List<Series>> =
+        combine(seriesSource, searchQuery, isOffline) { list, query, offline ->
+            Triple(list, query, offline)
+        }.flatMapLatest { (list, query, offline) ->
+            val queryFiltered = if (query.isEmpty()) list else list.filter { it.name.contains(query, ignoreCase = true) }
+            filterSeriesOffline(queryFiltered, offline)
+        }
+
+    private val collectionsProjection: Flow<List<Collection>> =
+        combine(collectionsSource, searchQuery, isOffline) { list, query, offline ->
+            Triple(list, query, offline)
+        }.flatMapLatest { (list, query, offline) ->
+            val queryFiltered = if (query.isEmpty()) list else list.filter { it.name.contains(query, ignoreCase = true) }
+            filterCollectionsOffline(queryFiltered, offline)
+        }
+
+    // When a query is active, search all items (including those in series/collections) so that
+    // books are findable by title/author regardless of grouping.
+    // When offline, only items available locally (downloaded or cached) are shown.
+    private val ungroupedProjection: Flow<List<LibraryItem>> =
+        combine(ungroupedSource, allItemsSource, searchQuery, isOffline) { ungrouped, all, query, offline ->
+            val base = if (query.isEmpty()) ungrouped
+                else all.filter { it.title.contains(query, ignoreCase = true) || it.author.contains(query, ignoreCase = true) }
+            if (offline) base.filter { offlineAvailability.isAvailableOffline(it) } else base
+        }
+
+    private val inProgressProjection: Flow<List<LibraryItem>> =
+        combine(inProgressSource, isOffline) { items, offline ->
+            if (offline) items.filter { offlineAvailability.isAvailableOffline(it) } else items
+        }
+
+    private val finishedProjection: Flow<List<LibraryItem>> =
+        combine(finishedSource, isOffline) { items, offline ->
+            if (offline) items.filter { offlineAvailability.isAvailableOffline(it) } else items
+        }
+
+    private val recentlyAddedProjection: Flow<List<LibraryItem>> =
+        combine(recentlyAddedSource, isOffline) { items, offline ->
+            val filtered = if (offline) items.filter { offlineAvailability.isAvailableOffline(it) } else items
+            filtered.take(50)
+        }
+
+    private val continueSeriesProjection: Flow<List<LibraryItem>> =
+        combine(continueSeriesSource, isOffline) { items, offline ->
+            val filtered = if (offline) items.filter { offlineAvailability.isAvailableOffline(it) } else items
+            filtered.take(20)
+        }
+
+    private val allBooksProjection: Flow<List<LibraryItem>> =
+        combine(allBooksSource, isOffline, notStartedFilterActive) { items, offline, notStartedOnly ->
+            val afterOffline = if (offline) items.filter { offlineAvailability.isAvailableOffline(it) } else items
+            if (notStartedOnly) afterOffline.filter { it.readingProgress == 0f } else afterOffline
+        }
+
+    private val toReadProjection: Flow<List<LibraryItem>> =
+        combine(toReadIdsSource, allBooksSource, isOffline) { ids, all, offline ->
+            val byId = all.associateBy { it.id }
+            val items = ids.mapNotNull { byId[it] }
+            if (offline) items.filter { offlineAvailability.isAvailableOffline(it) } else items
+        }
+
+    // Annotation search results, scoped to this library's items and matched on note text,
+    // highlighted snippet, or bookmark title. Independent of the Books section (a book is never
+    // promoted here because its annotations matched). Empty when the query is blank.
+    private val annotationsProjection: Flow<List<AnnotationSearchResult>> =
+        combine(allItemsSource, searchQuery) { items, query -> items to query }
+            .flatMapLatest { (items, query) ->
+                val serverId = items.firstOrNull()?.serverId
+                if (query.isBlank() || serverId.isNullOrEmpty()) {
+                    flowOf(emptyList())
+                } else {
+                    annotationStore.observeAnnotationsForServer(serverId)
+                        .map { annotations -> searchAnnotations(annotations, items, query) }
+                }
+            }
+
+    // Audiobook bookmark search results, scoped to this library's items and matched on title.
+    // Shares the same Annotations section in the UI. Empty when the query is blank.
+    private val audiobookBookmarksProjection: Flow<List<AudiobookBookmarkSearchResult>> =
+        combine(allItemsSource, searchQuery) { items, query -> items to query }
+            .flatMapLatest { (items, query) ->
+                val serverId = items.firstOrNull()?.serverId
+                if (query.isBlank() || serverId.isNullOrEmpty()) {
+                    flowOf(emptyList())
+                } else {
+                    audiobookBookmarkStore.observeForServer(serverId)
+                        .map { bookmarks -> searchAudiobookBookmarks(bookmarks, items, query) }
+                }
+            }
+
+    @Suppress("UNCHECKED_CAST")
+    val projection: Flow<LibraryProjection> = combine(
+        seriesProjection,
+        collectionsProjection,
+        ungroupedProjection,
+        inProgressProjection,
+        finishedProjection,
+        recentlyAddedProjection,
+        continueSeriesProjection,
+        allBooksProjection,
+        toReadProjection,
+        annotationsProjection,
+        audiobookBookmarksProjection,
+    ) { values ->
+        LibraryProjection(
+            series = values[0] as List<Series>,
+            collections = values[1] as List<Collection>,
+            ungrouped = values[2] as List<LibraryItem>,
+            inProgress = values[3] as List<LibraryItem>,
+            finished = values[4] as List<LibraryItem>,
+            recentlyAdded = values[5] as List<LibraryItem>,
+            continueSeries = values[6] as List<LibraryItem>,
+            allBooks = values[7] as List<LibraryItem>,
+            toRead = values[8] as List<LibraryItem>,
+            annotations = values[9] as List<AnnotationSearchResult>,
+            audiobookBookmarks = values[10] as List<AudiobookBookmarkSearchResult>,
+        )
+    }
+
+    private fun filterCollectionsOffline(collections: List<Collection>, offline: Boolean): Flow<List<Collection>> {
+        if (!offline || collections.isEmpty()) return flowOf(collections)
+        return combine(collections.map { col -> libraryRepository.observeCollectionItems(col.id) }) { itemArrays ->
+            collections.zip(itemArrays.toList())
+                .filter { (_, items) -> items.any { offlineAvailability.isAvailableOffline(it) } }
+                .map { (col, _) -> col }
+        }
+    }
+
+    private fun filterSeriesOffline(series: List<Series>, offline: Boolean): Flow<List<Series>> {
+        if (!offline || series.isEmpty()) return flowOf(series)
+        return combine(series.map { s -> libraryRepository.observeSeriesItems(s.id) }) { itemArrays ->
+            series.zip(itemArrays.toList())
+                .filter { (_, items) -> items.any { offlineAvailability.isAvailableOffline(it) } }
+                .map { (s, _) -> s }
+        }
+    }
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryFilterEngine.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryFilterEngine.kt
@@ -1,6 +1,5 @@
 package com.riffle.app.feature.library
 
-import com.riffle.core.data.ToReadRepository
 import com.riffle.core.domain.AnnotationStore
 import com.riffle.core.domain.AudiobookBookmarkStore
 import com.riffle.core.domain.Collection
@@ -45,29 +44,34 @@ data class LibraryProjection(
     }
 }
 
+/**
+ * Combines a library's source flows + UI filters into a single [LibraryProjection].
+ *
+ * Source flows are passed in (not observed from the repository here) so that the ViewModel's
+ * existing `stateIn(WhileSubscribed)` caches are reused instead of duplicating Room cursors.
+ * [libraryRepository] is only kept for the per-group offline filter, which needs to observe each
+ * series'/collection's items to decide whether to drop empty groups when offline.
+ */
 @OptIn(ExperimentalCoroutinesApi::class)
 class LibraryFilterEngine(
     private val libraryRepository: LibraryRepository,
     private val annotationStore: AnnotationStore,
     private val audiobookBookmarkStore: AudiobookBookmarkStore,
-    private val toReadRepository: ToReadRepository,
     private val offlineAvailability: LibraryItemOfflineAvailability,
-    private val libraryId: String,
-    private val isOffline: Flow<Boolean>,
-    private val searchQuery: Flow<String>,
-    private val notStartedFilterActive: Flow<Boolean>,
+    seriesSource: Flow<List<Series>>,
+    collectionsSource: Flow<List<Collection>>,
+    ungroupedSource: Flow<List<LibraryItem>>,
+    inProgressSource: Flow<List<LibraryItem>>,
+    finishedSource: Flow<List<LibraryItem>>,
+    recentlyAddedSource: Flow<List<LibraryItem>>,
+    continueSeriesSource: Flow<List<LibraryItem>>,
+    allBooksSource: Flow<List<LibraryItem>>,
+    allItemsSource: Flow<List<LibraryItem>>,
+    toReadIdsSource: Flow<Set<String>>,
+    isOffline: Flow<Boolean>,
+    searchQuery: Flow<String>,
+    notStartedFilterActive: Flow<Boolean>,
 ) {
-
-    private val seriesSource: Flow<List<Series>> = libraryRepository.observeSeries(libraryId)
-    private val collectionsSource: Flow<List<Collection>> = libraryRepository.observeCollections(libraryId)
-    private val ungroupedSource: Flow<List<LibraryItem>> = libraryRepository.observeUngroupedLibraryItems(libraryId)
-    private val inProgressSource: Flow<List<LibraryItem>> = libraryRepository.observeInProgressItems(libraryId)
-    private val finishedSource: Flow<List<LibraryItem>> = libraryRepository.observeFinishedItems(libraryId)
-    private val recentlyAddedSource: Flow<List<LibraryItem>> = libraryRepository.observeRecentlyAddedItems(libraryId)
-    private val continueSeriesSource: Flow<List<LibraryItem>> = libraryRepository.observeContinueSeriesItems(libraryId)
-    private val allBooksSource: Flow<List<LibraryItem>> = libraryRepository.observeAllBooks(libraryId)
-    private val allItemsSource: Flow<List<LibraryItem>> = libraryRepository.observeLibraryItems(libraryId)
-    private val toReadIdsSource: Flow<Set<String>> = toReadRepository.observeToReadItemIds(libraryId)
 
     private val seriesProjection: Flow<List<Series>> =
         combine(seriesSource, searchQuery, isOffline) { list, query, offline ->

--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsScreen.kt
@@ -140,22 +140,23 @@ fun LibraryItemsScreen(
     viewModel: LibraryItemsViewModel = hiltViewModel(),
 ) {
     val searchQuery by viewModel.searchQuery.collectAsState()
-    val filteredUngroupedItems by viewModel.filteredUngroupedItems.collectAsState()
-    val inProgress by viewModel.filteredInProgress.collectAsState()
-    val continueSeries by viewModel.continueSeriesItems.collectAsState()
-    val allBooks by viewModel.filteredAllBooks.collectAsState()
-    val finished by viewModel.filteredFinished.collectAsState()
-    val recentlyAdded by viewModel.filteredRecentlyAdded.collectAsState()
-    val series by viewModel.filteredSeries.collectAsState()
-    val collections by viewModel.filteredCollections.collectAsState()
-    val toReadItems by viewModel.toReadItems.collectAsState()
+    val projection by viewModel.projection.collectAsState()
+    val filteredUngroupedItems = projection.ungrouped
+    val inProgress = projection.inProgress
+    val continueSeries = projection.continueSeries
+    val allBooks = projection.allBooks
+    val finished = projection.finished
+    val recentlyAdded = projection.recentlyAdded
+    val series = projection.series
+    val collections = projection.collections
+    val toReadItems = projection.toRead
+    val annotationResults = projection.annotations
+    val audiobookBookmarkResults = projection.audiobookBookmarks
     val collectionCoverUrls by viewModel.collectionCoverUrls.collectAsState()
     val isOffline by viewModel.isOffline.collectAsState()
     val isLoading by viewModel.isLoading.collectAsState()
     val linkedItemIds by viewModel.linkedItemIds.collectAsState()
     val notStartedFilterActive by viewModel.notStartedFilterActive.collectAsState()
-    val annotationResults by viewModel.filteredAnnotations.collectAsState()
-    val audiobookBookmarkResults by viewModel.filteredAudiobookBookmarks.collectAsState()
 
     val coversAreSquare by viewModel.coversAreSquare.collectAsState()
     var selectedTab by rememberSaveable { mutableIntStateOf(0) }

--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsViewModel.kt
@@ -24,7 +24,6 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -165,78 +164,6 @@ class LibraryItemsViewModel @Inject constructor(
         !online || refreshFailed
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), false)
 
-    val filteredSeries: StateFlow<List<Series>> = combine(series, searchQuery, isOffline) { list, query, offline ->
-        Triple(list, query, offline)
-    }.flatMapLatest { (list, query, offline) ->
-        val queryFiltered = if (query.isEmpty()) list else list.filter { it.name.contains(query, ignoreCase = true) }
-        filterSeriesOffline(queryFiltered, offline)
-    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
-
-    val filteredCollections: StateFlow<List<Collection>> = combine(collections, searchQuery, isOffline) { list, query, offline ->
-        Triple(list, query, offline)
-    }.flatMapLatest { (list, query, offline) ->
-        val queryFiltered = if (query.isEmpty()) list else list.filter { it.name.contains(query, ignoreCase = true) }
-        filterCollectionsOffline(queryFiltered, offline)
-    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
-
-    // When a query is active, search all items (including those in series/collections) so that
-    // books are findable by title/author regardless of grouping.
-    // When offline, only items available locally (downloaded or cached) are shown.
-    val filteredUngroupedItems: StateFlow<List<LibraryItem>> = combine(ungroupedItems, allItems, searchQuery, isOffline) { ungrouped, all, query, offline ->
-        val base = if (query.isEmpty()) ungrouped
-            else all.filter { it.title.contains(query, ignoreCase = true) || it.author.contains(query, ignoreCase = true) }
-        if (offline) base.filter { offlineAvailability.isAvailableOffline(it) } else base
-    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
-
-    // Annotation search results, scoped to this library's items and matched on note text,
-    // highlighted snippet, or bookmark title. Independent of the Books section (a book is never
-    // promoted here because its annotations matched). Empty when the query is blank.
-    val filteredAnnotations: StateFlow<List<AnnotationSearchResult>> =
-        combine(allItems, searchQuery) { items, query -> items to query }
-            .flatMapLatest { (items, query) ->
-                val serverId = items.firstOrNull()?.serverId
-                if (query.isBlank() || serverId.isNullOrEmpty()) {
-                    flowOf(emptyList())
-                } else {
-                    annotationStore.observeAnnotationsForServer(serverId)
-                        .map { annotations -> searchAnnotations(annotations, items, query) }
-                }
-            }
-            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
-
-    // Audiobook bookmark search results, scoped to this library's items and matched on title.
-    // Shares the same Annotations section in the UI. Empty when the query is blank.
-    val filteredAudiobookBookmarks: StateFlow<List<AudiobookBookmarkSearchResult>> =
-        combine(allItems, searchQuery) { items, query -> items to query }
-            .flatMapLatest { (items, query) ->
-                val serverId = items.firstOrNull()?.serverId
-                if (query.isBlank() || serverId.isNullOrEmpty()) {
-                    flowOf(emptyList())
-                } else {
-                    audiobookBookmarkStore.observeForServer(serverId)
-                        .map { bookmarks -> searchAudiobookBookmarks(bookmarks, items, query) }
-                }
-            }
-            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
-
-    val filteredInProgress: StateFlow<List<LibraryItem>> = combine(inProgress, isOffline) { items, offline ->
-        if (offline) items.filter { offlineAvailability.isAvailableOffline(it) } else items
-    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
-
-    val filteredFinished: StateFlow<List<LibraryItem>> = combine(finished, isOffline) { items, offline ->
-        if (offline) items.filter { offlineAvailability.isAvailableOffline(it) } else items
-    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
-
-    val filteredRecentlyAdded: StateFlow<List<LibraryItem>> = combine(recentlyAdded, isOffline) { items, offline ->
-        val filtered = if (offline) items.filter { offlineAvailability.isAvailableOffline(it) } else items
-        filtered.take(50)
-    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
-
-    val continueSeriesItems: StateFlow<List<LibraryItem>> = combine(continueSeriesBase, isOffline) { items, offline ->
-        val filtered = if (offline) items.filter { offlineAvailability.isAvailableOffline(it) } else items
-        filtered.take(20)
-    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
-
     private val _notStartedFilterActive = MutableStateFlow(false)
     val notStartedFilterActive: StateFlow<Boolean> = _notStartedFilterActive.asStateFlow()
 
@@ -244,20 +171,20 @@ class LibraryItemsViewModel @Inject constructor(
         _notStartedFilterActive.value = !_notStartedFilterActive.value
     }
 
-    val filteredAllBooks: StateFlow<List<LibraryItem>> = combine(
-        allBooks,
-        isOffline,
-        _notStartedFilterActive,
-    ) { items, offline, notStartedOnly ->
-        val afterOffline = if (offline) items.filter { offlineAvailability.isAvailableOffline(it) } else items
-        if (notStartedOnly) afterOffline.filter { it.readingProgress == 0f } else afterOffline
-    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
+    private val filterEngine = LibraryFilterEngine(
+        libraryRepository = libraryRepository,
+        annotationStore = annotationStore,
+        audiobookBookmarkStore = audiobookBookmarkStore,
+        toReadRepository = toReadRepository,
+        offlineAvailability = offlineAvailability,
+        libraryId = libraryId,
+        isOffline = isOffline,
+        searchQuery = searchQuery,
+        notStartedFilterActive = _notStartedFilterActive,
+    )
 
-    val toReadItems: StateFlow<List<LibraryItem>> = combine(toReadItemIds, allBooks, isOffline) { ids, all, offline ->
-        val byId = all.associateBy { it.id }
-        val items = ids.mapNotNull { byId[it] }
-        if (offline) items.filter { offlineAvailability.isAvailableOffline(it) } else items
-    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
+    val projection: StateFlow<LibraryProjection> = filterEngine.projection
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), LibraryProjection.Empty)
 
     var authToken: String by mutableStateOf("")
         private set
@@ -343,24 +270,6 @@ class LibraryItemsViewModel @Inject constructor(
         toReadDeferred.await()
         _refreshFailed.value = results.any { it is LibraryRefreshResult.NetworkError }
         lastRefreshCompletedAt = System.currentTimeMillis()
-    }
-
-    private fun filterCollectionsOffline(collections: List<Collection>, offline: Boolean): Flow<List<Collection>> {
-        if (!offline || collections.isEmpty()) return flowOf(collections)
-        return combine(collections.map { col -> libraryRepository.observeCollectionItems(col.id) }) { itemArrays ->
-            collections.zip(itemArrays.toList())
-                .filter { (_, items) -> items.any { offlineAvailability.isAvailableOffline(it) } }
-                .map { (col, _) -> col }
-        }
-    }
-
-    private fun filterSeriesOffline(series: List<Series>, offline: Boolean): Flow<List<Series>> {
-        if (!offline || series.isEmpty()) return flowOf(series)
-        return combine(series.map { s -> libraryRepository.observeSeriesItems(s.id) }) { itemArrays ->
-            series.zip(itemArrays.toList())
-                .filter { (_, items) -> items.any { offlineAvailability.isAvailableOffline(it) } }
-                .map { (s, _) -> s }
-        }
     }
 
     private companion object {

--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsViewModel.kt
@@ -171,13 +171,24 @@ class LibraryItemsViewModel @Inject constructor(
         _notStartedFilterActive.value = !_notStartedFilterActive.value
     }
 
+    // Share the VM's already-stateIn'd source flows with the engine so we don't open a second
+    // set of Room cursors for the same observe* calls. libraryRepository is still passed through
+    // for the per-group offline filter, which needs to observe each series'/collection's items.
     private val filterEngine = LibraryFilterEngine(
         libraryRepository = libraryRepository,
         annotationStore = annotationStore,
         audiobookBookmarkStore = audiobookBookmarkStore,
-        toReadRepository = toReadRepository,
         offlineAvailability = offlineAvailability,
-        libraryId = libraryId,
+        seriesSource = series,
+        collectionsSource = collections,
+        ungroupedSource = ungroupedItems,
+        inProgressSource = inProgress,
+        finishedSource = finished,
+        recentlyAddedSource = recentlyAdded,
+        continueSeriesSource = continueSeriesBase,
+        allBooksSource = allBooks,
+        allItemsSource = allItems,
+        toReadIdsSource = toReadItemIds,
         isOffline = isOffline,
         searchQuery = searchQuery,
         notStartedFilterActive = _notStartedFilterActive,

--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibrarySectionScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibrarySectionScreen.kt
@@ -32,9 +32,10 @@ fun LibrarySectionScreen(
     onNavigateBack: () -> Unit,
     viewModel: LibraryItemsViewModel = hiltViewModel(),
 ) {
-    val inProgress by viewModel.filteredInProgress.collectAsState()
-    val finished by viewModel.filteredFinished.collectAsState()
-    val recentlyAdded by viewModel.filteredRecentlyAdded.collectAsState()
+    val projection by viewModel.projection.collectAsState()
+    val inProgress = projection.inProgress
+    val finished = projection.finished
+    val recentlyAdded = projection.recentlyAdded
 
     Scaffold(
         topBar = {

--- a/app/src/test/kotlin/com/riffle/app/feature/library/LibraryFilterEngineTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/LibraryFilterEngineTest.kt
@@ -1,6 +1,5 @@
 package com.riffle.app.feature.library
 
-import com.riffle.core.data.ToReadRepository
 import com.riffle.core.domain.AnnotationStore
 import com.riffle.core.domain.AudiobookBookmarkStore
 import com.riffle.core.domain.AudiobookDownloadRepository
@@ -105,15 +104,6 @@ class LibraryFilterEngineTest {
         override suspend fun delete(id: String, now: Long) = error("unused")
     }
 
-    private class FakeToReadRepository(initial: Set<String> = emptySet()) : ToReadRepository {
-        val ids = MutableStateFlow(initial)
-        override fun observeToReadItemIds(libraryId: String): Flow<Set<String>> = ids
-        override suspend fun refresh(libraryId: String): Boolean = true
-        override suspend fun isInToRead(libraryItemId: String, libraryId: String): Boolean = libraryItemId in ids.value
-        override suspend fun addToToRead(libraryItemId: String, libraryId: String): Boolean { ids.value = ids.value + libraryItemId; return true }
-        override suspend fun removeFromToRead(libraryItemId: String, libraryId: String): Boolean { ids.value = ids.value - libraryItemId; return true }
-    }
-
     private fun epubRepoWithDownloads(downloadedIds: Set<String>): EpubRepository = object : EpubRepository {
         override suspend fun openEpub(item: LibraryItem) = EpubOpenResult.Offline
         override suspend fun downloadEpub(item: LibraryItem, onProgress: (Long, Long) -> Unit) = EpubDownloadResult.Success
@@ -141,28 +131,39 @@ class LibraryFilterEngineTest {
 
     private fun makeEngine(
         epubRepository: EpubRepository = epubRepoWithDownloads(emptySet()),
-        toReadRepository: ToReadRepository = FakeToReadRepository(),
+        toReadIds: Set<String> = emptySet(),
         annotationStore: AnnotationStore = fakeAnnotationStore(),
         audiobookBookmarkStore: AudiobookBookmarkStore = fakeBookmarkStore(),
-    ): LibraryFilterEngine = LibraryFilterEngine(
-        libraryRepository = fakeRepo(),
-        annotationStore = annotationStore,
-        audiobookBookmarkStore = audiobookBookmarkStore,
-        toReadRepository = toReadRepository,
-        offlineAvailability = LibraryItemOfflineAvailability(
-            epubRepository,
-            fakePdfRepo(),
-            fakeAudiobookDownloadRepo(),
-            object : BundleAudiobookSource {
-                override suspend fun localSession(serverId: String, itemId: String) = null
-                override fun isAvailableOffline(serverId: String, itemId: String) = false
-            },
-        ),
-        libraryId = "lib-1",
-        isOffline = isOfflineFlow,
-        searchQuery = searchQueryFlow,
-        notStartedFilterActive = notStartedFilterFlow,
-    )
+    ): LibraryFilterEngine {
+        toReadIdsFlow.value = toReadIds
+        return LibraryFilterEngine(
+            libraryRepository = fakeRepo(),
+            annotationStore = annotationStore,
+            audiobookBookmarkStore = audiobookBookmarkStore,
+            offlineAvailability = LibraryItemOfflineAvailability(
+                epubRepository,
+                fakePdfRepo(),
+                fakeAudiobookDownloadRepo(),
+                object : BundleAudiobookSource {
+                    override suspend fun localSession(serverId: String, itemId: String) = null
+                    override fun isAvailableOffline(serverId: String, itemId: String) = false
+                },
+            ),
+            seriesSource = seriesFlow,
+            collectionsSource = collectionsFlow,
+            ungroupedSource = ungroupedFlow,
+            inProgressSource = inProgressFlow,
+            finishedSource = finishedFlow,
+            recentlyAddedSource = recentlyAddedFlow,
+            continueSeriesSource = continueSeriesFlow,
+            allBooksSource = allBooksFlow,
+            allItemsSource = allItemsFlow,
+            toReadIdsSource = toReadIdsFlow,
+            isOffline = isOfflineFlow,
+            searchQuery = searchQueryFlow,
+            notStartedFilterActive = notStartedFilterFlow,
+        )
+    }
 
     private fun series(name: String) = Series("id-$name", "lib-1", name, null, 1)
     private fun collection(name: String) = Collection("id-$name", "lib-1", name, 1)
@@ -338,7 +339,7 @@ class LibraryFilterEngineTest {
     fun `toRead intersects ids with allBooks then offline-filters`() = runTest {
         val engine = makeEngine(
             epubRepository = epubRepoWithDownloads(setOf("id-Dune")),
-            toReadRepository = FakeToReadRepository(setOf("id-Dune", "id-Foundation")),
+            toReadIds = setOf("id-Dune", "id-Foundation"),
         )
         allBooksFlow.value = listOf(item("Dune"), item("Foundation"), item("Other"))
         isOfflineFlow.value = true

--- a/app/src/test/kotlin/com/riffle/app/feature/library/LibraryFilterEngineTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/LibraryFilterEngineTest.kt
@@ -1,0 +1,397 @@
+package com.riffle.app.feature.library
+
+import com.riffle.core.data.ToReadRepository
+import com.riffle.core.domain.AnnotationStore
+import com.riffle.core.domain.AudiobookBookmarkStore
+import com.riffle.core.domain.AudiobookDownloadRepository
+import com.riffle.core.domain.AudiobookDownloadResult
+import com.riffle.core.domain.AudiobookSession
+import com.riffle.core.domain.BundleAudiobookSource
+import com.riffle.core.domain.Collection
+import com.riffle.core.domain.EbookFormat
+import com.riffle.core.domain.EpubDownloadResult
+import com.riffle.core.domain.EpubOpenResult
+import com.riffle.core.domain.EpubRepository
+import com.riffle.core.domain.Library
+import com.riffle.core.domain.LibraryItem
+import com.riffle.core.domain.LibraryItemOfflineAvailability
+import com.riffle.core.domain.LibraryRefreshResult
+import com.riffle.core.domain.LibraryRepository
+import com.riffle.core.domain.PdfDownloadResult
+import com.riffle.core.domain.PdfOpenResult
+import com.riffle.core.domain.PdfRepository
+import com.riffle.core.domain.Series
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class LibraryFilterEngineTest {
+
+    private val seriesFlow = MutableStateFlow<List<Series>>(emptyList())
+    private val collectionsFlow = MutableStateFlow<List<Collection>>(emptyList())
+    private val ungroupedFlow = MutableStateFlow<List<LibraryItem>>(emptyList())
+    private val allItemsFlow = MutableStateFlow<List<LibraryItem>>(emptyList())
+    private val inProgressFlow = MutableStateFlow<List<LibraryItem>>(emptyList())
+    private val finishedFlow = MutableStateFlow<List<LibraryItem>>(emptyList())
+    private val recentlyAddedFlow = MutableStateFlow<List<LibraryItem>>(emptyList())
+    private val continueSeriesFlow = MutableStateFlow<List<LibraryItem>>(emptyList())
+    private val allBooksFlow = MutableStateFlow<List<LibraryItem>>(emptyList())
+    private val seriesItemsBySeriesId = mutableMapOf<String, MutableStateFlow<List<LibraryItem>>>()
+    private val collectionItemsByCollectionId = mutableMapOf<String, MutableStateFlow<List<LibraryItem>>>()
+    private val annotationsFlow = MutableStateFlow<List<com.riffle.core.domain.Annotation>>(emptyList())
+    private val bookmarksFlow = MutableStateFlow<List<com.riffle.core.domain.AudiobookBookmark>>(emptyList())
+
+    private val isOfflineFlow = MutableStateFlow(false)
+    private val searchQueryFlow = MutableStateFlow("")
+    private val notStartedFilterFlow = MutableStateFlow(false)
+    private val toReadIdsFlow = MutableStateFlow<Set<String>>(emptySet())
+
+    private fun fakeRepo(): LibraryRepository = object : LibraryRepository {
+        override fun observeLibraries(): Flow<List<Library>> = MutableStateFlow(emptyList())
+        override fun observeLibraries(serverId: String): Flow<List<Library>> = observeLibraries()
+        override fun observeLibraryItems(libraryId: String): Flow<List<LibraryItem>> = allItemsFlow
+        override fun observeUngroupedLibraryItems(libraryId: String): Flow<List<LibraryItem>> = ungroupedFlow
+        override fun observeInProgressItems(libraryId: String): Flow<List<LibraryItem>> = inProgressFlow
+        override fun observeFinishedItems(libraryId: String): Flow<List<LibraryItem>> = finishedFlow
+        override fun observeRecentlyAddedItems(libraryId: String): Flow<List<LibraryItem>> = recentlyAddedFlow
+        override fun observeContinueSeriesItems(libraryId: String): Flow<List<LibraryItem>> = continueSeriesFlow
+        override fun observeAllBooks(libraryId: String): Flow<List<LibraryItem>> = allBooksFlow
+        override fun observeSeries(libraryId: String): Flow<List<Series>> = seriesFlow
+        override fun observeCollections(libraryId: String): Flow<List<Collection>> = collectionsFlow
+        override fun observeSeriesItems(seriesId: String): Flow<List<LibraryItem>> =
+            seriesItemsBySeriesId.getOrPut(seriesId) { MutableStateFlow(emptyList()) }
+        override fun observeCollectionItems(collectionId: String): Flow<List<LibraryItem>> =
+            collectionItemsByCollectionId.getOrPut(collectionId) { MutableStateFlow(emptyList()) }
+        override suspend fun getItem(itemId: String): LibraryItem? = null
+        override fun observeItem(itemId: String): Flow<LibraryItem?> = MutableStateFlow<LibraryItem?>(null)
+        override suspend fun getItem(serverId: String, itemId: String): LibraryItem? = null
+        override suspend fun getLibrary(libraryId: String): Library? = null
+        override suspend fun getSeriesIdForItem(serverId: String, itemId: String): String? = null
+        override suspend fun markItemOpened(itemId: String) {}
+        override suspend fun updateReadingProgress(itemId: String, progress: Float) {}
+        override suspend fun refreshLibraries() = LibraryRefreshResult.Success
+        override suspend fun refreshLibraryItems(libraryId: String) = LibraryRefreshResult.Success
+        override suspend fun refreshSeries(libraryId: String) = LibraryRefreshResult.Success
+        override suspend fun refreshCollections(libraryId: String) = LibraryRefreshResult.Success
+    }
+
+    private fun fakeAnnotationStore(): AnnotationStore = object : AnnotationStore {
+        override fun observeHighlights(serverId: String, itemId: String) = MutableStateFlow(emptyList<com.riffle.core.domain.Annotation>())
+        override fun observeBookmarks(serverId: String, itemId: String) = MutableStateFlow(emptyList<com.riffle.core.domain.Annotation>())
+        override fun observeAnnotations(serverId: String, itemId: String) = MutableStateFlow(emptyList<com.riffle.core.domain.Annotation>())
+        override fun observeAnnotationsForServer(serverId: String) =
+            annotationsFlow.map { all -> all.filter { it.serverId == serverId } }
+        override suspend fun createHighlight(serverId: String, itemId: String, cfi: String, textSnippet: String, chapterHref: String, textBefore: String, textAfter: String, color: String, spineIndex: Int, progression: Double) = error("unused")
+        override suspend fun createBookmark(serverId: String, itemId: String, cfi: String, textSnippet: String, chapterHref: String, spineIndex: Int, progression: Double, bookmarkTitle: String) = error("unused")
+        override suspend fun delete(id: String) = error("unused")
+        override suspend fun recolor(id: String, color: String) = error("unused")
+        override suspend fun updateNote(id: String, note: String?) = error("unused")
+        override suspend fun renameBookmark(id: String, title: String) = error("unused")
+        override suspend fun findByItemAndCfi(serverId: String, itemId: String, cfi: String): com.riffle.core.domain.Annotation? = null
+    }
+
+    private fun fakeBookmarkStore(): AudiobookBookmarkStore = object : AudiobookBookmarkStore {
+        override fun observe(serverId: String, itemId: String) = MutableStateFlow(emptyList<com.riffle.core.domain.AudiobookBookmark>())
+        override fun observeForServer(serverId: String) = bookmarksFlow.map { all -> all.filter { it.serverId == serverId } }
+        override fun observeHasUnsynced(serverId: String, itemId: String) = MutableStateFlow(false)
+        override suspend fun add(serverId: String, itemId: String, positionSec: Double, title: String, now: Long) = error("unused")
+        override suspend fun rename(id: String, title: String, now: Long) = error("unused")
+        override suspend fun delete(id: String, now: Long) = error("unused")
+    }
+
+    private class FakeToReadRepository(initial: Set<String> = emptySet()) : ToReadRepository {
+        val ids = MutableStateFlow(initial)
+        override fun observeToReadItemIds(libraryId: String): Flow<Set<String>> = ids
+        override suspend fun refresh(libraryId: String): Boolean = true
+        override suspend fun isInToRead(libraryItemId: String, libraryId: String): Boolean = libraryItemId in ids.value
+        override suspend fun addToToRead(libraryItemId: String, libraryId: String): Boolean { ids.value = ids.value + libraryItemId; return true }
+        override suspend fun removeFromToRead(libraryItemId: String, libraryId: String): Boolean { ids.value = ids.value - libraryItemId; return true }
+    }
+
+    private fun epubRepoWithDownloads(downloadedIds: Set<String>): EpubRepository = object : EpubRepository {
+        override suspend fun openEpub(item: LibraryItem) = EpubOpenResult.Offline
+        override suspend fun downloadEpub(item: LibraryItem, onProgress: (Long, Long) -> Unit) = EpubDownloadResult.Success
+        override suspend fun removeDownload(serverId: String, itemId: String) {}
+        override fun isDownloaded(serverId: String, itemId: String): Boolean = itemId in downloadedIds
+        override fun isCached(serverId: String, itemId: String): Boolean = false
+        override suspend fun saveReadingPosition(itemId: String, cfi: String) {}
+    }
+
+    private fun fakePdfRepo(): PdfRepository = object : PdfRepository {
+        override suspend fun openPdf(item: LibraryItem) = PdfOpenResult.Offline
+        override suspend fun downloadPdf(item: LibraryItem, onProgress: (Long, Long) -> Unit) = PdfDownloadResult.Success
+        override suspend fun removeDownload(serverId: String, itemId: String) {}
+        override fun isDownloaded(serverId: String, itemId: String): Boolean = false
+        override fun isCached(serverId: String, itemId: String): Boolean = false
+        override suspend fun saveReadingPosition(itemId: String, locatorJson: String) {}
+    }
+
+    private fun fakeAudiobookDownloadRepo(): AudiobookDownloadRepository = object : AudiobookDownloadRepository {
+        override fun isDownloaded(serverId: String, itemId: String): Boolean = false
+        override fun localSession(serverId: String, itemId: String): AudiobookSession? = null
+        override suspend fun download(serverId: String, itemId: String, onProgress: (Long, Long) -> Unit) = AudiobookDownloadResult.Success
+        override suspend fun remove(serverId: String, itemId: String): Long = 0L
+    }
+
+    private fun makeEngine(
+        epubRepository: EpubRepository = epubRepoWithDownloads(emptySet()),
+        toReadRepository: ToReadRepository = FakeToReadRepository(),
+        annotationStore: AnnotationStore = fakeAnnotationStore(),
+        audiobookBookmarkStore: AudiobookBookmarkStore = fakeBookmarkStore(),
+    ): LibraryFilterEngine = LibraryFilterEngine(
+        libraryRepository = fakeRepo(),
+        annotationStore = annotationStore,
+        audiobookBookmarkStore = audiobookBookmarkStore,
+        toReadRepository = toReadRepository,
+        offlineAvailability = LibraryItemOfflineAvailability(
+            epubRepository,
+            fakePdfRepo(),
+            fakeAudiobookDownloadRepo(),
+            object : BundleAudiobookSource {
+                override suspend fun localSession(serverId: String, itemId: String) = null
+                override fun isAvailableOffline(serverId: String, itemId: String) = false
+            },
+        ),
+        libraryId = "lib-1",
+        isOffline = isOfflineFlow,
+        searchQuery = searchQueryFlow,
+        notStartedFilterActive = notStartedFilterFlow,
+    )
+
+    private fun series(name: String) = Series("id-$name", "lib-1", name, null, 1)
+    private fun collection(name: String) = Collection("id-$name", "lib-1", name, 1)
+    private fun item(title: String, author: String = "Author") = LibraryItem(
+        "id-$title", "lib-1", title, author, null, 0f, false, false, EbookFormat.Epub,
+    )
+
+    private fun itemWithServerId(id: String, title: String, serverId: String) = LibraryItem(
+        id = id, libraryId = "lib-1", title = title, author = "A", coverUrl = null,
+        readingProgress = 0f, isCached = false, isDownloaded = false,
+        ebookFormat = EbookFormat.Epub, serverId = serverId,
+    )
+
+    private fun annotation(id: String, serverId: String, itemId: String, snippet: String) =
+        com.riffle.core.domain.Annotation(
+            id = id, serverId = serverId, itemId = itemId, type = "highlight",
+            cfi = "", color = "yellow", note = null, textSnippet = snippet,
+            textBefore = "", textAfter = "", chapterHref = "", spineIndex = 0,
+            progression = 0.0, bookmarkTitle = "", createdAt = 0L, updatedAt = 0L,
+        )
+
+    private fun bookmark(id: String, serverId: String, itemId: String, title: String) =
+        com.riffle.core.domain.AudiobookBookmark(
+            id = id, serverId = serverId, itemId = itemId, positionSec = 0.0,
+            title = title, createdAt = 0L,
+        )
+
+    // --- series ---
+
+    @Test
+    fun `series passes through when no query, online`() = runTest {
+        val engine = makeEngine()
+        seriesFlow.value = listOf(series("Mistborn"), series("Stormlight"))
+        val p = engine.projection.first { it.series.isNotEmpty() }
+        assertEquals(listOf(series("Mistborn"), series("Stormlight")), p.series)
+    }
+
+    @Test
+    fun `series query-filters by name case-insensitive`() = runTest {
+        val engine = makeEngine()
+        seriesFlow.value = listOf(series("Mistborn"), series("Stormlight"))
+        searchQueryFlow.value = "STORM"
+        val p = engine.projection.first { it.series.isNotEmpty() }
+        assertEquals(listOf(series("Stormlight")), p.series)
+    }
+
+    @Test
+    fun `series offline-filter drops groups with no offline items`() = runTest {
+        val engine = makeEngine(epubRepository = epubRepoWithDownloads(emptySet()))
+        seriesFlow.value = listOf(series("Mistborn"))
+        seriesItemsBySeriesId.getOrPut("id-Mistborn") { MutableStateFlow(emptyList()) }.value =
+            listOf(item("Final Empire"))
+        isOfflineFlow.value = true
+        val p = engine.projection.first()
+        assertEquals(emptyList<Series>(), p.series)
+    }
+
+    // --- collections ---
+
+    @Test
+    fun `collections query-filters by name`() = runTest {
+        val engine = makeEngine()
+        collectionsFlow.value = listOf(collection("Fantasy"), collection("Sci-Fi"))
+        searchQueryFlow.value = "sci"
+        val p = engine.projection.first { it.collections.isNotEmpty() }
+        assertEquals(listOf(collection("Sci-Fi")), p.collections)
+    }
+
+    @Test
+    fun `collections offline-filter drops empties`() = runTest {
+        val engine = makeEngine(epubRepository = epubRepoWithDownloads(setOf("id-Mistborn")))
+        collectionsFlow.value = listOf(collection("Fantasy"), collection("Sci-Fi"))
+        collectionItemsByCollectionId.getOrPut("id-Fantasy") { MutableStateFlow(emptyList()) }.value =
+            listOf(item("Mistborn"))
+        collectionItemsByCollectionId.getOrPut("id-Sci-Fi") { MutableStateFlow(emptyList()) }.value =
+            listOf(item("Dune"))
+        isOfflineFlow.value = true
+        val p = engine.projection.first { it.collections.isNotEmpty() }
+        assertEquals(listOf(collection("Fantasy")), p.collections)
+    }
+
+    // --- ungrouped ---
+
+    @Test
+    fun `ungrouped uses ungrouped source when query blank`() = runTest {
+        val engine = makeEngine()
+        ungroupedFlow.value = listOf(item("Dune"))
+        allItemsFlow.value = listOf(item("Dune"), item("Foundation"))
+        val p = engine.projection.first { it.ungrouped.isNotEmpty() }
+        assertEquals(listOf(item("Dune")), p.ungrouped)
+    }
+
+    @Test
+    fun `ungrouped searches allItems by title or author when query active`() = runTest {
+        val engine = makeEngine()
+        allItemsFlow.value = listOf(item("Dune", "Herbert"), item("Mistborn", "Sanderson"))
+        searchQueryFlow.value = "sand"
+        val p = engine.projection.first { it.ungrouped.isNotEmpty() }
+        assertEquals(listOf(item("Mistborn", "Sanderson")), p.ungrouped)
+    }
+
+    @Test
+    fun `ungrouped offline-filter drops unavailable`() = runTest {
+        val engine = makeEngine(epubRepository = epubRepoWithDownloads(setOf("id-Dune")))
+        ungroupedFlow.value = listOf(item("Dune"), item("Foundation"))
+        isOfflineFlow.value = true
+        val p = engine.projection.first { it.ungrouped.isNotEmpty() }
+        assertEquals(listOf(item("Dune")), p.ungrouped)
+    }
+
+    // --- inProgress / finished ---
+
+    @Test
+    fun `inProgress offline-filter`() = runTest {
+        val engine = makeEngine(epubRepository = epubRepoWithDownloads(setOf("id-Dune")))
+        inProgressFlow.value = listOf(item("Dune"), item("Foundation"))
+        isOfflineFlow.value = true
+        val p = engine.projection.first { it.inProgress.isNotEmpty() }
+        assertEquals(listOf(item("Dune")), p.inProgress)
+    }
+
+    @Test
+    fun `finished offline-filter`() = runTest {
+        val engine = makeEngine(epubRepository = epubRepoWithDownloads(setOf("id-Dune")))
+        finishedFlow.value = listOf(item("Dune"), item("Foundation"))
+        isOfflineFlow.value = true
+        val p = engine.projection.first { it.finished.isNotEmpty() }
+        assertEquals(listOf(item("Dune")), p.finished)
+    }
+
+    // --- recentlyAdded ---
+
+    @Test
+    fun `recentlyAdded caps at 50`() = runTest {
+        val engine = makeEngine()
+        recentlyAddedFlow.value = (1..60).map { item("Book $it") }
+        val p = engine.projection.first { it.recentlyAdded.isNotEmpty() }
+        assertEquals(50, p.recentlyAdded.size)
+    }
+
+    // --- continueSeries ---
+
+    @Test
+    fun `continueSeries caps at 20`() = runTest {
+        val engine = makeEngine()
+        continueSeriesFlow.value = (1..30).map { item("B$it") }
+        val p = engine.projection.first { it.continueSeries.isNotEmpty() }
+        assertEquals(20, p.continueSeries.size)
+    }
+
+    // --- allBooks ---
+
+    @Test
+    fun `allBooks notStartedFilter composes with offline`() = runTest {
+        val engine = makeEngine(epubRepository = epubRepoWithDownloads(setOf("id-Dune")))
+        allBooksFlow.value = listOf(
+            LibraryItem("id-Dune", "lib-1", "Dune", "H", null, 0f, false, false, EbookFormat.Epub),
+            LibraryItem("id-Foundation", "lib-1", "Foundation", "A", null, 0f, false, false, EbookFormat.Epub),
+            LibraryItem("id-Martian", "lib-1", "Martian", "W", null, 0.5f, false, false, EbookFormat.Epub),
+        )
+        isOfflineFlow.value = true
+        notStartedFilterFlow.value = true
+        val p = engine.projection.first { it.allBooks.isNotEmpty() }
+        assertEquals(
+            listOf(LibraryItem("id-Dune", "lib-1", "Dune", "H", null, 0f, false, false, EbookFormat.Epub)),
+            p.allBooks,
+        )
+    }
+
+    // --- toRead ---
+
+    @Test
+    fun `toRead intersects ids with allBooks then offline-filters`() = runTest {
+        val engine = makeEngine(
+            epubRepository = epubRepoWithDownloads(setOf("id-Dune")),
+            toReadRepository = FakeToReadRepository(setOf("id-Dune", "id-Foundation")),
+        )
+        allBooksFlow.value = listOf(item("Dune"), item("Foundation"), item("Other"))
+        isOfflineFlow.value = true
+        val p = engine.projection.first { it.toRead.isNotEmpty() }
+        assertEquals(listOf(item("Dune")), p.toRead)
+    }
+
+    // --- annotations ---
+
+    @Test
+    fun `annotations are empty when query blank`() = runTest {
+        val engine = makeEngine()
+        allItemsFlow.value = listOf(itemWithServerId("b1", "Dune", "srv1"))
+        annotationsFlow.value = listOf(annotation("a1", "srv1", "b1", "spice"))
+        val p = engine.projection.first()
+        assertEquals(emptyList<AnnotationSearchResult>(), p.annotations)
+    }
+
+    @Test
+    fun `annotations match query scoped to library items`() = runTest {
+        val engine = makeEngine()
+        allItemsFlow.value = listOf(itemWithServerId("b1", "Dune", "srv1"))
+        annotationsFlow.value = listOf(
+            annotation("a1", "srv1", "b1", "conscience matters"),
+            annotation("a2", "srv1", "b1", "irrelevant"),
+            annotation("aX", "srv1", "NOT_IN_LIB", "conscience"),
+        )
+        searchQueryFlow.value = "conscience"
+        val results = engine.projection.first { it.annotations.isNotEmpty() }.annotations
+        assertEquals(listOf("a1"), results.map { it.annotation.id })
+    }
+
+    // --- audiobook bookmarks ---
+
+    @Test
+    fun `audiobookBookmarks empty when query blank`() = runTest {
+        val engine = makeEngine()
+        allItemsFlow.value = listOf(itemWithServerId("b1", "Dune", "srv1"))
+        bookmarksFlow.value = listOf(bookmark("bm1", "srv1", "b1", "great line"))
+        val p = engine.projection.first()
+        assertEquals(emptyList<AudiobookBookmarkSearchResult>(), p.audiobookBookmarks)
+    }
+
+    @Test
+    fun `audiobookBookmarks match query by title`() = runTest {
+        val engine = makeEngine()
+        allItemsFlow.value = listOf(itemWithServerId("b1", "Dune", "srv1"))
+        bookmarksFlow.value = listOf(
+            bookmark("bm1", "srv1", "b1", "great line"),
+            bookmark("bm2", "srv1", "b1", "irrelevant"),
+        )
+        searchQueryFlow.value = "great"
+        val results = engine.projection.first { it.audiobookBookmarks.isNotEmpty() }.audiobookBookmarks
+        assertEquals(listOf("bm1"), results.map { it.bookmark.id })
+    }
+}

--- a/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemsViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemsViewModelTest.kt
@@ -244,30 +244,30 @@ class LibraryItemsViewModelTest {
     @Test
     fun `empty query returns all series`() = runTest {
         val vm = makeViewModel()
-        backgroundScope.launch { vm.filteredSeries.collect {} }
+        backgroundScope.launch { vm.projection.collect {} }
         seriesFlow.value = listOf(series("Mistborn"), series("Stormlight"))
         testDispatcher.scheduler.advanceUntilIdle()
-        assertEquals(listOf(series("Mistborn"), series("Stormlight")), vm.filteredSeries.value)
+        assertEquals(listOf(series("Mistborn"), series("Stormlight")), vm.projection.value.series)
     }
 
     @Test
     fun `empty query returns all collections`() = runTest {
         val vm = makeViewModel()
-        backgroundScope.launch { vm.filteredCollections.collect {} }
+        backgroundScope.launch { vm.projection.collect {} }
         collectionsFlow.value = listOf(collection("Fantasy"), collection("Sci-Fi"))
         testDispatcher.scheduler.advanceUntilIdle()
-        assertEquals(listOf(collection("Fantasy"), collection("Sci-Fi")), vm.filteredCollections.value)
+        assertEquals(listOf(collection("Fantasy"), collection("Sci-Fi")), vm.projection.value.collections)
     }
 
     @Test
     fun `empty query returns all ungrouped items`() = runTest {
         val vm = makeViewModel()
-        backgroundScope.launch { vm.filteredUngroupedItems.collect {} }
+        backgroundScope.launch { vm.projection.collect {} }
         itemsFlow.value = listOf(item("Dune", "Frank Herbert"), item("Foundation", "Isaac Asimov"))
         testDispatcher.scheduler.advanceUntilIdle()
         assertEquals(
             listOf(item("Dune", "Frank Herbert"), item("Foundation", "Isaac Asimov")),
-            vm.filteredUngroupedItems.value,
+            vm.projection.value.ungrouped,
         )
     }
 
@@ -276,21 +276,21 @@ class LibraryItemsViewModelTest {
     @Test
     fun `query filters series by name`() = runTest {
         val vm = makeViewModel()
-        backgroundScope.launch { vm.filteredSeries.collect {} }
+        backgroundScope.launch { vm.projection.collect {} }
         seriesFlow.value = listOf(series("Mistborn"), series("Stormlight Archive"))
         vm.onSearchQueryChange("storm")
         testDispatcher.scheduler.advanceUntilIdle()
-        assertEquals(listOf(series("Stormlight Archive")), vm.filteredSeries.value)
+        assertEquals(listOf(series("Stormlight Archive")), vm.projection.value.series)
     }
 
     @Test
     fun `series filtering is case-insensitive`() = runTest {
         val vm = makeViewModel()
-        backgroundScope.launch { vm.filteredSeries.collect {} }
+        backgroundScope.launch { vm.projection.collect {} }
         seriesFlow.value = listOf(series("The Wheel of Time"))
         vm.onSearchQueryChange("WHEEL")
         testDispatcher.scheduler.advanceUntilIdle()
-        assertEquals(listOf(series("The Wheel of Time")), vm.filteredSeries.value)
+        assertEquals(listOf(series("The Wheel of Time")), vm.projection.value.series)
     }
 
     // --- collection filtering ---
@@ -298,11 +298,11 @@ class LibraryItemsViewModelTest {
     @Test
     fun `query filters collections by name`() = runTest {
         val vm = makeViewModel()
-        backgroundScope.launch { vm.filteredCollections.collect {} }
+        backgroundScope.launch { vm.projection.collect {} }
         collectionsFlow.value = listOf(collection("Fantasy"), collection("Sci-Fi"))
         vm.onSearchQueryChange("sci")
         testDispatcher.scheduler.advanceUntilIdle()
-        assertEquals(listOf(collection("Sci-Fi")), vm.filteredCollections.value)
+        assertEquals(listOf(collection("Sci-Fi")), vm.projection.value.collections)
     }
 
     // --- item filtering ---
@@ -310,32 +310,32 @@ class LibraryItemsViewModelTest {
     @Test
     fun `query filters items by title`() = runTest {
         val vm = makeViewModel()
-        backgroundScope.launch { vm.filteredUngroupedItems.collect {} }
+        backgroundScope.launch { vm.projection.collect {} }
         allItemsFlow.value = listOf(item("Dune", "Frank Herbert"), item("Foundation", "Isaac Asimov"))
         vm.onSearchQueryChange("dun")
         testDispatcher.scheduler.advanceUntilIdle()
-        assertEquals(listOf(item("Dune", "Frank Herbert")), vm.filteredUngroupedItems.value)
+        assertEquals(listOf(item("Dune", "Frank Herbert")), vm.projection.value.ungrouped)
     }
 
     @Test
     fun `query filters items by author`() = runTest {
         val vm = makeViewModel()
-        backgroundScope.launch { vm.filteredUngroupedItems.collect {} }
+        backgroundScope.launch { vm.projection.collect {} }
         allItemsFlow.value = listOf(item("Mistborn", "Brandon Sanderson"), item("Dune", "Frank Herbert"))
         vm.onSearchQueryChange("sand")
         testDispatcher.scheduler.advanceUntilIdle()
-        assertEquals(listOf(item("Mistborn", "Brandon Sanderson")), vm.filteredUngroupedItems.value)
+        assertEquals(listOf(item("Mistborn", "Brandon Sanderson")), vm.projection.value.ungrouped)
     }
 
     @Test
     fun `query finds books that belong to series by title`() = runTest {
         val vm = makeViewModel()
-        backgroundScope.launch { vm.filteredUngroupedItems.collect {} }
+        backgroundScope.launch { vm.projection.collect {} }
         // allItemsFlow contains items in series; itemsFlow (ungrouped) does not
         allItemsFlow.value = listOf(item("The Final Empire", "Brandon Sanderson"), item("Dune", "Frank Herbert"))
         vm.onSearchQueryChange("final empire")
         testDispatcher.scheduler.advanceUntilIdle()
-        assertEquals(listOf(item("The Final Empire", "Brandon Sanderson")), vm.filteredUngroupedItems.value)
+        assertEquals(listOf(item("The Final Empire", "Brandon Sanderson")), vm.projection.value.ungrouped)
     }
 
     // --- no match ---
@@ -344,18 +344,18 @@ class LibraryItemsViewModelTest {
     fun `query with no match empties all filtered lists`() = runTest {
         val vm = makeViewModel()
         backgroundScope.launch {
-            vm.filteredSeries.collect {}
-            vm.filteredCollections.collect {}
-            vm.filteredUngroupedItems.collect {}
+            vm.projection.collect {}
+            vm.projection.collect {}
+            vm.projection.collect {}
         }
         seriesFlow.value = listOf(series("Mistborn"))
         collectionsFlow.value = listOf(collection("Fantasy"))
         allItemsFlow.value = listOf(item("Dune", "Frank Herbert"))
         vm.onSearchQueryChange("zzznomatch")
         testDispatcher.scheduler.advanceUntilIdle()
-        assertEquals(emptyList<Series>(), vm.filteredSeries.value)
-        assertEquals(emptyList<Collection>(), vm.filteredCollections.value)
-        assertEquals(emptyList<LibraryItem>(), vm.filteredUngroupedItems.value)
+        assertEquals(emptyList<Series>(), vm.projection.value.series)
+        assertEquals(emptyList<Collection>(), vm.projection.value.collections)
+        assertEquals(emptyList<LibraryItem>(), vm.projection.value.ungrouped)
     }
 
     // --- query state ---
@@ -374,11 +374,11 @@ class LibraryItemsViewModelTest {
     @Test
     fun `filteredInProgress emits items from repository when online`() = runTest {
         val vm = makeViewModel()
-        backgroundScope.launch { vm.filteredInProgress.collect {} }
+        backgroundScope.launch { vm.projection.collect {} }
         val expected = listOf(item("Dune", "Frank Herbert"), item("Foundation", "Isaac Asimov"))
         inProgressFlow.value = expected
         testDispatcher.scheduler.advanceUntilIdle()
-        assertEquals(expected, vm.filteredInProgress.value)
+        assertEquals(expected, vm.projection.value.inProgress)
     }
 
     // --- C2: filteredFinished flow ---
@@ -386,11 +386,11 @@ class LibraryItemsViewModelTest {
     @Test
     fun `filteredFinished emits items from repository when online`() = runTest {
         val vm = makeViewModel()
-        backgroundScope.launch { vm.filteredFinished.collect {} }
+        backgroundScope.launch { vm.projection.collect {} }
         val expected = listOf(item("1984", "George Orwell"))
         finishedFlow.value = expected
         testDispatcher.scheduler.advanceUntilIdle()
-        assertEquals(expected, vm.filteredFinished.value)
+        assertEquals(expected, vm.projection.value.finished)
     }
 
     // --- C3: filteredAllBooks flow ---
@@ -398,11 +398,11 @@ class LibraryItemsViewModelTest {
     @Test
     fun `filteredAllBooks emits all items from repository when online`() = runTest {
         val vm = makeViewModel()
-        backgroundScope.launch { vm.filteredAllBooks.collect {} }
+        backgroundScope.launch { vm.projection.collect {} }
         val expected = listOf(item("Dune", "Frank Herbert"), item("1984", "George Orwell"), item("Foundation", "Isaac Asimov"))
         allBooksFlow.value = expected
         testDispatcher.scheduler.advanceUntilIdle()
-        assertEquals(expected, vm.filteredAllBooks.value)
+        assertEquals(expected, vm.projection.value.allBooks)
     }
 
     // --- C4: series and collections unchanged ---
@@ -504,11 +504,11 @@ class LibraryItemsViewModelTest {
             connectivityObserver = FakeConnectivityObserver(online = false),
             epubRepository = fakeEpubRepoWithDownloads(setOf("id-Dune")),
         )
-        backgroundScope.launch { vm.filteredUngroupedItems.collect {} }
+        backgroundScope.launch { vm.projection.collect {} }
         backgroundScope.launch { vm.isOffline.collect {} }
         itemsFlow.value = listOf(item("Dune", "Frank Herbert"), item("Foundation", "Isaac Asimov"))
         testDispatcher.scheduler.advanceUntilIdle()
-        assertEquals(listOf(item("Dune", "Frank Herbert")), vm.filteredUngroupedItems.value)
+        assertEquals(listOf(item("Dune", "Frank Herbert")), vm.projection.value.ungrouped)
         assertEquals(true, vm.isOffline.value)
     }
 
@@ -523,11 +523,11 @@ class LibraryItemsViewModelTest {
             epubRepository = fakeEpubRepoWithDownloads(emptySet()),
             audiobookDownloadRepository = fakeAudiobookDownloadRepo(setOf("id-The Martian")),
         )
-        backgroundScope.launch { vm.filteredUngroupedItems.collect {} }
+        backgroundScope.launch { vm.projection.collect {} }
         backgroundScope.launch { vm.isOffline.collect {} }
         itemsFlow.value = listOf(audiobook, item("Foundation", "Isaac Asimov"))
         testDispatcher.scheduler.advanceUntilIdle()
-        assertEquals(listOf(audiobook), vm.filteredUngroupedItems.value)
+        assertEquals(listOf(audiobook), vm.projection.value.ungrouped)
     }
 
     @Test
@@ -536,10 +536,10 @@ class LibraryItemsViewModelTest {
             connectivityObserver = FakeConnectivityObserver(online = true),
             epubRepository = fakeEpubRepoWithDownloads(emptySet()),
         )
-        backgroundScope.launch { vm.filteredUngroupedItems.collect {} }
+        backgroundScope.launch { vm.projection.collect {} }
         itemsFlow.value = listOf(item("Dune", "Frank Herbert"), item("Foundation", "Isaac Asimov"))
         testDispatcher.scheduler.advanceUntilIdle()
-        assertEquals(2, vm.filteredUngroupedItems.value.size)
+        assertEquals(2, vm.projection.value.ungrouped.size)
         assertEquals(false, vm.isOffline.value)
     }
 
@@ -562,14 +562,14 @@ class LibraryItemsViewModelTest {
             connectivityObserver = FakeConnectivityObserver(online = false),
             epubRepository = fakeEpubRepoWithDownloads(emptySet()),
         )
-        backgroundScope.launch { vm.filteredCollections.collect {} }
+        backgroundScope.launch { vm.projection.collect {} }
         collectionsFlow.value = listOf(collection("Fantasy"), collection("Sci-Fi"))
         collectionItemsByCollectionId.getOrPut("id-Fantasy") { MutableStateFlow(emptyList()) }.value =
             listOf(item("Mistborn", "Brandon Sanderson"))
         collectionItemsByCollectionId.getOrPut("id-Sci-Fi") { MutableStateFlow(emptyList()) }.value =
             listOf(item("Dune", "Frank Herbert"))
         testDispatcher.scheduler.advanceUntilIdle()
-        assertEquals(emptyList<Collection>(), vm.filteredCollections.value)
+        assertEquals(emptyList<Collection>(), vm.projection.value.collections)
     }
 
     @Test
@@ -578,14 +578,14 @@ class LibraryItemsViewModelTest {
             connectivityObserver = FakeConnectivityObserver(online = false),
             epubRepository = fakeEpubRepoWithDownloads(setOf("id-Mistborn")),
         )
-        backgroundScope.launch { vm.filteredCollections.collect {} }
+        backgroundScope.launch { vm.projection.collect {} }
         collectionsFlow.value = listOf(collection("Fantasy"), collection("Sci-Fi"))
         collectionItemsByCollectionId.getOrPut("id-Fantasy") { MutableStateFlow(emptyList()) }.value =
             listOf(item("Mistborn", "Brandon Sanderson"))
         collectionItemsByCollectionId.getOrPut("id-Sci-Fi") { MutableStateFlow(emptyList()) }.value =
             listOf(item("Dune", "Frank Herbert"))
         testDispatcher.scheduler.advanceUntilIdle()
-        assertEquals(listOf(collection("Fantasy")), vm.filteredCollections.value)
+        assertEquals(listOf(collection("Fantasy")), vm.projection.value.collections)
     }
 
     @Test
@@ -594,14 +594,14 @@ class LibraryItemsViewModelTest {
             connectivityObserver = FakeConnectivityObserver(online = false),
             epubRepository = fakeEpubRepoWithDownloads(emptySet()),
         )
-        backgroundScope.launch { vm.filteredSeries.collect {} }
+        backgroundScope.launch { vm.projection.collect {} }
         seriesFlow.value = listOf(series("Mistborn"), series("Stormlight"))
         seriesItemsBySeriesId.getOrPut("id-Mistborn") { MutableStateFlow(emptyList()) }.value =
             listOf(item("The Final Empire", "Brandon Sanderson"))
         seriesItemsBySeriesId.getOrPut("id-Stormlight") { MutableStateFlow(emptyList()) }.value =
             listOf(item("The Way of Kings", "Brandon Sanderson"))
         testDispatcher.scheduler.advanceUntilIdle()
-        assertEquals(emptyList<Series>(), vm.filteredSeries.value)
+        assertEquals(emptyList<Series>(), vm.projection.value.series)
     }
 
     @Test
@@ -610,14 +610,14 @@ class LibraryItemsViewModelTest {
             connectivityObserver = FakeConnectivityObserver(online = false),
             epubRepository = fakeEpubRepoWithDownloads(setOf("id-The Way of Kings")),
         )
-        backgroundScope.launch { vm.filteredSeries.collect {} }
+        backgroundScope.launch { vm.projection.collect {} }
         seriesFlow.value = listOf(series("Mistborn"), series("Stormlight"))
         seriesItemsBySeriesId.getOrPut("id-Mistborn") { MutableStateFlow(emptyList()) }.value =
             listOf(item("The Final Empire", "Brandon Sanderson"))
         seriesItemsBySeriesId.getOrPut("id-Stormlight") { MutableStateFlow(emptyList()) }.value =
             listOf(item("The Way of Kings", "Brandon Sanderson"))
         testDispatcher.scheduler.advanceUntilIdle()
-        assertEquals(listOf(series("Stormlight")), vm.filteredSeries.value)
+        assertEquals(listOf(series("Stormlight")), vm.projection.value.series)
     }
 
     // --- isLoading sequencing (flickering regression guard) ---
@@ -682,20 +682,20 @@ class LibraryItemsViewModelTest {
     @Test
     fun `filteredRecentlyAdded emits items from repository when online`() = runTest {
         val vm = makeViewModel()
-        backgroundScope.launch { vm.filteredRecentlyAdded.collect {} }
+        backgroundScope.launch { vm.projection.collect {} }
         val expected = listOf(item("Dune", "Frank Herbert"), item("Foundation", "Isaac Asimov"))
         recentlyAddedFlow.value = expected
         testDispatcher.scheduler.advanceUntilIdle()
-        assertEquals(expected, vm.filteredRecentlyAdded.value)
+        assertEquals(expected, vm.projection.value.recentlyAdded)
     }
 
     @Test
     fun `filteredRecentlyAdded is capped at 50 items`() = runTest {
         val vm = makeViewModel()
-        backgroundScope.launch { vm.filteredRecentlyAdded.collect {} }
+        backgroundScope.launch { vm.projection.collect {} }
         recentlyAddedFlow.value = (1..60).map { i -> item("Book $i", "Author") }
         testDispatcher.scheduler.advanceUntilIdle()
-        assertEquals(50, vm.filteredRecentlyAdded.value.size)
+        assertEquals(50, vm.projection.value.recentlyAdded.size)
     }
 
     @Test
@@ -704,11 +704,11 @@ class LibraryItemsViewModelTest {
             connectivityObserver = FakeConnectivityObserver(online = false),
             epubRepository = fakeEpubRepoWithDownloads(setOf("id-Dune")),
         )
-        backgroundScope.launch { vm.filteredRecentlyAdded.collect {} }
+        backgroundScope.launch { vm.projection.collect {} }
         backgroundScope.launch { vm.isOffline.collect {} }
         recentlyAddedFlow.value = listOf(item("Dune", "Frank Herbert"), item("Foundation", "Isaac Asimov"))
         testDispatcher.scheduler.advanceUntilIdle()
-        assertEquals(listOf(item("Dune", "Frank Herbert")), vm.filteredRecentlyAdded.value)
+        assertEquals(listOf(item("Dune", "Frank Herbert")), vm.projection.value.recentlyAdded)
     }
 
     // --- toReadItems ---
@@ -717,7 +717,7 @@ class LibraryItemsViewModelTest {
     fun `toReadItems is the intersection of toReadItemIds and allBooks when online`() = runTest {
         val toRead = FakeToReadRepository(initial = setOf("id-Dune", "id-Foundation"))
         val vm = makeViewModel(toReadRepository = toRead)
-        backgroundScope.launch { vm.toReadItems.collect {} }
+        backgroundScope.launch { vm.projection.collect {} }
         allBooksFlow.value = listOf(
             item("Dune", "Frank Herbert"),
             item("Foundation", "Isaac Asimov"),
@@ -726,7 +726,7 @@ class LibraryItemsViewModelTest {
         testDispatcher.scheduler.advanceUntilIdle()
         assertEquals(
             listOf(item("Dune", "Frank Herbert"), item("Foundation", "Isaac Asimov")),
-            vm.toReadItems.value,
+            vm.projection.value.toRead,
         )
     }
 
@@ -738,13 +738,13 @@ class LibraryItemsViewModelTest {
             epubRepository = fakeEpubRepoWithDownloads(setOf("id-Dune")),
             toReadRepository = toRead,
         )
-        backgroundScope.launch { vm.toReadItems.collect {} }
+        backgroundScope.launch { vm.projection.collect {} }
         allBooksFlow.value = listOf(
             item("Dune", "Frank Herbert"),
             item("Foundation", "Isaac Asimov"),
         )
         testDispatcher.scheduler.advanceUntilIdle()
-        assertEquals(listOf(item("Dune", "Frank Herbert")), vm.toReadItems.value)
+        assertEquals(listOf(item("Dune", "Frank Herbert")), vm.projection.value.toRead)
     }
 
     @Test
@@ -893,11 +893,11 @@ class LibraryItemsViewModelTest {
             connectivityObserver = FakeConnectivityObserver(online = false),
             epubRepository = fakeEpubRepoWithDownloads(downloadedIds),
         )
-        backgroundScope.launch { vm.filteredRecentlyAdded.collect {} }
+        backgroundScope.launch { vm.projection.collect {} }
         backgroundScope.launch { vm.isOffline.collect {} }
         recentlyAddedFlow.value = (1..60).map { i -> item("Book $i", "Author") }
         testDispatcher.scheduler.advanceUntilIdle()
-        assertEquals(50, vm.filteredRecentlyAdded.value.size)
+        assertEquals(50, vm.projection.value.recentlyAdded.size)
     }
 
     // --- notStartedFilterActive ---
@@ -932,7 +932,7 @@ class LibraryItemsViewModelTest {
     @Test
     fun `filteredAllBooks shows only zero-progress items when notStartedFilterActive`() = runTest {
         val vm = makeViewModel()
-        backgroundScope.launch { vm.filteredAllBooks.collect {} }
+        backgroundScope.launch { vm.projection.collect {} }
         backgroundScope.launch { vm.notStartedFilterActive.collect {} }
         allBooksFlow.value = listOf(
             LibraryItem("id-Dune", "lib-1", "Dune", "Herbert", null, 0f, false, false, EbookFormat.Epub),
@@ -943,14 +943,14 @@ class LibraryItemsViewModelTest {
         testDispatcher.scheduler.advanceUntilIdle()
         assertEquals(
             listOf(LibraryItem("id-Dune", "lib-1", "Dune", "Herbert", null, 0f, false, false, EbookFormat.Epub)),
-            vm.filteredAllBooks.value,
+            vm.projection.value.allBooks,
         )
     }
 
     @Test
     fun `filteredAllBooks shows all items when notStartedFilter is toggled back off`() = runTest {
         val vm = makeViewModel()
-        backgroundScope.launch { vm.filteredAllBooks.collect {} }
+        backgroundScope.launch { vm.projection.collect {} }
         val all = listOf(
             LibraryItem("id-Dune", "lib-1", "Dune", "Herbert", null, 0f, false, false, EbookFormat.Epub),
             LibraryItem("id-Martian", "lib-1", "The Martian", "Weir", null, 0.42f, false, false, EbookFormat.Epub),
@@ -959,7 +959,7 @@ class LibraryItemsViewModelTest {
         vm.toggleNotStartedFilter()
         vm.toggleNotStartedFilter()
         testDispatcher.scheduler.advanceUntilIdle()
-        assertEquals(all, vm.filteredAllBooks.value)
+        assertEquals(all, vm.projection.value.allBooks)
     }
 
     @Test
@@ -968,7 +968,7 @@ class LibraryItemsViewModelTest {
             connectivityObserver = FakeConnectivityObserver(online = false),
             epubRepository = fakeEpubRepoWithDownloads(setOf("id-Dune")),
         )
-        backgroundScope.launch { vm.filteredAllBooks.collect {} }
+        backgroundScope.launch { vm.projection.collect {} }
         backgroundScope.launch { vm.isOffline.collect {} }
         allBooksFlow.value = listOf(
             // not started AND downloaded — should appear
@@ -982,14 +982,14 @@ class LibraryItemsViewModelTest {
         testDispatcher.scheduler.advanceUntilIdle()
         assertEquals(
             listOf(LibraryItem("id-Dune", "lib-1", "Dune", "Herbert", null, 0f, false, false, EbookFormat.Epub)),
-            vm.filteredAllBooks.value,
+            vm.projection.value.allBooks,
         )
     }
 
     @Test
     fun `filteredAllBooks includes zero-progress audiobook-only items when notStartedFilterActive`() = runTest {
         val vm = makeViewModel()
-        backgroundScope.launch { vm.filteredAllBooks.collect {} }
+        backgroundScope.launch { vm.projection.collect {} }
         val audiobook = LibraryItem(
             "id-Audiobook", "lib-1", "Project Hail Mary", "Weir", null, 0f, false, false,
             EbookFormat.Unsupported, hasAudio = true,
@@ -1000,7 +1000,7 @@ class LibraryItemsViewModelTest {
         )
         vm.toggleNotStartedFilter()
         testDispatcher.scheduler.advanceUntilIdle()
-        assertEquals(listOf(audiobook), vm.filteredAllBooks.value)
+        assertEquals(listOf(audiobook), vm.projection.value.allBooks)
     }
 
     // --- searchQuery persistence (issue #60) ---
@@ -1029,13 +1029,13 @@ class LibraryItemsViewModelTest {
     @Test
     fun `continueSeriesItems reflects repository emissions`() = runTest {
         val vm = makeViewModel()
-        backgroundScope.launch { vm.continueSeriesItems.collect {} }
+        backgroundScope.launch { vm.projection.collect {} }
 
         val nextBook = item("Abaddon's Gate", "James S. A. Corey")
         continueSeriesFlow.value = listOf(nextBook)
         testDispatcher.scheduler.advanceUntilIdle()
 
-        assertEquals(listOf(nextBook), vm.continueSeriesItems.value)
+        assertEquals(listOf(nextBook), vm.projection.value.continueSeries)
     }
 
     @Test
@@ -1047,12 +1047,12 @@ class LibraryItemsViewModelTest {
             override fun isCached(serverId: String, itemId: String): Boolean = itemId == availableItem.id
         }
         val vm = makeViewModel(connectivityObserver = connectivity, epubRepository = epubRepo)
-        backgroundScope.launch { vm.continueSeriesItems.collect {} }
+        backgroundScope.launch { vm.projection.collect {} }
 
         continueSeriesFlow.value = listOf(availableItem, unavailableItem)
         testDispatcher.scheduler.advanceUntilIdle()
 
-        assertEquals(listOf(availableItem), vm.continueSeriesItems.value)
+        assertEquals(listOf(availableItem), vm.projection.value.continueSeries)
     }
 
     // --- filteredAnnotations ---
@@ -1099,7 +1099,7 @@ class LibraryItemsViewModelTest {
     @Test
     fun `filteredAnnotations matches query scoped to library items`() = runTest {
         val vm = makeViewModel()
-        backgroundScope.launch { vm.filteredAnnotations.collect {} }
+        backgroundScope.launch { vm.projection.collect {} }
         allItemsFlow.value = listOf(itemWithServerId("b1", "Children of Dune", "srv1"))
         annotationsFlow.value = listOf(
             annotation(id = "a1", serverId = "srv1", itemId = "b1", textSnippet = "conscience is flexible"),
@@ -1108,7 +1108,7 @@ class LibraryItemsViewModelTest {
         )
         vm.onSearchQueryChange("conscience")
 
-        val results = vm.filteredAnnotations.first { it.isNotEmpty() }
+        val results = vm.projection.first { it.annotations.isNotEmpty() }.annotations
         assertEquals(listOf("a1"), results.map { it.annotation.id })
         assertEquals("Children of Dune", results.single().bookTitle)
     }
@@ -1116,13 +1116,13 @@ class LibraryItemsViewModelTest {
     @Test
     fun `filteredAnnotations returns empty list when query is blank`() = runTest {
         val vm = makeViewModel()
-        backgroundScope.launch { vm.filteredAnnotations.collect {} }
+        backgroundScope.launch { vm.projection.collect {} }
         allItemsFlow.value = listOf(itemWithServerId("b1", "Dune", "srv1"))
         annotationsFlow.value = listOf(
             annotation(id = "a1", serverId = "srv1", itemId = "b1", textSnippet = "spice"),
         )
         // No query set — blank by default
         testDispatcher.scheduler.advanceUntilIdle()
-        assertEquals(emptyList<AnnotationSearchResult>(), vm.filteredAnnotations.value)
+        assertEquals(emptyList<AnnotationSearchResult>(), vm.projection.value.annotations)
     }
 }


### PR DESCRIPTION
## Summary

- Replace the eleven hand-built `combine`-with-offline StateFlows in `LibraryItemsViewModel` with a single `LibraryFilterEngine` exposing one `StateFlow<LibraryProjection>`.
- ViewModel becomes a thin selector; `LibraryItemsScreen` and `LibrarySectionScreen` read slices off `projection`.
- Pure refactor — behaviour preserved 1:1. Adding an ADR 0027 facet (author / year / genre / language / has-readaloud) is now one engine entry + one selector.

Closes #343

## Test plan

- [x] `:app:testDebugUnitTest` — green (includes new `LibraryFilterEngineTest` and migrated `LibraryItemsViewModelTest`)
- [x] No `combine(..., isOffline) { ... }` boilerplate remains in the ViewModel
- [ ] Device smoke: open the library, run a search, toggle offline, drill into each section — verify the same items appear pre/post-refactor