### PR TITLE
feat(annotations): TTL-sweep aged tombstones and delete empty WebDAV files

### DIFF
--- a/app/src/test/kotlin/com/riffle/app/feature/settings/SettingsViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/settings/SettingsViewModelTest.kt
@@ -261,6 +261,7 @@ class SettingsViewModelTest {
         override fun observePendingCountAcrossAll() = flowOf(pendingCount)
         override suspend fun dirtyServerItems() = emptyList<AnnotationDao.DirtyServerItem>()
         override suspend fun markSynced(ids: List<String>, syncedAt: Long) {}
+        override suspend fun purgeAgedTombstones(serverId: String, itemId: String, cutoff: Long): Int = 0
     }
 
     private fun stubConfigStore(flow: MutableStateFlow<AnnotationSyncConfig?>) = object : AnnotationSyncConfigStore {

--- a/core/data/src/main/kotlin/com/riffle/core/data/AnnotationSyncController.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/AnnotationSyncController.kt
@@ -144,23 +144,17 @@ class AnnotationSyncController(
                 }
             }
 
-            // ADR 0038 rule 1 — sweep our own aged tombstones before reading local state for the
-            // merge. Rows are hard-deleted from Room only if they've been pushed at least once
-            // (guarded by `updatedAt <= lastSyncedAt` in the DAO query), so an offline delete stays
-            // put until it propagates. The pre-sweep snapshot is retained so we can detect the
-            // "sweep just emptied this device's row set" transition below (rule 2).
+            // ADR 0038 rule 1+2 — sweep aged tombstones and DELETE the resulting empty file.
+            // Ordering matters: compute the hypothetical post-sweep state in memory FIRST, so we
+            // can attempt the DELETE before mutating Room. If the DELETE throws, Room is untouched
+            // and the next sync sees the same transition and retries. Sweeping first would leave
+            // Room empty with a stale file on WebDAV and no signal to retry the DELETE.
             val now = clock()
+            val cutoff = now - TOMBSTONE_TTL_MS
             val beforeSweep = annotationDao.getAllForItemIncludingDeleted(serverId, itemId)
-            annotationDao.purgeAgedTombstones(serverId, itemId, now - TOMBSTONE_TTL_MS)
-
-            // Seed merge with the local set (including tombstones) so LWW spans both sides — a
-            // newer local edit isn't clobbered by an older remote copy, and a local tombstone wins
-            // over a remote pre-delete entry.
-            val localExistingEntities = annotationDao
-                .getAllForItemIncludingDeleted(serverId, itemId)
-            val localById = localExistingEntities.associateBy { it.id }
-            val localExisting = localExistingEntities
-                .map { AnnotationW3CCodec.entityToW3CAnnotation(it) }
+            val nonPurgeable = beforeSweep.filter { !isAgedSyncedTomb(it, cutoff) }
+            val localById = nonPurgeable.associateBy { it.id }
+            val localExisting = nonPurgeable.map { AnnotationW3CCodec.entityToW3CAnnotation(it) }
 
             // ADR 0038 rule 3 — ignore stale orphans. Incoming rows we've never seen locally and
             // whose updatedAt is past TTL are the delayed push from a peer that missed a
@@ -171,6 +165,19 @@ class AnnotationSyncController(
                 nowMs = now,
                 staleOrphanCutoffMs = TOMBSTONE_TTL_MS,
             )
+
+            // Rule 2 DELETE branch — the sweep would empty us and this device's own file is on
+            // WebDAV. DELETE first, then commit the sweep and any merge results. A failed DELETE
+            // aborts before Room changes so the retry sees the same beforeSweep transition.
+            if (merged.isEmpty() && beforeSweep.isNotEmpty()) {
+                val ownFilename = "annotations-${deviceIdStore.getOrCreate()}.jsonld"
+                if (ownFilename in filenames) {
+                    target.delete(namespace, itemId, ownFilename)
+                }
+            }
+
+            // Safe to commit Room mutations now — either no DELETE was needed, or it succeeded.
+            annotationDao.purgeAgedTombstones(serverId, itemId, cutoff)
 
             val entities = merged.map { w3cAnnotation ->
                 val existing = localById[w3cAnnotation.id]
@@ -210,25 +217,20 @@ class AnnotationSyncController(
             for (entity in entities) {
                 annotationDao.upsert(entity)
             }
-
-            // ADR 0038 rule 2 — if the sweep just emptied this device's row set for the item AND
-            // this device's own file is present in the peer listing, DELETE it. This catches the
-            // "user opens book with only aged tombs left, closes without editing" flow: the sweep
-            // runs here in the open path, so if we defer the DELETE to pushPending its transition
-            // guard misfires (Room was already emptied here, so beforeSweep in pushPending is
-            // trivially empty).
-            if (merged.isEmpty() && beforeSweep.isNotEmpty()) {
-                val ownFilename = "annotations-${deviceIdStore.getOrCreate()}.jsonld"
-                if (ownFilename in filenames) {
-                    target.delete(namespace, itemId, ownFilename)
-                }
-            }
             statusStore.report(CycleOutcome.Success(clock()))
             sentinelWriter.writeQuietly(target, namespace, serverId)
         } catch (e: Exception) {
             statusStore.report(e.toFailedCycleOutcome(clock()))
         }
     }
