### PR TITLE
refactor(network): consolidate insecure-TLS wrap into a shared helper

### DIFF
--- a/core/network/build.gradle.kts
+++ b/core/network/build.gradle.kts
@@ -12,4 +12,5 @@ dependencies {
     testImplementation(libs.junit)
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.okhttp.mockwebserver)
+    testImplementation(libs.okhttp.tls)
 }

--- a/core/network/src/main/kotlin/com/riffle/core/network/AbsApiClient.kt
+++ b/core/network/src/main/kotlin/com/riffle/core/network/AbsApiClient.kt
@@ -37,10 +37,6 @@ import okhttp3.Response
 import okhttp3.ResponseBody
 import okhttp3.RequestBody.Companion.toRequestBody
 import java.io.IOException
-import java.security.SecureRandom
-import java.security.cert.X509Certificate
-import javax.net.ssl.SSLContext
-import javax.net.ssl.X509TrustManager
 
 class AbsApiClient(
     private val httpClient: OkHttpClient,
@@ -612,7 +608,7 @@ class AbsApiClient(
     }
 
     private fun client(insecureAllowed: Boolean): OkHttpClient =
-        if (insecureAllowed) httpClient.trustAllCerts() else httpClient
+        if (insecureAllowed) httpClient.withInsecureTls() else httpClient
 
     private fun get(baseUrl: String, path: String, token: String, insecureAllowed: Boolean): Response {
         val request = Request.Builder()
@@ -621,20 +617,6 @@ class AbsApiClient(
             .get()
             .build()
         return client(insecureAllowed).newCall(request).execute()
-    }
-
-    private fun OkHttpClient.trustAllCerts(): OkHttpClient {
-        val trustAll = object : X509TrustManager {
-            override fun checkClientTrusted(chain: Array<out X509Certificate>, authType: String) = Unit
-            override fun checkServerTrusted(chain: Array<out X509Certificate>, authType: String) = Unit
-            override fun getAcceptedIssuers(): Array<X509Certificate> = emptyArray()
-        }
-        val sslContext = SSLContext.getInstance("TLS").apply {
-            init(null, arrayOf(trustAll), SecureRandom())
-        }
-        return newBuilder()
-            .sslSocketFactory(sslContext.socketFactory, trustAll)
-            .build()
     }
 }
 

--- a/core/network/src/main/kotlin/com/riffle/core/network/AudiobookBundleApi.kt
+++ b/core/network/src/main/kotlin/com/riffle/core/network/AudiobookBundleApi.kt
@@ -7,11 +7,7 @@ import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.ResponseBody
 import java.io.IOException
-import java.security.SecureRandom
-import java.security.cert.X509Certificate
 import java.util.concurrent.TimeUnit
-import javax.net.ssl.SSLContext
-import javax.net.ssl.X509TrustManager
 
 /**
  * A (possibly partial) byte stream of the Storyteller synced bundle.
@@ -55,7 +51,7 @@ class AudiobookBundleApiImpl(
         insecureAllowed: Boolean,
         fromByte: Long,
     ): NetworkResult<AudiobookBundleStream> = withContext(dispatchers.io) {
-        val effectiveClient = if (insecureAllowed) bundleClient.trustAllCerts() else bundleClient
+        val effectiveClient = if (insecureAllowed) bundleClient.withInsecureTls() else bundleClient
         val builder = Request.Builder()
             .url("$baseUrl/api/books/$bookId/synced")
             .addHeader("Authorization", "Bearer $token")
@@ -89,15 +85,4 @@ class AudiobookBundleApiImpl(
         }
     }
 
-    private fun OkHttpClient.trustAllCerts(): OkHttpClient {
-        val trustAll = object : X509TrustManager {
-            override fun checkClientTrusted(chain: Array<out X509Certificate>, authType: String) = Unit
-            override fun checkServerTrusted(chain: Array<out X509Certificate>, authType: String) = Unit
-            override fun getAcceptedIssuers(): Array<X509Certificate> = emptyArray()
-        }
-        val sslContext = SSLContext.getInstance("TLS").apply {
-            init(null, arrayOf(trustAll), SecureRandom())
-        }
-        return newBuilder().sslSocketFactory(sslContext.socketFactory, trustAll).build()
-    }
 }

--- a/core/network/src/main/kotlin/com/riffle/core/network/InsecureTls.kt
+++ b/core/network/src/main/kotlin/com/riffle/core/network/InsecureTls.kt
@@ -1,0 +1,28 @@
+package com.riffle.core.network
+
+import okhttp3.OkHttpClient
+import java.security.SecureRandom
+import java.security.cert.X509Certificate
+import javax.net.ssl.SSLContext
+import javax.net.ssl.X509TrustManager
+
+/**
+ * Returns a copy of this client that accepts self-signed / untrusted TLS certificates.
+ *
+ * Callers gate this on the per-server `insecureAllowed` flag (self-hosted Audiobookshelf and
+ * Storyteller servers commonly run behind self-signed certs on homelab domains). Never call
+ * unconditionally: the returned client bypasses certificate validation entirely.
+ */
+internal fun OkHttpClient.withInsecureTls(): OkHttpClient {
+    val trustAll = object : X509TrustManager {
+        override fun checkClientTrusted(chain: Array<out X509Certificate>, authType: String) = Unit
+        override fun checkServerTrusted(chain: Array<out X509Certificate>, authType: String) = Unit
+        override fun getAcceptedIssuers(): Array<X509Certificate> = emptyArray()
+    }
+    val sslContext = SSLContext.getInstance("TLS").apply {
+        init(null, arrayOf(trustAll), SecureRandom())
+    }
+    return newBuilder()
+        .sslSocketFactory(sslContext.socketFactory, trustAll)
+        .build()
+}

--- a/core/network/src/main/kotlin/com/riffle/core/network/StorytellerApiClient.kt
+++ b/core/network/src/main/kotlin/com/riffle/core/network/StorytellerApiClient.kt
@@ -10,10 +10,6 @@ import okhttp3.MultipartBody
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import java.io.IOException
-import java.security.SecureRandom
-import java.security.cert.X509Certificate
-import javax.net.ssl.SSLContext
-import javax.net.ssl.X509TrustManager
 
 class StorytellerApiClient(
     private val httpClient: OkHttpClient,
@@ -131,7 +127,7 @@ class StorytellerApiClient(
     }
 
     private fun client(insecureAllowed: Boolean): OkHttpClient =
-        if (insecureAllowed) httpClient.trustAllCerts() else httpClient
+        if (insecureAllowed) httpClient.withInsecureTls() else httpClient
 
     private fun StorytellerBookResponse.toNetwork(): NetworkStorytellerBook =
         NetworkStorytellerBook(
@@ -141,18 +137,4 @@ class StorytellerApiClient(
             isbn = isbn,
             asin = asin,
         )
-
-    private fun OkHttpClient.trustAllCerts(): OkHttpClient {
-        val trustAll = object : X509TrustManager {
-            override fun checkClientTrusted(chain: Array<out X509Certificate>, authType: String) = Unit
-            override fun checkServerTrusted(chain: Array<out X509Certificate>, authType: String) = Unit
-            override fun getAcceptedIssuers(): Array<X509Certificate> = emptyArray()
-        }
-        val sslContext = SSLContext.getInstance("TLS").apply {
-            init(null, arrayOf(trustAll), SecureRandom())
-        }
-        return newBuilder()
-            .sslSocketFactory(sslContext.socketFactory, trustAll)
-            .build()
-    }
 }

--- a/core/network/src/main/kotlin/com/riffle/core/network/StorytellerBundleApi.kt
+++ b/core/network/src/main/kotlin/com/riffle/core/network/StorytellerBundleApi.kt
@@ -7,11 +7,7 @@ import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.ResponseBody
 import java.io.IOException
-import java.security.SecureRandom
-import java.security.cert.X509Certificate
 import java.util.concurrent.TimeUnit
-import javax.net.ssl.SSLContext
-import javax.net.ssl.X509TrustManager
 
 /** A streaming Storyteller bundle response — caller must close [body]. */
 data class StorytellerBundleStream(val body: ResponseBody)
@@ -84,7 +80,7 @@ class StorytellerBundleApiImpl(
         token: String,
         insecureAllowed: Boolean,
     ): NetworkResult<StorytellerBundleStream> = withContext(dispatchers.io) {
-        val effectiveClient = if (insecureAllowed) chosenClient.trustAllCerts() else chosenClient
+        val effectiveClient = if (insecureAllowed) chosenClient.withInsecureTls() else chosenClient
         val request = Request.Builder()
             .url("$baseUrl/api/books/$bookId/synced")
             .addHeader("Authorization", "Bearer $token")
@@ -118,7 +114,7 @@ class StorytellerBundleApiImpl(
         token: String,
         insecureAllowed: Boolean,
     ): NetworkResult<Long> = withContext(dispatchers.io) {
-        val effectiveClient = if (insecureAllowed) sidecarClient.trustAllCerts() else sidecarClient
+        val effectiveClient = if (insecureAllowed) sidecarClient.withInsecureTls() else sidecarClient
         val request = Request.Builder()
             .url("$baseUrl/api/books/$bookId/synced")
             .head()
@@ -136,20 +132,6 @@ class StorytellerBundleApiImpl(
         } catch (e: IOException) {
             NetworkResult.Offline(e)
         }
-    }
-
-    private fun OkHttpClient.trustAllCerts(): OkHttpClient {
-        val trustAll = object : X509TrustManager {
-            override fun checkClientTrusted(chain: Array<out X509Certificate>, authType: String) = Unit
-            override fun checkServerTrusted(chain: Array<out X509Certificate>, authType: String) = Unit
-            override fun getAcceptedIssuers(): Array<X509Certificate> = emptyArray()
-        }
-        val sslContext = SSLContext.getInstance("TLS").apply {
-            init(null, arrayOf(trustAll), SecureRandom())
-        }
-        return newBuilder()
-            .sslSocketFactory(sslContext.socketFactory, trustAll)
-            .build()
     }
 
     private companion object {

--- a/core/network/src/main/kotlin/com/riffle/core/network/StorytellerPositionApi.kt
+++ b/core/network/src/main/kotlin/com/riffle/core/network/StorytellerPositionApi.kt
@@ -13,10 +13,6 @@ import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
 import java.io.IOException
-import java.security.SecureRandom
-import java.security.cert.X509Certificate
-import javax.net.ssl.SSLContext
-import javax.net.ssl.X509TrustManager
 
 /** [locatorJson] is the raw Readium `locator` object; [timestampMillis] its server `lastUpdate`. */
 data class StorytellerPosition(val locatorJson: String, val timestampMillis: Long)
@@ -53,7 +49,7 @@ class StorytellerPositionApiImpl(
         token: String,
         insecureAllowed: Boolean,
     ): NetworkResult<StorytellerPosition?> = withContext(dispatchers.io) {
-        val http = if (insecureAllowed) client.trustAllCerts() else client
+        val http = if (insecureAllowed) client.withInsecureTls() else client
         val request = Request.Builder()
             .url("$baseUrl/api/v2/books/$bookId/positions")
             .addHeader("Authorization", "Bearer $token")
@@ -88,7 +84,7 @@ class StorytellerPositionApiImpl(
         token: String,
         insecureAllowed: Boolean,
     ): NetworkResult<Unit> = withContext(dispatchers.io) {
-        val http = if (insecureAllowed) client.trustAllCerts() else client
+        val http = if (insecureAllowed) client.withInsecureTls() else client
         val payload = buildJsonObject {
             put("locator", json.parseToJsonElement(locatorJson))
             put("timestamp", JsonPrimitive(timestampMillis))
@@ -108,13 +104,4 @@ class StorytellerPositionApiImpl(
         }
     }
 
-    private fun OkHttpClient.trustAllCerts(): OkHttpClient {
-        val trustAll = object : X509TrustManager {
-            override fun checkClientTrusted(chain: Array<out X509Certificate>, authType: String) = Unit
-            override fun checkServerTrusted(chain: Array<out X509Certificate>, authType: String) = Unit
-            override fun getAcceptedIssuers(): Array<X509Certificate> = emptyArray()
-        }
-        val sslContext = SSLContext.getInstance("TLS").apply { init(null, arrayOf(trustAll), SecureRandom()) }
-        return newBuilder().sslSocketFactory(sslContext.socketFactory, trustAll).build()
-    }
 }

--- a/core/network/src/test/kotlin/com/riffle/core/network/InsecureTlsTest.kt
+++ b/core/network/src/test/kotlin/com/riffle/core/network/InsecureTlsTest.kt
@@ -1,0 +1,100 @@
+package com.riffle.core.network
+
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import okhttp3.tls.HandshakeCertificates
+import okhttp3.tls.HeldCertificate
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotSame
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Before
+import org.junit.Test
+import javax.net.ssl.SSLException
+
+private fun Throwable.hasSslCause(): Boolean {
+    val seen = mutableSetOf<Throwable>()
+    val stack = ArrayDeque<Throwable>().apply { add(this@hasSslCause) }
+    while (stack.isNotEmpty()) {
+        val e = stack.removeFirst()
+        if (!seen.add(e)) continue
+        if (e is SSLException) return true
+        e.cause?.let { stack.add(it) }
+        e.suppressed.forEach { stack.add(it) }
+    }
+    return false
+}
+
+class InsecureTlsTest {
+
+    private lateinit var server: MockWebServer
+
+    @Before
+    fun setUp() {
+        // Self-signed server cert bound to `localhost` — a plain client rejects it, a
+        // `withInsecureTls()` client accepts it.
+        val heldCertificate = HeldCertificate.Builder()
+            .addSubjectAlternativeName("localhost")
+            .build()
+        val serverCerts = HandshakeCertificates.Builder()
+            .heldCertificate(heldCertificate)
+            .build()
+        server = MockWebServer().apply {
+            useHttps(serverCerts.sslSocketFactory(), false)
+            enqueue(MockResponse().setResponseCode(200).setBody("ok"))
+            enqueue(MockResponse().setResponseCode(200).setBody("ok"))
+            start()
+        }
+    }
+
+    @After
+    fun tearDown() {
+        server.shutdown()
+    }
+
+    @Test
+    fun `default client rejects self-signed cert`() {
+        val client = OkHttpClient()
+        try {
+            client.newCall(Request.Builder().url(server.url("/")).build()).execute().close()
+            fail("expected SSL failure against self-signed cert")
+        } catch (e: Exception) {
+            // OkHttp's fast-fallback wraps the SSL failure as a ConnectException with the real
+            // handshake failure as a suppressed cause; either surface is acceptable proof that
+            // the plain client refuses the self-signed chain.
+            assertTrue(
+                "expected SSL cause, got ${e.stackTraceToString()}",
+                e.hasSslCause(),
+            )
+        }
+    }
+
+    @Test
+    fun `withInsecureTls client accepts self-signed cert`() {
+        val client = OkHttpClient().withInsecureTls()
+        client.newCall(Request.Builder().url(server.url("/")).build()).execute().use { response ->
+            assertEquals(200, response.code)
+            assertEquals("ok", response.body?.string())
+        }
+    }
+
+    @Test
+    fun `withInsecureTls returns a new client without mutating the source`() {
+        val base = OkHttpClient()
+        val insecure = base.withInsecureTls()
+        assertNotSame(base, insecure)
+        assertNotSame(base.sslSocketFactory, insecure.sslSocketFactory)
+        // Base client still rejects — proves the original is untouched.
+        try {
+            base.newCall(Request.Builder().url(server.url("/")).build()).execute().close()
+            fail("base client should still reject self-signed cert")
+        } catch (e: Exception) {
+            assertTrue("expected SSL cause, got ${e.stackTraceToString()}", e.hasSslCause())
+        }
+        // Trust manager returns no accepted issuers — Riffle's homelab-friendly semantics.
+        assertTrue(insecure.x509TrustManager?.acceptedIssuers?.isEmpty() == true)
+    }
+}

--- a/docs/superpowers/specs/2026-07-01-shared-insecure-tls-helper-design.md
+++ b/docs/superpowers/specs/2026-07-01-shared-insecure-tls-helper-design.md
@@ -1,0 +1,94 @@
+# Consolidate `trustAllCerts` into a shared TLS helper
+
+Closes #379 (partial — see "Scope" below).
+
+## Problem
+
+`OkHttpClient.trustAllCerts()` is copy-pasted verbatim in **five** network files under `core/network`:
+
+| File | Callsite line(s) |
+| --- | --- |
+| `AbsApiClient.kt` | 615, 626 |
+| `StorytellerApiClient.kt` | 134, 145 |
+| `StorytellerPositionApi.kt` | 56, 91, 111 |
+| `StorytellerBundleApi.kt` | 87, 121, 141 |
+| `AudiobookBundleApi.kt` | 58, 92 |
+
+Each copy is the same ~13-line `X509TrustManager` + `SSLContext("TLS")` boilerplate. Changing cert policy (e.g. to allow-list a CA) requires editing five files in parallel. DIP + OCP concern.
+
+## Why the issue's other recommendations do not ship in this PR
+
+The issue proposed three deepenings; only the SSL consolidation survives scrutiny:
+
+1. **Collapse `AbsApi*` interfaces into one narrow public interface.** — The five interfaces (`AbsApi`, `AbsLibraryApi`, `AbsSessionApi`, `AbsServerInfoApi`, `AbsPlaybackApi`, `AbsBookmarkApi`) are already used *narrowly* by every consumer (see `AudiobookRepositoryImplTest.kt`, `ServerRepositoryTest.kt`, `LibraryRepositoryTest.kt`, etc. — repositories depend on the narrow surface, not on `AbsApiClient`). This is the ISP-correct shape already; collapsing would be a regression.
+2. **Extract `ServerHttpClientFactory` and inject via DI.** — YAGNI. The insecure-TLS wrap is the only shared concern; timeouts/interceptors are per-client and diverge (bundle client has zero read timeout, sidecar has a bounded call timeout). A single extension function is the seam.
+3. **Extract `ServerAuthenticator` interface.** — YAGNI. Two call-sites (ABS JSON+POST /login, Storyteller multipart + different error-code mapping); no third planned. Introducing an interface for two shape-different implementations adds indirection without leverage.
+
+## Design
+
+### New file
+
+`core/network/src/main/kotlin/com/riffle/core/network/InsecureTls.kt`:
+
+```kotlin
+package com.riffle.core.network
+
+import okhttp3.OkHttpClient
+import java.security.SecureRandom
+import java.security.cert.X509Certificate
+import javax.net.ssl.SSLContext
+import javax.net.ssl.X509TrustManager
+
+/**
+ * Returns a copy of this client that accepts self-signed / untrusted TLS certificates.
+ * Riffle exposes this per-server via the `insecureAllowed` flag (self-hosted homelab servers
+ * often serve behind self-signed certs).
+ */
+internal fun OkHttpClient.withInsecureTls(): OkHttpClient {
+    val trustAll = object : X509TrustManager {
+        override fun checkClientTrusted(chain: Array<out X509Certificate>, authType: String) = Unit
+        override fun checkServerTrusted(chain: Array<out X509Certificate>, authType: String) = Unit
+        override fun getAcceptedIssuers(): Array<X509Certificate> = emptyArray()
+    }
+    val sslContext = SSLContext.getInstance("TLS").apply {
+        init(null, arrayOf(trustAll), SecureRandom())
+    }
+    return newBuilder()
+        .sslSocketFactory(sslContext.socketFactory, trustAll)
+        .build()
+}
+```
+
+### Callsite migration
+
+At each of the five files:
+
+- Delete the `private fun OkHttpClient.trustAllCerts()` body (~13 lines each).
+- Delete the now-unused `SecureRandom`, `X509Certificate`, `SSLContext`, `X509TrustManager` imports.
+- Rename `client.trustAllCerts()` → `client.withInsecureTls()`.
+
+Naming: `withInsecureTls` reads more accurately than `trustAllCerts` at the callsite (the boolean flag is already named `insecureAllowed`), and the site remains conditional (`if (insecureAllowed) client.withInsecureTls() else client`).
+
+### Test
+
+`core/network/src/test/kotlin/com/riffle/core/network/InsecureTlsTest.kt`:
+
+- Spin up an OkHttp `MockWebServer` with a self-signed TLS cert.
+- Verify a plain `OkHttpClient` fails against it (control).
+- Verify `.withInsecureTls()` succeeds.
+- Verify the original client is unchanged (functional call, returns a new client).
+
+If MockWebServer TLS setup is too heavy for one test, fall back to asserting the returned client's `sslSocketFactory` differs and that its wrapped `X509TrustManager` accepts a self-signed chain.
+
+## Non-goals
+
+- No behavior change. Every callsite receives an equivalent client.
+- No public-API change on `AbsApiClient`, `StorytellerApiClient`, or any `AbsApi*` interface.
+- No change to DI wiring (`NetworkModule`) — none of the shared client is a bean; the extension is invoked lazily inside each client class exactly as before.
+- No dev-server / AVD verification required — pure JVM refactor with a JVM unit test.
+
+## Verification
+
+- `./gradlew :core:network:test` green.
+- `./gradlew test` green across affected modules (network, data).
+- Grep confirms zero occurrences of `trustAllCerts` and `X509TrustManager` outside `InsecureTls.kt` after the change.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -54,6 +54,7 @@ androidx-datastore-preferences = { group = "androidx.datastore", name = "datasto
 androidx-work-runtime-ktx = { group = "androidx.work", name = "work-runtime-ktx", version.ref = "workmanager" }
 okhttp = { group = "com.squareup.okhttp3", name = "okhttp", version.ref = "okhttp" }
 okhttp-mockwebserver = { group = "com.squareup.okhttp3", name = "mockwebserver", version.ref = "okhttp" }
+okhttp-tls = { group = "com.squareup.okhttp3", name = "okhttp-tls", version.ref = "okhttp" }
 androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigation" }
 hilt-navigation-compose = { group = "androidx.hilt", name = "hilt-navigation-compose", version.ref = "hiltNavigation" }
 androidx-lifecycle-viewmodel-compose = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "lifecycleRuntimeKtx" }


### PR DESCRIPTION
Closes #379 (partial — see Skipped-with-rationale below).

## Summary

- Extracts the copy-pasted `OkHttpClient.trustAllCerts()` from five network files into a single `OkHttpClient.withInsecureTls()` extension in `core/network/…/InsecureTls.kt`.
- Migrated call-sites: `AbsApiClient`, `StorytellerApiClient`, `StorytellerPositionApi`, `StorytellerBundleApi`, `AudiobookBundleApi`. Cert policy now lives in one place.
- Net: ~80 duplicated lines removed. No behavior change, no public API change, no DI wiring change.

## Skipped (with rationale)

The issue additionally proposed:

1. **Collapse the five `AbsApi*` interfaces into one narrow public surface.** — Every consumer (LibraryRepository, AudiobookRepository, ServerRepository, their tests) already depends on the narrow interface, not on `AbsApiClient`. This is the ISP-correct shape today; collapsing would be a regression. Verified by grepping `core/data` + `app` for `AbsLibraryApi | AbsSessionApi | AbsServerInfoApi | AbsPlaybackApi | AbsBookmarkApi` — the narrow types are the actual dependencies.
2. **Extract a `ServerHttpClientFactory` and inject via DI.** — YAGNI. Insecure-TLS wrap is the only shared concern; timeouts/interceptors are per-client and diverge (bundle client has zero read timeout, sidecar has a bounded call timeout).
3. **Extract a `ServerAuthenticator` interface.** — YAGNI. Two shape-different call-sites (ABS JSON+POST /login vs. Storyteller multipart with different error-code mapping), no third planned.

Full design context in `docs/superpowers/specs/2026-07-01-shared-insecure-tls-helper-design.md`.

## Test plan

- [x] `./gradlew :core:network:test` green — includes the new `InsecureTlsTest` (MockWebServer + `okhttp-tls` `HeldCertificate` — a plain client rejects the self-signed chain, `withInsecureTls()` accepts it, source client stays untouched).
- [x] `./gradlew :core:data:test` green — repositories that talk to the network via these clients continue to pass.
- [x] `./gradlew test` green.
- [x] Grep confirms `trustAllCerts` / `X509TrustManager` no longer appear anywhere in `core/network/src/main` outside `InsecureTls.kt`.
- Pure JVM refactor with no Readium/WebView/device-layer touch — AVD verification not required.