### PR TITLE
fix(connectivity): heal stuck offline banner on Huawei and Android 13

### DIFF
--- a/core/data/src/main/kotlin/com/riffle/core/data/ConnectivityObserverImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/ConnectivityObserverImpl.kt
@@ -13,11 +13,14 @@ import com.riffle.core.domain.ConnectivityObserver
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -34,15 +37,35 @@ class ConnectivityObserverImpl @Inject constructor(
     private val scope = applicationScope.coroutineScope
 
     override val isOnline: StateFlow<Boolean> = callbackFlow {
-        // Online-state is derived from two signals, treating every radio identically — airplane
+        // Online-state is derived from three signals, treating every radio identically — airplane
         // mode is just "all radios off" and isn't special-cased:
         //   * NetworkCallback — primary, event-driven. onAvailable/onLost/onCapabilitiesChanged
         //     fire for every transport (wifi, cellular, ethernet, VPN) on every toggle.
         //   * ProcessLifecycleOwner ON_START — heals doze/wake drift on Android 13+ where
         //     NetworkCallback events can be dropped or coalesced. `activeNetwork` is the coarse
-        //     ground-truth: null → offline, non-null → union any newly-validated networks in.
+        //     ground-truth: null → offline, non-null → union any newly-qualifying networks in.
         //     The sweep never removes networks the callbacks have already reported, so a stale
         //     `getAllNetworks()` during teardown cannot revert a correct offline emit.
+        //   * Foreground poll ticker — every POLL_INTERVAL_MS re-emits with the tracker's current
+        //     state cross-checked against a FRESH `activeNetwork` read. This closes the
+        //     Android 13 gap where the OS drops the `onLost` for a network going away entirely
+        //     (airplane on, network vanishes) so no callback ever fires and neither the
+        //     `activeNetwork == null` veto nor the ON_START sweep can rescue us until the user
+        //     backgrounds+foregrounds the process or navigates enough to force a fresh
+        //     ViewModel-driven refresh. The tick is READ-ONLY against the tracker — it never
+        //     merges, never clears — so it cannot re-add a stale network the way the removed
+        //     PR #392 `syncNow()` could. It only lets the `activeNetwork == null` veto fire on a
+        //     bounded schedule instead of exclusively piggybacking on callback events.
+        //
+        // "Qualifying" here means `NET_CAPABILITY_INTERNET` only — we deliberately do NOT require
+        // `NET_CAPABILITY_VALIDATED`. That flag is set by Android's built-in probe to
+        // `connectivitycheck.gstatic.com/generate_204`, which is unreachable on Huawei devices
+        // without GMS and on any network that firewalls Google endpoints. Riffle never talks to
+        // Google — it talks to the user's Audiobookshelf server, WebDAV, and optional Storyteller
+        // peer — so making the banner depend on a Google reachability probe misreports offline for
+        // every affected user. Server-reachability is separately tracked by `_refreshFailed` in
+        // the library view model, which is the correct signal for "we can see the LAN but not
+        // your server." See `isQualifyingNetwork` below.
         val tracker = ValidatedNetworkTracker<Network>()
 
         // See `reconcileOnline` — every callback emit is cross-checked against `activeNetwork`
@@ -66,15 +89,16 @@ class ConnectivityObserverImpl @Inject constructor(
                 network: Network,
                 capabilities: NetworkCapabilities,
             ) {
-                val hasInternet = capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET) &&
-                    capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED)
-                emitReconciled(tracker.onCapabilitiesChanged(network, hasInternet))
+                val qualifies = isQualifyingNetwork(
+                    hasInternet = capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET),
+                    hasValidated = capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED),
+                )
+                emitReconciled(tracker.onCapabilitiesChanged(network, qualifies))
             }
         }
 
         val request = NetworkRequest.Builder()
             .addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
-            .addCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED)
             .build()
         connectivityManager.registerNetworkCallback(request, callback)
 
