### PR TITLE
fix(reader): disable tap-edge page turns in paginated/vertical mode

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -2291,16 +2291,12 @@ private fun EpubNavigatorView(
                     // Attach to the ReaderPresenter seam (#300 step 2). Today only decoration
                     // application flows through it; remaining concerns cut over in later steps.
                     readiumPresenter?.attach(fragment)
-                    // Readium's built-in ANIMATED page transition (Kotlin toolkit 3.2.0+): edge taps
-                    // turn the page with a smooth slide instead of an instant jump. Added before
-                    // tapListener so the adapter consumes horizontal edge taps and tapListener only
-                    // sees the center taps it doesn't handle.
-                    fragment.addInputListener(
-                        DirectionalNavigationAdapter(
-                            navigator = fragment,
-                            animatedTransition = true,
-                        ),
-                    )
+                    // Readium's built-in ANIMATED page transition (Kotlin toolkit 3.2.0+) for the
+                    // hardware-key path (arrow / page / space keys) — keyboard nav still slides
+                    // smoothly. Tap-edge page turning is disabled (empty tapEdges) so screen taps
+                    // toggle immersive mode (via tapListener) instead of turning the page; swipes
+                    // still work via the underlying pager.
+                    fragment.addInputListener(createPagedDirectionalNavigationAdapter(fragment))
                     fragment.addInputListener(tapListener)
                     coroutineScope.launch {
                         fragment.currentLocator.collect { locator ->
@@ -2700,6 +2696,19 @@ internal fun clampReaderSelectionRectBottomYs(
 // Compose closure that can't be exercised without a live Readium fragment.
 internal fun consumeSelectionSuppressedTap(activeAtDown: AtomicBoolean): Boolean =
     activeAtDown.getAndSet(false)
+
+// Builds the DirectionalNavigationAdapter Riffle attaches to paged/vertical mode. Extracted so a
+// JVM test can pin the tap-navigation config: tapEdges MUST stay empty so screen taps toggle
+// immersive mode instead of turning the page (Readium's default enables horizontal edge taps).
+// Keyboard nav and the animated ViewPager transition remain intact.
+internal fun createPagedDirectionalNavigationAdapter(
+    navigator: org.readium.r2.navigator.OverflowableNavigator,
+): DirectionalNavigationAdapter =
+    DirectionalNavigationAdapter(
+        navigator = navigator,
+        tapEdges = emptySet(),
+        animatedTransition = true,
+    )
 
 // Named class (not anonymous) so Android's addJavascriptInterface reflection can discover the
 // @JavascriptInterface-annotated methods reliably across all API levels and R8 configurations.

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/PagedDirectionalNavigationAdapterTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/PagedDirectionalNavigationAdapterTest.kt
@@ -1,0 +1,38 @@
+@file:OptIn(org.readium.r2.shared.ExperimentalReadiumApi::class)
+
+package com.riffle.app.feature.reader
+
+import io.mockk.mockk
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.readium.r2.navigator.OverflowableNavigator
+import org.readium.r2.navigator.util.DirectionalNavigationAdapter
+
+/**
+ * Regression pin for the "screen tap on the left/right edge turns the page" behaviour that
+ * shipped by default with Readium's DirectionalNavigationAdapter. Riffle disables tap-edge
+ * navigation so a tap only toggles immersive mode (via the paged InputListener) — swipes and
+ * hardware keys still turn the page.
+ *
+ * This test flips red if someone reverts [createPagedDirectionalNavigationAdapter] to the
+ * Readium default (which is `setOf(TapEdge.Horizontal)`).
+ */
+class PagedDirectionalNavigationAdapterTest {
+
+    @Test
+    fun `paged navigation adapter is configured with no tap edges`() {
+        val navigator = mockk<OverflowableNavigator>(relaxed = true)
+
+        val adapter = createPagedDirectionalNavigationAdapter(navigator)
+
+        val field = DirectionalNavigationAdapter::class.java.getDeclaredField("tapEdges")
+        field.isAccessible = true
+        @Suppress("UNCHECKED_CAST")
+        val tapEdges = field.get(adapter) as Set<DirectionalNavigationAdapter.TapEdge>
+
+        assertTrue(
+            "tapEdges must be empty — screen taps should not turn the page (they toggle immersive)",
+            tapEdges.isEmpty(),
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Tapping the left/right edge of the screen in paginated mode (and the top/bottom edge in vertical/scroll mode) was silently turning the page — Readium's `DirectionalNavigationAdapter` ships with `tapEdges = setOf(TapEdge.Horizontal)` on by default. Screen taps should only toggle immersive mode; page turns come from swipes and volume/keyboard keys.

Configure the adapter with `tapEdges = emptySet()` so the tap falls through to the existing `InputListener` that toggles immersive. Keyboard nav (arrow / page / space) and the animated ViewPager transition are preserved. Continuous mode uses a separate code path (`ChapterWebView`) and is unaffected.

Extracted the adapter builder into an `internal` factory `createPagedDirectionalNavigationAdapter` so a JVM regression test can reflectively pin `tapEdges` as empty — the test flips red on revert to Readium's default.

## Test plan

- [x] `./gradlew :app:testDebugUnitTest --tests 'com.riffle.app.feature.reader.PagedDirectionalNavigationAdapterTest'` — green
- [ ] On-device: paginated mode — left/right edge tap toggles immersive (no page turn); swipe still turns the page; volume keys still turn the page
- [ ] On-device: vertical/scroll mode — top/bottom edge tap toggles immersive (no page jump); scroll still works
- [ ] On-device: continuous mode — unaffected (sanity check)