### PR TITLE
fix(library): use stacked Bookmarks icon for To Read tab

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsScreen.kt
@@ -41,6 +41,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Bookmark
+import androidx.compose.material.icons.filled.Bookmarks
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Folder
 import androidx.compose.material.icons.filled.FormatListNumbered
@@ -1193,7 +1194,7 @@ private fun LibraryTabBar(selectedTab: Int, onTabSelected: (Int) -> Unit) {
         NavigationBarItem(
             selected = selectedTab == 1,
             onClick = { onTabSelected(1) },
-            icon = { Icon(Icons.Filled.Bookmark, contentDescription = "To Read") },
+            icon = { Icon(Icons.Filled.Bookmarks, contentDescription = "To Read") },
         )
         NavigationBarItem(
             selected = selectedTab == 2,


### PR DESCRIPTION
## Summary
The bottom-nav **To Read** tab used `Icons.Filled.Bookmark` — the same glyph rendered by ebook bookmark rows (`AnnotationsPanel`) and the audiobook bookmark chip (`PlayerListPills`), making the three affordances visually indistinguishable.

Swapped the tab to `Icons.Filled.Bookmarks` (stacked / plural). The reader and audiobook bookmark rows keep the singular `Bookmark` glyph, so a saved-position bookmark is now visually distinct from "the queue of books I want to read".

## Test plan
- [ ] Open the library — verify the **To Read** tab in the bottom nav now shows the stacked-bookmarks glyph, both unselected and selected (filled).
- [ ] Open the reader annotations panel — verify bookmark rows still use the singular ribbon glyph.
- [ ] Open the audiobook player — verify the bookmarks chip still uses the singular ribbon glyph.