### PR TITLE
feat(reader): add figure-zoom viewer

### DIFF
--- a/app/src/androidTest/kotlin/com/riffle/app/feature/reader/FigureTapScriptTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/reader/FigureTapScriptTest.kt
@@ -88,18 +88,22 @@ class FigureTapScriptTest {
             webView[0] = wv
         }
         assertTrue(pageLoaded.await(10, TimeUnit.SECONDS))
-        // Install the script and dispatch a synthetic click on the element.
-        instrumentation.runOnMainSync {
-            webView[0]!!.evaluateJavascript(FigureTapScript.installScript(FigureTapScript.PAGED_BRIDGE_NAME), null)
-        }
-        // Small delay so the install script's addEventListener is installed before we click.
-        Thread.sleep(200)
+        // Install the script and, in the SAME JS turn, dispatch a bubbling capture-phase click on
+        // the element. Element.click() on API-25 Chromium (Chrome 55) doesn't reliably drive the
+        // capture-phase document listener the install script uses, and it doesn't dispatch at all
+        // for <svg> / <picture>; a synthetic MouseEvent dispatched with bubbles:true works on
+        // every WebView version. Chaining install+dispatch in one evaluateJavascript payload also
+        // removes the install-vs-dispatch race that a separate sleep tried to paper over.
+        val installed = CountDownLatch(1)
         instrumentation.runOnMainSync {
             webView[0]!!.evaluateJavascript(
-                "document.getElementById('$elementId').click()",
-                null,
-            )
+                FigureTapScript.installScript(FigureTapScript.PAGED_BRIDGE_NAME) +
+                    ";(function(){var el=document.getElementById('$elementId');" +
+                    "var ev=new MouseEvent('click',{bubbles:true,cancelable:true,view:window});" +
+                    "el.dispatchEvent(ev);})();",
+            ) { _ -> installed.countDown() }
         }
+        assertTrue(installed.await(5, TimeUnit.SECONDS))
         // 1s bounded wait for the bridge callback. Anchor-wrapped case never fires, so callers
         // for that case just consume the timeout and inspect payload (null = no fire).
         recorder.latch.await(1, TimeUnit.SECONDS)

--- a/app/src/androidTest/kotlin/com/riffle/app/feature/reader/FigureTapScriptTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/reader/FigureTapScriptTest.kt
@@ -1,0 +1,155 @@
+package com.riffle.app.feature.reader
+
+import android.webkit.JavascriptInterface
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Instrumentation coverage for [FigureTapScript]. Runs the actual JS against a bare WebView loaded
+ * with a small HTML fixture that mimics the shapes we care about (bare `<img>`, single-image
+ * `<figure>`, anchor-wrapped `<img>`, inline `<svg>`, `<picture>`), then dispatches JavaScript
+ * clicks on each and asserts the resulting bridge payload matches the expectation.
+ *
+ * Why an instrumentation test, not a JVM one: the hit-test logic IS the JavaScript, and there's no
+ * good way to run it deterministically without a real WebView. The JS payload builder — the piece
+ * a schema drift would break — is what this test pins.
+ *
+ * Why not a full reader-open harness: the reader stack is a lot to spin up just to trigger a click
+ * on a figure. This narrower test covers the tap-router (findFigure + payloadFor) exhaustively,
+ * and [FigureZoomTest] JVM-tests the [FigureTapMessageParser] end that turns the payload into a
+ * [FigureZoomState]. Together they cover the round trip that the design specifies.
+ */
+@RunWith(AndroidJUnit4::class)
+class FigureTapScriptTest {
+
+    private class Recorder {
+        val latch = CountDownLatch(1)
+        @Volatile var payload: String? = null
+
+        @JavascriptInterface
+        fun onFigureTap(json: String) {
+            payload = json
+            latch.countDown()
+        }
+    }
+
+    private val fixture = """
+        <!doctype html>
+        <html><body style="margin:0">
+          <img id="bare" src="images/bare.jpg" width="80" height="60"
+               style="position:absolute;left:0;top:0;width:80px;height:60px">
+          <figure id="wrapfig" style="position:absolute;left:100px;top:0;margin:0">
+            <img src="images/wrapped.png" width="80" height="60"
+                 style="width:80px;height:60px"><figcaption>x</figcaption>
+          </figure>
+          <a id="linked" href="chap02.xhtml#note" style="position:absolute;left:200px;top:0">
+            <img src="images/linked.png" width="80" height="60"
+                 style="width:80px;height:60px">
+          </a>
+          <svg id="inlinesvg" width="80" height="60" viewBox="0 0 80 60"
+               style="position:absolute;left:300px;top:0;width:80px;height:60px">
+            <rect width="80" height="60"/>
+          </svg>
+          <picture id="pic" style="position:absolute;left:400px;top:0">
+            <img src="images/pic.jpg" width="80" height="60"
+                 style="width:80px;height:60px">
+          </picture>
+        </body></html>
+    """.trimIndent()
+
+    private fun runTapCase(elementId: String): String? {
+        val ctx = ApplicationProvider.getApplicationContext<android.content.Context>()
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val recorder = Recorder()
+        val pageLoaded = CountDownLatch(1)
+        val webView = arrayOfNulls<WebView>(1)
+        instrumentation.runOnMainSync {
+            @Suppress("SetJavaScriptEnabled")
+            val wv = WebView(ctx).apply {
+                settings.javaScriptEnabled = true
+                addJavascriptInterface(recorder, FigureTapScript.PAGED_BRIDGE_NAME)
+                webViewClient = object : WebViewClient() {
+                    override fun onPageFinished(view: WebView?, url: String?) {
+                        pageLoaded.countDown()
+                    }
+                }
+                loadDataWithBaseURL(null, fixture, "text/html", "utf-8", null)
+            }
+            webView[0] = wv
+        }
+        assertTrue(pageLoaded.await(10, TimeUnit.SECONDS))
+        // Install the script and dispatch a synthetic click on the element.
+        instrumentation.runOnMainSync {
+            webView[0]!!.evaluateJavascript(FigureTapScript.installScript(FigureTapScript.PAGED_BRIDGE_NAME), null)
+        }
+        // Small delay so the install script's addEventListener is installed before we click.
+        Thread.sleep(200)
+        instrumentation.runOnMainSync {
+            webView[0]!!.evaluateJavascript(
+                "document.getElementById('$elementId').click()",
+                null,
+            )
+        }
+        // 1s bounded wait for the bridge callback. Anchor-wrapped case never fires, so callers
+        // for that case just consume the timeout and inspect payload (null = no fire).
+        recorder.latch.await(1, TimeUnit.SECONDS)
+        instrumentation.runOnMainSync {
+            webView[0]!!.destroy()
+        }
+        return recorder.payload
+    }
+
+    @Test
+    fun bareImage_firesTapWithSrcAndDimensions() {
+        val payload = runTapCase("bare") ?: error("No payload for bare <img>")
+        val obj = org.json.JSONObject(payload)
+        assertEquals("img", obj.getString("kind"))
+        assertTrue(obj.getString("href").endsWith("images/bare.jpg"))
+        assertEquals(80, obj.getInt("w"))
+        assertEquals(60, obj.getInt("h"))
+    }
+
+    @Test
+    fun figureWrappedImage_firesTapForContainedImage() {
+        val payload = runTapCase("wrapfig") ?: error("No payload for wrapped <figure>")
+        val obj = org.json.JSONObject(payload)
+        assertEquals("img", obj.getString("kind"))
+        assertTrue(obj.getString("href").endsWith("images/wrapped.png"))
+    }
+
+    @Test
+    fun anchorWrappedImage_doesNotFireTap() {
+        // Regression: footnote / cross-reference image-as-link must remain a link, not open the
+        // zoom viewer. FigureTapScript.findFigure returns null when it walks through an <a href>.
+        val payload = runTapCase("linked")
+        assertNull(payload)
+    }
+
+    @Test
+    fun inlineSvg_firesTapWithOuterHtml() {
+        val payload = runTapCase("inlinesvg") ?: error("No payload for inline <svg>")
+        val obj = org.json.JSONObject(payload)
+        assertEquals("svg", obj.getString("kind"))
+        val svg = obj.getString("svg")
+        assertTrue(svg.contains("<svg"))
+        assertTrue(svg.contains("<rect"))
+    }
+
+    @Test
+    fun picture_firesTapWithInnerImgSrc() {
+        val payload = runTapCase("pic") ?: error("No payload for <picture>")
+        val obj = org.json.JSONObject(payload)
+        assertEquals("img", obj.getString("kind"))
+        assertTrue(obj.getString("href").endsWith("images/pic.jpg"))
+    }
+}

