### PR TITLE
fix(annotations): stabilize panel order for rows tied on (spineIndex, progression)

### DIFF
--- a/core/database/src/androidTest/kotlin/com/riffle/core/database/AnnotationDaoTest.kt
+++ b/core/database/src/androidTest/kotlin/com/riffle/core/database/AnnotationDaoTest.kt
@@ -112,6 +112,45 @@ class AnnotationDaoTest {
         assertEquals("device-B", tomb?.lastModifiedByDeviceId)
     }
 
+    // Regression: two annotations tied on (spineIndex, progression) — e.g. a bookmark at chapter
+    // top and a highlight on the chapter's first word — must keep a deterministic order across
+    // repeated upserts. Before the fix, upsert used INSERT OR REPLACE (which reallocates rowid)
+    // and observeAnnotationsByPosition had no tie-breaker, so every sync-driven merge flipped the
+    // pair in the annotations panel.
+    @Test
+    fun observeAnnotationsByPosition_isStableAcrossRepeatedUpsertsOnTiedSortKey() = runTest {
+        // Bookmark created first (older createdAt), highlight second. Ids are chosen so lex
+        // order (highlight first) is the OPPOSITE of creation order — mirroring
+        // AnnotationMergeService's `sortedBy { id }` iteration in the sync merge path. Under the
+        // old INSERT-OR-REPLACE upsert this made the re-upsert reallocate rowids in reverse of
+        // the intended order and, with no createdAt tie-breaker in the sort, flipped the pair.
+        val bookmark = highlight("z-bookmark-chapter-top", createdAt = 1000L).copy(
+            type = AnnotationEntity.TYPE_BOOKMARK,
+            spineIndex = 141,
+            progression = 0.0,
+        )
+        val hl = highlight("a-highlight-first-word", createdAt = 2000L).copy(
+            spineIndex = 141,
+            progression = 0.0,
+        )
+        dao.upsert(bookmark)
+        dao.upsert(hl)
+
+        val initial = dao.observeAnnotationsByPosition("abs1", "item1").first().map { it.id }
+        assertEquals(listOf("z-bookmark-chapter-top", "a-highlight-first-word"), initial)
+
+        // Simulate the sync merge path — iterate the id-sorted winners and upsert each.
+        val idSortedWinners = listOf(hl, bookmark)
+        repeat(3) { i ->
+            for (row in idSortedWinners) {
+                dao.upsert(row.copy(updatedAt = row.updatedAt + i + 1))
+            }
+        }
+
+        val afterMerges = dao.observeAnnotationsByPosition("abs1", "item1").first().map { it.id }
+        assertEquals(listOf("z-bookmark-chapter-top", "a-highlight-first-word"), afterMerges)
+    }
+
     @Test
     fun observeForItem_ordersByCreatedAtAscending() = runTest {
         dao.upsert(highlight("late", createdAt = 3000L))

--- a/core/database/src/main/kotlin/com/riffle/core/database/AnnotationDao.kt
+++ b/core/database/src/main/kotlin/com/riffle/core/database/AnnotationDao.kt
@@ -1,8 +1,6 @@
 package com.riffle.core.database
 
 import androidx.room.Dao
-import androidx.room.Insert
-import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import androidx.room.Upsert
 import kotlinx.coroutines.flow.Flow
@@ -51,7 +49,11 @@ interface AnnotationDao {
     )
     suspend fun getByItemAndCfi(serverId: String, itemId: String, cfi: String): AnnotationEntity?
 
-    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    // Real UPSERT (not INSERT-OR-REPLACE): REPLACE reallocates the rowid on every update, which
+    // shuffles the SQLite fallback order for rows that tie on the sort key (e.g. a bookmark and a
+    // highlight both at spineIndex=N, progression=0.0 at the top of a chapter). Every sync
+    // round-trip re-upserts and swaps their order in observeAnnotationsByPosition.
+    @Upsert
     suspend fun upsert(entity: AnnotationEntity)
 
     @Upsert
@@ -69,10 +71,13 @@ interface AnnotationDao {
     @Query("UPDATE annotations SET note = :note, updatedAt = :updatedAt, lastModifiedByDeviceId = :deviceId WHERE id = :id")
     suspend fun updateNote(id: String, note: String?, updatedAt: Long, deviceId: String)
 
-    /** Live, non-deleted annotations for an item sorted by reading position (spine order, then within-chapter). */
+    /** Live, non-deleted annotations for an item sorted by reading position (spine order, then
+     *  within-chapter). Ties on (spineIndex, progression) — common when a bookmark at chapter top
+     *  and a highlight on the first word both resolve to progression=0.0 — fall back to createdAt
+     *  and then id, so the order stays stable across sync-driven upserts. */
     @Query(
         "SELECT * FROM annotations WHERE serverId = :serverId AND itemId = :itemId AND deleted = 0 " +
-            "ORDER BY spineIndex ASC, progression ASC"
+            "ORDER BY spineIndex ASC, progression ASC, createdAt ASC, id ASC"
     )
     fun observeAnnotationsByPosition(serverId: String, itemId: String): Flow<List<AnnotationEntity>>
 


### PR DESCRIPTION
## Summary

The reader's annotations panel was silently swapping the order of two rows that landed at exactly the same `(spineIndex, progression)` — commonly a bookmark placed at the top of a chapter and a highlight on the chapter's first word, both resolving to `progression = 0.0`. The pair looked correct immediately after creation and then flipped after any subsequent sync round-trip.

Two things were combining to cause it:

1. `AnnotationDao.upsert()` was annotated `@Insert(onConflict = REPLACE)`. In SQLite that's DELETE + INSERT, which reallocates the row's `rowid` on every update. Every sync merge cycle re-upserts every row.
2. `observeAnnotationsByPosition` sorted only by `spineIndex ASC, progression ASC` with no tie-breaker, so SQLite fell back to `rowid` order for tied rows — the exact thing (1) kept mutating.

## Changes

- `AnnotationDao.upsert()` → Room's `@Upsert`. Real UPSERT preserves rowid on update.
- `observeAnnotationsByPosition` ORDER BY → `spineIndex ASC, progression ASC, createdAt ASC, id ASC`. Deterministic even if the rowid change ever regresses.

## Test plan

- [x] `AnnotationDaoTest.observeAnnotationsByPosition_isStableAcrossRepeatedUpsertsOnTiedSortKey` — new regression test. Creates a bookmark and a highlight both at `(spineIndex=141, progression=0.0)` with the bookmark first by `createdAt`, then simulates the sync merge path (id-sorted upserts, opposite of creation order) three times. Fails before the fix, passes after — verified locally by toggling both fixes off and running the test.
- [x] Full `AnnotationDaoTest` suite (10 tests) runs green on `Harness_Medium_Phone_2_2`.
- [ ] Manual repro on the user's Asus device with a fresh bookmark-then-highlight pair at chapter top and a forced sync to confirm the panel order sticks.