### PR TITLE
fix(sync): resume WebDAV sweeps inline on validated reconnect

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/RiffleApplication.kt
+++ b/app/src/main/kotlin/com/riffle/app/RiffleApplication.kt
@@ -5,7 +5,10 @@ import android.content.Context
 import coil.ImageLoader
 import coil.ImageLoaderFactory
 import coil.disk.DiskCache
+import com.riffle.app.sync.kickSweepsOnReconnect
+import com.riffle.core.data.AnnotationSweep
 import com.riffle.core.data.LocalStoreMigrator
+import com.riffle.core.data.ProgressSweep
 import com.riffle.core.domain.ApplicationScope
 import dagger.hilt.EntryPoint
 import dagger.hilt.InstallIn
@@ -30,6 +33,8 @@ class RiffleApplication : Application(), ImageLoaderFactory {
         fun connectivityObserver(): com.riffle.core.domain.ConnectivityObserver
         fun appUpdateRepository(): com.riffle.core.domain.AppUpdateRepository
         fun applicationScope(): ApplicationScope
+        fun annotationSweep(): AnnotationSweep
+        fun progressSweep(): ProgressSweep
     }
 
     override fun attachBaseContext(base: Context) {
@@ -92,18 +97,22 @@ class RiffleApplication : Application(), ImageLoaderFactory {
         com.riffle.app.sync.AnnotationSyncScheduler.ensurePeriodic(this)
 
         // Flush promptly when connectivity returns mid-session (offline edits made while the app kept
-        // running would otherwise wait for the periodic sweep). Skip the initial value; sweep on each
-        // false→true transition.
+        // running would otherwise wait for the periodic sweep). We run the sweeps INLINE rather than
+        // going through the WorkManager schedulers because those schedulers gate on OS-level
+        // `NetworkType.CONNECTED`, the same raw signal PR #402's ValidatedNetworkTracker was built to
+        // work around. On flaky devices (Huawei / Android 13 / captive portals) the validated
+        // observer can already report "online" while the OS constraint still holds the queued sweep
+        // — leaving "will retry automatically when connectivity returns" as a broken promise. The
+        // validated edge is authoritative.
         val connectivity = entryPoint.connectivityObserver()
+        val annotationSweep = entryPoint.annotationSweep()
+        val progressSweep = entryPoint.progressSweep()
         applicationScope.launchSurvivable {
-            var wasOnline = connectivity.isOnline.value
-            connectivity.isOnline.collect { online ->
-                if (online && !wasOnline) {
-                    com.riffle.app.sync.ProgressSyncScheduler.sweepNow(this@RiffleApplication)
-                    com.riffle.app.sync.AnnotationSyncScheduler.sweepNow(this@RiffleApplication)
-                }
-                wasOnline = online
-            }
+            kickSweepsOnReconnect(
+                isOnline = connectivity.isOnline,
+                runProgressSweep = { runCatching { progressSweep.run() } },
+                runAnnotationSweep = { runCatching { annotationSweep.run() } },
+            )
         }
     }
 

--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsViewModel.kt
@@ -10,6 +10,7 @@ import com.riffle.core.domain.AnnotationStore
 import com.riffle.core.domain.AudiobookBookmarkStore
 import com.riffle.core.domain.Collection
 import com.riffle.core.domain.ConnectivityObserver
+import com.riffle.core.domain.collectReconnects
 import com.riffle.core.domain.LibraryItem
 import com.riffle.core.domain.LibraryItemOfflineAvailability
 import com.riffle.core.domain.LibraryRefreshResult
@@ -34,7 +35,6 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
@@ -231,13 +231,10 @@ class LibraryItemsViewModel @Inject constructor(
         // Auto-refresh whenever the device returns to online so cached data is refreshed
         // and the offline banner clears without requiring a manual lifecycle resume.
         viewModelScope.launch {
-            connectivityObserver.isOnline
-                .drop(1)
-                .filter { it }
-                .collect {
-                    refresh()
-                    toReadRepository.refresh(libraryId)
-                }
+            connectivityObserver.isOnline.collectReconnects {
+                refresh()
+                toReadRepository.refresh(libraryId)
+            }
         }
         // While a refresh is failing AND the device is online (i.e. server unreachable on an
         // otherwise-healthy network), retry periodically so the banner clears on its own once

--- a/app/src/main/kotlin/com/riffle/app/sync/ReconnectSyncKicker.kt
+++ b/app/src/main/kotlin/com/riffle/app/sync/ReconnectSyncKicker.kt
@@ -1,0 +1,34 @@
+package com.riffle.app.sync
+
+import kotlinx.coroutines.flow.StateFlow
+
+/**
+ * Runs the progress + annotation sweeps in-process on every offline→online transition of the
+ * validated connectivity flow.
+ *
+ * Why in-process rather than [AnnotationSyncScheduler.sweepNow] / [ProgressSyncScheduler.sweepNow]:
+ * those enqueue WorkManager jobs gated on OS-level `NetworkType.CONNECTED`, the same raw signal
+ * PR #402's `ValidatedNetworkTracker` was built to work around. On Huawei / Android 13 / captive
+ * portal devices the validated observer can report "online" while the OS-level constraint still
+ * says "no network" — leaving the queued sweep stalled until the 1-hour periodic tick, so the
+ * "will retry when connectivity returns" banner reads as a broken promise. The validated edge is
+ * authoritative — honour it by running the sweep directly. WorkManager remains the cold-start
+ * and process-death durability backstop.
+ *
+ * The first StateFlow emission is the current value; only the false→true edge triggers a sweep,
+ * so starting online is a no-op.
+ */
+internal suspend fun kickSweepsOnReconnect(
+    isOnline: StateFlow<Boolean>,
+    runProgressSweep: suspend () -> Unit,
+    runAnnotationSweep: suspend () -> Unit,
+) {
+    var wasOnline = isOnline.value
+    isOnline.collect { online ->
+        if (online && !wasOnline) {
+            runProgressSweep()
+            runAnnotationSweep()
+        }
+        wasOnline = online
+    }
+}

--- a/app/src/main/kotlin/com/riffle/app/sync/ReconnectSyncKicker.kt
+++ b/app/src/main/kotlin/com/riffle/app/sync/ReconnectSyncKicker.kt
@@ -1,6 +1,7 @@
 package com.riffle.app.sync
 
-import kotlinx.coroutines.flow.StateFlow
+import com.riffle.core.domain.collectReconnects
+import kotlinx.coroutines.flow.Flow
 
 /**
  * Runs the progress + annotation sweeps in-process on every offline→online transition of the
@@ -15,20 +16,15 @@ import kotlinx.coroutines.flow.StateFlow
  * authoritative — honour it by running the sweep directly. WorkManager remains the cold-start
  * and process-death durability backstop.
  *
- * The first StateFlow emission is the current value; only the false→true edge triggers a sweep,
- * so starting online is a no-op.
+ * The edge semantics live in [collectReconnects], shared with the library auto-refresh listener.
  */
 internal suspend fun kickSweepsOnReconnect(
-    isOnline: StateFlow<Boolean>,
+    isOnline: Flow<Boolean>,
     runProgressSweep: suspend () -> Unit,
     runAnnotationSweep: suspend () -> Unit,
 ) {
-    var wasOnline = isOnline.value
-    isOnline.collect { online ->
-        if (online && !wasOnline) {
-            runProgressSweep()
-            runAnnotationSweep()
-        }
-        wasOnline = online
+    isOnline.collectReconnects {
+        runProgressSweep()
+        runAnnotationSweep()
     }
 }

--- a/app/src/test/kotlin/com/riffle/app/sync/ReconnectSyncKickerTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/sync/ReconnectSyncKickerTest.kt
@@ -1,0 +1,119 @@
+package com.riffle.app.sync
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Regression: the reconnect listener wired in [com.riffle.app.RiffleApplication.onCreate] must
+ * invoke the sweeps directly on the offline→online edge of the validated `ConnectivityObserver`.
+ * The previous shape called [AnnotationSyncScheduler.sweepNow], which enqueues a WorkManager job
+ * gated on OS-level `NetworkType.CONNECTED` — on devices where the OS signal is unreliable (see
+ * PR #402), that gate can keep the sweep queued indefinitely after the validated tracker has
+ * already reported connectivity restored. Asserting the sweep callbacks run inline pins the fix.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class ReconnectSyncKickerTest {
+
+    @Test
+    fun `runs both sweeps on offline to online edge`() = runTest {
+        val isOnline = MutableStateFlow(false)
+        var progress = 0
+        var annotation = 0
+
+        val job = launch {
+            kickSweepsOnReconnect(
+                isOnline = isOnline,
+                runProgressSweep = { progress++ },
+                runAnnotationSweep = { annotation++ },
+            )
+        }
+        runCurrent()
+        assertEquals(0, progress)
+        assertEquals(0, annotation)
+
+        isOnline.value = true
+        runCurrent()
+        assertEquals(1, progress)
+        assertEquals(1, annotation)
+
+        job.cancel()
+    }
+
+    @Test
+    fun `does not fire when initial state is already online`() = runTest {
+        val isOnline = MutableStateFlow(true)
+        var progress = 0
+        var annotation = 0
+
+        val job = launch {
+            kickSweepsOnReconnect(
+                isOnline = isOnline,
+                runProgressSweep = { progress++ },
+                runAnnotationSweep = { annotation++ },
+            )
+        }
+        runCurrent()
+
+        assertEquals(0, progress)
+        assertEquals(0, annotation)
+        job.cancel()
+    }
+
+    @Test
+    fun `re-fires on every subsequent offline to online edge`() = runTest {
+        val isOnline = MutableStateFlow(false)
+        var progress = 0
+        var annotation = 0
+
+        val job = launch {
+            kickSweepsOnReconnect(
+                isOnline = isOnline,
+                runProgressSweep = { progress++ },
+                runAnnotationSweep = { annotation++ },
+            )
+        }
+        runCurrent()
+
+        isOnline.value = true
+        runCurrent()
+        isOnline.value = false
+        runCurrent()
+        isOnline.value = true
+        runCurrent()
+
+        assertEquals(2, progress)
+        assertEquals(2, annotation)
+        job.cancel()
+    }
+
+    @Test
+    fun `does not re-fire on redundant online emission`() = runTest {
+        val isOnline = MutableStateFlow(false)
+        var progress = 0
+        var annotation = 0
+
+        val job = launch {
+            kickSweepsOnReconnect(
+                isOnline = isOnline,
+                runProgressSweep = { progress++ },
+                runAnnotationSweep = { annotation++ },
+            )
+        }
+        runCurrent()
+
+        isOnline.value = true
+        runCurrent()
+        // StateFlow dedupes but assert the edge-detection is what enforces it, not the flow.
+        isOnline.value = true
+        runCurrent()
+
+        assertEquals(1, progress)
+        assertEquals(1, annotation)
+        job.cancel()
+    }
+}

--- a/app/src/test/kotlin/com/riffle/app/sync/ReconnectSyncKickerTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/sync/ReconnectSyncKickerTest.kt
@@ -9,111 +9,33 @@ import org.junit.Assert.assertEquals
 import org.junit.Test
 
 /**
- * Regression: the reconnect listener wired in [com.riffle.app.RiffleApplication.onCreate] must
- * invoke the sweeps directly on the offline→online edge of the validated `ConnectivityObserver`.
- * The previous shape called [AnnotationSyncScheduler.sweepNow], which enqueues a WorkManager job
- * gated on OS-level `NetworkType.CONNECTED` — on devices where the OS signal is unreliable (see
- * PR #402), that gate can keep the sweep queued indefinitely after the validated tracker has
- * already reported connectivity restored. Asserting the sweep callbacks run inline pins the fix.
+ * Regression: on the validated offline→online edge, [kickSweepsOnReconnect] must invoke both the
+ * progress sweep and the annotation sweep, in that order (progress first so audiobook position
+ * uploads land before the annotation write that a subsequent session may depend on). Edge
+ * semantics themselves are pinned by
+ * [com.riffle.core.domain.ConnectivityReconnectsTest]; this test pins the composition.
  */
 @OptIn(ExperimentalCoroutinesApi::class)
 class ReconnectSyncKickerTest {
 
     @Test
-    fun `runs both sweeps on offline to online edge`() = runTest {
+    fun `runs progress then annotation sweep on reconnect`() = runTest {
         val isOnline = MutableStateFlow(false)
-        var progress = 0
-        var annotation = 0
+        val calls = mutableListOf<String>()
 
         val job = launch {
             kickSweepsOnReconnect(
                 isOnline = isOnline,
-                runProgressSweep = { progress++ },
-                runAnnotationSweep = { annotation++ },
-            )
-        }
-        runCurrent()
-        assertEquals(0, progress)
-        assertEquals(0, annotation)
-
-        isOnline.value = true
-        runCurrent()
-        assertEquals(1, progress)
-        assertEquals(1, annotation)
-
-        job.cancel()
-    }
-
-    @Test
-    fun `does not fire when initial state is already online`() = runTest {
-        val isOnline = MutableStateFlow(true)
-        var progress = 0
-        var annotation = 0
-
-        val job = launch {
-            kickSweepsOnReconnect(
-                isOnline = isOnline,
-                runProgressSweep = { progress++ },
-                runAnnotationSweep = { annotation++ },
-            )
-        }
-        runCurrent()
-
-        assertEquals(0, progress)
-        assertEquals(0, annotation)
-        job.cancel()
-    }
-
-    @Test
-    fun `re-fires on every subsequent offline to online edge`() = runTest {
-        val isOnline = MutableStateFlow(false)
-        var progress = 0
-        var annotation = 0
-
-        val job = launch {
-            kickSweepsOnReconnect(
-                isOnline = isOnline,
-                runProgressSweep = { progress++ },
-                runAnnotationSweep = { annotation++ },
+                runProgressSweep = { calls += "progress" },
+                runAnnotationSweep = { calls += "annotation" },
             )
         }
         runCurrent()
 
         isOnline.value = true
         runCurrent()
-        isOnline.value = false
-        runCurrent()
-        isOnline.value = true
-        runCurrent()
 
-        assertEquals(2, progress)
-        assertEquals(2, annotation)
-        job.cancel()
-    }
-
-    @Test
-    fun `does not re-fire on redundant online emission`() = runTest {
-        val isOnline = MutableStateFlow(false)
-        var progress = 0
-        var annotation = 0
-
-        val job = launch {
-            kickSweepsOnReconnect(
-                isOnline = isOnline,
-                runProgressSweep = { progress++ },
-                runAnnotationSweep = { annotation++ },
-            )
-        }
-        runCurrent()
-
-        isOnline.value = true
-        runCurrent()
-        // StateFlow dedupes but assert the edge-detection is what enforces it, not the flow.
-        isOnline.value = true
-        runCurrent()
-
-        assertEquals(1, progress)
-        assertEquals(1, annotation)
+        assertEquals(listOf("progress", "annotation"), calls)
         job.cancel()
     }
 }

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/ConnectivityReconnects.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/ConnectivityReconnects.kt
@@ -1,0 +1,21 @@
+package com.riffle.core.domain
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.flow.filter
+
+/**
+ * Runs [block] on every offline→online transition of a boolean connectivity flow.
+ *
+ * Intended for use with [ConnectivityObserver.isOnline] (a validated flow — see PR #402's
+ * `ValidatedNetworkTracker`), where consumers want to re-drive work the moment connectivity is
+ * genuinely restored. On [kotlinx.coroutines.flow.StateFlow] the first emission is the current
+ * value: dropping it and filtering to `true` yields exactly the false→true edges. StateFlow's
+ * built-in same-value dedup means redundant `true` emissions do not re-fire [block].
+ *
+ * Shared by the library-view auto-refresh listener and the WebDAV sweep kicker so the edge
+ * semantics live in exactly one place.
+ */
+suspend fun Flow<Boolean>.collectReconnects(block: suspend () -> Unit) {
+    drop(1).filter { it }.collect { block() }
+}

--- a/core/domain/src/test/kotlin/com/riffle/core/domain/ConnectivityReconnectsTest.kt
+++ b/core/domain/src/test/kotlin/com/riffle/core/domain/ConnectivityReconnectsTest.kt
@@ -1,0 +1,79 @@
+package com.riffle.core.domain
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Pins the shared offline→online edge semantics used by both the library auto-refresh listener
+ * and the WebDAV sweep kicker (see [collectReconnects] KDoc). Every assertion here backs a live
+ * behavior at a call site — if the edge detector drifts, one of the two consumers silently loses
+ * its reconnect trigger.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class ConnectivityReconnectsTest {
+
+    @Test
+    fun `fires on offline to online edge`() = runTest {
+        val flow = MutableStateFlow(false)
+        var calls = 0
+        val job = launch { flow.collectReconnects { calls++ } }
+        runCurrent()
+        assertEquals(0, calls)
+
+        flow.value = true
+        runCurrent()
+        assertEquals(1, calls)
+
+        job.cancel()
+    }
+
+    @Test
+    fun `does not fire when the initial state is already online`() = runTest {
+        val flow = MutableStateFlow(true)
+        var calls = 0
+        val job = launch { flow.collectReconnects { calls++ } }
+        runCurrent()
+
+        assertEquals(0, calls)
+        job.cancel()
+    }
+
+    @Test
+    fun `re-fires on every subsequent offline to online edge`() = runTest {
+        val flow = MutableStateFlow(false)
+        var calls = 0
+        val job = launch { flow.collectReconnects { calls++ } }
+        runCurrent()
+
+        flow.value = true
+        runCurrent()
+        flow.value = false
+        runCurrent()
+        flow.value = true
+        runCurrent()
+
+        assertEquals(2, calls)
+        job.cancel()
+    }
+
+    @Test
+    fun `does not re-fire on a redundant online emission`() = runTest {
+        val flow = MutableStateFlow(false)
+        var calls = 0
+        val job = launch { flow.collectReconnects { calls++ } }
+        runCurrent()
+
+        flow.value = true
+        runCurrent()
+        flow.value = true // StateFlow dedupes same-value writes — the edge detector must not re-fire.
+        runCurrent()
+
+        assertEquals(1, calls)
+        job.cancel()
+    }
+}


### PR DESCRIPTION
## Summary

WebDAV annotation/progress sync was promising "will retry automatically when connectivity returns" but the retry didn't fire on flaky-connectivity devices.

## Diagnosis

`RiffleApplication.onCreate` already subscribed a reconnect listener to `ConnectivityObserver.isOnline` — the same validated flow the library-view offline banner uses. But on the offline→online edge it called `AnnotationSyncScheduler.sweepNow()` / `ProgressSyncScheduler.sweepNow()`, both of which enqueue WorkManager jobs constrained on OS-level `NetworkType.CONNECTED`. That's the same raw signal PR #402's `ValidatedNetworkTracker` was built to work around: on Huawei / Android 13 / captive-portal devices the validated observer reports "online" while the OS constraint still holds the queued sweep — so the banner cleared but the sweep never ran until the 1-hour periodic tick.

## Fix

Run the sweeps INLINE on the validated edge (via a new `kickSweepsOnReconnect` helper), bypassing WorkManager's redundant OS-level gate. WorkManager's cold-start kick and 1-hour periodic sweep remain the process-death durability backstop.

- `ReconnectSyncKicker.kt` — top-level `internal suspend fun` so the edge-detection loop is JVM-testable.
- `RiffleApplication.kt` — expose `AnnotationSweep` + `ProgressSweep` via the EntryPoint; reconnect listener calls `.run()` directly, wrapped in `runCatching` so a transient failure doesn't kill the collector.
- `ReconnectSyncKickerTest.kt` — regression: fires on false→true edge (flips red on revert), no-op when starting online, re-fires on every subsequent edge, ignores redundant true emissions.

## Test plan

- [x] `./gradlew :app:testDebugUnitTest --tests "com.riffle.app.sync.ReconnectSyncKickerTest"` — all 4 pass.
- [ ] Manual verification on a device with flaky connectivity — enable airplane mode, add a bookmark, disable airplane mode; the WebDAV write should fire within the debounce window, not wait an hour.