### PR TITLE
fix(reader): route continuous-mode same-doc anchor taps through native

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ChapterWebView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ChapterWebView.kt
@@ -73,6 +73,17 @@ internal class ChapterWebView(context: Context) : WebView(context), ChapterWebVi
     override var onFootnoteContent: ((FootnoteContent) -> Unit)? = null
 
     /**
+     * Called on the main thread when the user taps a same-document anchor that is NOT a footnote
+     * (e.g. a "Figure 3.1" cross-reference). [fragmentId] is the target id, without the leading '#'.
+     * The host scrolls the outer viewport to that element inside this chapter's WebView and shows
+     * the return-to-position card so the user can hop back.
+     *
+     * Distinct from [onInternalLink] which fires only on cross-resource links routed through
+     * `shouldOverrideUrlLoading` — same-document `#id` clicks never reach that path.
+     */
+    override var onCrossReferenceTap: ((fragmentId: String) -> Unit)? = null
+
+    /**
      * The raw HTML of the chapter document currently loaded, retained so a footnote tap can resolve
      * the note body without a re-fetch. Set the first time an HTML resource is served for a load (the
      * main document is fetched first), cleared on each [loadChapter]. The parsed form is cached lazily
@@ -326,7 +337,7 @@ internal class ChapterWebView(context: Context) : WebView(context), ChapterWebVi
         evalJs("window.__riffleToken=$loadToken;")
         evalJs(ContinuousScriptInjector.HEIGHT_MEASUREMENT_JS)
         evalJs(ContinuousScriptInjector.TAP_LISTENER_JS)
-        evalJs(ContinuousScriptInjector.FOOTNOTE_LISTENER_JS)
+        evalJs(ContinuousScriptInjector.SAME_DOC_ANCHOR_LISTENER_JS)
     }
 
     /** Re-inject user styles and re-measure after a preference change. */
