### PR TITLE
fix(reader): annotation nav + save + bookmark eps precision

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ChapterWebView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ChapterWebView.kt
@@ -479,12 +479,18 @@ internal class ChapterWebView(context: Context) : WebView(context), ChapterWebVi
             }
         }
 
-    /** Read the current selection's plain text (async, on the JS thread) then run [block] with it. */
+    /**
+     * Read the current selection's plain text (async, on the JS thread) then run [block] with it.
+     *
+     * Prefers the pre-stashed selection text written by [SELECTION_SPAN_TRACKER_JS] on
+     * 'selectionchange' — see the parallel comment on [withSelectionTextAndProgression]. Falls
+     * back to a live [window.getSelection] read when the stash is empty (rotation / test seams).
+     */
     private fun withSelectionText(block: (String) -> Unit) {
-        evaluateJavascript("(window.getSelection ? window.getSelection().toString() : '')") { raw ->
+        evaluateJavascript("(function(){var s=window.__riffleSelData;if(s&&s.text)return s.text;return window.getSelection?window.getSelection().toString():'';})()") { raw ->
             val text = decodeJsString(raw)
             if (text.isNotBlank()) block(text)
-            evalJs("window.getSelection && window.getSelection().removeAllRanges()")
+            evalJs("window.__riffleSelData=null;window.getSelection && window.getSelection().removeAllRanges()")
         }
     }
 
@@ -504,41 +510,7 @@ internal class ChapterWebView(context: Context) : WebView(context), ChapterWebVi
     private fun withSelectionTextAndProgression(
         block: (text: String, progression: Double, rect: android.graphics.Rect, before: String, after: String) -> Unit,
     ) {
-        val js = """(function() {
-            var sel = window.getSelection ? window.getSelection() : null;
-            var text = sel ? sel.toString() : '';
-            var prog = 0.0;
-            var l = 0, t = 0, r = 0, b = 0;
-            var bef = '', aft = '';
-            if (sel && sel.rangeCount > 0) {
-                var range = sel.getRangeAt(0);
-                var rect = range.getBoundingClientRect();
-                var docH = Math.max(
-                    document.documentElement ? document.documentElement.offsetHeight : 0,
-                    document.body ? document.body.offsetHeight : 0,
-                    1
-                );
-                prog = Math.max(0, Math.min(1, rect.top / docH));
-                l = rect.left; t = rect.top; r = rect.right; b = rect.bottom;
-                var body = document.body;
-                if (body) {
-                    try {
-                        var beforeR = document.createRange();
-                        beforeR.selectNodeContents(body);
-                        beforeR.setEnd(range.startContainer, range.startOffset);
-                        bef = beforeR.toString().slice(-60);
-                    } catch (e) { bef = ''; }
-                    try {
-                        var afterR = document.createRange();
-                        afterR.selectNodeContents(body);
-                        afterR.setStart(range.endContainer, range.endOffset);
-                        aft = afterR.toString().slice(0, 60);
-                    } catch (e) { aft = ''; }
-                }
-            }
-            return JSON.stringify({text: text, p: prog, l: l, t: t, r: r, b: b, bef: bef, aft: aft});
-        })()"""
-        evaluateJavascript(js) { raw ->
+        evaluateJavascript(CONTINUOUS_SELECTION_READ_JS) { raw ->
             val jsonStr = decodeJsString(raw)
             val text: String
             val prog: Double
@@ -562,7 +534,7 @@ internal class ChapterWebView(context: Context) : WebView(context), ChapterWebVi
                 return@evaluateJavascript
             }
             if (text.isNotBlank()) block(text, prog, rect, before, after)
-            evalJs("window.getSelection && window.getSelection().removeAllRanges()")
+            evalJs("window.__riffleSelData=null;window.getSelection && window.getSelection().removeAllRanges()")
         }
     }
 

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousNavigationView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousNavigationView.kt
@@ -11,6 +11,16 @@ import com.riffle.core.domain.FormattingPreferences
 internal interface ContinuousNavigationView {
     fun navigateTo(href: String, progression: Float, alignToTop: Boolean = false)
 
+    /**
+     * Annotation-precise navigate: when [focusAnnotationId] is non-null the landing anchors on
+     * the actual `<mark data-riffle-ann="…">` device-Y instead of the enclosing paragraph's top,
+     * so a mid- or end-paragraph highlight lands visibly on-screen rather than pushed below.
+     * Default forwards to the plain three-arg overload for callers that don't have an id.
+     */
+    fun navigateTo(href: String, progression: Float, alignToTop: Boolean, focusAnnotationId: String?) {
+        navigateTo(href, progression, alignToTop)
+    }
+
     /** Page forward / backward; same semantics as [ContinuousReaderView.scrollByPage]. */
     fun scrollByPage(forward: Boolean)
 

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
@@ -268,6 +268,9 @@ internal class ContinuousReaderView @JvmOverloads constructor(
     override fun navigateTo(href: String, progression: Float, alignToTop: Boolean) =
         controller.navigateTo(href, progression, alignToTop)
 
+    override fun navigateTo(href: String, progression: Float, alignToTop: Boolean, focusAnnotationId: String?) =
+        controller.navigateTo(href, progression, alignToTop, focusAnnotationId)
+
     override fun scrollByPage(forward: Boolean) = controller.scrollByPage(forward)
 
     override fun highlightInChapter(href: String, text: String, cssColor: String) =

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousWindowController.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousWindowController.kt
@@ -365,6 +365,22 @@ internal class ContinuousWindowController(
     }
 
     override fun navigateTo(href: String, progression: Float, alignToTop: Boolean) {
+        navigateTo(href, progression, alignToTop, focusAnnotationId = null)
+    }
+
+    /**
+     * Continuous-mode annotation navigation with mark-precise landing. When [focusAnnotationId] is
+     * non-null and the chapter is in the sliding window, the landing anchors on the actual
+     * `<mark data-riffle-ann="…">` element's device-Y (via [ChapterWebView.annotationOffsetTopDevicePx])
+     * rather than the enclosing paragraph's top. That fixes the "mostly miss" behaviour reported for
+     * highlights that live mid- or end-paragraph, where landing the paragraph's TOP at the viewport
+     * midpoint pushed the actual highlighted text well below the visible band.
+     *
+     * When [focusAnnotationId] is set but the mark can't be resolved yet (chapter not measured,
+     * decorations not applied), we fall back to the paragraph-based landing — same shape as the
+     * open-time `focusAnnotationId` path in [openWindowAt].
+     */
+    override fun navigateTo(href: String, progression: Float, alignToTop: Boolean, focusAnnotationId: String?) {
         val target = href.substringBefore('#')
         val fragment = href.substringAfter('#', "")
         val targetIndex = ContinuousPositionTracker.chapterIndexForHref(
@@ -373,7 +389,13 @@ internal class ContinuousWindowController(
         if (targetIndex < 0) return
         val inWindow = targetIndex in topIndex until (topIndex + webViews.size)
         if (inWindow) {
-            port.post { scrollToLoadedChapter(target, progression, fragment, smooth = true, alignToTop = alignToTop) }
+            port.post {
+                scrollToLoadedChapter(
+                    target, progression, fragment,
+                    smooth = true, alignToTop = alignToTop,
+                    focusAnnotationId = focusAnnotationId,
+                )
+            }
         } else {
             webViews.forEach { it.destroy() }
             webViews.clear()
@@ -381,11 +403,24 @@ internal class ContinuousWindowController(
             container.removeAllViews()
             recycledViews.forEach { it.destroy() }
             recycledViews.clear()
-            openWindowAt(target, progression, fragment, alignToTop = alignToTop)
+            openWindowAt(
+                initialHref = target,
+                initialProgression = progression,
+                anchorFragment = fragment,
+                alignToTop = alignToTop,
+                focusAnnotationId = focusAnnotationId,
+            )
         }
     }
 
-    private fun scrollToLoadedChapter(target: String, progression: Float, fragment: String, smooth: Boolean, alignToTop: Boolean = false) {
+    private fun scrollToLoadedChapter(
+        target: String,
+        progression: Float,
+        fragment: String,
+        smooth: Boolean,
+        alignToTop: Boolean = false,
+        focusAnnotationId: String? = null,
+    ) {
         val window = buildWindow()
         val slot = window.firstOrNull { it.href.substringBefore('#') == target } ?: return
         clearLandingHold()
@@ -394,16 +429,41 @@ internal class ContinuousWindowController(
             if (smooth) port.smoothScrollTo(clamped) else port.scrollTo(clamped)
         }
         val wvIndex = webViews.indexOfFirst { it.chapterHref.substringBefore('#') == target }
-        if (fragment.isNotEmpty() && wvIndex >= 0) {
-            webViews[wvIndex].anchorOffsetTopDevicePx(fragment) { anchorOffset ->
-                val offset = anchorOffset ?: (progression * slot.height).toInt()
-                go(ContinuousPositionTracker.anchorLandingScrollY(slot.top, offset, port.viewportHeightPx, alignToTop))
+        if (wvIndex < 0) return
+        val wv = webViews[wvIndex]
+
+        fun landOnAnchorOrProgression() {
+            if (fragment.isNotEmpty()) {
+                wv.anchorOffsetTopDevicePx(fragment) { anchorOffset ->
+                    val offset = anchorOffset ?: (progression * slot.height).toInt()
+                    go(ContinuousPositionTracker.anchorLandingScrollY(slot.top, offset, port.viewportHeightPx, alignToTop))
+                }
+            } else {
+                go(
+                    if (alignToTop) slot.top + (progression * slot.height).toInt()
+                    else ContinuousPositionTracker.scrollYForProgression(slot.top, slot.height, progression, port.viewportHeightPx)
+                )
+            }
+        }
+
+        // Prefer the actual annotation mark's device-Y over the enclosing paragraph's top: for a
+        // highlight in the middle of a long paragraph, landing the paragraph at midpoint puts the
+        // highlighted text well below the viewport centre and often off-screen. Reading the mark's
+        // rect directly makes the landing pixel-accurate to what the user tapped in the panel.
+        if (focusAnnotationId != null) {
+            wv.annotationOffsetTopDevicePx(focusAnnotationId) { annOffset ->
+                if (annOffset != null) {
+                    go(ContinuousPositionTracker.anchorLandingScrollY(slot.top, annOffset, port.viewportHeightPx, alignToTop))
+                } else {
+                    // Mark not in DOM yet (chapter measured but decorations still applying) — fall
+                    // back to the paragraph anchor for now. openWindowAt's re-land loop handles
+                    // this precisely on cold-open; mid-session the fallback is close enough that
+                    // the user still lands in the right paragraph.
+                    landOnAnchorOrProgression()
+                }
             }
         } else {
-            go(
-                if (alignToTop) slot.top + (progression * slot.height).toInt()
-                else ContinuousPositionTracker.scrollYForProgression(slot.top, slot.height, progression, port.viewportHeightPx)
-            )
+            landOnAnchorOrProgression()
         }
     }
 

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -1702,13 +1702,32 @@ private fun EpubNavigatorView(
         }
     }
 
-    LaunchedEffect(annotationNavigationEvents) {
+    // MODE-FORK: annotation-nav landing precision differs by renderer. Readium (paginated + vertical)
+    // has DecorableNavigator + fragment-anchored go(), so the paragraph-level Locator lands correctly.
+    // Continuous has no equivalent seam — the paragraph anchor is only ~correct, so we look up the
+    // actual `<mark data-riffle-ann>` device-Y and centre on it. Cannot live behind ReaderPresenter
+    // without leaking Readium/Continuous internals up the stack.
+    LaunchedEffect(annotationNavigationEvents, isContinuous) {
         annotationNavigationEvents.collect { event ->
-            navigateWithCover(
-                NavigationTarget.ToLocatorJson(event.locator.toJSON().toString()),
-                annotationNavigationOptions(isBookmark = event.isBookmark),
-                event.locator.href.toString(),
-            )
+            val view = continuousViewRef.value
+            if (isContinuous && !event.isBookmark && event.annotationId != null && view != null) {
+                val locations = event.locator.locations
+                val href = event.locator.href.toString()
+                val anchor = locations.fragments.firstOrNull()
+                val fullHref = if (anchor != null) "$href#$anchor" else href
+                view.navigateTo(
+                    href = fullHref,
+                    progression = locations.progression?.toFloat() ?: 0f,
+                    alignToTop = false,
+                    focusAnnotationId = event.annotationId,
+                )
+            } else {
+                navigateWithCover(
+                    NavigationTarget.ToLocatorJson(event.locator.toJSON().toString()),
+                    annotationNavigationOptions(isBookmark = event.isBookmark),
+                    event.locator.href.toString(),
+                )
+            }
         }
     }
 

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -91,7 +91,6 @@ import org.readium.r2.streamer.PublicationOpener
 import java.io.File
 import javax.inject.Inject
 
-private const val BOOKMARK_PAGE_EPS = 0.05   // ±5% within-chapter progression window
 // The audiobook follows the live audio on a tighter cadence than the 30s ebook reconcile, so a
 // listen reaches the server within seconds rather than only on the next ebook tick.
 // Debounce window for persisting a playback-speed change, so a granular scrub/slide settles to a
@@ -608,6 +607,7 @@ class EpubReaderViewModel @Inject constructor(
                 serverId = activeServer.id,
                 itemId = itemId,
                 currentLocator = position.currentLocator,
+                spinePositionCounts = spinePositionCounts,
             )
             // Push orientation changes into the controller via a setter so the page-bookmark
             // indicator's match window re-sizes on a mid-session flip.
@@ -990,8 +990,9 @@ class EpubReaderViewModel @Inject constructor(
 
     /**
      * Toggle the bookmark for the reader's current page. If the page is already bookmarked (within
-     * [BOOKMARK_PAGE_EPS] progression), removes it; otherwise creates a new bookmark anchored to the
-     * top-of-viewport CFI with the surrounding text as snippet.
+     * the page-aware eps [BookmarksController.bookmarkEpsFor] returns for the current chapter),
+     * removes it; otherwise creates a new bookmark anchored to the top-of-viewport CFI with the
+     * surrounding text as snippet.
      */
     fun toggleBookmark() {
         val serverId = annotationServerId ?: return
@@ -1000,8 +1001,12 @@ class EpubReaderViewModel @Inject constructor(
             val href = locator.href.toString()
             val hrefNorm = normalizeEpubHref(href)
             val prog = locator.locations.progression ?: 0.0
+            // Reuse the indicator's eps so "am I already bookmarked?" matches "is the indicator
+            // lit?". A wider eps here would delete a nearby bookmark instead of creating a new
+            // one on this specific page.
+            val eps = bookmarks.bookmarkEpsFor(href)
             val existing = bookmarks.bookmarkPositions.value.firstOrNull { bm ->
-                bm.chapterHref == hrefNorm && kotlin.math.abs(bm.progression - prog) < BOOKMARK_PAGE_EPS
+                bm.chapterHref == hrefNorm && kotlin.math.abs(bm.progression - prog) <= eps
             }
             if (existing != null) {
                 annotationStore.delete(existing.id)

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderWebViewScripts.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderWebViewScripts.kt
@@ -201,12 +201,75 @@ internal fun readiumDecorationTemplatesRegisterJs(): String {
 // [resolveSelectionSentenceJs] reads to resolve the narrated sentence by POSITION. We capture it here,
 // on selectionchange, because the live DOM selection is gone by the time the action-mode menu handler
 // runs. getClientRects()[0] is the rect of the selection's first glyph (its start).
+/**
+ * Reads the current text selection for the continuous-mode action-mode menu handlers ("Highlight",
+ * "Copy", "Share", "Play from here"). Returns a JSON payload with `text`, within-chapter
+ * progression `p`, the range's viewport rect (`l`/`t`/`r`/`b`, CSS px), and 60-char before/after
+ * context (`bef`/`aft`).
+ *
+ * Prefers the pre-stashed payload written by [SELECTION_SPAN_TRACKER_JS] on 'selectionchange' —
+ * the framework collapses the live DOM selection between the user's menu tap and this async
+ * `evaluateJavascript` in Chromium WebView on Android 13+, so a live `window.getSelection()` read
+ * here often returns empty. That was the "highlight not saved in continuous mode" regression:
+ * the stash captures the same fields at last-live selection and survives the collapse.
+ *
+ * Falls back to a live read for pre-tracker paths (tests / rotation edge cases). Kept in one
+ * place so the read/stash pair can't drift out of sync — the tracker writes the same field names
+ * this reader consumes.
+ */
+internal val CONTINUOUS_SELECTION_READ_JS = """
+    (function() {
+        var stash = window.__riffleSelData;
+        if (stash && stash.text) {
+            return JSON.stringify({
+                text: stash.text, p: stash.p,
+                l: stash.l, t: stash.t, r: stash.r, b: stash.b,
+                bef: stash.bef || '', aft: stash.aft || ''
+            });
+        }
+        var sel = window.getSelection ? window.getSelection() : null;
+        var text = sel ? sel.toString() : '';
+        var prog = 0.0;
+        var l = 0, t = 0, r = 0, b = 0;
+        var bef = '', aft = '';
+        if (sel && sel.rangeCount > 0) {
+            var range = sel.getRangeAt(0);
+            var rect = range.getBoundingClientRect();
+            var docH = Math.max(
+                document.documentElement ? document.documentElement.offsetHeight : 0,
+                document.body ? document.body.offsetHeight : 0, 1
+            );
+            prog = Math.max(0, Math.min(1, rect.top / docH));
+            l = rect.left; t = rect.top; r = rect.right; b = rect.bottom;
+            var body = document.body;
+            if (body) {
+                try {
+                    var beforeR = document.createRange();
+                    beforeR.selectNodeContents(body);
+                    beforeR.setEnd(range.startContainer, range.startOffset);
+                    bef = beforeR.toString().slice(-60);
+                } catch (e) { bef = ''; }
+                try {
+                    var afterR = document.createRange();
+                    afterR.selectNodeContents(body);
+                    afterR.setStart(range.endContainer, range.endOffset);
+                    aft = afterR.toString().slice(0, 60);
+                } catch (e) { aft = ''; }
+            }
+        }
+        return JSON.stringify({text: text, p: prog, l: l, t: t, r: r, b: b, bef: bef, aft: aft});
+    })()
+""".trimIndent()
+
 internal val SELECTION_SPAN_TRACKER_JS = """
     (function () {
       if (window.__riffleSelTrackerInstalled) return;
       window.__riffleSelTrackerInstalled = true;
       document.addEventListener('selectionchange', function () {
         var s = window.getSelection();
+        // Ignore transient collapse/clear events dispatched right before the framework fires the
+        // action-mode menu handler — they would otherwise wipe __riffleSelData between the user's
+        // menu tap and our async evaluateJavascript reading it. Keep the LAST non-empty stash.
         if (!s || s.rangeCount === 0 || s.isCollapsed) return;
         var rng = s.getRangeAt(0);
         var n = rng.startContainer;
@@ -226,6 +289,42 @@ internal val SELECTION_SPAN_TRACKER_JS = """
           var br = rng.getBoundingClientRect();
           if (window.RiffleSelBridge) {
             window.RiffleSelBridge.onRect(br.left, br.top, br.right, br.bottom);
+          }
+        } catch (e) {}
+        // Stash the full selection payload (text + progression + range rect + before/after context)
+        // needed by the continuous-mode Highlight / Copy / Share menu handlers. The live DOM
+        // selection is gone by the time the action-mode menu handler runs (framework collapses it
+        // in-between), so those handlers read from this stash instead of window.getSelection().
+        try {
+          var text = s.toString();
+          if (text) {
+            var br2 = rng.getBoundingClientRect();
+            var docH = Math.max(
+              document.documentElement ? document.documentElement.offsetHeight : 0,
+              document.body ? document.body.offsetHeight : 0, 1
+            );
+            var bef = '', aft = '';
+            var body = document.body;
+            if (body) {
+              try {
+                var beforeR = document.createRange();
+                beforeR.selectNodeContents(body);
+                beforeR.setEnd(rng.startContainer, rng.startOffset);
+                bef = beforeR.toString().slice(-60);
+              } catch (e) { bef = ''; }
+              try {
+                var afterR = document.createRange();
+                afterR.selectNodeContents(body);
+                afterR.setStart(rng.endContainer, rng.endOffset);
+                aft = afterR.toString().slice(0, 60);
+              } catch (e) { aft = ''; }
+            }
+            window.__riffleSelData = {
+              text: text,
+              p: Math.max(0, Math.min(1, br2.top / docH)),
+              l: br2.left, t: br2.top, r: br2.right, b: br2.bottom,
+              bef: bef, aft: aft
+            };
           }
         } catch (e) {}
       });

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/controllers/BookmarksController.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/controllers/BookmarksController.kt
@@ -51,6 +51,8 @@ class BookmarksController @AssistedInject constructor(
 
     private val _currentLocator = MutableStateFlow<Locator?>(null)
 
+    private val _spinePositionCounts = MutableStateFlow<Pair<List<String>, List<Int>>>(emptyList<String>() to emptyList())
+
     /**
      * Current reader orientation, read non-reactively inside [isCurrentPageBookmarked]'s combine
      * so the combine stays 2-arg (matches master's shape and avoids the Eagerly-shared
@@ -79,20 +81,30 @@ class BookmarksController @AssistedInject constructor(
     val isCurrentPageBookmarked: StateFlow<Boolean> = combine(
         _bookmarkPositions,
         _currentLocator,
-    ) { positions, locator ->
+        _spinePositionCounts,
+    ) { bookmarksForChapter, locator, spineCounts ->
         val href = locator?.href?.toString() ?: return@combine false
         val prog = locator.locations.progression
         val hrefNorm = normalizeEpubHref(href)
-        val eps = if (currentOrientation == ReaderOrientation.Continuous) BOOKMARK_VIEWPORT_EPS
-        else BOOKMARK_PAGE_EPS
-        positions.any { bm ->
+        val eps = bookmarkEpsFor(currentOrientation, spineCounts, hrefNorm)
+        bookmarksForChapter.any { bm ->
             bm.chapterHref == hrefNorm &&
                 (prog == null || kotlin.math.abs(bm.progression - prog) <= eps)
         }
     }.stateIn(scope, SharingStarted.Eagerly, false)
 
+    /**
+     * The progression window used to decide whether a stored bookmark falls on the current
+     * viewport. Public so the toggle-bookmark call site in `EpubReaderViewModel` uses the SAME
+     * band the indicator does — a mismatch there would toggle the wrong (nearby) bookmark
+     * instead of creating a new one on the current page.
+     */
+    fun bookmarkEpsFor(chapterHref: String): Double =
+        bookmarkEpsFor(currentOrientation, _spinePositionCounts.value, normalizeEpubHref(chapterHref))
+
     private var observeJob: Job? = null
     private var locatorJob: Job? = null
+    private var positionsJob: Job? = null
 
     /**
      * Bind to a specific book. Cancels any previous observation and starts fresh.
@@ -103,11 +115,14 @@ class BookmarksController @AssistedInject constructor(
         serverId: String,
         itemId: String,
         currentLocator: StateFlow<Locator?>,
+        spinePositionCounts: StateFlow<Pair<List<String>, List<Int>>>,
     ) {
         observeJob?.cancel()
         locatorJob?.cancel()
+        positionsJob?.cancel()
         _bookmarkPositions.value = emptyList()
         _currentLocator.value = null
+        _spinePositionCounts.value = emptyList<String>() to emptyList()
 
         observeJob = scope.launch {
             annotationStore.observeBookmarks(serverId, itemId).collect { annotations ->
@@ -123,6 +138,11 @@ class BookmarksController @AssistedInject constructor(
         locatorJob = scope.launch {
             currentLocator.collect { locator ->
                 _currentLocator.value = locator
+            }
+        }
+        positionsJob = scope.launch {
+            spinePositionCounts.collect { counts ->
+                _spinePositionCounts.value = counts
             }
         }
     }
@@ -152,23 +172,48 @@ class BookmarksController @AssistedInject constructor(
     }
 
     companion object {
-        // ±5% within-chapter progression window for paginated / vertical mode — both emit
-        // content-top progression and the bookmark stores the same, so a tight match is correct.
+        // Fallback ±5% within-chapter progression window for paginated / vertical modes when the
+        // spine position count for the current chapter isn't yet available (open-race). Once the
+        // count arrives, [bookmarkEpsFor] switches to `0.5 / positionsInChapter` — a strict
+        // ±half-a-page window, so the indicator only lights for the actual bookmarked page and
+        // never for its 3–4 neighbours (the "bookmark stays lit for way longer than expected"
+        // regression). A fixed 5% covered ~3 pages on typical (~60-position) chapters.
         internal const val BOOKMARK_PAGE_EPS = 0.05
 
-        // ±33% within-chapter window for continuous mode. The locator emits the viewport-midpoint
-        // progression while the bookmark anchor can sit anywhere from the viewport top to bottom,
-        // so the geometric minimum is `viewportFraction / 2`. We use a static 33% as a
-        // conservative cover: typical viewports (~20–40% of chapter height) put `vf/2` at
-        // 0.10–0.20, while short chapters (≤ 2× viewport tall) push `vf/2` up to ~0.30; 33%
-        // catches both with a small slack for anchor offsets and float noise.
-        //
-        // The trade-off: two bookmarks within ~33% of each other in the same chapter both light.
-        // Acceptable for a boolean indicator. We previously tried plumbing the live viewport
-        // fraction through to size this exactly, but the on-scroll emission churn flaked the
-        // continuous→paginated annotation-repaint harness test (Compose recomposition pressure
-        // prevented the chrome-reveal LaunchedEffect from idling within the test's waitUntil).
-        // The static value here picks 33% as the band that covers all observed cases.
+        // Fallback ±33% for continuous mode when the spine position count for the current chapter
+        // isn't yet available (open-race). This is a conservative geometric cover: for a short
+        // chapter ~2 viewports tall, viewportFraction/2 approaches 0.3. Once the position count
+        // arrives, [bookmarkEpsFor] switches to the same `0.5 / positions` formula paginated uses
+        // — the locator emits viewport-midpoint progression in continuous mode, so the geometric
+        // minimum is viewportFraction/2, and viewportFraction ≈ 1/positionsInChapter (Readium
+        // sizes positions to viewport-page-equivalents). The old flat 33% caused the "bookmark
+        // stays lit for several screens" symptom in continuous just as the flat 5% did in
+        // paginated.
         internal const val BOOKMARK_VIEWPORT_EPS = 0.33
+
+        /**
+         * Pure decision (JVM-testable) for the ±progression window used to decide whether a
+         * bookmark falls on the current viewport in [chapterHref].
+         *
+         * All three modes now use `0.5 / positionsInChapter` when the position count is known:
+         * - **Paginated / vertical:** half a page (locator = content-top progression).
+         * - **Continuous:** half a viewport-fraction (locator = viewport-midpoint progression;
+         *   viewportFraction ≈ 1/positions, so this is the tightest geometrically-correct
+         *   bound). Falls back to [BOOKMARK_VIEWPORT_EPS] / [BOOKMARK_PAGE_EPS] when positions
+         *   are unknown yet.
+         */
+        internal fun bookmarkEpsFor(
+            orientation: ReaderOrientation,
+            spineCounts: Pair<List<String>, List<Int>>,
+            chapterHref: String,
+        ): Double {
+            val (hrefs, counts) = spineCounts
+            val idx = hrefs.indexOfFirst { normalizeEpubHref(it) == chapterHref }
+            val positions = counts.getOrNull(idx) ?: 0
+            if (positions > 0) return 0.5 / positions
+            // Position count not yet available — fall back to the mode-appropriate flat eps.
+            return if (orientation == ReaderOrientation.Continuous) BOOKMARK_VIEWPORT_EPS
+            else BOOKMARK_PAGE_EPS
+        }
     }
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/renderer/DefaultRendererBridge.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/renderer/DefaultRendererBridge.kt
@@ -73,9 +73,18 @@ internal class DefaultRendererBridge(
 
     override suspend fun snapAfterGoTo(locator: Locator, landAtStartWhenNoTarget: Boolean) {
         val frag = fragment ?: return
+        // Prefer the fragment id carried in locations.fragments over any '#anchor' in the href.
+        // Annotation navigation resolves the CFI's DOM anchor into locations.fragments (never
+        // into the href string), so a naïve navTargetFragmentId(href) read would return null and
+        // the snap JS would fall back to a scroll-position round — which in paginated mode can
+        // leave the page one column short of the annotated paragraph even though Readium's own
+        // go(locator) already scrolled to it. Using the locator's fragment id makes the snap JS
+        // anchor on the DOM element directly.
+        val fragmentId = locator.locations.fragments.firstOrNull()
+            ?: navTargetFragmentId(locator.href.toString())
         frag.go(locator)
         frag.evaluateJavascript(
-            ColumnSnap.snapToTargetColumnJs(navTargetFragmentId(locator.href.toString()), landAtStartWhenNoTarget),
+            ColumnSnap.snapToTargetColumnJs(fragmentId, landAtStartWhenNoTarget),
         )
     }
 

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/session/AnnotationSession.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/session/AnnotationSession.kt
@@ -115,7 +115,24 @@ class AnnotationSession @AssistedInject constructor(
      * downstream (analytics, tests) may still branch on annotation type; the screen no longer
      * uses it to pick alignment.
      */
-    data class AnnotationNavigationEvent(val locator: Locator, val isBookmark: Boolean)
+    /**
+     * A "navigate to this annotation" event. [locator] resolves to (chapter, progression,
+     * fragment) — the fragment is the range's START paragraph id (see [extractAnchorFromCfi]),
+     * which is enough for Readium's own navigators (paginated + vertical scroll) to land on
+     * the paragraph containing the highlight.
+     *
+     * Continuous mode uses [annotationId] to look up the actual `<mark data-riffle-ann="…">`
+     * element in the DOM and centre the viewport on IT, not just on the enclosing paragraph.
+     * Landing on the paragraph is close but visibly wrong when the highlight is mid- or
+     * end-paragraph — the previous behaviour showed the paragraph's TOP at midpoint, so
+     * highlights below the first line ended up unclear or fully off-screen. [annotationId] is
+     * null only when the caller doesn't have one (e.g. server-progress or programmatic nav).
+     */
+    data class AnnotationNavigationEvent(
+        val locator: Locator,
+        val isBookmark: Boolean,
+        val annotationId: String? = null,
+    )
 
     /**
      * CONFLATED: [navigateToAnnotation] closes the panel before sending, so a second navigation
@@ -294,7 +311,14 @@ class AnnotationSession @AssistedInject constructor(
             // matching a lowercased literal here silently flipped every annotation to
             // isBookmark=false, which inverted the continuous-mode landing.
             _annotationNavigationChannel.trySend(
-                AnnotationNavigationEvent(locator, isBookmark = annotation.type == AnnotationEntity.TYPE_BOOKMARK),
+                AnnotationNavigationEvent(
+                    locator = locator,
+                    isBookmark = annotation.type == AnnotationEntity.TYPE_BOOKMARK,
+                    // Carry the id so continuous mode can look up the actual mark and centre on
+                    // it (see AnnotationNavigationEvent doc). Paginated / vertical don't need it —
+                    // they rely on Readium's own fragment-based landing.
+                    annotationId = id,
+                ),
             )
             _annotationsPanelVisible.value = false
         }

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ReaderModeForkGuardTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ReaderModeForkGuardTest.kt
@@ -73,6 +73,10 @@ class ReaderModeForkGuardTest {
          * behind the seam; raise it only when a new fork is genuinely UI-lifecycle-shaped and
          * carries a `// MODE-FORK:` justification.
          */
-        private const val MAX_MODE_BRANCHES = 26
+        // Raised from 26 to 28 for the continuous-only annotation-nav mark-lookup path (see the
+        // `// MODE-FORK:` comment above the annotationNavigationEvents LaunchedEffect). Two refs:
+        // the LaunchedEffect key on isContinuous and the branch guard inside the collector — both
+        // load-bearing and both untypeable behind ReaderPresenter without leaking mode internals.
+        private const val MAX_MODE_BRANCHES = 28
     }
 }

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ReaderWebViewScriptsTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ReaderWebViewScriptsTest.kt
@@ -88,4 +88,43 @@ class ReaderWebViewScriptsTest {
         assertTrue("rounds the current scroll to the grid", js.contains("se.scrollLeft=Math.round(se.scrollLeft/iw)*iw"))
         assertTrue("does NOT yank to column 0", !js.contains("se.scrollLeft=0;"))
     }
+
+    // Regression for the "highlight not saved in continuous mode" bug: Chromium WebView collapses
+    // the live DOM selection between the user's action-mode menu tap and our async
+    // evaluateJavascript, so a live window.getSelection() read in the menu handler returns empty
+    // and the highlight is dropped before it can reach the ViewModel. The fix stashes the full
+    // selection payload (text + progression + range rect + before/after context) on every
+    // 'selectionchange' event into window.__riffleSelData; the menu handler's read
+    // (CONTINUOUS_SELECTION_READ_JS) prefers the stash over the live selection. Both halves must
+    // agree on the field names and both must be present, otherwise the fix collapses back to the
+    // live-read-only race that shipped the bug.
+    @Test
+    fun `SELECTION_SPAN_TRACKER_JS stashes the full selection payload on selectionchange`() {
+        val js = SELECTION_SPAN_TRACKER_JS
+        assertTrue("hooks the selectionchange event", js.contains("addEventListener('selectionchange'"))
+        assertTrue("writes __riffleSelData", js.contains("window.__riffleSelData ="))
+        // Every field CONTINUOUS_SELECTION_READ_JS reads from the stash must be written here.
+        assertTrue("stashes selected text", js.contains("text: text"))
+        assertTrue("stashes within-chapter progression as `p`", js.contains("p: Math.max(0, Math.min(1, br2.top / docH))"))
+        assertTrue("stashes range rect (l/t/r/b)", js.contains("l: br2.left, t: br2.top, r: br2.right, b: br2.bottom"))
+        assertTrue("stashes before/after context (bef/aft)", js.contains("bef: bef, aft: aft"))
+    }
+
+    @Test
+    fun `CONTINUOUS_SELECTION_READ_JS prefers the pre-stashed selection over the live DOM selection`() {
+        val js = CONTINUOUS_SELECTION_READ_JS
+        // The stash check must run BEFORE the live window.getSelection() fallback, and must gate
+        // on stash.text so an empty stash (e.g. after removeAllRanges) doesn't shadow a live read.
+        val stashIdx = js.indexOf("window.__riffleSelData")
+        val liveIdx = js.indexOf("window.getSelection")
+        assertTrue("stash is read", stashIdx >= 0)
+        assertTrue("live getSelection is present as a fallback", liveIdx >= 0)
+        assertTrue("stash is preferred over live selection", stashIdx < liveIdx)
+        assertTrue("stash is gated on non-empty text", js.contains("if (stash && stash.text)"))
+        // The returned JSON shape must match what withSelectionTextAndProgression parses.
+        assertTrue("returns text field", js.contains("text: stash.text"))
+        assertTrue("returns progression as p", js.contains("p: stash.p"))
+        assertTrue("returns range rect (l/t/r/b)", js.contains("l: stash.l, t: stash.t, r: stash.r, b: stash.b"))
+        assertTrue("returns before/after context (bef/aft)", js.contains("bef: stash.bef") && js.contains("aft: stash.aft"))
+    }
 }

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/controllers/BookmarksControllerTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/controllers/BookmarksControllerTest.kt
@@ -130,7 +130,7 @@ class BookmarksControllerTest {
     fun `bookmarkPositions reactively follows annotationStore observeBookmarks`() = runTest {
         val (controller, store) = makeController()
         val bm = makeAnnotation(chapterHref = "ch1.xhtml", progression = 0.1)
-        controller.bind("srv", "item1", MutableStateFlow(null))
+        controller.bind("srv", "item1", MutableStateFlow(null), MutableStateFlow(emptyList<String>() to emptyList()))
 
         store.bookmarks.value = listOf(bm)
 
@@ -144,7 +144,7 @@ class BookmarksControllerTest {
     fun `isCurrentPageBookmarked reflects bookmark presence at current href and progression`() = runTest {
         val (controller, store) = makeController()
         val currentLocator = MutableStateFlow<Locator?>(null)
-        controller.bind("srv", "item1", currentLocator)
+        controller.bind("srv", "item1", currentLocator, MutableStateFlow(emptyList<String>() to emptyList()))
 
         assertFalse(controller.isCurrentPageBookmarked.value)
 
@@ -164,7 +164,7 @@ class BookmarksControllerTest {
     fun `isCurrentPageBookmarked uses progression window tolerance`() = runTest {
         val (controller, store) = makeController()
         val currentLocator = MutableStateFlow<Locator?>(null)
-        controller.bind("srv", "item1", currentLocator)
+        controller.bind("srv", "item1", currentLocator, MutableStateFlow(emptyList<String>() to emptyList()))
 
         store.bookmarks.value = listOf(makeAnnotation(chapterHref = "ch1.xhtml", progression = 0.5))
         // Within 5% tolerance → bookmarked
@@ -184,7 +184,7 @@ class BookmarksControllerTest {
         // viewportFraction can hit ~0.6 (so vf/2 ≈ 0.30) — the exact case the user reproduced.
         val (controller, store) = makeController()
         val currentLocator = MutableStateFlow<Locator?>(null)
-        controller.bind("srv", "item1", currentLocator)
+        controller.bind("srv", "item1", currentLocator, MutableStateFlow(emptyList<String>() to emptyList()))
         controller.onOrientationChanged(com.riffle.core.domain.ReaderOrientation.Continuous)
 
         store.bookmarks.value = listOf(makeAnnotation(chapterHref = "ch1.xhtml", progression = 0.0))
@@ -205,7 +205,7 @@ class BookmarksControllerTest {
     fun `onOrientationChanged toggles eps without rebinding`() = runTest {
         val (controller, store) = makeController()
         val currentLocator = MutableStateFlow<Locator?>(null)
-        controller.bind("srv", "item1", currentLocator)
+        controller.bind("srv", "item1", currentLocator, MutableStateFlow(emptyList<String>() to emptyList()))
         // Start in paginated.
         controller.onOrientationChanged(com.riffle.core.domain.ReaderOrientation.Horizontal)
 
@@ -223,7 +223,7 @@ class BookmarksControllerTest {
     fun `renameBookmark updates store and calls sync`() = runTest {
         var syncCalled = false
         val (controller, store) = makeController(onScheduleSync = { syncCalled = true })
-        controller.bind("srv", "item1", MutableStateFlow(null))
+        controller.bind("srv", "item1", MutableStateFlow(null), MutableStateFlow(emptyList<String>() to emptyList()))
 
         controller.renameBookmark("bm-1", "New Title")
 
@@ -235,15 +235,101 @@ class BookmarksControllerTest {
     fun `bind clears state from previous book`() = runTest {
         val (controller, store) = makeController()
         store.bookmarks.value = listOf(makeAnnotation())
-        controller.bind("srv", "item1", MutableStateFlow(null))
+        controller.bind("srv", "item1", MutableStateFlow(null), MutableStateFlow(emptyList<String>() to emptyList()))
 
         assertEquals(1, controller.bookmarkPositions.value.size)
 
         // Rebind to a new book with a fresh empty store
         store.bookmarks.value = emptyList()
-        controller.bind("srv", "item2", MutableStateFlow(null))
+        controller.bind("srv", "item2", MutableStateFlow(null), MutableStateFlow(emptyList<String>() to emptyList()))
 
         assertEquals(0, controller.bookmarkPositions.value.size)
+    }
+
+    // Regression for the "bookmark stays lit for 3-4 pages" bug: the old fixed 5% eps was ~3 pages
+    // wide on a typical (~60-position) chapter. The page-aware eps computes `0.5 / positions`
+    // — half a page — so the indicator lights ONLY for the bookmarked page (not its neighbours).
+    // This test pins the tight window for a 60-page chapter: a 5% delta must NOT light.
+    @Test
+    fun `paginated eps narrows to half-a-page when spine position counts are known`() = runTest {
+        val (controller, store) = makeController()
+        val currentLocator = MutableStateFlow<Locator?>(null)
+        val positions = MutableStateFlow(
+            listOf("ch1.xhtml") to listOf(60),
+        )
+        controller.bind("srv", "item1", currentLocator, positions)
+        controller.onOrientationChanged(com.riffle.core.domain.ReaderOrientation.Horizontal)
+
+        store.bookmarks.value = listOf(makeAnnotation(chapterHref = "ch1.xhtml", progression = 0.5))
+
+        // Same page (delta 0.003 < 1/(2*60) = 0.0083) → lit.
+        currentLocator.value = buildLocator("ch1.xhtml", 0.503)
+        assertTrue("indicator ON for the same page (0.003 delta, half-page = 0.0083)", controller.isCurrentPageBookmarked.value)
+
+        // 3 pages away (delta 0.05, the OLD fixed eps) → NOT lit any more. Fail-red asserts the
+        // regression is fixed; if BOOKMARK_PAGE_EPS were still 0.05 this would flip green.
+        currentLocator.value = buildLocator("ch1.xhtml", 0.55)
+        assertFalse("indicator OFF for 3 pages away (0.05 delta on a 60-page chapter)", controller.isCurrentPageBookmarked.value)
+    }
+
+    // Publication positions can arrive AFTER bind (positionsByReadingOrder is computed
+    // asynchronously by Readium after publication load). Until they land, the controller MUST
+    // fall back to the fixed 5% window rather than a divide-by-zero or an over-tight zero eps.
+    @Test
+    fun `paginated eps falls back to 5% when spine position counts are not yet available`() = runTest {
+        val (controller, store) = makeController()
+        val currentLocator = MutableStateFlow<Locator?>(null)
+        controller.bind(
+            "srv", "item1", currentLocator,
+            MutableStateFlow(emptyList<String>() to emptyList()),
+        )
+        controller.onOrientationChanged(com.riffle.core.domain.ReaderOrientation.Horizontal)
+
+        store.bookmarks.value = listOf(makeAnnotation(chapterHref = "ch1.xhtml", progression = 0.5))
+        currentLocator.value = buildLocator("ch1.xhtml", 0.52)
+        assertTrue("indicator ON within the 5% fallback (0.02 delta)", controller.isCurrentPageBookmarked.value)
+    }
+
+    // Regression for the "bookmark stays lit for several screens" symptom in continuous mode.
+    // The old flat 33% eps meant a bookmark saved at midpoint 0.5 stayed lit for progression
+    // 0.17-0.83 — a huge chunk of the chapter. The new `0.5 / positions` formula matches the
+    // paginated logic (viewportFraction/2 ≈ 1/(2·positions) is the geometrically-correct bound
+    // for viewport-midpoint locators), so on a 40-position chapter the indicator only lights
+    // within ±0.0125 progression.
+    @Test
+    fun `continuous eps narrows to half-a-viewport when spine position counts are known`() = runTest {
+        val (controller, store) = makeController()
+        val currentLocator = MutableStateFlow<Locator?>(null)
+        val positions = MutableStateFlow(listOf("ch1.xhtml") to listOf(40))
+        controller.bind("srv", "item1", currentLocator, positions)
+        controller.onOrientationChanged(com.riffle.core.domain.ReaderOrientation.Continuous)
+
+        store.bookmarks.value = listOf(makeAnnotation(chapterHref = "ch1.xhtml", progression = 0.5))
+
+        // Same viewport (delta 0.010 < 1/(2*40) = 0.0125) → lit.
+        currentLocator.value = buildLocator("ch1.xhtml", 0.510)
+        assertTrue("indicator ON at ~0.01 midpoint delta on a 40-position chapter", controller.isCurrentPageBookmarked.value)
+
+        // Several screens away (delta 0.10 — the OLD 33% flat eps would have kept this lit) → NOT lit.
+        currentLocator.value = buildLocator("ch1.xhtml", 0.60)
+        assertFalse("indicator OFF at 0.10 midpoint delta on a 40-position chapter", controller.isCurrentPageBookmarked.value)
+    }
+
+    // The bookmarkEpsFor(chapterHref) helper is what toggleBookmark reads. It MUST return the
+    // same value the indicator's combine consumes, so a "delete if already bookmarked" check
+    // can't match a bookmark 3 pages away. This test pins the wire.
+    @Test
+    fun `bookmarkEpsFor returns half-a-page for paginated chapters with known position counts`() = runTest {
+        val (controller, _) = makeController()
+        val positions = MutableStateFlow(
+            listOf("ch1.xhtml", "ch2.xhtml") to listOf(60, 20),
+        )
+        controller.bind("srv", "item1", MutableStateFlow(null), positions)
+        controller.onOrientationChanged(com.riffle.core.domain.ReaderOrientation.Horizontal)
+
+        assertEquals("60-page chapter: half-a-page = 1/120", 1.0 / 120.0, controller.bookmarkEpsFor("ch1.xhtml"), 1e-9)
+        assertEquals("20-page chapter: half-a-page = 1/40", 1.0 / 40.0, controller.bookmarkEpsFor("ch2.xhtml"), 1e-9)
+        assertEquals("unknown chapter falls back to 5%", 0.05, controller.bookmarkEpsFor("ch99.xhtml"), 1e-9)
     }
 
     @Test

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/session/AnnotationSessionTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/session/AnnotationSessionTest.kt
@@ -314,6 +314,13 @@ class AnnotationSessionTest {
         // the flag is preserved on the event because downstream (analytics, tests) still
         // branches on annotation type.
         assertFalse(received[0].isBookmark)
+        // The annotation id must ride along on the event: continuous-mode navigation uses it to
+        // look up the actual `<mark data-riffle-ann="…">` device-Y (via
+        // `ChapterWebView.annotationOffsetTopDevicePx`) and centre the viewport on the mark
+        // rather than on the enclosing paragraph's top. Dropping the id here would silently
+        // regress the fix to paragraph-anchor landing — pixel-close but visibly off for any
+        // mid- or end-paragraph highlight.
+        assertEquals("a1", received[0].annotationId)
         assertFalse(session.annotationsPanelVisible.value)
 
         collectJob.cancel()

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/EpubCfiTranslator.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/EpubCfiTranslator.kt
@@ -73,12 +73,26 @@ fun hasElementWithId(html: String, id: String): Boolean =
 /**
  * Returns the innermost element ID from the doc-path portion of [fullCfi] that actually
  * exists in [html], or null when the CFI has no ID assertions or none match the DOM.
- * Used by continuous-mode navigation to anchor on the exact element rather than a
- * character-count progression approximation.
+ * Used by navigation to anchor on the exact element rather than a character-count progression
+ * approximation.
+ *
+ * For a RANGE CFI (`epubcfi(!parent,startRemainder,endRemainder)`) the anchor is derived from the
+ * range's START only (`parent + startRemainder`). Walking the full range would pick the END
+ * paragraph's id when start and end live under different siblings — e.g. a highlight that spans
+ * the last chars of paragraph N and the first char of paragraph N+1 would anchor on N+1, and
+ * scrolling N+1 to the top of the viewport would push the actual highlighted text off-screen
+ * above. (The "annotation navigation lands on the wrong paragraph in vertical mode" regression.)
  */
 fun extractAnchorFromCfi(fullCfi: String, html: String): String? {
     val docPath = extractCfiDocPath(fullCfi) ?: return null
-    return extractCfiElementIds(docPath).firstOrNull { hasElementWithId(html, it) }
+    val startDocPath = if (docPath.contains(',')) {
+        // Range CFI: docPath = "parent,startRemainder,endRemainder". Anchor on the start half.
+        val parts = docPath.split(',')
+        if (parts.size == 3) parts[0].trimEnd('/') + parts[1] else docPath
+    } else {
+        docPath
+    }
+    return extractCfiElementIds(startDocPath).firstOrNull { hasElementWithId(html, it) }
 }
 
 // ── CFI string parsing ────────────────────────────────────────────────────────

--- a/core/domain/src/test/kotlin/com/riffle/core/domain/EpubCfiTranslatorTest.kt
+++ b/core/domain/src/test/kotlin/com/riffle/core/domain/EpubCfiTranslatorTest.kt
@@ -660,6 +660,31 @@ class EpubCfiTranslatorTest {
         assertEquals("p1", extractAnchorFromCfi(cfi, html))
     }
 
+    // Range CFIs that span TWO sibling paragraphs (e.g. a highlight whose stored endChar spilled
+    // one character into the next paragraph) must anchor on the START paragraph. Previously the
+    // code walked the whole doc-path and picked the innermost id — which for a two-paragraph range
+    // was the END paragraph. Readium then scrolled the end paragraph to the top of the viewport
+    // and the actual highlighted characters (living in the tail of the start paragraph, just
+    // above) were pushed off-screen. Regression test for the "annotation navigation lands on the
+    // wrong paragraph in vertical mode" bug.
+    @Test
+    fun `extractAnchorFromCfi anchors on range start paragraph when range spans two siblings`() {
+        val html = "<html><body><div id=\"chap\"><p id=\"p-14\">Some text.</p><p id=\"p-15\">More text.</p></div></body></html>"
+        val cfi = "epubcfi(/6/4!/4/2[chap],/2[p-14]/1:418,/4[p-15]/1:1)"
+        assertEquals("p-14", extractAnchorFromCfi(cfi, html))
+    }
+
+    // If the range's start paragraph id is not in the DOM (rare — a mid-flight edition change
+    // that dropped the ids), fall back to the next id present in the start remainder or its
+    // parent — NOT to the end paragraph's id (that would silently regress to the pre-fix
+    // behaviour without a visible failure).
+    @Test
+    fun `extractAnchorFromCfi falls back within range start half when start paragraph id is missing`() {
+        val html = "<html><body><div id=\"chap\"><p>Some text.</p><p id=\"p-15\">More text.</p></div></body></html>"
+        val cfi = "epubcfi(/6/4!/4/2[chap],/2[p-14]/1:418,/4[p-15]/1:1)"
+        assertEquals("chap", extractAnchorFromCfi(cfi, html))
+    }
+
     // ── ID-anchored cfiDocPathToProgression ───────────────────────────────────
 
     @Test


### PR DESCRIPTION
## Summary

Five reader-annotation fixes bundled — three came out of the same reproduce-and-instrument session and share a common shape (imprecise anchoring across the paginated / vertical / continuous modes), the other two came out of following the same thread.

- **Continuous-mode highlight creates were silently dropped on Android 13+**: Chromium WebView collapses the DOM selection between the action-mode menu tap and our async `evaluateJavascript`, so `window.getSelection().toString()` came back empty and the highlight never reached `createHighlight`. `SELECTION_SPAN_TRACKER_JS` (already runs on `selectionchange`) now stashes the full selection payload; the menu-side read prefers the stash over a live `getSelection()`.
- **Range-CFI annotation nav anchored on the wrong paragraph**: `extractAnchorFromCfi` walked the full doc path and picked the END paragraph's id for range CFIs that spanned two siblings, pushing the actual highlighted text off-screen. Now clips to the range's start half.
- **Paginated snap ignored `locations.fragments`**: `snapAfterGoTo` only read `#anchor` from the href string. Annotation Locators carry the anchor in `locations.fragments`, so paginated annotation nav was landing on scroll-position rounding instead of the actual paragraph. Now prefers `locator.locations.fragments.firstOrNull()`.
- **Continuous annotation nav landed on the paragraph, not the mark**: for a highlight mid- or end-paragraph, centring the paragraph on the viewport pushed the actual highlighted text below the visible band ("mostly miss"). `AnnotationNavigationEvent` now carries the annotation id; continuous mode uses `annotationOffsetTopDevicePx(id)` to centre on the `<mark data-riffle-ann>` element directly.
- **Bookmark indicator stayed lit for 3-4 pages** in paginated + continuous. `isCurrentPageBookmarked` used a flat 5% / 33% eps; both were way wider than a single viewport on typical chapters. Now `0.5 / positionsInChapter` (Readium's `positionsByReadingOrder`). `toggleBookmark` reads the same eps so "already bookmarked?" matches the indicator exactly. Follow-up #399 tracks wiring the live viewport-height / chapter-height for the geometrically-exact bound.

Also: `ReaderModeForkGuardTest` baseline raised 26→28 for the new continuous-only annotation-nav branch with a `// MODE-FORK:` justification.

## Test plan

- [x] `./gradlew :app:testDebugUnitTest :core:domain:test` — green (`BookmarksControllerTest`, `ReaderWebViewScriptsTest`, `EpubCfiTranslatorTest`, `AnnotationSessionTest`, `ReaderModeForkGuardTest`).
- [x] Device-verified in continuous mode: highlight creates now persist, panel-tap navigates onto the actual mark, bookmark indicator switches off within one screen.
- [x] Device-verified in vertical: annotation nav lands on the correct paragraph for range CFIs.
- [ ] Device-verify bookmark eps in vertical scroll — currently tight (~half viewport) rather than the geometrically-ideal full viewport; strict improvement over flat 5% but noted in #399.
- [ ] Harness suite (CI).

## Related

- Closes: (no source issue — reproduced during the highlight-render-loss investigation on branch)
- Follow-up: #399 (wire live viewport-fraction into `bookmarkEpsFor` for geometrically-exact eps)