### PR TITLE
refactor(reader): migrate app reader-layer to DispatcherProvider

### DIFF
--- a/app/src/androidTest/kotlin/com/riffle/app/feature/reader/readaloud/ReadaloudStreamingSessionFactoryAndroidTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/reader/readaloud/ReadaloudStreamingSessionFactoryAndroidTest.kt
@@ -184,6 +184,7 @@ class ReadaloudStreamingSessionFactoryAndroidTest {
             serverRepository = repo,
             tokenStorage = StubTokenStorage,
             linkRepository = ReadaloudLinkRepositoryImpl(db.readaloudLinkDao()),
+            dispatchers = DefaultDispatcherProvider,
         )
     }
 

--- a/app/src/androidTest/kotlin/com/riffle/app/feature/reader/readaloud/StreamingAudioDownloaderAndroidTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/reader/readaloud/StreamingAudioDownloaderAndroidTest.kt
@@ -65,7 +65,7 @@ class StreamingAudioDownloaderAndroidTest {
         val items = listOf(StreamingMediaItem("seg", url, 0, 5000))
         var lastProgress = 0f
 
-        StreamingAudioDownloader.download(appCtx, items, "tok") { lastProgress = it }
+        StreamingAudioDownloader.download(appCtx, items, "tok", kotlinx.coroutines.Dispatchers.IO) { lastProgress = it }
 
         assertTrue("progress should reach 1.0, was $lastProgress", lastProgress >= 1f)
         val cached = StreamingAudioCache.get(appCtx).getCachedBytes(url, 0, Long.MAX_VALUE)

--- a/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookController.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookController.kt
@@ -10,12 +10,12 @@ import com.riffle.core.domain.ApplicationScope
 import com.riffle.core.domain.AudiobookTrackSpan
 import com.riffle.core.domain.AudiobookTracks
 import com.riffle.core.domain.Clock
+import com.riffle.core.domain.DispatcherProvider
 import com.riffle.core.domain.SystemClock
 import com.riffle.core.logging.LogChannel
 import com.riffle.core.logging.Logger
 import com.riffle.core.logging.RecordingLogger
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
@@ -44,13 +44,15 @@ import javax.inject.Singleton
 open class AudiobookController @Inject constructor(
     private val connector: MediaSessionConnector?,
     applicationScope: ApplicationScope?,
+    dispatchers: DispatcherProvider,
     private val logger: Logger,
     private val clock: Clock,
 ) {
     // Test seam: a subclass that overrides every member the player touches needs no real connector
     // (it's only consulted in [ensureConnected], which fakes never reach). Keeps the controller
-    // unit-fakeable without Robolectric.
-    protected constructor() : this(null, null, RecordingLogger(), SystemClock)
+    // unit-fakeable without Robolectric. Unconfined dispatchers — subclasses override every method
+    // that launches on the scope; the scope is constructed but never dispatched against.
+    protected constructor() : this(null, null, UnconfinedDispatcherProvider, RecordingLogger(), SystemClock)
 
     data class PlaybackState(
         val connected: Boolean = false,
@@ -65,8 +67,8 @@ open class AudiobookController @Inject constructor(
     // method that launches on this scope, so [applicationScope] is permitted to be null — the fallback
     // mirrors the production SupervisorJob semantics so a future partial-override test fake doesn't get
     // surprised by sibling-cancel behaviour.
-    private val scope: CoroutineScope = applicationScope?.scopeOn(Dispatchers.Main.immediate)
-        ?: CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+    private val scope: CoroutineScope = applicationScope?.scopeOn(dispatchers.mainImmediate)
+        ?: CoroutineScope(SupervisorJob() + dispatchers.mainImmediate)
     private val _state = MutableStateFlow(PlaybackState())
     open val state: StateFlow<PlaybackState> = _state.asStateFlow()
 
@@ -343,5 +345,12 @@ open class AudiobookController @Inject constructor(
         private const val POLL_INTERVAL_MS = 250L
         private const val FADE_STEPS = 50
         private const val FADE_STEP_MS = 100L
+
+        private val UnconfinedDispatcherProvider = object : DispatcherProvider {
+            override val main = kotlinx.coroutines.Dispatchers.Unconfined
+            override val mainImmediate = kotlinx.coroutines.Dispatchers.Unconfined
+            override val io = kotlinx.coroutines.Dispatchers.Unconfined
+            override val default = kotlinx.coroutines.Dispatchers.Unconfined
+        }
     }
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/navigation/HomeScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/navigation/HomeScreen.kt
@@ -21,7 +21,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
 @Composable
@@ -40,7 +39,7 @@ fun HomeScreen(
         // withContext(IO), the Compose test interceptor may resume this continuation
         // on the instrumentation thread. NavController.navigate() calls
         // LifecycleRegistry.setCurrentState() which requires the main thread.
-        withContext(Dispatchers.Main.immediate) {
+        withContext(viewModel.dispatchers.mainImmediate) {
             when (dest) {
                 is HomeViewModel.StartDestination.AddServer -> onNavigateToAddServer()
                 is HomeViewModel.StartDestination.Library -> onNavigateToLibrary(dest.libraryId, dest.libraryName)

--- a/app/src/main/kotlin/com/riffle/app/feature/navigation/HomeViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/navigation/HomeViewModel.kt
@@ -1,6 +1,7 @@
 package com.riffle.app.feature.navigation
 
 import androidx.lifecycle.ViewModel
+import com.riffle.core.domain.DispatcherProvider
 import com.riffle.core.domain.LastOpenedLibraryStore
 import com.riffle.core.domain.LibraryObserver
 import com.riffle.core.domain.LibraryRefreshResult
@@ -8,7 +9,6 @@ import com.riffle.core.domain.LibraryVisibilityPreferencesStore
 import com.riffle.core.domain.ServerRepository
 import com.riffle.core.domain.usecase.RefreshLibraries
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
@@ -20,6 +20,7 @@ class HomeViewModel @Inject constructor(
     private val refreshLibraries: RefreshLibraries,
     private val visibilityStore: LibraryVisibilityPreferencesStore,
     private val lastOpenedLibraryStore: LastOpenedLibraryStore,
+    val dispatchers: DispatcherProvider,
 ) : ViewModel() {
 
     sealed class StartDestination {
@@ -28,7 +29,7 @@ class HomeViewModel @Inject constructor(
         data class Library(val libraryId: String, val libraryName: String) : StartDestination()
     }
 
-    suspend fun getStartDestination(): StartDestination = withContext(Dispatchers.IO) {
+    suspend fun getStartDestination(): StartDestination = withContext(dispatchers.io) {
         val servers = serverRepository.observeAll().first()
         if (servers.isEmpty()) return@withContext StartDestination.AddServer
 

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -102,7 +102,6 @@ import com.riffle.core.domain.SentenceQuote
 import com.riffle.core.domain.ReaderTheme
 import com.riffle.core.domain.TimeRemaining
 import kotlin.math.roundToInt
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.filter
@@ -442,6 +441,7 @@ fun EpubReaderScreen(
                         onReachedEndOfBook = viewModel::reachedEndOfBookForAutoScroll,
                         onAutoScrollPause = viewModel::pauseAutoScroll,
                         onAutoScrollResume = viewModel::resumeAutoScrollIfPaused,
+                        dispatchers = viewModel.dispatchers,
                         modifier = Modifier
                             .fillMaxSize()
                             .testTag("reader_ready")
@@ -1108,6 +1108,7 @@ private fun EpubNavigatorView(
     onReachedEndOfBook: () -> Unit,
     onAutoScrollPause: (com.riffle.core.domain.autoscroll.PauseCause) -> Unit,
     onAutoScrollResume: () -> Unit,
+    dispatchers: com.riffle.core.domain.DispatcherProvider,
     modifier: Modifier = Modifier,
 ) {
     val context = LocalContext.current
@@ -1143,7 +1144,7 @@ private fun EpubNavigatorView(
             )
         }
     val readiumPresenter: ReadiumPresenter? = remember(state.publication, isContinuous, coroutineScope) {
-        if (isContinuous) null else ReadiumPresenter(coroutineScope, state.publication, rendererBridge)
+        if (isContinuous) null else ReadiumPresenter(coroutineScope, state.publication, rendererBridge, dispatchers.main)
     }
     val continuousPresenter: ContinuousPresenter? = remember(isContinuous) {
         if (isContinuous) ContinuousPresenter() else null
@@ -1503,7 +1504,7 @@ private fun EpubNavigatorView(
     // reserve isn't tied to the player opening, so this transition isn't one the user is staring at.
     LaunchedEffect(readaloudReservePx) {
         if (fragmentRef.value == null) return@LaunchedEffect
-        withContext(Dispatchers.Main) {
+        withContext(dispatchers.main) {
             rendererBridge.applyReadaloudReserve(readaloudReservePx)
         }
     }
@@ -1530,7 +1531,7 @@ private fun EpubNavigatorView(
             ) {
                 is FootnoteResolver.AnchorTarget.Footnote -> {
                     // Called from the JS binder thread; hop to main for Compose state.
-                    coroutineScope.launch(Dispatchers.Main) {
+                    coroutineScope.launch(dispatchers.main) {
                         currentOnFootnoteTapped(target.content)
                     }
                     true
@@ -1539,7 +1540,7 @@ private fun EpubNavigatorView(
                     // Capture where we are BEFORE the snap; offer a way back only if the target was
                     // actually off-page (the snap reports whether it changed columns).
                     val origin = currentLatestLocator()
-                    coroutineScope.launch(Dispatchers.Main) {
+                    coroutineScope.launch(dispatchers.main) {
                         val moved = if (fragmentRef.value != null) {
                             rendererBridge.snapToElement(fragmentId)
                         } else {
@@ -1943,7 +1944,7 @@ private fun EpubNavigatorView(
         while (true) {
             val container = containerRef.value
             if (container != null) {
-                withContext(Dispatchers.Main) {
+                withContext(dispatchers.main) {
                     val boundary = readerPresenter.scrollBoundary()
                     container.atForwardBoundary = boundary.atForwardBoundary
                     container.atBackwardBoundary = boundary.atBackwardBoundary
@@ -2168,7 +2169,7 @@ private fun EpubNavigatorView(
                             }
                             val key = locator.href.removeFragment().toString()
                             if (key.isNotEmpty() && !footnoteDocCache.containsKey(key)) {
-                                launch(Dispatchers.IO) {
+                                launch(dispatchers.io) {
                                     val bytes = currentPublication.get(locator.href.removeFragment())
                                         ?.read()?.getOrNull() ?: return@launch
                                     footnoteDocCache[key] = FootnoteResolver.parse(

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -24,6 +24,7 @@ import com.riffle.core.domain.AudioIdentityResolver
 import com.riffle.core.domain.AudioPlaybackPreferencesStore
 import com.riffle.core.domain.ListeningPreferencesStore
 import com.riffle.core.domain.ConnectivityObserver
+import com.riffle.core.domain.DispatcherProvider
 import com.riffle.core.domain.EpubOpenResult
 import com.riffle.core.domain.cfiDocPathToProgression
 import com.riffle.core.domain.extractAnchorFromCfi
@@ -62,7 +63,6 @@ import com.riffle.core.domain.resolveEpubHref
 import com.riffle.core.logging.LogChannel
 import com.riffle.core.logging.Logger
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -174,6 +174,7 @@ class EpubReaderViewModel @Inject constructor(
     private val readaloudSessionFactory: com.riffle.app.feature.reader.session.ReadaloudSession.Factory,
     private val logger: Logger,
     private val clock: Clock,
+    val dispatchers: DispatcherProvider,
 ) : AndroidViewModel(application) {
 
     // Formatting/typography/auto-scroll orchestrator — constructed with viewModelScope so
@@ -975,7 +976,7 @@ class EpubReaderViewModel @Inject constructor(
     }
 
     // Translates via character-count CFIs; see EpubCfiTranslator and ADR 0013.
-    private suspend fun Locator.toPayload(): SessionPayload = withContext(Dispatchers.Default) {
+    private suspend fun Locator.toPayload(): SessionPayload = withContext(dispatchers.default) {
         val readingOrder = publication?.readingOrder ?: emptyList()
         val spineIndex = readingOrder.indexOfFirst { link ->
             normalizeEpubHref(link.href.toString()) == normalizeEpubHref(href.toString())
@@ -1211,7 +1212,7 @@ class EpubReaderViewModel @Inject constructor(
 
     private suspend fun readChapterHtml(spineIndex: Int): String? {
         chapterHtmlCache[spineIndex]?.let { return it }
-        return withContext(Dispatchers.IO) {
+        return withContext(dispatchers.io) {
             val file = epubFile ?: return@withContext null
             val pub = publication ?: return@withContext null
             val link = pub.readingOrder.getOrNull(spineIndex) ?: return@withContext null

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/autoscroll/AutoScrollController.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/autoscroll/AutoScrollController.kt
@@ -1,6 +1,7 @@
 package com.riffle.app.feature.reader.autoscroll
 
 import com.riffle.core.domain.Clock
+import com.riffle.core.domain.DispatcherProvider
 import com.riffle.core.domain.SystemClock
 import com.riffle.core.domain.autoscroll.AutoScrollEvent
 import com.riffle.core.domain.autoscroll.AutoScrollSpeed
@@ -13,7 +14,6 @@ import com.riffle.core.domain.autoscroll.reduce
 import com.riffle.core.domain.autoscroll.speedOrNull
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
@@ -32,14 +32,14 @@ import javax.inject.Singleton
 /**
  * Coordinates an Auto-Scroll session: holds [state], emits pixel scroll deltas via [scrollDeltas],
  * and forwards lifecycle/UI events into the pure [reduce] state machine. Production uses
- * [Dispatchers.Main.immediate]; tests use [forTest] to inject a [StandardTestDispatcher].
+ * `DispatcherProvider.mainImmediate`; tests use [forTest] to inject a [StandardTestDispatcher].
  */
 @Singleton
 open class AutoScrollController internal constructor(
     dispatcher: CoroutineDispatcher,
     private var clock: Clock = SystemClock,
 ) {
-    @Inject constructor() : this(Dispatchers.Main.immediate, SystemClock)
+    @Inject constructor(dispatchers: DispatcherProvider) : this(dispatchers.mainImmediate, SystemClock)
 
     private val scope = CoroutineScope(SupervisorJob() + dispatcher)
     private val _state = MutableStateFlow<AutoScrollState>(AutoScrollState.Idle)

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/controllers/SearchController.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/controllers/SearchController.kt
@@ -1,11 +1,11 @@
 package com.riffle.app.feature.reader.controllers
 
 import com.riffle.app.feature.reader.session.OrchestratorScope
+import com.riffle.core.domain.DispatcherProvider
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.Channel
@@ -32,6 +32,7 @@ import org.readium.r2.shared.publication.services.search.SearchService
  */
 class SearchController @AssistedInject constructor(
     @Assisted private val scope: OrchestratorScope,
+    private val dispatchers: DispatcherProvider,
 ) {
 
     @AssistedFactory
@@ -145,7 +146,7 @@ class SearchController @AssistedInject constructor(
             return
         }
         val results = try {
-            withContext(Dispatchers.IO) {
+            withContext(dispatchers.io) {
                 val iterator = service.search(query)
                 val acc = mutableListOf<Locator>()
                 try {

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/presenter/ReadiumPresenter.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/presenter/ReadiumPresenter.kt
@@ -3,8 +3,8 @@ package com.riffle.app.feature.reader.presenter
 import com.riffle.app.feature.reader.renderer.RendererBridge
 import com.riffle.app.feature.reader.toEpubPreferences
 import com.riffle.core.domain.FormattingPreferences
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -37,6 +37,7 @@ internal class ReadiumPresenter(
     private val scope: CoroutineScope,
     private val publication: Publication,
     private val bridge: RendererBridge,
+    private val mainDispatcher: CoroutineDispatcher,
 ) : ReaderPresenter {
 
     private val _positionEvents = MutableSharedFlow<PositionUpdate>(replay = 0, extraBufferCapacity = 64)
@@ -175,7 +176,7 @@ internal class ReadiumPresenter(
      */
     suspend fun applyDecorations(decorations: List<Decoration>, group: String) {
         val nav = fragment as? DecorableNavigator ?: return
-        withContext(Dispatchers.Main) { nav.applyDecorations(decorations, group) }
+        withContext(mainDispatcher) { nav.applyDecorations(decorations, group) }
     }
 
     /** Stable token that changes whenever the attached fragment changes. */

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/PlayerCoordinator.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/PlayerCoordinator.kt
@@ -1,9 +1,9 @@
 package com.riffle.app.feature.reader.readaloud
 
+import com.riffle.core.domain.DispatcherProvider
 import com.riffle.core.domain.ReadaloudAudioRepository
 import com.riffle.core.domain.ReadaloudTrack
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -25,11 +25,12 @@ import javax.inject.Inject
 class PlayerCoordinator @Inject constructor(
     private val controller: ReadaloudController,
     private val audioRepository: ReadaloudAudioRepository,
+    dispatchers: DispatcherProvider,
 ) : PlayerController {
     /** Mirrors the controller's playback state so the screen has a single thing to observe. */
     override val state: StateFlow<ReadaloudController.PlaybackState> = controller.state
 
-    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+    private val scope = CoroutineScope(SupervisorJob() + dispatchers.mainImmediate)
 
     @Volatile private var track: ReadaloudTrack? = null
 

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/ReadaloudController.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/ReadaloudController.kt
@@ -7,13 +7,13 @@ import androidx.media3.session.MediaController
 import com.riffle.app.feature.audio.MediaSessionConnector
 import com.riffle.core.domain.ApplicationScope
 import com.riffle.core.domain.Clock
+import com.riffle.core.domain.DispatcherProvider
 import com.riffle.core.domain.ReadaloudTrack
 import com.riffle.core.domain.SystemClock
 import com.riffle.core.logging.LogChannel
 import com.riffle.core.logging.Logger
 import com.riffle.core.logging.RecordingLogger
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
@@ -37,13 +37,15 @@ import javax.inject.Singleton
 open class ReadaloudController @Inject constructor(
     private val connector: MediaSessionConnector?,
     applicationScope: ApplicationScope?,
+    dispatchers: DispatcherProvider,
     private val logger: Logger,
     private val clock: Clock,
 ) {
     // Test seam: subclasses that override the pre-warm methods need no real connector (only consulted
     // in [ensureConnected], which fakes never reach). Keeps the controller unit-fakeable without
-    // Robolectric.
-    protected constructor() : this(null, null, RecordingLogger(), SystemClock)
+    // Robolectric. Unconfined dispatchers are used here because test subclasses override every
+    // method that launches on the scope; the scope is still constructed but never dispatched against.
+    protected constructor() : this(null, null, UnconfinedDispatcherProvider, RecordingLogger(), SystemClock)
     data class PlaybackState(
         val connected: Boolean = false,
         val isPlaying: Boolean = false,
@@ -66,8 +68,8 @@ open class ReadaloudController @Inject constructor(
     // that launches on this scope, so [applicationScope] is permitted to be null — the fallback mirrors
     // the production SupervisorJob semantics so a future partial-override test fake doesn't get
     // surprised by sibling-cancel behaviour.
-    private val scope: CoroutineScope = applicationScope?.scopeOn(Dispatchers.Main.immediate)
-        ?: CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+    private val scope: CoroutineScope = applicationScope?.scopeOn(dispatchers.mainImmediate)
+        ?: CoroutineScope(SupervisorJob() + dispatchers.mainImmediate)
     private val _state = MutableStateFlow(PlaybackState())
     val state: StateFlow<PlaybackState> = _state.asStateFlow()
 
@@ -296,5 +298,12 @@ open class ReadaloudController @Inject constructor(
         const val FORWARD_SEC = 30.0
         private const val NEAR_START_SEC = 3.0
         private const val POLL_INTERVAL_MS = 250L
+
+        private val UnconfinedDispatcherProvider = object : DispatcherProvider {
+            override val main = kotlinx.coroutines.Dispatchers.Unconfined
+            override val mainImmediate = kotlinx.coroutines.Dispatchers.Unconfined
+            override val io = kotlinx.coroutines.Dispatchers.Unconfined
+            override val default = kotlinx.coroutines.Dispatchers.Unconfined
+        }
     }
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/ReadaloudOfflineDownloader.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/ReadaloudOfflineDownloader.kt
@@ -1,6 +1,7 @@
 package com.riffle.app.feature.reader.readaloud
 
 import android.content.Context
+import com.riffle.core.domain.DispatcherProvider
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 
@@ -24,6 +25,7 @@ interface ReadaloudOfflineDownloader {
 class ReadaloudOfflineDownloaderImpl @Inject constructor(
     @ApplicationContext private val context: Context,
     private val factory: ReadaloudStreamingSessionFactory,
+    private val dispatchers: DispatcherProvider,
 ) : ReadaloudOfflineDownloader {
     override suspend fun download(
         storytellerServerId: String,
@@ -37,6 +39,7 @@ class ReadaloudOfflineDownloaderImpl @Inject constructor(
                 context,
                 session.streaming.itemsByMediaId.values.toList(),
                 session.absToken,
+                dispatchers.io,
                 onProgress,
             )
         }.isSuccess

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/ReadaloudStreamingSessionFactory.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/ReadaloudStreamingSessionFactory.kt
@@ -7,6 +7,7 @@ import com.riffle.core.data.ReadaloudSidecarStore
 import com.riffle.core.data.StreamingSetupBuilder
 import com.riffle.core.domain.AudioIdentityResolver
 import com.riffle.core.domain.AudiobookIdentityResult
+import com.riffle.core.domain.DispatcherProvider
 import com.riffle.core.domain.ReadaloudLinkRepository
 import com.riffle.core.domain.ReadaloudTrack
 import com.riffle.core.domain.ServerRepository
@@ -15,7 +16,6 @@ import com.riffle.core.network.AbsLibraryApi
 import com.riffle.core.network.NetworkResult
 import com.riffle.core.network.StorytellerLibraryApi
 import dagger.hilt.android.qualifiers.ApplicationContext
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.io.File
 import javax.inject.Inject
@@ -34,6 +34,7 @@ class ReadaloudStreamingSessionFactory @Inject constructor(
     private val serverRepository: ServerRepository,
     private val tokenStorage: TokenStorage,
     private val linkRepository: ReadaloudLinkRepository,
+    private val dispatchers: DispatcherProvider,
 ) {
     // Guard against an evict-and-refetch loop when the Storyteller bundle is still partially aligned:
     // we attempt one fresh fetch per session, but if the re-fetched sidecar is also partial we stop.
@@ -50,7 +51,7 @@ class ReadaloudStreamingSessionFactory @Inject constructor(
         val absToken: String,
     )
 
-    suspend fun tryBuild(storytellerServerId: String, storytellerBookId: String): Session? = withContext(Dispatchers.IO) {
+    suspend fun tryBuild(storytellerServerId: String, storytellerBookId: String): Session? = withContext(dispatchers.io) {
         // 1. Resolve the ABS audiobook linked to this readaloud. No audiobook → not streamable.
         val audiobook = audioIdentityResolver.resolveForStorytellerBook(storytellerServerId, storytellerBookId)
         if (audiobook.serverId == storytellerServerId && audiobook.bookId == storytellerBookId) {

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/StreamingAudioDownloader.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/StreamingAudioDownloader.kt
@@ -9,7 +9,7 @@ import androidx.media3.datasource.DefaultHttpDataSource
 import androidx.media3.datasource.cache.CacheDataSource
 import androidx.media3.datasource.cache.CacheWriter
 import com.riffle.core.data.StreamingMediaItem
-import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.withContext
 import kotlin.coroutines.coroutineContext
@@ -27,8 +27,9 @@ object StreamingAudioDownloader {
         context: Context,
         items: List<StreamingMediaItem>,
         bearerToken: String,
+        ioDispatcher: CoroutineDispatcher,
         onProgress: (Float) -> Unit = {},
-    ) = withContext(Dispatchers.IO) {
+    ) = withContext(ioDispatcher) {
         val cache = StreamingAudioCache.get(context)
         val upstream = DefaultHttpDataSource.Factory()
             .setDefaultRequestProperties(mapOf("Authorization" to "Bearer $bearerToken"))

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/session/ReadaloudSession.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/session/ReadaloudSession.kt
@@ -20,6 +20,7 @@ import com.riffle.core.domain.AudioIdentity
 import com.riffle.core.domain.AudioIdentityResolver
 import com.riffle.core.domain.AudioPlaybackPreferencesStore
 import com.riffle.core.domain.ConnectivityObserver
+import com.riffle.core.domain.DispatcherProvider
 import com.riffle.core.domain.EpubRepository
 import com.riffle.core.domain.FormattingPreferences
 import com.riffle.core.domain.ListeningPreferencesStore
@@ -42,7 +43,6 @@ import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
@@ -94,6 +94,7 @@ class ReadaloudSession @AssistedInject constructor(
     private val audiobookHandoffState: AudiobookHandoffState,
     private val connectivityObserver: ConnectivityObserver,
     private val nowPlayingStore: NowPlayingStore,
+    private val dispatchers: DispatcherProvider,
     private val logger: Logger,
 ) {
 
@@ -1010,7 +1011,7 @@ class ReadaloudSession @AssistedInject constructor(
     internal fun buildSentenceQuotes(bundle: File) {
         if (quotesBuildStarted) return
         quotesBuildStarted = true
-        scope.launch(Dispatchers.IO) {
+        scope.launch(dispatchers.io) {
             try {
                 val chapters = com.riffle.core.domain.EpubContentExtractor.extract(bundle)?.chapters
                     ?: return@launch

--- a/app/src/test/kotlin/com/riffle/app/feature/navigation/HomeViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/navigation/HomeViewModelTest.kt
@@ -3,7 +3,10 @@ package com.riffle.app.feature.navigation
 import com.riffle.core.domain.AuthenticateResult
 import com.riffle.core.domain.CommitServerResult
 import com.riffle.core.domain.Collection
+import com.riffle.core.domain.DispatcherProvider
 import com.riffle.core.domain.PendingServer
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
 import com.riffle.core.domain.LastOpenedLibraryStore
 import com.riffle.core.domain.Library
 import com.riffle.core.domain.LibraryItem
@@ -103,6 +106,14 @@ class HomeViewModelTest {
         }
     }
 
+    private val unconfinedDispatchers = object : DispatcherProvider {
+        private val d: CoroutineDispatcher = Dispatchers.Unconfined
+        override val main = d
+        override val mainImmediate = d
+        override val io = d
+        override val default = d
+    }
+
     private fun makeVm(
         libraryRepo: LibraryObserver = fakeLibraryRepo(),
         refreshLibraries: com.riffle.core.domain.usecase.RefreshLibraries = FakeRefreshLibraries(),
@@ -112,6 +123,7 @@ class HomeViewModelTest {
         refreshLibraries = refreshLibraries,
         visibilityStore = fakeVisibilityStore(),
         lastOpenedLibraryStore = fakeLastOpenedStore(),
+        dispatchers = unconfinedDispatchers,
     )
 
     @Test

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/controllers/SearchControllerTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/controllers/SearchControllerTest.kt
@@ -1,6 +1,9 @@
 package com.riffle.app.feature.reader.controllers
 
 import android.net.FakeUri
+import com.riffle.core.domain.DispatcherProvider
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.launch
@@ -19,10 +22,18 @@ import org.readium.r2.shared.util.mediatype.MediaType
 @OptIn(ExperimentalCoroutinesApi::class)
 class SearchControllerTest {
 
+    private val unconfinedDispatchers = object : DispatcherProvider {
+        private val d: CoroutineDispatcher = Dispatchers.Unconfined
+        override val main = d
+        override val mainImmediate = d
+        override val io = d
+        override val default = d
+    }
+
     private fun makeController(): SearchController {
         val dispatcher = UnconfinedTestDispatcher()
         val scope = kotlinx.coroutines.CoroutineScope(dispatcher)
-        return SearchController(scope = scope)
+        return SearchController(scope = scope, dispatchers = unconfinedDispatchers)
     }
 
     // --- Tests ---
@@ -128,7 +139,7 @@ class SearchControllerTest {
         // Use StandardTestDispatcher so coroutine time is manually controlled.
         val testDispatcher = StandardTestDispatcher(testScheduler)
         val scope = kotlinx.coroutines.CoroutineScope(testDispatcher)
-        val controller = SearchController(scope = scope)
+        val controller = SearchController(scope = scope, dispatchers = unconfinedDispatchers)
 
         // bind(null) starts the debounce coroutine. publication=null means performSearch
         // exits early, but the debounce *fires* and applies the query-length<2 branch,

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/presenter/ReadiumPresenterTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/presenter/ReadiumPresenterTest.kt
@@ -44,6 +44,7 @@ class ReadiumPresenterTest {
             scope = kotlinx.coroutines.test.TestScope(),
             publication = stubPublication(),
             bridge = com.riffle.app.feature.reader.renderer.FakeRendererBridge(),
+            mainDispatcher = kotlinx.coroutines.test.StandardTestDispatcher(),
         )
         assertNull(presenter.attachmentStamp())
     }
@@ -57,6 +58,7 @@ class ReadiumPresenterTest {
             scope = kotlinx.coroutines.test.TestScope(),
             publication = stubPublication(),
             bridge = com.riffle.app.feature.reader.renderer.FakeRendererBridge(),
+            mainDispatcher = kotlinx.coroutines.test.StandardTestDispatcher(),
         )
         presenter.applyDecorations(emptyList(), "annotations")
         // No exception means contract preserved.

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/session/ReadaloudSessionTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/session/ReadaloudSessionTest.kt
@@ -70,6 +70,14 @@ import org.readium.r2.shared.util.mediatype.MediaType
  *   4. forward
  *   5. previousChapter / nextChapter
  */
+private val UnconfinedDispatchers = object : com.riffle.core.domain.DispatcherProvider {
+    private val d = kotlinx.coroutines.Dispatchers.Unconfined
+    override val main = d
+    override val mainImmediate = d
+    override val io = d
+    override val default = d
+}
+
 @OptIn(ExperimentalCoroutinesApi::class)
 class ReadaloudSessionTest {
 
@@ -230,6 +238,7 @@ class ReadaloudSessionTest {
                 io.mockk.every { it.isOnline } returns MutableStateFlow(true)
             },
             nowPlayingStore = NowPlayingStore(),
+            dispatchers = UnconfinedDispatchers,
             logger = RecordingLogger(),
         )
     }
@@ -445,6 +454,7 @@ class ReadaloudSessionTest {
                 every { it.isOnline } returns MutableStateFlow(true)
             },
             nowPlayingStore = NowPlayingStore(),
+            dispatchers = UnconfinedDispatchers,
             logger = RecordingLogger(),
         )
     }
@@ -598,6 +608,7 @@ class ReadaloudSessionTest {
                 every { it.isMetered() } returns false
             },
             nowPlayingStore = NowPlayingStore(),
+            dispatchers = UnconfinedDispatchers,
             logger = RecordingLogger(),
         )
     }
@@ -831,6 +842,7 @@ class ReadaloudSessionTest {
                     every { it.isOnline } returns MutableStateFlow(true)
                 },
                 nowPlayingStore = NowPlayingStore(),
+                dispatchers = UnconfinedDispatchers,
                 logger = RecordingLogger(),
             )
             // Wire up the audiobook item id that will be signalled
@@ -981,6 +993,7 @@ class ReadaloudSessionTest {
             every { it.isOnline } returns MutableStateFlow(true)
         },
         nowPlayingStore = NowPlayingStore(),
+        dispatchers = UnconfinedDispatchers,
         logger = RecordingLogger(),
     )
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -65,20 +65,6 @@ tasks.register("checkRiffleInfraSeams") {
             "app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModel.kt",
             "app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsViewModel.kt",
             "app/src/main/kotlin/com/riffle/app/feature/server/AddServerViewModel.kt",
-            // ---- Grandfathered — DispatcherProvider sweep follow-up (app/feature).
-            "app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookController.kt",
-            "app/src/main/kotlin/com/riffle/app/feature/navigation/HomeScreen.kt",
-            "app/src/main/kotlin/com/riffle/app/feature/navigation/HomeViewModel.kt",
-            "app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt",
-            "app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt",
-            "app/src/main/kotlin/com/riffle/app/feature/reader/autoscroll/AutoScrollController.kt",
-            "app/src/main/kotlin/com/riffle/app/feature/reader/controllers/SearchController.kt",
-            "app/src/main/kotlin/com/riffle/app/feature/reader/presenter/ReadiumPresenter.kt",
-            "app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/PlayerCoordinator.kt",
-            "app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/ReadaloudController.kt",
-            "app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/ReadaloudStreamingSessionFactory.kt",
-            "app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/StreamingAudioDownloader.kt",
-            "app/src/main/kotlin/com/riffle/app/feature/reader/session/ReadaloudSession.kt",
         )
 
         val scanRoots = listOf(

--- a/core/data/src/main/kotlin/com/riffle/core/data/di/modules/SyncModule.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/di/modules/SyncModule.kt
@@ -8,6 +8,7 @@ import com.riffle.core.data.StorytellerPositionSyncController
 import com.riffle.core.data.StorytellerReadaloudSyncer
 import com.riffle.core.database.LibraryItemDao
 import com.riffle.core.domain.AnnotationSyncConfigStore
+import com.riffle.core.domain.DispatcherProvider
 import com.riffle.core.domain.ReadingPositionStore
 import com.riffle.core.domain.ServerRepository
 import com.riffle.core.domain.TokenStorage
@@ -122,7 +123,7 @@ abstract class SyncModule {
         fun provideAnnotationSyncTargetHolder(
             configStore: AnnotationSyncConfigStore,
             factory: com.riffle.core.data.WebDavAnnotationSyncTargetFactory,
-            dispatchers: com.riffle.core.domain.DispatcherProvider,
+            dispatchers: DispatcherProvider,
         ): com.riffle.core.data.AnnotationSyncTargetHolder =
             com.riffle.core.data.AnnotationSyncTargetHolder(
                 configStore = configStore,
@@ -146,7 +147,7 @@ abstract class SyncModule {
             libraryItemDao: LibraryItemDao,
             locks: com.riffle.core.data.ReconcileLocks,
             sentinelWriter: com.riffle.core.data.DeviceMetaSentinelWriter,
-            dispatchers: com.riffle.core.domain.DispatcherProvider,
+            dispatchers: DispatcherProvider,
         ): com.riffle.core.data.AnnotationSyncController =
             com.riffle.core.data.AnnotationSyncController(
                 targetProvider = { holder.current() },


### PR DESCRIPTION
Closes #355

Drops the 13 app/feature reader allowlist entries for `checkRiffleInfraSeams` by routing every `Dispatchers.IO`/`Main`/`Main.immediate`/`Default` call through the injected `DispatcherProvider` seam (#338).

## Summary
- ViewModels / controllers (constructor-injected via Hilt): `AutoScrollController`, `ReadaloudController`, `AudiobookController`, `PlayerCoordinator`, `ReadaloudStreamingSessionFactory`, `ReadaloudSession`, `SearchController`, `HomeViewModel`, `EpubReaderViewModel` — each take `DispatcherProvider`.
- Non-Hilt instantiated: `ReadiumPresenter` and `StreamingAudioDownloader` take a `CoroutineDispatcher` parameter at the call site.
- Compose sites (`EpubReaderScreen`, `HomeScreen`) read `dispatchers` off the ViewModel (option **b** from the issue) so the seam stays out of Compose.
- `ReadaloudController`/`AudiobookController` keep their protected no-arg test constructor; it dispatches against `Dispatchers.Unconfined` via a private companion object since subclasses override every method that launches on the scope.
- `SyncModule.kt` (introduced by #362) had two unguarded `Dispatchers.IO` references that the seam check caught — also wired through `DispatcherProvider` here so the check stays green.
- Test fakes/fixtures updated to pass an unconfined `DispatcherProvider`.

## Test plan
- [x] `./gradlew check` green (includes `checkRiffleInfraSeams`)
- [x] `./gradlew test` green
- [x] Allowlist entries removed; new seam check passes with no further offenders