### PR TITLE
fix(reader): stop continuous-mode text blanking at chapter boundary

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -132,6 +132,7 @@ dependencies {
     implementation(project(":core:network"))
 
     implementation(libs.androidx.core.ktx)
+    implementation(libs.androidx.webkit)
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.activity.compose)
 

--- a/app/src/androidTest/kotlin/com/riffle/app/feature/reader/ChapterWebViewSettingsTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/reader/ChapterWebViewSettingsTest.kt
@@ -88,6 +88,38 @@ class ChapterWebViewSettingsTest {
         )
     }
 
+    /**
+     * Regression guard for the chapter-boundary blank flash: in Continuous mode we stack many
+     * [ChapterWebView]s inside a NestedScrollView, so each is typically only partially visible.
+     * Without `OFF_SCREEN_PRERASTER`, Chromium's tile pipeline can drop or lazily re-raster the
+     * off-screen portion — when a chapter's tail scrolls above the viewport top and the user
+     * scrolls back down, the last visible line briefly renders as blank until the tile is
+     * re-rasterized. See `reference_continuous_chapter_boundary_blank_flash` for the full
+     * investigation.
+     */
+    @Test
+    fun offscreenPreRasterIsEnabledWhenSupported() {
+        if (!androidx.webkit.WebViewFeature.isFeatureSupported(
+                androidx.webkit.WebViewFeature.OFF_SCREEN_PRERASTER,
+            )
+        ) {
+            return
+        }
+        var value = false
+        instrumentation.runOnMainSync {
+            val wv = ChapterWebView(context)
+            value = androidx.webkit.WebSettingsCompat.getOffscreenPreRaster(wv.settings)
+            wv.destroy()
+        }
+        assertTrue(
+            "OFF_SCREEN_PRERASTER must be enabled on every ChapterWebView so a chapter's " +
+                "off-screen tail stays rasterized while stacked in Continuous mode — otherwise the " +
+                "trailing text of the previous chapter briefly blanks out mid-scroll at every " +
+                "chapter boundary. Do not remove this setter without a comparable substitute.",
+            value,
+        )
+    }
+
     // ── Viewport behaviour ───────────────────────────────────────────────────────
 
     /**

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ChapterWebView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ChapterWebView.kt
@@ -207,6 +207,18 @@ internal class ChapterWebView(context: Context) : WebView(context), ChapterWebVi
         settings.useWideViewPort = false
         settings.loadWithOverviewMode = false
         settings.textZoom = 100
+        // Force each chapter WebView to keep its full content rasterized even when part of it is
+        // off-screen. In continuous mode we stack many WebViews inside a NestedScrollView, so any
+        // given WebView is typically only partially visible; Chromium's default tile pipeline can
+        // then drop or lazily re-raster the off-screen portion, producing brief blank flashes at
+        // chapter boundaries as the reader scrolls back and forth across them. OFF_SCREEN_PRERASTER
+        // is Android's supported knob for this exact case.
+        if (androidx.webkit.WebViewFeature.isFeatureSupported(
+                androidx.webkit.WebViewFeature.OFF_SCREEN_PRERASTER,
+            )
+        ) {
+            androidx.webkit.WebSettingsCompat.setOffscreenPreRaster(settings, true)
+        }
         addJavascriptInterface(HeightBridge(), "RiffleChapter")
         webViewClient = object : WebViewClient() {
             override fun onPageFinished(view: WebView?, url: String?) {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -30,9 +30,11 @@ kotlinx-serialization = "1.7.3"
 coil = "2.7.0"
 jsoup = "1.22.2"
 media3 = "1.10.1"
+webkit = "1.14.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
+androidx-webkit = { group = "androidx.webkit", name = "webkit", version.ref = "webkit" }
 androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycleRuntimeKtx" }
 androidx-lifecycle-process = { group = "androidx.lifecycle", name = "lifecycle-process", version.ref = "lifecycleRuntimeKtx" }
 androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activityCompose" }


### PR DESCRIPTION
## Summary

- In Continuous mode we stack many `ChapterWebView`s inside a `NestedScrollView`, so each is only partially visible. Chromium's tile pipeline can drop or lazily re-raster the off-screen portion of a partially-visible WebView — so when a chapter's tail scrolls above the viewport top and the reader scrolls back down, the last visible line briefly renders as blank until the tile is re-rasterized. User-visible as "text disappears when I scroll down, reappears when I scroll up" at every chapter boundary. Consistent, direction-dependent, repros on AVD and physical devices.
- Fix: `WebSettingsCompat.setOffscreenPreRaster(settings, true)` on every `ChapterWebView`, feature-gated on `WebViewFeature.OFF_SCREEN_PRERASTER`. This is the AndroidX-supported knob for exactly this case; adds one small dep (`androidx.webkit`).
- Regression guard added in `ChapterWebViewSettingsTest` so a future edit to `ChapterWebView.init` can't silently drop the fix.

## Test plan

- [x] `./gradlew :app:compileDebugKotlin :app:compileDebugAndroidTestKotlin` — green
- [x] Manual repro on physical device with the fix build: scroll back and forth across Ch. 2 → Ch. 3 boundary in Continuous mode. Confirmed no blanking.
- [ ] CI runs the new instrumentation guard (`ChapterWebViewSettingsTest.offscreenPreRasterIsEnabledWhenSupported`) — skips silently on WebViews that don't support the feature, asserts the setter stuck otherwise.