### PR TITLE
fix(reader): preserve immersive when tap dismisses selection popup

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousScriptInjector.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousScriptInjector.kt
@@ -109,6 +109,15 @@ internal object ContinuousScriptInjector {
         (function() {
             if (document.__riffleTapWired) return;
             document.__riffleTapWired = true;
+            // Snapshot selection state at touchstart so a tap-to-dismiss doesn't toggle immersive.
+            // Reading the selection inside the click handler is racy: on Chromium the WebView
+            // clears the selection on touchend before dispatching click, so the check would find
+            // no selection and toggle. Snapshotting at touchstart is race-free.
+            document.addEventListener('touchstart', function() {
+                var s = window.getSelection();
+                document.__riffleHadSelAtDown =
+                    !!(s && s.rangeCount > 0 && !s.isCollapsed);
+            }, true);
             document.addEventListener('click', function(e) {
                 // Only a tap on the background toggles the reader chrome. A tap on a link (footnote,
                 // cross-reference, external) or other interactive control must NOT also toggle the
@@ -120,6 +129,12 @@ internal object ContinuousScriptInjector {
                     if (tag === 'a' || tag === 'button' || tag === 'input' ||
                         tag === 'select' || tag === 'textarea' || tag === 'label') return;
                     t = t.parentNode;
+                }
+                // If a selection was live at touchstart, this tap only dismisses the selection popup.
+                // Consume the flag and skip the immersive toggle.
+                if (document.__riffleHadSelAtDown) {
+                    document.__riffleHadSelAtDown = false;
+                    return;
                 }
                 window.RiffleChapter.onTap();
             }, false);

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousScriptInjector.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousScriptInjector.kt
@@ -119,6 +119,13 @@ internal object ContinuousScriptInjector {
                     !!(s && s.rangeCount > 0 && !s.isCollapsed);
             }, true);
             document.addEventListener('click', function(e) {
+                // Consume-once: snapshot and clear the had-selection flag at the START of the click,
+                // regardless of what the target is. Clearing at the interactive-element early-return
+                // (below) alone would leak a stale `true` when a synthetic click reaches the listener
+                // without a preceding touchstart; consuming here guarantees the flag never survives
+                // past the click that follows the touchstart which set it.
+                var hadSel = document.__riffleHadSelAtDown;
+                document.__riffleHadSelAtDown = false;
                 // Only a tap on the background toggles the reader chrome. A tap on a link (footnote,
                 // cross-reference, external) or other interactive control must NOT also toggle the
                 // bars — otherwise following an internal link in Continuous mode flips out of
@@ -131,11 +138,7 @@ internal object ContinuousScriptInjector {
                     t = t.parentNode;
                 }
                 // If a selection was live at touchstart, this tap only dismisses the selection popup.
-                // Consume the flag and skip the immersive toggle.
-                if (document.__riffleHadSelAtDown) {
-                    document.__riffleHadSelAtDown = false;
-                    return;
-                }
+                if (hadSel) return;
                 window.RiffleChapter.onTap();
             }, false);
         })();

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -111,6 +111,7 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicReference
 import org.json.JSONObject
 import org.jsoup.nodes.Document
