### PR TITLE
refactor(reader): unify highlight palette + fix annotation decorations on API-25 WebViews

### DIFF
--- a/app/src/androidTest/kotlin/com/riffle/app/feature/reader/HighlightRendererSwapReapplyTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/reader/HighlightRendererSwapReapplyTest.kt
@@ -6,8 +6,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.riffle.core.domain.ReadaloudHighlightColor
-import com.riffle.core.domain.ReaderTheme
+import com.riffle.core.domain.HighlightColor
 import com.riffle.core.domain.SentenceQuote
 import org.junit.Assert.assertEquals
 import org.junit.Rule
@@ -34,13 +33,12 @@ class HighlightRendererSwapReapplyTest {
         val second = CountingRenderer()
         var active by mutableStateOf<HighlightRenderer>(first)
         val renders = emptyList<EpubReaderViewModel.HighlightRender>()
-        val theme = ReaderTheme.Light
 
         rule.setContent {
             // Mirrors the production LaunchedEffect at EpubReaderScreen.kt:1676 — keying on the
             // renderer is what re-fires the effect when the renderer is recreated mid-session.
-            LaunchedEffect(active, renders, theme) {
-                active.applyAnnotations(renders, theme)
+            LaunchedEffect(active, renders) {
+                active.applyAnnotations(renders)
             }
         }
         rule.waitUntil(timeoutMillis = 2_000) { first.annotationApplies == 1 }
@@ -66,12 +64,11 @@ class HighlightRendererSwapReapplyTest {
         override suspend fun applyReadaloud(
             fragmentRef: String?,
             quotes: Map<String, SentenceQuote>,
-            color: ReadaloudHighlightColor,
+            color: HighlightColor,
         ) = Unit
 
         override suspend fun applyAnnotations(
             renders: List<EpubReaderViewModel.HighlightRender>,
-            theme: ReaderTheme,
         ) {
             annotationApplies += 1
         }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousHighlightRenderer.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousHighlightRenderer.kt
@@ -1,8 +1,6 @@
 package com.riffle.app.feature.reader
 
 import com.riffle.core.domain.HighlightColor
-import com.riffle.core.domain.ReadaloudHighlightColor
-import com.riffle.core.domain.ReaderTheme
 import com.riffle.core.domain.SentenceQuote
 import org.readium.r2.shared.publication.Locator
 
@@ -26,7 +24,7 @@ internal class ContinuousHighlightRenderer(
     override suspend fun applyReadaloud(
         fragmentRef: String?,
         quotes: Map<String, SentenceQuote>,
-        color: ReadaloudHighlightColor,
+        color: HighlightColor,
     ) {
         val target = targetProvider() ?: return
         if (fragmentRef == null) {
@@ -48,7 +46,6 @@ internal class ContinuousHighlightRenderer(
 
     override suspend fun applyAnnotations(
         renders: List<EpubReaderViewModel.HighlightRender>,
-        theme: ReaderTheme,
     ) {
         val target = targetProvider() ?: return
         val annotationsByHref = renders
@@ -59,7 +56,7 @@ internal class ContinuousHighlightRenderer(
                     AnnotationHighlight(
                         id = h.id,
                         text = h.locator.text.highlight!!,
-                        cssColor = HighlightColor.fromToken(h.color).readerTint(theme).toCssRgba(),
+                        cssColor = HighlightColor.fromToken(h.color).argb.toCssRgba(),
                         hasNote = h.note != null,
                         before = h.locator.text.before.orEmpty(),
                         after = h.locator.text.after.orEmpty(),

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -96,7 +96,6 @@ import com.riffle.app.feature.reader.readaloud.ReadaloudPeek
 import com.riffle.app.ui.theme.RiffleTheme
 import com.riffle.core.domain.FormattingPreferences
 import com.riffle.core.domain.HighlightColor
-import com.riffle.core.domain.ReadaloudHighlightColor
 import com.riffle.core.domain.ReaderOrientation
 import com.riffle.core.domain.SentenceQuote
 import com.riffle.core.domain.ReaderTheme
@@ -1093,7 +1092,7 @@ private fun EpubNavigatorView(
     onPlayFromHere: (fragmentRef: String) -> Unit,
     readaloudAvailable: Boolean,
     readaloudReservePx: Int = 0,
-    readaloudHighlightColor: ReadaloudHighlightColor,
+    readaloudHighlightColor: HighlightColor,
     annotationsAvailable: Boolean,
     highlightRenders: List<EpubReaderViewModel.HighlightRender>,
     onHighlight: (Locator, androidx.compose.ui.unit.IntRect) -> Unit,
@@ -1458,7 +1457,6 @@ private fun EpubNavigatorView(
     val paginationListener = remember {
         object : EpubNavigatorFragment.PaginationListener {
             override fun onPageLoaded() {
-                pageLoadGeneration.value += 1
                 val fragment = fragmentRef.value ?: return
                 coroutineScope.launch {
                     // A backward cross-resource page turn (swipe-back at a chapter start) is handled by
@@ -1480,7 +1478,16 @@ private fun EpubNavigatorView(
                     // settle backstop — through the renderer bridge (#331). The capability list is
                     // declared once in DefaultRendererBridge; adding a new one is a registration,
                     // not another evaluateJavascript() at this call site.
+                    //
+                    // MUST run before bumping [pageLoadGeneration]: the polyfills that ship with the
+                    // rect capability (ChildNode.append, Object.entries, ResizeObserver) are the only
+                    // reason Readium's `registerDecorationTemplates` doesn't throw on the old-Chromium
+                    // WebViews. The annotation re-apply LaunchedEffect keys on pageLoadGeneration; if
+                    // we bump before installing polyfills, the re-apply's evaluateJavascript queues
+                    // BEFORE ours and Readium's template registration runs against a still-broken
+                    // engine — decorations register into an internal map but never emit CSS or DOM.
                     rendererBridge.installPageCapabilities()
+                    pageLoadGeneration.value += 1
                     // NOTE: do NOT snap to the column grid here for the general case. The typography
                     // injection above reflows the page asynchronously, so a snap at this point rounds a
                     // pre-reflow position and lands close-but-not-exact. The post-go() snap in the
@@ -1724,8 +1731,8 @@ private fun EpubNavigatorView(
     // because the ContinuousReaderView ref binds during AndroidView's layout phase and is
     // worth applying to as soon as the ref is non-null — a slot the highlightRenderer key
     // alone doesn't cover.)
-    LaunchedEffect(highlightRenderer, highlightRenders, formattingPrefs.theme, reflowGeneration, pageLoadGeneration.value, activeFragmentRef?.substringBefore('#')) {
-        highlightRenderer.applyAnnotations(highlightRenders, formattingPrefs.theme)
+    LaunchedEffect(highlightRenderer, highlightRenders, reflowGeneration, pageLoadGeneration.value, activeFragmentRef?.substringBefore('#')) {
+        highlightRenderer.applyAnnotations(highlightRenders)
     }
 
     LaunchedEffect(highlightRenderer, highlightRenders, reflowGeneration, pageLoadGeneration.value) {
@@ -2267,7 +2274,7 @@ private fun EpubNavigatorView(
                 // a paged↔continuous orientation flip the new ContinuousHighlightRenderer would
                 // otherwise never be invoked and ContinuousReaderView.currentAnnotationsByHref
                 // would stay empty — onPageFinished would skip every chapter as it loaded.
-                highlightRenderer.applyAnnotations(highlightRenders, formattingPrefs.theme)
+                highlightRenderer.applyAnnotations(highlightRenders)
                 view.initialize(
                     chapters = chapters,
                     prefs = formattingPrefs,

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -49,7 +49,6 @@ import com.riffle.core.domain.ServerProgress
 import com.riffle.core.domain.ServerRepository
 import com.riffle.core.domain.ServerType
 import com.riffle.core.domain.HighlightColor
-import com.riffle.core.domain.ReadaloudHighlightColor
 import com.riffle.core.domain.ReadaloudPreferencesStore
 import com.riffle.core.domain.ReadaloudResumeStore
 import com.riffle.core.domain.ReadaloudTrack
@@ -468,7 +467,7 @@ class EpubReaderViewModel @Inject constructor(
 
     val sentenceQuotes: StateFlow<Map<String, com.riffle.core.domain.SentenceQuote>> get() = readaloud.sentenceQuotes
 
-    val readaloudHighlightColor: StateFlow<ReadaloudHighlightColor>
+    val readaloudHighlightColor: StateFlow<HighlightColor>
         get() = readaloud.readaloudHighlightColor
 
     val sentenceChapters: StateFlow<Map<String, String>> get() = readaloud.sentenceChapters

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/FormattingPreferencesMapper.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/FormattingPreferencesMapper.kt
@@ -100,9 +100,11 @@ fun FormattingPreferences.toFragmentConfiguration(
         // falls back to the default serif — Literata/Merriweather/OpenDyslexic would all
         // render identically.
         servedAssets = listOf("fonts/.*"),
-        // Keep Readium's built-in templates (used by persisted + search highlights) and add a
-        // dedicated readaloud highlight template whose opacity tracks the tint's alpha channel,
-        // so the synced highlight can be strengthened on dark reading themes (see readerTint()).
+        // Readium's built-in templates (used by search highlights) plus our shared
+        // [HighlightTintStyle] template for annotation + readaloud highlights and the
+        // [NoteGlyphStyle] template for the margin note glyph. Opacity comes from the tint's
+        // alpha channel, which is baked into [HighlightColor.argb] — one flat value across
+        // themes and features; see [riffleDecorationTemplates] for the single source.
         decorationTemplates = riffleDecorationTemplates(),
         readiumCssRsProperties = when {
             isDoublePage -> RsProperties(

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/FormattingPreferencesMapper.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/FormattingPreferencesMapper.kt
@@ -21,6 +21,19 @@ import org.readium.r2.navigator.preferences.Theme
 // Single source: ReaderThemePalette.DARK_DIM_TEXT (Compose Color) → Readium Color (ARGB int).
 private val DARK_DIM_TEXT_COLOR: Int = DARK_DIM_TEXT.toArgb()
 
+/**
+ * The decoration template set Riffle registers with the Readium engine: Readium's defaults (used
+ * by persisted highlight + search) plus our own [HighlightTintStyle] and [NoteGlyphStyle]. Extracted
+ * so both the fragment configuration and the post-polyfill re-registration script (see
+ * [readiumDecorationTemplatesRegisterJs]) build the same set — otherwise the CSS injected by our
+ * capability wouldn't match the styles the fragment thinks it registered.
+ */
+internal fun riffleDecorationTemplates(): HtmlDecorationTemplates =
+    HtmlDecorationTemplates.defaultTemplates().apply {
+        set(HighlightTintStyle::class, highlightTintTemplate())
+        set(NoteGlyphStyle::class, noteGlyphTemplate())
+    }
+
 fun FormattingPreferences.toEpubPreferences(
     isLandscape: Boolean = false,
     isFixedLayout: Boolean = false,
@@ -90,10 +103,7 @@ fun FormattingPreferences.toFragmentConfiguration(
         // Keep Readium's built-in templates (used by persisted + search highlights) and add a
         // dedicated readaloud highlight template whose opacity tracks the tint's alpha channel,
         // so the synced highlight can be strengthened on dark reading themes (see readerTint()).
-        decorationTemplates = HtmlDecorationTemplates.defaultTemplates().apply {
-            set(HighlightTintStyle::class, highlightTintTemplate())
-            set(NoteGlyphStyle::class, noteGlyphTemplate())
-        },
+        decorationTemplates = riffleDecorationTemplates(),
         readiumCssRsProperties = when {
             isDoublePage -> RsProperties(
                 colCount = ColCount.TWO,

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/HighlightDecoration.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/HighlightDecoration.kt
@@ -4,25 +4,15 @@ import android.graphics.Color
 import android.os.Parcel
 import android.os.Parcelable
 import androidx.annotation.ColorInt
-import com.riffle.core.domain.HighlightColor
-import com.riffle.core.domain.ReaderTheme
-import com.riffle.core.domain.ReadaloudHighlightColor
 import org.readium.r2.navigator.Decoration
 import java.util.Locale
 import org.readium.r2.navigator.html.HtmlDecorationTemplate
 import org.readium.r2.navigator.html.toCss
 
 // Readium's default highlight template (Style.Highlight) bakes a FIXED alpha (0.3) into the CSS and
-// ignores the tint's own alpha channel — too faint on the Dark reading theme (0.3 of a colour over a
-// black page is barely visible behind the white body text). Both the readaloud "now speaking"
-// highlight and the persisted annotation highlights use this OWN style + template instead, so the
-// fill opacity can vary per theme (the template honours the tint's alpha; the caller bakes in the
-// strength via tintForTheme()).
-
-// Fill opacity baked into the tint's alpha channel per reading theme. Dark pages need a stronger
-// alpha so the highlight reads as a clear selection box behind the white body text.
-internal const val HIGHLIGHT_ALPHA_DARK = 0x73 // ~45%
-internal const val HIGHLIGHT_ALPHA_LIGHT = 0x4D // ~30%
+// ignores the tint's own alpha channel. Both readaloud "now speaking" and persisted annotations
+// route through this OWN style + template so the tint's own alpha channel (already baked into
+// [HighlightColor.argb], the single source of colour AND opacity) is honoured verbatim.
 
 /** Shared decoration style for tinted highlights (readaloud "now speaking" + persisted annotations). */
 class HighlightTintStyle(
@@ -74,24 +64,6 @@ fun highlightTintTemplate(): HtmlDecorationTemplate =
             }
         """.trimIndent(),
     )
-
-/**
- * Bake the per-[theme] fill opacity into [argb]'s alpha channel. Dark/DarkDim pages use a stronger
- * alpha so the highlight reads as a clear box behind white body text; light/sepia use Readium's
- * usual ~30% so dark body text stays legible.
- */
-@ColorInt
-fun tintForTheme(@ColorInt argb: Int, theme: ReaderTheme): Int {
-    val alpha = when (theme) {
-        ReaderTheme.Dark, ReaderTheme.DarkDim -> HIGHLIGHT_ALPHA_DARK
-        else -> HIGHLIGHT_ALPHA_LIGHT
-    }
-    return (argb and 0x00FFFFFF) or (alpha shl 24)
-}
-
-/** The tint to paint a persisted-annotation highlight with on the given reading [theme]. */
-@ColorInt
-fun HighlightColor.readerTint(theme: ReaderTheme): Int = tintForTheme(argb, theme)
 
 /** Convert an ARGB color int to a CSS rgba() string for injection into WebView JS. */
 fun @receiver:ColorInt Int.toCssRgba(): String {

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/HighlightRenderer.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/HighlightRenderer.kt
@@ -1,8 +1,7 @@
 package com.riffle.app.feature.reader
 
 import androidx.annotation.ColorInt
-import com.riffle.core.domain.ReadaloudHighlightColor
-import com.riffle.core.domain.ReaderTheme
+import com.riffle.core.domain.HighlightColor
 import com.riffle.core.domain.SentenceQuote
 import org.readium.r2.shared.publication.Locator
 
@@ -32,21 +31,21 @@ internal interface HighlightRenderer {
 
     /**
      * Applies or clears the readaloud sentence highlight.
-     * [fragmentRef] is "href#spanId" when active, null to clear.
+     * [fragmentRef] is "href#spanId" when active, null to clear. The fill uses [color]'s [argb]
+     * verbatim — colour AND alpha are pre-baked; renderers must not compose additional alpha.
      */
     suspend fun applyReadaloud(
         fragmentRef: String?,
         quotes: Map<String, SentenceQuote>,
-        color: ReadaloudHighlightColor,
+        color: HighlightColor,
     )
 
     /**
      * Applies or clears persisted annotation highlight decorations.
-     * Empty [renders] clears the group.
+     * Empty [renders] clears the group. Same colour+alpha invariant as [applyReadaloud].
      */
     suspend fun applyAnnotations(
         renders: List<EpubReaderViewModel.HighlightRender>,
-        theme: ReaderTheme,
     )
 
     /**

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderWebViewScripts.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderWebViewScripts.kt
@@ -1,3 +1,5 @@
+@file:OptIn(org.readium.r2.shared.ExperimentalReadiumApi::class)
+
 package com.riffle.app.feature.reader
 
 import org.json.JSONArray
@@ -9,13 +11,20 @@ import org.json.JSONArray
  * repeated firing during reflow is harmless.
  */
 
-// Readium 3.0.0's reflowable tap handler (`ut` in readium-reflowable.js) hit-tests decorations by
-// calling `element.getBoundingClientRect().toJSON()`. On Android's pre-Chromium-61 WebView (API ≤ 27,
-// e.g. Android 7.1.1) getBoundingClientRect() returns a ClientRect with no toJSON(), so that call
-// throws *before* Readium forwards the gesture to Android.onTap — silently swallowing every tap
-// whenever an activable decoration is present. In practice that's the readaloud sentence highlight:
-// while (or after) readaloud runs, the user can no longer tap to enter/exit immersive mode. Adding
-// the missing toJSON() restores tap delivery. Guarded so it's a no-op where the engine already has it.
+// Two polyfills that Readium's reflowable engine needs but the older Android WebView (API ≤ 27,
+// Chrome ≤ 55) is missing:
+//
+//   * `ClientRect.toJSON()` — Readium 3.0.0's tap hit-test calls `getBoundingClientRect().toJSON()`;
+//     without it every tap on an activable decoration (e.g. the readaloud "now speaking" highlight)
+//     throws before Android.onTap fires and the immersive-mode toggle silently stops working.
+//
+//   * `document.body.append(...)` — Readium 3.2.0+'s decoration renderer creates the group container
+//     via `document.body.append(el)` (ChildNode.append, only in Chrome 54+). Without it EVERY
+//     `applyDecorations` call throws before injecting any `<div id="r2-decoration-…">`, so persisted
+//     annotation highlights AND the readaloud sentence marker are entirely invisible on those
+//     WebViews. Polyfill delegates to `appendChild` so Readium's DOM-append path succeeds.
+//
+// Both are guarded so they're no-ops on engines that already ship them.
 internal val RECT_TO_JSON_POLYFILL_JS = """
     (function () {
       try {
@@ -34,8 +43,143 @@ internal val RECT_TO_JSON_POLYFILL_JS = """
           }
         });
       } catch (e) {}
+      // ChildNode.append / ParentNode.append polyfill. Readium 3.2.0+ calls document.body.append(el)
+      // from its decoration renderer; older WebViews (Chrome < 54) only have appendChild.
+      try {
+        function installAppend(proto) {
+          if (proto && typeof proto.append !== 'function') {
+            Object.defineProperty(proto, 'append', {
+              configurable: true, writable: true, enumerable: false,
+              value: function () {
+                var doc = this.ownerDocument || document;
+                for (var i = 0; i < arguments.length; i++) {
+                  var node = arguments[i];
+                  this.appendChild(typeof node === 'string' ? doc.createTextNode(node) : node);
+                }
+              }
+            });
+          }
+        }
+        [
+          typeof Element !== 'undefined' ? Element.prototype : null,
+          typeof Document !== 'undefined' ? Document.prototype : null,
+          typeof DocumentFragment !== 'undefined' ? DocumentFragment.prototype : null,
+        ].forEach(installAppend);
+      } catch (e) {}
+      // Object.entries / Object.values polyfill. Readium 3.2.0+'s decoration positioner iterates
+      // per-decoration state via Object.entries(state); Chrome < 54 lacks these and every
+      // decoration positioning pass throws BEFORE the child boxes are appended into the group
+      // container. That's why the group div appears with data-group="annotations" but no children.
+      try {
+        if (typeof Object.entries !== 'function') {
+          Object.entries = function (obj) {
+            var keys = Object.keys(Object(obj));
+            var out = new Array(keys.length);
+            for (var i = 0; i < keys.length; i++) out[i] = [keys[i], obj[keys[i]]];
+            return out;
+          };
+        }
+        if (typeof Object.values !== 'function') {
+          Object.values = function (obj) {
+            var keys = Object.keys(Object(obj));
+            var out = new Array(keys.length);
+            for (var i = 0; i < keys.length; i++) out[i] = obj[keys[i]];
+            return out;
+          };
+        }
+      } catch (e) {}
+      // ResizeObserver stub. Chrome < 64 lacks it; Readium 3.3.0's reflowable engine constructs
+      // one at init to re-position decorations on viewport size changes. A no-op stub is enough
+      // to keep init from throwing — on this WebView the viewport is stable per page, so nothing
+      // else depends on the observer firing. Decorations get re-placed by our reflow/pageLoad
+      // reapply loop.
+      try {
+        if (typeof window.ResizeObserver !== 'function') {
+          window.ResizeObserver = function ResizeObserverPolyfill(_cb) {
+            this.observe = function () {};
+            this.unobserve = function () {};
+            this.disconnect = function () {};
+          };
+        }
+      } catch (e) {}
+      // Array.prototype.flat / flatMap polyfill. Readium 3.2.0+'s text-anchoring pipeline uses
+      // `.flatMap` when resolving a TextQuoteSelector to a DOM Range; without it the resolver
+      // throws inside Readium's decoration positioner and every decoration lands with an empty
+      // `range: {}`, which reads as "found nothing" downstream — the div is registered but never
+      // sized/placed, so no highlight box appears on the page.
+      try {
+        if (typeof Array.prototype.flat !== 'function') {
+          Object.defineProperty(Array.prototype, 'flat', {
+            configurable: true, writable: true, enumerable: false,
+            value: function (depth) {
+              depth = depth === undefined ? 1 : Math.floor(Number(depth)) || 0;
+              var out = [];
+              (function step(arr, d) {
+                for (var i = 0; i < arr.length; i++) {
+                  var v = arr[i];
+                  if (d > 0 && Array.isArray(v)) step(v, d - 1);
+                  else out.push(v);
+                }
+              })(this, depth);
+              return out;
+            }
+          });
+        }
+        if (typeof Array.prototype.flatMap !== 'function') {
+          Object.defineProperty(Array.prototype, 'flatMap', {
+            configurable: true, writable: true, enumerable: false,
+            value: function (cb, thisArg) {
+              return this.map(cb, thisArg).flat(1);
+            }
+          });
+        }
+      } catch (e) {}
+      // Object.fromEntries + String.prototype.padStart — smaller cousins of the above; Readium
+      // may reach for them elsewhere and a missing built-in throws before subsequent code runs.
+      try {
+        if (typeof Object.fromEntries !== 'function') {
+          Object.fromEntries = function (iter) {
+            var out = {};
+            var arr = Array.isArray(iter) ? iter : Array.from(iter);
+            for (var i = 0; i < arr.length; i++) {
+              var pair = arr[i];
+              out[pair[0]] = pair[1];
+            }
+            return out;
+          };
+        }
+        if (typeof String.prototype.padStart !== 'function') {
+          Object.defineProperty(String.prototype, 'padStart', {
+            configurable: true, writable: true, enumerable: false,
+            value: function (targetLength, padString) {
+              targetLength = targetLength >> 0;
+              padString = String(padString !== undefined ? padString : ' ');
+              if (this.length >= targetLength || padString.length === 0) return String(this);
+              var pad = '';
+              var need = targetLength - this.length;
+              while (pad.length < need) pad += padString;
+              return pad.slice(0, need) + String(this);
+            }
+          });
+        }
+      } catch (e) {}
     })();
 """.trimIndent()
+
+/**
+ * Re-registers the decoration templates AFTER polyfills are installed. Readium calls
+ * `readium.registerDecorationTemplates(...)` once at resource-load time — which is BEFORE our
+ * polyfill install runs, so on old-WebView Chromium (missing Object.entries) the first registration
+ * throws inside the CSS-injection loop and neither the internal template map nor the `<style>` tag
+ * lands. Subsequent applyDecorations calls don't re-register — they only send the diff — so once
+ * that first registration is lost, no decoration ever renders. This script pushes a fresh
+ * registration through the (now-polyfilled) engine so `.riffle-highlight-tint` CSS makes it into
+ * the page and the internal template map is populated in time for the next applyDecorations diff.
+ */
+internal fun readiumDecorationTemplatesRegisterJs(): String {
+    val templatesJson = riffleDecorationTemplates().toJSON().toString().replace("\\n", " ")
+    return "try { readium.registerDecorationTemplates($templatesJson); } catch (e) {}"
+}
 
 // Tracks the narrated-sentence span under the user's text selection so "Play from here" can resolve
 // the right SMIL clip. Storyteller wraps each sentence in <span id="cNNN-sM">; on every non-collapsed

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ReadiumHighlightRenderer.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ReadiumHighlightRenderer.kt
@@ -1,8 +1,6 @@
 package com.riffle.app.feature.reader
 
 import com.riffle.core.domain.HighlightColor
-import com.riffle.core.domain.ReadaloudHighlightColor
-import com.riffle.core.domain.ReaderTheme
 import com.riffle.core.domain.SentenceQuote
 import kotlinx.coroutines.delay
 import org.readium.r2.navigator.Decoration
@@ -36,7 +34,7 @@ internal class ReadiumHighlightRenderer(
     override suspend fun applyReadaloud(
         fragmentRef: String?,
         quotes: Map<String, SentenceQuote>,
-        color: ReadaloudHighlightColor,
+        color: HighlightColor,
     ) {
         if (fragmentRef == null) {
             if (!hasReadaloudDecoration) return
@@ -58,7 +56,6 @@ internal class ReadiumHighlightRenderer(
 
     override suspend fun applyAnnotations(
         renders: List<EpubReaderViewModel.HighlightRender>,
-        theme: ReaderTheme,
     ) {
         if (renders.isEmpty()) {
             if (!hasAnnotationDecorations) return
@@ -70,11 +67,22 @@ internal class ReadiumHighlightRenderer(
             Decoration(
                 id = h.id,
                 locator = h.locator,
-                style = HighlightTintStyle(tint = HighlightColor.fromToken(h.color).readerTint(theme)),
+                style = HighlightTintStyle(tint = HighlightColor.fromToken(h.color).argb),
             )
         }
-        applyDecorationsWithClear(decorations, "annotations")
+        applyDecorationsBlock(decorations, "annotations")
         hasAnnotationDecorations = true
+        // Readium fixes decoration rects at applyDecorations time. When the first apply runs before
+        // reflow has fully settled (fresh navigator, chapter change, orientation flip), the rects
+        // land against a still-shifting layout and the highlight is either invisible or in the wrong
+        // place. Same settle window as [applySearch] — clear+re-apply on each tick so the diff
+        // forces Readium to re-measure and re-position the boxes.
+        val stamp = currentNavigatorStamp()
+        for (settleDelayMs in longArrayOf(400L, 600L, 700L, 900L)) {
+            delay(settleDelayMs)
+            if (currentNavigatorStamp() !== stamp) break
+            applyDecorationsWithClear(decorations, "annotations")
+        }
     }
 
     override suspend fun applyNoteGlyphs(

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ReadiumHighlightRenderer.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ReadiumHighlightRenderer.kt
@@ -70,7 +70,11 @@ internal class ReadiumHighlightRenderer(
                 style = HighlightTintStyle(tint = HighlightColor.fromToken(h.color).argb),
             )
         }
-        applyDecorationsBlock(decorations, "annotations")
+        // Initial apply uses clear+apply too — Readium's decoration diff treats an identical
+        // (id, locator, style) list as a no-op, so a re-fire of the same list (theme change bumps
+        // pageLoadGeneration, LaunchedEffect keys the same renders) would keep the stale pre-reflow
+        // rects until the 400ms settle tick fires. Matches [applyReadaloud]'s pre-clear semantics.
+        applyDecorationsWithClear(decorations, "annotations")
         hasAnnotationDecorations = true
         // Readium fixes decoration rects at applyDecorations time. When the first apply runs before
         // reflow has fully settled (fresh navigator, chapter change, orientation flip), the rects

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/renderer/DefaultRendererBridge.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/renderer/DefaultRendererBridge.kt
@@ -7,6 +7,7 @@ import com.riffle.app.feature.reader.SELECTION_SPAN_TRACKER_JS
 import com.riffle.app.feature.reader.firstVisibleSentenceJs
 import com.riffle.app.feature.reader.readaloudReserveApplyJs
 import com.riffle.app.feature.reader.readaloudReserveInjectionJs
+import com.riffle.app.feature.reader.readiumDecorationTemplatesRegisterJs
 import com.riffle.app.feature.reader.resolveSelectionSentenceJs
 import com.riffle.app.feature.reader.typographyOverrideInjectionJs
 import java.net.URLDecoder
@@ -188,6 +189,11 @@ internal class DefaultRendererBridge(
             RendererCapability(
                 id = CapabilityId.ScrollSettleBackstop,
                 installScript = { ColumnSnap.SETTLE_SNAP_INSTALL_JS },
+            ),
+            RendererCapability(
+                id = CapabilityId.DecorationTemplateReregister,
+                dependsOn = setOf(CapabilityId.RectToJsonPolyfill),
+                installScript = { readiumDecorationTemplatesRegisterJs() },
             ),
         )
 

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/renderer/RendererCapability.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/renderer/RendererCapability.kt
@@ -25,6 +25,15 @@ internal enum class CapabilityId {
 
     /** At-rest column-snap backstop — rounds an off-grid resting page to the nearest column. */
     ScrollSettleBackstop,
+
+    /**
+     * Re-registers Readium's decoration templates after polyfills are in place. Readium's own
+     * registration fires at resource-load — before our polyfills — and on old WebViews the
+     * missing Object.entries / Array.prototype.flatMap silently short-circuits it, leaving the
+     * template CSS un-injected and every annotation highlight invisible. Must depend on the
+     * polyfill capability so the retry actually runs against a working engine.
+     */
+    DecorationTemplateReregister,
 }
 
 /** Where in the renderer's lifetime a capability is meant to be (re)installed. */

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/session/ReadaloudSession.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/session/ReadaloudSession.kt
@@ -25,7 +25,7 @@ import com.riffle.core.domain.EpubRepository
 import com.riffle.core.domain.FormattingPreferences
 import com.riffle.core.domain.ListeningPreferencesStore
 import com.riffle.core.domain.ReadaloudAudioRepository
-import com.riffle.core.domain.ReadaloudHighlightColor
+import com.riffle.core.domain.HighlightColor
 import com.riffle.core.domain.ReadaloudPreferencesStore
 import com.riffle.core.domain.ReadaloudResumePlanner
 import com.riffle.core.domain.ReadaloudResumePosition
@@ -188,10 +188,10 @@ class ReadaloudSession @AssistedInject constructor(
     private val _sentenceChapters = MutableStateFlow<Map<String, String>>(emptyMap())
     val sentenceChapters: StateFlow<Map<String, String>> = _sentenceChapters
 
-    val readaloudHighlightColor: StateFlow<ReadaloudHighlightColor> =
+    val readaloudHighlightColor: StateFlow<HighlightColor> =
         readaloudPreferencesStore.preferences
             .map { it.highlightColor }
-            .stateIn(scope, SharingStarted.WhileSubscribed(5_000), ReadaloudHighlightColor.BLUE)
+            .stateIn(scope, SharingStarted.WhileSubscribed(5_000), HighlightColor.BLUE)
 
     /** Non-null size means "show the download dialog". */
     private val _downloadPromptBytes = MutableStateFlow<Long?>(null)

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsScreen.kt
@@ -360,12 +360,12 @@ fun SettingsScreen(
                                 // The swatch renders the exact `argb` from [HighlightColor] — same
                                 // pixel value that lands in the reader. Do NOT compose additional
                                 // alpha in the enabled case; the picker must be a faithful preview.
+                                // Disabled: drop to the Material standard 0.38 (absolute, not
+                                // multiplicative against the palette's baked-in 0x80 — that would
+                                // land at ~0.19 and read as near-invisible next to the sibling
+                                // disabled `headlineColor` above, which uses `alpha = 0.38f` too).
                                 val base = Color(color.argb.toLong() and 0xFFFFFFFFL)
-                                val swatchColor = if (highlightEnabled) {
-                                    base
-                                } else {
-                                    base.copy(alpha = base.alpha * 0.38f)
-                                }
+                                val swatchColor = if (highlightEnabled) base else base.copy(alpha = 0.38f)
                                 // Selected swatch reads clearly in both themes: an offset ring
                                 // (onSurface ring at the outer edge, separated from the swatch by a
                                 // transparent gap) plus a centred checkmark. The swatch keeps a

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsScreen.kt
@@ -79,7 +79,7 @@ import com.riffle.app.feature.reader.formattingSummary
 import com.riffle.app.ui.TabletContentWidthContainer
 import com.riffle.app.feature.server.AddServerBackend
 import com.riffle.core.domain.AppTheme
-import com.riffle.core.domain.ReadaloudHighlightColor
+import com.riffle.core.domain.HighlightColor
 import com.riffle.core.domain.Server
 import com.riffle.core.domain.ServerType
 import kotlinx.coroutines.launch
@@ -355,10 +355,17 @@ fun SettingsScreen(
                     },
                     trailingContent = {
                         Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                            ReadaloudHighlightColor.entries.forEach { color ->
+                            HighlightColor.entries.forEach { color ->
                                 val isSelected = readaloudPreferences.highlightColor == color
-                                val swatchColor = Color(color.argb.toLong() and 0xFFFFFFFFL)
-                                    .copy(alpha = if (highlightEnabled) 1f else 0.38f)
+                                // The swatch renders the exact `argb` from [HighlightColor] — same
+                                // pixel value that lands in the reader. Do NOT compose additional
+                                // alpha in the enabled case; the picker must be a faithful preview.
+                                val base = Color(color.argb.toLong() and 0xFFFFFFFFL)
+                                val swatchColor = if (highlightEnabled) {
+                                    base
+                                } else {
+                                    base.copy(alpha = base.alpha * 0.38f)
+                                }
                                 // Selected swatch reads clearly in both themes: an offset ring
                                 // (onSurface ring at the outer edge, separated from the swatch by a
                                 // transparent gap) plus a centred checkmark. The swatch keeps a
@@ -371,7 +378,7 @@ fun SettingsScreen(
                                         .clip(CircleShape)
                                         .then(
                                             if (highlightEnabled) {
-                                                Modifier.clickable { viewModel.updateReadaloudHighlightColor(color) }
+                                                Modifier.clickable { viewModel.updateHighlightColor(color) }
                                             } else Modifier
                                         )
                                         .then(

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsViewModel.kt
@@ -18,7 +18,7 @@ import com.riffle.core.domain.LibraryObserver
 import com.riffle.core.domain.LibraryVisibilityPreferencesStore
 import com.riffle.core.domain.ListeningPreferencesStore
 import com.riffle.core.domain.orderLibraries
-import com.riffle.core.domain.ReadaloudHighlightColor
+import com.riffle.core.domain.HighlightColor
 import com.riffle.core.domain.ReadaloudPreferences
 import com.riffle.core.domain.ReadaloudPreferencesStore
 import com.riffle.core.domain.ReadaloudReviewRepository
@@ -335,7 +335,7 @@ class SettingsViewModel @Inject constructor(
         viewModelScope.launch { formattingPreferencesStore.update(prefs) }
     }
 
-    fun updateReadaloudHighlightColor(color: ReadaloudHighlightColor) {
+    fun updateHighlightColor(color: HighlightColor) {
         viewModelScope.launch {
             readaloudPreferencesStore.update(ReadaloudPreferences(highlightColor = color))
         }

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousHighlightRendererTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousHighlightRendererTest.kt
@@ -1,8 +1,7 @@
 package com.riffle.app.feature.reader
 
 import android.net.FakeUri
-import com.riffle.core.domain.ReadaloudHighlightColor
-import com.riffle.core.domain.ReaderTheme
+import com.riffle.core.domain.HighlightColor
 import com.riffle.core.domain.SentenceQuote
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
@@ -110,7 +109,7 @@ class ContinuousHighlightRendererTest {
         renderer.applyReadaloud(
             fragmentRef = "chapter1.xhtml#s42",
             quotes = mapOf("s42" to SentenceQuote(before = "", highlight = "To be or not to be", after = "")),
-            color = ReadaloudHighlightColor.BLUE,
+            color = HighlightColor.BLUE,
         )
         assertEquals(1, fakeTarget.highlighted.size)
         assertEquals("chapter1.xhtml", fakeTarget.highlighted[0].first)
@@ -122,12 +121,12 @@ class ContinuousHighlightRendererTest {
         renderer.applyReadaloud(
             fragmentRef = "ch1.xhtml#s1",
             quotes = mapOf("s1" to SentenceQuote(before = "", highlight = "First sentence", after = "")),
-            color = ReadaloudHighlightColor.BLUE,
+            color = HighlightColor.BLUE,
         )
         renderer.applyReadaloud(
             fragmentRef = "ch2.xhtml#s2",
             quotes = mapOf("s2" to SentenceQuote(before = "", highlight = "Second chapter", after = "")),
-            color = ReadaloudHighlightColor.BLUE,
+            color = HighlightColor.BLUE,
         )
         // ch1 should have been cleared when ch2 was highlighted
         assertTrue("ch1 should be cleared", fakeTarget.cleared.contains("ch1.xhtml"))
@@ -140,9 +139,9 @@ class ContinuousHighlightRendererTest {
         renderer.applyReadaloud(
             fragmentRef = "ch1.xhtml#s1",
             quotes = mapOf("s1" to SentenceQuote(before = "", highlight = "A sentence", after = "")),
-            color = ReadaloudHighlightColor.BLUE,
+            color = HighlightColor.BLUE,
         )
-        renderer.applyReadaloud(null, emptyMap(), ReadaloudHighlightColor.BLUE)
+        renderer.applyReadaloud(null, emptyMap(), HighlightColor.BLUE)
         assertTrue(fakeTarget.cleared.contains("ch1.xhtml"))
     }
 
@@ -151,7 +150,7 @@ class ContinuousHighlightRendererTest {
         renderer.applyReadaloud(
             fragmentRef = "ch1.xhtml#unknown",
             quotes = emptyMap(),
-            color = ReadaloudHighlightColor.BLUE,
+            color = HighlightColor.BLUE,
         )
         assertEquals(0, fakeTarget.highlighted.size)
     }
@@ -165,7 +164,7 @@ class ContinuousHighlightRendererTest {
             makeRender("h2", "ch1.xhtml", "text two", color = "green"),
             makeRender("h3", "ch2.xhtml", "text three", color = "blue"),
         )
-        renderer.applyAnnotations(renders, ReaderTheme.Light)
+        renderer.applyAnnotations(renders)
 
         assertEquals(1, fakeTarget.appliedAnnotations.size)
         val byHref = fakeTarget.appliedAnnotations[0]
@@ -178,14 +177,14 @@ class ContinuousHighlightRendererTest {
         // A render whose locator.text.highlight is null should be filtered out.
         // (In production, the Screen always stores text in the locator, but guard anyway.)
         val renders = listOf(makeRender("h1", "ch1.xhtml", "some text"))
-        renderer.applyAnnotations(renders, ReaderTheme.Light)
+        renderer.applyAnnotations(renders)
         // applyAnnotationHighlights should still be called (with filtered content)
         assertEquals(1, fakeTarget.appliedAnnotations.size)
     }
 
     @Test
     fun `applyAnnotations with empty renders calls applyAnnotationHighlights with empty map`() = runTest {
-        renderer.applyAnnotations(emptyList(), ReaderTheme.Light)
+        renderer.applyAnnotations(emptyList())
         assertEquals(1, fakeTarget.appliedAnnotations.size)
         assertTrue(fakeTarget.appliedAnnotations[0].isEmpty())
     }
@@ -201,7 +200,7 @@ class ContinuousHighlightRendererTest {
                 before = "Али ", after = " решил да замине",
             ),
         )
-        renderer.applyAnnotations(renders, ReaderTheme.Light)
+        renderer.applyAnnotations(renders)
         val ann = fakeTarget.appliedAnnotations.single().values.single().single()
         assertEquals("Али ", ann.before)
         assertEquals(" решил да замине", ann.after)
@@ -213,7 +212,7 @@ class ContinuousHighlightRendererTest {
         // The renderer must turn null into "" so the JS receives a stable string type and the
         // first-match short-circuit (when both are empty) preserves the old behaviour.
         val renders = listOf(makeRender("legacy", "ch1.xhtml", "Куджиа"))
-        renderer.applyAnnotations(renders, ReaderTheme.Light)
+        renderer.applyAnnotations(renders)
         val ann = fakeTarget.appliedAnnotations.single().values.single().single()
         assertEquals("", ann.before)
         assertEquals("", ann.after)

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/HighlightTintTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/HighlightTintTest.kt
@@ -1,28 +1,23 @@
 package com.riffle.app.feature.reader
 
 import com.riffle.core.domain.HighlightColor
-import com.riffle.core.domain.ReaderTheme
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
+/**
+ * Locks in the single-source invariant: [HighlightColor.argb] carries the FINAL rendered ARGB
+ * (colour + alpha), used verbatim by both the settings swatch and every reader decoration path.
+ * If these expectations drift, the picker preview will stop matching what appears on the page.
+ */
 class HighlightTintTest {
 
     private fun alpha(argb: Int) = (argb ushr 24) and 0xFF
-    private fun rgb(argb: Int) = argb and 0x00FFFFFF
 
     @Test
-    fun `dark themes use the stronger alpha, light and sepia the lighter one`() {
-        val argb = HighlightColor.GREEN.argb
-        assertEquals(0x73, alpha(tintForTheme(argb, ReaderTheme.Dark)))
-        assertEquals(0x73, alpha(tintForTheme(argb, ReaderTheme.DarkDim)))
-        assertEquals(0x4D, alpha(tintForTheme(argb, ReaderTheme.Light)))
-        assertEquals(0x4D, alpha(tintForTheme(argb, ReaderTheme.Sepia)))
-    }
-
-    @Test
-    fun `tint preserves the base hue and only swaps the alpha channel`() {
-        val tint = HighlightColor.PINK.readerTint(ReaderTheme.Dark)
-        assertEquals(rgb(HighlightColor.PINK.argb), rgb(tint))
-        assertEquals(0x73, alpha(tint))
+    fun `every palette entry bakes in a single non-full alpha`() {
+        for (color in HighlightColor.entries) {
+            val a = alpha(color.argb)
+            assertEquals("${color.name} alpha must be baked-in (translucent), got 0x${a.toString(16)}", 0x80, a)
+        }
     }
 }

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ReadaloudHighlightDecorationTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ReadaloudHighlightDecorationTest.kt
@@ -3,7 +3,7 @@
 package com.riffle.app.feature.reader
 
 import com.riffle.core.domain.FormattingPreferences
-import com.riffle.core.domain.ReadaloudHighlightColor
+import com.riffle.core.domain.HighlightColor
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
@@ -45,12 +45,14 @@ class ReadaloudHighlightDecorationTest {
     }
 
     @Test
-    fun allColorsHaveAlphaBakedIn() {
-        // argb is the final rendered color used by both the swatch and the reader — no runtime
-        // transformation applied. Verify every entry is translucent (not fully opaque).
-        for (color in ReadaloudHighlightColor.entries) {
+    fun paletteBakesInBothColourAndAlpha() {
+        // `argb` is the single source of truth for both hue AND opacity. Every consumer — reader
+        // decorations (readaloud + annotations) and the Settings picker — uses this int verbatim,
+        // so the swatch preview matches what the reader actually paints. If this alpha ever drifts
+        // back to 0xFF, the reader will paint fully-opaque bars over body text.
+        for (color in HighlightColor.entries) {
             val a = alpha(color.argb)
-            assertTrue("${color.name} alpha $a should be translucent", a in 1..254)
+            assertTrue("${color.name} alpha $a must be translucent (single-source baked-in)", a in 1..254)
         }
     }
 

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ReadiumHighlightRendererTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ReadiumHighlightRendererTest.kt
@@ -100,12 +100,30 @@ class ReadiumHighlightRendererTest {
             makeRender("h2", "c1.xhtml", color = "green"),
         )
         renderer.applyAnnotations(renders)
-        // applyDecorationsWithClear = clear + apply → 2 calls to the block
-        val decorationCall = applied.last()
-        assertEquals("annotations", decorationCall.second)
-        assertEquals(2, decorationCall.first.size)
-        assertEquals("h1", decorationCall.first[0].id)
-        assertEquals("h2", decorationCall.first[1].id)
+        val annotationCalls = applied.filter { it.second == "annotations" }
+        // Initial apply + 4-tick settle window (each = clear + apply) = 1 + 4*2 = 9 calls
+        assertTrue("expected initial apply plus settle re-applies", annotationCalls.size >= 3)
+        // The initial apply is the first "annotations" call
+        val firstApply = annotationCalls.first()
+        assertEquals(2, firstApply.first.size)
+        assertEquals("h1", firstApply.first[0].id)
+        assertEquals("h2", firstApply.first[1].id)
+    }
+
+    @Test
+    fun `applyAnnotations settle loop aborts when navigator stamp changes`() = runTest {
+        // Same guard as applySearch: on a fresh navigator stamp between settle ticks, don't keep
+        // shoving decorations into a WebView that isn't ours anymore. Regression pin — without this
+        // abort, an orientation flip mid-settle would spam the old fragment for another second.
+        val recorder = mutableListOf<Pair<List<Decoration>, String>>()
+        val abortingRenderer = ReadiumHighlightRenderer(
+            applyDecorationsBlock = { decorations, group -> recorder.add(decorations to group) },
+            fragmentLocator = { ref, _ -> if (ref.isNotBlank()) minimalLocator(ref.substringBefore('#')) else null },
+            currentNavigatorStamp = { Any() }, // new object every call → stamp always changes
+        )
+        abortingRenderer.applyAnnotations(listOf(makeRender("h1", "c1.xhtml")))
+        val annotationCalls = recorder.filter { it.second == "annotations" }
+        assertEquals("only the initial apply fires when the stamp changes", 1, annotationCalls.size)
     }
 
     @Test

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ReadiumHighlightRendererTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ReadiumHighlightRendererTest.kt
@@ -101,13 +101,15 @@ class ReadiumHighlightRendererTest {
         )
         renderer.applyAnnotations(renders)
         val annotationCalls = applied.filter { it.second == "annotations" }
-        // Initial apply + 4-tick settle window (each = clear + apply) = 1 + 4*2 = 9 calls
-        assertTrue("expected initial apply plus settle re-applies", annotationCalls.size >= 3)
-        // The initial apply is the first "annotations" call
-        val firstApply = annotationCalls.first()
-        assertEquals(2, firstApply.first.size)
-        assertEquals("h1", firstApply.first[0].id)
-        assertEquals("h2", firstApply.first[1].id)
+        // Initial apply is clear+apply (2 dispatches); settle window is 4 ticks × (clear + apply) = 8.
+        // We assert on the shape: at least one dispatch carries both decorations, and the very
+        // first dispatch is the pre-apply clear (empty list).
+        assertTrue("expected initial clear+apply plus settle re-applies", annotationCalls.size >= 3)
+        assertEquals(emptyList<Decoration>(), annotationCalls.first().first)
+        val firstNonEmpty = annotationCalls.first { it.first.isNotEmpty() }
+        assertEquals(2, firstNonEmpty.first.size)
+        assertEquals("h1", firstNonEmpty.first[0].id)
+        assertEquals("h2", firstNonEmpty.first[1].id)
     }
 
     @Test
@@ -123,7 +125,9 @@ class ReadiumHighlightRendererTest {
         )
         abortingRenderer.applyAnnotations(listOf(makeRender("h1", "c1.xhtml")))
         val annotationCalls = recorder.filter { it.second == "annotations" }
-        assertEquals("only the initial apply fires when the stamp changes", 1, annotationCalls.size)
+        // Initial apply is clear + apply (2 dispatches); the settle loop aborts on the first tick
+        // because the stamp changes, so no settle re-applies fire.
+        assertEquals("only the initial clear+apply fires when the stamp changes", 2, annotationCalls.size)
     }
 
     @Test

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ReadiumHighlightRendererTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ReadiumHighlightRendererTest.kt
@@ -3,8 +3,6 @@
 package com.riffle.app.feature.reader
 
 import com.riffle.core.domain.HighlightColor
-import com.riffle.core.domain.ReadaloudHighlightColor
-import com.riffle.core.domain.ReaderTheme
 import com.riffle.core.domain.SentenceQuote
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -69,7 +67,7 @@ class ReadiumHighlightRendererTest {
         renderer.applyReadaloud(
             fragmentRef = "chapter1.xhtml#s1",
             quotes = mapOf("s1" to SentenceQuote(before = "", highlight = "Hello world", after = "")),
-            color = ReadaloudHighlightColor.BLUE,
+            color = HighlightColor.BLUE,
         )
         val readaloudCalls = applied.filter { it.second == "readaloud" }
         assertEquals(2, readaloudCalls.size) // applyDecorationsWithClear: clear then apply
@@ -81,13 +79,13 @@ class ReadiumHighlightRendererTest {
     @Test
     fun `applyReadaloud with null ref clears group and does not re-clear if already clear`() = runTest {
         // First call: nothing to clear → no dispatch
-        renderer.applyReadaloud(null, emptyMap(), ReadaloudHighlightColor.BLUE)
+        renderer.applyReadaloud(null, emptyMap(), HighlightColor.BLUE)
         assertEquals(0, applied.size)
 
         // Apply one, then clear
-        renderer.applyReadaloud("c.xhtml#s1", emptyMap(), ReadaloudHighlightColor.BLUE)
+        renderer.applyReadaloud("c.xhtml#s1", emptyMap(), HighlightColor.BLUE)
         applied.clear()
-        renderer.applyReadaloud(null, emptyMap(), ReadaloudHighlightColor.BLUE)
+        renderer.applyReadaloud(null, emptyMap(), HighlightColor.BLUE)
         assertEquals(1, applied.size)
         assertEquals(emptyList<Decoration>(), applied[0].first)
         assertEquals("readaloud", applied[0].second)
@@ -101,7 +99,7 @@ class ReadiumHighlightRendererTest {
             makeRender("h1", "c1.xhtml", color = "yellow"),
             makeRender("h2", "c1.xhtml", color = "green"),
         )
-        renderer.applyAnnotations(renders, ReaderTheme.Light)
+        renderer.applyAnnotations(renders)
         // applyDecorationsWithClear = clear + apply → 2 calls to the block
         val decorationCall = applied.last()
         assertEquals("annotations", decorationCall.second)
@@ -113,10 +111,10 @@ class ReadiumHighlightRendererTest {
     @Test
     fun `applyAnnotations with empty list clears group`() = runTest {
         // Apply something first so hasAnnotationDecorations = true
-        renderer.applyAnnotations(listOf(makeRender("h1", "c1.xhtml")), ReaderTheme.Light)
+        renderer.applyAnnotations(listOf(makeRender("h1", "c1.xhtml")))
         applied.clear()
 
-        renderer.applyAnnotations(emptyList(), ReaderTheme.Light)
+        renderer.applyAnnotations(emptyList())
         assertEquals(1, applied.size)
         assertEquals(emptyList<Decoration>(), applied[0].first)
         assertEquals("annotations", applied[0].second)
@@ -124,7 +122,7 @@ class ReadiumHighlightRendererTest {
 
     @Test
     fun `applyAnnotations empty list is no-op when no decorations active`() = runTest {
-        renderer.applyAnnotations(emptyList(), ReaderTheme.Light)
+        renderer.applyAnnotations(emptyList())
         assertEquals(0, applied.size)
     }
 

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/renderer/RendererCapabilityTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/renderer/RendererCapabilityTest.kt
@@ -67,6 +67,83 @@ class RendererCapabilityTest {
             "settle backstop must guard via __riffleSettleSnapInstalled",
             script(CapabilityId.ScrollSettleBackstop).contains("__riffleSettleSnapInstalled"),
         )
+        assertTrue(
+            "decoration template re-register must call readium.registerDecorationTemplates",
+            script(CapabilityId.DecorationTemplateReregister).contains("registerDecorationTemplates"),
+        )
+    }
+
+    /**
+     * Regression guard for the API-25 WebView (Chromium 52) missing modern DOM/JS APIs that
+     * Readium 3.2.0+ needs to render decorations. Losing any of these polyfills silently breaks
+     * annotation highlights in paginated + vertical modes: `document.body.append` blocks the
+     * decoration group container from ever landing; `Object.entries` blocks
+     * `registerDecorationTemplates` from populating its template map AND from injecting the
+     * `.riffle-highlight-tint` CSS into the `<style>` head tag; `Array.prototype.flatMap` blocks
+     * the TextQuote → DOM Range resolver, leaving every decoration with an empty `range: {}`.
+     * Full RFC in the polyfill's own comment block.
+     */
+    @Test fun `rect polyfill installs every API missing on old-Chromium WebViews`() {
+        val js = installOrder.first { it.id == CapabilityId.RectToJsonPolyfill }.installScript()
+        val requiredMarkers = listOf(
+            "toJSON",                       // ClientRect.toJSON polyfill
+            "typeof proto.append",          // ChildNode/ParentNode.append polyfill
+            "Object.entries = function",    // Object.entries polyfill
+            "Object.values = function",     // Object.values polyfill
+            "ResizeObserverPolyfill",       // ResizeObserver no-op stub
+            "Array.prototype.flat",         // Array.prototype.flat polyfill
+            "Array.prototype.flatMap",      // Array.prototype.flatMap polyfill
+            "Object.fromEntries",           // Object.fromEntries polyfill
+            "String.prototype.padStart",    // String.prototype.padStart polyfill
+        )
+        for (marker in requiredMarkers) {
+            assertTrue(
+                "rect polyfill script is missing marker \"$marker\" — a WebView-compat polyfill " +
+                    "was dropped; annotation highlights will break on API-25-era WebViews",
+                js.contains(marker),
+            )
+        }
+    }
+
+    /**
+     * Readium only calls `registerDecorationTemplates` at resource-load — BEFORE our polyfills
+     * run. On old WebViews the missing Object.entries silently short-circuits that first call, so
+     * no template CSS lands and no annotation renders. We re-register templates after polyfills
+     * install; if this dependency ever goes away, the re-register would race the polyfill and
+     * hit the same broken engine.
+     */
+    @Test fun `decoration template re-register depends on the polyfill`() {
+        val cap = installOrder.first { it.id == CapabilityId.DecorationTemplateReregister }
+        assertTrue(
+            "DecorationTemplateReregister must depend on RectToJsonPolyfill so it runs against a " +
+                "polyfilled engine — otherwise Object.entries throws inside registerDecorationTemplates",
+            CapabilityId.RectToJsonPolyfill in cap.dependsOn,
+        )
+        val polyIdx = installOrder.indexOfFirst { it.id == CapabilityId.RectToJsonPolyfill }
+        val regIdx = installOrder.indexOfFirst { it.id == CapabilityId.DecorationTemplateReregister }
+        assertTrue("polyfill must precede decoration re-register", polyIdx < regIdx)
+    }
+
+    /**
+     * The re-register script must serialise the SAME [riffleDecorationTemplates] set the
+     * fragment configuration passes to Readium. Otherwise the re-register would inject
+     * different CSS from what the applied decorations reference, and the highlight class the
+     * decoration `element` uses wouldn't have a matching stylesheet.
+     */
+    @Test fun `re-register script includes the riffle highlight tint class stylesheet`() {
+        val js = installOrder.first { it.id == CapabilityId.DecorationTemplateReregister }.installScript()
+        assertTrue(
+            "re-register script must inline the .riffle-highlight-tint stylesheet",
+            js.contains(".riffle-highlight-tint"),
+        )
+        assertTrue(
+            "re-register script must inline the .riffle-note-glyph stylesheet",
+            js.contains("riffle-note-glyph"),
+        )
+        assertTrue(
+            "re-register script must be try/catch-guarded so a still-broken engine doesn't kill the surrounding capability chain",
+            js.contains("try") && js.contains("catch"),
+        )
     }
 
     @Test fun `readaloud reserve capability reads the live provider on every install`() {

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/session/ReadaloudSessionTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/session/ReadaloudSessionTest.kt
@@ -20,7 +20,7 @@ import com.riffle.core.domain.EpubRepository
 import com.riffle.core.domain.ListeningPreferencesStore
 import com.riffle.core.domain.PositionSnapshot
 import com.riffle.core.domain.ReadaloudAudioRepository
-import com.riffle.core.domain.ReadaloudHighlightColor
+import com.riffle.core.domain.HighlightColor
 import com.riffle.core.domain.ReadaloudPreferencesStore
 import com.riffle.core.domain.ReadaloudResumePosition
 import com.riffle.core.domain.ReadaloudResumeStore
@@ -223,7 +223,7 @@ class ReadaloudSessionTest {
             audioIdentityResolver = mockk(relaxed = true),
             readaloudPreferencesStore = mockk<ReadaloudPreferencesStore>().also {
                 io.mockk.every { it.preferences } returns flowOf(
-                    com.riffle.core.domain.ReadaloudPreferences(highlightColor = ReadaloudHighlightColor.BLUE)
+                    com.riffle.core.domain.ReadaloudPreferences(highlightColor = HighlightColor.BLUE)
                 )
             },
             readaloudResumeStore = mockk(relaxed = true),
@@ -439,7 +439,7 @@ class ReadaloudSessionTest {
             audioIdentityResolver = mockk(relaxed = true),
             readaloudPreferencesStore = mockk<ReadaloudPreferencesStore>().also {
                 every { it.preferences } returns flowOf(
-                    com.riffle.core.domain.ReadaloudPreferences(highlightColor = ReadaloudHighlightColor.BLUE)
+                    com.riffle.core.domain.ReadaloudPreferences(highlightColor = HighlightColor.BLUE)
                 )
             },
             readaloudResumeStore = mockk(relaxed = true),
@@ -592,7 +592,7 @@ class ReadaloudSessionTest {
             audioIdentityResolver = mockk(relaxed = true),
             readaloudPreferencesStore = mockk<ReadaloudPreferencesStore>().also {
                 every { it.preferences } returns flowOf(
-                    com.riffle.core.domain.ReadaloudPreferences(highlightColor = ReadaloudHighlightColor.BLUE)
+                    com.riffle.core.domain.ReadaloudPreferences(highlightColor = HighlightColor.BLUE)
                 )
             },
             readaloudResumeStore = readaloudResumeStore,
@@ -827,7 +827,7 @@ class ReadaloudSessionTest {
                 audioIdentityResolver = mockk(relaxed = true),
                 readaloudPreferencesStore = mockk<ReadaloudPreferencesStore>().also {
                     every { it.preferences } returns flowOf(
-                        com.riffle.core.domain.ReadaloudPreferences(highlightColor = ReadaloudHighlightColor.BLUE)
+                        com.riffle.core.domain.ReadaloudPreferences(highlightColor = HighlightColor.BLUE)
                     )
                 },
                 readaloudResumeStore = mockk(relaxed = true),
@@ -975,7 +975,7 @@ class ReadaloudSessionTest {
         audioIdentityResolver = mockk(relaxed = true),
         readaloudPreferencesStore = mockk<ReadaloudPreferencesStore>().also {
             every { it.preferences } returns flowOf(
-                com.riffle.core.domain.ReadaloudPreferences(highlightColor = ReadaloudHighlightColor.BLUE)
+                com.riffle.core.domain.ReadaloudPreferences(highlightColor = HighlightColor.BLUE)
             )
         },
         readaloudResumeStore = readaloudResumeStore,

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/session/regressions/ReadaloudHighlightRotationReflowTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/session/regressions/ReadaloudHighlightRotationReflowTest.kt
@@ -1,7 +1,7 @@
 package com.riffle.app.feature.reader.session.regressions
 
 import com.riffle.app.feature.reader.ReadiumHighlightRenderer
-import com.riffle.core.domain.ReadaloudHighlightColor
+import com.riffle.core.domain.HighlightColor
 import com.riffle.core.domain.SentenceQuote
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
@@ -94,14 +94,14 @@ class ReadaloudHighlightRotationReflowTest {
     @Test
     fun `applyReadaloud re-applies decorations on every call when sentence is active`() = runTest {
         // First call — simulates the initial highlight apply (pre-rotation)
-        renderer.applyReadaloud(activeRef, quotes, ReadaloudHighlightColor.BLUE)
+        renderer.applyReadaloud(activeRef, quotes, HighlightColor.BLUE)
         val afterFirst = applied.count { it.second == "readaloud" }
 
         applied.clear()
 
         // Second call with IDENTICAL args — simulates the post-rotation re-key firing.
         // The screen relies on this NOT being a no-op.
-        renderer.applyReadaloud(activeRef, quotes, ReadaloudHighlightColor.BLUE)
+        renderer.applyReadaloud(activeRef, quotes, HighlightColor.BLUE)
         val afterSecond = applied.count { it.second == "readaloud" }
 
         assertTrue(
@@ -123,11 +123,11 @@ class ReadaloudHighlightRotationReflowTest {
     @Test
     fun `applyReadaloud decoration id is readaloud_active after rotation re-apply`() = runTest {
         // First call (pre-rotation)
-        renderer.applyReadaloud(activeRef, quotes, ReadaloudHighlightColor.BLUE)
+        renderer.applyReadaloud(activeRef, quotes, HighlightColor.BLUE)
         applied.clear()
 
         // Second call (post-rotation, triggered by pageLoadGeneration bump)
-        renderer.applyReadaloud(activeRef, quotes, ReadaloudHighlightColor.BLUE)
+        renderer.applyReadaloud(activeRef, quotes, HighlightColor.BLUE)
 
         val applyCall = applied.lastOrNull { it.second == "readaloud" && it.first.isNotEmpty() }
         assertTrue(
@@ -154,7 +154,7 @@ class ReadaloudHighlightRotationReflowTest {
      */
     @Test
     fun `without second applyReadaloud call no decorations reach the new fragment`() = runTest {
-        renderer.applyReadaloud(activeRef, quotes, ReadaloudHighlightColor.BLUE)
+        renderer.applyReadaloud(activeRef, quotes, HighlightColor.BLUE)
         // Simulate rotation: new fragment replaces old one. WITHOUT the pageLoadGeneration fix,
         // applyReadaloud is not called again, so the new fragment sees no decoration.
         applied.clear() // new fragment has no decorations yet
@@ -176,11 +176,11 @@ class ReadaloudHighlightRotationReflowTest {
      */
     @Test
     fun `applyReadaloud re-applies with updated color on rotation`() = runTest {
-        renderer.applyReadaloud(activeRef, quotes, ReadaloudHighlightColor.BLUE)
+        renderer.applyReadaloud(activeRef, quotes, HighlightColor.BLUE)
         applied.clear()
 
         // Rotation + color change
-        renderer.applyReadaloud(activeRef, quotes, ReadaloudHighlightColor.GREEN)
+        renderer.applyReadaloud(activeRef, quotes, HighlightColor.GREEN)
 
         val applyCall = applied.lastOrNull { it.second == "readaloud" && it.first.isNotEmpty() }
         assertTrue("Decoration must be present after rotation with updated color", applyCall != null)

--- a/app/src/test/kotlin/com/riffle/app/feature/settings/SettingsViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/settings/SettingsViewModelTest.kt
@@ -8,7 +8,7 @@ import com.riffle.core.domain.AnnotationSyncConfig
 import com.riffle.core.domain.AnnotationSyncConfigStore
 import com.riffle.core.domain.AppTheme
 import com.riffle.core.domain.AppThemeStore
-import com.riffle.core.domain.ReadaloudHighlightColor
+import com.riffle.core.domain.HighlightColor
 import com.riffle.core.domain.ReadaloudPreferences
 import com.riffle.core.domain.ReadaloudPreferencesStore
 import com.riffle.core.domain.AuthenticateResult
@@ -615,15 +615,15 @@ class SettingsViewModelTest {
     // --- readaloud highlight color ---
 
     @Test
-    fun `updateReadaloudHighlightColor persists new color to store and updates StateFlow`() = runTest {
+    fun `updateHighlightColor persists new color to store and updates StateFlow`() = runTest {
         val vm = makeViewModel()
-        val emitted = mutableListOf<ReadaloudHighlightColor>()
+        val emitted = mutableListOf<HighlightColor>()
         val job = launch { vm.readaloudPreferences.collect { emitted.add(it.highlightColor) } }
         testDispatcher.scheduler.advanceUntilIdle()
-        vm.updateReadaloudHighlightColor(ReadaloudHighlightColor.YELLOW)
+        vm.updateHighlightColor(HighlightColor.YELLOW)
         testDispatcher.scheduler.advanceUntilIdle()
-        assertEquals(ReadaloudHighlightColor.YELLOW, readaloudPrefsFlow.value.highlightColor)
-        assertEquals(ReadaloudHighlightColor.YELLOW, emitted.last())
+        assertEquals(HighlightColor.YELLOW, readaloudPrefsFlow.value.highlightColor)
+        assertEquals(HighlightColor.YELLOW, emitted.last())
         job.cancel()
     }
 

--- a/core/data/src/main/kotlin/com/riffle/core/data/PreferenceStoreFactories.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/PreferenceStoreFactories.kt
@@ -5,7 +5,7 @@ import androidx.datastore.preferences.core.Preferences
 import com.riffle.core.domain.AppTheme
 import com.riffle.core.domain.AppThemeStore
 import com.riffle.core.domain.CoverGridDensityStore
-import com.riffle.core.domain.ReadaloudHighlightColor
+import com.riffle.core.domain.HighlightColor
 import com.riffle.core.domain.ReadaloudPreferences
 import com.riffle.core.domain.ReadaloudPreferencesStore
 import com.riffle.core.domain.ReadingSpeedStore
@@ -65,12 +65,14 @@ fun WakeLockPreferencesStore(dataStore: DataStore<Preferences>): WakeLockPrefere
 }
 
 fun ReadaloudPreferencesStore(dataStore: DataStore<Preferences>): ReadaloudPreferencesStore {
+    // Legacy "PINK" / "PURPLE" values written by older builds fall through to BLUE via the
+    // codec's unknown-name fallback — acceptable since the user can re-pick from the new palette.
     val store = preferenceStore(
         dataStore,
         PrefCodecs.enum(
             "highlight_color",
-            ReadaloudHighlightColor.BLUE,
-            ReadaloudHighlightColor.entries.toTypedArray(),
+            HighlightColor.BLUE,
+            HighlightColor.entries.toTypedArray(),
         ),
     )
     return object : ReadaloudPreferencesStore {

--- a/core/data/src/test/kotlin/com/riffle/core/data/ReadaloudPreferencesStoreTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/ReadaloudPreferencesStoreTest.kt
@@ -3,7 +3,7 @@ package com.riffle.core.data
 import androidx.datastore.preferences.core.PreferenceDataStoreFactory
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
-import com.riffle.core.domain.ReadaloudHighlightColor
+import com.riffle.core.domain.HighlightColor
 import com.riffle.core.domain.ReadaloudPreferences
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
@@ -39,7 +39,7 @@ class ReadaloudPreferencesStoreTest {
     @Test
     fun `each highlight color round-trips through DataStore`() = testScope.runTest {
         val store = buildStore()
-        for (color in ReadaloudHighlightColor.entries) {
+        for (color in HighlightColor.entries) {
             store.update(ReadaloudPreferences(highlightColor = color))
             assertEquals(color, store.preferences.first().highlightColor)
         }
@@ -53,6 +53,53 @@ class ReadaloudPreferencesStoreTest {
         )
         rawStore.edit { it[stringPreferencesKey("highlight_color")] = "NOT_A_COLOR" }
         val store = ReadaloudPreferencesStore(rawStore)
-        assertEquals(ReadaloudHighlightColor.BLUE, store.preferences.first().highlightColor)
+        assertEquals(HighlightColor.BLUE, store.preferences.first().highlightColor)
+    }
+
+    // The fourth swatch was PINK before it became RED, and PURPLE was dropped from the palette
+    // entirely. Users who had either selected must still get a usable app on next launch — the
+    // unknown-name fallback picks the default (BLUE) so the reader has a valid colour to render
+    // and the picker shows a real selection. The persisted string stays "PINK"/"PURPLE" until
+    // the user re-picks, which is fine: every subsequent read takes the same fallback path.
+    @Test
+    fun `legacy PINK stored value falls back to default BLUE`() = testScope.runTest {
+        val rawStore = PreferenceDataStoreFactory.create(
+            scope = backgroundScope,
+            produceFile = { tmp.newFile("readaloud_prefs_pink.preferences_pb") },
+        )
+        rawStore.edit { it[stringPreferencesKey("highlight_color")] = "PINK" }
+        val store = ReadaloudPreferencesStore(rawStore)
+        assertEquals(HighlightColor.BLUE, store.preferences.first().highlightColor)
+    }
+
+    @Test
+    fun `legacy PURPLE stored value falls back to default BLUE`() = testScope.runTest {
+        val rawStore = PreferenceDataStoreFactory.create(
+            scope = backgroundScope,
+            produceFile = { tmp.newFile("readaloud_prefs_purple.preferences_pb") },
+        )
+        rawStore.edit { it[stringPreferencesKey("highlight_color")] = "PURPLE" }
+        val store = ReadaloudPreferencesStore(rawStore)
+        assertEquals(HighlightColor.BLUE, store.preferences.first().highlightColor)
+    }
+
+    // After a legacy value falls back and the user re-picks, the new choice must persist —
+    // guards against a codec that reads-through but forgets to overwrite on write.
+    @Test
+    fun `re-picking after a legacy fallback persists the new choice`() = testScope.runTest {
+        val rawStore = PreferenceDataStoreFactory.create(
+            scope = backgroundScope,
+            produceFile = { tmp.newFile("readaloud_prefs_repick.preferences_pb") },
+        )
+        rawStore.edit { it[stringPreferencesKey("highlight_color")] = "PURPLE" }
+        val store = ReadaloudPreferencesStore(rawStore)
+        assertEquals(HighlightColor.BLUE, store.preferences.first().highlightColor)
+
+        store.update(ReadaloudPreferences(highlightColor = HighlightColor.GREEN))
+        assertEquals(HighlightColor.GREEN, store.preferences.first().highlightColor)
+
+        // A fresh store instance reading the same DataStore must see GREEN, not fall back to BLUE.
+        val reopened = ReadaloudPreferencesStore(rawStore)
+        assertEquals(HighlightColor.GREEN, reopened.preferences.first().highlightColor)
     }
 }

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/HighlightColor.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/HighlightColor.kt
@@ -1,19 +1,23 @@
 package com.riffle.core.domain
 
 /**
- * The fixed annotation-highlight palette (ADR 0024): a colour is one of these four tokens, never a
+ * The single-source palette for every reader highlight — user annotations, readaloud "now speaking"
+ * markers, and the swatches in both Settings pickers. A colour is one of these four tokens, never a
  * freeform hex. [token] is the lowercase string persisted in `AnnotationEntity.color`; [argb] is the
- * full-opacity base hue (the reader theme bakes in per-theme alpha at render time).
+ * FINAL rendered ARGB — colour AND alpha baked in. Used verbatim by every consumer (settings swatch,
+ * annotation popup swatch, reader decoration) so the picker preview and the on-page highlight are
+ * literally the same pixel value. To change hue or opacity, edit this file only.
  *
- * Self-contained on purpose: the hues match the readaloud palette for visual consistency, but
- * annotations keep their own four-token vocabulary (no PURPLE, yellow default) and their own synced
- * persistence, decoupled from [ReadaloudHighlightColor].
+ * Annotations persist [token]; readaloud persists the enum [name] in `ReadaloudPreferences`.
  */
 enum class HighlightColor(val token: String, val argb: Int) {
-    YELLOW("yellow", 0xFFFBBF24.toInt()),
-    GREEN("green", 0xFF34D399.toInt()),
-    BLUE("blue", 0xFF38BDF8.toInt()),
-    PINK("pink", 0xFFFB7185.toInt());
+    // Alpha 0x80 (~50%) is baked into every entry — legible body text through the fill on both
+    // light and dark themes, saturated enough to read as a deliberate mark. Change the alpha
+    // nibble on every row together; there is no per-theme or per-feature override.
+    YELLOW("yellow", 0x80FBBF24.toInt()),
+    GREEN("green", 0x8034D399.toInt()),
+    BLUE("blue", 0x8038BDF8.toInt()),
+    RED("red", 0x80EF4444.toInt());
 
     companion object {
         val DEFAULT = YELLOW

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/ReadaloudPreferences.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/ReadaloudPreferences.kt
@@ -2,20 +2,13 @@ package com.riffle.core.domain
 
 import kotlinx.coroutines.flow.Flow
 
-// Medium-saturation (Tailwind ~400-level) hues at ~50% opacity. `argb` is the final rendered color
-// used by both the settings swatch and the reader — no further transformation applied. The alpha
-// is pre-baked so text remains legible through the highlight. Enum names are unchanged so persisted
-// preferences keep resolving without a migration.
-enum class ReadaloudHighlightColor(val argb: Int) {
-    BLUE(0x8038BDF8.toInt()),
-    YELLOW(0x80FBBF24.toInt()),
-    GREEN(0x8034D399.toInt()),
-    PINK(0x80FB7185.toInt()),
-    PURPLE(0x80A78BFA.toInt()),
-}
-
+// Readaloud reuses the shared [HighlightColor] palette so the two reader features (readaloud + user
+// annotations) render at exactly the same hue and saturation — one source of truth for base RGB,
+// one alpha treatment (`readerTint`) at render time, one picker appearance in Settings. The persisted
+// enum name lives in DataStore ("YELLOW"/"GREEN"/"BLUE"/"RED"); legacy "PINK" or "PURPLE" values
+// written by earlier builds fall through `PrefCodecs.enum`'s unknown-name path to the default.
 data class ReadaloudPreferences(
-    val highlightColor: ReadaloudHighlightColor = ReadaloudHighlightColor.BLUE,
+    val highlightColor: HighlightColor = HighlightColor.BLUE,
 )
 
 interface ReadaloudPreferencesStore {

--- a/core/domain/src/test/kotlin/com/riffle/core/domain/HighlightColorTest.kt
+++ b/core/domain/src/test/kotlin/com/riffle/core/domain/HighlightColorTest.kt
@@ -17,7 +17,7 @@ class HighlightColorTest {
         assertEquals("yellow", HighlightColor.YELLOW.token)
         assertEquals("green", HighlightColor.GREEN.token)
         assertEquals("blue", HighlightColor.BLUE.token)
-        assertEquals("pink", HighlightColor.PINK.token)
+        assertEquals("red", HighlightColor.RED.token)
     }
 
     @Test
@@ -33,10 +33,21 @@ class HighlightColorTest {
     }
 
     @Test
-    fun `hues match the shared readaloud palette values`() {
-        assertEquals(0xFFFBBF24.toInt(), HighlightColor.YELLOW.argb)
-        assertEquals(0xFF34D399.toInt(), HighlightColor.GREEN.argb)
-        assertEquals(0xFF38BDF8.toInt(), HighlightColor.BLUE.argb)
-        assertEquals(0xFFFB7185.toInt(), HighlightColor.PINK.argb)
+    fun `legacy pink token falls back to default (no alias, no migration)`() {
+        // The fourth swatch used to be "pink" (rose-400) — locally-stored rows written by that
+        // build, and inbound sync from clients still on it, both take the standard unknown-name
+        // fallback to YELLOW. Same policy as the readaloud pref on legacy "PINK"/"PURPLE".
+        assertEquals(HighlightColor.DEFAULT, HighlightColor.fromToken("pink"))
+    }
+
+    @Test
+    fun `argb bakes in the single palette alpha (0x80) plus the hue`() {
+        // `argb` is the final rendered ARGB — used verbatim by settings swatches and reader
+        // decorations. Any change here must be a deliberate palette redesign; a drift to full
+        // opacity would paint solid bars over body text.
+        assertEquals(0x80FBBF24.toInt(), HighlightColor.YELLOW.argb)
+        assertEquals(0x8034D399.toInt(), HighlightColor.GREEN.argb)
+        assertEquals(0x8038BDF8.toInt(), HighlightColor.BLUE.argb)
+        assertEquals(0x80EF4444.toInt(), HighlightColor.RED.argb)
     }
 }

--- a/docs/adr/0024-annotations-anchor-on-abs-epub-cfi.md
+++ b/docs/adr/0024-annotations-anchor-on-abs-epub-cfi.md
@@ -31,14 +31,33 @@ CFI is the same coordinate family ABS already stores in `mediaProgress.ebookLoca
 
 ## Amendment (2026-06-17): colour palette + rendering (#70)
 
-The highlight colour is one of four tokens — `yellow` (default), `green`, `blue`, `pink` —
+The highlight colour is one of four tokens — `yellow` (default), `green`, `blue`, `red` —
 modelled by `HighlightColor` (`core/domain`). Tokens are stored verbatim in
-`AnnotationEntity.color`; an unknown/missing token resolves to yellow (sync forward-compat).
+`AnnotationEntity.color`; an unknown/missing token resolves to yellow (sync forward-compat),
+and the legacy `pink` token (the fourth swatch before its palette rework) resolves to `red`.
 The four hues match the readaloud palette for visual consistency but are a separate, smaller
-vocabulary (no PURPLE, yellow default) decoupled from `ReadaloudHighlightColor`.
+vocabulary (yellow default) decoupled from `ReadaloudHighlightColor`.
 
-Rendering reuses the shared `HighlightTintStyle` decoration + `tintForTheme()`: the reader theme
-bakes per-theme alpha into the base hue (~45% on Dark/DarkDim, ~30% on Light/Sepia) so a highlight
-stays legible in any theme. Recolour updates the row in place (bumping `updatedAt`); delete sets the
+## Amendment (2026-07-01): unified palette + pink → red rework
+
+`HighlightColor` is the single source of truth for BOTH hue and opacity across every reader
+highlight — user annotations, the readaloud "now speaking" marker, the swatches in Settings,
+and the annotation actions popup. `argb` is the FINAL rendered ARGB (colour + baked-in alpha,
+`0x80` at time of writing); every consumer uses it verbatim, no per-theme override, no
+runtime alpha multiplication. Changing hue or opacity is a single-file edit on `HighlightColor`
+and it propagates to picker preview + rendered page in the same tick. The separate
+`ReadaloudHighlightColor` enum is gone; `ReadaloudPreferences.highlightColor` holds a
+`HighlightColor` directly.
+
+The fourth swatch also changed from `pink` (rose-400, `#FB7185`) to `red` (red-500, `#EF4444`).
+Any locally-stored `AnnotationEntity.color = 'pink'` row falls through
+`HighlightColor.fromToken`'s unknown-name path to the YELLOW default — same treatment as any
+stale token, no bespoke migration or alias. The readaloud palette also dropped `PURPLE`; a
+persisted `PINK` or `PURPLE` enum name falls through `PrefCodecs.enum`'s unknown-name path to
+the BLUE default. Consistent policy across both surfaces: fallback-to-default on read.
+
+Rendering uses the shared `HighlightTintStyle` decoration with `HighlightColor.argb` piped through
+verbatim — the tint's alpha channel is the palette's baked-in opacity (see the 2026-07-01
+amendment above). Recolour updates the row in place (bumping `updatedAt`); delete sets the
 `deleted` tombstone (bumping `updatedAt`) and tombstoned rows are excluded from the live query, so
 they never render.


### PR DESCRIPTION
## Summary

- `HighlightColor` is the single source of truth for reader-highlight colour AND opacity across every consumer — annotation popup, Settings picker, reader decoration. The parallel `ReadaloudHighlightColor` enum is gone; `ReadaloudPreferences.highlightColor` holds a `HighlightColor` directly. `argb` bakes in a flat `0x80` alpha; one edit propagates to picker preview + rendered page.
- Palette rework: fourth swatch changed from `pink` (rose-400) to `red` (red-500). Legacy tokens fall through the codec's unknown-name path to the default (YELLOW for annotations, BLUE for readaloud) — same policy as the readaloud pref before this branch.
- Fix annotation highlights invisible in paginated + vertical modes on API-25-era WebViews (Chromium 52). Readium 3.2.0+'s decoration engine needs `document.body.append`, `Object.entries`, `Array.prototype.flatMap`, `ResizeObserver`, and a few others; extended the `RECT_TO_JSON_POLYFILL_JS` install script to polyfill all of them, plus a new `DecorationTemplateReregister` capability that re-invokes `readium.registerDecorationTemplates` after the polyfills land (Readium only registers once, at resource-load, which is before our polyfills run).
- Reordered `paginationListener.onPageLoaded` to install polyfills before bumping `pageLoadGeneration` so the annotation-reapply LaunchedEffect can't race the polyfill's evaluateJavascript.
- Added a 400/600/700/900ms settle loop to `applyAnnotations` mirroring `applySearch`, so decorations re-land against final layout after reflow. Initial apply now uses `applyDecorationsWithClear` too — Readium's diff no-ops on an identical re-fire otherwise.

## Test plan

- [x] `:core:domain:test` — palette RGB+alpha invariant, unknown-token fallback
- [x] `:core:data:testDebugUnitTest` — legacy `PINK`/`PURPLE` readaloud values fall back to BLUE + re-pick persists
- [x] `:app:testDebugUnitTest` — every WebView-polyfill marker + `DecorationTemplateReregister` capability shape pinned in `RendererCapabilityTest`; annotation settle loop covered in `ReadiumHighlightRendererTest`
- [x] Manual on API-25 emulator: paginated annotations now render (previously invisible); readaloud + annotation highlights render at identical hue and saturation on the same page
- [ ] Instrumentation `MigrationTest` — unchanged in this PR (no schema bump)