### PR TITLE
feat(reader): let highlight snippets in annotations list expand to more lines

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/AnnotationsPanel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/AnnotationsPanel.kt
@@ -115,7 +115,10 @@ private fun AnnotationRow(
             .clickable(onClick = onClick)
             .padding(horizontal = 16.dp, vertical = 12.dp),
     ) {
-        Box(modifier = Modifier.size(32.dp), contentAlignment = Alignment.Center) {
+        Box(
+            modifier = Modifier.size(32.dp),
+            contentAlignment = Alignment.Center,
+        ) {
             if (annotation.type == AnnotationEntity.TYPE_BOOKMARK) {
                 Icon(
                     Icons.Filled.Bookmark,
@@ -142,7 +145,7 @@ private fun AnnotationRow(
                 text = title,
                 style = MaterialTheme.typography.bodyLarge,
                 color = MaterialTheme.colorScheme.onSurface,
-                maxLines = 2,
+                maxLines = maxLinesForAnnotationTitle(annotation.type),
                 overflow = TextOverflow.Ellipsis,
             )
             val note = annotation.note
@@ -198,6 +201,12 @@ private fun AnnotationOverflow(
         }
     }
 }
+
+internal const val BOOKMARK_TITLE_MAX_LINES = 2
+internal const val HIGHLIGHT_SNIPPET_MAX_LINES = 6
+
+internal fun maxLinesForAnnotationTitle(type: String): Int =
+    if (type == AnnotationEntity.TYPE_BOOKMARK) BOOKMARK_TITLE_MAX_LINES else HIGHLIGHT_SNIPPET_MAX_LINES
 
 @Composable
 private fun BookmarkRenameDialog(

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/AnnotationsPanelMaxLinesTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/AnnotationsPanelMaxLinesTest.kt
@@ -1,0 +1,27 @@
+package com.riffle.app.feature.reader
+
+import com.riffle.core.database.AnnotationEntity
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AnnotationsPanelMaxLinesTest {
+
+    @Test
+    fun bookmarkTitleIsCappedToTwoLines() {
+        assertEquals(2, maxLinesForAnnotationTitle(AnnotationEntity.TYPE_BOOKMARK))
+    }
+
+    @Test
+    fun highlightSnippetGetsMoreLinesThanBookmark() {
+        val highlight = maxLinesForAnnotationTitle(AnnotationEntity.TYPE_HIGHLIGHT)
+        val bookmark = maxLinesForAnnotationTitle(AnnotationEntity.TYPE_BOOKMARK)
+        assertTrue("highlight max ($highlight) must exceed bookmark max ($bookmark)", highlight > bookmark)
+    }
+
+    @Test
+    fun highlightSnippetStillHasFiniteMax() {
+        val max = maxLinesForAnnotationTitle(AnnotationEntity.TYPE_HIGHLIGHT)
+        assertTrue("highlight max should be a sensible cap, was $max", max in 3..20)
+    }
+}


### PR DESCRIPTION
## Summary

- Bookmark titles stay at 2 lines; highlight snippets grow up to 6 lines before ellipsizing so long quotes are readable at a glance.
- Extracted the per-type max into `maxLinesForAnnotationTitle(type)` so the decision is unit-testable off-device.
- Row height stays intrinsic per item — short highlights remain compact.

## Test plan

- [x] `AnnotationsPanelMaxLinesTest` pins bookmark=2, highlight>bookmark, and highlight has a finite cap.
- [ ] Visual sanity in the annotations bottom sheet on device.