@@ -1261,7 +1262,14 @@ private fun EpubNavigatorView(
     // RiffleSelBridge on every selectionchange — before the floating action-mode toolbar fires.
     // Written on the JS background thread; read on the main thread in onGetContentRect.
     val pagedSelectionRectCss = remember { AtomicReference<android.graphics.RectF?>(null) }
-    val pagedSelectionRectBridge = remember { RiffleSelectionRectBridge(pagedSelectionRectCss) }
+    // Set by the touchstart snapshot in SELECTION_SPAN_TRACKER_JS: true if a non-collapsed text
+    // selection was live at the start of the current touch. Read in the InputListener.onTap
+    // handler so a tap that only dismisses the text-selection popup does not also toggle
+    // immersive mode. Written on the JS background thread; consumed on the main thread.
+    val pagedSelectionActiveAtDown = remember { AtomicBoolean(false) }
+    val pagedSelectionRectBridge = remember {
+        RiffleSelectionRectBridge(pagedSelectionRectCss, pagedSelectionActiveAtDown)
+    }
     // Tracks whether Readium is currently in vertical-scroll mode (scroll=true). Read from the
     // startActionModeForChild wrapper to route the selection popup differently — the JS-captured
     // CSS rect is viewport-relative and works cleanly for paginated columns, but in scroll mode the
@@ -1489,6 +1497,7 @@ private fun EpubNavigatorView(
     val tapListener = remember {
         object : InputListener {
             override fun onTap(event: TapEvent): Boolean {
+                if (consumeSelectionSuppressedTap(pagedSelectionActiveAtDown)) return false
                 currentOnTap()
                 return false
             }
@@ -2634,13 +2643,30 @@ internal fun clampReaderSelectionRectBottomYs(
     return newTop to newBottom
 }
 
+// Returns true if the tap that just fired should be swallowed because it dismissed an active
+// text-selection popup. Consumes the flag (clears it) so subsequent taps toggle immersive
+// normally. Extracted for JVM unit-testing — the paged InputListener.onTap wraps around a
+// Compose closure that can't be exercised without a live Readium fragment.
+internal fun consumeSelectionSuppressedTap(activeAtDown: AtomicBoolean): Boolean =
+    activeAtDown.getAndSet(false)
+
 // Named class (not anonymous) so Android's addJavascriptInterface reflection can discover the
-// @JavascriptInterface-annotated method reliably across all API levels and R8 configurations.
-private class RiffleSelectionRectBridge(
+// @JavascriptInterface-annotated methods reliably across all API levels and R8 configurations.
+internal class RiffleSelectionRectBridge(
     private val store: java.util.concurrent.atomic.AtomicReference<android.graphics.RectF?>,
+    private val activeAtDown: java.util.concurrent.atomic.AtomicBoolean,
 ) {
     @android.webkit.JavascriptInterface
     fun onRect(left: Double, top: Double, right: Double, bottom: Double) {
         store.set(android.graphics.RectF(left.toFloat(), top.toFloat(), right.toFloat(), bottom.toFloat()))
+    }
+
+    // Called from the touchstart listener in SELECTION_SPAN_TRACKER_JS with the selection state
+    // at the start of the touch (before any tap-to-dismiss has cleared it). The paged
+    // InputListener.onTap handler consumes this on the same touch to decide whether the tap is
+    // a selection-popup dismissal (skip immersive toggle) or a normal tap (toggle as usual).
+    @android.webkit.JavascriptInterface
+    fun onActiveAtDown(active: Boolean) {
+        activeAtDown.set(active)
     }
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderWebViewScripts.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderWebViewScripts.kt
@@ -265,6 +265,22 @@ internal val SELECTION_SPAN_TRACKER_JS = """
     (function () {
       if (window.__riffleSelTrackerInstalled) return;
       window.__riffleSelTrackerInstalled = true;
+      // Snapshot selection state at touchstart, BEFORE the browser processes the up-gesture
+      // that would dismiss an active selection. Readium's InputListener.onTap fires from the
+      // WebView's click event and can race with the selectionchange that clears the selection
+      // on tap-outside — reading selection state at tap time is unreliable. Capturing at
+      // touchstart is race-free: the flag is set before the same touch's click reaches the
+      // Kotlin tap listener, which consumes it and skips the immersive-mode toggle so the tap
+      // only dismisses the selection popup.
+      document.addEventListener('touchstart', function () {
+        var s = window.getSelection();
+        var active = !!(s && s.rangeCount > 0 && !s.isCollapsed);
+        try {
+          if (window.RiffleSelBridge && window.RiffleSelBridge.onActiveAtDown) {
+            window.RiffleSelBridge.onActiveAtDown(active);
+          }
+        } catch (e) {}
+      }, true);
       document.addEventListener('selectionchange', function () {
         var s = window.getSelection();
         // Ignore transient collapse/clear events dispatched right before the framework fires the

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ReaderWebViewScriptsTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ReaderWebViewScriptsTest.kt
@@ -127,4 +127,56 @@ class ReaderWebViewScriptsTest {
         assertTrue("returns range rect (l/t/r/b)", js.contains("l: stash.l, t: stash.t, r: stash.r, b: stash.b"))
         assertTrue("returns before/after context (bef/aft)", js.contains("bef: stash.bef") && js.contains("aft: stash.aft"))
     }
+
+    // Regression pin: touchstart snapshot in SELECTION_SPAN_TRACKER_JS is what lets the paged
+    // InputListener.onTap swallow a tap-to-dismiss instead of toggling immersive. If this listener
+    // stops firing (removed, moved out of the capture phase, or renamed away from onActiveAtDown),
+    // the tap-to-dismiss bug reappears — the assertions here flip red on any of those regressions.
+    @Test
+    fun `SELECTION_SPAN_TRACKER_JS snapshots selection state at touchstart via RiffleSelBridge`() {
+        val js = SELECTION_SPAN_TRACKER_JS
+        val touchStartIdx = js.indexOf("addEventListener('touchstart'")
+        val selectionChangeIdx = js.indexOf("addEventListener('selectionchange'")
+        assertTrue("touchstart listener is installed", touchStartIdx >= 0)
+        assertTrue("selectionchange listener is still installed", selectionChangeIdx >= 0)
+        assertTrue(
+            "touchstart is registered on the capture phase so it beats descendants",
+            js.substring(touchStartIdx).contains("}, true)"),
+        )
+        assertTrue(
+            "snapshots the selection state at touchstart",
+            js.contains("!!(s && s.rangeCount > 0 && !s.isCollapsed)"),
+        )
+        assertTrue(
+            "reports the snapshot via the RiffleSelBridge.onActiveAtDown method",
+            js.contains("RiffleSelBridge.onActiveAtDown(active)"),
+        )
+    }
+
+    // Regression pin: continuous mode's TAP_LISTENER_JS must skip the immersive toggle when a
+    // selection was live at touchstart. Symmetric to the paged mode's onActiveAtDown gate.
+    @Test
+    fun `TAP_LISTENER_JS suppresses onTap when a selection was live at touchstart`() {
+        val js = ContinuousScriptInjector.TAP_LISTENER_JS
+        val touchStartIdx = js.indexOf("addEventListener('touchstart'")
+        val clickIdx = js.indexOf("addEventListener('click'")
+        val onTapIdx = js.indexOf("RiffleChapter.onTap()")
+        assertTrue("touchstart listener is installed", touchStartIdx >= 0)
+        assertTrue("click listener is still installed", clickIdx >= 0)
+        assertTrue("touchstart is registered before click", touchStartIdx < clickIdx)
+        assertTrue(
+            "snapshots the selection state at touchstart",
+            js.contains("!!(s && s.rangeCount > 0 && !s.isCollapsed)"),
+        )
+        val snapshotIdx = js.indexOf("document.__riffleHadSelAtDown =")
+        assertTrue("snapshot writes to the doc-level flag", snapshotIdx in 0 until onTapIdx)
+        val gateIdx = js.indexOf("if (document.__riffleHadSelAtDown) {")
+        assertTrue("click reads the flag", gateIdx in 0 until onTapIdx)
+        // The gate must clear the flag (so the next tap toggles immersive normally) and return
+        // before reaching RiffleChapter.onTap().
+        val gateBody = js.substring(gateIdx)
+        val clearIdx = gateBody.indexOf("document.__riffleHadSelAtDown = false")
+        val returnIdx = gateBody.indexOf("return;")
+        assertTrue("gate clears the flag before returning", clearIdx in 0 until returnIdx)
+    }
 }

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ReaderWebViewScriptsTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ReaderWebViewScriptsTest.kt
@@ -169,14 +169,15 @@ class ReaderWebViewScriptsTest {
             js.contains("!!(s && s.rangeCount > 0 && !s.isCollapsed)"),
         )
         val snapshotIdx = js.indexOf("document.__riffleHadSelAtDown =")
-        assertTrue("snapshot writes to the doc-level flag", snapshotIdx in 0 until onTapIdx)
-        val gateIdx = js.indexOf("if (document.__riffleHadSelAtDown) {")
-        assertTrue("click reads the flag", gateIdx in 0 until onTapIdx)
-        // The gate must clear the flag (so the next tap toggles immersive normally) and return
-        // before reaching RiffleChapter.onTap().
-        val gateBody = js.substring(gateIdx)
-        val clearIdx = gateBody.indexOf("document.__riffleHadSelAtDown = false")
-        val returnIdx = gateBody.indexOf("return;")
-        assertTrue("gate clears the flag before returning", clearIdx in 0 until returnIdx)
+        assertTrue("touchstart writes to the doc-level flag", snapshotIdx in 0 until onTapIdx)
+        // Consume-once: the click handler snapshots hadSel and clears the flag at the top,
+        // before the interactive-element early-return, so a synthetic click without a
+        // preceding touchstart can't leave a stale `true` behind to swallow the next tap.
+        val consumeIdx = js.indexOf("var hadSel = document.__riffleHadSelAtDown;")
+        val clearIdx = js.indexOf("document.__riffleHadSelAtDown = false;")
+        assertTrue("click snapshots the flag first", consumeIdx in 0 until onTapIdx)
+        assertTrue("click clears the flag immediately after snapshot", clearIdx in consumeIdx..onTapIdx)
+        val gateIdx = js.indexOf("if (hadSel) return;")
+        assertTrue("click skips onTap when a selection was live at touchstart", gateIdx in 0 until onTapIdx)
     }
 }

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/SelectionSuppressedTapTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/SelectionSuppressedTapTest.kt
@@ -1,0 +1,72 @@
+package com.riffle.app.feature.reader
+
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicReference
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Regression coverage for the "tap-to-dismiss text selection popup also toggled immersive mode"
+ * bug. The touchstart snapshot in `SELECTION_SPAN_TRACKER_JS` calls
+ * `RiffleSelBridge.onActiveAtDown(true)` when the touch starts while a selection is live;
+ * `consumeSelectionSuppressedTap` reads that flag inside the paged InputListener.onTap so the
+ * immersive-mode toggle is skipped for that tap only.
+ *
+ * These assertions fail if the flag is not consumed (so a subsequent tap is also swallowed) or
+ * if the bridge stops honouring `onActiveAtDown`.
+ */
+class SelectionSuppressedTapTest {
+
+    @Test
+    fun `bridge onActiveAtDown sets the atomic true`() {
+        val active = AtomicBoolean(false)
+        val bridge = RiffleSelectionRectBridge(AtomicReference(null), active)
+
+        bridge.onActiveAtDown(true)
+
+        assertTrue(active.get())
+    }
+
+    @Test
+    fun `bridge onActiveAtDown clears the atomic on false`() {
+        val active = AtomicBoolean(true)
+        val bridge = RiffleSelectionRectBridge(AtomicReference(null), active)
+
+        bridge.onActiveAtDown(false)
+
+        assertFalse(active.get())
+    }
+
+    @Test
+    fun `consumeSelectionSuppressedTap returns true and clears the flag when set`() {
+        val active = AtomicBoolean(true)
+
+        val consumed = consumeSelectionSuppressedTap(active)
+
+        assertTrue("first tap after a live selection must be swallowed", consumed)
+        assertFalse("flag must be cleared so the next tap toggles immersive", active.get())
+    }
+
+    @Test
+    fun `consumeSelectionSuppressedTap returns false when no selection was live at touchstart`() {
+        val active = AtomicBoolean(false)
+
+        val consumed = consumeSelectionSuppressedTap(active)
+
+        assertFalse("normal taps must not be swallowed", consumed)
+        assertFalse(active.get())
+    }
+
+    @Test
+    fun `second tap after a suppressed one is not swallowed`() {
+        val active = AtomicBoolean(true)
+
+        val first = consumeSelectionSuppressedTap(active)
+        val second = consumeSelectionSuppressedTap(active)
+
+        assertTrue(first)
+        assertFalse("only the tap that dismissed the selection is swallowed", second)
+    }
+
+}


### PR DESCRIPTION
## Summary

When a text-selection popup was active in the reader, tapping outside to dismiss it also toggled immersive mode as an unintended side effect. Both paged/vertical (Readium `InputListener.onTap`) and continuous mode (`TAP_LISTENER_JS`) fire from the WebView's `click` event, and Readium 3.3.0's own `isSelecting` guard races with `selectionchange` on tap-outside — so the guard is stale by the time the tap arrives.

**Fix:** snapshot selection state at `touchstart`, before the browser processes touchend and clears the selection. A capture-phase `touchstart` listener in `SELECTION_SPAN_TRACKER_JS` calls `RiffleSelBridge.onActiveAtDown(active)`; the paged `InputListener.onTap` consumes the flag via `consumeSelectionSuppressedTap` and skips the immersive toggle for that tap only. Continuous mode mirrors the same snapshot in `TAP_LISTENER_JS` via a doc-level flag with consume-once semantics.

Compose overlays (footnote popup, return-target card, highlight actions, formatting sheet) already scrim outside taps, so they don't have this defect. The Android `ActionMode` toolbar is the sole transient UI whose dismissal reaches the WebView, so this is the only case that needs suppression.

## Test plan

- [x] `./gradlew test` green — new `SelectionSuppressedTapTest` pins the bridge/helper contract; new `ReaderWebViewScriptsTest` assertions pin both JS wirings (capture phase, `onActiveAtDown` bridge call for paged; consume-once flag lifecycle for continuous).
- [ ] Manual repro on AVD in **paginated** mode: select text → tap outside → popup dismisses, immersive stays. Then tap on background → immersive toggles normally.
- [ ] Same repro in **vertical** mode (same `EpubNavigatorFragment` path, so coverage is automatic).
- [ ] Same repro in **continuous** mode (separate `TAP_LISTENER_JS` gate).
- [ ] Regression check: link taps still don't toggle immersive; taps on `Copy`/`Highlight`/etc. still fire; tap-to-toggle-immersive still works when no selection is live.