@@ -613,8 +624,8 @@ internal class ChapterWebView(context: Context) : WebView(context), ChapterWebVi
         /**
          * Resolve the same-document anchor [id] against this chapter's HTML. Returns true (so the JS
          * suppresses the default in-page scroll) and posts the note body to [onFootnoteContent] when
-         * the target is a footnote; false for a regular cross-reference (left to default handling).
-         * Runs on the JS binder thread — Jsoup parsing here is safe.
+         * the target is a footnote; false for a regular cross-reference (the JS then hands the tap
+         * to [onCrossReferenceTap] below). Runs on the JS binder thread — Jsoup parsing here is safe.
          */
         @JavascriptInterface
         fun onFootnoteAnchorTap(id: String): Boolean {
@@ -623,6 +634,19 @@ internal class ChapterWebView(context: Context) : WebView(context), ChapterWebVi
             val content = FootnoteResolver.extractFootnoteContent(doc, id) ?: return false
             post { this@ChapterWebView.onFootnoteContent?.invoke(content) }
             return true
+        }
+
+        /**
+         * Forwards a non-footnote same-document anchor tap ([id] is the fragment without '#') to the
+         * main thread so the host can scroll the outer viewport to the target and offer a return
+         * card. Runs on the JS binder thread; the [post] hop is what puts the callback on the main
+         * thread. See [ContinuousScriptInjector.SAME_DOC_ANCHOR_LISTENER_JS] for why the JS side
+         * always preventDefaults after calling this (the alternative desyncs child scrollY from the
+         * parent's stacked-chapter geometry).
+         */
+        @JavascriptInterface
+        fun onCrossReferenceTap(id: String) {
+            post { this@ChapterWebView.onCrossReferenceTap?.invoke(id) }
         }
     }
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ChapterWebViewBinder.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ChapterWebViewBinder.kt
@@ -24,6 +24,7 @@ internal interface ChapterWebViewLike {
     var onAnnotationTap: ((String, Rect) -> Unit)?
     var onAnnotationNoteTap: ((String, Rect) -> Unit)?
     var onFootnoteContent: ((FootnoteContent) -> Unit)?
+    var onCrossReferenceTap: ((String) -> Unit)?
 }
 
 /**
@@ -51,12 +52,14 @@ internal class ChapterWebViewBinder(
     private val screenRectOf: (ChapterWebViewLike, Rect) -> Rect,
     private val onRenderGone: () -> Unit,
     private val onInternalLink: (href: String) -> Unit,
+    private val onCrossReference: (chapterHref: String, fragmentId: String) -> Unit,
     private val onSelectionActiveChanged: (Boolean) -> Unit,
 ) {
     fun bind(wv: ChapterWebViewLike, annotationsAvailable: Boolean, readaloudAvailable: Boolean) {
         wv.onTap = { navigation.onTap() }
         wv.onRenderGone = { onRenderGone() }
         wv.onInternalLink = { onInternalLink(it) }
+        wv.onCrossReferenceTap = { id -> onCrossReference(wv.chapterHref, id) }
         wv.onExternalLink = { links.onExternalLink(it) }
         wv.annotationsAvailable = annotationsAvailable
         wv.onSelectionActiveChanged = onSelectionActiveChanged

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderCoordinator.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderCoordinator.kt
@@ -82,6 +82,17 @@ internal class ContinuousReaderCoordinator(
                     this.view?.navigateTo(href, 0f)
                 }
             },
+            // Same-document (`#id`) figure / cross-reference tap in the child WebView. The paged
+            // path (FootnoteAnchorBridge → snapToElement) doesn't apply here — Continuous mode
+            // has no Readium fragment to snap against, so we drive the outer viewport ourselves
+            // via view.navigateTo, which finds the target's device-Y through anchorOffsetTopDevicePx
+            // and scrolls the NestedScrollView to it. Capture the pre-jump origin so the return
+            // card can undo the jump, matching the paged-mode behaviour.
+            onCrossReference = { chapterHref, fragmentId ->
+                val origin = latestLocator()
+                if (origin != null) links.captureReturnAnchor(origin)
+                this.view?.navigateTo("$chapterHref#$fragmentId", 0f, alignToTop = false)
+            },
             onRawPosition = { href, progression ->
                 val (spineHrefs, counts) = spinePositionsProvider()
                 val locator = buildContinuousLocator(href, progression, spineHrefs, counts)

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
@@ -104,6 +104,7 @@ internal class ContinuousReaderView @JvmOverloads constructor(
         links: ContinuousLinkSink,
         annotations: ContinuousAnnotationSink,
         onInternalLink: (href: String) -> Unit,
+        onCrossReference: (chapterHref: String, fragmentId: String) -> Unit,
         onRawPosition: (href: String, progression: Float) -> Unit,
         onViewportFractionMeasured: (href: String, fraction: Double) -> Unit = { _, _ -> },
     ) {
@@ -116,6 +117,7 @@ internal class ContinuousReaderView @JvmOverloads constructor(
             screenRectOf = ::screenRectFor,
             onRenderGone = { controller.onRendererGone() },
             onInternalLink = onInternalLink,
+            onCrossReference = onCrossReference,
             onSelectionActiveChanged = ::onChildSelectionActiveChanged,
         )
         controller.install(binder)

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousScriptInjector.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousScriptInjector.kt
@@ -11,8 +11,9 @@ package com.riffle.app.feature.reader
  *     `window.RiffleChapter.onHeightMeasured` so the parent can size the WebView exactly.
  *  2. [TAP_LISTENER_JS] — forwards background taps to `window.RiffleChapter.onTap` to toggle
  *     reader chrome, matching the Readium navigator's `InputListener.onTap` behaviour.
- *  3. [FOOTNOTE_LISTENER_JS] — intercepts same-document anchor clicks before WebView's default
- *     in-page scroll and routes them through `window.RiffleChapter.onFootnoteAnchorTap`.
+ *  3. [SAME_DOC_ANCHOR_LISTENER_JS] — intercepts same-document anchor clicks before WebView's
+ *     default in-page scroll and routes them through `window.RiffleChapter.onFootnoteAnchorTap`
+ *     (footnote popup) or `window.RiffleChapter.onCrossReferenceTap` (figure / heading nav).
  *
  * Decoration JS (readaloud highlights, search, annotations) lives in [ContinuousStyleInjector]
  * because it is applied dynamically (not once at load time) and is tightly coupled to the
@@ -127,30 +128,61 @@ internal object ContinuousScriptInjector {
 
     /**
      * JS that intercepts taps on same-document anchors (`<a href="#id">`) in the capture phase,
-     * before the WebView performs its default in-page scroll, and asks the native side whether the
-     * target is a footnote via `window.RiffleChapter.onFootnoteAnchorTap(id)`. When it is (returns
-     * true) the default scroll is suppressed so the reader shows the footnote popup instead. In
-     * Continuous mode the WebView's own scrolling is disabled, so without this a footnote tap would
-     * do nothing at all. Mirrors the paged-mode [FootnoteAnchorBridge], but per-WebView (each stacked
-     * chapter resolves against its own document) rather than via the single shared bridge.
+     * before the WebView performs its default in-page scroll, and routes them into native so
+     * Continuous mode owns the navigation:
+     *  - `RiffleChapter.onFootnoteAnchorTap(id)` — footnote-style targets show the popup.
+     *  - `RiffleChapter.onCrossReferenceTap(id)` — everything else (figures, section headings,
+     *    other cross-references) triggers a native scroll of the parent viewport plus a
+     *    return-to-position card.
+     *
+     * The default in-page scroll is ALWAYS suppressed: allowing it to run in Continuous mode
+     * moves the child WebView's own `scrollY` (its content is taller than its measured viewport),
+     * shifting the visible band inside the chunk while the parent's stacked-chapter geometry
+     * assumes each WebView shows its content at scrollY=0. That desync makes it look like the
+     * outer scroll can't reach past the shifted band. Mirrors the paged-mode [FootnoteAnchorBridge]
+     * for both branches, but per-WebView (each stacked chapter resolves against its own document)
+     * rather than via the single shared bridge.
      */
