### PR TITLE
fix(library): don't cache empty TOC extraction results

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/library/ExtractEpubTocUseCase.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/ExtractEpubTocUseCase.kt
@@ -27,7 +27,11 @@ class ExtractEpubTocUseCase @Inject constructor(
         val inode = item.ebookFileIno ?: "unknown"
 
         val cached = tocRepository.getCachedToc(item.serverId, item.id)
-        if (cached != null && cached.first == inode) return cached.second
+        // Only trust a cache hit that has entries. An empty cached list is treated as a miss so a
+        // transient extraction failure (e.g. a Readium parse hiccup on first open) doesn't poison
+        // the cache forever — especially under the "unknown" inode key used for ABS < v2.36, where
+        // the key never changes and there's no other invalidation trigger.
+        if (cached != null && cached.first == inode && cached.second.isNotEmpty()) return cached.second
 
         val file = when (val r = epubRepository.openEpub(item)) {
             is EpubOpenResult.Success -> r.epubFile
@@ -46,7 +50,11 @@ class ExtractEpubTocUseCase @Inject constructor(
 
         return publication.use {
             val entries = it.tableOfContents.toTocEntries()
-            tocRepository.saveToc(item.serverId, item.id, inode, entries)
+            // Don't persist an empty TOC — it's almost always a transient parse failure, and
+            // caching it would prevent a healthy re-extract on the next open.
+            if (entries.isNotEmpty()) {
+                tocRepository.saveToc(item.serverId, item.id, inode, entries)
+            }
             entries
         }
     }

--- a/app/src/test/kotlin/com/riffle/app/feature/library/ExtractEpubTocUseCaseTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/ExtractEpubTocUseCaseTest.kt
@@ -80,6 +80,36 @@ class ExtractEpubTocUseCaseTest {
     }
 
     @Test
+    fun `treats empty cached list as a miss and re-extracts (unknown inode)`() = runTest {
+        // Regression: a transient extraction failure used to poison the cache with an empty list
+        // under the "unknown" inode key (ABS < v2.36). Since the key never changes, the empty
+        // list would be returned forever. The fix treats empty as a cache miss.
+        coEvery { tocRepository.getCachedToc("srv1", "item1") } returns ("unknown" to emptyList())
+        coEvery { epubRepository.openEpub(any()) } returns
+            EpubOpenResult.NetworkError(RuntimeException("offline"))
+
+        val result = useCase(makeItem(ebookFileIno = null))
+
+        // The empty cache is bypassed — openEpub is called even though a cache row exists.
+        coVerify(exactly = 1) { epubRepository.openEpub(any()) }
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun `treats empty cached list as a miss and re-extracts (matching inode)`() = runTest {
+        // Same regression, but for ABS >= v2.36 where a real inode is present. An empty cached
+        // list must not be trusted even when the inode matches.
+        coEvery { tocRepository.getCachedToc("srv1", "item1") } returns ("ino1" to emptyList())
+        coEvery { epubRepository.openEpub(any()) } returns
+            EpubOpenResult.NetworkError(RuntimeException("offline"))
+
+        val result = useCase(makeItem(ebookFileIno = "ino1"))
+
+        coVerify(exactly = 1) { epubRepository.openEpub(any()) }
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
     fun `ignores stale cache and re-extracts when inode does not match`() = runTest {
         val staleCached = listOf(TocEntry("Old Chapter", "old.html"))
         // Cache has inode "old-ino" but item now has "ino1"


### PR DESCRIPTION
## Summary

- A book's TOC could be permanently missing on the library detail screen even though the EPUB itself had a valid `nav.xhtml`/`toc.ncx`.
- Root cause: an empty result from Readium's `publication.tableOfContents` (transient parse failure, not-yet-finished download, etc.) was persisted to `toc_cache`. Under the `"unknown"` inode key used for ABS < v2.36 the key never changes, so the empty list was returned forever with no way to invalidate.
- Two changes in `ExtractEpubTocUseCase`:
  - Skip `saveToc(...)` when the extracted entry list is empty — a transient failure no longer becomes durable state.
  - Treat a cached empty list as a cache miss and re-extract — self-heals any already-poisoned rows on the next detail-screen open.

Discovered while debugging "A Philosophy of Software Design" on emulator-5554: `toc_cache.entriesJson` was `[]` for that book while other epubs on the same device had normal (~12KB) cached entries; the epub's own `nav.xhtml` parsed correctly and the manifest declared both `properties="nav"` and `spine toc="ncx"`.

## Test plan

- [x] New unit tests in `ExtractEpubTocUseCaseTest` assert that an empty cached list (both `"unknown"` and matching-inode variants) is bypassed and triggers `openEpub`. If either fix regresses, both tests flip red.
- [x] Existing "cache hit returns cached entries" tests still pass because they use non-empty cached lists.
- [x] `./gradlew :app:testDebugUnitTest --tests "com.riffle.app.feature.library.ExtractEpubTocUseCaseTest"` green.