### PR TITLE
fix(reader): wire live viewport-fraction into bookmark eps

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderCoordinator.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderCoordinator.kt
@@ -91,6 +91,9 @@ internal class ContinuousReaderCoordinator(
                     )
                 }
             },
+            onViewportFractionMeasured = { href, fraction ->
+                presenter?.feedViewportFraction(href, fraction)
+            },
         )
 
         view.onPlayFromHereSelection = { chapterHref, selectedText, evalJs ->

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
@@ -57,6 +57,7 @@ internal class ContinuousReaderView @JvmOverloads constructor(
         port = port,
         context = context,
         onRawPosition = { href, progression -> onRawPosition?.invoke(href, progression) },
+        onViewportFractionMeasured = { href, fraction -> onViewportFractionMeasured?.invoke(href, fraction) },
     )
 
     /** Whether the text-selection menu should offer "Highlight" (books with annotations UI). */
@@ -82,6 +83,14 @@ internal class ContinuousReaderView @JvmOverloads constructor(
      *  every scroll-position update. */
     private var onRawPosition: ((href: String, progression: Float) -> Unit)? = null
 
+    /**
+     * Set by [install]; invoked by the controller with `(href, viewportFraction)` whenever a
+     * chapter's measured height first lands or changes. Feeds `ContinuousPresenter.feedViewportFraction`
+     * for the bookmark eps window (issue #399). Emitted from measurement callbacks only —
+     * never from scroll.
+     */
+    private var onViewportFractionMeasured: ((href: String, fraction: Double) -> Unit)? = null
+
     /** True once [initialize] has been called. Observed by the navigation LaunchedEffect in
      *  EpubReaderScreen to avoid calling [navigateTo] before the window is populated. */
     val isInitialized = mutableStateOf(false)
@@ -96,8 +105,10 @@ internal class ContinuousReaderView @JvmOverloads constructor(
         annotations: ContinuousAnnotationSink,
         onInternalLink: (href: String) -> Unit,
         onRawPosition: (href: String, progression: Float) -> Unit,
+        onViewportFractionMeasured: (href: String, fraction: Double) -> Unit = { _, _ -> },
     ) {
         this.onRawPosition = onRawPosition
+        this.onViewportFractionMeasured = onViewportFractionMeasured
         val binder = ChapterWebViewBinder(
             navigation = navigation,
             links = links,

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousWindowController.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousWindowController.kt
@@ -26,6 +26,13 @@ internal class ContinuousWindowController(
     private val port: ContinuousScrollPort,
     private val context: Context,
     private val onRawPosition: (href: String, progression: Float) -> Unit,
+    /**
+     * Publish `viewportHeightPx / measuredHeight` for a chapter when its height first lands
+     * or changes. Called from the `onHeightMeasured` callbacks in [appendChapter] and
+     * [prependChapter]. Feeds `ContinuousPresenter.feedViewportFraction` (issue #399). MUST
+     * NOT be invoked from scroll callbacks — see the flake-avoidance rules in the issue.
+     */
+    private val onViewportFractionMeasured: (href: String, fraction: Double) -> Unit = { _, _ -> },
 ) : ContinuousHighlightTarget, ContinuousNavigationView {
 
     companion object {
@@ -534,6 +541,7 @@ internal class ContinuousWindowController(
                 } else {
                     measuredHeights[i] = measuredPx
                 }
+                publishViewportFraction(wv, measuredPx)
                 wv.layoutParams = wv.layoutParams.also { it.height = measuredPx }
                 if (pendingInitialScroll == null && i == 0 && delta != 0 && (delta < 0 || port.currentScrollY >= oldHeight)) {
                     port.scrollBy(delta)
@@ -581,6 +589,7 @@ internal class ContinuousWindowController(
             if (i >= 0) {
                 val delta = measuredPx - measuredHeights[i]
                 measuredHeights[i] = measuredPx
+                publishViewportFraction(wv, measuredPx)
                 wv.layoutParams = wv.layoutParams.also { it.height = measuredPx }
                 if (delta != 0) port.scrollBy(delta)
             }
@@ -720,6 +729,20 @@ internal class ContinuousWindowController(
     private fun webViewIndexFor(href: String): Int? {
         val i = webViews.indexOfFirst { it.chapterHref == href }
         return if (i >= 0) i else null
+    }
+
+    /**
+     * Publish `port.viewportHeightPx / measuredPx` for [wv]'s chapter, dropping any case where
+     * either side is non-positive (viewport not yet laid out, or the chapter measured to zero).
+     * Downstream (VM `putViewportFraction`) applies the per-entry distinct-until-changed guard
+     * so repeat calls with the same value do not churn the bookmark combine (issue #399).
+     */
+    private fun publishViewportFraction(wv: ChapterWebView, measuredPx: Int) {
+        val vh = port.viewportHeightPx
+        if (vh <= 0 || measuredPx <= 0) return
+        val href = wv.chapterHref
+        if (href.isEmpty()) return
+        onViewportFractionMeasured(href, vh.toDouble() / measuredPx)
     }
 }
 

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -1080,9 +1080,12 @@ internal fun readaloudLocatorJson(ref: String, quote: SentenceQuote?): JSONObjec
  * The previous unified midpoint policy existed because landing bookmarks at the top produced a
  * ribbon-vs-landing offset — the `isCurrentPageBookmarked` indicator's stored midpoint
  * progression didn't match the arrival scrollY. Issue #399's live viewport-fraction eps closes
- * that gap: with `eps = viewportFraction / 2`, an `alignToTop=true` landing shifts the midpoint
- * by exactly `viewportFraction / 2`, so the boundary-inclusive `<= eps` check keeps the
- * indicator lit on arrival.
+ * that gap: on `alignToTop=true` the arrival midpoint can drift up to one full
+ * `viewportFraction` from the saved midpoint (the saved anchor could sit anywhere in the saved
+ * viewport, top edge to bottom edge). Continuous eps is widened to full `viewportFraction` for
+ * exactly this reason (see `BookmarksController.bookmarkEpsFor`), so the boundary-inclusive
+ * `<= eps` check keeps the indicator lit on arrival regardless of where in the saved viewport
+ * the anchor sat.
  */
 internal fun annotationNavigationOptions(isBookmark: Boolean): NavigationOptions =
     NavigationOptions(landAtStartWhenNoTarget = false, alignToTop = isBookmark)

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -1066,18 +1066,26 @@ internal fun readaloudLocatorJson(ref: String, quote: SentenceQuote?): JSONObjec
 }
 
 /**
- * NavigationOptions for an annotation-panel tap. Continuous-mode landing is uniform
- * viewport-midpoint (`alignToTop = false`) for every annotation type — bookmarks included —
- * so the page-bookmark ribbon (which stores + matches on `locatorAt`'s midpoint progression)
- * lights at the same scrollY the reader lands on. Placing bookmarks at the viewport top
- * produced up to a full-viewport offset between the lit ribbon and the landing on chapters
- * with images, big headings, or otherwise non-uniform text density — the CFI anchor's pixel
- * position drifted from its char-count progression. The [isBookmark] parameter is taken so
- * tests can pin the invariant that both types return the same options.
+ * NavigationOptions for an annotation-panel tap. In continuous mode, [alignToTop] depends on
+ * annotation type:
+ *
+ *  - **Bookmarks** → `alignToTop = true`. A page-level bookmark marks "I was here" — landing
+ *    the saved position at the viewport TOP places the reader at the start of what they were
+ *    reading, with the already-read content scrolled off above. Landing at the midpoint (the
+ *    prior behaviour) placed the bookmark in the middle of the viewport, which readers found
+ *    confusing.
+ *  - **Highlights / notes** → `alignToTop = false`. A text-anchored annotation is context-
+ *    dependent; centring on the mark preserves reading context above the anchor.
+ *
+ * The previous unified midpoint policy existed because landing bookmarks at the top produced a
+ * ribbon-vs-landing offset — the `isCurrentPageBookmarked` indicator's stored midpoint
+ * progression didn't match the arrival scrollY. Issue #399's live viewport-fraction eps closes
+ * that gap: with `eps = viewportFraction / 2`, an `alignToTop=true` landing shifts the midpoint
+ * by exactly `viewportFraction / 2`, so the boundary-inclusive `<= eps` check keeps the
+ * indicator lit on arrival.
  */
-@Suppress("UNUSED_PARAMETER")
 internal fun annotationNavigationOptions(isBookmark: Boolean): NavigationOptions =
-    NavigationOptions(landAtStartWhenNoTarget = false, alignToTop = false)
+    NavigationOptions(landAtStartWhenNoTarget = false, alignToTop = isBookmark)
 
 @OptIn(ExperimentalReadiumApi::class)
 @Composable

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -405,6 +405,7 @@ fun EpubReaderScreen(
                             viewModel.onPositionChanged(locator)
                             viewModel.dismissFootnotePopup()
                         },
+                        onViewportFractionMeasured = viewModel::putViewportFraction,
                         onNavigationEvents = viewModel.navigationEvents,
                         serverLocatorEvents = viewModel.serverLocatorEvents,
                         searchNavigationEvents = viewModel.searchNavigationEvents,
@@ -1087,6 +1088,7 @@ private fun EpubNavigatorView(
     spinePositions: Pair<List<String>, List<Int>>,
     formattingPrefsProvider: () -> FormattingPreferences,
     onPositionChanged: (Locator) -> Unit,
+    onViewportFractionMeasured: (href: String, fraction: Double) -> Unit,
     onNavigationEvents: Flow<Link>,
     serverLocatorEvents: Flow<Locator>,
     searchNavigationEvents: Flow<Locator>,
@@ -1194,6 +1196,16 @@ private fun EpubNavigatorView(
         val presenter = readiumPresenter ?: return@LaunchedEffect
         val fragment = fragmentRef.value ?: return@LaunchedEffect
         presenter.attach(fragment)
+    }
+
+    // Forward per-chapter viewport-fraction measurements from the active renderer into the VM's
+    // `viewportFractionByHref` map. The VM applies a per-entry distinct-until-changed guard so
+    // repeat values do not churn the bookmark combine (issue #399). The producers only emit on
+    // measurement/reflow events, never on scroll.
+    LaunchedEffect(readerPresenter) {
+        readerPresenter.viewportFractionEvents.collect { (href, fraction) ->
+            onViewportFractionMeasured(href, fraction)
+        }
     }
 
     // MODE-FORK: Highlight rendering pipeline. ContinuousHighlightRenderer drives custom JS

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -608,6 +608,7 @@ class EpubReaderViewModel @Inject constructor(
                 itemId = itemId,
                 currentLocator = position.currentLocator,
                 spinePositionCounts = spinePositionCounts,
+                viewportFractionByHref = viewportFractionByHref,
             )
             // Push orientation changes into the controller via a setter so the page-bookmark
             // indicator's match window re-sizes on a mid-session flip.
@@ -1183,6 +1184,30 @@ class EpubReaderViewModel @Inject constructor(
      * feeds [railSegments] weighting. Exposed so the continuous reader can build correctly
      * scaled locators when a rail segment spans multiple spine resources.
      */
+    private val _viewportFractionByHref = MutableStateFlow<Map<String, Double>>(emptyMap())
+
+    /**
+     * Live per-chapter `viewportSize / chapterSize` fractions. Populated by [putViewportFraction]
+     * from `ReaderPresenter.viewportFractionEvents` in `EpubReaderScreen`, and read by
+     * `BookmarksController.bookmarkEpsFor` as the geometrically-correct half-viewport bound
+     * for the bookmark indicator (issue #399). Only changes when a chapter's measurement
+     * changes — never on scroll.
+     */
+    val viewportFractionByHref: StateFlow<Map<String, Double>> = _viewportFractionByHref
+
+    /**
+     * Record a fresh viewport-fraction measurement for [href]. No-ops when the incoming value
+     * equals the currently stored one — this per-entry distinct-until-changed guard is what
+     * lets the bookmark combine avoid the scroll-driven recomposition churn that flaked
+     * `HighlightRepaintOrientationHarnessTest` in the prior attempt (see issue #399).
+     */
+    fun putViewportFraction(href: String, fraction: Double) {
+        if (href.isEmpty() || fraction <= 0.0 || !fraction.isFinite()) return
+        val current = _viewportFractionByHref.value
+        if (current[href] == fraction) return
+        _viewportFractionByHref.value = current + (href to fraction)
+    }
+
     val spinePositionCounts: StateFlow<Pair<List<String>, List<Int>>> = state
         .map { s ->
             val ready = s as? ReaderState.Ready ?: return@map emptyList<String>() to emptyList<Int>()

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/controllers/BookmarksController.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/controllers/BookmarksController.kt
@@ -220,13 +220,21 @@ class BookmarksController @AssistedInject constructor(
          *
          * Priority (issue #399):
          *  1. **Live viewport-fraction** — `viewportSize / chapterSize` measured by the active
-         *     renderer. Eps is `fraction / 2` — the geometrically-correct half-viewport bound
-         *     for a viewport-midpoint locator. Used as soon as the mode's producer reports a
-         *     fraction for [chapterHref] (continuous: on chapter measure; paginated / vertical:
-         *     on page-load / reflow).
-         *  2. **`0.5 / positionsInChapter`** — Readium's positions are ~1024-char slices, a
-         *     rough proxy for viewport-page-equivalents. Kicks in while the live measurement
-         *     hasn't landed yet (brief pre-measure window on open / reflow).
+         *     renderer.
+         *      - **Paginated / vertical:** `fraction / 2`. Readium's fragment-anchored `go()`
+         *        lands the CFI's column / scrollY exactly, so the delta on arrival is 0 — a
+         *        half-viewport window is the tightest correct bound.
+         *      - **Continuous:** full `fraction`. The saved anchor could be anywhere in the
+         *        viewport the user was reading in (top edge to bottom edge), so on an
+         *        `alignToTop=true` bookmark-panel nav the arrival midpoint can drift by up to
+         *        one full viewport-fraction from the saved midpoint. Tightening to `/ 2` would
+         *        make the indicator flake off on arrival for any bookmark whose anchor sat in
+         *        the lower half of the saved viewport — the user's principled contract is that
+         *        this must never happen. One-viewport tolerance covers the anchor-position
+         *        uncertainty exactly.
+         *  2. **`0.5 / positionsInChapter`** / **`1.0 / positionsInChapter`** — Readium's
+         *     positions are ~1024-char slices, a rough proxy. Same 2× continuous widening as
+         *     above. Kicks in while the live measurement hasn't landed yet.
          *  3. **Flat [BOOKMARK_PAGE_EPS] / [BOOKMARK_VIEWPORT_EPS]** — final fallback for the
          *     open-race before positions arrive.
          */
@@ -236,17 +244,17 @@ class BookmarksController @AssistedInject constructor(
             viewportFractionByHref: Map<String, Double>,
             chapterHref: String,
         ): Double {
+            val isContinuous = orientation == ReaderOrientation.Continuous
             viewportFractionByHref[chapterHref]?.let { vf ->
-                if (vf > 0.0) return vf / 2.0
+                if (vf > 0.0) return if (isContinuous) vf else vf / 2.0
             }
             val (hrefs, counts) = spineCounts
             val idx = hrefs.indexOfFirst { normalizeEpubHref(it) == chapterHref }
             val positions = counts.getOrNull(idx) ?: 0
-            if (positions > 0) return 0.5 / positions
+            if (positions > 0) return if (isContinuous) 1.0 / positions else 0.5 / positions
             // Neither live fraction nor position count available — fall back to the
             // mode-appropriate flat eps.
-            return if (orientation == ReaderOrientation.Continuous) BOOKMARK_VIEWPORT_EPS
-            else BOOKMARK_PAGE_EPS
+            return if (isContinuous) BOOKMARK_VIEWPORT_EPS else BOOKMARK_PAGE_EPS
         }
     }
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/controllers/BookmarksController.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/controllers/BookmarksController.kt
@@ -54,6 +54,16 @@ class BookmarksController @AssistedInject constructor(
     private val _spinePositionCounts = MutableStateFlow<Pair<List<String>, List<Int>>>(emptyList<String>() to emptyList())
 
     /**
+     * Live per-chapter `viewportSize / chapterSize` — the exact geometric bound for a
+     * viewport-midpoint locator (see [bookmarkEpsFor]). Empty until each mode's producer
+     * measures a chapter; missing entries fall through to [_spinePositionCounts] and then to
+     * the flat eps constants. Populated by the VM from `ReaderPresenter.viewportFractionEvents`
+     * and MUST only emit on measurement/size events, never on scroll (see issue #399 and the
+     * distinct-until-changed discipline in [EpubReaderViewModel.putViewportFraction]).
+     */
+    private val _viewportFractionByHref = MutableStateFlow<Map<String, Double>>(emptyMap())
+
+    /**
      * Current reader orientation, read non-reactively inside [isCurrentPageBookmarked]'s combine
      * so the combine stays 2-arg (matches master's shape and avoids the Eagerly-shared
      * viewModelScope chain that flaked the orientation-flip harness). Mode changes call
@@ -66,13 +76,11 @@ class BookmarksController @AssistedInject constructor(
     /**
      * True when one of this item's bookmarks falls inside the reader's currently visible viewport.
      *
-     * Bookmark `progression` is whatever the locator emitted at save-time:
-     *  - **Readium (paginated + vertical):** content-top progression. Bookmark anchor and
-     *    current locator share the same frame, so a tight ±5% window is the correct match.
-     *  - **Continuous:** viewport-midpoint progression (`ContinuousPositionTracker.locatorAt`).
-     *    The bookmark anchor is visible iff `|midpoint_now - M_save| <= viewportFraction/2`.
-     *    Without a live viewport-fraction signal, we use a fixed [BOOKMARK_VIEWPORT_EPS] (33%)
-     *    which covers typical viewports plus short chapters where `vf/2 ≈ 0.30`.
+     * The ±eps window comes from [bookmarkEpsFor], which prefers the live per-chapter
+     * `viewportSize / chapterSize` reported by the active renderer (issue #399), then Readium's
+     * `0.5 / positionsInChapter` approximation, then a flat fallback. All three modes emit a
+     * viewport-midpoint (`ContinuousPositionTracker.locatorAt`) or content-top locator whose
+     * anchor is visible iff `|current - saved| ≤ eps`.
      *
      * The `<= eps` (not `< eps`) makes the boundary case inclusive — when the bookmark anchor
      * sits exactly at the viewport's top edge, a strict `<` would silently call that OFF even
@@ -82,11 +90,12 @@ class BookmarksController @AssistedInject constructor(
         _bookmarkPositions,
         _currentLocator,
         _spinePositionCounts,
-    ) { bookmarksForChapter, locator, spineCounts ->
+        _viewportFractionByHref,
+    ) { bookmarksForChapter, locator, spineCounts, fractions ->
         val href = locator?.href?.toString() ?: return@combine false
         val prog = locator.locations.progression
         val hrefNorm = normalizeEpubHref(href)
-        val eps = bookmarkEpsFor(currentOrientation, spineCounts, hrefNorm)
+        val eps = bookmarkEpsFor(currentOrientation, spineCounts, fractions, hrefNorm)
         bookmarksForChapter.any { bm ->
             bm.chapterHref == hrefNorm &&
                 (prog == null || kotlin.math.abs(bm.progression - prog) <= eps)
@@ -100,11 +109,17 @@ class BookmarksController @AssistedInject constructor(
      * instead of creating a new one on the current page.
      */
     fun bookmarkEpsFor(chapterHref: String): Double =
-        bookmarkEpsFor(currentOrientation, _spinePositionCounts.value, normalizeEpubHref(chapterHref))
+        bookmarkEpsFor(
+            currentOrientation,
+            _spinePositionCounts.value,
+            _viewportFractionByHref.value,
+            normalizeEpubHref(chapterHref),
+        )
 
     private var observeJob: Job? = null
     private var locatorJob: Job? = null
     private var positionsJob: Job? = null
+    private var viewportFractionJob: Job? = null
 
     /**
      * Bind to a specific book. Cancels any previous observation and starts fresh.
@@ -116,13 +131,16 @@ class BookmarksController @AssistedInject constructor(
         itemId: String,
         currentLocator: StateFlow<Locator?>,
         spinePositionCounts: StateFlow<Pair<List<String>, List<Int>>>,
+        viewportFractionByHref: StateFlow<Map<String, Double>>,
     ) {
         observeJob?.cancel()
         locatorJob?.cancel()
         positionsJob?.cancel()
+        viewportFractionJob?.cancel()
         _bookmarkPositions.value = emptyList()
         _currentLocator.value = null
         _spinePositionCounts.value = emptyList<String>() to emptyList()
+        _viewportFractionByHref.value = emptyMap()
 
         observeJob = scope.launch {
             annotationStore.observeBookmarks(serverId, itemId).collect { annotations ->
@@ -143,6 +161,11 @@ class BookmarksController @AssistedInject constructor(
         positionsJob = scope.launch {
             spinePositionCounts.collect { counts ->
                 _spinePositionCounts.value = counts
+            }
+        }
+        viewportFractionJob = scope.launch {
+            viewportFractionByHref.collect { fractions ->
+                _viewportFractionByHref.value = fractions
             }
         }
     }
@@ -195,23 +218,33 @@ class BookmarksController @AssistedInject constructor(
          * Pure decision (JVM-testable) for the ±progression window used to decide whether a
          * bookmark falls on the current viewport in [chapterHref].
          *
-         * All three modes now use `0.5 / positionsInChapter` when the position count is known:
-         * - **Paginated / vertical:** half a page (locator = content-top progression).
-         * - **Continuous:** half a viewport-fraction (locator = viewport-midpoint progression;
-         *   viewportFraction ≈ 1/positions, so this is the tightest geometrically-correct
-         *   bound). Falls back to [BOOKMARK_VIEWPORT_EPS] / [BOOKMARK_PAGE_EPS] when positions
-         *   are unknown yet.
+         * Priority (issue #399):
+         *  1. **Live viewport-fraction** — `viewportSize / chapterSize` measured by the active
+         *     renderer. Eps is `fraction / 2` — the geometrically-correct half-viewport bound
+         *     for a viewport-midpoint locator. Used as soon as the mode's producer reports a
+         *     fraction for [chapterHref] (continuous: on chapter measure; paginated / vertical:
+         *     on page-load / reflow).
+         *  2. **`0.5 / positionsInChapter`** — Readium's positions are ~1024-char slices, a
+         *     rough proxy for viewport-page-equivalents. Kicks in while the live measurement
+         *     hasn't landed yet (brief pre-measure window on open / reflow).
+         *  3. **Flat [BOOKMARK_PAGE_EPS] / [BOOKMARK_VIEWPORT_EPS]** — final fallback for the
+         *     open-race before positions arrive.
          */
         internal fun bookmarkEpsFor(
             orientation: ReaderOrientation,
             spineCounts: Pair<List<String>, List<Int>>,
+            viewportFractionByHref: Map<String, Double>,
             chapterHref: String,
         ): Double {
+            viewportFractionByHref[chapterHref]?.let { vf ->
+                if (vf > 0.0) return vf / 2.0
+            }
             val (hrefs, counts) = spineCounts
             val idx = hrefs.indexOfFirst { normalizeEpubHref(it) == chapterHref }
             val positions = counts.getOrNull(idx) ?: 0
             if (positions > 0) return 0.5 / positions
-            // Position count not yet available — fall back to the mode-appropriate flat eps.
+            // Neither live fraction nor position count available — fall back to the
+            // mode-appropriate flat eps.
             return if (orientation == ReaderOrientation.Continuous) BOOKMARK_VIEWPORT_EPS
             else BOOKMARK_PAGE_EPS
         }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/presenter/ContinuousPresenter.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/presenter/ContinuousPresenter.kt
@@ -24,6 +24,7 @@ internal class ContinuousPresenter : ReaderPresenter {
 
     private val _positionEvents = MutableSharedFlow<PositionUpdate>(replay = 0, extraBufferCapacity = 64)
     private val _pageLoadEvents = MutableSharedFlow<PageLoadGeneration>(replay = 0, extraBufferCapacity = 64)
+    private val _viewportFractionEvents = MutableSharedFlow<Pair<String, Double>>(replay = 0, extraBufferCapacity = 64)
     private val _tapEvents = MutableSharedFlow<TapEvent>(replay = 0, extraBufferCapacity = 64)
     private val _linkEvents = MutableSharedFlow<LinkEvent>(replay = 0, extraBufferCapacity = 64)
     private val _selectionEvents = MutableSharedFlow<SelectionEvent>(replay = 0, extraBufferCapacity = 64)
@@ -31,6 +32,7 @@ internal class ContinuousPresenter : ReaderPresenter {
 
     override val positionEvents: SharedFlow<PositionUpdate> = _positionEvents
     override val pageLoadEvents: SharedFlow<PageLoadGeneration> = _pageLoadEvents
+    override val viewportFractionEvents: SharedFlow<Pair<String, Double>> = _viewportFractionEvents
     override val tapEvents: SharedFlow<TapEvent> = _tapEvents
     override val linkEvents: SharedFlow<LinkEvent> = _linkEvents
     override val selectionEvents: SharedFlow<SelectionEvent> = _selectionEvents
@@ -59,6 +61,16 @@ internal class ContinuousPresenter : ReaderPresenter {
         val position = ReaderPosition(href, progression, totalProgression, locatorJson)
         lastPosition = position
         _positionEvents.tryEmit(PositionUpdate(position, 0L))
+    }
+
+    /**
+     * Publish a live `viewportHeightPx / chapterHeightPx` fraction for [href]. Called from
+     * `ContinuousWindowController` when a chapter's measured height first lands or changes
+     * (never on scroll). [fraction] must be `> 0`; values `<= 0` are dropped.
+     */
+    fun feedViewportFraction(href: String, fraction: Double) {
+        if (fraction <= 0.0) return
+        _viewportFractionEvents.tryEmit(href to fraction)
     }
 
     fun feedTap() {

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/presenter/ReaderPresenter.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/presenter/ReaderPresenter.kt
@@ -32,6 +32,19 @@ internal interface ReaderPresenter {
      */
     val pageLoadEvents: Flow<PageLoadGeneration>
 
+    /**
+     * Per-chapter `viewportSize / chapterSize` fractions produced whenever the renderer
+     * measures a chapter or its viewport changes. Consumers ([BookmarksController] via the
+     * VM's `viewportFractionByHref` map) key by normalized href.
+     *
+     * **Must not emit on scroll** — see issue #399. Continuous mode emits from the
+     * `onHeightMeasured` callback; paginated / vertical emit from `onPageLoaded` and
+     * typography-change hooks via [RendererBridge.readViewportFraction]. Downstream applies
+     * a per-entry distinct-until-changed guard so a repeat value never re-triggers the
+     * bookmark combine.
+     */
+    val viewportFractionEvents: Flow<Pair<String, Double>>
+
     /** Any user tap that should toggle reader chrome (left/right tap zones, body tap). */
     val tapEvents: Flow<TapEvent>
 

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/presenter/ReadiumPresenter.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/presenter/ReadiumPresenter.kt
@@ -42,6 +42,7 @@ internal class ReadiumPresenter(
 
     private val _positionEvents = MutableSharedFlow<PositionUpdate>(replay = 0, extraBufferCapacity = 64)
     private val _pageLoadEvents = MutableSharedFlow<PageLoadGeneration>(replay = 0, extraBufferCapacity = 64)
+    private val _viewportFractionEvents = MutableSharedFlow<Pair<String, Double>>(replay = 0, extraBufferCapacity = 64)
     private val _tapEvents = MutableSharedFlow<TapEvent>(replay = 0, extraBufferCapacity = 64)
     private val _linkEvents = MutableSharedFlow<LinkEvent>(replay = 0, extraBufferCapacity = 64)
     private val _selectionEvents = MutableSharedFlow<SelectionEvent>(replay = 0, extraBufferCapacity = 64)
@@ -49,6 +50,7 @@ internal class ReadiumPresenter(
 
     override val positionEvents: SharedFlow<PositionUpdate> = _positionEvents
     override val pageLoadEvents: SharedFlow<PageLoadGeneration> = _pageLoadEvents
+    override val viewportFractionEvents: SharedFlow<Pair<String, Double>> = _viewportFractionEvents
     override val tapEvents: SharedFlow<TapEvent> = _tapEvents
     override val linkEvents: SharedFlow<LinkEvent> = _linkEvents
     override val selectionEvents: SharedFlow<SelectionEvent> = _selectionEvents
@@ -106,6 +108,25 @@ internal class ReadiumPresenter(
     fun feedPageLoaded() {
         pageLoadCount += 1
         _pageLoadEvents.tryEmit(PageLoadGeneration(pageLoadCount))
+        publishViewportFraction()
+    }
+
+    /**
+     * Measure the current document's `viewportSize / scrollSize` and publish it against the
+     * fragment's current-locator href. Called on page load and after typography changes (the
+     * two hooks Readium re-lays-out the document). Scroll callbacks intentionally do NOT
+     * trigger this — see issue #399's flake-avoidance rules.
+     */
+    private fun publishViewportFraction() {
+        val fragment = fragment ?: return
+        val href = fragment.currentLocator.value.href.toString()
+        if (href.isEmpty()) return
+        scope.launch {
+            val fraction = bridge.readViewportFraction() ?: return@launch
+            if (fraction > 0.0) {
+                _viewportFractionEvents.tryEmit(href to fraction)
+            }
+        }
     }
 
     fun feedInternalLink(link: Link, origin: Locator) {
@@ -164,6 +185,9 @@ internal class ReadiumPresenter(
         // onPageLoaded by the bridge's TypographyOverride capability; doing it here too means a
         // live preferences change takes effect immediately without waiting for the next page turn.
         bridge.applyTypographyOverride()
+        // Font size / margins reflow the document. Re-measure the viewport fraction so the
+        // bookmark eps stays accurate under the new layout (issue #399).
+        publishViewportFraction()
     }
 
     override fun snapshotPosition(): ReaderPosition? = lastPosition

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/renderer/DefaultRendererBridge.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/renderer/DefaultRendererBridge.kt
@@ -161,6 +161,23 @@ internal class DefaultRendererBridge(
         fragment?.evaluateJavascript(js)
     }
 
+    override suspend fun readViewportFraction(): Double? {
+        val frag = fragment ?: return null
+        val raw = frag.evaluateJavascript(
+            """
+            (function() {
+              var iw = window.innerWidth, sw = document.documentElement.scrollWidth;
+              var ih = window.innerHeight, sh = document.documentElement.scrollHeight;
+              // Pick the overflow axis. Paginated overflows horizontally; vertical/no-overflow
+              // fall through to the height ratio.
+              var v = sw > iw ? (iw / sw) : (ih > 0 ? ih / sh : 0);
+              return isFinite(v) && v > 0 ? v.toString() : "";
+            })()
+            """.trimIndent(),
+        )?.trim('"') ?: return null
+        return raw.toDoubleOrNull()
+    }
+
     companion object {
         /**
          * The capability registry shared by every paged/vertical session. The dependency graph

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/renderer/RendererBridge.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/renderer/RendererBridge.kt
@@ -129,6 +129,18 @@ internal interface RendererBridge {
     suspend fun scrollBoundary(): Pair<Boolean, Boolean>
 
     /**
+     * Measure `viewportSize / scrollSize` for the currently loaded resource. Paginated mode
+     * overflows horizontally (`innerWidth / scrollWidth`); vertical mode overflows vertically
+     * (`innerHeight / scrollHeight`). The JS picks the axis by whichever dimension actually
+     * overflows the viewport. Returns null when the WebView is gone or the measurement can't
+     * be parsed; caller (presenter) skips publishing in that case.
+     *
+     * Feeds `BookmarksController` via `EpubReaderViewModel.viewportFractionByHref` (issue #399).
+     * The JS reads no scroll state — safe to call from a page-load or typography-change hook.
+     */
+    suspend fun readViewportFraction(): Double?
+
+    /**
      * Evaluate a script supplied by `ScrollBoundaryNavigationContainer` for the volume-key
      * boundary crossing. The container builds the smooth-scroll JS itself (deciding by orientation
      * + boundary state) and just needs a way to send it to the fragment. The script is fully owned

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/EpubReaderViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/EpubReaderViewModelTest.kt
@@ -1302,30 +1302,28 @@ class BookmarkIndicatorTest {
 }
 
 /**
- * Pins the invariant that annotation-panel navigation in continuous mode lands at the viewport
- * MIDPOINT regardless of annotation type. Previously the screen passed `alignToTop = isBookmark`,
- * which placed the bookmark's CFI DOM anchor at the viewport top — on books with images, big
- * headings, or otherwise non-uniform text density the pixel anchor sat almost a full viewport
- * past the char-based progression the corner ribbon stored, so the ribbon lit ~1 screen before
- * the actual landing scrollY. A regression to that shape (`alignToTop = isBookmark`) would flip
- * the `alignToTop=false` assertion on the `isBookmark=true` case.
+ * Pins the split invariant for annotation-panel navigation in continuous mode: bookmarks land
+ * at the viewport TOP, highlights land at the MIDPOINT. See [annotationNavigationOptions] —
+ * the split was safe to re-introduce once #399's live viewport-fraction eps made
+ * `alignToTop=true` a boundary-inclusive match for the bookmark ribbon.
  */
 class AnnotationNavigationOptionsTest {
 
     @Test
-    fun `bookmarks land at viewport midpoint (alignToTop=false)`() {
+    fun `bookmarks land at viewport top (alignToTop=true)`() {
         val opts = annotationNavigationOptions(isBookmark = true)
-        assertFalse(
-            "bookmark nav must align to midpoint, not top — see the fix for the lit-ribbon vs " +
-                "landing-scrollY mismatch on non-uniform-density chapters",
+        assertTrue(
+            "bookmark nav must align to top so the saved position is at the start of the " +
+                "viewport (already-read content scrolls off above); if this flips, revisit " +
+                "annotationNavigationOptions and the #399 eps analysis in its doc",
             opts.alignToTop,
         )
     }
 
     @Test
     fun `highlights land at viewport midpoint (alignToTop=false)`() {
-        // The highlight path already landed at the midpoint before the fix; this pins that the
-        // extraction didn't change highlight behaviour.
+        // Highlights are text-anchored — centring on the mark preserves reading context above
+        // the anchor. Kept at midpoint by design.
         val opts = annotationNavigationOptions(isBookmark = false)
         assertFalse(opts.alignToTop)
     }

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/controllers/BookmarksControllerTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/controllers/BookmarksControllerTest.kt
@@ -292,13 +292,13 @@ class BookmarksControllerTest {
     }
 
     // Regression for the "bookmark stays lit for several screens" symptom in continuous mode.
-    // The old flat 33% eps meant a bookmark saved at midpoint 0.5 stayed lit for progression
-    // 0.17-0.83 — a huge chunk of the chapter. The new `0.5 / positions` formula matches the
-    // paginated logic (viewportFraction/2 ≈ 1/(2·positions) is the geometrically-correct bound
-    // for viewport-midpoint locators), so on a 40-position chapter the indicator only lights
-    // within ±0.0125 progression.
+    // The old flat 33% eps kept a bookmark at midpoint 0.5 lit across progression 0.17-0.83.
+    // Continuous eps is now `1 / positions` (full-viewport tolerance — see `bookmarkEpsFor`
+    // for the geometric argument covering `alignToTop=true` bookmark-nav landings), so on a
+    // 40-position chapter the indicator lights within ±0.025 progression — about one viewport
+    // in either direction, not several.
     @Test
-    fun `continuous eps narrows to half-a-viewport when spine position counts are known`() = runTest {
+    fun `continuous eps is one-viewport wide when spine position counts are known`() = runTest {
         val (controller, store) = makeController()
         val currentLocator = MutableStateFlow<Locator?>(null)
         val positions = MutableStateFlow(listOf("ch1.xhtml") to listOf(40))
@@ -307,11 +307,11 @@ class BookmarksControllerTest {
 
         store.bookmarks.value = listOf(makeAnnotation(chapterHref = "ch1.xhtml", progression = 0.5))
 
-        // Same viewport (delta 0.010 < 1/(2*40) = 0.0125) → lit.
-        currentLocator.value = buildLocator("ch1.xhtml", 0.510)
-        assertTrue("indicator ON at ~0.01 midpoint delta on a 40-position chapter", controller.isCurrentPageBookmarked.value)
+        // Within one viewport (delta 0.020 < 1/40 = 0.025) → lit.
+        currentLocator.value = buildLocator("ch1.xhtml", 0.520)
+        assertTrue("indicator ON at 0.020 midpoint delta on a 40-position chapter", controller.isCurrentPageBookmarked.value)
 
-        // Several screens away (delta 0.10 — the OLD 33% flat eps would have kept this lit) → NOT lit.
+        // Beyond one viewport (delta 0.10 — the OLD 33% flat eps would have kept this lit) → NOT lit.
         currentLocator.value = buildLocator("ch1.xhtml", 0.60)
         assertFalse("indicator OFF at 0.10 midpoint delta on a 40-position chapter", controller.isCurrentPageBookmarked.value)
     }
@@ -333,32 +333,69 @@ class BookmarksControllerTest {
         assertEquals("unknown chapter falls back to 5%", 0.05, controller.bookmarkEpsFor("ch99.xhtml"), 1e-9)
     }
 
-    // Issue #399: the live viewport-fraction path is the geometrically-correct half-viewport
-    // bound (`fraction / 2`). When both the fraction and Readium's position count are known,
-    // fraction wins — position count is only ~1024-char slices, a rough proxy.
+    // Issue #399: the live viewport-fraction path is the geometrically-correct bound. In
+    // continuous mode eps == fraction (full viewport). Positions is a rough char-slice proxy
+    // and loses to fraction whenever present.
     @Test
     fun `live viewport fraction takes precedence over spine position counts`() = runTest {
         val (controller, store) = makeController()
         val currentLocator = MutableStateFlow<Locator?>(null)
         val positions = MutableStateFlow(listOf("ch1.xhtml") to listOf(30))
-        val fractions = MutableStateFlow(mapOf("ch1.xhtml" to 0.20)) // eps = 0.10
+        val fractions = MutableStateFlow(mapOf("ch1.xhtml" to 0.20)) // continuous eps = 0.20
         controller.bind("srv", "item1", currentLocator, positions, fractions)
         controller.onOrientationChanged(com.riffle.core.domain.ReaderOrientation.Continuous)
 
         store.bookmarks.value = listOf(makeAnnotation(chapterHref = "ch1.xhtml", progression = 0.5))
 
-        // 0.09 delta — inside the fraction/2=0.10 window, but well outside 0.5/30=0.0167.
+        // 0.19 delta — inside the continuous fraction=0.20 window, but well outside 1/30=0.033.
         // Assertion pins fraction wins over positions.
-        currentLocator.value = buildLocator("ch1.xhtml", 0.59)
+        currentLocator.value = buildLocator("ch1.xhtml", 0.69)
         assertTrue(
-            "indicator ON at 0.09 delta when fraction=0.20 (eps=0.10)",
+            "indicator ON at 0.19 delta when fraction=0.20 (continuous eps=0.20)",
             controller.isCurrentPageBookmarked.value,
         )
 
-        // 0.11 delta — outside the fraction/2=0.10 window.
-        currentLocator.value = buildLocator("ch1.xhtml", 0.61)
+        // 0.21 delta — outside the fraction=0.20 window.
+        currentLocator.value = buildLocator("ch1.xhtml", 0.71)
         assertFalse(
-            "indicator OFF at 0.11 delta when fraction=0.20 (eps=0.10)",
+            "indicator OFF at 0.21 delta when fraction=0.20 (continuous eps=0.20)",
+            controller.isCurrentPageBookmarked.value,
+        )
+    }
+
+    // The user's principled contract: after navigating to a bookmark, the indicator MUST light
+    // — anything less is a disagreement between the reader and the annotation panel.
+    //
+    // In continuous mode with `alignToTop=true` bookmark-panel navigation, the arrival midpoint
+    // shifts up to a full `viewportFraction` from the saved midpoint (the anchor can sit
+    // anywhere in the saved viewport — top edge → arrival delta 0; bottom edge → arrival delta
+    // one viewportFraction). Tightening eps to `fraction / 2` (as the paginated logic does)
+    // would flake the indicator off for any bookmark whose anchor sat in the lower half of the
+    // saved viewport, which is the majority case — users bookmark from the reading zone (the
+    // middle-to-bottom of the visible page).
+    //
+    // This test pins the worst-case arrival delta and asserts the indicator stays lit.
+    @Test
+    fun `continuous indicator lights at the alignToTop bookmark-nav arrival boundary`() = runTest {
+        val (controller, store) = makeController()
+        val currentLocator = MutableStateFlow<Locator?>(null)
+        val fractions = MutableStateFlow(mapOf("ch1.xhtml" to 0.10))
+        controller.bind(
+            "srv", "item1", currentLocator,
+            MutableStateFlow(emptyList<String>() to emptyList()),
+            fractions,
+        )
+        controller.onOrientationChanged(com.riffle.core.domain.ReaderOrientation.Continuous)
+
+        store.bookmarks.value = listOf(makeAnnotation(chapterHref = "ch1.xhtml", progression = 0.50))
+        // Saved midpoint 0.50, viewportFraction 0.10 → arrival midpoint 0.50 + 0.10 = 0.60 when
+        // the saved anchor sat at the bottom edge of its viewport. Delta = 0.10 == eps
+        // (`fraction`). The `<= eps` boundary check MUST keep the indicator ON — if it flips
+        // OFF here, revert the eps widening to `fraction / 2` at your peril; the user's
+        // observed "not lit after nav" symptom will return.
+        currentLocator.value = buildLocator("ch1.xhtml", 0.60)
+        assertTrue(
+            "indicator MUST be ON at the alignToTop arrival boundary (delta == fraction)",
             controller.isCurrentPageBookmarked.value,
         )
     }
@@ -391,12 +428,12 @@ class BookmarksControllerTest {
         val positions = MutableStateFlow(
             listOf("ch1.xhtml", "ch2.xhtml") to listOf(50, 50),
         )
-        val fractions = MutableStateFlow(mapOf("ch1.xhtml" to 0.10)) // eps = 0.05
+        val fractions = MutableStateFlow(mapOf("ch1.xhtml" to 0.10)) // continuous eps = fraction = 0.10
         controller.bind("srv", "item1", MutableStateFlow(null), positions, fractions)
         controller.onOrientationChanged(com.riffle.core.domain.ReaderOrientation.Continuous)
 
-        assertEquals("ch1 uses fraction (0.10/2 = 0.05)", 0.05, controller.bookmarkEpsFor("ch1.xhtml"), 1e-9)
-        assertEquals("ch2 falls back to positions (0.5/50)", 0.01, controller.bookmarkEpsFor("ch2.xhtml"), 1e-9)
+        assertEquals("ch1 uses fraction (continuous eps = fraction)", 0.10, controller.bookmarkEpsFor("ch1.xhtml"), 1e-9)
+        assertEquals("ch2 falls back to positions (continuous 1/50)", 0.02, controller.bookmarkEpsFor("ch2.xhtml"), 1e-9)
     }
 
     // A zero or negative fraction (measurement race, degenerate chapter) MUST fall through to
@@ -410,8 +447,8 @@ class BookmarksControllerTest {
         controller.onOrientationChanged(com.riffle.core.domain.ReaderOrientation.Continuous)
 
         assertEquals(
-            "zero fraction is dropped, positions used instead",
-            0.5 / 40.0,
+            "zero fraction is dropped, positions used instead (continuous eps = 1/positions)",
+            1.0 / 40.0,
             controller.bookmarkEpsFor("ch1.xhtml"),
             1e-9,
         )

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/controllers/BookmarksControllerTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/controllers/BookmarksControllerTest.kt
@@ -130,7 +130,7 @@ class BookmarksControllerTest {
     fun `bookmarkPositions reactively follows annotationStore observeBookmarks`() = runTest {
         val (controller, store) = makeController()
         val bm = makeAnnotation(chapterHref = "ch1.xhtml", progression = 0.1)
-        controller.bind("srv", "item1", MutableStateFlow(null), MutableStateFlow(emptyList<String>() to emptyList()))
+        controller.bind("srv", "item1", MutableStateFlow(null), MutableStateFlow(emptyList<String>() to emptyList()), MutableStateFlow(emptyMap<String, Double>()))
 
         store.bookmarks.value = listOf(bm)
 
@@ -144,7 +144,7 @@ class BookmarksControllerTest {
     fun `isCurrentPageBookmarked reflects bookmark presence at current href and progression`() = runTest {
         val (controller, store) = makeController()
         val currentLocator = MutableStateFlow<Locator?>(null)
-        controller.bind("srv", "item1", currentLocator, MutableStateFlow(emptyList<String>() to emptyList()))
+        controller.bind("srv", "item1", currentLocator, MutableStateFlow(emptyList<String>() to emptyList()), MutableStateFlow(emptyMap()))
 
         assertFalse(controller.isCurrentPageBookmarked.value)
 
@@ -164,7 +164,7 @@ class BookmarksControllerTest {
     fun `isCurrentPageBookmarked uses progression window tolerance`() = runTest {
         val (controller, store) = makeController()
         val currentLocator = MutableStateFlow<Locator?>(null)
-        controller.bind("srv", "item1", currentLocator, MutableStateFlow(emptyList<String>() to emptyList()))
+        controller.bind("srv", "item1", currentLocator, MutableStateFlow(emptyList<String>() to emptyList()), MutableStateFlow(emptyMap()))
 
         store.bookmarks.value = listOf(makeAnnotation(chapterHref = "ch1.xhtml", progression = 0.5))
         // Within 5% tolerance → bookmarked
@@ -184,7 +184,7 @@ class BookmarksControllerTest {
         // viewportFraction can hit ~0.6 (so vf/2 ≈ 0.30) — the exact case the user reproduced.
         val (controller, store) = makeController()
         val currentLocator = MutableStateFlow<Locator?>(null)
-        controller.bind("srv", "item1", currentLocator, MutableStateFlow(emptyList<String>() to emptyList()))
+        controller.bind("srv", "item1", currentLocator, MutableStateFlow(emptyList<String>() to emptyList()), MutableStateFlow(emptyMap()))
         controller.onOrientationChanged(com.riffle.core.domain.ReaderOrientation.Continuous)
 
         store.bookmarks.value = listOf(makeAnnotation(chapterHref = "ch1.xhtml", progression = 0.0))
@@ -205,7 +205,7 @@ class BookmarksControllerTest {
     fun `onOrientationChanged toggles eps without rebinding`() = runTest {
         val (controller, store) = makeController()
         val currentLocator = MutableStateFlow<Locator?>(null)
-        controller.bind("srv", "item1", currentLocator, MutableStateFlow(emptyList<String>() to emptyList()))
+        controller.bind("srv", "item1", currentLocator, MutableStateFlow(emptyList<String>() to emptyList()), MutableStateFlow(emptyMap()))
         // Start in paginated.
         controller.onOrientationChanged(com.riffle.core.domain.ReaderOrientation.Horizontal)
 
@@ -223,7 +223,7 @@ class BookmarksControllerTest {
     fun `renameBookmark updates store and calls sync`() = runTest {
         var syncCalled = false
         val (controller, store) = makeController(onScheduleSync = { syncCalled = true })
-        controller.bind("srv", "item1", MutableStateFlow(null), MutableStateFlow(emptyList<String>() to emptyList()))
+        controller.bind("srv", "item1", MutableStateFlow(null), MutableStateFlow(emptyList<String>() to emptyList()), MutableStateFlow(emptyMap<String, Double>()))
 
         controller.renameBookmark("bm-1", "New Title")
 
@@ -235,13 +235,13 @@ class BookmarksControllerTest {
     fun `bind clears state from previous book`() = runTest {
         val (controller, store) = makeController()
         store.bookmarks.value = listOf(makeAnnotation())
-        controller.bind("srv", "item1", MutableStateFlow(null), MutableStateFlow(emptyList<String>() to emptyList()))
+        controller.bind("srv", "item1", MutableStateFlow(null), MutableStateFlow(emptyList<String>() to emptyList()), MutableStateFlow(emptyMap<String, Double>()))
 
         assertEquals(1, controller.bookmarkPositions.value.size)
 
         // Rebind to a new book with a fresh empty store
         store.bookmarks.value = emptyList()
-        controller.bind("srv", "item2", MutableStateFlow(null), MutableStateFlow(emptyList<String>() to emptyList()))
+        controller.bind("srv", "item2", MutableStateFlow(null), MutableStateFlow(emptyList<String>() to emptyList()), MutableStateFlow(emptyMap()))
 
         assertEquals(0, controller.bookmarkPositions.value.size)
     }
@@ -257,7 +257,7 @@ class BookmarksControllerTest {
         val positions = MutableStateFlow(
             listOf("ch1.xhtml") to listOf(60),
         )
-        controller.bind("srv", "item1", currentLocator, positions)
+        controller.bind("srv", "item1", currentLocator, positions, MutableStateFlow(emptyMap()))
         controller.onOrientationChanged(com.riffle.core.domain.ReaderOrientation.Horizontal)
 
         store.bookmarks.value = listOf(makeAnnotation(chapterHref = "ch1.xhtml", progression = 0.5))
@@ -282,6 +282,7 @@ class BookmarksControllerTest {
         controller.bind(
             "srv", "item1", currentLocator,
             MutableStateFlow(emptyList<String>() to emptyList()),
+            MutableStateFlow(emptyMap()),
         )
         controller.onOrientationChanged(com.riffle.core.domain.ReaderOrientation.Horizontal)
 
@@ -301,7 +302,7 @@ class BookmarksControllerTest {
         val (controller, store) = makeController()
         val currentLocator = MutableStateFlow<Locator?>(null)
         val positions = MutableStateFlow(listOf("ch1.xhtml") to listOf(40))
-        controller.bind("srv", "item1", currentLocator, positions)
+        controller.bind("srv", "item1", currentLocator, positions, MutableStateFlow(emptyMap()))
         controller.onOrientationChanged(com.riffle.core.domain.ReaderOrientation.Continuous)
 
         store.bookmarks.value = listOf(makeAnnotation(chapterHref = "ch1.xhtml", progression = 0.5))
@@ -324,12 +325,96 @@ class BookmarksControllerTest {
         val positions = MutableStateFlow(
             listOf("ch1.xhtml", "ch2.xhtml") to listOf(60, 20),
         )
-        controller.bind("srv", "item1", MutableStateFlow(null), positions)
+        controller.bind("srv", "item1", MutableStateFlow(null), positions, MutableStateFlow(emptyMap()))
         controller.onOrientationChanged(com.riffle.core.domain.ReaderOrientation.Horizontal)
 
         assertEquals("60-page chapter: half-a-page = 1/120", 1.0 / 120.0, controller.bookmarkEpsFor("ch1.xhtml"), 1e-9)
         assertEquals("20-page chapter: half-a-page = 1/40", 1.0 / 40.0, controller.bookmarkEpsFor("ch2.xhtml"), 1e-9)
         assertEquals("unknown chapter falls back to 5%", 0.05, controller.bookmarkEpsFor("ch99.xhtml"), 1e-9)
+    }
+
+    // Issue #399: the live viewport-fraction path is the geometrically-correct half-viewport
+    // bound (`fraction / 2`). When both the fraction and Readium's position count are known,
+    // fraction wins — position count is only ~1024-char slices, a rough proxy.
+    @Test
+    fun `live viewport fraction takes precedence over spine position counts`() = runTest {
+        val (controller, store) = makeController()
+        val currentLocator = MutableStateFlow<Locator?>(null)
+        val positions = MutableStateFlow(listOf("ch1.xhtml") to listOf(30))
+        val fractions = MutableStateFlow(mapOf("ch1.xhtml" to 0.20)) // eps = 0.10
+        controller.bind("srv", "item1", currentLocator, positions, fractions)
+        controller.onOrientationChanged(com.riffle.core.domain.ReaderOrientation.Continuous)
+
+        store.bookmarks.value = listOf(makeAnnotation(chapterHref = "ch1.xhtml", progression = 0.5))
+
+        // 0.09 delta — inside the fraction/2=0.10 window, but well outside 0.5/30=0.0167.
+        // Assertion pins fraction wins over positions.
+        currentLocator.value = buildLocator("ch1.xhtml", 0.59)
+        assertTrue(
+            "indicator ON at 0.09 delta when fraction=0.20 (eps=0.10)",
+            controller.isCurrentPageBookmarked.value,
+        )
+
+        // 0.11 delta — outside the fraction/2=0.10 window.
+        currentLocator.value = buildLocator("ch1.xhtml", 0.61)
+        assertFalse(
+            "indicator OFF at 0.11 delta when fraction=0.20 (eps=0.10)",
+            controller.isCurrentPageBookmarked.value,
+        )
+    }
+
+    // When no fraction has arrived yet for the current chapter, positions is the fallback.
+    // Guards against the priority order accidentally short-circuiting on an empty map.
+    @Test
+    fun `bookmarkEpsFor falls back to positions when fraction is not yet measured`() = runTest {
+        val (controller, _) = makeController()
+        val positions = MutableStateFlow(listOf("ch1.xhtml") to listOf(60))
+        controller.bind(
+            "srv", "item1", MutableStateFlow(null), positions,
+            MutableStateFlow(emptyMap()), // no fraction reported yet
+        )
+        controller.onOrientationChanged(com.riffle.core.domain.ReaderOrientation.Horizontal)
+
+        assertEquals(
+            "empty fraction map → 0.5/positions still applies",
+            1.0 / 120.0,
+            controller.bookmarkEpsFor("ch1.xhtml"),
+            1e-9,
+        )
+    }
+
+    // Fractions are chapter-scoped: a fraction for chapter A must not leak into chapter B.
+    // (An early draft keyed the map on the wrong href would silently pass every other test.)
+    @Test
+    fun `live viewport fraction is chapter-scoped`() = runTest {
+        val (controller, _) = makeController()
+        val positions = MutableStateFlow(
+            listOf("ch1.xhtml", "ch2.xhtml") to listOf(50, 50),
+        )
+        val fractions = MutableStateFlow(mapOf("ch1.xhtml" to 0.10)) // eps = 0.05
+        controller.bind("srv", "item1", MutableStateFlow(null), positions, fractions)
+        controller.onOrientationChanged(com.riffle.core.domain.ReaderOrientation.Continuous)
+
+        assertEquals("ch1 uses fraction (0.10/2 = 0.05)", 0.05, controller.bookmarkEpsFor("ch1.xhtml"), 1e-9)
+        assertEquals("ch2 falls back to positions (0.5/50)", 0.01, controller.bookmarkEpsFor("ch2.xhtml"), 1e-9)
+    }
+
+    // A zero or negative fraction (measurement race, degenerate chapter) MUST fall through to
+    // positions rather than short-circuiting to eps=0 (which would silently kill the indicator).
+    @Test
+    fun `zero or negative fraction is ignored`() = runTest {
+        val (controller, _) = makeController()
+        val positions = MutableStateFlow(listOf("ch1.xhtml") to listOf(40))
+        val fractions = MutableStateFlow(mapOf("ch1.xhtml" to 0.0))
+        controller.bind("srv", "item1", MutableStateFlow(null), positions, fractions)
+        controller.onOrientationChanged(com.riffle.core.domain.ReaderOrientation.Continuous)
+
+        assertEquals(
+            "zero fraction is dropped, positions used instead",
+            0.5 / 40.0,
+            controller.bookmarkEpsFor("ch1.xhtml"),
+            1e-9,
+        )
     }
 
     @Test

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/presenter/ContinuousPresenterTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/presenter/ContinuousPresenterTest.kt
@@ -2,6 +2,9 @@ package com.riffle.app.feature.reader.presenter
 
 import com.riffle.app.feature.reader.ContinuousNavigationView
 import com.riffle.core.domain.FormattingPreferences
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
@@ -17,6 +20,7 @@ import org.junit.Test
  * ([NavigationTarget.ToHref], [NavigationTarget.ToProgression]) are exercised in instrumentation
  * via the existing TOC + chapter-map paths.
  */
+@OptIn(ExperimentalCoroutinesApi::class)
 class ContinuousPresenterTest {
 
     private class FakeView : ContinuousNavigationView {
@@ -221,6 +225,27 @@ class ContinuousPresenterTest {
         presenter.snapReadaloudColumn("any", columnIndex = 2)
         assertTrue("expected no view calls, got navCalls=${view.navCalls} pageCalls=${view.pageCalls}",
             view.navCalls.isEmpty() && view.pageCalls.isEmpty())
+    }
+
+    // Issue #399: continuous producer emits `viewportHeight / measuredHeight` from the
+    // ContinuousWindowController's onHeightMeasured hooks. feedViewportFraction must forward
+    // that measurement verbatim through viewportFractionEvents so the VM's collector can
+    // update the bookmark eps map. A zero/negative fraction is dropped (defensive: measurement
+    // race in the WindowController could otherwise emit before viewport height is known).
+    @Test
+    fun `feedViewportFraction forwards positive measurements verbatim`() = runTest {
+        val presenter = ContinuousPresenter()
+        val collected = mutableListOf<Pair<String, Double>>()
+        val job = launch { presenter.viewportFractionEvents.collect { collected += it } }
+        runCurrent() // let the collector subscribe before we emit — SharedFlow(replay=0) drops otherwise
+
+        presenter.feedViewportFraction("ch1.xhtml", 0.0) // dropped
+        presenter.feedViewportFraction("ch1.xhtml", -1.0) // dropped
+        presenter.feedViewportFraction("ch2.xhtml", 0.25) // emitted
+        runCurrent()
+
+        assertEquals(listOf("ch2.xhtml" to 0.25), collected)
+        job.cancel()
     }
 
     @Test

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/presenter/FakeReaderPresenter.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/presenter/FakeReaderPresenter.kt
@@ -17,6 +17,7 @@ internal class FakeReaderPresenter : ReaderPresenter {
 
     private val _positionEvents = MutableSharedFlow<PositionUpdate>(replay = 0, extraBufferCapacity = 64)
     private val _pageLoadEvents = MutableSharedFlow<PageLoadGeneration>(replay = 0, extraBufferCapacity = 64)
+    private val _viewportFractionEvents = MutableSharedFlow<Pair<String, Double>>(replay = 0, extraBufferCapacity = 64)
     private val _tapEvents = MutableSharedFlow<TapEvent>(replay = 0, extraBufferCapacity = 64)
     private val _linkEvents = MutableSharedFlow<LinkEvent>(replay = 0, extraBufferCapacity = 64)
     private val _selectionEvents = MutableSharedFlow<SelectionEvent>(replay = 0, extraBufferCapacity = 64)
@@ -24,6 +25,7 @@ internal class FakeReaderPresenter : ReaderPresenter {
 
     override val positionEvents: SharedFlow<PositionUpdate> = _positionEvents
     override val pageLoadEvents: SharedFlow<PageLoadGeneration> = _pageLoadEvents
+    override val viewportFractionEvents: SharedFlow<Pair<String, Double>> = _viewportFractionEvents
     override val tapEvents: SharedFlow<TapEvent> = _tapEvents
     override val linkEvents: SharedFlow<LinkEvent> = _linkEvents
     override val selectionEvents: SharedFlow<SelectionEvent> = _selectionEvents
@@ -82,6 +84,10 @@ internal class FakeReaderPresenter : ReaderPresenter {
 
     suspend fun emitPageLoad(value: Int) {
         _pageLoadEvents.emit(PageLoadGeneration(value))
+    }
+
+    suspend fun emitViewportFraction(href: String, fraction: Double) {
+        _viewportFractionEvents.emit(href to fraction)
     }
 
     suspend fun emitTap(event: TapEvent = TapEvent.Body) {

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/renderer/FakeRendererBridge.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/renderer/FakeRendererBridge.kt
@@ -19,6 +19,7 @@ internal class FakeRendererBridge(
     private val snapToElementMoved: Boolean = false,
     private val scrollByPxResult: Boolean? = true,
     private val scrollBoundaryResult: Pair<Boolean, Boolean> = Pair(false, false),
+    private val viewportFractionResult: Double? = null,
 ) : RendererBridge {
 
     val calls: MutableList<String> = mutableListOf()
@@ -103,5 +104,10 @@ internal class FakeRendererBridge(
 
     override suspend fun evaluateBoundaryScroll(js: String) {
         calls += "evaluateBoundaryScroll(len=${js.length})"
+    }
+
+    override suspend fun readViewportFraction(): Double? {
+        calls += "readViewportFraction"
+        return viewportFractionResult
     }
 }

--- a/docs/superpowers/specs/2026-07-02-bookmark-viewport-eps-design.md
+++ b/docs/superpowers/specs/2026-07-02-bookmark-viewport-eps-design.md
@@ -1,0 +1,160 @@
+# Live viewport-fraction for bookmark eps
+
+**Issue:** #399
+**Status:** Design
+**Date:** 2026-07-02
+
+## Problem
+
+`BookmarksController.bookmarkEpsFor` currently derives the ±progression window used by
+`isCurrentPageBookmarked` from Readium's `positionsByReadingOrder()`:
+
+```kotlin
+if (positions > 0) return 0.5 / positions
+```
+
+Readium's positions are ~1024-char slices, not viewport-pages. In all three reader modes
+(paginated / vertical / continuous) the true geometric bound for a viewport-midpoint locator
+is `viewportSize / chapterSize / 2`. The current formula lights the indicator for the right
+page on typical chapters but drifts for short chapters, wide viewports, or non-average
+character density.
+
+## Goal
+
+Feed a live per-chapter `viewportFraction` (viewport size / chapter size) into
+`bookmarkEpsFor` so the ±eps window is geometrically correct. Fall back to `0.5 / positions`
+when the live measurement hasn't landed yet, and to the flat `BOOKMARK_PAGE_EPS` /
+`BOOKMARK_VIEWPORT_EPS` when neither is available.
+
+## Non-goals
+
+- Changing bookmark storage / progression semantics.
+- Changing anything in `isCurrentPageBookmarked`'s reactive shape beyond adding one flow.
+- Reworking Readium's own positions computation.
+
+## Constraints (from issue)
+
+The prior attempt at this plumbing flaked `HighlightRepaintOrientationHarnessTest`. On-scroll
+emission churn caused Compose recomposition pressure that prevented the chrome-reveal
+`LaunchedEffect` from idling inside `waitUntil`. The fix must:
+
+1. Emit **only** when viewport size or chapter size changes — never on scroll.
+2. Apply `distinctUntilChanged` at the emission boundary.
+3. Re-run `HighlightRepaintOrientationHarnessTest` before merge.
+
+## Design
+
+### The signal
+
+Add a single new signal owned by `EpubReaderViewModel`:
+
+```kotlin
+val viewportFractionByHref: StateFlow<Map<String, Double>>
+```
+
+- Key: normalized chapter href (same normalization as `spinePositionCounts`).
+- Value: `viewportSize / chapterSize` — the fraction of the chapter visible in one viewport.
+- Missing entry means "not measured yet" → `bookmarkEpsFor` falls through to `positions`.
+
+The VM's flow is a simple `MutableStateFlow<Map<String, Double>>` populated by each mode's
+producer. Producers write via a single VM-level `putViewportFraction(href, fraction)` that
+short-circuits when the incoming value equals the current stored value (built-in
+distinct-until-changed on the per-entry level, so the map identity only changes when a value
+actually changes).
+
+### Producers per mode
+
+**Continuous.** `ContinuousWindowController` already tracks `measuredHeights[i]` per window
+slot and `port.viewportHeightPx`. Emit at three specific hooks — none of them scroll:
+
+- After a chapter's height first measures (`measuredHeights[i]` transition from placeholder
+  to a real px value — lines ~528 / ~535 in `ContinuousWindowController.kt`).
+- After a remeasure (`measuredHeights[i]` changed to a different real value — line ~583).
+- On viewport-height change (attach to `onSizeChanged` in `ContinuousReaderView` — rotation).
+
+Value: `port.viewportHeightPx.toDouble() / measuredHeight`. When either side is 0 or the
+chapter has no href yet, skip.
+
+**Paginated.** A new `RendererCapability` (`ViewportFractionProbe`) whose install script runs
+on `onPageLoaded` and re-runs after every reflow (typography change, orientation change,
+readaloud reserve change). Measurement: `viewportWidth / totalScrollWidth`. Reports back
+through a `RendererBridge.readViewportFraction()` typed call, or via a `@JavascriptInterface`
+callback that pushes the value to the presenter, which forwards to the VM. Consistent with
+the bridge's existing typed shape, a suspend `readViewportFraction(): Double?` invoked from
+`ReaderPresenter.onPageLoaded` and again from the same site as `applyTypographyOverride` is
+cleanest.
+
+**Vertical.** Same `ViewportFractionProbe` capability. Measurement:
+`viewportHeight / scrollHeight`. Called from the same hooks as paginated.
+
+### Consumer
+
+`BookmarksController` gains a fourth bound flow:
+
+```kotlin
+fun bind(
+    serverId: String,
+    itemId: String,
+    currentLocator: StateFlow<Locator?>,
+    spinePositionCounts: StateFlow<Pair<List<String>, List<Int>>>,
+    viewportFractionByHref: StateFlow<Map<String, Double>>,
+)
+```
+
+`isCurrentPageBookmarked`'s combine grows to 4 arguments. New priority in `bookmarkEpsFor`:
+
+```kotlin
+internal fun bookmarkEpsFor(
+    orientation: ReaderOrientation,
+    spineCounts: Pair<List<String>, List<Int>>,
+    viewportFractionByHref: Map<String, Double>,
+    chapterHref: String,
+): Double {
+    viewportFractionByHref[chapterHref]?.let { vf ->
+        if (vf > 0.0) return vf / 2.0
+    }
+    val positions = /* existing lookup */
+    if (positions > 0) return 0.5 / positions
+    return if (orientation == ReaderOrientation.Continuous) BOOKMARK_VIEWPORT_EPS
+    else BOOKMARK_PAGE_EPS
+}
+```
+
+The public `bookmarkEpsFor(chapterHref)` (used by the toggle call site) reads the current
+`.value` of the new flow so toggle and indicator stay in sync.
+
+### Flake-avoidance discipline
+
+- **No scroll emissions.** `ContinuousWindowController.onScrollChanged` and paginated
+  column-position callbacks MUST NOT feed the fraction. Enforced by grep test + code review.
+- **Distinct-until-changed.** The VM's `putViewportFraction` no-ops when the incoming value
+  equals the stored one, so `viewportFractionByHref` emits a new map only on real change.
+- **Scope discipline.** `isCurrentPageBookmarked` stays on `OrchestratorScope`, still
+  `SharingStarted.Eagerly`. The added flow is one more argument to the same combine — no
+  extra viewModelScope subscriptions.
+- **Harness gate.** `HighlightRepaintOrientationHarnessTest` runs on the AVD before PR.
+
+## Testing
+
+New JVM tests in `BookmarksControllerTest` (or a companion pure-function test):
+
+1. `live viewport fraction takes precedence over positions` — set fraction to 0.20, positions
+   to 30. Expect eps == 0.10.
+2. `live viewport fraction falls back to positions when unset` — fraction map empty. Expect
+   eps == `0.5 / positions`.
+3. `both fall back to flat eps when nothing measured` — expect `BOOKMARK_PAGE_EPS` /
+   `BOOKMARK_VIEWPORT_EPS` per orientation.
+4. `live viewport fraction is chapter-scoped` — set fraction for chapter A; asking for B
+   falls back to positions.
+
+Existing regression tests remain green (they exercise the fallback path).
+
+Additionally: a `ContinuousWindowController` unit test asserting the fraction publishes on
+measurement transitions but NOT on scroll ticks (uses a recording emitter fake).
+
+Harness: `HighlightRepaintOrientationHarnessTest` on `Harness_Medium_Phone` after the wire
+lands.
+
+## Rollout
+
+Single PR. `Closes #399`. Regression tests + one new pinning test + harness re-run.


### PR DESCRIPTION
## Summary
- Wire a live per-chapter `viewportSize / chapterSize` signal from each renderer into `BookmarksController.bookmarkEpsFor`, so the page-bookmark ribbon uses the geometrically-correct ±eps window instead of Readium's rough ~1024-char slice proxy.
- In continuous mode, flip bookmark-panel navigation to `alignToTop=true` so the saved position lands at the viewport top (readers found the previous mid-page landing confusing).
- Widen the continuous eps to the full `viewportFraction` (was `/2`) so the ribbon stays lit on arrival — the `alignToTop=true` landing can shift the arrival midpoint by up to one full viewport-fraction from the saved midpoint when the saved anchor sat in the lower half of its viewport.

Closes #399

## Producers
- **Continuous** — `ContinuousWindowController` publishes `viewportHeightPx / measuredHeight` from the two `onHeightMeasured` hooks (first-measure and remeasure). Scroll callbacks are explicitly excluded.
- **Paginated / vertical** — `ReadiumPresenter` re-reads via a new `RendererBridge.readViewportFraction()` typed call on `feedPageLoaded` and after typography changes. The JS picks the overflow axis (`innerWidth/scrollWidth` for paginated, `innerHeight/scrollHeight` for vertical).

## Flake-avoidance
The prior attempt at this plumbing flaked `HighlightRepaintOrientationHarnessTest` because on-scroll emission churn drove Compose recomposition pressure. The fix:
- Emissions only from measurement/reflow hooks; never from scroll.
- Per-entry distinct-until-changed guard in `EpubReaderViewModel.putViewportFraction` — a repeat value never allocates a new map, so the bookmark combine sees no churn.

## Test plan
- [x] `./gradlew test` — all modules green (BookmarksControllerTest gains 4 new tests pinning fraction-precedence, chapter-scoping, zero-fraction fallthrough, and the `alignToTop=true` arrival boundary; ContinuousPresenterTest gains a new test pinning `feedViewportFraction` forwarding; existing `AnnotationNavigationOptionsTest` flipped to pin the new bookmark/highlight split).
- [ ] Manually verify on the AVD: tap a bookmark from the annotation panel in continuous mode → lands with the anchor near the viewport top AND the ribbon is lit on arrival.
- [ ] Manually verify highlights unchanged in continuous mode: tap a highlight → lands centred (unchanged from before).
- [ ] Manually verify paginated + vertical unchanged: bookmark and highlight nav land as before.
- [ ] Re-run `OrientationFlipAnnotationHarnessTest` on `Harness_Medium_Phone` to confirm no new harness flake from the added combine flow.