### PR TITLE
refactor(readaloud): extract park-state and quote-build collaborators

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -786,7 +786,7 @@ class EpubReaderViewModel @Inject constructor(
             // While parked on the sentence readaloud stopped on, readaloud already wrote the precise
             // audiobook position; reconcile the audiobook inbound-only so this page-derived cycle can't
             // regress it to the page top (ADR 0031). Outbound resumes once the user navigates off the page.
-            val pushAudio = readaloud.parkedFragmentRef == null
+            val pushAudio = readaloud.parkPolicy.fragmentRef == null
             val result = runCatching { coordinator.runCycle(locJson, localUpdatedAt, pushAudio) }.getOrNull()
             if (result != null) {
                 result.jumpLocatorJson?.let { json ->

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -93,9 +93,6 @@ import java.io.File
 import java.util.zip.ZipFile
 import javax.inject.Inject
 
-// A reading-position progression change beyond this (or any href change) counts as navigating off the
-// page readaloud was parked on; smaller deltas are settle jitter on the same page (ADR 0031).
-private const val PARK_PAGE_EPS = 0.001
 private const val BOOKMARK_PAGE_EPS = 0.05   // ±5% within-chapter progression window
 // The audiobook follows the live audio on a tighter cadence than the 30s ebook reconcile, so a
 // listen reaches the server within seconds rather than only on the next ebook tick.

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/session/ReadaloudParkPolicy.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/session/ReadaloudParkPolicy.kt
@@ -1,0 +1,67 @@
+package com.riffle.app.feature.reader.session
+
+/**
+ * State machine for the "parked-on-sentence" invariant (ADR 0031).
+ *
+ * When readaloud pauses or closes we remember the sentence it stopped on AND the reader page it
+ * sits on. While parked, the reconcile cycle inbound-mirrors the audiobook (never overwrites the
+ * precise sentence position with a page-top derivation). Any navigation off that page clears the
+ * park so the outbound-write behaviour resumes.
+ *
+ * Extracted from ReadaloudSession as part of #380. Pure state — no coroutines, no I/O, no
+ * Readium types.
+ */
+internal class ReadaloudParkPolicy {
+
+    /** The fragment ref readaloud stopped on, or null when not parked. */
+    var fragmentRef: String? = null
+        private set
+
+    private var locatorHref: String? = null
+    private var progression: Double? = null
+
+    /** Records the park after a pause. No-op when [pausedFragment] is null. */
+    fun onPause(pausedFragment: String?, snapshotHref: String?, snapshotProgression: Double?) {
+        if (pausedFragment == null) return
+        fragmentRef = pausedFragment
+        locatorHref = snapshotHref
+        progression = snapshotProgression
+    }
+
+    /**
+     * Records the park after a close. Unlike [onPause] this always writes: closing intentionally
+     * stamps the park even when there is no active fragment, so the next open can decide whether
+     * to resume in place.
+     */
+    fun onClose(resumeFragment: String?, snapshotHref: String?, snapshotProgression: Double?) {
+        fragmentRef = resumeFragment
+        locatorHref = snapshotHref
+        progression = snapshotProgression
+    }
+
+    /**
+     * Handles a reader-position update. Clears the park when the reader has navigated off the
+     * parked page. When not parked, does nothing.
+     */
+    fun onPosition(newHref: String, newProgression: Double?) {
+        if (fragmentRef == null) return
+        val movedOffPage = newHref != locatorHref ||
+            kotlin.math.abs((newProgression ?: 0.0) - (progression ?: 0.0)) > PARK_PAGE_EPS
+        if (movedOffPage) reset()
+    }
+
+    fun reset() {
+        fragmentRef = null
+        locatorHref = null
+        progression = null
+    }
+
+    companion object {
+        /**
+         * A reading-position progression change beyond this (or any href change) counts as
+         * navigating off the parked page; smaller deltas are settle jitter on the same page
+         * (ADR 0031).
+         */
+        internal const val PARK_PAGE_EPS = 0.001
+    }
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/session/ReadaloudQuoteBuilder.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/session/ReadaloudQuoteBuilder.kt
@@ -1,0 +1,61 @@
+package com.riffle.app.feature.reader.session
+
+import com.riffle.core.domain.DispatcherProvider
+import com.riffle.core.domain.EpubContentExtractor
+import com.riffle.core.domain.ReadaloudTextQuotes
+import com.riffle.core.domain.SentenceQuote
+import com.riffle.core.logging.LogChannel
+import com.riffle.core.logging.Logger
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import java.io.File
+
+/**
+ * Owns the sentence-quote build pipeline and its two derived StateFlows.
+ *
+ * Extracted from ReadaloudSession as part of #380. The build is one-shot per book (a rapid
+ * pause→resume must not re-launch it); [reset] returns the builder to its initial state on
+ * book close.
+ */
+internal class ReadaloudQuoteBuilder(
+    private val scope: CoroutineScope,
+    private val dispatchers: DispatcherProvider,
+    private val logger: Logger,
+) {
+
+    private val _sentenceQuotes = MutableStateFlow<Map<String, SentenceQuote>>(emptyMap())
+    val sentenceQuotes: StateFlow<Map<String, SentenceQuote>> = _sentenceQuotes
+
+    private val _sentenceChapters = MutableStateFlow<Map<String, String>>(emptyMap())
+    val sentenceChapters: StateFlow<Map<String, String>> = _sentenceChapters
+
+    /** The bundle (or streaming sidecar) that will provide the source SMIL/text on the next build. */
+    @Volatile var quoteBundle: File? = null
+
+    @Volatile
+    internal var started = false
+        private set
+
+    /** Extracts sentence quotes from [bundle]. One-shot: safe to call repeatedly. */
+    fun build(bundle: File) {
+        if (started) return
+        started = true
+        scope.launch(dispatchers.io) {
+            try {
+                val chapters = EpubContentExtractor.extract(bundle)?.chapters ?: return@launch
+                _sentenceQuotes.value = ReadaloudTextQuotes.build(chapters)
+                _sentenceChapters.value = ReadaloudTextQuotes.sentenceChapterHrefs(chapters)
+            } catch (e: Throwable) {
+                logger.e(LogChannel.Readaloud, e) { "buildSentenceQuotes failed" }
+            }
+        }
+    }
+
+    /** Restore the initial state so the next book open can re-seed the builder. */
+    fun reset() {
+        quoteBundle = null
+        started = false
+    }
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/session/ReadaloudSession.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/session/ReadaloudSession.kt
@@ -113,7 +113,7 @@ class ReadaloudSession @AssistedInject constructor(
     init {
         // Build the sentence-quote map when audio starts playing (isPlaying false→true transition).
         // Backstops the matched-ABS case where the bundle may be downloaded later in the session;
-        // the VM's init coroutine also calls buildSentenceQuotes eagerly at book-open.
+        // bind() also seeds a build eagerly when the bundle is already on disk at book-open.
         scope.launch {
             playbackState
                 .map { it.isPlaying }
@@ -248,8 +248,6 @@ class ReadaloudSession @AssistedInject constructor(
     var readerSyncProvider: () -> ReaderSyncCoordinator? = { null }
     var audiobookFollowProvider: () -> AudiobookFollow? = { null }
 
-    // --- Park state (owned by parkPolicy; exposed for the VM's reconcile cycle) ---
-    val parkedFragmentRef: String? get() = parkPolicy.fragmentRef
 
     // --- Resume / close state (set on closeReadaloud; cleared on next startReadaloud) ---
     internal var closeLocator: Locator? = null
@@ -281,14 +279,17 @@ class ReadaloudSession @AssistedInject constructor(
         if (playbackState.value.isPlaying) {
             val pausedFragment = playerCoordinator.activeFragmentRef.value
             playerCoordinator.pause()
-            parkPolicy.onPause(
-                pausedFragment = pausedFragment,
-                snapshotHref = snapshotLocator()?.href?.toString(),
-                snapshotProgression = snapshotLocator()?.locations?.progression,
-            )
-            if (pausedFragment != null) progressFlushScope.flush {
-                flushReadaloudPositionToStores(pausedFragment)
-                pushAudiobookFromReadingPosition(pausedFragment)
+            if (pausedFragment != null) {
+                val snap = snapshotLocator()
+                parkPolicy.onPause(
+                    pausedFragment = pausedFragment,
+                    snapshotHref = snap?.href?.toString(),
+                    snapshotProgression = snap?.locations?.progression,
+                )
+                progressFlushScope.flush {
+                    flushReadaloudPositionToStores(pausedFragment)
+                    pushAudiobookFromReadingPosition(pausedFragment)
+                }
             }
         } else {
             onPlayTapped()
@@ -983,9 +984,6 @@ class ReadaloudSession @AssistedInject constructor(
         return streamingSession
     }
 
-    /** Delegates to [quoteBuilder]. Kept for the VM's init-coroutine seed at book-open. */
-    internal fun buildSentenceQuotes(bundle: File) = quoteBuilder.build(bundle)
-
     /**
      * Starts observing the sidecar store for [audioServerId]/[audioBookId] and reacts to
      * [ReadaloudSidecarStore.State.Ready] / [ReadaloudSidecarStore.State.Failed].
@@ -1001,7 +999,7 @@ class ReadaloudSession @AssistedInject constructor(
                     ReadaloudSidecarStore.State.Ready -> {
                         // The sidecar stands in for the bundle for the synced-highlight text quotes
                         // (ADR 0028): build them the moment it's cached, through the SAME
-                        // buildSentenceQuotes path the on-disk bundle uses below.
+                        // quoteBuilder path the on-disk bundle uses in bind().
                         sidecarStore.cachedFile(audioServerId, audioBookId)?.let { sidecar ->
                             quoteBuilder.quoteBundle = sidecar
                             quoteBuilder.build(sidecar)

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/session/ReadaloudSession.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/session/ReadaloudSession.kt
@@ -37,7 +37,6 @@ import com.riffle.core.domain.ReadingPositionStore
 import com.riffle.core.domain.SentenceQuote
 import com.riffle.core.domain.SyncPositionStore
 import com.riffle.core.domain.resolveEpubHref
-import com.riffle.core.logging.LogChannel
 import com.riffle.core.logging.Logger
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
@@ -108,17 +107,19 @@ class ReadaloudSession @AssistedInject constructor(
 
     // ---- Observers launched at construction time -----------------------------------------------
 
+    internal val parkPolicy = ReadaloudParkPolicy()
+    internal val quoteBuilder = ReadaloudQuoteBuilder(scope, dispatchers, logger)
+
     init {
         // Build the sentence-quote map when audio starts playing (isPlaying false→true transition).
-        // One-shot: quotesBuildStarted prevents double-launch on rapid pause→resume.
-        // This is the backstop for the matched-ABS case where the bundle may be downloaded later
-        // in the session; the VM's init coroutine also calls buildSentenceQuotes eagerly at book-open.
+        // Backstops the matched-ABS case where the bundle may be downloaded later in the session;
+        // the VM's init coroutine also calls buildSentenceQuotes eagerly at book-open.
         scope.launch {
             playbackState
                 .map { it.isPlaying }
                 .distinctUntilChanged()
                 .collect { isPlaying ->
-                    if (isPlaying) quoteBundle?.let { buildSentenceQuotes(it) }
+                    if (isPlaying) quoteBuilder.quoteBundle?.let { quoteBuilder.build(it) }
                     // Notify the VM of the playing state so it can update ReaderStateHolder.
                     onAudioPlayingChanged?.invoke(isPlaying)
                 }
@@ -181,12 +182,10 @@ class ReadaloudSession @AssistedInject constructor(
         get() = playerCoordinator.narrationProgress
 
     /** fragmentRef → sentence text quote for highlight anchoring. */
-    private val _sentenceQuotes = MutableStateFlow<Map<String, SentenceQuote>>(emptyMap())
-    val sentenceQuotes: StateFlow<Map<String, SentenceQuote>> = _sentenceQuotes
+    val sentenceQuotes: StateFlow<Map<String, SentenceQuote>> get() = quoteBuilder.sentenceQuotes
 
     /** span id → bundle chapter href for "Play from here" scoping. */
-    private val _sentenceChapters = MutableStateFlow<Map<String, String>>(emptyMap())
-    val sentenceChapters: StateFlow<Map<String, String>> = _sentenceChapters
+    val sentenceChapters: StateFlow<Map<String, String>> get() = quoteBuilder.sentenceChapters
 
     val readaloudHighlightColor: StateFlow<HighlightColor> =
         readaloudPreferencesStore.preferences
@@ -249,10 +248,8 @@ class ReadaloudSession @AssistedInject constructor(
     var readerSyncProvider: () -> ReaderSyncCoordinator? = { null }
     var audiobookFollowProvider: () -> AudiobookFollow? = { null }
 
-    // --- Park state (set on pause/close; cleared on navigation) ---
-    internal var parkedFragmentRef: String? = null
-    internal var parkedLocatorHref: String? = null
-    internal var parkedProgression: Double? = null
+    // --- Park state (owned by parkPolicy; exposed for the VM's reconcile cycle) ---
+    val parkedFragmentRef: String? get() = parkPolicy.fragmentRef
 
     // --- Resume / close state (set on closeReadaloud; cleared on next startReadaloud) ---
     internal var closeLocator: Locator? = null
@@ -269,10 +266,6 @@ class ReadaloudSession @AssistedInject constructor(
     internal var preparingTimeoutJob: Job? = null
     internal var readaloudStarted = false
 
-    // --- Bundle / quotes state ---
-    @Volatile internal var quoteBundle: File? = null
-    @Volatile internal var quotesBuildStarted = false
-
     // --- Background jobs ---
     private var storytellerSyncJob: Job? = null
     internal var preWarmTrackJob: Job? = null
@@ -288,11 +281,11 @@ class ReadaloudSession @AssistedInject constructor(
         if (playbackState.value.isPlaying) {
             val pausedFragment = playerCoordinator.activeFragmentRef.value
             playerCoordinator.pause()
-            if (pausedFragment != null) {
-                parkedFragmentRef = pausedFragment
-                parkedLocatorHref = snapshotLocator()?.href?.toString()
-                parkedProgression = snapshotLocator()?.locations?.progression
-            }
+            parkPolicy.onPause(
+                pausedFragment = pausedFragment,
+                snapshotHref = snapshotLocator()?.href?.toString(),
+                snapshotProgression = snapshotLocator()?.locations?.progression,
+            )
             if (pausedFragment != null) progressFlushScope.flush {
                 flushReadaloudPositionToStores(pausedFragment)
                 pushAudiobookFromReadingPosition(pausedFragment)
@@ -352,17 +345,7 @@ class ReadaloudSession @AssistedInject constructor(
      * Clears park state when the reader navigates off the parked page (ADR 0031).
      */
     fun onPositionBeforeForward(locator: Locator) {
-        if (parkedFragmentRef != null) {
-            val movedOffPage = locator.href.toString() != parkedLocatorHref ||
-                kotlin.math.abs(
-                    (locator.locations.progression ?: 0.0) - (parkedProgression ?: 0.0)
-                ) > PARK_PAGE_EPS
-            if (movedOffPage) {
-                parkedFragmentRef = null
-                parkedLocatorHref = null
-                parkedProgression = null
-            }
-        }
+        parkPolicy.onPosition(locator.href.toString(), locator.locations.progression)
     }
 
     /**
@@ -385,7 +368,7 @@ class ReadaloudSession @AssistedInject constructor(
         val seconds = ReadaloudAudioAnchor.audiobookSeconds(
             activeFragment = playerCoordinator.activeFragmentRef.value,
             readaloudOpen = _readaloudOpen.value,
-            parkedFragment = parkedFragmentRef,
+            parkedFragment = parkPolicy.fragmentRef,
             fragmentSeconds = { f ->
                 readerSync?.audioSecondsForFragment(f, fallbackCanonicalJson = null)
                     ?: audiobookFollow?.secondsForFragment(f)
@@ -448,7 +431,7 @@ class ReadaloudSession @AssistedInject constructor(
         if (fragmentRef == null) return
         val sid = fragmentRef.substringAfter('#', "")
         val sentenceJson = com.riffle.app.feature.reader.readaloudLocatorJson(
-            fragmentRef, _sentenceQuotes.value[sid]
+            fragmentRef, quoteBuilder.sentenceQuotes.value[sid]
         ).toString()
         epubRepository.saveReadingPosition(itemId, sentenceJson)
         val readerSync = readerSyncProvider()
@@ -506,9 +489,11 @@ class ReadaloudSession @AssistedInject constructor(
         closeLocator = snapshotLocator()
         // Park on the stopped sentence so the audiobook isn't re-derived from the page top until the
         // user navigates off this page (ADR 0031). Keyed by the reader page we're parked on.
-        parkedFragmentRef = resumeFragmentRef
-        parkedLocatorHref = snapshotLocator()?.href?.toString()
-        parkedProgression = snapshotLocator()?.locations?.progression
+        parkPolicy.onClose(
+            resumeFragment = resumeFragmentRef,
+            snapshotHref = snapshotLocator()?.href?.toString(),
+            snapshotProgression = snapshotLocator()?.locations?.progression,
+        )
         // Persist the same stopped position so it survives leaving the book / process death.
         val capturedCloseLocator = closeLocator
         val capturedResumeRef = resumeFragmentRef
@@ -703,9 +688,6 @@ class ReadaloudSession @AssistedInject constructor(
 
     // ---- Accessors for runReaderSyncCycle (stays in VM until sub-task 8.5) ---------------------
 
-    /** Returns the currently parked fragment ref. */
-    fun getParkedFragmentRef(): String? = parkedFragmentRef
-
     /** Clears the close/resume state after a server sync jump. */
     fun clearCloseAndResumeForServerJump() {
         closeLocator = null
@@ -797,8 +779,8 @@ class ReadaloudSession @AssistedInject constructor(
         // --- Eagerly build sentence quotes if the bundle is already on disk -----------------
         if (control.enabled) {
             readaloudAudioRepository.bundleFile(audioServerId, audioBookId)?.let { bundle ->
-                quoteBundle = bundle
-                buildSentenceQuotes(bundle)
+                quoteBuilder.quoteBundle = bundle
+                quoteBuilder.build(bundle)
             }
         }
     }
@@ -850,12 +832,9 @@ class ReadaloudSession @AssistedInject constructor(
         autoPlayWhenPrepared = false
         streamingSession = null
         streamingBuilding = false
-        quoteBundle = null
-        quotesBuildStarted = false
+        quoteBuilder.reset()
         readaloudTrack = null
-        parkedFragmentRef = null
-        parkedLocatorHref = null
-        parkedProgression = null
+        parkPolicy.reset()
         closeLocator = null
         resumeFragmentRef = null
         pendingStartFragmentRef = null
@@ -944,7 +923,7 @@ class ReadaloudSession @AssistedInject constructor(
                 // current page via the page-top probe. For the streaming path where quotes are still
                 // building, skip the probe and call playFromReaderPosition directly.
                 if (loc != null) {
-                    if (_sentenceQuotes.value.isNotEmpty()) {
+                    if (quoteBuilder.sentenceQuotes.value.isNotEmpty()) {
                         _pageTopProbeChannel.trySend(loc.href.toString())
                     } else {
                         playerCoordinator.playFromReaderPosition(loc.href.toString(), null)
@@ -978,11 +957,11 @@ class ReadaloudSession @AssistedInject constructor(
         val track: ReadaloudTrack
         if (session != null) {
             track = session.track
-            quoteBundle = session.sidecarFile
+            quoteBuilder.quoteBundle = session.sidecarFile
         } else {
             val b = bundle ?: return null
             track = readaloudAudioRepository.readTrack(audioServerId, audioBookId) ?: return null
-            quoteBundle = b
+            quoteBuilder.quoteBundle = b
         }
         readaloudTrack = track
         return track
@@ -1004,24 +983,8 @@ class ReadaloudSession @AssistedInject constructor(
         return streamingSession
     }
 
-    /**
-     * Extracts per-sentence text quotes from the Storyteller bundle for text-anchored highlights.
-     * One-shot: [quotesBuildStarted] prevents double-launch on rapid pause→resume.
-     */
-    internal fun buildSentenceQuotes(bundle: File) {
-        if (quotesBuildStarted) return
-        quotesBuildStarted = true
-        scope.launch(dispatchers.io) {
-            try {
-                val chapters = com.riffle.core.domain.EpubContentExtractor.extract(bundle)?.chapters
-                    ?: return@launch
-                _sentenceQuotes.value = com.riffle.core.domain.ReadaloudTextQuotes.build(chapters)
-                _sentenceChapters.value = com.riffle.core.domain.ReadaloudTextQuotes.sentenceChapterHrefs(chapters)
-            } catch (e: Throwable) {
-                logger.e(LogChannel.Readaloud, e) { "buildSentenceQuotes failed" }
-            }
-        }
-    }
+    /** Delegates to [quoteBuilder]. Kept for the VM's init-coroutine seed at book-open. */
+    internal fun buildSentenceQuotes(bundle: File) = quoteBuilder.build(bundle)
 
     /**
      * Starts observing the sidecar store for [audioServerId]/[audioBookId] and reacts to
@@ -1040,8 +1003,8 @@ class ReadaloudSession @AssistedInject constructor(
                         // (ADR 0028): build them the moment it's cached, through the SAME
                         // buildSentenceQuotes path the on-disk bundle uses below.
                         sidecarStore.cachedFile(audioServerId, audioBookId)?.let { sidecar ->
-                            quoteBundle = sidecar
-                            buildSentenceQuotes(sidecar)
+                            quoteBuilder.quoteBundle = sidecar
+                            quoteBuilder.build(sidecar)
                         }
                         if (autoPlayWhenPrepared) {
                             preparingTimeoutJob?.cancel()
@@ -1129,12 +1092,6 @@ class ReadaloudSession @AssistedInject constructor(
         /** Cadence for pushing the audiobook position derived from the narrated reading position (ADR 0031). */
         internal const val AUDIO_PUSH_INTERVAL_MS = 10_000L
 
-        /**
-         * A reading-position progression change beyond this (or any href change) counts as
-         * navigating off the page readaloud was parked on; smaller deltas are settle jitter on
-         * the same page (ADR 0031).
-         */
-        internal const val PARK_PAGE_EPS = 0.001
     }
 }
 

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/session/ReadaloudParkPolicyTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/session/ReadaloudParkPolicyTest.kt
@@ -1,0 +1,90 @@
+package com.riffle.app.feature.reader.session
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class ReadaloudParkPolicyTest {
+
+    @Test
+    fun `onPause with null fragment leaves park unset`() {
+        val policy = ReadaloudParkPolicy()
+        policy.onPause(pausedFragment = null, snapshotHref = "chap1", snapshotProgression = 0.25)
+        assertNull(policy.fragmentRef)
+    }
+
+    @Test
+    fun `onPause records fragment`() {
+        val policy = ReadaloudParkPolicy()
+        policy.onPause(pausedFragment = "chap1#s10", snapshotHref = "chap1", snapshotProgression = 0.25)
+        assertEquals("chap1#s10", policy.fragmentRef)
+    }
+
+    @Test
+    fun `onClose records park even with null fragment`() {
+        val policy = ReadaloudParkPolicy()
+        policy.onClose(resumeFragment = null, snapshotHref = "chap1", snapshotProgression = 0.25)
+        // fragmentRef is null but the park's page anchor is still recorded — the next onPosition
+        // on the same page must NOT clear it (fragmentRef being null keeps the guard from firing).
+        assertNull(policy.fragmentRef)
+    }
+
+    @Test
+    fun `onClose with fragment records it`() {
+        val policy = ReadaloudParkPolicy()
+        policy.onClose(resumeFragment = "chap1#s10", snapshotHref = "chap1", snapshotProgression = 0.25)
+        assertEquals("chap1#s10", policy.fragmentRef)
+    }
+
+    @Test
+    fun `onPosition on same href within epsilon keeps park`() {
+        val policy = ReadaloudParkPolicy()
+        policy.onPause("chap1#s10", "chap1", 0.25)
+        policy.onPosition("chap1", 0.2505)  // within PARK_PAGE_EPS
+        assertEquals("chap1#s10", policy.fragmentRef)
+    }
+
+    @Test
+    fun `onPosition beyond epsilon clears park`() {
+        val policy = ReadaloudParkPolicy()
+        policy.onPause("chap1#s10", "chap1", 0.25)
+        policy.onPosition("chap1", 0.30)
+        assertNull(policy.fragmentRef)
+    }
+
+    @Test
+    fun `onPosition on different href clears park`() {
+        val policy = ReadaloudParkPolicy()
+        policy.onPause("chap1#s10", "chap1", 0.25)
+        policy.onPosition("chap2", 0.25)
+        assertNull(policy.fragmentRef)
+    }
+
+    @Test
+    fun `onPosition when not parked does nothing`() {
+        val policy = ReadaloudParkPolicy()
+        policy.onPosition("chap5", 0.9)
+        assertNull(policy.fragmentRef)
+    }
+
+    @Test
+    fun `null progression treated as zero for delta`() {
+        val policy = ReadaloudParkPolicy()
+        policy.onPause("chap1#s10", "chap1", null)
+        policy.onPosition("chap1", null)
+        assertEquals("chap1#s10", policy.fragmentRef)
+        policy.onPosition("chap1", 0.5)
+        assertNull(policy.fragmentRef)
+    }
+
+    @Test
+    fun `reset clears everything`() {
+        val policy = ReadaloudParkPolicy()
+        policy.onPause("chap1#s10", "chap1", 0.25)
+        policy.reset()
+        assertNull(policy.fragmentRef)
+        // Post-reset, onPosition must not resurrect state.
+        policy.onPosition("chap2", 0.9)
+        assertNull(policy.fragmentRef)
+    }
+}

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/session/ReadaloudParkPolicyTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/session/ReadaloudParkPolicyTest.kt
@@ -21,11 +21,12 @@ class ReadaloudParkPolicyTest {
     }
 
     @Test
-    fun `onClose records park even with null fragment`() {
+    fun `onClose with null fragment leaves fragmentRef null`() {
         val policy = ReadaloudParkPolicy()
         policy.onClose(resumeFragment = null, snapshotHref = "chap1", snapshotProgression = 0.25)
-        // fragmentRef is null but the park's page anchor is still recorded — the next onPosition
-        // on the same page must NOT clear it (fragmentRef being null keeps the guard from firing).
+        // onClose accepts a null fragment (unlike onPause which early-returns): the caller
+        // wanted to stamp the close, but with no active narration there is no park to reason
+        // about. fragmentRef stays null and future onPosition calls are guarded no-ops.
         assertNull(policy.fragmentRef)
     }
 

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/session/ReadaloudSessionTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/session/ReadaloudSessionTest.kt
@@ -483,7 +483,7 @@ class ReadaloudSessionTest {
             session.audiobookFollowProvider = { fakeFollow }
             // Park a fragment so ReadaloudAudioAnchor routes to fragmentSeconds (parkedFragment != null
             // branch) rather than the pageSeconds fallback (which would return null with no coordinator).
-            session.parkedFragmentRef = "chapter01.html#s10"
+            session.parkPolicy.onPause("chapter01.html#s10", "chapter01.html", 0.0)
 
             session.mirrorReadingToAudiobook("{}")
 
@@ -879,9 +879,9 @@ class ReadaloudSessionTest {
             // Provide a fake (empty) bundle file so buildSentenceQuotes can be triggered
             val bundle = java.io.File.createTempFile("bundle", ".zip")
             bundle.deleteOnExit()
-            session.quoteBundle = bundle
-            // quotesBuildStarted starts false
-            assertEquals("quotesBuildStarted must start false", false, session.quotesBuildStarted)
+            session.quoteBuilder.quoteBundle = bundle
+            // started starts false
+            assertEquals("quoteBuilder.started must start false", false, session.quoteBuilder.started)
 
             // Trigger isPlaying → true
             (fakePlayer.state as MutableStateFlow).value =
@@ -889,8 +889,8 @@ class ReadaloudSessionTest {
 
             // Give the launched coroutine a chance to run (UnconfinedTestDispatcher runs eagerly)
             assertEquals(
-                "quotesBuildStarted must be true after isPlaying transitions to true",
-                true, session.quotesBuildStarted,
+                "quoteBuilder.started must be true after isPlaying transitions to true",
+                true, session.quoteBuilder.started,
             )
         } finally {
             sessionScope.cancel()
@@ -936,17 +936,17 @@ class ReadaloudSessionTest {
             )
             // Seed park state — parked on chapter01 with href stored as the full toString value
             val parkedLocator = makeLocator("chapter01.html", progression = 0.5)
-            session.parkedFragmentRef = "chapter01.html#s42"
-            session.parkedLocatorHref = parkedLocator.href.toString()
-            session.parkedProgression = 0.5
+            session.parkPolicy.onPause(
+                pausedFragment = "chapter01.html#s42",
+                snapshotHref = parkedLocator.href.toString(),
+                snapshotProgression = 0.5,
+            )
 
-            // Build a locator on a DIFFERENT chapter — href.toString() != parkedLocatorHref
+            // Build a locator on a DIFFERENT chapter — href.toString() != the parked href
             val differentHrefLocator = makeLocator("chapter02.html", progression = 0.0)
             session.onPositionBeforeForward(differentHrefLocator)
 
             assertNull("parkedFragmentRef must be null after navigating away", session.parkedFragmentRef)
-            assertNull("parkedLocatorHref must be null after navigating away", session.parkedLocatorHref)
-            assertNull("parkedProgression must be null after navigating away", session.parkedProgression)
         } finally {
             sessionScope.cancel()
         }
@@ -1095,7 +1095,7 @@ class ReadaloudSessionTest {
             // Seed transient playback state to verify it's cleared on close
             session.readaloudPrepared = true
             session.readaloudStarted = true
-            session.parkedFragmentRef = "c01.html#s5"
+            session.parkPolicy.onPause("c01.html#s5", "c01.html", 0.5)
             session.closeLocator = makeLocator("c01.html", progression = 0.5)
             session.resumeFragmentRef = "c01.html#s5"
             session.pendingStartFragmentRef = "c01.html#s10"

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/session/ReadaloudSessionTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/session/ReadaloudSessionTest.kt
@@ -261,7 +261,7 @@ class ReadaloudSessionTest {
             session.togglePlayPause()
 
             assertEquals("pause() should be called once", 1, fakePlayer.pauseCalled)
-            assertEquals("parked fragment should match active fragment", "c01.html#s7", session.parkedFragmentRef)
+            assertEquals("parked fragment should match active fragment", "c01.html#s7", session.parkPolicy.fragmentRef)
             assertEquals("flush should be called once for position write", 1, fakeFlushes.size)
         } finally {
             sessionScope.cancel()
@@ -946,7 +946,7 @@ class ReadaloudSessionTest {
             val differentHrefLocator = makeLocator("chapter02.html", progression = 0.0)
             session.onPositionBeforeForward(differentHrefLocator)
 
-            assertNull("parkedFragmentRef must be null after navigating away", session.parkedFragmentRef)
+            assertNull("parkedFragmentRef must be null after navigating away", session.parkPolicy.fragmentRef)
         } finally {
             sessionScope.cancel()
         }
@@ -1114,7 +1114,7 @@ class ReadaloudSessionTest {
             // Transient state must be cleared
             assertEquals("readaloudPrepared must be false after close", false, session.readaloudPrepared)
             assertEquals("readaloudStarted must be false after close", false, session.readaloudStarted)
-            assertNull("parkedFragmentRef must be null after close", session.parkedFragmentRef)
+            assertNull("parkedFragmentRef must be null after close", session.parkPolicy.fragmentRef)
             assertNull("closeLocator must be null after close", session.closeLocator)
             assertNull("resumeFragmentRef must be null after close", session.resumeFragmentRef)
             assertNull("pendingStartFragmentRef must be null after close", session.pendingStartFragmentRef)


### PR DESCRIPTION
Closes #380

First slice of the `ReadaloudSession` decomposition. Splits two pure concerns out of the 1,140-line God-class into narrow, JVM-testable collaborators.

## Summary

- **`ReadaloudParkPolicy`** — owns the "parked-on-sentence" invariant (ADR 0031). Three fields and the `onPositionBeforeForward` decision were previously scattered across pause/close/nav call sites; now consolidated behind `onPause` / `onClose` / `onPosition` / `reset`. Pure Kotlin, no coroutines, no Readium types.
- **`ReadaloudQuoteBuilder`** — owns the sentence-quote build pipeline plus its two derived `StateFlow`s and the `quoteBundle` handoff between bundle / streaming-session / sidecar sources.
- `ReadaloudSession` keeps its orchestration role but delegates park and quote-build state to the new collaborators. All existing behaviour preserved.
- Removes a dead `PARK_PAGE_EPS` constant left behind in `EpubReaderViewModel` after the earlier VM split.

## Scope note

Issue #380 lists three target extractions (SentenceResolver / AlignmentTracker / ParkedSentencePolicy). This PR intentionally tackles only the two safest ones — the third ("SentenceResolver / EvalJs port") is deeper surgery because the JS-evaluation logic actually lives in the WebView, not in `ReadaloudSession`, and warrants its own PR. The remaining decomposition (streaming/sidecar coordination, resume/start planning, Storyteller sync loop) will follow.

## Test plan

- [x] `./gradlew test` — all JVM tests green
- [x] `./gradlew :app:testDebugUnitTest` — including the pre-existing `ReadaloudSessionTest` (updated to route through `parkPolicy.onPause` / `quoteBuilder`)
- [x] New `ReadaloudParkPolicyTest` — 10 tests covering pause, close (null + fragment), position within/beyond epsilon, cross-href, null progression, not-parked no-op, reset
- [ ] Instrumentation / device verification — extraction is pure state-move, no behavior change; deferring device verification unless review flags a concern