### PR TITLE
fix(reader): keep auto-scroll pill park sticky through panel open/close

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/session/FormattingSession.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/session/FormattingSession.kt
@@ -181,10 +181,7 @@ class FormattingSession @AssistedInject constructor(
     }
 
     companion object {
-        // Chosen at ~90s — inside the "minute or two" the user asked for. Long enough that a brief
-        // interruption (drink of water, tap a message) doesn't drop the session; short enough that
-        // a walked-away pill self-cleans within a couple of minutes.
-        const val PILL_AUTO_HIDE_MS: Long = 90_000L
+        const val PILL_AUTO_HIDE_MS: Long = 60_000L
     }
 
     /**
@@ -240,7 +237,12 @@ class FormattingSession @AssistedInject constructor(
         if (paused) {
             autoScrollController.dispatch(AutoScrollEvent.Pause(cause))
         } else {
-            autoScrollController.dispatch(AutoScrollEvent.Resume)
+            // Scoped resume: only lift the pause if its cause matches the one we're clearing.
+            // Otherwise, a panel close would silently un-park a user's explicit HUD-pill pause.
+            val current = autoScrollController.state.value
+            if (current is AutoScrollState.Paused && current.cause == cause) {
+                autoScrollController.dispatch(AutoScrollEvent.Resume)
+            }
         }
     }
 

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/session/FormattingSessionTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/session/FormattingSessionTest.kt
@@ -245,6 +245,46 @@ class FormattingSessionTest {
         }
     }
 
+    // Regression: when the user has explicitly parked Auto-Scroll from the HUD pill,
+    // opening and closing a reader panel (formatting/TOC/search/annotations) must NOT
+    // silently resume scrolling. The pill-park is sticky.
+    @Test
+    fun `panel open then close leaves UserPausedPill parked`() = runTest {
+        val (session, _, _, _, autoScrollController, scope) = makeEager()
+        try {
+            autoScrollController.dispatch(AutoScrollEvent.Start)
+            session.pauseAutoScrollFromPill()
+            val parked = autoScrollController.state.value
+            assertTrue(parked is AutoScrollState.Paused)
+            assertEquals(
+                com.riffle.core.domain.autoscroll.PauseCause.UserPausedPill,
+                (parked as AutoScrollState.Paused).cause,
+            )
+
+            session.setAutoScrollPaused(
+                paused = true,
+                cause = com.riffle.core.domain.autoscroll.PauseCause.PanelOpen,
+            )
+            session.setAutoScrollPaused(
+                paused = false,
+                cause = com.riffle.core.domain.autoscroll.PauseCause.PanelOpen,
+            )
+
+            val after = autoScrollController.state.value
+            assertTrue(
+                "user-pill park must survive a panel open/close cycle",
+                after is AutoScrollState.Paused,
+            )
+            assertEquals(
+                com.riffle.core.domain.autoscroll.PauseCause.UserPausedPill,
+                (after as AutoScrollState.Paused).cause,
+            )
+        } finally {
+            autoScrollController.release()
+            scope.cancel()
+        }
+    }
+
     // 8. formattingPreferencesReady gates emission until prefs load
     @Test
     fun `formattingPreferencesReady is false before bindToBook and true after`() = runTest {

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/autoscroll/AutoScrollReducer.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/autoscroll/AutoScrollReducer.kt
@@ -33,7 +33,12 @@ fun reduce(
     is AutoScrollEvent.Pause -> when (state) {
         AutoScrollState.Idle -> state
         is AutoScrollState.Running -> AutoScrollState.Paused(state.speed, event.cause)
-        is AutoScrollState.Paused -> state.copy(cause = event.cause)
+        // A user's explicit park via the HUD pill is sticky: transient system-driven pauses
+        // (panel open, manual scroll, etc.) must not overwrite it, or resuming those pauses
+        // would silently un-park the user's explicit stop.
+        is AutoScrollState.Paused ->
+            if (state.cause == PauseCause.UserPausedPill) state
+            else state.copy(cause = event.cause)
     }
     AutoScrollEvent.ReachedEndOfBook -> when (state) {
         is AutoScrollState.Running -> AutoScrollState.Idle

--- a/core/domain/src/test/kotlin/com/riffle/core/domain/autoscroll/AutoScrollReducerTest.kt
+++ b/core/domain/src/test/kotlin/com/riffle/core/domain/autoscroll/AutoScrollReducerTest.kt
@@ -78,6 +78,13 @@ class AutoScrollReducerTest {
     }
 
     @Test
+    fun `Pause on UserPausedPill keeps the pill park sticky`() {
+        val parked = AutoScrollState.Paused(def, PauseCause.UserPausedPill)
+        val s = reduce(parked, AutoScrollEvent.Pause(PauseCause.PanelOpen), def)
+        assertEquals(parked, s)
+    }
+
+    @Test
     fun `Pause in Idle is a no-op`() {
         assertEquals(
             AutoScrollState.Idle,


### PR DESCRIPTION
## Summary

- Opening and closing a reader panel (formatting, TOC, search, annotations) silently resumed Auto-Scroll even after the user had explicitly parked it via the HUD pill. The reducer overwrote the pause cause on every `Pause` event, so `PanelOpen` replaced `UserPausedPill`; the matching close then unconditionally resumed.
- Fixed by making `UserPausedPill` sticky against transient system pauses in the reducer, and by scoping the panel-close resume in `FormattingSession` so it only lifts a pause whose cause matches the panel event.
- Reduced `PILL_AUTO_HIDE_MS` from 90s → 60s so a walked-away pill self-cleans faster.

## Test plan

- [x] `:core:domain:test` — new reducer test `Pause on UserPausedPill keeps the pill park sticky`
- [x] `:app:testDebugUnitTest` — new session test `panel open then close leaves UserPausedPill parked` (regression test for the exact reported scenario)
- [ ] Manual on device: park Auto-Scroll via pill → open formatting → close formatting → verify still parked and pill still visible
- [ ] Manual on device: park via pill, wait 60s, verify pill auto-hides