### PR TITLE
fix(reader): keep pre-R nav bars fully hidden in immersive mode

### DIFF
--- a/app/src/androidTest/kotlin/com/riffle/app/feature/reader/ImmersiveOnReadaloudPlayTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/reader/ImmersiveOnReadaloudPlayTest.kt
@@ -26,7 +26,7 @@ class ImmersiveOnReadaloudPlayTest {
         var showCount = 0
         override fun hide() { hideCount++ }
         override fun show() { showCount++ }
-        override fun setBehaviorDefault() {}
+        override fun applyImmersiveBehavior() {}
     }
 
     private fun setContent(

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ImmersiveModeState.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ImmersiveModeState.kt
@@ -1,5 +1,6 @@
 package com.riffle.app.feature.reader
 
+import android.os.Build
 import android.os.SystemClock
 import androidx.activity.compose.LocalActivity
 import androidx.annotation.VisibleForTesting
@@ -32,18 +33,40 @@ import androidx.lifecycle.compose.LocalLifecycleOwner
 internal interface SystemBarsController {
     fun hide()
     fun show()
-    fun setBehaviorDefault()
+    fun applyImmersiveBehavior()
 }
 
 private class WindowInsetsBarsController(
     private val delegate: WindowInsetsControllerCompat,
+    private val sdkInt: Int = Build.VERSION.SDK_INT,
 ) : SystemBarsController {
     override fun hide() = delegate.hide(WindowInsetsCompat.Type.systemBars())
     override fun show() = delegate.show(WindowInsetsCompat.Type.systemBars())
-    override fun setBehaviorDefault() {
-        delegate.systemBarsBehavior = WindowInsetsControllerCompat.BEHAVIOR_DEFAULT
+    override fun applyImmersiveBehavior() {
+        delegate.systemBarsBehavior = immersiveSystemBarsBehavior(sdkInt)
     }
 }
+
+/**
+ * On pre-R (API < 30) the AndroidX compat layer maps [BEHAVIOR_DEFAULT] to the
+ * non-sticky `SYSTEM_UI_FLAG_IMMERSIVE` flag: any tap/system event clears
+ * `FLAG_HIDE_NAVIGATION|FULLSCREEN` but leaves `LAYOUT_HIDE_NAVIGATION|LAYOUT_FULLSCREEN` set,
+ * so the status/nav bars re-appear as transparent overlays on top of the content and stay
+ * there. Because the layout flags remain, `WindowInsets.systemBars.getTop()` stays 0, so
+ * the topInset watcher in [rememberImmersiveModeState] cannot notice and re-hide.
+ *
+ * Using [BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE] on pre-R sets `IMMERSIVE_STICKY` instead, so
+ * the system auto-hides the bars again after the transient reveal. On API 30+ we keep
+ * [BEHAVIOR_DEFAULT] because the reader intentionally treats a side-edge page-turn swipe
+ * as a permanent reveal (see the comment on [ImmersiveModeState.onBarsRestoredExternally]).
+ */
+@VisibleForTesting
+internal fun immersiveSystemBarsBehavior(sdkInt: Int): Int =
+    if (sdkInt < Build.VERSION_CODES.R) {
+        WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
+    } else {
+        WindowInsetsControllerCompat.BEHAVIOR_DEFAULT
+    }
 
 @Stable
 class ImmersiveModeState internal constructor(
@@ -104,7 +127,7 @@ class ImmersiveModeState internal constructor(
         if (force) systemBarsHidden = false
         if (!systemBarsHidden) {
             systemBarsHidden = true
-            controller.setBehaviorDefault()
+            controller.applyImmersiveBehavior()
             controller.hide()
         }
         isImmersive = true

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ImmersiveModeStateTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ImmersiveModeStateTest.kt
@@ -11,7 +11,7 @@ class ImmersiveModeStateTest {
     private class FakeController : SystemBarsController {
         var hideCount = 0
         var showCount = 0
-        var setBehaviorDefaultCount = 0
+        var applyImmersiveBehaviorCount = 0
 
         override fun hide() {
             hideCount++
@@ -21,8 +21,8 @@ class ImmersiveModeStateTest {
             showCount++
         }
 
-        override fun setBehaviorDefault() {
-            setBehaviorDefaultCount++
+        override fun applyImmersiveBehavior() {
+            applyImmersiveBehaviorCount++
         }
     }
 
@@ -52,7 +52,7 @@ class ImmersiveModeStateTest {
         assertTrue(state.isImmersive)
         assertTrue(state.systemBarsHiddenForTest)
         assertEquals(1, controller.hideCount)
-        assertEquals(1, controller.setBehaviorDefaultCount)
+        assertEquals(1, controller.applyImmersiveBehaviorCount)
     }
 
     @Test

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ImmersiveSystemBarsBehaviorTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ImmersiveSystemBarsBehaviorTest.kt
@@ -1,0 +1,40 @@
+package com.riffle.app.feature.reader
+
+import android.os.Build
+import androidx.core.view.WindowInsetsControllerCompat
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Regression test for the Android 7.1.1 (API 25) transparent-bar bug: pre-R devices
+ * must use sticky-immersive so the OS re-hides bars after a transient reveal.
+ * Reverting this to [BEHAVIOR_DEFAULT] on pre-R leaves the nav/status bars showing with
+ * transparent backgrounds after any tap, because `SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN`
+ * remains set and the topInset watcher can't detect the reveal.
+ */
+class ImmersiveSystemBarsBehaviorTest {
+
+    @Test
+    fun `pre-R uses sticky transient bars so system auto-re-hides after reveal`() {
+        assertEquals(
+            WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE,
+            immersiveSystemBarsBehavior(Build.VERSION_CODES.N_MR1),
+        )
+        assertEquals(
+            WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE,
+            immersiveSystemBarsBehavior(Build.VERSION_CODES.Q),
+        )
+    }
+
+    @Test
+    fun `R and later use BEHAVIOR_DEFAULT so side-edge swipes do not flash chrome`() {
+        assertEquals(
+            WindowInsetsControllerCompat.BEHAVIOR_DEFAULT,
+            immersiveSystemBarsBehavior(Build.VERSION_CODES.R),
+        )
+        assertEquals(
+            WindowInsetsControllerCompat.BEHAVIOR_DEFAULT,
+            immersiveSystemBarsBehavior(Build.VERSION_CODES.UPSIDE_DOWN_CAKE),
+        )
+    }
+}


### PR DESCRIPTION
## Summary

On Android 7.1.1 users reported the nav bar and clock sometimes remaining visible in immersive mode with transparent backgrounds.

Root cause: on API < 30 the AndroidX compat layer maps `BEHAVIOR_DEFAULT` to non-sticky `SYSTEM_UI_FLAG_IMMERSIVE`. Any tap or system event clears `FLAG_HIDE_NAVIGATION|FULLSCREEN` (bars re-appear) but leaves `LAYOUT_HIDE_NAVIGATION|LAYOUT_FULLSCREEN` set — so the bars overlay transparently and stay there. The `topInset` watcher in `rememberImmersiveModeState` can't detect this because `LAYOUT_FULLSCREEN` keeps `WindowInsets.systemBars.getTop()` at 0.

Switch pre-R devices to `BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE` (sticky immersive) so the OS auto-hides again after any transient reveal. Keep `BEHAVIOR_DEFAULT` on R+ so the deliberate side-edge-swipe-stays-hidden behavior documented in `onBarsRestoredExternally` is preserved.

## Test plan

- [x] `ImmersiveSystemBarsBehaviorTest` pins both branches of the version gate; reverting the fix flips a red.
- [x] `ImmersiveModeStateTest` remains green after the internal `setBehaviorDefault` → `applyImmersiveBehavior` rename.
- [ ] Visual verification on the Android 7.1.1 device: enter immersive → tap around / trigger a locator update → confirm bars stay fully hidden with no transparent-overlay lingering.