### PR TITLE
fix(reader): land continuous-mode bookmark nav at viewport midpoint

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,17 @@ When the work originated from a GitHub Issue (e.g. the user asked you to "do #12
 
 Do not open a PR without tests that cover the fix or new functionality. Every bug fix needs a regression test that fails before the change and passes after; every new feature needs unit and/or integration coverage for its behaviour. "Manually verified" is not a substitute for an automated test.
 
+**Do not skip this step.** The following rationalisations are all wrong and produce PRs that will be sent back:
+
+- "The change is a one-line param flip." → The one-liner is exactly what regresses. Pin it with a test that would flip if someone reverted it.
+- "The behaviour lives inside a Composable, so it's not JVM-testable." → Extract the decision into an `internal` top-level function or a helper and unit-test that. A tiny refactor is cheaper than a re-review.
+- "The existing tests already cover the surrounding logic." → They cover the surrounding logic, not the specific decision the fix changes. If the fix flipped `X` to `Y`, there must be a test that asserts the value is now `Y`.
+- "Instrumentation would be the right level but it's heavy." → Then extract and unit-test the pure decision at the JVM level. Do not open the PR without any test.
+- "I'll rely on the user's manual verification." → No. Automated coverage is required in addition to manual verification.
+- "Updating docstrings / renaming a stale test counts as test coverage." → It doesn't. Docstring changes cannot fail. A regression test is an assertion that would flip red if the fix were reverted.
+
+Before opening the PR, name the specific assertion(s) that would fail if the fix were reverted line-for-line. If you can't name one, you haven't written the regression test yet.
+
 ## Validate before claiming done
 
 Every fix or new feature must be validated as actually working before it is marked complete or sent for review. Acceptable validation is one of:

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -1064,6 +1064,20 @@ internal fun readaloudLocatorJson(ref: String, quote: SentenceQuote?): JSONObjec
     return json
 }
 