+
+    /**
+     * Would [purgeAgedTombstones] delete this row? Kept in Kotlin so we can preview the sweep
+     * result before touching Room (ADR 0038 rule 2 needs to attempt the DELETE first and only
+     * commit the Room mutation if the DELETE succeeds).
+     */
+    private fun isAgedSyncedTomb(row: AnnotationEntity, cutoff: Long): Boolean =
+        row.deleted && row.updatedAt < cutoff && row.updatedAt <= row.lastSyncedAt
 
     /**
      * Start a per-book pull loop that polls for peer-device annotation files every
@@ -352,28 +354,31 @@ class AnnotationSyncController(
         // Include tombstones so deletes propagate; an annotation with deleted=1 still carries
         // its updatedAt/lastModifiedByDeviceId, and the LWW merge on the receiver will trust
         // the newer tombstone over any older live copy of the same id.
-        val beforeSweep = annotationDao.getAllForItemIncludingDeleted(serverId, itemId)
-        // ADR 0038 rule 1 — sweep our own aged, already-synced tombstones before we decide what to
-        // push. This is what makes files that hold nothing but old tombs shrink to zero rows.
         val now = clock()
-        annotationDao.purgeAgedTombstones(serverId, itemId, now - TOMBSTONE_TTL_MS)
-        val localEntities = annotationDao.getAllForItemIncludingDeleted(serverId, itemId)
+        val cutoff = now - TOMBSTONE_TTL_MS
+        val beforeSweep = annotationDao.getAllForItemIncludingDeleted(serverId, itemId)
+        // ADR 0038 rule 1+2 — preview the sweep in memory. If it would leave us empty, DELETE the
+        // WebDAV file BEFORE mutating Room. A failed DELETE aborts before Room changes so the
+        // next attempt still sees `beforeSweep.isNotEmpty()` and retries.
+        val remainingAfterSweep = beforeSweep.filter { !isAgedSyncedTomb(it, cutoff) }
 
-        if (localEntities.isEmpty()) {
-            // ADR 0038 rule 2 — if the sweep just emptied this device's row set for the item,
-            // DELETE the WebDAV file entirely instead of leaving a stale copy. The transition
-            // guard (beforeSweep non-empty → empty) is what tells "sweep emptied it" apart from
-            // "Room was already empty for a transient reason (cleared data, mid-migration)" —
-            // the latter case is still a no-op, preserving the pre-ADR-0038 behaviour that
-            // protected against overwriting a live remote file with `[]`.
+        if (remainingAfterSweep.isEmpty()) {
             if (beforeSweep.isNotEmpty()) {
+                // Rule 2 empty-file DELETE. Do it first, then commit the sweep to Room.
                 val deviceId = deviceIdStore.getOrCreate()
                 target.delete(namespace, itemId, "annotations-$deviceId.jsonld")
+                annotationDao.purgeAgedTombstones(serverId, itemId, cutoff)
                 statusStore.report(CycleOutcome.Success(now))
                 return true
             }
+            // Preserve pre-ADR-0038 behaviour: don't touch WebDAV on a transient/cleared-data
+            // Room-already-empty state.
             return false
         }
+
+        // Non-empty case: commit the sweep, then push the survivors.
+        annotationDao.purgeAgedTombstones(serverId, itemId, cutoff)
+        val localEntities = remainingAfterSweep
 
         val deviceId = deviceIdStore.getOrCreate()
         val jsonStrings = localEntities.map { entity ->

--- a/core/data/src/main/kotlin/com/riffle/core/data/AnnotationSyncController.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/AnnotationSyncController.kt
@@ -83,6 +83,13 @@ class AnnotationSyncController(
     companion object {
         private const val DEBOUNCE_DURATION_MS = 1000L
         private const val LIVE_SYNC_INTERVAL_MS = 30_000L
+
+        /**
+         * ADR 0038 — tombstones and the ignore-stale-orphan merge guard both use this cutoff.
+         * 90 days: cheap lever to reduce the "device offline > TTL, then edits a ghost" resurrection
+         * risk without meaningfully changing tidiness benefit. Not a user setting.
+         */
+        internal const val TOMBSTONE_TTL_MS = 90L * 24L * 60L * 60L * 1000L
     }
 
     private val debouncingJobs = mutableMapOf<Pair<String, String>, Job>()
@@ -137,6 +144,15 @@ class AnnotationSyncController(
                 }
             }
 
+            // ADR 0038 rule 1 — sweep our own aged tombstones before reading local state for the
+            // merge. Rows are hard-deleted from Room only if they've been pushed at least once
+            // (guarded by `updatedAt <= lastSyncedAt` in the DAO query), so an offline delete stays
+            // put until it propagates. The pre-sweep snapshot is retained so we can detect the
+            // "sweep just emptied this device's row set" transition below (rule 2).
+            val now = clock()
+            val beforeSweep = annotationDao.getAllForItemIncludingDeleted(serverId, itemId)
+            annotationDao.purgeAgedTombstones(serverId, itemId, now - TOMBSTONE_TTL_MS)
+
             // Seed merge with the local set (including tombstones) so LWW spans both sides — a
             // newer local edit isn't clobbered by an older remote copy, and a local tombstone wins
             // over a remote pre-delete entry.
