### PR TITLE
feat(reader): scale auto-scroll pace with typography and margins

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -203,6 +203,14 @@ fun EpubReaderScreen(
         if (state is ReaderState.Error) immersiveState.show()
     }
 
+    // Push the reader viewport width to the VM so Auto-Scroll can compute words-per-line from
+    // the actual on-screen column. Re-fires on rotation / configuration changes.
+    val configuration = LocalConfiguration.current
+    val displayDensity = context.resources.displayMetrics.density
+    LaunchedEffect(configuration.screenWidthDp, displayDensity) {
+        viewModel.setReaderViewportWidthPx((configuration.screenWidthDp * displayDensity).toInt())
+    }
+
     // Close reading session when screen is disposed (navigation away)
     DisposableEffect(viewModel) {
         onDispose { viewModel.onReaderClosed() }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -349,6 +349,8 @@ class EpubReaderViewModel @Inject constructor(
 
     fun resumeAutoScrollIfPaused() = formatting.resumeAutoScrollIfPaused()
 
+    fun setReaderViewportWidthPx(px: Int) = formatting.setViewportWidthPx(px)
+
     // ---- VolumeKeyDispatcher delegations -----------------------------------------------------------
 
     val volumeKeyNavigationEnabled = volumeKeyDispatcher.volumeKeyNavigationEnabled

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/session/FormattingSession.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/session/FormattingSession.kt
@@ -12,7 +12,7 @@ import com.riffle.core.domain.appearance.AppearanceCoordinator
 import com.riffle.core.domain.autoscroll.AutoScrollEvent
 import com.riffle.core.domain.autoscroll.AutoScrollSpeed
 import com.riffle.core.domain.autoscroll.AutoScrollState
-import com.riffle.core.domain.autoscroll.LayoutContext
+import com.riffle.core.domain.autoscroll.layoutContextFor
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
@@ -100,12 +100,27 @@ class FormattingSession @AssistedInject constructor(
     // using application.resources.displayMetrics.density.
     @Volatile private var deviceDensity: Float = 1f
 
+    // Reader viewport width in device pixels. The screen pushes it via [setViewportWidthPx]
+    // whenever the configuration width or density changes (orientation, foldable resize).
+    // Until set, wordsPerLine collapses to zero and pxPerSecond returns zero, so the controller
+    // simply doesn't advance — safer than guessing a width.
+    @Volatile private var viewportWidthPx: Int = 0
+
     /**
      * Provides the device pixel density so the Auto-Scroll layout context produces correct
      * device-pixel line heights. Call once from the VM init block.
      */
     fun setDeviceDensity(density: Float) {
         deviceDensity = density
+    }
+
+    /**
+     * Provides the reader viewport width in device pixels so the Auto-Scroll layout context can
+     * compute words-per-line from the actual on-screen column. Call whenever the configuration
+     * width or density changes.
+     */
+    fun setViewportWidthPx(px: Int) {
+        viewportWidthPx = px
     }
 
     init {
@@ -135,22 +150,16 @@ class FormattingSession @AssistedInject constructor(
                     )
                 }
         }
-        // Auto-Scroll layout context (line height in device pixels) follows the effective font
-        // size. Without this the px-per-second pace defaults to a CSS-px estimate and ends up
-        // ~3× too slow on a typical xxhdpi screen. Body text ~22 CSS px line height at default
-        // font size; scaled by user font multiplier and the device density.
-        scope.launch {
-            _formattingPreferences
-                .map { it.fontSize }
-                .distinctUntilChanged()
-                .collect { fontSize ->
-                    autoScrollController.setLayoutContext {
-                        LayoutContext(
-                            wordsPerLine = 9f,
-                            lineHeightPx = 22f * fontSize * deviceDensity,
-                        )
-                    }
-                }
+        // Auto-Scroll layout context is recomputed lazily on every tick from the live formatting
+        // preferences (font size, line spacing, margins, font family) and the latest viewport.
+        // The supplier captures `this`, so updates to `_formattingPreferences`, `deviceDensity`,
+        // and `viewportWidthPx` flow through without re-installing it.
+        autoScrollController.setLayoutContext {
+            layoutContextFor(
+                prefs = _formattingPreferences.value,
+                viewportWidthPx = viewportWidthPx,
+                deviceDensity = deviceDensity,
+            )
         }
         // Readaloud start ⇒ stop Auto-Scroll (mutual exclusion, ADR 0037).
         // Driven externally via onPlaybackStateChanged(isPlaying).

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/autoscroll/ScrollPace.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/autoscroll/ScrollPace.kt
@@ -1,5 +1,8 @@
 package com.riffle.core.domain.autoscroll
 
+import com.riffle.core.domain.FormattingPreferences
+import com.riffle.core.domain.ReaderFontFamily
+
 data class LayoutContext(
     val wordsPerLine: Float,
     val lineHeightPx: Float,
@@ -8,4 +11,42 @@ data class LayoutContext(
 fun pxPerSecond(speed: AutoScrollSpeed, layout: LayoutContext): Float {
     if (layout.wordsPerLine <= 0f || layout.lineHeightPx <= 0f) return 0f
     return (speed.wpm / 60f) * (layout.lineHeightPx / layout.wordsPerLine)
+}
+
+// Base body font size in CSS px (Readium's default 1rem).
+private const val BASE_FONT_CSS_PX: Float = 16f
+
+// Approximate average word length including the following space — matches typical English prose.
+private const val AVG_WORD_LEN_CHARS: Float = 6.1f
+
+// Readium's --RS__pageGutter default. Side padding per side ≈ pageGutter * --USER__pageMargins.
+private const val PAGE_GUTTER_CSS_PX: Float = 8f
+
+// Average glyph advance per em by family. Serif/sans condensed-ish; mono is roughly em-square at 0.6;
+// the dyslexic face is wider than typical sans. Numbers are approximations — good enough to scale
+// the auto-scroll pace, not to lay out text.
+private fun avgEmAdvance(family: ReaderFontFamily): Float = when (family) {
+    ReaderFontFamily.Serif, ReaderFontFamily.Literata, ReaderFontFamily.Merriweather -> 0.50f
+    ReaderFontFamily.SansSerif -> 0.52f
+    ReaderFontFamily.Monospace -> 0.60f
+    ReaderFontFamily.OpenDyslexic -> 0.58f
+}
+
+// Derive a LayoutContext from the live formatting preferences and viewport. The returned
+// wordsPerLine reflects font size, font family, and margins; lineHeightPx reflects font size,
+// line spacing, and device density. Both feed `pxPerSecond` so scroll pace tracks what the
+// reader can actually see on screen.
+fun layoutContextFor(
+    prefs: FormattingPreferences,
+    viewportWidthPx: Int,
+    deviceDensity: Float,
+): LayoutContext {
+    val fontSizeCssPx = BASE_FONT_CSS_PX * prefs.fontSize
+    val lineHeightDevicePx = fontSizeCssPx * prefs.lineSpacing * deviceDensity
+    val viewportCssPx = if (deviceDensity > 0f) viewportWidthPx / deviceDensity else 0f
+    val gutterCssPx = PAGE_GUTTER_CSS_PX * prefs.margins
+    val innerCssPx = (viewportCssPx - 2f * gutterCssPx).coerceAtLeast(0f)
+    val avgWordWidthCssPx = fontSizeCssPx * avgEmAdvance(prefs.fontFamily) * AVG_WORD_LEN_CHARS
+    val wordsPerLine = if (avgWordWidthCssPx > 0f) innerCssPx / avgWordWidthCssPx else 0f
+    return LayoutContext(wordsPerLine = wordsPerLine, lineHeightPx = lineHeightDevicePx)
 }

--- a/core/domain/src/test/kotlin/com/riffle/core/domain/autoscroll/ScrollPaceTest.kt
+++ b/core/domain/src/test/kotlin/com/riffle/core/domain/autoscroll/ScrollPaceTest.kt
@@ -1,6 +1,9 @@
 package com.riffle.core.domain.autoscroll
 
+import com.riffle.core.domain.FormattingPreferences
+import com.riffle.core.domain.ReaderFontFamily
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import kotlin.math.abs
 
@@ -47,5 +50,71 @@ class ScrollPaceTest {
     @Test
     fun `zero line height yields zero pace`() {
         assertEquals(0f, pxPerSecond(AutoScrollSpeed.Default, LayoutContext(9f, 0f)), 0.0001f)
+    }
+
+    // --- layoutContextFor -----------------------------------------------------
+
+    private val phone = LayoutInputs(viewportWidthPx = 1233, deviceDensity = 3f)
+
+    private data class LayoutInputs(val viewportWidthPx: Int, val deviceDensity: Float)
+
+    private fun ctxFor(
+        prefs: FormattingPreferences,
+        inputs: LayoutInputs = phone,
+    ): LayoutContext = layoutContextFor(prefs, inputs.viewportWidthPx, inputs.deviceDensity)
+
+    @Test
+    fun `doubling font size more than doubles px per second`() {
+        // Bigger font => bigger lineHeight AND fewer wordsPerLine => roughly 4x px/s.
+        val small = ctxFor(FormattingPreferences(fontSize = 1.0f))
+        val large = ctxFor(FormattingPreferences(fontSize = 2.0f))
+        val smallPace = pxPerSecond(AutoScrollSpeed.of(250), small)
+        val largePace = pxPerSecond(AutoScrollSpeed.of(250), large)
+        assertTrue(
+            "expected large pace > 3x small pace, got small=$smallPace large=$largePace",
+            largePace > 3f * smallPace,
+        )
+    }
+
+    @Test
+    fun `larger line spacing increases line height proportionally`() {
+        val tight = ctxFor(FormattingPreferences(lineSpacing = 1.0f))
+        val loose = ctxFor(FormattingPreferences(lineSpacing = 2.0f))
+        nearly(2f * tight.lineHeightPx, loose.lineHeightPx, eps = 0.5f)
+        // wordsPerLine independent of line spacing
+        nearly(tight.wordsPerLine, loose.wordsPerLine, eps = 0.01f)
+    }
+
+    @Test
+    fun `larger margins reduce words per line`() {
+        val narrow = ctxFor(FormattingPreferences(margins = 1.0f))
+        val wide = ctxFor(FormattingPreferences(margins = 3.0f))
+        assertTrue(
+            "wider margins should reduce wordsPerLine: narrow=${narrow.wordsPerLine} wide=${wide.wordsPerLine}",
+            wide.wordsPerLine < narrow.wordsPerLine,
+        )
+    }
+
+    @Test
+    fun `monospace has fewer words per line than serif at same size`() {
+        val serif = ctxFor(FormattingPreferences(fontFamily = ReaderFontFamily.Serif))
+        val mono = ctxFor(FormattingPreferences(fontFamily = ReaderFontFamily.Monospace))
+        assertTrue(
+            "monospace should fit fewer words per line: serif=${serif.wordsPerLine} mono=${mono.wordsPerLine}",
+            mono.wordsPerLine < serif.wordsPerLine,
+        )
+    }
+
+    @Test
+    fun `device density scales line height in device pixels`() {
+        val ldpi = ctxFor(FormattingPreferences(), LayoutInputs(411, 1f))
+        val xxhdpi = ctxFor(FormattingPreferences(), LayoutInputs(1233, 3f))
+        nearly(3f * ldpi.lineHeightPx, xxhdpi.lineHeightPx, eps = 0.5f)
+    }
+
+    @Test
+    fun `zero viewport width yields zero words per line`() {
+        val c = ctxFor(FormattingPreferences(), LayoutInputs(0, 3f))
+        assertEquals(0f, c.wordsPerLine, 0.0001f)
     }
 }


### PR DESCRIPTION
## Summary

Auto-scroll's px/sec used to scale only with font size (via `lineHeightPx`), with a hardcoded `wordsPerLine = 9`. Bumping the font felt only marginally faster because the drop in words-per-viewport was ignored. Line spacing, margins, and font family had no effect at all.

`layoutContextFor(prefs, viewportWidthPx, deviceDensity)` now derives both `wordsPerLine` and `lineHeightPx` from the live formatting preferences and the on-screen column:

- **fontSize**: affects both line height and word width (so doubling the font now ~quadruples px/s instead of just doubling)
- **lineSpacing**: folded into `lineHeightPx`
- **margins**: scales Readium's `--RS__pageGutter * --USER__pageMargins` per side → reduces inner column width → fewer words per line → faster scroll
- **fontFamily**: per-family avg em advance (serif/sans ≈ 0.50–0.52, monospace 0.60, OpenDyslexic 0.58)

At default settings (1.0 / 1.2 / 1.0 / serif, 411 dp wide, density 3) the new formula yields ~29.7 px/s vs the old 30.5 — baseline preserved; only the *scaling* behaviour changes.

The supplier closure in `FormattingSession` now reads live state lazily (replacing the old `fontSize`-only `.collect` rebuild), and `EpubReaderScreen` pushes the viewport width through the VM on rotation.

## Test plan

- [x] `core/domain` unit tests cover each input axis (font size, line spacing, margins, family, density, zero-viewport)
- [x] `./gradlew :core:domain:test :app:testDebugUnitTest` green
- [ ] Manually verify on a real device: open a book, crank the font, watch auto-scroll speed up noticeably