### PR TITLE
feat(reader): remember last-used highlight color per book

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/session/AnnotationSession.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/session/AnnotationSession.kt
@@ -19,7 +19,6 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.stateIn
@@ -144,13 +143,14 @@ class AnnotationSession @AssistedInject constructor(
     val annotationNavigationEvents: Flow<AnnotationNavigationEvent> = _annotationNavigationChannel.receiveAsFlow()
 
     /**
-     * The app-wide "last-used" highlight colour. New highlights are born in this colour so the
-     * user's most recent pick is remembered globally. Kept as a StateFlow so the VM can read
+     * The per-book "last-used" highlight colour. New highlights are born in this colour so the
+     * user's most recent pick is remembered PER BOOK. Kept as a StateFlow so the VM can read
      * [StateFlow.value] synchronously at creation time; the initial value falls back to
-     * [HighlightColor.DEFAULT] until DataStore emits its first value.
+     * [HighlightColor.DEFAULT] (the first entry in the palette) until [bind] wires up a book-
+     * scoped source and until DataStore emits the first value for that book.
      */
-    val lastUsedHighlightColor: StateFlow<HighlightColor> = highlightColorPreferencesStore.lastUsedColor
-        .stateIn(scope, SharingStarted.Eagerly, HighlightColor.DEFAULT)
+    private val _lastUsedHighlightColor = MutableStateFlow(HighlightColor.DEFAULT)
+    val lastUsedHighlightColor: StateFlow<HighlightColor> = _lastUsedHighlightColor
 
     /**
      * Reflects the last annotation sync outcome as a UI banner. Null = no cycle has run yet
@@ -191,6 +191,9 @@ class AnnotationSession @AssistedInject constructor(
     private var highlightObserveJob: Job? = null
     private var annotationsObserveJob: Job? = null
 
+    /** Observes the per-book last-used highlight colour. Cancelled on [bind]. */
+    private var lastUsedColorObserveJob: Job? = null
+
     // ---- Public API --------------------------------------------------------------------------
 
     /**
@@ -214,6 +217,11 @@ class AnnotationSession @AssistedInject constructor(
         annotationLiveSyncJob = null
         highlightObserveJob?.cancel()
         annotationsObserveJob?.cancel()
+        lastUsedColorObserveJob?.cancel()
+        // Reset to palette default so the previous book's colour doesn't leak into a new book that
+        // has never had a colour picked. If the DataStore has a value for this book, the observer
+        // below overwrites this on its first emission.
+        _lastUsedHighlightColor.value = HighlightColor.DEFAULT
         _highlightRenders.value = emptyList()
         _annotations.value = emptyList()
         _annotationsPanelVisible.value = false
@@ -239,6 +247,15 @@ class AnnotationSession @AssistedInject constructor(
         annotationsObserveJob = scope.launch {
             annotationStore.observeAnnotations(serverId, itemId).collect { list ->
                 _annotations.value = list
+            }
+        }
+
+        // Observe the per-book last-used highlight colour so new highlights in THIS book are
+        // born in whatever colour the user last picked here. Falls back to HighlightColor.DEFAULT
+        // for books the user has never picked a colour on (see HighlightColorPreferencesStore).
+        lastUsedColorObserveJob = scope.launch {
+            highlightColorPreferencesStore.lastUsedColor(serverId, itemId).collect {
+                _lastUsedHighlightColor.value = it
             }
         }
 
@@ -280,13 +297,16 @@ class AnnotationSession @AssistedInject constructor(
 
     /**
      * Recolour an existing highlight; [annotationStore] re-emits → [highlightRenders] re-renders.
-     * Also persists [color] as the app-wide last-used highlight colour so subsequent new
-     * highlights are born in it.
+     * Also persists [color] as the last-used highlight colour FOR THE CURRENT BOOK so subsequent
+     * new highlights in the same book are born in it. No-op on the last-used store if the session
+     * isn't bound (should not happen from the reader UI).
      */
     suspend fun recolorHighlight(id: String, color: HighlightColor) {
         annotationStore.recolor(id, color.token)
-        highlightColorPreferencesStore.setLastUsedColor(color)
-        scheduleSync(boundServerId ?: return, boundNamespace ?: return, boundItemId ?: return)
+        val sid = boundServerId ?: return
+        val iid = boundItemId ?: return
+        highlightColorPreferencesStore.setLastUsedColor(sid, iid, color)
+        scheduleSync(sid, boundNamespace ?: return, iid)
     }
 
     /** Soft-delete a highlight; [annotationStore] re-emits without it → decoration removed. */

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/session/AnnotationSessionTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/session/AnnotationSessionTest.kt
@@ -169,10 +169,21 @@ class AnnotationSessionTest {
     private class FakeHighlightColorPreferencesStore(
         initial: HighlightColor = HighlightColor.DEFAULT,
     ) : HighlightColorPreferencesStore {
-        private val state = MutableStateFlow(initial)
-        override val lastUsedColor: Flow<HighlightColor> = state
-        override suspend fun setLastUsedColor(value: HighlightColor) { state.value = value }
-        fun currentValue(): HighlightColor = state.value
+        // Per-book state keyed by "$serverId:$itemId". Unknown book → the shared [initial] fallback,
+        // so tests that don't care about book identity keep working. Tests that DO need per-book
+        // isolation call [setLastUsedColor] with distinct ids and read [currentValue] with them.
+        private val perBook = mutableMapOf<String, MutableStateFlow<HighlightColor>>()
+        private val defaultInitial = initial
+        private fun k(serverId: String, itemId: String) = "$serverId:$itemId"
+        private fun flowFor(serverId: String, itemId: String) =
+            perBook.getOrPut(k(serverId, itemId)) { MutableStateFlow(defaultInitial) }
+        override fun lastUsedColor(serverId: String, itemId: String): Flow<HighlightColor> =
+            flowFor(serverId, itemId)
+        override suspend fun setLastUsedColor(serverId: String, itemId: String, value: HighlightColor) {
+            flowFor(serverId, itemId).value = value
+        }
+        fun currentValue(serverId: String = "srv1", itemId: String = "item1"): HighlightColor =
+            flowFor(serverId, itemId).value
     }
 
     private fun makeSession(
@@ -266,12 +277,14 @@ class AnnotationSessionTest {
     }
 
     /**
-     * Regression: recolorHighlight must ALSO persist the picked colour to the app-wide
-     * last-used store, so subsequent new highlights are born in that colour. Reverting the
-     * `setLastUsedColor` call in AnnotationSession.recolorHighlight flips this assertion.
+     * Regression: recolorHighlight must ALSO persist the picked colour to the per-book
+     * last-used store keyed by the currently-bound (serverId, itemId), so subsequent new
+     * highlights in that book are born in that colour. Reverting the `setLastUsedColor` call
+     * in AnnotationSession.recolorHighlight (or dropping the bound-book ids from it) flips
+     * this assertion.
      */
     @Test
-    fun `recolorHighlight persists colour as app-wide last-used`() = runTest {
+    fun `recolorHighlight persists colour as last-used for the bound book`() = runTest {
         val dispatcher = UnconfinedTestDispatcher(testScheduler)
         val sessionScope = CoroutineScope(dispatcher)
         val store = FakeAnnotationStore()
@@ -283,28 +296,67 @@ class AnnotationSessionTest {
 
         session.recolorHighlight("h1", HighlightColor.GREEN)
 
-        assertEquals(HighlightColor.GREEN, colorPrefs.currentValue())
+        assertEquals(HighlightColor.GREEN, colorPrefs.currentValue(serverId = "srv1", itemId = "item1"))
+        // Other books stay on their own last-used (fake's initial fallback) — recolour must not
+        // leak across books.
+        assertEquals(HighlightColor.YELLOW, colorPrefs.currentValue(serverId = "srv1", itemId = "item2"))
 
         sessionScope.coroutineContext[Job]?.cancel()
     }
 
     /**
      * Regression: [AnnotationSession.lastUsedHighlightColor] must surface the stored value
-     * synchronously via its StateFlow, so the VM can read `.value` at highlight-creation time
-     * (see [EpubReaderViewModel.createHighlight]). If the wiring is broken and the SharingStarted
-     * mode is changed away from Eagerly, the initial value stays at DEFAULT and this test flips.
+     * synchronously via its StateFlow AFTER [bind], so the VM can read `.value` at highlight-
+     * creation time (see [EpubReaderViewModel.createHighlight]). If the per-book observation
+     * job is broken, the value stays at the palette default and this test flips.
      */
     @Test
-    fun `lastUsedHighlightColor StateFlow reflects the preferences store`() = runTest {
+    fun `lastUsedHighlightColor StateFlow reflects the bound book's stored value`() = runTest {
         val dispatcher = UnconfinedTestDispatcher(testScheduler)
         val sessionScope = CoroutineScope(dispatcher)
-        val colorPrefs = FakeHighlightColorPreferencesStore(initial = HighlightColor.BLUE)
+        val colorPrefs = FakeHighlightColorPreferencesStore(initial = HighlightColor.DEFAULT)
+        // Pre-seed the bound book's colour BEFORE bind so the first collection emits it.
+        colorPrefs.setLastUsedColor("srv1", "item1", HighlightColor.BLUE)
         val session = makeSession(syncOps = FakeSyncOps(), scope = sessionScope, colorPrefsStore = colorPrefs)
+
+        defaultBind(session)
 
         assertEquals(HighlightColor.BLUE, session.lastUsedHighlightColor.value)
 
-        colorPrefs.setLastUsedColor(HighlightColor.GREEN)
+        // A later update on the SAME book flows through.
+        colorPrefs.setLastUsedColor("srv1", "item1", HighlightColor.GREEN)
         assertEquals(HighlightColor.GREEN, session.lastUsedHighlightColor.value)
+
+        sessionScope.coroutineContext[Job]?.cancel()
+    }
+
+    /**
+     * Regression: rebinding to a different book must swap the last-used colour source to that
+     * book's own value. If [bind] fails to cancel the previous observation job (or fails to
+     * reset the state), the previous book's colour leaks into the newly-bound book and this
+     * test flips.
+     */
+    @Test
+    fun `lastUsedHighlightColor swaps to the new book on rebind`() = runTest {
+        val dispatcher = UnconfinedTestDispatcher(testScheduler)
+        val sessionScope = CoroutineScope(dispatcher)
+        val colorPrefs = FakeHighlightColorPreferencesStore(initial = HighlightColor.DEFAULT)
+        colorPrefs.setLastUsedColor("srv1", "item1", HighlightColor.BLUE)
+        colorPrefs.setLastUsedColor("srv1", "item2", HighlightColor.RED)
+        val session = makeSession(syncOps = FakeSyncOps(), scope = sessionScope, colorPrefsStore = colorPrefs)
+
+        defaultBind(session)
+        assertEquals(HighlightColor.BLUE, session.lastUsedHighlightColor.value)
+
+        // Rebind to a different book — colour must swap.
+        session.bind(
+            serverId = "srv1",
+            namespace = "ns1",
+            itemId = "item2",
+            highlightRenderResolver = { null },
+            cfiLocatorResolver = { null },
+        )
+        assertEquals(HighlightColor.RED, session.lastUsedHighlightColor.value)
 
         sessionScope.coroutineContext[Job]?.cancel()
     }

--- a/core/data/src/main/kotlin/com/riffle/core/data/PreferenceStoreFactories.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/PreferenceStoreFactories.kt
@@ -86,22 +86,28 @@ fun ReadaloudPreferencesStore(dataStore: DataStore<Preferences>): ReadaloudPrefe
     }
 }
 
+/**
+ * Per-book last-used-highlight-colour DataStore key. Exposed as `internal` so tests can reach it
+ * without duplicating the literal — a fixture that hard-codes the key silently diverges when the
+ * format changes and the fallback assertions become vacuous. Format is `"<prefix>:$serverId:$itemId"`.
+ */
+internal fun highlightColorPrefKey(serverId: String, itemId: String) =
+    stringPreferencesKey("last_used_highlight_color:$serverId:$itemId")
+
 fun HighlightColorPreferencesStore(dataStore: DataStore<Preferences>): HighlightColorPreferencesStore {
-    // Per-book last-used colour, keyed by "$serverId:$itemId". Unknown/absent → HighlightColor.DEFAULT
-    // (first entry in the palette), so a book the user has never picked a colour on opens with the
-    // palette default. Legacy names outside the current palette (e.g. "PINK", "PURPLE") also fall
-    // back to DEFAULT; the user can re-pick and it persists per-book thereafter.
-    fun key(serverId: String, itemId: String) =
-        stringPreferencesKey("last_used_highlight_color:$serverId:$itemId")
+    // Per-book last-used colour. Unknown/absent → HighlightColor.DEFAULT (first entry in the
+    // palette), so a book the user has never picked a colour on opens with the palette default.
+    // Legacy names outside the current palette (e.g. "PINK", "PURPLE") also fall back to DEFAULT;
+    // the user can re-pick and it persists per-book thereafter.
     return object : HighlightColorPreferencesStore {
         override fun lastUsedColor(serverId: String, itemId: String): Flow<HighlightColor> =
             dataStore.data.map { prefs ->
-                val name = prefs[key(serverId, itemId)] ?: return@map HighlightColor.DEFAULT
+                val name = prefs[highlightColorPrefKey(serverId, itemId)] ?: return@map HighlightColor.DEFAULT
                 runCatching { HighlightColor.valueOf(name) }.getOrDefault(HighlightColor.DEFAULT)
             }
 
         override suspend fun setLastUsedColor(serverId: String, itemId: String, value: HighlightColor) {
-            dataStore.edit { it[key(serverId, itemId)] = value.name }
+            dataStore.edit { it[highlightColorPrefKey(serverId, itemId)] = value.name }
         }
     }
 }

--- a/core/data/src/main/kotlin/com/riffle/core/data/PreferenceStoreFactories.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/PreferenceStoreFactories.kt
@@ -2,6 +2,8 @@ package com.riffle.core.data
 
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
 import com.riffle.core.domain.AppTheme
 import com.riffle.core.domain.AppThemeStore
 import com.riffle.core.domain.CoverGridDensityStore
@@ -85,19 +87,21 @@ fun ReadaloudPreferencesStore(dataStore: DataStore<Preferences>): ReadaloudPrefe
 }
 
 fun HighlightColorPreferencesStore(dataStore: DataStore<Preferences>): HighlightColorPreferencesStore {
-    // Default YELLOW matches AnnotationStore.DEFAULT_COLOR so first-time users see today's behaviour.
-    // Legacy names outside the current palette (e.g. "PINK", "PURPLE") fall through the enum codec's
-    // unknown-name path to YELLOW; the user can re-pick and it persists thereafter.
-    val store = preferenceStore(
-        dataStore,
-        PrefCodecs.enum(
-            "last_used_highlight_color",
-            HighlightColor.YELLOW,
-            HighlightColor.entries.toTypedArray(),
-        ),
-    )
+    // Per-book last-used colour, keyed by "$serverId:$itemId". Unknown/absent → HighlightColor.DEFAULT
+    // (first entry in the palette), so a book the user has never picked a colour on opens with the
+    // palette default. Legacy names outside the current palette (e.g. "PINK", "PURPLE") also fall
+    // back to DEFAULT; the user can re-pick and it persists per-book thereafter.
+    fun key(serverId: String, itemId: String) =
+        stringPreferencesKey("last_used_highlight_color:$serverId:$itemId")
     return object : HighlightColorPreferencesStore {
-        override val lastUsedColor: Flow<HighlightColor> = store.flow
-        override suspend fun setLastUsedColor(value: HighlightColor) = store.update(value)
+        override fun lastUsedColor(serverId: String, itemId: String): Flow<HighlightColor> =
+            dataStore.data.map { prefs ->
+                val name = prefs[key(serverId, itemId)] ?: return@map HighlightColor.DEFAULT
+                runCatching { HighlightColor.valueOf(name) }.getOrDefault(HighlightColor.DEFAULT)
+            }
+
+        override suspend fun setLastUsedColor(serverId: String, itemId: String, value: HighlightColor) {
+            dataStore.edit { it[key(serverId, itemId)] = value.name }
+        }
     }
 }

--- a/core/data/src/test/kotlin/com/riffle/core/data/HighlightColorPreferencesStoreTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/HighlightColorPreferencesStoreTest.kt
@@ -23,40 +23,67 @@ class HighlightColorPreferencesStoreTest {
     private val dispatcher = UnconfinedTestDispatcher()
     private val testScope = TestScope(dispatcher)
 
-    private fun buildStore() = HighlightColorPreferencesStore(
-        PreferenceDataStoreFactory.create(
-            scope = testScope.backgroundScope,
-            produceFile = { tmp.newFile("highlight_color_prefs.preferences_pb") },
+    private fun buildStore(fileName: String = "highlight_color_prefs.preferences_pb") =
+        HighlightColorPreferencesStore(
+            PreferenceDataStoreFactory.create(
+                scope = testScope.backgroundScope,
+                produceFile = { tmp.newFile(fileName) },
+            )
         )
-    )
 
-    // First-run default matches AnnotationStore.DEFAULT_COLOR ("yellow") so users who never touch
-    // the picker see the same colour they got before this feature landed.
+    // A book the user has never picked a colour on falls back to HighlightColor.DEFAULT — the
+    // first entry in the palette. Reverting the fallback in the factory (or defaulting to the
+    // last global pick instead of the palette default) flips this assertion red.
     @Test
-    fun `default is YELLOW when DataStore is empty`() = testScope.runTest {
-        assertEquals(HighlightColor.YELLOW, buildStore().lastUsedColor.first())
+    fun `default is DEFAULT for a book with no stored value`() = testScope.runTest {
+        assertEquals(HighlightColor.DEFAULT, buildStore().lastUsedColor("srv1", "book1").first())
     }
 
     @Test
-    fun `each highlight color round-trips through DataStore`() = testScope.runTest {
+    fun `each highlight color round-trips through DataStore per book`() = testScope.runTest {
         val store = buildStore()
         for (color in HighlightColor.entries) {
-            store.setLastUsedColor(color)
-            assertEquals(color, store.lastUsedColor.first())
+            store.setLastUsedColor("srv1", "book1", color)
+            assertEquals(color, store.lastUsedColor("srv1", "book1").first())
         }
     }
 
-    // A future palette rev that drops or renames a colour must not leave the store returning
-    // "unknown" — the codec falls back to the default so the picker still has a valid selection.
+    // Two books' last-used colours are independent — picking on one MUST NOT change the other's
+    // remembered colour. Reverting the per-book keying (falling back to a single global key)
+    // would make bookB inherit bookA's pick and this test would fail.
     @Test
-    fun `unrecognized stored value falls back to YELLOW`() = testScope.runTest {
+    fun `each book remembers its own last-used colour independently`() = testScope.runTest {
+        val store = buildStore()
+        store.setLastUsedColor("srv1", "bookA", HighlightColor.GREEN)
+        store.setLastUsedColor("srv1", "bookB", HighlightColor.BLUE)
+
+        assertEquals(HighlightColor.GREEN, store.lastUsedColor("srv1", "bookA").first())
+        assertEquals(HighlightColor.BLUE, store.lastUsedColor("srv1", "bookB").first())
+        // A third, never-picked book still falls back to DEFAULT — the picks on bookA/bookB
+        // must not leak into a book that was never touched.
+        assertEquals(HighlightColor.DEFAULT, store.lastUsedColor("srv1", "bookC").first())
+    }
+
+    // Same itemId on two different servers must not collide — server-scoping in the key is what
+    // guarantees this. Dropping serverId from the key would make srv2's bookX inherit srv1's pick.
+    @Test
+    fun `same itemId on different servers is independent`() = testScope.runTest {
+        val store = buildStore()
+        store.setLastUsedColor("srv1", "bookX", HighlightColor.RED)
+        assertEquals(HighlightColor.DEFAULT, store.lastUsedColor("srv2", "bookX").first())
+    }
+
+    // A future palette rev that drops or renames a colour must not leave the store returning
+    // an unknown value — it falls back to DEFAULT so the picker still has a valid selection.
+    @Test
+    fun `unrecognized stored value falls back to DEFAULT`() = testScope.runTest {
         val rawStore = PreferenceDataStoreFactory.create(
             scope = backgroundScope,
             produceFile = { tmp.newFile("highlight_color_prefs_fallback.preferences_pb") },
         )
-        rawStore.edit { it[stringPreferencesKey("last_used_highlight_color")] = "NOT_A_COLOR" }
+        rawStore.edit { it[stringPreferencesKey("last_used_highlight_color:srv1:book1")] = "NOT_A_COLOR" }
         val store = HighlightColorPreferencesStore(rawStore)
-        assertEquals(HighlightColor.YELLOW, store.lastUsedColor.first())
+        assertEquals(HighlightColor.DEFAULT, store.lastUsedColor("srv1", "book1").first())
     }
 
     // After the user re-picks following a fallback, the new choice must persist across store
@@ -67,14 +94,14 @@ class HighlightColorPreferencesStoreTest {
             scope = backgroundScope,
             produceFile = { tmp.newFile("highlight_color_prefs_repick.preferences_pb") },
         )
-        rawStore.edit { it[stringPreferencesKey("last_used_highlight_color")] = "NOT_A_COLOR" }
+        rawStore.edit { it[stringPreferencesKey("last_used_highlight_color:srv1:book1")] = "NOT_A_COLOR" }
         val store = HighlightColorPreferencesStore(rawStore)
-        assertEquals(HighlightColor.YELLOW, store.lastUsedColor.first())
+        assertEquals(HighlightColor.DEFAULT, store.lastUsedColor("srv1", "book1").first())
 
-        store.setLastUsedColor(HighlightColor.GREEN)
-        assertEquals(HighlightColor.GREEN, store.lastUsedColor.first())
+        store.setLastUsedColor("srv1", "book1", HighlightColor.GREEN)
+        assertEquals(HighlightColor.GREEN, store.lastUsedColor("srv1", "book1").first())
 
         val reopened = HighlightColorPreferencesStore(rawStore)
-        assertEquals(HighlightColor.GREEN, reopened.lastUsedColor.first())
+        assertEquals(HighlightColor.GREEN, reopened.lastUsedColor("srv1", "book1").first())
     }
 }

--- a/core/data/src/test/kotlin/com/riffle/core/data/HighlightColorPreferencesStoreTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/HighlightColorPreferencesStoreTest.kt
@@ -2,7 +2,6 @@ package com.riffle.core.data
 
 import androidx.datastore.preferences.core.PreferenceDataStoreFactory
 import androidx.datastore.preferences.core.edit
-import androidx.datastore.preferences.core.stringPreferencesKey
 import com.riffle.core.domain.HighlightColor
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
@@ -81,7 +80,7 @@ class HighlightColorPreferencesStoreTest {
             scope = backgroundScope,
             produceFile = { tmp.newFile("highlight_color_prefs_fallback.preferences_pb") },
         )
-        rawStore.edit { it[stringPreferencesKey("last_used_highlight_color:srv1:book1")] = "NOT_A_COLOR" }
+        rawStore.edit { it[highlightColorPrefKey("srv1", "book1")] = "NOT_A_COLOR" }
         val store = HighlightColorPreferencesStore(rawStore)
         assertEquals(HighlightColor.DEFAULT, store.lastUsedColor("srv1", "book1").first())
     }
@@ -94,7 +93,7 @@ class HighlightColorPreferencesStoreTest {
             scope = backgroundScope,
             produceFile = { tmp.newFile("highlight_color_prefs_repick.preferences_pb") },
         )
-        rawStore.edit { it[stringPreferencesKey("last_used_highlight_color:srv1:book1")] = "NOT_A_COLOR" }
+        rawStore.edit { it[highlightColorPrefKey("srv1", "book1")] = "NOT_A_COLOR" }
         val store = HighlightColorPreferencesStore(rawStore)
         assertEquals(HighlightColor.DEFAULT, store.lastUsedColor("srv1", "book1").first())
 

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/HighlightColorPreferencesStore.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/HighlightColorPreferencesStore.kt
@@ -3,14 +3,15 @@ package com.riffle.core.domain
 import kotlinx.coroutines.flow.Flow
 
 /**
- * The app-wide "last-used" highlight colour for user-created annotations.
+ * Per-book "last-used" highlight colour for user-created annotations.
  *
  * Every time the user picks a colour on a highlight (at creation or on recolour), that colour
- * becomes the default for the next new highlight, so the colour-picker opens with it already
- * selected. Global — not scoped per server or per book. Readaloud has its own separate
- * [ReadaloudPreferencesStore]; the two never share state.
+ * becomes the default for the next new highlight IN THE SAME BOOK, so the colour-picker opens
+ * with it already selected on that book. Books that the user has not picked a colour on yet
+ * fall back to [HighlightColor.DEFAULT] (the first entry in the palette). Readaloud has its own
+ * separate [ReadaloudPreferencesStore]; the two never share state.
  */
 interface HighlightColorPreferencesStore {
-    val lastUsedColor: Flow<HighlightColor>
-    suspend fun setLastUsedColor(value: HighlightColor)
+    fun lastUsedColor(serverId: String, itemId: String): Flow<HighlightColor>
+    suspend fun setLastUsedColor(serverId: String, itemId: String, value: HighlightColor)
 }

--- a/docs/superpowers/specs/2026-07-04-last-used-highlight-color-design.md
+++ b/docs/superpowers/specs/2026-07-04-last-used-highlight-color-design.md
@@ -8,20 +8,20 @@ Scope: user-created highlights only. Readaloud highlight color is a separate, al
 
 ## Behavior
 
-- The first time a user picks a color on a highlight (either at creation or a later recolor), that color becomes the app-wide default for subsequent new highlights.
-- Next time the user creates a highlight, it's born in that color — and the picker's swatch row shows it already selected (falls out of the existing `selected = current.color` logic in `HighlightActionsPopup`).
-- Preference is global (not per-server, not per-book). First-run default is `HighlightColor.YELLOW`, preserving today's behavior.
+- The first time a user picks a color on a highlight (either at creation or a later recolor), that color becomes the default for subsequent new highlights **in the same book**.
+- Next time the user creates a highlight in that book, it's born in that color — and the picker's swatch row shows it already selected (falls out of the existing `selected = current.color` logic in `HighlightActionsPopup`).
+- Preference is per-book (keyed by `serverId:itemId`), not global. A book the user has never picked a color on falls back to `HighlightColor.DEFAULT` — the first entry in the palette. There is no cross-book fallback: a pick in book A does not seed book B's default.
 
 ## Design
 
 ### 1. Preference store
 
-New `HighlightColorPreferencesStore` interface in `core/domain` and factory in `core/data/PreferenceStoreFactories.kt`. Single-key `PrefCodecs.enum` over `HighlightColor.entries`, key `last_used_highlight_color`, default `HighlightColor.YELLOW`. Modeled directly on the existing `ReadaloudPreferencesStore` factory a few lines above in the same file — same shape, same fallback semantics for unknown legacy names.
+`HighlightColorPreferencesStore` in `core/domain` (per-book API) and a hand-written factory in `core/data/PreferenceStoreFactories.kt` that keys DataStore entries by `"last_used_highlight_color:$serverId:$itemId"`. Absent/unknown values fall back to `HighlightColor.DEFAULT` (the first palette entry).
 
 ```kotlin
 interface HighlightColorPreferencesStore {
-    val lastUsedColor: Flow<HighlightColor>
-    suspend fun setLastUsedColor(value: HighlightColor)
+    fun lastUsedColor(serverId: String, itemId: String): Flow<HighlightColor>
+    suspend fun setLastUsedColor(serverId: String, itemId: String, value: HighlightColor)
 }
 ```
 
@@ -29,11 +29,11 @@ Bound in the same Hilt module that binds `ReadaloudPreferencesStore` (`DataModul
 
 ### 2. Wire into highlight creation
 
-`EpubReaderViewModel` gains a constructor-injected `HighlightColorPreferencesStore`. Inside `createHighlight()` (currently at line 947), read the current value once (`.first()`) and pass it into `annotationStore.createHighlight(..., color = lastUsed.token, ...)`. No default-argument change on the interface — the caller is now explicit.
+`AnnotationSession` observes the per-book flow on `bind(serverId, itemId, …)` and exposes the current colour as a `StateFlow<HighlightColor>` (`lastUsedHighlightColor`). The VM's `createHighlight()` reads `annotationSession.lastUsedHighlightColor.value` synchronously and passes `color = lastUsed.token` to `annotationStore.createHighlight(...)`. A book that has never had a colour picked emits `HighlightColor.DEFAULT` — the first palette entry.
 
 ### 3. Wire into recolor
 
-The popup's `onPick = { color -> onRecolorHighlight(editTarget.id, color) }` lambda in `EpubReaderScreen.kt:2475` calls into a VM method that today just calls `annotationStore.recolor(...)`. Extend that VM method to also `store.setLastUsedColor(color)` (fire-and-forget in `viewModelScope`). "Last-used" tracks both the initial pick at creation and any later change.
+`AnnotationSession.recolorHighlight(id, color)` calls `annotationStore.recolor(...)` AND `highlightColorPreferencesStore.setLastUsedColor(boundServerId, boundItemId, color)` — writing the pick under the currently-bound book only. Picks on book A never mutate book B's default.
 
 ### 4. UI
 
@@ -41,16 +41,17 @@ No changes. `HighlightActionsPopup` already shows the current highlight's color 
 
 ### 5. Tests (JVM only — logic doesn't touch Readium/WebView)
 
-- **`HighlightColorPreferencesStoreTest`** (mirrors `ReadaloudPreferencesStoreTest`) — first read is `YELLOW`; write-then-read round-trips; unknown legacy string falls back to `YELLOW`.
-- **`EpubReaderViewModelTest`** — two regression assertions that flip red if the wiring is reverted:
-  1. Given the pref store has `BLUE`, `createHighlight(...)` results in a call to `annotationStore.createHighlight(...)` with `color = "blue"` (not `"yellow"`).
-  2. Given `recolorHighlight(id, GREEN)` is called, the pref store's `lastUsedColor` becomes `GREEN`.
+- **`HighlightColorPreferencesStoreTest`** — first read for an untouched book is `HighlightColor.DEFAULT`; write-then-read round-trips per book; two books' picks are independent; same `itemId` on different servers is independent; unknown legacy string falls back to `DEFAULT`.
+- **`AnnotationSessionTest`** — regression assertions:
+  1. `recolorHighlight` writes the picked colour under the currently-bound `(serverId, itemId)` and leaves other books' entries untouched.
+  2. `lastUsedHighlightColor` StateFlow reflects the bound book's stored value after `bind`.
+  3. Rebinding to a different book swaps `lastUsedHighlightColor` to that book's value (no leak from the previous book).
 
 These use a fake `AnnotationStore` + an in-memory `HighlightColorPreferencesStore` — no device required.
 
 ## Non-goals
 
 - No Settings UI to view/set the default separately. The last-picked value is the default; a separate control would double the surface area without new capability.
-- No per-server or per-book scoping.
+- No cross-book fallback (i.e. new books never inherit a last-used pick from another book). Every book without a stored pick shows the palette default (`HighlightColor.DEFAULT`).
 - No touching the readaloud highlight color — that remains its own store.
 - No migration for existing highlights — recoloring old highlights is already possible via the popup.


### PR DESCRIPTION
## Summary

Extends #422 from a single global last-used highlight colour to a per-book one. Every book remembers its own last-picked colour, keyed by `serverId:itemId`. Books the user has never picked a colour on fall back to the palette default (`HighlightColor.DEFAULT` — the first entry) rather than inheriting another book's pick. Direct user request; this replaces the global scope introduced in #422.

- `HighlightColorPreferencesStore` now takes `(serverId, itemId)` on both read and write; DataStore entries are keyed by `"last_used_highlight_color:$serverId:$itemId"`.
- `AnnotationSession` observes the per-book flow on `bind()` and re-derives the `StateFlow<HighlightColor>` the VM reads at `createHighlight()` time; `recolorHighlight()` writes under the currently-bound book only.
- No migration from the #422 global key — intentional, per user request that new books must fall back to the palette default, not to a previous global pick. The old key becomes an orphan (one-time re-pick cost, no data loss).

## Test plan

- [x] `HighlightColorPreferencesStoreTest` — per-book independence, cross-server isolation for the same `itemId`, unknown/legacy value fallback to `DEFAULT`.
- [x] `AnnotationSessionTest` — `recolorHighlight` writes under bound `(serverId, itemId)` only; `lastUsedHighlightColor` reflects the bound book's stored value after `bind`; rebind swaps to the new book's value without leaking the previous book's pick.
- [x] Manually verified in the reader on an AVD by the author.

## Related

- Follow-up: opened #428 to track a transient reader-highlight bug spotted during manual verification (unrelated to this change; suspected WebView race in injected `createTreeWalker` scripts).