### PR TITLE
refactor(network): migrate core/network to DispatcherProvider (#353)

### DIFF
--- a/app/src/androidTest/kotlin/com/riffle/app/feature/reader/readaloud/ReadaloudStreamingSessionFactoryAndroidTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/reader/readaloud/ReadaloudStreamingSessionFactoryAndroidTest.kt
@@ -1,5 +1,7 @@
 package com.riffle.app.feature.reader.readaloud
 
+import com.riffle.core.domain.DefaultDispatcherProvider
+
 import androidx.room.Room
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -156,7 +158,7 @@ class ReadaloudStreamingSessionFactoryAndroidTest {
 
     private fun factory(): ReadaloudStreamingSessionFactory {
         val repo = StubServerRepository(mapOf(ABS_SERVER to baseUrl, ST_SERVER to baseUrl))
-        val fetcher = StorytellerSidecarFetcher(StorytellerBundleApiImpl(OkHttpClient()))
+        val fetcher = StorytellerSidecarFetcher(StorytellerBundleApiImpl(OkHttpClient(), DefaultDispatcherProvider))
         val sidecarScope = kotlinx.coroutines.CoroutineScope(
             kotlinx.coroutines.SupervisorJob() + kotlinx.coroutines.Dispatchers.IO,
         )
@@ -173,8 +175,8 @@ class ReadaloudStreamingSessionFactoryAndroidTest {
         return ReadaloudStreamingSessionFactory(
             context = ctx,
             audioIdentityResolver = AudioIdentityResolverImpl(db.readaloudLinkDao(), db.libraryItemDao()),
-            absApi = AbsApiClient(OkHttpClient()),
-            storytellerApi = StorytellerApiClient(OkHttpClient()),
+            absApi = AbsApiClient(OkHttpClient(), DefaultDispatcherProvider),
+            storytellerApi = StorytellerApiClient(OkHttpClient(), DefaultDispatcherProvider),
             sidecarStore = sidecarStore,
             serverRepository = repo,
             tokenStorage = StubTokenStorage,

--- a/app/src/androidTest/kotlin/com/riffle/app/harness/StubAbsServerTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/harness/StubAbsServerTest.kt
@@ -1,5 +1,7 @@
 package com.riffle.app.harness
 
+import com.riffle.core.domain.DefaultDispatcherProvider
+
 import com.riffle.core.network.NetworkResult
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -23,7 +25,7 @@ class StubAbsServerTest {
     fun setUp() {
         stub = StubAbsServer()
         stub.start()
-        client = AbsApiClient(OkHttpClient())
+        client = AbsApiClient(OkHttpClient(), DefaultDispatcherProvider)
     }
 
     @After

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -80,13 +80,6 @@ tasks.register("checkRiffleInfraSeams") {
             "app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModel.kt",
             "app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsViewModel.kt",
             "app/src/main/kotlin/com/riffle/app/feature/server/AddServerViewModel.kt",
-            // ---- Grandfathered — DispatcherProvider sweep follow-up (core/network).
-            "core/network/src/main/kotlin/com/riffle/core/network/AbsApiClient.kt",
-            "core/network/src/main/kotlin/com/riffle/core/network/AudiobookBundleApi.kt",
-            "core/network/src/main/kotlin/com/riffle/core/network/GitHubReleaseApi.kt",
-            "core/network/src/main/kotlin/com/riffle/core/network/StorytellerApiClient.kt",
-            "core/network/src/main/kotlin/com/riffle/core/network/StorytellerBundleApi.kt",
-            "core/network/src/main/kotlin/com/riffle/core/network/StorytellerPositionApi.kt",
             // ---- Grandfathered — DispatcherProvider sweep follow-up (core/data).
             "core/data/src/main/kotlin/com/riffle/core/data/AppUpdateRepositoryImpl.kt",
             "core/data/src/main/kotlin/com/riffle/core/data/AudiobookBundleDownloader.kt",

--- a/core/data/src/main/kotlin/com/riffle/core/data/di/DataModule.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/di/DataModule.kt
@@ -51,6 +51,7 @@ import com.riffle.core.data.ListeningPreferencesStoreImpl
 import com.riffle.core.domain.AnnotationStore
 import com.riffle.core.domain.AnnotationSyncConfigStore
 import com.riffle.core.domain.AudioIdentityResolver
+import com.riffle.core.domain.DispatcherProvider
 import com.riffle.core.domain.AudioPlaybackPreferencesStore
 import com.riffle.core.domain.BookFormattingPreferencesStore
 import com.riffle.core.domain.ConnectivityObserver
@@ -448,18 +449,18 @@ abstract class DataModule {
 
         @Provides
         @Singleton
-        fun provideGitHubReleaseApi(okHttpClient: OkHttpClient): com.riffle.core.network.GitHubReleaseApi =
-            com.riffle.core.network.GitHubReleaseApi(okHttpClient)
+        fun provideGitHubReleaseApi(okHttpClient: OkHttpClient, dispatchers: DispatcherProvider): com.riffle.core.network.GitHubReleaseApi =
+            com.riffle.core.network.GitHubReleaseApi(okHttpClient, dispatchers)
 
         @Provides
         @Singleton
-        fun provideAbsApiClient(okHttpClient: OkHttpClient): AbsApiClient =
-            AbsApiClient(okHttpClient)
+        fun provideAbsApiClient(okHttpClient: OkHttpClient, dispatchers: DispatcherProvider): AbsApiClient =
+            AbsApiClient(okHttpClient, dispatchers)
 
         @Provides
         @Singleton
-        fun provideStorytellerApiClient(okHttpClient: OkHttpClient): StorytellerApiClient =
-            StorytellerApiClient(okHttpClient)
+        fun provideStorytellerApiClient(okHttpClient: OkHttpClient, dispatchers: DispatcherProvider): StorytellerApiClient =
+            StorytellerApiClient(okHttpClient, dispatchers)
 
         @Provides
         @Singleton
@@ -516,8 +517,8 @@ abstract class DataModule {
 
         @Provides
         @Singleton
-        fun provideStorytellerBundleApiImpl(okHttpClient: OkHttpClient): StorytellerBundleApiImpl =
-            StorytellerBundleApiImpl(okHttpClient)
+        fun provideStorytellerBundleApiImpl(okHttpClient: OkHttpClient, dispatchers: DispatcherProvider): StorytellerBundleApiImpl =
+            StorytellerBundleApiImpl(okHttpClient, dispatchers)
 
         @Provides
         @Singleton
@@ -546,8 +547,8 @@ abstract class DataModule {
 
         @Provides
         @Singleton
-        fun provideAudiobookBundleApi(okHttpClient: OkHttpClient): AudiobookBundleApiImpl =
-            AudiobookBundleApiImpl(okHttpClient)
+        fun provideAudiobookBundleApi(okHttpClient: OkHttpClient, dispatchers: DispatcherProvider): AudiobookBundleApiImpl =
+            AudiobookBundleApiImpl(okHttpClient, dispatchers)
 
         @Provides
         @Singleton
@@ -566,8 +567,8 @@ abstract class DataModule {
 
         @Provides
         @Singleton
-        fun provideStorytellerPositionApi(okHttpClient: OkHttpClient): StorytellerPositionApi =
-            StorytellerPositionApiImpl(okHttpClient)
+        fun provideStorytellerPositionApi(okHttpClient: OkHttpClient, dispatchers: DispatcherProvider): StorytellerPositionApi =
+            StorytellerPositionApiImpl(okHttpClient, dispatchers)
 
         @Provides
         @Singleton

--- a/core/data/src/test/kotlin/com/riffle/core/data/EpubPositionIntegrationTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/EpubPositionIntegrationTest.kt
@@ -1,5 +1,7 @@
 package com.riffle.core.data
 
+import com.riffle.core.domain.DefaultDispatcherProvider
+
 import com.riffle.core.database.ReadingPositionDao
 import com.riffle.core.database.ReadingPositionEntity
 import com.riffle.core.domain.EbookFormat
@@ -60,7 +62,7 @@ class EpubPositionIntegrationTest {
     }
 
     private fun buildRepo(): EpubRepositoryImpl = EpubRepositoryImpl(
-        api = AbsApiClient(OkHttpClient()),
+        api = AbsApiClient(OkHttpClient(), DefaultDispatcherProvider),
         cacheStore = cacheStore,
         downloadsStore = LocalStoreImpl(tmp.newFolder("downloads-${System.nanoTime()}"), ".epub"),
         positionStore = ReadingPositionStoreImpl(sharedPositionDao),

--- a/core/data/src/test/kotlin/com/riffle/core/data/EpubRepositoryTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/EpubRepositoryTest.kt
@@ -1,5 +1,7 @@
 package com.riffle.core.data
 
+import com.riffle.core.domain.DefaultDispatcherProvider
+
 import com.riffle.core.network.NetworkResult
 
 import com.riffle.core.domain.EbookFormat
@@ -55,7 +57,7 @@ class EpubRepositoryTest {
         downloadsStore = LocalStoreImpl(tmp.newFolder("downloads"), ".epub")
         positionStore = FakePositionStore()
         repo = EpubRepositoryImpl(
-            api = AbsApiClient(OkHttpClient()),
+            api = AbsApiClient(OkHttpClient(), DefaultDispatcherProvider),
             cacheStore = cacheStore,
             downloadsStore = downloadsStore,
             positionStore = positionStore,

--- a/core/data/src/test/kotlin/com/riffle/core/data/PdfRepositoryTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/PdfRepositoryTest.kt
@@ -1,5 +1,7 @@
 package com.riffle.core.data
 
+import com.riffle.core.domain.DefaultDispatcherProvider
+
 import com.riffle.core.domain.EbookFormat
 import com.riffle.core.domain.LibraryItem
 import com.riffle.core.domain.PdfDownloadResult
@@ -48,7 +50,7 @@ class PdfRepositoryTest {
         downloadsStore = LocalStoreImpl(tmp.newFolder("pdf-downloads"), ".pdf")
         positionStore = FakePdfPositionStore()
         repo = PdfRepositoryImpl(
-            api = AbsApiClient(OkHttpClient()),
+            api = AbsApiClient(OkHttpClient(), DefaultDispatcherProvider),
             cacheStore = cacheStore,
             downloadsStore = downloadsStore,
             positionStore = positionStore,

--- a/core/data/src/test/kotlin/com/riffle/core/data/ProgressSyncIntegrationTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/ProgressSyncIntegrationTest.kt
@@ -1,5 +1,7 @@
 package com.riffle.core.data
 
+import com.riffle.core.domain.DefaultDispatcherProvider
+
 import com.riffle.core.domain.AuthenticateResult
 import com.riffle.core.domain.CommitServerResult
 import com.riffle.core.domain.PendingServer
@@ -47,7 +49,7 @@ class ProgressSyncIntegrationTest {
     }
 
     private fun buildRepo() = ReadingSessionRepositoryImpl(
-        api = AbsApiClient(OkHttpClient()),
+        api = AbsApiClient(OkHttpClient(), DefaultDispatcherProvider),
         serverRepository = object : ServerRepository {
             val activeServer = Server(
                 id = "server-1",

--- a/core/data/src/test/kotlin/com/riffle/core/data/ReadingSessionIntegrationTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/ReadingSessionIntegrationTest.kt
@@ -1,5 +1,7 @@
 package com.riffle.core.data
 
+import com.riffle.core.domain.DefaultDispatcherProvider
+
 import com.riffle.core.domain.ReadingPositionStore
 import com.riffle.core.domain.Server
 import com.riffle.core.domain.ServerRepository
@@ -36,7 +38,7 @@ class ReadingSessionIntegrationTest {
     fun tearDown() = server.shutdown()
 
     private fun buildRepo() = ReadingSessionRepositoryImpl(
-        api = AbsApiClient(OkHttpClient()),
+        api = AbsApiClient(OkHttpClient(), DefaultDispatcherProvider),
         serverRepository = object : ServerRepository {
             val activeServer = Server(
                 id = "server-1",

--- a/core/data/src/test/kotlin/com/riffle/core/data/SeriesIntegrationTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/SeriesIntegrationTest.kt
@@ -1,5 +1,7 @@
 package com.riffle.core.data
 
+import com.riffle.core.domain.DefaultDispatcherProvider
+
 import com.riffle.core.database.CollectionDao
 import com.riffle.core.database.CollectionEntity
 import com.riffle.core.database.CollectionItemEntity
@@ -141,7 +143,7 @@ class SeriesIntegrationTest {
     private fun makeRepo(seriesDao: FakeSeriesDao = FakeSeriesDao()): LibraryRepositoryImpl {
         val itemDao = FakeLibraryItemDao()
         return LibraryRepositoryImpl(
-            api = AbsApiClient(OkHttpClient()),
+            api = AbsApiClient(OkHttpClient(), DefaultDispatcherProvider),
             libraryDao = FakeLibraryDao(),
             libraryItemDao = itemDao,
             seriesDao = seriesDao,

--- a/core/network/src/main/kotlin/com/riffle/core/network/AbsApiClient.kt
+++ b/core/network/src/main/kotlin/com/riffle/core/network/AbsApiClient.kt
@@ -1,6 +1,7 @@
 package com.riffle.core.network
 
 import com.riffle.core.domain.AudiobookFingerprint
+import com.riffle.core.domain.DispatcherProvider
 import com.riffle.core.domain.EbookFormat
 import com.riffle.core.network.model.AbsCollectionBookRequest
 import com.riffle.core.network.model.AbsCollectionsResponse
@@ -41,7 +42,10 @@ import java.security.cert.X509Certificate
 import javax.net.ssl.SSLContext
 import javax.net.ssl.X509TrustManager
 
-class AbsApiClient(private val httpClient: OkHttpClient) : AbsApi, AbsLibraryApi, AbsSessionApi, AbsServerInfoApi, AbsPlaybackApi, AbsBookmarkApi {
+class AbsApiClient(
+    private val httpClient: OkHttpClient,
+    private val dispatchers: DispatcherProvider,
+) : AbsApi, AbsLibraryApi, AbsSessionApi, AbsServerInfoApi, AbsPlaybackApi, AbsBookmarkApi {
 
     private val json = Json { ignoreUnknownKeys = true; coerceInputValues = true }
     private val jsonMediaType = "application/json; charset=utf-8".toMediaType()
@@ -51,7 +55,7 @@ class AbsApiClient(private val httpClient: OkHttpClient) : AbsApi, AbsLibraryApi
         username: String,
         password: String,
         insecureAllowed: Boolean,
-    ): NetworkResult<NetworkLoginUser> = OkHttpClassifier.classify {
+    ): NetworkResult<NetworkLoginUser> = OkHttpClassifier.classify(dispatchers.io) {
         val client = client(insecureAllowed)
         val body = json.encodeToString(AbsLoginRequest(username, password)).toRequestBody(jsonMediaType)
         val request = Request.Builder().url("$baseUrl/login").post(body).build()
@@ -74,7 +78,7 @@ class AbsApiClient(private val httpClient: OkHttpClient) : AbsApi, AbsLibraryApi
         baseUrl: String,
         token: String,
         insecureAllowed: Boolean,
-    ): NetworkResult<List<NetworkLibrary>> = OkHttpClassifier.classify {
+    ): NetworkResult<List<NetworkLibrary>> = OkHttpClassifier.classify(dispatchers.io) {
         val response = get(baseUrl, "/api/libraries", token, insecureAllowed)
         val raw = response.requireSuccessful().requireBody()
         json.decodeFromString<AbsLibrariesResponse>(raw).libraries.map { dto ->
@@ -91,7 +95,7 @@ class AbsApiClient(private val httpClient: OkHttpClient) : AbsApi, AbsLibraryApi
         baseUrl: String,
         token: String,
         insecureAllowed: Boolean,
-    ): NetworkResult<Map<String, NetworkUserMediaProgress>> = OkHttpClassifier.classify {
+    ): NetworkResult<Map<String, NetworkUserMediaProgress>> = OkHttpClassifier.classify(dispatchers.io) {
         val response = get(baseUrl, "/api/me", token, insecureAllowed)
         val raw = response.requireSuccessful().requireBody()
         val parsed = json.decodeFromString<AbsMeResponse>(raw)
@@ -116,7 +120,7 @@ class AbsApiClient(private val httpClient: OkHttpClient) : AbsApi, AbsLibraryApi
         libraryId: String,
         token: String,
         insecureAllowed: Boolean,
-    ): NetworkResult<List<NetworkLibraryItem>> = OkHttpClassifier.classify {
+    ): NetworkResult<List<NetworkLibraryItem>> = OkHttpClassifier.classify(dispatchers.io) {
         val response = get(baseUrl, "/api/libraries/$libraryId/items", token, insecureAllowed)
         val raw = response.requireSuccessful().requireBody()
         val parsed = json.decodeFromString<AbsLibraryItemsResponse>(raw)
@@ -153,7 +157,7 @@ class AbsApiClient(private val httpClient: OkHttpClient) : AbsApi, AbsLibraryApi
         libraryId: String,
         token: String,
         insecureAllowed: Boolean,
-    ): NetworkResult<List<NetworkSeries>> = OkHttpClassifier.classify {
+    ): NetworkResult<List<NetworkSeries>> = OkHttpClassifier.classify(dispatchers.io) {
         val response = get(baseUrl, "/api/libraries/$libraryId/series?limit=500", token, insecureAllowed)
         val raw = response.requireSuccessful().requireBody()
         val parsed = json.decodeFromString<AbsSeriesResponse>(raw)
@@ -191,7 +195,7 @@ class AbsApiClient(private val httpClient: OkHttpClient) : AbsApi, AbsLibraryApi
         libraryId: String,
         token: String,
         insecureAllowed: Boolean,
-    ): NetworkResult<List<NetworkCollection>> = OkHttpClassifier.classify {
+    ): NetworkResult<List<NetworkCollection>> = OkHttpClassifier.classify(dispatchers.io) {
         val response = get(baseUrl, "/api/libraries/$libraryId/collections?limit=500", token, insecureAllowed)
         val raw = response.requireSuccessful().requireBody()
         json.decodeFromString<AbsCollectionsResponse>(raw).results.map { it.toNetworkCollection() }
@@ -242,7 +246,7 @@ class AbsApiClient(private val httpClient: OkHttpClient) : AbsApi, AbsLibraryApi
         token: String,
         insecureAllowed: Boolean,
         buildRequest: Request.Builder.() -> Unit,
-    ): NetworkResult<NetworkCollection?> = OkHttpClassifier.classify {
+    ): NetworkResult<NetworkCollection?> = OkHttpClassifier.classify(dispatchers.io) {
         val request = Request.Builder()
             .url(url)
             .addHeader("Authorization", "Bearer $token")
@@ -259,7 +263,7 @@ class AbsApiClient(private val httpClient: OkHttpClient) : AbsApi, AbsLibraryApi
         libraryId: String,
         token: String,
         insecureAllowed: Boolean,
-    ): NetworkResult<List<NetworkPlaylist>> = OkHttpClassifier.classify {
+    ): NetworkResult<List<NetworkPlaylist>> = OkHttpClassifier.classify(dispatchers.io) {
         val response = get(baseUrl, "/api/libraries/$libraryId/playlists?limit=500", token, insecureAllowed)
         val raw = response.requireSuccessful().requireBody()
         json.decodeFromString<AbsPlaylistsResponse>(raw).results.map { it.toNetworkPlaylist() }
@@ -312,7 +316,7 @@ class AbsApiClient(private val httpClient: OkHttpClient) : AbsApi, AbsLibraryApi
         token: String,
         insecureAllowed: Boolean,
         buildRequest: Request.Builder.() -> Unit,
-    ): NetworkResult<NetworkPlaylist?> = OkHttpClassifier.classify {
+    ): NetworkResult<NetworkPlaylist?> = OkHttpClassifier.classify(dispatchers.io) {
         val request = Request.Builder()
             .url(url)
             .addHeader("Authorization", "Bearer $token")
@@ -329,7 +333,7 @@ class AbsApiClient(private val httpClient: OkHttpClient) : AbsApi, AbsLibraryApi
         itemId: String,
         token: String,
         insecureAllowed: Boolean,
-    ): NetworkResult<String> = OkHttpClassifier.classify {
+    ): NetworkResult<String> = OkHttpClassifier.classify(dispatchers.io) {
         val response = get(baseUrl, "/api/items/$itemId", token, insecureAllowed).requireSuccessful()
         val raw = response.requireBody()
         json.decodeFromString<AbsItemResponse>(raw).media.ebookFile?.ino?.takeIf { it.isNotEmpty() }
@@ -341,7 +345,7 @@ class AbsApiClient(private val httpClient: OkHttpClient) : AbsApi, AbsLibraryApi
         itemId: String,
         token: String,
         insecureAllowed: Boolean,
-    ): NetworkResult<AudiobookFingerprint?> = OkHttpClassifier.classify {
+    ): NetworkResult<AudiobookFingerprint?> = OkHttpClassifier.classify(dispatchers.io) {
         get(baseUrl, "/api/items/$itemId?expanded=1", token, insecureAllowed).use { response ->
             response.requireSuccessful()
             val raw = response.requireBody()
@@ -355,7 +359,7 @@ class AbsApiClient(private val httpClient: OkHttpClient) : AbsApi, AbsLibraryApi
         itemId: String,
         token: String,
         insecureAllowed: Boolean,
-    ): NetworkResult<List<NetworkAbsAudioTrack>> = OkHttpClassifier.classify {
+    ): NetworkResult<List<NetworkAbsAudioTrack>> = OkHttpClassifier.classify(dispatchers.io) {
         get(baseUrl, "/api/items/$itemId?expanded=1", token, insecureAllowed).use { response ->
             response.requireSuccessful()
             val raw = response.requireBody()
@@ -370,7 +374,7 @@ class AbsApiClient(private val httpClient: OkHttpClient) : AbsApi, AbsLibraryApi
         fileIno: String,
         token: String,
         insecureAllowed: Boolean,
-    ): NetworkResult<ResponseBody> = OkHttpClassifier.classify {
+    ): NetworkResult<ResponseBody> = OkHttpClassifier.classify(dispatchers.io) {
         val response = get(baseUrl, "/api/items/$itemId/ebook/$fileIno", token, insecureAllowed)
         val body = response.body ?: throw IOException("Empty response body")
         if (!response.isSuccessful) {
@@ -385,7 +389,7 @@ class AbsApiClient(private val httpClient: OkHttpClient) : AbsApi, AbsLibraryApi
         itemId: String,
         token: String,
         insecureAllowed: Boolean,
-    ): NetworkResult<AbsItemDetailResponse> = OkHttpClassifier.classify {
+    ): NetworkResult<AbsItemDetailResponse> = OkHttpClassifier.classify(dispatchers.io) {
         val response = get(baseUrl, "/api/items/$itemId", token, insecureAllowed).requireSuccessful()
         json.decodeFromString<AbsItemDetailResponse>(response.requireBody())
     }
@@ -396,7 +400,7 @@ class AbsApiClient(private val httpClient: OkHttpClient) : AbsApi, AbsLibraryApi
         payload: NetworkEbookProgressPayload,
         token: String,
         insecureAllowed: Boolean,
-    ): NetworkResult<Long> = OkHttpClassifier.classify {
+    ): NetworkResult<Long> = OkHttpClassifier.classify(dispatchers.io) {
         val body = json.encodeToString(AbsEbookProgressRequest(payload.ebookLocation, payload.ebookProgress, payload.isFinished))
             .toRequestBody(jsonMediaType)
         val request = Request.Builder()
@@ -416,7 +420,7 @@ class AbsApiClient(private val httpClient: OkHttpClient) : AbsApi, AbsLibraryApi
         payload: NetworkAudiobookProgressPayload,
         token: String,
         insecureAllowed: Boolean,
-    ): NetworkResult<Long> = OkHttpClassifier.classify {
+    ): NetworkResult<Long> = OkHttpClassifier.classify(dispatchers.io) {
         val progress = if (payload.duration > 0.0) (payload.currentTime / payload.duration).coerceIn(0.0, 1.0) else 0.0
         val body = json.encodeToString(AbsAudiobookProgressRequest(payload.currentTime, payload.duration, progress))
             .toRequestBody(jsonMediaType)
@@ -436,7 +440,7 @@ class AbsApiClient(private val httpClient: OkHttpClient) : AbsApi, AbsLibraryApi
         libraryItemId: String,
         token: String,
         insecureAllowed: Boolean,
-    ): NetworkResult<NetworkServerProgress> = OkHttpClassifier.classify {
+    ): NetworkResult<NetworkServerProgress> = OkHttpClassifier.classify(dispatchers.io) {
         val response = get(baseUrl, "/api/me/progress/$libraryItemId", token, insecureAllowed)
         // A 404 means "no progress record yet" — synthesize an empty record so callers don't
         // have to special-case `ServerError(404)`.
@@ -462,7 +466,7 @@ class AbsApiClient(private val httpClient: OkHttpClient) : AbsApi, AbsLibraryApi
         deviceId: String,
         token: String,
         insecureAllowed: Boolean,
-    ): NetworkResult<NetworkPlaybackSession> = OkHttpClassifier.classify {
+    ): NetworkResult<NetworkPlaybackSession> = OkHttpClassifier.classify(dispatchers.io) {
         val payload = AbsPlayRequest(
             deviceInfo = AbsPlayDeviceInfo(deviceId = deviceId),
             // The MIME types Media3/ExoPlayer plays directly; ABS transcodes only if none match.
@@ -509,7 +513,7 @@ class AbsApiClient(private val httpClient: OkHttpClient) : AbsApi, AbsLibraryApi
     ): String? {
         // `/status` is unauthenticated and returns `{ serverVersion, app, isInit, ... }`.
         // The previously-targeted `/api/server-info` does not exist on ABS (404 even with auth).
-        val result = OkHttpClassifier.classify {
+        val result = OkHttpClassifier.classify(dispatchers.io) {
             val response = client(insecureAllowed).newCall(
                 Request.Builder().url("$baseUrl/status").get().build()
             ).execute().requireSuccessful()
@@ -523,7 +527,7 @@ class AbsApiClient(private val httpClient: OkHttpClient) : AbsApi, AbsLibraryApi
         token: String,
         insecureAllowed: Boolean,
     ): String? {
-        val result = OkHttpClassifier.classify {
+        val result = OkHttpClassifier.classify(dispatchers.io) {
             val response = get(baseUrl, "/api/me", token, insecureAllowed).requireSuccessful()
             json.decodeFromString<AbsMeResponse>(response.requireBody()).id.takeIf { it.isNotBlank() }
         }
@@ -537,7 +541,7 @@ class AbsApiClient(private val httpClient: OkHttpClient) : AbsApi, AbsLibraryApi
         title: String,
         token: String,
         insecureAllowed: Boolean,
-    ): NetworkResult<NetworkAbsBookmark> = OkHttpClassifier.classify {
+    ): NetworkResult<NetworkAbsBookmark> = OkHttpClassifier.classify(dispatchers.io) {
         val body = json.encodeToString(AbsBookmarkRequest(timeSec, title)).toRequestBody(jsonMediaType)
         val request = Request.Builder()
             .url("$baseUrl/api/me/item/$itemId/bookmark")
@@ -554,7 +558,7 @@ class AbsApiClient(private val httpClient: OkHttpClient) : AbsApi, AbsLibraryApi
         title: String,
         token: String,
         insecureAllowed: Boolean,
-    ): NetworkResult<NetworkAbsBookmark> = OkHttpClassifier.classify {
+    ): NetworkResult<NetworkAbsBookmark> = OkHttpClassifier.classify(dispatchers.io) {
         val body = json.encodeToString(AbsBookmarkRequest(timeSec, title)).toRequestBody(jsonMediaType)
         val request = Request.Builder()
             .url("$baseUrl/api/me/item/$itemId/bookmark")
@@ -576,7 +580,7 @@ class AbsApiClient(private val httpClient: OkHttpClient) : AbsApi, AbsLibraryApi
         timeSec: Int,
         token: String,
         insecureAllowed: Boolean,
-    ): NetworkResult<NetworkAbsBookmark> = OkHttpClassifier.classify {
+    ): NetworkResult<NetworkAbsBookmark> = OkHttpClassifier.classify(dispatchers.io) {
         val request = Request.Builder()
             .url("$baseUrl/api/me/item/$itemId/bookmark/$timeSec")
             .addHeader("Authorization", "Bearer $token")
@@ -599,7 +603,7 @@ class AbsApiClient(private val httpClient: OkHttpClient) : AbsApi, AbsLibraryApi
         baseUrl: String,
         token: String,
         insecureAllowed: Boolean,
-    ): NetworkResult<List<NetworkAbsBookmark>> = OkHttpClassifier.classify {
+    ): NetworkResult<List<NetworkAbsBookmark>> = OkHttpClassifier.classify(dispatchers.io) {
         val response = get(baseUrl, "/api/me", token, insecureAllowed).requireSuccessful()
         val raw = response.requireBody()
         // `/api/me` carries many fields; `json` is configured with ignoreUnknownKeys so the

--- a/core/network/src/main/kotlin/com/riffle/core/network/AudiobookBundleApi.kt
+++ b/core/network/src/main/kotlin/com/riffle/core/network/AudiobookBundleApi.kt
@@ -1,6 +1,6 @@
 package com.riffle.core.network
 
-import kotlinx.coroutines.Dispatchers
+import com.riffle.core.domain.DispatcherProvider
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.withContext
 import okhttp3.OkHttpClient
@@ -39,6 +39,7 @@ fun interface AudiobookBundleApi {
 
 class AudiobookBundleApiImpl(
     private val client: OkHttpClient,
+    private val dispatchers: DispatcherProvider,
 ) : AudiobookBundleApi {
 
     private val bundleClient: OkHttpClient = client.newBuilder()
@@ -53,7 +54,7 @@ class AudiobookBundleApiImpl(
         token: String,
         insecureAllowed: Boolean,
         fromByte: Long,
-    ): NetworkResult<AudiobookBundleStream> = withContext(Dispatchers.IO) {
+    ): NetworkResult<AudiobookBundleStream> = withContext(dispatchers.io) {
         val effectiveClient = if (insecureAllowed) bundleClient.trustAllCerts() else bundleClient
         val builder = Request.Builder()
             .url("$baseUrl/api/books/$bookId/synced")

--- a/core/network/src/main/kotlin/com/riffle/core/network/GitHubReleaseApi.kt
+++ b/core/network/src/main/kotlin/com/riffle/core/network/GitHubReleaseApi.kt
@@ -1,6 +1,6 @@
 package com.riffle.core.network
 
-import kotlinx.coroutines.Dispatchers
+import com.riffle.core.domain.DispatcherProvider
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -16,6 +16,7 @@ import java.io.IOException
  */
 class GitHubReleaseApi(
     private val httpClient: OkHttpClient,
+    private val dispatchers: DispatcherProvider,
     /** Overridable so tests can point at a local MockWebServer; defaults to the public GitHub API. */
     private val apiBaseUrl: String = "https://api.github.com",
 ) {
@@ -27,7 +28,7 @@ class GitHubReleaseApi(
      * Releases that exist but haven't finished their APK build yet are skipped so an in-flight release
      * doesn't stall the updater.
      */
-    suspend fun latestRelease(repo: String): GitHubReleaseResult = withContext(Dispatchers.IO) {
+    suspend fun latestRelease(repo: String): GitHubReleaseResult = withContext(dispatchers.io) {
         val request = Request.Builder()
             .url("$apiBaseUrl/repos/$repo/releases?per_page=10")
             .header("Accept", "application/vnd.github+json")
@@ -66,7 +67,7 @@ class GitHubReleaseApi(
      * failure [dest] is deleted, so a truncated APK is never handed to the installer.
      */
     suspend fun download(url: String, dest: File, onProgress: (percent: Int) -> Unit): Boolean =
-        withContext(Dispatchers.IO) {
+        withContext(dispatchers.io) {
             val request = Request.Builder().url(url).get().build()
             try {
                 httpClient.newCall(request).execute().use { response ->

--- a/core/network/src/main/kotlin/com/riffle/core/network/NetworkResult.kt
+++ b/core/network/src/main/kotlin/com/riffle/core/network/NetworkResult.kt
@@ -1,7 +1,7 @@
 package com.riffle.core.network
 
 import com.riffle.core.domain.InsecureConnectionType
-import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.SerializationException
 import java.io.IOException
@@ -46,7 +46,7 @@ object OkHttpClassifier {
      * `NetworkResult` variant. Block authors throw `HttpException` for non-success codes and
      * `IOException("Empty response body")` for missing bodies.
      */
-    suspend fun <T> classify(block: suspend () -> T): NetworkResult<T> = withContext(Dispatchers.IO) {
+    suspend fun <T> classify(io: CoroutineDispatcher, block: suspend () -> T): NetworkResult<T> = withContext(io) {
         try {
             NetworkResult.Success(block())
         } catch (e: HttpException) {

--- a/core/network/src/main/kotlin/com/riffle/core/network/StorytellerApiClient.kt
+++ b/core/network/src/main/kotlin/com/riffle/core/network/StorytellerApiClient.kt
@@ -1,6 +1,7 @@
 package com.riffle.core.network
 
 import com.riffle.core.domain.AudiobookFingerprint
+import com.riffle.core.domain.DispatcherProvider
 import com.riffle.core.network.model.StorytellerBookResponse
 import com.riffle.core.network.model.StorytellerLoginResponse
 import com.riffle.core.network.model.StorytellerV2BookResponse
@@ -16,6 +17,7 @@ import javax.net.ssl.X509TrustManager
 
 class StorytellerApiClient(
     private val httpClient: OkHttpClient,
+    private val dispatchers: DispatcherProvider,
 ) : StorytellerApi, StorytellerLibraryApi {
 
     private val json = Json { ignoreUnknownKeys = true; coerceInputValues = true }
@@ -25,7 +27,7 @@ class StorytellerApiClient(
         username: String,
         password: String,
         insecureAllowed: Boolean,
-    ): NetworkResult<String> = OkHttpClassifier.classify {
+    ): NetworkResult<String> = OkHttpClassifier.classify(dispatchers.io) {
         val client = client(insecureAllowed)
         val body = MultipartBody.Builder()
             .setType(MultipartBody.FORM)
@@ -50,7 +52,7 @@ class StorytellerApiClient(
         baseUrl: String,
         token: String,
         insecureAllowed: Boolean,
-    ): NetworkResult<Boolean> = OkHttpClassifier.classify {
+    ): NetworkResult<Boolean> = OkHttpClassifier.classify(dispatchers.io) {
         val request = Request.Builder()
             .url("$baseUrl/api/validate")
             .addHeader("Authorization", "Bearer $token")
@@ -69,7 +71,7 @@ class StorytellerApiClient(
         baseUrl: String,
         token: String,
         insecureAllowed: Boolean,
-    ): NetworkResult<List<NetworkStorytellerBook>> = OkHttpClassifier.classify {
+    ): NetworkResult<List<NetworkStorytellerBook>> = OkHttpClassifier.classify(dispatchers.io) {
         // ?synced=true: server-side filter to completed readalouds only (ADR 0020).
         val request = Request.Builder()
             .url("$baseUrl/api/books?synced=true")
@@ -88,7 +90,7 @@ class StorytellerApiClient(
         bookId: Long,
         token: String,
         insecureAllowed: Boolean,
-    ): NetworkResult<NetworkStorytellerBook> = OkHttpClassifier.classify {
+    ): NetworkResult<NetworkStorytellerBook> = OkHttpClassifier.classify(dispatchers.io) {
         val request = Request.Builder()
             .url("$baseUrl/api/books/$bookId")
             .addHeader("Authorization", "Bearer $token")
@@ -114,7 +116,7 @@ class StorytellerApiClient(
         bookId: Long,
         token: String,
         insecureAllowed: Boolean,
-    ): NetworkResult<AudiobookFingerprint?> = OkHttpClassifier.classify {
+    ): NetworkResult<AudiobookFingerprint?> = OkHttpClassifier.classify(dispatchers.io) {
         val request = Request.Builder()
             .url("$baseUrl/api/v2/books/$bookId")
             .addHeader("Authorization", "Bearer $token")

--- a/core/network/src/main/kotlin/com/riffle/core/network/StorytellerBundleApi.kt
+++ b/core/network/src/main/kotlin/com/riffle/core/network/StorytellerBundleApi.kt
@@ -1,6 +1,6 @@
 package com.riffle.core.network
 
-import kotlinx.coroutines.Dispatchers
+import com.riffle.core.domain.DispatcherProvider
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.withContext
 import okhttp3.OkHttpClient
@@ -36,6 +36,7 @@ fun interface StorytellerBundleProbeApi {
 
 class StorytellerBundleApiImpl(
     private val client: OkHttpClient,
+    private val dispatchers: DispatcherProvider,
     // Overridable so tests can assert the bounded-timeout fallback without waiting the full window.
     private val sidecarCallTimeoutSeconds: Long = SIDECAR_CALL_TIMEOUT_SECONDS,
     private val sidecarStreamTimeoutSeconds: Long = SIDECAR_STREAM_TIMEOUT_SECONDS,
@@ -82,7 +83,7 @@ class StorytellerBundleApiImpl(
         bookId: String,
         token: String,
         insecureAllowed: Boolean,
-    ): NetworkResult<StorytellerBundleStream> = withContext(Dispatchers.IO) {
+    ): NetworkResult<StorytellerBundleStream> = withContext(dispatchers.io) {
         val effectiveClient = if (insecureAllowed) chosenClient.trustAllCerts() else chosenClient
         val request = Request.Builder()
             .url("$baseUrl/api/books/$bookId/synced")
@@ -116,7 +117,7 @@ class StorytellerBundleApiImpl(
         bookId: String,
         token: String,
         insecureAllowed: Boolean,
-    ): NetworkResult<Long> = withContext(Dispatchers.IO) {
+    ): NetworkResult<Long> = withContext(dispatchers.io) {
         val effectiveClient = if (insecureAllowed) sidecarClient.trustAllCerts() else sidecarClient
         val request = Request.Builder()
             .url("$baseUrl/api/books/$bookId/synced")

--- a/core/network/src/main/kotlin/com/riffle/core/network/StorytellerPositionApi.kt
+++ b/core/network/src/main/kotlin/com/riffle/core/network/StorytellerPositionApi.kt
@@ -1,6 +1,6 @@
 package com.riffle.core.network
 
-import kotlinx.coroutines.Dispatchers
+import com.riffle.core.domain.DispatcherProvider
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonPrimitive
@@ -42,6 +42,7 @@ interface StorytellerPositionApi {
 
 class StorytellerPositionApiImpl(
     private val client: OkHttpClient,
+    private val dispatchers: DispatcherProvider,
 ) : StorytellerPositionApi {
 
     private val json = Json { ignoreUnknownKeys = true }
@@ -51,7 +52,7 @@ class StorytellerPositionApiImpl(
         bookId: String,
         token: String,
         insecureAllowed: Boolean,
-    ): NetworkResult<StorytellerPosition?> = withContext(Dispatchers.IO) {
+    ): NetworkResult<StorytellerPosition?> = withContext(dispatchers.io) {
         val http = if (insecureAllowed) client.trustAllCerts() else client
         val request = Request.Builder()
             .url("$baseUrl/api/v2/books/$bookId/positions")
@@ -86,7 +87,7 @@ class StorytellerPositionApiImpl(
         timestampMillis: Long,
         token: String,
         insecureAllowed: Boolean,
-    ): NetworkResult<Unit> = withContext(Dispatchers.IO) {
+    ): NetworkResult<Unit> = withContext(dispatchers.io) {
         val http = if (insecureAllowed) client.trustAllCerts() else client
         val payload = buildJsonObject {
             put("locator", json.parseToJsonElement(locatorJson))

--- a/core/network/src/test/kotlin/com/riffle/core/network/AbsApiClientCollectionsWriteTest.kt
+++ b/core/network/src/test/kotlin/com/riffle/core/network/AbsApiClientCollectionsWriteTest.kt
@@ -1,5 +1,7 @@
 package com.riffle.core.network
 
+import com.riffle.core.domain.DefaultDispatcherProvider
+
 import kotlinx.coroutines.test.runTest
 import okhttp3.OkHttpClient
 import okhttp3.mockwebserver.MockResponse
@@ -19,7 +21,7 @@ class AbsApiClientCollectionsWriteTest {
     fun setUp() {
         server = MockWebServer()
         server.start()
-        client = AbsApiClient(OkHttpClient())
+        client = AbsApiClient(OkHttpClient(), DefaultDispatcherProvider)
     }
 
     @After

--- a/core/network/src/test/kotlin/com/riffle/core/network/AbsApiClientLibraryTest.kt
+++ b/core/network/src/test/kotlin/com/riffle/core/network/AbsApiClientLibraryTest.kt
@@ -1,5 +1,7 @@
 package com.riffle.core.network
 
+import com.riffle.core.domain.DefaultDispatcherProvider
+
 import kotlinx.coroutines.test.runTest
 import okhttp3.OkHttpClient
 import okhttp3.mockwebserver.MockResponse
@@ -22,7 +24,7 @@ class AbsApiClientLibraryTest {
     fun setUp() {
         server = MockWebServer()
         server.start()
-        client = AbsApiClient(OkHttpClient())
+        client = AbsApiClient(OkHttpClient(), DefaultDispatcherProvider)
     }
 
     @After

--- a/core/network/src/test/kotlin/com/riffle/core/network/AbsApiClientPlaylistsTest.kt
+++ b/core/network/src/test/kotlin/com/riffle/core/network/AbsApiClientPlaylistsTest.kt
@@ -1,5 +1,7 @@
 package com.riffle.core.network
 
+import com.riffle.core.domain.DefaultDispatcherProvider
+
 import kotlinx.coroutines.test.runTest
 import okhttp3.OkHttpClient
 import okhttp3.mockwebserver.MockResponse
@@ -19,7 +21,7 @@ class AbsApiClientPlaylistsTest {
     fun setUp() {
         server = MockWebServer()
         server.start()
-        client = AbsApiClient(OkHttpClient())
+        client = AbsApiClient(OkHttpClient(), DefaultDispatcherProvider)
     }
 
     @After

--- a/core/network/src/test/kotlin/com/riffle/core/network/AbsApiClientSeriesCollectionTest.kt
+++ b/core/network/src/test/kotlin/com/riffle/core/network/AbsApiClientSeriesCollectionTest.kt
@@ -1,5 +1,7 @@
 package com.riffle.core.network
 
+import com.riffle.core.domain.DefaultDispatcherProvider
+
 import kotlinx.coroutines.test.runTest
 import okhttp3.OkHttpClient
 import okhttp3.mockwebserver.MockResponse
@@ -22,7 +24,7 @@ class AbsApiClientSeriesCollectionTest {
     fun setUp() {
         server = MockWebServer()
         server.start()
-        client = AbsApiClient(OkHttpClient())
+        client = AbsApiClient(OkHttpClient(), DefaultDispatcherProvider)
     }
 
     @After

--- a/core/network/src/test/kotlin/com/riffle/core/network/AbsApiClientSessionTest.kt
+++ b/core/network/src/test/kotlin/com/riffle/core/network/AbsApiClientSessionTest.kt
@@ -1,5 +1,7 @@
 package com.riffle.core.network
 
+import com.riffle.core.domain.DefaultDispatcherProvider
+
 import kotlinx.coroutines.test.runTest
 import okhttp3.OkHttpClient
 import okhttp3.mockwebserver.MockResponse
@@ -20,7 +22,7 @@ class AbsApiClientSessionTest {
     fun setUp() {
         server = MockWebServer()
         server.start()
-        client = AbsApiClient(OkHttpClient())
+        client = AbsApiClient(OkHttpClient(), DefaultDispatcherProvider)
     }
 
     @After

--- a/core/network/src/test/kotlin/com/riffle/core/network/AbsApiClientTest.kt
+++ b/core/network/src/test/kotlin/com/riffle/core/network/AbsApiClientTest.kt
@@ -1,5 +1,7 @@
 package com.riffle.core.network
 
+import com.riffle.core.domain.DefaultDispatcherProvider
+
 import com.riffle.core.domain.InsecureConnectionType
 import kotlinx.coroutines.test.runTest
 import okhttp3.OkHttpClient
@@ -20,7 +22,7 @@ class AbsApiClientTest {
     fun setUp() {
         server = MockWebServer()
         server.start()
-        client = AbsApiClient(OkHttpClient())
+        client = AbsApiClient(OkHttpClient(), DefaultDispatcherProvider)
     }
 
     @After

--- a/core/network/src/test/kotlin/com/riffle/core/network/AbsBookmarkApiTest.kt
+++ b/core/network/src/test/kotlin/com/riffle/core/network/AbsBookmarkApiTest.kt
@@ -1,5 +1,7 @@
 package com.riffle.core.network
 
+import com.riffle.core.domain.DefaultDispatcherProvider
+
 import kotlinx.coroutines.test.runTest
 import okhttp3.OkHttpClient
 import okhttp3.mockwebserver.MockResponse
@@ -19,7 +21,7 @@ class AbsBookmarkApiTest {
     fun setUp() {
         server = MockWebServer()
         server.start()
-        client = AbsApiClient(OkHttpClient())
+        client = AbsApiClient(OkHttpClient(), DefaultDispatcherProvider)
     }
 
     @After

--- a/core/network/src/test/kotlin/com/riffle/core/network/AudiobookBundleApiTest.kt
+++ b/core/network/src/test/kotlin/com/riffle/core/network/AudiobookBundleApiTest.kt
@@ -1,5 +1,7 @@
 package com.riffle.core.network
 
+import com.riffle.core.domain.DefaultDispatcherProvider
+
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -30,7 +32,7 @@ class AudiobookBundleApiTest {
     @Before
     fun setUp() {
         server = MockWebServer().also { it.start() }
-        api = AudiobookBundleApiImpl(OkHttpClient())
+        api = AudiobookBundleApiImpl(OkHttpClient(), DefaultDispatcherProvider)
     }
 
     @After
@@ -86,7 +88,7 @@ class AudiobookBundleApiTest {
                 override fun connectionReleased(call: Call, connection: Connection) { released.incrementAndGet() }
             })
             .build()
-        val leakApi: AudiobookBundleApi = AudiobookBundleApiImpl(countingClient)
+        val leakApi: AudiobookBundleApi = AudiobookBundleApiImpl(countingClient, DefaultDispatcherProvider)
 
         server.enqueue(
             MockResponse()

--- a/core/network/src/test/kotlin/com/riffle/core/network/AudiobookFingerprintClientTest.kt
+++ b/core/network/src/test/kotlin/com/riffle/core/network/AudiobookFingerprintClientTest.kt
@@ -1,5 +1,7 @@
 package com.riffle.core.network
 
+import com.riffle.core.domain.DefaultDispatcherProvider
+
 import kotlinx.coroutines.test.runTest
 import okhttp3.OkHttpClient
 import okhttp3.mockwebserver.MockResponse
@@ -26,7 +28,7 @@ class AudiobookFingerprintClientTest {
                    "manifest":{"readingOrder":[{"duration":39214.464}]}}}""",
             ),
         )
-        val client = StorytellerApiClient(OkHttpClient())
+        val client = StorytellerApiClient(OkHttpClient(), DefaultDispatcherProvider)
         val result = client.getAudiobookFingerprint(baseUrl(), 42L, "tok", false)
 
         assertTrue(result is NetworkResult.Success)
@@ -37,7 +39,7 @@ class AudiobookFingerprintClientTest {
     @Test
     fun `storyteller with no audiobook returns NoAudiobook`() = runTest {
         server.enqueue(MockResponse().setResponseCode(200).setBody("""{"title":"x"}"""))
-        val result = StorytellerApiClient(OkHttpClient()).getAudiobookFingerprint(baseUrl(), 1L, "tok", false)
+        val result = StorytellerApiClient(OkHttpClient(), DefaultDispatcherProvider).getAudiobookFingerprint(baseUrl(), 1L, "tok", false)
         assertTrue(result is NetworkResult.Success && result.value == null)
     }
 
@@ -50,7 +52,7 @@ class AudiobookFingerprintClientTest {
                    {"index":2,"duration":1721.0,"metadata":{"size":200}}]}}""",
             ),
         )
-        val result = AbsApiClient(OkHttpClient()).getAudiobookFingerprint(baseUrl(), "abc", "tok", false)
+        val result = AbsApiClient(OkHttpClient(), DefaultDispatcherProvider).getAudiobookFingerprint(baseUrl(), "abc", "tok", false)
 
         assertTrue(result is NetworkResult.Success)
         assertEquals(listOf(2204.0, 1721.0), (result as NetworkResult.Success).value!!.trackDurationsSec)
@@ -65,7 +67,7 @@ class AudiobookFingerprintClientTest {
                    {"ino":"7963985","index":1,"duration":39214.464}]}}""",
             ),
         )
-        val result = AbsApiClient(OkHttpClient()).getAudiobookTracks(baseUrl(), "abc", "tok", false)
+        val result = AbsApiClient(OkHttpClient(), DefaultDispatcherProvider).getAudiobookTracks(baseUrl(), "abc", "tok", false)
         assertTrue(result is NetworkResult.Success)
         assertEquals("7963985", (result as NetworkResult.Success).value.single().ino)
     }

--- a/core/network/src/test/kotlin/com/riffle/core/network/GitHubReleaseApiTest.kt
+++ b/core/network/src/test/kotlin/com/riffle/core/network/GitHubReleaseApiTest.kt
@@ -1,5 +1,7 @@
 package com.riffle.core.network
 
+import com.riffle.core.domain.DefaultDispatcherProvider
+
 import kotlinx.coroutines.test.runTest
 import okhttp3.OkHttpClient
 import okhttp3.mockwebserver.MockResponse
@@ -22,7 +24,7 @@ class GitHubReleaseApiTest {
     fun setUp() {
         server = MockWebServer().also { it.start() }
         val baseUrl = server.url("/").toString().trimEnd('/')
-        api = GitHubReleaseApi(OkHttpClient(), apiBaseUrl = baseUrl)
+        api = GitHubReleaseApi(OkHttpClient(), DefaultDispatcherProvider, apiBaseUrl = baseUrl)
     }
 
     @After

--- a/core/network/src/test/kotlin/com/riffle/core/network/PdfRoutingIntegrationTest.kt
+++ b/core/network/src/test/kotlin/com/riffle/core/network/PdfRoutingIntegrationTest.kt
@@ -1,5 +1,7 @@
 package com.riffle.core.network
 
+import com.riffle.core.domain.DefaultDispatcherProvider
+
 import com.riffle.core.domain.EbookFormat
 import kotlinx.coroutines.test.runTest
 import okhttp3.OkHttpClient
@@ -27,7 +29,7 @@ class PdfRoutingIntegrationTest {
     fun setUp() {
         server = MockWebServer()
         server.start()
-        client = AbsApiClient(OkHttpClient())
+        client = AbsApiClient(OkHttpClient(), DefaultDispatcherProvider)
     }
 
     @After

--- a/core/network/src/test/kotlin/com/riffle/core/network/StorytellerApiClientTest.kt
+++ b/core/network/src/test/kotlin/com/riffle/core/network/StorytellerApiClientTest.kt
@@ -1,5 +1,7 @@
 package com.riffle.core.network
 
+import com.riffle.core.domain.DefaultDispatcherProvider
+
 import kotlinx.coroutines.test.runTest
 import okhttp3.OkHttpClient
 import okhttp3.mockwebserver.MockResponse
@@ -19,7 +21,7 @@ class StorytellerApiClientTest {
     fun setUp() {
         server = MockWebServer()
         server.start()
-        client = StorytellerApiClient(OkHttpClient())
+        client = StorytellerApiClient(OkHttpClient(), DefaultDispatcherProvider)
     }
 
     @After

--- a/core/network/src/test/kotlin/com/riffle/core/network/StorytellerBundleApiTest.kt
+++ b/core/network/src/test/kotlin/com/riffle/core/network/StorytellerBundleApiTest.kt
@@ -1,5 +1,7 @@
 package com.riffle.core.network
 
+import com.riffle.core.domain.DefaultDispatcherProvider
+
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -30,7 +32,7 @@ class StorytellerBundleApiTest {
     @Before
     fun setUp() {
         server = MockWebServer().also { it.start() }
-        impl = StorytellerBundleApiImpl(OkHttpClient())
+        impl = StorytellerBundleApiImpl(OkHttpClient(), DefaultDispatcherProvider)
         api = impl
         probe = impl
     }
@@ -84,7 +86,7 @@ class StorytellerBundleApiTest {
                 override fun connectionReleased(call: Call, connection: Connection) { released.incrementAndGet() }
             })
             .build()
-        val leakApi: StorytellerBundleApi = StorytellerBundleApiImpl(countingClient)
+        val leakApi: StorytellerBundleApi = StorytellerBundleApiImpl(countingClient, DefaultDispatcherProvider)
 
         // Headers arrive only after 500ms, so execute() is still blocked when we cancel at ~100ms.
         server.enqueue(
@@ -153,7 +155,7 @@ class StorytellerBundleApiTest {
         // cold book that can be minutes. The size probe must NOT inherit the download's unbounded timeout
         // (else the streaming-play path that awaits the sidecar wedges forever, ADR 0028). A bounded
         // sidecar client makes a slow /synced fail fast so the caller falls back.
-        val bounded = StorytellerBundleApiImpl(OkHttpClient(), sidecarCallTimeoutSeconds = 1)
+        val bounded = StorytellerBundleApiImpl(OkHttpClient(), DefaultDispatcherProvider, sidecarCallTimeoutSeconds = 1)
         server.enqueue(
             MockResponse()
                 .setHeader("Content-Length", "315074677")
@@ -177,7 +179,7 @@ class StorytellerBundleApiTest {
         // A coroutine timeout can't cancel the blocking execute(), so the streaming sidecar fetch relies
         // on a real callTimeout to fail a wedged /synced — otherwise the "Preparing…" indicator sticks
         // forever (ADR 0028). With a 1s bound, a 10s-delayed response must come back as NetworkError fast.
-        val bounded = StorytellerBundleApiImpl(OkHttpClient(), sidecarStreamTimeoutSeconds = 1)
+        val bounded = StorytellerBundleApiImpl(OkHttpClient(), DefaultDispatcherProvider, sidecarStreamTimeoutSeconds = 1)
         server.enqueue(
             MockResponse().setBody(Buffer().write(ByteArray(64))).setHeadersDelay(10, TimeUnit.SECONDS),
         )

--- a/core/network/src/test/kotlin/com/riffle/core/network/StorytellerPositionApiTest.kt
+++ b/core/network/src/test/kotlin/com/riffle/core/network/StorytellerPositionApiTest.kt
@@ -1,5 +1,7 @@
 package com.riffle.core.network
 
+import com.riffle.core.domain.DefaultDispatcherProvider
+
 import kotlinx.coroutines.test.runTest
 import okhttp3.OkHttpClient
 import okhttp3.mockwebserver.MockResponse
@@ -17,7 +19,7 @@ class StorytellerPositionApiTest {
 
     @Before fun setUp() {
         server = MockWebServer().also { it.start() }
-        api = StorytellerPositionApiImpl(OkHttpClient())
+        api = StorytellerPositionApiImpl(OkHttpClient(), DefaultDispatcherProvider)
     }
 
     @After fun tearDown() = server.shutdown()


### PR DESCRIPTION
Closes #353

Follow-up to #338 (PR #352). Drops the six `core/network` allowlist entries from `checkRiffleInfraSeams` by routing every `withContext(Dispatchers.IO)` site through the injected `DispatcherProvider` seam.

## Changes

- Each API client (`AbsApiClient`, `StorytellerApiClient`, `GitHubReleaseApi`, `AudiobookBundleApiImpl`, `StorytellerBundleApiImpl`, `StorytellerPositionApiImpl`) takes `dispatchers: DispatcherProvider` alongside its OkHttp client and uses `dispatchers.io`.
- `OkHttpClassifier.classify` now takes the IO dispatcher as its first parameter; `AbsApiClient` / `StorytellerApiClient` thread `dispatchers.io` through every call site (~30 sites combined).
- `DataModule` providers updated; production binding is `DefaultDispatcherProvider` already wired in `AppModule`.
- All test constructors and Android instrumented tests updated to pass `DefaultDispatcherProvider`.

## Acceptance

- ✅ Six allowlist entries removed from `build.gradle.kts`
- ✅ `./gradlew test checkRiffleInfraSeams` green locally