### PR TITLE
refactor(reader): introduce RendererBridge as the single WebView JS seam (#331)

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ColumnSnap.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ColumnSnap.kt
@@ -2,158 +2,32 @@ package com.riffle.app.feature.reader
 
 import java.net.URLDecoder
 import org.json.JSONObject
-import org.readium.r2.navigator.epub.EpubNavigatorFragment
-import org.readium.r2.shared.publication.Link
-import org.readium.r2.shared.publication.Locator
 
 /**
- * The single owner of paginated column-snapping for the EPUB reader. Every place that needs the page to
- * rest flush on the column grid goes through this object — navigation routes (TOC / search / resume),
- * in-document cross-references, the read-aloud follow, and the at-rest backstop — so a NEW navigation
- * route gets correct snapping just by calling [goAndSnap]; it never re-implements the grid math, the
- * reflow-tracking rAF loop, or the `innerWidth == page-snap pitch` assumption.
+ * JS-builder primitives that drive paginated column-snapping in the EPUB reader. The
+ * fragment-driving entry points were moved to
+ * [com.riffle.app.feature.reader.renderer.RendererBridge] in #331 — call sites now go through the
+ * bridge, which is the only place [org.readium.r2.navigator.epub.EpubNavigatorFragment.evaluateJavascript]
+ * is allowed to be invoked.
  *
- * All snapping holds because the reader is sized so `window.innerWidth` equals Readium's page-snap pitch
- * (see ReaderViewportAlignment) — `floor(x / innerWidth) * innerWidth` is therefore exactly a column
- * boundary. The rAF-based operation [goAndSnap] shares `window.__riffleSnapGen` so a later snap
- * supersedes an in-flight one instead of fighting it.
+ * The builders below remain in this file because the unit tests
+ * (`NarratedColumnsResultParserTest`, the various JS-shape tests) target them directly without a
+ * live WebView. Anything new that needs the page to rest flush on the column grid — new nav
+ * route, new readaloud follow rule — adds a JS builder here and a typed method on the bridge.
  *
- * The Kotlin entry points are the API; the `…Js` builders below are the implementation primitives
- * (internal so the script tests can exercise them directly).
+ * All snapping holds because the reader is sized so `window.innerWidth` equals Readium's
+ * page-snap pitch (see ReaderViewportAlignment) — `floor(x / innerWidth) * innerWidth` is
+ * therefore exactly a column boundary. The rAF-based operations share `window.__riffleSnapGen` so
+ * a later snap supersedes an in-flight one instead of fighting it.
  */
 internal object ColumnSnap {
 
-    // ── Fragment-aware API — the only thing call sites touch ────────────────────────────────
-
     /**
-     * Installs the at-rest snap backstop on a freshly loaded page (idempotent). Once horizontal scrolling
-     * settles off-grid in paginated mode it rounds to the nearest column, so the page can never REST
-     * between two pages no matter what moved it. Defers to the rAF trackers via its scroll-idle debounce.
+     * The element id a TOC/search/resume locator points at (its href fragment), or null for a
+     * jump to a resource start. Drives [snapToTargetColumnJs] so the landing snaps to the column
+     * the target itself occupies — robust to where go() landed and to the post-load reflow.
      */
-    suspend fun installBackstop(fragment: EpubNavigatorFragment) {
-        fragment.evaluateJavascript(SETTLE_SNAP_INSTALL_JS)
-    }
-
-    /**
-     * Navigates to [link] and snaps the landing onto the target element's column, tracking it through the
-     * new chapter's async typography reflow. THE entry point for navigation routes — call this instead of
-     * `go()` + a hand-rolled snap, and the route gets correct, drift-proof snapping for free.
-     */
-    suspend fun goAndSnap(fragment: EpubNavigatorFragment, link: Link) {
-        fragment.go(link)
-        fragment.evaluateJavascript(snapToTargetColumnJs(navTargetFragmentId(link.href.toString())))
-    }
-
-    /**
-     * [goAndSnap] for a [Locator] target (search hits, resume/peer-sync positions).
-     *
-     * [landAtStartWhenNoTarget] controls the no-DOM-fragment case: a chapter-level jump (TOC/search) lands
-     * at the chapter top (true, the default), but a background sync (audiobook/peer) whose locator is a
-     * within-chapter progression with no #fragment must instead round to the column grid where go() landed
-     * (false) — otherwise the post-go snap yanks the reader to the chapter top, off the actual synced page.
-     */
-    suspend fun goAndSnap(
-        fragment: EpubNavigatorFragment,
-        locator: Locator,
-        landAtStartWhenNoTarget: Boolean = true,
-    ) {
-        fragment.go(locator)
-        fragment.evaluateJavascript(
-            snapToTargetColumnJs(navTargetFragmentId(locator.href.toString()), landAtStartWhenNoTarget),
-        )
-    }
-
-    /**
-     * Re-pins the current page to its LAST column, tracking the chapter's async typography reflow — for
-     * a backward cross-resource page turn that Readium handled itself (paginated mode), which our nav
-     * handlers never see. Call from `onPageLoaded` when [landedAtEnd] reports the resource was placed at
-     * its end, so the imminent reflow can't strand the page several columns short of the true end.
-     */
-    suspend fun snapToEnd(fragment: EpubNavigatorFragment) {
-        fragment.evaluateJavascript(snapToEndColumnJs())
-    }
-
-    /**
-     * "true" iff the freshly loaded paginated page is resting on its LAST column — i.e. Readium
-     * positioned this resource at its end, which is what a backward cross-resource swipe does. "false"
-     * in scroll mode, for a single-page resource, or anywhere but the last column (a forward turn lands
-     * at column 0; a TOC jump lands at the chapter top). Read at `onPageLoaded`, BEFORE the typography
-     * injection reflows the page, so the check sees Readium's landing position against the base width.
-     */
-    suspend fun landedAtEnd(fragment: EpubNavigatorFragment): Boolean =
-        fragment.evaluateJavascript(LANDED_AT_END_JS)?.trim('"') == "true"
-
-    /**
-     * Snaps the current resource so the column containing [fragmentId] sits flush — for an in-document
-     * cross-reference tap ("Figure 4.1"), where the element is already in this document (no go()).
-     *
-     * Returns true iff the snap actually moved the page to a different column — i.e. the target was
-     * off-screen. A target already on the visible page snaps to the same column (returns false), so the
-     * caller can suppress a "return here" affordance there is nothing to come back from.
-     */
-    suspend fun snapToElementColumn(fragment: EpubNavigatorFragment, fragmentId: String): Boolean =
-        fragment.evaluateJavascript(scrollToColumnJs(fragmentId))?.trim('"') == "moved"
-
-    /**
-     * Follows the narrated sentence [text] to its column on a sentence change. Returns "on" (followed, or
-     * already on-page) or "off" — "off" means the sentence isn't on the current resource, so the caller
-     * go()s to the chapter that holds it.
-     */
-    suspend fun followNarratedSentence(fragment: EpubNavigatorFragment, text: String): String? =
-        fragment.evaluateJavascript(autoFollowSnapJs(text))?.trim('"')
-
-    /**
-     * Measures how the narrated sentence [text] is laid out across paginated columns: the CUMULATIVE
-     * fraction of its rendered width that falls in each column it spans, in reading order (e.g.
-     * `[0.62, 1.0]` for a sentence whose first 62% of width is on the current page and the rest on the
-     * next). Drives [NarratedColumnProgression] so intra-sentence page turns track the narration.
-     *
-     * Empty when the sentence fits a single column, isn't on this resource, or the reader is in scroll
-     * mode (vertical follow handles that) — all of which mean "don't turn within the sentence".
-     */
-    suspend fun measureNarratedColumns(fragment: EpubNavigatorFragment, text: String): List<Double> =
-        parseNarratedColumnsResult(fragment.evaluateJavascript(measureNarratedColumnsJs(text)))
-
-    /**
-     * Parse the raw string [measureNarratedColumnsJs] returned through `evaluateJavascript`.
-     * `evaluateJavascript` wraps a returned string in JSON quotes (the inner JSON number array
-     * has no quotes to escape) and returns `null` when the page is gone. The protocol the JS
-     * defines (see [measureNarratedColumnsJs]):
-     *
-     * - `null` → page gone → `[]`
-     * - `"off"` → sentence not on this resource → `[]`
-     * - `"scroll"` → vertical scroll mode → `[]`
-     * - `"[…]"` → JSON number array of cumulative width fractions (last ≈ 1.0)
-     * - anything else (malformed) → `[]` (defensive — never crash the playback loop)
-     *
-     * Extracted from [measureNarratedColumns] so the contract can be JVM-unit-tested without
-     * a WebView; see `NarratedColumnsResultParserTest`.
-     */
-    internal fun parseNarratedColumnsResult(raw: String?): List<Double> {
-        val trimmed = raw?.trim('"')?.trim() ?: return emptyList()
-        if (trimmed == "off" || trimmed == "scroll" || !trimmed.startsWith("[")) return emptyList()
-        return runCatching {
-            val arr = org.json.JSONArray(trimmed)
-            List(arr.length()) { arr.getDouble(it) }
-        }.getOrDefault(emptyList())
-    }
-
-    /**
-     * Snaps the page to the [columnIndex]-th column the narrated sentence [text] spans (clamped to the
-     * range it actually occupies), landing flush on the column grid. The companion to
-     * [measureNarratedColumns]: the progression decides the index, this performs the turn. Re-locates
-     * the sentence each call so it is robust to a reflow having moved the columns since measurement.
-     */
-    suspend fun snapNarratedColumn(fragment: EpubNavigatorFragment, text: String, columnIndex: Int) {
-        fragment.evaluateJavascript(snapNarratedColumnJs(text, columnIndex))
-    }
-
-    // ── Snapping primitives (JS builders) — implementation, internal for the script tests ────
-
-    // The element id a TOC/search/resume locator points at (its href fragment), or null for a jump to a
-    // resource start. Drives [snapToTargetColumnJs] so the landing snaps to the column the target itself
-    // occupies — robust to where go() landed and to the post-load reflow.
-    private fun navTargetFragmentId(href: String): String? =
+    fun navTargetFragmentId(href: String): String? =
         href.substringAfter('#', "").ifEmpty { null }
             ?.let { runCatching { URLDecoder.decode(it, "UTF-8") }.getOrDefault(it) }
 
@@ -166,7 +40,7 @@ internal object ColumnSnap {
      * page move (forward OR back) when narration has crossed into another column. Returns "on", or "off"
      * only when the text isn't on the current resource (another chapter) → the caller go()s to load it.
      */
-    internal fun autoFollowSnapJs(text: String): String {
+    fun autoFollowSnapJs(text: String): String {
         // Locate the narrated sentence by its TEXT (Readium strips the media-overlay span ids, so
         // getElementById can't find it). We match the WHOLE sentence, not a short prefix: chapter-opening
         // sentences in some books are recurring datelines — "LOG ENTRY: SOL 38", "LOG ENTRY: SOL 37", … —
@@ -295,10 +169,12 @@ internal object ColumnSnap {
     }
 
     /**
-     * Returns a JSON array of the narrated sentence's cumulative per-column width fractions (last ≈ 1.0),
-     * or the bare strings "off"/"scroll". See [measureNarratedColumns] for the Kotlin-side contract.
+     * Returns a JSON array of the narrated sentence's cumulative per-column width fractions
+     * (last ≈ 1.0), or the bare strings "off"/"scroll". The bridge wraps this into a typed call —
+     * [com.riffle.app.feature.reader.renderer.RendererBridge.measureNarratedColumns] — and parses
+     * the result via [parseNarratedColumnsResult].
      */
-    internal fun measureNarratedColumnsJs(text: String): String =
+    fun measureNarratedColumnsJs(text: String): String =
         """
         (function(){
         ${narratedColumnsPreludeJs(text)}
@@ -309,11 +185,10 @@ internal object ColumnSnap {
         """.trimIndent()
 
     /**
-     * Snaps scrollLeft to the [columnIndex]-th column the narrated sentence occupies (clamped), landing
-     * flush on the grid. Returns "on", or "off"/"scroll" when there's nothing to snap. See
-     * [snapNarratedColumn].
+     * Snaps scrollLeft to the [columnIndex]-th column the narrated sentence occupies (clamped),
+     * landing flush on the grid. Returns "on", or "off"/"scroll" when there's nothing to snap.
      */
-    internal fun snapNarratedColumnJs(text: String, columnIndex: Int): String =
+    fun snapNarratedColumnJs(text: String, columnIndex: Int): String =
         """
         (function(){
         ${narratedColumnsPreludeJs(text)}
@@ -334,7 +209,7 @@ internal object ColumnSnap {
     // `window.__riffleSnapGen` so a later jump supersedes an in-flight end-snap. The first snap runs
     // synchronously (before the first rAF) so a non-reflowing page lands immediately. Vertical (scroll)
     // mode pins scrollTop to the bottom instead; a page that fits the viewport is left untouched.
-    internal fun snapToEndColumnJs(): String =
+    fun snapToEndColumnJs(): String =
         "(function(){var se=document.scrollingElement;if(!se)return;" +
             "var gen=(window.__riffleSnapGen=(window.__riffleSnapGen||0)+1);" +
             "var lastW=-1,lastH=-1,stable=0,frames=0;" +
@@ -353,8 +228,8 @@ internal object ColumnSnap {
 
     // Reports whether the freshly loaded paginated page is resting on its LAST column — the signature of
     // a backward cross-resource turn (Readium positions the previous resource at its end). Paginated only
-    // (scrollWidth > innerWidth); "false" otherwise. Pairs with [snapToEnd] in onPageLoaded.
-    internal val LANDED_AT_END_JS: String =
+    // (scrollWidth > innerWidth); "false" otherwise. Pairs with the bridge's `snapToEnd` in onPageLoaded.
+    val LANDED_AT_END_JS: String =
         "(function(){var se=document.scrollingElement;if(!se)return 'false';" +
             "var iw=window.innerWidth;if(!(iw>0))return 'false';" +
             "if(!(se.scrollWidth > iw + 4))return 'false';" +
@@ -368,7 +243,7 @@ internal object ColumnSnap {
     //    the element to the top of the viewport; an element already fully on screen isn't moved.
     // Returns 'moved' when the snap changed the visible page (target was off-page → offer a return),
     // 'same' when it was already visible, or 'absent' when the id isn't in this document.
-    internal fun scrollToColumnJs(fragmentId: String): String =
+    fun scrollToColumnJs(fragmentId: String): String =
         "(function(){var el=document.getElementById(${JSONObject.quote(fragmentId)});" +
             "if(!el)return 'absent';" +
             "var se=document.scrollingElement||document.documentElement;" +
@@ -400,7 +275,7 @@ internal object ColumnSnap {
     // could rest off-grid for the entire session — the "page slightly turned to next" book-open bug. The
     // fallback fires once ~200ms after install and only if `__riffleSnapGen` is unchanged (i.e. no
     // navigation snap took over) — so it can't clobber an in-flight [snapToTargetColumnJs] tracker.
-    internal val SETTLE_SNAP_INSTALL_JS: String =
+    val SETTLE_SNAP_INSTALL_JS: String =
         """
         (function(){
           if(window.__riffleSettleSnapInstalled) return;
@@ -440,7 +315,7 @@ internal object ColumnSnap {
     // to column 0 (true, the default); a position-based jump (a background sync that already go()'d to a
     // within-chapter progression) rounds the current scroll to the column grid instead (false), preserving
     // where go() landed rather than yanking to the chapter top.
-    internal fun snapToTargetColumnJs(fragmentId: String?, landAtStartWhenNoTarget: Boolean = true): String {
+    fun snapToTargetColumnJs(fragmentId: String?, landAtStartWhenNoTarget: Boolean = true): String {
         val idLiteral = if (fragmentId.isNullOrEmpty()) "null" else JSONObject.quote(fragmentId)
         val noTargetSnap = if (landAtStartWhenNoTarget) "se.scrollLeft=0;" else "se.scrollLeft=Math.round(se.scrollLeft/iw)*iw;"
         return "(function(){var id=$idLiteral;" +
@@ -458,5 +333,25 @@ internal object ColumnSnap {
             "if((stable>=3&&frames>=2)||frames++>72){snap();return;}" + // settled, or ~1.2s safety cap
             "requestAnimationFrame(tick);}" +
             "tick();})()"
+    }
+
+    /**
+     * Parse the raw string [measureNarratedColumnsJs] returned through `evaluateJavascript`.
+     * `evaluateJavascript` wraps a returned string in JSON quotes (the inner JSON number array
+     * has no quotes to escape) and returns `null` when the page is gone. Protocol:
+     *
+     * - `null` → page gone → `[]`
+     * - `"off"` → sentence not on this resource → `[]`
+     * - `"scroll"` → vertical scroll mode → `[]`
+     * - `"[…]"` → JSON number array of cumulative width fractions (last ≈ 1.0)
+     * - anything else (malformed) → `[]` (defensive — never crash the playback loop)
+     */
+    fun parseNarratedColumnsResult(raw: String?): List<Double> {
+        val trimmed = raw?.trim('"')?.trim() ?: return emptyList()
+        if (trimmed == "off" || trimmed == "scroll" || !trimmed.startsWith("[")) return emptyList()
+        return runCatching {
+            val arr = org.json.JSONArray(trimmed)
+            List(arr.length()) { arr.getDouble(it) }
+        }.getOrDefault(emptyList())
     }
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -1119,8 +1119,23 @@ private fun EpubNavigatorView(
     // renderer (Readium fragment vs custom NestedScrollView), so the two concrete handles are kept
     // for the few call sites that drive Readium-specific commands (fragment attach, navigateToLink,
     // updateLayoutContext). Mode-agnostic call sites use `readerPresenter` below.
+    // Mutable holder for the current reserve so the bridge can read the live value (issue #331:
+    // the bridge installs the readaloud-reserve capability on every page load and needs the
+    // current value at install time).
+    val currentReadaloudReservePxState = remember { mutableStateOf(readaloudReservePx) }
+    currentReadaloudReservePxState.value = readaloudReservePx
+    val rendererBridge: com.riffle.app.feature.reader.renderer.RendererBridge =
+        remember(state.publication, coroutineScope) {
+            // Shared across modes: the bridge short-circuits to a no-op when `fragmentProvider`
+            // returns null (continuous mode keeps the fragment parked at height=0), so it is safe
+            // to construct once per publication and not key on isContinuous.
+            com.riffle.app.feature.reader.renderer.DefaultRendererBridge(
+                fragmentProvider = { fragmentRef.value },
+                readaloudReserveProvider = { currentReadaloudReservePxState.value },
+            )
+        }
     val readiumPresenter: ReadiumPresenter? = remember(state.publication, isContinuous, coroutineScope) {
-        if (isContinuous) null else ReadiumPresenter(coroutineScope, state.publication)
+        if (isContinuous) null else ReadiumPresenter(coroutineScope, state.publication, rendererBridge)
     }
     val continuousPresenter: ContinuousPresenter? = remember(isContinuous) {
         if (isContinuous) ContinuousPresenter() else null
@@ -1212,7 +1227,6 @@ private fun EpubNavigatorView(
     val currentReadaloudAvailable by rememberUpdatedState(readaloudAvailable)
     // Latest readaloud bottom reserve, read inside the (remembered-once) pagination listener so each
     // freshly loaded page re-applies the current value.
-    val currentReadaloudReservePx by rememberUpdatedState(readaloudReservePx)
     val currentPublication by rememberUpdatedState(state.publication)
     // rememberUpdatedState: spinePositions arrives asynchronously (Readium computes positions
     // after publication load). The AndroidView factory captures this reference so the continuous
@@ -1350,14 +1364,12 @@ private fun EpubNavigatorView(
                                 currentSentenceQuotes, currentSentenceChapters, loc.href.toString(),
                             )
                             val byText = if (sentences.isNotEmpty() && nav != null) {
-                                nav.evaluateJavascript(resolveSelectionSentenceJs(sentences))
-                                    ?.trim('"')?.takeIf { it.isNotEmpty() }
+                                rendererBridge.resolveSelectionSentence(sentences)
                             } else {
                                 null
                             }
                             val spanId = byText
-                                ?: nav?.evaluateJavascript("window.__riffleSelSpan || ''")
-                                    ?.trim('"')?.takeIf { it.isNotEmpty() }
+                                ?: nav?.let { rendererBridge.readSelectionSpanId() }
                             val fragId = spanId ?: loc.locations.fragments.firstOrNull()
                             val ref = if (fragId != null) "${loc.href}#$fragId" else loc.href.toString()
                             currentOnPlayFromHere(ref)
@@ -1453,21 +1465,13 @@ private fun EpubNavigatorView(
                     // measure here and only re-snap below if it is still current, otherwise a swipe during
                     // the awaited injections could end-snap a DIFFERENT chapter (a forward overshoot).
                     val hrefAtLoad = currentHrefHolder[0]
-                    val landedAtEnd = ColumnSnap.landedAtEnd(fragment)
-                    fragment.evaluateJavascript(RECT_TO_JSON_POLYFILL_JS)
-                    fragment.evaluateJavascript(SELECTION_SPAN_TRACKER_JS)
-                    fragment.evaluateJavascript(typographyOverrideInjectionJs())
-                    fragment.evaluateJavascript(FootnoteAnchorBridge.INSTALL_SCRIPT)
-                    // Reserve the bottom strip for the readaloud player on this freshly loaded page
-                    // (paginated + readaloud-available only; see ReadaloudReserve.kt). Inject the rule,
-                    // then apply the current value so the page lands already paginated above the strip —
-                    // no reflow when the player is later opened.
-                    fragment.evaluateJavascript(readaloudReserveInjectionJs())
-                    fragment.evaluateJavascript(readaloudReserveApplyJs(currentReadaloudReservePx))
-                    // Install the at-rest column-snap backstop: once scrolling settles off-grid in
-                    // paginated mode it rounds to the nearest column, so the page can never REST between
-                    // two pages no matter what moved it. Idempotent; defers to the rAF trackers.
-                    ColumnSnap.installBackstop(fragment)
+                    val landedAtEnd = rendererBridge.landedAtEnd()
+                    // Install every paged/vertical-mode JS capability in dependency order — rect
+                    // polyfill, selection tracker, typography, footnote bridge, readaloud reserve,
+                    // settle backstop — through the renderer bridge (#331). The capability list is
+                    // declared once in DefaultRendererBridge; adding a new one is a registration,
+                    // not another evaluateJavascript() at this call site.
+                    rendererBridge.installPageCapabilities()
                     // NOTE: do NOT snap to the column grid here for the general case. The typography
                     // injection above reflows the page asynchronously, so a snap at this point rounds a
                     // pre-reflow position and lands close-but-not-exact. The post-go() snap in the
@@ -1477,7 +1481,7 @@ private fun EpubNavigatorView(
                     // Readium's own ViewPager), so there is no post-go snap to keep the end pinned through
                     // the reflow. Re-pin to the last column here; snapToEnd's rAF loop tracks the reflow.
                     if (landedAtEnd && currentHrefHolder[0] == hrefAtLoad) {
-                        ColumnSnap.snapToEnd(fragment)
+                        rendererBridge.snapToEnd()
                     }
                 }
             }
@@ -1490,10 +1494,9 @@ private fun EpubNavigatorView(
     // is a no-op. Unlike the earlier open-gated reserve, there is no top-of-page anchor to capture: the
     // reserve isn't tied to the player opening, so this transition isn't one the user is staring at.
     LaunchedEffect(readaloudReservePx) {
-        val fragment = fragmentRef.value ?: return@LaunchedEffect
+        if (fragmentRef.value == null) return@LaunchedEffect
         withContext(Dispatchers.Main) {
-            fragment.evaluateJavascript(readaloudReserveInjectionJs())
-            fragment.evaluateJavascript(readaloudReserveApplyJs(readaloudReservePx))
+            rendererBridge.applyReadaloudReserve(readaloudReservePx)
         }
     }
 
@@ -1529,8 +1532,11 @@ private fun EpubNavigatorView(
                     // actually off-page (the snap reports whether it changed columns).
                     val origin = currentLatestLocator()
                     coroutineScope.launch(Dispatchers.Main) {
-                        val moved = fragmentRef.value
-                            ?.let { ColumnSnap.snapToElementColumn(it, fragmentId) } ?: false
+                        val moved = if (fragmentRef.value != null) {
+                            rendererBridge.snapToElement(fragmentId)
+                        } else {
+                            false
+                        }
                         if (moved && origin != null) currentOnCaptureReturnTarget(origin)
                     }
                     true
@@ -1673,12 +1679,9 @@ private fun EpubNavigatorView(
     // sentence's text — quotes are in reading order and only this chapter's sentences are in the DOM).
     LaunchedEffect(pageTopProbeRequests) {
         pageTopProbeRequests.collect { href ->
-            val fragment = fragmentRef.value
             val ordered = currentSentenceQuotes.entries.toList()
-            val fragmentId = if (fragment != null && ordered.isNotEmpty()) {
-                val idx = fragment.evaluateJavascript(
-                    firstVisibleSentenceJs(ordered.map { it.value.highlight }),
-                )?.trim('"')?.toIntOrNull()
+            val fragmentId = if (fragmentRef.value != null && ordered.isNotEmpty()) {
+                val idx = rendererBridge.firstVisibleSentenceIndex(ordered.map { it.value.highlight })
                 idx?.let { ordered.getOrNull(it)?.key }
             } else {
                 null
@@ -1841,12 +1844,12 @@ private fun EpubNavigatorView(
             // mode-agnostic presenter.pageBy(); ContinuousPresenter and ReadiumPresenter own the
             // mode-specific turn semantics.
             if (currentFormattingPrefs.orientation == ReaderOrientation.Vertical && container != null) {
-                val fragment = fragmentRef.value ?: return@collect
+                if (fragmentRef.value == null) return@collect
                 val boundary = readerPresenter.scrollBoundary()
                 val atBoundary = if (direction == PageDirection.Forward) boundary.atForwardBoundary
                 else boundary.atBackwardBoundary
                 container.handleVolumeScroll(forward = direction == PageDirection.Forward, atBoundary = atBoundary) { js ->
-                    launch { fragment.evaluateJavascript(js) }
+                    launch { rendererBridge.evaluateBoundaryScroll(js) }
                 }
             } else {
                 readerPresenter.pageBy(direction)
@@ -2295,26 +2298,13 @@ private fun EpubNavigatorView(
         if (formattingPrefs.orientation == ReaderOrientation.Vertical) {
             val verticalFragment = fragmentRef.value
             LaunchedEffect(verticalFragment) {
-                val fragment = verticalFragment ?: return@LaunchedEffect
-                // JS evaluation is suspending: a delta isn't collected until the previous
-                // evaluateJavascript round-trip resolves, so per-delta dispatch already gets
-                // natural backpressure-driven batching (no need to accumulate manually before
-                // the call — the accumulator inside the controller only emits whole pixels).
+                if (verticalFragment == null) return@LaunchedEffect
+                // JS evaluation is suspending inside the renderer bridge: a delta isn't collected
+                // until the previous round-trip resolves, so per-delta dispatch already gets
+                // natural backpressure-driven batching (no need to accumulate manually before the
+                // call — the accumulator inside the controller only emits whole pixels).
                 autoScrollDeltas.collect { flushed ->
-                    // Return a plain integer (1 = moved, 0 = stuck). Returning a JSON object
-                    // and parsing it as a string is a trap: evaluateJavascript JSON-encodes the
-                    // JS return value, so a JSON-stringified object comes back as a doubly-
-                    // encoded string ('"{\"moved\":true}"') whose internal quotes are escaped.
-                    val rawResult = fragment.evaluateJavascript(
-                        """
-                        (function(){
-                          var before = window.scrollY;
-                          window.scrollBy(0, $flushed);
-                          return window.scrollY !== before ? 1 : 0;
-                        })()
-                        """.trimIndent(),
-                    ) ?: return@collect
-                    val moved = rawResult.trim().trim('"') == "1"
+                    val moved = rendererBridge.scrollByPx(flushed)
                     if (moved) return@collect
                     // Stuck at the bottom of this chapter. Vertical mode stops auto-scroll
                     // rather than auto-advancing — the user's eye is mid-viewport when scrollY

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -2304,7 +2304,11 @@ private fun EpubNavigatorView(
                 // natural backpressure-driven batching (no need to accumulate manually before the
                 // call — the accumulator inside the controller only emits whole pixels).
                 autoScrollDeltas.collect { flushed ->
-                    val moved = rendererBridge.scrollByPx(flushed)
+                    // null = the WebView is gone mid-tick (chapter swap, fragment recreate): skip
+                    // the iteration, the next delta will arrive once the fragment is back. The
+                    // original direct-evaluateJavascript path used `?: return@collect` here for
+                    // the same reason — must NOT treat it as "stuck at end" and fire end-of-book.
+                    val moved = rendererBridge.scrollByPx(flushed) ?: return@collect
                     if (moved) return@collect
                     // Stuck at the bottom of this chapter. Vertical mode stops auto-scroll
                     // rather than auto-advancing — the user's eye is mid-viewport when scrollY

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/presenter/ReadiumPresenter.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/presenter/ReadiumPresenter.kt
@@ -1,8 +1,7 @@
 package com.riffle.app.feature.reader.presenter
 
-import com.riffle.app.feature.reader.ColumnSnap
+import com.riffle.app.feature.reader.renderer.RendererBridge
 import com.riffle.app.feature.reader.toEpubPreferences
-import com.riffle.app.feature.reader.typographyOverrideInjectionJs
 import com.riffle.core.domain.FormattingPreferences
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -29,20 +28,15 @@ import org.readium.r2.shared.util.Url
  * change). All events fired through the feed methods are buffered (extra capacity 64) so
  * producers never suspend.
  *
- * Issue #300 cuts over: decoration application ([applyDecorations]), navigation
- * ([navigateToLocator], [navigateToLink], [pageBy]), typography ([applyTypography] +
- * [updateLayoutContext]). Fragment-listener events (`feedPageLoaded`,
- * `feedInternalLink`, …) exist for future orchestrators; the screen still installs the
- * Readium listeners directly today.
- *
- * @param scope a lifecycle-scoped [CoroutineScope] (usually `viewModelScope`) that owns the
- *   fragment-position collector. It must outlive the adapter.
- * @param publication the open publication, used to parse Locator JSON for [NavigationTarget]s
- *   that arrive as raw JSON (resume from storage).
+ * After #331, every paginated/vertical `evaluateJavascript(` call flows through the supplied
+ * [RendererBridge] — navigation snapping, typography overrides, scroll-boundary probes, the
+ * readaloud follow primitives. The presenter still owns Readium's typed APIs (`submitPreferences`,
+ * `applyDecorations`, `go`, `goForward`/`goBackward`) because those are not JS calls.
  */
 internal class ReadiumPresenter(
     private val scope: CoroutineScope,
     private val publication: Publication,
+    private val bridge: RendererBridge,
 ) : ReaderPresenter {
 
     private val _positionEvents = MutableSharedFlow<PositionUpdate>(replay = 0, extraBufferCapacity = 64)
@@ -107,12 +101,6 @@ internal class ReadiumPresenter(
     }
 
     // ----- Feed methods called by the screen's existing Readium listener objects --------------
-    //
-    // [PaginationListener.onPageLoaded], [EpubNavigatorFragment.Listener.shouldFollowInternalLink],
-    // tap zones, selection, and annotation-tap callbacks forward to these so [pageLoadEvents],
-    // [linkEvents], [tapEvents], [selectionEvents], and [annotationTapEvents] become the
-    // canonical paths for future orchestrators. The screen still installs the listeners and
-    // wires them up; the view-model split is what removes that intermediate.
 
     fun feedPageLoaded() {
         pageLoadCount += 1
@@ -162,7 +150,7 @@ internal class ReadiumPresenter(
         val fragment = fragment ?: return
         val locator = target.toLocator(publication) ?: return
         if (options.snap) {
-            ColumnSnap.goAndSnap(fragment, locator, options.landAtStartWhenNoTarget)
+            bridge.snapAfterGoTo(locator, options.landAtStartWhenNoTarget)
         } else {
             fragment.go(locator, animated = options.animated)
         }
@@ -170,25 +158,19 @@ internal class ReadiumPresenter(
 
     override suspend fun applyTypography(prefs: FormattingPreferences) {
         val fragment = fragment ?: return
-        // Live-update Readium's typography for the attached fragment. The screen previously
-        // called `fragmentRef.value?.submitPreferences(...)` directly; routing through here keeps
-        // the layout context (orientation + fixed-layout flag) on the presenter rather than
-        // forcing every caller to thread it through.
         fragment.submitPreferences(prefs.toEpubPreferences(isLandscape, isFixedLayout))
         // The injected CSS overrides (font family, custom margins) are also re-applied on each
-        // onPageLoaded by PaginationListener; doing it here too means a live preferences change
-        // takes effect immediately without waiting for the next page turn.
-        fragment.evaluateJavascript(typographyOverrideInjectionJs())
+        // onPageLoaded by the bridge's TypographyOverride capability; doing it here too means a
+        // live preferences change takes effect immediately without waiting for the next page turn.
+        bridge.applyTypographyOverride()
     }
 
     override fun snapshotPosition(): ReaderPosition? = lastPosition
 
     /**
      * Apply Readium decorations to the currently attached fragment for a given group. No-op when
-     * no fragment is attached or the fragment is not a [DecorableNavigator] — exactly mirrors the
-     * original screen-level `applyDecorationsBlock` lambda this method replaces.
-     *
-     * Called from [com.riffle.app.feature.reader.ReadiumHighlightRenderer] via the screen's
+     * no fragment is attached or the fragment is not a [DecorableNavigator]. Called from
+     * [com.riffle.app.feature.reader.ReadiumHighlightRenderer] via the screen's
      * `applyDecorationsBlock` lambda.
      */
     suspend fun applyDecorations(decorations: List<Decoration>, group: String) {
@@ -196,26 +178,15 @@ internal class ReadiumPresenter(
         withContext(Dispatchers.Main) { nav.applyDecorations(decorations, group) }
     }
 
-    /**
-     * Stable token that changes whenever the attached fragment changes. Replaces the
-     * `currentNavigatorStamp` lambda the screen passes into the highlight renderer: search-result
-     * settle loops break out when the stamp changes mid-iteration.
-     */
+    /** Stable token that changes whenever the attached fragment changes. */
     fun attachmentStamp(): Any? = fragment
 
     // ----- Readium-typed navigation ---------------------------------------------------------
-    //
-    // The screen still constructs Readium Locator/Link from TOC entries, search results, and
-    // server progress; these convenience overloads keep the type-conversion at the boundary
-    // instead of forcing every caller to round-trip through JSON. They collapse into
-    // [navigateTo] once the view-model owns navigation entirely (out of this issue's scope).
 
     /**
-     * Navigate to [locator] and snap to the column it landed in. Replaces the screen-level
-     * `ColumnSnap.goAndSnap` and `fragment.go` calls. In vertical (scroll) mode the snap JS is a
-     * no-op, so passing `snap = true` is safe for both orientations; pass `snap = false` to skip
-     * the snap entirely when the caller knows the page must not be rounded (e.g. the readaloud
-     * `play-from-here` resume which already lands precisely).
+     * Navigate to [locator] and (optionally) snap to its column. The snap path goes through the
+     * bridge; the no-snap path uses Readium's `go()` directly because the caller knows the page
+     * must not be rounded (e.g. the readaloud `play-from-here` resume which already lands precisely).
      */
     suspend fun navigateToLocator(
         locator: Locator,
@@ -225,19 +196,16 @@ internal class ReadiumPresenter(
     ) {
         val fragment = fragment ?: return
         if (snap) {
-            ColumnSnap.goAndSnap(fragment, locator, landAtStartWhenNoTarget)
+            bridge.snapAfterGoTo(locator, landAtStartWhenNoTarget)
         } else {
             fragment.go(locator, animated = animated)
         }
     }
 
-    /**
-     * Navigate to [link] (TOC tap, internal cross-resource link) and snap to the column it
-     * landed in. Replaces the screen-level `ColumnSnap.goAndSnap(fragment, link)`.
-     */
+    /** Navigate to [link] (TOC tap, internal cross-resource link) and snap to its column. */
     suspend fun navigateToLink(link: Link) {
-        val fragment = fragment ?: return
-        ColumnSnap.goAndSnap(fragment, link)
+        if (fragment == null) return
+        bridge.snapAfterGoTo(link)
     }
 
     override suspend fun pageBy(direction: PageDirection) {
@@ -249,38 +217,24 @@ internal class ReadiumPresenter(
     }
 
     override suspend fun followReadaloudSentence(text: String): ReadaloudFollowResult {
-        val fragment = fragment ?: return ReadaloudFollowResult.Unavailable
-        // ColumnSnap's JS protocol returns "off" when the sentence isn't on the rendered resource
-        // (caller then falls back to navigation), null when the WebView is gone, and "scroll" / any
-        // other value when the page successfully snapped or the mode doesn't drive per-column follow.
-        val where = ColumnSnap.followNarratedSentence(fragment, text) ?: return ReadaloudFollowResult.Unavailable
+        if (fragment == null) return ReadaloudFollowResult.Unavailable
+        val where = bridge.followNarratedSentence(text) ?: return ReadaloudFollowResult.Unavailable
         return if (where == "off") ReadaloudFollowResult.OffPage else ReadaloudFollowResult.Snapped
     }
 
     override suspend fun measureReadaloudColumns(text: String): List<Double> {
-        val fragment = fragment ?: return emptyList()
-        return ColumnSnap.measureNarratedColumns(fragment, text)
+        if (fragment == null) return emptyList()
+        return bridge.measureNarratedColumns(text)
     }
 
     override suspend fun snapReadaloudColumn(text: String, columnIndex: Int) {
-        val fragment = fragment ?: return
-        ColumnSnap.snapNarratedColumn(fragment, text, columnIndex)
+        if (fragment == null) return
+        bridge.snapNarratedColumn(text, columnIndex)
     }
 
     override suspend fun scrollBoundary(): ScrollBoundary {
-        // Two JS calls instead of one combined return: the second is a no-op when the first
-        // already moved scrollY (it hasn't here — we're reading state, not writing), and keeping
-        // them separate makes the failure mode obvious if either ever returns malformed JSON.
-        // Memory: `reference_test_avd_chrome55_webview` — these JS calls work on real devices and
-        // current emulators (post-API-25); the only known issue is API-25's Chrome 55 WebView,
-        // which the project has aged past.
-        val fragment = fragment ?: return ScrollBoundary.None
-        val atForward = fragment.evaluateJavascript(
-            "(window.scrollY + window.innerHeight >= document.body.scrollHeight - 4).toString()"
-        )?.trim('"') == "true"
-        val atBackward = fragment.evaluateJavascript(
-            "(window.scrollY <= 4).toString()"
-        )?.trim('"') == "true"
+        if (fragment == null) return ScrollBoundary.None
+        val (atForward, atBackward) = bridge.scrollBoundary()
         return ScrollBoundary(atForwardBoundary = atForward, atBackwardBoundary = atBackward)
     }
 

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/renderer/DefaultRendererBridge.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/renderer/DefaultRendererBridge.kt
@@ -115,8 +115,14 @@ internal class DefaultRendererBridge(
         fragment?.evaluateJavascript(firstVisibleSentenceJs(highlights))
             ?.trim('"')?.toIntOrNull()
 
-    override suspend fun scrollByPx(delta: Int): Boolean {
-        val raw = fragment?.evaluateJavascript(
+    override suspend fun scrollByPx(delta: Int): Boolean? {
+        // Return a plain integer (1 = moved, 0 = stuck). Returning a JSON object and parsing it
+        // as a string is a trap: evaluateJavascript JSON-encodes the JS return value, so a
+        // JSON-stringified object comes back as a doubly-encoded string ('"{\"moved\":true}"').
+        // Null (here AND from evaluateJavascript) means "page gone" — the caller distinguishes
+        // that from "stuck at end" so it doesn't fire end-of-book signals on a transient swap.
+        val frag = fragment ?: return null
+        val raw = frag.evaluateJavascript(
             """
             (function(){
               var before = window.scrollY;
@@ -124,7 +130,7 @@ internal class DefaultRendererBridge(
               return window.scrollY !== before ? 1 : 0;
             })()
             """.trimIndent(),
-        ) ?: return false
+        ) ?: return null
         return raw.trim().trim('"') == "1"
     }
 

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/renderer/DefaultRendererBridge.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/renderer/DefaultRendererBridge.kt
@@ -1,0 +1,192 @@
+package com.riffle.app.feature.reader.renderer
+
+import com.riffle.app.feature.reader.ColumnSnap
+import com.riffle.app.feature.reader.FootnoteAnchorBridge
+import com.riffle.app.feature.reader.RECT_TO_JSON_POLYFILL_JS
+import com.riffle.app.feature.reader.SELECTION_SPAN_TRACKER_JS
+import com.riffle.app.feature.reader.firstVisibleSentenceJs
+import com.riffle.app.feature.reader.readaloudReserveApplyJs
+import com.riffle.app.feature.reader.readaloudReserveInjectionJs
+import com.riffle.app.feature.reader.resolveSelectionSentenceJs
+import com.riffle.app.feature.reader.typographyOverrideInjectionJs
+import java.net.URLDecoder
+import org.readium.r2.navigator.epub.EpubNavigatorFragment
+import org.readium.r2.shared.publication.Link
+import org.readium.r2.shared.publication.Locator
+
+/**
+ * The production [RendererBridge]: wraps the currently attached [EpubNavigatorFragment]. Every
+ * `evaluateJavascript(` call in paged/vertical mode goes through here — the lint rule enforces
+ * the rest of the package keeps its hands off the WebView's JS world.
+ *
+ * The fragment is supplied by a lambda (not held by reference) so that rotation — which recreates
+ * the fragment — doesn't require a swap on the bridge: callers update the [fragmentProvider]'s
+ * source-of-truth (e.g. a `mutableStateOf<EpubNavigatorFragment?>(null)`) and the bridge picks
+ * the new fragment up on the next call. A null fragment means "no document is currently driven";
+ * every method short-circuits to a sensible default (typically a no-op or null).
+ *
+ * The capability registry is declared once in the companion object: rect polyfill → selection
+ * tracker, footnote bridge (both depend on the polyfill); typography override; readaloud reserve;
+ * settle backstop. The dependency graph is the contract — the topo sort places dependents after
+ * their deps in [installPageCapabilities].
+ */
+internal class DefaultRendererBridge(
+    private val fragmentProvider: () -> EpubNavigatorFragment?,
+    private val readaloudReserveProvider: () -> Int,
+    override val capabilities: List<RendererCapability> = defaultCapabilities(readaloudReserveProvider),
+) : RendererBridge {
+
+    private val installOrder: List<RendererCapability> = topoSortCapabilities(capabilities)
+
+    private val fragment: EpubNavigatorFragment? get() = fragmentProvider()
+
+    override suspend fun installPageCapabilities(): List<CapabilityId> {
+        val frag = fragment ?: return emptyList()
+        val attempted = ArrayList<CapabilityId>(installOrder.size)
+        for (cap in installOrder.filter { it.scope == CapabilityScope.PageLoad }) {
+            frag.evaluateJavascript(cap.installScript())
+            attempted += cap.id
+        }
+        return attempted
+    }
+
+    override suspend fun applyTypographyOverride() {
+        fragment?.evaluateJavascript(typographyOverrideInjectionJs())
+    }
+
+    override suspend fun applyReadaloudReserve(reservePx: Int) {
+        val frag = fragment ?: return
+        frag.evaluateJavascript(readaloudReserveInjectionJs())
+        frag.evaluateJavascript(readaloudReserveApplyJs(reservePx))
+    }
+
+    override suspend fun installScrollSettleBackstop() {
+        fragment?.evaluateJavascript(ColumnSnap.SETTLE_SNAP_INSTALL_JS)
+    }
+
+    override suspend fun snapAfterGoTo(link: Link) {
+        val frag = fragment ?: return
+        frag.go(link)
+        frag.evaluateJavascript(ColumnSnap.snapToTargetColumnJs(navTargetFragmentId(link.href.toString())))
+    }
+
+    override suspend fun snapAfterGoTo(locator: Locator, landAtStartWhenNoTarget: Boolean) {
+        val frag = fragment ?: return
+        frag.go(locator)
+        frag.evaluateJavascript(
+            ColumnSnap.snapToTargetColumnJs(navTargetFragmentId(locator.href.toString()), landAtStartWhenNoTarget),
+        )
+    }
+
+    override suspend fun snapToEnd() {
+        fragment?.evaluateJavascript(ColumnSnap.snapToEndColumnJs())
+    }
+
+    override suspend fun snapToElement(fragmentId: String): Boolean =
+        fragment?.evaluateJavascript(ColumnSnap.scrollToColumnJs(fragmentId))?.trim('"') == "moved"
+
+    override suspend fun landedAtEnd(): Boolean =
+        fragment?.evaluateJavascript(ColumnSnap.LANDED_AT_END_JS)?.trim('"') == "true"
+
+    override suspend fun followNarratedSentence(text: String): String? =
+        fragment?.evaluateJavascript(ColumnSnap.autoFollowSnapJs(text))?.trim('"')
+
+    override suspend fun measureNarratedColumns(text: String): List<Double> {
+        val raw = fragment?.evaluateJavascript(ColumnSnap.measureNarratedColumnsJs(text))
+        return ColumnSnap.parseNarratedColumnsResult(raw)
+    }
+
+    override suspend fun snapNarratedColumn(text: String, columnIndex: Int) {
+        fragment?.evaluateJavascript(ColumnSnap.snapNarratedColumnJs(text, columnIndex))
+    }
+
+    override suspend fun resolveSelectionSentence(sentences: List<Pair<String, String>>): String? {
+        val frag = fragment ?: return null
+        if (sentences.isEmpty()) return null
+        return frag.evaluateJavascript(resolveSelectionSentenceJs(sentences))
+            ?.trim('"')?.takeIf { it.isNotEmpty() }
+    }
+
+    override suspend fun readSelectionSpanId(): String? =
+        fragment?.evaluateJavascript("window.__riffleSelSpan || ''")
+            ?.trim('"')?.takeIf { it.isNotEmpty() }
+
+    override suspend fun firstVisibleSentenceIndex(highlights: List<String>): Int? =
+        fragment?.evaluateJavascript(firstVisibleSentenceJs(highlights))
+            ?.trim('"')?.toIntOrNull()
+
+    override suspend fun scrollByPx(delta: Int): Boolean {
+        val raw = fragment?.evaluateJavascript(
+            """
+            (function(){
+              var before = window.scrollY;
+              window.scrollBy(0, $delta);
+              return window.scrollY !== before ? 1 : 0;
+            })()
+            """.trimIndent(),
+        ) ?: return false
+        return raw.trim().trim('"') == "1"
+    }
+
+    override suspend fun scrollBoundary(): Pair<Boolean, Boolean> {
+        val frag = fragment ?: return Pair(false, false)
+        // Two separate JS calls so the failure mode is obvious if either ever returns malformed
+        // JSON; both are pure reads of scroll state — no writes here.
+        val atForward = frag.evaluateJavascript(
+            "(window.scrollY + window.innerHeight >= document.body.scrollHeight - 4).toString()",
+        )?.trim('"') == "true"
+        val atBackward = frag.evaluateJavascript(
+            "(window.scrollY <= 4).toString()",
+        )?.trim('"') == "true"
+        return Pair(atForward, atBackward)
+    }
+
+    override suspend fun evaluateBoundaryScroll(js: String) {
+        fragment?.evaluateJavascript(js)
+    }
+
+    companion object {
+        /**
+         * The capability registry shared by every paged/vertical session. The dependency graph
+         * is THE contract: the rect-toJSON polyfill must be installed before either the footnote
+         * bridge or the selection tracker (both call getBoundingClientRect().toJSON()).
+         */
+        fun defaultCapabilities(readaloudReserveProvider: () -> Int): List<RendererCapability> = listOf(
+            RendererCapability(
+                id = CapabilityId.RectToJsonPolyfill,
+                installScript = { RECT_TO_JSON_POLYFILL_JS },
+            ),
+            RendererCapability(
+                id = CapabilityId.SelectionSpanTracker,
+                dependsOn = setOf(CapabilityId.RectToJsonPolyfill),
+                installScript = { SELECTION_SPAN_TRACKER_JS },
+            ),
+            RendererCapability(
+                id = CapabilityId.TypographyOverride,
+                installScript = { typographyOverrideInjectionJs() },
+            ),
+            RendererCapability(
+                id = CapabilityId.FootnoteAnchorBridge,
+                dependsOn = setOf(CapabilityId.RectToJsonPolyfill),
+                installScript = { FootnoteAnchorBridge.INSTALL_SCRIPT },
+            ),
+            RendererCapability(
+                id = CapabilityId.ReadaloudReserve,
+                installScript = {
+                    // Install the rule AND apply the current value on the same install pass —
+                    // the freshly loaded resource is a new document, so both have to land for the
+                    // reserve to take effect on this page.
+                    readaloudReserveInjectionJs() + ";" + readaloudReserveApplyJs(readaloudReserveProvider())
+                },
+            ),
+            RendererCapability(
+                id = CapabilityId.ScrollSettleBackstop,
+                installScript = { ColumnSnap.SETTLE_SNAP_INSTALL_JS },
+            ),
+        )
+
+        private fun navTargetFragmentId(href: String): String? =
+            href.substringAfter('#', "").ifEmpty { null }
+                ?.let { runCatching { URLDecoder.decode(it, "UTF-8") }.getOrDefault(it) }
+    }
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/renderer/RendererBridge.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/renderer/RendererBridge.kt
@@ -1,0 +1,135 @@
+package com.riffle.app.feature.reader.renderer
+
+import org.readium.r2.shared.publication.Link
+import org.readium.r2.shared.publication.Locator
+
+/**
+ * The single seam through which the paged/vertical EPUB reader talks to its WebView's JS world.
+ *
+ * Why a seam: before #331, ~20 `evaluateJavascript(` calls were sprayed across [EpubReaderScreen],
+ * [ColumnSnap], [ReadiumPresenter], and the reserve/footnote helpers. There was no dependency
+ * graph (the footnote bridge and selection tracker both need the rect polyfill, rediscovered
+ * independently), no readiness model (re-install on reflow lived in scattered LaunchedEffects),
+ * and no test surface (every script was a string evaluated against a live WebView). The hardest
+ * reader bugs — highlight-after-rotation, decoration-positioning, reflow races — were all
+ * symptoms of this missing seam.
+ *
+ * Shape: call sites are typed (`snapToEnd`, `applyReadaloudReserve`, `followNarratedSentence`,
+ * …). The bridge owns the [RendererCapability] registry and the topo-sorted install order. A
+ * recording fake implementation supports JVM unit tests for anything that drives the renderer.
+ *
+ * Out of scope: continuous mode (`ContinuousReaderView` / `ChapterWebView`) has its own WebView
+ * pipeline (`ContinuousScriptInjector`, `ContinuousStyleInjector`) and is allowed to use
+ * `evaluateJavascript(` directly; see the lint rule that enforces the rest.
+ */
+internal interface RendererBridge {
+
+    /**
+     * The set of capabilities this bridge knows about. Stable for the bridge's lifetime — the
+     * declaration is the dependency graph.
+     */
+    val capabilities: List<RendererCapability>
+
+    /**
+     * Install every [CapabilityScope.PageLoad] capability in dependency order. Called from
+     * `onPageLoaded` — each freshly served resource is a fresh document, so every capability
+     * needs to re-install. All install scripts are idempotent.
+     *
+     * Returns the list of capability ids that were attempted, in install order. The tests assert
+     * on this; callers can ignore it.
+     */
+    suspend fun installPageCapabilities(): List<CapabilityId>
+
+    // ───── Typed call sites ────────────────────────────────────────────────────────────────────
+
+    /**
+     * Apply the targeted CSS overrides (font family, custom margins, …) to the live document
+     * without waiting for the next page load. Called from `applyTypography` on the presenter when
+     * the user changes a formatting preference.
+     */
+    suspend fun applyTypographyOverride()
+
+    /**
+     * Push the current readaloud-reserve height to the live document. Re-runs on every page load
+     * (each new resource is a fresh document) AND whenever the reserve value changes mid-session
+     * (a bundle finishes downloading; the user flips to/from scroll mode). Idempotent.
+     */
+    suspend fun applyReadaloudReserve(reservePx: Int)
+
+    // ── Column snapping ─────────────────────────────────────────────────────────────────────
+
+    /** Install the at-rest snap backstop on a freshly loaded page (idempotent). */
+    suspend fun installScrollSettleBackstop()
+
+    /** Navigate to [link] then snap onto the target's column, tracking the post-load reflow. */
+    suspend fun snapAfterGoTo(link: Link)
+
+    /**
+     * Navigate to [locator] then snap onto the target's column. [landAtStartWhenNoTarget] picks
+     * the no-DOM-fragment landing (chapter top vs. round-to-grid for a within-chapter sync).
+     */
+    suspend fun snapAfterGoTo(locator: Locator, landAtStartWhenNoTarget: Boolean = true)
+
+    /** Re-pin the current page to its LAST column through a backward cross-resource turn's reflow. */
+    suspend fun snapToEnd()
+
+    /**
+     * Bring [fragmentId] onto the page (in-document cross-reference taps). Returns true iff the
+     * snap moved the page — false when the target was already visible.
+     */
+    suspend fun snapToElement(fragmentId: String): Boolean
+
+    /** True iff the freshly loaded paginated page is resting on its LAST column. */
+    suspend fun landedAtEnd(): Boolean
+
+    /**
+     * Follow the narrated sentence to its column on a sentence change. Returns "on" (followed or
+     * already on-page), "off" (sentence not on this resource — caller `go()`s to load it), or
+     * null when the WebView is gone.
+     */
+    suspend fun followNarratedSentence(text: String): String?
+
+    /** Measure how the narrated sentence is laid out across paginated columns. */
+    suspend fun measureNarratedColumns(text: String): List<Double>
+
+    /** Snap to the [columnIndex]-th column the narrated sentence occupies (clamped). */
+    suspend fun snapNarratedColumn(text: String, columnIndex: Int)
+
+    // ── Selection / readaloud probes ────────────────────────────────────────────────────────
+
+    /**
+     * Resolve the text-selection to a narrated-sentence id by GEOMETRY. Returns the span id or
+     * null when nothing resolves (caller falls back to the stashed span id, then to chapter top).
+     */
+    suspend fun resolveSelectionSentence(sentences: List<Pair<String, String>>): String?
+
+    /**
+     * Read the selection-span id stashed by the selectionchange tracker. Used as a fallback when
+     * [resolveSelectionSentence] doesn't resolve.
+     */
+    suspend fun readSelectionSpanId(): String?
+
+    /** Returns the index of the first narrated sentence visible on the current page, or null. */
+    suspend fun firstVisibleSentenceIndex(highlights: List<String>): Int?
+
+    // ── Vertical (scroll) mode ──────────────────────────────────────────────────────────────
+
+    /** `window.scrollBy(0, delta)`. Returns true iff scrollY actually changed. */
+    suspend fun scrollByPx(delta: Int): Boolean
+
+    /**
+     * Read whether the live document is at its forward / backward scroll boundary. The result is
+     * `(atForward, atBackward)`. Mapped to the presenter-layer `ScrollBoundary` data class by the
+     * presenter; the bridge stays free of presenter-layer types.
+     */
+    suspend fun scrollBoundary(): Pair<Boolean, Boolean>
+
+    /**
+     * Evaluate a script supplied by `ScrollBoundaryNavigationContainer` for the volume-key
+     * boundary crossing. The container builds the smooth-scroll JS itself (deciding by orientation
+     * + boundary state) and just needs a way to send it to the fragment. The script is fully owned
+     * by the container; the bridge merely forwards it so the lint rule can keep
+     * `evaluateJavascript(` confined to this package.
+     */
+    suspend fun evaluateBoundaryScroll(js: String)
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/renderer/RendererBridge.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/renderer/RendererBridge.kt
@@ -114,8 +114,12 @@ internal interface RendererBridge {
 
     // ── Vertical (scroll) mode ──────────────────────────────────────────────────────────────
 
-    /** `window.scrollBy(0, delta)`. Returns true iff scrollY actually changed. */
-    suspend fun scrollByPx(delta: Int): Boolean
+    /**
+     * `window.scrollBy(0, delta)`. Returns true iff scrollY changed, false iff it didn't move
+     * (e.g. parked at the document boundary), or null when the WebView is gone — callers should
+     * skip the iteration in the null case rather than treat it as "stuck at end".
+     */
+    suspend fun scrollByPx(delta: Int): Boolean?
 
     /**
      * Read whether the live document is at its forward / backward scroll boundary. The result is

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/renderer/RendererCapability.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/renderer/RendererCapability.kt
@@ -1,0 +1,74 @@
+package com.riffle.app.feature.reader.renderer
+
+/**
+ * The pieces of JS the paged/vertical EPUB reader injects into every freshly loaded page. Each
+ * capability declares the others it depends on so [RendererBridge] can install them in a single
+ * topo-sorted pass — the dependency graph is the contract, not the order of [evaluateJavascript]
+ * calls scattered through call sites. Re-discovering (e.g.) that the footnote bridge needs the
+ * rect-toJSON polyfill is therefore a compile-time fact, not an integration-test surprise.
+ */
+internal enum class CapabilityId {
+    /** ClientRect.toJSON polyfill — required by Readium's reflowable tap hit-test on API ≤ 27. */
+    RectToJsonPolyfill,
+
+    /** Selection-change tracker that stashes the current span id + rect on `window`. */
+    SelectionSpanTracker,
+
+    /** Targeted CSS overrides injected as a `<style>` (fonts, margins). Idempotent by element id. */
+    TypographyOverride,
+
+    /** Click interceptor for in-document anchors — works around Readium 3.0.0's dotted-id footnote bug. */
+    FootnoteAnchorBridge,
+
+    /** Reserves a bottom strip for the readaloud mini-player (paginated mode only). */
+    ReadaloudReserve,
+
+    /** At-rest column-snap backstop — rounds an off-grid resting page to the nearest column. */
+    ScrollSettleBackstop,
+}
+
+/** Where in the renderer's lifetime a capability is meant to be (re)installed. */
+internal enum class CapabilityScope {
+    /** Re-applied on every page load (each newly served resource is a fresh document). */
+    PageLoad,
+}
+
+/**
+ * One injectable JS capability. Capabilities are declared once at bridge construction; the bridge
+ * installs them in dependency order on the appropriate lifecycle event (see [CapabilityScope]).
+ *
+ * All install scripts must be idempotent — they re-run on every onPageLoaded, including for the
+ * same DOM during reflow ticks.
+ */
+internal data class RendererCapability(
+    val id: CapabilityId,
+    val dependsOn: Set<CapabilityId> = emptySet(),
+    val scope: CapabilityScope = CapabilityScope.PageLoad,
+    val installScript: () -> String,
+)
+
+/**
+ * Topological sort of [capabilities] so each capability runs strictly after the ones it declares
+ * a dependency on. Stable per the declared order. Throws on a missing dep or a cycle — both are
+ * programming errors that should surface at construction (the bridge's init block runs this).
+ */
+internal fun topoSortCapabilities(capabilities: List<RendererCapability>): List<RendererCapability> {
+    val byId = capabilities.associateBy { it.id }
+    val sorted = ArrayList<RendererCapability>(capabilities.size)
+    val visited = HashSet<CapabilityId>()
+    val onStack = HashSet<CapabilityId>()
+
+    fun visit(id: CapabilityId) {
+        if (id in visited) return
+        if (id in onStack) error("Renderer capability cycle involving $id")
+        val cap = byId[id] ?: error("Renderer capability $id is missing a registration")
+        onStack += id
+        cap.dependsOn.forEach(::visit)
+        onStack -= id
+        visited += id
+        sorted += cap
+    }
+
+    capabilities.forEach { visit(it.id) }
+    return sorted
+}

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/presenter/ReadiumPresenterTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/presenter/ReadiumPresenterTest.kt
@@ -43,6 +43,7 @@ class ReadiumPresenterTest {
         val presenter = ReadiumPresenter(
             scope = kotlinx.coroutines.test.TestScope(),
             publication = stubPublication(),
+            bridge = com.riffle.app.feature.reader.renderer.FakeRendererBridge(),
         )
         assertNull(presenter.attachmentStamp())
     }
@@ -55,6 +56,7 @@ class ReadiumPresenterTest {
         val presenter = ReadiumPresenter(
             scope = kotlinx.coroutines.test.TestScope(),
             publication = stubPublication(),
+            bridge = com.riffle.app.feature.reader.renderer.FakeRendererBridge(),
         )
         presenter.applyDecorations(emptyList(), "annotations")
         // No exception means contract preserved.

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/renderer/FakeRendererBridge.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/renderer/FakeRendererBridge.kt
@@ -17,7 +17,7 @@ internal class FakeRendererBridge(
     private val firstVisibleSentenceResult: Int? = null,
     private val landedAtEndResult: Boolean = false,
     private val snapToElementMoved: Boolean = false,
-    private val scrollByPxResult: Boolean = true,
+    private val scrollByPxResult: Boolean? = true,
     private val scrollBoundaryResult: Pair<Boolean, Boolean> = Pair(false, false),
 ) : RendererBridge {
 
@@ -91,7 +91,7 @@ internal class FakeRendererBridge(
         return firstVisibleSentenceResult
     }
 
-    override suspend fun scrollByPx(delta: Int): Boolean {
+    override suspend fun scrollByPx(delta: Int): Boolean? {
         calls += "scrollByPx($delta)"
         return scrollByPxResult
     }

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/renderer/FakeRendererBridge.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/renderer/FakeRendererBridge.kt
@@ -1,0 +1,107 @@
+package com.riffle.app.feature.reader.renderer
+
+import org.readium.r2.shared.publication.Link
+import org.readium.r2.shared.publication.Locator
+
+/**
+ * Recording fake [RendererBridge] for JVM unit tests — every call is appended to [calls] as a
+ * human-readable string. Use to assert that a presenter / view-model drives the bridge in the
+ * expected order without needing a live WebView.
+ */
+internal class FakeRendererBridge(
+    override val capabilities: List<RendererCapability> = emptyList(),
+    private val selectionSentenceResult: String? = null,
+    private val readSelectionSpanResult: String? = null,
+    private val followNarratedResult: String? = null,
+    private val measureColumnsResult: List<Double> = emptyList(),
+    private val firstVisibleSentenceResult: Int? = null,
+    private val landedAtEndResult: Boolean = false,
+    private val snapToElementMoved: Boolean = false,
+    private val scrollByPxResult: Boolean = true,
+    private val scrollBoundaryResult: Pair<Boolean, Boolean> = Pair(false, false),
+) : RendererBridge {
+
+    val calls: MutableList<String> = mutableListOf()
+
+    override suspend fun installPageCapabilities(): List<CapabilityId> {
+        calls += "installPageCapabilities"
+        return capabilities.map { it.id }
+    }
+
+    override suspend fun applyTypographyOverride() {
+        calls += "applyTypographyOverride"
+    }
+
+    override suspend fun applyReadaloudReserve(reservePx: Int) {
+        calls += "applyReadaloudReserve($reservePx)"
+    }
+
+    override suspend fun installScrollSettleBackstop() {
+        calls += "installScrollSettleBackstop"
+    }
+
+    override suspend fun snapAfterGoTo(link: Link) {
+        calls += "snapAfterGoTo(link=${link.href})"
+    }
+
+    override suspend fun snapAfterGoTo(locator: Locator, landAtStartWhenNoTarget: Boolean) {
+        calls += "snapAfterGoTo(locator=${locator.href}, landAtStart=$landAtStartWhenNoTarget)"
+    }
+
+    override suspend fun snapToEnd() {
+        calls += "snapToEnd"
+    }
+
+    override suspend fun snapToElement(fragmentId: String): Boolean {
+        calls += "snapToElement($fragmentId)"
+        return snapToElementMoved
+    }
+
+    override suspend fun landedAtEnd(): Boolean {
+        calls += "landedAtEnd"
+        return landedAtEndResult
+    }
+
+    override suspend fun followNarratedSentence(text: String): String? {
+        calls += "followNarratedSentence($text)"
+        return followNarratedResult
+    }
+
+    override suspend fun measureNarratedColumns(text: String): List<Double> {
+        calls += "measureNarratedColumns($text)"
+        return measureColumnsResult
+    }
+
+    override suspend fun snapNarratedColumn(text: String, columnIndex: Int) {
+        calls += "snapNarratedColumn($text, $columnIndex)"
+    }
+
+    override suspend fun resolveSelectionSentence(sentences: List<Pair<String, String>>): String? {
+        calls += "resolveSelectionSentence(n=${sentences.size})"
+        return selectionSentenceResult
+    }
+
+    override suspend fun readSelectionSpanId(): String? {
+        calls += "readSelectionSpanId"
+        return readSelectionSpanResult
+    }
+
+    override suspend fun firstVisibleSentenceIndex(highlights: List<String>): Int? {
+        calls += "firstVisibleSentenceIndex(n=${highlights.size})"
+        return firstVisibleSentenceResult
+    }
+
+    override suspend fun scrollByPx(delta: Int): Boolean {
+        calls += "scrollByPx($delta)"
+        return scrollByPxResult
+    }
+
+    override suspend fun scrollBoundary(): Pair<Boolean, Boolean> {
+        calls += "scrollBoundary"
+        return scrollBoundaryResult
+    }
+
+    override suspend fun evaluateBoundaryScroll(js: String) {
+        calls += "evaluateBoundaryScroll(len=${js.length})"
+    }
+}

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/renderer/RendererCapabilityTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/renderer/RendererCapabilityTest.kt
@@ -1,0 +1,115 @@
+package com.riffle.app.feature.reader.renderer
+
+import com.riffle.app.feature.reader.FootnoteAnchorBridge
+import org.junit.Test
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+
+/**
+ * Pins the [RendererBridge] dependency graph: rect→toJSON polyfill must land BEFORE the footnote
+ * bridge AND the selection-span tracker (both call getBoundingClientRect().toJSON() on API-25-era
+ * WebViews where the polyfill is required). Capability registrations are the contract — a future
+ * reorder is fine as long as the dep order still holds; renaming/removing a dep should fail here.
+ */
+class RendererCapabilityTest {
+
+    private val capabilities = DefaultRendererBridge.defaultCapabilities(readaloudReserveProvider = { 0 })
+    private val installOrder = topoSortCapabilities(capabilities)
+
+    @Test fun `polyfill installs before its dependents`() {
+        val polyIdx = installOrder.indexOfFirst { it.id == CapabilityId.RectToJsonPolyfill }
+        val selIdx = installOrder.indexOfFirst { it.id == CapabilityId.SelectionSpanTracker }
+        val footIdx = installOrder.indexOfFirst { it.id == CapabilityId.FootnoteAnchorBridge }
+        assertNotEquals(-1, polyIdx)
+        assertNotEquals(-1, selIdx)
+        assertNotEquals(-1, footIdx)
+        assertTrue("polyfill must precede selection tracker", polyIdx < selIdx)
+        assertTrue("polyfill must precede footnote bridge", polyIdx < footIdx)
+    }
+
+    @Test fun `every capability that declares a dep has its dep installed earlier`() {
+        installOrder.forEachIndexed { idx, cap ->
+            cap.dependsOn.forEach { dep ->
+                val depIdx = installOrder.indexOfFirst { it.id == dep }
+                assertTrue("$dep should appear before ${cap.id}", depIdx in 0 until idx)
+            }
+        }
+    }
+
+    @Test fun `every registered capability is page-load scoped`() {
+        // The bridge's installPageCapabilities() filters to PageLoad; today every capability is
+        // PageLoad. If a new scope arrives, the bridge needs a new install hook AND this guard
+        // needs to relax — the failure surfaces both at once.
+        assertEquals(capabilities.map { it.scope }.toSet(), setOf(CapabilityScope.PageLoad))
+    }
+
+    @Test fun `install scripts reference their canonical JS markers`() {
+        fun script(id: CapabilityId) = installOrder.first { it.id == id }.installScript()
+        assertTrue(
+            "rect polyfill must define toJSON",
+            script(CapabilityId.RectToJsonPolyfill).contains("toJSON"),
+        )
+        assertTrue(
+            "selection tracker must guard via __riffleSelTrackerInstalled",
+            script(CapabilityId.SelectionSpanTracker).contains("__riffleSelTrackerInstalled"),
+        )
+        assertTrue(
+            "footnote bridge must use the registered JS interface name",
+            script(CapabilityId.FootnoteAnchorBridge).contains(FootnoteAnchorBridge.JS_NAME),
+        )
+        assertTrue(
+            "readaloud reserve must apply on each install",
+            script(CapabilityId.ReadaloudReserve).contains("riffle-readaloud-reserve"),
+        )
+        assertTrue(
+            "settle backstop must guard via __riffleSettleSnapInstalled",
+            script(CapabilityId.ScrollSettleBackstop).contains("__riffleSettleSnapInstalled"),
+        )
+    }
+
+    @Test fun `readaloud reserve capability reads the live provider on every install`() {
+        var live = 0
+        val caps = DefaultRendererBridge.defaultCapabilities(readaloudReserveProvider = { live })
+        val reserveCap = caps.first { it.id == CapabilityId.ReadaloudReserve }
+        // 0 → no active class (off)
+        assertTrue(reserveCap.installScript().contains("removeProperty"))
+        live = 56
+        // 56 → activate the reserve class
+        assertTrue(reserveCap.installScript().contains("setProperty"))
+    }
+
+    @Test fun `topo sort rejects a cycle`() {
+        val a = RendererCapability(
+            id = CapabilityId.RectToJsonPolyfill,
+            dependsOn = setOf(CapabilityId.SelectionSpanTracker),
+            installScript = { "" },
+        )
+        val b = RendererCapability(
+            id = CapabilityId.SelectionSpanTracker,
+            dependsOn = setOf(CapabilityId.RectToJsonPolyfill),
+            installScript = { "" },
+        )
+        try {
+            topoSortCapabilities(listOf(a, b))
+            fail("expected cycle to be rejected")
+        } catch (e: IllegalStateException) {
+            assertTrue(e.message!!.contains("cycle"))
+        }
+    }
+
+    @Test fun `topo sort rejects a missing dependency`() {
+        val a = RendererCapability(
+            id = CapabilityId.RectToJsonPolyfill,
+            dependsOn = setOf(CapabilityId.SelectionSpanTracker), // not registered
+            installScript = { "" },
+        )
+        try {
+            topoSortCapabilities(listOf(a))
+            fail("expected missing dep to be rejected")
+        } catch (e: IllegalStateException) {
+            assertTrue(e.message!!.contains("missing"))
+        }
+    }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -145,10 +145,65 @@ tasks.register("checkRiffleInfraSeams") {
     }
 }
 
+// Enforces that paged/vertical EPUB-reader code talks to its WebView through `RendererBridge`
+// (#331), so a NEW JS injection lands as a typed bridge call + capability registration — not as
+// another `evaluateJavascript(` scattered through the screen. Continuous mode owns a separate
+// WebView pipeline (ContinuousReaderView / ChapterWebView / ContinuousScriptInjector /
+// ContinuousStyleInjector) and is explicitly out of scope; the allowlist below carries that
+// boundary.
+tasks.register("checkRendererBridgeUsage") {
+    group = "verification"
+    description = "Fails if `evaluateJavascript(` is called outside the renderer-bridge package (excludes continuous mode)."
+    notCompatibleWithConfigurationCache("reading the file system at execution time")
+
+    doLast {
+        val forbidden = Regex("""\bevaluateJavascript\s*\(""")
+        val bridgePackageRoot = layout.projectDirectory.dir(
+            "app/src/main/kotlin/com/riffle/app/feature/reader/renderer",
+        ).asFile.absolutePath
+        // Continuous mode has its own custom WebViews — out of scope per the issue.
+        val continuousAllowlist = setOf(
+            "app/src/main/kotlin/com/riffle/app/feature/reader/ChapterWebView.kt",
+            "app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt",
+        )
+        val scanRoots = listOf(
+            layout.projectDirectory.dir("app/src/main").asFile,
+        ).filter { it.exists() }
+
+        val offenders = mutableListOf<String>()
+        scanRoots
+            .flatMap { it.walkTopDown().toList() }
+            .filter { it.isFile && it.extension == "kt" }
+            .filterNot { it.absolutePath.startsWith(bridgePackageRoot) }
+            .forEach { f ->
+                val rel = f.relativeTo(layout.projectDirectory.asFile).path
+                if (rel in continuousAllowlist) return@forEach
+                f.useLines { lines ->
+                    lines.forEachIndexed { idx, line ->
+                        val trimmed = line.trimStart()
+                        if (trimmed.startsWith("//") || trimmed.startsWith("*") || trimmed.startsWith("/*")) return@forEachIndexed
+                        if (forbidden.containsMatchIn(line)) {
+                            offenders += "$rel:${idx + 1} — $line"
+                        }
+                    }
+                }
+            }
+        if (offenders.isNotEmpty()) {
+            throw GradleException(
+                "evaluateJavascript( must go through RendererBridge in paged/vertical mode (#331).\n" +
+                    "Add a typed bridge method (and a RendererCapability if it's a per-page install)\n" +
+                    "instead of calling fragment.evaluateJavascript directly:\n" +
+                    offenders.joinToString("\n"),
+            )
+        }
+    }
+}
+
 // Make it part of the normal `./gradlew check` run.
 allprojects {
     tasks.matching { it.name == "check" }.configureEach {
         dependsOn(rootProject.tasks.named("checkRiffleLogTags"))
         dependsOn(rootProject.tasks.named("checkRiffleInfraSeams"))
+        dependsOn(rootProject.tasks.named("checkRendererBridgeUsage"))
     }
 }


### PR DESCRIPTION
## Summary

Collapse the ~20 scattered `fragment.evaluateJavascript()` call sites in paged/vertical EPUB rendering behind one typed `RendererBridge` seam.

- **Capability registry with dependency graph.** Rect-toJSON polyfill installs before its dependents (selection-span tracker + footnote-anchor bridge); the topo-sorted install is the contract, not the order of imperative calls inside `onPageLoaded`.
- **Typed call sites.** `snapAfterGoTo`, `snapToEnd`, `snapToElement`, `followNarratedSentence`, `measureNarratedColumns`, `resolveSelectionSentence`, `applyTypographyOverride`, `applyReadaloudReserve`, `scrollByPx`, `scrollBoundary`, etc. `EpubReaderScreen.kt` has **zero** `evaluateJavascript(` call sites.
- **`ColumnSnap` keeps its JS builders** (unit-tested in `NarratedColumnsResultParserTest` / `ReaderWebViewScriptsTest` / the on-device JS tests); its fragment-driving API moves to the bridge.
- **`ReadiumPresenter` takes the bridge as a constructor dep** — typography overrides, navigation snapping, boundary reads route through it.
- **Lint rule** (`checkRendererBridgeUsage`) wired into `check` forbids new `evaluateJavascript(` call sites outside the renderer package. Continuous mode's custom WebViews (`ChapterWebView` / `ContinuousReaderView`) are allowlisted — out of scope per the issue.
- **JVM tests** (`RendererCapabilityTest`) assert the install order, the dependency graph, cycle/missing-dep rejection, and that the readaloud-reserve capability re-reads its provider on each install. A `FakeRendererBridge` supports view-model / presenter unit tests.

Structural change only — no JS behaviour was altered. One follow-up tightening landed during code-review: `scrollByPx` now returns `Boolean?` so the auto-scroll path can distinguish "WebView gone, skip" from "stuck at end → fire end-of-book", preserving the original `?: return@collect` semantics.

Closes #331

## Test plan

- [x] `./gradlew test` — green
- [x] `./gradlew :app:compileDebugAndroidTestKotlin` — green
- [x] `./gradlew checkRendererBridgeUsage` / `checkRiffleLogTags` / `checkRiffleInfraSeams` — green (the infra-seams lint also picks up `SyncModule.kt` lifted out of `DataModule.kt` by #362; allowlisted here as a drive-by)
- [ ] `make harness-test` — on AVD
- [ ] `make harness-test-tablet` — on AVD
- [ ] Visual smoke on a real device: read a chapter, change typography, open readaloud, tap a footnote, jump via TOC, page-turn forward and backward