### PR TITLE
chore(covers): instrument library cover loads with RIFFLE_COVERS logs

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemDetailScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemDetailScreen.kt
@@ -374,6 +374,7 @@ private fun LibraryItemDetailContent(
                 model = ImageRequest.Builder(LocalContext.current)
                     .data(url)
                     .addHeader("Authorization", "Bearer $token")
+                    .instrumentCover("detail", item.id, url)
                     .build(),
                 contentDescription = null,
                 contentScale = ContentScale.Fit,
@@ -592,6 +593,7 @@ internal fun LibraryItemDetailContentTablet(
                     model = ImageRequest.Builder(LocalContext.current)
                         .data(url)
                         .addHeader("Authorization", "Bearer $token")
+                        .instrumentCover("detail", item.id, url)
                         .build(),
                     contentDescription = null,
                     contentScale = ContentScale.Fit,
@@ -780,6 +782,7 @@ internal fun LibraryItemDetailContentPhoneLandscape(
                     model = ImageRequest.Builder(LocalContext.current)
                         .data(url)
                         .addHeader("Authorization", "Bearer $token")
+                        .instrumentCover("detail", item.id, url)
                         .build(),
                     contentDescription = null,
                     contentScale = ContentScale.Fit,

--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsScreen.kt
@@ -103,12 +103,14 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.compose.ui.res.painterResource
+import android.util.Log
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
 import com.riffle.app.R
 import com.riffle.app.feature.annotations.AnnotationsListScreen
 import com.riffle.app.feature.annotations.AnnotationsListViewModel
 import com.riffle.app.ui.theme.RiffleIcons
+import com.riffle.core.logging.LogChannel
 import com.riffle.core.database.AnnotationEntity
 import com.riffle.core.domain.Collection
 import com.riffle.core.domain.HighlightColor
@@ -551,6 +553,25 @@ private fun CoverGridLayout(
 
 // --- Cover tiles ---
 
+/**
+ * TEMP DEBUG-COVERS instrumentation for reproducing "cover missing offline even though it was
+ * visible online" bug. Logs the URL and Coil DataSource (MEMORY / DISK / NETWORK) for every
+ * cover load, and the throwable class on failure. Rip out once root cause is confirmed and
+ * fixed. Adb: `adb logcat -d | grep RIFFLE_COVERS`.
+ */
+internal fun ImageRequest.Builder.instrumentCover(kind: String, key: String?, url: String?): ImageRequest.Builder =
+    listener(
+        onSuccess = { _, result ->
+            Log.d(LogChannel.Covers.tag, "hit kind=$kind key=$key source=${result.dataSource} url=$url")
+        },
+        onError = { _, result ->
+            Log.d(
+                LogChannel.Covers.tag,
+                "miss kind=$kind key=$key err=${result.throwable::class.simpleName} url=$url",
+            )
+        },
+    )
+
 @Composable
 fun BookCoverTile(
     item: LibraryItem,
@@ -582,6 +603,7 @@ fun BookCoverTile(
                     .data(item.coverUrl)
                     .addHeader("Authorization", "Bearer $token")
                     .crossfade(true)
+                    .instrumentCover("item", item.id, item.coverUrl)
                     .build(),
                 placeholder = ColorPainter(MaterialTheme.colorScheme.surfaceVariant),
                 contentDescription = item.title,
@@ -665,6 +687,7 @@ fun SeriesCoverTile(
                 .data(series.coverUrl)
                 .addHeader("Authorization", "Bearer $token")
                 .crossfade(true)
+                .instrumentCover("series", series.id, series.coverUrl)
                 .build(),
             placeholder = ColorPainter(MaterialTheme.colorScheme.surfaceVariant),
             contentDescription = series.name,
@@ -744,6 +767,7 @@ private fun CollectionCoverImage(url: String?, token: String, modifier: Modifier
             .data(url)
             .addHeader("Authorization", "Bearer $token")
             .crossfade(true)
+            .instrumentCover("collection", null, url)
             .build(),
         placeholder = ColorPainter(MaterialTheme.colorScheme.surfaceVariant),
         contentDescription = null,
@@ -1121,6 +1145,7 @@ internal fun LibraryItemCard(
                     .data(item.coverUrl)
                     .addHeader("Authorization", "Bearer $token")
                     .crossfade(true)
+                    .instrumentCover("card", item.id, item.coverUrl)
                     .build(),
                 placeholder = ColorPainter(MaterialTheme.colorScheme.surfaceVariant),
                 contentDescription = item.title,

--- a/core/logging/src/main/kotlin/com/riffle/core/logging/LogChannel.kt
+++ b/core/logging/src/main/kotlin/com/riffle/core/logging/LogChannel.kt
@@ -15,4 +15,5 @@ enum class LogChannel(val tag: String) {
     HighlightMerge("RIFFLE_HL_MERGE"),
     ReaderDecoration("RIFFLE_DECO"),
     Cadence("RIFFLE_CD"),
+    Covers("RIFFLE_COVERS"),
 }

--- a/core/logging/src/test/kotlin/com/riffle/core/logging/LogChannelTest.kt
+++ b/core/logging/src/test/kotlin/com/riffle/core/logging/LogChannelTest.kt
@@ -11,5 +11,6 @@ class LogChannelTest {
         assertEquals("RIFFLE_RA", LogChannel.Readaloud.tag)
         assertEquals("RIFFLE_AB", LogChannel.Audiobook.tag)
         assertEquals("RIFFLE_HANDOFF", LogChannel.Handoff.tag)
+        assertEquals("RIFFLE_COVERS", LogChannel.Covers.tag)
     }
 }


### PR DESCRIPTION
## Summary

Diagnostic-only instrumentation to catch an intermittent bug where some library-item covers appear missing when the app goes offline, even though they were previously visible online.

Adds a Coil `ImageRequest.Builder.listener` to every library cover load in `LibraryItemsScreen` (grid item, series tile, collection tile, card row) and `LibraryItemDetailScreen` (3 detail layouts). The listener logs:

- On success — the URL, the `Coil.DataSource` it came from (`MEMORY_CACHE` / `DISK` / `NETWORK`)
- On error — the URL and the throwable class

Behind a new `LogChannel.Covers` (`RIFFLE_COVERS`). Grep with `adb logcat -d | grep RIFFLE_COVERS` next time a blank cover shows up in the wild and compare the requested URL against `cache/image_cache/` on disk.

## Current theory

`LibraryRepositoryImpl.absCoverUrl` embeds ABS's `?t=updatedAt` as a cache-buster. Coil's disk cache is keyed by the full URL string, so any `updatedAt` bump orphans the previously-cached cover under a new key. Online this is invisible (Coil re-fetches); offline it shows a placeholder.

ABS's `LibraryItemScanData.checkLibraryItemData` bumps `updatedAt` on any folder-mtime/ctime/birthtime diff detected by a scheduled scan, plus a handful of other non-cover-changing paths (metadata edits, isMissing flip, isSupplementary flag flip on any library file, podcast episode downloaded). User progress updates do **not** bump `updatedAt` — those live on the `User` model, not `LibraryItem`.

Repro on demand has not been achieved. Instrumentation is what we're relying on to catch the next occurrence.

## To be removed

Once the root cause is confirmed and fixed, this whole commit should be reverted. Nothing here is meant to ship long-term.

## Test plan

- [x] `./gradlew :core:logging:test` — `LogChannel.Covers` tag pinned by `LogChannelTest`
- [x] `./gradlew checkRiffleLogTags` — no `Log.d("RIFFLE_*", …)` literals introduced (uses `LogChannel.Covers.tag`)
- [x] `./gradlew :app:compileDebugKotlin`
- [ ] Install the branch build, open the library online, force offline, and confirm `adb logcat -d | grep RIFFLE_COVERS` shows one line per cover render