-    val FOOTNOTE_LISTENER_JS = """
+    val SAME_DOC_ANCHOR_LISTENER_JS = """
         (function() {
-            if (document.__riffleFootnoteWired) return;
-            document.__riffleFootnoteWired = true;
+            if (document.__riffleSameDocAnchorWired) return;
+            document.__riffleSameDocAnchorWired = true;
             document.addEventListener('click', function(e) {
                 var t = e.target;
                 while (t && t.nodeType === 1 && (!t.tagName || t.tagName.toLowerCase() !== 'a')) t = t.parentNode;
                 if (!t || !t.tagName || t.tagName.toLowerCase() !== 'a') return;
                 var href = t.getAttribute('href');
-                if (!href || href.charAt(0) !== '#') return;
-                var id = href.substring(1);
+                if (!href) return;
+                // Resolve `href` against document.location so path-prefixed same-chapter
+                // references ('part0007.xhtml#a2C8' clicked from part0007.xhtml — a common
+                // EPUB convention for cross-references) count as same-document. Without this
+                // the guard used to skip them and the WebView's default fragment scroll ran,
+                // which desyncs child scrollY from the parent's stacked-chapter geometry AND
+                // gives no hook to show the return card. Truly cross-resource links (a
+                // different chapter's pathname) fall through and are handled by
+                // shouldOverrideUrlLoading -> ChapterWebView.onInternalLink.
+                var resolved;
+                try { resolved = new URL(href, document.location.href); }
+                catch (e) { return; }
+                var sameDoc = href.charAt(0) === '#' ||
+                    (resolved.origin === document.location.origin &&
+                     resolved.pathname === document.location.pathname);
+                if (!sameDoc) return;
+                var id = (resolved.hash || '').replace(/^#/, '');
                 if (!id) return;
                 try {
                     if (window.RiffleChapter.onFootnoteAnchorTap(id)) {
                         e.preventDefault();
                         e.stopPropagation();
+                        return;
                     }
+                    // Not a footnote — treat as a cross-reference (figure, heading, etc.). Native
+                    // scrolls the outer viewport to the target and captures a return anchor. We
+                    // always preventDefault so the WebView's own in-page scroll never runs; see
+                    // this file's KDoc for why that scroll breaks parent scroll continuity.
+                    window.RiffleChapter.onCrossReferenceTap(id);
+                    e.preventDefault();
+                    e.stopPropagation();
                 } catch (err) {}
             }, true);
         })();

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousScriptInjector.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousScriptInjector.kt
@@ -153,22 +153,32 @@ internal object ContinuousScriptInjector {
                 if (!t || !t.tagName || t.tagName.toLowerCase() !== 'a') return;
                 var href = t.getAttribute('href');
                 if (!href) return;
-                // Resolve `href` against document.location so path-prefixed same-chapter
-                // references ('part0007.xhtml#a2C8' clicked from part0007.xhtml — a common
-                // EPUB convention for cross-references) count as same-document. Without this
-                // the guard used to skip them and the WebView's default fragment scroll ran,
-                // which desyncs child scrollY from the parent's stacked-chapter geometry AND
-                // gives no hook to show the return card. Truly cross-resource links (a
-                // different chapter's pathname) fall through and are handled by
-                // shouldOverrideUrlLoading -> ChapterWebView.onInternalLink.
-                var resolved;
-                try { resolved = new URL(href, document.location.href); }
-                catch (e) { return; }
-                var sameDoc = href.charAt(0) === '#' ||
-                    (resolved.origin === document.location.origin &&
-                     resolved.pathname === document.location.pathname);
-                if (!sameDoc) return;
-                var id = (resolved.hash || '').replace(/^#/, '');
+                // Same-doc classification. Two accepted shapes:
+                //  1. bare '#id' — cheapest to detect, skip URL parsing on the hot path.
+                //  2. path-prefixed same-chapter reference ('part0007.xhtml#a2C8' clicked from
+                //     part0007.xhtml — a common EPUB convention for cross-references). Resolve
+                //     against document.location and compare pathname; without this the guard used
+                //     to skip these and the WebView's default fragment scroll ran, desyncing
+                //     child scrollY from the parent's stacked-chapter geometry AND giving no
+                //     hook to show the return card.
+                // Truly cross-resource links (a different chapter's pathname) fall through and
+                // are handled by shouldOverrideUrlLoading -> ChapterWebView.onInternalLink.
+                var id;
+                if (href.charAt(0) === '#') {
+                    id = href.substring(1);
+                } else {
+                    var resolved;
+                    try { resolved = new URL(href, document.location.href); }
+                    catch (e) { return; }
+                    var sameDoc = resolved.origin === document.location.origin &&
+                        resolved.pathname === document.location.pathname;
+                    if (!sameDoc) return;
+                    id = resolved.hash ? resolved.hash.substring(1) : '';
+                    // resolved.hash preserves percent-encoding (e.g. '#figure%201'); decode so
+                    // native's document.getElementById() matches the raw id in the DOM
+                    // ('figure 1'). getAttribute-driven bare '#id' hrefs are already raw.
+                    try { id = decodeURIComponent(id); } catch (e) {}
+                }
                 if (!id) return;
                 try {
                     if (window.RiffleChapter.onFootnoteAnchorTap(id)) {

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousSinks.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousSinks.kt
@@ -22,6 +22,13 @@ internal interface ContinuousLinkSink {
     fun onFollowInternalLink(link: Link, origin: Locator)
     fun onExternalLink(url: String)
     fun onFootnote(content: FootnoteContent)
+
+    /**
+     * A same-document non-footnote anchor was tapped and the outer viewport is about to scroll to
+     * it. Passes the pre-jump [origin] so the host can offer a "Back" card, mirroring the paged
+     * mode's [FootnoteAnchorBridge] cross-reference path.
+     */
+    fun captureReturnAnchor(origin: Locator)
 }
 
 /**

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousWindowController.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousWindowController.kt
@@ -204,6 +204,7 @@ internal class ContinuousWindowController(
         wv.onAnnotationNoteTap = null
         wv.onPlayFromHere = null
         wv.onFootnoteContent = null
+        wv.onCrossReferenceTap = null
         wv.onSelectionActiveChanged = null
         if (recycledViews.size < WINDOW_SIZE) recycledViews.addLast(wv) else wv.destroy()
     }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -1329,6 +1329,7 @@ private fun EpubNavigatorView(
                     }
                 }
                 override fun onFootnote(content: FootnoteContent) = currentOnFootnoteTapped(content)
+                override fun captureReturnAnchor(origin: Locator) = currentOnCaptureReturnTarget(origin)
             },
             annotations = object : ContinuousAnnotationSink {
                 override fun onAnnotationTap(id: String, rect: IntRect) =

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ChapterWebViewBinderTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ChapterWebViewBinderTest.kt
@@ -33,11 +33,13 @@ class ChapterWebViewBinderTest {
         override var onAnnotationTap: ((String, Rect) -> Unit)? = null
         override var onAnnotationNoteTap: ((String, Rect) -> Unit)? = null
         override var onFootnoteContent: ((FootnoteContent) -> Unit)? = null
+        override var onCrossReferenceTap: ((String) -> Unit)? = null
 
         fun emitTap() = onTap?.invoke()
         fun emitAnnotationTap(id: String, rect: Rect) = onAnnotationTap?.invoke(id, rect)
         fun emitAnnotationNoteTap(id: String, rect: Rect) = onAnnotationNoteTap?.invoke(id, rect)
         fun emitFootnoteContent(content: FootnoteContent) = onFootnoteContent?.invoke(content)
+        fun emitCrossReferenceTap(fragmentId: String) = onCrossReferenceTap?.invoke(fragmentId)
     }
 
     private class RecordingNav : ContinuousNavigationSink {
@@ -61,6 +63,7 @@ class ChapterWebViewBinderTest {
         override fun onFollowInternalLink(link: org.readium.r2.shared.publication.Link, origin: Locator) = Unit
         override fun onExternalLink(url: String) = Unit
         override fun onFootnote(content: FootnoteContent) { footnotes += content }
+        override fun captureReturnAnchor(origin: Locator) = Unit
     }
 
     private fun binderOf(
@@ -68,6 +71,7 @@ class ChapterWebViewBinderTest {
         links: ContinuousLinkSink = NoopLinks,
         ann: ContinuousAnnotationSink = RecordingAnn(),
         screenRectOf: (ChapterWebViewLike, Rect) -> Rect = { _, r -> r },
+        onCrossReference: (String, String) -> Unit = { _, _ -> },
     ) = ChapterWebViewBinder(
         navigation = nav,
         links = links,
@@ -75,6 +79,7 @@ class ChapterWebViewBinderTest {
         screenRectOf = screenRectOf,
         onRenderGone = {},
         onInternalLink = {},
+        onCrossReference = onCrossReference,
         onSelectionActiveChanged = {},
     )
 
@@ -90,6 +95,7 @@ class ChapterWebViewBinderTest {
             screenRectOf = { _, r -> rectOf(r.left + 10, r.top + 20, r.right + 10, r.bottom + 20) },
             onRenderGone = {},
             onInternalLink = {},
+            onCrossReference = { _, _ -> },
             onSelectionActiveChanged = {},
         )
         binder.bind(fake, annotationsAvailable = true, readaloudAvailable = true)
@@ -131,6 +137,23 @@ class ChapterWebViewBinderTest {
     }
 
     @Test
+    fun `cross-reference tap forwards fragmentId with the chapter href`() {
+        // Regression: same-doc figure/heading anchors used to be dropped in continuous mode — the
+        // JS listener only asked whether the target was a footnote and let the WebView's default
+        // in-page scroll handle everything else, which broke parent scroll continuity AND skipped
+        // the return-to-position card. The binder must now route the tap up as (chapterHref, id).
+        val calls = mutableListOf<Pair<String, String>>()
+        val fake = FakeChapterWebView(chapterHref = "ch03.xhtml")
+        binderOf(
+            onCrossReference = { chapterHref, fragmentId -> calls += chapterHref to fragmentId },
+        ).bind(fake, annotationsAvailable = false, readaloudAvailable = false)
+
+        fake.emitCrossReferenceTap("c03-fig-0001")
+
+        assertEquals(listOf("ch03.xhtml" to "c03-fig-0001"), calls)
+    }
+
+    @Test
     fun `footnote content forwards to link sink`() {
         val links = RecordingLinks()
         val fake = FakeChapterWebView("chapter-1.xhtml")
@@ -147,5 +170,6 @@ class ChapterWebViewBinderTest {
         override fun onFollowInternalLink(link: org.readium.r2.shared.publication.Link, origin: Locator) = Unit
         override fun onExternalLink(url: String) = Unit
         override fun onFootnote(content: FootnoteContent) = Unit
+        override fun captureReturnAnchor(origin: Locator) = Unit
     }
 }

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousDecorationControllerTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousDecorationControllerTest.kt
@@ -35,6 +35,7 @@ class ContinuousDecorationControllerTest {
         override var onAnnotationTap: ((String, android.graphics.Rect) -> Unit)? = null
         override var onAnnotationNoteTap: ((String, android.graphics.Rect) -> Unit)? = null
         override var onFootnoteContent: ((FootnoteContent) -> Unit)? = null
+        override var onCrossReferenceTap: ((String) -> Unit)? = null
     }
 
     private class FakePort : ContinuousDecorationController.Port {

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousScriptInjectorTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousScriptInjectorTest.kt
@@ -1,0 +1,78 @@
+package com.riffle.app.feature.reader
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pins the anchor-tap listener's dual-branch behaviour so regressions can't quietly return to the
+ * pre-fix single-branch code. The old script only asked native whether the tapped anchor was a
+ * footnote and let WebView's default in-page scroll run for everything else — that scroll shifted
+ * child-WebView scrollY inside a stacked chapter, breaking the parent's continuous scroll AND
+ * skipping the return-to-position card for figures / cross-references.
+ */
+class ContinuousScriptInjectorTest {
+
+    private val js = ContinuousScriptInjector.SAME_DOC_ANCHOR_LISTENER_JS
+
+    @Test
+    fun `listener still routes footnote-style anchors through onFootnoteAnchorTap`() {
+        assertTrue("expected onFootnoteAnchorTap in $js", js.contains("onFootnoteAnchorTap"))
+    }
+
+    @Test
+    fun `listener routes non-footnote anchors through onCrossReferenceTap`() {
+        assertTrue("expected onCrossReferenceTap in $js", js.contains("onCrossReferenceTap"))
+    }
+
+    @Test
+    fun `listener suppresses the WebView default scroll on every same-doc anchor tap`() {
+        // The comment below the KDoc explains why: allowing the default in-page scroll to run
+        // moves the child WebView's own scrollY, desyncing the parent's stacked-chapter geometry.
+        // Regression assertion: onCrossReferenceTap must always be followed by preventDefault().
+        val crossRefBranch = js.substringAfter("onCrossReferenceTap")
+        assertTrue(
+            "expected preventDefault() to run after onCrossReferenceTap in $js",
+            crossRefBranch.contains("preventDefault"),
+        )
+    }
+
+    @Test
+    fun `listener uses a capture-phase click listener so it runs before default scroll`() {
+        // The third argument to addEventListener is the capture flag; without it the default scroll
+        // handler on the WebView would fire first.
+        assertTrue(
+            "expected capture-phase click listener in $js",
+            js.contains("addEventListener('click'") && js.contains(", true)"),
+        )
+    }
+
+    @Test
+    fun `listener resolves path-prefixed hrefs against document location so same-chapter refs count as same-doc`() {
+        // Regression: EPUBs frequently write same-chapter cross-references as full-path hrefs
+        // ('part0007.xhtml#a2C8' clicked from part0007.xhtml) instead of bare '#a2C8'. The first
+        // version of the fix skipped anything not starting with '#', which fell straight through
+        // to WebView's default fragment scroll — no return card, and broke parent scroll continuity.
+        // Assert the resolved-URL branch exists so this can't silently regress.
+        assertTrue("expected URL resolution against document.location", js.contains("new URL(href, document.location.href)"))
+        assertTrue("expected same-doc test against pathname", js.contains("resolved.pathname === document.location.pathname"))
+        assertTrue("expected fragment extraction from resolved URL", js.contains("resolved.hash"))
+    }
+
+    @Test
+    fun `listener defers truly cross-resource links to shouldOverrideUrlLoading`() {
+        // We DO want a cross-resource link (part0008.xhtml#foo clicked from part0007.xhtml) to
+        // fall through: the WebView's shouldOverrideUrlLoading path handles it via onInternalLink.
+        // Regression assertion: the non-same-doc branch must NOT call onCrossReferenceTap.
+        val crossResourceBranch = js.substringAfter("if (!sameDoc)").substringBefore("var id")
+        assertTrue(
+            "cross-resource branch must return without calling onCrossReferenceTap in $js",
+            crossResourceBranch.contains("return") && !crossResourceBranch.contains("onCrossReferenceTap"),
+        )
+    }
+
+    @Test
+    fun `listener is idempotent per document`() {
+        // Injected on every page load; guards keep it from stacking multiple handlers.
+        assertTrue(js.contains("__riffleSameDocAnchorWired"))
+    }
+}

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousScriptInjectorTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousScriptInjectorTest.kt
@@ -55,7 +55,7 @@ class ContinuousScriptInjectorTest {
         // Assert the resolved-URL branch exists so this can't silently regress.
         assertTrue("expected URL resolution against document.location", js.contains("new URL(href, document.location.href)"))
         assertTrue("expected same-doc test against pathname", js.contains("resolved.pathname === document.location.pathname"))
-        assertTrue("expected fragment extraction from resolved URL", js.contains("resolved.hash"))
+        assertTrue("expected fragment extraction from resolved URL hash", js.contains("resolved.hash"))
     }
 
     @Test
@@ -63,10 +63,38 @@ class ContinuousScriptInjectorTest {
         // We DO want a cross-resource link (part0008.xhtml#foo clicked from part0007.xhtml) to
         // fall through: the WebView's shouldOverrideUrlLoading path handles it via onInternalLink.
         // Regression assertion: the non-same-doc branch must NOT call onCrossReferenceTap.
-        val crossResourceBranch = js.substringAfter("if (!sameDoc)").substringBefore("var id")
+        val crossResourceBranch = js.substringAfter("if (!sameDoc)").substringBefore("if (!id)")
         assertTrue(
             "cross-resource branch must return without calling onCrossReferenceTap in $js",
             crossResourceBranch.contains("return") && !crossResourceBranch.contains("onCrossReferenceTap"),
+        )
+    }
+
+    @Test
+    fun `listener skips URL parsing on the hot path when href starts with a bare hash`() {
+        // Regression: URL parsing used to run unconditionally; the OR shortcut on href.charAt(0)
+        // was only checked AFTER `new URL(...)` had already allocated. Most in-book anchors are
+        // bare '#id' (this is what Readium emits for TOC entries and what most EPUBs use for
+        // in-chapter cross-references), so the bare-hash branch must extract id WITHOUT going
+        // through new URL().
+        val bareHashBranch = js.substringAfter("if (href.charAt(0) === '#')").substringBefore("} else {")
+        assertTrue(
+            "bare-hash branch must not call new URL() in $js",
+            bareHashBranch.contains("href.substring(1)") && !bareHashBranch.contains("new URL"),
+        )
+    }
+
+    @Test
+    fun `listener decodes percent-encoded fragment ids so getElementById matches raw DOM ids`() {
+        // Regression: URL.hash preserves percent-encoding. An EPUB with '<a href="#figure%201">'
+        // pointing at '<figure id="figure 1">' would extract id="figure%201" and native's
+        // document.getElementById would silently fail. decodeURIComponent must run on the
+        // path-prefixed branch (bare '#id' hrefs are already raw — no encoding survives
+        // getAttribute).
+        val pathPrefixedBranch = js.substringAfter("} else {").substringBefore("if (!id) return")
+        assertTrue(
+            "path-prefixed branch must decodeURIComponent the fragment id in $js",
+            pathPrefixedBranch.contains("decodeURIComponent"),
         )
     }
 


### PR DESCRIPTION
## Summary

In continuous scroll mode, tapping an in-book link like **"Figure 3.1"** or **"Figure 2a"** did nothing visible, showed no "Back" card, and left the reader unable to scroll past nearby sections. Same for path-prefixed same-chapter refs (`part0007.xhtml#a2C8` from `part0007.xhtml` — the shape "Philosophy of Software Design" uses).

Root cause: the JS listener only intercepted footnotes. Non-footnote same-doc anchors fell through to WebView's default fragment scroll, which:
- didn't move the outer `NestedScrollView` → user "doesn't navigate to the figure",
- didn't route through the return-anchor system → no Back card,
- moved the child WebView's own `scrollY` → parent's stacked-chapter geometry desynced, so a band of content sat behind the neighbouring chunk and outer scroll couldn't reach it.

Fix: intercept every same-doc anchor tap, route non-footnotes through a new `onCrossReferenceTap` native bridge → `ContinuousReaderCoordinator` → `view.navigateTo("<chapterHref>#<fragmentId>", 0f)`. Always `preventDefault` so the WebView's built-in scroll never fires. Path-prefixed hrefs are resolved against `document.location` so same-chapter refs are recognised as same-doc.

The paged-mode `FootnoteAnchorBridge` cross-reference behaviour is unchanged; this brings continuous mode to parity.

## Notable review-driven follow-ups (second commit)

- `URL.hash` preserves percent-encoding, so `<a href="#figure%201">` at `<figure id="figure 1">` used to silently miss. Decode on the path-prefixed branch.
- `ContinuousWindowController.recycle()` clears every callback on WebView return-to-pool; `onCrossReferenceTap` was missing from the sweep → recycled WebView retained the previous coordinator.
- Bare `#id` clicks used to allocate a `URL` object unconditionally; reordered so the common case skips URL parsing.

## Test plan

- [x] `ContinuousScriptInjectorTest` — pins bare-hash fast path, path-prefixed same-doc routing, percent-decode, cross-resource fall-through, always-preventDefault, capture-phase, idempotent guard.
- [x] `ChapterWebViewBinderTest` — cross-reference tap forwards `(chapterHref, fragmentId)` up through the sink wiring.
- [x] Full `./gradlew test` green.
- [ ] Device: tap Figure 2a / 2b / 3.1 in "Philosophy of Software Design" in continuous mode, confirm landing on the figure + Back card + surrounding sections remain scrollable.
- [ ] Regression: paged and vertical modes' existing footnote / TOC / figure taps still behave.