### PR TITLE
fix(reader): in-view cross-reference tap is a no-op in continuous mode

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousPositionTracker.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousPositionTracker.kt
@@ -68,6 +68,21 @@ internal object ContinuousPositionTracker {
         return target.coerceAtLeast(0)
     }
 
+    /**
+     * Whether an anchor whose absolute (parent-viewport) Y is [absoluteY] is already visible in a
+     * viewport currently scrolled to [currentScrollY] with height [viewportHeight]. Null means
+     * "couldn't resolve" — treat as not visible so the caller still navigates.
+     *
+     * Used by the continuous-mode same-document cross-reference handler to make an in-view link
+     * tap a no-op: paginated mode gets this for free from `ColumnSnap.scrollToColumnJs` returning
+     * `'same'` when the column is unchanged (see `snapToElement`), but continuous mode owns its
+     * own scroll and must decide explicitly. Without the check, tapping an internal link whose
+     * target is already on-screen would still recentre it AND drop a return-to-position card —
+     * both wrong (the user is already looking at the target).
+     */
+    fun anchorAlreadyInViewport(absoluteY: Int?, currentScrollY: Int, viewportHeight: Int): Boolean =
+        absoluteY != null && absoluteY >= currentScrollY && absoluteY < currentScrollY + viewportHeight
+
     /** Host that [ChapterWebView] serves all EPUB resources from. */
     const val RESOURCE_HOST = "readium_package"
 

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderCoordinator.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderCoordinator.kt
@@ -86,12 +86,30 @@ internal class ContinuousReaderCoordinator(
             // path (FootnoteAnchorBridge → snapToElement) doesn't apply here — Continuous mode
             // has no Readium fragment to snap against, so we drive the outer viewport ourselves
             // via view.navigateTo, which finds the target's device-Y through anchorOffsetTopDevicePx
-            // and scrolls the NestedScrollView to it. Capture the pre-jump origin so the return
-            // card can undo the jump, matching the paged-mode behaviour.
+            // and scrolls the NestedScrollView to it.
+            //
+            // In-viewport taps are a no-op: if the target's absolute Y is already inside the
+            // currently visible band, the user is already looking at it — recentring it and
+            // dropping a return-to-position card would both be wrong. Paged mode gets this for
+            // free (`snapToElement` returns 'same' → the return anchor isn't captured); continuous
+            // owns its own scroll and must decide explicitly. Otherwise capture the pre-jump
+            // origin so the return card can undo the jump, matching paged-mode behaviour.
             onCrossReference = { chapterHref, fragmentId ->
-                val origin = latestLocator()
-                if (origin != null) links.captureReturnAnchor(origin)
-                this.view?.navigateTo("$chapterHref#$fragmentId", 0f, alignToTop = false)
+                val v = this.view
+                if (v != null) {
+                    val origin = latestLocator()
+                    v.anchorAbsoluteY(chapterHref, fragmentId) { absoluteY ->
+                        handleContinuousCrossReferenceTap(
+                            absoluteY = absoluteY,
+                            currentScrollY = v.scrollY,
+                            viewportHeight = v.height,
+                            onCaptureAndScroll = {
+                                if (origin != null) links.captureReturnAnchor(origin)
+                                v.navigateTo("$chapterHref#$fragmentId", 0f, alignToTop = false)
+                            },
+                        )
+                    }
+                }
             },
             onRawPosition = { href, progression ->
                 val (spineHrefs, counts) = spinePositionsProvider()
@@ -146,6 +164,26 @@ internal class ContinuousReaderCoordinator(
     fun onPreferencesChanged(prefs: FormattingPreferences) {
         view?.updatePreferences(prefs)
     }
+}
+
+/**
+ * Pure body of Continuous mode's same-document cross-reference tap decision. Extracted so the
+ * "in-viewport tap = no-op" rule is exercisable at the JVM unit level without wiring up a real
+ * [ContinuousReaderView]. Callsite: [ContinuousReaderCoordinator.attach]'s `onCrossReference`.
+ *
+ * If [absoluteY] is inside the currently visible band, do nothing — the user is already looking
+ * at the target, so recentring the page AND dropping a return-to-position card would both be
+ * wrong. Otherwise invoke [onCaptureAndScroll], which captures the pre-jump origin and scrolls
+ * to the target.
+ */
+internal fun handleContinuousCrossReferenceTap(
+    absoluteY: Int?,
+    currentScrollY: Int,
+    viewportHeight: Int,
+    onCaptureAndScroll: () -> Unit,
+) {
+    if (ContinuousPositionTracker.anchorAlreadyInViewport(absoluteY, currentScrollY, viewportHeight)) return
+    onCaptureAndScroll()
 }
 
 /**

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
@@ -284,6 +284,14 @@ internal class ContinuousReaderView @JvmOverloads constructor(
     override fun navigateTo(href: String, progression: Float, alignToTop: Boolean, focusAnnotationId: String?) =
         controller.navigateTo(href, progression, alignToTop, focusAnnotationId)
 
+    /**
+     * Resolve the parent-viewport Y (in scrollY-space) of anchor [fragmentId] within [chapterHref].
+     * See [ContinuousWindowController.anchorAbsoluteY]. Used to make an in-view same-document
+     * cross-reference tap a no-op.
+     */
+    internal fun anchorAbsoluteY(chapterHref: String, fragmentId: String, callback: (Int?) -> Unit) =
+        controller.anchorAbsoluteY(chapterHref, fragmentId, callback)
+
     override fun scrollByPage(forward: Boolean) = controller.scrollByPage(forward)
 
     override fun highlightInChapter(href: String, text: String, cssColor: String) =

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousWindowController.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousWindowController.kt
@@ -421,6 +421,25 @@ internal class ContinuousWindowController(
         }
     }
 
+    /**
+     * Resolve the absolute (parent-viewport) Y of the anchor [fragmentId] within [chapterHref].
+     * Returns null via [callback] when the chapter isn't in the current window, the WebView for
+     * it isn't measured yet, or the element id can't be found. Used by the cross-reference tap
+     * handler to detect in-viewport taps and skip both the scroll and the return-to-position card.
+     */
+    fun anchorAbsoluteY(chapterHref: String, fragmentId: String, callback: (Int?) -> Unit) {
+        val target = chapterHref.substringBefore('#')
+        val slot = buildWindow().firstOrNull { it.href.substringBefore('#') == target }
+        val wv = webViews.firstOrNull { it.chapterHref.substringBefore('#') == target }
+        if (slot == null || wv == null) {
+            callback(null)
+            return
+        }
+        wv.anchorOffsetTopDevicePx(fragmentId) { offset ->
+            callback(if (offset == null) null else slot.top + offset)
+        }
+    }
+
     private fun scrollToLoadedChapter(
         target: String,
         progression: Float,

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousCrossReferenceTapTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousCrossReferenceTapTest.kt
@@ -1,0 +1,75 @@
+package com.riffle.app.feature.reader
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pins the "tapping a same-document cross-reference whose target is already visible must be a
+ * no-op" rule for Continuous mode. Without the fix, [handleContinuousCrossReferenceTap] would
+ * always invoke `onCaptureAndScroll`, dropping a return-to-position card and recentring the
+ * page on an anchor the user is already looking at.
+ */
+class ContinuousCrossReferenceTapTest {
+
+    @Test
+    fun `anchor already visible — onCaptureAndScroll is NOT invoked`() {
+        var invoked = 0
+        handleContinuousCrossReferenceTap(
+            absoluteY = 1500,
+            currentScrollY = 1000,
+            viewportHeight = 800,
+            onCaptureAndScroll = { invoked++ },
+        )
+        assertEquals("in-viewport tap must be a no-op", 0, invoked)
+    }
+
+    @Test
+    fun `anchor above the viewport — onCaptureAndScroll IS invoked`() {
+        var invoked = 0
+        handleContinuousCrossReferenceTap(
+            absoluteY = 200,
+            currentScrollY = 1000,
+            viewportHeight = 800,
+            onCaptureAndScroll = { invoked++ },
+        )
+        assertEquals("off-screen (above) tap must scroll + capture return", 1, invoked)
+    }
+
+    @Test
+    fun `anchor below the viewport — onCaptureAndScroll IS invoked`() {
+        var invoked = 0
+        handleContinuousCrossReferenceTap(
+            absoluteY = 3000,
+            currentScrollY = 1000,
+            viewportHeight = 800,
+            onCaptureAndScroll = { invoked++ },
+        )
+        assertEquals("off-screen (below) tap must scroll + capture return", 1, invoked)
+    }
+
+    @Test
+    fun `anchor at the top edge of the viewport — no-op`() {
+        var invoked = 0
+        handleContinuousCrossReferenceTap(
+            absoluteY = 1000,
+            currentScrollY = 1000,
+            viewportHeight = 800,
+            onCaptureAndScroll = { invoked++ },
+        )
+        assertTrue("top edge counts as visible", invoked == 0)
+    }
+
+    @Test
+    fun `unresolved anchor (null absoluteY) — falls through to scroll so the tap is not silently dropped`() {
+        var invoked = 0
+        handleContinuousCrossReferenceTap(
+            absoluteY = null,
+            currentScrollY = 1000,
+            viewportHeight = 800,
+            onCaptureAndScroll = { invoked++ },
+        )
+        assertFalse("null anchor must not be treated as visible", invoked == 0)
+    }
+}

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousPositionTrackerTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousPositionTrackerTest.kt
@@ -604,4 +604,61 @@ class ContinuousPositionTrackerTest {
         )
         assertEquals(0, y)
     }
+
+    // Cross-reference tap on an on-screen target must be a no-op in continuous mode: an anchor
+    // whose absolute Y falls anywhere inside [scrollY, scrollY + viewportHeight) is already
+    // visible, so the caller must skip both the scroll and the return-to-position capture.
+    // Without this, tapping an internal link whose target is already on the page recentres the
+    // page AND drops a "Back" card — the regression this pins.
+
+    @Test
+    fun `anchorAlreadyInViewport — anchor inside the visible band is true`() {
+        assertTrue(
+            ContinuousPositionTracker.anchorAlreadyInViewport(
+                absoluteY = 1500, currentScrollY = 1000, viewportHeight = 800,
+            ),
+        )
+    }
+
+    @Test
+    fun `anchorAlreadyInViewport — anchor exactly at the top edge is true`() {
+        assertTrue(
+            ContinuousPositionTracker.anchorAlreadyInViewport(
+                absoluteY = 1000, currentScrollY = 1000, viewportHeight = 800,
+            ),
+        )
+    }
+
+    @Test
+    fun `anchorAlreadyInViewport — anchor above the viewport is false`() {
+        assertFalse(
+            ContinuousPositionTracker.anchorAlreadyInViewport(
+                absoluteY = 500, currentScrollY = 1000, viewportHeight = 800,
+            ),
+        )
+    }
+
+    @Test
+    fun `anchorAlreadyInViewport — anchor at or past the bottom edge is false`() {
+        // scrollY + viewportHeight is the first Y NOT visible (half-open interval).
+        assertFalse(
+            ContinuousPositionTracker.anchorAlreadyInViewport(
+                absoluteY = 1800, currentScrollY = 1000, viewportHeight = 800,
+            ),
+        )
+        assertFalse(
+            ContinuousPositionTracker.anchorAlreadyInViewport(
+                absoluteY = 2500, currentScrollY = 1000, viewportHeight = 800,
+            ),
+        )
+    }
+
+    @Test
+    fun `anchorAlreadyInViewport — null absoluteY is false so caller still navigates`() {
+        assertFalse(
+            ContinuousPositionTracker.anchorAlreadyInViewport(
+                absoluteY = null, currentScrollY = 1000, viewportHeight = 800,
+            ),
+        )
+    }
 }


