### PR TITLE
refactor(reader): tighten ContinuousReaderView seams (sinks + binder + decoration controller)

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ChapterWebView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ChapterWebView.kt
@@ -131,6 +131,15 @@ internal class ChapterWebView(context: Context) : WebView(context), ChapterWebVi
     override var chapterHref: String = ""
         private set
 
+    /**
+     * Explicit override to disambiguate [ChapterWebViewLike.evaluateJavascript]'s Kotlin-lambda
+     * signature from [WebView]'s own `evaluateJavascript(String, ValueCallback<String>?)` — without
+     * this, every in-class call site becomes an overload-resolution-ambiguity compile error.
+     */
+    override fun evaluateJavascript(script: String, resultCallback: ((String?) -> Unit)?) {
+        super.evaluateJavascript(script, resultCallback)
+    }
+
     private var publication: Publication? = null
 
     /**
@@ -304,14 +313,14 @@ internal class ChapterWebView(context: Context) : WebView(context), ChapterWebVi
      * @param styleJs output of [ContinuousStyleInjector.buildStyleInjectionJs]
      */
     fun injectStylesAndMeasure(styleJs: String) {
-        evaluateJavascript(styleJs, null)
+        evaluateJavascript(styleJs, null as ((String?) -> Unit)?)
         // Stamp this page with the current load token BEFORE wiring measurement, so every height
         // report (including late ResizeObserver / timeout fires) carries it and the bridge can
         // reject reports from a recycled WebView's previous page.
-        evaluateJavascript("window.__riffleToken=$loadToken;", null)
-        evaluateJavascript(ContinuousScriptInjector.HEIGHT_MEASUREMENT_JS, null)
-        evaluateJavascript(ContinuousScriptInjector.TAP_LISTENER_JS, null)
-        evaluateJavascript(ContinuousScriptInjector.FOOTNOTE_LISTENER_JS, null)
+        evaluateJavascript("window.__riffleToken=$loadToken;", null as ((String?) -> Unit)?)
+        evaluateJavascript(ContinuousScriptInjector.HEIGHT_MEASUREMENT_JS, null as ((String?) -> Unit)?)
+        evaluateJavascript(ContinuousScriptInjector.TAP_LISTENER_JS, null as ((String?) -> Unit)?)
+        evaluateJavascript(ContinuousScriptInjector.FOOTNOTE_LISTENER_JS, null as ((String?) -> Unit)?)
     }
 
     /** Re-inject user styles and re-measure after a preference change. */
@@ -469,7 +478,7 @@ internal class ChapterWebView(context: Context) : WebView(context), ChapterWebVi
         evaluateJavascript("(window.getSelection ? window.getSelection().toString() : '')") { raw ->
             val text = decodeJsString(raw)
             if (text.isNotBlank()) block(text)
-            evaluateJavascript("window.getSelection && window.getSelection().removeAllRanges()", null)
+            evaluateJavascript("window.getSelection && window.getSelection().removeAllRanges()", null as ((String?) -> Unit)?)
         }
     }
 
@@ -547,7 +556,7 @@ internal class ChapterWebView(context: Context) : WebView(context), ChapterWebVi
                 return@evaluateJavascript
             }
             if (text.isNotBlank()) block(text, prog, rect, before, after)
-            evaluateJavascript("window.getSelection && window.getSelection().removeAllRanges()", null)
+            evaluateJavascript("window.getSelection && window.getSelection().removeAllRanges()", null as ((String?) -> Unit)?)
         }
     }
 

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ChapterWebView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ChapterWebView.kt
@@ -140,6 +140,12 @@ internal class ChapterWebView(context: Context) : WebView(context), ChapterWebVi
         super.evaluateJavascript(script, resultCallback)
     }
 
+    /** Fire-and-forget JS eval. Centralises the Kotlin-lambda-overload disambiguation cast so
+     *  in-class callers read as a plain call instead of repeating `null as ((String?) -> Unit)?`. */
+    private fun evalJs(script: String) {
+        evaluateJavascript(script, null as ((String?) -> Unit)?)
+    }
+
     private var publication: Publication? = null
 
     /**
@@ -313,14 +319,14 @@ internal class ChapterWebView(context: Context) : WebView(context), ChapterWebVi
      * @param styleJs output of [ContinuousStyleInjector.buildStyleInjectionJs]
      */
     fun injectStylesAndMeasure(styleJs: String) {
-        evaluateJavascript(styleJs, null as ((String?) -> Unit)?)
+        evalJs(styleJs)
         // Stamp this page with the current load token BEFORE wiring measurement, so every height
         // report (including late ResizeObserver / timeout fires) carries it and the bridge can
         // reject reports from a recycled WebView's previous page.
-        evaluateJavascript("window.__riffleToken=$loadToken;", null as ((String?) -> Unit)?)
-        evaluateJavascript(ContinuousScriptInjector.HEIGHT_MEASUREMENT_JS, null as ((String?) -> Unit)?)
-        evaluateJavascript(ContinuousScriptInjector.TAP_LISTENER_JS, null as ((String?) -> Unit)?)
-        evaluateJavascript(ContinuousScriptInjector.FOOTNOTE_LISTENER_JS, null as ((String?) -> Unit)?)
+        evalJs("window.__riffleToken=$loadToken;")
+        evalJs(ContinuousScriptInjector.HEIGHT_MEASUREMENT_JS)
+        evalJs(ContinuousScriptInjector.TAP_LISTENER_JS)
+        evalJs(ContinuousScriptInjector.FOOTNOTE_LISTENER_JS)
     }
 
     /** Re-inject user styles and re-measure after a preference change. */
@@ -478,7 +484,7 @@ internal class ChapterWebView(context: Context) : WebView(context), ChapterWebVi
         evaluateJavascript("(window.getSelection ? window.getSelection().toString() : '')") { raw ->
             val text = decodeJsString(raw)
             if (text.isNotBlank()) block(text)
-            evaluateJavascript("window.getSelection && window.getSelection().removeAllRanges()", null as ((String?) -> Unit)?)
+            evalJs("window.getSelection && window.getSelection().removeAllRanges()")
         }
     }
 
@@ -556,7 +562,7 @@ internal class ChapterWebView(context: Context) : WebView(context), ChapterWebVi
                 return@evaluateJavascript
             }
             if (text.isNotBlank()) block(text, prog, rect, before, after)
-            evaluateJavascript("window.getSelection && window.getSelection().removeAllRanges()", null as ((String?) -> Unit)?)
+            evalJs("window.getSelection && window.getSelection().removeAllRanges()")
         }
     }
 

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ChapterWebView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ChapterWebView.kt
@@ -23,7 +23,7 @@ import org.readium.r2.shared.util.Url
  * the main thread after [ContinuousScriptInjector.HEIGHT_MEASUREMENT_JS] fires.
  */
 @SuppressLint("SetJavaScriptEnabled")
