### PR TITLE
feat(reader): auto-merge adjacent same-colour highlights on popup dismiss

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubCfiRange.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubCfiRange.kt
@@ -6,6 +6,9 @@ import com.riffle.core.domain.countBodyChars
 import com.riffle.core.domain.extractCfiDocPath
 import com.riffle.core.domain.findNodeAtChar
 import org.jsoup.Jsoup
+import org.jsoup.nodes.Element
+import org.jsoup.nodes.Node
+import org.jsoup.nodes.TextNode
 
 // Builds an EPUB CFI *range* for a highlight (ADR 0024). Reuses the char-count positioning model
 // of EpubCfiTranslator so the range's endpoints are in the same coordinate family ABS stores.
@@ -90,4 +93,99 @@ internal fun rangeStartDocPath(rangeCfi: String): String? {
 internal fun highlightStartProgression(rangeCfi: String, html: String): Double? {
     val startDocPath = rangeStartDocPath(rangeCfi) ?: return null
     return cfiDocPathToProgression(startDocPath, html)
+}
+
+/**
+ * Concatenation of the body's readable-text (blank-only text nodes skipped) — the "flat" view of
+ * the chapter that [countBodyChars] measures. All char offsets used by highlight merging are
+ * indices into this string.
+ */
+internal fun readableBodyText(html: String): String {
+    val body = Jsoup.parse(html).body()
+    val out = StringBuilder()
+    fun visit(node: Node) {
+        when (node) {
+            is TextNode -> if (!node.wholeText.isBlank()) out.append(node.wholeText)
+            is Element -> node.childNodes().forEach(::visit)
+        }
+    }
+    body.childNodes().forEach(::visit)
+    return out.toString()
+}
+
+/**
+ * Locate the char position of [snippet] in [html]'s readable-text stream, using [before]'s last
+ * ~30 chars as a disambiguating anchor. Returns the start-char of [snippet] in the readable
+ * stream, or null if not locatable / ambiguous.
+ *
+ * Why we need this: `Locator.locations.progression` from a paginated Readium selection is the
+ * *page*'s progression, not the selection's. Every highlight created on the same page gets the
+ * same stored progression and CFI start offset, so the persisted char-position is useless for
+ * pinning down the selection's true location. Text-searching the DOM with the surrounding-text
+ * anchor recovers the real position.
+ */
+internal fun locateSnippetInBody(
+    html: String,
+    snippet: String,
+    before: String,
+): Long? {
+    if (snippet.isBlank()) return null
+    val body = readableBodyText(html)
+    val anchorTail = before.takeLast(30).trimStart()
+    if (anchorTail.isNotEmpty()) {
+        val query = anchorTail + snippet
+        val idx = body.indexOf(query)
+        if (idx >= 0) return (idx + anchorTail.length).toLong()
+    }
+    // Anchor-less fallback: only trustworthy if the snippet appears exactly once in the chapter.
+    val first = body.indexOf(snippet)
+    if (first < 0) return null
+    if (body.indexOf(snippet, first + 1) >= 0) return null
+    return first.toLong()
+}
+
+/**
+ * Extract the readable-text substring of [html]'s body between [startChar] (inclusive) and
+ * [endChar] (exclusive) — using the same "readable char" walk as [countBodyChars] (blank-only
+ * text nodes skipped). Returns null if the range is empty or falls outside the doc.
+ *
+ * Used by the highlight-merge path so the stored merged `textSnippet` is byte-exact against the
+ * DOM. Concatenating the two source snippets with a captured whitespace run can drift from the
+ * actual DOM (Readium's `textAfter`/`textBefore` may normalise NBSP/newlines differently than
+ * `textSnippet`), and any drift makes Readium's decorator fail-then-fallback to a partial range.
+ */
+internal fun readableTextBetween(html: String, startChar: Long, endChar: Long): String? {
+    if (endChar <= startChar) return null
+    val body = Jsoup.parse(html).body()
+    val out = StringBuilder()
+    var cursor = 0L
+
+    fun visit(node: Node): Boolean {
+        if (cursor >= endChar) return true
+        when (node) {
+            is TextNode -> {
+                val text = node.wholeText
+                if (text.isBlank()) return false
+                val nodeStart = cursor
+                val nodeLen = text.length.toLong()
+                val nodeEnd = nodeStart + nodeLen
+                if (nodeEnd > startChar) {
+                    val takeFrom = maxOf(0L, startChar - nodeStart).toInt()
+                    val takeTo = minOf(nodeLen, endChar - nodeStart).toInt()
+                    out.append(text, takeFrom, takeTo)
+                }
+                cursor = nodeEnd
+            }
+            is Element -> {
+                for (child in node.childNodes()) {
+                    if (visit(child)) return true
+                }
+            }
+        }
+        return cursor >= endChar
+    }
+    for (child in body.childNodes()) {
+        if (visit(child)) break
+    }
+    return out.toString().takeIf { it.isNotEmpty() }
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -279,6 +279,7 @@ fun EpubReaderScreen(
     val isCurrentPageBookmarked by viewModel.isCurrentPageBookmarked.collectAsState()
     val highlightRenders by viewModel.highlightRenders.collectAsState()
     val highlightToEdit by viewModel.highlightToEdit.collectAsState()
+    val noteEditorTarget by viewModel.noteEditorTarget.collectAsState()
     val railSegments by viewModel.railSegments.collectAsState()
     val readaloudAvailable by viewModel.readaloudAvailable.collectAsState()
     val readaloudVisible by viewModel.readaloudVisible.collectAsState()
@@ -453,9 +454,13 @@ fun EpubReaderScreen(
                         highlightRenders = highlightRenders,
                         onHighlight = viewModel::createHighlight,
                         highlightToEdit = highlightToEdit,
+                        noteEditorTarget = noteEditorTarget,
                         onOpenHighlightActions = viewModel::openHighlightActions,
                         onOpenNoteReader = viewModel::openNoteReader,
                         onDismissHighlightActions = viewModel::dismissHighlightActions,
+                        onOpenNoteEditor = viewModel::openNoteEditor,
+                        onCommitNoteEdit = viewModel::commitNoteEdit,
+                        onCancelNoteEdit = viewModel::cancelNoteEdit,
                         onRecolorHighlight = viewModel::recolorHighlight,
                         onDeleteHighlight = viewModel::deleteHighlight,
                         onUpdateHighlightNote = viewModel::updateHighlightNote,
@@ -1164,9 +1169,13 @@ private fun EpubNavigatorView(
     highlightRenders: List<EpubReaderViewModel.HighlightRender>,
     onHighlight: (Locator, androidx.compose.ui.unit.IntRect) -> Unit,
     highlightToEdit: EpubReaderViewModel.HighlightEditTarget?,
+    noteEditorTarget: EpubReaderViewModel.HighlightEditTarget?,
     onOpenHighlightActions: (String, androidx.compose.ui.unit.IntRect) -> Unit,
     onOpenNoteReader: (String, androidx.compose.ui.unit.IntRect) -> Unit,
     onDismissHighlightActions: () -> Unit,
+    onOpenNoteEditor: (String, androidx.compose.ui.unit.IntRect) -> Unit,
+    onCommitNoteEdit: (String, String?) -> Unit,
+    onCancelNoteEdit: () -> Unit,
     onRecolorHighlight: (String, HighlightColor) -> Unit,
     onDeleteHighlight: (String) -> Unit,
     onUpdateHighlightNote: (String, String?) -> Unit,
@@ -2527,7 +2536,6 @@ private fun EpubNavigatorView(
         // Highlight actions sheet — opens when the user taps an existing highlight or immediately
         // after creating one. Floats as an overlay inside the reader so it has access to the
         // reader's BoxWithConstraints scope and sits above the reader content.
-        var noteEditorTarget by remember { mutableStateOf<EpubReaderViewModel.HighlightEditTarget?>(null) }
         val editTarget = highlightToEdit
         if (editTarget != null) {
             val current = highlightRenders.firstOrNull { it.id == editTarget.id }
@@ -2537,9 +2545,7 @@ private fun EpubNavigatorView(
                 note = current?.note,
                 onPick = { color -> onRecolorHighlight(editTarget.id, color) },
                 onDelete = { onDeleteHighlight(editTarget.id) },
-                onOpenNoteEditor = {
-                    noteEditorTarget = editTarget
-                },
+                onOpenNoteEditor = { onOpenNoteEditor(editTarget.id, editTarget.anchorRect) },
                 onDismiss = onDismissHighlightActions,
                 noteOnly = editTarget.noteOnly,
                 showOpenInBook = showOpenInBook,
@@ -2551,11 +2557,8 @@ private fun EpubNavigatorView(
             val current = highlightRenders.firstOrNull { it.id == noteTarget.id }
             NoteEditorDialog(
                 initialNote = current?.note ?: "",
-                onConfirm = { text ->
-                    onUpdateHighlightNote(noteTarget.id, text.takeIf { it.isNotBlank() })
-                    noteEditorTarget = null
-                },
-                onDismiss = { noteEditorTarget = null },
+                onConfirm = { text -> onCommitNoteEdit(noteTarget.id, text.takeIf { it.isNotBlank() }) },
+                onDismiss = onCancelNoteEdit,
             )
         }
     }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -260,6 +260,9 @@ class EpubReaderViewModel @Inject constructor(
             syncOnClose = { sid, ns, iid ->
                 annotationSyncController.syncOnClose(sid, ns, iid)
             },
+            mergeAfterEdit = { id, color, note ->
+                mergeAdjacentIntoHighlight(id, color, note)
+            },
         )
 
     private val itemId: String = checkNotNull(savedStateHandle["itemId"])
@@ -525,6 +528,18 @@ class EpubReaderViewModel @Inject constructor(
         annotationSession.openNoteReader(id, anchorRect)
 
     fun dismissHighlightActions() = annotationSession.dismissHighlightActions()
+
+    /** Note-editor target — non-null while the note-editor dialog is open. */
+    val noteEditorTarget: StateFlow<HighlightEditTarget?> = annotationSession.noteEditorTarget
+
+    fun openNoteEditor(id: String, anchorRect: IntRect) =
+        annotationSession.openNoteEditor(id, anchorRect)
+
+    fun commitNoteEdit(id: String, note: String?) {
+        viewModelScope.launch { annotationSession.commitNoteEdit(id, note) }
+    }
+
+    fun cancelNoteEdit() = annotationSession.cancelNoteEdit()
 
     // ---- Readaloud state delegations (state now lives in the session) -----------------------
 
@@ -1140,7 +1155,22 @@ class EpubReaderViewModel @Inject constructor(
             if (spineIndex < 0) return@launch
             val spineStep = (spineIndex + 1) * 2
             val html = readChapterHtml(spineIndex) ?: return@launch
-            val progression = selectionLocator.locations.progression ?: 0.0
+            val textBeforeCaptured = selectionLocator.text.before ?: ""
+            // Recover the selection's true within-chapter position via anchored text-search.
+            // Readium's `Locator.locations.progression` in paginated mode is the PAGE start, not
+            // the selection start — every highlight created on the same page would otherwise
+            // share the same stored progression, making the annotations-panel order (which sorts
+            // by progression + createdAt) print same-page highlights in creation order instead of
+            // reading order. See docs/superpowers/specs/2026-07-05-highlight-auto-merge-design.md.
+            val totalChars = com.riffle.core.domain.countBodyChars(org.jsoup.Jsoup.parse(html).body())
+            val locatedChar = if (totalChars > 0) {
+                locateSnippetInBody(html, snippet, textBeforeCaptured)
+            } else null
+            val progression = if (locatedChar != null) {
+                locatedChar.toDouble() / totalChars.toDouble()
+            } else {
+                selectionLocator.locations.progression ?: 0.0
+            }
 
             // Delete existing highlights in the same chapter that the new selection covers.
             val newAfter = selectionLocator.text.after ?: ""
@@ -1154,16 +1184,26 @@ class EpubReaderViewModel @Inject constructor(
                     }
                 }
 
-            val cfiRange = buildHighlightCfiRangeForSelection(spineStep, html, progression, snippet)
-                ?: return@launch
+            // NOTE: create-time auto-merge was removed after the 2026-07-05 initial rollout. It
+            // surprised users who wanted to keep a fresh selection separate from a same-colour
+            // neighbour (to recolour or note it differently). Merging now only fires at *edit*
+            // time via [mergeAdjacentIntoHighlight] — recolour to match or note-cleared. See
+            // docs/superpowers/specs/2026-07-05-highlight-auto-merge-design.md ("On note-clear").
+            val cfiRange = if (locatedChar != null) {
+                buildHighlightCfiRange(
+                    spineStep, html, locatedChar, (locatedChar + snippet.length - 1L).coerceAtLeast(locatedChar),
+                )
+            } else {
+                buildHighlightCfiRangeForSelection(spineStep, html, progression, snippet)
+            } ?: return@launch
             val created = annotationStore.createHighlight(
                 sourceId = sourceId,
                 itemId = itemId,
                 cfi = cfiRange,
                 textSnippet = snippet,
                 chapterHref = href,
-                textBefore = selectionLocator.text.before ?: "",
-                textAfter = selectionLocator.text.after ?: "",
+                textBefore = textBeforeCaptured,
+                textAfter = newAfter,
                 color = annotationSession.lastUsedHighlightColor.value.token,
                 spineIndex = spineIndex,
                 progression = progression,
@@ -1171,6 +1211,200 @@ class EpubReaderViewModel @Inject constructor(
             openHighlightActions(created.id, anchorRect)
             scheduleAnnotationSync()
             // observeHighlights re-emits → highlightRenders updates → the screen re-applies decorations.
+        }
+    }
+
+    /**
+     * Called by [AnnotationSession] after a recolour or note-clear that could newly make the row
+     * merge-eligible with a same-chapter neighbour (spec: 2026-07-05-highlight-auto-merge-design.md).
+     * Publication-dependent, so it lives here and is passed in as a factory param.
+     *
+     * [effectiveColor] and [effectiveNote] describe the post-mutation state so we don't race the
+     * DAO Flow emit that refreshes [AnnotationSession.annotations].
+     */
+    private suspend fun mergeAdjacentIntoHighlight(
+        id: String,
+        effectiveColor: String,
+        effectiveNote: String?,
+    ) {
+        logger.d(LogChannel.HighlightMerge) {
+            "edit-merge entry id=$id color=$effectiveColor note=${effectiveNote?.let { "'${it.take(20)}'" }}"
+        }
+        if (!effectiveNote.isNullOrBlank()) {
+            logger.d(LogChannel.HighlightMerge) { "edit-merge skip id=$id reason=note-still-present" }
+            return
+        }
+        val sourceId = annotationServerId ?: run {
+            logger.d(LogChannel.HighlightMerge) { "edit-merge skip id=$id reason=no-sourceId" }
+            return
+        }
+        val current = annotationSession.annotations.value.firstOrNull { it.id == id }
+        if (current == null) {
+            logger.d(LogChannel.HighlightMerge) {
+                "edit-merge skip id=$id reason=not-in-annotations poolSize=${annotationSession.annotations.value.size}"
+            }
+            return
+        }
+        if (current.type != AnnotationEntity.TYPE_HIGHLIGHT) {
+            logger.d(LogChannel.HighlightMerge) { "edit-merge skip id=$id reason=type=${current.type}" }
+            return
+        }
+        val pool = annotationSession.annotations.value
+        // Trial-run the merge WITHOUT touching the DB. Track the leftmost source highlight as we
+        // chain-absorb — its stored textBefore is our anchor for text-searching the actual char
+        // position of the merged range in the chapter DOM. We can NOT use the stored progression
+        // (or the CFI derived from it): Readium's `Locator.locations.progression` from a paginated
+        // selection is the PAGE's progression, not the selection's, so every highlight on the same
+        // page shares the same stored start position — useless for locating the merged range.
+        var trialAnchor = current.toMergeAnchor().copy(color = effectiveColor, note = null)
+        // Track leftmost + rightmost source highlights separately so we can text-search each
+        // endpoint's position in the DOM. We can NOT compute `endChar = leftmost.start + composed.length`
+        // because composed includes whitespace from Readium's textAfter (paragraph boundaries,
+        // NBSP, etc.) that our readable-text char model does NOT count — the composed string is
+        // longer than the actual DOM span for cross-paragraph merges.
+        var leftmost: MergeAnchor = trialAnchor
+        var rightmost: MergeAnchor = trialAnchor
+        val toAbsorb = mutableListOf<Annotation>()
+        val absorbedIds = mutableSetOf(id)
+        logger.d(LogChannel.HighlightMerge) {
+            "edit-merge anchor snippet='${trialAnchor.textSnippet.take(30)}' " +
+                "before='${trialAnchor.textBefore.takeLast(30)}' after='${trialAnchor.textAfter.take(30)}' " +
+                "poolSize=${pool.size}"
+        }
+        while (true) {
+            val match = findAnyMergeableNeighbor(trialAnchor, pool, excludeIds = absorbedIds) ?: break
+            logger.d(LogChannel.HighlightMerge) {
+                "edit-merge absorb neighborId=${match.neighbor.id} side=${match.side} " +
+                    "neighborSnippet='${match.neighbor.textSnippet.take(30)}'"
+            }
+            when (match.side) {
+                MergeSide.CANDIDATE_BEFORE_ANCHOR -> leftmost = match.neighbor.toMergeAnchor()
+                MergeSide.CANDIDATE_AFTER_ANCHOR -> rightmost = match.neighbor.toMergeAnchor()
+            }
+            toAbsorb += match.neighbor
+            absorbedIds += match.neighbor.id
+            trialAnchor = applyMerge(trialAnchor, match)
+        }
+        if (toAbsorb.isEmpty()) {
+            debugLogNoMergeReasons(trialAnchor, pool, id)
+            return
+        }
+        val html = readChapterHtml(trialAnchor.spineIndex)
+        if (html == null) {
+            logger.d(LogChannel.HighlightMerge) { "edit-merge FAIL id=$id reason=no-html spine=${trialAnchor.spineIndex}" }
+            return
+        }
+        val totalChars = com.riffle.core.domain.countBodyChars(org.jsoup.Jsoup.parse(html).body())
+        if (totalChars <= 0) {
+            logger.d(LogChannel.HighlightMerge) { "edit-merge FAIL id=$id reason=totalChars=0" }
+            return
+        }
+        // Locate both endpoints of the merged range in the chapter's readable text via anchored
+        // searches. Rightmost's endChar is *not* startChar + composed.length: composed carries
+        // Readium's raw whitespace between snippets (newlines at paragraph boundaries, NBSP, etc.)
+        // that our readable char model does not count.
+        val startChar = locateSnippetInBody(html, leftmost.textSnippet, leftmost.textBefore)
+        if (startChar == null) {
+            logger.d(LogChannel.HighlightMerge) {
+                "edit-merge FAIL id=$id reason=leftmost-not-locatable " +
+                    "snippet='${leftmost.textSnippet.take(30)}' " +
+                    "beforeTail='${leftmost.textBefore.takeLast(30)}'"
+            }
+            return
+        }
+        val rightmostStart = locateSnippetInBody(html, rightmost.textSnippet, rightmost.textBefore)
+        if (rightmostStart == null) {
+            logger.d(LogChannel.HighlightMerge) {
+                "edit-merge FAIL id=$id reason=rightmost-not-locatable " +
+                    "snippet='${rightmost.textSnippet.take(30)}' " +
+                    "beforeTail='${rightmost.textBefore.takeLast(30)}'"
+            }
+            return
+        }
+        val endChar = (rightmostStart + rightmost.textSnippet.length).coerceAtMost(totalChars)
+        if (endChar <= startChar) {
+            logger.d(LogChannel.HighlightMerge) {
+                "edit-merge FAIL id=$id reason=invalid-range startChar=$startChar endChar=$endChar"
+            }
+            return
+        }
+        val domSnippet = readableTextBetween(html, startChar, endChar)
+        if (domSnippet.isNullOrEmpty()) {
+            logger.d(LogChannel.HighlightMerge) { "edit-merge FAIL id=$id reason=dom-text-empty startChar=$startChar endChar=$endChar" }
+            return
+        }
+        // Safety: our composed snippet and the DOM text must agree modulo whitespace normalisation.
+        // If they diverge, the adjacency check false-matched (probably a suffix-of-context
+        // coincidence) — abort rather than commit a broken merge.
+        if (!snippetsAgreeIgnoringWhitespace(domSnippet, trialAnchor.textSnippet)) {
+            logger.d(LogChannel.HighlightMerge) {
+                "edit-merge FAIL id=$id reason=dom-mismatch " +
+                    "dom='${domSnippet.take(60)}' composed='${trialAnchor.textSnippet.take(60)}'"
+            }
+            return
+        }
+        val spineStep = (trialAnchor.spineIndex + 1) * 2
+        val cfiRange = buildHighlightCfiRange(spineStep, html, startChar, endChar - 1L)
+        if (cfiRange == null) {
+            logger.d(LogChannel.HighlightMerge) { "edit-merge FAIL id=$id reason=cfi-build-null" }
+            return
+        }
+        val storedProgression = startChar.toDouble() / totalChars.toDouble()
+        // All computations succeeded — commit: delete neighbours, then replace the anchor row.
+        toAbsorb.forEach { annotationStore.delete(it.id) }
+        annotationStore.delete(id)
+        val created = annotationStore.createHighlight(
+            sourceId = sourceId,
+            itemId = itemId,
+            cfi = cfiRange,
+            textSnippet = domSnippet,
+            chapterHref = trialAnchor.chapterHref,
+            textBefore = trialAnchor.textBefore,
+            textAfter = trialAnchor.textAfter,
+            color = trialAnchor.color,
+            spineIndex = trialAnchor.spineIndex,
+            progression = storedProgression,
+        )
+        logger.d(LogChannel.HighlightMerge) {
+            "edit-merge done anchorReplaced=$id newId=${created.id} absorbedCount=${toAbsorb.size} " +
+                "domLen=${domSnippet.length} startChar=$startChar"
+        }
+    }
+
+    /**
+     * Content equality ignoring all whitespace. The composed snippet carries Readium's captured
+     * whitespace between source snippets (single space, NBSP, `\n` at paragraph boundaries) but
+     * the DOM extract's whitespace comes from the readable char model, which does not count
+     * paragraph breaks as chars. Stripping whitespace on both sides compares just the letters —
+     * enough to catch false-positive adjacency matches (extra CONTENT between the endpoints)
+     * without tripping on the paragraph-break case.
+     */
+    private fun snippetsAgreeIgnoringWhitespace(a: String, b: String): Boolean {
+        val na = a.filterNot { it.isWhitespace() }
+        val nb = b.filterNot { it.isWhitespace() }
+        return na.equals(nb, ignoreCase = true)
+    }
+
+    /** Per-neighbour reason line, so a "why no merge?" can be answered from a single logcat grep. */
+    private fun debugLogNoMergeReasons(anchor: MergeAnchor, pool: List<Annotation>, anchorId: String) {
+        val sameChapterOthers = pool.filter { it.id != anchorId && it.spineIndex == anchor.spineIndex }
+        logger.d(LogChannel.HighlightMerge) {
+            "edit-merge no-neighbor anchorId=$anchorId sameChapterOthers=${sameChapterOthers.size}"
+        }
+        for (n in sameChapterOthers) {
+            val reason = when {
+                n.type != AnnotationEntity.TYPE_HIGHLIGHT -> "type=${n.type}"
+                !anchor.color.equals(n.color, ignoreCase = true) -> "color-mismatch anchor=${anchor.color} n=${n.color}"
+                !n.note.isNullOrBlank() -> "neighbor-has-note"
+                findAdjacency(anchor, n) == null -> "not-adjacent " +
+                    "anchorAfterHead='${anchor.textAfter.take(40)}' " +
+                    "anchorBeforeTail='${anchor.textBefore.takeLast(40)}' " +
+                    "nSnippet='${n.textSnippet.take(30)}' " +
+                    "nBeforeTail='${n.textBefore.takeLast(40)}' " +
+                    "nAfterHead='${n.textAfter.take(40)}'"
+                else -> "should-have-matched?"
+            }
+            logger.d(LogChannel.HighlightMerge) { "edit-merge candidate id=${n.id} reason=$reason" }
         }
     }
 

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/HighlightActionsSheet.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/HighlightActionsSheet.kt
@@ -173,7 +173,7 @@ fun HighlightActionsPopup(
                                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                             )
                             TextButton(
-                                onClick = { onDismiss(); onOpenNoteEditor() },
+                                onClick = { onOpenNoteEditor() },
                                 modifier = Modifier.align(Alignment.End),
                             ) {
                                 Text("Edit")
@@ -187,7 +187,7 @@ fun HighlightActionsPopup(
                             .fillMaxWidth()
                             .clickable {
                                 when {
-                                    note == null -> { onDismiss(); onOpenNoteEditor() }
+                                    note == null -> onOpenNoteEditor()
                                     noteExpanded -> noteExpanded = false
                                     else -> noteExpanded = true
                                 }
@@ -218,7 +218,7 @@ fun HighlightActionsPopup(
                                     style = MaterialTheme.typography.bodyMedium,
                                 )
                                 TextButton(
-                                    onClick = { onDismiss(); onOpenNoteEditor() },
+                                    onClick = { onOpenNoteEditor() },
                                     modifier = Modifier.align(Alignment.End),
                                 ) {
                                     Text("Edit")

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/HighlightMerge.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/HighlightMerge.kt
@@ -1,0 +1,204 @@
+package com.riffle.app.feature.reader
+
+import com.riffle.core.database.AnnotationEntity
+import com.riffle.core.domain.Annotation
+
+// Auto-merge adjacent highlights (2026-07-05 spec). Pure text-anchored logic so both the
+// create-time path (fresh selection, no id yet) and the edit-time path (existing row that just
+// changed colour or had its note cleared) can drive the same merge decision. See:
+//   docs/superpowers/specs/2026-07-05-highlight-auto-merge-design.md
+
+/** Which side of the anchor the candidate sits on in the reading order. */
+internal enum class MergeSide { CANDIDATE_BEFORE_ANCHOR, CANDIDATE_AFTER_ANCHOR }
+
+/**
+ * A concrete adjacency match: which neighbour to absorb, which side, and the whitespace run to
+ * preserve between the two snippets when concatenating.
+ */
+internal data class MergeCandidate(
+    val neighbor: Annotation,
+    val side: MergeSide,
+    val whitespaceBetween: String,
+)
+
+/**
+ * The mutable state of a highlight being grown by merges.
+ *
+ * At create-time the caller seeds this from the user's selection; at edit-time it's seeded from
+ * the row that just changed. Either way merging mutates only these fields — CFI is rebuilt from
+ * `progression` + `textSnippet` at the end.
+ */
+internal data class MergeAnchor(
+    val spineIndex: Int,
+    val color: String,
+    val note: String?,
+    val textSnippet: String,
+    val textBefore: String,
+    val textAfter: String,
+    val progression: Double,
+    val chapterHref: String,
+)
+
+internal fun Annotation.toMergeAnchor(): MergeAnchor = MergeAnchor(
+    spineIndex = spineIndex,
+    color = color,
+    note = note,
+    textSnippet = textSnippet,
+    textBefore = textBefore,
+    textAfter = textAfter,
+    progression = progression,
+    chapterHref = chapterHref,
+)
+
+/**
+ * Static eligibility gate — same chapter, same colour, both notes empty/blank.
+ * Adjacency is checked separately by [findAdjacency].
+ */
+internal fun isMergeEligible(anchor: MergeAnchor, candidate: Annotation): Boolean {
+    if (candidate.type != AnnotationEntity.TYPE_HIGHLIGHT) return false
+    if (anchor.spineIndex != candidate.spineIndex) return false
+    if (!anchor.color.equals(candidate.color, ignoreCase = true)) return false
+    if (!anchor.note.isNullOrBlank()) return false
+    if (!candidate.note.isNullOrBlank()) return false
+    return true
+}
+
+/**
+ * Detect text-adjacency between [anchor] and [candidate]. Returns non-null iff the candidate's
+ * snippet is exactly what sits immediately after (or before) the anchor's snippet in the DOM —
+ * modulo a single run of whitespace between them.
+ *
+ * Both sides' text contexts are checked (bidirectional): Readium bounds `textBefore`/`textAfter` to
+ * a fixed window, so a long snippet may not fit in one side's context but does fit in the other's.
+ * As long as EITHER side's context proves the abutment, we accept — the two views must agree since
+ * they're both extracted from the same DOM text.
+ *
+ * "Modulo a single whitespace run" means zero-or-more whitespace chars, all contiguous. Any
+ * non-whitespace character between = not adjacent.
+ */
+internal fun findAdjacency(anchor: MergeAnchor, candidate: Annotation): MergeCandidate? {
+    val anchorSnippet = anchor.textSnippet.takeIf { it.isNotBlank() } ?: return null
+    val neighborSnippet = candidate.textSnippet.takeIf { it.isNotBlank() } ?: return null
+
+    // Candidate sits AFTER anchor:
+    //   • anchor.textAfter starts with [ws][neighborSnippet], OR
+    //   • candidate.textBefore ends with [anchorSnippet][ws]
+    matchAtStart(anchor.textAfter, neighborSnippet)?.let { ws ->
+        return MergeCandidate(candidate, MergeSide.CANDIDATE_AFTER_ANCHOR, ws)
+    }
+    matchAtEnd(candidate.textBefore, anchorSnippet)?.let { ws ->
+        return MergeCandidate(candidate, MergeSide.CANDIDATE_AFTER_ANCHOR, ws)
+    }
+
+    // Candidate sits BEFORE anchor:
+    //   • anchor.textBefore ends with [neighborSnippet][ws], OR
+    //   • candidate.textAfter starts with [ws][anchorSnippet]
+    matchAtEnd(anchor.textBefore, neighborSnippet)?.let { ws ->
+        return MergeCandidate(candidate, MergeSide.CANDIDATE_BEFORE_ANCHOR, ws)
+    }
+    matchAtStart(candidate.textAfter, anchorSnippet)?.let { ws ->
+        return MergeCandidate(candidate, MergeSide.CANDIDATE_BEFORE_ANCHOR, ws)
+    }
+    return null
+}
+
+/**
+ * Whitespace-normalised prefix match. Returns the raw whitespace prefix from [context] if, after
+ * collapsing runs of whitespace to a single space and stripping outer whitespace, [context] begins
+ * with [target] (or [target]'s first ~15 chars — enough uniqueness — when [target] is longer than
+ * [context] allows). Null otherwise.
+ *
+ * Whitespace normalisation is essential: Readium can capture the same DOM whitespace differently
+ * across `Locator.text.highlight` vs `Locator.text.after`/`before` (single space vs NBSP vs
+ * multiple runs after DOM traversal), so a byte-exact comparison misses many genuinely-adjacent
+ * highlights.
+ */
+private fun matchAtStart(context: String, target: String): String? {
+    if (context.isEmpty() || target.isBlank()) return null
+    val normContext = normaliseWs(context).trimStart()
+    val normTarget = normaliseWs(target).trim()
+    if (normTarget.isEmpty()) return null
+    val prefixLen = minOf(normTarget.length, normContext.length)
+    if (prefixLen < MIN_MATCH_CHARS && prefixLen < normTarget.length) return null
+    if (!normContext.regionMatches(0, normTarget, 0, prefixLen, ignoreCase = false)) return null
+    var i = 0
+    while (i < context.length && context[i].isWhitespace()) i++
+    return context.substring(0, i)
+}
+
+/** Symmetric to [matchAtStart] at the tail end. */
+private fun matchAtEnd(context: String, target: String): String? {
+    if (context.isEmpty() || target.isBlank()) return null
+    val normContext = normaliseWs(context).trimEnd()
+    val normTarget = normaliseWs(target).trim()
+    if (normTarget.isEmpty()) return null
+    val suffixLen = minOf(normTarget.length, normContext.length)
+    if (suffixLen < MIN_MATCH_CHARS && suffixLen < normTarget.length) return null
+    val ctxOffset = normContext.length - suffixLen
+    val tgtOffset = normTarget.length - suffixLen
+    if (!normContext.regionMatches(ctxOffset, normTarget, tgtOffset, suffixLen, ignoreCase = false)) return null
+    var i = context.length
+    while (i > 0 && context[i - 1].isWhitespace()) i--
+    return context.substring(i)
+}
+
+/** Collapse every run of whitespace (any Unicode WS) to a single ASCII space. */
+private fun normaliseWs(s: String): String {
+    val out = StringBuilder(s.length)
+    var lastWasWs = false
+    for (ch in s) {
+        if (ch.isWhitespace()) {
+            if (!lastWasWs) out.append(' ')
+            lastWasWs = true
+        } else {
+            out.append(ch)
+            lastWasWs = false
+        }
+    }
+    return out.toString()
+}
+
+/**
+ * Minimum number of characters that must line up when the context is TOO SHORT to hold the full
+ * target (e.g. Readium bounds textAfter to ~30 chars but the target snippet is 100 chars). Below
+ * this floor we don't trust the match — a 5-char coincidence is too easy to hit randomly.
+ */
+private const val MIN_MATCH_CHARS = 12
+
+/**
+ * Apply a merge: produce a new anchor whose snippet spans both sides and whose text-before /
+ * text-after / progression are inherited from the outermost endpoints.
+ */
+internal fun applyMerge(anchor: MergeAnchor, match: MergeCandidate): MergeAnchor {
+    val neighbor = match.neighbor
+    return when (match.side) {
+        MergeSide.CANDIDATE_AFTER_ANCHOR -> anchor.copy(
+            textSnippet = anchor.textSnippet + match.whitespaceBetween + neighbor.textSnippet,
+            textAfter = neighbor.textAfter,
+        )
+        MergeSide.CANDIDATE_BEFORE_ANCHOR -> anchor.copy(
+            textSnippet = neighbor.textSnippet + match.whitespaceBetween + anchor.textSnippet,
+            textBefore = neighbor.textBefore,
+            progression = neighbor.progression,
+        )
+    }
+}
+
+/**
+ * Find any eligible + adjacent neighbour in [pool]. Returns the first match; the caller loops
+ * (chain-merge until no more matches). [excludeIds] carries the anchor's own id (if it already
+ * exists) plus any neighbours already absorbed this round.
+ */
+internal fun findAnyMergeableNeighbor(
+    anchor: MergeAnchor,
+    pool: List<Annotation>,
+    excludeIds: Set<String>,
+): MergeCandidate? {
+    for (candidate in pool) {
+        if (candidate.id in excludeIds) continue
+        if (!isMergeEligible(anchor, candidate)) continue
+        val adjacency = findAdjacency(anchor, candidate) ?: continue
+        return adjacency
+    }
+    return null
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/session/AnnotationSession.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/session/AnnotationSession.kt
@@ -68,6 +68,13 @@ class AnnotationSession @AssistedInject constructor(
     @Assisted("open") private val syncOnOpen: suspend (sourceId: String, namespace: String, itemId: String) -> Unit,
     /** Called on [onBookClosed] via [ProgressFlushScope] to push pending annotations. */
     @Assisted("close") private val syncOnClose: suspend (sourceId: String, namespace: String, itemId: String) -> Unit,
+    /**
+     * Called after a recolour or note-clear on a highlight that might now be merge-eligible with a
+     * same-chapter neighbour. Publication-dependent (needs to rebuild the CFI range), so the VM
+     * owns the implementation. Params: annotation id + the post-mutation colour + post-mutation note.
+     * See docs/superpowers/specs/2026-07-05-highlight-auto-merge-design.md.
+     */
+    @Assisted("merge") private val mergeAfterEdit: suspend (id: String, color: String, note: String?) -> Unit,
 ) {
 
     @AssistedFactory
@@ -78,6 +85,7 @@ class AnnotationSession @AssistedInject constructor(
             scheduleSync: (String, String, String) -> Unit,
             @Assisted("open") syncOnOpen: suspend (String, String, String) -> Unit,
             @Assisted("close") syncOnClose: suspend (String, String, String) -> Unit,
+            @Assisted("merge") mergeAfterEdit: suspend (String, String, String?) -> Unit,
         ): AnnotationSession
     }
 
@@ -278,9 +286,77 @@ class AnnotationSession @AssistedInject constructor(
         _highlightToEdit.value = EpubReaderViewModel.HighlightEditTarget(id, anchorRect, noteOnly = true)
     }
 
-    /** Dismiss the highlight actions popup. */
-    fun dismissHighlightActions() {
+    /**
+     * The note-editor target — non-null while the note editor dialog is open. Kept in session
+     * state (not Compose-local) so [dismissHighlightActions] can tell whether the actions popup
+     * is closing to *transition into* the note editor (no merge yet) or as a true commit close.
+     * See docs/superpowers/specs/2026-07-05-highlight-auto-merge-design.md.
+     */
+    private val _noteEditorTarget = MutableStateFlow<EpubReaderViewModel.HighlightEditTarget?>(null)
+    val noteEditorTarget: StateFlow<EpubReaderViewModel.HighlightEditTarget?> = _noteEditorTarget
+
+    /**
+     * Transition from the highlight-actions popup to the note editor. Closes the actions popup
+     * *without* firing the merge check — the commit point is deferred to [dismissNoteEditor], so
+     * a merge cannot absorb the row before the note has been saved onto it.
+     */
+    fun openNoteEditor(id: String, anchorRect: androidx.compose.ui.unit.IntRect) {
+        val target = _highlightToEdit.value?.takeIf { it.id == id }
+            ?: EpubReaderViewModel.HighlightEditTarget(id, anchorRect)
+        _noteEditorTarget.value = target
         _highlightToEdit.value = null
+    }
+
+    /**
+     * Commit the note editor: persist [note] onto highlight [id], close the editor, then fire the
+     * merge check with the row's post-commit state. Ordered so [mergeAfterEdit] sees the just-
+     * written note — a race between "update note" and "close editor" would otherwise let a merge
+     * absorb the row before the note blocks eligibility.
+     */
+    suspend fun commitNoteEdit(id: String, note: String?) {
+        val normalized = note?.takeIf { it.isNotBlank() }
+        annotationStore.updateNote(id, normalized)
+        _noteEditorTarget.value = null
+        val row = _annotations.value.firstOrNull { it.id == id }
+        val color = row?.color ?: run {
+            scheduleSync(boundServerId ?: return, boundNamespace ?: return, boundItemId ?: return)
+            return
+        }
+        scheduleSync(boundServerId ?: return, boundNamespace ?: return, boundItemId ?: return)
+        mergeAfterEdit(id, color, normalized)
+    }
+
+    /**
+     * Cancel the note editor without changes. Still a commit point — the underlying row may have
+     * been recoloured / had its note previously cleared inside the actions popup, and this dismiss
+     * is the moment the user is done editing.
+     */
+    fun cancelNoteEdit() {
+        val target = _noteEditorTarget.value
+        _noteEditorTarget.value = null
+        val id = target?.id ?: return
+        val row = _annotations.value.firstOrNull { it.id == id } ?: return
+        if (row.type != AnnotationEntity.TYPE_HIGHLIGHT) return
+        scope.launch { mergeAfterEdit(id, row.color, row.note) }
+    }
+
+    /**
+     * Dismiss the highlight actions popup. Popup close = commit — auto-merge with a same-colour
+     * no-note neighbour if the row's final state is eligible. Individual recolours / note edits
+     * inside the popup do NOT fire; the user is still iterating.
+     *
+     * If the note editor is currently open (user tapped "Add note"), this is a *transition*, not a
+     * commit — [openNoteEditor] already cleared [highlightToEdit], and the merge check is deferred
+     * to [dismissNoteEditor].
+     */
+    fun dismissHighlightActions() {
+        val target = _highlightToEdit.value
+        _highlightToEdit.value = null
+        if (_noteEditorTarget.value != null) return
+        val id = target?.id ?: return
+        val row = _annotations.value.firstOrNull { it.id == id } ?: return
+        if (row.type != AnnotationEntity.TYPE_HIGHLIGHT) return
+        scope.launch { mergeAfterEdit(id, row.color, row.note) }
     }
 
     /**
@@ -306,6 +382,9 @@ class AnnotationSession @AssistedInject constructor(
         val sid = boundServerId ?: return
         val iid = boundItemId ?: return
         highlightColorPreferencesStore.setLastUsedColor(sid, iid, color)
+        // Merge check is deferred to [dismissHighlightActions] — the popup close is the commit
+        // point. Firing here would absorb a neighbour mid-iteration while the user is still
+        // deciding on colour/note.
         scheduleSync(sid, boundNamespace ?: return, iid)
     }
 
@@ -318,7 +397,9 @@ class AnnotationSession @AssistedInject constructor(
 
     /** Save (or clear) the note on a highlight. Blank text is treated as null. */
     suspend fun updateHighlightNote(id: String, note: String?) {
-        annotationStore.updateNote(id, note?.takeIf { it.isNotBlank() })
+        val normalized = note?.takeIf { it.isNotBlank() }
+        annotationStore.updateNote(id, normalized)
+        // Merge check is deferred to [dismissHighlightActions] — see recolorHighlight.
         scheduleSync(boundServerId ?: return, boundNamespace ?: return, boundItemId ?: return)
     }
 

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/EpubCfiRangeTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/EpubCfiRangeTest.kt
@@ -83,6 +83,22 @@ class EpubCfiRangeTest {
     }
 
     @Test
+    fun `readableTextBetween returns the exact readable substring across nodes`() {
+        // body readable chars: "Hello world"(0..10) + "Second paragraph"(11..26)
+        assertEquals("Hello", readableTextBetween(simpleHtml, 0, 5))
+        assertEquals("world", readableTextBetween(simpleHtml, 6, 11))
+        // spanning both paragraphs — jsoup concatenation is contiguous per readable-node walk.
+        assertEquals("worldSecond", readableTextBetween(simpleHtml, 6, 17))
+    }
+
+    @Test
+    fun `readableTextBetween returns null for empty or degenerate ranges`() {
+        assertNull(readableTextBetween(simpleHtml, 0, 0))
+        assertNull(readableTextBetween(simpleHtml, 5, 5))
+        assertNull(readableTextBetween(simpleHtml, 5, 3))
+    }
+
+    @Test
     fun `selection with blank selected text yields null`() {
         assertNull(
             buildHighlightCfiRangeForSelection(

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/EpubCfiRangeTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/EpubCfiRangeTest.kt
@@ -99,6 +99,49 @@ class EpubCfiRangeTest {
     }
 
     @Test
+    fun `readableBodyText concatenates all readable text nodes in order`() {
+        assertEquals("Hello worldSecond paragraph", readableBodyText(simpleHtml))
+    }
+
+    /**
+     * Regression: locateSnippetInBody uses textBefore's tail as a disambiguating anchor when the
+     * snippet appears in multiple places. Without the anchor we'd fall back to first-occurrence
+     * (the wrong position for a highlight that lives on a later match).
+     */
+    @Test
+    fun `locateSnippetInBody uses textBefore anchor to pick the right occurrence`() {
+        val html = """
+            <html><body>
+                <p>Once upon a time</p>
+                <p>She said hello world and smiled</p>
+                <p>He whispered hello world softly</p>
+            </body></html>
+        """.trimIndent()
+        // readable stream: "Once upon a timeShe said hello world and smiledHe whispered hello world softly"
+        val second = locateSnippetInBody(html, snippet = "hello world", before = "He whispered ")
+        val body = readableBodyText(html)
+        assertEquals(body.indexOf("hello world", startIndex = body.indexOf("hello world") + 1).toLong(), second)
+    }
+
+    @Test
+    fun `locateSnippetInBody falls back to unique-only match when anchor is empty`() {
+        val html = "<html><body><p>Hello world</p><p>Second paragraph</p></body></html>"
+        assertEquals(0L, locateSnippetInBody(html, snippet = "Hello world", before = ""))
+    }
+
+    @Test
+    fun `locateSnippetInBody returns null when snippet is ambiguous and anchor doesnt disambiguate`() {
+        val html = "<html><body><p>hello world one</p><p>hello world two</p></body></html>"
+        assertNull(locateSnippetInBody(html, snippet = "hello world", before = ""))
+    }
+
+    @Test
+    fun `locateSnippetInBody returns null when snippet not in body`() {
+        val html = "<html><body><p>Hello world</p></body></html>"
+        assertNull(locateSnippetInBody(html, snippet = "goodbye", before = ""))
+    }
+
+    @Test
     fun `selection with blank selected text yields null`() {
         assertNull(
             buildHighlightCfiRangeForSelection(

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/HighlightMergeTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/HighlightMergeTest.kt
@@ -1,0 +1,318 @@
+package com.riffle.app.feature.reader
+
+import com.riffle.core.database.AnnotationEntity
+import com.riffle.core.domain.Annotation
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Regression tests for auto-merging adjacent highlights (spec: 2026-07-05-highlight-auto-merge-design.md).
+ *
+ * These assertions would flip red if the merge rules were reverted line-for-line — see individual
+ * doc comments for which line of the design each pins.
+ */
+class HighlightMergeTest {
+
+    private fun annotation(
+        id: String = "n",
+        color: String = "yellow",
+        note: String? = null,
+        textSnippet: String = "",
+        textBefore: String = "",
+        textAfter: String = "",
+        spineIndex: Int = 0,
+        progression: Double = 0.0,
+        type: String = AnnotationEntity.TYPE_HIGHLIGHT,
+    ) = Annotation(
+        id = id,
+        sourceId = "srv",
+        itemId = "item",
+        type = type,
+        cfi = "epubcfi(/6/2!/4/2,/1:0,/1:5)",
+        color = color,
+        note = note,
+        textSnippet = textSnippet,
+        textBefore = textBefore,
+        textAfter = textAfter,
+        chapterHref = "ch1.xhtml",
+        spineIndex = spineIndex,
+        progression = progression,
+        bookmarkTitle = "",
+        createdAt = 0L,
+        updatedAt = 0L,
+    )
+
+    private fun anchor(
+        color: String = "yellow",
+        note: String? = null,
+        textSnippet: String,
+        textBefore: String = "",
+        textAfter: String = "",
+        spineIndex: Int = 0,
+        progression: Double = 0.5,
+    ) = MergeAnchor(
+        spineIndex = spineIndex,
+        color = color,
+        note = note,
+        textSnippet = textSnippet,
+        textBefore = textBefore,
+        textAfter = textAfter,
+        progression = progression,
+        chapterHref = "ch1.xhtml",
+    )
+
+    // -------- Eligibility (pins design rule: same colour, both notes empty, same chapter) --------
+
+    @Test
+    fun `same-colour no-note in same chapter is eligible`() {
+        val a = anchor(textSnippet = "Foo", textAfter = " Bar")
+        val n = annotation(id = "b", color = "yellow", textSnippet = "Bar")
+        assertTrue(isMergeEligible(a, n))
+    }
+
+    @Test
+    fun `different colours are not eligible`() {
+        val a = anchor(color = "yellow", textSnippet = "Foo", textAfter = " Bar")
+        val n = annotation(color = "blue", textSnippet = "Bar")
+        assertEquals(false, isMergeEligible(a, n))
+    }
+
+    @Test
+    fun `anchor with a note is not eligible`() {
+        val a = anchor(note = "Look at this", textSnippet = "Foo", textAfter = " Bar")
+        val n = annotation(textSnippet = "Bar")
+        assertEquals(false, isMergeEligible(a, n))
+    }
+
+    @Test
+    fun `candidate with a note is not eligible`() {
+        val a = anchor(textSnippet = "Foo", textAfter = " Bar")
+        val n = annotation(note = "Interesting", textSnippet = "Bar")
+        assertEquals(false, isMergeEligible(a, n))
+    }
+
+    @Test
+    fun `blank note counts as empty`() {
+        val a = anchor(note = "   ", textSnippet = "Foo", textAfter = " Bar")
+        val n = annotation(note = "\n\t", textSnippet = "Bar")
+        assertTrue(isMergeEligible(a, n))
+    }
+
+    @Test
+    fun `different chapters are not eligible`() {
+        val a = anchor(textSnippet = "Foo", textAfter = " Bar", spineIndex = 3)
+        val n = annotation(textSnippet = "Bar", spineIndex = 4)
+        assertEquals(false, isMergeEligible(a, n))
+    }
+
+    @Test
+    fun `bookmarks are not eligible`() {
+        val a = anchor(textSnippet = "Foo", textAfter = " Bar")
+        val n = annotation(textSnippet = "Bar", type = AnnotationEntity.TYPE_BOOKMARK)
+        assertEquals(false, isMergeEligible(a, n))
+    }
+
+    // -------- Adjacency (pins design rule: textAfter/textBefore contain neighbour snippet) --------
+
+    @Test
+    fun `adjacent after with single space collapses whitespace`() {
+        val a = anchor(textSnippet = "Foo", textAfter = " Bar and more")
+        val n = annotation(textSnippet = "Bar")
+        val match = findAdjacency(a, n)
+        assertNotNull(match)
+        assertEquals(MergeSide.CANDIDATE_AFTER_ANCHOR, match!!.side)
+        assertEquals(" ", match.whitespaceBetween)
+    }
+
+    @Test
+    fun `adjacent before with single space collapses whitespace`() {
+        val a = anchor(textSnippet = "Bar", textBefore = "Something Foo ")
+        val n = annotation(textSnippet = "Foo")
+        val match = findAdjacency(a, n)
+        assertNotNull(match)
+        assertEquals(MergeSide.CANDIDATE_BEFORE_ANCHOR, match!!.side)
+        assertEquals(" ", match.whitespaceBetween)
+    }
+
+    @Test
+    fun `strict abutment matches with empty whitespace run`() {
+        val a = anchor(textSnippet = "Foo", textAfter = "Bar and more")
+        val n = annotation(textSnippet = "Bar")
+        val match = findAdjacency(a, n)
+        assertNotNull(match)
+        assertEquals("", match!!.whitespaceBetween)
+    }
+
+    @Test
+    fun `gap with non-whitespace chars is not adjacent`() {
+        val a = anchor(textSnippet = "Foo", textAfter = ", Bar and more")
+        val n = annotation(textSnippet = "Bar")
+        assertNull(findAdjacency(a, n))
+    }
+
+    @Test
+    fun `neighbour must sit at start of textAfter not further into it`() {
+        val a = anchor(textSnippet = "Foo", textAfter = " middle Bar")
+        val n = annotation(textSnippet = "Bar")
+        assertNull(findAdjacency(a, n))
+    }
+
+    @Test
+    fun `blank snippets never match`() {
+        val a = anchor(textSnippet = "  ", textAfter = "Bar")
+        val n = annotation(textSnippet = "Bar")
+        assertNull(findAdjacency(a, n))
+    }
+
+    // -------- Merge action (pins design rule for merged-field computation) --------
+
+    @Test
+    fun `after-merge combines snippets with whitespace and inherits candidate textAfter`() {
+        val a = anchor(
+            textSnippet = "Foo",
+            textBefore = "Before ",
+            textAfter = " Bar and continues",
+            progression = 0.3,
+        )
+        val n = annotation(textSnippet = "Bar", textAfter = "and continues", progression = 0.5)
+        val match = findAdjacency(a, n)!!
+        val merged = applyMerge(a, match)
+        assertEquals("Foo Bar", merged.textSnippet)
+        assertEquals("Before ", merged.textBefore)
+        assertEquals("and continues", merged.textAfter)
+        assertEquals(0.3, merged.progression, 1e-9)
+    }
+
+    @Test
+    fun `before-merge inherits candidate textBefore and progression`() {
+        val a = anchor(
+            textSnippet = "Bar",
+            textBefore = "Prev Foo ",
+            textAfter = "After",
+            progression = 0.5,
+        )
+        val n = annotation(textSnippet = "Foo", textBefore = "Prev ", progression = 0.4)
+        val match = findAdjacency(a, n)!!
+        val merged = applyMerge(a, match)
+        assertEquals("Foo Bar", merged.textSnippet)
+        assertEquals("Prev ", merged.textBefore)
+        assertEquals("After", merged.textAfter)
+        assertEquals(0.4, merged.progression, 1e-9)
+    }
+
+    // -------- Chain merge (pins loop-until-stable) --------
+
+    @Test
+    fun `chain merge absorbs both neighbours across two passes`() {
+        // Layout: [L] "Foo" [A] "Bar" [R] where A is the anchor and there are two same-colour
+        // no-note neighbours on either side.
+        var a = anchor(
+            textSnippet = "Bar",
+            textBefore = "Foo ",
+            textAfter = " Baz",
+            progression = 0.5,
+        )
+        val left = annotation(id = "L", textSnippet = "Foo", textBefore = "", textAfter = " Bar Baz", progression = 0.4)
+        val right = annotation(id = "R", textSnippet = "Baz", textBefore = "Foo Bar ", textAfter = "", progression = 0.6)
+        val pool = listOf(left, right)
+
+        val consumed = mutableSetOf<String>()
+        var iterations = 0
+        while (true) {
+            val m = findAnyMergeableNeighbor(a, pool, consumed) ?: break
+            consumed += m.neighbor.id
+            a = applyMerge(a, m)
+            iterations++
+            check(iterations < 10)
+        }
+        assertEquals(2, consumed.size)
+        assertEquals(setOf("L", "R"), consumed)
+        assertEquals("Foo Bar Baz", a.textSnippet)
+        assertEquals("", a.textBefore)
+        assertEquals("", a.textAfter)
+        assertEquals(0.4, a.progression, 1e-9)
+    }
+
+    @Test
+    fun `excluded id is skipped even if otherwise eligible`() {
+        val a = anchor(textSnippet = "Foo", textAfter = " Bar")
+        val n = annotation(id = "self", textSnippet = "Bar")
+        assertNull(findAnyMergeableNeighbor(a, listOf(n), excludeIds = setOf("self")))
+    }
+
+    /**
+     * Readium bounds textAfter/textBefore to a fixed window; a long neighbour snippet may not fit
+     * in the anchor's textAfter but does fit in the neighbour's own textBefore. Adjacency must
+     * still be detected via the neighbour's context.
+     */
+    @Test
+    fun `adjacency detected via neighbours textBefore when anchor textAfter is truncated`() {
+        val a = anchor(textSnippet = "Foo", textAfter = "") // truncated / unavailable
+        val n = annotation(
+            textSnippet = "Bar",
+            textBefore = "Some earlier prose Foo ",
+        )
+        val match = findAdjacency(a, n)
+        assertNotNull(match)
+        assertEquals(MergeSide.CANDIDATE_AFTER_ANCHOR, match!!.side)
+    }
+
+    @Test
+    fun `adjacency detected via neighbours textAfter when anchor textBefore is truncated`() {
+        val a = anchor(textSnippet = "Bar", textBefore = "")
+        val n = annotation(
+            textSnippet = "Foo",
+            textAfter = " Bar rest of paragraph",
+        )
+        val match = findAdjacency(a, n)
+        assertNotNull(match)
+        assertEquals(MergeSide.CANDIDATE_BEFORE_ANCHOR, match!!.side)
+    }
+
+    /**
+     * Reproduces the on-device miss from the 2026-07-05 note-clear scenario: anchor snippet is
+     * ~30 chars, candidate.textAfter starts with " " + <the exact anchor snippet>, but Readium
+     * emitted an NBSP (U+00A0) as one of the interior spaces in candidate.textAfter — a byte-exact
+     * regionMatches misses; whitespace-normalised match catches it.
+     */
+    @Test
+    fun `adjacency tolerates NBSP-vs-space in captured DOM whitespace`() {
+        val a = anchor(textSnippet = "as a new feature or a bug fix.", textBefore = "such ")
+        // Same words, but the space between "new" and "feature" is a non-breaking space.
+        val nbspVariant = " as a new feature or a bug fix. At first"
+        val n = annotation(textSnippet = "Most programmers approach software", textAfter = nbspVariant)
+        assertNotNull(findAdjacency(a, n))
+    }
+
+    /**
+     * Reproduces the 2026-07-05 scenario more directly: candidate.textAfter begins with the
+     * anchor's full snippet plus trailing prose, and the anchor's textBefore is short — the
+     * bidirectional check MUST catch it via the candidate's own textAfter.
+     */
+    @Test
+    fun `adjacency detected via neighbours textAfter even when anchor textBefore does not carry it`() {
+        val a = anchor(
+            textSnippet = "as a new feature or a bug fix.",
+            textBefore = "o get something working, such ",
+            textAfter = "\nThe problem with tactical pro",
+        )
+        val n = annotation(
+            textSnippet = "Most programmers approach software design as a tactical activity",
+            textBefore = "the long run.\n3.1  Tactical programming\n",
+            textAfter = " as a new feature or a bug fix. At first",
+        )
+        val match = findAdjacency(a, n)
+        assertNotNull(match)
+        assertEquals(MergeSide.CANDIDATE_BEFORE_ANCHOR, match!!.side)
+    }
+
+    @Test
+    fun `color match is case-insensitive`() {
+        val a = anchor(color = "YELLOW", textSnippet = "Foo", textAfter = " Bar")
+        val n = annotation(color = "yellow", textSnippet = "Bar")
+        assertTrue(isMergeEligible(a, n))
+    }
+}

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/session/AnnotationSessionTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/session/AnnotationSessionTest.kt
@@ -6,6 +6,7 @@ import com.riffle.app.feature.reader.ProgressFlushScope
 import com.riffle.app.testing.TestApplicationScope
 import com.riffle.core.data.AnnotationSyncStatusStore
 import com.riffle.core.data.CycleOutcome
+import com.riffle.core.database.AnnotationEntity
 import com.riffle.core.domain.Annotation
 import com.riffle.core.domain.AnnotationStore
 import com.riffle.core.domain.HighlightColor
@@ -118,7 +119,7 @@ class AnnotationSessionTest {
 
     private fun fakeAnnotation(
         id: String = "a1",
-        type: String = "highlight",
+        type: String = AnnotationEntity.TYPE_HIGHLIGHT,
         cfi: String = "epubcfi(/6/4!/4/2)",
         color: String = "yellow",
     ) = makeAnnotation(id, type, cfi, color)
@@ -126,7 +127,7 @@ class AnnotationSessionTest {
     companion object {
         fun makeAnnotation(
             id: String = "a1",
-            type: String = "highlight",
+            type: String = AnnotationEntity.TYPE_HIGHLIGHT,
             cfi: String = "epubcfi(/6/4!/4/2)",
             color: String = "yellow",
         ) = Annotation(
@@ -195,6 +196,7 @@ class AnnotationSessionTest {
         flushScope: ProgressFlushScope = ProgressFlushScope(
             TestApplicationScope(CoroutineScope(UnconfinedTestDispatcher() + SupervisorJob()))
         ),
+        mergeAfterEdit: suspend (String, String, String?) -> Unit = { _, _, _ -> },
     ) = AnnotationSession(
         scope = scope,
         annotationStore = store,
@@ -205,6 +207,7 @@ class AnnotationSessionTest {
         scheduleSync = syncOps.makeScheduleDebounce(),
         syncOnOpen = syncOps.makeSyncOnOpen(),
         syncOnClose = syncOps.makeSyncOnClose(),
+        mergeAfterEdit = mergeAfterEdit,
     )
 
     private fun defaultBind(
@@ -357,7 +360,200 @@ class AnnotationSessionTest {
             cfiLocatorResolver = { null },
         )
         assertEquals(HighlightColor.RED, session.lastUsedHighlightColor.value)
+        sessionScope.coroutineContext[Job]?.cancel()
+    }
 
+    /**
+     * Regression: individual edits (recolour, note-add/edit, note-clear) INSIDE the highlight
+     * actions popup must NOT fire [mergeAfterEdit]. The user is still iterating; a mid-session
+     * merge would silently absorb neighbours before they've committed. Commit is signalled by
+     * popup dismissal — see [AnnotationSession.dismissHighlightActions].
+     */
+    @Test
+    fun `individual edits do not fire mergeAfterEdit`() = runTest {
+        val dispatcher = UnconfinedTestDispatcher(testScheduler)
+        val sessionScope = CoroutineScope(dispatcher)
+        val store = FakeAnnotationStore()
+        val syncOps = FakeSyncOps()
+        val mergeCalls = mutableListOf<Triple<String, String, String?>>()
+        val session = makeSession(
+            store = store, syncOps = syncOps, scope = sessionScope,
+            mergeAfterEdit = { id, color, note -> mergeCalls += Triple(id, color, note) },
+        )
+        defaultBind(session)
+        store.allAnnotations.value = listOf(makeAnnotation(id = "h1", color = "yellow"))
+
+        session.recolorHighlight("h1", HighlightColor.BLUE)
+        session.updateHighlightNote("h1", "hello")
+        session.updateHighlightNote("h1", null)
+
+        assertEquals(0, mergeCalls.size)
+        sessionScope.coroutineContext[Job]?.cancel()
+    }
+
+    /**
+     * Regression: [AnnotationSession.dismissHighlightActions] is the merge commit point. On
+     * dismiss it must fire [mergeAfterEdit] with the row's CURRENT colour + note so the VM can
+     * absorb a same-chapter same-colour no-note neighbour. Dropping this call reintroduces the
+     * "user closed popup, expected merge, nothing happened" report.
+     */
+    @Test
+    fun `dismissHighlightActions fires mergeAfterEdit with the current row state`() = runTest {
+        val dispatcher = UnconfinedTestDispatcher(testScheduler)
+        val sessionScope = CoroutineScope(dispatcher)
+        val store = FakeAnnotationStore()
+        val syncOps = FakeSyncOps()
+        val mergeCalls = mutableListOf<Triple<String, String, String?>>()
+        val session = makeSession(
+            store = store, syncOps = syncOps, scope = sessionScope,
+            mergeAfterEdit = { id, color, note -> mergeCalls += Triple(id, color, note) },
+        )
+        defaultBind(session)
+        store.allAnnotations.value = listOf(makeAnnotation(id = "h1", color = "green").copy(note = null))
+        session.openHighlightActions("h1", androidx.compose.ui.unit.IntRect(0, 0, 0, 0))
+
+        session.dismissHighlightActions()
+
+        assertEquals(1, mergeCalls.size)
+        assertEquals("h1", mergeCalls[0].first)
+        assertEquals("green", mergeCalls[0].second)
+        assertNull(mergeCalls[0].third)
+        // And the popup is closed.
+        assertNull(session.highlightToEdit.value)
+        sessionScope.coroutineContext[Job]?.cancel()
+    }
+
+    /**
+     * Regression: tapping "Add note" transitions the actions popup into the note editor. The
+     * actions popup closes, but this MUST NOT fire mergeAfterEdit — the row is about to receive
+     * a note. A merge fired here would (a) absorb the row into a same-colour neighbour and (b)
+     * cause the incoming note to land on a tombstoned id (video-reported bug).
+     */
+    @Test
+    fun `openNoteEditor closes actions popup without firing merge`() = runTest {
+        val dispatcher = UnconfinedTestDispatcher(testScheduler)
+        val sessionScope = CoroutineScope(dispatcher)
+        val store = FakeAnnotationStore()
+        val syncOps = FakeSyncOps()
+        val mergeCalls = mutableListOf<Triple<String, String, String?>>()
+        val session = makeSession(
+            store = store, syncOps = syncOps, scope = sessionScope,
+            mergeAfterEdit = { id, color, note -> mergeCalls += Triple(id, color, note) },
+        )
+        defaultBind(session)
+        store.allAnnotations.value = listOf(makeAnnotation(id = "h1"))
+        session.openHighlightActions("h1", androidx.compose.ui.unit.IntRect(0, 0, 0, 0))
+
+        session.openNoteEditor("h1", androidx.compose.ui.unit.IntRect(0, 0, 0, 0))
+
+        assertNull(session.highlightToEdit.value)
+        assertEquals("h1", session.noteEditorTarget.value?.id)
+        assertEquals(0, mergeCalls.size)
+        sessionScope.coroutineContext[Job]?.cancel()
+    }
+
+    /** Regression: while the note editor is open, dismissing the actions popup is a no-op. */
+    @Test
+    fun `dismissHighlightActions is a no-op when note editor is open`() = runTest {
+        val dispatcher = UnconfinedTestDispatcher(testScheduler)
+        val sessionScope = CoroutineScope(dispatcher)
+        val store = FakeAnnotationStore()
+        val syncOps = FakeSyncOps()
+        val mergeCalls = mutableListOf<Triple<String, String, String?>>()
+        val session = makeSession(
+            store = store, syncOps = syncOps, scope = sessionScope,
+            mergeAfterEdit = { id, color, note -> mergeCalls += Triple(id, color, note) },
+        )
+        defaultBind(session)
+        store.allAnnotations.value = listOf(makeAnnotation(id = "h1"))
+        session.openHighlightActions("h1", androidx.compose.ui.unit.IntRect(0, 0, 0, 0))
+        session.openNoteEditor("h1", androidx.compose.ui.unit.IntRect(0, 0, 0, 0))
+
+        session.dismissHighlightActions()
+
+        assertEquals(0, mergeCalls.size)
+        sessionScope.coroutineContext[Job]?.cancel()
+    }
+
+    /**
+     * Regression: commitNoteEdit persists the note THEN fires merge with the NEW note. If the
+     * merge check ran before the note was persisted, eligibility would pass (both notes empty)
+     * and the row would be absorbed — losing the just-written note.
+     */
+    @Test
+    fun `commitNoteEdit fires mergeAfterEdit with the new note`() = runTest {
+        val dispatcher = UnconfinedTestDispatcher(testScheduler)
+        val sessionScope = CoroutineScope(dispatcher)
+        val store = FakeAnnotationStore()
+        val syncOps = FakeSyncOps()
+        val mergeCalls = mutableListOf<Triple<String, String, String?>>()
+        val session = makeSession(
+            store = store, syncOps = syncOps, scope = sessionScope,
+            mergeAfterEdit = { id, color, note -> mergeCalls += Triple(id, color, note) },
+        )
+        defaultBind(session)
+        store.allAnnotations.value = listOf(makeAnnotation(id = "h1", color = "blue"))
+        session.openNoteEditor("h1", androidx.compose.ui.unit.IntRect(0, 0, 0, 0))
+
+        session.commitNoteEdit("h1", "my thought")
+
+        assertEquals(listOf("h1" to "my thought"), store.updatedNotes)
+        assertNull(session.noteEditorTarget.value)
+        assertEquals(1, mergeCalls.size)
+        assertEquals("h1", mergeCalls[0].first)
+        assertEquals("blue", mergeCalls[0].second)
+        assertEquals("my thought", mergeCalls[0].third)
+        sessionScope.coroutineContext[Job]?.cancel()
+    }
+
+    /**
+     * Regression: cancelNoteEdit is still a commit point — the actions-popup edits (recolour,
+     * note-clear) that preceded opening the note editor need to see a final merge attempt.
+     */
+    @Test
+    fun `cancelNoteEdit fires mergeAfterEdit with unchanged row state`() = runTest {
+        val dispatcher = UnconfinedTestDispatcher(testScheduler)
+        val sessionScope = CoroutineScope(dispatcher)
+        val store = FakeAnnotationStore()
+        val syncOps = FakeSyncOps()
+        val mergeCalls = mutableListOf<Triple<String, String, String?>>()
+        val session = makeSession(
+            store = store, syncOps = syncOps, scope = sessionScope,
+            mergeAfterEdit = { id, color, note -> mergeCalls += Triple(id, color, note) },
+        )
+        defaultBind(session)
+        store.allAnnotations.value = listOf(makeAnnotation(id = "h1", color = "green"))
+        session.openNoteEditor("h1", androidx.compose.ui.unit.IntRect(0, 0, 0, 0))
+
+        session.cancelNoteEdit()
+
+        assertNull(session.noteEditorTarget.value)
+        assertEquals(1, mergeCalls.size)
+        assertEquals("h1", mergeCalls[0].first)
+        assertEquals("green", mergeCalls[0].second)
+        assertNull(mergeCalls[0].third)
+        sessionScope.coroutineContext[Job]?.cancel()
+    }
+
+    /**
+     * If the popup was never opened (no target), dismiss must be a no-op — no false merge fires.
+     */
+    @Test
+    fun `dismissHighlightActions with no target does not fire merge`() = runTest {
+        val dispatcher = UnconfinedTestDispatcher(testScheduler)
+        val sessionScope = CoroutineScope(dispatcher)
+        val store = FakeAnnotationStore()
+        val syncOps = FakeSyncOps()
+        val mergeCalls = mutableListOf<Triple<String, String, String?>>()
+        val session = makeSession(
+            store = store, syncOps = syncOps, scope = sessionScope,
+            mergeAfterEdit = { id, color, note -> mergeCalls += Triple(id, color, note) },
+        )
+        defaultBind(session)
+
+        session.dismissHighlightActions()
+
+        assertEquals(0, mergeCalls.size)
         sessionScope.coroutineContext[Job]?.cancel()
     }
 

--- a/core/logging/src/main/kotlin/com/riffle/core/logging/LogChannel.kt
+++ b/core/logging/src/main/kotlin/com/riffle/core/logging/LogChannel.kt
@@ -12,4 +12,5 @@ enum class LogChannel(val tag: String) {
     Readaloud("RIFFLE_RA"),
     Audiobook("RIFFLE_AB"),
     Handoff("RIFFLE_HANDOFF"),
+    HighlightMerge("RIFFLE_HL_MERGE"),
 }

--- a/docs/superpowers/specs/2026-07-05-highlight-auto-merge-design.md
+++ b/docs/superpowers/specs/2026-07-05-highlight-auto-merge-design.md
@@ -1,0 +1,105 @@
+# Highlight auto-merge — design
+
+## Problem
+
+Readers often highlight adjacent text in two operations: they highlight one phrase, then extend by highlighting the next phrase. The result is two separate `AnnotationEntity` rows that visually look like one continuous highlight but behave like two — separate delete taps, separate colors on recolor, separate rows in the annotations panel.
+
+We want adjacent highlights to auto-merge into a single annotation when it's safe to do so.
+
+## Scope
+
+- **In scope (post-rollout amendment 2026-07-05):** merge at *recolor* and *note-clear* only. Create-time merge was removed after user testing — it silently absorbed brand-new selections into an adjacent same-colour neighbour, blocking the user from differentiating the new highlight (recolour, add note) before the merge fired. Merge is now a purely opt-in-by-edit operation.
+- **Out of scope:** bulk migration of existing highlights. Existing separate-but-adjacent highlights stay as-is unless the user re-touches one of them.
+- **Out of scope:** merging across chapter boundaries (different `spineIndex`).
+- **Out of scope:** any UI to disable auto-merge. Merge is unconditional when the eligibility rules pass.
+
+## Eligibility rules
+
+Two highlights A and B merge only if **all** of these hold:
+
+1. Same `spineIndex` (same chapter).
+2. Same `color`.
+3. Both `note` fields are null or empty.
+4. A and B are **text-adjacent** (see below).
+
+If any of these fails, the highlights stay separate. In particular:
+
+- Different colors → separate (semantic distinction: yellow-important vs blue-question).
+- Either side has a note → separate (merging would drop or awkwardly concatenate notes).
+- Any gap that isn't a single whitespace run → separate (user intentionally skipped text).
+
+## Text-adjacency
+
+Reuses the text-matching pattern already used by `highlightOverlapsAtSamePosition` at `app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt:1501`.
+
+A is adjacent to B (in that order in the document) when:
+
+- `A.textAfter` starts with `B.textSnippet`, **or**
+- equivalently, `B.textBefore` ends with `A.textSnippet`.
+
+A single run of whitespace between the two snippets is collapsed for the comparison — so "end of one sentence." + " " + "Start of next" merges naturally. Any non-whitespace character between them means "not adjacent."
+
+**Judgment call flagged for review:** whitespace-collapse rule. Alternative is strict abutment (no gap at all). Default here is collapse-one-whitespace-run because sentence-boundary highlights are the most common merge case.
+
+## When merge fires (post-rollout amendment 2026-07-05)
+
+**Only on highlight-actions popup dismiss** (`AnnotationSession.dismissHighlightActions`). The popup close is the commit point: the user has finished iterating on colour and note. On dismiss we read the row's *final* colour + note and run the adjacency scan; if a same-chapter same-colour no-note neighbour matches, absorb it.
+
+Firing on the individual recolour / note edits (as this doc initially proposed) surprised users. While they were still iterating in the popup — trying a colour, adding then removing a note — the first same-colour recolour or note-clear would silently absorb a neighbour before they had a chance to differentiate it. Deferring the check to popup close makes the merge feel intentional.
+
+**Not triggered on:** create (see Scope), delete (only removes rows), popup open (state hasn't been committed).
+
+## Merge action
+
+Given surviving highlight S (the row being edited) and neighbour N to be absorbed:
+
+1. Compute merged text fields:
+   - `textBefore` = leftmost highlight's `textBefore`.
+   - `textAfter` = rightmost highlight's `textAfter`.
+   - `progression` = leftmost highlight's `progression`.
+2. **DOM-derive the merged `textSnippet`** (post-rollout amendment): extract the exact readable-text substring from the chapter DOM covering `[startChar, startChar + composedLength)`. Naïvely concatenating the two source snippets with a captured whitespace run drifts from the DOM whenever Readium's whitespace capture differs between `text.highlight` and `text.after`/`text.before` (NBSP vs space, newline vs space), which makes Readium's decorator fall back to a partial-range placement (visible as "first part missing").
+3. **Safety check:** if the DOM-derived snippet doesn't agree with the composed snippet under whitespace-normalised, case-insensitive comparison, abort the merge. This catches false-positive adjacency matches (e.g. tail-of-context coincidence) before they commit.
+4. Rebuild a spanning CFI range covering both via `buildHighlightCfiRangeForSelection` on the DOM-derived snippet.
+5. **Defer neighbour deletes until all computations succeed** — no orphaned deletes if CFI build fails.
+6. Delete each absorbed neighbour + the anchor row; upsert the merged row.
+7. Schedule sync (`scheduleAnnotationSync()`) once at the end — one debounce for the whole merge.
+
+## Chain merge
+
+After a merge, the surviving highlight may now be adjacent to another neighbor (e.g. user highlights the middle of three touching phrases last, joining left and right in one go, or recolor unifies three-in-a-row). Loop the adjacency scan on the surviving row until no more neighbors match. Bounded by "number of same-chapter same-color no-note highlights" — cheap, and in practice ≤ a few iterations.
+
+## Reader-mode considerations
+
+All three reader modes (paginated, vertical, continuous) share a single highlight creation path via `EpubReaderViewModel.createHighlight`. The merge logic lives there and applies uniformly.
+
+Continuous mode renders highlights via DOM `data-riffle-ann` marks (`AnnotationSession.applyAnnotationHighlights`); a deleted-then-upserted row will re-render on the next annotation-state emission, same as any recolor or note edit today. No mode-specific code needed.
+
+## Sync
+
+Merge = one delete + one upsert on the same chapter. Both flow through the existing `annotationStore` + `scheduleAnnotationSync()` path, so the sync layer treats it as two independent operations. Devices without this feature receiving a merged annotation see the merged row appear and the neighbor row tombstone — normal behavior, no protocol change.
+
+## Testing
+
+Regression tests must cover the eligibility matrix and the merge action. All at the JVM level — the merge decision is pure logic over `AnnotationEntity` fields plus text-adjacency over strings.
+
+Extract the eligibility + adjacency + merged-field computation into a top-level `internal` helper (e.g. `HighlightMerge.kt`) so it's unit-testable without a ViewModel harness.
+
+Assertions that would flip red if the fix were reverted:
+
+- **Merge happens:** same color, both notes empty, snippets abutting → after create, exactly one row exists with the combined snippet.
+- **Different colors don't merge:** yellow next to blue → two rows survive.
+- **Note blocks merge:** left has a note, right doesn't → two rows survive; ditto right-has-note.
+- **Gap blocks merge:** two characters between snippets → two rows survive.
+- **Whitespace collapses:** exactly one space between snippets → one row after create.
+- **Recolor triggers merge:** two adjacent different-color no-note rows; recolor one to match → one row after recolor.
+- **Note-clear triggers merge:** two adjacent same-color rows where one has a note; clear the note → one row after the update.
+- **Note edit (still non-empty) does not trigger merge:** same setup; edit the note text without clearing it → still two rows.
+- **Chain merge:** three adjacent same-color no-note rows created in outer-then-middle order → one row after the middle create.
+- **textAfter/textBefore preserved:** merged row's `textBefore` = leftmost's, `textAfter` = rightmost's.
+- **Sync scheduled once:** exactly one `scheduleAnnotationSync` call per merge.
+
+Existing highlights are untouched (out of scope) — no test needed for "old adjacent rows stay separate on app launch" beyond the standing invariant that nothing scans the DB at launch.
+
+## Migration
+
+None. Schema unchanged. Existing rows untouched.


### PR DESCRIPTION
## Summary

Adjacent highlights that share the same colour and carry no notes merge into a single row when the user closes the highlight-actions popup. The commit point is popup dismissal (or the note editor's confirm/cancel when a note edit was in flight) — mid-edit iteration inside the popup does not fire a merge, so the user can recolour or add a note before the merge decision is made.

Snippet stitching uses text-anchored DOM search (`locateSnippetInBody`) to recover each highlight's true chapter char position. Readium's stored `progression` for a paginated selection is the page start rather than the selection start, so before this change every highlight created on the same page shared the same char position — merged ranges landed off, and the annotations panel sorted same-page highlights by createdAt instead of reading order. The text-search is now also applied on create so the panel prints reading order.

Spec: `docs/superpowers/specs/2026-07-05-highlight-auto-merge-design.md`.

## What's covered

- Popup-dismiss commit semantics — `AnnotationSession` tracks the note-editor target so `dismissHighlightActions` can distinguish "transition to note editor" from a true commit.
- Same-chapter same-colour no-note text-adjacency (whitespace-run tolerant, bidirectional, minimum-overlap floor).
- Chain merge, with both endpoints re-located via text-search so cross-paragraph merges (where our readable-char model differs from Readium's captured whitespace) don't false-fail.
- Safety abort if the DOM-derived text disagrees with the composed snippet under whitespace-strip equality — catches false-positive adjacency without tripping on paragraph boundaries.
- Neighbour deletes are deferred until every downstream step (CFI build, DOM extraction, safety check) succeeds. No orphaned deletes on failure.
- Debug tag `RIFFLE_HL_MERGE` (`LogChannel.HighlightMerge`) with per-step diagnostics.

## Test plan

- [x] `HighlightMergeTest` — eligibility matrix (colour / note / gap / whitespace / bookmark), bidirectional adjacency, chain merge, case-insensitive colour match, NBSP tolerance.
- [x] `AnnotationSessionTest` — popup-dismiss fires merge with current state, individual edits (recolour, note-add, note-edit, note-clear) do NOT fire, `openNoteEditor` closes actions popup without merge, `dismissHighlightActions` is a no-op while note editor is open, `commitNoteEdit` orders write-then-merge with the new note, `cancelNoteEdit` fires merge with unchanged state.
- [x] `EpubCfiRangeTest` — `readableBodyText` concatenation, `readableTextBetween` range extraction, `locateSnippetInBody` anchored / fallback / ambiguous / missing.
- [x] Full JVM suite green.
- [x] Manually verified on emulator: yellow-yellow-no-note dismiss → merged; different-colour or note-present dismiss → not merged; overlap-create still deletes covered highlight via existing `highlightOverlapsAtSamePosition`.

## Notes

- The migration path is empty. Highlights created before this branch retain page-level `progression` so their annotations-panel ordering will only correct on delete+recreate. New highlights sort by real reading order.
- Merge is EPUB-only (as-is with the rest of `EpubReaderViewModel` highlight flow). PDF has no equivalent.