### PR DESCRIPTION
## Summary

Same-document `#anchor` link taps in Continuous mode were unconditionally scrolling + dropping a return-to-position card, even when the target was already on-screen — the user would see the page recentre and a "Back" card offering to undo a jump they didn't need. Paged mode gets this correct for free because `ColumnSnap.scrollToColumnJs` returns `'same'` when scrollLeft wouldn't change, and `snapToElement` gates `captureReturnAnchor` on `'moved'`. Continuous owns its own scroll and had no equivalent check since #409.

Now: probe the anchor's parent-viewport Y through the child WebView's `anchorOffsetTopDevicePx` before acting. If it falls inside the visible band, do nothing. Otherwise capture origin and scroll as before.

## Changes

- **`ContinuousPositionTracker.kt`** — new pure `anchorAlreadyInViewport(absoluteY, currentScrollY, viewportHeight)` predicate.
- **`ContinuousWindowController.kt` / `ContinuousReaderView.kt`** — new `anchorAbsoluteY(chapterHref, fragmentId, callback)` that resolves the anchor's parent-viewport Y via the loaded chapter's WebView.
- **`ContinuousReaderCoordinator.kt`** — `onCrossReference` now delegates to a pure `handleContinuousCrossReferenceTap` helper that gates capture + scroll on visibility.

## Test plan

- [x] `ContinuousCrossReferenceTapTest` — pins the coordinator-level decision: in-viewport tap does NOT invoke `onCaptureAndScroll`; off-screen (above/below) taps DO; null-anchor falls through to scroll.
- [x] `ContinuousPositionTrackerTest` — pins the pure predicate at top-edge, mid-band, above, at-bottom-edge, past-bottom, and null-anchor cases.
- [x] Reverting the callsite's `if (anchorAlreadyInViewport) return` flips the in-viewport assertion red.
- [x] `./gradlew :app:testDebugUnitTest` green.
- [x] User verified in-app: back popup behaves correctly.