### PR TITLE
refactor(icons): centralize To Read and Annotations glyphs

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsScreen.kt
@@ -41,7 +41,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Bookmark
-import androidx.compose.material.icons.filled.Bookmarks
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Folder
 import androidx.compose.material.icons.filled.FormatListNumbered
@@ -105,6 +104,7 @@ import androidx.compose.ui.res.painterResource
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
 import com.riffle.app.R
+import com.riffle.app.ui.theme.RiffleIcons
 import com.riffle.core.database.AnnotationEntity
 import com.riffle.core.domain.Collection
 import com.riffle.core.domain.HighlightColor
@@ -1194,7 +1194,7 @@ private fun LibraryTabBar(selectedTab: Int, onTabSelected: (Int) -> Unit) {
         NavigationBarItem(
             selected = selectedTab == 1,
             onClick = { onTabSelected(1) },
-            icon = { Icon(Icons.Filled.Bookmarks, contentDescription = "To Read") },
+            icon = { Icon(RiffleIcons.ToReadFilled, contentDescription = "To Read") },
         )
         NavigationBarItem(
             selected = selectedTab == 2,

--- a/app/src/main/kotlin/com/riffle/app/feature/library/ToReadToggleButton.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/ToReadToggleButton.kt
@@ -6,9 +6,6 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Bookmark
-import androidx.compose.material.icons.outlined.BookmarkBorder
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
@@ -16,6 +13,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.dp
+import com.riffle.app.ui.theme.RiffleIcons
 
 @Composable
 fun ToReadToggleButton(
@@ -35,7 +33,7 @@ fun ToReadToggleButton(
         contentAlignment = Alignment.Center,
     ) {
         Icon(
-            imageVector = if (isInToRead) Icons.Filled.Bookmark else Icons.Outlined.BookmarkBorder,
+            imageVector = if (isInToRead) RiffleIcons.ToReadFilled else RiffleIcons.ToRead,
             contentDescription = if (isInToRead) "Remove from To Read" else "Add to To Read",
             tint = if (isInToRead) MaterialTheme.colorScheme.onPrimary else MaterialTheme.colorScheme.outline,
             modifier = Modifier.size(20.dp),

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -33,7 +33,6 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.List
-import androidx.compose.material.icons.filled.Bookmarks
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.ui.res.painterResource
 import com.riffle.app.R
@@ -95,6 +94,7 @@ import com.riffle.app.feature.reader.readaloud.PlayerCoordinator
 import com.riffle.app.feature.reader.readaloud.ReadaloudDownloadDialog
 import com.riffle.app.feature.reader.readaloud.ReadaloudMiniPlayer
 import com.riffle.app.feature.reader.readaloud.ReadaloudPeek
+import com.riffle.app.ui.theme.RiffleIcons
 import com.riffle.app.ui.theme.RiffleTheme
 import com.riffle.core.domain.FormattingPreferences
 import com.riffle.core.domain.HighlightColor
@@ -633,7 +633,7 @@ fun EpubReaderScreen(
                                 Icon(Icons.AutoMirrored.Filled.List, contentDescription = "Table of Contents")
                             }
                             IconButton(onClick = viewModel::openAnnotationsPanel) {
-                                Icon(Icons.Filled.Bookmarks, contentDescription = "Annotations")
+                                Icon(RiffleIcons.Annotations, contentDescription = "Annotations")
                             }
                             IconButton(onClick = { showFormattingPanel = true }) {
                                 Text(

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/PdfReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/PdfReaderScreen.kt
@@ -17,7 +17,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.List
-import androidx.compose.material.icons.filled.Bookmarks
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -58,6 +57,7 @@ import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import com.riffle.app.feature.reader.formatting.RenderCapabilities
 import com.riffle.app.feature.reader.formatting.toPdfiumPreferences
+import com.riffle.app.ui.theme.RiffleIcons
 import com.riffle.core.domain.FormattingPreferences
 import com.riffle.core.domain.ReaderTheme
 import kotlinx.coroutines.flow.Flow
@@ -266,7 +266,7 @@ fun PdfReaderScreen(
                             onClick = viewModel::openAnnotationsPanel,
                             modifier = Modifier.testTag("pdf_open_annotations"),
                         ) {
-                            Icon(Icons.Filled.Bookmarks, contentDescription = "Annotations")
+                            Icon(RiffleIcons.Annotations, contentDescription = "Annotations")
                         }
                         IconButton(
                             onClick = { showFormattingPanel = true },

--- a/app/src/main/kotlin/com/riffle/app/ui/theme/RiffleIcons.kt
+++ b/app/src/main/kotlin/com/riffle/app/ui/theme/RiffleIcons.kt
@@ -1,0 +1,24 @@
+package com.riffle.app.ui.theme
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.PlaylistAddCheck
+import androidx.compose.material.icons.automirrored.outlined.PlaylistAdd
+import androidx.compose.material.icons.filled.Bookmarks
+import androidx.compose.ui.graphics.vector.ImageVector
+
+/**
+ * Central icon registry. Keeps a single glyph per concept so the same feature reads the same
+ * everywhere it surfaces. Route every icon that represents one of these concepts through here;
+ * never re-import the underlying Material symbol at a call site.
+ *
+ * - [ToRead] / [ToReadFilled]: the reading-queue / "save for later" concept. Used by the
+ *   details-screen toggle and the library nav tab.
+ * - [Annotations]: highlights + notes + reader-level bookmarks. Used by the reader's annotations
+ *   panel button and (future) the main-screen Annotations view. This concept owns the
+ *   `Bookmark*` family; do not use it for anything else.
+ */
+object RiffleIcons {
+    val ToRead: ImageVector = Icons.AutoMirrored.Outlined.PlaylistAdd
+    val ToReadFilled: ImageVector = Icons.AutoMirrored.Filled.PlaylistAddCheck
+    val Annotations: ImageVector = Icons.Filled.Bookmarks
+}

--- a/app/src/test/kotlin/com/riffle/app/ui/theme/RiffleIconsTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/ui/theme/RiffleIconsTest.kt
@@ -1,0 +1,35 @@
+package com.riffle.app.ui.theme
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.PlaylistAddCheck
+import androidx.compose.material.icons.automirrored.outlined.PlaylistAdd
+import androidx.compose.material.icons.filled.Bookmarks
+import org.junit.Assert.assertSame
+import org.junit.Test
+
+/**
+ * These pin each central icon to the chosen Material vector. A regression that "just re-imports
+ * Bookmark at a call site" or silently swaps ToRead back to the Bookmark family flips one of
+ * these red, which is the point — the central object exists to prevent drift, and the test
+ * exists to prevent the central object from silently drifting.
+ */
+class RiffleIconsTest {
+
+    @Test
+    fun toReadOutlineIsPlaylistAdd() {
+        assertSame(Icons.AutoMirrored.Outlined.PlaylistAdd, RiffleIcons.ToRead)
+    }
+
+    @Test
+    fun toReadFilledIsPlaylistAddCheck() {
+        assertSame(Icons.AutoMirrored.Filled.PlaylistAddCheck, RiffleIcons.ToReadFilled)
+    }
+
+    @Test
+    fun annotationsIsBookmarks() {
+        // Bookmark* family belongs to the Annotations concept — reader panel button and the future
+        // main-screen Annotations view. If this flips, the To-Read / Annotations separation is
+        // being re-collided.
+        assertSame(Icons.Filled.Bookmarks, RiffleIcons.Annotations)
+    }
+}


### PR DESCRIPTION
## Why

Two concepts had drifted across four call sites:

| # | Location | Was |
|---|---|---|
| 1 | Reader annotations panel button (`EpubReaderScreen.kt`, `PdfReaderScreen.kt`) | `Icons.Filled.Bookmarks` |
| 2 | Details screen To Read toggle (`ToReadToggleButton.kt`) | `Icons.Filled.Bookmark` / `Icons.Outlined.BookmarkBorder` |
| 3 | Library nav To Read tab (`LibraryItemsScreen.kt:1197`) | `Icons.Filled.Bookmarks` |

The two To Read sites disagreed with each other (singular vs plural), and the To Read tab collided visually with the reader's Annotations button. A future main-screen Annotations view (planned) will also want the Bookmark family — which is the correct semantic home for it, since a reader-level bookmark is one of the artifacts an annotations view lists.

## Change

Introduce `RiffleIcons` (in `app/ui/theme/`) with three constants:

```kotlin
object RiffleIcons {
    val ToRead        = Icons.AutoMirrored.Outlined.PlaylistAdd
    val ToReadFilled  = Icons.AutoMirrored.Filled.PlaylistAddCheck
    val Annotations   = Icons.Filled.Bookmarks
}
```

Point every affected call site at it. To Read moves to the PlaylistAdd family (AutoMirrored variants for RTL). Annotations keeps `Icons.Filled.Bookmarks` — now the sole owner of the Bookmark family and ready to be reused by the future main-screen Annotations view (no additional constant needed at that time).

## Test

`RiffleIconsTest` pins each constant to its chosen `ImageVector`. A silent revert of any of the three flips it red. Behavior at call sites is otherwise unchanged (identical shapes, states, and tints).

## Verification

- `./gradlew :app:testDebugUnitTest --tests "com.riffle.app.ui.theme.RiffleIconsTest"` → BUILD SUCCESSFUL (compiles the whole `:app` main source set, so all four call-site edits compile too).
- Not yet visually verified on an AVD — the swap is 1:1 and one of the three constants (`Annotations`) is pixel-identical to what shipped previously, so the risk surface is the To Read toggle + tab rendering `PlaylistAdd` at the intended size. Reviewer welcome to sanity-check.