@@ -86,8 +110,10 @@ class ConnectivityObserverImpl @Inject constructor(
             val fresh = mutableSetOf<Network>()
             for (network in connectivityManager.allNetworks) {
                 val caps = connectivityManager.getNetworkCapabilities(network) ?: continue
-                if (caps.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET) &&
-                    caps.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED)
+                if (isQualifyingNetwork(
+                        hasInternet = caps.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET),
+                        hasValidated = caps.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED),
+                    )
                 ) {
                     fresh += network
                 }
@@ -104,7 +130,20 @@ class ConnectivityObserverImpl @Inject constructor(
             lifecycleOwner.lifecycle.addObserver(lifecycleObserver)
         }
 
+        // See the block comment at the top of this callbackFlow — read-only re-emit on a bounded
+        // schedule so the `activeNetwork == null` veto in `reconcileOnline` fires without needing
+        // a callback event that Android 13 may have silently dropped. `distinctUntilChanged`
+        // downstream suppresses no-op emits, so a healthy foreground app pays only the cost of
+        // one `activeNetwork` read per interval.
+        val pollJob = launch {
+            while (isActive) {
+                delay(POLL_INTERVAL_MS)
+                emitReconciled(tracker.isOnline())
+            }
+        }
+
         awaitClose {
+            pollJob.cancel()
             connectivityManager.unregisterNetworkCallback(callback)
             lifecycleOwner.lifecycle.removeObserver(lifecycleObserver)
         }
@@ -115,11 +154,20 @@ class ConnectivityObserverImpl @Inject constructor(
     private fun currentOnline(): Boolean {
         val network = connectivityManager.activeNetwork ?: return false
         val capabilities = connectivityManager.getNetworkCapabilities(network) ?: return false
-        return capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET) &&
-            capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED)
+        return isQualifyingNetwork(
+            hasInternet = capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET),
+            hasValidated = capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED),
+        )
     }
 
     override fun isMetered(): Boolean = connectivityManager.isActiveNetworkMetered
+
+    private companion object {
+        // 15s is a compromise between "banner appears reasonably soon after airplane on" and
+        // "we don't pay noticeable cost polling `activeNetwork` all day." The Android 13 dropped-
+        // `onLost` case is the whole reason this exists — see the callbackFlow block comment.
+        const val POLL_INTERVAL_MS = 15_000L
+    }
 }
 
 /**
@@ -132,7 +180,7 @@ class ConnectivityObserverImpl @Inject constructor(
  * unit-tested. Each corner encodes a real, previously-shipped regression:
  *
  *   * `(true, false)` — the fourth-time-around regression: on Android 13 the OS silently drops
- *     one of the `onLost` callbacks when airplane mode turns multiple validated networks off at
+ *     one of the `onLost` callbacks when airplane mode turns multiple qualifying networks off at
  *     once, so the tracker retains a stale network and thinks we're online. `activeNetwork ==
  *     null` vetoes it → offline.
  *   * `(false, true)` — the airplane-mode/#294 regression: during teardown `activeNetwork` can
@@ -143,3 +191,25 @@ class ConnectivityObserverImpl @Inject constructor(
  */
 internal fun reconcileOnline(trackerOnline: Boolean, hasActiveNetwork: Boolean): Boolean =
     trackerOnline && hasActiveNetwork
+
+/**
+ * Whether a network qualifies as "we have connectivity" for Riffle's purposes. The
+ * observer/tracker only counts networks that satisfy this predicate; the ON_START sweep only
+ * merges networks that satisfy this predicate.
+ *
+ * The rule is: `NET_CAPABILITY_INTERNET` is required; `NET_CAPABILITY_VALIDATED` is deliberately
+ * **not** required. VALIDATED is set by Android's `NetworkMonitor` after a successful probe to
+ * `connectivitycheck.gstatic.com/generate_204`. That probe host is unreachable on Huawei devices
+ * without GMS and on any network that firewalls Google endpoints, so the OS marks the WiFi as
+ * `INTERNET` without `VALIDATED` and Riffle would report the user permanently offline. Riffle
+ * only ever talks to the user's Audiobookshelf server, their WebDAV endpoint, and an optional
+ * Storyteller peer — none of which route through Google. Server-reachability is separately
+ * tracked by `LibraryItemsViewModel._refreshFailed`, which is the correct signal for "we can see
+ * the LAN but not your server."
+ *
+ * Pure so a JVM test can fence off the "someone re-adds && hasValidated" regression without
+ * needing an Android instrumentation harness. Do not fold `hasValidated` back into the return
+ * value.
+ */
+@Suppress("UNUSED_PARAMETER")
+internal fun isQualifyingNetwork(hasInternet: Boolean, hasValidated: Boolean): Boolean = hasInternet

