### PR TITLE
fix(webdav): tick "Last sync N ago" banner on wall clock, not upstream state

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/server/AddServerViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/server/AddServerViewModel.kt
@@ -27,6 +27,7 @@ import com.riffle.core.domain.ServerUrl
 import com.riffle.core.domain.TokenStorage
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
@@ -35,6 +36,7 @@ import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import javax.inject.Inject
+import javax.inject.Named
 
 /**
  * Backend kind selectable in [AddServerScreen]. Distinct from [ServerType] because WebDAV is
@@ -54,6 +56,7 @@ class AddServerViewModel @Inject constructor(
     private val readaloudMatcher: ReadaloudMatchingService,
     private val tokenStorage: TokenStorage,
     private val clock: Clock,
+    @Named(WEBDAV_BANNER_TICKER) private val bannerTicker: Flow<Unit>,
     savedStateHandle: SavedStateHandle,
 ) : ViewModel() {
 
@@ -87,7 +90,8 @@ class AddServerViewModel @Inject constructor(
         webdavConfigStore.observe(),
         webdavStatusStore.lastCycleOutcome,
         webdavStatusStore.lastSuccessAtMs,
-    ) { config, outcome, lastSuccessAtMs ->
+        bannerTicker,
+    ) { config, outcome, lastSuccessAtMs, _ ->
         config?.let { webdavBanner(it, outcome, lastSuccessAtMs) }
     }.stateIn(viewModelScope, SharingStarted.Eagerly, null)
 
@@ -318,6 +322,15 @@ class AddServerViewModel @Inject constructor(
             elapsedSec < 86_400 -> "${elapsedSec / 3_600} h ago"
             else -> "${elapsedSec / 86_400} d ago"
         }
+    }
+
+    companion object {
+        /**
+         * Hilt qualifier for the [webdavBanner]'s wall-clock ticker. See [WebdavBannerTickerModule]
+         * for the production ticker (once a minute), and [AddServerViewModelTest] for the test
+         * override.
+         */
+        const val WEBDAV_BANNER_TICKER = "webdavBannerTicker"
     }
 }
 

--- a/app/src/main/kotlin/com/riffle/app/feature/server/WebdavBannerTickerModule.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/server/WebdavBannerTickerModule.kt
@@ -1,0 +1,36 @@
+package com.riffle.app.feature.server
+
+import com.riffle.app.feature.server.AddServerViewModel.Companion.WEBDAV_BANNER_TICKER
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import javax.inject.Named
+import javax.inject.Singleton
+
+/**
+ * Wall-clock ticker driving the [AddServerViewModel.webdavBanner] combine — emits Unit once a
+ * minute so the "Last sync N ago" relative label advances even while nothing upstream changes.
+ * Without it the banner freezes whenever offline: WorkManager gates the sweep on CONNECTED, so
+ * no CycleOutcome reports fire, and the label sticks at whatever value was computed when
+ * connectivity dropped.
+ */
+@Module
+@InstallIn(SingletonComponent::class)
+object WebdavBannerTickerModule {
+
+    private const val TICK_INTERVAL_MS = 60_000L
+
+    @Provides
+    @Singleton
+    @Named(WEBDAV_BANNER_TICKER)
+    fun provideWebdavBannerTicker(): Flow<Unit> = flow {
+        while (true) {
+            emit(Unit)
+            delay(TICK_INTERVAL_MS)
+        }
+    }
+}

--- a/app/src/test/kotlin/com/riffle/app/feature/server/AddServerViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/server/AddServerViewModelTest.kt
@@ -18,9 +18,11 @@ import com.riffle.core.domain.ServerUrl
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.flowOf
 import okhttp3.OkHttpClient
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -149,12 +151,19 @@ class AddServerViewModelTest {
         override suspend fun clear() {}
     }
 
