### PR TITLE
refactor(reader): split PositionOrchestrator into ServerJump + ResumeRestorer

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/session/PositionOrchestrator.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/session/PositionOrchestrator.kt
@@ -9,26 +9,23 @@ import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.collect
-import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
 import org.readium.r2.shared.publication.Locator
 
 /**
- * Owns the canonical reading-position stream. Lifted from EpubReaderViewModel as part of the VM
- * split (#303).
+ * Owns the canonical reading-position stream — the intake for onPositionChanged and the source of
+ * truth for the current locator, its href, and the two progression coordinates.
  *
- * Holds all the hot-path fields that were previously bare private vars on the VM:
- * [lastLocator], [_serverLocatorChannel], [pendingServerJumpStamp], [_currentLocatorHref],
- * [_currentLocatorProgression], [_currentLocatorTotalProgression], [suppressNextServerLocator],
- * [initialLocatorSeen], [pendingReturnLocator], [returnRestoreAttempts].
+ * Composes two focused collaborators (extracted per #376):
+ *   - [serverJump] — remote-win jump channel + suppress latch + pending server timestamp
+ *   - [resumeRestorer] — background-return retry watcher + return anchor
  *
- * The VM's public [onPositionChanged] delegates here after handling readaloud "park" state (Task 8
- * code) which remains in the VM until ReadaloudSession is extracted.
+ * The pre-#376 public API is preserved as thin delegations so the ViewModel is not churned by the
+ * split.
  *
  * MUST NOT import android.webkit.* or ContinuousReaderView.
  */
