### PR TITLE
feat(reader): keep auto-scroll pill visible when paused via the pill

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -736,7 +736,8 @@ fun EpubReaderScreen(
         // Auto-Scroll HUD pill — overlays everything else and survives Immersive Mode.
         com.riffle.app.feature.reader.autoscroll.AutoScrollHudPill(
             state = autoScrollStateForPill,
-            onPause = { viewModel.stopAutoScroll() },
+            onPause = { viewModel.pauseAutoScrollFromPill() },
+            onResume = { viewModel.resumeAutoScrollFromPill() },
             onSlower = { viewModel.nudgeAutoScroll(by = -com.riffle.core.domain.autoscroll.AutoScrollSpeed.STEP_WPM) },
             onFaster = { viewModel.nudgeAutoScroll(by = com.riffle.core.domain.autoscroll.AutoScrollSpeed.STEP_WPM) },
         )

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -346,6 +346,10 @@ class EpubReaderViewModel @Inject constructor(
 
     fun resumeAutoScrollIfPaused() = formatting.resumeAutoScrollIfPaused()
 
+    fun pauseAutoScrollFromPill() = formatting.pauseAutoScrollFromPill()
+
+    fun resumeAutoScrollFromPill() = formatting.resumeAutoScrollIfPaused()
+
     fun setReaderViewportWidthPx(px: Int) = formatting.setViewportWidthPx(px)
 
     // ---- VolumeKeyDispatcher delegations -----------------------------------------------------------

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/autoscroll/AutoScrollUi.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/autoscroll/AutoScrollUi.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Pause
+import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Remove
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -36,6 +37,7 @@ import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.runtime.remember
 import com.riffle.core.domain.autoscroll.AutoScrollState
+import com.riffle.core.domain.autoscroll.isHudPillVisible
 import com.riffle.core.domain.autoscroll.speedOrNull
 
 // The HUD pill anchors to BottomEnd inside the system-bar insets, but the reader still paints its
@@ -104,13 +106,14 @@ private fun DrawScope.drawPlayDownUnderEvenText(color: Color) {
 fun AutoScrollHudPill(
     state: AutoScrollState,
     onPause: () -> Unit,
+    onResume: () -> Unit,
     onSlower: () -> Unit,
     onFaster: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val running = state is AutoScrollState.Running
-    if (!running) return
+    if (!state.isHudPillVisible) return
     val speed = state.speedOrNull?.wpm ?: return
+    val running = state is AutoScrollState.Running
 
     val insets = WindowInsets.systemBars.asPaddingValues()
     Box(
@@ -127,10 +130,13 @@ fun AutoScrollHudPill(
                 .padding(horizontal = 4.dp, vertical = 2.dp)
                 .heightIn(min = 28.dp),
         ) {
-            IconButton(onClick = onPause, modifier = Modifier.size(28.dp)) {
+            IconButton(
+                onClick = if (running) onPause else onResume,
+                modifier = Modifier.size(28.dp),
+            ) {
                 Icon(
-                    Icons.Filled.Pause,
-                    contentDescription = "Pause auto-scroll",
+                    if (running) Icons.Filled.Pause else Icons.Filled.PlayArrow,
+                    contentDescription = if (running) "Pause auto-scroll" else "Resume auto-scroll",
                     tint = Color.White,
                     modifier = Modifier.size(14.dp),
                 )

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/session/FormattingSession.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/session/FormattingSession.kt
@@ -17,16 +17,19 @@ import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
+import com.riffle.core.domain.autoscroll.PauseCause
 
 /**
  * Owns all formatting/typography/auto-scroll state for a single open book. Lifted from
@@ -163,6 +166,25 @@ class FormattingSession @AssistedInject constructor(
         }
         // Readaloud start ⇒ stop Auto-Scroll (mutual exclusion, ADR 0037).
         // Driven externally via onPlaybackStateChanged(isPlaying).
+        // When the user parks Auto-Scroll from the HUD pill, keep the pill on-screen for a couple
+        // of minutes so they can resume or tweak speed. If they never act, auto-stop so the pill
+        // doesn't linger forever. collectLatest cancels the timer if state moves off UserPausedPill
+        // (resume, another pause cause, stop, etc.).
+        scope.launch {
+            autoScrollController.state.collectLatest { s ->
+                if (s is AutoScrollState.Paused && s.cause == PauseCause.UserPausedPill) {
+                    delay(PILL_AUTO_HIDE_MS)
+                    autoScrollController.dispatch(AutoScrollEvent.Stop)
+                }
+            }
+        }
+    }
+
+    companion object {
+        // Chosen at ~90s — inside the "minute or two" the user asked for. Long enough that a brief
+        // interruption (drink of water, tap a message) doesn't drop the session; short enough that
+        // a walked-away pill self-cleans within a couple of minutes.
+        const val PILL_AUTO_HIDE_MS: Long = 90_000L
     }
 
     /**
@@ -244,6 +266,15 @@ class FormattingSession @AssistedInject constructor(
 
     fun pauseAutoScroll(cause: com.riffle.core.domain.autoscroll.PauseCause) {
         autoScrollController.dispatch(AutoScrollEvent.Pause(cause))
+    }
+
+    /**
+     * Pause from the HUD pill and keep the pill on-screen so the user can resume or nudge speed.
+     * If the user doesn't act within [PILL_AUTO_HIDE_MS], the session auto-stops so the pill
+     * doesn't linger indefinitely.
+     */
+    fun pauseAutoScrollFromPill() {
+        autoScrollController.dispatch(AutoScrollEvent.Pause(PauseCause.UserPausedPill))
     }
 
     fun resumeAutoScrollIfPaused() {

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/session/FormattingSessionTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/session/FormattingSessionTest.kt
@@ -368,4 +368,111 @@ class FormattingSessionTest {
             scope.cancel()
         }
     }
+
+    // 15. pauseAutoScrollFromPill lands in Paused with UserPausedPill so the pill stays visible.
+    @Test
+    fun `pauseAutoScrollFromPill parks state as Paused with UserPausedPill`() = runTest {
+        val dispatcher = UnconfinedTestDispatcher(testScheduler)
+        val autoScrollController = AutoScrollController.forTest(dispatcher)
+        val sessionScope = kotlinx.coroutines.CoroutineScope(dispatcher)
+        val session = FormattingSession(
+            scope = sessionScope,
+            formattingPreferencesStore = FakeFormattingPreferencesStore(),
+            bookFormattingPreferencesStore = FakeBookFormattingPreferencesStore(),
+            wakeLockPreferencesStore = FakeWakeLockPreferencesStore(),
+            listeningPreferencesStore = FakeListeningPreferencesStore(),
+            autoScrollController = autoScrollController,
+            appearanceCoordinator = FakeAppearanceCoordinator(),
+        )
+        try {
+            autoScrollController.dispatch(AutoScrollEvent.Start)
+            assertTrue(autoScrollController.state.value is AutoScrollState.Running)
+
+            session.pauseAutoScrollFromPill()
+            val s = autoScrollController.state.value
+            assertTrue(s is AutoScrollState.Paused)
+            assertEquals(
+                com.riffle.core.domain.autoscroll.PauseCause.UserPausedPill,
+                (s as AutoScrollState.Paused).cause,
+            )
+        } finally {
+            autoScrollController.release()
+            sessionScope.cancel()
+        }
+    }
+
+    // 16. After PILL_AUTO_HIDE_MS elapses in the UserPausedPill state, the session auto-stops so the
+    //     pill doesn't linger forever. Reverting the fix (removing the collectLatest+delay) would
+    //     leave state at Paused indefinitely and flip this assertion red.
+    @Test
+    fun `UserPausedPill auto-stops after PILL_AUTO_HIDE_MS`() = runTest {
+        val dispatcher = UnconfinedTestDispatcher(testScheduler)
+        val autoScrollController = AutoScrollController.forTest(dispatcher)
+        val sessionScope = kotlinx.coroutines.CoroutineScope(dispatcher)
+        val session = FormattingSession(
+            scope = sessionScope,
+            formattingPreferencesStore = FakeFormattingPreferencesStore(),
+            bookFormattingPreferencesStore = FakeBookFormattingPreferencesStore(),
+            wakeLockPreferencesStore = FakeWakeLockPreferencesStore(),
+            listeningPreferencesStore = FakeListeningPreferencesStore(),
+            autoScrollController = autoScrollController,
+            appearanceCoordinator = FakeAppearanceCoordinator(),
+        )
+        try {
+            autoScrollController.dispatch(AutoScrollEvent.Start)
+            session.pauseAutoScrollFromPill()
+            assertTrue(autoScrollController.state.value is AutoScrollState.Paused)
+
+            testScheduler.advanceTimeBy(FormattingSession.PILL_AUTO_HIDE_MS - 1)
+            testScheduler.runCurrent()
+            assertTrue(
+                "pill must still be up just before auto-hide",
+                autoScrollController.state.value is AutoScrollState.Paused,
+            )
+
+            testScheduler.advanceTimeBy(2)
+            testScheduler.runCurrent()
+            assertTrue(
+                "session must auto-stop after PILL_AUTO_HIDE_MS",
+                autoScrollController.state.value is AutoScrollState.Idle,
+            )
+        } finally {
+            autoScrollController.release()
+            sessionScope.cancel()
+        }
+    }
+
+    // 17. Resuming from the pill before the timeout cancels the auto-hide so a live session isn't
+    //     stopped out from under the user.
+    @Test
+    fun `resuming before auto-hide cancels the timer`() = runTest {
+        val dispatcher = UnconfinedTestDispatcher(testScheduler)
+        val autoScrollController = AutoScrollController.forTest(dispatcher)
+        val sessionScope = kotlinx.coroutines.CoroutineScope(dispatcher)
+        val session = FormattingSession(
+            scope = sessionScope,
+            formattingPreferencesStore = FakeFormattingPreferencesStore(),
+            bookFormattingPreferencesStore = FakeBookFormattingPreferencesStore(),
+            wakeLockPreferencesStore = FakeWakeLockPreferencesStore(),
+            listeningPreferencesStore = FakeListeningPreferencesStore(),
+            autoScrollController = autoScrollController,
+            appearanceCoordinator = FakeAppearanceCoordinator(),
+        )
+        try {
+            autoScrollController.dispatch(AutoScrollEvent.Start)
+            session.pauseAutoScrollFromPill()
+            testScheduler.advanceTimeBy(FormattingSession.PILL_AUTO_HIDE_MS / 2)
+
+            session.resumeAutoScrollIfPaused()
+            assertTrue(autoScrollController.state.value is AutoScrollState.Running)
+
+            // Advance well past the timeout — Resumed state must not be auto-stopped.
+            testScheduler.advanceTimeBy(FormattingSession.PILL_AUTO_HIDE_MS * 2)
+            testScheduler.runCurrent()
+            assertTrue(autoScrollController.state.value is AutoScrollState.Running)
+        } finally {
+            autoScrollController.release()
+            sessionScope.cancel()
+        }
+    }
 }

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/autoscroll/AutoScrollState.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/autoscroll/AutoScrollState.kt
@@ -14,7 +14,15 @@ enum class PauseCause {
     OrientationChange,
     PanelOpen,
     ReadaloudStarted,
+    UserPausedPill,
 }
+
+// The HUD pill is visible while Auto-Scroll is Running, or while the user has explicitly paused it
+// from the pill itself. All other pause causes (backgrounding, panel open, manual scroll, etc.) hide
+// the pill immediately — those are transient system-driven pauses, not a user parking action.
+val AutoScrollState.isHudPillVisible: Boolean
+    get() = this is AutoScrollState.Running ||
+        (this is AutoScrollState.Paused && cause == PauseCause.UserPausedPill)
 
 val AutoScrollState.isActive: Boolean
     get() = this is AutoScrollState.Running

--- a/core/domain/src/test/kotlin/com/riffle/core/domain/autoscroll/AutoScrollStateTest.kt
+++ b/core/domain/src/test/kotlin/com/riffle/core/domain/autoscroll/AutoScrollStateTest.kt
@@ -40,6 +40,32 @@ class AutoScrollStateTest {
         assertTrue(PauseCause.OrientationChange in all)
         assertTrue(PauseCause.PanelOpen in all)
         assertTrue(PauseCause.ReadaloudStarted in all)
-        assertEquals(7, all.size)
+        assertTrue(PauseCause.UserPausedPill in all)
+        assertEquals(8, all.size)
+    }
+
+    @Test
+    fun `HUD pill is visible while Running`() {
+        assertTrue(AutoScrollState.Running(AutoScrollSpeed.Default).isHudPillVisible)
+    }
+
+    @Test
+    fun `HUD pill is visible when the user paused it from the pill`() {
+        val s: AutoScrollState = AutoScrollState.Paused(AutoScrollSpeed.Default, PauseCause.UserPausedPill)
+        assertTrue(s.isHudPillVisible)
+    }
+
+    @Test
+    fun `HUD pill is hidden for system-driven pause causes`() {
+        val systemCauses = PauseCause.values().filter { it != PauseCause.UserPausedPill }
+        for (cause in systemCauses) {
+            val s: AutoScrollState = AutoScrollState.Paused(AutoScrollSpeed.Default, cause)
+            assertFalse("pill must hide for $cause", s.isHudPillVisible)
+        }
+    }
+
+    @Test
+    fun `HUD pill is hidden when Idle`() {
+        assertFalse(AutoScrollState.Idle.isHudPillVisible)
     }
 }


### PR DESCRIPTION
## Summary

Tapping pause on the auto-scroll HUD pill previously stopped the session outright and hid the pill immediately, so resuming meant going back up to the top-bar toggle. Instead, park state in a new `PauseCause.UserPausedPill` so the pill stays on-screen with a play icon that resumes in place. `FormattingSession` auto-stops after `PILL_AUTO_HIDE_MS` (90s) so a walked-away pill self-cleans within a couple of minutes.

Other pause causes (backgrounding, panel open, manual scroll, readaloud, orientation change, screen off) still hide the pill immediately — those are transient system-driven pauses, not a user parking action.

## Test plan

- [x] `:core:domain:test` — new `PauseCause.UserPausedPill` + 4 `isHudPillVisible` assertions.
- [x] `:app:testDebugUnitTest` — `FormattingSessionTest` new cases:
  - `pauseAutoScrollFromPill` parks state as `Paused(UserPausedPill)`.
  - Auto-stops after `PILL_AUTO_HIDE_MS` (regression pin for the timer — reverting the `collectLatest` block flips it red).
  - Resuming before timeout cancels the timer.
- [ ] Device: pause from pill → pill stays with play icon → resume in place works; pause + walk away → pill self-cleans after ~90s.