+    private class MutableClock(var nowMs: Long = 0L) : com.riffle.core.domain.Clock {
+        override fun nowMs(): Long = nowMs
+        override fun nowNs(): Long = nowMs * 1_000_000L
+    }
+
     private fun makeVm(
         repository: ServerRepository,
         savedState: SavedStateHandle = SavedStateHandle(),
         configStore: AnnotationSyncConfigStore = NullConfigStore,
         tokenStorage: com.riffle.core.domain.TokenStorage = io.mockk.mockk(relaxed = true),
         statusStore: AnnotationSyncStatusStore = AnnotationSyncStatusStore(),
+        clock: com.riffle.core.domain.Clock = MutableClock(),
+        bannerTicker: Flow<Unit> = flowOf(Unit),
     ): AddServerViewModel = AddServerViewModel(
         repository = repository,
         webdavConfigStore = configStore,
@@ -164,10 +173,8 @@ class AddServerViewModelTest {
         storytellerSyncer = io.mockk.mockk(relaxed = true),
         readaloudMatcher = io.mockk.mockk(relaxed = true),
         tokenStorage = tokenStorage,
-        clock = object : com.riffle.core.domain.Clock {
-            override fun nowMs(): Long = 0L
-            override fun nowNs(): Long = 0L
-        },
+        clock = clock,
+        bannerTicker = bannerTicker,
         savedStateHandle = savedState,
     )
 
@@ -408,6 +415,51 @@ class AddServerViewModelTest {
         assertNotNull(synced)
         assertEquals(WebdavBannerKind.Synced, synced!!.kind)
         assertEquals("just now", synced.lastSyncRelative)
+    }
+
+    /**
+     * Regression: when offline, WorkManager gates the sweep on CONNECTED and no CycleOutcome
+     * reports fire. Without a wall-clock ticker in the combine, the "Last sync N ago" string
+     * froze at whatever elapsed value was computed when connectivity dropped and never advanced.
+     * The banner must re-emit on ticker signals alone so "1 h ago" becomes "2 h ago" without any
+     * upstream state change. In production the ticker fires once a minute
+     * ([WebdavBannerTickerModule]); here the test drives it explicitly.
+     */
+    @Test
+    fun `webdavBanner lastSyncRelative advances with wall-clock time when no cycle outcomes fire`() = runTest {
+        val existing = com.riffle.core.domain.AnnotationSyncConfig(
+            baseUrl = "https://dav.example.com/store",
+            username = "syncuser",
+            password = "syncpass",
+        )
+        val statusStore = AnnotationSyncStatusStore()
+        val clock = MutableClock(nowMs = 0L)
+        // Successful sync 1 hour ago.
+        val oneHourMs = 60L * 60L * 1_000L
+        clock.nowMs = oneHourMs
+        statusStore.report(CycleOutcome.Success(atMs = 0L))
+        val ticker = MutableSharedFlow<Unit>(replay = 1).apply { tryEmit(Unit) }
+
+        val vm = makeVm(
+            fakeRepo(AuthenticateResult.WrongCredentials("x")),
+            savedState = SavedStateHandle(mapOf("type" to "webdav")),
+            configStore = RecordingConfigStore(initial = existing),
+            statusStore = statusStore,
+            clock = clock,
+            bannerTicker = ticker,
+        )
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals("1 h ago", vm.webdavBanner.value!!.lastSyncRelative)
+
+        // Simulate going offline for another hour: only wall-clock advances. No config change,
+        // no new CycleOutcome. Banner must still update because the ticker fires the combine,
+        // which re-reads clock.nowMs().
+        clock.nowMs = 2 * oneHourMs
+        ticker.emit(Unit)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals("2 h ago", vm.webdavBanner.value!!.lastSyncRelative)
     }
 
     @Test


### PR DESCRIPTION
## Summary

- The WebDAV \"Last sync N ago\" banner froze whenever the device went offline: the sweep worker is gated on WorkManager's CONNECTED constraint, so no new `CycleOutcome` reports fire, and the pull-based `combine(...)` producing the banner had no independent tick source. The relative label stuck at whatever elapsed value was computed when connectivity dropped (\"1 h ago\" indefinitely).
- Add an injected `Flow<Unit>` ticker as a 4th arm of the combine; production binding in `WebdavBannerTickerModule` emits once a minute so the label advances on wall-clock alone.
- Regression test drives an in-memory ticker with a mutable clock: seeds a successful sync at t=0, asserts \"1 h ago\" at t=1h, then advances the clock to 2h and emits one tick with no config or outcome change — asserts \"2 h ago\". Reverting the ticker arm from the combine makes the second assertion see the stale \"1 h ago\".

## Test plan

- [x] `./gradlew :app:testDebugUnitTest --tests com.riffle.app.feature.server.AddServerViewModelTest`
- [x] `./gradlew :app:testDebugUnitTest` (full suite)
- [ ] Manual: open Settings → WebDAV while offline; confirm the \"Last sync\" label advances past 1 h once wall-clock has moved.