### PR TITLE
refactor(reader): extract ReadingSessionCoordinator — collapse reader session lifecycle dup

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -904,9 +904,13 @@ class EpubReaderViewModel @Inject constructor(
         readerStateHolder.isReaderActive = true
         closeSyncDone = false
         position.resetInitialLocatorSeen()
+        // Arm the speed-tracker baseline unconditionally — pre-refactor set sessionStart{Progression,Ms}
+        // on every resume regardless of state, so a session that resumes while still loading and closes
+        // before [ReaderState.Ready] still contributes its time delta. The heartbeat ticks here too;
+        // they are safe no-ops until a locator exists ([syncCurrentPosition] early-returns on null).
+        startReadingSession(initialTotalProgression = currentLocatorTotalProgression.value)
         if (_state.value is ReaderState.Ready) {
             syncCurrentPosition()
-            startReadingSession(initialTotalProgression = currentLocatorTotalProgression.value)
             // Re-arm the per-book annotation live-pull loop alongside position sync.
             annotationSession.onReaderResumed()
         }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -41,6 +41,7 @@ import com.riffle.core.domain.ProgressSyncController
 import com.riffle.core.domain.ReadaloudAudioRepository
 import com.riffle.core.domain.ReadaloudLinkRepository
 import com.riffle.core.domain.ReaderOrientation
+import com.riffle.core.domain.ReadingSessionCoordinator
 import com.riffle.core.domain.ReadingSessionRepository
 import com.riffle.core.domain.ServerProgress
 import com.riffle.core.domain.ServerRepository
@@ -52,7 +53,6 @@ import com.riffle.core.domain.ReadaloudResumeStore
 import com.riffle.core.domain.ReadaloudTrack
 import com.riffle.core.domain.ReadingPositionStore
 import com.riffle.core.domain.ReadingSpeedStore
-import com.riffle.core.domain.ReadingSpeedTracker
 import com.riffle.core.domain.SessionPayload
 import com.riffle.core.domain.TimeRemaining
 import com.riffle.core.domain.TocEntry
@@ -61,9 +61,7 @@ import com.riffle.core.logging.LogChannel
 import com.riffle.core.logging.Logger
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -94,7 +92,6 @@ import java.io.File
 import java.util.zip.ZipFile
 import javax.inject.Inject
 
-private const val SYNC_INTERVAL_MS = 30_000L
 // A reading-position progression change beyond this (or any href change) counts as navigating off the
 // page readaloud was parked on; smaller deltas are settle jitter on the same page (ADR 0031).
 private const val PARK_PAGE_EPS = 0.001
@@ -269,6 +266,12 @@ class EpubReaderViewModel @Inject constructor(
         onSyncError = { _syncErrorEvents.tryEmit(Unit) },
     )
 
+    private val readingSessionCoordinator = ReadingSessionCoordinator(
+        clock = clock,
+        readingSpeedStore = readingSpeedStore,
+        scope = viewModelScope,
+    )
+
     private val positionSaveCoordinator = PositionSaveCoordinator<String>(
         savePosition = { cfi ->
             epubRepository.saveReadingPosition(itemId, cfi)
@@ -293,7 +296,6 @@ class EpubReaderViewModel @Inject constructor(
     private var epubFile: File? = null
     @Volatile private var epubZip: ZipFile? = null
     private val chapterHtmlCache = mutableMapOf<Int, String>()
-    private var syncJob: Job? = null
     private var closeSyncDone = false
     // Non-null once a matched book's reconciliation prerequisites are cached: the unified cycle then
     // replaces the single-peer ABS/Storyteller paths. [readerSyncServerId] is the active server
@@ -735,21 +737,21 @@ class EpubReaderViewModel @Inject constructor(
                     progressSyncController.sync(itemId, locator?.toPayload() ?: SessionPayload("", 0f))
                 }
 
-                startPeriodicSync()
+                // Heartbeat only — no speed-tracker baseline yet (openBook can fire well before the
+                // first onReaderResumed; the lifecycle handler below resets the baseline once the
+                // reader is actually visible).
+                startReadingSession(initialTotalProgression = null)
             }
             is EpubOpenResult.NetworkError -> _state.value = ReaderState.Error("Network error: ${result.cause.message}")
             EpubOpenResult.Offline -> _state.value = ReaderState.Error("Book not available offline")
         }
     }
 
-    private fun startPeriodicSync() {
-        syncJob?.cancel()
-        syncJob = viewModelScope.launch {
-            while (true) {
-                delay(SYNC_INTERVAL_MS)
-                syncCurrentPosition()
-            }
-        }
+    private fun startReadingSession(initialTotalProgression: Float?) {
+        readingSessionCoordinator.onResumed(
+            initialTotalProgression = initialTotalProgression,
+            onTick = { syncCurrentPosition() },
+        )
     }
 
     private fun syncCurrentPosition() {
@@ -902,11 +904,9 @@ class EpubReaderViewModel @Inject constructor(
         readerStateHolder.isReaderActive = true
         closeSyncDone = false
         position.resetInitialLocatorSeen()
-        sessionStartProgression = currentLocatorTotalProgression.value
-        sessionStartMs = clock.nowMs()
         if (_state.value is ReaderState.Ready) {
             syncCurrentPosition()
-            startPeriodicSync()
+            startReadingSession(initialTotalProgression = currentLocatorTotalProgression.value)
             // Re-arm the per-book annotation live-pull loop alongside position sync.
             annotationSession.onReaderResumed()
         }
@@ -924,11 +924,13 @@ class EpubReaderViewModel @Inject constructor(
     }
 
     fun onReaderClosed() {
-        flushReadingSession()
+        readingSessionCoordinator.onClosed(
+            currentTotalProgression = currentLocatorTotalProgression.value,
+            totalPositions = railSegments.value.fold(0f) { acc, seg -> acc + seg.weight },
+        )
         readerStateHolder.isReaderActive = false
         readerStateHolder.isPanelOpen = false
         readerStateHolder.isAudioPlaying = false
-        syncJob?.cancel()
         // Cancel the Storyteller sync loop while the reader is backgrounded; reopening restarts it
         // when the readaloud player is re-opened. Owned by the session; cancel via method.
         readaloud.cancelStorytellerSync()
@@ -1346,25 +1348,9 @@ class EpubReaderViewModel @Inject constructor(
         weightedRailCursorPosition(i, segments, withinSeg)
     }.stateIn(viewModelScope, SharingStarted.Eagerly, 0f)
 
-    // ---- Reading speed tracking & time-remaining estimates -----------------------------------
-
-    private var sessionStartProgression: Float? = null
-    private var sessionStartMs: Long = 0L
-
-    private fun flushReadingSession() {
-        val startProg = sessionStartProgression ?: return
-        sessionStartProgression = null
-        val timeDeltaSec = (clock.nowMs() - sessionStartMs) / 1000.0
-        val totalProg = currentLocatorTotalProgression.value ?: return
-        val progressDelta = totalProg - startProg
-        val totalPos = railSegments.value.fold(0f) { acc, seg -> acc + seg.weight }
-        if (totalPos == 0f) return
-        viewModelScope.launch {
-            val prior = readingSpeedStore.speedSecPerPosition.first()
-            val updated = ReadingSpeedTracker.recordSession(progressDelta, timeDeltaSec, totalPos, prior)
-            if (updated != null) readingSpeedStore.updateSpeed(updated)
-        }
-    }
+    // ---- Time-remaining estimates -------------------------------------------------------------
+    // Reading-speed tracking now lives in [readingSessionCoordinator]; the time-remaining
+    // computations below still read [readingSpeedStore] for the persisted speed.
 
     private data class PositionSnapshot(
         val totalProgression: Float?,

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/PdfReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/PdfReaderViewModel.kt
@@ -6,19 +6,20 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import com.riffle.core.domain.Annotation
 import com.riffle.core.domain.AnnotationStore
+import com.riffle.core.domain.Clock
 import com.riffle.core.domain.LibraryRepository
 import com.riffle.core.domain.PdfOpenResult
 import com.riffle.core.domain.PdfRepository
 import com.riffle.core.domain.ProgressSyncController
+import com.riffle.core.domain.ReadingSessionCoordinator
 import com.riffle.core.domain.ReadingSessionRepository
+import com.riffle.core.domain.ReadingSpeedStore
 import com.riffle.core.domain.ServerRepository
 import com.riffle.core.domain.SessionPayload
 import com.riffle.core.domain.TocEntry
 import com.riffle.core.domain.WakeLockPreferencesStore
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -41,8 +42,6 @@ import org.readium.r2.streamer.PublicationOpener
 import java.io.File
 import javax.inject.Inject
 
-private const val PDF_SYNC_INTERVAL_MS = 30_000L
-
 @HiltViewModel
 class PdfReaderViewModel @Inject constructor(
     application: Application,
@@ -57,6 +56,8 @@ class PdfReaderViewModel @Inject constructor(
     private val readerStateHolder: ReaderStateHolder,
     private val annotationStore: AnnotationStore,
     private val serverRepository: ServerRepository,
+    clock: Clock,
+    readingSpeedStore: ReadingSpeedStore,
 ) : AndroidViewModel(application) {
 
     private val itemId: String = checkNotNull(savedStateHandle["itemId"])
@@ -88,9 +89,17 @@ class PdfReaderViewModel @Inject constructor(
 
     private var lastLocator: Locator? = null
     val latestLocator: Locator? get() = lastLocator
-    private var syncJob: Job? = null
     private var closeSyncDone = false
     private var initialLocatorSeen = false
+
+    // PDF heartbeat-sync only — speed-tracking stays opt-out (PDF "position" units don't share
+    // semantics with EPUB's locator positions, so we leave the speed-store untouched by passing
+    // null initialTotalProgression on resume; the coordinator suppresses its speed write).
+    private val readingSessionCoordinator = ReadingSessionCoordinator(
+        clock = clock,
+        readingSpeedStore = readingSpeedStore,
+        scope = viewModelScope,
+    )
 
     // Cached at book-open so navigateToEntry can resolve a TocEntry click back to
     // the original Readium Link without re-walking the publication. Index-aligned
@@ -204,7 +213,10 @@ class PdfReaderViewModel @Inject constructor(
                     initialLocator = locator,
                 )
                 progressSyncController.sync(itemId, locator?.toPayload() ?: SessionPayload("", 0f))
-                startPeriodicSync()
+                readingSessionCoordinator.onResumed(
+                    initialTotalProgression = null,
+                    onTick = { syncCurrentPosition() },
+                )
             }
             is PdfOpenResult.NetworkError -> _state.value = ReaderState.Error("Network error: ${result.cause.message}")
             PdfOpenResult.Offline -> _state.value = ReaderState.Error("Book not available offline")
@@ -390,16 +402,6 @@ class PdfReaderViewModel @Inject constructor(
         }
     }
 
-    private fun startPeriodicSync() {
-        syncJob?.cancel()
-        syncJob = viewModelScope.launch {
-            while (true) {
-                delay(PDF_SYNC_INTERVAL_MS)
-                syncCurrentPosition()
-            }
-        }
-    }
-
     private fun syncCurrentPosition() {
         val locator = lastLocator ?: return
         progressSyncController.sync(itemId, locator.toPayload())
@@ -411,14 +413,17 @@ class PdfReaderViewModel @Inject constructor(
         initialLocatorSeen = false
         if (_state.value is ReaderState.Ready) {
             syncCurrentPosition()
-            startPeriodicSync()
+            readingSessionCoordinator.onResumed(
+                initialTotalProgression = null,
+                onTick = { syncCurrentPosition() },
+            )
         }
     }
 
     fun onReaderClosed() {
         readerStateHolder.isReaderActive = false
         readerStateHolder.isPanelOpen = false
-        syncJob?.cancel()
+        readingSessionCoordinator.onClosed(currentTotalProgression = null, totalPositions = 0f)
         if (closeSyncDone) return
         closeSyncDone = true
         val locator = lastLocator ?: return

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/EpubReaderViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/EpubReaderViewModelTest.kt
@@ -39,7 +39,7 @@ import org.junit.Test
 @OptIn(ExperimentalCoroutinesApi::class, FlowPreview::class)
 class EpubReaderViewModelTest {
 
-    // Must match EpubReaderViewModel.SYNC_INTERVAL_MS
+    // Must match ReadingSessionCoordinator.SYNC_INTERVAL_MS
     private val syncIntervalMs = 30_000L
 
     @Test

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/EpubReaderViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/EpubReaderViewModelTest.kt
@@ -33,9 +33,9 @@ import org.junit.Test
 
 // EpubReaderViewModel is an AndroidViewModel with Readium dependencies that rely on
 // android.net.Uri, which cannot be used in JVM unit tests without Robolectric.
-// These tests verify the `while (true) { delay(SYNC_INTERVAL_MS); sync() }` pattern
-// from EpubReaderViewModel.startPeriodicSync() using virtual time, replacing the
-// 35-second real-time harness test sessionUpdateSentAfterReading.
+// These tests verify the `while (true) { delay(SYNC_INTERVAL_MS); sync() }` pattern that
+// drives the periodic position sync (now lifted to ReadingSessionCoordinator) using virtual
+// time, replacing the 35-second real-time harness test sessionUpdateSentAfterReading.
 @OptIn(ExperimentalCoroutinesApi::class, FlowPreview::class)
 class EpubReaderViewModelTest {
 

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/ReadingSessionCoordinator.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/ReadingSessionCoordinator.kt
@@ -1,0 +1,93 @@
+package com.riffle.core.domain
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+
+/**
+ * Lifts the ABS Reading Session lifecycle out of the reader ViewModels (issue #339) so EPUB, PDF,
+ * and any future reader format share one implementation of:
+ *
+ *  - the periodic position-sync heartbeat (`delay(syncIntervalMs) → onTick()`),
+ *  - the per-resume reading-speed session (start progression + start instant → on close, feed
+ *    [ReadingSpeedTracker] and persist via [ReadingSpeedStore]).
+ *
+ * The actual per-tick sync action is supplied by the caller as [onTick] in [onResumed] so the
+ * coordinator stays oblivious to EPUB's `readerSync` / inbound-jump branch and PDF's plain
+ * `progressSyncController.sync(...)` path. ViewModels keep the small amount of format-specific
+ * code, but the timer and the speed-tracker session live here.
+ *
+ * Scope: [scope] is intended to be the caller's `viewModelScope` — the heartbeat dies with the
+ * screen by design (no value in heartbeating an unmounted reader). The terminal speed-tracker
+ * write fires from [onClosed] before [scope] is cancelled.
+ */
+class ReadingSessionCoordinator(
+    private val clock: Clock,
+    private val readingSpeedStore: ReadingSpeedStore,
+    private val scope: CoroutineScope,
+    private val syncIntervalMs: Long = SYNC_INTERVAL_MS,
+) {
+
+    private var syncJob: Job? = null
+    private var sessionStartProgression: Float? = null
+    private var sessionStartMs: Long = 0L
+
+    /**
+     * Start (or restart) a reading session.
+     *
+     * @param initialTotalProgression the canonical book-wide progression at the moment the reader
+     *   becomes active; captured as the baseline so [onClosed] can compute the session delta. Null
+     *   means "we don't know the position yet" — the speed-tracker session is suppressed until the
+     *   next [onResumed] call provides a real value.
+     * @param onTick the per-heartbeat action — typically a position-sync call. Invoked on [scope]
+     *   every [syncIntervalMs] ms after a fresh delay (so the first tick fires one interval in,
+     *   matching the pre-refactor behaviour); callers that want an immediate sync should call it
+     *   themselves alongside [onResumed].
+     */
+    fun onResumed(initialTotalProgression: Float?, onTick: suspend () -> Unit) {
+        sessionStartProgression = initialTotalProgression
+        sessionStartMs = clock.nowMs()
+        syncJob?.cancel()
+        syncJob = scope.launch {
+            while (true) {
+                delay(syncIntervalMs)
+                onTick()
+            }
+        }
+    }
+
+    /**
+     * End the session: cancel the heartbeat and flush the speed-tracker. Safe to call when no
+     * session is active (no-op).
+     *
+     * @param currentTotalProgression the canonical book-wide progression at close — paired with
+     *   the [onResumed] baseline to compute [ReadingSpeedTracker.recordSession]'s `progressDelta`.
+     * @param totalPositions the book's total weighted positions (sum of chapter weights); same
+     *   value the rail uses. A zero total skips the speed write (we'd divide by zero).
+     */
+    fun onClosed(currentTotalProgression: Float?, totalPositions: Float) {
+        syncJob?.cancel()
+        syncJob = null
+        flushSpeedSession(currentTotalProgression, totalPositions)
+    }
+
+    private fun flushSpeedSession(currentTotalProgression: Float?, totalPositions: Float) {
+        val startProg = sessionStartProgression ?: return
+        sessionStartProgression = null
+        val timeDeltaSec = (clock.nowMs() - sessionStartMs) / 1000.0
+        val totalProg = currentTotalProgression ?: return
+        if (totalPositions == 0f) return
+        val progressDelta = totalProg - startProg
+        scope.launch {
+            val prior = readingSpeedStore.speedSecPerPosition.first()
+            val updated = ReadingSpeedTracker.recordSession(progressDelta, timeDeltaSec, totalPositions, prior)
+            if (updated != null) readingSpeedStore.updateSpeed(updated)
+        }
+    }
+
+    companion object {
+        const val SYNC_INTERVAL_MS = 30_000L
+    }
+}

--- a/core/domain/src/test/kotlin/com/riffle/core/domain/ReadingSessionCoordinatorTest.kt
+++ b/core/domain/src/test/kotlin/com/riffle/core/domain/ReadingSessionCoordinatorTest.kt
@@ -1,0 +1,178 @@
+package com.riffle.core.domain
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ReadingSessionCoordinatorTest {
+
+    private class FakeSpeedStore(initial: Double = ReadingSpeedTracker.DEFAULT_SECS_PER_POSITION) : ReadingSpeedStore {
+        private val flow = MutableStateFlow(initial)
+        override val speedSecPerPosition: Flow<Double> = flow.asStateFlow()
+        override suspend fun updateSpeed(newSecPerPosition: Double) { flow.value = newSecPerPosition }
+        val current: Double get() = flow.value
+    }
+
+    @Test
+    fun `the heartbeat fires onTick on every interval`() = runTest {
+        val clock = TestClock()
+        val coord = ReadingSessionCoordinator(clock, FakeSpeedStore(), this, syncIntervalMs = 30_000L)
+        var ticks = 0
+        coord.onResumed(initialTotalProgression = 0f, onTick = { ticks++ })
+
+        advanceTimeBy(29_999L)
+        assertEquals(0, ticks)
+        advanceTimeBy(2L) // crosses the first interval boundary
+        assertEquals(1, ticks)
+        advanceTimeBy(60_000L)
+        assertEquals(3, ticks)
+
+        coord.onClosed(currentTotalProgression = 0f, totalPositions = 0f)
+        advanceUntilIdle()
+    }
+
+    @Test
+    fun `onClosed cancels the heartbeat`() = runTest {
+        val clock = TestClock()
+        val coord = ReadingSessionCoordinator(clock, FakeSpeedStore(), this, syncIntervalMs = 30_000L)
+        var ticks = 0
+        coord.onResumed(initialTotalProgression = 0f, onTick = { ticks++ })
+
+        advanceTimeBy(30_001L)
+        assertEquals(1, ticks)
+        coord.onClosed(currentTotalProgression = 0f, totalPositions = 0f)
+        advanceTimeBy(60_000L)
+        assertEquals(1, ticks)
+    }
+
+    @Test
+    fun `a second onResumed restarts the heartbeat without leaking the first`() = runTest {
+        val clock = TestClock()
+        val coord = ReadingSessionCoordinator(clock, FakeSpeedStore(), this, syncIntervalMs = 30_000L)
+        var ticks = 0
+        coord.onResumed(initialTotalProgression = 0f, onTick = { ticks++ })
+        advanceTimeBy(15_000L)
+        coord.onResumed(initialTotalProgression = 0.1f, onTick = { ticks++ })
+        advanceTimeBy(15_000L) // would have fired the first job — but it was cancelled
+        assertEquals(0, ticks)
+        advanceTimeBy(15_001L) // first tick of the new job
+        assertEquals(1, ticks)
+
+        coord.onClosed(currentTotalProgression = 0.1f, totalPositions = 0f)
+        advanceUntilIdle()
+    }
+
+    @Test
+    fun `onClosed feeds the speed tracker and persists the updated speed`() = runTest {
+        val clock = TestClock(initialMs = 1_000L)
+        val store = FakeSpeedStore(initial = 100.0)
+        val coord = ReadingSessionCoordinator(clock, store, this, syncIntervalMs = 30_000L)
+        coord.onResumed(initialTotalProgression = 0.10f, onTick = {})
+
+        // 600s elapsed, progressDelta = 0.05, totalPositions = 100 → positionsDelta = 5 → 120 s/pos.
+        // ALPHA=0.2: 0.2*120 + 0.8*100 = 104.0
+        clock.advance(600_000L)
+        coord.onClosed(currentTotalProgression = 0.15f, totalPositions = 100f)
+        advanceUntilIdle()
+
+        assertEquals(104.0, store.current, 1e-5)
+    }
+
+    @Test
+    fun `onClosed without an initialTotalProgression skips the speed write`() = runTest {
+        val clock = TestClock()
+        val store = FakeSpeedStore(initial = 100.0)
+        val coord = ReadingSessionCoordinator(clock, store, this, syncIntervalMs = 30_000L)
+        coord.onResumed(initialTotalProgression = null, onTick = {})
+
+        clock.advance(600_000L)
+        coord.onClosed(currentTotalProgression = 0.5f, totalPositions = 100f)
+        advanceUntilIdle()
+
+        assertEquals(100.0, store.current, 1e-9)
+    }
+
+    @Test
+    fun `onClosed with zero totalPositions skips the speed write`() = runTest {
+        val clock = TestClock()
+        val store = FakeSpeedStore(initial = 100.0)
+        val coord = ReadingSessionCoordinator(clock, store, this, syncIntervalMs = 30_000L)
+        coord.onResumed(initialTotalProgression = 0f, onTick = {})
+
+        clock.advance(600_000L)
+        coord.onClosed(currentTotalProgression = 0.5f, totalPositions = 0f)
+        advanceUntilIdle()
+
+        assertEquals(100.0, store.current, 1e-9)
+    }
+
+    @Test
+    fun `onClosed with no current progression skips the speed write`() = runTest {
+        val clock = TestClock()
+        val store = FakeSpeedStore(initial = 100.0)
+        val coord = ReadingSessionCoordinator(clock, store, this, syncIntervalMs = 30_000L)
+        coord.onResumed(initialTotalProgression = 0.1f, onTick = {})
+
+        clock.advance(600_000L)
+        coord.onClosed(currentTotalProgression = null, totalPositions = 100f)
+        advanceUntilIdle()
+
+        assertEquals(100.0, store.current, 1e-9)
+    }
+
+    @Test
+    fun `a second onClosed after a flush is a no-op`() = runTest {
+        val clock = TestClock()
+        val store = FakeSpeedStore(initial = 100.0)
+        val coord = ReadingSessionCoordinator(clock, store, this, syncIntervalMs = 30_000L)
+        coord.onResumed(initialTotalProgression = 0.10f, onTick = {})
+
+        clock.advance(600_000L)
+        coord.onClosed(currentTotalProgression = 0.15f, totalPositions = 100f)
+        advanceUntilIdle()
+        val afterFirst = store.current
+
+        coord.onClosed(currentTotalProgression = 0.20f, totalPositions = 100f)
+        advanceUntilIdle()
+        assertEquals(afterFirst, store.current, 1e-9)
+    }
+
+    @Test
+    fun `onClosed without a prior onResumed is a no-op`() = runTest {
+        val clock = TestClock()
+        val store = FakeSpeedStore(initial = 100.0)
+        val coord = ReadingSessionCoordinator(clock, store, this, syncIntervalMs = 30_000L)
+
+        coord.onClosed(currentTotalProgression = 0.5f, totalPositions = 100f)
+        advanceUntilIdle()
+
+        assertEquals(100.0, store.current, 1e-9)
+    }
+
+    @Test
+    fun `a too-short session yields no speed update`() = runTest {
+        // ReadingSpeedTracker requires at least MIN_SESSION_SEC=30s of elapsed time.
+        val clock = TestClock()
+        val store = FakeSpeedStore(initial = 100.0)
+        val coord = ReadingSessionCoordinator(clock, store, this, syncIntervalMs = 30_000L)
+        coord.onResumed(initialTotalProgression = 0.10f, onTick = {})
+
+        clock.advance(10_000L)
+        coord.onClosed(currentTotalProgression = 0.15f, totalPositions = 100f)
+        advanceUntilIdle()
+
+        assertEquals(100.0, store.current, 1e-9)
+    }
+
+    @Test
+    fun `the default interval is 30s`() {
+        assertEquals(30_000L, ReadingSessionCoordinator.SYNC_INTERVAL_MS)
+    }
+}


### PR DESCRIPTION
Closes #339

## Summary

Lifts the ABS Reading Session lifecycle — the periodic position-sync heartbeat (`while (true) { delay(30s); sync() }`) and the per-resume reading-speed session math — out of `EpubReaderViewModel` and `PdfReaderViewModel` into a single `ReadingSessionCoordinator` in `core/domain`. A bug fix in one reader can no longer silently no-op in the other.

## What moved

`ReadingSessionCoordinator` owns:
- the periodic sync timer (start / restart / cancel),
- the [`ReadingSpeedTracker`](core/domain/src/main/kotlin/com/riffle/core/domain/ReadingSpeedTracker.kt) session — start progression + start instant on resume, flush on close and persist via [`ReadingSpeedStore`](core/domain/src/main/kotlin/com/riffle/core/domain/ReadingSpeedStore.kt).

ViewModels supply the per-tick sync action as an `onTick` callback so EPUB keeps its `readerSync` / inbound-jump branch in place; the coordinator stays oblivious to format-specific sync paths.

## Why slimmer than the issue's sketch

The issue proposed a richer interface (`OpenBook`, `CanonicalPosition`, `ReadingSpeed` value type, `ReadingSessionRepository` + `ApplicationScope` + `PositionTranslator` deps). The actually-duplicated code is just the heartbeat timer plus the speed-tracker session — `ReadingSessionRepository` is already abstracted behind `ProgressSyncController` at every callsite, so the acceptance criterion *"neither VM calls `ReadingSessionRepository` directly"* is satisfied by today's code. Going slim follows the "no hypothetical future requirements" rule; richer typing can layer on cleanly when a third reader format actually lands.

## PDF behaviour

PDF gets the heartbeat for free; speed-tracking stays opt-out (PDF *position* units don't share semantics with EPUB locator positions). PDF passes `null` as the baseline so the coordinator suppresses the speed write — same observable behaviour as today.

## Tests

11 new JVM contract tests in `ReadingSessionCoordinatorTest` cover:
- heartbeat firing on the interval boundary, cancellation on close, restart-without-leak across two `onResumed` calls,
- speed-tracker math against a deterministic clock,
- the four no-write guards (null baseline / null current progression / zero totalPositions / too-short session),
- safety of `onClosed` without a prior `onResumed` and of a second `onClosed` after a flush,
- the `SYNC_INTERVAL_MS` default.

Existing reader VM tests, including the freestanding heartbeat virtual-time pattern test in `EpubReaderViewModelTest`, still pass — `./gradlew test` green.

## Test plan

- [x] `./gradlew test` — all JVM suites pass
- [ ] Smoke-test on device: open an EPUB, read for >30s, background+foreground, verify position syncs on the heartbeat and reading-speed estimates calibrate
- [ ] Smoke-test on device: open a PDF, page through, background+foreground, verify position syncs on the heartbeat (no speed-tracker contribution expected from PDF)