### PR TITLE
fix(reader): calibrate auto-scroll pace so 250 wpm no longer feels sluggish

### DIFF
--- a/core/domain/src/main/kotlin/com/riffle/core/domain/autoscroll/ScrollPace.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/autoscroll/ScrollPace.kt
@@ -16,8 +16,14 @@ fun pxPerSecond(speed: AutoScrollSpeed, layout: LayoutContext): Float {
 // Base body font size in CSS px (Readium's default 1rem).
 private const val BASE_FONT_CSS_PX: Float = 16f
 
-// Approximate average word length including the following space — matches typical English prose.
-private const val AVG_WORD_LEN_CHARS: Float = 6.1f
+// Approximate average word length including the following space — matches typical English prose
+// (~4.7-char word + 1 space).
+private const val AVG_WORD_LEN_CHARS: Float = 5.5f
+
+// Real prose does not fill lines to the margin — paragraph endings, dialog, chapter breaks, and
+// hyphenation avoidance leave the average line noticeably shorter than the maximum. Without this
+// correction the derived wordsPerLine is too high and auto-scroll pace comes out too slow.
+private const val LINE_FILL_FACTOR: Float = 0.75f
 
 // Readium's --RS__pageGutter default. Side padding per side ≈ pageGutter * --USER__pageMargins.
 private const val PAGE_GUTTER_CSS_PX: Float = 8f
@@ -47,6 +53,7 @@ fun layoutContextFor(
     val gutterCssPx = PAGE_GUTTER_CSS_PX * prefs.margins
     val innerCssPx = (viewportCssPx - 2f * gutterCssPx).coerceAtLeast(0f)
     val avgWordWidthCssPx = fontSizeCssPx * avgEmAdvance(prefs.fontFamily) * AVG_WORD_LEN_CHARS
-    val wordsPerLine = if (avgWordWidthCssPx > 0f) innerCssPx / avgWordWidthCssPx else 0f
+    val wordsPerLine = if (avgWordWidthCssPx > 0f)
+        (innerCssPx / avgWordWidthCssPx) * LINE_FILL_FACTOR else 0f
     return LayoutContext(wordsPerLine = wordsPerLine, lineHeightPx = lineHeightDevicePx)
 }

--- a/core/domain/src/test/kotlin/com/riffle/core/domain/autoscroll/ScrollPaceTest.kt
+++ b/core/domain/src/test/kotlin/com/riffle/core/domain/autoscroll/ScrollPaceTest.kt
@@ -117,4 +117,17 @@ class ScrollPaceTest {
         val c = ctxFor(FormattingPreferences(), LayoutInputs(0, 3f))
         assertEquals(0f, c.wordsPerLine, 0.0001f)
     }
+
+    // Calibration guard: pins the derived pace at default prefs on a typical phone. If either the
+    // average-word-length constant or the real-prose line-fill factor regresses, this flips red.
+    // Numbers are chosen so the pace stays visibly faster than the pre-calibration ~29.6 px/s.
+    @Test
+    fun `default prefs on typical phone yield around 35 px per second at 250 wpm`() {
+        val ctx = ctxFor(FormattingPreferences(), phone)
+        val pace = pxPerSecond(AutoScrollSpeed.of(250), ctx)
+        assertTrue(
+            "expected pace in [33, 38] px/s, got $pace (wpl=${ctx.wordsPerLine}, lh=${ctx.lineHeightPx})",
+            pace in 33f..38f,
+        )
+    }
 }


### PR DESCRIPTION
## Summary

Auto-scroll at 250 wpm felt visibly slower than actual 250 wpm reading. The pace model in `core/domain/.../autoscroll/ScrollPace.kt` computes `pxPerSecond = (wpm/60) × (lineHeightPx / wordsPerLine)`, and `wordsPerLine` was over-estimated for two reasons:

1. `AVG_WORD_LEN_CHARS = 6.1` was too high — English averages ~4.7-char word + 1 space ≈ **5.5**.
2. No correction for the fact that real prose does not fill every line to the margin — paragraph endings, dialog, chapter breaks, and hyphenation avoidance leave the average line noticeably shorter than the maximum.

Together these under-scaled the pace so 250 wpm scrolled at ~30 px/s on a typical phone, closer to what ~210 wpm should be.

## Changes

- `AVG_WORD_LEN_CHARS` 6.1 → **5.5**.
- New `LINE_FILL_FACTOR = 0.75f`, applied to `wordsPerLine` inside `layoutContextFor`.
- Net effect at default prefs on a typical phone (density 3, viewport 1233, serif, defaults): 250 wpm now scrolls at ~35–36 px/s vs. the previous ~29.6 px/s (~1.20×).

All existing `ScrollPaceTest` cases pass since they were relative (doubling, monospace-vs-serif, margins narrower reduces words) — not absolute-value checks. The two "~13 px/s" tests use a hardcoded `LayoutContext(9, 28)` that bypasses `layoutContextFor`, so they're unaffected.

## Test plan

- [x] `./gradlew :core:domain:test --tests "com.riffle.core.domain.autoscroll.ScrollPaceTest"` — all cases pass, including the new calibration guard.
- [x] New regression test `default prefs on typical phone yield around 35 px per second at 250 wpm` pins the derived pace into `[33, 38]` px/s at defaults — a revert of either constant lands outside the window and flips it red.
- [ ] Manual: try auto-scroll at 250 wpm in the reader on a real device and confirm it now tracks a natural reading pace.