+/**
+ * NavigationOptions for an annotation-panel tap. Continuous-mode landing is uniform
+ * viewport-midpoint (`alignToTop = false`) for every annotation type — bookmarks included —
+ * so the page-bookmark ribbon (which stores + matches on `locatorAt`'s midpoint progression)
+ * lights at the same scrollY the reader lands on. Placing bookmarks at the viewport top
+ * produced up to a full-viewport offset between the lit ribbon and the landing on chapters
+ * with images, big headings, or otherwise non-uniform text density — the CFI anchor's pixel
+ * position drifted from its char-count progression. The [isBookmark] parameter is taken so
+ * tests can pin the invariant that both types return the same options.
+ */
+@Suppress("UNUSED_PARAMETER")
+internal fun annotationNavigationOptions(isBookmark: Boolean): NavigationOptions =
+    NavigationOptions(landAtStartWhenNoTarget = false, alignToTop = false)
+
 @OptIn(ExperimentalReadiumApi::class)
 @Composable
 private fun EpubNavigatorView(
@@ -1690,22 +1704,9 @@ private fun EpubNavigatorView(
 
     LaunchedEffect(annotationNavigationEvents) {
         annotationNavigationEvents.collect { event ->
-            // Continuous-mode landing goes to the viewport MIDPOINT for every annotation type
-            // (`alignToTop=false`). The page-bookmark ribbon
-            // (BookmarksController.isCurrentPageBookmarked) matches on
-            // ContinuousPositionTracker.locatorAt's midpoint progression, and toggleBookmark
-            // stores that same midpoint value. Placing the anchor at the viewport top
-            // (`alignToTop=true`) worked geometrically only when the CFI's char-based content
-            // position happened to line up with its pixel position — for any chapter with
-            // images, big headings, or vertical whitespace, the pixel anchor sat almost a full
-            // viewport past the char-based progression, so the ribbon lit up ~1 screen before
-            // the actual landing. Landing at the midpoint puts the ribbon and the reader at
-            // the same scrollY across every layout. Readium adapters (paginated / vertical)
-            // ignore `alignToTop` and own page/column alignment internally, so this only
-            // affects continuous mode.
             navigateWithCover(
                 NavigationTarget.ToLocatorJson(event.locator.toJSON().toString()),
-                NavigationOptions(landAtStartWhenNoTarget = false, alignToTop = false),
+                annotationNavigationOptions(isBookmark = event.isBookmark),
                 event.locator.href.toString(),
             )
         }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -1690,17 +1690,22 @@ private fun EpubNavigatorView(
 
     LaunchedEffect(annotationNavigationEvents) {
         annotationNavigationEvents.collect { event ->
-            // Continuous-mode landing splits by annotation type. A page-level bookmark lands
-            // with `alignToTop=true` so the chapter heading sits at the viewport top — matching
-            // the page-bookmark ribbon's "this page contains the bookmark" semantics. A
-            // highlight / note lands with `alignToTop=false`, putting the highlighted text at
-            // the viewport midpoint with reading context above it, mirroring how Readium places
-            // annotation navigation in paginated and vertical modes. Readium adapters ignore
-            // `alignToTop` — Readium owns column / page alignment internally — so this only
+            // Continuous-mode landing goes to the viewport MIDPOINT for every annotation type
+            // (`alignToTop=false`). The page-bookmark ribbon
+            // (BookmarksController.isCurrentPageBookmarked) matches on
+            // ContinuousPositionTracker.locatorAt's midpoint progression, and toggleBookmark
+            // stores that same midpoint value. Placing the anchor at the viewport top
+            // (`alignToTop=true`) worked geometrically only when the CFI's char-based content
+            // position happened to line up with its pixel position — for any chapter with
+            // images, big headings, or vertical whitespace, the pixel anchor sat almost a full
+            // viewport past the char-based progression, so the ribbon lit up ~1 screen before
+            // the actual landing. Landing at the midpoint puts the ribbon and the reader at
+            // the same scrollY across every layout. Readium adapters (paginated / vertical)
+            // ignore `alignToTop` and own page/column alignment internally, so this only
             // affects continuous mode.
             navigateWithCover(
                 NavigationTarget.ToLocatorJson(event.locator.toJSON().toString()),
-                NavigationOptions(landAtStartWhenNoTarget = false, alignToTop = event.isBookmark),
+                NavigationOptions(landAtStartWhenNoTarget = false, alignToTop = false),
                 event.locator.href.toString(),
             )
         }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/session/AnnotationSession.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/session/AnnotationSession.kt
@@ -243,7 +243,8 @@ class AnnotationSession @AssistedInject constructor(
      * openBook() path to snap to the initial annotation-nav target (openAtCfi) using the same
      * channel that [navigateToAnnotation] uses — so the screen only needs one subscriber.
      * The openAtCfi path is highlight/note-shaped (text anchor), so we send `isBookmark = false`
-     * to get the midpoint-landing treatment in continuous mode.
+     * to reflect the annotation type on the event. Continuous-mode landing is uniform midpoint
+     * for both types; the flag no longer affects alignment.
      */
     fun emitAnnotationNavigation(locator: Locator) {
         _annotationNavigationChannel.trySend(AnnotationNavigationEvent(locator, isBookmark = false))

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/session/AnnotationSession.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/session/AnnotationSession.kt
@@ -107,11 +107,13 @@ class AnnotationSession @AssistedInject constructor(
 
     /**
      * Carries both the resolved locator and a flag for whether the annotation was a page-level
-     * bookmark vs a text-anchored highlight/note. The screen uses [isBookmark] to choose the
-     * continuous-mode landing: bookmarks land at the viewport top (heading visible at top); a
-     * highlight/note lands at the viewport midpoint (with reading context above it, matching
-     * Readium's vertical-mode placement). In Readium modes Readium owns placement, so the flag
-     * is ignored.
+     * bookmark vs a text-anchored highlight/note. Continuous-mode landing now goes to the viewport
+     * midpoint for BOTH types so the page-bookmark ribbon's stored midpoint progression matches
+     * the reader's scrollY on arrival — landing bookmarks at the viewport top produced a full-
+     * viewport offset between the lit ribbon position and the actual scroll landing on any book
+     * with images or non-uniform text density. The flag is preserved on the event because
+     * downstream (analytics, tests) may still branch on annotation type; the screen no longer
+     * uses it to pick alignment.
      */
     data class AnnotationNavigationEvent(val locator: Locator, val isBookmark: Boolean)
 

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/EpubReaderViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/EpubReaderViewModelTest.kt
@@ -1300,3 +1300,41 @@ class BookmarkIndicatorTest {
         assertFalse(isCurrentPageBookmarked(listOf(bm), "ch1.xhtml", 0.50f, continuous = true))
     }
 }
+
+/**
+ * Pins the invariant that annotation-panel navigation in continuous mode lands at the viewport
+ * MIDPOINT regardless of annotation type. Previously the screen passed `alignToTop = isBookmark`,
+ * which placed the bookmark's CFI DOM anchor at the viewport top — on books with images, big
+ * headings, or otherwise non-uniform text density the pixel anchor sat almost a full viewport
+ * past the char-based progression the corner ribbon stored, so the ribbon lit ~1 screen before
+ * the actual landing scrollY. A regression to that shape (`alignToTop = isBookmark`) would flip
+ * the `alignToTop=false` assertion on the `isBookmark=true` case.
+ */
+class AnnotationNavigationOptionsTest {
+
+    @Test
+    fun `bookmarks land at viewport midpoint (alignToTop=false)`() {
+        val opts = annotationNavigationOptions(isBookmark = true)
+        assertFalse(
+            "bookmark nav must align to midpoint, not top — see the fix for the lit-ribbon vs " +
+                "landing-scrollY mismatch on non-uniform-density chapters",
+            opts.alignToTop,
+        )
+    }
+
+    @Test
+    fun `highlights land at viewport midpoint (alignToTop=false)`() {
+        // The highlight path already landed at the midpoint before the fix; this pins that the
+        // extraction didn't change highlight behaviour.
+        val opts = annotationNavigationOptions(isBookmark = false)
+        assertFalse(opts.alignToTop)
+    }
+
+    @Test
+    fun `annotation nav never lands at chapter start when target has no fragment`() {
+        // landAtStartWhenNoTarget only matters for Readium modes when the locator carries no DOM
+        // anchor; annotation nav always carries one, but pin the flag so a change is intentional.
+        assertFalse(annotationNavigationOptions(isBookmark = true).landAtStartWhenNoTarget)
+        assertFalse(annotationNavigationOptions(isBookmark = false).landAtStartWhenNoTarget)
+    }
+}

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/presenter/ContinuousPresenterTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/presenter/ContinuousPresenterTest.kt
@@ -175,8 +175,10 @@ class ContinuousPresenterTest {
 
     @Test
     fun `navigateTo ToProgression honours alignToTop from options`() = runTest {
-        // Bookmark progression carries a content-top reference; the screen passes alignToTop=true
-        // in continuous mode to invert the locatorAt midpoint inverse the resume path uses.
+        // Pins that ContinuousPresenter forwards the NavigationOptions.alignToTop flag to the
+        // view unchanged. The screen currently passes alignToTop=false for annotation nav
+        // (uniform midpoint landing), but the presenter must remain option-driven so callers
+        // that want a top-aligned landing (TOC taps, chapter-start jumps) still get it.
         val presenter = ContinuousPresenter()
         val view = FakeView()
         presenter.attach(view)

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/session/AnnotationSessionTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/session/AnnotationSessionTest.kt
@@ -310,7 +310,9 @@ class AnnotationSessionTest {
         assertEquals(1, received.size)
         assertEquals(targetLocator, received[0].locator)
         // The seeded annotation in this test has type="highlight", so the event must carry
-        // isBookmark=false so the screen lands it at the viewport midpoint in continuous mode.
+        // isBookmark=false. Continuous-mode landing now uses viewport-midpoint for both types;
+        // the flag is preserved on the event because downstream (analytics, tests) still
+        // branches on annotation type.
         assertFalse(received[0].isBookmark)
         assertFalse(session.annotationsPanelVisible.value)
 
@@ -319,7 +321,7 @@ class AnnotationSessionTest {
     }
 
     @Test
-    fun `navigateToAnnotation tags bookmarks as isBookmark=true so continuous-mode landing differs`() = runTest {
+    fun `navigateToAnnotation tags bookmarks as isBookmark=true so downstream can branch on type`() = runTest {
         val dispatcher = UnconfinedTestDispatcher(testScheduler)
         val sessionScope = CoroutineScope(dispatcher)
         val store = FakeAnnotationStore()


### PR DESCRIPTION
## Summary

Tapping a bookmark in the annotations list, in continuous mode, could land the reader up to a full viewport past the position where the corner bookmark ribbon lit up. On books with images, big headings, or otherwise non-uniform text density the gap was often ~1 screen.

Root cause: two different coordinate systems.

- `toggleBookmark` stores `locator.locations.progression` — in continuous mode this is `ContinuousPositionTracker.locatorAt`'s **viewport-midpoint pixel-fraction**.
- The ribbon (`BookmarksController.isCurrentPageBookmarked`) matches against the live `locatorAt` midpoint — same coordinate. ✅
- But annotation nav resolved the CFI via `cfiStringToLocator`, then landed the DOM anchor at the viewport **top** via `anchorOffsetTopDevicePx` (actual pixel offset). The stored progression came from `progressionToCfiDocPath` (char offset). When the DOM anchor's pixel position drifts from its char position — anything with images, dividers, big headings, or long paragraphs of dense text — the pixel landing ended up nearly a viewport past where the ribbon match window sat.

Fix: land bookmarks at the viewport **midpoint** (`alignToTop=false`) so the post-nav `locatorAt` reading equals the stored midpoint by construction, regardless of DOM layout. Highlights already landed this way, so bookmark nav is now uniform with them. Readium adapters (paginated / vertical) ignore `alignToTop` and own page/column alignment internally, so nothing changes there.

Trade-off: the chapter heading no longer sits pinned at the viewport top on bookmark taps — the anchor sits centered instead, mirroring how Readium's vertical mode places bookmark nav.

## Test plan

- [x] `:app:testDebugUnitTest` — `EpubReaderViewModelTest`, `BookmarkIndicatorTest`, `BookmarksControllerTest`, `AnnotationSessionTest`, `ContinuousPresenterTest` all pass.
- [ ] On device / AVD, continuous mode: create a bookmark on a chapter with images or non-uniform density → close & re-open panel → tap the bookmark → ribbon lights AND reader lands at the same scrollY.
- [ ] Same reproduction on a short chapter (~1× viewport) — used to fail hard.
- [ ] Paginated + vertical modes unaffected (Readium owns placement).
- [ ] Highlight nav in continuous mode still lands with reading context above (no regression).