### PR TITLE
feat(reader): add fading scrollbar to the annotations list

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/AnnotationsPanel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/AnnotationsPanel.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Bookmark
@@ -41,6 +42,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import com.riffle.app.ui.fadingScrollbar
 import com.riffle.core.database.AnnotationEntity
 import com.riffle.core.domain.Annotation
 import com.riffle.core.domain.HighlightColor
@@ -74,7 +76,11 @@ fun AnnotationsPanel(
                     modifier = Modifier.fillMaxWidth().padding(16.dp),
                 )
             } else {
-                LazyColumn(modifier = Modifier.fillMaxWidth()) {
+                val listState = rememberLazyListState()
+                LazyColumn(
+                    state = listState,
+                    modifier = Modifier.fillMaxWidth().fadingScrollbar(listState),
+                ) {
                     items(annotations, key = { it.id }) { annotation ->
                         AnnotationRow(
                             annotation = annotation,

--- a/app/src/main/kotlin/com/riffle/app/ui/FadingScrollbar.kt
+++ b/app/src/main/kotlin/com/riffle/app/ui/FadingScrollbar.kt
@@ -52,6 +52,7 @@ fun Modifier.fadingScrollbar(
                 visibleSizeSum = sizeSum,
                 firstVisibleIndex = state.firstVisibleItemIndex,
                 firstVisibleScrollOffset = state.firstVisibleItemScrollOffset,
+                firstVisibleItemSize = visible.first().size,
             )
         }
     }
@@ -114,14 +115,20 @@ internal fun computeListScrollMetrics(
     visibleSizeSum: Long,
     firstVisibleIndex: Int,
     firstVisibleScrollOffset: Int,
+    firstVisibleItemSize: Int,
 ): ScrollbarMetrics? {
     if (total <= 0 || viewport <= 0 || visibleCount <= 0) return null
     val avgItemSize = (visibleSizeSum.toFloat() / visibleCount).coerceAtLeast(1f)
     val contentHeight = avgItemSize * total
     if (contentHeight <= viewport) return null
     val extent = (viewport / contentHeight).coerceIn(0f, 1f)
-    val offsetPx = firstVisibleIndex * avgItemSize + firstVisibleScrollOffset
-    val offset = (offsetPx / contentHeight).coerceIn(0f, 1f - extent)
+    // Derive the offset in "items", not pixels, so a shifting avg item size (variable-height
+    // rows like the annotations list) can't rescale the fraction mid-scroll. Within an item
+    // we advance by scrollOffset/itemSize; at the item boundary scrollOffset resets to 0 and
+    // firstVisibleIndex increments, so handoff is continuous.
+    val itemSize = firstVisibleItemSize.coerceAtLeast(1)
+    val perItemOffset = (firstVisibleIndex + firstVisibleScrollOffset.toFloat() / itemSize) / total
+    val offset = perItemOffset.coerceIn(0f, 1f - extent)
     return ScrollbarMetrics(offset, extent)
 }
 

--- a/app/src/test/kotlin/com/riffle/app/ui/FadingScrollbarMetricsTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/ui/FadingScrollbarMetricsTest.kt
@@ -25,6 +25,7 @@ class FadingScrollbarMetricsTest {
                 visibleSizeSum = 5 * 100L,
                 firstVisibleIndex = 0,
                 firstVisibleScrollOffset = 0,
+                firstVisibleItemSize = 100,
             ),
         )
     }
@@ -34,7 +35,7 @@ class FadingScrollbarMetricsTest {
         assertNull(
             computeListScrollMetrics(
                 total = 20, viewport = 500, visibleCount = 0, visibleSizeSum = 0L,
-                firstVisibleIndex = 0, firstVisibleScrollOffset = 0,
+                firstVisibleIndex = 0, firstVisibleScrollOffset = 0, firstVisibleItemSize = 0,
             ),
         )
     }
@@ -44,7 +45,7 @@ class FadingScrollbarMetricsTest {
         // 20 items of 100px each = 2000 content, viewport 500 -> extent = 0.25
         val m = computeListScrollMetrics(
             total = 20, viewport = 500, visibleCount = 5, visibleSizeSum = 500L,
-            firstVisibleIndex = 0, firstVisibleScrollOffset = 0,
+            firstVisibleIndex = 0, firstVisibleScrollOffset = 0, firstVisibleItemSize = 100,
         )!!
         assertClose(0.25f, m.extentFraction)
         assertClose(0f, m.offsetFraction)
@@ -54,9 +55,9 @@ class FadingScrollbarMetricsTest {
     fun `list metrics offset advances with scroll offset within an item`() {
         val m = computeListScrollMetrics(
             total = 20, viewport = 500, visibleCount = 5, visibleSizeSum = 500L,
-            firstVisibleIndex = 4, firstVisibleScrollOffset = 50,
+            firstVisibleIndex = 4, firstVisibleScrollOffset = 50, firstVisibleItemSize = 100,
         )!!
-        // offsetPx = 4*100 + 50 = 450, content = 2000, offset = 0.225
+        // (4 + 50/100) / 20 = 4.5/20 = 0.225
         assertClose(0.225f, m.offsetFraction)
     }
 
@@ -64,10 +65,51 @@ class FadingScrollbarMetricsTest {
     fun `list metrics clamps offset to leave room for the thumb`() {
         val m = computeListScrollMetrics(
             total = 20, viewport = 500, visibleCount = 1, visibleSizeSum = 100L,
-            firstVisibleIndex = 100, firstVisibleScrollOffset = 9999,
+            firstVisibleIndex = 100, firstVisibleScrollOffset = 9999, firstVisibleItemSize = 100,
         )!!
         // Extent = 0.25 (500/2000). Max allowed offset = 1 - 0.25 = 0.75.
         assertClose(0.75f, m.offsetFraction)
+    }
+
+    @Test
+    fun `list metrics offset stays continuous when avg item size shifts mid-scroll`() {
+        // Regression: annotations list has 2-line bookmarks and 6-line highlights sharing a
+        // LazyColumn. As tall highlights enter/leave the viewport the running avg shifts, and
+        // the old avg-scaled offset would jitter mid-scroll. Now that offset is derived from
+        // the first visible item's own size, two frames scrolling forward within the same item
+        // must produce monotonically-increasing offsets even if avg changed between them.
+        val itemSize = 300
+        val a = computeListScrollMetrics(
+            total = 40, viewport = 900,
+            // Frame 1: viewport shows one 300px item and two 100px items -> avg = 166.
+            visibleCount = 3, visibleSizeSum = 300L + 100L + 100L,
+            firstVisibleIndex = 5, firstVisibleScrollOffset = 60,
+            firstVisibleItemSize = itemSize,
+        )!!
+        val b = computeListScrollMetrics(
+            total = 40, viewport = 900,
+            // Frame 2: another 300px item scrolled in, avg jumps -> avg = 233.
+            visibleCount = 3, visibleSizeSum = 300L + 300L + 100L,
+            firstVisibleIndex = 5, firstVisibleScrollOffset = 90,
+            firstVisibleItemSize = itemSize,
+        )!!
+        assert(b.offsetFraction > a.offsetFraction) {
+            "offset regressed on forward scroll: a=${a.offsetFraction}, b=${b.offsetFraction}"
+        }
+        // Continuity across the item boundary: scrolled fully through item 5, handoff to item 6.
+        val boundaryA = computeListScrollMetrics(
+            total = 40, viewport = 900,
+            visibleCount = 3, visibleSizeSum = 300L + 100L + 100L,
+            firstVisibleIndex = 5, firstVisibleScrollOffset = itemSize,
+            firstVisibleItemSize = itemSize,
+        )!!
+        val boundaryB = computeListScrollMetrics(
+            total = 40, viewport = 900,
+            visibleCount = 3, visibleSizeSum = 100L + 100L + 100L,
+            firstVisibleIndex = 6, firstVisibleScrollOffset = 0,
+            firstVisibleItemSize = 100,
+        )!!
+        assertClose(boundaryA.offsetFraction, boundaryB.offsetFraction, tol = 0.0001f)
     }
 
     // --- computeGridScrollMetrics ---


### PR DESCRIPTION
## Summary

- Wire `rememberLazyListState()` + `Modifier.fadingScrollbar(...)` into the annotations bottom-sheet `LazyColumn`, matching the reader TOC and library grids.
- Fix `computeListScrollMetrics` offset jitter on variable-height rows: the annotations list mixes 2-line bookmark rows and up-to-6-line highlight snippets, so the previous avg-scaled offset drifted as tall items entered/left the viewport. Offset is now derived in item-space from the first visible item's own size, so within-item scroll advances linearly and item boundaries hand off continuously. Uniform-height callers keep identical numbers to the old formula.
- Add regression tests: monotonic offset across an avg-size shift mid-item, and continuity across a variable-height item boundary.

## Test plan

- [x] `./gradlew :app:testDebugUnitTest --tests com.riffle.app.ui.FadingScrollbarMetricsTest`
- [ ] Manually open the annotations panel with a mix of long highlights and short bookmarks and confirm the scrollbar moves smoothly.