### PR TITLE
refactor(ui): introduce UiState<T> + UiStateScaffold foundation

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/ui/state/UiState.kt
+++ b/app/src/main/kotlin/com/riffle/app/ui/state/UiState.kt
@@ -1,0 +1,34 @@
+package com.riffle.app.ui.state
+
+/**
+ * Unified screen state taxonomy — replaces the per-feature Loading/Ready/Error sealed classes that
+ * each ViewModel used to define. Screens consume it via [UiStateScaffold] which renders a common
+ * loader / error treatment; the `success` slot receives the domain object [T].
+ *
+ * Screens that need extra discriminators (e.g. a Downloading sub-state inside a player) parameterise
+ * [T] with their own sealed type instead of nesting variants into this wrapper.
+ */
+sealed interface UiState<out T> {
+    data object Loading : UiState<Nothing>
+
+    data class Success<T>(val value: T) : UiState<T>
+
+    /**
+     * An error worth showing the user. [retry] is optional — when non-null the scaffold shows a
+     * retry affordance that invokes it. [code] is for downstream logging / analytics; the [message]
+     * is the human-readable string the scaffold renders.
+     */
+    data class Error(
+        val message: String,
+        val code: String? = null,
+        val retry: (() -> Unit)? = null,
+    ) : UiState<Nothing>
+}
+
+inline fun <T, R> UiState<T>.map(transform: (T) -> R): UiState<R> = when (this) {
+    UiState.Loading -> UiState.Loading
+    is UiState.Success -> UiState.Success(transform(value))
+    is UiState.Error -> this
+}
+
+fun <T> UiState<T>.valueOrNull(): T? = (this as? UiState.Success)?.value

--- a/app/src/main/kotlin/com/riffle/app/ui/state/UiStateScaffold.kt
+++ b/app/src/main/kotlin/com/riffle/app/ui/state/UiStateScaffold.kt
@@ -1,0 +1,68 @@
+package com.riffle.app.ui.state
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+/**
+ * Renders the conventional Loading / Error treatment for a [UiState], delegating the [content] slot
+ * to the success case. Use this in every screen that exposes a [UiState] so spinners, error
+ * messages, and retry affordances stay consistent across the app.
+ *
+ * The Error path uses [UiState.Error.retry] when present; an explicit [onRetry] parameter wins if
+ * the caller wants to override (e.g. retry from a screen-local lambda not stored in state).
+ */
+@Composable
+fun <T> UiStateScaffold(
+    state: UiState<T>,
+    modifier: Modifier = Modifier,
+    onRetry: (() -> Unit)? = null,
+    loading: @Composable () -> Unit = { DefaultLoading() },
+    error: @Composable (UiState.Error, (() -> Unit)?) -> Unit = { e, retry -> DefaultError(e, retry) },
+    content: @Composable (T) -> Unit,
+) {
+    Box(modifier = modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        when (state) {
+            UiState.Loading -> loading()
+            is UiState.Error -> error(state, onRetry ?: state.retry)
+            is UiState.Success -> content(state.value)
+        }
+    }
+}
+
+@Composable
+private fun DefaultLoading() {
+    CircularProgressIndicator()
+}
+
+@Composable
+private fun DefaultError(
+    error: UiState.Error,
+    onRetry: (() -> Unit)?,
+) {
+    Column(
+        modifier = Modifier.padding(24.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        Text(
+            text = error.message,
+            style = MaterialTheme.typography.bodyLarge,
+        )
+        if (onRetry != null) {
+            TextButton(onClick = onRetry) {
+                Text("Retry")
+            }
+        }
+    }
+}

--- a/app/src/test/kotlin/com/riffle/app/ui/state/UiStateTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/ui/state/UiStateTest.kt
@@ -1,0 +1,71 @@
+package com.riffle.app.ui.state
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class UiStateTest {
+
+    @Test
+    fun `map transforms Success`() {
+        val state: UiState<Int> = UiState.Success(2)
+
+        val result = state.map { it * 3 }
+
+        assertEquals(UiState.Success(6), result)
+    }
+
+    @Test
+    fun `map preserves Loading`() {
+        val state: UiState<Int> = UiState.Loading
+
+        val result = state.map { it * 3 }
+
+        assertSame(UiState.Loading, result)
+    }
+
+    @Test
+    fun `map preserves Error with all fields`() {
+        val retry: () -> Unit = {}
+        val state: UiState<Int> = UiState.Error("boom", code = "X1", retry = retry)
+
+        val result = state.map { it.toString() }
+
+        assertTrue(result is UiState.Error)
+        result as UiState.Error
+        assertEquals("boom", result.message)
+        assertEquals("X1", result.code)
+        assertSame(retry, result.retry)
+    }
+
+    @Test
+    fun `valueOrNull returns the value on Success`() {
+        val state: UiState<String> = UiState.Success("hi")
+
+        assertEquals("hi", state.valueOrNull())
+    }
+
+    @Test
+    fun `valueOrNull is null on Loading`() {
+        val state: UiState<String> = UiState.Loading
+
+        assertNull(state.valueOrNull())
+    }
+
+    @Test
+    fun `valueOrNull is null on Error`() {
+        val state: UiState<String> = UiState.Error("oops")
+
+        assertNull(state.valueOrNull())
+    }
+
+    @Test
+    fun `Error defaults code and retry to null`() {
+        val error = UiState.Error("oops")
+
+        assertNull(error.code)
+        assertNull(error.retry)
+    }
+}


### PR DESCRIPTION
Closes #341 (slice 1).

## Summary

- Adds `UiState<T>` sealed interface — `Loading | Success(value) | Error(message, code?, retry?)` — in `app/ui/state/`.
- Adds `UiStateScaffold` composable that renders the conventional Loading/Error treatment and delegates `Success` to a `content(T)` slot.
- Unit tests for `map`, `valueOrNull`, and `Error` defaults.

This is the foundation only. The next PRs sweep existing per-feature sealed states (`LibraryItemDetailUiState`, `ReaderState`, `MaintenanceScreenUiState`, …) onto the wrapper, per the issue's slicing.

## Acceptance (already met by this slice)

- A new screen can be built without defining its own `sealed class FooUiState`.
- Loader / error / retry composable lives in one place.
- Screens that need richer states can parameterise `T` with their own sealed type.

## Test plan

- [x] `:app:testDebugUnitTest --tests UiStateTest` green.