### PR TITLE
fix(reader): same-doc anchor navigation + Back button in all three modes

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ColumnSnap.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ColumnSnap.kt
@@ -240,7 +240,13 @@ internal object ColumnSnap {
     //  - paginated: FLOOR scrollLeft to the column the element starts in (go(cssSelector) lands flush to
     //    the box → a sliver of the neighbour shows; flooring to innerWidth lands on the column boundary).
     //  - scroll mode (scrollHeight > innerHeight): there is no column grid, so scroll VERTICALLY to bring
-    //    the element to the top of the viewport; an element already fully on screen isn't moved.
+    //    the element to the VIEWPORT MIDPOINT — matching Continuous mode's `alignToTop=false` cross-
+    //    reference landing (see [com.riffle.app.feature.reader.ContinuousPositionTracker.anchorLandingScrollY]).
+    //    Landing at the top with an 8-px margin (the earlier behaviour) puts the anchor's own line at Y=0,
+    //    which for anchors placed on a caption BELOW a figure image pushes the image off-screen — the
+    //    "wrong location" bug when tapping a "Figure X.Y" link in Vertical. Midpoint preserves context
+    //    above (usually where the referenced diagram / heading lives) and below.
+    //    An element already fully on screen isn't moved.
     // Returns 'moved' when the snap changed the visible page (target was off-page → offer a return),
     // 'same' when it was already visible, or 'absent' when the id isn't in this document.
     fun scrollToColumnJs(fragmentId: String): String =
@@ -251,7 +257,7 @@ internal object ColumnSnap {
             "if(se.scrollHeight > window.innerHeight + 4){" + // scroll (vertical) mode → no column grid
             "if(r.top>=0 && r.bottom<=window.innerHeight)return 'same';" + // already fully visible
             "var beforeTop=se.scrollTop;" +
-            "se.scrollTop=Math.max(0, r.top + se.scrollTop - 8);" +
+            "se.scrollTop=Math.max(0, r.top + se.scrollTop - Math.floor(window.innerHeight/2));" +
             "return (Math.abs(se.scrollTop-beforeTop)>1)?'moved':'same';}" +
             "var iw=window.innerWidth;" +
             "var before=se.scrollLeft;" +

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -1744,7 +1744,13 @@ private fun EpubNavigatorView(
         }
     }
 
-    LaunchedEffect(returnNavEvents) {
+    // Key on readerPresenter so a mode flip (paginated/vertical ↔ continuous) restarts the collect
+    // with the fresh presenter and isContinuous. Without this, navigateWithCover's `if (!isContinuous)`
+    // branch and the captured presenter reference stay pinned to whichever presenter was active when
+    // the composable first entered the composition — a Back tap after switching modes then drives the
+    // OLD (now invisible) navigator instead of the visible one, and the popup does nothing.
+    // returnNavEvents is a Channel(CONFLATED) flow, so a pending emission survives a re-launch.
+    LaunchedEffect(returnNavEvents, readerPresenter) {
         returnNavEvents.collect { locator ->
             navigateWithCover(
                 NavigationTarget.ToLocatorJson(locator.toJSON().toString()),

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -1732,7 +1732,10 @@ private fun EpubNavigatorView(
         }
     }
 
-    LaunchedEffect(serverLocatorEvents) {
+    // Key on readerPresenter — see the returnNavEvents effect below for the rationale. Without
+    // this, a peer-position update that arrives after a mode flip would drive the OLD presenter
+    // (invisible in Continuous) and the peer sync would silently no-op.
+    LaunchedEffect(serverLocatorEvents, readerPresenter) {
         // Background server-progress sync: honour the locator's progression (no chapter-top yank),
         // no cover — a flash mid-reading would be jarring.
         serverLocatorEvents.collect { locator ->
@@ -1760,7 +1763,9 @@ private fun EpubNavigatorView(
         }
     }
 
-    LaunchedEffect(searchNavigationEvents) {
+    // Key on readerPresenter — same rationale as the returnNavEvents effect above. Tapping a search
+    // result after a mode flip must drive the current visible navigator, not the stale one.
+    LaunchedEffect(searchNavigationEvents, readerPresenter) {
         searchNavigationEvents.collect { locator ->
             navigateWithCover(
                 NavigationTarget.ToLocatorJson(locator.toJSON().toString()),

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/FootnoteAnchorBridge.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/FootnoteAnchorBridge.kt
@@ -32,6 +32,18 @@ internal object FootnoteAnchorBridge {
     }
 
     // Injected once per loaded resource — idempotent thanks to the window flag.
+    //
+    // Two accepted same-doc href shapes, matching Continuous mode's
+    // [com.riffle.app.feature.reader.ContinuousScriptInjector.SAME_DOC_ANCHOR_LISTENER_JS]:
+    //  1. bare '#id' — cheap to detect, skip URL parsing on the hot path.
+    //  2. path-prefixed same-chapter reference ('part0007.xhtml#a2C8' clicked from part0007.xhtml —
+    //     a common EPUB convention). Resolve against document.location and compare pathname; without
+    //     this the guard would skip these and the WebView's default fragment scroll runs, so an
+    //     in-view tap still recentres and (worse) the "no-op if already visible" contract silently
+    //     bypasses the [FootnoteAnchorBridge] → snapToElement gate that gives that contract to bare
+    //     '#id' taps in paged and vertical modes.
+    // Truly cross-resource links (a different chapter's pathname) fall through and are handled by
+    // Readium's shouldFollowInternalLink → EpubReaderViewModel.followInternalLink.
     val INSTALL_SCRIPT: String = """
         (function(){
           if (window.__riffleFootnoteInstalled) return 'already';
@@ -45,8 +57,23 @@ internal object FootnoteAnchorBridge {
             while (t && t.nodeType === 1 && !isAnchor(t)) t = t.parentNode;
             if (!isAnchor(t)) return;
             var href = t.getAttribute('href');
-            if (!href || href.charAt(0) !== '#') return;
-            var id = href.substring(1);
+            if (!href) return;
+            var id;
+            if (href.charAt(0) === '#') {
+              id = href.substring(1);
+            } else {
+              var resolved;
+              try { resolved = new URL(href, document.location.href); }
+              catch (err) { return; }
+              var sameDoc = resolved.origin === document.location.origin &&
+                resolved.pathname === document.location.pathname;
+              if (!sameDoc) return;
+              id = resolved.hash ? resolved.hash.substring(1) : '';
+              // resolved.hash preserves percent-encoding (e.g. '#figure%201'); decode so
+              // native's document.getElementById() matches the raw id in the DOM ('figure 1').
+              // getAttribute-driven bare '#id' hrefs are already raw.
+              try { id = decodeURIComponent(id); } catch (err) {}
+            }
             if (!id) return;
             try {
               if (window.$JS_NAME.onAnchorTap(id)) {

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/FootnoteAnchorBridgeInstallScriptTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/FootnoteAnchorBridgeInstallScriptTest.kt
@@ -1,0 +1,65 @@
+package com.riffle.app.feature.reader
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pins the Paged and Vertical (Readium-driven) anchor listener's same-doc classification so it
+ * matches the Continuous-mode listener's behaviour ([ContinuousScriptInjectorTest]). Before the
+ * dual-shape change, the bridge only intercepted bare `#id` hrefs — a common EPUB idiom of writing
+ * a same-chapter cross-reference as `part0007.xhtml#a2C8` (full path plus fragment) fell straight
+ * through to the WebView's default in-page scroll, bypassing the [FootnoteAnchorBridge] →
+ * `snapToElement` gate and the "already visible = no-op" contract with it.
+ */
+class FootnoteAnchorBridgeInstallScriptTest {
+
+    private val js = FootnoteAnchorBridge.INSTALL_SCRIPT
+
+    @Test
+    fun `listener resolves path-prefixed hrefs against document location so same-chapter refs count as same-doc`() {
+        assertTrue("expected URL resolution against document.location", js.contains("new URL(href, document.location.href)"))
+        assertTrue("expected same-doc test against pathname", js.contains("resolved.pathname === document.location.pathname"))
+        assertTrue("expected fragment extraction from resolved URL hash", js.contains("resolved.hash"))
+    }
+
+    @Test
+    fun `listener defers truly cross-resource links to shouldOverrideUrlLoading`() {
+        // A cross-resource link (part0008.xhtml#foo clicked from part0007.xhtml) must fall through
+        // so Readium's shouldFollowInternalLink → EpubReaderViewModel.followInternalLink handles it.
+        val crossResourceBranch = js.substringAfter("if (!sameDoc)").substringBefore("if (!id)")
+        assertTrue(
+            "cross-resource branch must return without calling onAnchorTap in $js",
+            crossResourceBranch.contains("return") && !crossResourceBranch.contains("onAnchorTap"),
+        )
+    }
+
+    @Test
+    fun `listener skips URL parsing on the hot path when href starts with a bare hash`() {
+        val bareHashBranch = js.substringAfter("if (href.charAt(0) === '#')").substringBefore("} else {")
+        assertTrue(
+            "bare-hash branch must not call new URL() in $js",
+            bareHashBranch.contains("href.substring(1)") && !bareHashBranch.contains("new URL"),
+        )
+    }
+
+    @Test
+    fun `listener decodes percent-encoded fragment ids so getElementById matches raw DOM ids`() {
+        // URL.hash preserves percent-encoding — an EPUB with <a href="#figure%201"> pointing at
+        // <figure id="figure 1"> would extract id="figure%201" and getElementById would miss.
+        val pathPrefixedBranch = js.substringAfter("} else {").substringBefore("if (!id) return")
+        assertTrue(
+            "path-prefixed branch must decodeURIComponent the fragment id in $js",
+            pathPrefixedBranch.contains("decodeURIComponent"),
+        )
+    }
+
+    @Test
+    fun `listener still routes bare hash anchors through onAnchorTap`() {
+        assertTrue("expected onAnchorTap in $js", js.contains("${FootnoteAnchorBridge.JS_NAME}.onAnchorTap"))
+    }
+
+    @Test
+    fun `listener is idempotent per document`() {
+        assertTrue(js.contains("__riffleFootnoteInstalled"))
+    }
+}

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/FootnoteResolverTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/FootnoteResolverTest.kt
@@ -244,7 +244,9 @@ class FootnoteResolverTest {
     fun `install script registers click listener in capture phase`() {
         // addEventListener('click', handler, true) — the trailing true is what makes
         // our handler fire before Readium's bubble-phase ut() click handler.
-        val pattern = Regex("""addEventListener\(\s*['"]click['"]\s*,[^,]+,\s*true\s*\)""")
+        // Use DOT_MATCHES_ALL + reluctant match so the handler body can contain commas
+        // (e.g. `new URL(href, document.location.href)` for path-prefixed same-doc anchors).
+        val pattern = Regex("""addEventListener\(\s*['"]click['"]\s*,.+?,\s*true\s*\)""", RegexOption.DOT_MATCHES_ALL)
         assertTrue(
             "INSTALL_SCRIPT must register a capture-phase click listener",
             pattern.containsMatchIn(FootnoteAnchorBridge.INSTALL_SCRIPT),

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ReaderWebViewScriptsTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ReaderWebViewScriptsTest.kt
@@ -45,6 +45,24 @@ class ReaderWebViewScriptsTest {
         assertTrue("leaves an already-visible target alone", js.contains("r.bottom<=window.innerHeight"))
     }
 
+    // Vertical (scroll) mode cross-reference tap must land the anchor at the VIEWPORT MIDPOINT, not
+    // 8 px from the top. Landing at the top puts a caption placed BELOW its figure image at Y=0 —
+    // pushing the image (the thing the reader wanted) above the viewport. Continuous mode's
+    // ContinuousPositionTracker.anchorLandingScrollY already lands at midpoint (`- viewportHeight/2`);
+    // this pins that vertical does the same.
+    @Test
+    fun `scrollToColumnJs vertical branch lands the anchor at viewport midpoint`() {
+        val js = ColumnSnap.scrollToColumnJs("c04-fig-0001")
+        // The vertical branch is the block gated on scrollHeight > innerHeight.
+        val verticalBranch = js.substringAfter("scrollHeight > window.innerHeight")
+            .substringBefore("var iw=window.innerWidth")
+        assertTrue(
+            "vertical branch must subtract half a viewport, not a fixed 8-px margin, in $verticalBranch",
+            verticalBranch.contains("Math.floor(window.innerHeight/2)") &&
+                !Regex("""se\.scrollTop\s*=\s*Math\.max\(0,\s*r\.top\s*\+\s*se\.scrollTop\s*-\s*8\s*\)""").containsMatchIn(verticalBranch),
+        )
+    }
+
     // snapToTargetColumnJs anchors a go()-based TOC/search jump to the column the TARGET occupies,
     // re-applying it across the async typography reflow until scrollWidth settles — the fix for the
     // "TOC lands a page before/after" bug where a one-shot snap locked onto the pre-reflow column.

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ReturnNavEffectKeysTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ReturnNavEffectKeysTest.kt
@@ -32,20 +32,33 @@ class ReturnNavEffectKeysTest {
         file!!.readText()
     }
 
-    @Test
-    fun `returnNavEvents LaunchedEffect keys on readerPresenter so a mode flip restarts the collect`() {
-        val marker = "LaunchedEffect(returnNavEvents"
-        val start = screenSource.indexOf(marker)
+    private fun assertKeysOnPresenter(effectMarker: String) {
+        val start = screenSource.indexOf(effectMarker)
         assertTrue(
-            "expected `$marker` in EpubReaderScreen — did the effect move or get renamed?",
+            "expected `$effectMarker` in EpubReaderScreen — did the effect move or get renamed?",
             start >= 0,
         )
         val header = screenSource.substring(start, start + 200)
         val keyList = header.substringAfter("LaunchedEffect(").substringBefore(")")
         assertTrue(
-            "returnNavEvents LaunchedEffect must key on readerPresenter to survive a mode flip; " +
+            "`$effectMarker` LaunchedEffect must key on readerPresenter to survive a mode flip; " +
                 "current keys: `$keyList`",
             keyList.contains("readerPresenter"),
         )
+    }
+
+    @Test
+    fun `returnNavEvents LaunchedEffect keys on readerPresenter so a mode flip restarts the collect`() {
+        assertKeysOnPresenter("LaunchedEffect(returnNavEvents")
+    }
+
+    @Test
+    fun `serverLocatorEvents LaunchedEffect keys on readerPresenter so a peer-position sync after a mode flip lands on the visible navigator`() {
+        assertKeysOnPresenter("LaunchedEffect(serverLocatorEvents")
+    }
+
+    @Test
+    fun `searchNavigationEvents LaunchedEffect keys on readerPresenter so tapping a search result after a mode flip lands on the visible navigator`() {
+        assertKeysOnPresenter("LaunchedEffect(searchNavigationEvents")
     }
 }

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ReturnNavEffectKeysTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ReturnNavEffectKeysTest.kt
@@ -1,0 +1,51 @@
+package com.riffle.app.feature.reader
+
+import java.io.File
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pins the `LaunchedEffect(returnNavEvents, …)` key list in `EpubReaderScreen`. The bug the fix
+ * closes: the effect was keyed only on the Flow itself, which is the same instance across every
+ * mode switch. On a paginated/vertical ↔ continuous flip the coroutine kept running with the
+ * `readerPresenter` and `isContinuous` it had captured at first entry — so tapping Back after
+ * switching modes drove the OLD (now invisible) navigator and the return card did nothing.
+ *
+ * Adding `readerPresenter` to the key list restarts the coroutine on every mode flip, letting it
+ * re-capture the correct presenter and mode. This test asserts the key list contains it, because
+ * removing it — either by intent or by a stale merge conflict resolution — silently reintroduces
+ * the "Back popup does nothing after switching modes" regression.
+ *
+ * Compose LaunchedEffect keying is a runtime property; there is no isolated pure decision to test.
+ * A source-level pin is the only assertion that flips red on a literal revert of the fix.
+ */
+class ReturnNavEffectKeysTest {
+
+    private val screenSource: String by lazy {
+        val candidates = listOf(
+            "app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt",
+            "src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt",
+        )
+        val file = candidates.map(::File).firstOrNull { it.exists() }
+        assertNotNull("EpubReaderScreen.kt must be readable from the test cwd", file)
+        file!!.readText()
+    }
+
+    @Test
+    fun `returnNavEvents LaunchedEffect keys on readerPresenter so a mode flip restarts the collect`() {
+        val marker = "LaunchedEffect(returnNavEvents"
+        val start = screenSource.indexOf(marker)
+        assertTrue(
+            "expected `$marker` in EpubReaderScreen — did the effect move or get renamed?",
+            start >= 0,
+        )
+        val header = screenSource.substring(start, start + 200)
+        val keyList = header.substringAfter("LaunchedEffect(").substringBefore(")")
+        assertTrue(
+            "returnNavEvents LaunchedEffect must key on readerPresenter to survive a mode flip; " +
+                "current keys: `$keyList`",
+            keyList.contains("readerPresenter"),
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Follow-up to #416 which fixed the in-view cross-reference no-op contract for Continuous mode. This PR brings the other two modes into parity and fixes several related issues surfaced during AVD verification.

### 1. Route path-prefixed same-doc anchor taps through the paged bridge (`FootnoteAnchorBridge`)

Paged and Vertical get the "already visible = no-op" contract via `FootnoteAnchorBridge` → `snapToElement` returning `'same'`, but the bridge's `INSTALL_SCRIPT` only intercepted bare `#id` hrefs. A common EPUB idiom of writing a same-chapter cross-reference as `part0007.xhtml#a2C8` (full path + fragment) fell straight through to the WebView's default fragment scroll, bypassing the gate. Now mirrors `ContinuousScriptInjector.SAME_DOC_ANCHOR_LISTENER_JS`'s dual-shape classification.

### 2. Land vertical cross-reference tap at viewport midpoint (`ColumnSnap`)

Vertical (scroll) mode was landing the tapped anchor 8 px from the top of the viewport. For a "Figure X.Y" link whose target id sits on the caption BELOW the figure image, this puts the caption at Y=0 and pushes the image off-screen. Continuous already lands anchors at midpoint (`anchorLandingScrollY` with `alignToTop=false`). Vertical now matches.

### 3. Key `returnNavEvents` / `serverLocatorEvents` / `searchNavigationEvents` LaunchedEffects on `readerPresenter`

**The most severe fix**. All three effects were keyed only on their Flow, which is a stable instance across mode switches — so the running coroutine kept its originally-captured `navigateWithCover` / `readerPresenter` / `isContinuous`. After a paginated/vertical ↔ continuous flip, Back / peer sync / search-result navigation drove the OLD (invisible in Continuous) navigator and the visible view never moved. Verified by adb logcat showing `isContinuous=false` in every returnNavEvents emission even when the visible mode was Continuous. Adding `readerPresenter` to each key list restarts the collect on every mode flip.

## Test plan

- [x] `FootnoteAnchorBridgeInstallScriptTest` — pathname test, bare-hash hot path, cross-resource fall-through, `decodeURIComponent`.
- [x] `ReaderWebViewScriptsTest` — new pin that the vertical branch subtracts half a viewport, not a fixed 8 px.
- [x] `FootnoteResolverTest` — capture-phase regex loosened to tolerate commas in the extended handler.
- [x] `ReturnNavEffectKeysTest` — source-inspection pin per effect asserting `readerPresenter` is in the LaunchedEffect key list; flips red on literal revert.
- [x] `./gradlew :app:testDebugUnitTest` green.
- [x] AVD-verified: Back popup now works across paginated/vertical/continuous and survives mode flips.