### PR TITLE
feat(annotations): show "Annotations (N)" header on tab

### DIFF
--- a/app/src/androidTest/kotlin/com/riffle/app/feature/annotations/AnnotationsListHeaderTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/annotations/AnnotationsListHeaderTest.kt
@@ -1,0 +1,50 @@
+package com.riffle.app.feature.annotations
+
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.riffle.core.data.AnnotatedBook
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Regression: the Annotations tab must render an "Annotations (N)" section
+ * header above the cover grid, matching the "To Read (N)" / "All Books (N)"
+ * pattern used by sibling tabs in the Library Tab Bar.
+ */
+@RunWith(AndroidJUnit4::class)
+class AnnotationsListHeaderTest {
+
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+    @Test
+    fun headerShowsBookCount() {
+        val books = listOf(
+            annotatedBook(itemId = "a"),
+            annotatedBook(itemId = "b"),
+            annotatedBook(itemId = "c"),
+        )
+        composeTestRule.setContent {
+            AnnotationsListScreen(
+                state = AnnotationsListUiState(loading = false, books = books),
+                onBookClick = { _, _ -> },
+            )
+        }
+
+        composeTestRule.onNodeWithText("Annotations (3)").assertIsDisplayed()
+    }
+
+    private fun annotatedBook(itemId: String): AnnotatedBook = AnnotatedBook(
+        sourceId = "s1",
+        itemId = itemId,
+        title = "Book $itemId",
+        author = "Author",
+        coverUrl = null,
+        highlightCount = 1,
+        latestUpdatedAt = 0L,
+    )
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/annotations/AnnotationsListScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/annotations/AnnotationsListScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.GridItemSpan
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.lazy.grid.rememberLazyGridState
@@ -69,6 +70,13 @@ fun AnnotationsListScreen(
                         .fillMaxSize()
                         .fadingScrollbar(gridState),
                 ) {
+                    item(span = { GridItemSpan(maxLineSpan) }) {
+                        Text(
+                            text = "Annotations (${state.books.size})",
+                            style = MaterialTheme.typography.titleMedium,
+                            modifier = Modifier.padding(start = 4.dp, end = 4.dp, top = 8.dp, bottom = 8.dp),
+                        )
+                    }
                     items(state.books, key = { "${it.sourceId}_${it.itemId}" }) { book ->
                         Box(modifier = Modifier.padding(4.dp)) {
                             AnnotatedBookCoverTile(

--- a/app/src/main/kotlin/com/riffle/app/feature/annotations/AnnotationsListScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/annotations/AnnotationsListScreen.kt
@@ -74,7 +74,7 @@ fun AnnotationsListScreen(
                         Text(
                             text = "Annotations (${state.books.size})",
                             style = MaterialTheme.typography.titleMedium,
-                            modifier = Modifier.padding(start = 4.dp, end = 4.dp, top = 8.dp, bottom = 8.dp),
+                            modifier = Modifier.padding(start = 16.dp, end = 16.dp, top = 16.dp, bottom = 8.dp),
                         )
                     }
                     items(state.books, key = { "${it.sourceId}_${it.itemId}" }) { book ->


### PR DESCRIPTION
## Summary

The Annotations tab in the Library Tab Bar had no header, while its sibling tabs (To Read, All Books, Series, Collections) all render a `SectionHeader("<Name> (${size})")` above their grids. This adds a matching `Annotations (N)` header — same `titleMedium` style, same padding (`start=16, end=16, top=16, bottom=8`) — as a full-width grid item so it scrolls with the covers.

## Test plan

- [ ] `AnnotationsListHeaderTest.headerShowsBookCount` — asserts "Annotations (3)" is displayed when three annotated books are in state.
- [ ] Visual: open the Annotations tab and confirm the header reads `Annotations (N)` and aligns with `To Read (N)` on the sibling tab.