### PR TITLE
fix(library): heal stuck offline banner after resume from sleep

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsViewModel.kt
@@ -8,7 +8,6 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.riffle.core.domain.AnnotationStore
 import com.riffle.core.domain.AudiobookBookmarkStore
-import com.riffle.core.domain.Clock
 import com.riffle.core.domain.Collection
 import com.riffle.core.domain.ConnectivityObserver
 import com.riffle.core.domain.LibraryItem
@@ -64,7 +63,6 @@ class LibraryItemsViewModel @Inject constructor(
     private val coverGridDensityStore: com.riffle.core.domain.CoverGridDensityStore,
     private val annotationStore: AnnotationStore,
     private val audiobookBookmarkStore: AudiobookBookmarkStore,
-    private val clock: Clock,
 ) : ViewModel() {
 
     val libraryId: String = savedStateHandle.get<String>("libraryId") ?: ""
@@ -264,15 +262,13 @@ class LibraryItemsViewModel @Inject constructor(
         savedStateHandle[KEY_SEARCH_QUERY] = query
     }
 
-    private var lastRefreshCompletedAt = 0L
-
-    /** Called from ON_RESUME. Skips if a refresh completed within the last 30s to avoid a
-     * redundant network round-trip when the library screen first enters RESUMED state immediately
-     * after init (which already launched its own refresh). */
+    /** Called from ON_RESUME. Reconciles the ConnectivityObserver against the live system state —
+     * doze/wake on Android 13 can drop `NetworkCallback` events, leaving the event-derived tracker
+     * holding stale offline state after the device wakes — then refreshes so the banner clears the
+     * moment the library screen returns to the foreground. */
     fun onScreenResumed() {
-        if (clock.nowMs() - lastRefreshCompletedAt > RESUME_REFRESH_DEBOUNCE_MS) {
-            refresh()
-        }
+        connectivityObserver.syncNow()
+        refresh()
     }
 
     fun refresh() {
@@ -288,12 +284,10 @@ class LibraryItemsViewModel @Inject constructor(
         val results = listOf(itemsDeferred.await(), seriesDeferred.await(), collectionsDeferred.await())
         toReadDeferred.await()
         _refreshFailed.value = results.any { it is LibraryRefreshResult.NetworkError }
-        lastRefreshCompletedAt = clock.nowMs()
     }
 
     private companion object {
         const val FAILED_REFRESH_RETRY_INTERVAL_MS = 10_000L
         const val KEY_SEARCH_QUERY = "searchQuery"
-        const val RESUME_REFRESH_DEBOUNCE_MS = 30_000L
     }
 }

--- a/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemsViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemsViewModelTest.kt
@@ -165,7 +165,9 @@ class LibraryItemsViewModelTest {
 
     private class FakeConnectivityObserver(online: Boolean = true) : ConnectivityObserver {
         val state = MutableStateFlow(online)
+        var syncNowCount = 0
         override val isOnline: StateFlow<Boolean> = state
+        override fun syncNow() { syncNowCount++ }
     }
 
     private class FakeToReadRepository(initial: Set<String> = emptySet()) : ToReadRepository {
@@ -230,10 +232,6 @@ class LibraryItemsViewModelTest {
         coverGridDensityStore = coverGridDensityStore,
         annotationStore = annotationStore,
         audiobookBookmarkStore = audiobookBookmarkStore,
-        clock = object : com.riffle.core.domain.Clock {
-            override fun nowMs(): Long = 0L
-            override fun nowNs(): Long = 0L
-        },
     )
 
     private fun series(name: String) = Series("id-$name", "lib-1", name, null, 1)
@@ -1111,5 +1109,30 @@ class LibraryItemsViewModelTest {
         // No query set — blank by default
         testDispatcher.scheduler.advanceUntilIdle()
         assertEquals(emptyList<AnnotationSearchResult>(), vm.projection.value.annotations)
+    }
+
+    // Regression: Android 13 doze/wake can coalesce NetworkCallback events, leaving the
+    // ConnectivityObserver's event-derived tracker stale — the banner then sticks after the device
+    // wakes. On ON_RESUME we now (1) poke syncNow() so the observer reconciles against reality and
+    // (2) always refresh so refreshFailed clears if the server is back.
+    @Test
+    fun `onScreenResumed reconciles connectivity and refreshes`() = runTest {
+        val connectivity = FakeConnectivityObserver()
+        val toRead = FakeToReadRepository()
+        val refreshItems = com.riffle.app.testing.NoopRefreshLibraryItems()
+        val vm = makeViewModel(
+            connectivityObserver = connectivity,
+            toReadRepository = toRead,
+            refreshLibraryItemsUseCase = refreshItems,
+        )
+        testDispatcher.scheduler.advanceUntilIdle()
+        val syncNowBefore = connectivity.syncNowCount
+        val refreshBefore = refreshItems.calls
+
+        vm.onScreenResumed()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(syncNowBefore + 1, connectivity.syncNowCount)
+        assertTrue(refreshItems.calls > refreshBefore)
     }
 }

--- a/core/data/src/main/kotlin/com/riffle/core/data/ConnectivityObserverImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/ConnectivityObserverImpl.kt
@@ -8,12 +8,15 @@ import android.net.NetworkRequest
 import com.riffle.core.domain.ApplicationScope
 import com.riffle.core.domain.ConnectivityObserver
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -27,6 +30,14 @@ class ConnectivityObserverImpl @Inject constructor(
         context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
 
     private val scope = applicationScope.coroutineScope
+
+    // syncNow() pokes this; the callbackFlow collector reconciles the tracker against the live
+    // ConnectivityManager snapshot. Buffered + DROP_OLDEST so a caller storm doesn't wedge the
+    // emitter but the next reconciliation still happens.
+    private val syncSignal = MutableSharedFlow<Unit>(
+        extraBufferCapacity = 1,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST,
+    )
 
     override val isOnline: StateFlow<Boolean> = callbackFlow {
         // Online-state is derived from callback events rather than re-queried on each transition.
@@ -62,10 +73,35 @@ class ConnectivityObserverImpl @Inject constructor(
             .build()
         connectivityManager.registerNetworkCallback(request, callback)
 
-        awaitClose { connectivityManager.unregisterNetworkCallback(callback) }
+        // Doze/wake on Android 13 can coalesce or drop NetworkCallback events, leaving the tracker
+        // holding stale state (banner sticks after resume). syncNow() sweeps allNetworks() and
+        // reseeds the tracker so state matches reality on the next lifecycle-resume hop.
+        val syncJob = launch {
+            syncSignal.collect {
+                val fresh = mutableSetOf<Network>()
+                for (network in connectivityManager.allNetworks) {
+                    val caps = connectivityManager.getNetworkCapabilities(network) ?: continue
+                    if (caps.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET) &&
+                        caps.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED)
+                    ) {
+                        fresh += network
+                    }
+                }
+                trySend(tracker.reset(fresh))
+            }
+        }
+
+        awaitClose {
+            syncJob.cancel()
+            connectivityManager.unregisterNetworkCallback(callback)
+        }
     }
         .distinctUntilChanged()
         .stateIn(scope, SharingStarted.Eagerly, currentOnline())
+
+    override fun syncNow() {
+        syncSignal.tryEmit(Unit)
+    }
 
     private fun currentOnline(): Boolean {
         val network = connectivityManager.activeNetwork ?: return false

--- a/core/data/src/main/kotlin/com/riffle/core/data/ValidatedNetworkTracker.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/ValidatedNetworkTracker.kt
@@ -23,4 +23,16 @@ internal class ValidatedNetworkTracker<K : Any> {
         if (hasValidatedInternet) validated += network else validated -= network
         return validated.isNotEmpty()
     }
+
+    /**
+     * Discard the event-derived set and replace it with [fresh]. Used by
+     * `ConnectivityObserverImpl.syncNow()` to heal drift when NetworkCallback events were dropped
+     * or coalesced during doze — the ground truth comes from a fresh sweep of
+     * `ConnectivityManager.getAllNetworks()` rather than the accumulated event history.
+     */
+    fun reset(fresh: Set<K>): Boolean {
+        validated.clear()
+        validated += fresh
+        return validated.isNotEmpty()
+    }
 }

--- a/core/data/src/test/kotlin/com/riffle/core/data/ValidatedNetworkTrackerTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/ValidatedNetworkTrackerTest.kt
@@ -59,4 +59,25 @@ class ValidatedNetworkTrackerTest {
 
         assertTrue(tracker.onLost("cellular"))
     }
+
+    @Test
+    fun `reset replaces the tracked set with the fresh snapshot`() {
+        // Regression for the resume-from-sleep bug: NetworkCallback events can be coalesced during
+        // Android 13 doze so onLost fires without a matching onAvailable on wake. syncNow() must
+        // discard the accumulated event history and re-seed from a live ConnectivityManager sweep.
+        val tracker = ValidatedNetworkTracker<String>()
+        tracker.onAvailable("stale-wifi")
+
+        assertTrue(tracker.reset(setOf("live-wifi")))
+        assertTrue(tracker.onLost("stale-wifi"))
+        assertFalse(tracker.onLost("live-wifi"))
+    }
+
+    @Test
+    fun `reset to an empty snapshot flips online to false`() {
+        val tracker = ValidatedNetworkTracker<String>()
+        tracker.onAvailable("wifi")
+
+        assertFalse(tracker.reset(emptySet()))
+    }
 }

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/ConnectivityObserver.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/ConnectivityObserver.kt
@@ -10,4 +10,12 @@ interface ConnectivityObserver {
      * "Wi-Fi only" download choice. Defaults to false so non-Android fakes need not implement it.
      */
     fun isMetered(): Boolean = false
+
+    /**
+     * Re-synchronise [isOnline] with the current system state. Call from lifecycle-resume paths:
+     * during doze/wake on Android 13+, `NetworkCallback` events can be coalesced or dropped, and
+     * the event-derived tracker inside the observer then holds stale state indefinitely. This
+     * hop reconciles it against `ConnectivityManager.getAllNetworks()`.
+     */
+    fun syncNow() {}
 }


### PR DESCRIPTION
## Summary
- Restores the pre-refactor \"library banner clears on resume\" behavior on Android 13+.
- Two recent commits combined to leave the library offline banner stuck indefinitely after the device resumed from sleep:
  - `55e321c3c` moved `isOnline` from a live re-query on `onLost` to a purely event-derived `ValidatedNetworkTracker` set. When `NetworkCallback` events are coalesced or dropped during doze (common on Android 13), the tracker holds stale offline state and never self-heals.
  - `039e93a64` added a 30 s `lastRefreshCompletedAt` debounce inside `onScreenResumed()`. Short lock/unlock cycles hit the debounce, so `ON_RESUME` skipped the refresh that would otherwise have cleared `_refreshFailed`.
- Fix reconciles on both axes on every `ON_RESUME`:
  - New `ConnectivityObserver.syncNow()` (default no-op on the interface) is wired inside `ConnectivityObserverImpl` to a `MutableSharedFlow` collector that sweeps `ConnectivityManager.allNetworks`, keeps only `INTERNET+VALIDATED` networks, and reseeds the tracker via a new `ValidatedNetworkTracker.reset(fresh)`. The airplane-mode invariant of #294 is preserved because the reset is a full replacement — an empty live snapshot correctly emits `isOnline=false`.
  - `LibraryItemsViewModel.onScreenResumed()` drops the 30 s debounce and calls `connectivityObserver.syncNow()` then `refresh()` every `ON_RESUME`. Removed the now-unused `Clock` dependency.

## Test plan
- [x] `./gradlew test` — full JVM suite green.
- [x] New `ValidatedNetworkTrackerTest` regression tests: `reset` replaces the tracked set; empty snapshot flips `isOnline` to false.
- [x] New `LibraryItemsViewModelTest` regression test asserts `onScreenResumed` pokes `syncNow()` and kicks a refresh.
- [ ] Device: on Android 13 physical device, background the app for a short lock/unlock cycle over toggling wifi and confirm the banner clears when the library screen returns to foreground.