@@ -146,7 +162,15 @@ class AnnotationSyncController(
             val localExisting = localExistingEntities
                 .map { AnnotationW3CCodec.entityToW3CAnnotation(it) }
 
-            val merged = mergeService.merge(parsed = parsedAnnotations, existing = localExisting)
+            // ADR 0038 rule 3 — ignore stale orphans. Incoming rows we've never seen locally and
+            // whose updatedAt is past TTL are the delayed push from a peer that missed a
+            // household-wide sweep; applying them would silently resurrect long-deleted content.
+            val merged = mergeService.merge(
+                parsed = parsedAnnotations,
+                existing = localExisting,
+                nowMs = now,
+                staleOrphanCutoffMs = TOMBSTONE_TTL_MS,
+            )
 
             val entities = merged.map { w3cAnnotation ->
                 val existing = localById[w3cAnnotation.id]
@@ -185,6 +209,19 @@ class AnnotationSyncController(
 
             for (entity in entities) {
                 annotationDao.upsert(entity)
+            }
+
+            // ADR 0038 rule 2 — if the sweep just emptied this device's row set for the item AND
+            // this device's own file is present in the peer listing, DELETE it. This catches the
+            // "user opens book with only aged tombs left, closes without editing" flow: the sweep
+            // runs here in the open path, so if we defer the DELETE to pushPending its transition
+            // guard misfires (Room was already emptied here, so beforeSweep in pushPending is
+            // trivially empty).
+            if (merged.isEmpty() && beforeSweep.isNotEmpty()) {
+                val ownFilename = "annotations-${deviceIdStore.getOrCreate()}.jsonld"
+                if (ownFilename in filenames) {
+                    target.delete(namespace, itemId, ownFilename)
+                }
             }
             statusStore.report(CycleOutcome.Success(clock()))
             sentinelWriter.writeQuietly(target, namespace, serverId)
@@ -315,13 +352,28 @@ class AnnotationSyncController(
         // Include tombstones so deletes propagate; an annotation with deleted=1 still carries
         // its updatedAt/lastModifiedByDeviceId, and the LWW merge on the receiver will trust
         // the newer tombstone over any older live copy of the same id.
+        val beforeSweep = annotationDao.getAllForItemIncludingDeleted(serverId, itemId)
+        // ADR 0038 rule 1 — sweep our own aged, already-synced tombstones before we decide what to
+        // push. This is what makes files that hold nothing but old tombs shrink to zero rows.
+        val now = clock()
+        annotationDao.purgeAgedTombstones(serverId, itemId, now - TOMBSTONE_TTL_MS)
         val localEntities = annotationDao.getAllForItemIncludingDeleted(serverId, itemId)
-        // Don't overwrite this device's existing remote file with an empty list when local has
-        // nothing — that erases the cloud copy of annotations on transient local-empty states
-        // (cleared data, mid-migration). We only push when there's at least one row (live or
-        // tombstoned) to record. Genuine "user deleted everything" still propagates because
-        // each delete leaves a tombstone in this list.
-        if (localEntities.isEmpty()) return false
+
+        if (localEntities.isEmpty()) {
+            // ADR 0038 rule 2 — if the sweep just emptied this device's row set for the item,
+            // DELETE the WebDAV file entirely instead of leaving a stale copy. The transition
+            // guard (beforeSweep non-empty → empty) is what tells "sweep emptied it" apart from
+            // "Room was already empty for a transient reason (cleared data, mid-migration)" —
+            // the latter case is still a no-op, preserving the pre-ADR-0038 behaviour that
+            // protected against overwriting a live remote file with `[]`.
+            if (beforeSweep.isNotEmpty()) {
+                val deviceId = deviceIdStore.getOrCreate()
+                target.delete(namespace, itemId, "annotations-$deviceId.jsonld")
+                statusStore.report(CycleOutcome.Success(now))
+                return true
+            }
+            return false
+        }
 
         val deviceId = deviceIdStore.getOrCreate()
         val jsonStrings = localEntities.map { entity ->
@@ -338,7 +390,6 @@ class AnnotationSyncController(
         val jsonArray = AnnotationFileHeaderCodec.buildFileBody(header, jsonStrings)
         val filename = "annotations-$deviceId.jsonld"
         target.write(namespace, itemId, filename, jsonArray)
-        val now = clock()
         annotationDao.markSynced(localEntities.map { it.id }, now)
         statusStore.report(CycleOutcome.Success(now))
         return true

--- a/core/data/src/test/kotlin/com/riffle/core/data/AnnotationStoreImplTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/AnnotationStoreImplTest.kt
@@ -88,6 +88,8 @@ class AnnotationStoreImplTest {
         override suspend fun markSynced(ids: List<String>, syncedAt: Long) {
             rows.value = rows.value.map { if (it.id in ids) it.copy(lastSyncedAt = syncedAt) else it }
         }
+
+        override suspend fun purgeAgedTombstones(serverId: String, itemId: String, cutoff: Long): Int = 0
     }
 
     private val deviceIdStore = object : DeviceIdStore {

--- a/core/data/src/test/kotlin/com/riffle/core/data/AnnotationStoreTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/AnnotationStoreTest.kt
@@ -84,6 +84,8 @@ class AnnotationStoreTest {
         override suspend fun markSynced(ids: List<String>, syncedAt: Long) {
             rows.value = rows.value.map { if (it.id in ids) it.copy(lastSyncedAt = syncedAt) else it }
         }
+
+        override suspend fun purgeAgedTombstones(serverId: String, itemId: String, cutoff: Long): Int = 0
     }
 
     private class FakeDeviceIdStore(private val id: String) : DeviceIdStore {

--- a/core/data/src/test/kotlin/com/riffle/core/data/AnnotationSweepTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/AnnotationSweepTest.kt
@@ -340,4 +340,5 @@ abstract class StubAnnotationDao : AnnotationDao {
     override fun observePendingCountAcrossAll() = kotlinx.coroutines.flow.flowOf(0)
     override suspend fun dirtyServerItems() = emptyList<AnnotationDao.DirtyServerItem>()
     override suspend fun markSynced(ids: List<String>, syncedAt: Long) {}
+    override suspend fun purgeAgedTombstones(serverId: String, itemId: String, cutoff: Long): Int = 0
 }

--- a/core/data/src/test/kotlin/com/riffle/core/data/AnnotationSyncControllerLifecycleTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/AnnotationSyncControllerLifecycleTest.kt
@@ -302,11 +302,142 @@ class AnnotationSyncControllerLifecycleTest {
     fun `pushPending skips the write entirely when the local set is empty`() = runTest {
         // No local rows at all. Pre-condition: don't overwrite this device's existing remote file
         // with `[]` — a transient local empty (clear-data, mid-migration) would otherwise erase
-        // the cloud copy of this device's annotations.
+        // the cloud copy of this device's annotations. And crucially, don't DELETE either — that
+        // would erase a live remote file the same way. Pre-ADR-0038 behaviour preserved.
         newController().syncOnClose(SRV, NS, ITEM)
         advanceUntilIdle()
 
         assertTrue("expected no write when local is empty, got ${target.writes}", target.writes.isEmpty())
+        assertTrue("must not DELETE either — Room-already-empty is not a sweep transition, " +
+            "got ${target.deletes}", target.deletes.isEmpty())
+    }
+
+    // ===== ADR 0038 — tomb sweep + empty-file DELETE =====
+
+    @Test
+    fun `pushPending sweeps aged synced tombstones before deciding what to write`() = runTest {
+        // now = 1_000_000. TTL = 90 days ≈ 7.776e9 ms — so any updatedAt < now-TTL is aged.
+        // We set clock to a value >> TTL so a tomb with updatedAt=1 is aged.
+        val nowMs = 100L * 24L * 60L * 60L * 1000L  // 100 days
+        val agedTombSyncedAt = 1L
+        // Aged + synced tomb → should be purged by sweep.
+        dao.localAnnotations += highlightEntity("tomb-aged", updatedAt = 1L, deleted = true)
+            .copy(lastSyncedAt = agedTombSyncedAt)
+        // Live row that must survive the sweep and appear in the pushed file.
+        dao.localAnnotations += highlightEntity("live-1", updatedAt = 500L)
+
+        newController(clock = { nowMs }).syncOnClose(SRV, NS, ITEM)
+        advanceUntilIdle()
+
+        val payload = target.writes.single().content
+        val ids = AnnotationW3CCodec.w3cFileToAnnotations(payload).map { it.id }.toSet()
+        assertEquals("aged tomb must be purged; live row must be pushed", setOf("live-1"), ids)
+    }
+
+    @Test
+    fun `pushPending keeps aged but unsynced tombstones so peers still receive the delete`() = runTest {
+        val nowMs = 100L * 24L * 60L * 60L * 1000L
+        // Aged tomb that has NEVER synced (lastSyncedAt = 0). Sweep must NOT purge — peers depend
+        // on this device pushing the delete signal at least once.
+        dao.localAnnotations += highlightEntity("tomb-unsynced", updatedAt = 1L, deleted = true)
+
+        newController(clock = { nowMs }).syncOnClose(SRV, NS, ITEM)
+        advanceUntilIdle()
+
+        val payload = target.writes.single().content
+        val ids = AnnotationW3CCodec.w3cFileToAnnotations(payload).map { it.id }.toSet()
+        assertEquals("unsynced tomb must survive sweep and reach the file",
+            setOf("tomb-unsynced"), ids)
+    }
+
+    @Test
+    fun `pushPending DELETEs own WebDAV file when sweep empties the row set`() = runTest {
+        val nowMs = 100L * 24L * 60L * 60L * 1000L
+        // The device previously held one live annotation that has since been deleted (tomb) and
+        // successfully synced. The tomb is now aged past TTL, so this push should sweep it away
+        // and the file should be DELETEd from WebDAV rather than left as an aged-empty file.
+        dao.localAnnotations += highlightEntity("tomb-aged", updatedAt = 1L, deleted = true)
+            .copy(lastSyncedAt = 1L)
+
+        newController(clock = { nowMs }).syncOnClose(SRV, NS, ITEM)
+        advanceUntilIdle()
+
+        assertTrue("must not write an empty file: ${target.writes}", target.writes.isEmpty())
+        val delete = target.deletes.single()
+        assertEquals(NS, delete.namespace)
+        assertEquals(ITEM, delete.itemId)
+        assertEquals("annotations-$DEVICE_ID.jsonld", delete.filename)
+    }
+
+    @Test
+    fun `pushPending does NOT DELETE when Room was already empty (no sweep transition)`() = runTest {
+        val nowMs = 100L * 24L * 60L * 60L * 1000L
+        // No local rows at all — Room-already-empty is the transient/clear-data state, not a
+        // sweep transition. Same protection the pre-ADR-0038 code carried: don't DELETE, don't
+        // write.
+        newController(clock = { nowMs }).syncOnClose(SRV, NS, ITEM)
+        advanceUntilIdle()
+
+        assertTrue("must not write empty", target.writes.isEmpty())
+        assertTrue("must not DELETE either", target.deletes.isEmpty())
+    }
+
+    @Test
+    fun `syncOnOpen DELETEs own WebDAV file when sweep empties Room and own file is on WebDAV`() = runTest {
+        // The archetypal "empty file lingers forever" flow: WebDAV holds a file that contains
+        // only aged, previously-synced tombstones. User opens the book, doesn't touch anything,
+        // and closes. syncOnOpen must detect that the sweep just cleared the last row this device
+        // was responsible for and DELETE the file directly — pushPending on close would otherwise
+        // observe an already-empty Room and skip.
+        val nowMs = 100L * 24L * 60L * 60L * 1000L
+        val ownFile = "annotations-$DEVICE_ID.jsonld"
+        target.files[ownFile] = jsonArrayOf(
+            w3cTombstone("tomb-aged", updatedAt = 1L, deviceId = DEVICE_ID),
+        )
+        // Mirror the WebDAV state locally: we've pushed this tomb before and lastSyncedAt tracks
+        // that. The sweep guard (`updatedAt <= lastSyncedAt`) fires only for already-synced rows.
+        dao.localAnnotations += highlightEntity("tomb-aged", updatedAt = 1L, deleted = true)
+            .copy(lastSyncedAt = 1L)
+
+        newController(clock = { nowMs }).syncOnOpen(SRV, NS, ITEM)
+
+        val delete = target.deletes.singleOrNull { it.filename == ownFile }
+        assertTrue("expected own-file DELETE fired from syncOnOpen sweep, got ${target.deletes}",
+            delete != null)
+        assertEquals(NS, delete!!.namespace)
+        assertEquals(ITEM, delete.itemId)
+    }
+
+    @Test
+    fun `syncOnOpen does NOT DELETE when own file is absent from WebDAV listing`() = runTest {
+        // Cleared-data / never-pushed protection: Room is empty, no own file on WebDAV. DELETE
+        // must not fire — nothing to delete, and the 404-safe transport would still emit a
+        // pointless request if we didn't guard.
+        val nowMs = 100L * 24L * 60L * 60L * 1000L
+        // Peer file, but no own file.
+        target.files["annotations-device-peer.jsonld"] = jsonArrayOf(
+            w3c("uuid-peer", updatedAt = nowMs - 1_000L, deviceId = "device-peer"),
+        )
+
+        newController(clock = { nowMs }).syncOnOpen(SRV, NS, ITEM)
+
+        assertTrue("must not DELETE when own file isn't present, got ${target.deletes}",
+            target.deletes.none { it.filename == "annotations-$DEVICE_ID.jsonld" })
+    }
+
+    @Test
+    fun `syncOnOpen ignores a stale orphan live record pushed by a long-offline peer`() = runTest {
+        // The resurrection guard end-to-end: a peer with `updatedAt` past TTL pushes a live copy
+        // of a UUID we no longer have (we swept it long ago). The controller must NOT upsert.
+        val nowMs = 100L * 24L * 60L * 60L * 1000L
+        target.files["annotations-device-offline.jsonld"] = jsonArrayOf(
+            w3c("uuid-ghost", updatedAt = 1L, deviceId = "device-offline"),
+        )
+
+        newController(clock = { nowMs }).syncOnOpen(SRV, NS, ITEM)
+
+        assertTrue("stale orphan must not be upserted — resurrection blocked, got ${dao.upserts}",
+            dao.upserts.none { it.id == "uuid-ghost" })
     }
 
     @Test
@@ -650,6 +781,7 @@ class AnnotationSyncControllerLifecycleTest {
 private class LifecycleRecordingTarget : AnnotationSyncTarget {
     val files: MutableMap<String, String> = mutableMapOf()
     val writes: MutableList<Write> = mutableListOf()
+    val deletes: MutableList<Delete> = mutableListOf()
     val deviceMetaWrites: MutableList<DeviceMetaWrite> = mutableListOf()
     val listNamespaceArgs: MutableList<String> = mutableListOf()
     var listCalls = 0
@@ -657,6 +789,7 @@ private class LifecycleRecordingTarget : AnnotationSyncTarget {
     var writeException: Throwable? = null
 
     data class Write(val namespace: String, val itemId: String, val filename: String, val content: String)
+    data class Delete(val namespace: String, val itemId: String, val filename: String)
     data class DeviceMetaWrite(val namespace: String, val deviceId: String, val content: String)
 
     override suspend fun list(namespace: String, itemId: String): List<String> {
@@ -679,6 +812,7 @@ private class LifecycleRecordingTarget : AnnotationSyncTarget {
 
     override suspend fun delete(namespace: String, itemId: String, filename: String) {
         files.remove(filename)
+        deletes += Delete(namespace, itemId, filename)
     }
     override suspend fun readDeviceMeta(namespace: String, deviceId: String): String? = null
     override suspend fun writeDeviceMeta(namespace: String, deviceId: String, content: String) {
@@ -731,5 +865,23 @@ private class LifecycleInMemoryAnnotationDao : AnnotationDao {
         markSyncedCalls++
         lastMarkSyncedIds = ids
         lastMarkSyncedAt = syncedAt
+        // Mirror the production DAO's UPDATE ... WHERE id IN (:ids) semantics so a subsequent
+        // purgeAgedTombstones can observe the newly-bumped lastSyncedAt.
+        for (i in localAnnotations.indices) {
+            val row = localAnnotations[i]
+            if (row.id in ids) localAnnotations[i] = row.copy(lastSyncedAt = syncedAt)
+        }
+    }
+
+    override suspend fun purgeAgedTombstones(serverId: String, itemId: String, cutoff: Long): Int {
+        val before = localAnnotations.size
+        localAnnotations.removeAll { row ->
+            row.serverId == serverId &&
+                row.itemId == itemId &&
+                row.deleted &&
+                row.updatedAt < cutoff &&
+                row.updatedAt <= row.lastSyncedAt
+        }
+        return before - localAnnotations.size
     }
 }

--- a/core/data/src/test/kotlin/com/riffle/core/data/AnnotationSyncControllerLifecycleTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/AnnotationSyncControllerLifecycleTest.kt
@@ -426,6 +426,38 @@ class AnnotationSyncControllerLifecycleTest {
     }
 
     @Test
+    fun `syncOnOpen DELETE failure keeps aged tomb in Room so the next sync retries`() = runTest {
+        // Regression: previously the sweep purged Room BEFORE attempting DELETE. If DELETE threw
+        // (network hiccup), the row was gone from Room, `beforeSweep.isNotEmpty()` misfired on
+        // the retry, and the WebDAV file lingered forever. ADR 0038's whole point is that empty
+        // files disappear — this scenario broke that promise.
+        val nowMs = 100L * 24L * 60L * 60L * 1000L
+        val ownFile = "annotations-$DEVICE_ID.jsonld"
+        target.files[ownFile] = jsonArrayOf(
+            w3cTombstone("tomb-aged", updatedAt = 1L, deviceId = DEVICE_ID),
+        )
+        dao.localAnnotations += highlightEntity("tomb-aged", updatedAt = 1L, deleted = true)
+            .copy(lastSyncedAt = 1L)
+        target.deleteException = RuntimeException("transient WebDAV DELETE failure")
+
+        newController(clock = { nowMs }).syncOnOpen(SRV, NS, ITEM)
+
+        // Room must still hold the aged tomb — the sweep was NOT committed because DELETE threw.
+        val stillHasTomb = dao.localAnnotations.any { it.id == "tomb-aged" && it.deleted }
+        assertTrue("aged tomb must remain in Room when DELETE fails so retry sees the transition",
+            stillHasTomb)
+
+        // Clear the fault; the next syncOnOpen must retry the DELETE and succeed.
+        target.deleteException = null
+        newController(clock = { nowMs }).syncOnOpen(SRV, NS, ITEM)
+
+        assertTrue("second attempt must actually DELETE the file",
+            target.deletes.any { it.filename == ownFile })
+        assertTrue("second attempt must finally purge the tomb from Room",
+            dao.localAnnotations.none { it.id == "tomb-aged" })
+    }
+
+    @Test
     fun `syncOnOpen ignores a stale orphan live record pushed by a long-offline peer`() = runTest {
         // The resurrection guard end-to-end: a peer with `updatedAt` past TTL pushes a live copy
         // of a UUID we no longer have (we swept it long ago). The controller must NOT upsert.
@@ -787,6 +819,7 @@ private class LifecycleRecordingTarget : AnnotationSyncTarget {
     var listCalls = 0
     var failNextList: Boolean = false
     var writeException: Throwable? = null
+    var deleteException: Throwable? = null
 
     data class Write(val namespace: String, val itemId: String, val filename: String, val content: String)
     data class Delete(val namespace: String, val itemId: String, val filename: String)
@@ -811,6 +844,7 @@ private class LifecycleRecordingTarget : AnnotationSyncTarget {
     }
 
     override suspend fun delete(namespace: String, itemId: String, filename: String) {
+        deleteException?.let { throw it }
         files.remove(filename)
         deletes += Delete(namespace, itemId, filename)
     }

--- a/core/data/src/test/kotlin/com/riffle/core/data/AnnotationSyncControllerReactiveTargetTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/AnnotationSyncControllerReactiveTargetTest.kt
@@ -90,4 +90,5 @@ private class NoOpAnnotationDao : AnnotationDao {
     override fun observePendingCountAcrossAll(): Flow<Int> = flowOf(0)
     override suspend fun dirtyServerItems(): List<AnnotationDao.DirtyServerItem> = emptyList()
     override suspend fun markSynced(ids: List<String>, syncedAt: Long) = Unit
+    override suspend fun purgeAgedTombstones(serverId: String, itemId: String, cutoff: Long): Int = 0
 }

--- a/core/database/src/androidTest/kotlin/com/riffle/core/database/AnnotationDaoTest.kt
+++ b/core/database/src/androidTest/kotlin/com/riffle/core/database/AnnotationDaoTest.kt
@@ -148,4 +148,51 @@ class AnnotationDaoTest {
 
         assertEquals(listOf("a1", "a2"), result.map { it.id })
     }
+
+    // ===== ADR 0038 — purgeAgedTombstones =====
+
+    @Test
+    fun purgeAgedTombstones_removesOnlyAgedAlreadySyncedTombstones() = runTest {
+        // Live rows must survive regardless of age (only tombstones age).
+        dao.upsert(highlight("live-old", createdAt = 0L))
+        dao.upsert(highlight("live-fresh", createdAt = 5000L))
+        // Aged tomb that has been synced → purge.
+        dao.upsert(highlight("tomb-aged-synced", createdAt = 100L, deleted = true).copy(lastSyncedAt = 200L))
+        // Aged tomb that never synced → keep (peers haven't received the delete yet).
+        dao.upsert(highlight("tomb-aged-unsynced", createdAt = 100L, deleted = true))
+        // Fresh tomb (past cutoff by wall-clock) → keep.
+        dao.upsert(highlight("tomb-fresh", createdAt = 9_000L, deleted = true).copy(lastSyncedAt = 9_000L))
+
+        val purged = dao.purgeAgedTombstones(serverId = "abs1", itemId = "item1", cutoff = 5_000L)
+
+        assertEquals(1, purged)
+        val remaining = dao.observeForItem("abs1", "item1").first().map { it.id }.toSet()
+        val allIncludingDeleted = dao.getAllForItemIncludingDeleted("abs1", "item1").map { it.id }.toSet()
+        assertTrue("live-old must survive age-based purge", "live-old" in remaining)
+        assertTrue("live-fresh must survive", "live-fresh" in remaining)
+        assertTrue("unsynced tomb must survive so peers still receive the delete",
+            "tomb-aged-unsynced" in allIncludingDeleted)
+        assertTrue("fresh tomb must survive", "tomb-fresh" in allIncludingDeleted)
+        assertEquals("aged+synced tomb must be gone", false, "tomb-aged-synced" in allIncludingDeleted)
+    }
+
+    @Test
+    fun purgeAgedTombstones_isScopedToServerAndItem() = runTest {
+        // Same "aged + synced tombstone" pattern under a different itemId and a different serverId.
+        // A per-item purge call must not touch either.
+        dao.upsert(highlight("tomb-target", serverId = "abs1", itemId = "item1", createdAt = 100L, deleted = true)
+            .copy(lastSyncedAt = 200L))
+        dao.upsert(highlight("tomb-other-item", serverId = "abs1", itemId = "item2", createdAt = 100L, deleted = true)
+            .copy(lastSyncedAt = 200L))
+        dao.upsert(highlight("tomb-other-server", serverId = "abs2", itemId = "item1", createdAt = 100L, deleted = true)
+            .copy(lastSyncedAt = 200L))
+
+        val purged = dao.purgeAgedTombstones(serverId = "abs1", itemId = "item1", cutoff = 5_000L)
+
+        assertEquals(1, purged)
+        assertTrue("other-item tomb must survive a scoped purge",
+            "tomb-other-item" in dao.getAllForItemIncludingDeleted("abs1", "item2").map { it.id })
+        assertTrue("other-server tomb must survive",
+            "tomb-other-server" in dao.getAllForItemIncludingDeleted("abs2", "item1").map { it.id })
+    }
 }

--- a/core/database/src/main/kotlin/com/riffle/core/database/AnnotationDao.kt
+++ b/core/database/src/main/kotlin/com/riffle/core/database/AnnotationDao.kt
@@ -96,6 +96,19 @@ interface AnnotationDao {
     @Query("UPDATE annotations SET lastSyncedAt = :syncedAt WHERE id IN (:ids)")
     suspend fun markSynced(ids: List<String>, syncedAt: Long)
 
+    /**
+     * ADR 0038 — hard-delete tombstones whose `updatedAt` is older than [cutoff]. The
+     * `updatedAt <= lastSyncedAt` guard restricts purge to tombs whose current state has been
+     * pushed successfully from this device at least once; a tomb that never made it to WebDAV
+     * (offline at delete time) is preserved until it does, so peers still receive the delete.
+     * Returns the row count purged.
+     */
+    @Query(
+        "DELETE FROM annotations WHERE serverId = :serverId AND itemId = :itemId " +
+            "AND deleted = 1 AND updatedAt < :cutoff AND updatedAt <= lastSyncedAt"
+    )
+    suspend fun purgeAgedTombstones(serverId: String, itemId: String, cutoff: Long): Int
+
     /** Result row for [dirtyServerItems]. */
     data class DirtyServerItem(val serverId: String, val itemId: String)
 }

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/AnnotationMergeService.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/AnnotationMergeService.kt
@@ -17,24 +17,44 @@ class AnnotationMergeService {
      * @param parsed List of parsed W3C annotations from sync source (e.g., file or server).
      * @param existing Existing W3CAnnotation records (e.g., from previous merge or Room conversion);
      *        if omitted, merge is just the parsed set as-is.
+     * @param nowMs Wall-clock (ms) used to filter stale orphan incoming records (ADR 0038 rule 3).
+     *        Omit or pass 0 to disable the filter (used by pure-merge tests).
+     * @param staleOrphanCutoffMs Records in [parsed] whose `updatedAt < nowMs - staleOrphanCutoffMs`
+     *        AND whose UUID has no matching row in [existing] are ignored — they are the delayed
+     *        push from a peer that missed a household-wide sweep. Applying them would silently
+     *        resurrect long-deleted content (see ADR 0038). Rows we already have locally, and
+     *        fresh rows, are unaffected.
      * @return List of W3CAnnotation winners, ready to convert to AnnotationEntity.
      *
      * Algorithm:
-     * 1. Group all annotations (parsed + existing) by UUID (annotation identity).
-     * 2. For each UUID:
+     * 1. Drop stale orphans from [parsed] per the TTL rule above.
+     * 2. Group all remaining annotations (parsed + existing) by UUID (annotation identity).
+     * 3. For each UUID:
      *    - Pick the version with the highest updatedAt.
      *    - Tie-breaker: if updatedAt is equal, use lastModifiedByDeviceId lexicographically.
-     * 3. Include tombstones (deleted=true) if they are the latest version.
+     * 4. Include tombstones (deleted=true) if they are the latest version.
      *
      * Deterministic: calling merge multiple times with the same input produces the same output.
-     * Idempotent: merge(merge(parsed)) == merge(parsed).
+     * Idempotent: merge(merge(parsed)) == merge(parsed) (given the same nowMs).
      */
     fun merge(
         parsed: List<W3CAnnotation>,
         existing: List<W3CAnnotation> = emptyList(),
+        nowMs: Long = 0L,
+        staleOrphanCutoffMs: Long = Long.MAX_VALUE,
     ): List<W3CAnnotation> {
+        // Rule 3 — ignore stale orphans. A staleness threshold of Long.MAX_VALUE (or nowMs=0)
+        // makes `staleCutoff` non-positive-or-past-Long.MIN and the predicate `updatedAt < cutoff`
+        // never fires; use that as the "disabled" mode for callers that don't want the filter.
+        val existingIds = existing.map { it.id }.toSet()
+        val staleCutoff = if (staleOrphanCutoffMs == Long.MAX_VALUE) Long.MIN_VALUE
+        else nowMs - staleOrphanCutoffMs
+        val filteredParsed = parsed.filter { p ->
+            !(p.updatedAt < staleCutoff && p.id !in existingIds)
+        }
+
         // Combine parsed and existing.
-        val allAnnotations = parsed + existing
+        val allAnnotations = filteredParsed + existing
 
         // Group by UUID and pick the LWW winner for each group.
         val mergedByUuid = allAnnotations

--- a/core/domain/src/test/kotlin/com/riffle/core/domain/AnnotationMergeServiceTest.kt
+++ b/core/domain/src/test/kotlin/com/riffle/core/domain/AnnotationMergeServiceTest.kt
@@ -600,6 +600,149 @@ class AnnotationMergeServiceTest {
         assertEquals("zzzz", result[2].id)
     }
 
+    // ===== ADR 0038 rule 3 — stale-orphan filter on merge =====
+    //
+    // When a peer that has been offline > TTL comes online and pushes rows whose updatedAt is
+    // older than (now - TTL), we ignore any such row whose UUID we have no local copy of. This is
+    // the resurrection guard: without it, LWW would upsert the stale live copy back into every
+    // peer's Room. Rows we DO have locally, and fresh rows, are unaffected — normal LWW applies.
+
+    @Test
+    fun `stale orphan live record is ignored when no existing row matches its UUID`() {
+        // Peer pushes uuid-ghost as live with updatedAt=100. Local Room has no uuid-ghost row (it
+        // was deleted household-wide and swept). now=10_000_000 with cutoffMs=90 → cutoff=9_999_910;
+        // 100 < 9_999_910, so the row is stale and orphaned → ignore.
+        val staleOrphan = W3CAnnotation(
+            id = "uuid-ghost",
+            cfi = "/2/4!/4/2/2,/1:0,/1:10",
+            textSnippet = "should not resurrect",
+            chapterHref = "chapter1.html",
+            type = "HIGHLIGHT",
+            color = "yellow",
+            originDeviceId = "device-offline",
+            lastModifiedByDeviceId = "device-offline",
+            updatedAt = 100L,
+            createdAt = 100L,
+        )
+
+        val result = service.merge(
+            parsed = listOf(staleOrphan),
+            existing = emptyList(),
+            nowMs = 10_000_000L,
+            staleOrphanCutoffMs = 90L,
+        )
+
+        assertEquals("stale orphan must not be applied", 0, result.size)
+    }
+
+    @Test
+    fun `stale orphan tombstone is ignored when no existing row matches its UUID`() {
+        val staleTombOrphan = W3CAnnotation(
+            id = "uuid-old-tomb",
+            cfi = "/2/4!/4/2/2,/1:0,/1:10",
+            textSnippet = "",
+            chapterHref = "chapter1.html",
+            type = "HIGHLIGHT",
+            color = "yellow",
+            originDeviceId = "device-A",
+            lastModifiedByDeviceId = "device-A",
+            updatedAt = 100L,
+            createdAt = 100L,
+            deleted = true,
+        )
+
+        val result = service.merge(
+            parsed = listOf(staleTombOrphan),
+            existing = emptyList(),
+            nowMs = 10_000_000L,
+            staleOrphanCutoffMs = 90L,
+        )
+
+        assertEquals("stale orphan tombstone is noise — do not propagate", 0, result.size)
+    }
+
+    @Test
+    fun `stale incoming record is applied when we already have a local row for its UUID`() {
+        // We have a live copy locally. Peer pushes a stale tombstone for the same UUID (they
+        // deleted it a long time ago but we've been the offline one this time). LWW must fire.
+        val localLive = W3CAnnotation(
+            id = "uuid-shared",
+            cfi = "/2/4!/4/2/2,/1:0,/1:10",
+            textSnippet = "local live",
+            chapterHref = "chapter1.html",
+            type = "HIGHLIGHT",
+            color = "yellow",
+            originDeviceId = "device-self",
+            lastModifiedByDeviceId = "device-self",
+            updatedAt = 50L,
+            createdAt = 50L,
+        )
+        val staleIncomingTomb = localLive.copy(
+            lastModifiedByDeviceId = "device-peer",
+            updatedAt = 100L,
+            deleted = true,
+        )
+
+        val result = service.merge(
+            parsed = listOf(staleIncomingTomb),
+            existing = listOf(localLive),
+            nowMs = 10_000_000L,
+            staleOrphanCutoffMs = 90L,
+        )
+
+        assertEquals(1, result.size)
+        assertTrue("we have the row locally — stale-orphan filter must not fire", result[0].deleted)
+    }
+
+    @Test
+    fun `fresh orphan record is applied normally`() {
+        // Peer creates a brand-new annotation while we happen to have nothing yet. Fresh timestamp
+        // → filter does not fire → upsert.
+        val freshOrphan = W3CAnnotation(
+            id = "uuid-brand-new",
+            cfi = "/2/4!/4/2/2,/1:0,/1:10",
+            textSnippet = "new from peer",
+            chapterHref = "chapter1.html",
+            type = "HIGHLIGHT",
+            color = "green",
+            originDeviceId = "device-peer",
+            lastModifiedByDeviceId = "device-peer",
+            updatedAt = 9_999_950L,
+            createdAt = 9_999_950L,
+        )
+
+        val result = service.merge(
+            parsed = listOf(freshOrphan),
+            existing = emptyList(),
+            nowMs = 10_000_000L,
+            staleOrphanCutoffMs = 90L,
+        )
+
+        assertEquals(1, result.size)
+        assertEquals("uuid-brand-new", result[0].id)
+    }
+
+    @Test
+    fun `filter is disabled by default so legacy callers see no behavior change`() {
+        // Without nowMs/staleOrphanCutoffMs, the merge must behave like the pre-ADR-0038 version.
+        val ancientOrphan = W3CAnnotation(
+            id = "uuid-ancient",
+            cfi = "/2/4!/4/2/2,/1:0,/1:10",
+            textSnippet = "ancient",
+            chapterHref = "chapter1.html",
+            type = "HIGHLIGHT",
+            color = "yellow",
+            originDeviceId = "device-old",
+            lastModifiedByDeviceId = "device-old",
+            updatedAt = 0L,
+            createdAt = 0L,
+        )
+
+        val result = service.merge(parsed = listOf(ancientOrphan))
+
+        assertEquals("no TTL args → filter must not fire", 1, result.size)
+    }
+
     // Test 14: Tie-breaker with multiple candidates at same timestamp
     @Test
     fun `multiple tie-breaks applied in order`() {

--- a/docs/adr/0025-annotation-sync-pluggable-target-w3c-format.md
+++ b/docs/adr/0025-annotation-sync-pluggable-target-w3c-format.md
@@ -2,6 +2,7 @@
 
 **Status:** Accepted
 **Extends:** [ADR 0003](0003-local-first-annotations.md) (local-first annotations) — keeps its local-first core, supersedes its "defer sync until ABS adds native support / push bookmarks to the ABS bookmark API" stance.
+**Superseded-in-part by:** [ADR 0038](0038-annotation-tombstone-ttl-and-file-gc.md) — replaces the "No automatic GC" policy and the "Manual tombstone compaction was prototyped and removed" discussion with a wall-clock TTL sweep of tombstones plus WebDAV file deletion when a device's file becomes empty.
 
 ## Context
 

--- a/docs/adr/0035-annotation-sync-webdav-first-target.md
+++ b/docs/adr/0035-annotation-sync-webdav-first-target.md
@@ -3,6 +3,7 @@
 **Status:** Accepted
 **Withdraws:** ADR 0033 (Google Drive appDataFolder as first cloud target) — never implemented; the underlying assumption no longer holds.
 **Reaffirms:** [ADR 0025](0025-annotation-sync-pluggable-target-w3c-format.md) (pluggable target, W3C format, per-device-file merge) — its **original** first-target plan: WebDAV.
+**Superseded-in-part by:** [ADR 0038](0038-annotation-tombstone-ttl-and-file-gc.md) — replaces the "No automatic GC" clause with a wall-clock TTL sweep of tombstones plus WebDAV file deletion when a device's file becomes empty.
 
 ## Context
 

--- a/docs/adr/0038-annotation-tombstone-ttl-and-file-gc.md
+++ b/docs/adr/0038-annotation-tombstone-ttl-and-file-gc.md
@@ -1,0 +1,68 @@
+# ADR 0038 — Annotation tombstones expire on a wall-clock TTL, and empty per-device files are deleted from WebDAV
+
+**Status:** Proposed
+
+**Supersedes:** [ADR 0025 §"No automatic GC" and §"Manual tombstone compaction was prototyped and removed"](0025-annotation-sync-pluggable-target-w3c-format.md); [ADR 0035 §"No automatic GC"](0035-annotation-sync-webdav-first-target.md).
+
+## Context
+
+Annotation sync ([ADR 0025](0025-annotation-sync-pluggable-target-w3c-format.md), [ADR 0034](0034-annotation-sync-local-directory-scaffold-and-merge-service.md), [ADR 0035](0035-annotation-sync-webdav-first-target.md)) uses one WebDAV file per device per book. Deletes propagate as tombstones (`riffle:deleted=true` records with `updatedAt`); merge is last-write-wins on `(uuid, updatedAt)`. Room stores tombstones so they participate in future LWW resolutions.
+
+The original design (ADR 0025) declared **no automatic GC**: tombstones and per-device files stay indefinitely, on the argument that they are small and that any compaction is self-undoing without coordination.
+
+That policy has one visible cost: **WebDAV accumulates per-device annotation files that consist entirely of tombstones**, and empty-in-effect files are never deleted. For a user browsing their WebDAV directory (or paying attention to file counts), this is untidy and stays untidy forever. In practice the tombstones themselves are tiny, but the presence of files is the annoyance.
+
+Issue #78 previously prototyped a manual "Compact tombstones" action and withdrew it. The failure mode was: compaction rewrote WebDAV files, but every peer's local Room still held those tombstones, so the next `pushPending` from any peer re-uploaded them. Compaction was cosmetic and self-undoing. ADR 0025 sketched a durable alternative (a `<namespace>__compact-gen.json` generation counter + a TTL, so peers observing a bump drop their aged tombstones) and rejected it as more UX asterisk than the marginal savings justified.
+
+Revisiting: the generation counter is unnecessary if every device applies the TTL to its **own** Room state independently on every sync. Wall-clock time is a coordination-free shared signal. Combined with a small filter on the merge path, the result is convergence without coordination and files that actually get deleted when they hold nothing live to say.
+
+## Decision
+
+Three rules, applied by every device on every sync:
+
+**1. Sweep own aged tombstones from Room and from own file.**
+On sync, drop from Room and omit from the device's own file any annotation row where `deleted=true` AND `updatedAt < now - TTL`. Live records are **never** swept — highlights, bookmarks, and notes persist indefinitely. Only tombstones age.
+
+**2. Delete empty own files from WebDAV.**
+After (1), if the device's own file contains no records, `DELETE` it from WebDAV. Re-created on the next mutation the device authors.
+
+**3. On merge, ignore stale orphans.**
+When applying a peer's file to Room: if the incoming UUID has no corresponding local row AND the incoming `updatedAt < now - TTL`, ignore the record (live or tombstone). Incoming records for UUIDs the device already has a row for, and incoming records with fresh `updatedAt`, follow normal LWW.
+
+TTL is 90 days. This is longer than the 30-day figure sketched in ADR 0025 and deliberately so: the dominant failure mode of any TTL choice is the "device offline > TTL, then touches a ghost" resurrection scenario, and lengthening the window is the cheapest lever for reducing its incidence. 90 days covers a phone-lost-in-a-drawer-for-a-summer without meaningfully changing the tidiness benefit — a tomb that's 89 days old is still eventually swept.
+
+Rules (1) and (2) purge the household of stale tombstones and empty files. Rule (3) is the resurrection guard: it prevents a peer that missed a delete and then reconnects from pushing its stale live copy back into everyone else's Room.
+
+## Why not the alternatives
+
+**Keep the current "no GC" policy.**
+Rejected: files-forever is the tidiness complaint this ADR exists to address. Sizes are small but growth is unbounded and visible.
+
+**The manual "Compact tombstones" action from Issue #78.**
+Rejected: self-undoing without coordination. Any peer's next push re-uploads the tombstones the action removed. See ADR 0025 §"Manual tombstone compaction was prototyped and removed". Under this ADR the action is not just rejected but **unnecessary** — sweeping is part of the standard sync cycle, so there is no user-visible maintenance task to expose. "Forget device" (from ADR 0025) remains the only manual annotation-hygiene action.
+
+**Generation-counter design (ADR 0025 Option 2).**
+Rejected: strictly more machinery than the wall-clock rule for the same end result. The counter's job was to trigger peers to drop their tombstones; wall-clock time triggers each peer independently. No shared metadata file is needed.
+
+**Skip incoming tombstones from Room entirely (ADR 0034 Option D).**
+Rejected: loses redundancy. Under the current design, N devices independently hold each tombstone in Room and re-emit it in their files; if the deleter uninstalls before all peers have synced, other peers still propagate the delete. Under Option D, the tombstone lives only in the deleter's file — a single point of durability. The wall-clock TTL rule preserves the redundancy up to the TTL and closes the resurrection window with rule (3).
+
+**Sweep live records by TTL too (symmetric TTL).**
+Rejected: highlights and bookmarks would evaporate on every device once the user hasn't re-touched them for TTL days. That is not what users expect from annotations. Only tombstones age.
+
+## Consequences
+
+- **Empty files disappear.** After a device deletes its last live annotation for a book and the TTL passes, its file is removed from WebDAV. A user browsing WebDAV sees only files that currently contribute content.
+- **Tombstones age out household-wide without coordination.** Every peer sweeps its own Room independently; convergence is by wall-clock, not by shared state.
+- **Live annotations never expire.** A highlight created once and never re-touched persists indefinitely on every device that pulled it.
+- **Resurrection asterisk (narrowed, not eliminated).** A device offline > TTL that holds a live copy of an annotation the household deleted will see a "ghost" copy locally. The ghost is invisible to all other devices (rule 3 filters its push). It becomes visible again — resurrecting on all devices — only if the offline device *edits* the ghost (recolor, note, any mutation that bumps `updatedAt` to fresh). This is the same asterisk LWW-without-coordination has always had; the TTL does not create it, and no coordination-free design can close it. Documented, not fixed.
+- **Devices that sync less often than TTL are unaffected.** Rule (1) applies to a device's own Room, so a rarely-synced device sweeps its own aged tombstones on its next connection whether that is day 31 or day 300. It does not need to be online during the "sweep window" of any other device.
+- **Clock skew is tolerated.** A device with a wall-clock off by hours or days will sweep slightly early or late compared to peers. The failure mode is a marginally longer or shorter tombstone lifetime on that device — not divergence, not resurrection.
+- **Legitimate offline creations older than TTL do not propagate.** A device that creates a highlight, never syncs for > TTL, then reconnects will keep the highlight locally (live records never expire on their author), but rule (3) causes peers to ignore its stale `updatedAt=creation-time` push. If the user ever re-touches the highlight, it propagates as fresh. Documented cost; accepted.
+
+## Rollout notes
+
+- No wire-format change. The `riffle:` extension already carries `deleted` and `updatedAt`; both rules are pure client-side logic.
+- No schema migration. Rule (1) reads existing `deleted` and `updatedAt` columns.
+- Rule (2) needs the WebDAV target to expose `DELETE`, which is standard.
+- The 30-day TTL should be a single constant, colocated with the merge service, tunable at compile time. It is not a user setting.


### PR DESCRIPTION
Implements [ADR 0038](docs/adr/0038-annotation-tombstone-ttl-and-file-gc.md) — annotation tombstones expire on a wall-clock TTL (90 days) and empty per-device files are deleted from WebDAV.

## Why

Per-device annotation files accumulate on WebDAV forever, and a file that contains nothing but months-old tombstones never gets cleaned up. ADR 0025 shipped without automatic GC because the manual "Compact tombstones" action from Issue #78 was self-undoing without coordination. This PR replaces the "no GC" clause with a wall-clock TTL each device applies to its own Room state — no coordination required.

## Rules (all in ADR 0038)

1. **Sweep aged tombstones from Room + own file.** `AnnotationDao.purgeAgedTombstones` hard-deletes rows where `deleted=1 AND updatedAt < now - TTL AND updatedAt <= lastSyncedAt`. The `lastSyncedAt` guard keeps offline-authored deletes intact until they propagate.
2. **DELETE empty own file from WebDAV.** When the sweep would leave this device's row set empty for a book, `target.delete()` fires. The DELETE now happens **before** the Room mutation so a transient failure keeps the tombstone in Room and the next sync retries — regression test included.
3. **Ignore stale orphans on merge.** `AnnotationMergeService.merge` gains optional `nowMs` / `staleOrphanCutoffMs` params. Incoming records with `updatedAt < now - TTL` and no local row are ignored — the resurrection guard for a peer that missed a household-wide sweep.

Live records never expire — only tombstones age. Documented resurrection asterisk (peer offline > TTL then edits a ghost) survives; that's LWW-without-coordination, called out in the ADR.

## What's superseded

- ADR 0025 §"No automatic GC" and §"Manual tombstone compaction was prototyped and removed"
- ADR 0035 §"No automatic GC"

Backpointers added to both.

## Test plan

- [x] `./gradlew test` — new merge tests (5), DAO purge tests (2 androidTest), sync-controller sweep/DELETE tests (8 lifecycle) all pass
- [x] Regression: `DELETE failure keeps aged tomb in Room so the next sync retries` — fakes a network error at DELETE and asserts (a) Room still holds the tomb, (b) second attempt actually deletes
- [ ] `make harness-test` — DAO androidTests (`purgeAgedTombstones_*`) exercise the real Room query via the emulator
- [ ] Real WebDAV validation (Synology) — verify the DELETE hits the wire on a real book with aged tombs