### PR TITLE
fix(settings): count books, not rows, in "N book(s) pending" copy

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsViewModel.kt
@@ -82,7 +82,7 @@ class SettingsViewModel @Inject constructor(
     val annotationSyncRow: StateFlow<AnnotationSyncRowState> = combine(
         annotationSyncConfigStore.observe(),
         annotationSyncStatusStore.lastCycleOutcome,
-        annotationDao.observePendingCountAcrossAll(),
+        annotationDao.observePendingBookCountAcrossAll(),
     ) { config, outcome, pendingCount ->
         deriveRow(config, outcome, pendingCount)
     }.stateIn(

--- a/app/src/test/kotlin/com/riffle/app/feature/settings/SettingsViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/settings/SettingsViewModelTest.kt
@@ -213,7 +213,7 @@ class SettingsViewModelTest {
     private fun makeViewModel(
         reports: List<CrashReport> = emptyList(),
         annotationSyncStatusStore: AnnotationSyncStatusStore = AnnotationSyncStatusStore(),
-        annotationDao: AnnotationDao = stubAnnotationDao(pendingCount = 0),
+        annotationDao: AnnotationDao = stubAnnotationDao(pendingBookCount = 0),
     ) = SettingsViewModel(
         crashReportRepository = object : CrashReportRepository {
             private val current = reports.toMutableList()
@@ -243,7 +243,7 @@ class SettingsViewModelTest {
         annotationDao = annotationDao,
     )
 
-    private fun stubAnnotationDao(pendingCount: Int): AnnotationDao = object : AnnotationDao {
+    private fun stubAnnotationDao(pendingBookCount: Int): AnnotationDao = object : AnnotationDao {
         override fun observeForItem(serverId: String, itemId: String) = flowOf(emptyList<AnnotationEntity>())
         override fun observeForServer(serverId: String) = flowOf(emptyList<AnnotationEntity>())
         override suspend fun getForItem(serverId: String, itemId: String) = emptyList<AnnotationEntity>()
@@ -258,7 +258,7 @@ class SettingsViewModelTest {
         override fun observeAnnotationsByPosition(serverId: String, itemId: String) = flowOf(emptyList<AnnotationEntity>())
         override suspend fun renameBookmark(id: String, title: String, updatedAt: Long, deviceId: String) {}
         override fun observePendingCountForBook(serverId: String, itemId: String) = flowOf(0)
-        override fun observePendingCountAcrossAll() = flowOf(pendingCount)
+        override fun observePendingBookCountAcrossAll() = flowOf(pendingBookCount)
         override suspend fun dirtyServerItems() = emptyList<AnnotationDao.DirtyServerItem>()
         override suspend fun markSynced(ids: List<String>, syncedAt: Long) {}
         override suspend fun purgeAgedTombstones(serverId: String, itemId: String, cutoff: Long): Int = 0
@@ -671,7 +671,7 @@ class SettingsViewModelTest {
     fun `annotationSyncRow is Local when unconfigured`() = runTest {
         val config = MutableStateFlow<AnnotationSyncConfig?>(null)
         val status = AnnotationSyncStatusStore()
-        val dao = stubAnnotationDao(pendingCount = 0)
+        val dao = stubAnnotationDao(pendingBookCount = 0)
         val vm = newSettingsViewModel(configStore = stubConfigStore(config), statusStore = status, annotationDao = dao)
         backgroundScope.launch { vm.annotationSyncRow.collect {} }
         testDispatcher.scheduler.advanceUntilIdle()
@@ -689,7 +689,7 @@ class SettingsViewModelTest {
         val status = AnnotationSyncStatusStore() // NeverRun by default
         val vm = newSettingsViewModel(
             configStore = stubConfigStore(config), statusStore = status,
-            annotationDao = stubAnnotationDao(pendingCount = 0),
+            annotationDao = stubAnnotationDao(pendingBookCount = 0),
         )
         backgroundScope.launch { vm.annotationSyncRow.collect {} }
         testDispatcher.scheduler.advanceUntilIdle()
@@ -706,7 +706,7 @@ class SettingsViewModelTest {
         val status = AnnotationSyncStatusStore().apply { report(CycleOutcome.Success(1_000L)) }
         val vm = newSettingsViewModel(
             configStore = stubConfigStore(config), statusStore = status,
-            annotationDao = stubAnnotationDao(pendingCount = 0),
+            annotationDao = stubAnnotationDao(pendingBookCount = 0),
         )
         backgroundScope.launch { vm.annotationSyncRow.collect {} }
         testDispatcher.scheduler.advanceUntilIdle()
@@ -723,7 +723,7 @@ class SettingsViewModelTest {
         val status = AnnotationSyncStatusStore().apply { report(CycleOutcome.Failed.Network(1_000L, "offline")) }
         val vm = newSettingsViewModel(
             configStore = stubConfigStore(config), statusStore = status,
-            annotationDao = stubAnnotationDao(pendingCount = 2),
+            annotationDao = stubAnnotationDao(pendingBookCount = 2),
         )
         backgroundScope.launch { vm.annotationSyncRow.collect {} }
         testDispatcher.scheduler.advanceUntilIdle()
@@ -740,7 +740,7 @@ class SettingsViewModelTest {
         val status = AnnotationSyncStatusStore().apply { report(CycleOutcome.Failed.Auth(1_000L, 401)) }
         val vm = newSettingsViewModel(
             configStore = stubConfigStore(config), statusStore = status,
-            annotationDao = stubAnnotationDao(pendingCount = 0),
+            annotationDao = stubAnnotationDao(pendingBookCount = 0),
         )
         backgroundScope.launch { vm.annotationSyncRow.collect {} }
         testDispatcher.scheduler.advanceUntilIdle()
@@ -757,7 +757,7 @@ class SettingsViewModelTest {
         val status = AnnotationSyncStatusStore().apply { report(CycleOutcome.Failed.Tls(1_000L, "cert untrusted")) }
         val vm = newSettingsViewModel(
             configStore = stubConfigStore(config), statusStore = status,
-            annotationDao = stubAnnotationDao(pendingCount = 0),
+            annotationDao = stubAnnotationDao(pendingBookCount = 0),
         )
         backgroundScope.launch { vm.annotationSyncRow.collect {} }
         testDispatcher.scheduler.advanceUntilIdle()
@@ -767,13 +767,33 @@ class SettingsViewModelTest {
         assertTrue(row.sub.contains("TLS error"))
     }
 
+    // Regression: the WebDAV row copy is "$N book(s) pending" and N must reflect *books*, not
+    // dirty annotation rows. Wired through AnnotationDao.observePendingBookCountAcrossAll, which
+    // counts distinct (serverId, itemId). This test pins the wording; AnnotationDaoTest pins the
+    // SQL. Together they prevent the "8 highlights on 1 book showing as '8 books pending'" bug.
+    @Test
+    fun `annotationSyncRow reads book count into 'N book(s) pending' copy`() = runTest {
+        val config = MutableStateFlow<AnnotationSyncConfig?>(AnnotationSyncConfig("https://srv.example/dav/", "alice", "pw"))
+        val status = AnnotationSyncStatusStore().apply { report(CycleOutcome.Success(1_000L)) }
+        val vm = newSettingsViewModel(
+            configStore = stubConfigStore(config), statusStore = status,
+            annotationDao = stubAnnotationDao(pendingBookCount = 3),
+        )
+        backgroundScope.launch { vm.annotationSyncRow.collect {} }
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        val row = vm.annotationSyncRow.value
+        assertEquals(AnnotationSyncRowState.Badge.Pending, row.badge)
+        assertTrue("sub should read '3 book(s) pending' — got: ${row.sub}", row.sub.contains("3 book(s) pending"))
+    }
+
     @Test
     fun `annotationSyncRow is Pending when Network failure with no pending books`() = runTest {
         val config = MutableStateFlow<AnnotationSyncConfig?>(AnnotationSyncConfig("https://srv.example/dav/", "alice", "pw"))
         val status = AnnotationSyncStatusStore().apply { report(CycleOutcome.Failed.Network(1_000L, "timeout")) }
         val vm = newSettingsViewModel(
             configStore = stubConfigStore(config), statusStore = status,
-            annotationDao = stubAnnotationDao(pendingCount = 0),
+            annotationDao = stubAnnotationDao(pendingBookCount = 0),
         )
         backgroundScope.launch { vm.annotationSyncRow.collect {} }
         testDispatcher.scheduler.advanceUntilIdle()

--- a/core/data/src/test/kotlin/com/riffle/core/data/AnnotationStoreImplTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/AnnotationStoreImplTest.kt
@@ -77,7 +77,7 @@ class AnnotationStoreImplTest {
         override fun observePendingCountForBook(serverId: String, itemId: String): Flow<Int> =
             rows.map { all -> all.count { it.serverId == serverId && it.itemId == itemId && it.updatedAt > it.lastSyncedAt } }
 
-        override fun observePendingCountAcrossAll(): Flow<Int> =
+        override fun observePendingBookCountAcrossAll(): Flow<Int> =
             rows.map { all -> all.count { it.updatedAt > it.lastSyncedAt } }
 
         override suspend fun dirtyServerItems(): List<AnnotationDao.DirtyServerItem> =

--- a/core/data/src/test/kotlin/com/riffle/core/data/AnnotationStoreImplTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/AnnotationStoreImplTest.kt
@@ -78,7 +78,7 @@ class AnnotationStoreImplTest {
             rows.map { all -> all.count { it.serverId == serverId && it.itemId == itemId && it.updatedAt > it.lastSyncedAt } }
 
         override fun observePendingBookCountAcrossAll(): Flow<Int> =
-            rows.map { all -> all.count { it.updatedAt > it.lastSyncedAt } }
+            rows.map { all -> all.filter { it.updatedAt > it.lastSyncedAt }.distinctBy { it.serverId to it.itemId }.size }
 
         override suspend fun dirtyServerItems(): List<AnnotationDao.DirtyServerItem> =
             rows.value.filter { it.updatedAt > it.lastSyncedAt }

--- a/core/data/src/test/kotlin/com/riffle/core/data/AnnotationStoreTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/AnnotationStoreTest.kt
@@ -74,7 +74,7 @@ class AnnotationStoreTest {
             rows.map { all -> all.count { it.serverId == serverId && it.itemId == itemId && it.updatedAt > it.lastSyncedAt } }
 
         override fun observePendingBookCountAcrossAll(): Flow<Int> =
-            rows.map { all -> all.count { it.updatedAt > it.lastSyncedAt } }
+            rows.map { all -> all.filter { it.updatedAt > it.lastSyncedAt }.distinctBy { it.serverId to it.itemId }.size }
 
         override suspend fun dirtyServerItems(): List<AnnotationDao.DirtyServerItem> =
             rows.value.filter { it.updatedAt > it.lastSyncedAt }

--- a/core/data/src/test/kotlin/com/riffle/core/data/AnnotationStoreTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/AnnotationStoreTest.kt
@@ -73,7 +73,7 @@ class AnnotationStoreTest {
         override fun observePendingCountForBook(serverId: String, itemId: String): Flow<Int> =
             rows.map { all -> all.count { it.serverId == serverId && it.itemId == itemId && it.updatedAt > it.lastSyncedAt } }
 
-        override fun observePendingCountAcrossAll(): Flow<Int> =
+        override fun observePendingBookCountAcrossAll(): Flow<Int> =
             rows.map { all -> all.count { it.updatedAt > it.lastSyncedAt } }
 
         override suspend fun dirtyServerItems(): List<AnnotationDao.DirtyServerItem> =

--- a/core/data/src/test/kotlin/com/riffle/core/data/AnnotationSweepTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/AnnotationSweepTest.kt
@@ -337,7 +337,7 @@ abstract class StubAnnotationDao : AnnotationDao {
         kotlinx.coroutines.flow.flowOf(emptyList<AnnotationEntity>())
     override suspend fun renameBookmark(id: String, title: String, updatedAt: Long, deviceId: String) {}
     override fun observePendingCountForBook(serverId: String, itemId: String) = kotlinx.coroutines.flow.flowOf(0)
-    override fun observePendingCountAcrossAll() = kotlinx.coroutines.flow.flowOf(0)
+    override fun observePendingBookCountAcrossAll() = kotlinx.coroutines.flow.flowOf(0)
     override suspend fun dirtyServerItems() = emptyList<AnnotationDao.DirtyServerItem>()
     override suspend fun markSynced(ids: List<String>, syncedAt: Long) {}
     override suspend fun purgeAgedTombstones(serverId: String, itemId: String, cutoff: Long): Int = 0

--- a/core/data/src/test/kotlin/com/riffle/core/data/AnnotationSyncControllerLifecycleTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/AnnotationSyncControllerLifecycleTest.kt
@@ -991,7 +991,7 @@ private class LifecycleInMemoryAnnotationDao : AnnotationDao {
     override fun observeAnnotationsByPosition(serverId: String, itemId: String): Flow<List<AnnotationEntity>> = flowOf(emptyList())
     override suspend fun renameBookmark(id: String, title: String, updatedAt: Long, deviceId: String) = Unit
     override fun observePendingCountForBook(serverId: String, itemId: String): Flow<Int> = flowOf(0)
-    override fun observePendingCountAcrossAll(): Flow<Int> = flowOf(0)
+    override fun observePendingBookCountAcrossAll(): Flow<Int> = flowOf(0)
     override suspend fun dirtyServerItems(): List<AnnotationDao.DirtyServerItem> = emptyList()
     override suspend fun markSynced(ids: List<String>, syncedAt: Long) {
         markSyncedCalls++

--- a/core/data/src/test/kotlin/com/riffle/core/data/AnnotationSyncControllerReactiveTargetTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/AnnotationSyncControllerReactiveTargetTest.kt
@@ -87,7 +87,7 @@ private class NoOpAnnotationDao : AnnotationDao {
     override fun observeAnnotationsByPosition(serverId: String, itemId: String): Flow<List<AnnotationEntity>> = flowOf(emptyList())
     override suspend fun renameBookmark(id: String, title: String, updatedAt: Long, deviceId: String) = Unit
     override fun observePendingCountForBook(serverId: String, itemId: String): Flow<Int> = flowOf(0)
-    override fun observePendingCountAcrossAll(): Flow<Int> = flowOf(0)
+    override fun observePendingBookCountAcrossAll(): Flow<Int> = flowOf(0)
     override suspend fun dirtyServerItems(): List<AnnotationDao.DirtyServerItem> = emptyList()
     override suspend fun markSynced(ids: List<String>, syncedAt: Long) = Unit
     override suspend fun purgeAgedTombstones(serverId: String, itemId: String, cutoff: Long): Int = 0

--- a/core/database/src/androidTest/kotlin/com/riffle/core/database/AnnotationDaoTest.kt
+++ b/core/database/src/androidTest/kotlin/com/riffle/core/database/AnnotationDaoTest.kt
@@ -234,4 +234,43 @@ class AnnotationDaoTest {
         assertTrue("other-server tomb must survive",
             "tomb-other-server" in dao.getAllForItemIncludingDeleted("abs2", "item1").map { it.id })
     }
+
+    // Regression: the Settings WebDAV row displays "$N book(s) pending" and must count books, not
+    // annotation rows. Five dirty highlights on one book must read as 1, not 5. See
+    // observePendingBookCountAcrossAll.
+    @Test
+    fun observePendingBookCountAcrossAll_countsDistinctBooks() = runTest {
+        // Book A: three dirty rows (updatedAt > lastSyncedAt via the default lastSyncedAt = 0L).
+        dao.upsert(highlight("a1", serverId = "abs1", itemId = "item1", createdAt = 1_000L))
+        dao.upsert(highlight("a2", serverId = "abs1", itemId = "item1", createdAt = 1_100L))
+        dao.upsert(highlight("a3", serverId = "abs1", itemId = "item1", createdAt = 1_200L))
+        // Book B: two dirty rows.
+        dao.upsert(highlight("b1", serverId = "abs1", itemId = "item2", createdAt = 1_300L))
+        dao.upsert(highlight("b2", serverId = "abs1", itemId = "item2", createdAt = 1_400L))
+        // Book C on a second server: one dirty row.
+        dao.upsert(highlight("c1", serverId = "abs2", itemId = "item1", createdAt = 1_500L))
+        // Book D: fully synced (lastSyncedAt == updatedAt) — must NOT count.
+        dao.upsert(highlight("d1", serverId = "abs1", itemId = "item3", createdAt = 1_600L)
+            .copy(lastSyncedAt = 1_600L))
+
+        assertEquals(3, dao.observePendingBookCountAcrossAll().first())
+    }
+
+    // Once every row for a book is stamped synced, the book must drop out of the count.
+    @Test
+    fun observePendingBookCountAcrossAll_dropsBookOnceMarkSyncedClearsAllRows() = runTest {
+        dao.upsert(highlight("a1", serverId = "abs1", itemId = "item1", createdAt = 1_000L))
+        dao.upsert(highlight("a2", serverId = "abs1", itemId = "item1", createdAt = 1_100L))
+        dao.upsert(highlight("b1", serverId = "abs1", itemId = "item2", createdAt = 1_200L))
+
+        assertEquals(2, dao.observePendingBookCountAcrossAll().first())
+
+        // Only one of book A's two rows is marked synced — book A still has a dirty row, so still 2.
+        dao.markSynced(listOf("a1"), syncedAt = 2_000L)
+        assertEquals(2, dao.observePendingBookCountAcrossAll().first())
+
+        // Now the last of book A's rows is clean too — book A drops out.
+        dao.markSynced(listOf("a2"), syncedAt = 2_100L)
+        assertEquals(1, dao.observePendingBookCountAcrossAll().first())
+    }
 }

--- a/core/database/src/main/kotlin/com/riffle/core/database/AnnotationDao.kt
+++ b/core/database/src/main/kotlin/com/riffle/core/database/AnnotationDao.kt
@@ -89,9 +89,14 @@ interface AnnotationDao {
     @Query("SELECT COUNT(*) FROM annotations WHERE serverId = :serverId AND itemId = :itemId AND updatedAt > lastSyncedAt")
     fun observePendingCountForBook(serverId: String, itemId: String): Flow<Int>
 
-    /** Pending-row count across every book — live Flow for the Settings list-row badge. */
-    @Query("SELECT COUNT(*) FROM annotations WHERE updatedAt > lastSyncedAt")
-    fun observePendingCountAcrossAll(): Flow<Int>
+    /** Count of distinct books with at least one dirty annotation — live Flow for the Settings
+     *  list-row badge. Scoped by book, not by annotation row, so the "N book(s) pending" wording
+     *  actually matches: five dirty highlights on one book still reads as "1 book pending". */
+    @Query(
+        "SELECT COUNT(*) FROM (SELECT DISTINCT serverId, itemId FROM annotations " +
+            "WHERE updatedAt > lastSyncedAt)"
+    )
+    fun observePendingBookCountAcrossAll(): Flow<Int>
 
     /** One row per `(serverId, itemId)` with at least one dirty annotation. Used by AnnotationSweep. */
     @Query("SELECT DISTINCT serverId, itemId FROM annotations WHERE updatedAt > lastSyncedAt")


### PR DESCRIPTION
## Summary

The Settings WebDAV row reads `"$N book(s) pending"` but was wired to
`AnnotationDao.observePendingCountAcrossAll()`, which counts dirty annotation
**rows** — not books. Five dirty highlights on one book showed as "5 book(s)
pending"; an offline reader could see the number climb from 8 to 11 while
touching a single book, because peer-pulled annotations land with
`lastSyncedAt = 0L` and immediately count as dirty from this device's POV.

Rename `observePendingCountAcrossAll` → `observePendingBookCountAcrossAll` and
change the SQL to `SELECT COUNT(*) FROM (SELECT DISTINCT serverId, itemId
FROM annotations WHERE updatedAt > lastSyncedAt)`. The compile-forced rename
threads through all fake DAOs so nothing keeps counting rows silently.

## Tests

- `AnnotationDaoTest.observePendingBookCountAcrossAll_countsDistinctBooks` —
  seeds 3 dirty rows on book A, 2 on B, 1 on C, and a fully-synced D; asserts
  count = 3. Reverting the SQL to `COUNT(*) FROM annotations` fails with 6.
- `AnnotationDaoTest.observePendingBookCountAcrossAll_dropsBookOnceMarkSyncedClearsAllRows` —
  after `markSynced` on one of book A's two rows the count stays 2; after
  clearing the last one it drops to 1.
- `SettingsViewModelTest.annotationSyncRow reads book count into 'N book(s)
  pending' copy` — feeds `pendingBookCount = 3` and asserts `row.sub`
  contains `"3 book(s) pending"`.

## Test plan

- [x] `./gradlew test` — full JVM suite green.
- [x] `./gradlew :core:database:compileDebugAndroidTestKotlin` — new DAO test
  compiles against Room.
- [ ] `AnnotationDaoTest` instrumentation run on emulator (requires an AVD; JVM
  tests + the `dirtyServerItems` DAO test above already exercise the same
  distinct-pair pattern, so this is verification, not discovery).