### PR TITLE
feat(reader): add Original font passthrough; make Serif force a real serif

### DIFF
--- a/app/src/androidTest/kotlin/com/riffle/app/feature/reader/FormattingPreferencesMapperTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/reader/FormattingPreferencesMapperTest.kt
@@ -61,14 +61,23 @@ class FormattingPreferencesMapperTest {
         assertEquals(Theme.LIGHT, result.theme)
     }
 
-    // Serif is the default ReaderFontFamily; mapping it to null leaves --USER__fontFamily
+    // Original is the default ReaderFontFamily; mapping it to null leaves --USER__fontFamily
     // unset on :root so the publisher's typography is preserved on books the user hasn't
     // customized. See typographyOverrideCss() — the gate `:root[style*="--USER__fontFamily"]`
     // requires the variable to be present for any override to apply.
     @Test
-    fun defaultSerifFontFamilyMapsToNullSoPublisherTypographyIsPreserved() {
-        val result = FormattingPreferences(fontFamily = ReaderFontFamily.Serif).toEpubPreferences()
+    fun defaultOriginalFontFamilyMapsToNullSoPublisherTypographyIsPreserved() {
+        val result = FormattingPreferences(fontFamily = ReaderFontFamily.Original).toEpubPreferences()
         assertNull(result.fontFamily)
+    }
+
+    // Regression: the generic "Serif" chip must force a real serif face, not passthrough. The
+    // previous behaviour (Serif → null → publisher font) misled users who picked "Serif" to
+    // force serif letterforms and instead got whatever the publisher shipped.
+    @Test
+    fun serifFontFamilyMapsToCssSerif() {
+        val result = FormattingPreferences(fontFamily = ReaderFontFamily.Serif).toEpubPreferences()
+        assertEquals("serif", result.fontFamily?.name)
     }
 
     @Test

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjector.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjector.kt
@@ -71,8 +71,9 @@ internal object ContinuousStyleInjector {
             props["--USER__textColor"] = DARK_DIM_TEXT_HEX
         }
 
-        // Font family: Serif maps to null (no override → publisher/system font, exactly like
-        // Readium). Other families set --USER__fontFamily + the readium-font-on flag.
+        // Font family: Original maps to null (no override → publisher font, exactly like
+        // Readium's null mapping). Other families set --USER__fontFamily + the readium-font-on
+        // flag; the generic "Serif" resolves to the CSS `serif` system font.
         val fontStack = fontFamilyStack(prefs.fontFamily)
         if (fontStack != null) {
             props["--USER__fontOverride"] = "readium-font-on"
@@ -102,13 +103,14 @@ internal object ContinuousStyleInjector {
     }
 
     /**
-     * The font stack for [family], or null when no override should be emitted (Serif → publisher
-     * font). Mirrors Readium's `resolveFontStack`: our app registers Literata/Merriweather/
-     * OpenDyslexic with no alternates, so each resolves to a single-entry stack — identical to
-     * what Scroll mode produces.
+     * The font stack for [family], or null when no override should be emitted (Original →
+     * publisher font). Mirrors Readium's `resolveFontStack`: our app registers Literata/
+     * Merriweather/OpenDyslexic with no alternates, so each resolves to a single-entry stack
+     * — identical to what Scroll mode produces. Generic "Serif" resolves to CSS `serif`.
      */
     private fun fontFamilyStack(family: ReaderFontFamily): List<String>? = when (family) {
-        ReaderFontFamily.Serif -> null
+        ReaderFontFamily.Original -> null
+        ReaderFontFamily.Serif -> listOf("serif")
         ReaderFontFamily.SansSerif -> listOf("sans-serif")
         ReaderFontFamily.Monospace -> listOf("monospace")
         ReaderFontFamily.Literata -> listOf("Literata")

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/FormattingPreferencesMapper.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/FormattingPreferencesMapper.kt
@@ -52,14 +52,14 @@ fun FormattingPreferences.toEpubPreferences(
         },
         // DarkDim is "dark with slightly muted body text" — same dark background, dimmer text.
         textColor = if (theme == ReaderTheme.DarkDim) Color(DARK_DIM_TEXT_COLOR) else null,
-        // Null-gating: when the user value equals the default, pass null so Readium leaves
-        // the corresponding --USER__* CSS variable unset on :root. The typography-override
-        // stylesheet (see TypographyOverride.kt) is gated on the variable's presence, so an
-        // unset variable means the publisher's typography is preserved on uncustomised books.
-        // The moment the user nudges a setting away from default, the variable appears and
-        // both Readium's own rules and our targeted override start applying.
+        // Null-gating: Original (the default) passes null so Readium leaves --USER__fontFamily
+        // unset on :root. The typography-override stylesheet (see TypographyOverride.kt) is
+        // gated on the variable's presence, so an unset variable means the publisher's
+        // typography is preserved on uncustomised books. Every other choice — including the
+        // generic "Serif" — sets the variable and overrides the publisher font.
         fontFamily = when (fontFamily) {
-            ReaderFontFamily.Serif -> null  // Serif is the default; see FormattingPreferences.DEFAULT_FONT_FAMILY
+            ReaderFontFamily.Original -> null  // Default: see FormattingPreferences.DEFAULT_FONT_FAMILY
+            ReaderFontFamily.Serif -> FontFamily("serif")
             ReaderFontFamily.SansSerif -> FontFamily("sans-serif")
             ReaderFontFamily.Monospace -> FontFamily("monospace")
             ReaderFontFamily.Literata -> FontFamily("Literata")

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/FormattingSection.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/FormattingSection.kt
@@ -48,7 +48,7 @@ fun FormattingSection(
 
         if (capabilities.supportsFontFamily) {
             Text("Font", style = MaterialTheme.typography.labelMedium)
-            val genericFonts = listOf(ReaderFontFamily.Serif, ReaderFontFamily.SansSerif, ReaderFontFamily.Monospace)
+            val genericFonts = listOf(ReaderFontFamily.Original, ReaderFontFamily.Serif, ReaderFontFamily.SansSerif, ReaderFontFamily.Monospace)
             val bundledFonts = listOf(ReaderFontFamily.Literata, ReaderFontFamily.Merriweather, ReaderFontFamily.OpenDyslexic)
             FontChipRow(genericFonts, prefs.fontFamily) { onPrefsChange(prefs.copy(fontFamily = it)) }
             Spacer(Modifier.height(4.dp))

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderSettingsControls.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderSettingsControls.kt
@@ -213,6 +213,7 @@ internal fun FontChipRow(
 
 @Composable
 private fun ReaderFontFamily.previewFontFamily(): FontFamily? = when (this) {
+    ReaderFontFamily.Original -> null
     ReaderFontFamily.Serif -> FontFamily.Serif
     ReaderFontFamily.SansSerif -> FontFamily.SansSerif
     ReaderFontFamily.Monospace -> FontFamily.Monospace

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderSettingsSummaries.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderSettingsSummaries.kt
@@ -17,6 +17,7 @@ fun ReaderTheme.label(): String = when (this) {
 }
 
 fun ReaderFontFamily.label(): String = when (this) {
+    ReaderFontFamily.Original -> "Original"
     ReaderFontFamily.Serif -> "Serif"
     ReaderFontFamily.SansSerif -> "Sans serif"
     ReaderFontFamily.Monospace -> "Mono"

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjectorTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjectorTest.kt
@@ -70,10 +70,18 @@ class ContinuousStyleInjectorTest {
     // ── font family ──────────────────────────────────────────────────────────────
 
     @Test
-    fun `Serif (default) emits no font override — publisher font, matching Readium null mapping`() {
-        val s = attr(FormattingPreferences(fontFamily = ReaderFontFamily.Serif))
+    fun `Original (default) emits no font override — publisher font, matching Readium null mapping`() {
+        val s = attr(FormattingPreferences(fontFamily = ReaderFontFamily.Original))
         assertFalse("no font override", s.contains("--USER__fontOverride"))
         assertFalse("no font family", s.contains("--USER__fontFamily"))
+    }
+
+    // Regression: the generic "Serif" chip must emit a real serif override, not passthrough.
+    @Test
+    fun `Serif sets fontOverride and quoted CSS serif family`() {
+        val s = attr(FormattingPreferences(fontFamily = ReaderFontFamily.Serif))
+        assertTrue(s.contains("--USER__fontOverride: readium-font-on !important;"))
+        assertTrue(s.contains("--USER__fontFamily: \"serif\" !important;"))
     }
 
     @Test

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ReaderSettingsSummariesTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ReaderSettingsSummariesTest.kt
@@ -20,6 +20,7 @@ class ReaderSettingsSummariesTest {
     }
 
     @Test fun fontLabels() {
+        assertEquals("Original", ReaderFontFamily.Original.label())
         assertEquals("Serif", ReaderFontFamily.Serif.label())
         assertEquals("Sans serif", ReaderFontFamily.SansSerif.label())
         assertEquals("Dyslexic", ReaderFontFamily.OpenDyslexic.label())

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/presenter/FakeReaderPresenterTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/presenter/FakeReaderPresenterTest.kt
@@ -27,7 +27,7 @@ class FakeReaderPresenterTest {
 
     private val defaultPrefs = FormattingPreferences(
         theme = ReaderTheme.Light,
-        fontFamily = ReaderFontFamily.Serif,
+        fontFamily = ReaderFontFamily.Original,
         fontSize = 1.0f,
         lineSpacing = 1.2f,
         margins = 1.0f,

--- a/core/data/src/main/kotlin/com/riffle/core/data/BookFormattingPreferencesStoreImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/BookFormattingPreferencesStoreImpl.kt
@@ -24,7 +24,7 @@ class BookFormattingPreferencesStoreImpl @Inject constructor(
         return BookFormattingOverrides(
             fontSize = entity.fontSize,
             theme = entity.theme?.let { runCatching { ReaderTheme.valueOf(it) }.getOrNull() },
-            fontFamily = entity.fontFamily?.let { runCatching { ReaderFontFamily.valueOf(it) }.getOrNull() },
+            fontFamily = entity.fontFamily?.decodeFontFamily(),
             lineSpacing = entity.lineSpacing,
             margins = entity.margins,
             orientation = entity.orientation?.let { runCatching { ReaderOrientation.valueOf(it) }.getOrNull() },
@@ -49,7 +49,7 @@ class BookFormattingPreferencesStoreImpl @Inject constructor(
                 itemId = itemId,
                 fontSize = overrides.fontSize,
                 theme = overrides.theme?.name,
-                fontFamily = overrides.fontFamily?.name,
+                fontFamily = overrides.fontFamily?.encodePersistName(),
                 lineSpacing = overrides.lineSpacing,
                 margins = overrides.margins,
                 orientation = overrides.orientation?.name,

--- a/core/data/src/main/kotlin/com/riffle/core/data/FormattingPreferencesStoreImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/FormattingPreferencesStoreImpl.kt
@@ -107,15 +107,19 @@ class FormattingPreferencesStoreImpl @Inject constructor(
 // Before the Original split, the "Serif" enum value was passthrough — it rendered the publisher's
 // font. Any legacy "Serif" string on disk therefore encoded that passthrough intent and must load
 // as Original, not as the new real-serif Serif. To distinguish new picks from legacy data we
-// persist the new Serif under a distinct name ("SerifV2"). All other values keep their enum name.
+// persist the new Serif under a distinct name (SERIF_V2_PERSIST_NAME). All other values keep
+// their enum name.
+private const val SERIF_V2_PERSIST_NAME = "SerifV2"
+private const val LEGACY_SERIF_PERSIST_NAME = "Serif"
+
 internal fun ReaderFontFamily.encodePersistName(): String = when (this) {
-    ReaderFontFamily.Serif -> "SerifV2"
+    ReaderFontFamily.Serif -> SERIF_V2_PERSIST_NAME
     else -> name
 }
 
 internal fun String.decodeFontFamily(): ReaderFontFamily? = when (this) {
-    "SerifV2" -> ReaderFontFamily.Serif
-    "Serif" -> ReaderFontFamily.Original
+    SERIF_V2_PERSIST_NAME -> ReaderFontFamily.Serif
+    LEGACY_SERIF_PERSIST_NAME -> ReaderFontFamily.Original
     else -> runCatching { ReaderFontFamily.valueOf(this) }.getOrNull()
 }
 

--- a/core/data/src/main/kotlin/com/riffle/core/data/FormattingPreferencesStoreImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/FormattingPreferencesStoreImpl.kt
@@ -29,9 +29,7 @@ class FormattingPreferencesStoreImpl @Inject constructor(
             theme = prefs[KEY_THEME]
                 ?.let { runCatching { ReaderTheme.valueOf(it) }.getOrNull() }
                 ?: ReaderTheme.Light,
-            fontFamily = prefs[KEY_FONT_FAMILY]
-                ?.let { runCatching { ReaderFontFamily.valueOf(it) }.getOrNull() }
-                ?: ReaderFontFamily.Serif,
+            fontFamily = prefs[KEY_FONT_FAMILY]?.decodeFontFamily() ?: ReaderFontFamily.Original,
             lineSpacing = prefs[KEY_LINE_SPACING] ?: 1.2f,
             margins = prefs[KEY_MARGINS] ?: 1.0f,
             orientation = prefs[KEY_ORIENTATION]
@@ -65,7 +63,7 @@ class FormattingPreferencesStoreImpl @Inject constructor(
         dataStore.edit { prefs ->
             prefs[KEY_FONT_SIZE] = preferences.fontSize
             prefs[KEY_THEME] = preferences.theme.name
-            prefs[KEY_FONT_FAMILY] = preferences.fontFamily.name
+            prefs[KEY_FONT_FAMILY] = preferences.fontFamily.encodePersistName()
             prefs[KEY_LINE_SPACING] = preferences.lineSpacing
             prefs[KEY_MARGINS] = preferences.margins
             prefs[KEY_ORIENTATION] = preferences.orientation.name
@@ -102,6 +100,23 @@ class FormattingPreferencesStoreImpl @Inject constructor(
         val KEY_SCHEDULE_DAY_THEME = stringPreferencesKey("theme_schedule_day_theme")
         val KEY_SCHEDULE_NIGHT_THEME = stringPreferencesKey("theme_schedule_night_theme")
     }
+}
+
+// Persisted-name codec for ReaderFontFamily.
+//
+// Before the Original split, the "Serif" enum value was passthrough — it rendered the publisher's
+// font. Any legacy "Serif" string on disk therefore encoded that passthrough intent and must load
+// as Original, not as the new real-serif Serif. To distinguish new picks from legacy data we
+// persist the new Serif under a distinct name ("SerifV2"). All other values keep their enum name.
+internal fun ReaderFontFamily.encodePersistName(): String = when (this) {
+    ReaderFontFamily.Serif -> "SerifV2"
+    else -> name
+}
+
+internal fun String.decodeFontFamily(): ReaderFontFamily? = when (this) {
+    "SerifV2" -> ReaderFontFamily.Serif
+    "Serif" -> ReaderFontFamily.Original
+    else -> runCatching { ReaderFontFamily.valueOf(this) }.getOrNull()
 }
 
 private fun LocalTime.toMinuteOfDay(): Int = hour * 60 + minute

--- a/core/data/src/test/kotlin/com/riffle/core/data/FormattingPreferencesStoreTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/FormattingPreferencesStoreTest.kt
@@ -59,6 +59,29 @@ class FormattingPreferencesStoreTest {
         assertEquals(ReaderFontFamily.OpenDyslexic, store.preferences.first().fontFamily)
     }
 
+    // Regression: the new Serif (real CSS serif face) must round-trip through the DataStore
+    // without collapsing to Original. The codec persists it as "SerifV2" specifically so that
+    // legacy "Serif" strings (previously passthrough) can be distinguished from new picks.
+    @Test
+    fun `new Serif round-trips as Serif, not Original`() = testScope.runTest {
+        val store = buildStore()
+        store.update(FormattingPreferences(fontFamily = ReaderFontFamily.Serif))
+        assertEquals(ReaderFontFamily.Serif, store.preferences.first().fontFamily)
+    }
+
+    // Regression: users upgrading from a build where "Serif" was the passthrough default (and
+    // was persisted verbatim by update()) must land on Original, not on the new real-serif
+    // Serif. If this flipped, every upgrader would suddenly see every book forced into CSS
+    // serif rather than the publisher font they had been reading.
+    @Test fun `legacy 'Serif' persisted name decodes to Original`() {
+        assertEquals(ReaderFontFamily.Original, "Serif".decodeFontFamily())
+    }
+
+    @Test fun `new Serif encodes to SerifV2 so it survives the legacy decode`() {
+        assertEquals("SerifV2", ReaderFontFamily.Serif.encodePersistName())
+        assertEquals(ReaderFontFamily.Serif, "SerifV2".decodeFontFamily())
+    }
+
     @Test
     fun `saved lineSpacing is returned after update`() = testScope.runTest {
         val store = buildStore()

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/FormattingPreferences.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/FormattingPreferences.kt
@@ -30,13 +30,13 @@ data class FormattingPreferences(
         const val DEFAULT_JUSTIFY_TEXT: Boolean = false
         const val DEFAULT_AUTO_SCROLL_WPM: Int = 250
         val DEFAULT_THEME: ReaderTheme = ReaderTheme.Light
-        val DEFAULT_FONT_FAMILY: ReaderFontFamily = ReaderFontFamily.Serif
+        val DEFAULT_FONT_FAMILY: ReaderFontFamily = ReaderFontFamily.Original
         val DEFAULT_ORIENTATION: ReaderOrientation = ReaderOrientation.Horizontal
     }
 }
 
 enum class ReaderTheme { Light, Dark, DarkDim, Sepia, Auto }
-enum class ReaderFontFamily { Serif, SansSerif, Monospace, Literata, Merriweather, OpenDyslexic }
+enum class ReaderFontFamily { Original, Serif, SansSerif, Monospace, Literata, Merriweather, OpenDyslexic }
 enum class ReaderOrientation { Horizontal, Vertical, Continuous }
 
 data class ThemeSchedule(

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/autoscroll/ScrollPace.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/autoscroll/ScrollPace.kt
@@ -32,7 +32,7 @@ private const val PAGE_GUTTER_CSS_PX: Float = 8f
 // the dyslexic face is wider than typical sans. Numbers are approximations — good enough to scale
 // the auto-scroll pace, not to lay out text.
 private fun avgEmAdvance(family: ReaderFontFamily): Float = when (family) {
-    ReaderFontFamily.Serif, ReaderFontFamily.Literata, ReaderFontFamily.Merriweather -> 0.50f
+    ReaderFontFamily.Original, ReaderFontFamily.Serif, ReaderFontFamily.Literata, ReaderFontFamily.Merriweather -> 0.50f
     ReaderFontFamily.SansSerif -> 0.52f
     ReaderFontFamily.Monospace -> 0.60f
     ReaderFontFamily.OpenDyslexic -> 0.58f


### PR DESCRIPTION
## What & why

The reader's font-family list had a "Serif" chip that the user (me!) reasonably assumed would force a serif face. It didn't: `Serif` was actually the *passthrough* value that left `--USER__fontFamily` unset so the publisher's own CSS won. Anyone picking "Serif" thinking they were forcing serif letterforms got whatever the publisher shipped.

This PR splits the concept:

- **`Original`** — new value, now the global default. Passthrough. Publisher's font wins.
- **`Serif`** — now forces CSS `serif` with `!important`, like every other font chip.

The chip appears leftmost in the generic row and reads "Original" in the UI.

## Upgrade safety

Existing users have `"Serif"` written to disk (either because they were on the old default or because `update()` wrote every field). Under the new semantics that string would mean "force real serif" — every book would suddenly flip typography on upgrade.

To prevent that, the persistence layer uses a small codec:

- **Encode**: new `Serif` picks are written as `"SerifV2"`; every other value uses its enum name.
- **Decode**: `"SerifV2"` → `Serif`; legacy `"Serif"` → `Original`; anything else → `valueOf()`.

The two persistence strings live in named constants (`SERIF_V2_PERSIST_NAME`, `LEGACY_SERIF_PERSIST_NAME`) so a typo in either the encoder or decoder can't silently break the migration.

## Test coverage (regression pins)

- `FormattingPreferencesMapperTest.serifFontFamilyMapsToCssSerif` — proves the new `Serif` is no longer passthrough (would fail if the mapper flipped back to `null`).
- `ContinuousStyleInjectorTest."Serif sets fontOverride and quoted CSS serif family"` — same guarantee for continuous mode.
- `FormattingPreferencesStoreTest."new Serif round-trips as Serif, not Original"` — the codec doesn't collapse new picks.
- `FormattingPreferencesStoreTest."legacy 'Serif' persisted name decodes to Original"` — upgrader migration pin.
- `FormattingPreferencesStoreTest."new Serif encodes to SerifV2 …"` — locks the wire format so a future refactor can't silently break the migration.

## Not device-verified

Per AGENTS.md, WebView-touching changes deserve an on-device sanity check. I have not built + installed on the AVD yet — will do before merging.

## Notes on review

- Correctness finders (line-by-line, removed-behavior, cross-file) returned zero findings; `when` expressions are exhaustive across all five call sites.
- Applied: hoisted the persistence strings into named constants (AGENTS.md rule), and updated `FakeReaderPresenterTest.defaultPrefs` from `Serif` to `Original` to keep the fixture's "defaults" meaning aligned with the new default.
- Dismissed: shared `ReaderFontFamily.cssFontName()` extension (mapper and continuous injector wrap the CSS name into different container types — deduplication would need judgement); replacing the codec with a schema-version system (fair architectural point, but overkill for a one-off migration — noted as debt if another split follows).