### PR TITLE
fix(webdav): sync Settings row and WebDAV banner status

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/annotationsync/AnnotationSyncStatus.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/annotationsync/AnnotationSyncStatus.kt
@@ -1,0 +1,35 @@
+package com.riffle.app.feature.annotationsync
+
+import com.riffle.core.data.CycleOutcome
+import com.riffle.core.domain.AnnotationSyncConfig
+
+/**
+ * Single source of truth for the WebDAV sync "kind" (Local / Synced / Pending / Error) rendered by
+ * the main Settings row ([com.riffle.app.feature.settings.SettingsViewModel.annotationSyncRow]) and
+ * the AddServer WebDAV banner
+ * ([com.riffle.app.feature.server.AddServerViewModel.webdavBanner]).
+ *
+ * Both surfaces observe the same singleton [com.riffle.core.data.AnnotationSyncStatusStore] and the
+ * same pending-book count, and both call this function to decide their badge/kind — so the two
+ * views cannot contradict each other. Adding a new rule (e.g. degrading Success → Pending while
+ * books are unsynced) is done here so both places pick it up.
+ */
+enum class AnnotationSyncKind { Local, Synced, Pending, Error }
+
+fun deriveAnnotationSyncKind(
+    config: AnnotationSyncConfig?,
+    outcome: CycleOutcome,
+    pendingBookCount: Int,
+): AnnotationSyncKind {
+    if (config == null) return AnnotationSyncKind.Local
+    return when (outcome) {
+        CycleOutcome.NeverRun -> AnnotationSyncKind.Pending
+        is CycleOutcome.Failed.Auth,
+        is CycleOutcome.Failed.Tls,
+        is CycleOutcome.Failed.Server,
+        is CycleOutcome.Failed.Unknown -> AnnotationSyncKind.Error
+        is CycleOutcome.Failed.Network -> AnnotationSyncKind.Pending
+        is CycleOutcome.Success ->
+            if (pendingBookCount > 0) AnnotationSyncKind.Pending else AnnotationSyncKind.Synced
+    }
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/server/AddServerViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/server/AddServerViewModel.kt
@@ -7,9 +7,12 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.riffle.app.BuildConfig
+import com.riffle.app.feature.annotationsync.AnnotationSyncKind
+import com.riffle.app.feature.annotationsync.deriveAnnotationSyncKind
 import com.riffle.core.data.AnnotationSyncStatusStore
 import com.riffle.core.data.CycleOutcome
 import com.riffle.core.data.ReadaloudMatchingService
+import com.riffle.core.database.AnnotationDao
 import com.riffle.core.data.StorytellerReadaloudSyncer
 import com.riffle.core.data.TestConnectionResult
 import com.riffle.core.data.WebDavAnnotationSyncTargetFactory
@@ -56,6 +59,7 @@ class AddServerViewModel @Inject constructor(
     private val readaloudMatcher: ReadaloudMatchingService,
     private val tokenStorage: TokenStorage,
     private val clock: Clock,
+    private val annotationDao: AnnotationDao,
     @Named(WEBDAV_BANNER_TICKER) private val bannerTicker: Flow<Unit>,
     savedStateHandle: SavedStateHandle,
 ) : ViewModel() {
@@ -90,9 +94,10 @@ class AddServerViewModel @Inject constructor(
         webdavConfigStore.observe(),
         webdavStatusStore.lastCycleOutcome,
         webdavStatusStore.lastSuccessAtMs,
+        annotationDao.observePendingBookCountAcrossAll(),
         bannerTicker,
-    ) { config, outcome, lastSuccessAtMs, _ ->
-        config?.let { webdavBanner(it, outcome, lastSuccessAtMs) }
+    ) { config, outcome, lastSuccessAtMs, pendingCount, _ ->
+        config?.let { webdavBanner(it, outcome, pendingCount, lastSuccessAtMs) }
     }.stateIn(viewModelScope, SharingStarted.Eagerly, null)
 
     var insecureWarning by mutableStateOf<InsecureConnectionType?>(null)
@@ -281,25 +286,41 @@ class AddServerViewModel @Inject constructor(
     private fun webdavBanner(
         config: AnnotationSyncConfig,
         outcome: CycleOutcome,
+        pendingBookCount: Int,
         lastSuccessAtMs: Long?,
     ): WebdavBanner {
-        val (kind, prescription) = when (outcome) {
-            is CycleOutcome.NeverRun -> WebdavBannerKind.Pending to null
-            is CycleOutcome.Success -> WebdavBannerKind.Synced to null
-            is CycleOutcome.Failed.Auth -> WebdavBannerKind.Error to
+        // Kind comes from the shared derivation so this banner cannot disagree with the Settings
+        // "WebDAV" row (see [AnnotationSyncKind]). Prescription copy stays local because the
+        // banner surfaces action guidance the Settings row does not.
+        val bannerKind = when (deriveAnnotationSyncKind(config, outcome, pendingBookCount)) {
+            AnnotationSyncKind.Synced -> WebdavBannerKind.Synced
+            AnnotationSyncKind.Pending -> WebdavBannerKind.Pending
+            AnnotationSyncKind.Error -> WebdavBannerKind.Error
+            // config is non-null on this code path (banner is hidden otherwise), so Local is
+            // unreachable — fall back to Pending defensively.
+            AnnotationSyncKind.Local -> WebdavBannerKind.Pending
+        }
+        val prescription = when {
+            outcome is CycleOutcome.Failed.Auth ->
                 "Authentication failed — your credentials may have expired. Re-enter them below; sync will retry once saved."
-            is CycleOutcome.Failed.Tls -> WebdavBannerKind.Error to
+            outcome is CycleOutcome.Failed.Tls ->
                 "TLS error — the server's certificate could not be verified. Update the URL below; sync will retry once saved."
-            is CycleOutcome.Failed.Server -> WebdavBannerKind.Error to
+            outcome is CycleOutcome.Failed.Server ->
                 "Server returned HTTP ${outcome.code}. Will retry automatically."
-            is CycleOutcome.Failed.Network -> WebdavBannerKind.Pending to
+            outcome is CycleOutcome.Failed.Unknown ->
+                "Sync failed. Will retry automatically."
+            outcome is CycleOutcome.Failed.Network ->
                 "Couldn't reach the server. Will retry automatically when connectivity returns."
-            is CycleOutcome.Failed.Unknown -> WebdavBannerKind.Error to "Sync failed. Will retry automatically."
+            outcome is CycleOutcome.Success && pendingBookCount > 0 ->
+                "$pendingBookCount book(s) pending · will sync shortly."
+            outcome is CycleOutcome.NeverRun && pendingBookCount > 0 ->
+                "$pendingBookCount book(s) pending · waiting for first sync."
+            else -> null
         }
         val host = runCatching { java.net.URI(config.baseUrl).host ?: config.baseUrl }
             .getOrElse { config.baseUrl }
         return WebdavBanner(
-            kind = kind,
+            kind = bannerKind,
             host = host,
             baseUrl = config.baseUrl,
             username = config.username,

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsViewModel.kt
@@ -111,8 +111,13 @@ class SettingsViewModel @Inject constructor(
             AnnotationSyncKind.Error -> AnnotationSyncRowState.Tone.Error
         }
         val identity = config?.let { "${it.username}@${shortHost(it.baseUrl)}" }
+        // NeverRun outranks a positive pending count so the row keeps saying
+        // "Waiting for first sync…" for a freshly-configured install — matching pre-refactor
+        // behavior. The kind is still Pending either way, so the badge stays in sync with the
+        // banner via [deriveAnnotationSyncKind].
         val sub = when {
             config == null -> "Not configured · tap to set up a WebDAV server"
+            outcome is CycleOutcome.NeverRun -> "Waiting for first sync…"
             outcome is CycleOutcome.Failed.Auth -> "Authentication failed · tap to re-enter credentials"
             outcome is CycleOutcome.Failed.Tls -> "TLS error · tap to check server URL"
             outcome is CycleOutcome.Failed.Server -> "Server error (HTTP ${outcome.code}) · will retry automatically"
@@ -121,7 +126,6 @@ class SettingsViewModel @Inject constructor(
                 "$pendingCount book(s) pending · will sync when online"
             outcome is CycleOutcome.Failed.Network -> "Offline · will sync when connected"
             pendingCount > 0 -> "$pendingCount book(s) pending · will sync when online"
-            outcome is CycleOutcome.NeverRun -> "Waiting for first sync…"
             else -> "Synced · $identity"
         }
         return AnnotationSyncRowState(badge, "WebDAV", sub, subTone)

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsViewModel.kt
@@ -24,6 +24,8 @@ import com.riffle.core.domain.ReadaloudPreferencesStore
 import com.riffle.core.domain.ReadaloudReviewRepository
 import com.riffle.core.domain.Server
 import com.riffle.core.domain.ServerType
+import com.riffle.app.feature.annotationsync.AnnotationSyncKind
+import com.riffle.app.feature.annotationsync.deriveAnnotationSyncKind
 import com.riffle.core.data.AnnotationSyncStatusStore
 import com.riffle.core.data.CycleOutcome
 import com.riffle.core.database.AnnotationDao
@@ -96,58 +98,33 @@ class SettingsViewModel @Inject constructor(
         outcome: CycleOutcome,
         pendingCount: Int,
     ): AnnotationSyncRowState {
-        if (config == null) {
-            return AnnotationSyncRowState(
-                badge = AnnotationSyncRowState.Badge.Local,
-                headline = "WebDAV",
-                sub = "Not configured · tap to set up a WebDAV server",
-                subTone = AnnotationSyncRowState.Tone.Normal,
-            )
+        val kind = deriveAnnotationSyncKind(config, outcome, pendingCount)
+        val badge = when (kind) {
+            AnnotationSyncKind.Local -> AnnotationSyncRowState.Badge.Local
+            AnnotationSyncKind.Synced -> AnnotationSyncRowState.Badge.Synced
+            AnnotationSyncKind.Pending -> AnnotationSyncRowState.Badge.Pending
+            AnnotationSyncKind.Error -> AnnotationSyncRowState.Badge.Error
         }
-        val identity = "${config.username}@${shortHost(config.baseUrl)}"
-        return when {
-            outcome is CycleOutcome.NeverRun -> AnnotationSyncRowState(
-                AnnotationSyncRowState.Badge.Pending, "WebDAV",
-                "Waiting for first sync…",
-                AnnotationSyncRowState.Tone.Pending,
-            )
-            outcome is CycleOutcome.Failed.Auth -> AnnotationSyncRowState(
-                AnnotationSyncRowState.Badge.Error, "WebDAV",
-                "Authentication failed · tap to re-enter credentials",
-                AnnotationSyncRowState.Tone.Error,
-            )
-            outcome is CycleOutcome.Failed.Tls -> AnnotationSyncRowState(
-                AnnotationSyncRowState.Badge.Error, "WebDAV",
-                "TLS error · tap to check server URL",
-                AnnotationSyncRowState.Tone.Error,
-            )
-            outcome is CycleOutcome.Failed.Server -> AnnotationSyncRowState(
-                AnnotationSyncRowState.Badge.Error, "WebDAV",
-                "Server error (HTTP ${outcome.code}) · will retry automatically",
-                AnnotationSyncRowState.Tone.Error,
-            )
-            outcome is CycleOutcome.Failed.Unknown -> AnnotationSyncRowState(
-                AnnotationSyncRowState.Badge.Error, "WebDAV",
-                "Sync failed · will retry automatically",
-                AnnotationSyncRowState.Tone.Error,
-            )
-            outcome is CycleOutcome.Failed.Network -> AnnotationSyncRowState(
-                AnnotationSyncRowState.Badge.Pending, "WebDAV",
-                if (pendingCount > 0) "$pendingCount book(s) pending · will sync when online"
-                else "Offline · will sync when connected",
-                AnnotationSyncRowState.Tone.Pending,
-            )
-            pendingCount > 0 -> AnnotationSyncRowState(
-                AnnotationSyncRowState.Badge.Pending, "WebDAV",
-                "$pendingCount book(s) pending · will sync when online",
-                AnnotationSyncRowState.Tone.Pending,
-            )
-            else -> AnnotationSyncRowState(
-                AnnotationSyncRowState.Badge.Synced, "WebDAV",
-                "Synced · $identity",
-                AnnotationSyncRowState.Tone.Normal,
-            )
+        val subTone = when (kind) {
+            AnnotationSyncKind.Local, AnnotationSyncKind.Synced -> AnnotationSyncRowState.Tone.Normal
+            AnnotationSyncKind.Pending -> AnnotationSyncRowState.Tone.Pending
+            AnnotationSyncKind.Error -> AnnotationSyncRowState.Tone.Error
         }
+        val identity = config?.let { "${it.username}@${shortHost(it.baseUrl)}" }
+        val sub = when {
+            config == null -> "Not configured · tap to set up a WebDAV server"
+            outcome is CycleOutcome.Failed.Auth -> "Authentication failed · tap to re-enter credentials"
+            outcome is CycleOutcome.Failed.Tls -> "TLS error · tap to check server URL"
+            outcome is CycleOutcome.Failed.Server -> "Server error (HTTP ${outcome.code}) · will retry automatically"
+            outcome is CycleOutcome.Failed.Unknown -> "Sync failed · will retry automatically"
+            outcome is CycleOutcome.Failed.Network && pendingCount > 0 ->
+                "$pendingCount book(s) pending · will sync when online"
+            outcome is CycleOutcome.Failed.Network -> "Offline · will sync when connected"
+            pendingCount > 0 -> "$pendingCount book(s) pending · will sync when online"
+            outcome is CycleOutcome.NeverRun -> "Waiting for first sync…"
+            else -> "Synced · $identity"
+        }
+        return AnnotationSyncRowState(badge, "WebDAV", sub, subTone)
     }
 
     private val _crashReports = MutableStateFlow(crashReportRepository.listCrashReports())

--- a/app/src/test/kotlin/com/riffle/app/feature/server/AddServerViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/server/AddServerViewModelTest.kt
@@ -4,6 +4,8 @@ import androidx.lifecycle.SavedStateHandle
 import com.riffle.core.data.AnnotationSyncStatusStore
 import com.riffle.core.data.CycleOutcome
 import com.riffle.core.data.WebDavAnnotationSyncTargetFactory
+import com.riffle.core.database.AnnotationDao
+import com.riffle.core.database.AnnotationEntity
 import com.riffle.core.domain.AnnotationSweepEnqueuer
 import com.riffle.core.domain.AnnotationSyncConfig
 import com.riffle.core.domain.AnnotationSyncConfigStore
@@ -163,6 +165,7 @@ class AddServerViewModelTest {
         tokenStorage: com.riffle.core.domain.TokenStorage = io.mockk.mockk(relaxed = true),
         statusStore: AnnotationSyncStatusStore = AnnotationSyncStatusStore(),
         clock: com.riffle.core.domain.Clock = MutableClock(),
+        annotationDao: AnnotationDao = stubAnnotationDao(pendingBookCount = 0),
         bannerTicker: Flow<Unit> = flowOf(Unit),
     ): AddServerViewModel = AddServerViewModel(
         repository = repository,
@@ -174,9 +177,31 @@ class AddServerViewModelTest {
         readaloudMatcher = io.mockk.mockk(relaxed = true),
         tokenStorage = tokenStorage,
         clock = clock,
+        annotationDao = annotationDao,
         bannerTicker = bannerTicker,
         savedStateHandle = savedState,
     )
+
+    private fun stubAnnotationDao(pendingBookCount: Int): AnnotationDao = object : AnnotationDao {
+        override fun observeForItem(serverId: String, itemId: String) = flowOf(emptyList<AnnotationEntity>())
+        override fun observeForServer(serverId: String) = flowOf(emptyList<AnnotationEntity>())
+        override suspend fun getForItem(serverId: String, itemId: String) = emptyList<AnnotationEntity>()
+        override suspend fun getAllForItemIncludingDeleted(serverId: String, itemId: String) = emptyList<AnnotationEntity>()
+        override suspend fun getById(id: String): AnnotationEntity? = null
+        override suspend fun getByItemAndCfi(serverId: String, itemId: String, cfi: String): AnnotationEntity? = null
+        override suspend fun upsert(entity: AnnotationEntity) {}
+        override suspend fun upsertAll(annotations: List<AnnotationEntity>) {}
+        override suspend fun tombstone(id: String, updatedAt: Long, deviceId: String) {}
+        override suspend fun recolor(id: String, color: String, updatedAt: Long, deviceId: String) {}
+        override suspend fun updateNote(id: String, note: String?, updatedAt: Long, deviceId: String) {}
+        override fun observeAnnotationsByPosition(serverId: String, itemId: String) = flowOf(emptyList<AnnotationEntity>())
+        override suspend fun renameBookmark(id: String, title: String, updatedAt: Long, deviceId: String) {}
+        override fun observePendingCountForBook(serverId: String, itemId: String) = flowOf(0)
+        override fun observePendingBookCountAcrossAll() = flowOf(pendingBookCount)
+        override suspend fun dirtyServerItems() = emptyList<AnnotationDao.DirtyServerItem>()
+        override suspend fun markSynced(ids: List<String>, syncedAt: Long) {}
+        override suspend fun purgeAgedTombstones(serverId: String, itemId: String, cutoff: Long): Int = 0
+    }
 
     @Test
     fun `updateHost auto-splits a pasted http url into scheme and host`() {
@@ -415,6 +440,94 @@ class AddServerViewModelTest {
         assertNotNull(synced)
         assertEquals(WebdavBannerKind.Synced, synced!!.kind)
         assertEquals("just now", synced.lastSyncRelative)
+    }
+
+    /**
+     * Regression: the AddServer WebDAV banner and the main Settings row derive their kind from the
+     * same [com.riffle.app.feature.annotationsync.deriveAnnotationSyncKind] function, so a Success
+     * outcome with un-pushed books must downgrade to Pending on the banner too — otherwise the
+     * banner would say "Synced" while Settings said "N book(s) pending". Pin the banner side here;
+     * `SettingsViewModelTest` pins the Settings side; both would flip if the shared rule regressed.
+     */
+    @Test
+    fun `webdavBanner is Pending when Success outcome has pending books unsynced`() = runTest {
+        val existing = com.riffle.core.domain.AnnotationSyncConfig(
+            baseUrl = "https://dav.example.com/store",
+            username = "syncuser",
+            password = "syncpass",
+        )
+        val statusStore = AnnotationSyncStatusStore().apply {
+            report(CycleOutcome.Success(1_000L))
+        }
+        val vm = makeVm(
+            fakeRepo(AuthenticateResult.WrongCredentials("x")),
+            savedState = SavedStateHandle(mapOf("type" to "webdav")),
+            configStore = RecordingConfigStore(initial = existing),
+            statusStore = statusStore,
+            annotationDao = stubAnnotationDao(pendingBookCount = 2),
+        )
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        val banner = vm.webdavBanner.value
+        assertNotNull(banner)
+        assertEquals(WebdavBannerKind.Pending, banner!!.kind)
+        assertTrue(
+            "prescription should mention pending books, got: ${banner.prescription}",
+            banner.prescription?.contains("2 book") == true,
+        )
+    }
+
+    /**
+     * Complements the previous test: when the pending count reactively drops to 0 (books get
+     * pushed), the banner must flip Pending → Synced without navigating away and back. This is the
+     * "update in realtime" half of the invariant — the Settings row also observes the same
+     * pending-book count Flow, so both surfaces move together.
+     */
+    @Test
+    fun `webdavBanner flips Pending to Synced when pending book count reactively drops to 0`() = runTest {
+        val existing = com.riffle.core.domain.AnnotationSyncConfig(
+            baseUrl = "https://dav.example.com/store",
+            username = "syncuser",
+            password = "syncpass",
+        )
+        val statusStore = AnnotationSyncStatusStore().apply {
+            report(CycleOutcome.Success(1_000L))
+        }
+        val pending = MutableStateFlow(2)
+        val dao = object : AnnotationDao {
+            override fun observeForItem(serverId: String, itemId: String) = flowOf(emptyList<AnnotationEntity>())
+            override fun observeForServer(serverId: String) = flowOf(emptyList<AnnotationEntity>())
+            override suspend fun getForItem(serverId: String, itemId: String) = emptyList<AnnotationEntity>()
+            override suspend fun getAllForItemIncludingDeleted(serverId: String, itemId: String) = emptyList<AnnotationEntity>()
+            override suspend fun getById(id: String): AnnotationEntity? = null
+            override suspend fun getByItemAndCfi(serverId: String, itemId: String, cfi: String): AnnotationEntity? = null
+            override suspend fun upsert(entity: AnnotationEntity) {}
+            override suspend fun upsertAll(annotations: List<AnnotationEntity>) {}
+            override suspend fun tombstone(id: String, updatedAt: Long, deviceId: String) {}
+            override suspend fun recolor(id: String, color: String, updatedAt: Long, deviceId: String) {}
+            override suspend fun updateNote(id: String, note: String?, updatedAt: Long, deviceId: String) {}
+            override fun observeAnnotationsByPosition(serverId: String, itemId: String) = flowOf(emptyList<AnnotationEntity>())
+            override suspend fun renameBookmark(id: String, title: String, updatedAt: Long, deviceId: String) {}
+            override fun observePendingCountForBook(serverId: String, itemId: String) = flowOf(0)
+            override fun observePendingBookCountAcrossAll() = pending
+            override suspend fun dirtyServerItems() = emptyList<AnnotationDao.DirtyServerItem>()
+            override suspend fun markSynced(ids: List<String>, syncedAt: Long) {}
+            override suspend fun purgeAgedTombstones(serverId: String, itemId: String, cutoff: Long): Int = 0
+        }
+        val vm = makeVm(
+            fakeRepo(AuthenticateResult.WrongCredentials("x")),
+            savedState = SavedStateHandle(mapOf("type" to "webdav")),
+            configStore = RecordingConfigStore(initial = existing),
+            statusStore = statusStore,
+            annotationDao = dao,
+        )
+        testDispatcher.scheduler.advanceUntilIdle()
+        assertEquals(WebdavBannerKind.Pending, vm.webdavBanner.value!!.kind)
+
+        pending.value = 0
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(WebdavBannerKind.Synced, vm.webdavBanner.value!!.kind)
     }
 
     /**

--- a/app/src/test/kotlin/com/riffle/app/feature/settings/SettingsViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/settings/SettingsViewModelTest.kt
@@ -700,6 +700,27 @@ class SettingsViewModelTest {
         // Should NOT show the Synced badge before any cycle has completed.
     }
 
+    // Regression: NeverRun must win over a positive pending count in the sub-text — a
+    // freshly-installed device with un-pushed local highlights should say "Waiting for first
+    // sync…", not "N book(s) pending · will sync when online". Introduced when the row's
+    // when-branches were re-ordered around the shared kind derivation; without this test a
+    // future refactor could re-invert the ordering and no assertion would flip.
+    @Test
+    fun `annotationSyncRow shows Waiting for first sync when NeverRun even with pending books`() = runTest {
+        val config = MutableStateFlow<AnnotationSyncConfig?>(AnnotationSyncConfig("https://srv.example/dav/", "alice", "pw"))
+        val status = AnnotationSyncStatusStore() // NeverRun
+        val vm = newSettingsViewModel(
+            configStore = stubConfigStore(config), statusStore = status,
+            annotationDao = stubAnnotationDao(pendingBookCount = 3),
+        )
+        backgroundScope.launch { vm.annotationSyncRow.collect {} }
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        val row = vm.annotationSyncRow.value
+        assertEquals(AnnotationSyncRowState.Badge.Pending, row.badge)
+        assertTrue("sub should be 'Waiting for first sync…', got: ${row.sub}", row.sub.contains("Waiting for first sync"))
+    }
+
     @Test
     fun `annotationSyncRow is Synced when configured + Success + no pending`() = runTest {
         val config = MutableStateFlow<AnnotationSyncConfig?>(AnnotationSyncConfig("https://srv.example/dav/", "alice", "pw"))


### PR DESCRIPTION
## Summary

The main Settings "WebDAV" row and the AddServer WebDAV banner derived their kind from separate rules, so a `Success` outcome with un-pushed books showed **"Synced"** on the banner while Settings showed **"N book(s) pending"** — two surfaces contradicting each other on the same underlying state.

- Extract a single `deriveAnnotationSyncKind(config, outcome, pendingBookCount)` in `com.riffle.app.feature.annotationsync` and route both surfaces through it. The invariant "Settings badge and banner kind agree" is now enforced by construction.
- `AddServerViewModel` gains `AnnotationDao.observePendingBookCountAcrossAll()` as a 5th `combine` input, so the banner degrades `Success → Pending` when books remain unsynced, matching what Settings has always shown.
- Both surfaces subscribe to the same singleton `AnnotationSyncStatusStore` StateFlow and the same Room Flow, so they update in real time — no navigate-away required.

## Test plan

- [x] `AddServerViewModelTest.webdavBanner is Pending when Success outcome has pending books unsynced` — pins the banner side of the invariant.
- [x] `AddServerViewModelTest.webdavBanner flips Pending to Synced when pending book count reactively drops to 0` — pins the realtime half.
- [x] `SettingsViewModelTest.annotationSyncRow shows Waiting for first sync when NeverRun even with pending books` — pins the `NeverRun` sub-text (regression discovered during code review).
- [x] Pre-existing Settings/AddServer VM tests continue to pass.