### PR TITLE
feat(logging): in-app debug log viewer + continuous highlight instrumentation

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ChapterWebView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ChapterWebView.kt
@@ -244,14 +244,18 @@ internal class ChapterWebView(context: Context) : WebView(context), ChapterWebVi
         webChromeClient = object : WebChromeClient() {
             override fun onConsoleMessage(consoleMessage: ConsoleMessage?): Boolean {
                 val m = consoleMessage ?: return false
-                val line = "JS ${m.sourceId()?.substringAfterLast('/') ?: "?"}:${m.lineNumber()} ${m.message()}"
                 when (m.messageLevel()) {
-                    ConsoleMessage.MessageLevel.ERROR -> jsConsoleLogger.e(LogChannel.ReaderDecoration) { line }
-                    ConsoleMessage.MessageLevel.WARNING -> jsConsoleLogger.w(LogChannel.ReaderDecoration) { line }
+                    ConsoleMessage.MessageLevel.ERROR ->
+                        jsConsoleLogger.e(LogChannel.ReaderDecoration) { formatConsoleLine(m) }
+                    ConsoleMessage.MessageLevel.WARNING ->
+                        jsConsoleLogger.w(LogChannel.ReaderDecoration) { formatConsoleLine(m) }
                     else -> Unit
                 }
                 return false
             }
+
+            private fun formatConsoleLine(m: ConsoleMessage): String =
+                "JS ${m.sourceId()?.substringAfterLast('/') ?: "?"}:${m.lineNumber()} ${m.message()}"
         }
         webViewClient = object : WebViewClient() {
             override fun onPageFinished(view: WebView?, url: String?) {

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ChapterWebView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ChapterWebView.kt
@@ -4,11 +4,16 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.webkit.JavascriptInterface
 import android.webkit.RenderProcessGoneDetail
+import android.webkit.ConsoleMessage
+import android.webkit.WebChromeClient
 import android.webkit.WebResourceRequest
 import android.webkit.WebResourceResponse
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import com.riffle.core.domain.FormattingPreferences
+import com.riffle.core.logging.LogChannel
+import com.riffle.core.logging.Logger
+import com.riffle.core.logging.NoopLogger
 import kotlinx.coroutines.runBlocking
 import org.readium.r2.shared.publication.Publication
 import org.readium.r2.shared.util.Url
@@ -189,6 +194,15 @@ internal class ChapterWebView(context: Context) : WebView(context), ChapterWebVi
         publication = pub
     }
 
+    /**
+     * Optional sink for JS console messages emitted by this chapter's page. Set by
+     * [ContinuousWindowController] to the ReaderDecoration [Logger] so the in-app debug screen
+     * shows DOM-side errors (e.g. #428's `createTreeWalker` throw) alongside the Kotlin-side
+     * decoration events. WARNING/ERROR forward to `logger.w`/`logger.e`; DEBUG/LOG/TIP are dropped
+     * to keep noise low.
+     */
+    var jsConsoleLogger: Logger = NoopLogger
+
     init {
         isScrollContainer = false
         isVerticalScrollBarEnabled = false
@@ -227,6 +241,18 @@ internal class ChapterWebView(context: Context) : WebView(context), ChapterWebVi
             androidx.webkit.WebSettingsCompat.setOffscreenPreRaster(settings, true)
         }
         addJavascriptInterface(HeightBridge(), FigureTapScript.CONTINUOUS_BRIDGE_NAME)
+        webChromeClient = object : WebChromeClient() {
+            override fun onConsoleMessage(consoleMessage: ConsoleMessage?): Boolean {
+                val m = consoleMessage ?: return false
+                val line = "JS ${m.sourceId()?.substringAfterLast('/') ?: "?"}:${m.lineNumber()} ${m.message()}"
+                when (m.messageLevel()) {
+                    ConsoleMessage.MessageLevel.ERROR -> jsConsoleLogger.e(LogChannel.ReaderDecoration) { line }
+                    ConsoleMessage.MessageLevel.WARNING -> jsConsoleLogger.w(LogChannel.ReaderDecoration) { line }
+                    else -> Unit
+                }
+                return false
+            }
+        }
         webViewClient = object : WebViewClient() {
             override fun onPageFinished(view: WebView?, url: String?) {
                 this@ChapterWebView.onPageFinished?.invoke()

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousDecorationController.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousDecorationController.kt
@@ -1,5 +1,8 @@
 package com.riffle.app.feature.reader
 
+import com.riffle.core.logging.LogChannel
+import com.riffle.core.logging.Logger
+import com.riffle.core.logging.NoopLogger
 import kotlin.math.abs
 
 /**
@@ -32,20 +35,33 @@ internal class ContinuousDecorationController(
         val currentScrollY: Int
     }
 
+    /** Set by the host ([ContinuousWindowController.logger]) once the reader is wired up.
+     *  Emissions land on [LogChannel.ReaderDecoration] (tag `RIFFLE_DECO`) and mirror to
+     *  the in-app debug log screen — see docs/agents/domain.md. */
+    internal var logger: Logger = NoopLogger
+
     private var currentAnnotationsByHref: Map<String, List<AnnotationHighlight>> = emptyMap()
     private var currentSearchHighlights: SearchHighlightsState? = null
 
     /** Called by [ContinuousReaderView.onPageFinished] once a chapter's page has loaded so it
      *  re-applies whatever decorations belong to it. */
     fun onChapterLoaded(wv: ChapterWebViewLike, onAnnotationsApplied: () -> Unit = {}) {
-        val annotations = currentAnnotationsByHref[wv.chapterHref]
+        val href = wv.chapterHref
+        val annotations = currentAnnotationsByHref[href]
+        val count = annotations?.size ?: 0
+        logger.d(LogChannel.ReaderDecoration) {
+            "onChapterLoaded href='$href' annotationsForHref=$count knownHrefs=${currentAnnotationsByHref.size}"
+        }
         if (!annotations.isNullOrEmpty()) {
             wv.evaluateJavascript(ContinuousStyleInjector.applyAnnotationHighlightsJs(annotations)) { _ ->
+                logger.d(LogChannel.ReaderDecoration) {
+                    "onChapterLoaded apply-complete href='$href' count=$count"
+                }
                 onAnnotationsApplied()
             }
         }
         val search = currentSearchHighlights
-        if (search != null && search.resultsByHref.containsKey(wv.chapterHref)) {
+        if (search != null && search.resultsByHref.containsKey(href)) {
             applySearchTo(wv, search)
         }
     }
@@ -68,14 +84,26 @@ internal class ContinuousDecorationController(
         onEachApplied: (ChapterWebViewLike) -> Unit,
     ) {
         currentAnnotationsByHref = annotationsByHref
+        val loadedHrefs = mutableListOf<String>()
+        port.forEachLoadedWebView { loadedHrefs += it.chapterHref }
+        logger.d(LogChannel.ReaderDecoration) {
+            val perHref = annotationsByHref.entries.joinToString(",") { "${it.key}=${it.value.size}" }
+            "applyAnnotationHighlights hrefsWithMarks=${annotationsByHref.size} loadedHrefs=$loadedHrefs perHref=[$perHref]"
+        }
         port.forEachLoadedWebView { wv ->
             val href = wv.chapterHref
-            if (href.isEmpty()) return@forEachLoadedWebView
+            if (href.isEmpty()) {
+                logger.w(LogChannel.ReaderDecoration) { "applyAnnotationHighlights skip: empty chapterHref on WebView" }
+                return@forEachLoadedWebView
+            }
             val annotations = annotationsByHref[href]
             if (annotations.isNullOrEmpty()) {
+                logger.d(LogChannel.ReaderDecoration) { "apply→clear href='$href'" }
                 wv.evaluateJavascript(ContinuousStyleInjector.CLEAR_ANNOTATION_HIGHLIGHTS_JS, null)
             } else {
+                logger.d(LogChannel.ReaderDecoration) { "apply→highlights href='$href' count=${annotations.size}" }
                 wv.evaluateJavascript(ContinuousStyleInjector.applyAnnotationHighlightsJs(annotations)) { _ ->
+                    logger.d(LogChannel.ReaderDecoration) { "apply-complete href='$href' count=${annotations.size}" }
                     onEachApplied(wv)
                 }
             }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
@@ -37,6 +37,14 @@ internal class ContinuousReaderView @JvmOverloads constructor(
     attrs: AttributeSet? = null,
 ) : NestedScrollView(context, attrs), ContinuousHighlightTarget, ContinuousNavigationView {
 
+    /** Wired from the reader ViewModel; forwards to [ContinuousWindowController.logger] so the
+     *  decoration path logs to [com.riffle.core.logging.LogChannel.ReaderDecoration]. */
+    internal var logger: com.riffle.core.logging.Logger = com.riffle.core.logging.NoopLogger
+        set(value) {
+            field = value
+            controller.logger = value
+        }
+
     data class ChapterEntry(val link: Link, val url: String)
 
     private val port = object : ContinuousScrollPort {

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousWindowController.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousWindowController.kt
@@ -5,6 +5,9 @@ import android.view.ViewGroup.LayoutParams.MATCH_PARENT
 import android.view.ViewGroup.LayoutParams.WRAP_CONTENT
 import android.widget.LinearLayout
 import com.riffle.core.domain.FormattingPreferences
+import com.riffle.core.logging.LogChannel
+import com.riffle.core.logging.Logger
+import com.riffle.core.logging.NoopLogger
 import org.readium.r2.shared.publication.Publication
 
 /**
@@ -105,6 +108,15 @@ internal class ContinuousWindowController(
     /** Parallel list to the loaded WebViews; index i matches container.getChildAt(i). */
     private val webViews = mutableListOf<ChapterWebView>()
 
+    /** Wired by [ContinuousReaderView.logger] from the reader ViewModel so decoration-path
+     *  diagnostics land in the in-app debug screen (channel [LogChannel.ReaderDecoration]).
+     *  Setter propagates to the child [ContinuousDecorationController]. */
+    internal var logger: Logger = NoopLogger
+        set(value) {
+            field = value
+            decorations.logger = value
+        }
+
     /** Owns annotation + search decoration state and the apply-to-window loops. */
     private val decorations = ContinuousDecorationController(
         port = object : ContinuousDecorationController.Port {
@@ -187,7 +199,13 @@ internal class ContinuousWindowController(
     private val recycledViews = ArrayDeque<ChapterWebView>()
 
     private fun obtainWebView(): ChapterWebView =
-        recycledViews.removeFirstOrNull() ?: ChapterWebView(context)
+        (recycledViews.removeFirstOrNull() ?: ChapterWebView(context)).also { wv ->
+            // Route JS console errors/warnings to the ReaderDecoration log channel so the in-app
+            // debug screen surfaces DOM-side throws (e.g. #428's createTreeWalker-on-null-body)
+            // alongside the Kotlin-side decoration events. Wired here so recycled views also
+            // pick up the current logger.
+            wv.jsConsoleLogger = logger
+        }
 
     /**
      * Detach [wv] from active use and pool it for reuse (or destroy it if the pool is full).
@@ -519,7 +537,11 @@ internal class ContinuousWindowController(
 
     /** Hook fired once a chapter's `applyAnnotationHighlightsJs` JS finishes. */
     private fun onAnnotationHighlightsApplied(wv: ChapterWebViewLike) {
-        if (wv.chapterHref != pendingTargetHref) return
+        val matches = wv.chapterHref == pendingTargetHref
+        logger.d(LogChannel.ReaderDecoration) {
+            "onAnnotationHighlightsApplied href='${wv.chapterHref}' matchesPendingTarget=$matches pendingTargetHref='$pendingTargetHref'"
+        }
+        if (!matches) return
         reapplyLandingAfterFallback?.invoke()
         scrollToPendingFocusAnnotation(wv.chapterHref)
     }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -472,6 +472,7 @@ fun EpubReaderScreen(
                         onAutoScrollResume = viewModel::resumeAutoScrollIfPaused,
                         onFigureTap = viewModel::onFigureTapPayload,
                         dispatchers = viewModel.dispatchers,
+                        logger = viewModel.logger,
                         modifier = Modifier
                             .fillMaxSize()
                             .testTag("reader_ready")
@@ -1187,6 +1188,7 @@ private fun EpubNavigatorView(
     onAutoScrollResume: () -> Unit,
     onFigureTap: (payload: String) -> Unit,
     dispatchers: com.riffle.core.domain.DispatcherProvider,
+    logger: com.riffle.core.logging.Logger,
     modifier: Modifier = Modifier,
 ) {
     val context = LocalContext.current
@@ -2396,6 +2398,9 @@ private fun EpubNavigatorView(
                 factory = { ctx ->
                     ContinuousReaderView(ctx).also { view ->
                         continuousViewRef.value = view
+                        // Route continuous decoration + WebView console diagnostics to
+                        // LogChannel.ReaderDecoration (RIFFLE_DECO) for the in-app debug screen.
+                        view.logger = logger
                         // Wire the presenter BEFORE attach so the coordinator's onRawPosition
                         // handler routes raw-position events through it on the very first scroll.
                         coordinator.presenter = continuousPresenter

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -185,7 +185,7 @@ class EpubReaderViewModel @Inject constructor(
     private val annotationSessionFactory: com.riffle.app.feature.reader.session.AnnotationSession.Factory,
     private val readaloudSessionFactory: com.riffle.app.feature.reader.session.ReadaloudSession.Factory,
     private val readerSessionLifecycleFactory: com.riffle.app.feature.reader.session.ReaderSessionLifecycle.Factory,
-    private val logger: Logger,
+    internal val logger: Logger,
     private val clock: Clock,
     val dispatchers: DispatcherProvider,
     private val highlightsPublicationFactory: HighlightsPublicationFactory,

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsScreen.kt
@@ -94,6 +94,7 @@ fun SettingsScreen(
     onNavigateToAddServer: (backend: AddServerBackend, editId: String?) -> Unit,
     onNavigateToReadaloudMatches: (String) -> Unit = {},
     onNavigateToAnnotationSyncMaintenance: () -> Unit = {},
+    onNavigateToDebugLogs: () -> Unit = {},
     viewModel: SettingsViewModel = hiltViewModel(),
 ) {
     val crashReports by viewModel.crashReports.collectAsState()
@@ -473,10 +474,22 @@ fun SettingsScreen(
                 HorizontalDivider()
 
                 Text(
-                    text = "Crash reports",
+                    text = "Diagnostics",
                     style = MaterialTheme.typography.titleSmall,
                     fontWeight = FontWeight.Bold,
                     modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+                )
+                HorizontalDivider()
+                ListItem(
+                    modifier = Modifier.clickable { onNavigateToDebugLogs() },
+                    headlineContent = { Text("Debug logs") },
+                    supportingContent = { Text("View / share the in-app log buffer") },
+                    trailingContent = {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                            contentDescription = null,
+                        )
+                    },
                 )
                 HorizontalDivider()
                 if (crashReports.isEmpty()) {

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/debug/DebugLogScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/debug/DebugLogScreen.kt
@@ -1,0 +1,191 @@
+package com.riffle.app.feature.settings.debug
+
+import android.content.Intent
+import androidx.compose.foundation.background
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FilterChipDefaults
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.riffle.core.logging.InMemoryLogBuffer
+import com.riffle.core.logging.LogChannel
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+/**
+ * In-app viewer for [InMemoryLogBuffer]. Reverse-chronological (newest first), channel-filter
+ * chips, and a "Share" action that hands the current view off via FileProvider so the log can be
+ * emailed / messaged without adb. This is what makes decoration-path diagnostics accessible on
+ * devices that don't support wireless debugging.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun DebugLogScreen(
+    onNavigateBack: () -> Unit,
+    viewModel: DebugLogViewModel = hiltViewModel(),
+) {
+    val entries by viewModel.entries.collectAsState()
+    val context = LocalContext.current
+    val activeChannels = remember { mutableStateOf<Set<LogChannel>>(emptySet()) }
+
+    val filtered = remember(entries, activeChannels.value) {
+        if (activeChannels.value.isEmpty()) entries else entries.filter { it.channel in activeChannels.value }
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Debug logs") },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+                actions = {
+                    TextButton(onClick = {
+                        val intent = viewModel.buildShareIntent(activeChannels.value.takeIf { it.isNotEmpty() })
+                        if (intent != null) {
+                            context.startActivity(Intent.createChooser(intent, "Share debug log"))
+                        }
+                    }) {
+                        Text("Share")
+                    }
+                    TextButton(onClick = { viewModel.clear() }) {
+                        Text("Clear")
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        Column(modifier = Modifier.fillMaxSize().padding(padding)) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .horizontalScroll(rememberScrollState())
+                    .padding(horizontal = 12.dp, vertical = 8.dp),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                LogChannel.entries.forEach { ch ->
+                    val selected = ch in activeChannels.value
+                    FilterChip(
+                        selected = selected,
+                        onClick = {
+                            activeChannels.value = if (selected) activeChannels.value - ch else activeChannels.value + ch
+                        },
+                        label = { Text(ch.tag) },
+                        colors = FilterChipDefaults.filterChipColors(),
+                    )
+                }
+            }
+            Text(
+                text = "${filtered.size}/${entries.size} entries (buffer holds ${InMemoryLogBuffer.CAPACITY})",
+                style = MaterialTheme.typography.labelSmall,
+                modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),
+            )
+            HorizontalDivider()
+
+            if (filtered.isEmpty()) {
+                Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                    Text(
+                        text = if (entries.isEmpty()) "No log entries yet" else "No entries match the current filter",
+                        style = MaterialTheme.typography.bodyMedium,
+                    )
+                }
+            } else {
+                val listState = rememberLazyListState()
+                // Reverse so newest is at the top and remains visible without manual scrolling
+                // when new entries land.
+                LaunchedEffect(filtered.size) {
+                    if (listState.firstVisibleItemIndex <= 1) listState.animateScrollToItem(0)
+                }
+                LazyColumn(
+                    state = listState,
+                    modifier = Modifier.fillMaxSize(),
+                    reverseLayout = true,
+                ) {
+                    items(filtered, key = { it.hashCode() }) { entry ->
+                        LogRow(entry)
+                        HorizontalDivider(color = Color(0x11000000))
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun LogRow(entry: InMemoryLogBuffer.Entry) {
+    val time = remember(entry.timestampMs) { TIME_FMT.format(Date(entry.timestampMs)) }
+    val (bg, fg) = when (entry.level) {
+        InMemoryLogBuffer.Entry.Level.D -> Color.Transparent to MaterialTheme.colorScheme.onSurface
+        InMemoryLogBuffer.Entry.Level.W -> Color(0x33FFC107) to MaterialTheme.colorScheme.onSurface
+        InMemoryLogBuffer.Entry.Level.E -> Color(0x33F44336) to MaterialTheme.colorScheme.onSurface
+    }
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(bg)
+            .padding(horizontal = 12.dp, vertical = 4.dp),
+    ) {
+        Text(
+            text = "$time  ${entry.level.name}  [${entry.channel.tag}]",
+            style = MaterialTheme.typography.labelSmall,
+            fontFamily = FontFamily.Monospace,
+            color = fg.copy(alpha = 0.7f),
+        )
+        Text(
+            text = entry.message,
+            style = MaterialTheme.typography.bodySmall,
+            fontFamily = FontFamily.Monospace,
+            fontSize = 12.sp,
+            color = fg,
+        )
+        entry.throwableSummary?.let {
+            Text(
+                text = it,
+                style = MaterialTheme.typography.bodySmall,
+                fontFamily = FontFamily.Monospace,
+                fontSize = 11.sp,
+                color = fg.copy(alpha = 0.8f),
+            )
+        }
+    }
+}
+
+private val TIME_FMT = SimpleDateFormat("HH:mm:ss.SSS", Locale.US)

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/debug/DebugLogViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/debug/DebugLogViewModel.kt
@@ -43,6 +43,10 @@ class DebugLogViewModel @Inject constructor(
 
         val app = getApplication<Application>()
         val dir = File(app.filesDir, "debug_logs").apply { mkdirs() }
+        // Reuse one filename so successive shares overwrite instead of piling on disk. The
+        // timestamp still appears in the file contents (per-entry) and in the share subject,
+        // so the recipient can still tell captures apart.
+        dir.listFiles { f -> f.isFile && f.name.startsWith("riffle-debug-") }?.forEach { it.delete() }
         val stamp = SimpleDateFormat("yyyyMMdd-HHmmss", Locale.US).format(Date())
         val file = File(dir, "riffle-debug-$stamp.txt")
         val fmt = SimpleDateFormat("HH:mm:ss.SSS", Locale.US)

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/debug/DebugLogViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/debug/DebugLogViewModel.kt
@@ -1,0 +1,67 @@
+package com.riffle.app.feature.settings.debug
+
+import android.app.Application
+import android.content.Intent
+import androidx.core.content.FileProvider
+import androidx.lifecycle.AndroidViewModel
+import com.riffle.core.logging.InMemoryLogBuffer
+import com.riffle.core.logging.LogChannel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.StateFlow
+import java.io.File
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import javax.inject.Inject
+
+/**
+ * Backs [DebugLogScreen]. Owns no state of its own — the [InMemoryLogBuffer] is the source of truth
+ * and its [StateFlow] drives the UI directly. The VM exists to give the Compose screen a stable
+ * Hilt-injected handle to the singleton buffer and to package the "share as .txt" workflow.
+ */
+@HiltViewModel
+class DebugLogViewModel @Inject constructor(
+    application: Application,
+    private val buffer: InMemoryLogBuffer,
+) : AndroidViewModel(application) {
+
+    val entries: StateFlow<List<InMemoryLogBuffer.Entry>> = buffer.entries
+
+    fun clear() = buffer.clear()
+
+    /**
+     * Write the current buffer snapshot (optionally filtered to [channels]) to a temp file in
+     * `filesDir/debug_logs/`, return a share [Intent] pointing at it via FileProvider. The share
+     * sheet lets the user email / message the file — no adb required.
+     *
+     * Returns null when the buffer is empty (nothing to share).
+     */
+    fun buildShareIntent(channels: Set<LogChannel>?): Intent? {
+        val entries = buffer.snapshot()
+            .let { all -> if (channels.isNullOrEmpty()) all else all.filter { it.channel in channels } }
+        if (entries.isEmpty()) return null
+
+        val app = getApplication<Application>()
+        val dir = File(app.filesDir, "debug_logs").apply { mkdirs() }
+        val stamp = SimpleDateFormat("yyyyMMdd-HHmmss", Locale.US).format(Date())
+        val file = File(dir, "riffle-debug-$stamp.txt")
+        val fmt = SimpleDateFormat("HH:mm:ss.SSS", Locale.US)
+        file.bufferedWriter().use { w ->
+            entries.forEach { e ->
+                w.append(fmt.format(Date(e.timestampMs)))
+                w.append(' ').append(e.level.name)
+                w.append(" [").append(e.channel.tag).append("] ")
+                w.append(e.message)
+                e.throwableSummary?.let { w.append(" | ").append(it) }
+                w.newLine()
+            }
+        }
+        val uri = FileProvider.getUriForFile(app, "${app.packageName}.fileprovider", file)
+        return Intent(Intent.ACTION_SEND).apply {
+            type = "text/plain"
+            putExtra(Intent.EXTRA_STREAM, uri)
+            putExtra(Intent.EXTRA_SUBJECT, "Riffle debug log ($stamp)")
+            addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+        }
+    }
+}

--- a/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
@@ -42,6 +42,7 @@ import com.riffle.app.feature.server.SelectLibrariesScreen
 import com.riffle.app.feature.server.ServerSetupViewModel
 import com.riffle.app.feature.settings.SettingsScreen
 import com.riffle.app.feature.settings.annotationsync.AnnotationSyncMaintenanceScreen
+import com.riffle.app.feature.settings.debug.DebugLogScreen
 import com.riffle.app.feature.settings.readaloud.ReadaloudMatchesScreen
 import com.riffle.app.playback.NowPlaying
 import com.riffle.app.ui.isTabletLayout
@@ -56,6 +57,7 @@ private const val ADD_SERVER_ROUTE = "add_server?type={type}&editId={editId}"
 private const val SELECT_LIBRARIES = "select_libraries"
 private const val SETTINGS = "settings"
 private const val ANNOTATION_SYNC_MAINTENANCE = "settings/annotation_sync/maintenance"
+private const val DEBUG_LOGS = "settings/debug_logs"
 private const val READALOUD_MATCHES = "readaloud_matches/{sourceId}?pairBookId={pairBookId}"
 private const val DOWNLOADS = "downloads"
 private const val LIBRARY_ITEMS = "library_items/{libraryId}/{libraryName}"
@@ -245,12 +247,16 @@ fun MainScreen(
                         navController.navigate("readaloud_matches/$encoded")
                     },
                     onNavigateToAnnotationSyncMaintenance = { navController.navigate(ANNOTATION_SYNC_MAINTENANCE) },
+                    onNavigateToDebugLogs = { navController.navigate(DEBUG_LOGS) },
                 )
             }
             composable(ANNOTATION_SYNC_MAINTENANCE) {
                 AnnotationSyncMaintenanceScreen(
                     onNavigateBack = { navController.popBackStack() },
                 )
+            }
+            composable(DEBUG_LOGS) {
+                DebugLogScreen(onNavigateBack = { navController.popBackStack() })
             }
             composable(
                 route = READALOUD_MATCHES,

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousDecorationControllerTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousDecorationControllerTest.kt
@@ -1,5 +1,7 @@
 package com.riffle.app.feature.reader
 
+import com.riffle.core.logging.LogChannel
+import com.riffle.core.logging.RecordingLogger
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -186,5 +188,67 @@ class ContinuousDecorationControllerTest {
 
         assertEquals(67, port.lastSmoothScrollY)
         assertTrue(port.landingHoldCleared)
+    }
+
+    // ---- instrumentation (ReaderDecoration channel) --------------------------
+    // Pins the log emissions the in-app Debug logs screen relies on to correlate
+    // "highlight silently failed to render" reports with the underlying apply/complete
+    // events. A revert of the instrumentation flips these red.
+
+    @Test
+    fun `applyAnnotationHighlights logs entry and per-webview branch to ReaderDecoration channel`() {
+        val logger = RecordingLogger()
+        val port = FakePort()
+        val c = ContinuousDecorationController(port).apply { this.logger = logger }
+        val hrefWithMark = "ch-1.xhtml"
+        val hrefWithoutMark = "ch-2.xhtml"
+        val wvWith = FakeChapterWebView(chapterHref = hrefWithMark).also { port.loaded += it }
+        val wvWithout = FakeChapterWebView(chapterHref = hrefWithoutMark).also { port.loaded += it }
+
+        c.applyAnnotationHighlights(
+            mapOf(hrefWithMark to listOf(AnnotationHighlight("id1", "text", "rgba(0,0,0,1)"))),
+        )
+        wvWith.completeLast()
+
+        val msgs = logger.records(LogChannel.ReaderDecoration).map { it.message }
+        assertTrue(
+            "entry log missing: $msgs",
+            msgs.any { it.startsWith("applyAnnotationHighlights") && it.contains(hrefWithMark) },
+        )
+        assertTrue(
+            "apply→highlights branch log missing: $msgs",
+            msgs.any { it.startsWith("apply→highlights") && it.contains("href='$hrefWithMark'") },
+        )
+        assertTrue(
+            "apply→clear branch log missing: $msgs",
+            msgs.any { it.startsWith("apply→clear") && it.contains("href='$hrefWithoutMark'") },
+        )
+        assertTrue(
+            "apply-complete log missing: $msgs",
+            msgs.any { it.startsWith("apply-complete") && it.contains("href='$hrefWithMark'") },
+        )
+    }
+
+    @Test
+    fun `onChapterLoaded logs annotation count for the loaded href`() {
+        val logger = RecordingLogger()
+        val port = FakePort()
+        val c = ContinuousDecorationController(port).apply { this.logger = logger }
+        val href = "ch-1.xhtml"
+        c.applyAnnotationHighlights(
+            mapOf(href to listOf(AnnotationHighlight("id1", "text", "rgba(0,0,0,1)"))),
+        )
+        logger.clear()
+        val wv = FakeChapterWebView(chapterHref = href).also { port.loaded += it }
+
+        c.onChapterLoaded(wv)
+
+        val msgs = logger.records(LogChannel.ReaderDecoration).map { it.message }
+        assertTrue(
+            "onChapterLoaded log missing count=1: $msgs",
+            msgs.any {
+                it.startsWith("onChapterLoaded") && it.contains("href='$href'") && it.contains("annotationsForHref=1")
+            },
+        )
     }
 }

--- a/core/logging/build.gradle.kts
+++ b/core/logging/build.gradle.kts
@@ -23,9 +23,11 @@ dependencies {
     coreLibraryDesugaring(libs.desugar.jdk.libs)
 
     implementation(libs.hilt.android)
+    implementation(libs.kotlinx.coroutines.core)
     ksp(libs.hilt.compiler)
 
     testImplementation(libs.junit)
+    testImplementation(libs.kotlinx.coroutines.test)
 }
 
 kotlin {

--- a/core/logging/src/main/kotlin/com/riffle/core/logging/AndroidLogger.kt
+++ b/core/logging/src/main/kotlin/com/riffle/core/logging/AndroidLogger.kt
@@ -5,23 +5,70 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 /**
- * Production [Logger]: forwards to [android.util.Log] using the channel's tag.
+ * Production [Logger]: forwards to [android.util.Log] using the channel's tag and
+ * simultaneously appends to [InMemoryLogBuffer] so the in-app debug screen can display
+ * the same emissions without adb.
  *
- * No release-build gating today — every call hits `Log.*`. The lambda message arg keeps the
- * door open for a future `if (channel !in enabledChannels) return` short-circuit.
+ * The [logcatSink] and [clock] seams exist so pure JVM tests can verify buffer appends
+ * without touching `android.util.Log` (which is unmocked in unit tests).
  */
 @Singleton
-class AndroidLogger @Inject constructor() : Logger {
+class AndroidLogger @Inject constructor(
+    private val buffer: InMemoryLogBuffer,
+) : Logger {
 
-    override fun d(channel: LogChannel, t: Throwable?, msg: () -> String) {
-        if (t != null) Log.d(channel.tag, msg(), t) else Log.d(channel.tag, msg())
+    fun interface LogcatSink { fun write(level: InMemoryLogBuffer.Entry.Level, tag: String, msg: String, t: Throwable?) }
+    fun interface Clock { fun nowMs(): Long }
+
+    private var logcatSink: LogcatSink = DefaultSink
+    private var clock: Clock = SystemClock
+
+    internal constructor(
+        buffer: InMemoryLogBuffer,
+        logcatSink: LogcatSink,
+        clock: Clock,
+    ) : this(buffer) {
+        this.logcatSink = logcatSink
+        this.clock = clock
     }
 
-    override fun w(channel: LogChannel, t: Throwable?, msg: () -> String) {
-        if (t != null) Log.w(channel.tag, msg(), t) else Log.w(channel.tag, msg())
+    override fun d(channel: LogChannel, t: Throwable?, msg: () -> String) =
+        emit(InMemoryLogBuffer.Entry.Level.D, channel, t, msg)
+
+    override fun w(channel: LogChannel, t: Throwable?, msg: () -> String) =
+        emit(InMemoryLogBuffer.Entry.Level.W, channel, t, msg)
+
+    override fun e(channel: LogChannel, t: Throwable?, msg: () -> String) =
+        emit(InMemoryLogBuffer.Entry.Level.E, channel, t, msg)
+
+    private inline fun emit(
+        level: InMemoryLogBuffer.Entry.Level,
+        channel: LogChannel,
+        t: Throwable?,
+        msg: () -> String,
+    ) {
+        val m = msg()
+        logcatSink.write(level, channel.tag, m, t)
+        buffer.append(
+            InMemoryLogBuffer.Entry(
+                timestampMs = clock.nowMs(),
+                level = level,
+                channel = channel,
+                message = m,
+                throwableSummary = t?.let { "${it::class.java.simpleName}: ${it.message}" },
+            ),
+        )
     }
 
-    override fun e(channel: LogChannel, t: Throwable?, msg: () -> String) {
-        if (t != null) Log.e(channel.tag, msg(), t) else Log.e(channel.tag, msg())
+    private object DefaultSink : LogcatSink {
+        override fun write(level: InMemoryLogBuffer.Entry.Level, tag: String, msg: String, t: Throwable?) {
+            when (level) {
+                InMemoryLogBuffer.Entry.Level.D -> if (t != null) Log.d(tag, msg, t) else Log.d(tag, msg)
+                InMemoryLogBuffer.Entry.Level.W -> if (t != null) Log.w(tag, msg, t) else Log.w(tag, msg)
+                InMemoryLogBuffer.Entry.Level.E -> if (t != null) Log.e(tag, msg, t) else Log.e(tag, msg)
+            }
+        }
     }
+
+    private object SystemClock : Clock { override fun nowMs(): Long = System.currentTimeMillis() }
 }

--- a/core/logging/src/main/kotlin/com/riffle/core/logging/InMemoryLogBuffer.kt
+++ b/core/logging/src/main/kotlin/com/riffle/core/logging/InMemoryLogBuffer.kt
@@ -1,0 +1,56 @@
+package com.riffle.core.logging
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Bounded ring buffer of recent log entries so an in-app debug screen can display them
+ * without adb. [AndroidLogger] appends every emission here in addition to forwarding to
+ * `android.util.Log`.
+ *
+ * Thread-safe: writes synchronise on [lock]. Reads take an immutable snapshot via the
+ * exposed [StateFlow] — subscribers receive the current buffer contents on collect and a
+ * fresh snapshot after every append.
+ */
+@Singleton
+class InMemoryLogBuffer @Inject constructor() {
+
+    data class Entry(
+        val timestampMs: Long,
+        val level: Level,
+        val channel: LogChannel,
+        val message: String,
+        val throwableSummary: String?,
+    ) {
+        enum class Level { D, W, E }
+    }
+
+    private val lock = Any()
+    private val ring = ArrayDeque<Entry>(CAPACITY)
+    private val _entries = MutableStateFlow<List<Entry>>(emptyList())
+
+    val entries: StateFlow<List<Entry>> = _entries.asStateFlow()
+
+    fun append(entry: Entry) {
+        val snapshot: List<Entry> = synchronized(lock) {
+            if (ring.size >= CAPACITY) ring.removeFirst()
+            ring.addLast(entry)
+            ring.toList()
+        }
+        _entries.value = snapshot
+    }
+
+    fun snapshot(): List<Entry> = synchronized(lock) { ring.toList() }
+
+    fun clear() {
+        synchronized(lock) { ring.clear() }
+        _entries.value = emptyList()
+    }
+
+    companion object {
+        const val CAPACITY: Int = 2000
+    }
+}

--- a/core/logging/src/main/kotlin/com/riffle/core/logging/LogChannel.kt
+++ b/core/logging/src/main/kotlin/com/riffle/core/logging/LogChannel.kt
@@ -13,4 +13,5 @@ enum class LogChannel(val tag: String) {
     Audiobook("RIFFLE_AB"),
     Handoff("RIFFLE_HANDOFF"),
     HighlightMerge("RIFFLE_HL_MERGE"),
+    ReaderDecoration("RIFFLE_DECO"),
 }

--- a/core/logging/src/main/kotlin/com/riffle/core/logging/NoopLogger.kt
+++ b/core/logging/src/main/kotlin/com/riffle/core/logging/NoopLogger.kt
@@ -1,0 +1,14 @@
+package com.riffle.core.logging
+
+/**
+ * No-op [Logger] for defaulting fields that are wired up post-construction
+ * (e.g. [ContinuousDecorationController.logger] before the reader view is installed).
+ *
+ * Prefer injecting the real [Logger] where possible — this exists so that classes constructed
+ * before the reader is wired can still safely emit without null checks at every call site.
+ */
+object NoopLogger : Logger {
+    override fun d(channel: LogChannel, t: Throwable?, msg: () -> String) = Unit
+    override fun w(channel: LogChannel, t: Throwable?, msg: () -> String) = Unit
+    override fun e(channel: LogChannel, t: Throwable?, msg: () -> String) = Unit
+}

--- a/core/logging/src/test/kotlin/com/riffle/core/logging/AndroidLoggerBufferTest.kt
+++ b/core/logging/src/test/kotlin/com/riffle/core/logging/AndroidLoggerBufferTest.kt
@@ -1,0 +1,60 @@
+package com.riffle.core.logging
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class AndroidLoggerBufferTest {
+
+    private val sinkCalls = mutableListOf<Triple<InMemoryLogBuffer.Entry.Level, String, String>>()
+    private val sink = AndroidLogger.LogcatSink { level, tag, msg, _ ->
+        sinkCalls += Triple(level, tag, msg)
+    }
+    private val clock = AndroidLogger.Clock { 42L }
+
+    @Test
+    fun `d appends to buffer and logcat with matching level channel message`() {
+        val buffer = InMemoryLogBuffer()
+        val logger = AndroidLogger(buffer, sink, clock)
+
+        logger.d(LogChannel.ReaderDecoration) { "hi" }
+
+        val snap = buffer.snapshot()
+        assertEquals(1, snap.size)
+        assertEquals(InMemoryLogBuffer.Entry.Level.D, snap[0].level)
+        assertEquals(LogChannel.ReaderDecoration, snap[0].channel)
+        assertEquals("hi", snap[0].message)
+        assertEquals(42L, snap[0].timestampMs)
+        assertNull(snap[0].throwableSummary)
+
+        assertEquals(1, sinkCalls.size)
+        assertEquals(InMemoryLogBuffer.Entry.Level.D, sinkCalls[0].first)
+        assertEquals("RIFFLE_DECO", sinkCalls[0].second)
+        assertEquals("hi", sinkCalls[0].third)
+    }
+
+    @Test
+    fun `w and e produce their own levels`() {
+        val buffer = InMemoryLogBuffer()
+        val logger = AndroidLogger(buffer, sink, clock)
+
+        logger.w(LogChannel.ReaderDecoration) { "warn" }
+        logger.e(LogChannel.ReaderDecoration) { "err" }
+
+        val snap = buffer.snapshot()
+        assertEquals(
+            listOf(InMemoryLogBuffer.Entry.Level.W, InMemoryLogBuffer.Entry.Level.E),
+            snap.map { it.level },
+        )
+    }
+
+    @Test
+    fun `throwable is summarised as ClassName colon message`() {
+        val buffer = InMemoryLogBuffer()
+        val logger = AndroidLogger(buffer, sink, clock)
+
+        logger.e(LogChannel.ReaderDecoration, t = IllegalStateException("boom")) { "x" }
+
+        assertEquals("IllegalStateException: boom", buffer.snapshot().single().throwableSummary)
+    }
+}

--- a/core/logging/src/test/kotlin/com/riffle/core/logging/InMemoryLogBufferTest.kt
+++ b/core/logging/src/test/kotlin/com/riffle/core/logging/InMemoryLogBufferTest.kt
@@ -1,0 +1,64 @@
+package com.riffle.core.logging
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class InMemoryLogBufferTest {
+
+    private fun entry(i: Int) = InMemoryLogBuffer.Entry(
+        timestampMs = i.toLong(),
+        level = InMemoryLogBuffer.Entry.Level.D,
+        channel = LogChannel.ReaderDecoration,
+        message = "m$i",
+        throwableSummary = null,
+    )
+
+    @Test
+    fun `append preserves order and exposes via snapshot`() {
+        val buf = InMemoryLogBuffer()
+        buf.append(entry(1))
+        buf.append(entry(2))
+        buf.append(entry(3))
+        assertEquals(listOf("m1", "m2", "m3"), buf.snapshot().map { it.message })
+    }
+
+    @Test
+    fun `ring evicts oldest at capacity`() {
+        val buf = InMemoryLogBuffer()
+        repeat(InMemoryLogBuffer.CAPACITY + 5) { buf.append(entry(it)) }
+        val snap = buf.snapshot()
+        assertEquals(InMemoryLogBuffer.CAPACITY, snap.size)
+        // Oldest 5 evicted → first surviving entry has timestampMs == 5.
+        assertEquals(5L, snap.first().timestampMs)
+        assertEquals((InMemoryLogBuffer.CAPACITY + 4).toLong(), snap.last().timestampMs)
+    }
+
+    @Test
+    fun `clear empties the buffer and StateFlow`() {
+        val buf = InMemoryLogBuffer()
+        buf.append(entry(1))
+        buf.clear()
+        assertTrue(buf.snapshot().isEmpty())
+        assertTrue(buf.entries.value.isEmpty())
+    }
+
+    @Test
+    fun `entries StateFlow emits appended snapshots`() {
+        val buf = InMemoryLogBuffer()
+        assertTrue(buf.entries.value.isEmpty())
+        buf.append(entry(1))
+        assertEquals(1, buf.entries.value.size)
+        buf.append(entry(2))
+        assertEquals(2, buf.entries.value.size)
+    }
+
+    @Test
+    fun `snapshot is independent of subsequent appends`() {
+        val buf = InMemoryLogBuffer()
+        buf.append(entry(1))
+        val snap = buf.snapshot()
+        buf.append(entry(2))
+        assertEquals(1, snap.size)
+    }
+}


### PR DESCRIPTION
## Summary

Adds an in-memory ring buffer to `core/logging` that mirrors every `Logger` emission alongside the existing `Log.*` forwarding, and a **Settings → Diagnostics → Debug logs** screen that displays, filters, and shares it via `FileProvider`. Debug data no longer requires adb — a hard-blocker for the tablet, which doesn't support wireless debugging.

Instruments the continuous-mode decoration path so a repro of "highlights silently fail to render on continuous" leaves a trail:

- `ContinuousDecorationController` — `applyAnnotationHighlights` entry, per-WebView `apply→highlights` / `apply→clear` / `apply-complete`, `onChapterLoaded` (annotation count for the loaded href y/n)
- `ContinuousWindowController` — `onAnnotationHighlightsApplied` completion (whether it matched `pendingTargetHref`)
- `ChapterWebView` — `WebChromeClient.onConsoleMessage` pipes JS `ERROR`/`WARNING` lines into the same `ReaderDecoration` channel. Captures the #428 `createTreeWalker`-on-null-body throw class if it also bites continuous.

Related: #428 (this branch **diagnoses** rather than **fixes** #428 — the six offending `createTreeWalker(document.body, …)` sites are unchanged; separate PR).

## Test plan

- [x] `./gradlew :core:logging:test :app:testDebugUnitTest checkRiffleLogTags` — all green
- [x] New JVM tests:
  - `InMemoryLogBufferTest` (ring eviction at capacity, snapshot immutability, `StateFlow` emission, clear)
  - `AndroidLoggerBufferTest` (D/W/E emit through both sinks, throwable summary, level tagging)
  - `ContinuousDecorationControllerTest` — pins the four log emissions (entry / apply→highlights / apply→clear / apply-complete / onChapterLoaded) — a plain revert of any of them flips the assertions red
- [ ] **Not device-verified** per repo policy — the Settings entry, log viewer render, WebView console capture, and Share intent still need eyes on a real device. Would appreciate a manual pass before merge.

## Notes

- Buffer is unpersisted (2000-entry ring, in-memory). Capture BEFORE an app restart to escape the wedged state that #428 describes.
- One user-visible reorg: existing "Crash reports" section renamed to **Diagnostics**, "Debug logs" row added at the top of it (drill-in), crash reports below. No functional change to crash reports.