--- a/core/data/src/main/kotlin/com/riffle/core/data/ConnectivityObserverImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/ConnectivityObserverImpl.kt
@@ -12,6 +12,7 @@ import com.riffle.core.domain.ApplicationScope
 import com.riffle.core.domain.ConnectivityObserver
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.SharingStarted
@@ -63,9 +64,19 @@ class ConnectivityObserverImpl @Inject constructor(
         // without GMS and on any network that firewalls Google endpoints. Riffle never talks to
         // Google — it talks to the user's Audiobookshelf server, WebDAV, and optional Storyteller
         // peer — so making the banner depend on a Google reachability probe misreports offline for
-        // every affected user. Server-reachability is separately tracked by `_refreshFailed` in
-        // the library view model, which is the correct signal for "we can see the LAN but not
-        // your server." See `isQualifyingNetwork` below.
+        // every affected user. See `isQualifyingNetwork` below.
+        //
+        // Tradeoff: on a network where INTERNET is set but the server is actually unreachable
+        // (captive portal that hasn't been signed into, away-from-LAN with a LAN-only server),
+        // `isOnline` will now report true. On the main library screens the shim is
+        // `LibraryItemsViewModel._refreshFailed` (and the analogous `_refreshFailed` in
+        // `SeriesDetailViewModel` / `CollectionDetailViewModel`), which flips the banner when a
+        // library refresh returns `NetworkError`. Other consumers of `isOnline` —
+        // `LibraryItemDetailViewModel`, `FilteredBooksViewModel`, `ReadaloudSession`'s
+        // download-prompt guard — do NOT have this shim, so on unvalidated-server-unreachable
+        // networks they will show the online state and fail at request time. That is a strictly
+        // narrower failure mode than the Huawei bug (which broke the primary use case entirely)
+        // but is a real UX regression on captive portals; treated as follow-up work.
         val tracker = ValidatedNetworkTracker<Network>()
 
         // See `reconcileOnline` — every callback emit is cross-checked against `activeNetwork`
@@ -121,29 +132,42 @@ class ConnectivityObserverImpl @Inject constructor(
             emitReconciled(tracker.mergeIn(fresh))
         }
 
+        // Foreground-gated poll — see the block comment at the top of this callbackFlow. Started
+        // on ON_START (foreground) and cancelled on ON_STOP (background) so we only pay the poll
+        // cost while the banner is actually observable to the user; the ON_START sweep still
+        // provides a one-shot heal at foregrounding for the "missed onAvailable during doze"
+        // direction. `distinctUntilChanged` downstream suppresses no-op emits.
+        var pollJob: Job? = null
         val lifecycleOwner = ProcessLifecycleOwner.get()
         val lifecycleObserver = LifecycleEventObserver { _, event ->
-            if (event == Lifecycle.Event.ON_START) reconcile()
+            when (event) {
+                Lifecycle.Event.ON_START -> {
+                    reconcile()
+                    pollJob?.cancel()
+                    pollJob = launch {
+                        while (isActive) {
+                            delay(POLL_INTERVAL_MS)
+                            emitReconciled(tracker.isOnline())
+                        }
+                    }
+                }
+                Lifecycle.Event.ON_STOP -> {
+                    pollJob?.cancel()
+                    pollJob = null
+                }
+                else -> Unit
+            }
         }
-        // LifecycleRegistry requires main-thread registration.
+        // LifecycleRegistry requires main-thread registration. Adding an observer while the
+        // lifecycle is already in the STARTED state replays ON_CREATE + ON_START to bring the
+        // observer up to date, so a foreground subscribe immediately runs the sweep and starts
+        // the poll — no separate priming path needed.
         withContext(Dispatchers.Main.immediate) {
             lifecycleOwner.lifecycle.addObserver(lifecycleObserver)
         }
 
-        // See the block comment at the top of this callbackFlow — read-only re-emit on a bounded
-        // schedule so the `activeNetwork == null` veto in `reconcileOnline` fires without needing
-        // a callback event that Android 13 may have silently dropped. `distinctUntilChanged`
-        // downstream suppresses no-op emits, so a healthy foreground app pays only the cost of
-        // one `activeNetwork` read per interval.
-        val pollJob = launch {
-            while (isActive) {
-                delay(POLL_INTERVAL_MS)
-                emitReconciled(tracker.isOnline())
-            }
-        }
-
         awaitClose {
-            pollJob.cancel()
+            pollJob?.cancel()
             connectivityManager.unregisterNetworkCallback(callback)
             lifecycleOwner.lifecycle.removeObserver(lifecycleObserver)
         }

--- a/core/data/src/main/kotlin/com/riffle/core/data/ValidatedNetworkTracker.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/ValidatedNetworkTracker.kt
@@ -25,6 +25,12 @@ internal class ValidatedNetworkTracker<K : Any> {
     }
 
     /**
+     * Current online view derived purely from previously-received callback events. Read-only —
+     * safe to call from the periodic self-heal tick without mutating tracker state.
+     */
+    fun isOnline(): Boolean = validated.isNotEmpty()
+
+    /**
      * Union [fresh] into the tracked set. Callback events are authoritative for removal — a
      * reconciliation sweep only heals the "we missed an onAvailable during doze" direction and
      * must never re-add a network the callbacks have already reported as lost, or an airplane-mode

--- a/core/data/src/test/kotlin/com/riffle/core/data/ConnectivityReconcileTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/ConnectivityReconcileTest.kt
@@ -70,6 +70,35 @@ class ConnectivityReconcileTest {
     }
 
     @Test
+    fun `foreground poll rescues stuck-online tracker on Android 13 dropped onLost`() {
+        // The regression the user reported on an Android 13 device: airplane mode ON while the
+        // library screen is in the foreground. The OS drops the `onLost` for the single
+        // qualifying network entirely — not just one-of-two, the only one — so the tracker
+        // remains non-empty and the banner never appears until the user navigates to a
+        // different library and forces a fresh refresh in a new ViewModel.
+        //
+        // Neither the callback-driven path nor the ON_START sweep can rescue this: no callback
+        // fires (dropped), and ON_START only fires on background→foreground transitions
+        // (irrelevant while the user is sitting on the screen).
+        //
+        // The foreground poll inside `ConnectivityObserverImpl` closes this gap: every
+        // POLL_INTERVAL_MS it calls `emitReconciled(tracker.isOnline())`, which threads through
+        // this predicate with a FRESH `activeNetwork` read. Airplane on → `activeNetwork == null`
+        // → veto fires → offline. This test captures the exact tracker+activeNetwork state that
+        // the poll observes at that moment. Do not delete it if the poll is refactored — rewire
+        // the assertion to the new mechanism.
+        val tracker = ValidatedNetworkTracker<String>()
+        tracker.onAvailable("wifi")
+        val trackerStillOnline = tracker.isOnline()
+
+        assertTrue("Tracker never received the dropped onLost", trackerStillOnline)
+        assertFalse(
+            "The poll's fresh activeNetwork read (null after airplane on) must veto to offline",
+            reconcileOnline(trackerStillOnline, hasActiveNetwork = false),
+        )
+    }
+
+    @Test
     fun `dropped onAvailable scenario end-to-end via tracker`() {
         // Symmetric case — post-doze/wake on Android 13, the OS can drop an `onAvailable` after
         // the process resumes, so the tracker remains empty (offline) even though a validated

--- a/core/data/src/test/kotlin/com/riffle/core/data/QualifyingNetworkTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/QualifyingNetworkTest.kt
@@ -1,0 +1,61 @@
+package com.riffle.core.data
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Fence off the Huawei-shaped "banner permanently shows offline while the user's server, WebDAV,
+ * and Storyteller peer are all reachable" regression class.
+ *
+ * The historical bug: `ConnectivityObserverImpl` required both `NET_CAPABILITY_INTERNET` and
+ * `NET_CAPABILITY_VALIDATED` on every path (callback registration, capability change, ON_START
+ * sweep, initial `currentOnline`). `NET_CAPABILITY_VALIDATED` is set by Android's `NetworkMonitor`
+ * after a successful probe to `connectivitycheck.gstatic.com/generate_204`. On Huawei devices
+ * without GMS — and on any network that firewalls Google endpoints — that probe never succeeds,
+ * so the OS marks the WiFi as INTERNET-only and Riffle reported the user as offline forever,
+ * even though the ABS server on the same LAN was reachable the whole time.
+ *
+ * The fix routed every capability check through [isQualifyingNetwork], which requires INTERNET
+ * only. The `hasValidated` argument is retained in the signature — deliberately unused — so
+ * future readers see the flag was considered and rejected, and so a well-meaning "let me also
+ * require VALIDATED again" edit is a visible, mechanical change that must delete the parameter,
+ * flip the return value, and delete these tests all at once. The assertion below on the Huawei
+ * case would fail red on any revert.
+ *
+ * Do NOT collapse these into a parameterised runner — the failure name on a broken build should
+ * read like a mini-changelog of the regression.
+ */
+class QualifyingNetworkTest {
+
+    @Test
+    fun `internet plus validated is online`() {
+        // Healthy state on a GMS-enabled Android device whose network passed the Google probe.
+        assertTrue(isQualifyingNetwork(hasInternet = true, hasValidated = true))
+    }
+
+    @Test
+    fun `internet without validated is online — Huawei and Google-firewalled networks`() {
+        // The load-bearing assertion for this regression class. Huawei-without-GMS, corporate
+        // networks that block `connectivitycheck.gstatic.com`, and users in regions where Google
+        // is unreachable all end up here. The OS cannot validate, but Riffle does not talk to
+        // Google — it talks to the user's ABS server, WebDAV, and Storyteller peer — so we must
+        // treat these networks as online. Server-reachability is signalled separately via
+        // `LibraryItemsViewModel._refreshFailed`.
+        assertTrue(isQualifyingNetwork(hasInternet = true, hasValidated = false))
+    }
+
+    @Test
+    fun `no internet capability is offline even if validated is set`() {
+        // Defensive: a callback that reports VALIDATED without INTERNET is a system-invariant
+        // violation we don't expect in practice, but if it ever happens we still treat it as
+        // offline because the whole point of the check is "does this network route traffic."
+        assertFalse(isQualifyingNetwork(hasInternet = false, hasValidated = true))
+    }
+
+    @Test
+    fun `neither capability is offline`() {
+        // Clean disconnect — nothing to route traffic through.
+        assertFalse(isQualifyingNetwork(hasInternet = false, hasValidated = false))
+    }
+}

--- a/core/data/src/test/kotlin/com/riffle/core/data/ValidatedNetworkTrackerTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/ValidatedNetworkTrackerTest.kt
@@ -86,6 +86,26 @@ class ValidatedNetworkTrackerTest {
     }
 
     @Test
+    fun `isOnline mirrors the tracker set without mutating it`() {
+        // The 15s foreground poll in ConnectivityObserverImpl re-emits `emitReconciled(
+        // tracker.isOnline())` on a schedule so the `activeNetwork == null` veto can fire even
+        // when Android 13 drops the `onLost` callback entirely. The tick must be READ-ONLY — if
+        // isOnline() ever grew a side effect, the poll would silently mutate tracker state and
+        // resurrect the class of bug PR #396 removed the old syncNow() to fix.
+        val tracker = ValidatedNetworkTracker<String>()
+        assertFalse(tracker.isOnline())
+
+        tracker.onAvailable("wifi")
+        assertTrue(tracker.isOnline())
+        // Repeated reads must be idempotent — same answer, no state change.
+        assertTrue(tracker.isOnline())
+        assertTrue(tracker.isOnline())
+        // Losing the network still flows through the callback path normally.
+        assertFalse(tracker.onLost("wifi"))
+        assertFalse(tracker.isOnline())
+    }
+
+    @Test
     fun `clear drops every tracked network`() {
         // Called from the ProcessLifecycleOwner ON_START sweep when
         // `ConnectivityManager.activeNetwork` is null — the coarse ground-truth signal that no


### PR DESCRIPTION
## Summary

Two independent stuck-offline-banner regressions surfaced from the same file. Both were reported live; both are fixed here.

- **Huawei / GMS-firewalled networks.** `ConnectivityObserverImpl` required `NET_CAPABILITY_VALIDATED` on every path (callback registration, `onCapabilitiesChanged`, ON_START sweep, initial `currentOnline`). VALIDATED is set by Android's `NetworkMonitor` after a successful probe to `connectivitycheck.gstatic.com/generate_204` — unreachable on Huawei devices without GMS and on any network that firewalls Google endpoints. The OS marks WiFi as `INTERNET` without `VALIDATED` and the banner stays on permanently even while Audiobookshelf / WebDAV / Storyteller are all reachable on the LAN.
  - Fix: route every capability check through a pure `isQualifyingNetwork(hasInternet, hasValidated)` that requires `INTERNET` only. The `hasValidated` parameter is retained in the signature as a documented tombstone so any future revert is a mechanical, visible change.
- **Android 13 dropped `onLost` in foreground.** When airplane mode toggles the only qualifying network off, Android 13 can silently drop the `onLost` callback. No callback fires → no re-emit → the `activeNetwork == null` veto (PR #396) never runs → the banner stays hidden until the user switches libraries and a new ViewModel-driven refresh returns `NetworkError`, at which point `_refreshFailed` flips the banner via `!online || refreshFailed`.
  - Fix: read-only 15-second poll gated on `ProcessLifecycleOwner` ON_START/ON_STOP that re-emits `emitReconciled(tracker.isOnline())`. This threads through `reconcileOnline` with a fresh `activeNetwork` read on a bounded schedule, so the null-veto self-fires without needing a callback event. The tick never mutates the tracker — no `mergeIn`, no `clear` — so it cannot re-add a stale network the way the removed PR #392 `syncNow()` could. Lifecycle-gated so it only ticks while foreground.

## Tests

- `QualifyingNetworkTest` (new): four-corner truth table for the INTERNET / VALIDATED matrix. Load-bearing assertion is `isQualifyingNetwork(true, false) == true` — the Huawei case, which would fail red on any revert that re-adds the VALIDATED requirement.
- `ConnectivityReconcileTest`: new scenario `foreground poll rescues stuck-online tracker on Android 13 dropped onLost` captures the exact `(trackerOnline=true, hasActiveNetwork=false)` shape the poll observes at that moment.
- `ValidatedNetworkTrackerTest`: new read-only invariant test on `isOnline()` — the tick calls this every 15s, so a side effect here would silently resurrect PR #396's fix.

## Known follow-up gap

Dropping VALIDATED means `isOnline` will now report true on captive portals and other networks where INTERNET is set but the actual server is unreachable. `LibraryItemsViewModel` / `SeriesDetailViewModel` / `CollectionDetailViewModel` already combine `!online || refreshFailed` so their banner remains accurate — but `LibraryItemDetailViewModel`, `FilteredBooksViewModel`, and the download-prompt guard in `ReadaloudSession` derive `isOffline` from `!isOnline` alone. On unvalidated-and-server-unreachable networks they will show the online state and fail at request time. Documented in the block comment as a follow-up (needs a shared server-reachability signal or per-VM `_refreshFailed` shims). Strictly narrower failure mode than the Huawei bug this PR closes.

## Test plan

- [x] `:core:data:testDebugUnitTest` — green
- [x] `:app:testDebugUnitTest` — green
- [x] User confirmed live on the affected Android 13 device that the banner now appears within seconds of airplane on while sitting on the same library screen (Fix 2)
- [ ] Not yet device-verified on the affected Huawei that reproduced Fix 1