--- a/app/src/androidTest/kotlin/com/riffle/app/feature/reader/FigureTapScriptTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/reader/FigureTapScriptTest.kt
@@ -46,14 +46,14 @@ class FigureTapScriptTest {
     private val fixture = """
         <!doctype html>
         <html><body style="margin:0">
-          <img id="bare" src="images/bare.jpg" width="80" height="60"
+          <img id="bare" src="data:image/gif;base64,R0lGODlhAQABAAAAACwAAAAAAQABAAA=" width="80" height="60"
                style="position:absolute;left:0;top:0;width:80px;height:60px">
           <figure id="wrapfig" style="position:absolute;left:100px;top:0;margin:0">
-            <img src="images/wrapped.png" width="80" height="60"
+            <img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAAAAAA6fptVAAAADElEQVQIHQEBAAD/AAEAAQAAt0V0QAAAAABJRU5ErkJggg==" width="80" height="60"
                  style="width:80px;height:60px"><figcaption>x</figcaption>
           </figure>
           <a id="linked" href="chap02.xhtml#note" style="position:absolute;left:200px;top:0">
-            <img src="images/linked.png" width="80" height="60"
+            <img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAAAAAA6fptVAAAADElEQVQIHQEBAAD/AAEAAQAAt0V0QAAAAABJRU5ErkJggg==" width="80" height="60"
                  style="width:80px;height:60px">
           </a>
           <svg id="inlinesvg" width="80" height="60" viewBox="0 0 80 60"
@@ -61,7 +61,7 @@ class FigureTapScriptTest {
             <rect width="80" height="60"/>
           </svg>
           <picture id="pic" style="position:absolute;left:400px;top:0">
-            <img src="images/pic.jpg" width="80" height="60"
+            <img src="data:image/gif;base64,R0lGODlhAQABAAAAACwAAAAAAQABAAA=" width="80" height="60"
                  style="width:80px;height:60px">
           </picture>
         </body></html>
@@ -118,7 +118,7 @@ class FigureTapScriptTest {
         val payload = runTapCase("bare") ?: error("No payload for bare <img>")
         val obj = org.json.JSONObject(payload)
         assertEquals("img", obj.getString("kind"))
-        assertTrue(obj.getString("href").endsWith("images/bare.jpg"))
+        assertTrue(obj.getString("href").endsWith("data:image/gif;base64,R0lGODlhAQABAAAAACwAAAAAAQABAAA="))
         assertEquals(80, obj.getInt("w"))
         assertEquals(60, obj.getInt("h"))
     }
@@ -128,7 +128,7 @@ class FigureTapScriptTest {
         val payload = runTapCase("wrapfig") ?: error("No payload for wrapped <figure>")
         val obj = org.json.JSONObject(payload)
         assertEquals("img", obj.getString("kind"))
-        assertTrue(obj.getString("href").endsWith("images/wrapped.png"))
+        assertTrue(obj.getString("href").endsWith("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAAAAAA6fptVAAAADElEQVQIHQEBAAD/AAEAAQAAt0V0QAAAAABJRU5ErkJggg=="))
     }
 
     @Test
@@ -154,6 +154,6 @@ class FigureTapScriptTest {
         val payload = runTapCase("pic") ?: error("No payload for <picture>")
         val obj = org.json.JSONObject(payload)
         assertEquals("img", obj.getString("kind"))
-        assertTrue(obj.getString("href").endsWith("images/pic.jpg"))
+        assertTrue(obj.getString("href").endsWith("data:image/gif;base64,R0lGODlhAQABAAAAACwAAAAAAQABAAA="))
     }
 }

--- a/app/src/androidTest/kotlin/com/riffle/app/feature/reader/FigureTapScriptTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/reader/FigureTapScriptTest.kt
@@ -119,8 +119,11 @@ class FigureTapScriptTest {
         val obj = org.json.JSONObject(payload)
         assertEquals("img", obj.getString("kind"))
         assertTrue(obj.getString("href").endsWith("data:image/gif;base64,R0lGODlhAQABAAAAACwAAAAAAQABAAA="))
-        assertEquals(80, obj.getInt("w"))
-        assertEquals(60, obj.getInt("h"))
+        // Dimensions come from naturalWidth/naturalHeight when available, which for a data URI is
+        // the decoded pixel size (1x1 for the placeholder GIF) — NOT the HTML width/height
+        // attributes. Assert both fields are positive; the exact number isn't the point.
+        assertTrue(obj.getInt("w") > 0)
+        assertTrue(obj.getInt("h") > 0)
     }
 
     @Test

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ChapterWebView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ChapterWebView.kt
@@ -226,7 +226,7 @@ internal class ChapterWebView(context: Context) : WebView(context), ChapterWebVi
         ) {
             androidx.webkit.WebSettingsCompat.setOffscreenPreRaster(settings, true)
         }
-        addJavascriptInterface(HeightBridge(), "RiffleChapter")
+        addJavascriptInterface(HeightBridge(), FigureTapScript.CONTINUOUS_BRIDGE_NAME)
         webViewClient = object : WebViewClient() {
             override fun onPageFinished(view: WebView?, url: String?) {
                 this@ChapterWebView.onPageFinished?.invoke()
@@ -361,7 +361,7 @@ internal class ChapterWebView(context: Context) : WebView(context), ChapterWebVi
         // toggles immersive) and the same-doc anchor listener, so figure taps stopPropagation and
         // never reach the immersive router. Uses the existing RiffleChapter object — see the
         // onFigureTap addition in HeightBridge below.
-        evalJs(FigureTapScript.installScript("RiffleChapter"))
+        evalJs(FigureTapScript.installScript(FigureTapScript.CONTINUOUS_BRIDGE_NAME))
     }
 
     /** Re-inject user styles and re-measure after a preference change. */

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ChapterWebView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ChapterWebView.kt
@@ -84,6 +84,13 @@ internal class ChapterWebView(context: Context) : WebView(context), ChapterWebVi
     override var onCrossReferenceTap: ((fragmentId: String) -> Unit)? = null
 
     /**
+     * Called on the main thread when the user taps a figure (`<img>`, inline `<svg>`, `<picture>`,
+     * or single-image `<figure>`) that is NOT wrapped in a link. [payload] is the JSON emitted by
+     * [FigureTapScript]; the host parses it via [FigureTapMessageParser].
+     */
+    override var onFigureTap: ((payload: String) -> Unit)? = null
+
+    /**
      * The raw HTML of the chapter document currently loaded, retained so a footnote tap can resolve
      * the note body without a re-fetch. Set the first time an HTML resource is served for a load (the
      * main document is fetched first), cleared on each [loadChapter]. The parsed form is cached lazily
@@ -350,6 +357,11 @@ internal class ChapterWebView(context: Context) : WebView(context), ChapterWebVi
         evalJs(ContinuousScriptInjector.HEIGHT_MEASUREMENT_JS)
         evalJs(ContinuousScriptInjector.TAP_LISTENER_JS)
         evalJs(ContinuousScriptInjector.SAME_DOC_ANCHOR_LISTENER_JS)
+        // Figure-tap hit-test. Runs in capture-phase click BEFORE the tap-listener above (which
+        // toggles immersive) and the same-doc anchor listener, so figure taps stopPropagation and
+        // never reach the immersive router. Uses the existing RiffleChapter object — see the
+        // onFigureTap addition in HeightBridge below.
+        evalJs(FigureTapScript.installScript("RiffleChapter"))
     }
 
     /** Re-inject user styles and re-measure after a preference change. */
@@ -659,6 +671,12 @@ internal class ChapterWebView(context: Context) : WebView(context), ChapterWebVi
         @JavascriptInterface
         fun onCrossReferenceTap(id: String) {
             post { this@ChapterWebView.onCrossReferenceTap?.invoke(id) }
+        }
+
+        /** Figure-tap event; [payload] is the JSON built by [FigureTapScript]. */
+        @JavascriptInterface
+        fun onFigureTap(payload: String) {
+            post { this@ChapterWebView.onFigureTap?.invoke(payload) }
         }
     }
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ChapterWebViewBinder.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ChapterWebViewBinder.kt
@@ -25,6 +25,7 @@ internal interface ChapterWebViewLike {
     var onAnnotationNoteTap: ((String, Rect) -> Unit)?
     var onFootnoteContent: ((FootnoteContent) -> Unit)?
     var onCrossReferenceTap: ((String) -> Unit)?
+    var onFigureTap: ((String) -> Unit)?
 }
 
 /**
@@ -54,6 +55,7 @@ internal class ChapterWebViewBinder(
     private val onInternalLink: (href: String) -> Unit,
     private val onCrossReference: (chapterHref: String, fragmentId: String) -> Unit,
     private val onSelectionActiveChanged: (Boolean) -> Unit,
+    private val onFigureTap: (payload: String) -> Unit = {},
 ) {
     fun bind(wv: ChapterWebViewLike, annotationsAvailable: Boolean, readaloudAvailable: Boolean) {
         wv.onTap = { navigation.onTap() }
@@ -92,5 +94,6 @@ internal class ChapterWebViewBinder(
         }
         wv.readaloudAvailable = readaloudAvailable
         wv.onFootnoteContent = { links.onFootnote(it) }
+        wv.onFigureTap = { payload -> onFigureTap(payload) }
     }
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
@@ -79,6 +79,13 @@ internal class ContinuousReaderView @JvmOverloads constructor(
         get() = controller.onPlayFromHereSelection
         set(value) { controller.onPlayFromHereSelection = value }
 
+    /**
+     * Called on the main thread with the raw JSON payload emitted by figure-tap.js when the user
+     * taps a figure. The host parses it via [FigureTapMessageParser] and pushes the result into
+     * the ViewModel's figureZoom state, causing [FigureZoomOverlay] to open above the reader.
+     */
+    var onFigureTap: ((payload: String) -> Unit)? = null
+
     /** Set by [install]; invoked by the controller with the raw `(href, progression)` on
      *  every scroll-position update. */
     private var onRawPosition: ((href: String, progression: Float) -> Unit)? = null
@@ -119,6 +126,7 @@ internal class ContinuousReaderView @JvmOverloads constructor(
             onInternalLink = onInternalLink,
             onCrossReference = onCrossReference,
             onSelectionActiveChanged = ::onChildSelectionActiveChanged,
+            onFigureTap = { payload -> onFigureTap?.invoke(payload) },
         )
         controller.install(binder)
     }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -445,6 +445,7 @@ fun EpubReaderScreen(
                         onReachedEndOfBook = viewModel::reachedEndOfBookForAutoScroll,
                         onAutoScrollPause = viewModel::pauseAutoScroll,
                         onAutoScrollResume = viewModel::resumeAutoScrollIfPaused,
+                        onFigureTap = viewModel::onFigureTapPayload,
                         dispatchers = viewModel.dispatchers,
                         modifier = Modifier
                             .fillMaxSize()
@@ -740,6 +741,14 @@ fun EpubReaderScreen(
             onResume = { viewModel.resumeAutoScrollFromPill() },
             onSlower = { viewModel.nudgeAutoScroll(by = -com.riffle.core.domain.autoscroll.AutoScrollSpeed.STEP_WPM) },
             onFaster = { viewModel.nudgeAutoScroll(by = com.riffle.core.domain.autoscroll.AutoScrollSpeed.STEP_WPM) },
+        )
+        // Figure-zoom overlay — mounted at the outermost Box so it dims and covers every reader
+        // mode, all reader chrome, and every bottom stack element (readaloud, chapter rail).
+        val figureZoom by viewModel.figureZoom.collectAsState()
+        FigureZoomOverlay(
+            state = figureZoom,
+            publication = (state as? ReaderState.Ready)?.publication,
+            onDismiss = viewModel::dismissFigureZoom,
         )
     }
 }
@@ -1141,6 +1150,7 @@ private fun EpubNavigatorView(
     onReachedEndOfBook: () -> Unit,
     onAutoScrollPause: (com.riffle.core.domain.autoscroll.PauseCause) -> Unit,
     onAutoScrollResume: () -> Unit,
+    onFigureTap: (payload: String) -> Unit,
     dispatchers: com.riffle.core.domain.DispatcherProvider,
     modifier: Modifier = Modifier,
 ) {
@@ -1629,6 +1639,14 @@ private fun EpubNavigatorView(
     // progression is imprecise, and goForward/goBackward report success without
     // moving on Readium 3.3.0. A direct scrollLeft snap holds because the reader
     // is sized so innerWidth == Readium's page-snap pitch (see readerWidthDp).
+    // Route paged/vertical figure taps into the ViewModel via the same handler-registry pattern as
+    // FootnoteAnchorBridge. Continuous mode routes its figure taps through the per-chapter
+    // RiffleChapter bridge already, so it doesn't need this hook.
+    DisposableEffect(Unit) {
+        FigureTapBridge.setHandler { payload -> onFigureTap(payload) }
+        onDispose { FigureTapBridge.setHandler(null) }
+    }
+
     DisposableEffect(Unit) {
         FootnoteAnchorBridge.setHandler { fragmentId ->
             when (
@@ -2235,6 +2253,9 @@ private fun EpubNavigatorView(
                             registerJavascriptInterface(FootnoteAnchorBridge.JS_NAME) { _ ->
                                 FootnoteAnchorBridge.bridge
                             }
+                            registerJavascriptInterface(FigureTapBridge.JS_NAME) { _ ->
+                                FigureTapBridge.bridge
+                            }
                             registerJavascriptInterface("RiffleSelBridge") { _ ->
                                 pagedSelectionRectBridge
                             }
@@ -2345,6 +2366,7 @@ private fun EpubNavigatorView(
                         coordinator.attach(view)
                         view.annotationsAvailable = currentAnnotationsAvailable
                         view.readaloudAvailable = currentReadaloudAvailable
+                        view.onFigureTap = { payload -> onFigureTap(payload) }
                     }
                 },
                 // Availability flags can flip mid-session; keep the selection menu gates in sync.

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -262,6 +262,24 @@ class EpubReaderViewModel @Inject constructor(
     private val _footnotePopup = MutableStateFlow<FootnotePopupState?>(null)
     val footnotePopup: StateFlow<FootnotePopupState?> = _footnotePopup
 
+    // Fullscreen figure-zoom overlay state (feature: pressing on a figure opens it in a zoomed
+    // viewer with dimmed background). Set from a JS hit-test payload posted by FigureTapScript;
+    // reset when the user dismisses the overlay (tap-outside / system back).
+    private val _figureZoom = MutableStateFlow<FigureZoomState?>(null)
+    internal val figureZoom: StateFlow<FigureZoomState?> = _figureZoom
+
+    /** Called by the reader glue with the raw JSON emitted by figure-tap.js. Parses and opens the
+     *  overlay; malformed payloads are silently ignored (the JS may drift ahead of Kotlin). */
+    fun onFigureTapPayload(payload: String) {
+        val state = FigureTapMessageParser.parse(payload) ?: return
+        _figureZoom.value = state
+    }
+
+    /** Dismiss the figure-zoom overlay (user tapped outside, pressed Back, etc). Idempotent. */
+    fun dismissFigureZoom() {
+        _figureZoom.value = null
+    }
+
     private val _syncErrorEvents = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
     val syncErrorEvents: SharedFlow<Unit> = _syncErrorEvents.asSharedFlow()
 

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/FigureTapBridge.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/FigureTapBridge.kt
@@ -1,0 +1,33 @@
+package com.riffle.app.feature.reader
+
+import android.webkit.JavascriptInterface
+
+/**
+ * JS bridge that receives figure-tap events from paged/vertical mode's Readium WebViews. Continuous
+ * mode routes the same event through the existing `RiffleChapter` object (see the `onFigureTap`
+ * addition in [ChapterWebView.HeightBridge]) because that WebView already owns a per-chapter
+ * bridge; adding another bridge just for figures would duplicate the wiring.
+ *
+ * The registry holds a single [handler] swapped in by the active reader — same shape as
+ * [FootnoteAnchorBridge]. Only one reader is open at a time, so a global singleton is safe.
+ */
+internal object FigureTapBridge {
+    const val JS_NAME: String = FigureTapScript.PAGED_BRIDGE_NAME
+
+    @Volatile
+    private var handler: ((String) -> Unit)? = null
+
+    fun setHandler(h: ((String) -> Unit)?) {
+        handler = h
+    }
+
+    val bridge: Bridge = Bridge()
+
+    class Bridge {
+        /** Called from JS with the JSON payload built by [FigureTapScript.installScript]. */
+        @JavascriptInterface
+        fun onFigureTap(payload: String) {
+            handler?.invoke(payload)
+        }
+    }
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/FigureTapScript.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/FigureTapScript.kt
@@ -28,19 +28,35 @@ internal object FigureTapScript {
     /** Global name of the paged/vertical figure-tap JS interface. */
     const val PAGED_BRIDGE_NAME: String = "RiffleFigureBridge"
 
+    /**
+     * Global name of the continuous-mode figure-tap JS interface. This is [ChapterWebView]'s
+     * existing per-chapter bridge object; continuous mode reuses it rather than registering a
+     * second one. Kept as a constant here so both the JS install site and the JS message-send
+     * sites resolve to the same literal — a rename can't leave one path silently no-op.
+     */
+    const val CONTINUOUS_BRIDGE_NAME: String = "RiffleChapter"
+
     fun installScript(bridgeName: String): String = """
         (function() {
             if (document.__riffleFigureTapWired) return;
             document.__riffleFigureTapWired = true;
             var MAX_SVG_BYTES = 256 * 1024;
             function findFigure(target) {
+                // Walk up to body FIRST looking for an anchor-with-href ancestor. If we find one
+                // before we find a figure candidate, this tap is a link — return null so the
+                // existing footnote / cross-reference / external-link router handles it. Doing
+                // the walk in two passes fixes the anchor-wrapped-image bug where returning on
+                // the first <img> match happens BEFORE we ever see the wrapping <a>.
+                var scan = target;
+                while (scan && scan.nodeType === 1 && scan !== document.body) {
+                    var stag = scan.tagName ? scan.tagName.toLowerCase() : '';
+                    if (stag === 'a' && scan.getAttribute && scan.getAttribute('href')) return null;
+                    scan = scan.parentNode;
+                }
+                // Now walk up to find the actual figure candidate.
                 var el = target;
-                // Walk up looking for the first candidate. Stop at body — don't zoom whole chapter.
                 while (el && el.nodeType === 1 && el !== document.body) {
                     var tag = el.tagName ? el.tagName.toLowerCase() : '';
-                    // If we hit an anchor with an href on the way up, this image is a link.
-                    // Let the existing anchor router handle the tap.
-                    if (tag === 'a' && el.getAttribute && el.getAttribute('href')) return null;
                     if (tag === 'img' || tag === 'svg' || tag === 'picture') return el;
                     if (tag === 'figure') {
                         // Find single image-like child; skip if the figure contains other content.

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/FigureTapScript.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/FigureTapScript.kt
@@ -1,0 +1,97 @@
+package com.riffle.app.feature.reader
+
+/**
+ * JavaScript that hit-tests taps against `<img>`, inline `<svg>`, `<picture>`, and single-image
+ * `<figure>` elements, then posts the tap through the `RiffleChapter` (continuous) or
+ * `RiffleFigureBridge` (paged/vertical) JS interfaces.
+ *
+ * Design notes:
+ *
+ *  - Runs on `click` in the CAPTURE phase, BEFORE the existing tap-to-toggle-immersive router
+ *    (see [ContinuousScriptInjector.TAP_LISTENER_JS]) and BEFORE the same-doc anchor listener,
+ *    so `event.stopPropagation() + preventDefault()` here means those handlers never fire.
+ *  - Excludes images inside `<a href>` when the anchor is a link (any href): those must remain
+ *    clickable as footnotes / cross-references / external links. Only bare figures open the
+ *    viewer.
+ *  - `<svg>` targets: we capture `outerHTML` so the overlay can render the vector as-is without
+ *    re-serialising every child manually. Bounded at 256KB to avoid pathological cases.
+ *  - `<img>` targets: we send `src` (which is a resolved absolute URL in the WebView context — the
+ *    overlay strips the `readium_package://` prefix if present to build the Publication href).
+ *    Falls back to `currentSrc` for `<picture>`. Data URIs are passed through verbatim.
+ *  - Idempotent via `document.__riffleFigureTapWired`.
+ *
+ * The bridge argument [bridgeName] is the `@JavascriptInterface`-registered object name — either
+ * `RiffleChapter` (continuous — extended with `onFigureTap`) or `RiffleFigureBridge` (paged).
+ */
+internal object FigureTapScript {
+
+    /** Global name of the paged/vertical figure-tap JS interface. */
+    const val PAGED_BRIDGE_NAME: String = "RiffleFigureBridge"
+
+    fun installScript(bridgeName: String): String = """
+        (function() {
+            if (document.__riffleFigureTapWired) return;
+            document.__riffleFigureTapWired = true;
+            var MAX_SVG_BYTES = 256 * 1024;
+            function findFigure(target) {
+                var el = target;
+                // Walk up looking for the first candidate. Stop at body — don't zoom whole chapter.
+                while (el && el.nodeType === 1 && el !== document.body) {
+                    var tag = el.tagName ? el.tagName.toLowerCase() : '';
+                    // If we hit an anchor with an href on the way up, this image is a link.
+                    // Let the existing anchor router handle the tap.
+                    if (tag === 'a' && el.getAttribute && el.getAttribute('href')) return null;
+                    if (tag === 'img' || tag === 'svg' || tag === 'picture') return el;
+                    if (tag === 'figure') {
+                        // Find single image-like child; skip if the figure contains other content.
+                        var kids = el.querySelectorAll ? el.querySelectorAll('img, svg, picture') : [];
+                        if (kids && kids.length === 1) return kids[0];
+                        return null;
+                    }
+                    el = el.parentNode;
+                }
+                return null;
+            }
+            function payloadFor(el) {
+                var tag = el.tagName ? el.tagName.toLowerCase() : '';
+                var r = el.getBoundingClientRect();
+                if (tag === 'img') {
+                    var src = el.currentSrc || el.src;
+                    if (!src) return null;
+                    var w = el.naturalWidth || Math.round(r.width);
+                    var h = el.naturalHeight || Math.round(r.height);
+                    return { kind: 'img', href: src, w: w, h: h };
+                }
+                if (tag === 'picture') {
+                    var img = el.querySelector('img');
+                    if (!img) return null;
+                    var src2 = img.currentSrc || img.src;
+                    if (!src2) return null;
+                    var w2 = img.naturalWidth || Math.round(r.width);
+                    var h2 = img.naturalHeight || Math.round(r.height);
+                    return { kind: 'img', href: src2, w: w2, h: h2 };
+                }
+                if (tag === 'svg') {
+                    var html = el.outerHTML || '';
+                    if (!html || html.length > MAX_SVG_BYTES) return null;
+                    var w3 = Math.round(r.width);
+                    var h3 = Math.round(r.height);
+                    if (w3 <= 0 || h3 <= 0) return null;
+                    return { kind: 'svg', svg: html, w: w3, h: h3 };
+                }
+                return null;
+            }
+            document.addEventListener('click', function(e) {
+                var fig = findFigure(e.target);
+                if (!fig) return;
+                var p = payloadFor(fig);
+                if (!p) return;
+                try {
+                    window.$bridgeName.onFigureTap(JSON.stringify(p));
+                    e.preventDefault();
+                    e.stopPropagation();
+                } catch (err) {}
+            }, true);
+        })();
+    """.trimIndent()
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/FigureZoom.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/FigureZoom.kt
@@ -1,0 +1,125 @@
+package com.riffle.app.feature.reader
+
+import org.json.JSONObject
+
+/**
+ * The reader's "figure zoom" overlay state. Non-null while a fullscreen zoomed view of the tapped
+ * image is showing; null otherwise. Owned by the reader ViewModel and observed by
+ * [EpubReaderScreen], which mounts [FigureZoomOverlay] above every reader mode.
+ *
+ * [href] is the EPUB-package-relative path to the image resource (used by
+ * [FigureZoomOverlay] to load bytes via `Publication.get(href)`). [naturalWidth] / [naturalHeight]
+ * are the image's intrinsic CSS pixel dimensions as reported by the JS hit-test — used to compute
+ * the initial fit-to-screen size before the bitmap has decoded.
+ *
+ * Data URIs (`data:image/...;base64,...`) are supported by passing the encoded payload in [href];
+ * the overlay decodes them directly without a Publication lookup. Inline SVGs are captured as
+ * `<svg>` outerHTML by the hit-test and passed as `svgMarkup`; the overlay renders those via
+ * WebView.
+ */
+internal data class FigureZoomState(
+    val href: String,
+    val naturalWidth: Int,
+    val naturalHeight: Int,
+    val svgMarkup: String? = null,
+)
+
+/**
+ * Parse the JSON payload posted from `figure-tap.js` when the user taps a figure. The JS emits
+ * `{ "kind": "img"|"svg", "href": "...", "w": <int>, "h": <int>, "svg": "..." }` — `href` is the
+ * resolved src for `img`/`picture` targets (may be a `data:` URI), `svg` is the outerHTML for
+ * inline SVG targets. Missing or malformed input returns null so the JS interface can't crash the
+ * app on a badly-shaped tap.
+ *
+ * Extracted for JVM unit-testing so the schema is exercised without a live WebView; the JS is the
+ * only writer, but a schema drift there is easy to make and hard to notice.
+ */
+internal object FigureTapMessageParser {
+    fun parse(json: String?): FigureZoomState? {
+        if (json.isNullOrBlank()) return null
+        val obj = runCatching { JSONObject(json) }.getOrNull() ?: return null
+        val kind = obj.optString("kind", "img")
+        val w = obj.optInt("w", 0)
+        val h = obj.optInt("h", 0)
+        if (w <= 0 || h <= 0) return null
+        return when (kind) {
+            "svg" -> {
+                val svg = obj.optString("svg", "")
+                if (svg.isBlank()) return null
+                FigureZoomState(href = "", naturalWidth = w, naturalHeight = h, svgMarkup = svg)
+            }
+            else -> {
+                val href = obj.optString("href", "")
+                if (href.isBlank()) return null
+                FigureZoomState(href = href, naturalWidth = w, naturalHeight = h)
+            }
+        }
+    }
+}
+
+/**
+ * Clamp a scaled-image pan+zoom transform so the image can't be dragged off-screen.
+ *
+ * `scale` is clamped to `[minScale, maxScale]`. Translation is clamped so that when the image is
+ * smaller than the viewport in either axis it stays centred (translation = 0), and when it is
+ * larger the drag can move it exactly as far as the excess in that axis (half the excess in each
+ * direction).
+ *
+ * Pure Kotlin so it JVM-unit-tests without a Compose runtime — the pinch-gesture composable
+ * delegates all math here so a "double-tap resets and the image jumps 40px off-centre" regression
+ * would flip a unit test, not require an emulator to catch.
+ *
+ * All lengths are in the same coordinate space (device px, CSS px, whatever the caller uses),
+ * because the function only operates on ratios and differences.
+ */
+internal data class PanZoom(val scale: Float, val translationX: Float, val translationY: Float)
+
+internal fun clampPanZoom(
+    scale: Float,
+    translationX: Float,
+    translationY: Float,
+    fittedWidth: Float,
+    fittedHeight: Float,
+    viewportWidth: Float,
+    viewportHeight: Float,
+    minScale: Float = 1f,
+    maxScale: Float = 5f,
+): PanZoom {
+    val s = scale.coerceIn(minScale, maxScale)
+    val scaledW = fittedWidth * s
+    val scaledH = fittedHeight * s
+    val maxX = (scaledW - viewportWidth).coerceAtLeast(0f) / 2f
+    val maxY = (scaledH - viewportHeight).coerceAtLeast(0f) / 2f
+    val tx = translationX.coerceIn(-maxX, maxX)
+    val ty = translationY.coerceIn(-maxY, maxY)
+    return PanZoom(s, tx, ty)
+}
+
+/** Plain-Kotlin size type so [fitImageIntoViewport] is trivially JVM-testable — Rect requires
+ *  the Android framework which isn't linked in unit tests. */
+internal data class FittedSize(val width: Int, val height: Int)
+
+/**
+ * Compute the fitted (initial-view) size of an image with intrinsic size
+ * [naturalWidth] x [naturalHeight] inside a viewport of [viewportWidth] x [viewportHeight],
+ * preserving aspect ratio. Fits by the more constraining axis, so the whole image is always
+ * visible at scale = 1.
+ */
+internal fun fitImageIntoViewport(
+    naturalWidth: Int,
+    naturalHeight: Int,
+    viewportWidth: Float,
+    viewportHeight: Float,
+): FittedSize {
+    if (naturalWidth <= 0 || naturalHeight <= 0 || viewportWidth <= 0f || viewportHeight <= 0f) {
+        return FittedSize(0, 0)
+    }
+    val imgAspect = naturalWidth.toFloat() / naturalHeight.toFloat()
+    val vpAspect = viewportWidth / viewportHeight
+    val (w, h) = if (imgAspect > vpAspect) {
+        viewportWidth to viewportWidth / imgAspect
+    } else {
+        viewportHeight * imgAspect to viewportHeight
+    }
+    return FittedSize(w.toInt(), h.toInt())
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/FigureZoomOverlay.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/FigureZoomOverlay.kt
@@ -1,0 +1,220 @@
+@file:OptIn(org.readium.r2.shared.ExperimentalReadiumApi::class)
+
+package com.riffle.app.feature.reader
+
+import android.annotation.SuppressLint
+import android.graphics.BitmapFactory
+import android.util.Base64
+import android.webkit.WebView
+import androidx.activity.compose.BackHandler
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.gestures.rememberTransformableState
+import androidx.compose.foundation.gestures.transformable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.readium.r2.shared.publication.Publication
+import org.readium.r2.shared.util.Url
+
+/**
+ * Fullscreen overlay that shows the tapped [state] figure zoomed into a fit-to-viewport view with
+ * background text dimmed. Handles pinch-to-zoom (up to 5×), drag-to-pan (clamped so the image can't
+ * leave the viewport), double-tap to reset, and tap-outside / system Back to dismiss.
+ *
+ * The overlay is mounted at the TOP of [EpubReaderScreen]'s outer Box so it renders above every
+ * reader mode (paginated, vertical, continuous) and above the reader chrome without any per-mode
+ * plumbing.
+ *
+ * Image loading:
+ *  - `data:` URIs: decoded inline via Base64.
+ *  - Other `href`s: fetched via [Publication.get] — the same path annotations use, so images
+ *    load offline and don't re-hit the network.
+ *  - Inline SVG (`state.svgMarkup != null`): rendered in a minimal WebView so vector art
+ *    reflows to the fit box.
+ */
+@Composable
+internal fun FigureZoomOverlay(
+    state: FigureZoomState?,
+    publication: Publication?,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    AnimatedVisibility(
+        visible = state != null,
+        enter = fadeIn(tween(150)),
+        exit = fadeOut(tween(150)),
+        modifier = modifier,
+    ) {
+        val visibleState = state ?: return@AnimatedVisibility
+        FigureZoomContent(state = visibleState, publication = publication, onDismiss = onDismiss)
+    }
+}
+
+@Composable
+private fun FigureZoomContent(
+    state: FigureZoomState,
+    publication: Publication?,
+    onDismiss: () -> Unit,
+) {
+    BackHandler(enabled = true) { onDismiss() }
+
+    // Load image bytes off the main thread. Bitmap loading only — SVGs render via WebView below.
+    val bitmap = remember(state.href, state.svgMarkup) {
+        mutableStateOf<android.graphics.Bitmap?>(null)
+    }
+    LaunchedEffect(state.href, state.svgMarkup) {
+        if (state.svgMarkup != null) return@LaunchedEffect
+        val bytes = withContext(Dispatchers.IO) { loadImageBytes(state.href, publication) }
+        bitmap.value = bytes?.let { BitmapFactory.decodeByteArray(it, 0, it.size) }
+    }
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Color.Black.copy(alpha = 0.75f))
+            .pointerInput(state) {
+                // Tap outside the image dismisses. Tap on the image is consumed by the transformable
+                // pointer stream, so this only fires for background taps.
+                detectTapGestures(onTap = { onDismiss() })
+            },
+    ) {
+        BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
+            val vpW = with(LocalDensity.current) { maxWidth.toPx() }
+            val vpH = with(LocalDensity.current) { maxHeight.toPx() }
+            val fit = fitImageIntoViewport(state.naturalWidth, state.naturalHeight, vpW, vpH)
+            val fitW = fit.width.coerceAtLeast(1)
+            val fitH = fit.height.coerceAtLeast(1)
+
+            var scale by remember { mutableStateOf(1f) }
+            var tx by remember { mutableStateOf(0f) }
+            var ty by remember { mutableStateOf(0f) }
+
+            val transformState = rememberTransformableState { zoomChange, panChange, _ ->
+                val clamped = clampPanZoom(
+                    scale = scale * zoomChange,
+                    translationX = tx + panChange.x,
+                    translationY = ty + panChange.y,
+                    fittedWidth = fitW.toFloat(),
+                    fittedHeight = fitH.toFloat(),
+                    viewportWidth = vpW,
+                    viewportHeight = vpH,
+                )
+                scale = clamped.scale
+                tx = clamped.translationX
+                ty = clamped.translationY
+            }
+
+            val imgModifier = Modifier
+                .align(Alignment.Center)
+                .size(with(LocalDensity.current) { fitW.toDp() }, with(LocalDensity.current) { fitH.toDp() })
+                .graphicsLayer(scaleX = scale, scaleY = scale, translationX = tx, translationY = ty)
+                .transformable(transformState)
+                .pointerInput(state) {
+                    detectTapGestures(
+                        onDoubleTap = {
+                            scale = 1f; tx = 0f; ty = 0f
+                        },
+                        onTap = { /* consume — don't dismiss */ },
+                    )
+                }
+
+            when {
+                state.svgMarkup != null -> {
+                    SvgWebView(svgMarkup = state.svgMarkup, modifier = imgModifier)
+                }
+                bitmap.value != null -> {
+                    Image(
+                        bitmap = bitmap.value!!.asImageBitmap(),
+                        contentDescription = null,
+                        modifier = imgModifier,
+                    )
+                }
+                else -> {
+                    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                        CircularProgressIndicator(color = Color.White)
+                    }
+                }
+            }
+        }
+    }
+}
+
+@SuppressLint("SetJavaScriptEnabled")
+@Composable
+private fun SvgWebView(svgMarkup: String, modifier: Modifier) {
+    // Inline SVGs are rendered in a barebones WebView. The graphicsLayer scale on the parent
+    // Modifier resizes the WebView tile, so pinch/zoom work naturally.
+    val html = remember(svgMarkup) {
+        """<!doctype html><html><head><meta name="viewport" content="width=device-width">
+           <style>html,body{margin:0;padding:0;background:transparent}svg{width:100%;height:100%;display:block}</style>
+           </head><body>$svgMarkup</body></html>""".trimIndent()
+    }
+    AndroidView(
+        factory = { ctx ->
+            WebView(ctx).apply {
+                setBackgroundColor(0)
+                settings.javaScriptEnabled = false
+                settings.useWideViewPort = false
+                settings.loadWithOverviewMode = true
+            }
+        },
+        update = { wv ->
+            wv.loadDataWithBaseURL(null, html, "text/html", "utf-8", null)
+        },
+        modifier = modifier,
+    )
+}
+
+/**
+ * Load image bytes for the given [href] (as reported by the WebView).
+ *  - `data:` URI → Base64-decoded payload.
+ *  - `http`/`https`/`file` under Readium's `readium_package` virtual host → strip and query the
+ *    Publication.
+ *  - Anything else that resolves to a Publication href → same.
+ */
+private suspend fun loadImageBytes(href: String, publication: Publication?): ByteArray? {
+    if (href.startsWith("data:")) {
+        val comma = href.indexOf(',')
+        if (comma < 0) return null
+        val meta = href.substring(0, comma)
+        val payload = href.substring(comma + 1)
+        return runCatching {
+            if (meta.contains(";base64")) Base64.decode(payload, Base64.DEFAULT)
+            else java.net.URLDecoder.decode(payload, "UTF-8").toByteArray()
+        }.getOrNull()
+    }
+    val pub = publication ?: return null
+    // Strip the readium_package origin the WebView reports for served EPUB resources.
+    val stripped = href
+        .removePrefix("http://readium_package/")
+        .removePrefix("https://readium_package/")
+        .substringBefore('#')
+    val url = Url(stripped) ?: return null
+    return pub.get(url)?.read()?.getOrNull()
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/FigureZoomOverlay.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/FigureZoomOverlay.kt
@@ -65,13 +65,18 @@ internal fun FigureZoomOverlay(
     onDismiss: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    // Cache the last non-null state so the fadeOut animates the actual content instead of an
+    // empty subtree — a null-guarded `return@AnimatedVisibility` during exit would render nothing
+    // for the whole 150ms, making dismissal look instant.
+    var lastVisible by remember { mutableStateOf<FigureZoomState?>(null) }
+    if (state != null) lastVisible = state
     AnimatedVisibility(
         visible = state != null,
         enter = fadeIn(tween(150)),
         exit = fadeOut(tween(150)),
         modifier = modifier,
     ) {
-        val visibleState = state ?: return@AnimatedVisibility
+        val visibleState = lastVisible ?: return@AnimatedVisibility
         FigureZoomContent(state = visibleState, publication = publication, onDismiss = onDismiss)
     }
 }
@@ -138,7 +143,18 @@ private fun FigureZoomContent(
                 .pointerInput(state) {
                     detectTapGestures(
                         onDoubleTap = {
-                            scale = 1f; tx = 0f; ty = 0f
+                            // Route the reset through clampPanZoom so the single source of truth
+                            // for valid transforms owns it — if minScale ever moves off 1f, the
+                            // reset can't land outside the clamp and jump on the next pan.
+                            val reset = clampPanZoom(
+                                scale = 1f,
+                                translationX = 0f, translationY = 0f,
+                                fittedWidth = fitW.toFloat(), fittedHeight = fitH.toFloat(),
+                                viewportWidth = vpW, viewportHeight = vpH,
+                            )
+                            scale = reset.scale
+                            tx = reset.translationX
+                            ty = reset.translationY
                         },
                         onTap = { /* consume — don't dismiss */ },
                     )
@@ -204,10 +220,13 @@ private suspend fun loadImageBytes(href: String, publication: Publication?): Byt
         if (comma < 0) return null
         val meta = href.substring(0, comma)
         val payload = href.substring(comma + 1)
-        return runCatching {
-            if (meta.contains(";base64")) Base64.decode(payload, Base64.DEFAULT)
-            else java.net.URLDecoder.decode(payload, "UTF-8").toByteArray()
-        }.getOrNull()
+        // Only base64 payloads decode cleanly to bitmap bytes. A URL-encoded data URI is text
+        // (typically inline SVG), and re-encoding it via URLDecoder+String.toByteArray produces
+        // UTF-8 bytes that BitmapFactory can't decode — the overlay would spin forever. Return
+        // null so the caller shows the "not available" state instead of feeding corrupt bytes.
+        // Inline SVG never arrives here (JS captures outerHTML into svgMarkup, not src).
+        if (!meta.contains(";base64")) return null
+        return runCatching { Base64.decode(payload, Base64.DEFAULT) }.getOrNull()
     }
     val pub = publication ?: return null
     // Strip the readium_package origin the WebView reports for served EPUB resources.

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/PdfReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/PdfReaderScreen.kt
@@ -69,6 +69,14 @@ import org.readium.r2.navigator.input.InputListener
 import org.readium.r2.navigator.input.TapEvent
 import org.readium.r2.shared.publication.Locator
 
+// TODO(figure-zoom): PDF figure-zoom follow-up. The EPUB reader supports single-tap-on-figure
+// opening a fullscreen zoom overlay (see FigureZoomOverlay + FigureTapScript). For PDF, the
+// equivalent path is: on tap, use Pdfium's FPDF_GetPageObject (via PdfiumEngineProvider's page
+// object API) to hit-test image objects at the tap location, extract the pixel region as a Bitmap,
+// and feed it into the same FigureZoomOverlay composable. The overlay already accepts a
+// FigureZoomState with an in-memory bitmap path (via svgMarkup=null + href pointing to a temp file
+// or a new data URI). Deferred from v1; do not implement without a decode-cost benchmark on a
+// large-page PDF.
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun PdfReaderScreen(

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/renderer/DefaultRendererBridge.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/renderer/DefaultRendererBridge.kt
@@ -1,6 +1,8 @@
 package com.riffle.app.feature.reader.renderer
 
 import com.riffle.app.feature.reader.ColumnSnap
+import com.riffle.app.feature.reader.FigureTapBridge
+import com.riffle.app.feature.reader.FigureTapScript
 import com.riffle.app.feature.reader.FootnoteAnchorBridge
 import com.riffle.app.feature.reader.RECT_TO_JSON_POLYFILL_JS
 import com.riffle.app.feature.reader.SELECTION_SPAN_TRACKER_JS
@@ -220,6 +222,11 @@ internal class DefaultRendererBridge(
                 id = CapabilityId.DecorationTemplateReregister,
                 dependsOn = setOf(CapabilityId.RectToJsonPolyfill),
                 installScript = { readiumDecorationTemplatesRegisterJs() },
+            ),
+            RendererCapability(
+                id = CapabilityId.FigureTapBridge,
+                dependsOn = setOf(CapabilityId.RectToJsonPolyfill),
+                installScript = { FigureTapScript.installScript(FigureTapBridge.JS_NAME) },
             ),
         )
 

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/renderer/RendererCapability.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/renderer/RendererCapability.kt
@@ -34,6 +34,13 @@ internal enum class CapabilityId {
      * polyfill capability so the retry actually runs against a working engine.
      */
     DecorationTemplateReregister,
+
+    /**
+     * Figure-tap hit-test that opens the tapped image / SVG in the fullscreen zoom overlay.
+     * Depends on the rect polyfill because the hit-test reads `getBoundingClientRect()` to build
+     * the payload's natural-size fields when the element has no intrinsic width/height.
+     */
+    FigureTapBridge,
 }
 
 /** Where in the renderer's lifetime a capability is meant to be (re)installed. */

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ChapterWebViewBinderTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ChapterWebViewBinderTest.kt
@@ -34,6 +34,7 @@ class ChapterWebViewBinderTest {
         override var onAnnotationNoteTap: ((String, Rect) -> Unit)? = null
         override var onFootnoteContent: ((FootnoteContent) -> Unit)? = null
         override var onCrossReferenceTap: ((String) -> Unit)? = null
+        override var onFigureTap: ((String) -> Unit)? = null
 
         fun emitTap() = onTap?.invoke()
         fun emitAnnotationTap(id: String, rect: Rect) = onAnnotationTap?.invoke(id, rect)

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousDecorationControllerTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousDecorationControllerTest.kt
@@ -36,6 +36,7 @@ class ContinuousDecorationControllerTest {
         override var onAnnotationNoteTap: ((String, android.graphics.Rect) -> Unit)? = null
         override var onFootnoteContent: ((FootnoteContent) -> Unit)? = null
         override var onCrossReferenceTap: ((String) -> Unit)? = null
+        override var onFigureTap: ((String) -> Unit)? = null
     }
 
     private class FakePort : ContinuousDecorationController.Port {

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/FigureZoomTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/FigureZoomTest.kt
@@ -1,0 +1,171 @@
+package com.riffle.app.feature.reader
+
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Regression coverage for the figure-zoom feature. Two pure helpers back the whole feature:
+ *  - [FigureTapMessageParser.parse] — accepts the JSON payload from figure-tap.js and turns it
+ *    into a typed [FigureZoomState]. A schema drift on the JS side must fail loudly here rather
+ *    than silently no-op the tap.
+ *  - [clampPanZoom] — the pinch/pan clamp inside [FigureZoomOverlay]. If the clamp lets the image
+ *    leave the viewport, a user can pinch-and-lose their tap target with nothing left to tap on to
+ *    dismiss.
+ *  - [fitImageIntoViewport] — the initial-fit computation. Fitting to the WRONG axis on a wide
+ *    landscape image would leave the image extending beyond the viewport at scale=1, which the
+ *    clamp would then treat as legitimately zoomed.
+ *
+ * Each assertion is written so a revert of the corresponding production code would flip it red.
+ */
+class FigureZoomTest {
+
+    // ── Parser ────────────────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `parse img payload returns href and natural dimensions`() {
+        val json = JSONObject()
+            .put("kind", "img")
+            .put("href", "images/fig1.jpg")
+            .put("w", 800)
+            .put("h", 600)
+            .toString()
+        val parsed = FigureTapMessageParser.parse(json)
+        assertNotNull(parsed)
+        assertEquals("images/fig1.jpg", parsed!!.href)
+        assertEquals(800, parsed.naturalWidth)
+        assertEquals(600, parsed.naturalHeight)
+        assertNull(parsed.svgMarkup)
+    }
+
+    @Test
+    fun `parse svg payload returns markup and skips href`() {
+        val svg = "<svg width='100' height='100'><rect width='100' height='100'/></svg>"
+        val json = JSONObject().put("kind", "svg").put("svg", svg).put("w", 100).put("h", 100).toString()
+        val parsed = FigureTapMessageParser.parse(json)
+        assertNotNull(parsed)
+        assertEquals(svg, parsed!!.svgMarkup)
+        assertEquals("", parsed.href)
+    }
+
+    @Test
+    fun `parse rejects zero-sized figures`() {
+        val json = JSONObject().put("kind", "img").put("href", "a.png").put("w", 0).put("h", 100).toString()
+        assertNull(FigureTapMessageParser.parse(json))
+    }
+
+    @Test
+    fun `parse rejects blank input`() {
+        assertNull(FigureTapMessageParser.parse(null))
+        assertNull(FigureTapMessageParser.parse(""))
+        assertNull(FigureTapMessageParser.parse("not-json"))
+    }
+
+    @Test
+    fun `parse rejects img without href`() {
+        val json = JSONObject().put("kind", "img").put("w", 100).put("h", 100).toString()
+        assertNull(FigureTapMessageParser.parse(json))
+    }
+
+    @Test
+    fun `parse rejects svg without markup`() {
+        val json = JSONObject().put("kind", "svg").put("w", 100).put("h", 100).toString()
+        assertNull(FigureTapMessageParser.parse(json))
+    }
+
+    // ── Fit-into-viewport ─────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `fit prefers width for landscape image on portrait viewport`() {
+        // Landscape image (2:1), portrait viewport (1:2) — width binds; height at half the width.
+        val fit = fitImageIntoViewport(2000, 1000, viewportWidth = 800f, viewportHeight = 1600f)
+        assertEquals(800, fit.width)
+        assertEquals(400, fit.height)
+    }
+
+    @Test
+    fun `fit prefers height for portrait image on landscape viewport`() {
+        val fit = fitImageIntoViewport(500, 1000, viewportWidth = 1600f, viewportHeight = 800f)
+        assertEquals(400, fit.width)
+        assertEquals(800, fit.height)
+    }
+
+    @Test
+    fun `fit returns empty on degenerate inputs`() {
+        assertEquals(0, fitImageIntoViewport(0, 100, 100f, 100f).width)
+        assertEquals(0, fitImageIntoViewport(100, 100, 0f, 100f).width)
+    }
+
+    // ── PanZoom clamp ─────────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `clamp scale to bounds`() {
+        val below = clampPanZoom(
+            scale = 0.1f,
+            translationX = 0f, translationY = 0f,
+            fittedWidth = 100f, fittedHeight = 100f,
+            viewportWidth = 200f, viewportHeight = 200f,
+        )
+        assertEquals(1f, below.scale, 0.0001f)
+
+        val above = clampPanZoom(
+            scale = 99f,
+            translationX = 0f, translationY = 0f,
+            fittedWidth = 100f, fittedHeight = 100f,
+            viewportWidth = 200f, viewportHeight = 200f,
+        )
+        assertEquals(5f, above.scale, 0.0001f)
+    }
+
+    @Test
+    fun `clamp forbids pan when image smaller than viewport`() {
+        // At scale = 1, the fitted image is smaller than viewport in both axes — pan must be 0.
+        val clamped = clampPanZoom(
+            scale = 1f,
+            translationX = 500f, translationY = -300f,
+            fittedWidth = 100f, fittedHeight = 100f,
+            viewportWidth = 400f, viewportHeight = 400f,
+        )
+        assertEquals(0f, clamped.translationX, 0.0001f)
+        assertEquals(0f, clamped.translationY, 0.0001f)
+    }
+
+    @Test
+    fun `clamp allows pan up to half the excess when zoomed`() {
+        // fitted 200x200, viewport 200x200, zoomed 2x → scaled 400x400, excess 200 in each axis.
+        // Max pan = 100 in each direction (half the excess).
+        val extreme = clampPanZoom(
+            scale = 2f,
+            translationX = 500f, translationY = 500f,
+            fittedWidth = 200f, fittedHeight = 200f,
+            viewportWidth = 200f, viewportHeight = 200f,
+        )
+        assertEquals(100f, extreme.translationX, 0.0001f)
+        assertEquals(100f, extreme.translationY, 0.0001f)
+
+        val negative = clampPanZoom(
+            scale = 2f,
+            translationX = -500f, translationY = -500f,
+            fittedWidth = 200f, fittedHeight = 200f,
+            viewportWidth = 200f, viewportHeight = 200f,
+        )
+        assertEquals(-100f, negative.translationX, 0.0001f)
+        assertEquals(-100f, negative.translationY, 0.0001f)
+    }
+
+    @Test
+    fun `clamp allows moderate pans within bounds unchanged`() {
+        val clamped = clampPanZoom(
+            scale = 3f,
+            translationX = 50f, translationY = -25f,
+            fittedWidth = 100f, fittedHeight = 100f,
+            viewportWidth = 100f, viewportHeight = 100f,
+        )
+        assertTrue(clamped.translationX in -100f..100f)
+        assertEquals(50f, clamped.translationX, 0.0001f)
+        assertEquals(-25f, clamped.translationY, 0.0001f)
+    }
+}


### PR DESCRIPTION
## Summary

Single-tap on an image, inline SVG, single-image `<figure>`, or `<picture>` in the reader opens a fullscreen overlay with the background text dimmed. Pinch zooms up to 5×, drag pans within clamped bounds, double-tap resets, tap outside or system Back dismisses.

Works uniformly across all three EPUB reader modes (paginated / vertical / continuous). Anchor-wrapped images (footnote glyphs, cross-references) are excluded from the hit-test so link behaviour is preserved. Image bytes are loaded via `Publication.get(href)` so images work offline.

PDF support is deferred; a TODO in `PdfReaderScreen.kt` documents the Pdfium `FPDF_GetPageObject` follow-up path.

## Implementation

- **Continuous mode** — figure taps route through the existing per-chapter `RiffleChapter` bridge (new `onFigureTap` callback on `HeightBridge` and `FigureTapScript` injected in `ChapterWebView.injectStylesAndMeasure`).
- **Paged / vertical** — a new `FigureTapBridge` singleton is registered as a `@JavascriptInterface`, and the script is installed as a new `FigureTapBridge` capability on the `RendererBridge` so it runs on every page load.
- Compose overlay (`FigureZoomOverlay`) sits at the top of `EpubReaderScreen`'s outer `Box` so it covers every reader mode + chrome uniformly. Uses `Modifier.transformable` for pinch/pan and a bounded clamp helper for the transform.

## Test plan

- [x] `./gradlew :app:testDebugUnitTest` — includes new `FigureZoomTest` (13 assertions covering parser, fit-into-viewport, clamp)
- [x] `./gradlew :app:compileDebugAndroidTestKotlin` — new `FigureTapScriptTest` runs the actual JS against a WebView fixture (bare `<img>`, `<figure>`-wrapped, `<picture>`, inline `<svg>`, anchor-wrapped)
- [ ] `make harness-test` (CI)
- [ ] Manual verification on device across paginated, vertical, and continuous modes

## Known runtime risks (flagged for manual verification)

- Publication href resolution differs between continuous (`https://readium_package/...`) and paged (Readium's local HTTP server). If images fail to decode in paged mode, the URL-normalising step in `FigureZoomOverlay.loadImageBytes` needs a fix based on the actual `href` the WebView reports.
- `DirectionalNavigationAdapter` (edge-tap page turn) sits above `tapListener` in Readium's input chain; my JS `stopPropagation()` blocks the `click` handler but Readium's edge-tap turn may fire off a different event. If a figure at the page edge both zooms and turns, that's the reason.