### PR TITLE
refactor(reader): extract ReaderSessionLifecycle from EpubReaderViewModel

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -201,7 +201,6 @@ class EpubReaderViewModel @Inject constructor(
     // per-book collaborators (readaloud, position, bookmarks, annotationSession).
     private val lifecycle: com.riffle.app.feature.reader.session.ReaderSessionLifecycle =
         readerSessionLifecycleFactory.create(
-            scope = viewModelScope,
             openPublication = { file -> openPublication(file) },
             cfiStringToLocator = { cfi -> cfiStringToLocator(cfi) },
         )

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -47,7 +47,6 @@ import com.riffle.core.domain.ReadingSessionCoordinator
 import com.riffle.core.domain.ReadingSessionRepository
 import com.riffle.core.domain.ServerProgress
 import com.riffle.core.domain.ServerRepository
-import com.riffle.core.domain.ServerType
 import com.riffle.core.domain.HighlightColor
 import com.riffle.core.domain.ReadaloudPreferencesStore
 import com.riffle.core.domain.ReadaloudResumeStore
@@ -90,7 +89,6 @@ import org.readium.r2.shared.util.Try
 import org.readium.r2.shared.util.asset.AssetRetriever
 import org.readium.r2.streamer.PublicationOpener
 import java.io.File
-import java.util.zip.ZipFile
 import javax.inject.Inject
 
 private const val BOOKMARK_PAGE_EPS = 0.05   // ±5% within-chapter progression window
@@ -168,6 +166,7 @@ class EpubReaderViewModel @Inject constructor(
     private val positionOrchestratorFactory: PositionOrchestrator.Factory,
     private val annotationSessionFactory: com.riffle.app.feature.reader.session.AnnotationSession.Factory,
     private val readaloudSessionFactory: com.riffle.app.feature.reader.session.ReadaloudSession.Factory,
+    private val readerSessionLifecycleFactory: com.riffle.app.feature.reader.session.ReaderSessionLifecycle.Factory,
     private val logger: Logger,
     private val clock: Clock,
     val dispatchers: DispatcherProvider,
@@ -196,6 +195,17 @@ class EpubReaderViewModel @Inject constructor(
     // (lastLocator, serverLocatorChannel, pendingServerJumpStamp, suppressNextServerLocator, etc.).
     private val position: PositionOrchestrator = positionOrchestratorFactory.create(viewModelScope)
 
+    // Session lifecycle — owns Publication/epubFile/epubZip, matched-book cross-sync state
+    // (readerSync + audiobookFollow + serverId), and the close-sync guard. The VM keeps the
+    // Compose-facing composer role: after lifecycle.open() returns Ready, the VM binds the
+    // per-book collaborators (readaloud, position, bookmarks, annotationSession).
+    private val lifecycle: com.riffle.app.feature.reader.session.ReaderSessionLifecycle =
+        readerSessionLifecycleFactory.create(
+            scope = viewModelScope,
+            openPublication = { file -> openPublication(file) },
+            cfiStringToLocator = { cfi -> cfiStringToLocator(cfi) },
+        )
+
     // Readaloud session — owns readaloud state and leaf controls. Full extraction happens across
     // sub-tasks 8.1–8.5; each sub-task lifts more logic here from the VM.
     private val readaloud: com.riffle.app.feature.reader.session.ReadaloudSession =
@@ -205,8 +215,8 @@ class EpubReaderViewModel @Inject constructor(
         ).also { session ->
             // Option-B provider seam (sub-task 8.2): session reads VM's live vars without setters.
             // itemId is wired in init {} because it is declared after readaloud in the class body.
-            session.readerSyncProvider = { readerSync }
-            session.audiobookFollowProvider = { audiobookFollow }
+            session.readerSyncProvider = { lifecycle.matchedSync.value?.readerSync }
+            session.audiobookFollowProvider = { lifecycle.matchedSync.value?.audiobookFollow }
         }
 
     // Annotation session — owns highlight/annotation state, panel visibility, navigation channel,
@@ -292,20 +302,10 @@ class EpubReaderViewModel @Inject constructor(
 
     // -----------------------------------------------------------------------------------------
 
-    private var publication: Publication? = null
-    private var epubFile: File? = null
-    @Volatile private var epubZip: ZipFile? = null
+    // publication, epubFile, epubZip, closeSyncDone, readerSync, audiobookFollow, readerSyncServerId
+    // now live on [lifecycle] (issue #376). Reads route through lifecycle.publication.value and
+    // lifecycle.matchedSync.value; teardown via lifecycle.onCleared().
     private val chapterHtmlCache = mutableMapOf<Int, String>()
-    private var closeSyncDone = false
-    // Non-null once a matched book's reconciliation prerequisites are cached: the unified cycle then
-    // replaces the single-peer ABS/Storyteller paths. [readerSyncServerId] is the active server
-    // (the displayed side) that keys the canonical localUpdatedAt.
-    private var readerSync: ReaderSyncCoordinator? = null
-    // Bundle-SMIL-only audiobook sync used when the full coordinator can't be built (cross-EPUB index
-    // not ready). Lets readaloud still sync to the audiobook (ADR 0031). Null when there's no audio
-    // target / bundle, or when the full coordinator is present (which supersedes it).
-    private var audiobookFollow: AudiobookFollow? = null
-    private var readerSyncServerId: String? = null
     // True after the navigator emits its first locator (the restored position on open).
     // The first emission is not new user progress — the position is already in DB — so we skip
     // the DB write to avoid stomping localUpdatedAt before the initial sync cycle runs.
@@ -393,13 +393,9 @@ class EpubReaderViewModel @Inject constructor(
 
     // ---- Readaloud (ADR 0023) ----------------------------------------------------------------
 
-    // True once we know the active server type. Every Storyteller book qualifies (its bundle can
-    // be downloaded on demand); ABS books qualify only when a synced bundle is already present.
-    private var isStorytellerServer = false
-
-    // The reader's active Server id, resolved inside openBook(). Keys the reconcile-targets cleanup
-    // in onCleared(). The session also holds this; kept here so onCleared() doesn't need a session accessor.
-    private var readerServerId: String? = null
+    // isStorytellerServer and readerServerId now live on [lifecycle] (issue #376). The single
+    // remaining read site (annotation binding) captures activeServer + isStorytellerServer from
+    // the Ready payload directly.
 
     // ---- Annotations (ADR 0024 / 0025) -------------------------------------------------------
 
@@ -518,235 +514,136 @@ class EpubReaderViewModel @Inject constructor(
     }
 
     private suspend fun openBook() {
-        val item = libraryObserver.getItem(itemId)
-        if (item == null) {
-            _state.value = ReaderState.Error("Book not found")
-            return
+        val outcome = lifecycle.open(
+            com.riffle.app.feature.reader.session.ReaderSessionLifecycle.OpenParams(
+                itemId = itemId,
+                openAtCfi = openAtCfi,
+                startTocHref = startTocHref,
+            ),
+        )
+        when (outcome) {
+            is com.riffle.app.feature.reader.session.ReaderSessionLifecycle.OpenOutcome.Error ->
+                _state.value = ReaderState.Error(outcome.message)
+            is com.riffle.app.feature.reader.session.ReaderSessionLifecycle.OpenOutcome.Ready ->
+                onOpenReady(outcome)
         }
-        when (val result = epubRepository.openEpub(item)) {
-            is EpubOpenResult.Success -> {
-                epubFile = result.epubFile
-                val pub = openPublication(result.epubFile)
-                if (pub == null) {
-                    _state.value = ReaderState.Error("Failed to open EPUB")
-                    return
-                }
-                publication = pub
-                // Bind the search controller to the new publication so it can execute queries.
-                search.bind(pub)
+    }
 
-                // ── Option α: resolve active-server + readaloud link sequentially in openBook ──
-                // Active-server type decides Readaloud availability: every Storyteller book qualifies,
-                // while ABS books qualify only when a synced bundle has already been downloaded.
-                val activeServer = serverRepository.getActive()
-                isStorytellerServer = activeServer?.serverType == ServerType.STORYTELLER
+    private suspend fun onOpenReady(
+        o: com.riffle.app.feature.reader.session.ReaderSessionLifecycle.OpenOutcome.Ready,
+    ) {
+        val pub = o.publication
+        // Bind the search controller to the new publication so it can execute queries.
+        search.bind(pub)
 
-                // Matched ABS book → key the bundle by the linked Storyteller book id (the bundle
-                // is stored under that id, not the ABS item id). Storyteller side keeps itemId.
-                val link = if (!isStorytellerServer && activeServer != null) {
-                    readaloudLinkRepository.findByAbsItem(activeServer.id, itemId)
-                } else {
-                    null
-                }
-                val resolvedAudioBookId = link?.storytellerBookId ?: itemId
-                val resolvedAudioServerId = link?.storytellerServerId ?: activeServer?.id ?: ""
-                val resolvedReaderServerId = activeServer?.id
+        // Mirror the resolved speed into the readaloud session before bind() so its startup state
+        // uses the right value.
+        readaloud.initialSpeed = o.resolvedInitialSpeed
 
-                // The audiobook to switch to on swipe-up: among this readaloud's ABS targets, the listenable
-                // one (the audiobook in a split library), or this same item if it's a combined ebook+audio.
-                val resolvedAudiobookItemId = link?.let { l ->
-                    readaloudLinkRepository.findByStorytellerBook(l.storytellerServerId, l.storytellerBookId)
-                        .firstOrNull { t ->
-                            t.absLibraryItemId != itemId &&
-                                libraryObserver.getItem(t.absServerId, t.absLibraryItemId)?.isListenable == true
-                        }
-                        ?.absLibraryItemId
-                }
-                logger.d(LogChannel.Handoff) { "RA.audiobookItemId resolved=$resolvedAudiobookItemId (overlay can now mount)" }
+        // ── Bind the readaloud session — must happen before position.bindBook() ────────
+        // All per-book readaloud wiring is consolidated here (Option α). After this call,
+        // availability flags are set and background work (pre-warm, sidecar, quotes) is launched.
+        readaloud.bind(
+            serverId = o.resolvedReaderServerId ?: "",
+            itemId = itemId,
+            isStorytellerServer = o.isStorytellerServer,
+            audioBookId = o.resolvedAudioBookId,
+            audioServerId = o.resolvedAudioServerId,
+            audioSettingsIdentity = o.resolvedAudioSettingsIdentity,
+            audiobookItemId = o.resolvedAudiobookItemId,
+            effectiveFormattingPreferencesFlow = formatting.effectiveFormattingPreferences,
+            currentLocatorFlow = position.currentLocator,
+            readerSyncProvider = { lifecycle.matchedSync.value?.readerSync },
+            audiobookFollowProvider = { lifecycle.matchedSync.value?.audiobookFollow },
+            readerSyncServerIdProvider = { lifecycle.matchedSync.value?.serverId },
+        )
 
-                // Resolve the audio-settings key and load the saved speed (ADR 0028). With a link,
-                // the resolver prefers the linked audiobook's id; without one, settings key on this ABS item.
-                val resolvedAudioSettingsIdentity = if (link != null) {
-                    audioIdentityResolver.resolveForStorytellerBook(link.storytellerServerId, link.storytellerBookId)
-                } else {
-                    AudioIdentity(activeServer?.id ?: "", itemId)
-                }
-                val resolvedInitialSpeed = audioPlaybackPreferencesStore.load(resolvedAudioSettingsIdentity)
-                    ?: listeningPreferencesStore.defaultPlaybackSpeed.first()
+        // Bind the position orchestrator so it can save positions for this book.
+        position.bindBook(
+            itemId = itemId,
+            serverId = o.resolvedReaderServerId ?: "",
+            positionSaveCoordinator = positionSaveCoordinator,
+            readingPositionStore = readingPositionStore,
+            spinePositionCounts = spinePositionCounts,
+        )
+        // When openAtCfi resolved, an ABS server-progress event arriving right after open must not
+        // stomp the explicit nav intent (annotation tap / search hit). Drop the first
+        // server-locator that follows; subsequent syncs (peer / live progress) still apply normally.
+        if (o.openAtLocator != null) position.markSuppressNextServerLocator()
 
-                // Mirror the resolved speed into the session.
-                readaloud.initialSpeed = resolvedInitialSpeed
-                // Claim this book so the durable sweep leaves it to this reader's own cycle (ADR 0030).
-                activeServer?.id?.let { openReconcileTargets.markOpen(it, itemId) }
+        _state.value = ReaderState.Ready(
+            publication = pub,
+            title = o.title,
+            initialLocator = o.initialLocator,
+            initialFocusAnnotationId = o.initialFocusAnnotationId,
+        )
 
-                // ── Bind the readaloud session — must happen before position.bindBook() ────────
-                // All per-book readaloud wiring is consolidated here (Option α). After this call,
-                // availability flags are set and background work (pre-warm, sidecar, quotes) is launched.
-                readaloud.bind(
-                    serverId = resolvedReaderServerId ?: "",
-                    itemId = itemId,
-                    isStorytellerServer = isStorytellerServer,
-                    audioBookId = resolvedAudioBookId,
-                    audioServerId = resolvedAudioServerId,
-                    audioSettingsIdentity = resolvedAudioSettingsIdentity,
-                    audiobookItemId = resolvedAudiobookItemId,
-                    effectiveFormattingPreferencesFlow = formatting.effectiveFormattingPreferences,
-                    currentLocatorFlow = position.currentLocator,
-                    readerSyncProvider = { readerSync },
-                    audiobookFollowProvider = { audiobookFollow },
-                    readerSyncServerIdProvider = { readerSyncServerId },
-                )
+        // Navigate to the requested TOC entry using the same path as an in-reader TOC tap.
+        // formattingPrefsProvider in the nav event handler ensures the correct continuous vs paged
+        // path is taken even when Compose state hasn't caught up yet.
+        startTocHref?.let { navigateToEntry(TocEntry(title = "", href = it)) }
 
-                // Bind the position orchestrator so it can save positions for this book.
-                // readerSyncServerId is now resolved above (Option α); use it directly.
-                position.bindBook(
-                    itemId = itemId,
-                    serverId = resolvedReaderServerId ?: "",
-                    positionSaveCoordinator = positionSaveCoordinator,
-                    readingPositionStore = readingPositionStore,
-                    spinePositionCounts = spinePositionCounts,
-                )
-                // Stored lastPosition is Readium Locator JSON. Rows written before ADR 0030's
-                // translation fix (< 2.6.x) may still hold a raw ABS `epubcfi(...)` — convert
-                // those on open so legacy progress isn't lost (one-time healing; new rows are
-                // always canonical Locator JSON). A genuinely unusable value falls back to null.
-                // A search-result open overrides the saved position; cfiStringToLocator needs `publication`,
-                // which is set by this point (same call used just below for legacy CFI healing).
-                val openAtLocator = openAtCfi?.takeIf { it.isNotBlank() }?.let { cfiStringToLocator(it) }
-                // When openAtCfi resolved, an ABS server-progress event arriving right after open
-                // must not stomp the explicit nav intent (annotation tap / search hit). Drop the
-                // first server-locator that follows; subsequent syncs (peer / live progress) still
-                // apply normally.
-                if (openAtLocator != null) position.markSuppressNextServerLocator()
-                // Bind openAtCfi to its source annotation (if any) so continuous mode can scroll to
-                // the DOM mark for that annotation — a precise post-reflow Y — instead of guessing
-                // from char-fraction × measured-WebView-height (which lands short of the highlight
-                // when the chapter's text-density differs from char-density).
-                val openAtCfiNonBlank = openAtCfi?.takeIf { it.isNotBlank() }
-                val initialFocusAnnotationId = if (openAtLocator != null && resolvedReaderServerId != null && openAtCfiNonBlank != null) {
-                    runCatching { annotationStore.findByItemAndCfi(resolvedReaderServerId, itemId, openAtCfiNonBlank) }
-                        .getOrNull()?.id
-                } else null
-                val locator = openAtLocator
-                    ?: result.lastPosition?.takeIf { it.isNotBlank() }?.let { stored ->
-                        runCatching { Locator.fromJSON(JSONObject(stored)) }.getOrNull()
-                            ?: cfiStringToLocator(stored)
-                    }
-                // When a TOC chapter is requested, pass null as initialLocator so Readium's
-                // async restore doesn't race with the navigateToEntry nav event. Navigation
-                // ownership is handed entirely to navigateToEntry, which waits for
-                // ContinuousReaderView.isInitialized before calling navigateTo. The paged
-                // navigator similarly receives null and lets fragment.go() handle it.
-                _state.value = ReaderState.Ready(
-                    publication = pub,
-                    title = item.title,
-                    initialLocator = if (startTocHref == null) locator else null,
-                    initialFocusAnnotationId = if (startTocHref == null) initialFocusAnnotationId else null,
-                )
-                // Navigate to the requested TOC entry using the same path as an in-reader TOC tap.
-                // formattingPrefsProvider in the nav event handler ensures the correct continuous vs
-                // paged path is taken even when Compose state hasn't caught up yet.
-                startTocHref?.let { navigateToEntry(TocEntry(title = "", href = it)) }
-                // Paged-mode only: after initialLocator opens the right chapter, fire the locator
-                // through the annotation-nav channel so the post-go() column-snap runs (the
-                // architectural invariant: the paged reader never rests off-grid). Without this,
-                // Readium's progression-based landing isn't snapped — onPageLoaded deliberately
-                // defers snapping to the post-go path. Before suppressNextServerLocator existed,
-                // a fast-arriving server-locator event accidentally provided that snap; suppressing
-                // it correctly broke the side effect. This restores it explicitly.
-                //
-                // Continuous mode is INTENTIONALLY excluded: its initialize()/openWindowAt path has
-                // its own reflow-tracking re-land logic that lands at the exact target as the
-                // chapter measures. A redundant nav event here would race scrollToLoadedChapter
-                // (which doesn't reflow-track) against that careful machinery and break the landing.
-                // Vertical mode is also excluded — initialLocator already lands correctly without a
-                // snap, and a redundant fragment.go() would only add a same-place re-positioning.
-                if (openAtLocator != null && formatting.effectiveFormattingPreferences.value.orientation == ReaderOrientation.Horizontal) {
-                    annotationSession.emitAnnotationNavigation(openAtLocator)
-                }
-                // A matched book with cached prerequisites runs the reconciliation cycle instead of
-                // the single-peer ABS/Storyteller paths; otherwise this is null and nothing changes.
-                readerSync = runCatching { readerSyncFactory.createIfApplicable(itemId) }.getOrNull()
-                // readerSyncServerId and readerServerId are the active server resolved earlier via Option α.
-                readerSyncServerId = resolvedReaderServerId
-                readerServerId = resolvedReaderServerId
-                // Update the session's readerSyncServerId now that readerSync is resolved.
-                // (bind() set it to resolvedReaderServerId already; this keeps them in sync.)
-                readaloud.readerSyncServerId = readerSyncServerId
-                // When the full coordinator can't be built (no cross-EPUB index yet), fall back to the
-                // bundle-SMIL-only audiobook follow so readaloud still syncs to the audiobook (ADR 0031).
-                audiobookFollow = if (readerSync == null) {
-                    runCatching { readerSyncFactory.createAudiobookFollowIfApplicable(itemId) }.getOrNull()
-                } else null
-                // A matched book also drives the audiobook ABS record from this reader, so the sweep
-                // must skip that (possibly split-library) item too while the reader is open (ADR 0030).
-                readerSyncServerId?.let { sid ->
-                    (readerSync?.audioItemId ?: audiobookFollow?.audioItemId)?.let { openReconcileTargets.markOpen(sid, it) }
-                }
+        // Paged-mode only: after initialLocator opens the right chapter, fire the locator through
+        // the annotation-nav channel so the post-go() column-snap runs (the architectural invariant:
+        // the paged reader never rests off-grid). Continuous / Vertical are intentionally excluded —
+        // they land correctly without this snap.
+        if (o.openAtLocator != null &&
+            formatting.effectiveFormattingPreferences.value.orientation == ReaderOrientation.Horizontal
+        ) {
+            annotationSession.emitAnnotationNavigation(o.openAtLocator)
+        }
 
-                // Audiobook→readaloud handoff: opened by swiping the audiobook player down. Auto-start
-                // readaloud from the audiobook's position so narration continues where listening stopped.
-                // The auto-follow drives the reader page to the narrated sentence once the navigator is up.
-                if (startReadaloudAtSec >= 0.0 && readaloud.readaloudAvailable.value) {
-                    startReadaloudAtSecond(startReadaloudAtSec)
-                }
+        // Audiobook→readaloud handoff: opened by swiping the audiobook player down. Auto-start
+        // readaloud from the audiobook's position so narration continues where listening stopped.
+        if (startReadaloudAtSec >= 0.0 && readaloud.readaloudAvailable.value) {
+            startReadaloudAtSecond(startReadaloudAtSec)
+        }
 
-                // ── Annotation binding — ABS-side only (ADR 0024) ────────────────────────────
-                if (!isStorytellerServer && activeServer != null) {
-                    annotationServerId = activeServer.id
-                    // Bind the bookmarks controller so it can observe bookmarks and track the current
-                    // locator for page-bookmark detection.
-                    bookmarks.bind(
-                        serverId = activeServer.id,
-                        itemId = itemId,
-                        currentLocator = position.currentLocator,
-                    )
-                    // Push orientation changes into the controller via a setter (instead of
-                    // collecting via combine) so the page-bookmark indicator's match window
-                    // re-sizes on a mid-session flip without dragging a third StateFlow into
-                    // every locator-update recompute.
-                    bookmarks.onOrientationChanged(formatting.formattingPreferences.value.orientation)
-                    viewModelScope.launch {
-                        formatting.formattingPreferences
-                            .map { it.orientation }
-                            .distinctUntilChanged()
-                            .collect { bookmarks.onOrientationChanged(it) }
-                    }
-                    // Resolve the ABS-side stable account id (`/api/me` → user.id) as the WebDAV path
-                    // namespace. ensureAbsUserId backfills it for legacy server rows. A null result
-                    // means we can't sync this session (offline or non-ABS or backfill failed) — the
-                    // local DB stays as the source of truth and sync resumes on the next open.
-                    val namespace = serverRepository.ensureAbsUserId(activeServer.id)
-                    annotationNamespace = namespace
-                    // Bind the annotation session: starts observation, syncOnOpen, and live-pull loop.
-                    // Observation always starts (shows local highlights). A blank namespace means the
-                    // ABS user id wasn't resolved this session — syncOnOpen/scheduleSync/startLiveSync
-                    // lambdas delegate to AnnotationSyncController which self-guards via targetProvider.
-                    annotationSession.bind(
-                        serverId = activeServer.id,
-                        namespace = namespace ?: "",
-                        itemId = itemId,
-                        highlightRenderResolver = { a -> annotationToRender(a) },
-                        cfiLocatorResolver = { cfi -> cfiStringToLocator(cfi) },
-                    )
-                }
-
-                // Sync immediately while localUpdatedAt is still the genuine stored value —
-                // before the navigator restore emits and would stamp localUpdatedAt = now.
-                if (readerSync != null) {
-                    runReaderSyncCycle(locator)
-                } else {
-                    progressSyncController.sync(itemId, locator?.toPayload() ?: SessionPayload("", 0f))
-                }
-
-                // Heartbeat only — no speed-tracker baseline yet (openBook can fire well before the
-                // first onReaderResumed; the lifecycle handler below resets the baseline once the
-                // reader is actually visible).
-                startReadingSession(initialTotalProgression = null)
+        // ── Annotation binding — ABS-side only (ADR 0024) ────────────────────────────
+        val activeServer = o.activeServer
+        if (!o.isStorytellerServer && activeServer != null) {
+            annotationServerId = activeServer.id
+            // Bind the bookmarks controller so it can observe bookmarks and track the current
+            // locator for page-bookmark detection.
+            bookmarks.bind(
+                serverId = activeServer.id,
+                itemId = itemId,
+                currentLocator = position.currentLocator,
+            )
+            // Push orientation changes into the controller via a setter so the page-bookmark
+            // indicator's match window re-sizes on a mid-session flip.
+            bookmarks.onOrientationChanged(formatting.formattingPreferences.value.orientation)
+            viewModelScope.launch {
+                formatting.formattingPreferences
+                    .map { it.orientation }
+                    .distinctUntilChanged()
+                    .collect { bookmarks.onOrientationChanged(it) }
             }
-            is EpubOpenResult.NetworkError -> _state.value = ReaderState.Error("Network error: ${result.cause.message}")
-            EpubOpenResult.Offline -> _state.value = ReaderState.Error("Book not available offline")
+            // Resolve the ABS-side stable account id (`/api/me` → user.id) as the WebDAV path
+            // namespace. A null result means sync is skipped this session; DB stays canonical.
+            val namespace = serverRepository.ensureAbsUserId(activeServer.id)
+            annotationNamespace = namespace
+            annotationSession.bind(
+                serverId = activeServer.id,
+                namespace = namespace ?: "",
+                itemId = itemId,
+                highlightRenderResolver = { a -> annotationToRender(a) },
+                cfiLocatorResolver = { cfi -> cfiStringToLocator(cfi) },
+            )
         }
+
+        // Sync immediately while localUpdatedAt is still the genuine stored value — before the
+        // navigator restore emits and would stamp localUpdatedAt = now.
+        val syncLocator = o.effectiveInitialLocator
+        if (lifecycle.matchedSync.value?.readerSync != null) {
+            runReaderSyncCycle(syncLocator)
+        } else {
+            progressSyncController.sync(itemId, syncLocator?.toPayload() ?: SessionPayload("", 0f))
+        }
+
+        // Heartbeat only — no speed-tracker baseline yet (openBook can fire well before the first
+        // onReaderResumed; the lifecycle handler resets the baseline once the reader is visible).
+        startReadingSession(initialTotalProgression = null)
     }
 
     private fun startReadingSession(initialTotalProgression: Float?) {
@@ -759,7 +656,7 @@ class EpubReaderViewModel @Inject constructor(
     private fun syncCurrentPosition() {
         val locator = position.snapshotLastLocator() ?: return
         viewModelScope.launch {
-            if (readerSync != null) runReaderSyncCycle(locator)
+            if (lifecycle.matchedSync.value?.readerSync != null) runReaderSyncCycle(locator)
             else progressSyncController.sync(itemId, locator.toPayload())
         }
     }
@@ -778,8 +675,9 @@ class EpubReaderViewModel @Inject constructor(
      * write never reads back as a newer remote and drives the ebook (the loop that erased progress).
      */
     private suspend fun runReaderSyncCycle(locator: Locator?) {
-        val coordinator = readerSync ?: return
-        val serverId = readerSyncServerId ?: return
+        val ms = lifecycle.matchedSync.value ?: return
+        val coordinator = ms.readerSync ?: return
+        val serverId = ms.serverId ?: return
         val locJson = (locator ?: position.snapshotLastLocator())?.toJSON()?.toString()
         if (locJson != null) {
             val localUpdatedAt = readingPositionStore.loadLocalUpdatedAt(serverId, itemId)
@@ -904,7 +802,7 @@ class EpubReaderViewModel @Inject constructor(
 
     fun onReaderResumed() {
         readerStateHolder.isReaderActive = true
-        closeSyncDone = false
+        lifecycle.resetCloseSync()
         position.resetInitialLocatorSeen()
         // Arm the speed-tracker baseline unconditionally — pre-refactor set sessionStart{Progression,Ms}
         // on every resume regardless of state, so a session that resumes while still loading and closes
@@ -946,8 +844,7 @@ class EpubReaderViewModel @Inject constructor(
         // pre-armed this with the pre-popup origin (see captureFootnotePopupLinkOrigin); don't
         // overwrite that with the popup-nudged lastLocator. setReturnAnchor honours this contract.
         position.setReturnAnchor(position.snapshotLastLocator())
-        if (closeSyncDone) return
-        closeSyncDone = true
+        if (!lifecycle.tryClaimCloseSync()) return
         // Leaving the book without first pressing X: persist the sentence narrating now so re-entry
         // resumes there. (Pressing X already persisted via closeReadaloud, which closes the player.)
         // Below the closeSyncDone guard so the ON_STOP + onDispose pair doesn't double-write.
@@ -962,7 +859,7 @@ class EpubReaderViewModel @Inject constructor(
         viewModelScope.launch {
             val payload = locator.toPayload()
             positionSaveCoordinator.onClose(locator.toJSON().toString(), payload.ebookProgress)
-            if (readerSync != null) runReaderSyncCycle(locator)
+            if (lifecycle.matchedSync.value?.readerSync != null) runReaderSyncCycle(locator)
             else progressSyncController.sync(itemId, payload)
         }
     }
@@ -973,7 +870,7 @@ class EpubReaderViewModel @Inject constructor(
 
     // Translates via character-count CFIs; see EpubCfiTranslator and ADR 0013.
     private suspend fun Locator.toPayload(): SessionPayload = withContext(dispatchers.default) {
-        val readingOrder = publication?.readingOrder ?: emptyList()
+        val readingOrder = lifecycle.publication.value?.readingOrder ?: emptyList()
         val spineIndex = readingOrder.indexOfFirst { link ->
             normalizeEpubHref(link.href.toString()) == normalizeEpubHref(href.toString())
         }
@@ -999,7 +896,7 @@ class EpubReaderViewModel @Inject constructor(
      * when the string isn't an epubcfi or can't be resolved, letting callers fall back.
      */
     private suspend fun cfiStringToLocator(rawCfi: String): Locator? {
-        val pub = publication ?: return null
+        val pub = lifecycle.publication.value ?: return null
         val cfi = rawCfi.takeIf { it.startsWith("epubcfi(") } ?: return null
         val spineIndex = epubCfiToSpineIndex(cfi)
         val link = spineIndex?.let { pub.readingOrder.getOrNull(it) }
@@ -1034,7 +931,7 @@ class EpubReaderViewModel @Inject constructor(
     }
 
     private suspend fun serverProgressToLocator(serverProgress: ServerProgress): Locator? {
-        val pub = publication ?: return null
+        val pub = lifecycle.publication.value ?: return null
         cfiStringToLocator(serverProgress.ebookLocation)?.let { return it }
         // Fallback: no usable CFI — navigate via book-wide progress float
         val progress = serverProgress.ebookProgress.toDouble().coerceIn(0.0, 1.0)
@@ -1050,7 +947,7 @@ class EpubReaderViewModel @Inject constructor(
     fun createHighlight(selectionLocator: Locator, anchorRect: IntRect) {
         val serverId = annotationServerId ?: return
         viewModelScope.launch {
-            val pub = publication ?: return@launch
+            val pub = lifecycle.publication.value ?: return@launch
             val snippet = selectionLocator.text.highlight?.takeIf { it.isNotBlank() } ?: return@launch
             val href = selectionLocator.href.toString()
             val spineIndex = pub.readingOrder.indexOfFirst {
@@ -1111,7 +1008,7 @@ class EpubReaderViewModel @Inject constructor(
                 annotationStore.delete(existing.id)
                 scheduleAnnotationSync()
             } else {
-                val pub = publication ?: return@launch
+                val pub = lifecycle.publication.value ?: return@launch
                 val spineIdx = pub.readingOrder.indexOfFirst { normalizeEpubHref(it.url().toString()) == normalizeEpubHref(href) }.coerceAtLeast(0)
                 val totalProg = locator.locations.totalProgression
                 val spineHrefs = pub.readingOrder.map { it.url().toString() }
@@ -1184,7 +1081,7 @@ class EpubReaderViewModel @Inject constructor(
     // the within-chapter position; the text snippet lets Readium's decorator locate the range.
     // Called as the highlightRenderResolver injected into annotationSession.bind().
     private suspend fun annotationToRender(a: Annotation): HighlightRender? {
-        val pub = publication ?: return null
+        val pub = lifecycle.publication.value ?: return null
         val spineIndex = epubCfiToSpineIndex(a.cfi) ?: return null
         val link = pub.readingOrder.getOrNull(spineIndex) ?: return null
         val html = readChapterHtml(spineIndex) ?: return null
@@ -1209,15 +1106,10 @@ class EpubReaderViewModel @Inject constructor(
     private suspend fun readChapterHtml(spineIndex: Int): String? {
         chapterHtmlCache[spineIndex]?.let { return it }
         return withContext(dispatchers.io) {
-            val file = epubFile ?: return@withContext null
-            val pub = publication ?: return@withContext null
+            val pub = lifecycle.publication.value ?: return@withContext null
             val link = pub.readingOrder.getOrNull(spineIndex) ?: return@withContext null
             val entryPath = normalizeEpubHref(link.href.toString())
-            val zip = try {
-                epubZip ?: synchronized(this@EpubReaderViewModel) {
-                    epubZip ?: ZipFile(file).also { epubZip = it }
-                }
-            } catch (_: Exception) { return@withContext null }
+            val zip = lifecycle.zip() ?: return@withContext null
             try {
                 zip.getEntry(entryPath)?.let { entry ->
                     zip.getInputStream(entry).bufferedReader().readText()
@@ -1237,15 +1129,8 @@ class EpubReaderViewModel @Inject constructor(
         annotationSession.onBookClosed()
         // Tear down all readaloud session background jobs (pre-warm, sidecar obs, sync, speed debounce).
         readaloud.onBookClosed()
-        // Release this book to the durable sweep again (ADR 0030).
-        readerServerId?.let { sid ->
-            openReconcileTargets.markClosed(sid, itemId)
-            (readerSync?.audioItemId ?: audiobookFollow?.audioItemId)?.let { openReconcileTargets.markClosed(sid, it) }
-        }
-        epubZip?.close()
-        epubZip = null
-        publication?.close()
-        publication = null
+        // Release openReconcile claims, close the zip and publication.
+        lifecycle.onCleared()
         // Tear down the audio session so it doesn't outlive the reader (clears the highlight too).
         playerCoordinator.close()
         // Readaloud can't outlive the reader, so this session is no longer playing.

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/session/ReaderSessionLifecycle.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/session/ReaderSessionLifecycle.kt
@@ -1,0 +1,298 @@
+@file:OptIn(org.readium.r2.shared.ExperimentalReadiumApi::class)
+
+package com.riffle.app.feature.reader.session
+
+import com.riffle.app.feature.reader.AudiobookFollow
+import com.riffle.app.feature.reader.ReaderSyncCoordinator
+import com.riffle.app.feature.reader.ReaderSyncFactory
+import com.riffle.core.data.OpenReconcileTargets
+import com.riffle.core.domain.AnnotationStore
+import com.riffle.core.domain.AudioIdentity
+import com.riffle.core.domain.AudioIdentityResolver
+import com.riffle.core.domain.AudioPlaybackPreferencesStore
+import com.riffle.core.domain.EpubOpenResult
+import com.riffle.core.domain.EpubRepository
+import com.riffle.core.domain.LibraryObserver
+import com.riffle.core.domain.ListeningPreferencesStore
+import com.riffle.core.domain.ReadaloudLinkRepository
+import com.riffle.core.domain.Server
+import com.riffle.core.domain.ServerRepository
+import com.riffle.core.domain.ServerType
+import com.riffle.core.logging.LogChannel
+import com.riffle.core.logging.Logger
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.first
+import org.json.JSONObject
+import org.readium.r2.shared.publication.Locator
+import org.readium.r2.shared.publication.Publication
+import java.io.File
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.zip.ZipFile
+
+/**
+ * Owns book-open orchestration, matched-book cross-sync state, and per-session bookkeeping
+ * (`Publication`, `epubFile`, `epubZip`, `closeSyncDone`) previously scattered across
+ * [com.riffle.app.feature.reader.EpubReaderViewModel].
+ *
+ * The lifecycle resolves everything the VM needs to bind its per-book collaborators
+ * (readaloud, position, bookmarks, annotations) and hands back an [OpenOutcome.Ready] payload.
+ * Binding itself stays in the VM — the seam is intentionally Compose-facing-composer + resolver,
+ * not a super-orchestrator.
+ *
+ * MUST NOT import android.webkit.*, ContinuousReaderView, or any Compose types.
+ */
+class ReaderSessionLifecycle @AssistedInject constructor(
+    @Suppress("UNUSED_PARAMETER") @Assisted scope: CoroutineScope,
+    @Assisted private val openPublication: suspend (File) -> Publication?,
+    @Assisted private val cfiStringToLocator: suspend (String) -> Locator?,
+    private val libraryObserver: LibraryObserver,
+    private val epubRepository: EpubRepository,
+    private val serverRepository: ServerRepository,
+    private val readaloudLinkRepository: ReadaloudLinkRepository,
+    private val audioIdentityResolver: AudioIdentityResolver,
+    private val audioPlaybackPreferencesStore: AudioPlaybackPreferencesStore,
+    private val listeningPreferencesStore: ListeningPreferencesStore,
+    private val openReconcileTargets: OpenReconcileTargets,
+    private val readerSyncFactory: ReaderSyncFactory,
+    private val annotationStore: AnnotationStore,
+    private val logger: Logger,
+) {
+
+    @AssistedFactory
+    interface Factory {
+        fun create(
+            scope: CoroutineScope,
+            openPublication: suspend (File) -> Publication?,
+            cfiStringToLocator: suspend (String) -> Locator?,
+        ): ReaderSessionLifecycle
+    }
+
+    private val _publication = MutableStateFlow<Publication?>(null)
+    val publication: StateFlow<Publication?> = _publication
+
+    private val _matchedSync = MutableStateFlow<MatchedSync?>(null)
+    val matchedSync: StateFlow<MatchedSync?> = _matchedSync
+
+    @Volatile private var epubFile: File? = null
+    @Volatile private var epubZip: ZipFile? = null
+
+    // Teardown state — needed to release the openReconcile claims made during open(). Held here
+    // rather than derived from matchedSync because matchedSync.serverId is only set when a match
+    // was resolved; a single-peer session still needs to release its own claim.
+    @Volatile private var readerServerId: String? = null
+    @Volatile private var readerItemId: String? = null
+
+    private val closeSyncDone = AtomicBoolean(false)
+
+    /**
+     * Legacy raw-`epubcfi(...)` translation is passed as a suspending lambda so the lifecycle
+     * stays free of the CFI-parsing helpers the VM already owns. A follow-up may lift these here.
+     */
+    suspend fun open(params: OpenParams): OpenOutcome {
+        val item = libraryObserver.getItem(params.itemId)
+            ?: return OpenOutcome.Error("Book not found")
+
+        return when (val result = epubRepository.openEpub(item)) {
+            is EpubOpenResult.Success -> resolveReady(result, item.title, params)
+            is EpubOpenResult.NetworkError -> OpenOutcome.Error("Network error: ${result.cause.message}")
+            EpubOpenResult.Offline -> OpenOutcome.Error("Book not available offline")
+        }
+    }
+
+    private suspend fun resolveReady(
+        result: EpubOpenResult.Success,
+        title: String,
+        params: OpenParams,
+    ): OpenOutcome {
+        epubFile = result.epubFile
+        val pub = openPublication(result.epubFile)
+            ?: return OpenOutcome.Error("Failed to open EPUB")
+        _publication.value = pub
+
+        val activeServer: Server? = serverRepository.getActive()
+        val isStorytellerServer = activeServer?.serverType == ServerType.STORYTELLER
+
+        // Matched ABS book → key the bundle by the linked Storyteller book id (the bundle is
+        // stored under that id, not the ABS item id). Storyteller side keeps itemId.
+        val link = if (!isStorytellerServer && activeServer != null) {
+            readaloudLinkRepository.findByAbsItem(activeServer.id, params.itemId)
+        } else {
+            null
+        }
+        val resolvedAudioBookId = link?.storytellerBookId ?: params.itemId
+        val resolvedAudioServerId = link?.storytellerServerId ?: activeServer?.id ?: ""
+        val resolvedReaderServerId = activeServer?.id
+
+        // The audiobook to switch to on swipe-up: among this readaloud's ABS targets, the
+        // listenable one (in a split library), or this same item if it's a combined ebook+audio.
+        val resolvedAudiobookItemId = link?.let { l ->
+            readaloudLinkRepository.findByStorytellerBook(l.storytellerServerId, l.storytellerBookId)
+                .firstOrNull { t ->
+                    t.absLibraryItemId != params.itemId &&
+                        libraryObserver.getItem(t.absServerId, t.absLibraryItemId)?.isListenable == true
+                }
+                ?.absLibraryItemId
+        }
+        logger.d(LogChannel.Handoff) { "RA.audiobookItemId resolved=$resolvedAudiobookItemId (overlay can now mount)" }
+
+        val resolvedAudioSettingsIdentity = if (link != null) {
+            audioIdentityResolver.resolveForStorytellerBook(link.storytellerServerId, link.storytellerBookId)
+        } else {
+            AudioIdentity(activeServer?.id ?: "", params.itemId)
+        }
+        val resolvedInitialSpeed = audioPlaybackPreferencesStore.load(resolvedAudioSettingsIdentity)
+            ?: listeningPreferencesStore.defaultPlaybackSpeed.first()
+
+        // Claim this book so the durable sweep leaves it to this reader's own cycle (ADR 0030).
+        activeServer?.id?.let { openReconcileTargets.markOpen(it, params.itemId) }
+        readerServerId = resolvedReaderServerId
+        readerItemId = params.itemId
+
+        val openAtCfiNonBlank = params.openAtCfi?.takeIf { it.isNotBlank() }
+        // A search-result / annotation-tap open overrides the saved position. Requires `publication`
+        // (set above) — cfiStringToLocator resolves against it.
+        val openAtLocator = openAtCfiNonBlank?.let { cfiStringToLocator(it) }
+        // openAtCfiNonBlank is non-null whenever openAtLocator is (openAtLocator is derived from it).
+        val initialFocusAnnotationId = if (openAtLocator != null && resolvedReaderServerId != null && openAtCfiNonBlank != null) {
+            runCatching {
+                annotationStore.findByItemAndCfi(resolvedReaderServerId, params.itemId, openAtCfiNonBlank)
+            }.getOrNull()?.id
+        } else {
+            null
+        }
+
+        // Stored lastPosition is Readium Locator JSON. Rows written before ADR 0030's translation
+        // fix may still hold a raw ABS `epubcfi(...)` — heal those on open so legacy progress
+        // isn't lost. A genuinely unusable value falls back to null.
+        val storedLocator = result.lastPosition?.takeIf { it.isNotBlank() }?.let { stored ->
+            runCatching { Locator.fromJSON(JSONObject(stored)) }.getOrNull()
+                ?: cfiStringToLocator(stored)
+        }
+
+        // Effective initial locator — openAtCfi wins over stored. When a TOC entry is requested,
+        // pass null so Readium's async restore doesn't race with the VM's navigateToEntry.
+        val effectiveInitial = openAtLocator ?: storedLocator
+        val initialLocator = if (params.startTocHref == null) effectiveInitial else null
+        val effectiveFocusAnnotationId = if (params.startTocHref == null) initialFocusAnnotationId else null
+
+        // Build matched-sync — a matched book runs the reconciliation cycle instead of the
+        // single-peer ABS/Storyteller paths. When the full coordinator can't be built (no
+        // cross-EPUB index yet), fall back to bundle-SMIL-only follow (ADR 0031).
+        val readerSync = runCatching { readerSyncFactory.createIfApplicable(params.itemId) }.getOrNull()
+        val audiobookFollow = if (readerSync == null) {
+            runCatching { readerSyncFactory.createAudiobookFollowIfApplicable(params.itemId) }.getOrNull()
+        } else {
+            null
+        }
+        _matchedSync.value = MatchedSync(
+            readerSync = readerSync,
+            audiobookFollow = audiobookFollow,
+            serverId = resolvedReaderServerId,
+        )
+        // A matched book also drives the audiobook ABS record from this reader, so the sweep must
+        // skip that (possibly split-library) item too while the reader is open (ADR 0030).
+        resolvedReaderServerId?.let { sid ->
+            (readerSync?.audioItemId ?: audiobookFollow?.audioItemId)?.let {
+                openReconcileTargets.markOpen(sid, it)
+            }
+        }
+
+        return OpenOutcome.Ready(
+            publication = pub,
+            title = title,
+            initialLocator = initialLocator,
+            initialFocusAnnotationId = effectiveFocusAnnotationId,
+            effectiveInitialLocator = effectiveInitial,
+            openAtLocator = openAtLocator,
+            activeServer = activeServer,
+            isStorytellerServer = isStorytellerServer,
+            resolvedAudioBookId = resolvedAudioBookId,
+            resolvedAudioServerId = resolvedAudioServerId,
+            resolvedReaderServerId = resolvedReaderServerId,
+            resolvedAudiobookItemId = resolvedAudiobookItemId,
+            resolvedAudioSettingsIdentity = resolvedAudioSettingsIdentity,
+            resolvedInitialSpeed = resolvedInitialSpeed,
+        )
+    }
+
+    /**
+     * Lazy zip handle for chapter-HTML extraction; cached across calls, closed by [onCleared].
+     * Null before [open] succeeds.
+     */
+    fun zip(): ZipFile? {
+        epubZip?.let { return it }
+        val file = epubFile ?: return null
+        return synchronized(this) {
+            epubZip ?: runCatching { ZipFile(file) }.getOrNull()?.also { epubZip = it }
+        }
+    }
+
+    /**
+     * Guard for the ON_STOP / onDispose double-write on close. Returns true the first time it is
+     * called within a session; subsequent calls (until [resetCloseSync]) return false so the caller
+     * short-circuits its close-sync payload.
+     */
+    fun tryClaimCloseSync(): Boolean = closeSyncDone.compareAndSet(false, true)
+
+    /** Called from `onReaderResumed` — arms the guard for the next backgrounding. */
+    fun resetCloseSync() { closeSyncDone.set(false) }
+
+    /**
+     * Terminal teardown — mirrors the field-clearing block in `EpubReaderViewModel.onCleared`.
+     * Releases open-reconcile claims, closes the cached zip and publication.
+     */
+    fun onCleared() {
+        val sid = readerServerId
+        val iid = readerItemId
+        if (sid != null && iid != null) {
+            openReconcileTargets.markClosed(sid, iid)
+            val ms = _matchedSync.value
+            (ms?.readerSync?.audioItemId ?: ms?.audiobookFollow?.audioItemId)?.let {
+                openReconcileTargets.markClosed(sid, it)
+            }
+        }
+        epubZip?.close()
+        epubZip = null
+        _publication.value?.close()
+        _publication.value = null
+    }
+
+    data class OpenParams(
+        val itemId: String,
+        val openAtCfi: String?,
+        val startTocHref: String?,
+    )
+
+    sealed interface OpenOutcome {
+        data class Ready(
+            val publication: Publication,
+            val title: String,
+            val initialLocator: Locator?,
+            val initialFocusAnnotationId: String?,
+            /** The initial locator without the TOC-nav null-out. Used by the initial sync cycle. */
+            val effectiveInitialLocator: Locator?,
+            val openAtLocator: Locator?,
+            val activeServer: Server?,
+            val isStorytellerServer: Boolean,
+            val resolvedAudioBookId: String,
+            val resolvedAudioServerId: String,
+            val resolvedReaderServerId: String?,
+            val resolvedAudiobookItemId: String?,
+            val resolvedAudioSettingsIdentity: AudioIdentity,
+            val resolvedInitialSpeed: Float,
+        ) : OpenOutcome
+
+        data class Error(val message: String) : OpenOutcome
+    }
+
+    data class MatchedSync(
+        val readerSync: ReaderSyncCoordinator?,
+        val audiobookFollow: AudiobookFollow?,
+        val serverId: String?,
+    )
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/session/ReaderSessionLifecycle.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/session/ReaderSessionLifecycle.kt
@@ -23,7 +23,6 @@ import com.riffle.core.logging.Logger
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.first
@@ -47,7 +46,6 @@ import java.util.zip.ZipFile
  * MUST NOT import android.webkit.*, ContinuousReaderView, or any Compose types.
  */
 class ReaderSessionLifecycle @AssistedInject constructor(
-    @Suppress("UNUSED_PARAMETER") @Assisted scope: CoroutineScope,
     @Assisted private val openPublication: suspend (File) -> Publication?,
     @Assisted private val cfiStringToLocator: suspend (String) -> Locator?,
     private val libraryObserver: LibraryObserver,
@@ -66,7 +64,6 @@ class ReaderSessionLifecycle @AssistedInject constructor(
     @AssistedFactory
     interface Factory {
         fun create(
-            scope: CoroutineScope,
             openPublication: suspend (File) -> Publication?,
             cfiStringToLocator: suspend (String) -> Locator?,
         ): ReaderSessionLifecycle
@@ -148,10 +145,13 @@ class ReaderSessionLifecycle @AssistedInject constructor(
         val resolvedInitialSpeed = audioPlaybackPreferencesStore.load(resolvedAudioSettingsIdentity)
             ?: listeningPreferencesStore.defaultPlaybackSpeed.first()
 
-        // Claim this book so the durable sweep leaves it to this reader's own cycle (ADR 0030).
-        activeServer?.id?.let { openReconcileTargets.markOpen(it, params.itemId) }
+        // Record teardown state BEFORE the markOpen so any suspend between here and the return
+        // still gets its claim released via onCleared() — else a slow / failing DataStore read on
+        // the initial-speed load below would leak an openReconcile claim forever.
         readerServerId = resolvedReaderServerId
         readerItemId = params.itemId
+        // Claim this book so the durable sweep leaves it to this reader's own cycle (ADR 0030).
+        activeServer?.id?.let { openReconcileTargets.markOpen(it, params.itemId) }
 
         val openAtCfiNonBlank = params.openAtCfi?.takeIf { it.isNotBlank() }
         // A search-result / annotation-tap open overrides the saved position. Requires `publication`

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/session/ReaderSessionLifecycleTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/session/ReaderSessionLifecycleTest.kt
@@ -1,0 +1,407 @@
+package com.riffle.app.feature.reader.session
+
+import com.riffle.core.data.OpenReconcileTargets
+import com.riffle.core.domain.Annotation
+import com.riffle.core.domain.AnnotationStore
+import com.riffle.core.domain.AudioIdentity
+import com.riffle.core.domain.AudioIdentityResolver
+import com.riffle.core.domain.AudioPlaybackPreferencesStore
+import com.riffle.core.domain.AudiobookIdentityResult
+import com.riffle.core.domain.EbookFormat
+import com.riffle.core.domain.EpubOpenResult
+import com.riffle.core.domain.EpubRepository
+import com.riffle.core.domain.LibraryItem
+import com.riffle.core.domain.LibraryObserver
+import com.riffle.core.domain.ListeningPreferencesStore
+import com.riffle.core.domain.ReadaloudLink
+import com.riffle.core.domain.ReadaloudLinkRepository
+import com.riffle.core.domain.Server
+import com.riffle.core.domain.ServerRepository
+import com.riffle.core.domain.ServerType
+import com.riffle.core.domain.ServerUrl
+import com.riffle.core.logging.RecordingLogger
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.readium.r2.shared.publication.Locator
+import org.readium.r2.shared.publication.Publication
+import java.io.File
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ReaderSessionLifecycleTest {
+
+    private val scope = CoroutineScope(SupervisorJob() + UnconfinedTestDispatcher())
+
+    @After
+    fun tearDown() {
+        scope.coroutineContext[kotlinx.coroutines.Job]?.cancel()
+    }
+
+    // ── Fakes ────────────────────────────────────────────────────────────────────────────
+
+    private class FakeLibraryObserver(
+        private val items: Map<Pair<String, String>, LibraryItem>,
+        private val activeItems: Map<String, LibraryItem>,
+    ) : LibraryObserver {
+        override fun observeLibraries(): Flow<List<com.riffle.core.domain.Library>> = flowOf(emptyList())
+        override fun observeLibraries(serverId: String): Flow<List<com.riffle.core.domain.Library>> = flowOf(emptyList())
+        override fun observeLibraryItems(libraryId: String): Flow<List<LibraryItem>> = flowOf(emptyList())
+        override fun observeUngroupedLibraryItems(libraryId: String): Flow<List<LibraryItem>> = flowOf(emptyList())
+        override fun observeInProgressItems(libraryId: String): Flow<List<LibraryItem>> = flowOf(emptyList())
+        override fun observeFinishedItems(libraryId: String): Flow<List<LibraryItem>> = flowOf(emptyList())
+        override fun observeRecentlyAddedItems(libraryId: String): Flow<List<LibraryItem>> = flowOf(emptyList())
+        override fun observeAllBooks(libraryId: String): Flow<List<LibraryItem>> = flowOf(emptyList())
+        override fun observeSeries(libraryId: String): Flow<List<com.riffle.core.domain.Series>> = flowOf(emptyList())
+        override fun observeCollections(libraryId: String): Flow<List<com.riffle.core.domain.Collection>> = flowOf(emptyList())
+        override fun observeSeriesItems(seriesId: String): Flow<List<LibraryItem>> = flowOf(emptyList())
+        override fun observeContinueSeriesItems(libraryId: String): Flow<List<LibraryItem>> = flowOf(emptyList())
+        override fun observeCollectionItems(collectionId: String): Flow<List<LibraryItem>> = flowOf(emptyList())
+        override suspend fun getItem(itemId: String): LibraryItem? = activeItems[itemId]
+        override fun observeItem(itemId: String): Flow<LibraryItem?> = MutableStateFlow(activeItems[itemId])
+        override suspend fun getItem(serverId: String, itemId: String): LibraryItem? = items[serverId to itemId]
+        override suspend fun getLibrary(libraryId: String): com.riffle.core.domain.Library? = null
+        override suspend fun getSeriesIdForItem(serverId: String, itemId: String): String? = null
+    }
+
+    private class FakeEpubRepository(
+        private val outcome: EpubOpenResult,
+    ) : EpubRepository {
+        override suspend fun openEpub(item: LibraryItem): EpubOpenResult = outcome
+        override suspend fun downloadEpub(item: LibraryItem, onProgress: (Long, Long) -> Unit) =
+            error("not needed")
+        override suspend fun removeDownload(serverId: String, itemId: String) {}
+        override fun isDownloaded(serverId: String, itemId: String) = false
+        override fun isCached(serverId: String, itemId: String) = false
+        override suspend fun saveReadingPosition(itemId: String, cfi: String) {}
+    }
+
+    private class FakeServerRepository(private val active: Server?) : ServerRepository {
+        override fun observeAll(): Flow<List<Server>> = flowOf(active?.let { listOf(it) } ?: emptyList())
+        override suspend fun getActive(): Server? = active
+        override suspend fun authenticate(
+            url: ServerUrl, username: String, password: String,
+            insecureAllowed: Boolean, serverType: ServerType,
+        ) = com.riffle.core.domain.AuthenticateResult.WrongCredentials()
+        override suspend fun commit(
+            pending: com.riffle.core.domain.PendingServer, hiddenLibraryIds: Set<String>,
+        ) = com.riffle.core.domain.CommitServerResult.Failure(RuntimeException("not needed"))
+        override suspend fun setActive(serverId: String) {}
+        override suspend fun remove(serverId: String) {}
+        override suspend fun getServerVersion(serverId: String): String? = null
+        override suspend fun ensureAbsUserId(serverId: String): String? = "abs-user"
+    }
+
+    private class FakeReadaloudLinkRepository(
+        private val absLookup: Map<Pair<String, String>, ReadaloudLink> = emptyMap(),
+        private val storytellerLookup: Map<Pair<String, String>, List<ReadaloudLink>> = emptyMap(),
+    ) : ReadaloudLinkRepository {
+        override fun observeAll(): Flow<List<ReadaloudLink>> = flowOf(absLookup.values.toList())
+        override fun observeLinkedAbsItemIds(): Flow<Set<String>> = flowOf(emptySet())
+        override suspend fun findByAbsItem(absServerId: String, absLibraryItemId: String): ReadaloudLink? =
+            absLookup[absServerId to absLibraryItemId]
+        override suspend fun findByStorytellerBook(storytellerServerId: String, storytellerBookId: String): List<ReadaloudLink> =
+            storytellerLookup[storytellerServerId to storytellerBookId] ?: emptyList()
+        override suspend fun unlinkAbsItem(absServerId: String, absLibraryItemId: String) {}
+        override suspend fun countForServer(serverId: String): Int = 0
+    }
+
+    private class FakeAudioIdentityResolver(
+        private val identity: AudioIdentity = AudioIdentity("srv", "audio-id"),
+    ) : AudioIdentityResolver {
+        override suspend fun resolveForStorytellerBook(storytellerServerId: String, storytellerBookId: String) = identity
+    }
+
+    private class FakeAudioPlaybackPreferencesStore(private val speed: Float? = null) : AudioPlaybackPreferencesStore {
+        override suspend fun load(identity: AudioIdentity): Float? = speed
+        override suspend fun save(identity: AudioIdentity, speed: Float) {}
+        override suspend fun clear(identity: AudioIdentity) {}
+        override suspend fun rekey(old: AudioIdentity, new: AudioIdentity) {}
+    }
+
+    private class FakeListeningPreferencesStore(
+        private val defaultSpeed: Float = 1.0f,
+    ) : ListeningPreferencesStore {
+        override val defaultPlaybackSpeed: Flow<Float> = flowOf(defaultSpeed)
+        override val skipIntervalSeconds: Flow<Int> = flowOf(30)
+        override val rewindIntervalSeconds: Flow<Int> = flowOf(15)
+        override val rewindOnResumeSeconds: Flow<Int> = flowOf(0)
+        override suspend fun setDefaultPlaybackSpeed(speed: Float) {}
+        override suspend fun setSkipIntervalSeconds(seconds: Int) {}
+        override suspend fun setRewindIntervalSeconds(seconds: Int) {}
+        override suspend fun setRewindOnResumeSeconds(seconds: Int) {}
+    }
+
+    private class FakeAnnotationStore(
+        private val byCfi: Map<Triple<String, String, String>, Annotation> = emptyMap(),
+    ) : AnnotationStore {
+        override fun observeHighlights(serverId: String, itemId: String): Flow<List<Annotation>> = flowOf(emptyList())
+        override fun observeBookmarks(serverId: String, itemId: String): Flow<List<Annotation>> = flowOf(emptyList())
+        override fun observeAnnotations(serverId: String, itemId: String): Flow<List<Annotation>> = flowOf(emptyList())
+        override fun observeAnnotationsForServer(serverId: String): Flow<List<Annotation>> = flowOf(emptyList())
+        override suspend fun createHighlight(
+            serverId: String, itemId: String, cfi: String, textSnippet: String, chapterHref: String,
+            textBefore: String, textAfter: String, color: String, spineIndex: Int, progression: Double,
+        ): Annotation = error("not needed")
+        override suspend fun createBookmark(
+            serverId: String, itemId: String, cfi: String, textSnippet: String, chapterHref: String,
+            spineIndex: Int, progression: Double, bookmarkTitle: String,
+        ): Annotation = error("not needed")
+        override suspend fun delete(id: String) {}
+        override suspend fun recolor(id: String, color: String) {}
+        override suspend fun updateNote(id: String, note: String?) {}
+        override suspend fun renameBookmark(id: String, title: String) {}
+        override suspend fun findByItemAndCfi(serverId: String, itemId: String, cfi: String): Annotation? =
+            byCfi[Triple(serverId, itemId, cfi)]
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────────────────
+
+    private val activeServer = Server(
+        id = "srv-abs",
+        url = ServerUrl.parse("https://example.test")!!,
+        isActive = true,
+        insecureConnectionAllowed = false,
+        username = "u",
+        serverType = ServerType.AUDIOBOOKSHELF,
+    )
+
+    private val storytellerServer = activeServer.copy(id = "srv-st", serverType = ServerType.STORYTELLER)
+
+    private val ebookItem = LibraryItem(
+        id = "item-1",
+        libraryId = "lib-1",
+        title = "Book Title",
+        author = "Author",
+        coverUrl = null,
+        readingProgress = 0f,
+        isCached = true,
+        isDownloaded = true,
+        ebookFormat = EbookFormat.Epub,
+        serverId = "srv-abs",
+    )
+
+    private fun makeLifecycle(
+        openReconcileTargets: OpenReconcileTargets = OpenReconcileTargets(),
+        libraryObserver: LibraryObserver = FakeLibraryObserver(
+            items = mapOf(("srv-abs" to "item-1") to ebookItem),
+            activeItems = mapOf("item-1" to ebookItem),
+        ),
+        epubRepository: EpubRepository = FakeEpubRepository(
+            EpubOpenResult.Success(epubFile = File("/tmp/dummy.epub"), lastPosition = null),
+        ),
+        serverRepository: ServerRepository = FakeServerRepository(activeServer),
+        readaloudLinkRepository: ReadaloudLinkRepository = FakeReadaloudLinkRepository(),
+        audioPlaybackPreferencesStore: AudioPlaybackPreferencesStore = FakeAudioPlaybackPreferencesStore(speed = 1.25f),
+        annotationStore: AnnotationStore = FakeAnnotationStore(),
+        pub: Publication? = mockk(relaxed = true),
+        cfiResolver: suspend (String) -> Locator? = { null },
+    ): Pair<ReaderSessionLifecycle, OpenReconcileTargets> {
+        val readerSyncFactory = mockk<com.riffle.app.feature.reader.ReaderSyncFactory>(relaxed = true).also {
+            io.mockk.coEvery { it.createIfApplicable(any()) } returns null
+            io.mockk.coEvery { it.createAudiobookFollowIfApplicable(any()) } returns null
+        }
+        val lifecycle = ReaderSessionLifecycle(
+            scope = scope,
+            openPublication = { pub },
+            cfiStringToLocator = cfiResolver,
+            libraryObserver = libraryObserver,
+            epubRepository = epubRepository,
+            serverRepository = serverRepository,
+            readaloudLinkRepository = readaloudLinkRepository,
+            audioIdentityResolver = FakeAudioIdentityResolver(),
+            audioPlaybackPreferencesStore = audioPlaybackPreferencesStore,
+            listeningPreferencesStore = FakeListeningPreferencesStore(defaultSpeed = 1.0f),
+            openReconcileTargets = openReconcileTargets,
+            readerSyncFactory = readerSyncFactory,
+            annotationStore = annotationStore,
+            logger = RecordingLogger(),
+        )
+        return lifecycle to openReconcileTargets
+    }
+
+    private fun params(
+        itemId: String = "item-1",
+        openAtCfi: String? = null,
+        startTocHref: String? = null,
+    ) = ReaderSessionLifecycle.OpenParams(itemId, openAtCfi, startTocHref)
+
+    // ── Tests ────────────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `open returns Error when item is missing`() = runTest {
+        val (lifecycle, _) = makeLifecycle(
+            libraryObserver = FakeLibraryObserver(items = emptyMap(), activeItems = emptyMap()),
+        )
+        val outcome = lifecycle.open(params())
+        assertTrue(outcome is ReaderSessionLifecycle.OpenOutcome.Error)
+        assertEquals("Book not found", (outcome as ReaderSessionLifecycle.OpenOutcome.Error).message)
+        assertNull(lifecycle.publication.value)
+    }
+
+    @Test
+    fun `open returns Error when EPUB open fails`() = runTest {
+        val (lifecycle, _) = makeLifecycle(
+            epubRepository = FakeEpubRepository(EpubOpenResult.Offline),
+        )
+        val outcome = lifecycle.open(params())
+        assertTrue(outcome is ReaderSessionLifecycle.OpenOutcome.Error)
+        assertEquals("Book not available offline", (outcome as ReaderSessionLifecycle.OpenOutcome.Error).message)
+    }
+
+    @Test
+    fun `open returns Error when publication cannot be opened`() = runTest {
+        val (lifecycle, _) = makeLifecycle(pub = null)
+        val outcome = lifecycle.open(params())
+        assertTrue(outcome is ReaderSessionLifecycle.OpenOutcome.Error)
+        assertEquals("Failed to open EPUB", (outcome as ReaderSessionLifecycle.OpenOutcome.Error).message)
+        assertNull(lifecycle.publication.value)
+    }
+
+    @Test
+    fun `open on ABS server without match uses itemId as audio ids and marks reconcile open`() = runTest {
+        val reconcile = OpenReconcileTargets()
+        val (lifecycle, _) = makeLifecycle(openReconcileTargets = reconcile)
+        val outcome = lifecycle.open(params()) as ReaderSessionLifecycle.OpenOutcome.Ready
+
+        assertFalse(outcome.isStorytellerServer)
+        assertEquals("item-1", outcome.resolvedAudioBookId)
+        assertEquals("srv-abs", outcome.resolvedAudioServerId)
+        assertEquals("srv-abs", outcome.resolvedReaderServerId)
+        assertNull(outcome.resolvedAudiobookItemId)
+        assertEquals(1.25f, outcome.resolvedInitialSpeed, 0.0001f)
+        assertSame(activeServer, outcome.activeServer)
+        assertTrue(reconcile.isOpen("srv-abs", "item-1"))
+        assertNotNull(lifecycle.publication.value)
+    }
+
+    @Test
+    fun `open with matched link resolves audiobook id and identity from link`() = runTest {
+        val link = ReadaloudLink(
+            storytellerServerId = "srv-st",
+            storytellerBookId = "st-book-1",
+            absServerId = "srv-abs",
+            absLibraryItemId = "item-1",
+            userConfirmed = true,
+            identityResult = AudiobookIdentityResult.UNKNOWN,
+        )
+        val audiobookItem = ebookItem.copy(id = "item-2", hasAudio = true)
+        val siblingLinks = listOf(
+            link,
+            link.copy(absLibraryItemId = "item-2"),
+        )
+        val (lifecycle, _) = makeLifecycle(
+            libraryObserver = FakeLibraryObserver(
+                items = mapOf(
+                    ("srv-abs" to "item-1") to ebookItem,
+                    ("srv-abs" to "item-2") to audiobookItem,
+                ),
+                activeItems = mapOf("item-1" to ebookItem, "item-2" to audiobookItem),
+            ),
+            readaloudLinkRepository = FakeReadaloudLinkRepository(
+                absLookup = mapOf(("srv-abs" to "item-1") to link),
+                storytellerLookup = mapOf(("srv-st" to "st-book-1") to siblingLinks),
+            ),
+        )
+        val outcome = lifecycle.open(params()) as ReaderSessionLifecycle.OpenOutcome.Ready
+
+        assertEquals("st-book-1", outcome.resolvedAudioBookId)
+        assertEquals("srv-st", outcome.resolvedAudioServerId)
+        assertEquals("item-2", outcome.resolvedAudiobookItemId)
+    }
+
+    @Test
+    fun `open on Storyteller server keeps itemId as audio ids`() = runTest {
+        val (lifecycle, _) = makeLifecycle(
+            serverRepository = FakeServerRepository(storytellerServer),
+        )
+        val outcome = lifecycle.open(params()) as ReaderSessionLifecycle.OpenOutcome.Ready
+
+        assertTrue(outcome.isStorytellerServer)
+        assertEquals("item-1", outcome.resolvedAudioBookId)
+        assertEquals("srv-st", outcome.resolvedAudioServerId)
+    }
+
+    @Test
+    fun `open with openAtCfi resolves openAtLocator and initialFocusAnnotationId`() = runTest {
+        val cfi = "epubcfi(/6/2!/4/2)"
+        val resolvedLocator = mockk<Locator>(relaxed = true)
+        val annotation = mockk<Annotation>(relaxed = true).also { every { it.id } returns "ann-99" }
+        val (lifecycle, _) = makeLifecycle(
+            annotationStore = FakeAnnotationStore(
+                byCfi = mapOf(Triple("srv-abs", "item-1", cfi) to annotation),
+            ),
+            cfiResolver = { c -> if (c == cfi) resolvedLocator else null },
+        )
+        val outcome = lifecycle.open(params(openAtCfi = cfi)) as ReaderSessionLifecycle.OpenOutcome.Ready
+
+        assertSame(resolvedLocator, outcome.openAtLocator)
+        assertEquals("ann-99", outcome.initialFocusAnnotationId)
+        assertSame(resolvedLocator, outcome.initialLocator)
+        assertSame(resolvedLocator, outcome.effectiveInitialLocator)
+    }
+
+    @Test
+    fun `open with TOC nav nulls initialLocator but retains effectiveInitialLocator`() = runTest {
+        val cfi = "epubcfi(/6/2!/4/2)"
+        val resolved = mockk<Locator>(relaxed = true)
+        val (lifecycle, _) = makeLifecycle(
+            cfiResolver = { resolved },
+        )
+        val outcome = lifecycle.open(params(openAtCfi = cfi, startTocHref = "chapter-2.xhtml"))
+            as ReaderSessionLifecycle.OpenOutcome.Ready
+
+        assertNull(outcome.initialLocator)
+        assertNull(outcome.initialFocusAnnotationId)
+        assertSame(resolved, outcome.effectiveInitialLocator)
+        assertSame(resolved, outcome.openAtLocator)
+    }
+
+    @Test
+    fun `open builds matchedSync from readerSyncFactory`() = runTest {
+        val (lifecycle, _) = makeLifecycle()
+        val outcome = lifecycle.open(params())
+        assertTrue(outcome is ReaderSessionLifecycle.OpenOutcome.Ready)
+        val ms = lifecycle.matchedSync.value
+        assertNotNull(ms)
+        assertNull(ms!!.readerSync)
+        assertNull(ms.audiobookFollow)
+        assertEquals("srv-abs", ms.serverId)
+    }
+
+    @Test
+    fun `tryClaimCloseSync is idempotent until resetCloseSync`() = runTest {
+        val (lifecycle, _) = makeLifecycle()
+        lifecycle.open(params())
+        assertTrue(lifecycle.tryClaimCloseSync())
+        assertFalse(lifecycle.tryClaimCloseSync())
+        lifecycle.resetCloseSync()
+        assertTrue(lifecycle.tryClaimCloseSync())
+    }
+
+    @Test
+    fun `onCleared releases openReconcile claim`() = runTest {
+        val reconcile = OpenReconcileTargets()
+        val (lifecycle, _) = makeLifecycle(openReconcileTargets = reconcile)
+        lifecycle.open(params())
+        assertTrue(reconcile.isOpen("srv-abs", "item-1"))
+        lifecycle.onCleared()
+        assertFalse(reconcile.isOpen("srv-abs", "item-1"))
+        assertNull(lifecycle.publication.value)
+    }
+}

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/session/ReaderSessionLifecycleTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/session/ReaderSessionLifecycleTest.kt
@@ -217,7 +217,6 @@ class ReaderSessionLifecycleTest {
             io.mockk.coEvery { it.createAudiobookFollowIfApplicable(any()) } returns null
         }
         val lifecycle = ReaderSessionLifecycle(
-            scope = scope,
             openPublication = { pub },
             cfiStringToLocator = cfiResolver,
             libraryObserver = libraryObserver,

--- a/docs/superpowers/specs/2026-07-01-reader-session-lifecycle-design.md
+++ b/docs/superpowers/specs/2026-07-01-reader-session-lifecycle-design.md
@@ -1,0 +1,164 @@
+# ReaderSessionLifecycle — Design
+
+Extract book-open/close lifecycle and matched-book cross-sync state out of `EpubReaderViewModel` into a `ReaderSessionLifecycle` collaborator. Narrower re-scoping of GitHub issue #376.
+
+## Context
+
+Issue #376 originally called for splitting `EpubReaderViewModel` (1,591 lines, ~40 injected deps) into `ReaderSession`, `FormatCompositor`, and further splitting `PositionOrchestrator` into `ServerJumpCoordinator` + `ResumeRestorer`.
+
+The four last items are already shipped in `app/src/main/kotlin/com/riffle/app/feature/reader/session/`:
+
+- `PositionOrchestrator` (moved out of VM)
+- `ServerJumpCoordinator` and `ResumeRestorer` (split inside PositionOrchestrator's package)
+- `FormattingSession` + separate `WakeLockController` / `SearchController` (the "FormatCompositor" role, split as three seams rather than one composite — chosen because wake-lock has a different dependency and lifecycle than typography)
+- `AnnotationSession`, `ReadaloudSession`, `BookmarksController`, `VolumeKeyDispatcher`
+
+What remains bloating the VM is the book-open pipeline and its shared state. This spec extracts that.
+
+## Scope
+
+**In:** move book-open orchestration, close-side teardown, and matched-book cross-sync state onto a new `ReaderSessionLifecycle` collaborator.
+
+**Out:**
+
+- Legacy raw-`epubcfi(...)` healing (needs VM-private `cfiStringToLocator`) — follow-up.
+- Footnote-popup origin capture — follow-up.
+- Compose-facing state assembly cleanup — follow-up.
+- Any behavior change. This is a pure refactor.
+
+## The seam
+
+New file: `app/src/main/kotlin/com/riffle/app/feature/reader/session/ReaderSessionLifecycle.kt`.
+
+State owned by the lifecycle (moved off the VM):
+
+- `publication: StateFlow<Publication?>` — null until `open()` resolves; observable so future Compose-facing code can react without threading a snapshot.
+- `epubFile: File?`, `epubZip: ZipFile?` (with lazy-cached `zipFor(file)` accessor).
+- `matchedSync: StateFlow<MatchedSync?>` bundling `readerSync`, `audiobookFollow`, `serverId`.
+- `closeSyncDone: Boolean` (idempotency guard for close).
+
+Constructor deps lifted from the VM (into `ReaderSessionLifecycle`'s assisted-factory):
+
+`libraryObserver`, `epubRepository`, `serverRepository`, `readaloudLinkRepository`, `audioIdentityResolver`, `audioPlaybackPreferencesStore`, `listeningPreferencesStore`, `openReconcileTargets`, `readerSyncFactory`, `annotationStore`, `logger`.
+
+## Interface
+
+```kotlin
+class ReaderSessionLifecycle @AssistedInject constructor(
+    @Assisted private val scope: CoroutineScope,
+    private val libraryObserver: LibraryObserver,
+    private val epubRepository: EpubRepository,
+    private val serverRepository: ServerRepository,
+    private val readaloudLinkRepository: ReadaloudLinkRepository,
+    private val audioIdentityResolver: AudioIdentityResolver,
+    private val audioPlaybackPreferencesStore: AudioPlaybackPreferencesStore,
+    private val listeningPreferencesStore: ListeningPreferencesStore,
+    private val openReconcileTargets: OpenReconcileTargets,
+    private val readerSyncFactory: ReaderSyncFactory,
+    private val annotationStore: AnnotationStore,
+    private val logger: Logger,
+    // Publication opening is passed as a lambda so the lifecycle stays free of
+    // AssetRetriever/PublicationOpener plumbing; the VM already owns openPublication().
+    private val openPublication: suspend (File) -> Publication?,
+    // Legacy raw-`epubcfi(...)` translation — needed at open time to resolve openAtCfi.
+    // Left as a lambda for now; a follow-up lifts cfiStringToLocator into the lifecycle.
+    private val cfiStringToLocator: (String) -> Locator?,
+) {
+    @AssistedFactory
+    interface Factory {
+        fun create(
+            scope: CoroutineScope,
+            openPublication: suspend (File) -> Publication?,
+            cfiStringToLocator: (String) -> Locator?,
+        ): ReaderSessionLifecycle
+    }
+
+    val publication: StateFlow<Publication?>
+    val matchedSync: StateFlow<MatchedSync?>
+
+    suspend fun open(params: OpenParams): OpenOutcome
+    suspend fun close()          // idempotent
+    fun zipFor(file: File): ZipFile
+    fun onCleared()
+}
+
+data class OpenParams(
+    val itemId: String,
+    val openAtCfi: String?,
+    val startTocHref: String?,
+)
+
+sealed interface OpenOutcome {
+    data class Ready(
+        val publication: Publication,
+        val title: String,
+        val initialLocator: Locator?,
+        val initialFocusAnnotationId: String?,
+        val openAtLocator: Locator?,
+        val activeServer: Server?,
+        val isStorytellerServer: Boolean,
+        val resolvedAudioBookId: String,
+        val resolvedAudioServerId: String,
+        val resolvedReaderServerId: String?,
+        val resolvedAudiobookItemId: String?,
+        val resolvedAudioSettingsIdentity: AudioIdentity,
+        val resolvedInitialSpeed: Float,
+    ) : OpenOutcome
+
+    data class Error(val message: String) : OpenOutcome
+}
+
+data class MatchedSync(
+    val readerSync: ReaderSyncCoordinator?,
+    val audiobookFollow: AudiobookFollow?,
+    val serverId: String?,
+)
+```
+
+## What the VM keeps
+
+- Bind orchestration. After `lifecycle.open(...)` returns `Ready`, the VM calls `readaloud.bind(...)`, `position.bindBook(...)`, `bookmarks.bind(...)`, `search.bind(publication)`, then emits `ReaderState.Ready`. This preserves the Compose-facing composer role and does not push Readium types into the lifecycle beyond `Publication` / `Locator`.
+- Publication-touching helpers (footnote resolution, CFI translation, spine-position counts). Their signatures do not change; they read `lifecycle.publication.value ?: return` instead of the removed VM field. Follow-ups may lift some of these later.
+- Providers threaded into other sessions become `{ lifecycle.matchedSync.value?.readerSync }` / `{ lifecycle.matchedSync.value?.audiobookFollow }` / `{ lifecycle.matchedSync.value?.serverId }`.
+- Handoff auto-start (`startReadaloudAtSec`). The lifecycle does not touch `readaloud`; the VM calls `startReadaloudAtSecond(...)` post-`Ready` as today.
+- TOC nav on open (`startTocHref`). The lifecycle returns it via `Ready.initialLocator = null` when the flag is set (matching the existing "let navigateToEntry own it" comment); the VM calls `navigateToEntry(...)` post-`Ready`.
+- The Horizontal-only paged post-open annotation-nav emit (`annotationSession.emitAnnotationNavigation(openAtLocator)`). Stays in the VM because it depends on `formatting.effectiveFormattingPreferences.value.orientation`.
+- `markSuppressNextServerLocator()` when `openAtLocator != null`. Stays in the VM because `position` is a VM-held collaborator; the lifecycle just returns `openAtLocator` in `Ready`.
+
+## Close path
+
+`lifecycle.close()`:
+
+1. Return immediately if `closeSyncDone`.
+2. Set `closeSyncDone = true`.
+3. Call `openReconcileTargets.markClosed(serverId, itemId)` for the reader item and (if resolved) the audio item.
+4. No sync writes — sync teardown remains in the VM's `performCloseSync()` path (ADR 0030's ordering with `progressFlushScope` is delicate; touching it is out of scope).
+
+`lifecycle.onCleared()`: clears `epubZip`, `publication`.
+
+## Testing
+
+New `app/src/test/kotlin/.../session/ReaderSessionLifecycleTest.kt` (JVM):
+
+- Open happy path against a Storyteller server.
+- Open ABS with matched readaloud link → resolves `audioBookId`, `audioServerId`, `audiobookItemId` from `readaloudLinkRepository`.
+- Open with `openAtCfi` non-blank → returns `openAtLocator` non-null and `initialFocusAnnotationId` from `annotationStore.findByItemAndCfi`.
+- Open with `startTocHref` non-null → `Ready.initialLocator` is null.
+- Open failure: item not found → `Error("Book not found")`.
+- Open failure: EPUB open returns null publication → `Error("Failed to open EPUB")`.
+- `close()` is idempotent (second call is a no-op).
+- `matchedSync` reflects `readerSyncFactory.createIfApplicable(itemId)` success and its `null` fallback path (`createAudiobookFollowIfApplicable`).
+
+Existing `EpubReaderViewModelTest` cases involving the open flow stay green — the lifecycle is a collaborator behind an assisted factory and is replaced with a fake in VM tests.
+
+No instrumentation. This seam does not touch Readium's WebView, the navigator, or JS injection. JVM tests are the AGENTS.md-approved validation tier for this refactor.
+
+## Rollout
+
+Single PR, single commit. Behavior-preserving. No user-visible change; no ADR update; no migration.
+
+PR body includes `Closes #376` and a "Deferred to follow-ups" section listing:
+
+- `cfiStringToLocator` + legacy-CFI healing → lifecycle
+- Footnote-popup origin capture → lifecycle
+- Compose-facing state assembly cleanup on the VM


### PR DESCRIPTION
Closes #376

## Summary

Lifts book-open orchestration and matched-book cross-sync state out of `EpubReaderViewModel` into a new `ReaderSessionLifecycle` collaborator in the `session/` package. Re-scopes issue #376 to what actually remained after prior extractions (see the issue body for the "already shipped" audit).

State moved off the VM: `publication`, `epubFile`, `epubZip`, `closeSyncDone`, `readerSync`, `audiobookFollow`, `readerSyncServerId`, `readerServerId`, `isStorytellerServer`. Exposed via `lifecycle.publication: StateFlow<Publication?>` and `lifecycle.matchedSync: StateFlow<MatchedSync?>`.

Logic moved: the 170-line `openBook()` resolution pipeline (item lookup, EPUB open, publication build, active-server + readaloud-link resolution, audio-identity + initial-speed resolution, openReconcile claim, `openAtCfi` + `initialFocusAnnotationId` + stored-locator resolution, matched-sync build) becomes `lifecycle.open(OpenParams): OpenOutcome`.

The VM keeps its Compose-facing composer role: after `Ready`, it binds `readaloud`, `position`, `bookmarks`, `annotationSession`, `search` and emits `ReaderState.Ready`. Providers threaded into other sessions now read from `lifecycle.matchedSync`.

Behavior-preserving. VM: 1591 → 1476 lines.

## Test plan

- [x] `./gradlew :app:testDebugUnitTest` green (full app JVM suite)
- [x] New `ReaderSessionLifecycleTest` covers 10 scenarios: missing item, offline / open-fail errors, ABS/Storyteller paths, matched-link audio-id resolution, `openAtCfi` + focus-annotation lookup, TOC-nav initialLocator null-out, matchedSync build, close-sync idempotency, `onCleared` release.
- [x] Two commits: initial extraction + review fixes (openReconcile leak-on-throw, dropped unused `@Assisted scope`).

Design doc: `docs/superpowers/specs/2026-07-01-reader-session-lifecycle-design.md`.

Deferred to follow-ups (called out in the spec, not in this PR): lifting `cfiStringToLocator` + legacy-CFI healing into the lifecycle; lifting footnote-popup origin capture; Compose-facing state assembly cleanup on the VM.