-internal class ChapterWebView(context: Context) : WebView(context) {
+internal class ChapterWebView(context: Context) : WebView(context), ChapterWebViewLike {
 
     private companion object {
         // Text-selection menu item ids (see wrapSelectionCallback).
@@ -45,7 +45,7 @@ internal class ChapterWebView(context: Context) : WebView(context) {
      * Wire this to the reader's chrome toggle so taps in Continuous mode show/hide the
      * top/bottom bars, matching the behaviour of the standard Readium navigator.
      */
-    var onTap: (() -> Unit)? = null
+    override var onTap: (() -> Unit)? = null
 
     /**
      * Called on the main thread when this WebView's renderer process is gone (reclaimed by the
@@ -53,24 +53,24 @@ internal class ChapterWebView(context: Context) : WebView(context) {
      * the parent must rebuild it. If this event is not consumed the platform's default behaviour is
      * to crash the whole app.
      */
-    var onRenderGone: (() -> Unit)? = null
+    override var onRenderGone: (() -> Unit)? = null
 
     /**
      * Called on the main thread when the user taps an in-book link (footnote / cross-reference).
      * [href] is the target EPUB resource path with any `#fragment`. The WebView does NOT follow the
      * link itself (that would replace this chapter's content); the parent navigates instead.
      */
-    var onInternalLink: ((href: String) -> Unit)? = null
+    override var onInternalLink: ((href: String) -> Unit)? = null
 
     /** Called on the main thread when the user taps an external (http/https) link. */
-    var onExternalLink: ((url: String) -> Unit)? = null
+    override var onExternalLink: ((url: String) -> Unit)? = null
 
     /**
      * Called on the main thread with the resolved footnote body when the user taps a same-document
      * footnote anchor. The host shows the footnote popup. Continuous mode resolves the note from the
      * chapter's own HTML (see [rawChapterHtml]) using [FootnoteResolver].
      */
-    var onFootnoteContent: ((FootnoteContent) -> Unit)? = null
+    override var onFootnoteContent: ((FootnoteContent) -> Unit)? = null
 
     /**
      * The raw HTML of the chapter document currently loaded, retained so a footnote tap can resolve
@@ -93,10 +93,10 @@ internal class ChapterWebView(context: Context) : WebView(context) {
      * `onInterceptTouchEvent`) steals the gesture the moment the user drags vertically, scrolling
      * the page mid-selection and breaking the highlight.
      */
-    var onSelectionActiveChanged: ((active: Boolean) -> Unit)? = null
+    override var onSelectionActiveChanged: ((active: Boolean) -> Unit)? = null
 
     /** When true, the text-selection menu offers "Highlight" (books with annotations UI). */
-    var annotationsAvailable: Boolean = false
+    override var annotationsAvailable: Boolean = false
 
     /**
      * Called on the main thread with the selected text, its within-chapter progression (0..1),
@@ -104,22 +104,22 @@ internal class ChapterWebView(context: Context) : WebView(context) {
      * `before` / `after` document-text context windows used to disambiguate which occurrence
      * the user picked when the selected text repeats in the chapter.
      */
-    var onHighlight: ((selectedText: String, progression: Double, rect: android.graphics.Rect, before: String, after: String) -> Unit)? = null
+    override var onHighlight: ((selectedText: String, progression: Double, rect: android.graphics.Rect, before: String, after: String) -> Unit)? = null
 
     /**
      * Called on the main thread when the user taps an injected annotation mark (`<mark
      * data-riffle-ann>`). [rect] is in device pixels relative to this WebView's top-left corner.
      */
-    var onAnnotationTap: ((id: String, rect: android.graphics.Rect) -> Unit)? = null
+    override var onAnnotationTap: ((id: String, rect: android.graphics.Rect) -> Unit)? = null
 
     /**
      * Called on the main thread when the user taps the note glyph (`<span data-riffle-note-glyph>`)
      * next to an annotation that has a note. [rect] is in device pixels relative to this WebView.
      */
-    var onAnnotationNoteTap: ((id: String, rect: android.graphics.Rect) -> Unit)? = null
+    override var onAnnotationNoteTap: ((id: String, rect: android.graphics.Rect) -> Unit)? = null
 
     /** When true, the text-selection menu offers "Play" (readaloud books only). */
-    var readaloudAvailable: Boolean = false
+    override var readaloudAvailable: Boolean = false
 
     /**
      * Called on the main thread when the user taps "Play". Receives the selected text and this
@@ -128,7 +128,7 @@ internal class ChapterWebView(context: Context) : WebView(context) {
     var onPlayFromHere: ((selectedText: String, evalJs: (String, (String?) -> Unit) -> Unit) -> Unit)? = null
 
     /** The chapter href this view is currently loading (e.g. `"EPUB/chapter01.xhtml"`). */
-    var chapterHref: String = ""
+    override var chapterHref: String = ""
         private set
 
     private var publication: Publication? = null

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ChapterWebViewBinder.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ChapterWebViewBinder.kt
@@ -1,0 +1,92 @@
+package com.riffle.app.feature.reader
+
+import android.graphics.Rect
+import androidx.compose.ui.unit.IntRect
+import org.json.JSONObject
+import org.readium.r2.shared.publication.Locator
+
+/**
+ * The subset of [ChapterWebView]'s callback surface that [ChapterWebViewBinder] wires. Extracted
+ * as an interface (rather than operating on [ChapterWebView] directly) so tests can drive the
+ * binder against a hand-written fake instead of spinning up a live [android.webkit.WebView].
+ */
+internal interface ChapterWebViewLike {
+    val chapterHref: String
+    var onTap: (() -> Unit)?
+    var onRenderGone: (() -> Unit)?
+    var onInternalLink: ((String) -> Unit)?
+    var onExternalLink: ((String) -> Unit)?
+    var annotationsAvailable: Boolean
+    var readaloudAvailable: Boolean
+    var onSelectionActiveChanged: ((Boolean) -> Unit)?
+    var onHighlight: ((String, Double, Rect, String, String) -> Unit)?
+    var onAnnotationTap: ((String, Rect) -> Unit)?
+    var onAnnotationNoteTap: ((String, Rect) -> Unit)?
+    var onFootnoteContent: ((FootnoteContent) -> Unit)?
+}
+
+/**
+ * Wires every event callback on a [ChapterWebViewLike] to the three sink interfaces, folding the
+ * screen-coordinate transform for tap rects, the render-recovery hook, and the selection-active
+ * counter update into one place.
+ *
+ * Introduced to dedup the identical wire-up previously inlined in
+ * [ContinuousReaderView.appendChapter] and [ContinuousReaderView.prependChapter], and to give the
+ * annotation-tap coordinate transform a JVM-testable seam that doesn't need a live WebView.
+ *
+ * Does NOT resolve `onInternalLink` itself and does NOT wire `onPlayFromHere`:
+ * - Internal-link resolution needs `publication.readingOrder` + the latest [Locator] + a
+ *   same-document navigateTo fallback — state the binder does not have. The raw href is instead
+ *   forwarded to [onInternalLink], a View-owned callback (mirrors [onRenderGone]) that the
+ *   coordinator supplies with that resolution logic.
+ * - Sentence-scoped play-from-here needs publication state
+ *   ([ContinuousReaderCoordinator]'s `sentenceQuotesProvider` / `sentenceChaptersProvider`) that
+ *   this binder does not have. [ContinuousReaderView] retains that wiring directly.
+ */
+internal class ChapterWebViewBinder(
+    private val navigation: ContinuousNavigationSink,
+    private val links: ContinuousLinkSink,
+    private val annotations: ContinuousAnnotationSink,
+    private val screenRectOf: (ChapterWebViewLike, Rect) -> Rect,
+    private val onRenderGone: () -> Unit,
+    private val onInternalLink: (href: String) -> Unit,
+    private val onSelectionActiveChanged: (Boolean) -> Unit,
+) {
+    fun bind(wv: ChapterWebViewLike, annotationsAvailable: Boolean, readaloudAvailable: Boolean) {
+        wv.onTap = { navigation.onTap() }
+        wv.onRenderGone = { onRenderGone() }
+        wv.onInternalLink = { onInternalLink(it) }
+        wv.onExternalLink = { links.onExternalLink(it) }
+        wv.annotationsAvailable = annotationsAvailable
+        wv.onSelectionActiveChanged = onSelectionActiveChanged
+        wv.onHighlight = { text, prog, rect, before, after ->
+            val screen = screenRectOf(wv, rect)
+            val locator = Locator.fromJSON(
+                JSONObject()
+                    .put("href", wv.chapterHref)
+                    .put("type", "application/xhtml+xml")
+                    .put("locations", JSONObject().put("progression", prog))
+                    .put("text", JSONObject()
+                        .put("before", before)
+                        .put("highlight", text)
+                        .put("after", after)),
+            )
+            if (locator != null) {
+                annotations.onHighlight(
+                    locator,
+                    IntRect(screen.left, screen.top, screen.right, screen.bottom),
+                )
+            }
+        }
+        wv.onAnnotationTap = { id, rect ->
+            val s = screenRectOf(wv, rect)
+            annotations.onAnnotationTap(id, IntRect(s.left, s.top, s.right, s.bottom))
+        }
+        wv.onAnnotationNoteTap = { id, rect ->
+            val s = screenRectOf(wv, rect)
+            annotations.onAnnotationNoteTap(id, IntRect(s.left, s.top, s.right, s.bottom))
+        }
+        wv.readaloudAvailable = readaloudAvailable
+        wv.onFootnoteContent = { links.onFootnote(it) }
+    }
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ChapterWebViewBinder.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ChapterWebViewBinder.kt
@@ -12,6 +12,7 @@ import org.readium.r2.shared.publication.Locator
  */
 internal interface ChapterWebViewLike {
     val chapterHref: String
+    fun evaluateJavascript(script: String, resultCallback: ((String?) -> Unit)?)
     var onTap: (() -> Unit)?
     var onRenderGone: (() -> Unit)?
     var onInternalLink: ((String) -> Unit)?

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousDecorationController.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousDecorationController.kt
@@ -1,0 +1,158 @@
+package com.riffle.app.feature.reader
+
+import kotlin.math.abs
+
+/**
+ * Owns annotation + search decoration state for continuous mode and applies it to the current
+ * sliding-window of loaded chapters.
+ *
+ * Moved out of [ContinuousReaderView] so:
+ *  - state persistence (currentAnnotationsByHref, currentSearchHighlights) is JVM-testable,
+ *  - the View no longer holds every decoration path alongside the sliding-window state machine,
+ *  - a chapter entering the window (onPageFinished) has a single re-apply entry point:
+ *    [onChapterLoaded].
+ *
+ * Readaloud highlight orchestration remains in the pre-existing [ContinuousHighlightRenderer]
+ * which owns `prevReadaloudHref`; the controller only exposes [highlightInChapter] /
+ * [clearHighlightInChapter] because they are part of the [ContinuousHighlightTarget] contract.
+ */
+internal class ContinuousDecorationController(
+    private val port: Port,
+) : ContinuousHighlightTarget {
+
+    interface Port {
+        fun forEachLoadedWebView(block: (ChapterWebViewLike) -> Unit)
+        fun findLoadedWebView(href: String): ChapterWebViewLike?
+        fun scrollTo(y: Int)
+        fun smoothScrollTo(y: Int)
+        fun clearLandingHold()
+        fun buildWindow(): List<ContinuousPositionTracker.ChapterSlot>
+        val viewportHeightPx: Int
+        val currentScrollY: Int
+    }
+
+    private var currentAnnotationsByHref: Map<String, List<AnnotationHighlight>> = emptyMap()
+    private var currentSearchHighlights: SearchHighlightsState? = null
+
+    /** Called by [ContinuousReaderView.onPageFinished] once a chapter's page has loaded so it
+     *  re-applies whatever decorations belong to it. */
+    fun onChapterLoaded(wv: ChapterWebViewLike, onAnnotationsApplied: () -> Unit = {}) {
+        val annotations = currentAnnotationsByHref[wv.chapterHref]
+        if (!annotations.isNullOrEmpty()) {
+            wv.evaluateJavascript(ContinuousStyleInjector.applyAnnotationHighlightsJs(annotations)) { _ ->
+                onAnnotationsApplied()
+            }
+        }
+        val search = currentSearchHighlights
+        if (search != null && search.resultsByHref.containsKey(wv.chapterHref)) {
+            applySearchTo(wv, search)
+        }
+    }
+
+    override fun applyAnnotationHighlights(annotationsByHref: Map<String, List<AnnotationHighlight>>) {
+        applyAnnotationHighlights(annotationsByHref, onEachApplied = {})
+    }
+
+    /**
+     * Bulk-apply persisted annotation highlights to all currently loaded chapters and remember the
+     * state so that chapters entering the sliding window later (via [onChapterLoaded]) automatically
+     * receive their marks.
+     *
+     * [onEachApplied] fires once per WebView that received annotation-apply JS (not clear JS), once
+     * that JS completes — mirrors the completion callback the View wires to re-fire its pending
+     * landing/focus logic ([ContinuousReaderView.onAnnotationHighlightsApplied]).
+     */
+    fun applyAnnotationHighlights(
+        annotationsByHref: Map<String, List<AnnotationHighlight>>,
+        onEachApplied: (ChapterWebViewLike) -> Unit,
+    ) {
+        currentAnnotationsByHref = annotationsByHref
+        port.forEachLoadedWebView { wv ->
+            val href = wv.chapterHref
+            if (href.isEmpty()) return@forEachLoadedWebView
+            val annotations = annotationsByHref[href]
+            if (annotations.isNullOrEmpty()) {
+                wv.evaluateJavascript(ContinuousStyleInjector.CLEAR_ANNOTATION_HIGHLIGHTS_JS, null)
+            } else {
+                wv.evaluateJavascript(ContinuousStyleInjector.applyAnnotationHighlightsJs(annotations)) { _ ->
+                    onEachApplied(wv)
+                }
+            }
+        }
+    }
+
+    override fun applySearchHighlights(state: SearchHighlightsState?) {
+        currentSearchHighlights = state
+        if (state == null) {
+            port.forEachLoadedWebView { wv ->
+                wv.evaluateJavascript(ContinuousStyleInjector.CLEAR_SEARCH_HIGHLIGHTS_JS, null)
+            }
+            return
+        }
+        port.forEachLoadedWebView { applySearchTo(it, state) }
+    }
+
+    private fun applySearchTo(wv: ChapterWebViewLike, state: SearchHighlightsState) {
+        val href = wv.chapterHref
+        if (href.isEmpty()) return
+        val texts = state.resultsByHref[href] ?: return
+        val isActive = href == state.activeHref
+        val js = ContinuousStyleInjector.applySearchHighlightsJs(
+            inactiveTexts = texts,
+            inactiveCssColor = state.inactiveCssColor,
+            activeText = if (isActive) state.activeText else null,
+            activeProgression = if (isActive) state.activeProgression else -1f,
+            activeCssColor = state.activeCssColor,
+        )
+        // Clear first, then re-apply in callback: Chrome won't reliably find text in a DOM
+        // that was just mutated synchronously (see ContinuousStyleInjector.applyAnnotationHighlightsJs).
+        wv.evaluateJavascript(ContinuousStyleInjector.CLEAR_SEARCH_HIGHLIGHTS_JS) { _ ->
+            wv.evaluateJavascript(js, null)
+        }
+    }
+
+    override fun highlightInChapter(href: String, text: String, cssColor: String) {
+        val wv = port.findLoadedWebView(href) ?: return
+        wv.evaluateJavascript(ContinuousStyleInjector.highlightTextJs(text, cssColor)) { _ ->
+            // Re-lookup by href rather than reusing wv directly: the window may have shifted
+            // between the evaluateJavascript call and this callback.
+            scrollToReadaloudHighlight(href)
+        }
+    }
+
+    override fun clearHighlightInChapter(href: String) {
+        val wv = port.findLoadedWebView(href) ?: return
+        wv.evaluateJavascript(ContinuousStyleInjector.CLEAR_HIGHLIGHT_JS, null)
+    }
+
+    /** Same recipe as the prior in-View `scrollToHighlight`: query `_riffle_hl`'s device-px Y,
+     *  add slot.top, subtract height/3, then scroll iff |delta| > height/8. */
+    private fun scrollToReadaloudHighlight(href: String) {
+        val wv = port.findLoadedWebView(href) ?: return
+        wv.evaluateJavascript(
+            """(function(){
+                var el=document.getElementById('_riffle_hl');
+                if(!el) return -1;
+                var r=el.getBoundingClientRect();
+                var y=r.top+(window.pageYOffset||document.documentElement.scrollTop||0);
+                return Math.max(0,Math.round(y*(window.devicePixelRatio||1)));
+            })()""",
+        ) { result ->
+            val elementTop = result?.toFloatOrNull()?.toInt() ?: return@evaluateJavascript
+            if (elementTop < 0) return@evaluateJavascript
+            // Re-lookup window state fresh — a shift between the two evaluateJavascript calls
+            // would have changed slot positions.
+            val slot = port.buildWindow().firstOrNull { it.href == href } ?: return@evaluateJavascript
+            val vh = port.viewportHeightPx
+            val absoluteY = slot.top + elementTop
+            val targetScrollY = (absoluteY - vh / 3).coerceAtLeast(0)
+            // Scroll whenever the current position is more than height/8 away from the target.
+            // Using abs() avoids a bug where a target just inside the top of the viewport would
+            // trigger a spurious backward scroll (target < scrollY + margin => target < scrollY).
+            if (abs(targetScrollY - port.currentScrollY) > vh / 8) {
+                port.clearLandingHold()
+                port.smoothScrollTo(targetScrollY)
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderCoordinator.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderCoordinator.kt
@@ -1,7 +1,6 @@
 package com.riffle.app.feature.reader
 
 import androidx.compose.runtime.snapshotFlow
-import androidx.compose.ui.unit.IntRect
 import com.riffle.app.feature.reader.presenter.ContinuousPresenter
 import com.riffle.core.domain.FormattingPreferences
 import com.riffle.core.domain.SentenceQuote
@@ -9,7 +8,6 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
-import org.json.JSONObject
 import org.readium.r2.shared.publication.Link
 import org.readium.r2.shared.publication.Locator
 import org.readium.r2.shared.publication.Publication
@@ -66,63 +64,34 @@ internal class ContinuousReaderCoordinator(
         this.view = view
         viewFlow.value = view
 
-        view.onRawPosition = { href, progression ->
-            val (spineHrefs, counts) = spinePositionsProvider()
-            val locator = buildContinuousLocator(href, progression, spineHrefs, counts)
-            if (locator != null) {
-                navigation.onLocator(locator)
-                presenter?.feedPosition(
-                    href = locator.href.toString(),
-                    progression = locator.locations.progression?.toFloat() ?: progression,
-                    totalProgression = locator.locations.totalProgression?.toFloat(),
-                    locatorJson = locator.toJSON().toString(),
-                )
-            }
-        }
-
-        view.onTap = { navigation.onTap() }
-
-        view.onInternalLinkTapped = { href ->
-            val origin = latestLocator()
-            val path = href.substringBefore('#')
-            val link = publication.readingOrder.firstOrNull { it.href.toString() == path }
-            if (link != null && origin != null) {
-                links.onFollowInternalLink(link, origin)
-            } else {
-                this.view?.navigateTo(href, 0f)
-            }
-        }
-
-        view.onExternalLinkTapped = { url -> links.onExternalLink(url) }
-
-        view.onFootnoteContent = { content -> links.onFootnote(content) }
-
-        view.onAnnotationTap = { _, id, androidRect ->
-            annotations.onAnnotationTap(id, IntRect(androidRect.left, androidRect.top, androidRect.right, androidRect.bottom))
-        }
-
-        view.onAnnotationNoteTap = { _, id, androidRect ->
-            annotations.onAnnotationNoteTap(id, IntRect(androidRect.left, androidRect.top, androidRect.right, androidRect.bottom))
-        }
-
-        view.onHighlightSelection = { chapterHref, selectedText, progression, selectionScreenRect, before, after ->
-            val locator = Locator.fromJSON(
-                JSONObject()
-                    .put("href", chapterHref)
-                    .put("type", "application/xhtml+xml")
-                    .put("locations", JSONObject().put("progression", progression))
-                    .put("text", JSONObject()
-                        .put("before", before)
-                        .put("highlight", selectedText)
-                        .put("after", after)),
-            )
-            if (locator != null) {
-                annotations.onHighlight(
-                    locator,
-                    IntRect(selectionScreenRect.left, selectionScreenRect.top, selectionScreenRect.right, selectionScreenRect.bottom),
-                )
-            }
-        }
+        view.install(
+            navigation = navigation,
+            links = links,
+            annotations = annotations,
+            onInternalLink = { href ->
+                val origin = latestLocator()
+                val path = href.substringBefore('#')
+                val link = publication.readingOrder.firstOrNull { it.href.toString() == path }
+                if (link != null && origin != null) {
+                    links.onFollowInternalLink(link, origin)
+                } else {
+                    this.view?.navigateTo(href, 0f)
+                }
+            },
+            onRawPosition = { href, progression ->
+                val (spineHrefs, counts) = spinePositionsProvider()
+                val locator = buildContinuousLocator(href, progression, spineHrefs, counts)
+                if (locator != null) {
+                    navigation.onLocator(locator)
+                    presenter?.feedPosition(
+                        href = locator.href.toString(),
+                        progression = locator.locations.progression?.toFloat() ?: progression,
+                        totalProgression = locator.locations.totalProgression?.toFloat(),
+                        locatorJson = locator.toJSON().toString(),
+                    )
+                }
+            },
+        )
 
         view.onPlayFromHereSelection = { chapterHref, selectedText, evalJs ->
             val scoped = scopeSentencesToChapter(

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderCoordinator.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderCoordinator.kt
@@ -22,25 +22,20 @@ import org.readium.r2.shared.publication.Publication
  * factory as soon as the view is created. Navigation methods are suspending and are called from
  * the screen's LaunchedEffects.
  *
- * All callback lambdas are passed at construction time. They close over the screen's
+ * The [ContinuousNavigationSink], [ContinuousLinkSink], and [ContinuousAnnotationSink]
+ * implementations are passed at construction time. They close over the screen's
  * [rememberUpdatedState] delegates, so each invocation reads the latest value rather than the
  * value captured at [remember] time.
  */
 internal class ContinuousReaderCoordinator(
     private val publication: Publication,
     private val spinePositionsProvider: () -> Pair<List<String>, List<Int>>,
-    private val onLocator: (Locator) -> Unit,
-    private val onTap: () -> Unit,
     private val latestLocator: () -> Locator?,
-    private val onFollowInternalLink: (Link, Locator) -> Unit,
-    private val onExternalLink: (url: String) -> Unit,
-    private val onFootnote: (FootnoteContent) -> Unit,
-    private val onAnnotationTap: (id: String, rect: IntRect) -> Unit,
-    private val onAnnotationNoteTap: (id: String, rect: IntRect) -> Unit,
-    private val onHighlight: (Locator, IntRect) -> Unit,
     private val sentenceQuotesProvider: () -> Map<String, SentenceQuote>,
     private val sentenceChaptersProvider: () -> Map<String, String>,
-    private val onPlayFromHere: (String) -> Unit,
+    private val navigation: ContinuousNavigationSink,
+    private val links: ContinuousLinkSink,
+    private val annotations: ContinuousAnnotationSink,
 ) {
     private var view: ContinuousReaderView? = null
 
@@ -75,7 +70,7 @@ internal class ContinuousReaderCoordinator(
             val (spineHrefs, counts) = spinePositionsProvider()
             val locator = buildContinuousLocator(href, progression, spineHrefs, counts)
             if (locator != null) {
-                onLocator(locator)
+                navigation.onLocator(locator)
                 presenter?.feedPosition(
                     href = locator.href.toString(),
                     progression = locator.locations.progression?.toFloat() ?: progression,
@@ -85,29 +80,29 @@ internal class ContinuousReaderCoordinator(
             }
         }
 
-        view.onTap = { onTap() }
+        view.onTap = { navigation.onTap() }
 
         view.onInternalLinkTapped = { href ->
             val origin = latestLocator()
             val path = href.substringBefore('#')
             val link = publication.readingOrder.firstOrNull { it.href.toString() == path }
             if (link != null && origin != null) {
-                onFollowInternalLink(link, origin)
+                links.onFollowInternalLink(link, origin)
             } else {
                 this.view?.navigateTo(href, 0f)
             }
         }
 
-        view.onExternalLinkTapped = { url -> onExternalLink(url) }
+        view.onExternalLinkTapped = { url -> links.onExternalLink(url) }
 
-        view.onFootnoteContent = { content -> onFootnote(content) }
+        view.onFootnoteContent = { content -> links.onFootnote(content) }
 
         view.onAnnotationTap = { _, id, androidRect ->
-            onAnnotationTap(id, IntRect(androidRect.left, androidRect.top, androidRect.right, androidRect.bottom))
+            annotations.onAnnotationTap(id, IntRect(androidRect.left, androidRect.top, androidRect.right, androidRect.bottom))
         }
 
         view.onAnnotationNoteTap = { _, id, androidRect ->
-            onAnnotationNoteTap(id, IntRect(androidRect.left, androidRect.top, androidRect.right, androidRect.bottom))
+            annotations.onAnnotationNoteTap(id, IntRect(androidRect.left, androidRect.top, androidRect.right, androidRect.bottom))
         }
 
         view.onHighlightSelection = { chapterHref, selectedText, progression, selectionScreenRect, before, after ->
@@ -122,7 +117,7 @@ internal class ContinuousReaderCoordinator(
                         .put("after", after)),
             )
             if (locator != null) {
-                onHighlight(
+                annotations.onHighlight(
                     locator,
                     IntRect(selectionScreenRect.left, selectionScreenRect.top, selectionScreenRect.right, selectionScreenRect.bottom),
                 )
@@ -137,7 +132,7 @@ internal class ContinuousReaderCoordinator(
                 val geomId = raw?.trim('"')?.takeIf { it.isNotEmpty() }
                 val sid = geomId
                     ?: ContinuousPositionTracker.sentenceIdForSelection(selectedText, scoped.toMap())
-                if (sid != null) onPlayFromHere("$chapterHref#$sid")
+                if (sid != null) annotations.onPlayFromHere("$chapterHref#$sid")
             }
         }
     }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderCoordinator.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderCoordinator.kt
@@ -42,8 +42,8 @@ internal class ContinuousReaderCoordinator(
      * continuous-mode raw-position events also feed [ContinuousPresenter.feedPosition] so
      * [ContinuousPresenter.positionEvents] becomes the canonical event source for any orchestrator
      * built on top of [com.riffle.app.feature.reader.presenter.ReaderPresenter]. The existing
-     * [onLocator] callback path is unchanged in this step — full bypass deletion is the step 7
-     * cleanup pass.
+     * [ContinuousNavigationSink.onLocator] path is unchanged in this step — full bypass
+     * deletion is the step 7 cleanup pass.
      */
     var presenter: ContinuousPresenter? = null
 

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
@@ -174,6 +174,23 @@ internal class ContinuousReaderView @JvmOverloads constructor(
     /** Parallel list to the loaded WebViews; index i matches container.getChildAt(i). */
     private val webViews = mutableListOf<ChapterWebView>()
 
+    /** Owns annotation + search decoration state and the apply-to-window loops; see
+     *  [ContinuousDecorationController]. The View retains only the landing/focus machinery that
+     *  needs the sliding-window state ([onAnnotationHighlightsApplied]). */
+    private val decorations = ContinuousDecorationController(
+        port = object : ContinuousDecorationController.Port {
+            override fun forEachLoadedWebView(block: (ChapterWebViewLike) -> Unit) = webViews.forEach(block)
+            override fun findLoadedWebView(href: String): ChapterWebViewLike? =
+                webViews.firstOrNull { it.chapterHref == href }
+            override fun scrollTo(y: Int) = this@ContinuousReaderView.scrollTo(0, y)
+            override fun smoothScrollTo(y: Int) = this@ContinuousReaderView.smoothScrollTo(0, y)
+            override fun clearLandingHold() = this@ContinuousReaderView.clearLandingHold()
+            override fun buildWindow(): List<ContinuousPositionTracker.ChapterSlot> = this@ContinuousReaderView.buildWindow()
+            override val viewportHeightPx: Int get() = height
+            override val currentScrollY: Int get() = scrollY
+        },
+    )
+
     /**
      * True while a window-shift operation (removeTop/removeBottom/prependChapter) is in
      * progress. Prevents re-entrant handleScrollChange calls — programmatic scrollBy() calls
@@ -857,91 +874,17 @@ internal class ContinuousReaderView @JvmOverloads constructor(
 
     /** Inject a readaloud highlight for the sentence with [text] in the chapter matching [href] and scroll it into view. */
     override fun highlightInChapter(href: String, text: String, cssColor: String) {
-        val i = webViewIndexFor(href) ?: return
-        webViews[i].evaluateJavascript(ContinuousStyleInjector.highlightTextJs(text, cssColor)) { _ ->
-            // Re-lookup by href rather than using the captured index: the window may have shifted
-            // between the evaluateJavascript call and this callback, making i stale.
-            scrollToHighlight(href)
-        }
-    }
-
-    private fun scrollToHighlight(href: String) {
-        val i = webViewIndexFor(href) ?: return
-        val wv = webViews[i]
-        // getBoundingClientRect().top is in CSS pixels; multiply by devicePixelRatio to get device
-        // pixels so the result is in the same coordinate space as slot.top and scrollY.
-        wv.evaluateJavascript(
-            """(function(){
-                var el=document.getElementById('_riffle_hl');
-                if(!el) return -1;
-                var r=el.getBoundingClientRect();
-                var y=r.top+(window.pageYOffset||document.documentElement.scrollTop||0);
-                return Math.max(0,Math.round(y*(window.devicePixelRatio||1)));
-            })()"""
-        ) { result ->
-            val elementTop = result?.toFloatOrNull()?.toInt() ?: return@evaluateJavascript
-            if (elementTop < 0) return@evaluateJavascript
-            // Re-lookup window state fresh — a shift between the two evaluateJavascript calls
-            // would have changed slot positions.
-            val freshI = webViewIndexFor(href) ?: return@evaluateJavascript
-            val slot = buildWindow().getOrNull(freshI) ?: return@evaluateJavascript
-            val absoluteY = slot.top + elementTop
-            val targetScrollY = (absoluteY - height / 3).coerceAtLeast(0)
-            // Scroll whenever the current position is more than height/8 away from the target.
-            // Using abs() avoids the previous bug where absoluteY just inside the top of the
-            // viewport triggered a backward scroll (absoluteY < scrollY+margin → target < scrollY).
-            if (abs(targetScrollY - scrollY) > height / 8) {
-                clearLandingHold()
-                smoothScrollTo(0, targetScrollY)
-            }
-        }
+        decorations.highlightInChapter(href, text, cssColor)
     }
 
     /** Clear any active readaloud highlight in the chapter at [href]. */
     override fun clearHighlightInChapter(href: String) {
-        val i = webViewIndexFor(href) ?: return
-        webViews[i].evaluateJavascript(ContinuousStyleInjector.CLEAR_HIGHLIGHT_JS, null)
+        decorations.clearHighlightInChapter(href)
     }
-
-    // Search highlight state — persisted across the window so onPageFinished can re-apply marks
-    // when a chapter enters the sliding window or when a chapter reloads after a far-jump.
-    private var currentSearchHighlights: SearchHighlightsState? = null
 
     override fun applySearchHighlights(state: SearchHighlightsState?) {
-        currentSearchHighlights = state
-        if (state == null) {
-            for (wv in webViews) {
-                wv.evaluateJavascript(ContinuousStyleInjector.CLEAR_SEARCH_HIGHLIGHTS_JS, null)
-            }
-            return
-        }
-        for (wv in webViews) {
-            applySearchHighlightsToWebView(wv, state)
-        }
+        decorations.applySearchHighlights(state)
     }
-
-    private fun applySearchHighlightsToWebView(wv: ChapterWebView, state: SearchHighlightsState) {
-        val href = wv.chapterHref
-        if (href.isEmpty()) return
-        val texts = state.resultsByHref[href] ?: return
-        val isActive = href == state.activeHref
-        val js = ContinuousStyleInjector.applySearchHighlightsJs(
-            inactiveTexts = texts,
-            inactiveCssColor = state.inactiveCssColor,
-            activeText = if (isActive) state.activeText else null,
-            activeProgression = if (isActive) state.activeProgression else -1f,
-            activeCssColor = state.activeCssColor,
-        )
-        // Clear first, then re-apply in callback: Chrome won't reliably find text in a DOM
-        // that was just mutated synchronously (see ContinuousStyleInjector.applyAnnotationHighlightsJs).
-        wv.evaluateJavascript(ContinuousStyleInjector.CLEAR_SEARCH_HIGHLIGHTS_JS) { _ ->
-            wv.evaluateJavascript(js, null)
-        }
-    }
-
-    // Annotation state persisted so onPageFinished can re-apply marks when a chapter loads or
-    // the sliding window cycles in a new chapter without the LaunchedEffect re-running.
-    private var currentAnnotationsByHref: Map<String, List<AnnotationHighlight>> = emptyMap()
 
     /**
      * Apply persisted annotation highlights to all currently loaded chapters and remember the
@@ -949,24 +892,7 @@ internal class ContinuousReaderView @JvmOverloads constructor(
      * [prependChapter]) automatically receive their marks in [onPageFinished].
      */
     override fun applyAnnotationHighlights(annotationsByHref: Map<String, List<AnnotationHighlight>>) {
-        currentAnnotationsByHref = annotationsByHref
-        for (wv in webViews) {
-            val href = wv.chapterHref
-            if (href.isEmpty()) continue
-            val annotations = annotationsByHref[href]
-            if (annotations.isNullOrEmpty()) {
-                wv.evaluateJavascript(ContinuousStyleInjector.CLEAR_ANNOTATION_HIGHLIGHTS_JS, null)
-            } else {
-                // Same re-land-on-completion hook as in appendChapter.onPageFinished: when the
-                // bulk-apply runs against the pending-target chapter, the mark only exists AFTER
-                // this JS finishes; re-fire the armed landing closure AND/OR a direct mark scroll
-                // (the latter even when the reapply chain has been disarmed) so the focus lands
-                // precisely on the freshly-decorated mark.
-                wv.evaluateJavascript(ContinuousStyleInjector.applyAnnotationHighlightsJs(annotations)) { _ ->
-                    onAnnotationHighlightsApplied(wv)
-                }
-            }
-        }
+        decorations.applyAnnotationHighlights(annotationsByHref, onEachApplied = ::onAnnotationHighlightsApplied)
     }
 
     /**
@@ -979,18 +905,22 @@ internal class ContinuousReaderView @JvmOverloads constructor(
      * could have shifted while the JS was in flight) so they're together in one guarded helper —
      * call sites just invoke this and don't need to repeat the index check.
      */
-    private fun onAnnotationHighlightsApplied(wv: ChapterWebView) {
+    private fun onAnnotationHighlightsApplied(wv: ChapterWebViewLike) {
         if (wv.chapterHref != pendingTargetHref) return
         reapplyLandingAfterFallback?.invoke()
-        scrollToPendingFocusAnnotation(wv)
+        scrollToPendingFocusAnnotation(wv.chapterHref)
     }
 
     /** Once the target chapter's `<mark data-riffle-ann="<id>">` exists in the DOM, scroll to it.
      *  Independent of [reapplyLandingAfterFallback] so it still fires when the reapply chain has
      *  been disarmed (touch event, height stabilised before the mark was created). Clears
-     *  [pendingFocusAnnotationId] once landed so it doesn't replay on later annotation refreshes. */
-    private fun scrollToPendingFocusAnnotation(wv: ChapterWebView) {
+     *  [pendingFocusAnnotationId] once landed so it doesn't replay on later annotation refreshes.
+     *  Re-looked-up by [href] (rather than taking the [ChapterWebView] directly) because
+     *  [annotationOffsetTopDevicePx] is a [ChapterWebView]-only capability not on the narrower
+     *  [ChapterWebViewLike] surface the decoration controller's callbacks pass through. */
+    private fun scrollToPendingFocusAnnotation(href: String) {
         val id = pendingFocusAnnotationId ?: return
+        val wv = webViewIndexFor(href)?.let { webViews.getOrNull(it) } ?: return
         wv.annotationOffsetTopDevicePx(id) { annOffset ->
             if (annOffset == null) return@annotationOffsetTopDevicePx
             // Resolve by href, not by index — a window shift between the JS in-flight and this
@@ -1095,26 +1025,17 @@ internal class ContinuousReaderView @JvmOverloads constructor(
         wv.onPageFinished = {
             val styleJs = ContinuousStyleInjector.buildStyleInjectionJs(formattingPrefs)
             wv.injectStylesAndMeasure(styleJs)
-            wv.evaluateJavascript(SELECTION_SPAN_TRACKER_JS, null)
-            val annotations = currentAnnotationsByHref[wv.chapterHref]
-            if (!annotations.isNullOrEmpty()) {
-                // Re-fire the armed landing closure on completion: applyAnnotationHighlightsJs
-                // inserts the `<mark data-riffle-ann="<id>">` whose rect is what
-                // [annotationOffsetTopDevicePx] looks for. The first pendingInitialScroll fire
-                // usually happens BEFORE this JS completes (height-measurement reflow triggers it
-                // earlier), so the annotation-mark query in that first fire returns null and falls
-                // back to anchor/progression. Re-firing the closure here — once the mark is in the
-                // DOM — lets the mark query succeed and re-land precisely; and the explicit
-                // [scrollToPendingFocusAnnotation] covers the case where reapply has been disarmed
-                // (touch event during boot, height stabilised before the mark was created, etc).
-                wv.evaluateJavascript(ContinuousStyleInjector.applyAnnotationHighlightsJs(annotations)) { _ ->
-                    onAnnotationHighlightsApplied(wv)
-                }
-            }
-            val searchState = currentSearchHighlights
-            if (searchState != null && searchState.resultsByHref.containsKey(wv.chapterHref)) {
-                applySearchHighlightsToWebView(wv, searchState)
-            }
+            wv.evaluateJavascript(SELECTION_SPAN_TRACKER_JS, null as ((String?) -> Unit)?)
+            // Re-fire the armed landing closure on completion: applyAnnotationHighlightsJs inserts
+            // the `<mark data-riffle-ann="<id>">` whose rect is what [annotationOffsetTopDevicePx]
+            // looks for. The first pendingInitialScroll fire usually happens BEFORE this JS
+            // completes (height-measurement reflow triggers it earlier), so the annotation-mark
+            // query in that first fire returns null and falls back to anchor/progression.
+            // Re-firing the closure here — once the mark is in the DOM — lets the mark query
+            // succeed and re-land precisely; and the explicit [scrollToPendingFocusAnnotation]
+            // covers the case where reapply has been disarmed (touch event during boot, height
+            // stabilised before the mark was created, etc).
+            decorations.onChapterLoaded(wv, onAnnotationsApplied = { onAnnotationHighlightsApplied(wv) })
         }
         webViews.add(wv)
         measuredHeights.add(placeholder)
@@ -1144,18 +1065,9 @@ internal class ContinuousReaderView @JvmOverloads constructor(
         wv.onPageFinished = {
             val styleJs = ContinuousStyleInjector.buildStyleInjectionJs(formattingPrefs)
             wv.injectStylesAndMeasure(styleJs)
-            wv.evaluateJavascript(SELECTION_SPAN_TRACKER_JS, null)
-            val annotations = currentAnnotationsByHref[wv.chapterHref]
-            if (!annotations.isNullOrEmpty()) {
-                // Same re-land-on-completion hook as in appendChapter.onPageFinished.
-                wv.evaluateJavascript(ContinuousStyleInjector.applyAnnotationHighlightsJs(annotations)) { _ ->
-                    onAnnotationHighlightsApplied(wv)
-                }
-            }
-            val searchState = currentSearchHighlights
-            if (searchState != null && searchState.resultsByHref.containsKey(wv.chapterHref)) {
-                applySearchHighlightsToWebView(wv, searchState)
-            }
+            wv.evaluateJavascript(SELECTION_SPAN_TRACKER_JS, null as ((String?) -> Unit)?)
+            // Same re-land-on-completion hook as in appendChapter.onPageFinished.
+            decorations.onChapterLoaded(wv, onAnnotationsApplied = { onAnnotationHighlightsApplied(wv) })
         }
         webViews.add(0, wv)
         measuredHeights.add(0, placeholder)

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
@@ -83,43 +83,12 @@ internal class ContinuousReaderView @JvmOverloads constructor(
 
     data class ChapterEntry(val link: Link, val url: String)
 
-    /** Called on main thread when scroll position changes; emits raw `(href, progression)` — NOT a full Locator. */
-    var onRawPosition: ((href: String, progression: Float) -> Unit)? = null
-
-
-    /**
-     * Called on main thread when the user taps a chapter without scrolling.
-     * Wire to the reader's chrome toggle so top/bottom bars show/hide on tap.
-     */
-    var onTap: (() -> Unit)? = null
-
-    /**
-     * Called on the main thread when the user taps an in-book link inside a chapter (footnote,
-     * cross-reference). [href] is the target resource path (with any `#fragment`). The host wires
-     * this to the return-aware navigation path so a "Back" card can restore the pre-jump position.
-     */
-    var onInternalLinkTapped: ((href: String) -> Unit)? = null
-
-    /**
-     * Called on the main thread when the user taps an external (http/https) link. [url] is the
-     * absolute URL; the host opens it in a browser.
-     */
-    var onExternalLinkTapped: ((url: String) -> Unit)? = null
-
     /** Whether the text-selection menu should offer "Highlight" (books with annotations UI). */
     var annotationsAvailable: Boolean = false
         set(value) {
             field = value
             webViews.forEach { it.annotationsAvailable = value }
         }
-
-    /**
-     * Called on the main thread with (chapter href, selected text, within-chapter progression,
-     * screen rect of the selection in device pixels) when the user taps "Highlight".
-     * The progression lets the host build a correctly-anchored CFI range; the rect positions
-     * the highlight-actions popup next to the selected text.
-     */
-    var onHighlightSelection: ((href: String, selectedText: String, progression: Double, screenRect: android.graphics.Rect, before: String, after: String) -> Unit)? = null
 
     /** Whether the text-selection menu should offer "Play" (readaloud books only). */
     var readaloudAvailable: Boolean = false
@@ -131,15 +100,52 @@ internal class ContinuousReaderView @JvmOverloads constructor(
     /**
      * Called on the main thread with (chapter href, selected text, evalJs) when the user taps
      * "Play". [evalJs] is the WebView's evaluateJavascript so the host can run geometry-based
-     * sentence resolution before falling back to text matching.
+     * sentence resolution before falling back to text matching. Retained as a View-owned callback
+     * (unlike the other per-chapter callbacks, which route through [ChapterWebViewBinder]) because
+     * sentence-scoped resolution needs publication state that only the coordinator holds.
      */
     var onPlayFromHereSelection: ((href: String, selectedText: String, evalJs: (String, (String?) -> Unit) -> Unit) -> Unit)? = null
 
+    /** Constructed by [install] once the coordinator supplies the three sinks. Binds every
+     *  per-chapter [ChapterWebView] callback except `onInternalLink` and `onPlayFromHere` (see
+     *  [ChapterWebViewBinder] doc). */
+    private var binder: ChapterWebViewBinder? = null
+
+    /** Set by [install]; invoked from [handleScrollChange] with the raw `(href, progression)` on
+     *  every scroll-position update. */
+    private var onRawPosition: ((href: String, progression: Float) -> Unit)? = null
+
     /**
-     * Called on the main thread with the resolved footnote body when the user taps a footnote
-     * anchor in a chapter. The host shows the footnote popup.
+     * Wire this view to the coordinator's sinks. Must be called once, from
+     * [ContinuousReaderCoordinator.attach], before any chapter is appended/prepended — the binder
+     * it constructs is what [appendChapter] / [prependChapter] use to wire each [ChapterWebView].
      */
-    var onFootnoteContent: ((FootnoteContent) -> Unit)? = null
+    internal fun install(
+        navigation: ContinuousNavigationSink,
+        links: ContinuousLinkSink,
+        annotations: ContinuousAnnotationSink,
+        onInternalLink: (href: String) -> Unit,
+        onRawPosition: (href: String, progression: Float) -> Unit,
+    ) {
+        this.onRawPosition = onRawPosition
+        binder = ChapterWebViewBinder(
+            navigation = navigation,
+            links = links,
+            annotations = annotations,
+            screenRectOf = ::screenRectFor,
+            onRenderGone = ::recoverFromRendererGone,
+            onInternalLink = onInternalLink,
+            onSelectionActiveChanged = ::onChildSelectionActiveChanged,
+        )
+    }
+
+    /** Screen-space rect of [r] (in [wv]-local device pixels), used by [ChapterWebViewBinder] to
+     *  position annotation/highlight popups and mark taps against the actual on-screen location. */
+    private fun screenRectFor(wv: ChapterWebViewLike, r: android.graphics.Rect): android.graphics.Rect {
+        val loc = IntArray(2)
+        (wv as android.view.View).getLocationOnScreen(loc)
+        return android.graphics.Rect(loc[0] + r.left, loc[1] + r.top, loc[0] + r.right, loc[1] + r.bottom)
+    }
 
     private val container = LinearLayout(context).apply {
         orientation = LinearLayout.VERTICAL
@@ -933,12 +939,6 @@ internal class ContinuousReaderView @JvmOverloads constructor(
         }
     }
 
-    /** Called on the main thread when the user taps an annotation highlight mark in any chapter. */
-    var onAnnotationTap: ((href: String, id: String, screenRect: android.graphics.Rect) -> Unit)? = null
-
-    /** Called on the main thread when the user taps a note glyph next to an annotation mark. */
-    var onAnnotationNoteTap: ((href: String, id: String, screenRect: android.graphics.Rect) -> Unit)? = null
-
     // Annotation state persisted so onPageFinished can re-apply marks when a chapter loads or
     // the sliding window cycles in a new chapter without the LaunchedEffect re-running.
     private var currentAnnotationsByHref: Map<String, List<AnnotationHighlight>> = emptyMap()
@@ -1009,46 +1009,12 @@ internal class ContinuousReaderView @JvmOverloads constructor(
 
     // ── private ────────────────────────────────────────────────────────────────
 
-    /**
-     * Wire all annotation-related callbacks on [wv]. The coordinate transform is done at event
-     * time (not at wiring time) so it always reflects the WebView's current screen position.
-     * Extracted to avoid duplication between [appendChapter] and [prependChapter].
-     */
-    private fun wireAnnotationCallbacks(wv: ChapterWebView) {
-        wv.onHighlight = { text, prog, rect, before, after ->
-            val loc = IntArray(2)
-            wv.getLocationOnScreen(loc)
-            val screenRect = android.graphics.Rect(loc[0] + rect.left, loc[1] + rect.top, loc[0] + rect.right, loc[1] + rect.bottom)
-            onHighlightSelection?.invoke(wv.chapterHref, text, prog, screenRect, before, after)
-        }
-        wv.onAnnotationTap = { id, rect ->
-            val loc = IntArray(2)
-            wv.getLocationOnScreen(loc)
-            val screenRect = android.graphics.Rect(loc[0] + rect.left, loc[1] + rect.top, loc[0] + rect.right, loc[1] + rect.bottom)
-            onAnnotationTap?.invoke(wv.chapterHref, id, screenRect)
-        }
-        wv.onAnnotationNoteTap = { id, rect ->
-            val loc = IntArray(2)
-            wv.getLocationOnScreen(loc)
-            val screenRect = android.graphics.Rect(loc[0] + rect.left, loc[1] + rect.top, loc[0] + rect.right, loc[1] + rect.bottom)
-            onAnnotationNoteTap?.invoke(wv.chapterHref, id, screenRect)
-        }
-    }
-
     private fun appendChapter(index: Int) {
         val entry = allChapters[index]
         val wv = obtainWebView()
         publication?.let { wv.setPublication(it) }
-        wv.onTap = { onTap?.invoke() }
-        wv.onRenderGone = { recoverFromRendererGone() }
-        wv.onInternalLink = { onInternalLinkTapped?.invoke(it) }
-        wv.onExternalLink = { onExternalLinkTapped?.invoke(it) }
-        wv.annotationsAvailable = annotationsAvailable
-        wv.onSelectionActiveChanged = ::onChildSelectionActiveChanged
-        wireAnnotationCallbacks(wv)
-        wv.readaloudAvailable = readaloudAvailable
+        binder?.bind(wv, annotationsAvailable = annotationsAvailable, readaloudAvailable = readaloudAvailable)
         wv.onPlayFromHere = { text, evalJs -> onPlayFromHereSelection?.invoke(wv.chapterHref, text, evalJs) }
-        wv.onFootnoteContent = { onFootnoteContent?.invoke(it) }
         val placeholder = placeholderHeight
         wv.onHeightMeasured = { measuredPx ->
             val i = webViews.indexOf(wv)
@@ -1160,16 +1126,8 @@ internal class ContinuousReaderView @JvmOverloads constructor(
         val entry = allChapters[index]
         val wv = obtainWebView()
         publication?.let { wv.setPublication(it) }
-        wv.onTap = { onTap?.invoke() }
-        wv.onRenderGone = { recoverFromRendererGone() }
-        wv.onInternalLink = { onInternalLinkTapped?.invoke(it) }
-        wv.onExternalLink = { onExternalLinkTapped?.invoke(it) }
-        wv.annotationsAvailable = annotationsAvailable
-        wv.onSelectionActiveChanged = ::onChildSelectionActiveChanged
-        wireAnnotationCallbacks(wv)
-        wv.readaloudAvailable = readaloudAvailable
+        binder?.bind(wv, annotationsAvailable = annotationsAvailable, readaloudAvailable = readaloudAvailable)
         wv.onPlayFromHere = { text, evalJs -> onPlayFromHereSelection?.invoke(wv.chapterHref, text, evalJs) }
-        wv.onFootnoteContent = { onFootnoteContent?.invoke(it) }
         val placeholder = placeholderHeight
         wv.onHeightMeasured = { measuredPx ->
             val i = webViews.indexOf(wv)

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
@@ -108,8 +108,10 @@ internal class ContinuousReaderView @JvmOverloads constructor(
 
     /** Constructed by [install] once the coordinator supplies the three sinks. Binds every
      *  per-chapter [ChapterWebView] callback except `onInternalLink` and `onPlayFromHere` (see
-     *  [ChapterWebViewBinder] doc). */
-    private var binder: ChapterWebViewBinder? = null
+     *  [ChapterWebViewBinder] doc). `lateinit` so a mis-ordered `initialize()` before `attach()`
+     *  fails fast with `UninitializedPropertyAccessException` at the real bug site instead of
+     *  silently binding every chapter without callbacks (no tap, no highlight, no link handling). */
+    private lateinit var binder: ChapterWebViewBinder
 
     /** Set by [install]; invoked from [handleScrollChange] with the raw `(href, progression)` on
      *  every scroll-position update. */
@@ -943,7 +945,7 @@ internal class ContinuousReaderView @JvmOverloads constructor(
         val entry = allChapters[index]
         val wv = obtainWebView()
         publication?.let { wv.setPublication(it) }
-        binder?.bind(wv, annotationsAvailable = annotationsAvailable, readaloudAvailable = readaloudAvailable)
+        binder.bind(wv, annotationsAvailable = annotationsAvailable, readaloudAvailable = readaloudAvailable)
         wv.onPlayFromHere = { text, evalJs -> onPlayFromHereSelection?.invoke(wv.chapterHref, text, evalJs) }
         val placeholder = placeholderHeight
         wv.onHeightMeasured = { measuredPx ->
@@ -1047,7 +1049,7 @@ internal class ContinuousReaderView @JvmOverloads constructor(
         val entry = allChapters[index]
         val wv = obtainWebView()
         publication?.let { wv.setPublication(it) }
-        binder?.bind(wv, annotationsAvailable = annotationsAvailable, readaloudAvailable = readaloudAvailable)
+        binder.bind(wv, annotationsAvailable = annotationsAvailable, readaloudAvailable = readaloudAvailable)
         wv.onPlayFromHere = { text, evalJs -> onPlayFromHereSelection?.invoke(wv.chapterHref, text, evalJs) }
         val placeholder = placeholderHeight
         wv.onHeightMeasured = { measuredPx ->

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousSinks.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousSinks.kt
@@ -1,0 +1,36 @@
+package com.riffle.app.feature.reader
+
+import androidx.compose.ui.unit.IntRect
+import org.readium.r2.shared.publication.Link
+import org.readium.r2.shared.publication.Locator
+
+/**
+ * Navigation events the continuous stack surfaces upward — chrome toggle taps and
+ * raw-position updates that feed the reader's position pipeline.
+ */
+internal interface ContinuousNavigationSink {
+    fun onTap()
+    fun onLocator(locator: Locator)
+}
+
+/**
+ * Hyperlink events surfaced from tapped chapter content. `onFollowInternalLink` gets
+ * the resolved reading-order [Link] plus the origin [Locator] so the host can build a
+ * return-to-position card; `onFootnote` receives the resolved footnote body.
+ */
+internal interface ContinuousLinkSink {
+    fun onFollowInternalLink(link: Link, origin: Locator)
+    fun onExternalLink(url: String)
+    fun onFootnote(content: FootnoteContent)
+}
+
+/**
+ * Annotation + readaloud events surfaced from chapter selections or taps on existing marks.
+ * Rects are in device pixels relative to the reader viewport.
+ */
+internal interface ContinuousAnnotationSink {
+    fun onAnnotationTap(id: String, rect: IntRect)
+    fun onAnnotationNoteTap(id: String, rect: IntRect)
+    fun onHighlight(locator: Locator, rect: IntRect)
+    fun onPlayFromHere(fragmentRef: String)
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -79,6 +79,7 @@ import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.IntRect
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.core.view.ViewCompat
@@ -1249,25 +1250,38 @@ private fun EpubNavigatorView(
         ContinuousReaderCoordinator(
             publication = state.publication,
             spinePositionsProvider = { currentSpinePositions },
-            onLocator = onPositionChanged,
-            onTap = { currentOnTap() },
             latestLocator = { currentLatestLocator() },
-            onFollowInternalLink = { link, origin -> currentOnFollowInternalLink(link, origin) },
-            onExternalLink = { url ->
-                runCatching {
-                    fragmentActivity.startActivity(
-                        android.content.Intent(android.content.Intent.ACTION_VIEW, android.net.Uri.parse(url))
-                            .addFlags(android.content.Intent.FLAG_ACTIVITY_NEW_TASK),
-                    )
-                }
-            },
-            onFootnote = { content -> currentOnFootnoteTapped(content) },
-            onAnnotationTap = { id, rect -> currentOnOpenHighlightActions(id, rect) },
-            onAnnotationNoteTap = { id, rect -> currentOnOpenNoteReader(id, rect) },
-            onHighlight = { locator, rect -> currentOnHighlight(locator, rect) },
             sentenceQuotesProvider = { currentSentenceQuotes },
             sentenceChaptersProvider = { currentSentenceChapters },
-            onPlayFromHere = { ref -> currentOnPlayFromHere(ref) },
+            navigation = object : ContinuousNavigationSink {
+                override fun onTap() = currentOnTap()
+                override fun onLocator(locator: Locator) = onPositionChanged(locator)
+            },
+            links = object : ContinuousLinkSink {
+                override fun onFollowInternalLink(link: Link, origin: Locator) =
+                    currentOnFollowInternalLink(link, origin)
+                override fun onExternalLink(url: String) {
+                    runCatching {
+                        fragmentActivity.startActivity(
+                            android.content.Intent(
+                                android.content.Intent.ACTION_VIEW,
+                                android.net.Uri.parse(url),
+                            ).addFlags(android.content.Intent.FLAG_ACTIVITY_NEW_TASK),
+                        )
+                    }
+                }
+                override fun onFootnote(content: FootnoteContent) = currentOnFootnoteTapped(content)
+            },
+            annotations = object : ContinuousAnnotationSink {
+                override fun onAnnotationTap(id: String, rect: IntRect) =
+                    currentOnOpenHighlightActions(id, rect)
+                override fun onAnnotationNoteTap(id: String, rect: IntRect) =
+                    currentOnOpenNoteReader(id, rect)
+                override fun onHighlight(locator: Locator, rect: IntRect) =
+                    currentOnHighlight(locator, rect)
+                override fun onPlayFromHere(fragmentRef: String) =
+                    currentOnPlayFromHere(fragmentRef)
+            },
         )
     }
 

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -2288,8 +2288,9 @@ private fun EpubNavigatorView(
                 // the persisted-highlights LaunchedEffect above this block doesn't re-fire on the
                 // ref-null→view transition (its keys don't include continuousViewRef.value), so on
                 // a paged↔continuous orientation flip the new ContinuousHighlightRenderer would
-                // otherwise never be invoked and ContinuousReaderView.currentAnnotationsByHref
-                // would stay empty — onPageFinished would skip every chapter as it loaded.
+                // otherwise never be invoked and ContinuousDecorationController's persisted
+                // annotation state would stay empty — onPageFinished would skip every chapter as
+                // it loaded.
                 highlightRenderer.applyAnnotations(highlightRenders)
                 view.initialize(
                     chapters = chapters,

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ChapterWebViewBinderTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ChapterWebViewBinderTest.kt
@@ -19,6 +19,9 @@ class ChapterWebViewBinderTest {
 
     /** Hand-written fake driving [ChapterWebViewLike] without a live Android WebView. */
     private class FakeChapterWebView(override val chapterHref: String) : ChapterWebViewLike {
+        override fun evaluateJavascript(script: String, resultCallback: ((String?) -> Unit)?) {
+            resultCallback?.invoke(null)
+        }
         override var onTap: (() -> Unit)? = null
         override var onRenderGone: (() -> Unit)? = null
         override var onInternalLink: ((String) -> Unit)? = null

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ChapterWebViewBinderTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ChapterWebViewBinderTest.kt
@@ -1,0 +1,148 @@
+package com.riffle.app.feature.reader
+
+import android.graphics.Rect
+import androidx.compose.ui.unit.IntRect
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.readium.r2.shared.publication.Locator
+
+class ChapterWebViewBinderTest {
+
+    /**
+     * [Rect]'s 4-arg constructor is a no-op under the plain-JVM android.jar unit-test stub (it
+     * doesn't populate the fields — only the default no-arg constructor + field writes work), so
+     * every [Rect] in this test is built through field assignment via this helper instead.
+     */
+    private fun rectOf(left: Int, top: Int, right: Int, bottom: Int): Rect =
+        Rect().apply { this.left = left; this.top = top; this.right = right; this.bottom = bottom }
+
+    /** Hand-written fake driving [ChapterWebViewLike] without a live Android WebView. */
+    private class FakeChapterWebView(override val chapterHref: String) : ChapterWebViewLike {
+        override var onTap: (() -> Unit)? = null
+        override var onRenderGone: (() -> Unit)? = null
+        override var onInternalLink: ((String) -> Unit)? = null
+        override var onExternalLink: ((String) -> Unit)? = null
+        override var annotationsAvailable: Boolean = false
+        override var readaloudAvailable: Boolean = false
+        override var onSelectionActiveChanged: ((Boolean) -> Unit)? = null
+        override var onHighlight: ((String, Double, Rect, String, String) -> Unit)? = null
+        override var onAnnotationTap: ((String, Rect) -> Unit)? = null
+        override var onAnnotationNoteTap: ((String, Rect) -> Unit)? = null
+        override var onFootnoteContent: ((FootnoteContent) -> Unit)? = null
+
+        fun emitTap() = onTap?.invoke()
+        fun emitAnnotationTap(id: String, rect: Rect) = onAnnotationTap?.invoke(id, rect)
+        fun emitAnnotationNoteTap(id: String, rect: Rect) = onAnnotationNoteTap?.invoke(id, rect)
+        fun emitFootnoteContent(content: FootnoteContent) = onFootnoteContent?.invoke(content)
+    }
+
+    private class RecordingNav : ContinuousNavigationSink {
+        val taps = mutableListOf<Unit>()
+        override fun onTap() { taps += Unit }
+        override fun onLocator(locator: Locator) = error("not used")
+    }
+
+    private class RecordingAnn : ContinuousAnnotationSink {
+        val taps = mutableListOf<Pair<String, IntRect>>()
+        val notes = mutableListOf<Pair<String, IntRect>>()
+        val plays = mutableListOf<String>()
+        override fun onAnnotationTap(id: String, rect: IntRect) { taps += id to rect }
+        override fun onAnnotationNoteTap(id: String, rect: IntRect) { notes += id to rect }
+        override fun onHighlight(locator: Locator, rect: IntRect) = error("not used in this test")
+        override fun onPlayFromHere(fragmentRef: String) { plays += fragmentRef }
+    }
+
+    private class RecordingLinks : ContinuousLinkSink {
+        val footnotes = mutableListOf<FootnoteContent>()
+        override fun onFollowInternalLink(link: org.readium.r2.shared.publication.Link, origin: Locator) = Unit
+        override fun onExternalLink(url: String) = Unit
+        override fun onFootnote(content: FootnoteContent) { footnotes += content }
+    }
+
+    private fun binderOf(
+        nav: ContinuousNavigationSink = RecordingNav(),
+        links: ContinuousLinkSink = NoopLinks,
+        ann: ContinuousAnnotationSink = RecordingAnn(),
+        screenRectOf: (ChapterWebViewLike, Rect) -> Rect = { _, r -> r },
+    ) = ChapterWebViewBinder(
+        navigation = nav,
+        links = links,
+        annotations = ann,
+        screenRectOf = screenRectOf,
+        onRenderGone = {},
+        onInternalLink = {},
+        onSelectionActiveChanged = {},
+    )
+
+    @Test
+    fun `annotation tap converts rect through provided screenRectOf transform`() {
+        val nav = RecordingNav()
+        val ann = RecordingAnn()
+        val fake = FakeChapterWebView(chapterHref = "chapter-1.xhtml")
+        val binder = ChapterWebViewBinder(
+            navigation = nav,
+            links = NoopLinks,
+            annotations = ann,
+            screenRectOf = { _, r -> rectOf(r.left + 10, r.top + 20, r.right + 10, r.bottom + 20) },
+            onRenderGone = {},
+            onInternalLink = {},
+            onSelectionActiveChanged = {},
+        )
+        binder.bind(fake, annotationsAvailable = true, readaloudAvailable = true)
+
+        fake.emitAnnotationTap(id = "a1", rect = rectOf(0, 0, 5, 5))
+
+        assertEquals(1, ann.taps.size)
+        val (id, rect) = ann.taps.single()
+        assertEquals("a1", id)
+        assertEquals(IntRect(10, 20, 15, 25), rect)
+    }
+
+    @Test
+    fun `tap forwards to navigation sink`() {
+        val nav = RecordingNav()
+        val fake = FakeChapterWebView("chapter-1.xhtml")
+        binderOf(nav = nav).bind(fake, annotationsAvailable = false, readaloudAvailable = false)
+
+        fake.emitTap()
+
+        assertTrue(nav.taps.isNotEmpty())
+    }
+
+    @Test
+    fun `annotation note tap converts rect through provided screenRectOf transform`() {
+        val ann = RecordingAnn()
+        val fake = FakeChapterWebView("chapter-1.xhtml")
+        binderOf(
+            ann = ann,
+            screenRectOf = { _, r -> rectOf(r.left + 3, r.top + 4, r.right + 3, r.bottom + 4) },
+        ).bind(fake, annotationsAvailable = true, readaloudAvailable = false)
+
+        fake.emitAnnotationNoteTap(id = "n1", rect = rectOf(1, 1, 2, 2))
+
+        assertEquals(1, ann.notes.size)
+        val (id, rect) = ann.notes.single()
+        assertEquals("n1", id)
+        assertEquals(IntRect(4, 5, 5, 6), rect)
+    }
+
+    @Test
+    fun `footnote content forwards to link sink`() {
+        val links = RecordingLinks()
+        val fake = FakeChapterWebView("chapter-1.xhtml")
+        binderOf(links = links).bind(fake, annotationsAvailable = false, readaloudAvailable = false)
+
+        val content = FootnoteContent(text = "note")
+        fake.emitFootnoteContent(content)
+
+        assertEquals(1, links.footnotes.size)
+        assertEquals(content, links.footnotes.single())
+    }
+
+    private object NoopLinks : ContinuousLinkSink {
+        override fun onFollowInternalLink(link: org.readium.r2.shared.publication.Link, origin: Locator) = Unit
+        override fun onExternalLink(url: String) = Unit
+        override fun onFootnote(content: FootnoteContent) = Unit
+    }
+}

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousDecorationControllerTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousDecorationControllerTest.kt
@@ -1,0 +1,188 @@
+package com.riffle.app.feature.reader
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ContinuousDecorationControllerTest {
+
+    /** Hand-written fake driving [ChapterWebViewLike] without a live Android WebView. Records
+     *  every (script, callback) pair passed to [evaluateJavascript] so tests can invoke the
+     *  callback synchronously and assert on how many/which scripts were evaluated. */
+    private class FakeChapterWebView(override val chapterHref: String) : ChapterWebViewLike {
+        val evaluatedJs = mutableListOf<Pair<String, ((String?) -> Unit)?>>()
+        val evaluatedJsCount: Int get() = evaluatedJs.size
+
+        override fun evaluateJavascript(script: String, resultCallback: ((String?) -> Unit)?) {
+            evaluatedJs += script to resultCallback
+        }
+
+        /** Invokes the most recently recorded callback (if any) with [result], simulating the
+         *  WebView completing evaluation of the last-issued script. */
+        fun completeLast(result: String? = null) {
+            evaluatedJs.lastOrNull()?.second?.invoke(result)
+        }
+
+        override var onTap: (() -> Unit)? = null
+        override var onRenderGone: (() -> Unit)? = null
+        override var onInternalLink: ((String) -> Unit)? = null
+        override var onExternalLink: ((String) -> Unit)? = null
+        override var annotationsAvailable: Boolean = false
+        override var readaloudAvailable: Boolean = false
+        override var onSelectionActiveChanged: ((Boolean) -> Unit)? = null
+        override var onHighlight: ((String, Double, android.graphics.Rect, String, String) -> Unit)? = null
+        override var onAnnotationTap: ((String, android.graphics.Rect) -> Unit)? = null
+        override var onAnnotationNoteTap: ((String, android.graphics.Rect) -> Unit)? = null
+        override var onFootnoteContent: ((FootnoteContent) -> Unit)? = null
+    }
+
+    private class FakePort : ContinuousDecorationController.Port {
+        val loaded = mutableListOf<FakeChapterWebView>()
+        override fun forEachLoadedWebView(block: (ChapterWebViewLike) -> Unit) { loaded.forEach(block) }
+        override fun findLoadedWebView(href: String): ChapterWebViewLike? =
+            loaded.firstOrNull { it.chapterHref == href }
+        override fun scrollTo(y: Int) { lastScrollY = y }
+        override fun smoothScrollTo(y: Int) { lastSmoothScrollY = y }
+        override fun clearLandingHold() { landingHoldCleared = true }
+        override fun buildWindow(): List<ContinuousPositionTracker.ChapterSlot> = window
+        override val viewportHeightPx: Int = 1000
+        override val currentScrollY: Int get() = scrollY
+
+        var lastScrollY: Int? = null
+        var lastSmoothScrollY: Int? = null
+        var landingHoldCleared: Boolean = false
+        var window: List<ContinuousPositionTracker.ChapterSlot> = emptyList()
+        var scrollY: Int = 0
+    }
+
+    // ---- annotation state persistence ----------------------------------------
+
+    @Test
+    fun `applyAnnotationHighlights persists state and applies to newly loaded chapter via onChapterLoaded`() {
+        val port = FakePort()
+        val c = ContinuousDecorationController(port)
+        val state = mapOf(
+            "ch-1.xhtml" to listOf(AnnotationHighlight("id1", "text", "rgba(255,0,0,0.4)")),
+        )
+
+        c.applyAnnotationHighlights(state)              // no chapter loaded yet — no-op
+        assertEquals(0, port.loaded.sumOf { it.evaluatedJsCount })
+
+        val wv = FakeChapterWebView(chapterHref = "ch-1.xhtml").also { port.loaded += it }
+        c.onChapterLoaded(wv)                            // simulates onPageFinished re-apply
+
+        assertEquals(1, wv.evaluatedJsCount)             // annotation JS re-applied
+    }
+
+    @Test
+    fun `applyAnnotationHighlights then clearing state issues clear JS, not apply JS, on next chapter load`() {
+        val port = FakePort()
+        val c = ContinuousDecorationController(port)
+        val href = "ch-1.xhtml"
+        c.applyAnnotationHighlights(mapOf(href to listOf(AnnotationHighlight("id1", "text", "rgba(0,0,0,1)"))))
+        c.applyAnnotationHighlights(emptyMap())          // clears persisted state
+
+        val wv = FakeChapterWebView(chapterHref = href).also { port.loaded += it }
+        c.onChapterLoaded(wv)
+
+        // No annotations persisted for this href anymore -> onChapterLoaded issues no annotation JS.
+        assertEquals(0, wv.evaluatedJsCount)
+    }
+
+    @Test
+    fun `onChapterLoaded fires onAnnotationsApplied callback once annotation JS completes`() {
+        val port = FakePort()
+        val c = ContinuousDecorationController(port)
+        val href = "ch-1.xhtml"
+        c.applyAnnotationHighlights(mapOf(href to listOf(AnnotationHighlight("id1", "text", "rgba(0,0,0,1)"))))
+        val wv = FakeChapterWebView(chapterHref = href)
+
+        var applied = false
+        c.onChapterLoaded(wv, onAnnotationsApplied = { applied = true })
+        assertFalse(applied)                             // JS issued, not yet completed
+        wv.completeLast()
+        assertTrue(applied)
+    }
+
+    // ---- search state persistence + clearing ----------------------------------
+
+    @Test
+    fun `applySearchHighlights(null) clears state and issues clear JS to every loaded chapter`() {
+        val port = FakePort()
+        val c = ContinuousDecorationController(port)
+        port.loaded += FakeChapterWebView("ch-1.xhtml")
+        port.loaded += FakeChapterWebView("ch-2.xhtml")
+
+        c.applySearchHighlights(SearchHighlightsState(
+            resultsByHref = mapOf("ch-1.xhtml" to listOf("foo")),
+            activeHref = "ch-1.xhtml",
+            activeText = "foo",
+            activeProgression = 0.5f,
+            activeCssColor = "rgba(1,1,1,1)",
+            inactiveCssColor = "rgba(2,2,2,1)",
+        ))
+        val before = port.loaded.sumOf { it.evaluatedJsCount }
+        c.applySearchHighlights(null)
+        val after = port.loaded.sumOf { it.evaluatedJsCount }
+
+        assertEquals(2, after - before)                  // one clear per loaded WebView
+    }
+
+    @Test
+    fun `search state persists across chapter loads and is applied via onChapterLoaded`() {
+        val port = FakePort()
+        val c = ContinuousDecorationController(port)
+        c.applySearchHighlights(SearchHighlightsState(
+            resultsByHref = mapOf("ch-1.xhtml" to listOf("foo")),
+            activeHref = "ch-1.xhtml",
+            activeText = "foo",
+            activeProgression = 0.5f,
+            activeCssColor = "rgba(1,1,1,1)",
+            inactiveCssColor = "rgba(2,2,2,1)",
+        ))
+
+        val wv = FakeChapterWebView(chapterHref = "ch-1.xhtml")
+        c.onChapterLoaded(wv)
+
+        assertTrue("search JS should be applied for a chapter with pending results", wv.evaluatedJsCount > 0)
+    }
+
+    // ---- readaloud scroll-jitter guard -----------------------------------------
+
+    @Test
+    fun `highlightInChapter does not scroll when target is within viewportHeightPx div 8 of current scrollY`() {
+        val port = FakePort()
+        port.window = listOf(ContinuousPositionTracker.ChapterSlot(href = "ch-1.xhtml", top = 0, height = 2000))
+        // vh = 1000; target = slot.top + elementTop - vh/3 = 0 + 400 - 333 = 67
+        // Set currentScrollY close enough that |target - current| <= vh/8 (125) -> no scroll.
+        port.scrollY = 67
+        val c = ContinuousDecorationController(port)
+        val wv = FakeChapterWebView(chapterHref = "ch-1.xhtml").also { port.loaded += it }
+
+        c.highlightInChapter("ch-1.xhtml", "some text", "rgba(0,0,0,1)")
+        wv.completeLast() // completes highlightTextJs -> triggers scrollToReadaloudHighlight's evaluateJavascript
+        wv.completeLast("400") // completes the position-query JS with elementTop = 400 device px
+
+        assertEquals(null, port.lastScrollY)
+        assertEquals(null, port.lastSmoothScrollY)
+        assertFalse(port.landingHoldCleared)
+    }
+
+    @Test
+    fun `highlightInChapter scrolls when target delta exceeds viewportHeightPx div 8`() {
+        val port = FakePort()
+        port.window = listOf(ContinuousPositionTracker.ChapterSlot(href = "ch-1.xhtml", top = 0, height = 2000))
+        // target = 0 + 400 - 333 = 67; put currentScrollY far away so |delta| > 125.
+        port.scrollY = 1000
+        val c = ContinuousDecorationController(port)
+        val wv = FakeChapterWebView(chapterHref = "ch-1.xhtml").also { port.loaded += it }
+
+        c.highlightInChapter("ch-1.xhtml", "some text", "rgba(0,0,0,1)")
+        wv.completeLast()
+        wv.completeLast("400")
+
+        assertEquals(67, port.lastSmoothScrollY)
+        assertTrue(port.landingHoldCleared)
+    }
+}


### PR DESCRIPTION
Closes #377.

## Summary

- Collapse `ContinuousReaderCoordinator`'s 12 forwarding lambdas into 3 sink interfaces (`ContinuousNavigationSink`, `ContinuousLinkSink`, `ContinuousAnnotationSink`).
- Dedup per-chapter `ChapterWebView` callback wiring shared between `appendChapter` / `prependChapter` into `ChapterWebViewBinder`, with a JVM-testable coordinate-transform seam via a new `ChapterWebViewLike` interface.
- Move annotation + search decoration state and apply-to-loaded-window loops out of `ContinuousReaderView` into `ContinuousDecorationController` behind a narrow view port. Preserves the readaloud scroll-jitter guard (`|delta| > vh/8`) and the `onAnnotationHighlightsApplied` landing-hold callback semantics.

Post-review tightening:
- `binder`: nullable → `lateinit` so a mis-ordered `initialize()` before `install()` fails fast instead of silently binding chapters without callbacks.
- `ChapterWebView.evalJs(script)` helper centralises the Kotlin-lambda overload disambiguation cast that was inlined at 7 no-callback JS injection sites.

No behavior change. Sliding-window state machine and `NestedScrollView` gesture arbitration are intentionally out of scope — the remaining structural extraction is tracked as follow-up #390.

## Test plan

- [x] `./gradlew :app:test` — full JVM suite green, including new `ChapterWebViewBinderTest` (4 cases) and `ContinuousDecorationControllerTest` (6 cases).
- [ ] `make harness-test` — user's call whether to run pre-merge; refactor is byte-for-byte behavior-preserving.
- [ ] Continuous-mode sanity on-device (readaloud highlight follows, annotation tap positions actions, search-highlight lands, TOC nav lands on right paragraph) — deferred to reviewer install.