### PR TITLE
fix(annotations): preserve spineIndex/progression across sync round-trip

### DIFF
--- a/core/data/src/main/kotlin/com/riffle/core/data/AnnotationMergeOrchestrator.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/AnnotationMergeOrchestrator.kt
@@ -114,13 +114,15 @@ internal class AnnotationMergeOrchestrator(
                     textBefore = w3cAnnotation.textBefore,
                     textAfter = w3cAnnotation.textAfter,
                     chapterHref = w3cAnnotation.chapterHref,
-                    // W3C JSON doesn't persist spineIndex/progression. When the row already exists
-                    // locally, keep the values that were stored at creation time — the CFI hasn't
-                    // moved, so the position sort key is still correct. Overwriting with (0, 0.0)
-                    // on every sync round-trip collapses every annotation to the same sort key and
-                    // reshuffles the panel shortly after a bookmark is added.
-                    spineIndex = existing?.spineIndex ?: 0,
-                    progression = existing?.progression ?: 0.0,
+                    // Sort-key round-trip: prefer the locally-stored values when we already have a
+                    // row (the CFI hasn't moved, so the sort key computed at creation time is still
+                    // correct). Otherwise trust the peer's riffle:spineIndex / riffle:progression
+                    // extension so cross-device bookmarks land in reading order on first receive.
+                    // Files predating the extension deserialize as 0/0.0 — those brand-new peer
+                    // rows will cluster at the top until re-opened locally, which is the same
+                    // pre-extension behavior.
+                    spineIndex = existing?.spineIndex ?: w3cAnnotation.spineIndex,
+                    progression = existing?.progression ?: w3cAnnotation.progression,
                     bookmarkTitle = w3cAnnotation.bookmarkTitle ?: "",
                     createdAt = w3cAnnotation.createdAt,
                     updatedAt = w3cAnnotation.updatedAt,

--- a/core/data/src/main/kotlin/com/riffle/core/data/AnnotationMergeOrchestrator.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/AnnotationMergeOrchestrator.kt
@@ -114,8 +114,13 @@ internal class AnnotationMergeOrchestrator(
                     textBefore = w3cAnnotation.textBefore,
                     textAfter = w3cAnnotation.textAfter,
                     chapterHref = w3cAnnotation.chapterHref,
-                    spineIndex = 0,
-                    progression = 0.0,
+                    // W3C JSON doesn't persist spineIndex/progression. When the row already exists
+                    // locally, keep the values that were stored at creation time — the CFI hasn't
+                    // moved, so the position sort key is still correct. Overwriting with (0, 0.0)
+                    // on every sync round-trip collapses every annotation to the same sort key and
+                    // reshuffles the panel shortly after a bookmark is added.
+                    spineIndex = existing?.spineIndex ?: 0,
+                    progression = existing?.progression ?: 0.0,
                     bookmarkTitle = w3cAnnotation.bookmarkTitle ?: "",
                     createdAt = w3cAnnotation.createdAt,
                     updatedAt = w3cAnnotation.updatedAt,

--- a/core/data/src/main/kotlin/com/riffle/core/data/AnnotationW3CCodec.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/AnnotationW3CCodec.kt
@@ -10,6 +10,7 @@ import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.add
+import kotlinx.serialization.json.doubleOrNull
 import kotlinx.serialization.json.intOrNull
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
@@ -164,6 +165,11 @@ object AnnotationW3CCodec {
             put("riffle:lastModifiedByDeviceId", entity.lastModifiedByDeviceId)
             put("riffle:updatedAt", entity.updatedAt)
             put("riffle:deleted", entity.deleted)
+            // Sort-key extension (see W3CAnnotation kdoc): keep the annotations panel in reading
+            // order after a WebDAV round-trip. Derivable from the CFI but the merge orchestrator
+            // is spine-agnostic, so we carry them explicitly.
+            put("riffle:spineIndex", JsonPrimitive(entity.spineIndex))
+            put("riffle:progression", JsonPrimitive(entity.progression))
             if (entity.type == AnnotationEntity.TYPE_BOOKMARK && entity.bookmarkTitle.isNotEmpty()) {
                 put("riffle:bookmarkTitle", entity.bookmarkTitle)
             }
@@ -201,6 +207,8 @@ object AnnotationW3CCodec {
         updatedAt = entity.updatedAt,
         createdAt = entity.createdAt,
         deleted = entity.deleted,
+        spineIndex = entity.spineIndex,
+        progression = entity.progression,
     )
 
     /**
@@ -319,6 +327,11 @@ object AnnotationW3CCodec {
             val originDeviceId = root["riffle:originDeviceId"]?.jsonPrimitive?.content ?: ""
             val lastModifiedByDeviceId = root["riffle:lastModifiedByDeviceId"]?.jsonPrimitive?.content ?: ""
             val deleted = root["riffle:deleted"]?.jsonPrimitive?.content?.toBoolean() ?: false
+            // Sort-key extension. Absent on files written before the extension existed — the
+            // merge orchestrator falls back to any locally-known values (else 0/0.0) in that
+            // case, so old files sort at the top on first receive.
+            val spineIndex = root["riffle:spineIndex"]?.jsonPrimitive?.intOrNull ?: 0
+            val progression = root["riffle:progression"]?.jsonPrimitive?.doubleOrNull ?: 0.0
 
             // Use riffle:bookmarkTitle if available, otherwise from body
             val finalBookmarkTitle = root["riffle:bookmarkTitle"]?.jsonPrimitive?.content ?: (bookmarkTitle ?: "")
@@ -339,6 +352,8 @@ object AnnotationW3CCodec {
                 updatedAt = updatedAt,
                 createdAt = createdAt,
                 deleted = deleted,
+                spineIndex = spineIndex,
+                progression = progression,
             )
         } catch (_: Exception) {
             return emptyAnnotation()

--- a/core/data/src/test/kotlin/com/riffle/core/data/AnnotationSyncControllerLifecycleTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/AnnotationSyncControllerLifecycleTest.kt
@@ -761,6 +761,28 @@ class AnnotationSyncControllerLifecycleTest {
         assertEquals("local wins — lastSyncedAt must be preserved", 500L, upserted.lastSyncedAt)
     }
 
+    // ===== Fix 2: syncOnOpen preserves spineIndex/progression on existing rows =====
+
+    @Test
+    fun `syncOnOpen preserves spineIndex and progression on existing rows`() = runTest {
+        // Seed Room with a bookmark whose sort key is (spineIndex=5, progression=0.3).
+        val local = highlightEntity("uuid-bookmark", updatedAt = 1000L)
+            .copy(spineIndex = 5, progression = 0.3)
+        dao.localAnnotations += local
+
+        // Own-device file is on WebDAV (round-tripped): the W3C JSON does NOT carry
+        // spineIndex/progression, so the parsed peer row will lack them.
+        target.files["annotations-own.jsonld"] = jsonArrayOf(
+            w3c("uuid-bookmark", updatedAt = 1000L, deviceId = DEVICE_ID),
+        )
+
+        newController().syncOnOpen(SRV, NS, ITEM)
+
+        val upserted = dao.upserts.single { it.id == "uuid-bookmark" }
+        assertEquals("spineIndex must survive the sync round-trip", 5, upserted.spineIndex)
+        assertEquals("progression must survive the sync round-trip", 0.3, upserted.progression, 0.0)
+    }
+
     // ===== stamp + report + enqueue-on-failure =====
 
     @Test

--- a/core/data/src/test/kotlin/com/riffle/core/data/AnnotationSyncControllerLifecycleTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/AnnotationSyncControllerLifecycleTest.kt
@@ -692,6 +692,8 @@ class AnnotationSyncControllerLifecycleTest {
         updatedAt: Long,
         deviceId: String,
         color: String = "yellow",
+        spineIndex: Int = 0,
+        progression: Double = 0.0,
     ): String = AnnotationW3CCodec.annotationEntityToW3C(
         AnnotationEntity(
             id = id,
@@ -709,6 +711,8 @@ class AnnotationSyncControllerLifecycleTest {
             updatedAt = updatedAt,
             originDeviceId = deviceId,
             lastModifiedByDeviceId = deviceId,
+            spineIndex = spineIndex,
+            progression = progression,
         ),
     )
 
@@ -770,8 +774,10 @@ class AnnotationSyncControllerLifecycleTest {
             .copy(spineIndex = 5, progression = 0.3)
         dao.localAnnotations += local
 
-        // Own-device file is on WebDAV (round-tripped): the W3C JSON does NOT carry
-        // spineIndex/progression, so the parsed peer row will lack them.
+        // Simulate a peer file that omits the sort-key extension (e.g. written before the extension
+        // existed, or by a device that didn't know the values): the parsed W3CAnnotation surfaces
+        // (0, 0.0). Local values must still win because the CFI — and therefore the sort key —
+        // hasn't moved.
         target.files["annotations-own.jsonld"] = jsonArrayOf(
             w3c("uuid-bookmark", updatedAt = 1000L, deviceId = DEVICE_ID),
         )
@@ -781,6 +787,28 @@ class AnnotationSyncControllerLifecycleTest {
         val upserted = dao.upserts.single { it.id == "uuid-bookmark" }
         assertEquals("spineIndex must survive the sync round-trip", 5, upserted.spineIndex)
         assertEquals("progression must survive the sync round-trip", 0.3, upserted.progression, 0.0)
+    }
+
+    @Test
+    fun `syncOnOpen adopts peer spineIndex and progression for new cross-device annotations`() = runTest {
+        // No local row for this id — the annotation was created on another device. The peer file
+        // carries the sort-key extension (riffle:spineIndex / riffle:progression) so the row lands
+        // in the correct reading-order slot on first receive.
+        target.files["annotations-peer.jsonld"] = jsonArrayOf(
+            w3c(
+                id = "uuid-peer-bookmark",
+                updatedAt = 2000L,
+                deviceId = "peer-device",
+                spineIndex = 7,
+                progression = 0.42,
+            ),
+        )
+
+        newController().syncOnOpen(SRV, NS, ITEM)
+
+        val upserted = dao.upserts.single { it.id == "uuid-peer-bookmark" }
+        assertEquals("cross-device: adopt peer spineIndex", 7, upserted.spineIndex)
+        assertEquals("cross-device: adopt peer progression", 0.42, upserted.progression, 0.0)
     }
 
     // ===== stamp + report + enqueue-on-failure =====

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/W3CAnnotation.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/W3CAnnotation.kt
@@ -39,4 +39,13 @@ data class W3CAnnotation(
     val createdAt: Long,
     /** Tombstone flag; true if this annotation has been deleted. */
     val deleted: Boolean = false,
+    /** Zero-based spine position of the containing chapter — cross-chapter sort key for the panel.
+     *  Derivable from [cfi] but not part of the W3C spec, so it rides along as a Riffle extension
+     *  to keep the sort order stable across a WebDAV round-trip (see ADR 0038 / AnnotationDao
+     *  observeAnnotationsByPosition). Defaults to 0 for backward-compat with files written before
+     *  the extension existed. */
+    val spineIndex: Int = 0,
+    /** Within-chapter fractional offset (0.0–1.0) — secondary sort key. Same round-trip rationale
+     *  as [spineIndex]. Defaults to 0.0 for backward-compat. */
+    val progression: Double = 0.0,
 )


### PR DESCRIPTION
## Summary

- Reader annotations panel appeared to reshuffle shortly after adding a bookmark (and again after switching reading modes / resuming). Root cause: the WebDAV sync-merge upsert in `AnnotationMergeOrchestrator` hardcoded `spineIndex = 0, progression = 0.0` on every row it wrote, because the W3C JSON on disk didn't carry those columns.
- The panel orders by `spineIndex ASC, progression ASC`, so every synced annotation collapsed to the same sort key and Room fell back to rowid order — hence the "new bookmark shows at the bottom, then jumps" behaviour.

## Fix

Two commits, two halves of the same round-trip:

1. **Local round-trip (`886b830`)** — when the merged row already exists locally, reuse the existing local `spineIndex`/`progression`. The CFI hasn't moved, so the sort key is still correct.
2. **Cross-device round-trip (`60f6fae`)** — carry `riffle:spineIndex` / `riffle:progression` as W3C JSON extensions so peer-created annotations land in the correct reading-order slot on first receive, instead of clustering at `(0, 0.0)`. The picking rule becomes: prefer `existing` (local knowledge is authoritative for the anchor, which is immutable per id), fall back to the peer's extension. Files written before the extension existed deserialize as `0/0.0` and behave as before.

Content fields (`bookmarkTitle`, `color`, `note`, `deleted`, timestamps) continue to take the LWW winner from `mergeService.merge()`. The asymmetry is intentional: mutable content → merge winner; anchor-derived immutables → local existing.

## Test plan

- [x] `AnnotationSyncControllerLifecycleTest.syncOnOpen preserves spineIndex and progression on existing rows` — seeds a bookmark at `(5, 0.3)`, round-trips it through a W3C file missing the extension, asserts local values survive.
- [x] `AnnotationSyncControllerLifecycleTest.syncOnOpen adopts peer spineIndex and progression for new cross-device annotations` — peer file carries `(7, 0.42)` for an id we've never seen, asserts we adopt those values.
- [x] `:core:data:test` and `:core:domain:test` green.
- [ ] Manual: add a bookmark on the connected device, watch the panel — it should stay in position (spine order) both immediately and after the debounced sync fires.