### PR TITLE
fix(reader): highlights and theme switch survive Dark/DarkDim on continuous mode

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjector.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjector.kt
@@ -204,6 +204,25 @@ internal object ContinuousStyleInjector {
      * `readium-*-on` flags straight from this attribute via its `[style*=…]` selectors, so setting
      * the whole attribute string is enough to re-style without reloading the chapter.
      */
+    // Force Chromium to invalidate the composited raster tiles for this WebView after every live
+    // preference change. WebSettingsCompat.setOffscreenPreRaster(true) (#413) keeps rasterised
+    // tiles alive for off-screen chapters so the chapter-boundary blank-flash doesn't return; the
+    // side-effect is that a bare `:root` style-attribute mutation — how every live theme /
+    // typography change is applied — doesn't reliably invalidate those cached tiles. The CSSOM
+    // updates, ReadiumCSS re-cascades, `getComputedStyle` returns the new colours, but the
+    // composited image on screen still shows the pre-change theme: users see the OLD background
+    // survive a Sepia → Dim switch, with the text vanishing entirely because the stale sepia
+    // raster is now displaying dark-mode text against sepia bg with contrast the tile was never
+    // rasterised for.
+    //
+    // Toggling `visibility: hidden` on `:root`, then restoring on the next animation frame, is a
+    // paint-invalidating change that overrides the pre-raster tile cache. Restoration is
+    // unconditional (always `''`, never a captured "previous value") so overlapping fast switches
+    // can't leave the document stuck hidden — the earlier iteration captured the current visibility
+    // as the previous, which under rapid switches was a mid-flight `hidden` from an in-progress
+    // toggle, and RAF then restored to hidden and stuck-hid the WebView. A `setTimeout` belt-and-
+    // suspenders guards against `requestAnimationFrame` being throttled or paused (Chromium pauses
+    // RAF for backgrounded WebViews; off-screen stacked WebViews can hit that state).
     fun buildStyleInjectionJs(prefs: FormattingPreferences): String {
         val styleAttr = buildHtmlStyleAttr(prefs)
             .replace("\\", "\\\\")
@@ -211,6 +230,11 @@ internal object ContinuousStyleInjector {
         return """
             (function() {
                 document.documentElement.setAttribute('style', '$styleAttr');
+                var de = document.documentElement;
+                de.style.visibility = 'hidden';
+                var restore = function() { de.style.visibility = ''; };
+                requestAnimationFrame(restore);
+                setTimeout(restore, 100);
             })();
         """.trimIndent()
     }
@@ -348,7 +372,7 @@ internal object ContinuousStyleInjector {
                         }
                         var mark = document.createElement('mark');
                         mark.setAttribute('data-riffle-si', '');
-                        mark.style.cssText = 'background:' + inactiveCss + ';color:inherit;';
+                        mark.style.cssText = 'background:' + inactiveCss + '$HIGHLIGHT_INLINE_STYLE_SUFFIX';
                         if (!window.__riffleSafeWrap(range, mark)) {
                             // Cross-block match — skip past the END of this hit (a collapsed
                             // selection at range.end* makes window.find resume strictly after the
@@ -381,7 +405,7 @@ internal object ContinuousStyleInjector {
                     if (best) {
                         best.setAttribute('data-riffle-sa', '');
                         best.removeAttribute('data-riffle-si');
-                        best.style.background = activeCss;
+                        best.style.cssText = 'background:' + activeCss + '$HIGHLIGHT_INLINE_STYLE_SUFFIX';
                     }
                 }
                 if (sel) sel.removeAllRanges();
@@ -560,7 +584,7 @@ internal object ContinuousStyleInjector {
                     // per block. Update colour in-place across all of them and skip relocation.
                     var existingAll = document.querySelectorAll('[data-riffle-ann="' + ann.id + '"]');
                     if (existingAll.length > 0) {
-                        existingAll.forEach(function(m) { m.style.background = ann.c; });
+                        existingAll.forEach(function(m) { m.style.cssText = 'background:' + ann.c + '$HIGHLIGHT_INLINE_STYLE_SUFFIX'; });
                         var eg = document.querySelector('[data-riffle-note-glyph="' + ann.id + '"]');
                         if (ann.n && !eg) {
                             makeGlyph(ann.id, existingAll[0]);
@@ -580,7 +604,7 @@ internal object ContinuousStyleInjector {
                     ranges.forEach(function(range) {
                         var mark = document.createElement('mark');
                         mark.setAttribute('data-riffle-ann', ann.id);
-                        mark.style.cssText = 'background:' + ann.c + ';color:inherit;';
+                        mark.style.cssText = 'background:' + ann.c + '$HIGHLIGHT_INLINE_STYLE_SUFFIX';
                         if (!window.__riffleSafeWrap(range, mark)) return;
                         // The mark just split a text node — invalidate the flat index so the NEXT
                         // annotation's locateRanges() rebuilds against the updated DOM. The other
@@ -651,7 +675,7 @@ internal object ContinuousStyleInjector {
                 var range = sel.getRangeAt(0);
                 var mark = document.createElement('mark');
                 mark.id = '_riffle_hl';
-                mark.style.cssText = 'background:$cssColor;color:inherit;';
+                mark.style.cssText = '${highlightInlineStyle("$cssColor")}';
                 // Skip cross-block matches — extractContents would reparent block elements as
                 // inline children of <mark>, breaking the surrounding paragraphs.
                 if (!window.__riffleSafeWrap(range, mark)) { sel.removeAllRanges(); return; }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/HighlightDecoration.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/HighlightDecoration.kt
@@ -105,6 +105,20 @@ fun highlightAccentBarTemplate(): HtmlDecorationTemplate =
         """.trimIndent(),
     )
 
+// Every Riffle highlight paint — paginated decoration template AND every continuous-mode
+// <mark> the JS emitters inject (annotations, search, readaloud sentence) — must use this
+// exact suffix on its inline `background:` declaration. ReadiumCSS night mode injects
+// `background-color: transparent !important` on every `:not(a)` descendant of :root; without
+// the inline `!important` the highlight is nuked on Dark / DarkDim. Author-sheet `!important`
+// competes with inline `!important` on specificity; inline (1,0,0,0) beats the night selector
+// (0,2,1), so inline wins. `color:inherit` is a defensive echo of the same rule's `color`
+// clobber so highlighted text keeps the theme foreground.
+internal const val HIGHLIGHT_INLINE_STYLE_SUFFIX = " !important;color:inherit;"
+
+/** Inline `style` block for a Riffle highlight background. See [HIGHLIGHT_INLINE_STYLE_SUFFIX]. */
+internal fun highlightInlineStyle(cssColor: String): String =
+    "background:$cssColor$HIGHLIGHT_INLINE_STYLE_SUFFIX"
+
 /**
  * Template for [HighlightTintStyle]. Geometry mirrors Readium's built-in highlight (BOXES layout,
  * 1px horizontal padding, 3px corner radius) so positioning is unchanged; the only difference is the
@@ -115,7 +129,7 @@ fun highlightTintTemplate(): HtmlDecorationTemplate =
         layout = HtmlDecorationTemplate.Layout.BOXES,
         element = { decoration ->
             val tint = (decoration.style as? Decoration.Style.Tinted)?.tint ?: Color.YELLOW
-            """<div class="$HIGHLIGHT_TINT_CLASS" style="background-color: ${tint.toCss()} !important;"/>"""
+            """<div class="$HIGHLIGHT_TINT_CLASS" style="${highlightInlineStyle(tint.toCss())}"/>"""
         },
         stylesheet = """
             .$HIGHLIGHT_TINT_CLASS {

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjectorTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjectorTest.kt
@@ -202,6 +202,136 @@ class ContinuousStyleInjectorTest {
         assertFalse("--USER__textAlign absent when justifyText=false", js.contains("--USER__textAlign"))
     }
 
+    // ── theme-switch tile-cache invalidation ───────────────────────────────────
+    //
+    // WebSettingsCompat.setOffscreenPreRaster(true) (see #413) is required to stop the
+    // chapter-boundary blank flash in Continuous mode, but its side-effect is that a bare
+    // :root style-attribute mutation doesn't invalidate the rasterised tiles. The CSSOM
+    // updates and getComputedStyle returns the new values, but the composited image on
+    // screen still shows the pre-change theme — visible bug: Sepia → Dim leaves sepia
+    // background AND the text vanishes entirely.
+    //
+    // Fix: after the setAttribute, toggle `visibility` on :root to force Chromium to
+    // repaint the entire subtree. Restore is idempotent (unconditional `''`) and covered
+    // by BOTH requestAnimationFrame AND setTimeout so overlapping rapid switches don't
+    // capture a mid-flight `'hidden'` as the "previous" value (which the earlier version
+    // did and left the WebView stuck hidden), and a backgrounded WebView with RAF paused
+    // still gets restored via the setTimeout fallback.
+
+    @Test
+    fun `buildStyleInjectionJs sets root visibility hidden to force Chromium tile invalidation`() {
+        val js = ContinuousStyleInjector.buildStyleInjectionJs(FormattingPreferences())
+        assertTrue(
+            "must set documentElement visibility to 'hidden' after the attribute change — " +
+                "this is the ONLY reliable way to invalidate the raster tiles pre-raster keeps alive",
+            js.contains("de.style.visibility = 'hidden'"),
+        )
+    }
+
+    @Test
+    fun `buildStyleInjectionJs restores visibility unconditionally not via captured previous value`() {
+        // The earlier iteration read `var prevVis = de.style.visibility` and restored via
+        // `prevVis || ''`. That looked correct but broke under rapid theme switches: the
+        // second call captured `'hidden'` (mid-flight from the first still-pending toggle)
+        // and RAF restored to `'hidden'`, stuck-hiding the WebView. This assertion pins
+        // the always-empty-string restore so the regression can't return.
+        val js = ContinuousStyleInjector.buildStyleInjectionJs(FormattingPreferences())
+        assertTrue("restore sets visibility to '' unconditionally", js.contains("de.style.visibility = '';"))
+        assertFalse(
+            "must NOT restore via captured previous value — race with overlapping switches",
+            js.contains("prevVis"),
+        )
+    }
+
+    @Test
+    fun `buildStyleInjectionJs schedules restore via both requestAnimationFrame and setTimeout`() {
+        // requestAnimationFrame is paused for backgrounded WebViews; the setTimeout is the
+        // belt-and-suspenders fallback so a WV that never comes back on-screen isn't left
+        // stuck at `visibility: hidden`.
+        val js = ContinuousStyleInjector.buildStyleInjectionJs(FormattingPreferences())
+        assertTrue("schedules restore via requestAnimationFrame", js.contains("requestAnimationFrame(restore)"))
+        assertTrue("schedules restore via setTimeout fallback", js.contains("setTimeout(restore,"))
+    }
+
+    // ── night-mode !important survival ──────────────────────────────────────────
+    //
+    // ReadiumCSS night mode injects `background-color: transparent !important` on every
+    // `:not(a)` descendant of :root. The continuous-mode `<mark>`s are exactly that. Without
+    // inline `!important` on each mark's background the highlight paints transparent on Dark
+    // / DarkDim — the whole "highlights don't render on dark themes" bug. These assertions
+    // pin the `!important` marker on every mark-emitting JS path so a plain revert flips red.
+
+    @Test
+    fun `applyAnnotationHighlightsJs new-mark background carries !important`() {
+        val js = ContinuousStyleInjector.applyAnnotationHighlightsJs(
+            listOf(AnnotationHighlight("id", "text", "rgba(251,191,36,0.50)")),
+        )
+        // The new-mark assignment is `mark.style.cssText = 'background:' + ann.c + '<suffix>';`.
+        // The suffix, embedded verbatim into the JS string, is what carries `!important`.
+        assertTrue(
+            "new-mark cssText must contain '!important' — actual JS lacks it",
+            js.contains("'background:' + ann.c + ' !important;color:inherit;'"),
+        )
+    }
+
+    @Test
+    fun `applyAnnotationHighlightsJs existing-mark recolor carries !important`() {
+        // Updating the colour of an already-wrapped annotation must use the same `!important`
+        // suffix as the initial wrap. The `.style.background = ann.c` shortcut without
+        // `!important` was the original bug on this path.
+        val js = ContinuousStyleInjector.applyAnnotationHighlightsJs(
+            listOf(AnnotationHighlight("id", "text", "rgba(0,0,0,0.50)")),
+        )
+        assertTrue(
+            "existing-mark recolor must contain '!important' — actual JS lacks it",
+            js.contains("m.style.cssText = 'background:' + ann.c + ' !important;color:inherit;'"),
+        )
+    }
+
+    @Test
+    fun `applySearchHighlightsJs inactive-mark background carries !important`() {
+        val js = ContinuousStyleInjector.applySearchHighlightsJs(
+            inactiveTexts = listOf("query"),
+            inactiveCssColor = "rgba(245,166,35,0.30)",
+            activeText = null,
+            activeProgression = 0f,
+            activeCssColor = "rgba(245,166,35,0.30)",
+        )
+        assertTrue(
+            "inactive search mark cssText must contain '!important' — actual JS lacks it",
+            js.contains("'background:' + inactiveCss + ' !important;color:inherit;'"),
+        )
+    }
+
+    @Test
+    fun `applySearchHighlightsJs active-mark background carries !important`() {
+        val js = ContinuousStyleInjector.applySearchHighlightsJs(
+            inactiveTexts = listOf("query"),
+            inactiveCssColor = "rgba(245,166,35,0.30)",
+            activeText = "query",
+            activeProgression = 0.5f,
+            activeCssColor = "rgba(245,166,35,0.50)",
+        )
+        assertTrue(
+            "active search mark cssText must contain '!important' — actual JS lacks it",
+            js.contains("'background:' + activeCss + ' !important;color:inherit;'"),
+        )
+    }
+
+    @Test
+    fun `highlightTextJs readaloud-sentence mark background carries !important`() {
+        val js = ContinuousStyleInjector.highlightTextJs(
+            "the quick brown fox",
+            "rgba(56,189,248,0.50)",
+        )
+        // Kotlin-interpolated cssColor bakes into the JS literal — pin the whole background:...
+        // decl including the required `!important` marker.
+        assertTrue(
+            "readaloud-sentence mark cssText must contain '!important' — actual JS lacks it",
+            js.contains("'background:rgba(56,189,248,0.50) !important;color:inherit;'"),
+        )
+    }
+
     // ── highlight helpers (unchanged) ───────────────────────────────────────────
 
     @Test
@@ -401,11 +531,13 @@ class ContinuousStyleInjectorTest {
     }
 
     @Test
-    fun `existing marks are updated in-place via style-background`() {
+    fun `existing marks are updated in-place via cssText rewrite`() {
         val js = applyJs(AnnotationHighlight("ann1", "text", "#abc"))
         // Multi-paragraph annotations produce one <mark> per block — the in-place update path
-        // walks every mark that already shares the id and recolours each.
-        assertTrue(js.contains("m.style.background"))
+        // walks every mark that already shares the id and recolours each. cssText (not the
+        // .background shortcut) is required so the `!important` suffix survives ReadiumCSS
+        // night-mode's `background-color: transparent !important` on `:not(a)`.
+        assertTrue(js.contains("m.style.cssText"))
         // And it relocates only for NEW annotations (after the in-place branch returns).
         assertTrue(js.contains("existingAll"))
     }

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ReadaloudHighlightDecorationTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ReadaloudHighlightDecorationTest.kt
@@ -56,6 +56,37 @@ class ReadaloudHighlightDecorationTest {
         }
     }
 
+    // ---- highlightInlineStyle ------------------------------------------------
+    //
+    // ReadiumCSS night mode injects `background-color: transparent !important` on every
+    // `:not(a)` descendant of :root. Every Riffle highlight paint — the paginated template
+    // below AND the five continuous-mode <mark>s in ContinuousStyleInjector — must beat that
+    // via inline `!important`. This test pins the shared suffix so a plain revert on either
+    // side would flip red here first.
+
+    @Test
+    fun `highlightInlineStyle wraps the css color with important and color inherit`() {
+        assertEquals(
+            "background:rgba(251,191,36,0.50) !important;color:inherit;",
+            highlightInlineStyle("rgba(251,191,36,0.50)"),
+        )
+    }
+
+    @Test
+    fun `HIGHLIGHT_INLINE_STYLE_SUFFIX carries the important marker that beats ReadiumCSS night mode`() {
+        // The suffix is what makes Dark / DarkDim not swallow the highlight. Any change to
+        // this constant is a change to the fix that shipped for issue "highlights don't render
+        // on dark themes"; if this assertion drifts, the regression is back on all paths.
+        assertTrue(
+            "suffix must contain '!important'",
+            HIGHLIGHT_INLINE_STYLE_SUFFIX.contains("!important"),
+        )
+        assertTrue(
+            "suffix must reset foreground to inherit so text stays legible",
+            HIGHLIGHT_INLINE_STYLE_SUFFIX.contains("color:inherit"),
+        )
+    }
+
     @Test
     fun fragmentConfigurationRegistersHighlightTemplateAlongsideDefaults() {
         val templates = FormattingPreferences().toFragmentConfiguration().decorationTemplates


### PR DESCRIPTION
## Summary

Two visible bugs on Continuous mode with Dark / DarkDim themes, one shared root cause: ReadiumCSS night-mode's `:not(a){background-color:transparent!important;color:inherit!important}` rule, interacting with continuous mode's JS-injected marks and Chromium's \`setOffscreenPreRaster\` tile cache.

### Highlights invisible on Dark / DarkDim

Continuous-mode highlights (user annotations, search, readaloud sentence) build a \`<mark>\` and set \`background\` via JS without \`!important\` — author-sheet \`!important\` won on the cascade and marks painted transparent. Paginated / vertical escaped this because \`HighlightTintStyle\` template already emits inline \`!important\` (inline wins on specificity).

Unified via a shared \`HIGHLIGHT_INLINE_STYLE_SUFFIX\` + \`highlightInlineStyle()\` helper used by both the paginated template and all five continuous JS sites — the invariant "highlight background carries inline \`!important\`" lives in one place instead of five parallel string literals.

### Theme switch keeps stale raster

\`setOffscreenPreRaster(true)\` (from #413, needed for the chapter-boundary blank-flash fix) keeps rasterised tiles alive for off-screen chapters. Side-effect: a bare \`:root\` style-attribute mutation — how every live theme / typography change is applied — doesn't invalidate those cached tiles. The CSSOM updates and \`getComputedStyle\` returns the new values, but the composited image on screen keeps the pre-change theme; users saw Sepia bg survive Sepia→Dim with text vanishing entirely (dark-mode text against the stale sepia raster).

Fix in \`buildStyleInjectionJs\`: after the setAttribute, toggle \`visibility: hidden\` → \`''\` on documentElement to force Chromium to repaint the subtree. Restore is unconditional (never a captured "previous value" — that raced under rapid switches and stuck-hid the WebView) and double-scheduled (rAF + \`setTimeout(_, 100)\` so backgrounded WebViews with paused rAF still recover).

## Test plan

- [x] JVM: \`ContinuousStyleInjectorTest\` pins \`!important\` on every highlight-emitting JS path (annotations new+recolor, search inactive+active, readaloud sentence) + the visibility toggle + unconditional restore + rAF/setTimeout dual schedule.
- [x] JVM: \`ReadaloudHighlightDecorationTest\` pins \`highlightInlineStyle\` output + the \`HIGHLIGHT_INLINE_STYLE_SUFFIX\` constant.
- [x] Manual on device: highlights render on Dark / DarkDim / Sepia; theme switches update background and text; rapid switching doesn't stick-hide the WebView.