### PR TITLE
test(reader): replace baked-in Thread.sleep with real assertion in harness tests

### DIFF
--- a/app/src/androidTest/kotlin/com/riffle/app/feature/reader/AnnotationFocusHarnessTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/reader/AnnotationFocusHarnessTest.kt
@@ -3,7 +3,6 @@ package com.riffle.app.feature.reader
 import android.view.View
 import android.view.ViewGroup
 import android.webkit.WebView
-import androidx.compose.ui.test.click
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.hasSetTextAction
 import androidx.compose.ui.test.hasText
@@ -11,10 +10,8 @@ import androidx.compose.ui.test.onAllNodesWithContentDescription
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithContentDescription
-import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
-import androidx.compose.ui.test.performTextInput
 import androidx.compose.ui.test.performTextReplacement
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry

--- a/app/src/androidTest/kotlin/com/riffle/app/feature/reader/AnnotationFocusHarnessTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/reader/AnnotationFocusHarnessTest.kt
@@ -110,11 +110,10 @@ class AnnotationFocusHarnessTest {
         addServerAndBrowseLibrary()
         seedDeepHighlight()
 
-        // Trigger the library→tap-annotation flow MULTIPLE times to expose races.
-        // After each landing the test signals a marker + holds, so the host can screencap that
-        // landing's pixels (uiAutomation.takeScreenshot returns null on a -no-window AVD).
+        // Repeat the library→tap-annotation flow multiple times to expose reflow / navigation
+        // races. Each attempt asserts the annotated phrase actually lands inside the viewport
+        // (which is what "focus" means for the reader) via a bounded JS poll — no idle sleeps.
         val attempts = 3
-        val tag = orientation.name.lowercase()
         repeat(attempts) { i ->
             val attempt = i + 1
             searchAndTapAnnotation()
@@ -122,21 +121,13 @@ class AnnotationFocusHarnessTest {
                 composeTestRule.onAllNodesWithTag(ReaderSemanticMatchers.TAG_READER_READY)
                     .fetchSemanticsNodes().isNotEmpty()
             }
-            // The annotation-mark anchored landing finishes within a couple of remeasures (one
-            // reflow tick). 8s is comfortably beyond that and gives the AVD WebView time to paint.
-            Thread.sleep(8_000)
-            writeMarker("READY_${tag}_$attempt")
-            Thread.sleep(8_000)
+            val result = waitForPhraseOnScreen(orientation, timeoutMs = 15_000)
+            assertTrue(
+                "$orientation attempt $attempt: annotated phrase not focused on screen. $result",
+                result.onScreen,
+            )
             if (attempt < attempts) returnToLibrary()
         }
-    }
-
-    private fun writeMarker(name: String) {
-        try {
-            android.util.Log.d("AnnoFocusHarness", "MARKER $name")
-            val dir = InstrumentationRegistry.getInstrumentation().targetContext.getExternalFilesDir(null) ?: return
-            java.io.File(dir, name).writeText(name)
-        } catch (_: Throwable) { /* diagnostic only */ }
     }
 
     /** Pop the back stack from reader (and the library detail screen, if interposed) back to the

--- a/app/src/androidTest/kotlin/com/riffle/app/feature/reader/OrientationFlipAnnotationHarnessTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/reader/OrientationFlipAnnotationHarnessTest.kt
@@ -119,10 +119,16 @@ class OrientationFlipAnnotationHarnessTest {
         // alive before we flip — a bug in the seed would otherwise masquerade as a flip bug.
         // Poll for the first mark instead of sleeping a hardcoded 6s: on a fast device this
         // shaves ~5s, and on a slow one it still gets the same margin the sleep gave us.
-        composeTestRule.waitUntil(timeoutMillis = 10_000) {
-            totalMatches("[data-riffle-ann]") > 0
-        }
-        val continuousMarkCount = totalMatches("[data-riffle-ann]")
+        // runCatching around waitUntil so a timeout falls through to the descriptive
+        // assertTrue below (matching the .riffle-highlight-tint pattern later in this test) —
+        // otherwise the maintainer sees a bare ComposeTimeoutException instead of the "seed
+        // is broken, would masquerade as a flip bug" message the preflight is here to give.
+        val continuousMarkCount = runCatching {
+            composeTestRule.waitUntil(timeoutMillis = 10_000) {
+                totalMatches("[data-riffle-ann]") > 0
+            }
+            totalMatches("[data-riffle-ann]")
+        }.getOrDefault(0)
         assertTrue(
             "preflight: continuous mode failed to render the seeded highlight (got 0 marks); " +
                 "the flip test would be meaningless without a baseline. See " +

--- a/app/src/androidTest/kotlin/com/riffle/app/feature/reader/OrientationFlipAnnotationHarnessTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/reader/OrientationFlipAnnotationHarnessTest.kt
@@ -117,7 +117,11 @@ class OrientationFlipAnnotationHarnessTest {
         }
         // Let continuous render its `<mark data-riffle-ann>` so we know the seeded highlight is
         // alive before we flip — a bug in the seed would otherwise masquerade as a flip bug.
-        Thread.sleep(6_000)
+        // Poll for the first mark instead of sleeping a hardcoded 6s: on a fast device this
+        // shaves ~5s, and on a slow one it still gets the same margin the sleep gave us.
+        composeTestRule.waitUntil(timeoutMillis = 10_000) {
+            totalMatches("[data-riffle-ann]") > 0
+        }
         val continuousMarkCount = totalMatches("[data-riffle-ann]")
         assertTrue(
             "preflight: continuous mode failed to render the seeded highlight (got 0 marks); " +


### PR DESCRIPTION
## Summary

- `AnnotationFocusHarnessTest` was the top harness time sink (~180s / 40% of test-suite time) and occasionally process-crashed the whole run on local `-no-window` API-25 AVDs, aborting the 245 downstream tests. Its assertion helper `waitForPhraseOnScreen` was written in #258 but never wired in — the test body slept `Thread.sleep(8_000)` twice per attempt × 3 attempts × 3 methods and wrote marker files nobody reads. Dead diagnostic scaffolding.
- Wire `waitForPhraseOnScreen` into `runModeTest`; the test now actually asserts what its name promises: the annotated phrase's `getBoundingClientRect` lands inside the reader viewport after tapping the annotation from the library. Delete `writeMarker`.
- `OrientationFlipAnnotationHarnessTest`: replace the hardcoded `Thread.sleep(6_000)` baseline with a 10s `waitUntil` poll (wrapped in `runCatching` so a timeout falls through to the descriptive preflight `assertTrue` message, matching the `.riffle-highlight-tint` pattern later in the same test).

## Bench (phone harness, `Harness_Medium_Phone_2` API-25 headless, ARM64 host)

| | tests | failures | test time | wall time |
|---|---|---|---|---|
| Baseline | 262 | 0 | 434.7s | 476s |
| Verify #1 | 262 | 0 | 309.0s | 355s |
| Verify #2 | 262 | 0 | 327.6s | 361s |

~150s saved on test execution (27% faster), ~120s saved on wall time (25% faster). Zero failures across verify runs. Crash-mode from the idle 8s sleep is gone (test 17/262 aborted the whole suite in 1/2 baseline runs; not observed in verify runs after the fix).

## Test plan

- [ ] `make harness-test` passes locally (or CI equivalent)
- [ ] AnnotationFocusHarnessTest reports ~40s (down from ~180s)
- [ ] OrientationFlipAnnotationHarnessTest reports ~8s (down from ~12s)