### PR TITLE
fix(annotations): keep bookmark indicator lit across book re-opens

### DIFF
--- a/core/data/src/main/kotlin/com/riffle/core/data/AnnotationMergeOrchestrator.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/AnnotationMergeOrchestrator.kt
@@ -113,7 +113,16 @@ internal class AnnotationMergeOrchestrator(
                     textSnippet = w3cAnnotation.textSnippet,
                     textBefore = w3cAnnotation.textBefore,
                     textAfter = w3cAnnotation.textAfter,
-                    chapterHref = w3cAnnotation.chapterHref,
+                    // chapterHref round-trip: the W3C wire format encodes `target.source` as
+                    // `epub://item-<itemId>` (see AnnotationW3CCodec), so a parsed W3CAnnotation
+                    // carries the itemId in `chapterHref`, not the real chapter path. LWW ties
+                    // (same device, same updatedAt right after our own push) resolve to the
+                    // parsed row, so upserting `w3cAnnotation.chapterHref` unconditionally
+                    // silently overwrites the local row's real href with the itemId — and the
+                    // reader's page-bookmarked indicator, which matches on normalized chapterHref,
+                    // goes dark on re-open. The CFI is immutable per annotation, so the local
+                    // href is authoritative when we have a row.
+                    chapterHref = existing?.chapterHref ?: w3cAnnotation.chapterHref,
                     // Sort-key round-trip: prefer the locally-stored values when we already have a
                     // row (the CFI hasn't moved, so the sort key computed at creation time is still
                     // correct). Otherwise trust the peer's riffle:spineIndex / riffle:progression

--- a/core/data/src/main/kotlin/com/riffle/core/data/AnnotationW3CCodec.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/AnnotationW3CCodec.kt
@@ -170,6 +170,11 @@ object AnnotationW3CCodec {
             // is spine-agnostic, so we carry them explicitly.
             put("riffle:spineIndex", JsonPrimitive(entity.spineIndex))
             put("riffle:progression", JsonPrimitive(entity.progression))
+            // Real chapter resource path (e.g. "OPS/chapter-139.xhtml"). `target.source` only
+            // encodes the itemId, so without this extension a peer receiving the file cannot
+            // recover the chapter path — and the reader's page-bookmarked indicator, which
+            // matches on normalized chapterHref, stays dark for cross-device bookmarks.
+            put("riffle:chapterHref", entity.chapterHref)
             if (entity.type == AnnotationEntity.TYPE_BOOKMARK && entity.bookmarkTitle.isNotEmpty()) {
                 put("riffle:bookmarkTitle", entity.bookmarkTitle)
             }
@@ -256,6 +261,16 @@ object AnnotationW3CCodec {
                 else -> AnnotationEntity.TYPE_HIGHLIGHT
             }
 
+            // Real chapter path extension. When present, prefer it over the itemId derived from
+            // `target.source` — otherwise a WebDAV round-trip loses the real chapter path (only
+            // the itemId is on the wire in `target.source = "epub://item-<itemId>"`), which
+            // makes the reader's page-bookmarked indicator go dark. Files predating the
+            // extension fall through to the source-derived path; the merge orchestrator
+            // preserves any locally-known chapterHref in that case. Read here — before the
+            // target selectors run — so `reassemblePdfLocator` also sees the real path.
+            val chapterHrefExtension = root["riffle:chapterHref"]?.jsonPrimitive?.content
+                ?.takeIf { it.isNotEmpty() }
+
             // Extract target and selectors
             val target = root["target"]?.jsonObject
             var cfi = ""
@@ -266,7 +281,8 @@ object AnnotationW3CCodec {
 
             target?.let {
                 val src = it["source"]?.jsonPrimitive?.content ?: ""
-                chapterHref = src.removePrefix("epub://item-").removePrefix("pdf://item-")
+                chapterHref = chapterHrefExtension
+                    ?: src.removePrefix("epub://item-").removePrefix("pdf://item-")
                 val selectors = it["selector"]?.jsonArray ?: emptyList()
                 for (selector in selectors) {
                     val selectorObj = selector.jsonObject

--- a/core/data/src/test/kotlin/com/riffle/core/data/AnnotationSyncControllerLifecycleTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/AnnotationSyncControllerLifecycleTest.kt
@@ -811,6 +811,54 @@ class AnnotationSyncControllerLifecycleTest {
         assertEquals("cross-device: adopt peer progression", 0.42, upserted.progression, 0.0)
     }
 
+    // ===== Fix 3: syncOnOpen preserves chapterHref on existing rows =====
+
+    @Test
+    fun `syncOnOpen preserves chapterHref on existing rows`() = runTest {
+        // Seed Room with a bookmark whose real chapterHref is a normalized EPUB resource path —
+        // what the reader stores at toggle-time. The W3C wire format writes `target.source` as
+        // `epub://item-<itemId>` and re-parses it back as `itemId`, so a naive upsert of the
+        // parsed W3CAnnotation's chapterHref clobbers the real value with the itemId on every
+        // sync round-trip. The reader's page-bookmarked indicator matches on normalized
+        // chapterHref, so the clobber makes the top-right indicator go dark after exit/re-enter
+        // even though the bookmark still exists in the annotations panel.
+        val realChapterHref = "OEBPS/chapter1.xhtml"
+        val local = highlightEntity("uuid-bookmark", updatedAt = 1000L)
+            .copy(chapterHref = realChapterHref)
+        dao.localAnnotations += local
+
+        // Own device's file on WebDAV (right after a push): same id, same updatedAt, same
+        // deviceId. LWW ties with `parsed + existing` grouping resolve to parsed on ties, so
+        // without the fix the upsert would take the wire's chapterHref (== ITEM).
+        target.files["annotations-own.jsonld"] = jsonArrayOf(
+            w3c("uuid-bookmark", updatedAt = 1000L, deviceId = DEVICE_ID),
+        )
+
+        newController().syncOnOpen(SRV, NS, ITEM)
+
+        val upserted = dao.upserts.single { it.id == "uuid-bookmark" }
+        assertEquals("chapterHref must survive the sync round-trip", realChapterHref, upserted.chapterHref)
+    }
+
+    @Test
+    fun `syncOnOpen adopts peer chapterHref for new cross-device annotations`() = runTest {
+        // No local row — the annotation was created on another device. The peer's file carries
+        // the real chapter path via the `riffle:chapterHref` extension, so on first receive the
+        // row lands with the actual chapter href (not the itemId derived from `target.source`).
+        // Under that assumption the reader's page-bookmarked indicator lights up on the correct
+        // chapter for cross-device bookmarks, mirroring the sort-key extension's behavior.
+        target.files["annotations-peer.jsonld"] = jsonArrayOf(
+            w3c(id = "uuid-peer-bookmark", updatedAt = 2000L, deviceId = "peer-device"),
+        )
+
+        newController().syncOnOpen(SRV, NS, ITEM)
+
+        val upserted = dao.upserts.single { it.id == "uuid-peer-bookmark" }
+        // The w3c() helper builds the entity with chapterHref = "c1"; the extension carries that
+        // through the round-trip. Before the extension existed this would have been ITEM.
+        assertEquals("cross-device: adopt peer chapterHref via extension", "c1", upserted.chapterHref)
+    }
+
     // ===== stamp + report + enqueue-on-failure =====
 
     @Test

--- a/core/data/src/test/kotlin/com/riffle/core/data/AnnotationW3CCodecTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/AnnotationW3CCodecTest.kt
@@ -731,13 +731,12 @@ class AnnotationW3CCodecTest {
         val roundTripped = rawJson.parseToJsonElement(parsed.cfi).jsonObject
 
         assertEquals("application/pdf", roundTripped["type"]?.jsonPrimitive?.content)
-        // chapterHref on the round-tripped locator comes from the W3C source URL
-        // (`pdf://item-<id>`), which carries entity.itemId per the existing
-        // codec convention shared with EPUB. The locator's original `href` field
-        // isn't transmitted separately on the wire — chapterHref subsumes it.
-        // This is a pre-existing pattern; PDF mirrors EPUB.
-        assertEquals("pdf-item", roundTripped["href"]?.jsonPrimitive?.content)
-        assertEquals("pdf-item", parsed.chapterHref)
+        // The `riffle:chapterHref` extension carries the real chapter path across the wire, so
+        // both the parsed W3CAnnotation and the reassembled locator's `href` recover the
+        // entity's original chapterHref instead of the source-derived itemId. Files predating
+        // the extension fall back to the itemId (same PDF ⇄ EPUB shape as before).
+        assertEquals("books/x.pdf", roundTripped["href"]?.jsonPrimitive?.content)
+        assertEquals("books/x.pdf", parsed.chapterHref)
 
         val locations = roundTripped["locations"]?.jsonObject!!
         assertEquals(42, locations["position"]?.jsonPrimitive?.intOrNull)


### PR DESCRIPTION
## Summary

- Preserve the local row's `chapterHref` on the sync-open merge upsert. The wire-parsed `W3CAnnotation` carries the itemId in `chapterHref` (because `target.source` is `epub://item-<itemId>`), and the LWW tie right after our own push resolves to the parsed row — silently overwriting the DB's real chapter path with the itemId. The reader's page-bookmarked indicator matches on normalized `chapterHref`, so the corner icon went dark after exit + re-enter even though the bookmark was still in the panel. Mirrors #389 for `spineIndex`/`progression`.
- Carry the real chapter path over the wire as a `riffle:chapterHref` extension. Peer-created bookmarks now land in Room with the actual chapter href on first receive, so the indicator also lights up on the right chapter for cross-device bookmarks. Read the extension before the target selectors run so the PDF locator reassembly picks up the real path too.

## Test plan

- [x] `./gradlew :core:data:testDebugUnitTest` — green
- [x] `./gradlew test` — full JVM suite green
- [x] New regression: `syncOnOpen preserves chapterHref on existing rows` fails without the merge-orchestrator fix, passes with it
- [x] Peer-adoption test updated: `syncOnOpen adopts peer chapterHref for new cross-device annotations` now asserts the extension-carried real path
- [x] PDF codec round-trip test updated to assert the extension-carried real path in both the parsed W3CAnnotation and the reassembled locator's `href`
- [x] APK installed on Android_13 AVD; live DB inspection confirmed 2 existing bookmarks retain `chapterHref = "OPS/chapter-139.xhtml"` (would have been clobbered to the itemId under the old code path)
- [ ] End-to-end AVD reproduction (toggle bookmark → exit → re-enter → observe indicator remains lit) — not driven, since fix lives in pure sync/merge logic covered by JVM tests