### PR TITLE
fix(data): key ebook open/download by item.serverId, not active server

### DIFF
--- a/core/data/src/main/kotlin/com/riffle/core/data/EpubRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/EpubRepositoryImpl.kt
@@ -22,23 +22,33 @@ class EpubRepositoryImpl(
 ) : EpubRepository {
 
     override suspend fun openEpub(item: LibraryItem): EpubOpenResult {
-        val activeServer = serverRepository.getActive()
-            ?: return EpubOpenResult.NetworkError(IllegalStateException("No active server"))
-        val local = downloadsStore.get(activeServer.id, item.id) ?: cacheStore.get(activeServer.id, item.id)
+        // Resolve the item's OWN server row, not `getActive()`. A user-switch on the same URL mints
+        // a fresh server row (ServerRepositoryImpl.commit → UUID.randomUUID), leaving the previous
+        // row (and its cached files under cacheDir/epubs/<oldId>/) in place. Keying by activeServer
+        // here made the opener look under the new row's dir, miss the truly-cached file, and fall
+        // into the network branch — surfacing "unable to resolve host" when offline even though the
+        // library detail badge (which correctly keys by item.serverId) said the book was cached.
+        val server = serverRepository.getById(item.serverId)
+            ?: return EpubOpenResult.NetworkError(IllegalStateException("No server for item"))
+        val local = downloadsStore.get(item.serverId, item.id) ?: cacheStore.get(item.serverId, item.id)
         val epubFile = if (local != null) {
             local
         } else {
-            val token = tokenStorage.getToken(activeServer.id)
+            val token = tokenStorage.getToken(server.id)
                 ?: return EpubOpenResult.NetworkError(IllegalStateException("No token for server"))
             val ino = item.ebookFileIno ?: run {
-                val r = api.getItemEbookFileIno(activeServer.url.value, item.id, token, activeServer.insecureConnectionAllowed)
+                val r = api.getItemEbookFileIno(server.url.value, item.id, token, server.insecureConnectionAllowed)
                 if (r is NetworkResult.Success) r.value else return EpubOpenResult.NetworkError(r.errorAsThrowable())
             }
-            val download = api.downloadEpub(activeServer.url.value, item.id, ino, token, activeServer.insecureConnectionAllowed)
+            val download = api.downloadEpub(server.url.value, item.id, ino, token, server.insecureConnectionAllowed)
             if (download !is NetworkResult.Success) return EpubOpenResult.NetworkError(download.errorAsThrowable())
-            download.value.use { body -> cacheStore.save(activeServer.id, item.id, body.byteStream()) }
+            download.value.use { body -> cacheStore.save(item.serverId, item.id, body.byteStream()) }
         }
-        val lastPosition = positionStore.load(activeServer.id, item.id)
+        // Position load intentionally stays keyed by activeServer.id — [saveReadingPosition] also
+        // uses it, so this pair stays consistent within a session. Round-trip across a user-switch
+        // is a separate concern tracked apart from this fix.
+        val activeServer = serverRepository.getActive()
+        val lastPosition = activeServer?.let { positionStore.load(it.id, item.id) }
         return EpubOpenResult.Success(epubFile = epubFile, lastPosition = lastPosition)
     }
 
@@ -56,8 +66,10 @@ class EpubRepositoryImpl(
             cacheStore.delete(item.serverId, item.id)
             return EpubDownloadResult.Success
         }
-        val server = serverRepository.getActive()
-            ?: return EpubDownloadResult.NetworkError(IllegalStateException("No active server"))
+        // Same rationale as [openEpub]: resolve by item.serverId so a user-switch (or any second
+        // ServerEntity row for the same URL) still fetches from the item's owning server.
+        val server = serverRepository.getById(item.serverId)
+            ?: return EpubDownloadResult.NetworkError(IllegalStateException("No server for item"))
         val token = tokenStorage.getToken(server.id)
             ?: return EpubDownloadResult.NetworkError(IllegalStateException("No token for server"))
         val ino = item.ebookFileIno ?: run {

--- a/core/data/src/main/kotlin/com/riffle/core/data/PdfRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/PdfRepositoryImpl.kt
@@ -23,26 +23,29 @@ class PdfRepositoryImpl(
 ) : PdfRepository {
 
     override suspend fun openPdf(item: LibraryItem): PdfOpenResult {
-        val activeServer = serverRepository.getActive()
-            ?: return PdfOpenResult.NetworkError(IllegalStateException("No active server"))
-        val local = (downloadsStore.get(activeServer.id, item.id) ?: cacheStore.get(activeServer.id, item.id))?.takeIf { it.isValidPdf() }
+        // Resolve the item's OWN server row, not `getActive()`. See EpubRepositoryImpl.openEpub
+        // for the rationale — this is the same bug on the PDF side.
+        val server = serverRepository.getById(item.serverId)
+            ?: return PdfOpenResult.NetworkError(IllegalStateException("No server for item"))
+        val local = (downloadsStore.get(item.serverId, item.id) ?: cacheStore.get(item.serverId, item.id))?.takeIf { it.isValidPdf() }
         if (local == null) {
-            cacheStore.delete(activeServer.id, item.id)
+            cacheStore.delete(item.serverId, item.id)
         }
         val pdfFile = if (local != null) {
             local
         } else {
-            val token = tokenStorage.getToken(activeServer.id)
+            val token = tokenStorage.getToken(server.id)
                 ?: return PdfOpenResult.NetworkError(IllegalStateException("No token for server"))
             val ino = item.ebookFileIno ?: run {
-                val r = api.getItemEbookFileIno(activeServer.url.value, item.id, token, activeServer.insecureConnectionAllowed)
+                val r = api.getItemEbookFileIno(server.url.value, item.id, token, server.insecureConnectionAllowed)
                 if (r is NetworkResult.Success) r.value else return PdfOpenResult.NetworkError(r.errorAsThrowable())
             }
-            val result = api.downloadEpub(activeServer.url.value, item.id, ino, token, activeServer.insecureConnectionAllowed)
+            val result = api.downloadEpub(server.url.value, item.id, ino, token, server.insecureConnectionAllowed)
             if (result !is NetworkResult.Success) return PdfOpenResult.NetworkError(result.errorAsThrowable())
-            result.value.use { body -> cacheStore.save(activeServer.id, item.id, body.byteStream()) }
+            result.value.use { body -> cacheStore.save(item.serverId, item.id, body.byteStream()) }
         }
-        val lastPosition = positionStore.load(activeServer.id, item.id)
+        val activeServer = serverRepository.getActive()
+        val lastPosition = activeServer?.let { positionStore.load(it.id, item.id) }
         return PdfOpenResult.Success(pdfFile = pdfFile, lastPosition = lastPosition)
     }
 
@@ -60,8 +63,10 @@ class PdfRepositoryImpl(
             cacheStore.delete(item.serverId, item.id)
             return PdfDownloadResult.Success
         }
-        val server = serverRepository.getActive()
-            ?: return PdfDownloadResult.NetworkError(IllegalStateException("No active server"))
+        // Same rationale as [openPdf]: resolve by item.serverId so a user-switch (or any second
+        // ServerEntity row for the same URL) still fetches from the item's owning server.
+        val server = serverRepository.getById(item.serverId)
+            ?: return PdfDownloadResult.NetworkError(IllegalStateException("No server for item"))
         val token = tokenStorage.getToken(server.id)
             ?: return PdfDownloadResult.NetworkError(IllegalStateException("No token for server"))
         val ino = item.ebookFileIno ?: run {

--- a/core/data/src/test/kotlin/com/riffle/core/data/EpubPositionIntegrationTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/EpubPositionIntegrationTest.kt
@@ -76,6 +76,7 @@ class EpubPositionIntegrationTest {
             )
             override fun observeAll(): Flow<List<Server>> = flowOf(listOf(activeServer))
             override suspend fun getActive(): Server = activeServer
+            override suspend fun getById(serverId: String): Server? = activeServer.takeIf { it.id == serverId }
             override suspend fun authenticate(url: ServerUrl, username: String, password: String, insecureAllowed: Boolean, serverType: com.riffle.core.domain.ServerType) =
                 throw UnsupportedOperationException()
             override suspend fun commit(pending: com.riffle.core.domain.PendingServer, hiddenLibraryIds: Set<String>) =

--- a/core/data/src/test/kotlin/com/riffle/core/data/EpubPositionIntegrationTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/EpubPositionIntegrationTest.kt
@@ -103,6 +103,7 @@ class EpubPositionIntegrationTest {
         isDownloaded = false,
         ebookFormat = EbookFormat.Epub,
         ebookFileIno = "ino-42",
+        serverId = "server-1",
     )
 
     @Test

--- a/core/data/src/test/kotlin/com/riffle/core/data/EpubRepositoryTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/EpubRepositoryTest.kt
@@ -29,6 +29,8 @@ import okhttp3.mockwebserver.MockWebServer
 import okio.Buffer
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -71,29 +73,25 @@ class EpubRepositoryTest {
         server.shutdown()
     }
 
-    private fun fakeServerRepository(baseUrl: String): ServerRepository = object : ServerRepository {
-        val activeServer = Server(
-            id = "server-1",
-            url = ServerUrl.parse(baseUrl)!!,
-            isActive = true,
-            insecureConnectionAllowed = false,
-            username = "",
-            serverType = ServerType.AUDIOBOOKSHELF,
+    private fun fakeServerRepository(baseUrl: String): ServerRepository =
+        multiServerRepository(
+            servers = listOf(
+                Server(
+                    id = "server-1",
+                    url = ServerUrl.parse(baseUrl)!!,
+                    isActive = true,
+                    insecureConnectionAllowed = false,
+                    username = "",
+                    serverType = ServerType.AUDIOBOOKSHELF,
+                ),
+            ),
+            activeId = "server-1",
         )
-        override fun observeAll(): Flow<List<Server>> = flowOf(listOf(activeServer))
-        override suspend fun getActive(): Server = activeServer
-        override suspend fun authenticate(url: ServerUrl, username: String, password: String, insecureAllowed: Boolean, serverType: com.riffle.core.domain.ServerType) =
-            throw UnsupportedOperationException()
-        override suspend fun commit(pending: com.riffle.core.domain.PendingServer, hiddenLibraryIds: Set<String>) =
-            throw UnsupportedOperationException()
-        override suspend fun setActive(serverId: String) = Unit
-        override suspend fun remove(serverId: String) = Unit
-        override suspend fun getServerVersion(serverId: String): String? = null
-    }
 
-    private fun fakeServerRepositoryForServer(activeServer: Server): ServerRepository = object : ServerRepository {
-        override fun observeAll(): Flow<List<Server>> = flowOf(listOf(activeServer))
-        override suspend fun getActive(): Server = activeServer
+    private fun multiServerRepository(servers: List<Server>, activeId: String?): ServerRepository = object : ServerRepository {
+        override fun observeAll(): Flow<List<Server>> = flowOf(servers)
+        override suspend fun getActive(): Server? = servers.firstOrNull { it.id == activeId }
+        override suspend fun getById(serverId: String): Server? = servers.firstOrNull { it.id == serverId }
         override suspend fun authenticate(url: ServerUrl, username: String, password: String, insecureAllowed: Boolean, serverType: com.riffle.core.domain.ServerType) =
             throw UnsupportedOperationException()
         override suspend fun commit(pending: com.riffle.core.domain.PendingServer, hiddenLibraryIds: Set<String>) =
@@ -260,6 +258,233 @@ class EpubRepositoryTest {
         assertTrue(result is EpubDownloadResult.Success)
         assertTrue(downloadsStore.get("server-1", "item-1") != null)
         assertNull(cacheStore.get("server-1", "item-1"))
+    }
+
+    // ─── User-switch regression (item.serverId ≠ activeServer.id) ─────────────────────────────
+    //
+    // A user-switch on the same URL mints a fresh ServerEntity UUID (ServerRepositoryImpl.commit)
+    // while leaving the previous row and its cached files under cacheDir/epubs/<oldId>/ in place.
+    // The item stays keyed by its original serverId; the opener must too, or it looks in the wrong
+    // directory, misses the truly-cached file, and falls into the network branch. That's the
+    // "unable to resolve host" symptom on a cached book while offline.
+
+    private fun multiTokenStorage(tokens: Map<String, String>): TokenStorage = object : TokenStorage {
+        override suspend fun saveToken(serverId: String, token: String) = Unit
+        override suspend fun getToken(serverId: String): String? = tokens[serverId]
+        override suspend fun deleteToken(serverId: String) = Unit
+    }
+
+    private fun serverRow(id: String, baseUrl: String, isActive: Boolean) = Server(
+        id = id,
+        url = ServerUrl.parse(baseUrl)!!,
+        isActive = isActive,
+        insecureConnectionAllowed = false,
+        username = "",
+        serverType = ServerType.AUDIOBOOKSHELF,
+    )
+
+    private fun repoWith(serverRepository: ServerRepository, tokenStorage: TokenStorage): EpubRepository =
+        EpubRepositoryImpl(
+            api = AbsApiClient(OkHttpClient(), DefaultDispatcherProvider),
+            cacheStore = cacheStore,
+            downloadsStore = downloadsStore,
+            positionStore = positionStore,
+            serverRepository = serverRepository,
+            tokenStorage = tokenStorage,
+        )
+
+    @Test
+    fun `openEpub after user switch resolves cached file under item's serverId with zero network`() = runTest {
+        val baseUrl = server.url("/").toString().trimEnd('/')
+        val oldId = "old-user-server"
+        val newId = "new-user-server"
+        val repo = repoWith(
+            multiServerRepository(
+                servers = listOf(
+                    serverRow(oldId, baseUrl, isActive = false),
+                    serverRow(newId, baseUrl, isActive = true),
+                ),
+                activeId = newId,
+            ),
+            multiTokenStorage(mapOf(oldId to "old-token", newId to "new-token")),
+        )
+        cacheStore.save(oldId, "item-1", epubBytes.inputStream())
+
+        val result = repo.openEpub(item(serverId = oldId))
+
+        assertEquals("no network call should fire when cached file exists", 0, server.requestCount)
+        assertTrue("Expected Success but got: $result", result is EpubOpenResult.Success)
+    }
+
+    @Test
+    fun `openEpub after user switch resolves downloaded file under item's serverId with zero network`() = runTest {
+        val baseUrl = server.url("/").toString().trimEnd('/')
+        val oldId = "old-user-server"
+        val newId = "new-user-server"
+        val repo = repoWith(
+            multiServerRepository(
+                servers = listOf(
+                    serverRow(oldId, baseUrl, isActive = false),
+                    serverRow(newId, baseUrl, isActive = true),
+                ),
+                activeId = newId,
+            ),
+            multiTokenStorage(mapOf(oldId to "old-token", newId to "new-token")),
+        )
+        downloadsStore.save(oldId, "item-1", epubBytes.inputStream())
+
+        val result = repo.openEpub(item(serverId = oldId))
+
+        assertEquals(0, server.requestCount)
+        assertTrue("Expected Success but got: $result", result is EpubOpenResult.Success)
+    }
+
+    @Test
+    fun `openEpub cache miss hits the server matching item's serverId not the active one`() = runTest {
+        val activeMock = MockWebServer().also { it.start() }
+        try {
+            val activeBase = activeMock.url("/").toString().trimEnd('/')
+            val itemBase = server.url("/").toString().trimEnd('/')
+            val activeId = "active-server"
+            val itemId = "item-server"
+            val repo = repoWith(
+                multiServerRepository(
+                    servers = listOf(
+                        serverRow(itemId, itemBase, isActive = false),
+                        serverRow(activeId, activeBase, isActive = true),
+                    ),
+                    activeId = activeId,
+                ),
+                multiTokenStorage(mapOf(itemId to "item-token", activeId to "active-token")),
+            )
+            server.enqueue(MockResponse().setResponseCode(200).setBody(Buffer().write(epubBytes)))
+
+            val result = repo.openEpub(item(serverId = itemId))
+
+            assertTrue("Expected Success but got: $result", result is EpubOpenResult.Success)
+            assertEquals("the item's own server must receive the request", 1, server.requestCount)
+            assertEquals("the active-but-unrelated server must be untouched", 0, activeMock.requestCount)
+            val recorded = server.takeRequest()
+            assertEquals("Bearer item-token", recorded.getHeader("Authorization"))
+        } finally {
+            activeMock.shutdown()
+        }
+    }
+
+    @Test
+    fun `openEpub returns NetworkError when item's serverId matches no server row`() = runTest {
+        val baseUrl = server.url("/").toString().trimEnd('/')
+        val repo = repoWith(
+            multiServerRepository(
+                servers = listOf(serverRow("some-other-server", baseUrl, isActive = true)),
+                activeId = "some-other-server",
+            ),
+            multiTokenStorage(mapOf("some-other-server" to "some-token")),
+        )
+
+        val result = repo.openEpub(item(serverId = "orphaned-server"))
+
+        assertTrue("Expected NetworkError but got: $result", result is EpubOpenResult.NetworkError)
+        assertEquals("no network call should fire when the server row is missing", 0, server.requestCount)
+    }
+
+    @Test
+    fun `openEpub after user switch writes newly-fetched file under item's serverId cache dir`() = runTest {
+        val baseUrl = server.url("/").toString().trimEnd('/')
+        val oldId = "old-user-server"
+        val newId = "new-user-server"
+        val repo = repoWith(
+            multiServerRepository(
+                servers = listOf(
+                    serverRow(oldId, baseUrl, isActive = false),
+                    serverRow(newId, baseUrl, isActive = true),
+                ),
+                activeId = newId,
+            ),
+            multiTokenStorage(mapOf(oldId to "old-token", newId to "new-token")),
+        )
+        server.enqueue(MockResponse().setResponseCode(200).setBody(Buffer().write(epubBytes)))
+
+        repo.openEpub(item(serverId = oldId))
+
+        assertNotNull("cache write must land under item.serverId", cacheStore.get(oldId, "item-1"))
+        assertNull("cache write must NOT land under the active server id", cacheStore.get(newId, "item-1"))
+    }
+
+    @Test
+    fun `downloadEpub after user switch promotes cached file under item's serverId with zero network`() = runTest {
+        val baseUrl = server.url("/").toString().trimEnd('/')
+        val oldId = "old-user-server"
+        val newId = "new-user-server"
+        val repo = repoWith(
+            multiServerRepository(
+                servers = listOf(
+                    serverRow(oldId, baseUrl, isActive = false),
+                    serverRow(newId, baseUrl, isActive = true),
+                ),
+                activeId = newId,
+            ),
+            multiTokenStorage(mapOf(oldId to "old-token", newId to "new-token")),
+        )
+        cacheStore.save(oldId, "item-1", epubBytes.inputStream())
+
+        val result = repo.downloadEpub(item(serverId = oldId))
+
+        assertEquals(0, server.requestCount)
+        assertTrue("Expected Success but got: $result", result is EpubDownloadResult.Success)
+        assertNotNull(downloadsStore.get(oldId, "item-1"))
+        assertNull("original cache entry must be moved, not left behind", cacheStore.get(oldId, "item-1"))
+    }
+
+    @Test
+    fun `downloadEpub cache miss hits the server matching item's serverId not the active one`() = runTest {
+        val activeMock = MockWebServer().also { it.start() }
+        try {
+            val activeBase = activeMock.url("/").toString().trimEnd('/')
+            val itemBase = server.url("/").toString().trimEnd('/')
+            val activeId = "active-server"
+            val itemId = "item-server"
+            val repo = repoWith(
+                multiServerRepository(
+                    servers = listOf(
+                        serverRow(itemId, itemBase, isActive = false),
+                        serverRow(activeId, activeBase, isActive = true),
+                    ),
+                    activeId = activeId,
+                ),
+                multiTokenStorage(mapOf(itemId to "item-token", activeId to "active-token")),
+            )
+            server.enqueue(MockResponse().setResponseCode(200).setBody(Buffer().write(epubBytes)))
+
+            val result = repo.downloadEpub(item(serverId = itemId))
+
+            assertTrue("Expected Success but got: $result", result is EpubDownloadResult.Success)
+            assertEquals(1, server.requestCount)
+            assertEquals(0, activeMock.requestCount)
+            val recorded = server.takeRequest()
+            assertEquals("Bearer item-token", recorded.getHeader("Authorization"))
+            assertNotNull(downloadsStore.get(itemId, "item-1"))
+        } finally {
+            activeMock.shutdown()
+        }
+    }
+
+    @Test
+    fun `downloadEpub returns NetworkError when item's serverId matches no server row and no cache`() = runTest {
+        val baseUrl = server.url("/").toString().trimEnd('/')
+        val repo = repoWith(
+            multiServerRepository(
+                servers = listOf(serverRow("some-other-server", baseUrl, isActive = true)),
+                activeId = "some-other-server",
+            ),
+            multiTokenStorage(mapOf("some-other-server" to "some-token")),
+        )
+
+        val result = repo.downloadEpub(item(serverId = "orphaned-server"))
+
+        assertTrue("Expected NetworkError but got: $result", result is EpubDownloadResult.NetworkError)
+        assertEquals(0, server.requestCount)
+        assertFalse(repo.isDownloaded("orphaned-server", "item-1"))
     }
 
 }

--- a/core/data/src/test/kotlin/com/riffle/core/data/PdfRepositoryTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/PdfRepositoryTest.kt
@@ -10,6 +10,7 @@ import com.riffle.core.domain.PdfRepository
 import com.riffle.core.domain.ReadingPositionStore
 import com.riffle.core.domain.Server
 import com.riffle.core.domain.ServerRepository
+import com.riffle.core.domain.ServerType
 import com.riffle.core.domain.ServerUrl
 import com.riffle.core.domain.TokenStorage
 import com.riffle.core.network.AbsApiClient
@@ -22,6 +23,8 @@ import okhttp3.mockwebserver.MockWebServer
 import okio.Buffer
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -64,16 +67,24 @@ class PdfRepositoryTest {
         server.shutdown()
     }
 
-    private fun fakeServerRepository(baseUrl: String): ServerRepository = object : ServerRepository {
-        val activeServer = Server(
-            id = "server-1",
-            url = ServerUrl.parse(baseUrl)!!,
-            isActive = true,
-            insecureConnectionAllowed = false,
-            username = "",
+    private fun fakeServerRepository(baseUrl: String): ServerRepository =
+        multiServerRepository(
+            servers = listOf(
+                Server(
+                    id = "server-1",
+                    url = ServerUrl.parse(baseUrl)!!,
+                    isActive = true,
+                    insecureConnectionAllowed = false,
+                    username = "",
+                ),
+            ),
+            activeId = "server-1",
         )
-        override fun observeAll(): Flow<List<Server>> = flowOf(listOf(activeServer))
-        override suspend fun getActive(): Server = activeServer
+
+    private fun multiServerRepository(servers: List<Server>, activeId: String?): ServerRepository = object : ServerRepository {
+        override fun observeAll(): Flow<List<Server>> = flowOf(servers)
+        override suspend fun getActive(): Server? = servers.firstOrNull { it.id == activeId }
+        override suspend fun getById(serverId: String): Server? = servers.firstOrNull { it.id == serverId }
         override suspend fun authenticate(url: ServerUrl, username: String, password: String, insecureAllowed: Boolean, serverType: com.riffle.core.domain.ServerType) =
             throw UnsupportedOperationException()
         override suspend fun commit(pending: com.riffle.core.domain.PendingServer, hiddenLibraryIds: Set<String>) =
@@ -99,7 +110,7 @@ class PdfRepositoryTest {
         override suspend fun updateLocalTimestamp(serverId: String, itemId: String, millis: Long) = Unit
     }
 
-    private fun item(id: String = "item-1", ino: String? = "ino-42") = LibraryItem(
+    private fun item(id: String = "item-1", ino: String? = "ino-42", serverId: String = "server-1") = LibraryItem(
         id = id,
         libraryId = "lib-1",
         title = "Test PDF",
@@ -110,7 +121,7 @@ class PdfRepositoryTest {
         isDownloaded = false,
         ebookFormat = EbookFormat.Pdf,
         ebookFileIno = ino,
-        serverId = "server-1",
+        serverId = serverId,
     )
 
     // --- openPdf ---
@@ -234,5 +245,230 @@ class PdfRepositoryTest {
         assertTrue(result is PdfDownloadResult.Success)
         assertTrue(downloadsStore.get("server-1", "item-1") != null)
         assertNull(cacheStore.get("server-1", "item-1"))
+    }
+
+    // ─── User-switch regression (item.serverId ≠ activeServer.id) ─────────────────────────────
+    //
+    // Mirror of the EPUB regression suite for the PDF opener. See EpubRepositoryTest for the full
+    // rationale — a user-switch on the same URL leaves the previous server row (and its cached
+    // files) in place; the opener must key by item.serverId, not activeServer.id.
+
+    private fun multiTokenStorage(tokens: Map<String, String>): TokenStorage = object : TokenStorage {
+        override suspend fun saveToken(serverId: String, token: String) = Unit
+        override suspend fun getToken(serverId: String): String? = tokens[serverId]
+        override suspend fun deleteToken(serverId: String) = Unit
+    }
+
+    private fun serverRow(id: String, baseUrl: String, isActive: Boolean) = Server(
+        id = id,
+        url = ServerUrl.parse(baseUrl)!!,
+        isActive = isActive,
+        insecureConnectionAllowed = false,
+        username = "",
+        serverType = ServerType.AUDIOBOOKSHELF,
+    )
+
+    private fun repoWith(serverRepository: ServerRepository, tokenStorage: TokenStorage): PdfRepository =
+        PdfRepositoryImpl(
+            api = AbsApiClient(OkHttpClient(), com.riffle.core.domain.DefaultDispatcherProvider),
+            cacheStore = cacheStore,
+            downloadsStore = downloadsStore,
+            positionStore = positionStore,
+            serverRepository = serverRepository,
+            tokenStorage = tokenStorage,
+        )
+
+    @Test
+    fun `openPdf after user switch resolves cached file under item's serverId with zero network`() = runTest {
+        val baseUrl = server.url("/").toString().trimEnd('/')
+        val oldId = "old-user-server"
+        val newId = "new-user-server"
+        val repo = repoWith(
+            multiServerRepository(
+                servers = listOf(
+                    serverRow(oldId, baseUrl, isActive = false),
+                    serverRow(newId, baseUrl, isActive = true),
+                ),
+                activeId = newId,
+            ),
+            multiTokenStorage(mapOf(oldId to "old-token", newId to "new-token")),
+        )
+        cacheStore.save(oldId, "item-1", pdfBytes.inputStream())
+
+        val result = repo.openPdf(item(serverId = oldId))
+
+        assertEquals("no network call should fire when cached file exists", 0, server.requestCount)
+        assertTrue("Expected Success but got: $result", result is PdfOpenResult.Success)
+    }
+
+    @Test
+    fun `openPdf after user switch resolves downloaded file under item's serverId with zero network`() = runTest {
+        val baseUrl = server.url("/").toString().trimEnd('/')
+        val oldId = "old-user-server"
+        val newId = "new-user-server"
+        val repo = repoWith(
+            multiServerRepository(
+                servers = listOf(
+                    serverRow(oldId, baseUrl, isActive = false),
+                    serverRow(newId, baseUrl, isActive = true),
+                ),
+                activeId = newId,
+            ),
+            multiTokenStorage(mapOf(oldId to "old-token", newId to "new-token")),
+        )
+        downloadsStore.save(oldId, "item-1", pdfBytes.inputStream())
+
+        val result = repo.openPdf(item(serverId = oldId))
+
+        assertEquals(0, server.requestCount)
+        assertTrue("Expected Success but got: $result", result is PdfOpenResult.Success)
+    }
+
+    @Test
+    fun `openPdf cache miss hits the server matching item's serverId not the active one`() = runTest {
+        val activeMock = MockWebServer().also { it.start() }
+        try {
+            val activeBase = activeMock.url("/").toString().trimEnd('/')
+            val itemBase = server.url("/").toString().trimEnd('/')
+            val activeId = "active-server"
+            val itemId = "item-server"
+            val repo = repoWith(
+                multiServerRepository(
+                    servers = listOf(
+                        serverRow(itemId, itemBase, isActive = false),
+                        serverRow(activeId, activeBase, isActive = true),
+                    ),
+                    activeId = activeId,
+                ),
+                multiTokenStorage(mapOf(itemId to "item-token", activeId to "active-token")),
+            )
+            server.enqueue(MockResponse().setResponseCode(200).setBody(Buffer().write(pdfBytes)))
+
+            val result = repo.openPdf(item(serverId = itemId))
+
+            assertTrue("Expected Success but got: $result", result is PdfOpenResult.Success)
+            assertEquals("the item's own server must receive the request", 1, server.requestCount)
+            assertEquals("the active-but-unrelated server must be untouched", 0, activeMock.requestCount)
+            val recorded = server.takeRequest()
+            assertEquals("Bearer item-token", recorded.getHeader("Authorization"))
+        } finally {
+            activeMock.shutdown()
+        }
+    }
+
+    @Test
+    fun `openPdf returns NetworkError when item's serverId matches no server row`() = runTest {
+        val baseUrl = server.url("/").toString().trimEnd('/')
+        val repo = repoWith(
+            multiServerRepository(
+                servers = listOf(serverRow("some-other-server", baseUrl, isActive = true)),
+                activeId = "some-other-server",
+            ),
+            multiTokenStorage(mapOf("some-other-server" to "some-token")),
+        )
+
+        val result = repo.openPdf(item(serverId = "orphaned-server"))
+
+        assertTrue("Expected NetworkError but got: $result", result is PdfOpenResult.NetworkError)
+        assertEquals(0, server.requestCount)
+    }
+
+    @Test
+    fun `openPdf after user switch writes newly-fetched file under item's serverId cache dir`() = runTest {
+        val baseUrl = server.url("/").toString().trimEnd('/')
+        val oldId = "old-user-server"
+        val newId = "new-user-server"
+        val repo = repoWith(
+            multiServerRepository(
+                servers = listOf(
+                    serverRow(oldId, baseUrl, isActive = false),
+                    serverRow(newId, baseUrl, isActive = true),
+                ),
+                activeId = newId,
+            ),
+            multiTokenStorage(mapOf(oldId to "old-token", newId to "new-token")),
+        )
+        server.enqueue(MockResponse().setResponseCode(200).setBody(Buffer().write(pdfBytes)))
+
+        repo.openPdf(item(serverId = oldId))
+
+        assertNotNull("cache write must land under item.serverId", cacheStore.get(oldId, "item-1"))
+        assertNull("cache write must NOT land under the active server id", cacheStore.get(newId, "item-1"))
+    }
+
+    @Test
+    fun `downloadPdf after user switch promotes cached file under item's serverId with zero network`() = runTest {
+        val baseUrl = server.url("/").toString().trimEnd('/')
+        val oldId = "old-user-server"
+        val newId = "new-user-server"
+        val repo = repoWith(
+            multiServerRepository(
+                servers = listOf(
+                    serverRow(oldId, baseUrl, isActive = false),
+                    serverRow(newId, baseUrl, isActive = true),
+                ),
+                activeId = newId,
+            ),
+            multiTokenStorage(mapOf(oldId to "old-token", newId to "new-token")),
+        )
+        cacheStore.save(oldId, "item-1", pdfBytes.inputStream())
+
+        val result = repo.downloadPdf(item(serverId = oldId))
+
+        assertEquals(0, server.requestCount)
+        assertTrue("Expected Success but got: $result", result is PdfDownloadResult.Success)
+        assertNotNull(downloadsStore.get(oldId, "item-1"))
+        assertNull("original cache entry must be moved, not left behind", cacheStore.get(oldId, "item-1"))
+    }
+
+    @Test
+    fun `downloadPdf cache miss hits the server matching item's serverId not the active one`() = runTest {
+        val activeMock = MockWebServer().also { it.start() }
+        try {
+            val activeBase = activeMock.url("/").toString().trimEnd('/')
+            val itemBase = server.url("/").toString().trimEnd('/')
+            val activeId = "active-server"
+            val itemId = "item-server"
+            val repo = repoWith(
+                multiServerRepository(
+                    servers = listOf(
+                        serverRow(itemId, itemBase, isActive = false),
+                        serverRow(activeId, activeBase, isActive = true),
+                    ),
+                    activeId = activeId,
+                ),
+                multiTokenStorage(mapOf(itemId to "item-token", activeId to "active-token")),
+            )
+            server.enqueue(MockResponse().setResponseCode(200).setBody(Buffer().write(pdfBytes)))
+
+            val result = repo.downloadPdf(item(serverId = itemId))
+
+            assertTrue("Expected Success but got: $result", result is PdfDownloadResult.Success)
+            assertEquals(1, server.requestCount)
+            assertEquals(0, activeMock.requestCount)
+            val recorded = server.takeRequest()
+            assertEquals("Bearer item-token", recorded.getHeader("Authorization"))
+            assertNotNull(downloadsStore.get(itemId, "item-1"))
+        } finally {
+            activeMock.shutdown()
+        }
+    }
+
+    @Test
+    fun `downloadPdf returns NetworkError when item's serverId matches no server row and no cache`() = runTest {
+        val baseUrl = server.url("/").toString().trimEnd('/')
+        val repo = repoWith(
+            multiServerRepository(
+                servers = listOf(serverRow("some-other-server", baseUrl, isActive = true)),
+                activeId = "some-other-server",
+            ),
+            multiTokenStorage(mapOf("some-other-server" to "some-token")),
+        )
+
+        val result = repo.downloadPdf(item(serverId = "orphaned-server"))
+
+        assertTrue("Expected NetworkError but got: $result", result is PdfDownloadResult.NetworkError)
+        assertEquals(0, server.requestCount)
+        assertFalse(repo.isDownloaded("orphaned-server", "item-1"))
     }
 }


### PR DESCRIPTION
## Summary

Opening a book that the library UI (correctly) shows as cached was throwing "Unable to resolve host" when offline, after the user had switched accounts on the same server URL.

Root cause: `ServerRepositoryImpl.commit` mints a fresh `ServerEntity` UUID on every login (`core/data/.../ServerRepositoryImpl.kt:131`), leaving the previous row and its cached files under `cacheDir/epubs/<oldId>/` in place. `EpubRepositoryImpl.openEpub` was keying the local cache lookup and the network fetch off `serverRepository.getActive().id`, so it looked under the new row's dir, missed the truly-cached file, fell into the network branch, and — offline — surfaced `UnknownHostException`. `PdfRepositoryImpl.openPdf` had the same shape.

Both openers now resolve the item's own server row via `serverRepository.getById(item.serverId)` and key `cacheStore` / `downloadsStore` paths + `api.downloadEpub` URL and token off it. The same fix applies to the network branch of `downloadEpub` / `downloadPdf`. Position load stays keyed by `activeServer.id` to remain paired with `saveReadingPosition` (out-of-scope signature-change).

## Regression coverage

Sixteen new tests (eight per repository) set up a two-`ServerEntity`-rows-same-URL fixture (user-switch scenario) and assert:

- Cached / downloaded file under `item.serverId` resolves with **zero** network calls.
- Cache miss hits the mock server matching `item.serverId` (with its token); the "active" server's mock is untouched.
- Fresh downloads write under `item.serverId`'s dir, not the active one.
- Missing `item.serverId` row returns `NetworkError` without touching the wire.

Each assertion is one that would flip red if the fix were reverted (e.g. `takeRequest().getHeader("Authorization") == "Bearer item-token"`, `activeMock.requestCount == 0`, cache write lands under `oldId` and not `newId`).

## Test plan

- [x] `./gradlew test` — all JVM suites green (`:core:data`, `:app`, etc.)
- [ ] Manual repro on device: with two `ServerEntity` rows for the same URL (user A then user B on the same server), a book cached under user A now opens offline from user A's library-item entry.