### PR TITLE
refactor(audio): extract MediaSourceRegistry + MediaSessionConnector

### DIFF
--- a/app/src/androidTest/kotlin/com/riffle/app/feature/reader/readaloud/ReadaloudDataSourceRoutingTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/reader/readaloud/ReadaloudDataSourceRoutingTest.kt
@@ -1,24 +1,24 @@
 package com.riffle.app.feature.reader.readaloud
 
-import android.net.Uri
 import androidx.media3.common.C
 import androidx.media3.datasource.DataSpec
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.riffle.app.feature.audio.BundleAudioSourceFactory
+import com.riffle.app.feature.audio.MediaSourceRegistry
+import com.riffle.core.logging.RecordingLogger
 import org.junit.After
 import org.junit.Assert.assertArrayEquals
-import org.junit.Assert.fail
 import org.junit.Test
 import org.junit.runner.RunWith
 import java.io.ByteArrayOutputStream
 import java.io.File
-import java.io.IOException
 import java.util.zip.ZipEntry
 import java.util.zip.ZipOutputStream
 
 /**
- * On-device check (ADR 0028) that the shared data source routes by URI scheme: `zipaudio://` reads
- * out of the on-disk bundle (the unchanged bundle path), while an `http` URI with no streaming
- * context fails cleanly rather than misrouting. Validates the dispatch the player now relies on.
+ * On-device check (ADR 0028) that the registry routes by URI scheme: `zipaudio://` reads out of the
+ * on-disk bundle (the unchanged bundle path). Streaming-vs-bundle dispatch is now in
+ * [MediaSourceRegistry] (issue #333); this test guards the bundle path the registry assembles.
  */
 @RunWith(AndroidJUnit4::class)
 class ReadaloudDataSourceRoutingTest {
@@ -40,7 +40,8 @@ class ReadaloudDataSourceRoutingTest {
         SharedBundle.current = bundle
         SharedBundle.streaming = null
 
-        val ds = SharedBundle.dataSourceFactory().createDataSource()
+        val registry = MediaSourceRegistry(listOf(BundleAudioSourceFactory(RecordingLogger())))
+        val ds = registry.asDataSourceFactory().createDataSource()
         ds.open(DataSpec.Builder().setUri(ZipAudioDataSource.uriFor("Audio/x.mp3")).build())
         val out = ByteArrayOutputStream()
         val buf = ByteArray(1024)
@@ -53,18 +54,5 @@ class ReadaloudDataSourceRoutingTest {
         bundle.delete()
 
         assertArrayEquals(audio, out.toByteArray())
-    }
-
-    @Test
-    fun http_uri_without_streaming_context_fails_cleanly() {
-        SharedBundle.current = null
-        SharedBundle.streaming = null
-        val ds = SharedBundle.dataSourceFactory().createDataSource()
-        try {
-            ds.open(DataSpec.Builder().setUri(Uri.parse("http://example/track")).build())
-            fail("expected IOException when no streaming source is set")
-        } catch (e: IOException) {
-            // expected
-        }
     }
 }

--- a/app/src/androidTest/kotlin/com/riffle/app/feature/reader/readaloud/StreamingPlaybackAndroidTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/reader/readaloud/StreamingPlaybackAndroidTest.kt
@@ -7,6 +7,10 @@ import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
+import com.riffle.app.feature.audio.BundleAudioSourceFactory
+import com.riffle.app.feature.audio.HttpAudioSourceFactory
+import com.riffle.app.feature.audio.MediaSourceRegistry
+import com.riffle.core.logging.RecordingLogger
 import okhttp3.mockwebserver.Dispatcher
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
@@ -69,10 +73,14 @@ class StreamingPlaybackAndroidTest {
     fun streaming_playback_advances_position() {
         val url = server.url("/audio").toString()
         instrumentation.runOnMainSync {
-            // streaming context must be set so the dispatch routes http → the cache/HTTP source.
+            // streaming context still tracked here for parity with prepareStreaming(), even though
+            // the production registry uses bare DefaultHttpDataSource for http/https (issue #333).
             SharedBundle.streaming = SharedBundle.Streaming(StreamingAudioCache.dataSourceFactory(appCtx, "tok"), emptyMap())
+            val registry = MediaSourceRegistry(
+                listOf(HttpAudioSourceFactory(), BundleAudioSourceFactory(RecordingLogger())),
+            )
             val p = ExoPlayer.Builder(appCtx)
-                .setMediaSourceFactory(DefaultMediaSourceFactory(SharedBundle.dataSourceFactory()))
+                .setMediaSourceFactory(DefaultMediaSourceFactory(registry.asDataSourceFactory()))
                 .build()
             p.setMediaItem(
                 MediaItem.Builder()

--- a/app/src/androidTest/kotlin/com/riffle/app/feature/reader/readaloud/StreamingPlaybackAndroidTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/reader/readaloud/StreamingPlaybackAndroidTest.kt
@@ -75,7 +75,7 @@ class StreamingPlaybackAndroidTest {
         instrumentation.runOnMainSync {
             // streaming context still tracked here for parity with prepareStreaming(), even though
             // the production registry uses bare DefaultHttpDataSource for http/https (issue #333).
-            SharedBundle.streaming = SharedBundle.Streaming(StreamingAudioCache.dataSourceFactory(appCtx, "tok"), emptyMap())
+            SharedBundle.streaming = SharedBundle.Streaming(emptyMap())
             val registry = MediaSourceRegistry(
                 listOf(HttpAudioSourceFactory(), BundleAudioSourceFactory(RecordingLogger())),
             )

--- a/app/src/main/kotlin/com/riffle/app/feature/audio/AudioModule.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audio/AudioModule.kt
@@ -1,0 +1,42 @@
+package com.riffle.app.feature.audio
+
+import dagger.Binds
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+/**
+ * Hilt bindings for the audio source / session seams (issue #333). The two ordered lists are
+ * vended explicitly here because dispatch order matters — `StreamingReadaloudItemRestorer` must
+ * try first (its mediaIds collide with what `AudiobookHttpItemRestorer` would otherwise claim),
+ * and `BundleZipItemRestorer` is the trailing catch-all.
+ */
+@Module
+@InstallIn(SingletonComponent::class)
+object AudioModule {
+
+    @Provides
+    @Singleton
+    fun provideMediaSourceFactories(
+        http: HttpAudioSourceFactory,
+        file: FileAudioSourceFactory,
+        bundle: BundleAudioSourceFactory,
+    ): List<MediaSourceFactory> = listOf(http, file, bundle)
+
+    @Provides
+    @Singleton
+    fun provideMediaItemRestorers(
+        streaming: StreamingReadaloudItemRestorer,
+        audiobook: AudiobookHttpItemRestorer,
+        bundle: BundleZipItemRestorer,
+    ): List<MediaItemRestorer> = listOf(streaming, audiobook, bundle)
+}
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class MediaSessionConnectorModule {
+    @Binds
+    abstract fun bindConnector(impl: DefaultMediaSessionConnector): MediaSessionConnector
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/audio/MediaItemRestorer.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audio/MediaItemRestorer.kt
@@ -1,0 +1,84 @@
+package com.riffle.app.feature.audio
+
+import android.net.Uri
+import androidx.annotation.OptIn
+import androidx.media3.common.MediaItem
+import androidx.media3.common.util.UnstableApi
+import com.riffle.app.feature.reader.readaloud.SharedBundle
+import com.riffle.app.feature.reader.readaloud.ZipAudioDataSource
+import javax.inject.Inject
+
+/**
+ * Rebuilds a [MediaItem] whose playback URI Media3 stripped when the controller sent it across the
+ * session Binder (only `mediaId` + metadata survive that hop). Each restorer recognises one item
+ * shape and returns the rebuilt item, or `null` to defer to the next restorer in the
+ * [MediaItemRestorerRegistry] chain.
+ */
+@OptIn(UnstableApi::class)
+interface MediaItemRestorer {
+    fun restore(item: MediaItem): MediaItem?
+}
+
+/**
+ * Readaloud-while-streaming items (ADR 0028): the mediaId is the canonical `audioSrc` and the
+ * concrete ABS URL + per-segment clip window are pulled from the active streaming context.
+ */
+@OptIn(UnstableApi::class)
+class StreamingReadaloudItemRestorer @Inject constructor() : MediaItemRestorer {
+    override fun restore(item: MediaItem): MediaItem? {
+        val streamItem = SharedBundle.streaming?.itemsByMediaId?.get(item.mediaId) ?: return null
+        return item.buildUpon()
+            .setUri(streamItem.url)
+            .setClippingConfiguration(
+                MediaItem.ClippingConfiguration.Builder()
+                    .setStartPositionMs(streamItem.clipStartMs)
+                    .setEndPositionMs(streamItem.clipEndMs)
+                    .build(),
+            )
+            .build()
+    }
+}
+
+/**
+ * Audiobook tracks (ADR 0029): each track's mediaId is its full URL — `http(s)` while streaming,
+ * `file://` once downloaded. Parse-and-restore is enough; no clipping is needed.
+ */
+@OptIn(UnstableApi::class)
+class AudiobookHttpItemRestorer @Inject constructor() : MediaItemRestorer {
+    override fun restore(item: MediaItem): MediaItem? {
+        val id = item.mediaId
+        if (!(id.startsWith("http") || id.startsWith("file"))) return null
+        return item.buildUpon().setUri(Uri.parse(id)).build()
+    }
+}
+
+/**
+ * Readaloud bundle items (ADR 0023): the mediaId is the zip-entry path of the audio resource.
+ * Rebuilt to the `zipaudio:///<path>` URI [BundleAudioSourceFactory] consumes.
+ */
+@OptIn(UnstableApi::class)
+class BundleZipItemRestorer @Inject constructor() : MediaItemRestorer {
+    override fun restore(item: MediaItem): MediaItem? {
+        // Trailing fallback: a zip-path mediaId is anything that isn't recognised by the upstream
+        // restorers in the registry's ordered chain.
+        if (item.mediaId.isEmpty()) return null
+        return item.buildUpon().setUri(ZipAudioDataSource.uriFor(item.mediaId)).build()
+    }
+}
+
+/**
+ * Walks an ordered [restorers] chain until one returns a non-null rebuilt item. Items whose
+ * [MediaItem.localConfiguration] is already populated, or whose mediaId is empty, pass through
+ * untouched — Media3 only strips the URI on the controller→service Binder hop, so items built in
+ * the service itself reach this point with their URI intact.
+ */
+@OptIn(UnstableApi::class)
+class MediaItemRestorerRegistry @Inject constructor(
+    private val restorers: List<@JvmSuppressWildcards MediaItemRestorer>,
+) {
+    fun restoreAll(items: List<MediaItem>): MutableList<MediaItem> =
+        items.map { item ->
+            if (item.localConfiguration != null || item.mediaId.isEmpty()) return@map item
+            restorers.firstNotNullOfOrNull { it.restore(item) } ?: item
+        }.toMutableList()
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/audio/MediaSessionConnector.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audio/MediaSessionConnector.kt
@@ -1,0 +1,94 @@
+package com.riffle.app.feature.audio
+
+import android.content.ComponentName
+import android.content.Context
+import androidx.core.content.ContextCompat
+import androidx.media3.common.Player
+import androidx.media3.session.MediaController
+import androidx.media3.session.SessionToken
+import com.riffle.app.feature.reader.readaloud.AudioPlayerService
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.suspendCancellableCoroutine
+import javax.inject.Inject
+import kotlin.coroutines.resume
+
+/**
+ * Shared [MediaController] lifecycle the audiobook and readaloud controllers used to hand-roll
+ * each (~50 lines of identical buildAsync → suspendCancellableCoroutine → listener-attach). ADR 0032
+ * makes any divergence between the two controllers' connection state load-bearing for the
+ * pre-warmed handoff — one connector to debug instead of two.
+ *
+ * Each consumer holds its own instance (the dance is per-handle); the controller binder this
+ * connector vends still talks to the single shared [AudioPlayerService] session.
+ */
+interface MediaSessionConnector {
+    /**
+     * Returns the active [MediaController], building+binding one if needed. May return `null` if
+     * no Android [Context] is available (a test fake configured without one).
+     */
+    suspend fun ensureConnected(): MediaController?
+
+    /** The current controller without connecting; `null` when no session is bound. */
+    val controller: MediaController?
+
+    /** Attach a [Player.Listener] idempotently — repeat calls are no-ops. */
+    fun attachListener(listener: Player.Listener)
+
+    /**
+     * Pause + detach the listener but keep the binder alive — used during the audiobook↔readaloud
+     * swipe handoff so the incoming side reconnects in ~0 ms (ADR 0032). Does NOT stop or clear
+     * media items: the incoming side replaces the queue with its own [MediaController.setMediaItems].
+     */
+    fun releaseForHandoff()
+
+    /** Stop, clear, release the controller and forget it. */
+    fun release()
+}
+
+class DefaultMediaSessionConnector @Inject constructor(
+    @ApplicationContext private val context: Context?,
+) : MediaSessionConnector {
+
+    private var _controller: MediaController? = null
+    override val controller: MediaController? get() = _controller
+    private var attached: Player.Listener? = null
+
+    override suspend fun ensureConnected(): MediaController? {
+        val existing = _controller
+        if (existing != null) return existing
+        val ctx = context ?: return null
+        val token = SessionToken(ctx, ComponentName(ctx, AudioPlayerService::class.java))
+        val future = MediaController.Builder(ctx, token).buildAsync()
+        val newC = suspendCancellableCoroutine<MediaController?> { cont ->
+            future.addListener(
+                { cont.resume(runCatching { future.get() }.getOrNull()) },
+                ContextCompat.getMainExecutor(ctx),
+            )
+        }
+        _controller = newC
+        return newC
+    }
+
+    override fun attachListener(listener: Player.Listener) {
+        if (attached === listener) return
+        _controller?.addListener(listener)
+        attached = listener
+    }
+
+    override fun releaseForHandoff() {
+        val c = _controller ?: return
+        attached?.let { c.removeListener(it) }
+        attached = null
+        // The caller has already pause()d via its own controller reference; binder stays alive.
+    }
+
+    override fun release() {
+        val c = _controller ?: return
+        attached?.let { c.removeListener(it) }
+        c.stop()
+        c.clearMediaItems()
+        c.release()
+        _controller = null
+        attached = null
+    }
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/audio/MediaSessionConnector.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audio/MediaSessionConnector.kt
@@ -45,6 +45,13 @@ interface MediaSessionConnector {
     fun release()
 }
 
+/**
+ * Deliberately UNscoped — each `@Inject` site gets its own connector instance. The audiobook and
+ * readaloud controllers must each own their own `MediaController` binder so ADR 0032's pre-warmed
+ * handoff can pause one side while the other takes over the shared session. Annotating this with
+ * `@Singleton` would silently collapse both controllers onto one binder and re-introduce the very
+ * divergence the connector was extracted to prevent.
+ */
 class DefaultMediaSessionConnector @Inject constructor(
     @ApplicationContext private val context: Context?,
 ) : MediaSessionConnector {

--- a/app/src/main/kotlin/com/riffle/app/feature/audio/MediaSourceFactory.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audio/MediaSourceFactory.kt
@@ -1,0 +1,103 @@
+package com.riffle.app.feature.audio
+
+import androidx.annotation.OptIn
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.datasource.DataSource
+import androidx.media3.datasource.DataSpec
+import androidx.media3.datasource.DefaultHttpDataSource
+import androidx.media3.datasource.FileDataSource
+import androidx.media3.datasource.TransferListener
+import com.riffle.app.feature.reader.readaloud.SharedBundle
+import com.riffle.app.feature.reader.readaloud.ZipAudioDataSource
+import com.riffle.core.logging.Logger
+import java.io.IOException
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * A scheme-keyed [DataSource] factory. The [MediaSourceRegistry] composes a list of these and
+ * dispatches each [DataSpec] open to the factory whose [handles] matches the URI scheme. Adding a
+ * new audio backend (e.g. an S3 source, a local cache layer) is a new [MediaSourceFactory] entry —
+ * no edits in `AudioPlayerService`.
+ */
+@OptIn(UnstableApi::class)
+interface MediaSourceFactory {
+    fun handles(scheme: String?): Boolean
+    fun createDataSource(): DataSource
+}
+
+/** Streamed ABS audiobook tracks (ADR 0029). */
+@OptIn(UnstableApi::class)
+@Singleton
+class HttpAudioSourceFactory @Inject constructor() : MediaSourceFactory {
+    override fun handles(scheme: String?): Boolean = scheme == "http" || scheme == "https"
+    override fun createDataSource(): DataSource = DefaultHttpDataSource.Factory().createDataSource()
+}
+
+/** Downloaded audiobook tracks (ADR 0029, file:// after offline download). */
+@OptIn(UnstableApi::class)
+@Singleton
+class FileAudioSourceFactory @Inject constructor() : MediaSourceFactory {
+    override fun handles(scheme: String?): Boolean = scheme == "file"
+    override fun createDataSource(): DataSource = FileDataSource()
+}
+
+/**
+ * Readaloud bundle audio served out of the synced EPUB zip (ADR 0023). The active bundle file
+ * pointer lives in [SharedBundle] — set by `ReadaloudController` / `AudiobookController` before
+ * the controller queues media items.
+ */
+@OptIn(UnstableApi::class)
+@Singleton
+class BundleAudioSourceFactory @Inject constructor(private val logger: Logger) : MediaSourceFactory {
+    override fun handles(scheme: String?): Boolean = scheme == ZIP_SCHEME
+    override fun createDataSource(): DataSource {
+        val bundle = SharedBundle.current ?: throw IOException("No Readaloud bundle set")
+        return ZipAudioDataSource.Factory(bundle, logger).createDataSource()
+    }
+
+    companion object {
+        const val ZIP_SCHEME = "zipaudio"
+    }
+}
+
+/**
+ * Composes a list of [MediaSourceFactory] into a single Media3 [DataSource.Factory] that dispatches
+ * by URI scheme. Replaces the two duplicated per-scheme switches previously hand-rolled in
+ * `AudioPlayerService.SchemeResolvingDataSource` and `SharedBundle.ReadaloudDataSource`.
+ */
+@OptIn(UnstableApi::class)
+class MediaSourceRegistry @Inject constructor(private val factories: List<@JvmSuppressWildcards MediaSourceFactory>) {
+    fun asDataSourceFactory(): DataSource.Factory = DataSource.Factory { ResolvingDataSource(factories) }
+
+    private class ResolvingDataSource(
+        private val factories: List<MediaSourceFactory>,
+    ) : DataSource {
+        private val listeners = mutableListOf<TransferListener>()
+        private var delegate: DataSource? = null
+
+        override fun addTransferListener(transferListener: TransferListener) {
+            listeners += transferListener
+        }
+
+        override fun open(dataSpec: DataSpec): Long {
+            val scheme = dataSpec.uri.scheme
+            val factory = factories.firstOrNull { it.handles(scheme) }
+                ?: throw IOException("No MediaSourceFactory for scheme=$scheme uri=${dataSpec.uri}")
+            val source = factory.createDataSource()
+            listeners.forEach { source.addTransferListener(it) }
+            delegate = source
+            return source.open(dataSpec)
+        }
+
+        override fun read(buffer: ByteArray, offset: Int, length: Int): Int =
+            (delegate ?: throw IOException("read before open")).read(buffer, offset, length)
+
+        override fun getUri() = delegate?.uri
+
+        override fun close() {
+            delegate?.close()
+            delegate = null
+        }
+    }
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookController.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookController.kt
@@ -1,14 +1,10 @@
 package com.riffle.app.feature.audiobook
 
-import android.content.ComponentName
-import android.content.Context
-import androidx.core.content.ContextCompat
 import androidx.media3.common.MediaItem
 import androidx.media3.common.PlaybackException
 import androidx.media3.common.Player
 import androidx.media3.session.MediaController
-import androidx.media3.session.SessionToken
-import com.riffle.app.feature.reader.readaloud.AudioPlayerService
+import com.riffle.app.feature.audio.MediaSessionConnector
 import com.riffle.app.feature.reader.readaloud.SharedBundle
 import com.riffle.core.domain.ApplicationScope
 import com.riffle.core.domain.AudiobookTrackSpan
@@ -18,7 +14,6 @@ import com.riffle.core.domain.SystemClock
 import com.riffle.core.logging.LogChannel
 import com.riffle.core.logging.Logger
 import com.riffle.core.logging.RecordingLogger
-import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -31,11 +26,9 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.suspendCancellableCoroutine
 import java.io.File
 import javax.inject.Inject
 import javax.inject.Singleton
-import kotlin.coroutines.resume
 
 /**
  * App-facing handle to the [AudioPlayerService] for [Audiobook] playback (ADR 0029). Connects via a
@@ -49,14 +42,14 @@ import kotlin.coroutines.resume
  */
 @Singleton
 open class AudiobookController @Inject constructor(
-    @ApplicationContext private val context: Context?,
+    private val connector: MediaSessionConnector?,
     applicationScope: ApplicationScope?,
     private val logger: Logger,
     private val clock: Clock,
 ) {
-    // Test seam: a subclass that overrides every member the player touches needs no real Context (it's
-    // only consulted in [ensureConnected], which fakes never reach). Keeps the controller unit-fakeable
-    // without Robolectric.
+    // Test seam: a subclass that overrides every member the player touches needs no real connector
+    // (it's only consulted in [ensureConnected], which fakes never reach). Keeps the controller
+    // unit-fakeable without Robolectric.
     protected constructor() : this(null, null, RecordingLogger(), SystemClock)
 
     data class PlaybackState(
@@ -88,8 +81,7 @@ open class AudiobookController @Inject constructor(
     open val playbackEnded: SharedFlow<Unit> = _playbackEnded.asSharedFlow()
     private var timerJob: Job? = null
 
-    private var controller: MediaController? = null
-    private var listenerAttached = false
+    private val controller: MediaController? get() = connector?.controller
     private var pollJob: Job? = null
     private var spans: List<AudiobookTrackSpan> = emptyList()
     private var durationSec: Double = 0.0
@@ -274,14 +266,7 @@ open class AudiobookController @Inject constructor(
         // Drop any cached end-of-book event so the next book opened on this singleton controller
         // doesn't inherit the previous book's Finished signal at first-subscribe.
         _playbackEnded.resetReplayCache()
-        controller?.run {
-            stop()
-            clearMediaItems()
-            removeListener(listener)
-            release()
-        }
-        controller = null
-        listenerAttached = false
+        connector?.release()
         spans = emptyList()
         prepared = false
         wantsToPlay = false
@@ -313,9 +298,8 @@ open class AudiobookController @Inject constructor(
         controller?.run {
             setVolume(1f)
             pause()
-            removeListener(listener)
         }
-        listenerAttached = false
+        connector?.releaseForHandoff()
         spans = emptyList()
         prepared = false
         wantsToPlay = false
@@ -326,20 +310,8 @@ open class AudiobookController @Inject constructor(
     }
 
     private suspend fun ensureConnected(): MediaController? {
-        val c = controller ?: run {
-            val context = this.context ?: return null
-            val token = SessionToken(context, ComponentName(context, AudioPlayerService::class.java))
-            val future = MediaController.Builder(context, token).buildAsync()
-            val newC = suspendCancellableCoroutine<MediaController?> { cont ->
-                future.addListener({ cont.resume(runCatching { future.get() }.getOrNull()) }, ContextCompat.getMainExecutor(context))
-            }
-            controller = newC
-            newC
-        }
-        if (!listenerAttached && c != null) {
-            c.addListener(listener)
-            listenerAttached = true
-        }
+        val c = connector?.ensureConnected() ?: return null
+        connector.attachListener(listener)
         pushState()
         return c
     }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/AudioPlayerService.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/AudioPlayerService.kt
@@ -2,19 +2,15 @@ package com.riffle.app.feature.reader.readaloud
 
 import android.app.PendingIntent
 import android.content.Intent
-import android.net.Uri
 import android.os.Bundle
-import com.riffle.app.MainActivity
 import androidx.annotation.OptIn
 import androidx.media3.common.AudioAttributes
 import androidx.media3.common.C
 import androidx.media3.common.MediaItem
+import androidx.media3.common.Player
 import androidx.media3.common.util.UnstableApi
-import androidx.media3.datasource.DataSource
-import androidx.media3.datasource.DefaultHttpDataSource
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
-import androidx.media3.common.Player
 import androidx.media3.session.CommandButton
 import androidx.media3.session.DefaultMediaNotificationProvider
 import androidx.media3.session.MediaSession
@@ -24,8 +20,13 @@ import androidx.media3.session.SessionResult
 import com.google.common.collect.ImmutableList
 import com.google.common.util.concurrent.Futures
 import com.google.common.util.concurrent.ListenableFuture
+import com.riffle.app.MainActivity
 import com.riffle.app.R
+import com.riffle.app.feature.audio.MediaItemRestorerRegistry
+import com.riffle.app.feature.audio.MediaSourceRegistry
 import com.riffle.app.feature.audiobook.AbsolutePositionPlayer
+import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 
 /**
  * Foreground [MediaSessionService] that plays Readaloud audio. Media3 supplies the media
@@ -33,14 +34,17 @@ import com.riffle.app.feature.audiobook.AbsolutePositionPlayer
  * via the [MediaSession]; [ExoPlayer] manages audio focus (incoming calls / nav voice pause us)
  * and the "becoming noisy" pause-on-unplug behaviour.
  *
- * Two audio sources flow through this one service. **Readaloud** streams out of the synced EPUB
- * bundle on disk via [ZipAudioDataSource] (`zipaudio://`, ADR 0023). An **[Audiobook]** streams its
- * tracks directly over HTTP(S) from ABS (`http(s)://`, with the auth token carried as a `?token=`
- * query param so a plain HTTP data source suffices — ADR 0029). The [resolvingDataSourceFactory]
- * dispatches by URI scheme so both work without a second player or service.
+ * Per-scheme data-source dispatch (HTTP audiobook tracks, on-disk bundle, streamed readaloud
+ * segments) is delegated to [MediaSourceRegistry]; the controller→service Binder hop's URI-strip
+ * is undone by [MediaItemRestorerRegistry]. Both are injected — a new audio source is one
+ * `MediaSourceFactory` + `MediaItemRestorer` entry, no edits here (issue #333).
  */
 @OptIn(UnstableApi::class)
+@AndroidEntryPoint
 class AudioPlayerService : MediaSessionService() {
+
+    @Inject lateinit var mediaSourceRegistry: MediaSourceRegistry
+    @Inject lateinit var mediaItemRestorerRegistry: MediaItemRestorerRegistry
 
     private var mediaSession: MediaSession? = null
 
@@ -65,13 +69,13 @@ class AudioPlayerService : MediaSessionService() {
             // DefaultMediaSourceFactory (not ProgressiveMediaSource.Factory) so the streaming path's
             // per-segment MediaItem.clippingConfiguration is honoured. Bundle items carry no clipping,
             // so their behaviour is unchanged.
-            .setMediaSourceFactory(DefaultMediaSourceFactory(resolvingDataSourceFactory()))
+            .setMediaSourceFactory(DefaultMediaSourceFactory(mediaSourceRegistry.asDataSourceFactory()))
             .build()
         // Wraps ExoPlayer so the OS media controls (notification, lock screen, Bluetooth) see
         // book-absolute position / total duration rather than per-track (per-chapter) values.
         val player = AbsolutePositionPlayer(exoPlayer)
         mediaSession = MediaSession.Builder(this, player)
-            .setCallback(MediaItemUriRestoringCallback)
+            .setCallback(MediaItemUriRestoringCallback(mediaItemRestorerRegistry))
             .setSessionActivity(openRiffleIntent())
             .build()
             .also { session ->
@@ -119,49 +123,20 @@ class AudioPlayerService : MediaSessionService() {
 
     /**
      * Media3 strips a [MediaItem]'s playback URI (`localConfiguration`) when a `MediaController`
-     * sends items across the session Binder — only `mediaId` + metadata survive. Without restoring
-     * the URI here the player receives unplayable items and stays silent. [ReadaloudController] sets
-     * each `mediaId` to the audio resource's zip-entry path, so we rebuild the `zipaudio://` URI
-     * from it (see [ZipAudioDataSource]).
+     * sends items across the session Binder — only `mediaId` + metadata survive. The
+     * [MediaItemRestorerRegistry] rebuilds the URI (and per-segment clipping where applicable) from
+     * the `mediaId` so the player receives playable items instead of staying silent.
      */
-    private object MediaItemUriRestoringCallback : MediaSession.Callback {
+    private class MediaItemUriRestoringCallback(
+        private val restorers: MediaItemRestorerRegistry,
+    ) : MediaSession.Callback {
 
         override fun onAddMediaItems(
             mediaSession: MediaSession,
             controller: MediaSession.ControllerInfo,
             mediaItems: MutableList<MediaItem>,
-        ): ListenableFuture<MutableList<MediaItem>> {
-            val streaming = SharedBundle.streaming
-            val restored = mediaItems.map { item ->
-                if (item.localConfiguration != null || item.mediaId.isEmpty()) {
-                    return@map item
-                }
-                val streamItem = streaming?.itemsByMediaId?.get(item.mediaId)
-                if (streamItem != null) {
-                    // Streaming: point at the ABS track, clipped to this segment's window.
-                    item.buildUpon()
-                        .setUri(streamItem.url)
-                        .setClippingConfiguration(
-                            MediaItem.ClippingConfiguration.Builder()
-                                .setStartPositionMs(streamItem.clipStartMs)
-                                .setEndPositionMs(streamItem.clipEndMs)
-                                .build(),
-                        )
-                        .build()
-                } else {
-                    // An Audiobook track's mediaId is its full URL — HTTP(S) when streaming, or a
-                    // file:// URL when downloaded for offline (ADR 0029); a Readaloud clip's is the
-                    // zip-entry path.
-                    val uri = if (item.mediaId.startsWith("http") || item.mediaId.startsWith("file")) {
-                        Uri.parse(item.mediaId)
-                    } else {
-                        ZipAudioDataSource.uriFor(item.mediaId)
-                    }
-                    item.buildUpon().setUri(uri).build()
-                }
-            }.toMutableList()
-            return Futures.immediateFuture(restored)
-        }
+        ): ListenableFuture<MutableList<MediaItem>> =
+            Futures.immediateFuture(restorers.restoreAll(mediaItems))
 
         // Advertise the two custom seek commands so controllers can dispatch them.
         // Button ordering is handled by setMediaButtonPreferences() in onCreate() —
@@ -180,7 +155,6 @@ class AudioPlayerService : MediaSessionService() {
                 .build()
         }
 
-        // ── new: dispatch custom button taps to the player ──────────────────────
         override fun onCustomCommand(
             session: MediaSession,
             controller: MediaSession.ControllerInfo,
@@ -205,51 +179,9 @@ class AudioPlayerService : MediaSessionService() {
         }
     }
 
-    /**
-     * Dispatches by URI scheme: `http`/`https` → a default HTTP data source (ABS audiobook tracks,
-     * ADR 0029); anything else → the [ZipAudioDataSource] for Readaloud bundle audio (ADR 0023).
-     * The concrete delegate is chosen lazily in [SchemeResolvingDataSource.open] from the DataSpec's
-     * scheme, so neither source is built until a URI is known.
-     */
-    private fun resolvingDataSourceFactory(): DataSource.Factory =
-        DataSource.Factory { SchemeResolvingDataSource(DefaultHttpDataSource.Factory(), SharedBundle.dataSourceFactory()) }
-
-    private class SchemeResolvingDataSource(
-        private val http: DataSource.Factory,
-        private val zip: DataSource.Factory,
-    ) : DataSource {
-        private val transferListeners = mutableListOf<androidx.media3.datasource.TransferListener>()
-        private var delegate: DataSource? = null
-
-        override fun addTransferListener(transferListener: androidx.media3.datasource.TransferListener) {
-            transferListeners.add(transferListener)
-        }
-
-        override fun open(dataSpec: androidx.media3.datasource.DataSpec): Long {
-            val source = when (dataSpec.uri.scheme) {
-                "http", "https" -> http.createDataSource() // streamed ABS audiobook tracks
-                "file" -> androidx.media3.datasource.FileDataSource() // downloaded audiobook tracks
-                else -> zip.createDataSource() // Readaloud bundle audio
-            }
-            transferListeners.forEach { source.addTransferListener(it) }
-            delegate = source
-            return source.open(dataSpec)
-        }
-
-        override fun read(buffer: ByteArray, offset: Int, length: Int): Int =
-            delegate?.read(buffer, offset, length) ?: throw IllegalStateException("read before open")
-
-        override fun getUri(): Uri? = delegate?.uri
-
-        override fun close() {
-            delegate?.close()
-            delegate = null
-        }
-    }
-
     override fun onGetSession(controllerInfo: MediaSession.ControllerInfo): MediaSession? = mediaSession
 
-    override fun onTaskRemoved(rootIntent: android.content.Intent?) {
+    override fun onTaskRemoved(rootIntent: Intent?) {
         // If the user swipes the app away while paused, stop the service; if playing, keep going.
         val player = mediaSession?.player
         if (player == null || !player.playWhenReady || player.mediaItemCount == 0) {

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/ReadaloudController.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/ReadaloudController.kt
@@ -1,13 +1,10 @@
 package com.riffle.app.feature.reader.readaloud
 
-import android.content.ComponentName
-import android.content.Context
-import androidx.core.content.ContextCompat
 import androidx.media3.common.MediaItem
 import androidx.media3.common.PlaybackException
 import androidx.media3.common.Player
 import androidx.media3.session.MediaController
-import androidx.media3.session.SessionToken
+import com.riffle.app.feature.audio.MediaSessionConnector
 import com.riffle.core.domain.ApplicationScope
 import com.riffle.core.domain.Clock
 import com.riffle.core.domain.ReadaloudTrack
@@ -15,7 +12,6 @@ import com.riffle.core.domain.SystemClock
 import com.riffle.core.logging.LogChannel
 import com.riffle.core.logging.Logger
 import com.riffle.core.logging.RecordingLogger
-import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -25,11 +21,9 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.suspendCancellableCoroutine
 import java.io.File
 import javax.inject.Inject
 import javax.inject.Singleton
-import kotlin.coroutines.resume
 
 /**
  * App-facing handle to the Readaloud [AudioPlayerService]. Connects via a Media3 [MediaController],
@@ -41,13 +35,14 @@ import kotlin.coroutines.resume
  */
 @Singleton
 open class ReadaloudController @Inject constructor(
-    @ApplicationContext private val context: Context?,
+    private val connector: MediaSessionConnector?,
     applicationScope: ApplicationScope?,
     private val logger: Logger,
     private val clock: Clock,
 ) {
-    // Test seam: subclasses that override the pre-warm methods need no real Context (only consulted in
-    // [ensureConnected], which fakes never reach). Keeps the controller unit-fakeable without Robolectric.
+    // Test seam: subclasses that override the pre-warm methods need no real connector (only consulted
+    // in [ensureConnected], which fakes never reach). Keeps the controller unit-fakeable without
+    // Robolectric.
     protected constructor() : this(null, null, RecordingLogger(), SystemClock)
     data class PlaybackState(
         val connected: Boolean = false,
@@ -76,8 +71,7 @@ open class ReadaloudController @Inject constructor(
     private val _state = MutableStateFlow(PlaybackState())
     val state: StateFlow<PlaybackState> = _state.asStateFlow()
 
-    private var controller: MediaController? = null
-    private var listenerAttached = false
+    private val controller: MediaController? get() = connector?.controller
     private var pollJob: Job? = null
     private var track: ReadaloudTrack? = null
     /** Maps a distinct audio file to its index in the queued playlist. */
@@ -192,11 +186,8 @@ open class ReadaloudController @Inject constructor(
         logger.d(LogChannel.Handoff) { "RA.releaseForHandoff (T0 — audio pausing)" }
         pollJob?.cancel()
         pollJob = null
-        controller?.run {
-            pause()
-            removeListener(listener)
-        }
-        listenerAttached = false
+        controller?.pause()
+        connector?.releaseForHandoff()
         preWarmedPosition = null
         _state.value = PlaybackState()
     }
@@ -253,14 +244,7 @@ open class ReadaloudController @Inject constructor(
     fun stop() {
         pollJob?.cancel()
         pollJob = null
-        controller?.run {
-            stop()
-            clearMediaItems()
-            removeListener(listener)
-            release()
-        }
-        controller = null
-        listenerAttached = false
+        connector?.release()
         track = null
         preWarmedPosition = null
         SharedBundle.current = null
@@ -274,22 +258,8 @@ open class ReadaloudController @Inject constructor(
     }
 
     private suspend fun ensureConnected(): MediaController? {
-        val c = controller ?: run {
-            val ctx = context ?: return null
-            val token = SessionToken(ctx, ComponentName(ctx, AudioPlayerService::class.java))
-            val future = MediaController.Builder(ctx, token).buildAsync()
-            val newC = suspendCancellableCoroutine<MediaController?> { cont ->
-                future.addListener({
-                    cont.resume(runCatching { future.get() }.getOrNull())
-                }, ContextCompat.getMainExecutor(ctx))
-            }
-            controller = newC
-            newC
-        }
-        if (!listenerAttached && c != null) {
-            c.addListener(listener)
-            listenerAttached = true
-        }
+        val c = connector?.ensureConnected() ?: return null
+        connector.attachListener(listener)
         pushState()
         return c
     }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/ReadaloudStreamingSessionFactory.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/ReadaloudStreamingSessionFactory.kt
@@ -97,8 +97,7 @@ class ReadaloudStreamingSessionFactory @Inject constructor(
             return@withContext null
         }
 
-        val httpFactory = StreamingAudioCache.dataSourceFactory(context, absToken)
-        Session(setup.track, SharedBundle.Streaming(httpFactory, setup.items.associateBy { it.audioSrc }), sidecarFile, absToken)
+        Session(setup.track, SharedBundle.Streaming(setup.items.associateBy { it.audioSrc }), sidecarFile, absToken)
     }
 
     /**

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/SharedBundle.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/SharedBundle.kt
@@ -1,26 +1,22 @@
 package com.riffle.app.feature.reader.readaloud
 
-import androidx.annotation.OptIn
-import androidx.media3.common.util.UnstableApi
 import androidx.media3.datasource.DataSource
-import androidx.media3.datasource.DataSpec
-import androidx.media3.datasource.TransferListener
 import com.riffle.core.data.StreamingMediaItem
 import com.riffle.core.logging.Logger
 import java.io.File
-import java.io.IOException
 
 /**
  * Process-scoped pointer to the Readaloud audio source the [AudioPlayerService] should play from.
- * The service is constructed by the platform (no DI handle to the chosen book), so the
- * [ReadaloudController] sets the current source here before connecting and queuing media.
+ * The service is constructed by the platform; before issue #333's refactor it could not be injected,
+ * and even now the *active book pointer* still flows out-of-band between the controllers (which
+ * choose the book) and the service-side media sources (which read from disk). One holder, two modes.
  *
  * Two modes coexist (ADR 0028): the **bundle** path streams audio entries out of the synced EPUB on
- * disk ([current]); the **streaming** path plays ABS tracks over HTTP with a write-through cache
- * ([streaming]). A single [dataSourceFactory] serves both — it routes per request by URI scheme, so
- * the player never needs to be rebuilt when switching. There is only ever one Readaloud at a time.
+ * disk ([current], read by [com.riffle.app.feature.audio.BundleAudioSourceFactory]); the **streaming**
+ * path plays ABS tracks over HTTP with a write-through cache ([streaming], consumed by
+ * [com.riffle.app.feature.audio.StreamingReadaloudItemRestorer]). There is only ever one Readaloud
+ * at a time.
  */
-@OptIn(UnstableApi::class)
 object SharedBundle {
     @Volatile
     var current: File? = null
@@ -36,54 +32,4 @@ object SharedBundle {
         val httpFactory: DataSource.Factory,
         val itemsByMediaId: Map<String, StreamingMediaItem>,
     )
-
-    fun dataSourceFactory(): DataSource.Factory = DataSource.Factory {
-        ReadaloudDataSource(
-            makeZip = { ZipAudioDataSource(current ?: error("No Readaloud bundle set"), logger ?: error("SharedBundle.logger not set")) },
-            makeHttp = { streaming?.httpFactory?.createDataSource() },
-        )
-    }
-}
-
-/**
- * Delegates each open to the bundle ([makeZip]) or streaming ([makeHttp]) source by URI scheme —
- * `zipaudio://` for the on-disk bundle, `http(s)://` for ABS. Transfer listeners registered before
- * open are forwarded to whichever delegate handles the request.
- */
-@OptIn(UnstableApi::class)
-private class ReadaloudDataSource(
-    private val makeZip: () -> DataSource,
-    private val makeHttp: () -> DataSource?,
-) : DataSource {
-    private val listeners = ArrayList<TransferListener>()
-    private var delegate: DataSource? = null
-
-    override fun addTransferListener(transferListener: TransferListener) {
-        listeners += transferListener
-    }
-
-    override fun open(dataSpec: DataSpec): Long {
-        val d = if (dataSpec.uri.scheme == ZIP_SCHEME) {
-            makeZip()
-        } else {
-            makeHttp() ?: throw IOException("No streaming source set for ${dataSpec.uri}")
-        }
-        listeners.forEach { d.addTransferListener(it) }
-        delegate = d
-        return d.open(dataSpec)
-    }
-
-    override fun read(buffer: ByteArray, offset: Int, length: Int): Int =
-        (delegate ?: throw IOException("read before open")).read(buffer, offset, length)
-
-    override fun getUri() = delegate?.uri
-
-    override fun close() {
-        delegate?.close()
-        delegate = null
-    }
-
-    private companion object {
-        const val ZIP_SCHEME = "zipaudio"
-    }
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/SharedBundle.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/SharedBundle.kt
@@ -1,6 +1,5 @@
 package com.riffle.app.feature.reader.readaloud
 
-import androidx.media3.datasource.DataSource
 import com.riffle.core.data.StreamingMediaItem
 import com.riffle.core.logging.Logger
 import java.io.File
@@ -27,9 +26,8 @@ object SharedBundle {
     @Volatile
     var logger: Logger? = null
 
-    /** Streaming state for the active book: how to fetch ABS audio, and the per-segment plan. */
+    /** Per-segment plan for the active book's streamed audio. */
     class Streaming(
-        val httpFactory: DataSource.Factory,
         val itemsByMediaId: Map<String, StreamingMediaItem>,
     )
 }

--- a/app/src/test/kotlin/com/riffle/app/feature/audio/MediaSourceFactoryHandlesTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/audio/MediaSourceFactoryHandlesTest.kt
@@ -1,0 +1,44 @@
+package com.riffle.app.feature.audio
+
+import com.riffle.core.logging.RecordingLogger
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Each `MediaSourceFactory` is keyed by URI scheme — adding a new audio backend is just a new
+ * factory + scheme. Locks the dispatch contract for the three production factories so a typo
+ * (`"http://"` vs `"http"`) doesn't silently route an item to the wrong source. See issue #333.
+ */
+class MediaSourceFactoryHandlesTest {
+
+    @Test
+    fun `http factory handles http and https`() {
+        val f = HttpAudioSourceFactory()
+        assertTrue(f.handles("http"))
+        assertTrue(f.handles("https"))
+        assertFalse(f.handles("file"))
+        assertFalse(f.handles("zipaudio"))
+        assertFalse(f.handles(null))
+    }
+
+    @Test
+    fun `file factory handles file only`() {
+        val f = FileAudioSourceFactory()
+        assertTrue(f.handles("file"))
+        assertFalse(f.handles("http"))
+        assertFalse(f.handles("https"))
+        assertFalse(f.handles("zipaudio"))
+        assertFalse(f.handles(null))
+    }
+
+    @Test
+    fun `bundle factory handles zipaudio only`() {
+        val f = BundleAudioSourceFactory(RecordingLogger())
+        assertTrue(f.handles("zipaudio"))
+        assertFalse(f.handles("http"))
+        assertFalse(f.handles("https"))
+        assertFalse(f.handles("file"))
+        assertFalse(f.handles(null))
+    }
+}


### PR DESCRIPTION
Closes #333

Splits `AudioPlayerService` into a thin Media3 host plus three seams in a new `app/feature/audio/` package:

## Summary

- **`MediaSourceFactory` + `MediaSourceRegistry`** — per-scheme `DataSource` dispatch. The dual `SchemeResolvingDataSource` (in the service) and `ReadaloudDataSource` (in `SharedBundle`) duplicates collapse into one registry composing `HttpAudioSourceFactory`, `FileAudioSourceFactory`, and `BundleAudioSourceFactory`. Adding a new audio source is one factory entry — no edits in `AudioPlayerService`.

- **`MediaItemRestorer` + `MediaItemRestorerRegistry`** — chain-of-responsibility for the `mediaId → URI` restoration Media3 forces across the controller binder hop. Three restorers (`StreamingReadaloudItemRestorer`, `AudiobookHttpItemRestorer`, `BundleZipItemRestorer`) replace the inlined switch in `MediaItemUriRestoringCallback`.

- **`MediaSessionConnector`** — shared `MediaController` connect / `buildAsync` / listener-attach / release-for-handoff lifecycle. Both controllers now consume an injected connector instance instead of hand-rolling ~50 lines each. ADR 0032's pre-warm handoff has one connector to debug instead of two divergent implementations.

`AudioPlayerService` gains `@AndroidEntryPoint` and field-injects the two registries; the file shrinks to its Media3-host responsibilities (notification, transport buttons, custom seek commands, foreground lifecycle). `SharedBundle` shrinks to the active-session state holder it actually is — the dead `httpFactory` field is dropped along the way.

## Test plan

- [x] `./gradlew test` — all JVM suites pass (new `MediaSourceFactoryHandlesTest` locks each factory's scheme contract; existing controller tests via the `protected constructor()` seam still pass)
- [x] `./gradlew :app:compileDebugAndroidTestKotlin` — instrumentation sources compile; `ReadaloudDataSourceRoutingTest` rewritten against `MediaSourceRegistry`, `StreamingPlaybackAndroidTest` updated to construct the registry inline
- [ ] On-device readaloud playback (bundle + streaming) — not yet device-verified
- [ ] On-device audiobook playback (HTTP + downloaded file) — not yet device-verified
- [ ] Audiobook↔readaloud swipe handoff (ADR 0032) — not yet device-verified

Behaviour is preserved: production routes were `http`/`https`/`file` → bare `DefaultHttpDataSource`/`FileDataSource` and `zipaudio` → `ZipAudioDataSource`. The registry composes the same chain in the same order.