@@ -40,6 +37,9 @@ class PositionOrchestrator @AssistedInject constructor(
     interface Factory {
         fun create(scope: CoroutineScope): PositionOrchestrator
     }
+
+    val serverJump: ServerJumpCoordinator = ServerJumpCoordinator()
+    val resumeRestorer: ResumeRestorer = ResumeRestorer(refire = { serverJump.requestJump(it) })
 
     // ---- Per-book state (reset by bindBook) ----
 
@@ -61,44 +61,14 @@ class PositionOrchestrator @AssistedInject constructor(
     private val _currentLocatorTotalProgression = MutableStateFlow<Float?>(null)
     val currentLocatorTotalProgression: StateFlow<Float?> = _currentLocatorTotalProgression
 
-    /**
-     * Carries server-win jumps (sync cycle + Storyteller loop + background-return restore) to the
-     * EpubNavigatorFragment. A conflated channel so a request survives until the screen's collector
-     * receives it — a reopen can emit before the collector re-subscribes after a config change.
-     */
-    private val _serverLocatorChannel = Channel<Locator>(Channel.CONFLATED)
-    val serverLocatorEvents: Flow<Locator> = _serverLocatorChannel.receiveAsFlow()
+    /** Facade — see [ServerJumpCoordinator.serverLocatorEvents]. */
+    val serverLocatorEvents: Flow<Locator> get() = serverJump.serverLocatorEvents
 
     // Private mutable backing; also exposed to the VM via snapshotLastLocator().
     @Volatile private var lastLocator: Locator? = null
 
-    /**
-     * True when this reader was opened with an explicit openAtCfi (e.g. a library annotation tap or
-     * a search-result jump). Consumed (and cleared) by [requestServerJumpWithSuppressCheck].
-     */
-    @Volatile private var suppressNextServerLocator: Boolean = false
-
     /** True after the navigator emits its first locator (the restored position on open). */
     private var initialLocatorSeen = false
-
-    /**
-     * Set to the winning server timestamp when the cycle drives a remote-win jump; consumed by the
-     * jump's resulting onPositionChanged. That emission persists the CFI but keeps this server
-     * timestamp instead of stamping `now`.
-     */
-    @Volatile private var pendingServerJumpStamp: Long? = null
-
-    /**
-     * The locator to restore on [onReaderResumed]. Armed in [onReaderClosed] from [lastLocator];
-     * the footnote-popup URL-tap path pre-arms it earlier via [setReturnAnchor].
-     */
-    private var pendingReturnLocator: Locator? = null
-
-    /**
-     * How many remaining onPositionChanged → chapter-top emissions to suppress while restoring
-     * after a background return.
-     */
-    private var returnRestoreAttempts = 0
 
     // ---- Per-book dependencies (set by bindBook) ----
 
@@ -130,11 +100,9 @@ class PositionOrchestrator @AssistedInject constructor(
         _currentLocatorProgression.value = null
         _currentLocatorTotalProgression.value = null
         lastLocator = null
-        suppressNextServerLocator = false
         initialLocatorSeen = false
-        pendingServerJumpStamp = null
-        pendingReturnLocator = null
-        returnRestoreAttempts = 0
+        serverJump.reset()
+        resumeRestorer.reset()
 
         // Back-fill totalProgression when spine position counts arrive after the first position event.
         // In continuous mode the initial scroll may fire before positions load, leaving
@@ -166,40 +134,7 @@ class PositionOrchestrator @AssistedInject constructor(
         spineHrefs: List<String> = emptyList(),
         spineCounts: List<Int> = emptyList(),
     ) {
-        // Defensive re-restore: Readium's post-resume column-snap can emit a chapter-top position
-        // AFTER our [onReaderResumed] navigateTo, sometimes more than once — including a delayed
-        // clobber that arrives AFTER a first emission has already landed at the captured origin.
-        // Stay armed (within the attempt budget) as long as we're parked at-or-near the origin;
-        // only disarm when the user clearly navigates AWAY (different href, or progression past
-        // origin). An emission AT origin means this round took, not that future emissions can't
-        // re-clobber us, so don't clear pending on equality.
-        returnRestoreAttempts.let { remaining ->
-            if (remaining > 0) {
-                val pending = pendingReturnLocator
-                if (pending != null) {
-                    val originHref = pending.href.toString()
-                    val originProg = pending.locations.progression ?: 0.0
-                    val incomingHref = locator.href.toString()
-                    val incomingProg = locator.locations.progression ?: 0.0
-                    when {
-                        incomingHref == originHref && incomingProg < originProg - 0.01 -> {
-                            // Spurious chapter-top emission while we're still restoring — re-fire.
-                            returnRestoreAttempts = remaining - 1
-                            _serverLocatorChannel.trySend(pending)
-                        }
-                        incomingHref != originHref || incomingProg > originProg + 0.01 -> {
-                            // User navigated away — stop watching.
-                            returnRestoreAttempts = 0
-                            pendingReturnLocator = null
-                        }
-                        // else: incoming ≈ origin — restore took this round; stay armed in case
-                        // a delayed column-snap re-clobbers before the budget is exhausted.
-                    }
-                } else {
-                    returnRestoreAttempts = 0
-                }
-            }
-        }
+        resumeRestorer.onPositionEmitted(locator)
         lastLocator = locator
         _currentLocator.value = locator
         _currentLocatorHref.value = locator.href.toString()
@@ -218,10 +153,9 @@ class PositionOrchestrator @AssistedInject constructor(
             return
         }
         // If this emission is the reader settling onto a position the cycle jumped it to (a remote
-        // win), persist the CFI but restore the server timestamp the cycle adopted — see
-        // pendingServerJumpStamp. A genuine user navigation leaves the flag null and stamps `now`.
-        val serverJumpStamp = pendingServerJumpStamp
-        pendingServerJumpStamp = null
+        // win), persist the CFI but restore the server timestamp the cycle adopted. A genuine user
+        // navigation leaves no pending stamp and we let PositionSaveCoordinator stamp `now`.
+        val serverJumpStamp = serverJump.consumePendingStamp()
         scope.launch {
             positionSaveCoordinator?.onChanged(locator.toJSON().toString())
             if (serverJumpStamp != null) {
@@ -230,38 +164,20 @@ class PositionOrchestrator @AssistedInject constructor(
         }
     }
 
-    /**
-     * Send [locator] through the server-locator channel unconditionally. Used by sync cycles that
-     * want to jump the reader to a remote-win position.
-     */
-    fun requestServerJump(locator: Locator) {
-        _serverLocatorChannel.trySend(locator)
-    }
+    // ---- Facade delegations preserved so the VM's call sites don't churn ---------------------
 
-    /**
-     * Variant used by the progressSyncController observer: honours [suppressNextServerLocator]
-     * and clears it once consumed, so an explicit openAtCfi navigation is not overridden.
-     */
-    fun requestServerJumpWithSuppressCheck(locator: Locator) {
-        if (suppressNextServerLocator) {
-            suppressNextServerLocator = false
-            return
-        }
-        _serverLocatorChannel.trySend(locator)
-    }
+    /** @see ServerJumpCoordinator.requestJump */
+    fun requestServerJump(locator: Locator) = serverJump.requestJump(locator)
 
-    /**
-     * Mark that the next server-locator event should be suppressed. Called from [openBook] when
-     * openAtCfi is resolved, before the sync starts.
-     */
-    fun markSuppressNextServerLocator() {
-        suppressNextServerLocator = true
-    }
+    /** @see ServerJumpCoordinator.requestJumpWithSuppressCheck */
+    fun requestServerJumpWithSuppressCheck(locator: Locator) =
+        serverJump.requestJumpWithSuppressCheck(locator)
 
-    /** Called when [pendingServerJumpStamp] should be set from a sync cycle result. */
-    fun setPendingServerJumpStamp(stamp: Long) {
-        pendingServerJumpStamp = stamp
-    }
+    /** @see ServerJumpCoordinator.markSuppressNext */
+    fun markSuppressNextServerLocator() = serverJump.markSuppressNext()
+
+    /** @see ServerJumpCoordinator.setPendingStamp */
+    fun setPendingServerJumpStamp(stamp: Long) = serverJump.setPendingStamp(stamp)
 
     /** Returns the most-recently-reported locator without consuming it. */
     fun snapshotLastLocator(): Locator? = lastLocator
@@ -271,53 +187,27 @@ class PositionOrchestrator @AssistedInject constructor(
      * state-update side effects. Used when a sync cycle jumps the reader and needs to update the
      * snapshot so subsequent cycles use the jumped position (not the stale pre-jump position).
      * The actual Readium [onPositionChanged] emission that follows the navigator jump is the one
-     * that carries the [pendingServerJumpStamp] and triggers persistence.
+     * that carries the pending server-jump stamp and triggers persistence.
      */
     fun updateLastLocatorSnapshot(locator: Locator) {
         lastLocator = locator
         _currentLocator.value = locator
     }
 
-    /**
-     * Sets the pending return anchor — the locator the reader should restore to after returning
-     * from background. Called from [captureFootnotePopupLinkOrigin] and [onReaderClosed].
-     * Does NOT overwrite an existing non-null value (the footnote-popup URL-tap pre-arms with the
-     * pre-popup origin; [onReaderClosed] must not clobber that with the popup-nudged lastLocator).
-     */
-    fun setReturnAnchor(locator: Locator?) {
-        if (pendingReturnLocator == null) pendingReturnLocator = locator
-    }
+    /** @see ResumeRestorer.setReturnAnchor */
+    fun setReturnAnchor(locator: Locator?) = resumeRestorer.setReturnAnchor(locator)
 
-    /**
-     * Forcibly overwrites the return anchor. Used by [captureFootnotePopupLinkOrigin] which
-     * explicitly captures the pre-popup origin.
-     */
-    fun forceSetReturnAnchor(locator: Locator?) {
-        pendingReturnLocator = locator
-    }
+    /** @see ResumeRestorer.forceSetReturnAnchor */
+    fun forceSetReturnAnchor(locator: Locator?) = resumeRestorer.forceSetReturnAnchor(locator)
 
-    /**
-     * Consume the pending return anchor and clear it. Returns null if none was set.
-     */
-    fun consumeReturnAnchor(): Locator? {
-        val current = pendingReturnLocator
-        pendingReturnLocator = null
-        return current
-    }
+    /** @see ResumeRestorer.consumeReturnAnchor */
+    fun consumeReturnAnchor(): Locator? = resumeRestorer.consumeReturnAnchor()
 
-    /** Read the pending return anchor without clearing it. */
-    fun peekReturnAnchor(): Locator? = pendingReturnLocator
+    /** @see ResumeRestorer.peekReturnAnchor */
+    fun peekReturnAnchor(): Locator? = resumeRestorer.peekReturnAnchor()
 
-    /**
-     * Arms the resume restore that [onReaderResumed] uses: stores [origin] as the pending return
-     * locator (so the retry watcher in [onPositionChanged] can access it) and emits it through the
-     * server-locator channel so the navigator jumps there. Sets [returnRestoreAttempts] = 5.
-     */
-    fun armReturnRestore(origin: Locator) {
-        pendingReturnLocator = origin
-        returnRestoreAttempts = 5
-        _serverLocatorChannel.trySend(origin)
-    }
+    /** @see ResumeRestorer.armReturnRestore */
+    fun armReturnRestore(origin: Locator) = resumeRestorer.armReturnRestore(origin)
 
     /** Resets [initialLocatorSeen] — called when the reader is resumed so the first Readium
      *  emission (the WebView restoration) is not treated as user progress. */

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/session/ResumeRestorer.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/session/ResumeRestorer.kt
@@ -1,0 +1,110 @@
+@file:OptIn(org.readium.r2.shared.ExperimentalReadiumApi::class)
+
+package com.riffle.app.feature.reader.session
+
+import org.readium.r2.shared.publication.Locator
+
+/**
+ * Owns the background-return restore loop: the [pendingReturnLocator] anchor and its
+ * [returnRestoreAttempts] retry budget. On each onPositionChanged the intake calls
+ * [onPositionEmitted]; if a spurious chapter-top emission arrives while a restore is in flight,
+ * the origin locator is re-fired through [refire] until either the reader settles at the origin,
+ * the user navigates away, or the budget runs out.
+ *
+ * Split out of [PositionOrchestrator] as part of #376 to isolate the retry state machine from the
+ * canonical position stream and from remote-win jump policy.
+ */
+class ResumeRestorer(
+    private val refire: (Locator) -> Unit,
+) {
+
+    /**
+     * The locator to restore on onReaderResumed. Armed in onReaderClosed from the last known
+     * locator; the footnote-popup URL-tap path pre-arms it earlier via [setReturnAnchor].
+     */
+    private var pendingReturnLocator: Locator? = null
+
+    /**
+     * How many remaining onPositionChanged → chapter-top emissions to suppress while restoring
+     * after a background return.
+     */
+    private var returnRestoreAttempts = 0
+
+    /**
+     * Retry watcher — invoked from the position intake before it updates the position streams.
+     *
+     * Defensive re-restore: Readium's post-resume column-snap can emit a chapter-top position
+     * AFTER the resume navigateTo, sometimes more than once — including a delayed clobber that
+     * arrives AFTER a first emission has already landed at the captured origin. Stay armed
+     * (within the attempt budget) as long as we're parked at-or-near the origin; only disarm when
+     * the user clearly navigates AWAY (different href, or progression past origin). An emission
+     * AT origin means this round took, not that future emissions can't re-clobber us, so don't
+     * clear pending on equality.
+     */
+    fun onPositionEmitted(locator: Locator) {
+        val remaining = returnRestoreAttempts
+        if (remaining <= 0) return
+        val pending = pendingReturnLocator
+        if (pending == null) {
+            returnRestoreAttempts = 0
+            return
+        }
+        val originHref = pending.href.toString()
+        val originProg = pending.locations.progression ?: 0.0
+        val incomingHref = locator.href.toString()
+        val incomingProg = locator.locations.progression ?: 0.0
+        when {
+            incomingHref == originHref && incomingProg < originProg - 0.01 -> {
+                returnRestoreAttempts = remaining - 1
+                refire(pending)
+            }
+            incomingHref != originHref || incomingProg > originProg + 0.01 -> {
+                returnRestoreAttempts = 0
+                pendingReturnLocator = null
+            }
+        }
+    }
+
+    /**
+     * Sets the pending return anchor. Does NOT overwrite an existing non-null value — the
+     * footnote-popup URL-tap path pre-arms with the pre-popup origin, and onReaderClosed must
+     * not clobber that with the popup-nudged lastLocator.
+     */
+    fun setReturnAnchor(locator: Locator?) {
+        if (pendingReturnLocator == null) pendingReturnLocator = locator
+    }
+
+    /**
+     * Forcibly overwrites the return anchor. Used by captureFootnotePopupLinkOrigin which
+     * explicitly captures the pre-popup origin.
+     */
+    fun forceSetReturnAnchor(locator: Locator?) {
+        pendingReturnLocator = locator
+    }
+
+    /** Consume the pending return anchor and clear it. Returns null if none was set. */
+    fun consumeReturnAnchor(): Locator? {
+        val current = pendingReturnLocator
+        pendingReturnLocator = null
+        return current
+    }
+
+    /** Read the pending return anchor without clearing it. */
+    fun peekReturnAnchor(): Locator? = pendingReturnLocator
+
+    /**
+     * Arms the resume restore: stores [origin] as the pending return locator (so [onPositionEmitted]
+     * can access it) and fires it through [refire] so the navigator jumps there. Budget = 5.
+     */
+    fun armReturnRestore(origin: Locator) {
+        pendingReturnLocator = origin
+        returnRestoreAttempts = 5
+        refire(origin)
+    }
+
+    /** Reset all per-book state. Called from [PositionOrchestrator.bindBook]. */
+    fun reset() {
+        pendingReturnLocator = null
+        returnRestoreAttempts = 0
+    }
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/session/ServerJumpCoordinator.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/session/ServerJumpCoordinator.kt
@@ -1,0 +1,90 @@
+@file:OptIn(org.readium.r2.shared.ExperimentalReadiumApi::class)
+
+package com.riffle.app.feature.reader.session
+
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.receiveAsFlow
+import org.readium.r2.shared.publication.Locator
+
+/**
+ * Owns the server-win jump seam: the channel that carries remote-win Locators to the
+ * EpubNavigatorFragment, the [suppressNextServerLocator] latch that lets an explicit openAtCfi
+ * survive the first sync round, and the [pendingServerJumpStamp] that lets a resulting
+ * onPositionChanged persist the adopted server timestamp instead of `now`.
+ *
+ * Split out of [PositionOrchestrator] as part of #376 to separate remote-win jump policy from the
+ * canonical position stream and from the resume-restore watcher.
+ */
+class ServerJumpCoordinator {
+
+    /**
+     * Carries server-win jumps (sync cycle + Storyteller loop + background-return restore) to the
+     * EpubNavigatorFragment. A conflated channel so a request survives until the screen's collector
+     * receives it — a reopen can emit before the collector re-subscribes after a config change.
+     */
+    private val channel = Channel<Locator>(Channel.CONFLATED)
+    val serverLocatorEvents: Flow<Locator> = channel.receiveAsFlow()
+
+    /**
+     * True when this reader was opened with an explicit openAtCfi (e.g. a library annotation tap or
+     * a search-result jump). Consumed (and cleared) by [requestJumpWithSuppressCheck].
+     */
+    @Volatile private var suppressNextServerLocator: Boolean = false
+
+    /**
+     * Set to the winning server timestamp when the cycle drives a remote-win jump; consumed by the
+     * jump's resulting onPositionChanged. That emission persists the CFI but keeps this server
+     * timestamp instead of stamping `now`.
+     */
+    @Volatile private var pendingServerJumpStamp: Long? = null
+
+    /**
+     * Send [locator] through the server-locator channel unconditionally. Used by sync cycles that
+     * want to jump the reader to a remote-win position.
+     */
+    fun requestJump(locator: Locator) {
+        channel.trySend(locator)
+    }
+
+    /**
+     * Variant used by the progressSyncController observer: honours [suppressNextServerLocator]
+     * and clears it once consumed, so an explicit openAtCfi navigation is not overridden.
+     */
+    fun requestJumpWithSuppressCheck(locator: Locator) {
+        if (suppressNextServerLocator) {
+            suppressNextServerLocator = false
+            return
+        }
+        channel.trySend(locator)
+    }
+
+    /**
+     * Mark that the next server-locator event should be suppressed. Called from openBook when
+     * openAtCfi is resolved, before the sync starts.
+     */
+    fun markSuppressNext() {
+        suppressNextServerLocator = true
+    }
+
+    /** Called when [pendingServerJumpStamp] should be set from a sync cycle result. */
+    fun setPendingStamp(stamp: Long) {
+        pendingServerJumpStamp = stamp
+    }
+
+    /**
+     * Consume and clear [pendingServerJumpStamp]. Called from the position intake right before it
+     * persists a settled locator, so a remote-win jump adopts the server timestamp.
+     */
+    fun consumePendingStamp(): Long? {
+        val stamp = pendingServerJumpStamp
+        pendingServerJumpStamp = null
+        return stamp
+    }
+
+    /** Reset all per-book state. Called from [PositionOrchestrator.bindBook]. */
+    fun reset() {
+        suppressNextServerLocator = false
+        pendingServerJumpStamp = null
+    }
+}

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/session/ResumeRestorerTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/session/ResumeRestorerTest.kt
@@ -1,0 +1,133 @@
+package com.riffle.app.feature.reader.session
+
+import android.net.FakeUri
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.readium.r2.shared.publication.Locator
+import org.readium.r2.shared.util.AbsoluteUrl
+import org.readium.r2.shared.util.mediatype.MediaType
+
+class ResumeRestorerTest {
+
+    @Suppress("UNCHECKED_CAST")
+    private fun buildLocator(href: String, progression: Double = 0.0): Locator {
+        val unsafe = Class.forName("sun.misc.Unsafe")
+            .getDeclaredField("theUnsafe")
+            .also { it.isAccessible = true }
+            .get(null) as sun.misc.Unsafe
+        val url = unsafe.allocateInstance(AbsoluteUrl::class.java) as AbsoluteUrl
+        AbsoluteUrl::class.java.getDeclaredField("uri")
+            .also { it.isAccessible = true }
+            .set(url, FakeUri(href))
+        return Locator(
+            href = url,
+            mediaType = MediaType.XHTML,
+            locations = Locator.Locations(progression = progression),
+        )
+    }
+
+    private class Fixture {
+        val refired = mutableListOf<Locator>()
+        val restorer = ResumeRestorer(refire = { refired.add(it) })
+    }
+
+    @Test
+    fun `setReturnAnchor does not overwrite existing anchor`() {
+        val f = Fixture()
+        f.restorer.setReturnAnchor(buildLocator("a.html", 0.5))
+        f.restorer.setReturnAnchor(buildLocator("b.html", 0.3))
+        assertEquals("first anchor wins", "a.html", f.restorer.peekReturnAnchor()?.href?.toString())
+    }
+
+    @Test
+    fun `forceSetReturnAnchor overwrites existing anchor`() {
+        val f = Fixture()
+        f.restorer.setReturnAnchor(buildLocator("a.html", 0.5))
+        f.restorer.forceSetReturnAnchor(buildLocator("b.html", 0.3))
+        assertEquals("b.html", f.restorer.peekReturnAnchor()?.href?.toString())
+    }
+
+    @Test
+    fun `consumeReturnAnchor round-trips then clears`() {
+        val f = Fixture()
+        f.restorer.setReturnAnchor(buildLocator("a.html", 0.5))
+        assertEquals("a.html", f.restorer.consumeReturnAnchor()?.href?.toString())
+        assertNull(f.restorer.consumeReturnAnchor())
+    }
+
+    @Test
+    fun `armReturnRestore refires immediately and sets budget`() {
+        val f = Fixture()
+        val origin = buildLocator("a.html", 0.5)
+        f.restorer.armReturnRestore(origin)
+        assertEquals("armed anchor stored", "a.html", f.restorer.peekReturnAnchor()?.href?.toString())
+        assertEquals("armed refire emitted", 1, f.refired.size)
+    }
+
+    @Test
+    fun `onPositionEmitted refires when spurious chapter-top clobbers origin`() {
+        val f = Fixture()
+        f.restorer.armReturnRestore(buildLocator("a.html", 0.5))
+        f.refired.clear()
+        f.restorer.onPositionEmitted(buildLocator("a.html", 0.0))
+        assertEquals("spurious clobber triggers refire", 1, f.refired.size)
+        assertEquals("a.html", f.refired.first().href.toString())
+    }
+
+    @Test
+    fun `onPositionEmitted stays armed when incoming is at origin`() {
+        val f = Fixture()
+        f.restorer.armReturnRestore(buildLocator("a.html", 0.5))
+        f.refired.clear()
+        // A near-origin emission means the restore took this round — don't disarm.
+        f.restorer.onPositionEmitted(buildLocator("a.html", 0.5))
+        assertEquals("no refire when at origin", 0, f.refired.size)
+        assertEquals("anchor still armed", "a.html", f.restorer.peekReturnAnchor()?.href?.toString())
+        // A later spurious clobber must still be re-fired.
+        f.restorer.onPositionEmitted(buildLocator("a.html", 0.0))
+        assertEquals("late clobber still re-fired", 1, f.refired.size)
+    }
+
+    @Test
+    fun `onPositionEmitted disarms when user navigates to a different href`() {
+        val f = Fixture()
+        f.restorer.armReturnRestore(buildLocator("a.html", 0.5))
+        f.refired.clear()
+        f.restorer.onPositionEmitted(buildLocator("b.html", 0.0))
+        assertEquals("no refire when href differs", 0, f.refired.size)
+        assertNull("anchor cleared on navigation away", f.restorer.peekReturnAnchor())
+    }
+
+    @Test
+    fun `onPositionEmitted disarms when progression moves past origin`() {
+        val f = Fixture()
+        f.restorer.armReturnRestore(buildLocator("a.html", 0.5))
+        f.refired.clear()
+        f.restorer.onPositionEmitted(buildLocator("a.html", 0.7))
+        assertEquals("no refire when past origin", 0, f.refired.size)
+        assertNull("anchor cleared", f.restorer.peekReturnAnchor())
+    }
+
+    @Test
+    fun `budget bounds the number of refires`() {
+        val f = Fixture()
+        f.restorer.armReturnRestore(buildLocator("a.html", 0.5))
+        f.refired.clear()
+        // Budget starts at 5; ten spurious clobbers should refire at most 5 times.
+        repeat(10) { f.restorer.onPositionEmitted(buildLocator("a.html", 0.0)) }
+        assertTrue("bounded refires: got ${f.refired.size}", f.refired.size <= 5)
+    }
+
+    @Test
+    fun `reset clears anchor and budget`() {
+        val f = Fixture()
+        f.restorer.armReturnRestore(buildLocator("a.html", 0.5))
+        f.refired.clear()
+        f.restorer.reset()
+        f.restorer.onPositionEmitted(buildLocator("a.html", 0.0))
+        assertEquals("no refire after reset", 0, f.refired.size)
+        assertNull(f.restorer.peekReturnAnchor())
+    }
+}

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/session/ServerJumpCoordinatorTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/session/ServerJumpCoordinatorTest.kt
@@ -1,0 +1,92 @@
+package com.riffle.app.feature.reader.session
+
+import android.net.FakeUri
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.readium.r2.shared.publication.Locator
+import org.readium.r2.shared.util.AbsoluteUrl
+import org.readium.r2.shared.util.mediatype.MediaType
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ServerJumpCoordinatorTest {
+
+    @Suppress("UNCHECKED_CAST")
+    private fun buildLocator(href: String, progression: Double = 0.0): Locator {
+        val unsafe = Class.forName("sun.misc.Unsafe")
+            .getDeclaredField("theUnsafe")
+            .also { it.isAccessible = true }
+            .get(null) as sun.misc.Unsafe
+        val url = unsafe.allocateInstance(AbsoluteUrl::class.java) as AbsoluteUrl
+        AbsoluteUrl::class.java.getDeclaredField("uri")
+            .also { it.isAccessible = true }
+            .set(url, FakeUri(href))
+        return Locator(
+            href = url,
+            mediaType = MediaType.XHTML,
+            locations = Locator.Locations(progression = progression),
+        )
+    }
+
+    @Test
+    fun `requestJump emits to serverLocatorEvents`() = runTest(UnconfinedTestDispatcher()) {
+        val sjc = ServerJumpCoordinator()
+        val received = mutableListOf<Locator>()
+        val job = launch { sjc.serverLocatorEvents.collect { received.add(it) } }
+        sjc.requestJump(buildLocator("a.html", 0.1))
+        job.cancel()
+        assertEquals(1, received.size)
+        assertEquals("a.html", received.first().href.toString())
+    }
+
+    @Test
+    fun `markSuppressNext drops next requestJumpWithSuppressCheck exactly once`() = runTest(UnconfinedTestDispatcher()) {
+        val sjc = ServerJumpCoordinator()
+        val received = mutableListOf<Locator>()
+        val job = launch { sjc.serverLocatorEvents.collect { received.add(it) } }
+        sjc.markSuppressNext()
+        sjc.requestJumpWithSuppressCheck(buildLocator("a.html"))
+        assertEquals("first jump suppressed", 0, received.size)
+        sjc.requestJumpWithSuppressCheck(buildLocator("b.html"))
+        assertEquals("second jump passes", 1, received.size)
+        job.cancel()
+    }
+
+    @Test
+    fun `requestJump ignores suppress latch`() = runTest(UnconfinedTestDispatcher()) {
+        val sjc = ServerJumpCoordinator()
+        val received = mutableListOf<Locator>()
+        val job = launch { sjc.serverLocatorEvents.collect { received.add(it) } }
+        sjc.markSuppressNext()
+        sjc.requestJump(buildLocator("a.html"))
+        assertEquals("unconditional jump bypasses suppress", 1, received.size)
+        job.cancel()
+    }
+
+    @Test
+    fun `consumePendingStamp returns then clears`() {
+        val sjc = ServerJumpCoordinator()
+        assertNull(sjc.consumePendingStamp())
+        sjc.setPendingStamp(42L)
+        assertEquals(42L, sjc.consumePendingStamp())
+        assertNull("stamp cleared after consumption", sjc.consumePendingStamp())
+    }
+
+    @Test
+    fun `reset clears suppress and pending stamp`() = runTest(UnconfinedTestDispatcher()) {
+        val sjc = ServerJumpCoordinator()
+        sjc.markSuppressNext()
+        sjc.setPendingStamp(7L)
+        sjc.reset()
+        val received = mutableListOf<Locator>()
+        val job = launch { sjc.serverLocatorEvents.collect { received.add(it) } }
+        sjc.requestJumpWithSuppressCheck(buildLocator("a.html"))
+        assertEquals("reset cleared suppress", 1, received.size)
+        assertNull("reset cleared pending stamp", sjc.consumePendingStamp())
+        job.cancel()
+    }
+}


### PR DESCRIPTION
Partially addresses #376.

## Summary

`PositionOrchestrator` (327 lines) mixed three concerns:
1. Canonical reading-position stream (`currentLocator*` + `onPositionChanged` intake + persistence).
2. Server-win jump channel (Locator channel, `suppressNextServerLocator` latch, `pendingServerJumpStamp`).
3. Background-return restore watcher (`pendingReturnLocator`, `returnRestoreAttempts`, retry logic tucked into `onPositionChanged`).

This PR extracts (2) and (3) into focused collaborators — the smallest ISP win in #376's plan, and the one with the tightest test surface:

- **`ServerJumpCoordinator`** — owns the conflated `Channel<Locator>`, the suppress latch, and the pending server timestamp.
- **`ResumeRestorer`** — owns the return anchor + retry budget, exposes `onPositionEmitted(locator)` for the intake to call, and re-fires through an injected `(Locator) -> Unit` callback wired to the coordinator.

`PositionOrchestrator` composes both and delegates its previous methods as thin facades, so the ViewModel's ~15 call sites are untouched. `bindBook()` resets both collaborators alongside its local state.

The `ReaderSession` and `FormatCompositor` slices from the parent issue remain as follow-up work — they mutate the 1,595-line ViewModel and warrant separate PRs.

## Test plan

- [x] `./gradlew test` — all JVM tests green (`:app:testDebugUnitTest` and every core module).
- [x] New `ServerJumpCoordinatorTest` (5 tests) — request/suppress/pending-stamp/reset semantics.
- [x] New `ResumeRestorerTest` (10 tests) — anchor set/force/consume, arm-refire, clobber detection, disarm-on-navigation, budget bound, reset.
- [x] Existing `PositionOrchestratorTest` (10 tests) unmodified — facade delegations preserve public behavior.