### PR TITLE
feat(reader): annotations view polish — per-scope prefs, accent-bar tap, delete-last fix, no on-text highlight

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/RiffleApplication.kt
+++ b/app/src/main/kotlin/com/riffle/app/RiffleApplication.kt
@@ -17,6 +17,7 @@ import dagger.hilt.android.HiltAndroidApp
 import dagger.hilt.components.SingletonComponent
 import okhttp3.Interceptor
 import okhttp3.OkHttpClient
+import org.acra.ACRA
 import org.acra.ReportField
 import org.acra.config.dialog
 import org.acra.config.limiter
@@ -70,6 +71,7 @@ class RiffleApplication : Application(), ImageLoaderFactory {
 
     override fun onCreate() {
         super.onCreate()
+        if (shouldSkipMainProcessStartup(ACRA.isACRASenderServiceProcess())) return
         val entryPoint = EntryPointAccessors.fromApplication(this, MigratorEntryPoint::class.java)
         val applicationScope = entryPoint.applicationScope()
 
@@ -127,6 +129,15 @@ class RiffleApplication : Application(), ImageLoaderFactory {
             }
             .build()
 }
+
+/**
+ * ACRA spawns a private `:acra` process to render the crash dialog, and `Application.onCreate` runs
+ * in that process too. WorkManager's ContentProvider auto-initializer is scoped to the main
+ * process, so touching WorkManager from `:acra` (as `ProgressSyncScheduler.sweepNow` does) throws
+ * `WorkManager is not initialized properly` and crash-loops the reporter. Skip main-process init
+ * when we're the ACRA process.
+ */
+internal fun shouldSkipMainProcessStartup(isAcraProcess: Boolean): Boolean = isAcraProcess
 
 /** 100 MB cap for the on-disk cover cache. */
 internal const val IMAGE_DISK_CACHE_MAX_BYTES = 100L * 1024 * 1024

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ChapterWebView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ChapterWebView.kt
@@ -268,6 +268,28 @@ internal class ChapterWebView(context: Context) : WebView(context), ChapterWebVi
                 // chapter's content; route in-book links to the parent (which navigates the reader
                 // with a return card) and external links out to a browser.
                 val url = request.url.toString()
+                // Highlights-mode accent-bar tap: the synthesised HTML's tap span navigates here.
+                // Route the annotation id + tap rect back to the highlight-actions popup and
+                // swallow the navigation so the chapter content stays put. The URL carries the
+                // tap element's bounding rect in CSS pixels (see HighlightsPublicationFactory);
+                // convert to device px so the downstream binder (ChapterWebViewBinder.onAnnotationTap)
+                // sees the same shape it would from the JS bridge's HeightBridge.onAnnotationTap.
+                val parts = com.riffle.app.feature.reader.highlights.parseAnnotationTapUrlParts(url)
+                if (parts != null) {
+                    val dpr = resources.displayMetrics.density
+                    val rect = if (parts.hasRect()) {
+                        android.graphics.Rect(
+                            (parts.cssLeft!! * dpr).toInt(),
+                            (parts.cssTop!! * dpr).toInt(),
+                            (parts.cssRight!! * dpr).toInt(),
+                            (parts.cssBottom!! * dpr).toInt(),
+                        )
+                    } else {
+                        android.graphics.Rect()
+                    }
+                    onAnnotationTap?.invoke(parts.annotationId, rect)
+                    return true
+                }
                 val internal = ContinuousPositionTracker.internalLinkHref(url)
                 return if (internal != null) {
                     onInternalLink?.invoke(internal)

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousHighlightRenderer.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousHighlightRenderer.kt
@@ -21,6 +21,16 @@ internal class ContinuousHighlightRenderer(
     /** Href of the chapter that holds the current sentence highlight, for clearing on chapter change. */
     private var prevSentenceHref: String? = null
 
+    companion object {
+        /**
+         * CSS colour token emitted for Highlights-mode (ADR 0041) annotation marks in continuous
+         * mode. The `<mark>` still wraps the text so annotation locator resolution works, but the
+         * fill is transparent — paginated/vertical don't paint any decoration for accent-bar
+         * highlights either. `internal` for regression pinning.
+         */
+        internal const val ACCENT_BAR_TRANSPARENT_CSS = "transparent"
+    }
+
     override suspend fun applySentenceHighlight(
         fragmentRef: String?,
         quotes: Map<String, SentenceQuote>,
@@ -62,10 +72,25 @@ internal class ContinuousHighlightRenderer(
                     AnnotationHighlight(
                         id = h.id,
                         text = h.locator.text.highlight!!,
-                        cssColor = HighlightColor.fromToken(h.color).argb.toCssRgba(),
+                        // Highlights-mode (ADR 0041): paginated/vertical emit no Readium decoration
+                        // and rely entirely on the synthesised HTML's border-left as the visible
+                        // accent bar. Continuous still wraps the text itself in a <mark>, so a
+                        // palette background here would paint on-text fill that the other modes
+                        // don't paint. Emit a transparent background instead — the mark stays only
+                        // to satisfy annotation locator resolution; tap dispatch is owned by the
+                        // accent-bar span baked into the synthesised HTML.
+                        cssColor = if (h.useAccentBarStyle) {
+                            ACCENT_BAR_TRANSPARENT_CSS
+                        } else {
+                            HighlightColor.fromToken(h.color).argb.toCssRgba()
+                        },
                         hasNote = h.note != null,
                         before = h.locator.text.before.orEmpty(),
                         after = h.locator.text.after.orEmpty(),
+                        // Highlights-mode: the on-text tap listener MUST NOT fire — the accent-bar
+                        // span baked into the synthesised HTML owns tap dispatch. See
+                        // AnnotationHighlight.suppressMarkClick.
+                        suppressMarkClick = h.useAccentBarStyle,
                     )
                 }
             }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
@@ -30,6 +30,14 @@ internal data class AnnotationHighlight(
     val hasNote: Boolean = false,
     val before: String = "",
     val after: String = "",
+    /**
+     * Highlights-mode (ADR 0041): when true, the injected `<mark>` MUST NOT carry a click listener.
+     * Tap dispatch is owned by the accent-bar span baked into the synthesised HTML by
+     * [com.riffle.app.feature.reader.highlights.HighlightsPublicationFactory] — a `<mark>` listener
+     * here would let a tap on the text itself open the highlight menu, which the annotations view
+     * explicitly disallows.
+     */
+    val suppressMarkClick: Boolean = false,
 )
 
 internal class ContinuousReaderView @JvmOverloads constructor(

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjector.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjector.kt
@@ -449,7 +449,13 @@ internal object ContinuousStyleInjector {
                 val safeBefore = ann.before.replace("\\", "\\\\").replace("'", "\\'").replace("\n", "\\n").replace("\r", "\\r")
                 val safeAfter = ann.after.replace("\\", "\\\\").replace("'", "\\'").replace("\n", "\\n").replace("\r", "\\r")
                 // cssColor is machine-generated (e.g. "rgba(56,189,248,0.50)") — no quote escaping needed.
-                append("{id:'$safeId',t:'$safeText',b:'$safeBefore',a:'$safeAfter',c:'${ann.cssColor}',n:${if (ann.hasNote) 1 else 0}}")
+                // s: suppressMarkClick — the emitted `<mark>` gets NO click listener when 1. Owned
+                // by the accent-bar span in the synthesised HTML in that case (Highlights mode).
+                append(
+                    "{id:'$safeId',t:'$safeText',b:'$safeBefore',a:'$safeAfter'," +
+                        "c:'${ann.cssColor}',n:${if (ann.hasNote) 1 else 0}," +
+                        "s:${if (ann.suppressMarkClick) 1 else 0}}"
+                )
             }
             append(']')
         }
@@ -586,9 +592,13 @@ internal object ContinuousStyleInjector {
                     if (existingAll.length > 0) {
                         existingAll.forEach(function(m) { m.style.cssText = 'background:' + ann.c + '$HIGHLIGHT_INLINE_STYLE_SUFFIX'; });
                         var eg = document.querySelector('[data-riffle-note-glyph="' + ann.id + '"]');
-                        if (ann.n && !eg) {
+                        // Highlights mode (ann.s === 1) suppresses the note glyph: the glyph would
+                        // overlap the accent-bar tap span in the left gutter and swallow taps that
+                        // should open the highlight-actions popup. The note is already visible as
+                        // an <aside> beneath the highlight in the synthesised HTML.
+                        if (ann.n && !eg && !ann.s) {
                             makeGlyph(ann.id, existingAll[0]);
-                        } else if (!ann.n && eg) {
+                        } else if ((!ann.n || ann.s) && eg) {
                             eg.remove();
                         }
                         return;
@@ -612,16 +622,19 @@ internal object ContinuousStyleInjector {
                         // pre-wrap by idxToRange), and they live in different blocks, so the wrap
                         // here doesn't disturb their boundaries.
                         flatIdx = null;
-                        (function(markEl, annId) {
-                            markEl.addEventListener('click', function(e) {
-                                e.stopPropagation();
-                                var r = markEl.getBoundingClientRect();
-                                window.RiffleChapter.onAnnotationTap(annId, r.left, r.top, r.right, r.bottom);
-                            });
-                        })(mark, ann.id);
+                        if (!ann.s) {
+                            (function(markEl, annId) {
+                                markEl.addEventListener('click', function(e) {
+                                    e.stopPropagation();
+                                    var r = markEl.getBoundingClientRect();
+                                    window.RiffleChapter.onAnnotationTap(annId, r.left, r.top, r.right, r.bottom);
+                                });
+                            })(mark, ann.id);
+                        }
                         if (!firstMark) firstMark = mark;
                     });
-                    if (firstMark && ann.n) makeGlyph(ann.id, firstMark);
+                    // Highlights mode suppresses the glyph (see the in-place branch above).
+                    if (firstMark && ann.n && !ann.s) makeGlyph(ann.id, firstMark);
                 });
                 if (sel) sel.removeAllRanges();
             })($json);

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -1714,7 +1714,31 @@ private fun EpubNavigatorView(
                 return false
             }
 
-            override fun onExternalLinkActivated(url: AbsoluteUrl) = Unit
+            override fun onExternalLinkActivated(url: AbsoluteUrl) {
+                // Highlights-mode accent-bar tap: the synthesised HTML's tap span navigates to a
+                // riffle:// URL (see HighlightsPublicationFactory), which Readium classifies as
+                // external (non-http). Convert the URL's CSS-px rect to a window IntRect anchored
+                // on the reader container so [HighlightActionsPopup] positions next to the tap
+                // instead of the top-left of the screen (the empty-rect fallback).
+                val parts = com.riffle.app.feature.reader.highlights.parseAnnotationTapUrlParts(
+                    url.toString(),
+                ) ?: return
+                val container = containerRef.value
+                val rect = if (parts.hasRect() && container != null) {
+                    val loc = IntArray(2)
+                    container.getLocationOnScreen(loc)
+                    val dpr = container.resources.displayMetrics.density
+                    androidx.compose.ui.unit.IntRect(
+                        left = loc[0] + (parts.cssLeft!! * dpr).toInt(),
+                        top = loc[1] + (parts.cssTop!! * dpr).toInt(),
+                        right = loc[0] + (parts.cssRight!! * dpr).toInt(),
+                        bottom = loc[1] + (parts.cssBottom!! * dpr).toInt(),
+                    )
+                } else {
+                    androidx.compose.ui.unit.IntRect.Zero
+                }
+                currentOnOpenHighlightActions(parts.annotationId, rect)
+            }
         }
     }
 
@@ -2375,7 +2399,13 @@ private fun EpubNavigatorView(
     val isPaginated = !isFixedLayout && formattingPrefs.orientation == ReaderOrientation.Horizontal
     val isDoublePage = isPaginated && formattingPrefs.doublePageSpread && isLandscape
     val alignViewport = isPaginated && !isDoublePage
-    val containerModifier = if (alignViewport) {
+    // MODE-FORK: continuous needs the container's own background painted (see the paginated-only
+    // gutter branch above). ContinuousReaderView's NestedScrollView paints only over its child
+    // heights; a short chapter (Highlights view with few annotations) leaves the area beneath
+    // transparent and the app-chrome grey shows through. Paginated only needs this behind the
+    // column gutters (`alignViewport`), so the two conditions live at the same site. This is a
+    // Compose UI-lifecycle fork, not a reader behaviour — nothing to route behind ReaderPresenter.
+    val containerModifier = if (alignViewport || isContinuous) {
         modifier.background(formattingPrefs.theme.palette.background)
     } else {
         modifier

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -65,6 +65,7 @@ import com.riffle.core.database.AnnotationEntity
 import com.riffle.app.feature.reader.highlights.ChapterElision
 import com.riffle.app.feature.reader.highlights.HighlightsPublicationFactory
 import com.riffle.app.feature.reader.highlights.ReaderSource
+import com.riffle.app.feature.reader.highlights.toFormattingScope
 import com.riffle.core.logging.LogChannel
 import com.riffle.core.logging.Logger
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -676,7 +677,7 @@ class EpubReaderViewModel @Inject constructor(
      *
      * [useAccentBarStyle] is Highlights-mode only (ADR 0041): when true,
      * [com.riffle.app.feature.reader.ReadiumHighlightRenderer.applyAnnotations] paints via
-     * [com.riffle.app.feature.reader.HighlightAccentBarStyle] instead of the usual tinted style,
+     * the accent-bar rendering path (synthesised HTML border-left + injected tap span) instead of the usual tinted style,
      * which renders no fill and confines Readium's tap hit-testing to a narrow gutter strip on
      * the left of the paragraph — taps in the middle of highlighted text fall through to the
      * immersive-mode toggle. FullBook mode leaves it false → normal tinted painting on the whole
@@ -782,7 +783,7 @@ class EpubReaderViewModel @Inject constructor(
             // Sequential: formatting prefs must be available before openBook() so the
             // navigator never sees the stateIn default on first paint (FormattingSession.bindToBook
             // waits for effectiveFormattingPreferences to reflect the loaded value).
-            formatting.bindToBook(itemId)
+            formatting.bindToBook(itemId, source.toFormattingScope())
             openBook()
         }
         // Readaloud start ⇒ stop Auto-Scroll (mutual exclusion, ADR 0037). Stop (not Pause):
@@ -1672,7 +1673,28 @@ class EpubReaderViewModel @Inject constructor(
 
     /** Recolour an existing highlight; annotationStore re-emits → decoration re-applies. */
     fun recolorHighlight(id: String, color: HighlightColor) {
-        viewModelScope.launch { annotationSession.recolorHighlight(id, color) }
+        viewModelScope.launch {
+            annotationSession.recolorHighlight(id, color)
+            // Highlights mode bakes the accent-bar colour into the synthesised HTML at build
+            // time; a live decoration recolour doesn't reach the border-left CSS. Reload so the
+            // accent bar tracks the new palette pick.
+            if (source == ReaderSource.Highlights) reloadHighlightsView()
+        }
+    }
+
+    /**
+     * Reload the Highlights-mode reader so the synthesised chapters re-render against the
+     * updated annotation store (colour, note text, deletions). A back-to-back
+     * `Loading→Ready(newPub)` set through StateFlow can be coalesced — the collector may only
+     * see the last value and never leave composition, so the new Publication is handed to the
+     * SAME Readium fragment instance and its diff-check treats it as a no-op. The delay yields
+     * one frame so Compose observes the Loading state and unmounts before the fresh Ready
+     * arrives.
+     */
+    private suspend fun reloadHighlightsView() {
+        _state.value = ReaderState.Loading
+        kotlinx.coroutines.delay(16)
+        openBook()
     }
 
     /** Soft-delete a highlight; annotationStore re-emits without it → decoration is removed. */
@@ -1683,6 +1705,7 @@ class EpubReaderViewModel @Inject constructor(
             // decoration removal alone leaves the synthesised <p class="riffle-hl"> visible.
             // Reload so the deleted highlight's paragraph disappears entirely.
             if (source == ReaderSource.Highlights) {
+                if (reloadOrCloseHighlightsAfterDelete()) return@launch
                 // Force the reader composable to unmount its WebView by transitioning through
                 // Loading — a Ready→Ready swap with a new Publication instance isn't seen by
                 // Readium's fragment as a reload, and the deleted highlight's <p> stays on
@@ -1704,6 +1727,7 @@ class EpubReaderViewModel @Inject constructor(
         viewModelScope.launch {
             annotationSession.deleteAnnotation(id)
             if (source == ReaderSource.Highlights) {
+                if (reloadOrCloseHighlightsAfterDelete()) return@launch
                 // Force the reader composable to unmount its WebView by transitioning through
                 // Loading — a Ready→Ready swap with a new Publication instance isn't seen by
                 // Readium's fragment as a reload, and the deleted highlight's <p> stays on
@@ -1714,9 +1738,32 @@ class EpubReaderViewModel @Inject constructor(
         }
     }
 
+    /**
+     * After a delete in Highlights mode: if the book has no live highlights left, emit
+     * [ReaderNavEvent.CloseEmptyHighlights] so the nav host can pop this reader off the back stack,
+     * and return `true` — the synthesised Publication would otherwise be built with an empty
+     * readingOrder and Readium's navigator crashes on that. Returns `false` when at least one
+     * highlight remains, meaning the caller should proceed with the normal reload.
+     */
+    private suspend fun reloadOrCloseHighlightsAfterDelete(): Boolean {
+        val sourceId = annotationServerId ?: return false
+        val rows = annotationDao.getForItem(sourceId, itemId)
+        if (!highlightsShouldCloseAfterDelete(rows)) return false
+        _readerNavEvents.send(ReaderNavEvent.CloseEmptyHighlights)
+        return true
+    }
+
     /** Save (or clear) the note on a highlight; blank text is treated as null (removes the note). */
     fun updateHighlightNote(id: String, note: String?) {
-        viewModelScope.launch { annotationSession.updateHighlightNote(id, note) }
+        viewModelScope.launch {
+            annotationSession.updateHighlightNote(id, note)
+            // Highlights mode's synthesised HTML bakes the note into the chapter body as an
+            // <aside>. The runtime decoration path doesn't touch that body, so the note change
+            // is invisible until the reader reopens — reload for the same reason
+            // [deleteHighlight] does. Note edits never empty the book, so the close-if-empty
+            // branch never applies.
+            if (source == ReaderSource.Highlights) reloadHighlightsView()
+        }
     }
 
     /**
@@ -2225,10 +2272,11 @@ internal fun highlightsAnnotationToRender(
         locations = Locator.Locations(),
         text = Locator.Text(highlight = a.textSnippet),
     )
-    // useAccentBarStyle = true routes the decoration through HighlightAccentBarStyle, which paints
-    // no fill and confines tap hit-testing to a narrow left-gutter strip. The visual is entirely
-    // driven by the synthesised HTML's own left accent bar (see HighlightsPublicationFactory).
-    // Highlights mode only — FullBook's annotationToRender leaves this false.
+    // useAccentBarStyle = true routes the highlight through the accent-bar rendering path: no
+    // Readium decoration in paginated/vertical, transparent <mark> in continuous, and tap dispatch
+    // owned by the injected accent-bar span in the synthesised HTML (see HighlightsPublicationFactory
+    // + AnnotationTapUrl). FullBook's annotationToRender leaves this false so tinted highlights and
+    // whole-selection tap targets stay unchanged.
     return EpubReaderViewModel.HighlightRender(a.id, locator, a.color, a.note, useAccentBarStyle = true)
 }
 
@@ -2296,6 +2344,22 @@ internal fun resolveChapterTitle(href: String, toc: List<TocEntry>): String? {
  * `internal` so [EpubReaderViewModel.openBook]'s grouping logic is unit-testable from `app:test`
  * without constructing the (Android-dependency-laden) ViewModel itself.
  */
+/**
+ * Highlights-mode delete decision (ADR 0041 follow-up): given the DB rows for this book *after*
+ * a soft-delete has been applied, returns `true` when the reader should be closed instead of
+ * reloaded. Closing is required whenever no live highlights remain — the synthesised Publication
+ * would otherwise be built with an empty readingOrder and Readium's navigator crashes on that
+ * (reproduced by deleting the last remaining annotation in the annotations reading view).
+ *
+ * Bookmarks and soft-deleted highlights don't keep the view alive — [buildChapterElisions] already
+ * strips both — so a book whose only remaining rows are bookmarks or `deleted=true` highlights is
+ * still "empty" from Highlights-mode's perspective.
+ *
+ * `internal` so this decision is unit-testable from `app:test` without constructing the ViewModel.
+ */
+internal fun highlightsShouldCloseAfterDelete(rows: List<AnnotationEntity>): Boolean =
+    buildChapterElisions(rows).isEmpty()
+
 internal fun buildChapterElisions(rows: List<AnnotationEntity>): List<ChapterElision> {
     val live = rows
         .filter { it.type == AnnotationEntity.TYPE_HIGHLIGHT && !it.deleted }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/FormattingPreferencesMapper.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/FormattingPreferencesMapper.kt
@@ -32,7 +32,6 @@ internal fun riffleDecorationTemplates(): HtmlDecorationTemplates =
     HtmlDecorationTemplates.defaultTemplates().apply {
         set(HighlightTintStyle::class, highlightTintTemplate())
         set(NoteGlyphStyle::class, noteGlyphTemplate())
-        set(HighlightAccentBarStyle::class, highlightAccentBarTemplate())
     }
 
 fun FormattingPreferences.toEpubPreferences(

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/HighlightDecoration.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/HighlightDecoration.kt
@@ -42,68 +42,6 @@ class HighlightTintStyle(
 }
 
 private const val HIGHLIGHT_TINT_CLASS = "riffle-highlight-tint"
-private const val HIGHLIGHT_ACCENT_BAR_CLASS = "riffle-highlight-accent-bar"
-private const val HIGHLIGHT_ACCENT_BAR_TAP_CLASS = "riffle-highlight-accent-bar-tap"
-
-/**
- * Highlights-mode-only decoration style (ADR 0041). The synthesised chapter renders its own left
- * accent bar via a `<p>` border-left; this decoration exists solely so tap-to-edit can dispatch
- * through Readium's `onDecorationActivated` listener — but only on a narrow strip at the left
- * of the selection. Uses [HtmlDecorationTemplate.Layout.BOUNDS] so the whole selection resolves
- * to one rect (the `data-activable` child rect Readium hit-tests can then be positioned into
- * the paragraph's left padding). No fill — the visual is entirely the synthesised HTML.
- * FullBook mode never uses this style, so its whole-selection tap target is preserved.
- */
-class HighlightAccentBarStyle : Decoration.Style, Parcelable {
-
-    override fun describeContents(): Int = 0
-
-    override fun writeToParcel(dest: Parcel, flags: Int) = Unit
-
-    override fun equals(other: Any?): Boolean = other is HighlightAccentBarStyle
-
-    override fun hashCode(): Int = HighlightAccentBarStyle::class.hashCode()
-
-    companion object {
-        @JvmField
-        val CREATOR: Parcelable.Creator<HighlightAccentBarStyle> =
-            object : Parcelable.Creator<HighlightAccentBarStyle> {
-                override fun createFromParcel(source: Parcel) = HighlightAccentBarStyle()
-                override fun newArray(size: Int): Array<HighlightAccentBarStyle?> = arrayOfNulls(size)
-            }
-    }
-}
-
-/**
- * Template for [HighlightAccentBarStyle]. BOUNDS layout so we get one rect for the whole
- * selection; the `data-activable="1"` child is positioned in the left gutter (like
- * [NoteGlyphStyle]'s icon) so Readium's rect-based decoration hit-testing fires only on taps
- * near the paragraph's left accent bar. Taps in the middle of highlighted text miss the
- * decoration and fall through to the WebView's own tap handler (immersive toggle).
- */
-fun highlightAccentBarTemplate(): HtmlDecorationTemplate =
-    HtmlDecorationTemplate(
-        layout = HtmlDecorationTemplate.Layout.BOUNDS,
-        element = { _ ->
-            """<div class="$HIGHLIGHT_ACCENT_BAR_CLASS"><div class="$HIGHLIGHT_ACCENT_BAR_TAP_CLASS" data-activable="1"></div></div>"""
-        },
-        stylesheet = """
-            .$HIGHLIGHT_ACCENT_BAR_CLASS {
-                position: absolute;
-                inset: 0;
-                background: none;
-                overflow: visible;
-            }
-            .$HIGHLIGHT_ACCENT_BAR_TAP_CLASS {
-                position: absolute;
-                left: -20px;
-                top: 0;
-                bottom: 0;
-                width: 20px;
-                background: transparent;
-            }
-        """.trimIndent(),
-    )
 
 // Every Riffle highlight paint — paginated decoration template AND every continuous-mode
 // <mark> the JS emitters inject (annotations, search, readaloud sentence) — must use this

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderNavEvent.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderNavEvent.kt
@@ -7,4 +7,12 @@ package com.riffle.app.feature.reader
  */
 sealed interface ReaderNavEvent {
     data class OpenInSourceBook(val sourceId: String, val itemId: String, val cfi: String) : ReaderNavEvent
+
+    /**
+     * Highlights-mode reader has no highlights left (user deleted the last one). The synthesised
+     * Publication would have an empty readingOrder — Readium's navigator crashes on that — so the
+     * nav host must pop the reader off the back stack instead of letting the VM reopen an empty
+     * book.
+     */
+    object CloseEmptyHighlights : ReaderNavEvent
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ReadiumHighlightRenderer.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ReadiumHighlightRenderer.kt
@@ -65,16 +65,24 @@ internal class ReadiumHighlightRenderer(
             hasAnnotationDecorations = false
             return
         }
-        val decorations = renders.map { h ->
+        // Highlights mode: accent-bar highlights emit NO Readium decoration — the visible bar and
+        // the tap dispatch both live in the synthesised HTML (see HighlightsPublicationFactory +
+        // AnnotationTapUrl). Applying an empty decoration list still clears any previously-applied
+        // decorations for this group; if the list is empty we take the early-return above.
+        val decorations = renders.mapNotNull { h ->
+            if (h.useAccentBarStyle) return@mapNotNull null
             Decoration(
                 id = h.id,
                 locator = h.locator,
-                style = if (h.useAccentBarStyle) {
-                    HighlightAccentBarStyle()
-                } else {
-                    HighlightTintStyle(tint = HighlightColor.fromToken(h.color).argb)
-                },
+                style = HighlightTintStyle(tint = HighlightColor.fromToken(h.color).argb),
             )
+        }
+        if (decorations.isEmpty()) {
+            if (hasAnnotationDecorations) {
+                applyDecorationsBlock(emptyList(), "annotations")
+                hasAnnotationDecorations = false
+            }
+            return
         }
         // Initial apply uses clear+apply too — Readium's decoration diff treats an identical
         // (id, locator, style) list as a no-op, so a re-fire of the same list (theme change bumps
@@ -98,7 +106,10 @@ internal class ReadiumHighlightRenderer(
     override suspend fun applyNoteGlyphs(
         renders: List<EpubReaderViewModel.HighlightRender>,
     ) {
-        val noted = renders.filter { it.note != null }
+        // Highlights mode (useAccentBarStyle) skips glyphs: the note is already visible as an
+        // <aside> in the synthesised HTML, and a glyph in the left gutter would overlap the
+        // accent-bar tap span and swallow taps that should open the highlight-actions popup.
+        val noted = renders.filter { it.note != null && !it.useAccentBarStyle }
         if (noted.isEmpty()) {
             if (!hasNoteGlyphDecorations) return
             applyDecorationsBlock(emptyList(), "annotation-notes")

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/highlights/AnnotationTapUrl.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/highlights/AnnotationTapUrl.kt
@@ -1,0 +1,80 @@
+package com.riffle.app.feature.reader.highlights
+
+import java.net.URLDecoder
+import java.net.URLEncoder
+
+// Riffle-only URL scheme fired from the accent-bar tap span in synthesised Highlights-mode HTML.
+// Both continuous ([com.riffle.app.feature.reader.ChapterWebView]) and paginated/vertical
+// ([com.riffle.app.feature.reader.EpubReaderScreen]) intercept navigations targeting this scheme
+// and route the annotation id back to the highlight-actions handler. The single hop through a URL
+// is what makes the same injected HTML work in every reader mode — the JS bridge available in
+// continuous does not exist in Readium's fragment WebViews, and the scheme string lets us bypass
+// Readium's own external-link handling too (it treats non-http URLs as external anyway).
+//
+// The URL also carries the tap element's bounding rect in **CSS pixels** relative to the WebView's
+// origin, encoded as `?l=&t=&r=&b=`. Both interceptors turn those into a window IntRect so the
+// [com.riffle.app.feature.reader.HighlightActionsPopup] anchors next to the tapped accent bar
+// instead of at the top-left of the screen.
+const val ANNOTATION_TAP_URL_SCHEME = "riffle"
+const val ANNOTATION_TAP_URL_AUTHORITY = "annotation-tap"
+const val ANNOTATION_TAP_URL_PREFIX = "$ANNOTATION_TAP_URL_SCHEME://$ANNOTATION_TAP_URL_AUTHORITY/"
+
+/**
+ * Parsed form of a `riffle://annotation-tap/<id>` navigation, including the accent-bar element's
+ * bounding rect in CSS pixels (see [buildAnnotationTapUrl]). Rect is null when the JS onclick
+ * couldn't produce one (defensive — the emitter always writes it).
+ */
+data class AnnotationTapUrlParts(
+    val annotationId: String,
+    val cssLeft: Float?,
+    val cssTop: Float?,
+    val cssRight: Float?,
+    val cssBottom: Float?,
+) {
+    fun hasRect(): Boolean =
+        cssLeft != null && cssTop != null && cssRight != null && cssBottom != null
+}
+
+/**
+ * Parse a URL back into the annotation id it targets, or null if the URL is not one of ours.
+ * Round-trips [buildAnnotationTapUrl].
+ */
+fun parseAnnotationTapUrl(url: String): String? = parseAnnotationTapUrlParts(url)?.annotationId
+
+/** Full parse including the CSS-px rect params. Round-trips the emitter in [buildAnnotationTapUrl]. */
+fun parseAnnotationTapUrlParts(url: String): AnnotationTapUrlParts? {
+    if (!url.startsWith(ANNOTATION_TAP_URL_PREFIX)) return null
+    val after = url.removePrefix(ANNOTATION_TAP_URL_PREFIX)
+    val idPart = after.substringBefore('?')
+    if (idPart.isEmpty()) return null
+    val decoded = try {
+        // Two-arg (String, String) — the (String, Charset) overload is Java 10+ and does not
+        // exist on API 25's runtime (NoSuchMethodError observed on the harness AVD).
+        URLDecoder.decode(idPart, "UTF-8")
+    } catch (_: IllegalArgumentException) {
+        return null
+    }
+    if (decoded.isEmpty()) return null
+    val query = if ('?' in after) after.substringAfter('?') else ""
+    val params = queryParams(query)
+    return AnnotationTapUrlParts(
+        annotationId = decoded,
+        cssLeft = params["l"]?.toFloatOrNull(),
+        cssTop = params["t"]?.toFloatOrNull(),
+        cssRight = params["r"]?.toFloatOrNull(),
+        cssBottom = params["b"]?.toFloatOrNull(),
+    )
+}
+
+/** Build the URL an accent-bar tap element navigates to. Percent-encodes the annotation id. */
+fun buildAnnotationTapUrl(annotationId: String): String =
+    ANNOTATION_TAP_URL_PREFIX + URLEncoder.encode(annotationId, "UTF-8")
+
+private fun queryParams(query: String): Map<String, String> {
+    if (query.isEmpty()) return emptyMap()
+    return query.split('&').mapNotNull { pair ->
+        val eq = pair.indexOf('=')
+        if (eq <= 0) return@mapNotNull null
+        pair.substring(0, eq) to pair.substring(eq + 1)
+    }.toMap()
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/highlights/HighlightsPublicationFactory.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/highlights/HighlightsPublicationFactory.kt
@@ -106,22 +106,33 @@ class HighlightsPublicationFactory @Inject constructor() {
                 // Riffle's [Book Search] results card style — the text itself renders in the
                 // theme's normal body colour so dense highlights don't fatigue the eye. `!important`
                 // so ReadiumCSS's theme rules (e.g. Dark's `:not(a){border-color: currentColor}`)
-                // can't strip the colour. Tap dispatch still flows through Readium's decoration
-                // overlay on the <span data-ann-id> — see [highlightsAnnotationToRender].
+                // can't strip the colour. Tap dispatch runs off the injected [ACCENT_BAR_TAP_CLASS]
+                // span below, which navigates to a [buildAnnotationTapUrl]; both continuous
+                // (ChapterWebView) and paginated/vertical (EpubReaderScreen) intercept that URL and
+                // open the highlight-actions popup. Tapping the text itself does nothing — the
+                // reason this HTML is authored here and not decorated on top of it via Readium.
                 val accent = highlightBackgroundCss(highlight.color)
+                val idEscaped = highlight.id.xmlEscape()
+                val tapUrl = buildAnnotationTapUrl(highlight.id).xmlEscape()
                 append("  <p style=\"")
                 append(PARAGRAPH_GAP_STYLE)
-                append("; border-left: 4px solid ")
+                append("; position: relative; border-left: 4px solid ")
                 append(accent)
-                append(" !important; padding-left: 12px;\"><span class=\"riffle-hl\" data-ann-id=\"")
-                append(highlight.id.xmlEscape())
+                append(" !important; padding-left: 12px;\"><span class=\"")
+                append(ACCENT_BAR_TAP_CLASS)
+                append("\" data-ann-id=\"")
+                append(idEscaped)
+                append("\" onclick=\"var e=event,x=e.clientX,y=e.clientY;location.href='")
+                append(tapUrl)
+                append("?l='+x+'&amp;t='+y+'&amp;r='+(x+1)+'&amp;b='+(y+1);return false;\"></span><span class=\"riffle-hl\" data-ann-id=\"")
+                append(idEscaped)
                 append("\">")
                 append(highlight.textSnippet.xmlEscape())
                 append("</span></p>\n")
                 val note = highlight.note
                 if (note != null) {
                     append("  <aside class=\"riffle-note\" data-ann-id=\"")
-                    append(highlight.id.xmlEscape())
+                    append(idEscaped)
                     append("\" style=\"border-left: 2px solid ")
                     append(accent)
                     append(" !important; padding-left: 12px; font-style: italic; opacity: 0.75;\">")
@@ -133,7 +144,7 @@ class HighlightsPublicationFactory @Inject constructor() {
         val title = chapter.title.xmlEscape()
         return """
             |<?xml version="1.0" encoding="UTF-8"?>
-            |<html xmlns="http://www.w3.org/1999/xhtml"><head><title>$title</title>$READIUM_DEFAULT_CSS_LINK</head>
+            |<html xmlns="http://www.w3.org/1999/xhtml"><head><title>$title</title>$READIUM_DEFAULT_CSS_LINK<style>$ACCENT_BAR_TAP_CSS</style></head>
             |<body>
             |  <h1>$title</h1>
             |${body.trimEnd('\n')}
@@ -141,6 +152,23 @@ class HighlightsPublicationFactory @Inject constructor() {
         """.trimMargin()
     }
 }
+
+// Class name on the transparent absolute-positioned span that owns tap dispatch for a highlight.
+// Injected inside each synthesised `<p>` next to the visible text; its CSS (see
+// [ACCENT_BAR_TAP_CSS]) sizes it to overlap the paragraph's border-left + padding-left gutter so a
+// tap on the visible colored bar lands here and NOT on the text. The `<span>` intentionally has no
+// text content; its `onclick` navigates to a [buildAnnotationTapUrl] which is intercepted by both
+// reader modes' URL handlers. Kept `internal const` so JVM regression tests can pin the class name
+// against the rendered HTML.
+internal const val ACCENT_BAR_TAP_CLASS = "riffle-hl-tap"
+
+// Sizes the tap element to cover the paragraph's 4px border-left + 12px padding-left plus a small
+// extra margin outward — inline with what the reader actually paints. `pointer-events: auto`
+// defends against a ReadiumCSS reset stripping default cursor semantics. `background: transparent`
+// stays invisible on every theme.
+internal const val ACCENT_BAR_TAP_CSS =
+    ".$ACCENT_BAR_TAP_CLASS{position:absolute;left:-4px;top:0;bottom:0;width:20px;" +
+        "background:transparent;cursor:pointer;pointer-events:auto;}"
 
 /**
  * Guaranteed-visible background paint for a synthesised `<p class="riffle-hl">` (Fix A,

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/highlights/ReaderSource.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/highlights/ReaderSource.kt
@@ -1,5 +1,7 @@
 package com.riffle.app.feature.reader.highlights
 
+import com.riffle.core.domain.FormattingScope
+
 /**
  * Which content the reader is currently displaying.
  *
@@ -9,3 +11,10 @@ package com.riffle.app.feature.reader.highlights
  * highlight, each rendered down to its highlighted passages and notes.
  */
 enum class ReaderSource { FullBook, Highlights }
+
+// Formatting-preferences chain to use for this reading context. The annotations reading view has
+// its own independent chain so tweaks there never leak into the full-book reader (and vice versa).
+fun ReaderSource.toFormattingScope(): FormattingScope = when (this) {
+    ReaderSource.FullBook -> FormattingScope.FullBook
+    ReaderSource.Highlights -> FormattingScope.Highlights
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/session/FormattingSession.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/session/FormattingSession.kt
@@ -4,7 +4,8 @@ import com.riffle.app.feature.reader.autoscroll.AutoScrollController
 import com.riffle.core.domain.BookFormattingOverrides
 import com.riffle.core.domain.BookFormattingPreferencesStore
 import com.riffle.core.domain.FormattingPreferences
-import com.riffle.core.domain.FormattingPreferencesStore
+import com.riffle.core.domain.FormattingPreferencesStoreProvider
+import com.riffle.core.domain.FormattingScope
 import com.riffle.core.domain.ListeningPreferencesStore
 import com.riffle.core.domain.ReaderTheme
 import com.riffle.core.domain.WakeLockPreferencesStore
@@ -26,8 +27,10 @@ import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.launch
 import com.riffle.core.domain.autoscroll.PauseCause
 
@@ -38,15 +41,26 @@ import com.riffle.core.domain.autoscroll.PauseCause
  *
  * MUST NOT import org.readium.*, android.webkit.*, or ContinuousReaderView.
  */
+@OptIn(ExperimentalCoroutinesApi::class)
 class FormattingSession @AssistedInject constructor(
     @Assisted private val scope: OrchestratorScope,
-    private val formattingPreferencesStore: FormattingPreferencesStore,
+    private val formattingPreferencesStoreProvider: FormattingPreferencesStoreProvider,
     private val bookFormattingPreferencesStore: BookFormattingPreferencesStore,
     private val wakeLockPreferencesStore: WakeLockPreferencesStore,
     private val listeningPreferencesStore: ListeningPreferencesStore,
     private val autoScrollController: AutoScrollController,
     private val appearanceCoordinator: AppearanceCoordinator,
 ) {
+
+    // The reading context this session is bound to. Flips only at bindToBook() time — highlights
+    // mode uses the Highlights scope's independent global store + per-book override chain, while
+    // the full-book reader uses the default FullBook chain. Emitted as a StateFlow so the init
+    // combine below can flatMapLatest into the correct global preferences source when the scope
+    // changes (e.g., process reuse across sessions).
+    private val _scope = MutableStateFlow(FormattingScope.FullBook)
+    // Snapshot for suspend paths (bindToBook, resetToGlobalDefaults) so they read the same scope
+    // the flow-driven state is using.
+    private val activeScope: FormattingScope get() = _scope.value
 
     @AssistedFactory
     interface Factory {
@@ -131,12 +145,18 @@ class FormattingSession @AssistedInject constructor(
         // book open so a session that wasn't cleanly torn down (process kill mid-scroll, then
         // restart into a different book) does not auto-start the new book mid-air.
         autoScrollController.dispatch(AutoScrollEvent.Stop)
-        // Keep effective prefs in sync with both global changes and override updates.
+        // Keep effective prefs in sync with both global changes and override updates. flatMapLatest
+        // over `_scope` so the global source switches when the scope flips (e.g. entering the
+        // annotations reading view mid-process). The scope defaults to FullBook so the very first
+        // emission — before bindToBook() runs — mirrors the previous single-store behaviour.
         scope.launch {
-            combine(
-                formattingPreferencesStore.preferences,
-                _bookOverrides,
-            ) { global, overrides -> overrides.applyTo(global) to !overrides.isEmpty }
+            _scope
+                .flatMapLatest { scope ->
+                    combine(
+                        formattingPreferencesStoreProvider.store(scope).preferences,
+                        _bookOverrides,
+                    ) { global, overrides -> overrides.applyTo(global) to !overrides.isEmpty }
+                }
                 .collect { (effective, hasOverrides) ->
                     _formattingPreferences.value = effective
                     _hasBookOverrides.value = hasOverrides
@@ -188,11 +208,12 @@ class FormattingSession @AssistedInject constructor(
      * Load book-specific overrides and mark prefs as ready. Must be called once per book open,
      * before [effectiveFormattingPreferences] is consumed by the navigator.
      */
-    fun bindToBook(itemId: String) {
+    fun bindToBook(itemId: String, scope: FormattingScope = FormattingScope.FullBook) {
         bookId = itemId
-        scope.launch {
-            val overrides = bookFormattingPreferencesStore.load(itemId)
-            val global = formattingPreferencesStore.preferences.first()
+        _scope.value = scope
+        this.scope.launch {
+            val overrides = bookFormattingPreferencesStore.load(itemId, scope)
+            val global = formattingPreferencesStoreProvider.store(scope).preferences.first()
             _bookOverrides.value = overrides
             val effective = overrides.applyTo(global)
             _formattingPreferences.value = effective
@@ -218,7 +239,8 @@ class FormattingSession @AssistedInject constructor(
         _bookOverrides.value = updated
         _formattingPreferences.value = prefs
         _hasBookOverrides.value = !updated.isEmpty
-        scope.launch { bookFormattingPreferencesStore.save(itemId, updated) }
+        val boundScope = activeScope
+        scope.launch { bookFormattingPreferencesStore.save(itemId, boundScope, updated) }
     }
 
     /**
@@ -228,15 +250,17 @@ class FormattingSession @AssistedInject constructor(
      * The VM calls this once per open book when the JS probe reports its Intl.Segmenter answer.
      */
     fun persistCadencePlatformSupported(supported: Boolean) {
-        scope.launch { formattingPreferencesStore.setCadencePlatformSupported(supported) }
+        scope.launch { formattingPreferencesStoreProvider.store(activeScope).setCadencePlatformSupported(supported) }
     }
 
     /** Clear all book-level overrides, reverting to the global formatting preferences. */
     fun resetToGlobalDefaults(itemId: String) {
+        val boundScope = activeScope
         scope.launch {
-            bookFormattingPreferencesStore.clear(itemId)
+            bookFormattingPreferencesStore.clear(itemId, boundScope)
             _bookOverrides.value = BookFormattingOverrides()
-            _formattingPreferences.value = formattingPreferencesStore.preferences.first()
+            _formattingPreferences.value =
+                formattingPreferencesStoreProvider.store(boundScope).preferences.first()
             _hasBookOverrides.value = false
         }
     }

--- a/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
@@ -500,6 +500,9 @@ fun MainScreen(
                                 navController.popBackStack()
                                 navController.navigate("epub_reader/$encodedId?openAtCfi=$encodedCfi")
                             }
+                            com.riffle.app.feature.reader.ReaderNavEvent.CloseEmptyHighlights -> {
+                                navController.popBackStack()
+                            }
                         }
                     }
                 }

--- a/app/src/test/kotlin/com/riffle/app/RiffleApplicationStartupTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/RiffleApplicationStartupTest.kt
@@ -1,0 +1,25 @@
+package com.riffle.app
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pins the guard in [RiffleApplication.onCreate] that prevents main-process startup work — which
+ * touches WorkManager via `ProgressSyncScheduler.sweepNow` — from running in ACRA's private
+ * `:acra` reporter process. Without the guard the reporter crash-loops with
+ * `WorkManager is not initialized properly` because WorkManager's ContentProvider auto-initializer
+ * is scoped to the main process.
+ */
+class RiffleApplicationStartupTest {
+
+    @Test
+    fun `skips main-process startup in ACRA reporter process`() {
+        assertTrue(shouldSkipMainProcessStartup(isAcraProcess = true))
+    }
+
+    @Test
+    fun `runs main-process startup in the main process`() {
+        assertFalse(shouldSkipMainProcessStartup(isAcraProcess = false))
+    }
+}

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousHighlightRendererTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousHighlightRendererTest.kt
@@ -85,6 +85,7 @@ class ContinuousHighlightRendererTest {
         note: String? = null,
         before: String? = null,
         after: String? = null,
+        useAccentBarStyle: Boolean = false,
     ) = EpubReaderViewModel.HighlightRender(
         id = id,
         locator = Locator(
@@ -94,6 +95,7 @@ class ContinuousHighlightRendererTest {
         ),
         color = color,
         note = note,
+        useAccentBarStyle = useAccentBarStyle,
     )
 
     /** Creates a [Locator] with href and text highlight, suitable for search result tests. */
@@ -236,6 +238,34 @@ class ContinuousHighlightRendererTest {
         val ann = fakeTarget.appliedAnnotations.single().values.single().single()
         assertEquals("", ann.before)
         assertEquals("", ann.after)
+    }
+
+    // Regression: in the annotations reading view (ADR 0041 Highlights mode) the highlight must
+    // NOT paint over the text — only the synthesised HTML's left accent bar. Paginated/vertical
+    // already honour this via [HighlightAccentBarStyle]; continuous mode used to always paint the
+    // palette colour as the <mark>'s background because [applyAnnotations] didn't check
+    // [HighlightRender.useAccentBarStyle]. Pin: when useAccentBarStyle=true, the emitted
+    // AnnotationHighlight.cssColor is `transparent` so the mark exists (tap-to-edit still fires)
+    // but paints nothing. If reverted, the palette colour flows back into cssColor and the fill
+    // reappears on device in continuous mode.
+    @Test
+    fun `applyAnnotations emits transparent cssColor when useAccentBarStyle is true`() = runTest {
+        val renders = listOf(
+            makeRender("h1", "ch1.xhtml", "text one", color = "yellow", useAccentBarStyle = true),
+        )
+        renderer.applyAnnotations(renders)
+        val ann = fakeTarget.appliedAnnotations.single().values.single().single()
+        assertEquals(ContinuousHighlightRenderer.ACCENT_BAR_TRANSPARENT_CSS, ann.cssColor)
+    }
+
+    @Test
+    fun `applyAnnotations emits palette color when useAccentBarStyle is false`() = runTest {
+        val renders = listOf(
+            makeRender("h1", "ch1.xhtml", "text one", color = "yellow", useAccentBarStyle = false),
+        )
+        renderer.applyAnnotations(renders)
+        val ann = fakeTarget.appliedAnnotations.single().values.single().single()
+        assertEquals(HighlightColor.fromToken("yellow").argb.toCssRgba(), ann.cssColor)
     }
 
     // ---- applyNoteGlyphs (no-op) --------------------------------------------

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjectorTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjectorTest.kt
@@ -627,17 +627,34 @@ class ContinuousStyleInjectorTest {
     @Test
     fun `glyph is added when annotation gains a note`() {
         val js = applyJs(AnnotationHighlight("ann1", "text", "#abc", hasNote = true))
-        // The branch: if ann.n && !eg → makeGlyph
-        assertTrue(js.contains("ann.n && !eg"))
+        // The branch: if ann.n && !eg && !ann.s → makeGlyph. Highlights mode gates on `!ann.s`
+        // because the glyph would overlap the accent-bar tap span.
+        assertTrue(js.contains("ann.n && !eg && !ann.s"))
         assertTrue(js.contains("makeGlyph"))
     }
 
     @Test
     fun `glyph is removed when annotation loses its note`() {
         val js = applyJs(AnnotationHighlight("ann1", "text", "#abc", hasNote = false))
-        // The branch: !ann.n && eg → eg.remove()
-        assertTrue(js.contains("!ann.n && eg"))
+        // The branch: (!ann.n || ann.s) && eg → eg.remove(). Removing on ann.s covers the
+        // FullBook → Highlights toggle so a stale glyph doesn't linger after the transition.
+        assertTrue(js.contains("(!ann.n || ann.s) && eg"))
         assertTrue(js.contains("eg.remove()"))
+    }
+
+    // Highlights-mode annotations must NOT get a note glyph — the glyph sits in the same left
+    // gutter as the accent-bar tap span and, injected later than the static tap span, catches the
+    // click first (only the note reader opens instead of highlight actions). Both the new-mark
+    // branch and the in-place update branch are gated on `!ann.s`; reverting either regresses.
+    @Test
+    fun `Highlights mode suppresses the note glyph on new marks`() {
+        val js = applyJs(
+            AnnotationHighlight("ann1", "text", "#abc", hasNote = true, suppressMarkClick = true),
+        )
+        assertTrue(
+            "new-mark glyph creation gated on !ann.s",
+            js.contains("firstMark && ann.n && !ann.s"),
+        )
     }
 
     @Test
@@ -657,6 +674,32 @@ class ContinuousStyleInjectorTest {
     fun `mark click calls onAnnotationTap bridge method`() {
         val js = applyJs(AnnotationHighlight("ann1", "text", "#abc"))
         assertTrue(js.contains("onAnnotationTap"))
+    }
+
+    // Highlights-mode annotations must NOT install a mark click listener — the accent-bar span in
+    // the synthesised HTML owns tap dispatch. The `s:` field on the emitted annotation payload
+    // gates the addEventListener call; regressing either the JSON field or the `if (!ann.s)` guard
+    // reinstates the on-text tap that the Highlights view explicitly disallows.
+    @Test
+    fun `suppressMarkClick emits s field of 1 in JSON payload`() {
+        val js = applyJs(AnnotationHighlight("ann1", "text", "#abc", suppressMarkClick = true))
+        assertTrue("s:1 in payload", js.contains("s:1"))
+    }
+
+    @Test
+    fun `default suppressMarkClick emits s field of 0 (FullBook mode)`() {
+        val js = applyJs(AnnotationHighlight("ann1", "text", "#abc"))
+        assertTrue("s:0 in payload", js.contains("s:0"))
+    }
+
+    @Test
+    fun `mark addEventListener call is gated by the s field so Highlights mode taps skip the mark`() {
+        val js = applyJs(AnnotationHighlight("ann1", "text", "#abc", suppressMarkClick = true))
+        // The guard: `if (!ann.s) { … markEl.addEventListener('click', …) … }`. Verifying both the
+        // guard and the listener call are present in the SAME JS body — reverting the guard would
+        // let the click listener attach unconditionally.
+        assertTrue("guard uses !ann.s", js.contains("if (!ann.s)"))
+        assertTrue("addEventListener is present inside the guarded block", js.contains("markEl.addEventListener('click'"))
     }
 
     @Test

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/EpubReaderViewModelHighlightsSourceTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/EpubReaderViewModelHighlightsSourceTest.kt
@@ -10,8 +10,10 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.readium.r2.shared.util.RelativeUrl
 import org.readium.r2.shared.util.Url
@@ -197,6 +199,45 @@ class EpubReaderViewModelHighlightsSourceTest {
         val chapters = buildChapterElisions(listOf(highlight("h1", "chA.xhtml", spineIndex = 0)))
         assertEquals(null, highlightsResumeAnnotationIdForHref(chapters, "not-a-highlights-href.xhtml"))
         assertEquals(null, highlightsResumeAnnotationIdForHref(chapters, "highlights/ch7.xhtml"))
+    }
+
+    // ---- Delete-last-annotation crash fix ---------------------------------------------------
+
+    // Regression: deleting the last remaining annotation in the annotations reading view (ADR 0041
+    // "Highlights" reader) used to hard-crash — deleteAnnotation reloaded openBook(), which built a
+    // synthesised Publication with an empty readingOrder, and Readium's EpubNavigatorFragment
+    // throws on that. The fix keys off this predicate: when no live highlights remain, close the
+    // reader (via ReaderNavEvent.CloseEmptyHighlights) instead of reloading. If the fix is
+    // reverted, [reloadOrCloseHighlightsAfterDelete] returns false for the empty case and the
+    // reader crashes again on device.
+    @Test
+    fun `highlightsShouldCloseAfterDelete is true when only a soft-deleted highlight remains`() {
+        val rows = listOf(highlight("h1", "chA.xhtml", spineIndex = 0, deleted = true))
+        assertTrue(highlightsShouldCloseAfterDelete(rows))
+    }
+
+    @Test
+    fun `highlightsShouldCloseAfterDelete is true when the book has zero rows at all`() {
+        assertTrue(highlightsShouldCloseAfterDelete(emptyList()))
+    }
+
+    @Test
+    fun `highlightsShouldCloseAfterDelete is true when only bookmarks remain`() {
+        // Bookmarks are stripped by buildChapterElisions, so a book whose only remaining rows are
+        // bookmarks is empty from Highlights mode's perspective — the reader must close.
+        val rows = listOf(
+            highlight("b1", "chA.xhtml", spineIndex = 0, type = AnnotationEntity.TYPE_BOOKMARK),
+        )
+        assertTrue(highlightsShouldCloseAfterDelete(rows))
+    }
+
+    @Test
+    fun `highlightsShouldCloseAfterDelete is false when at least one live highlight remains`() {
+        val rows = listOf(
+            highlight("h1", "chA.xhtml", spineIndex = 0),
+            highlight("h2", "chB.xhtml", spineIndex = 1, deleted = true),
+        )
+        assertFalse(highlightsShouldCloseAfterDelete(rows))
     }
 
     // ---- Important #2: case-insensitive ReaderSource decoding -----------------------------

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/HighlightsReloadOnMutationGuardTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/HighlightsReloadOnMutationGuardTest.kt
@@ -1,0 +1,93 @@
+package com.riffle.app.feature.reader
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+/**
+ * Regression guard: mutations that change a highlight's rendered representation in the synthesised
+ * Highlights-mode HTML (note add/remove, recolour, and delete) MUST reload the reader in Highlights
+ * mode. The runtime decoration path doesn't touch the synthesised `<p>`/`<aside>` bodies, so
+ * without a reload the on-screen view drifts from the underlying annotation store.
+ *
+ * The three mutating VM methods each need to include:
+ *   if (source == ReaderSource.Highlights) { … openBook() … }
+ *
+ * ...within their `viewModelScope.launch { … }` body. This test flunks if any of the three loses
+ * that pattern — cheaper than standing up an Android-heavy VM harness just to observe the reload
+ * side-effect via a fake session, and covers the exact regression a future refactor could reintroduce
+ * (either by moving the reload into a helper called from the wrong place or by dropping it).
+ */
+class HighlightsReloadOnMutationGuardTest {
+
+    @Test
+    fun `updateHighlightNote reloads openBook in Highlights mode`() {
+        assertReloadsInHighlightsMode(functionName = "updateHighlightNote")
+    }
+
+    @Test
+    fun `recolorHighlight reloads openBook in Highlights mode`() {
+        assertReloadsInHighlightsMode(functionName = "recolorHighlight")
+    }
+
+    @Test
+    fun `deleteHighlight reloads openBook in Highlights mode`() {
+        assertReloadsInHighlightsMode(functionName = "deleteHighlight")
+    }
+
+    @Test
+    fun `deleteAnnotation reloads openBook in Highlights mode`() {
+        assertReloadsInHighlightsMode(functionName = "deleteAnnotation")
+    }
+
+    private fun assertReloadsInHighlightsMode(functionName: String) {
+        val source = resolveVmSource().readText()
+        val funBody = extractFunctionBody(source, functionName)
+            ?: error("Could not locate `fun $functionName` body in EpubReaderViewModel.kt — did it move?")
+        // The guard is intentionally loose: any `openBook()` call inside a
+        // `if (source == ReaderSource.Highlights) { … }` branch counts. Delete flows fold in
+        // reloadOrCloseHighlightsAfterDelete() plus the openBook call; note/recolor flows call
+        // openBook directly. Both patterns satisfy this assertion.
+        val hasHighlightsBranch = funBody.contains("source == ReaderSource.Highlights")
+        // Either an explicit openBook() call (delete flows) OR the reloadHighlightsView() helper
+        // (note/recolor flows). The helper internally calls openBook() plus the frame-yield the
+        // note/recolor flows need to force Compose to observe the Loading state.
+        val callsReload = funBody.contains("openBook()") || funBody.contains("reloadHighlightsView()")
+        assertTrue(
+            "$functionName must include an `if (source == ReaderSource.Highlights)` branch that " +
+                "reloads via openBook() or reloadHighlightsView() — otherwise the synthesised HTML " +
+                "shows stale note/colour state until the reader is reopened. Function body:\n$funBody",
+            hasHighlightsBranch && callsReload,
+        )
+    }
+
+    /** Locate the whole body of a top-level `fun <name>(…) { … }` in the VM source. */
+    private fun extractFunctionBody(source: String, name: String): String? {
+        val declRegex = Regex("""(?m)^\s{4}fun\s+$name\b""")
+        val declMatch = declRegex.find(source) ?: return null
+        // Find the first `{` after the declaration and walk to its matching `}`.
+        var i = source.indexOf('{', startIndex = declMatch.range.first)
+        if (i < 0) return null
+        var depth = 0
+        val start = i
+        while (i < source.length) {
+            when (source[i]) {
+                '{' -> depth++
+                '}' -> {
+                    depth--
+                    if (depth == 0) return source.substring(start, i + 1)
+                }
+            }
+            i++
+        }
+        return null
+    }
+
+    private fun resolveVmSource(): File {
+        val rel = "src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt"
+        val candidates = listOf(File(rel), File("app/$rel"))
+        return candidates.firstOrNull { it.exists() } ?: error(
+            "EpubReaderViewModel.kt not found. Tried: ${candidates.map { it.absolutePath }}",
+        )
+    }
+}

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/PdfReaderViewModelFormattingTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/PdfReaderViewModelFormattingTest.kt
@@ -6,6 +6,8 @@ import com.riffle.core.domain.BookFormattingOverrides
 import com.riffle.core.domain.BookFormattingPreferencesStore
 import com.riffle.core.domain.FormattingPreferences
 import com.riffle.core.domain.FormattingPreferencesStore
+import com.riffle.core.domain.FormattingPreferencesStoreProvider
+import com.riffle.core.domain.FormattingScope
 import com.riffle.core.domain.ListeningPreferencesStore
 import com.riffle.core.domain.WakeLockPreferencesStore
 import com.riffle.core.domain.appearance.AppearanceCoordinator
@@ -45,14 +47,15 @@ class PdfReaderViewModelFormattingTest {
     }
 
     private class FakeBookFormattingPreferencesStore : BookFormattingPreferencesStore {
-        private val saved = mutableMapOf<String, BookFormattingOverrides>()
-        override suspend fun load(itemId: String): BookFormattingOverrides =
-            saved[itemId] ?: BookFormattingOverrides()
-        override suspend fun save(itemId: String, overrides: BookFormattingOverrides) {
-            saved[itemId] = overrides
+        private val saved = mutableMapOf<Pair<String, FormattingScope>, BookFormattingOverrides>()
+        override suspend fun load(itemId: String, scope: FormattingScope): BookFormattingOverrides =
+            saved[itemId to scope] ?: BookFormattingOverrides()
+        override suspend fun save(itemId: String, scope: FormattingScope, overrides: BookFormattingOverrides) {
+            saved[itemId to scope] = overrides
         }
-        override suspend fun clear(itemId: String) { saved.remove(itemId) }
-        fun captured(itemId: String): BookFormattingOverrides? = saved[itemId]
+        override suspend fun clear(itemId: String, scope: FormattingScope) { saved.remove(itemId to scope) }
+        fun captured(itemId: String, scope: FormattingScope = FormattingScope.FullBook): BookFormattingOverrides? =
+            saved[itemId to scope]
     }
 
     private class FakeWakeLockPreferencesStore : WakeLockPreferencesStore {
@@ -98,7 +101,10 @@ class PdfReaderViewModelFormattingTest {
         val bookStore = FakeBookFormattingPreferencesStore()
         val session = FormattingSession(
             scope = scope,
-            formattingPreferencesStore = FakeFormattingPreferencesStore(),
+            formattingPreferencesStoreProvider = object : FormattingPreferencesStoreProvider {
+                private val store = FakeFormattingPreferencesStore()
+                override fun store(scope: FormattingScope) = store
+            },
             bookFormattingPreferencesStore = bookStore,
             wakeLockPreferencesStore = FakeWakeLockPreferencesStore(),
             listeningPreferencesStore = FakeListeningPreferencesStore(),

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ReaderModeForkGuardTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ReaderModeForkGuardTest.kt
@@ -87,6 +87,11 @@ class ReaderModeForkGuardTest {
         // on isContinuous to pick the right presenter (Continuous window scan vs. Readium
         // rendererBridge + latestLocator pair). Both refs live inside one LaunchedEffect and are
         // load-bearing — Cadence can't seed at the visible sentence otherwise.
-        private const val MAX_MODE_BRANCHES = 33
+        //
+        // Raised from 33 to 35 for the continuous backdrop paint (see the `// MODE-FORK:` comment
+        // above `containerModifier`). Continuous needs Modifier.background(theme.palette.background)
+        // when paginated-viewport-align is off; otherwise a short chapter (Highlights view, few
+        // annotations) leaves app-chrome grey visible beneath ContinuousReaderView.
+        private const val MAX_MODE_BRANCHES = 35
     }
 }

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/highlights/AnnotationTapUrlTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/highlights/AnnotationTapUrlTest.kt
@@ -1,0 +1,78 @@
+package com.riffle.app.feature.reader.highlights
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Regression pins for the `riffle-annotation-tap:` scheme handed to
+ * [com.riffle.app.feature.reader.ChapterWebView] (continuous) and
+ * [com.riffle.app.feature.reader.EpubReaderScreen]'s `onExternalLinkActivated`
+ * (paginated/vertical). The synthesised HTML in
+ * [HighlightsPublicationFactory] embeds a `location.href='<buildAnnotationTapUrl(id)>'` on the
+ * accent-bar tap span; if the parser drifts from the builder (or from either interceptor's
+ * `startsWith` check), the highlight menu simply never opens. Both halves are pinned by the
+ * round-trip case below plus explicit rejection of unrelated URL shapes.
+ */
+class AnnotationTapUrlTest {
+
+    @Test
+    fun `parse returns the id round-tripped from build`() {
+        val id = "abc-123"
+        assertEquals(id, parseAnnotationTapUrl(buildAnnotationTapUrl(id)))
+    }
+
+    @Test
+    fun `parse decodes percent-encoded ids with spaces and hashes`() {
+        val id = "id with space & #hash?"
+        val url = buildAnnotationTapUrl(id)
+        assertEquals(id, parseAnnotationTapUrl(url))
+    }
+
+    @Test
+    fun `parse returns null for http URLs`() {
+        assertNull(parseAnnotationTapUrl("https://example.com/foo"))
+        assertNull(parseAnnotationTapUrl("http://readium_package/OEBPS/ch1.xhtml"))
+    }
+
+    @Test
+    fun `parse returns null for the wrong scheme prefix`() {
+        // A missed `startsWith` check that swallowed unrelated riffle URLs would be caught here.
+        assertNull(parseAnnotationTapUrl("riffle://other-thing/abc"))
+        assertNull(parseAnnotationTapUrl("riffle-annotation-tap:abc"))
+    }
+
+    @Test
+    fun `parse returns null when the id is empty`() {
+        assertNull(parseAnnotationTapUrl("riffle://annotation-tap/"))
+    }
+
+    @Test
+    fun `parse ignores query fragments so future rect params are safe`() {
+        // Reserved for future expansion (e.g. bounding rect appended as ?l=&t=&r=&b=). Today the
+        // interceptors pass through with a zero rect, and the parser must still return the id.
+        assertEquals("abc", parseAnnotationTapUrl("riffle://annotation-tap/abc?l=1&t=2&r=3&b=4"))
+    }
+
+    // Rect query params are what makes [HighlightActionsPopup] anchor next to the tapped accent
+    // bar; without them the popup lands at (0, 0) because HighlightPopupPositionProvider derives
+    // its position from anchorRect. Regressing either the emitter or this parser would flip the
+    // popup back to the top-left of the screen.
+    @Test
+    fun `parts parses rect query params for popup positioning`() {
+        val parts = parseAnnotationTapUrlParts("riffle://annotation-tap/abc?l=12&t=34&r=56&b=78")
+        assertEquals("abc", parts?.annotationId)
+        assertEquals(12f, parts?.cssLeft)
+        assertEquals(34f, parts?.cssTop)
+        assertEquals(56f, parts?.cssRight)
+        assertEquals(78f, parts?.cssBottom)
+        assertEquals(true, parts?.hasRect())
+    }
+
+    @Test
+    fun `parts hasRect is false when no query is present`() {
+        val parts = parseAnnotationTapUrlParts("riffle://annotation-tap/abc")
+        assertEquals("abc", parts?.annotationId)
+        assertEquals(false, parts?.hasRect())
+    }
+}

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/highlights/HighlightsPublicationFactoryTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/highlights/HighlightsPublicationFactoryTest.kt
@@ -211,6 +211,79 @@ class HighlightsPublicationFactoryTest {
         )
     }
 
+    // The accent-bar tap span owns tap dispatch in Highlights mode: taps on the visible left
+    // border-left land on this transparent absolute-positioned span (see ACCENT_BAR_TAP_CSS),
+    // whose onclick navigates to a riffle://annotation-tap/<id> URL that both continuous
+    // (ChapterWebView.shouldOverrideUrlLoading) and paginated/vertical (EpubReaderScreen
+    // .onExternalLinkActivated) intercept. Reverting the accent-bar tap element would let taps
+    // land on the highlighted text again, reintroducing the pre-2026-07 behaviour where any
+    // on-text tap opened the highlight menu.
+    @Test
+    fun highlightParagraphCarriesAccentBarTapSpanTargetingRiffleUrl() {
+        val pub = factory.build(
+            sourceId = "S1",
+            itemId = "B1",
+            bookTitle = null,
+            chapters = listOf(
+                ChapterElision("ch1.xhtml", "Chapter One", listOf(hl("h1", "the spice must flow"))),
+            ),
+            urlFactory = ::testUrlFactory,
+        )
+        val html = readChapterHtml(pub, index = 0)
+        assertTrue(
+            "expected a tap span with data-ann-id=h1 in the emitted HTML, got: $html",
+            html.contains("<span class=\"riffle-hl-tap\" data-ann-id=\"h1\""),
+        )
+        assertTrue(
+            "tap span must navigate to the riffle:// scheme parsed by parseAnnotationTapUrl, got: $html",
+            html.contains("location.href='riffle://annotation-tap/h1?l='+x+"),
+        )
+        // Raw XHTML: `&` in attribute values is escaped as `&amp;`. When the parser hands the
+        // string to JS at page load time it turns back into `&`, so the emitted URL is
+        // `?l=<L>&t=<T>&r=<R>&b=<B>`. Position uses `event.clientX/clientY` (the actual tap
+        // point, WebView-viewport CSS px) so the popup anchors right where the user touched
+        // rather than at the paragraph's top edge — the tap span itself spans the whole `<p>`,
+        // which would otherwise anchor the popup a full paragraph away for a multi-line highlight.
+        assertTrue(
+            "tap span must anchor the popup to event.clientX/Y, not to the whole element's rect; " +
+                "got: $html",
+            html.contains("var e=event,x=e.clientX,y=e.clientY;") &&
+                html.contains("'&amp;t='+y+'&amp;r='+(x+1)+'&amp;b='+(y+1)"),
+        )
+        assertTrue(
+            "the tap span's absolute positioning only works when the parent <p> is position: relative",
+            html.contains("position: relative"),
+        )
+        assertTrue(
+            "the tap CSS class must be defined in a <style> block so the tap zone has a size",
+            html.contains(".riffle-hl-tap{position:absolute;"),
+        )
+    }
+
+    // The percent-encoding path must survive an id that contains characters (spaces, `#`, `?`)
+    // Uri would otherwise treat as URL syntax. The synthesised HTML embeds the id twice — once in
+    // data-ann-id (XML-escaped) and once in the onclick's URL (URL-encoded) — so the emitted URL
+    // must be the URL-encoded form. Pairing this pin with AnnotationTapUrlTest's round-trip means
+    // reverting either half fails one or the other.
+    @Test
+    fun accentBarTapSpanUrlEncodesTheAnnotationId() {
+        val pub = factory.build(
+            sourceId = "S1",
+            itemId = "B1",
+            bookTitle = null,
+            chapters = listOf(
+                ChapterElision("ch1.xhtml", "Chapter One", listOf(hl("has space", "text"))),
+            ),
+            urlFactory = ::testUrlFactory,
+        )
+        val html = readChapterHtml(pub, index = 0)
+        assertTrue(
+            "id `has space` must be url-encoded in the tap URL, got: $html",
+            html.contains("location.href='riffle://annotation-tap/has+space?") ||
+                html.contains("location.href='riffle://annotation-tap/has%20space?"),
+        )
+    }
+
     // Notes need their own paler/neutral background so they read as visually distinct from the
     // highlight paragraph above them.
     @Test

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/session/FormattingSessionTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/session/FormattingSessionTest.kt
@@ -5,6 +5,8 @@ import com.riffle.core.domain.BookFormattingOverrides
 import com.riffle.core.domain.BookFormattingPreferencesStore
 import com.riffle.core.domain.FormattingPreferences
 import com.riffle.core.domain.FormattingPreferencesStore
+import com.riffle.core.domain.FormattingPreferencesStoreProvider
+import com.riffle.core.domain.FormattingScope
 import com.riffle.core.domain.ListeningPreferencesStore
 import com.riffle.core.domain.ReaderTheme
 import com.riffle.core.domain.WakeLockPreferencesStore
@@ -44,12 +46,27 @@ class FormattingSessionTest {
     }
 
     private class FakeBookFormattingPreferencesStore : BookFormattingPreferencesStore {
-        val saved = mutableMapOf<String, BookFormattingOverrides>()
+        // Keyed by (itemId, scope) so the annotations-view chain and full-book chain don't collide
+        // in the same fake. Existing FullBook-only tests key with FormattingScope.FullBook.
+        val saved = mutableMapOf<Pair<String, FormattingScope>, BookFormattingOverrides>()
         private var toReturn = BookFormattingOverrides()
         fun willReturn(o: BookFormattingOverrides) { toReturn = o }
-        override suspend fun load(itemId: String): BookFormattingOverrides = saved[itemId] ?: toReturn
-        override suspend fun save(itemId: String, overrides: BookFormattingOverrides) { saved[itemId] = overrides }
-        override suspend fun clear(itemId: String) { saved.remove(itemId) }
+        override suspend fun load(itemId: String, scope: FormattingScope): BookFormattingOverrides =
+            saved[itemId to scope] ?: toReturn
+        override suspend fun save(itemId: String, scope: FormattingScope, overrides: BookFormattingOverrides) {
+            saved[itemId to scope] = overrides
+        }
+        override suspend fun clear(itemId: String, scope: FormattingScope) { saved.remove(itemId to scope) }
+    }
+
+    private class FakeFormattingPreferencesStoreProvider(
+        private val fullBook: FormattingPreferencesStore,
+        private val highlights: FormattingPreferencesStore = fullBook,
+    ) : FormattingPreferencesStoreProvider {
+        override fun store(scope: FormattingScope): FormattingPreferencesStore = when (scope) {
+            FormattingScope.FullBook -> fullBook
+            FormattingScope.Highlights -> highlights
+        }
     }
 
     private class FakeWakeLockPreferencesStore : WakeLockPreferencesStore {
@@ -106,7 +123,7 @@ class FormattingSessionTest {
         val sessionScope = kotlinx.coroutines.CoroutineScope(dispatcher)
         val session = FormattingSession(
             scope = sessionScope,
-            formattingPreferencesStore = fakeGlobal,
+            formattingPreferencesStoreProvider = FakeFormattingPreferencesStoreProvider(fakeGlobal),
             bookFormattingPreferencesStore = fakeBook,
             wakeLockPreferencesStore = FakeWakeLockPreferencesStore(),
             listeningPreferencesStore = FakeListeningPreferencesStore(),
@@ -161,7 +178,7 @@ class FormattingSessionTest {
             session.bindToBook("item1")
             val newPrefs = FormattingPreferences(fontSize = 1.8f)
             session.updateFormatting("item1", newPrefs)
-            assertTrue(bookStore.saved.containsKey("item1"))
+            assertTrue(bookStore.saved.containsKey("item1" to FormattingScope.FullBook))
         } finally {
             scope.cancel()
         }
@@ -177,7 +194,7 @@ class FormattingSessionTest {
             assertTrue(session.hasBookOverrides.value)
             session.resetToGlobalDefaults("item1")
             assertFalse(session.hasBookOverrides.value)
-            assertFalse(bookStore.saved.containsKey("item1"))
+            assertFalse(bookStore.saved.containsKey("item1" to FormattingScope.FullBook))
         } finally {
             scope.cancel()
         }
@@ -319,8 +336,8 @@ class FormattingSessionTest {
     fun `bindToBook applies overrides for each book`() = runTest {
         val fakeGlobal = FakeFormattingPreferencesStore(FormattingPreferences(fontSize = 1.0f))
         val fakeBook = FakeBookFormattingPreferencesStore()
-        fakeBook.saved["book-a"] = BookFormattingOverrides(fontSize = 1.5f)
-        fakeBook.saved["book-b"] = BookFormattingOverrides(fontSize = 2.0f)
+        fakeBook.saved["book-a" to FormattingScope.FullBook] = BookFormattingOverrides(fontSize = 1.5f)
+        fakeBook.saved["book-b" to FormattingScope.FullBook] = BookFormattingOverrides(fontSize = 2.0f)
         val (session, _, _, _, _, scope) = makeEager(fakeGlobal = fakeGlobal, fakeBook = fakeBook)
         try {
             session.bindToBook("book-a")
@@ -382,7 +399,7 @@ class FormattingSessionTest {
         try {
             FormattingSession(
                 scope = sessionScope,
-                formattingPreferencesStore = FakeFormattingPreferencesStore(),
+                formattingPreferencesStoreProvider = FakeFormattingPreferencesStoreProvider(FakeFormattingPreferencesStore()),
                 bookFormattingPreferencesStore = FakeBookFormattingPreferencesStore(),
                 wakeLockPreferencesStore = FakeWakeLockPreferencesStore(),
                 listeningPreferencesStore = FakeListeningPreferencesStore(),
@@ -420,7 +437,7 @@ class FormattingSessionTest {
         val sessionScope = kotlinx.coroutines.CoroutineScope(dispatcher)
         val session = FormattingSession(
             scope = sessionScope,
-            formattingPreferencesStore = FakeFormattingPreferencesStore(),
+            formattingPreferencesStoreProvider = FakeFormattingPreferencesStoreProvider(FakeFormattingPreferencesStore()),
             bookFormattingPreferencesStore = FakeBookFormattingPreferencesStore(),
             wakeLockPreferencesStore = FakeWakeLockPreferencesStore(),
             listeningPreferencesStore = FakeListeningPreferencesStore(),
@@ -454,7 +471,7 @@ class FormattingSessionTest {
         val sessionScope = kotlinx.coroutines.CoroutineScope(dispatcher)
         val session = FormattingSession(
             scope = sessionScope,
-            formattingPreferencesStore = FakeFormattingPreferencesStore(),
+            formattingPreferencesStoreProvider = FakeFormattingPreferencesStoreProvider(FakeFormattingPreferencesStore()),
             bookFormattingPreferencesStore = FakeBookFormattingPreferencesStore(),
             wakeLockPreferencesStore = FakeWakeLockPreferencesStore(),
             listeningPreferencesStore = FakeListeningPreferencesStore(),
@@ -485,6 +502,76 @@ class FormattingSessionTest {
         }
     }
 
+    // Scope isolation: binding with FormattingScope.Highlights routes both reads and writes to the
+    // highlights global store and to the (itemId, Highlights) per-book slot. Revert either half of
+    // the split (the DAO scope column, the FormattingSession's flatMapLatest over _scope, or the
+    // provider selection in bindToBook) and this pins that regression.
+    @Test
+    fun `bindToBook Highlights reads global from Highlights store not FullBook`() = runTest {
+        val fullBook = FakeFormattingPreferencesStore(FormattingPreferences(fontSize = 1.0f))
+        val highlights = FakeFormattingPreferencesStore(FormattingPreferences(fontSize = 2.0f))
+        val provider = FakeFormattingPreferencesStoreProvider(fullBook, highlights)
+        val dispatcher = UnconfinedTestDispatcher()
+        val autoScrollController = AutoScrollController.forTest(dispatcher)
+        val sessionScope = kotlinx.coroutines.CoroutineScope(dispatcher)
+        val session = FormattingSession(
+            scope = sessionScope,
+            formattingPreferencesStoreProvider = provider,
+            bookFormattingPreferencesStore = FakeBookFormattingPreferencesStore(),
+            wakeLockPreferencesStore = FakeWakeLockPreferencesStore(),
+            listeningPreferencesStore = FakeListeningPreferencesStore(),
+            autoScrollController = autoScrollController,
+            appearanceCoordinator = FakeAppearanceCoordinator(),
+        )
+        try {
+            session.bindToBook("item1", FormattingScope.Highlights)
+            assertEquals(
+                "Highlights bind must expose the highlights global's fontSize, not FullBook's",
+                2.0f,
+                session.effectiveFormattingPreferences.value.fontSize,
+            )
+        } finally {
+            autoScrollController.release()
+            sessionScope.cancel()
+        }
+    }
+
+    @Test
+    fun `updateFormatting under Highlights writes to Highlights per-book slot`() = runTest {
+        val fullBook = FakeFormattingPreferencesStore()
+        val highlights = FakeFormattingPreferencesStore()
+        val provider = FakeFormattingPreferencesStoreProvider(fullBook, highlights)
+        val bookStore = FakeBookFormattingPreferencesStore()
+        val dispatcher = UnconfinedTestDispatcher()
+        val autoScrollController = AutoScrollController.forTest(dispatcher)
+        val sessionScope = kotlinx.coroutines.CoroutineScope(dispatcher)
+        val session = FormattingSession(
+            scope = sessionScope,
+            formattingPreferencesStoreProvider = provider,
+            bookFormattingPreferencesStore = bookStore,
+            wakeLockPreferencesStore = FakeWakeLockPreferencesStore(),
+            listeningPreferencesStore = FakeListeningPreferencesStore(),
+            autoScrollController = autoScrollController,
+            appearanceCoordinator = FakeAppearanceCoordinator(),
+        )
+        try {
+            session.bindToBook("book-x", FormattingScope.Highlights)
+            session.updateFormatting("book-x", FormattingPreferences(fontSize = 1.75f))
+
+            assertTrue(
+                "Highlights write must land in the Highlights per-book slot",
+                bookStore.saved.containsKey("book-x" to FormattingScope.Highlights),
+            )
+            assertFalse(
+                "Highlights write must NOT leak into the FullBook per-book slot",
+                bookStore.saved.containsKey("book-x" to FormattingScope.FullBook),
+            )
+        } finally {
+            autoScrollController.release()
+            sessionScope.cancel()
+        }
+    }
+
     // 17. Resuming from the pill before the timeout cancels the auto-hide so a live session isn't
     //     stopped out from under the user.
     @Test
@@ -494,7 +581,7 @@ class FormattingSessionTest {
         val sessionScope = kotlinx.coroutines.CoroutineScope(dispatcher)
         val session = FormattingSession(
             scope = sessionScope,
-            formattingPreferencesStore = FakeFormattingPreferencesStore(),
+            formattingPreferencesStoreProvider = FakeFormattingPreferencesStoreProvider(FakeFormattingPreferencesStore()),
             bookFormattingPreferencesStore = FakeBookFormattingPreferencesStore(),
             wakeLockPreferencesStore = FakeWakeLockPreferencesStore(),
             listeningPreferencesStore = FakeListeningPreferencesStore(),

--- a/core/data/src/main/kotlin/com/riffle/core/data/BookFormattingPreferencesStoreImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/BookFormattingPreferencesStoreImpl.kt
@@ -4,23 +4,25 @@ import com.riffle.core.database.BookFormattingPreferencesDao
 import com.riffle.core.database.BookFormattingPreferencesEntity
 import com.riffle.core.domain.BookFormattingOverrides
 import com.riffle.core.domain.BookFormattingPreferencesStore
+import com.riffle.core.domain.FormattingScope
 import com.riffle.core.domain.ReaderFontFamily
 import com.riffle.core.domain.ReaderOrientation
 import com.riffle.core.domain.ReaderTheme
 import com.riffle.core.domain.SourceRepository
 import javax.inject.Inject
 
-// Formatting is per-device but keyed by (sourceId, itemId) so two Servers' colliding item ids
-// don't share one row (ADR 0025). Like LibraryRepositoryImpl, the active Server is resolved here
-// — you format the book you're actively reading — keeping the domain interface itemId-only.
+// Formatting is per-device but keyed by (sourceId, itemId, scope) so two Sources' colliding item
+// ids don't share one row (ADR 0025) and so the annotations reading view keeps a chain independent
+// from the full-book reader. Like LibraryRepositoryImpl, the active Source is resolved here — you
+// format the book you're actively reading — keeping the domain interface itemId-only.
 class BookFormattingPreferencesStoreImpl @Inject constructor(
     private val dao: BookFormattingPreferencesDao,
     private val sourceRepository: SourceRepository,
 ) : BookFormattingPreferencesStore {
 
-    override suspend fun load(itemId: String): BookFormattingOverrides {
+    override suspend fun load(itemId: String, scope: FormattingScope): BookFormattingOverrides {
         val sourceId = sourceRepository.getActive()?.id ?: return BookFormattingOverrides()
-        val entity = dao.getByItemId(sourceId, itemId) ?: return BookFormattingOverrides()
+        val entity = dao.getByItemId(sourceId, itemId, scope.name) ?: return BookFormattingOverrides()
         return BookFormattingOverrides(
             fontSize = entity.fontSize,
             theme = entity.theme?.let { runCatching { ReaderTheme.valueOf(it) }.getOrNull() },
@@ -37,16 +39,17 @@ class BookFormattingPreferencesStoreImpl @Inject constructor(
         )
     }
 
-    override suspend fun save(itemId: String, overrides: BookFormattingOverrides) {
+    override suspend fun save(itemId: String, scope: FormattingScope, overrides: BookFormattingOverrides) {
         val sourceId = sourceRepository.getActive()?.id ?: return
         if (overrides.isEmpty) {
-            dao.deleteByItemId(sourceId, itemId)
+            dao.deleteByItemId(sourceId, itemId, scope.name)
             return
         }
         dao.upsert(
             BookFormattingPreferencesEntity(
                 sourceId = sourceId,
                 itemId = itemId,
+                scope = scope.name,
                 fontSize = overrides.fontSize,
                 theme = overrides.theme?.name,
                 fontFamily = overrides.fontFamily?.encodePersistName(),
@@ -63,8 +66,8 @@ class BookFormattingPreferencesStoreImpl @Inject constructor(
         )
     }
 
-    override suspend fun clear(itemId: String) {
+    override suspend fun clear(itemId: String, scope: FormattingScope) {
         val sourceId = sourceRepository.getActive()?.id ?: return
-        dao.deleteByItemId(sourceId, itemId)
+        dao.deleteByItemId(sourceId, itemId, scope.name)
     }
 }

--- a/core/data/src/main/kotlin/com/riffle/core/data/FormattingPreferencesStoreProviderImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/FormattingPreferencesStoreProviderImpl.kt
@@ -1,0 +1,17 @@
+package com.riffle.core.data
+
+import com.riffle.core.domain.FormattingPreferencesStore
+import com.riffle.core.domain.FormattingPreferencesStoreProvider
+import com.riffle.core.domain.FormattingScope
+
+// Selects the right global store instance for a reading context. Both instances are `Singleton` in
+// Hilt so calling this repeatedly is free — no per-call DataStore construction.
+class FormattingPreferencesStoreProviderImpl(
+    private val fullBook: FormattingPreferencesStore,
+    private val highlights: FormattingPreferencesStore,
+) : FormattingPreferencesStoreProvider {
+    override fun store(scope: FormattingScope): FormattingPreferencesStore = when (scope) {
+        FormattingScope.FullBook -> fullBook
+        FormattingScope.Highlights -> highlights
+    }
+}

--- a/core/data/src/main/kotlin/com/riffle/core/data/di/DataModule.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/di/DataModule.kt
@@ -21,6 +21,10 @@ annotation class FormattingPreferencesDataStore
 
 @Qualifier
 @Retention(AnnotationRetention.BINARY)
+annotation class HighlightsFormattingPreferencesDataStore
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
 annotation class LibraryVisibilityPreferencesDataStore
 
 @Qualifier

--- a/core/data/src/main/kotlin/com/riffle/core/data/di/DatabaseModule.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/di/DatabaseModule.kt
@@ -79,6 +79,7 @@ object DatabaseModule {
                 RiffleDatabase.MIGRATION_41_42,
                 RiffleDatabase.MIGRATION_42_43,
                 RiffleDatabase.MIGRATION_43_44,
+                RiffleDatabase.MIGRATION_44_45,
             )
             .build()
 

--- a/core/data/src/main/kotlin/com/riffle/core/data/di/FormattingPreferencesDataStoreExt.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/di/FormattingPreferencesDataStoreExt.kt
@@ -7,3 +7,9 @@ import androidx.datastore.preferences.preferencesDataStore
 
 val Context.formattingPreferencesDataStore: DataStore<Preferences>
     by preferencesDataStore(name = "formatting_preferences")
+
+// Second, fully independent DataStore file backing the annotations reading view's global prefs
+// chain. Kept in a distinct file (not key-prefixed in the same file) so the two chains cannot
+// accidentally read/write each other's values via a missed prefix.
+val Context.formattingPreferencesHighlightsDataStore: DataStore<Preferences>
+    by preferencesDataStore(name = "formatting_preferences_highlights")

--- a/core/data/src/main/kotlin/com/riffle/core/data/di/modules/PreferencesModule.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/di/modules/PreferencesModule.kt
@@ -6,6 +6,7 @@ import androidx.datastore.preferences.core.Preferences
 import com.riffle.core.data.AudioPlaybackPreferencesStoreImpl
 import com.riffle.core.data.BookFormattingPreferencesStoreImpl
 import com.riffle.core.data.FormattingPreferencesStoreImpl
+import com.riffle.core.data.FormattingPreferencesStoreProviderImpl
 import com.riffle.core.data.LastOpenedLibraryStoreImpl
 import com.riffle.core.data.LibraryOrderPreferencesStoreImpl
 import com.riffle.core.data.LibraryVisibilityPreferencesStoreImpl
@@ -16,6 +17,7 @@ import com.riffle.core.data.di.CoverGridDensityDataStore
 import com.riffle.core.data.di.DeviceIdDataStore
 import com.riffle.core.data.di.DeviceLabelDataStore
 import com.riffle.core.data.di.FormattingPreferencesDataStore
+import com.riffle.core.data.di.HighlightsFormattingPreferencesDataStore
 import com.riffle.core.data.di.HighlightColorPreferencesDataStore
 import com.riffle.core.data.di.HighlightsResumePreferencesDataStore
 import com.riffle.core.data.di.LastOpenedLibraryDataStore
@@ -31,6 +33,7 @@ import com.riffle.core.data.di.coverGridDensityDataStore
 import com.riffle.core.data.di.deviceIdDataStore
 import com.riffle.core.data.di.deviceLabelDataStore
 import com.riffle.core.data.di.formattingPreferencesDataStore
+import com.riffle.core.data.di.formattingPreferencesHighlightsDataStore
 import com.riffle.core.data.di.highlightColorPreferencesDataStore
 import com.riffle.core.data.di.highlightsResumePreferencesDataStore
 import com.riffle.core.data.di.lastOpenedLibraryDataStore
@@ -46,6 +49,8 @@ import com.riffle.core.domain.AudioPlaybackPreferencesStore
 import com.riffle.core.domain.BookFormattingPreferencesStore
 import com.riffle.core.domain.CoverGridDensityStore
 import com.riffle.core.domain.FormattingPreferencesStore
+import com.riffle.core.domain.FormattingPreferencesStoreProvider
+import com.riffle.core.domain.FormattingScope
 import com.riffle.core.domain.HighlightColorPreferencesStore
 import com.riffle.core.domain.HighlightsResumeStore
 import com.riffle.core.domain.LastOpenedLibraryStore
@@ -110,6 +115,23 @@ abstract class PreferencesModule {
     companion object {
         @Provides @Singleton @FormattingPreferencesDataStore
         fun provideFormattingPreferencesDataStore(@ApplicationContext c: Context): DataStore<Preferences> = c.formattingPreferencesDataStore
+
+        @Provides @Singleton @HighlightsFormattingPreferencesDataStore
+        fun provideHighlightsFormattingPreferencesDataStore(@ApplicationContext c: Context): DataStore<Preferences> = c.formattingPreferencesHighlightsDataStore
+
+        // FormattingPreferencesStoreProvider gives [FormattingSession] the right global store per
+        // reading context. The unqualified [FormattingPreferencesStore] binding continues to point
+        // at the FullBook instance so consumers that don't care about scope (e.g. Settings) work
+        // unchanged; the Highlights instance is constructed here around its own DataStore file.
+        @Provides
+        @Singleton
+        fun provideFormattingPreferencesStoreProvider(
+            fullBook: FormattingPreferencesStoreImpl,
+            @HighlightsFormattingPreferencesDataStore highlightsDs: DataStore<Preferences>,
+        ): FormattingPreferencesStoreProvider = FormattingPreferencesStoreProviderImpl(
+            fullBook = fullBook,
+            highlights = FormattingPreferencesStoreImpl(highlightsDs),
+        )
 
         @Provides @Singleton @LibraryVisibilityPreferencesDataStore
         fun provideLibraryVisibilityPreferencesDataStore(@ApplicationContext c: Context): DataStore<Preferences> = c.libraryVisibilityPreferencesDataStore

--- a/core/data/src/test/kotlin/com/riffle/core/data/BookFormattingPreferencesStoreScopeIsolationTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/BookFormattingPreferencesStoreScopeIsolationTest.kt
@@ -1,0 +1,139 @@
+package com.riffle.core.data
+
+import com.riffle.core.database.BookFormattingPreferencesDao
+import com.riffle.core.database.BookFormattingPreferencesEntity
+import com.riffle.core.domain.AuthenticateResult
+import com.riffle.core.domain.BookFormattingOverrides
+import com.riffle.core.domain.CommitSourceResult
+import com.riffle.core.domain.FormattingScope
+import com.riffle.core.domain.PendingSource
+import com.riffle.core.domain.ReaderTheme
+import com.riffle.core.domain.ServerType
+import com.riffle.core.domain.Source
+import com.riffle.core.domain.SourceRepository
+import com.riffle.core.domain.SourceUrl
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Regression pins for the annotations-view separate-preferences change: a save under one
+ * [FormattingScope] must not leak into a read under the other scope for the same book, and clear
+ * must be scope-scoped. Revert the DAO's `scope` PK column or the [BookFormattingPreferencesStoreImpl]
+ * threading of `scope.name` into DAO calls and these assertions flip red.
+ */
+class BookFormattingPreferencesStoreScopeIsolationTest {
+
+    private class InMemoryDao : BookFormattingPreferencesDao {
+        val rows = mutableMapOf<Triple<String, String, String>, BookFormattingPreferencesEntity>()
+        override suspend fun upsert(entity: BookFormattingPreferencesEntity) {
+            rows[Triple(entity.sourceId, entity.itemId, entity.scope)] = entity
+        }
+        override suspend fun getByItemId(
+            sourceId: String,
+            itemId: String,
+            scope: String,
+        ): BookFormattingPreferencesEntity? = rows[Triple(sourceId, itemId, scope)]
+        override suspend fun deleteByItemId(sourceId: String, itemId: String, scope: String) {
+            rows.remove(Triple(sourceId, itemId, scope))
+        }
+    }
+
+    private class FixedActiveSourceRepository(private val active: Source) : SourceRepository {
+        override fun observeAll(): Flow<List<Source>> = MutableStateFlow(listOf(active))
+        override suspend fun getActive(): Source? = active
+        override suspend fun getById(sourceId: String): Source? =
+            active.takeIf { it.id == sourceId }
+        override suspend fun authenticate(
+            url: SourceUrl,
+            username: String,
+            password: String,
+            insecureAllowed: Boolean,
+            serverType: ServerType,
+        ): AuthenticateResult = throw UnsupportedOperationException()
+        override suspend fun commit(
+            pending: PendingSource,
+            hiddenLibraryIds: Set<String>,
+        ): CommitSourceResult = throw UnsupportedOperationException()
+        override suspend fun setActive(sourceId: String) = Unit
+        override suspend fun remove(sourceId: String) = Unit
+        override suspend fun getSourceVersion(sourceId: String): String? = null
+    }
+
+    private fun newStore(): BookFormattingPreferencesStoreImpl = BookFormattingPreferencesStoreImpl(
+        dao = InMemoryDao(),
+        sourceRepository = FixedActiveSourceRepository(
+            Source(
+                id = "srv-A",
+                url = SourceUrl.parse("http://localhost")!!,
+                isActive = true,
+                insecureConnectionAllowed = false,
+                username = "",
+                serverType = ServerType.AUDIOBOOKSHELF,
+            ),
+        ),
+    )
+
+    @Test
+    fun `save under FullBook does not affect read under Highlights`() = runTest {
+        val store = newStore()
+        store.save("item-1", FormattingScope.FullBook, BookFormattingOverrides(fontSize = 2.0f))
+
+        assertEquals(
+            "FullBook read must return what FullBook wrote",
+            2.0f,
+            store.load("item-1", FormattingScope.FullBook).fontSize,
+        )
+        assertNull(
+            "Highlights read must not see FullBook's write",
+            store.load("item-1", FormattingScope.Highlights).fontSize,
+        )
+    }
+
+    @Test
+    fun `save under Highlights does not affect read under FullBook`() = runTest {
+        val store = newStore()
+        store.save("item-1", FormattingScope.Highlights, BookFormattingOverrides(theme = ReaderTheme.Dark))
+
+        assertEquals(
+            ReaderTheme.Dark,
+            store.load("item-1", FormattingScope.Highlights).theme,
+        )
+        assertNull(
+            "FullBook read must not see Highlights' write",
+            store.load("item-1", FormattingScope.FullBook).theme,
+        )
+    }
+
+    @Test
+    fun `both scopes hold independent values for the same book`() = runTest {
+        val store = newStore()
+        store.save("item-1", FormattingScope.FullBook, BookFormattingOverrides(fontSize = 1.4f))
+        store.save("item-1", FormattingScope.Highlights, BookFormattingOverrides(fontSize = 1.8f))
+
+        assertEquals(1.4f, store.load("item-1", FormattingScope.FullBook).fontSize)
+        assertEquals(1.8f, store.load("item-1", FormattingScope.Highlights).fontSize)
+    }
+
+    @Test
+    fun `clear only removes the targeted scope`() = runTest {
+        val store = newStore()
+        store.save("item-1", FormattingScope.FullBook, BookFormattingOverrides(fontSize = 1.4f))
+        store.save("item-1", FormattingScope.Highlights, BookFormattingOverrides(fontSize = 1.8f))
+
+        store.clear("item-1", FormattingScope.Highlights)
+
+        assertEquals(
+            "FullBook value must survive a Highlights-scoped clear",
+            1.4f,
+            store.load("item-1", FormattingScope.FullBook).fontSize,
+        )
+        assertNull(
+            "Highlights value must be gone after a Highlights-scoped clear",
+            store.load("item-1", FormattingScope.Highlights).fontSize,
+        )
+    }
+}

--- a/core/database/schemas/com.riffle.core.database.RiffleDatabase/45.json
+++ b/core/database/schemas/com.riffle.core.database.RiffleDatabase/45.json
@@ -1,0 +1,1429 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 45,
+    "identityHash": "d580436768c1e3778387615857e5583f",
+    "entities": [
+      {
+        "tableName": "sources",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `url` TEXT NOT NULL, `isActive` INTEGER NOT NULL, `insecureConnectionAllowed` INTEGER NOT NULL, `username` TEXT NOT NULL, `serverType` TEXT NOT NULL, `absUserId` TEXT, `type` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "isActive",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "insecureConnectionAllowed",
+            "columnName": "insecureConnectionAllowed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "username",
+            "columnName": "username",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverType",
+            "columnName": "serverType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absUserId",
+            "columnName": "absUserId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "libraries",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `mediaType` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `isUnsupported` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `id`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaType",
+            "columnName": "mediaType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isUnsupported",
+            "columnName": "isUnsupported",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_libraries_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_libraries_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "library_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `id` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `title` TEXT NOT NULL, `author` TEXT NOT NULL, `coverUrl` TEXT, `readingProgress` REAL NOT NULL, `ebookFileIno` TEXT, `ebookFormat` TEXT NOT NULL, `hasAudio` INTEGER NOT NULL, `audioDurationSec` REAL NOT NULL, `description` TEXT, `seriesName` TEXT, `publishedYear` TEXT, `genres` TEXT NOT NULL, `publisher` TEXT, `language` TEXT, `lastOpenedAt` INTEGER, `addedAt` INTEGER, `isbn` TEXT, `asin` TEXT, `finishedAt` INTEGER, PRIMARY KEY(`sourceId`, `id`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "coverUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "readingProgress",
+            "columnName": "readingProgress",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ebookFileIno",
+            "columnName": "ebookFileIno",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "ebookFormat",
+            "columnName": "ebookFormat",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hasAudio",
+            "columnName": "hasAudio",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "audioDurationSec",
+            "columnName": "audioDurationSec",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seriesName",
+            "columnName": "seriesName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "publishedYear",
+            "columnName": "publishedYear",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "genres",
+            "columnName": "genres",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "publisher",
+            "columnName": "publisher",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "language",
+            "columnName": "language",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastOpenedAt",
+            "columnName": "lastOpenedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "isbn",
+            "columnName": "isbn",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "asin",
+            "columnName": "asin",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "finishedAt",
+            "columnName": "finishedAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_library_items_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_library_items_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "series",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `name` TEXT NOT NULL, `coverUrl` TEXT, `bookCount` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "coverUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "bookCount",
+            "columnName": "bookCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "collections",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `name` TEXT NOT NULL, `bookCount` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookCount",
+            "columnName": "bookCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "series_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`seriesId` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `sequenceOrder` REAL NOT NULL, PRIMARY KEY(`seriesId`, `sourceId`, `itemId`))",
+        "fields": [
+          {
+            "fieldPath": "seriesId",
+            "columnName": "seriesId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sequenceOrder",
+            "columnName": "sequenceOrder",
+            "affinity": "REAL",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "seriesId",
+            "sourceId",
+            "itemId"
+          ]
+        }
+      },
+      {
+        "tableName": "collection_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`collectionId` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, PRIMARY KEY(`collectionId`, `sourceId`, `itemId`))",
+        "fields": [
+          {
+            "fieldPath": "collectionId",
+            "columnName": "collectionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "collectionId",
+            "sourceId",
+            "itemId"
+          ]
+        }
+      },
+      {
+        "tableName": "reading_positions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `cfi` TEXT NOT NULL, `localUpdatedAt` INTEGER NOT NULL, `lastSyncedAt` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `itemId`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cfi",
+            "columnName": "cfi",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localUpdatedAt",
+            "columnName": "localUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncedAt",
+            "columnName": "lastSyncedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "itemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_reading_positions_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_reading_positions_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "book_formatting_preferences",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `scope` TEXT NOT NULL, `fontSize` REAL, `theme` TEXT, `fontFamily` TEXT, `lineSpacing` REAL, `margins` REAL, `orientation` TEXT, `showChapterMap` INTEGER, `showReadingProgressLabels` INTEGER, `showCurrentChapterLabel` INTEGER, `doublePageSpread` INTEGER, `justifyText` INTEGER, `showReadingTimeEstimate` INTEGER, PRIMARY KEY(`sourceId`, `itemId`, `scope`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scope",
+            "columnName": "scope",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fontSize",
+            "columnName": "fontSize",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "theme",
+            "columnName": "theme",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "fontFamily",
+            "columnName": "fontFamily",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lineSpacing",
+            "columnName": "lineSpacing",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "margins",
+            "columnName": "margins",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "orientation",
+            "columnName": "orientation",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "showChapterMap",
+            "columnName": "showChapterMap",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "showReadingProgressLabels",
+            "columnName": "showReadingProgressLabels",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "showCurrentChapterLabel",
+            "columnName": "showCurrentChapterLabel",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "doublePageSpread",
+            "columnName": "doublePageSpread",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "justifyText",
+            "columnName": "justifyText",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "showReadingTimeEstimate",
+            "columnName": "showReadingTimeEstimate",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "itemId",
+            "scope"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_book_formatting_preferences_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_book_formatting_preferences_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "readaloud_links",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`absSourceId` TEXT NOT NULL, `absLibraryItemId` TEXT NOT NULL, `storytellerSourceId` TEXT NOT NULL, `storytellerBookId` TEXT NOT NULL, `state` TEXT NOT NULL, `userConfirmed` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `identityResult` TEXT NOT NULL, PRIMARY KEY(`absSourceId`, `absLibraryItemId`), FOREIGN KEY(`storytellerSourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`absSourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "absSourceId",
+            "columnName": "absSourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absLibraryItemId",
+            "columnName": "absLibraryItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerSourceId",
+            "columnName": "storytellerSourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerBookId",
+            "columnName": "storytellerBookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userConfirmed",
+            "columnName": "userConfirmed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityResult",
+            "columnName": "identityResult",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "absSourceId",
+            "absLibraryItemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_readaloud_links_storytellerSourceId_storytellerBookId",
+            "unique": false,
+            "columnNames": [
+              "storytellerSourceId",
+              "storytellerBookId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_readaloud_links_storytellerSourceId_storytellerBookId` ON `${TABLE_NAME}` (`storytellerSourceId`, `storytellerBookId`)"
+          },
+          {
+            "name": "index_readaloud_links_storytellerSourceId",
+            "unique": false,
+            "columnNames": [
+              "storytellerSourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_readaloud_links_storytellerSourceId` ON `${TABLE_NAME}` (`storytellerSourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "storytellerSourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "absSourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "readaloud_candidates",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`storytellerSourceId` TEXT NOT NULL, `storytellerBookId` TEXT NOT NULL, `absSourceId` TEXT NOT NULL, `absLibraryItemId` TEXT NOT NULL, `score` REAL NOT NULL, PRIMARY KEY(`storytellerSourceId`, `storytellerBookId`, `absSourceId`, `absLibraryItemId`), FOREIGN KEY(`storytellerSourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`absSourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "storytellerSourceId",
+            "columnName": "storytellerSourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerBookId",
+            "columnName": "storytellerBookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absSourceId",
+            "columnName": "absSourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absLibraryItemId",
+            "columnName": "absLibraryItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "score",
+            "columnName": "score",
+            "affinity": "REAL",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "storytellerSourceId",
+            "storytellerBookId",
+            "absSourceId",
+            "absLibraryItemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_readaloud_candidates_absSourceId",
+            "unique": false,
+            "columnNames": [
+              "absSourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_readaloud_candidates_absSourceId` ON `${TABLE_NAME}` (`absSourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "storytellerSourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "absSourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "readaloud_dismissals",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`storytellerSourceId` TEXT NOT NULL, `storytellerBookId` TEXT NOT NULL, `scope` TEXT NOT NULL, `absSourceId` TEXT NOT NULL, `absLibraryItemId` TEXT NOT NULL, PRIMARY KEY(`storytellerSourceId`, `storytellerBookId`, `absSourceId`, `absLibraryItemId`), FOREIGN KEY(`storytellerSourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "storytellerSourceId",
+            "columnName": "storytellerSourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerBookId",
+            "columnName": "storytellerBookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scope",
+            "columnName": "scope",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absSourceId",
+            "columnName": "absSourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absLibraryItemId",
+            "columnName": "absLibraryItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "storytellerSourceId",
+            "storytellerBookId",
+            "absSourceId",
+            "absLibraryItemId"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "storytellerSourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "cross_epub_index",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`absEpubChecksum` TEXT NOT NULL, `storytellerEpubChecksum` TEXT NOT NULL, `perChapterMapsBlob` TEXT NOT NULL, `builtAt` INTEGER NOT NULL, PRIMARY KEY(`absEpubChecksum`, `storytellerEpubChecksum`))",
+        "fields": [
+          {
+            "fieldPath": "absEpubChecksum",
+            "columnName": "absEpubChecksum",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerEpubChecksum",
+            "columnName": "storytellerEpubChecksum",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "perChapterMapsBlob",
+            "columnName": "perChapterMapsBlob",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "builtAt",
+            "columnName": "builtAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "absEpubChecksum",
+            "storytellerEpubChecksum"
+          ]
+        }
+      },
+      {
+        "tableName": "annotations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `type` TEXT NOT NULL, `cfi` TEXT NOT NULL, `color` TEXT NOT NULL, `note` TEXT, `textSnippet` TEXT NOT NULL, `textBefore` TEXT NOT NULL, `textAfter` TEXT NOT NULL, `chapterHref` TEXT NOT NULL, `spineIndex` INTEGER NOT NULL, `progression` REAL NOT NULL, `bookmarkTitle` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `originDeviceId` TEXT NOT NULL, `lastModifiedByDeviceId` TEXT NOT NULL, `deleted` INTEGER NOT NULL, `lastSyncedAt` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cfi",
+            "columnName": "cfi",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "color",
+            "columnName": "color",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "note",
+            "columnName": "note",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "textSnippet",
+            "columnName": "textSnippet",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "textBefore",
+            "columnName": "textBefore",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "textAfter",
+            "columnName": "textAfter",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chapterHref",
+            "columnName": "chapterHref",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "spineIndex",
+            "columnName": "spineIndex",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "progression",
+            "columnName": "progression",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookmarkTitle",
+            "columnName": "bookmarkTitle",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "originDeviceId",
+            "columnName": "originDeviceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastModifiedByDeviceId",
+            "columnName": "lastModifiedByDeviceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deleted",
+            "columnName": "deleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncedAt",
+            "columnName": "lastSyncedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_annotations_sourceId_itemId",
+            "unique": false,
+            "columnNames": [
+              "sourceId",
+              "itemId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_annotations_sourceId_itemId` ON `${TABLE_NAME}` (`sourceId`, `itemId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "readaloud_resume_positions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `href` TEXT NOT NULL, `progression` REAL, `fragmentRef` TEXT, `localUpdatedAt` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `itemId`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "href",
+            "columnName": "href",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "progression",
+            "columnName": "progression",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "fragmentRef",
+            "columnName": "fragmentRef",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localUpdatedAt",
+            "columnName": "localUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "itemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_readaloud_resume_positions_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_readaloud_resume_positions_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "audio_playback_preferences",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `bookId` TEXT NOT NULL, `speed` REAL, PRIMARY KEY(`sourceId`, `bookId`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "speed",
+            "columnName": "speed",
+            "affinity": "REAL"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "bookId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_audio_playback_preferences_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_audio_playback_preferences_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "audiobook_positions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `positionSec` REAL NOT NULL, `localUpdatedAt` INTEGER NOT NULL, `lastSyncedAt` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `itemId`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "positionSec",
+            "columnName": "positionSec",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localUpdatedAt",
+            "columnName": "localUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncedAt",
+            "columnName": "lastSyncedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "itemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_audiobook_positions_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_audiobook_positions_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "audiobook_bookmarks",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `positionSec` REAL NOT NULL, `title` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `localUpdatedAt` INTEGER NOT NULL, `lastSyncedAt` INTEGER NOT NULL, `deleted` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "positionSec",
+            "columnName": "positionSec",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localUpdatedAt",
+            "columnName": "localUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncedAt",
+            "columnName": "lastSyncedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deleted",
+            "columnName": "deleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_audiobook_bookmarks_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_audiobook_bookmarks_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          },
+          {
+            "name": "index_audiobook_bookmarks_sourceId_itemId",
+            "unique": false,
+            "columnNames": [
+              "sourceId",
+              "itemId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_audiobook_bookmarks_sourceId_itemId` ON `${TABLE_NAME}` (`sourceId`, `itemId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "toc_cache",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `ebookFileIno` TEXT NOT NULL, `entriesJson` TEXT NOT NULL, PRIMARY KEY(`sourceId`, `itemId`))",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ebookFileIno",
+            "columnName": "ebookFileIno",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entriesJson",
+            "columnName": "entriesJson",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "itemId"
+          ]
+        }
+      },
+      {
+        "tableName": "audiobook_chapter_cache",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `chaptersJson` TEXT NOT NULL, PRIMARY KEY(`sourceId`, `itemId`))",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chaptersJson",
+            "columnName": "chaptersJson",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "itemId"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'd580436768c1e3778387615857e5583f')"
+    ]
+  }
+}

--- a/core/database/src/androidTest/kotlin/com/riffle/core/database/MigrationTest.kt
+++ b/core/database/src/androidTest/kotlin/com/riffle/core/database/MigrationTest.kt
@@ -1781,6 +1781,71 @@ class MigrationTest {
     }
 
     @Test
+    fun migration44To45_addsScopeToBookFormattingPreferencesPk() {
+        helper.createDatabase(TEST_DB, 44).use { db ->
+            // Seed a source (FK target) and one book_formatting_preferences row so we can verify
+            // pre-existing rows are preserved verbatim and backfilled with scope='FullBook'.
+            db.execSQL(
+                "INSERT INTO sources (id, url, isActive, insecureConnectionAllowed, username, serverType, absUserId, type) " +
+                    "VALUES ('srv-A', 'https://abs.example.com', 1, 0, 'alice', 'AUDIOBOOKSHELF', NULL, 'ABS')"
+            )
+            db.execSQL(
+                "INSERT INTO book_formatting_preferences " +
+                    "(sourceId, itemId, fontSize, theme, fontFamily, lineSpacing, margins, orientation, " +
+                    " showChapterMap, showReadingProgressLabels, showCurrentChapterLabel, doublePageSpread, " +
+                    " justifyText, showReadingTimeEstimate) " +
+                    "VALUES ('srv-A', 'item-1', 1.5, 'Dark', 'Serif', 1.3, 1.2, 'Vertical', " +
+                    " 1, 1, 0, 0, 1, 1)"
+            )
+        }
+        helper.runMigrationsAndValidate(TEST_DB, 45, true, RiffleDatabase.MIGRATION_44_45).use { db ->
+            // Pre-existing row landed as FullBook with every column preserved.
+            db.query(
+                "SELECT sourceId, itemId, scope, fontSize, theme, fontFamily, lineSpacing, margins, " +
+                    "orientation, showChapterMap, showReadingProgressLabels, showCurrentChapterLabel, " +
+                    "doublePageSpread, justifyText, showReadingTimeEstimate " +
+                    "FROM book_formatting_preferences WHERE sourceId = 'srv-A' AND itemId = 'item-1'"
+            ).use { c ->
+                assertEquals(1, c.count)
+                c.moveToFirst()
+                assertEquals("srv-A", c.getString(0))
+                assertEquals("item-1", c.getString(1))
+                assertEquals("FullBook", c.getString(2))  // backfilled — this is the whole point.
+                assertEquals(1.5, c.getDouble(3), 0.001)
+                assertEquals("Dark", c.getString(4))
+                assertEquals("Serif", c.getString(5))
+                assertEquals(1.3, c.getDouble(6), 0.001)
+                assertEquals(1.2, c.getDouble(7), 0.001)
+                assertEquals("Vertical", c.getString(8))
+                assertEquals(1, c.getInt(9))
+                assertEquals(1, c.getInt(10))
+                assertEquals(0, c.getInt(11))
+                assertEquals(0, c.getInt(12))
+                assertEquals(1, c.getInt(13))
+                assertEquals(1, c.getInt(14))
+            }
+            // Highlights-scope row must not collide with the FullBook row on the same book — the
+            // whole point of promoting `scope` into the PK.
+            db.execSQL(
+                "INSERT INTO book_formatting_preferences (sourceId, itemId, scope, fontSize) " +
+                    "VALUES ('srv-A', 'item-1', 'Highlights', 2.0)"
+            )
+            db.query(
+                "SELECT scope, fontSize FROM book_formatting_preferences " +
+                    "WHERE sourceId = 'srv-A' AND itemId = 'item-1' ORDER BY scope"
+            ).use { c ->
+                assertEquals(2, c.count)
+                c.moveToFirst()
+                assertEquals("FullBook", c.getString(0))
+                assertEquals(1.5, c.getDouble(1), 0.001)
+                c.moveToNext()
+                assertEquals("Highlights", c.getString(0))
+                assertEquals(2.0, c.getDouble(1), 0.001)
+            }
+        }
+    }
+
+    @Test
     fun migrateFullChain() {
         helper.createDatabase(TEST_DB, 1).use { db ->
             db.execSQL(
@@ -1789,7 +1854,7 @@ class MigrationTest {
         }
 
         val db = helper.runMigrationsAndValidate(
-            TEST_DB, 44, true,
+            TEST_DB, 45, true,
             RiffleDatabase.MIGRATION_1_2,
             RiffleDatabase.MIGRATION_2_3,
             RiffleDatabase.MIGRATION_3_4,
@@ -1833,6 +1898,7 @@ class MigrationTest {
             RiffleDatabase.MIGRATION_41_42,
             RiffleDatabase.MIGRATION_42_43,
             RiffleDatabase.MIGRATION_43_44,
+            RiffleDatabase.MIGRATION_44_45,
         )
 
         db.query("SELECT url, username, serverType, absUserId, type FROM sources WHERE id = 's1'").use { cursor ->

--- a/core/database/src/main/kotlin/com/riffle/core/database/BookFormattingPreferencesDao.kt
+++ b/core/database/src/main/kotlin/com/riffle/core/database/BookFormattingPreferencesDao.kt
@@ -11,9 +11,15 @@ interface BookFormattingPreferencesDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun upsert(entity: BookFormattingPreferencesEntity)
 
-    @Query("SELECT * FROM book_formatting_preferences WHERE sourceId = :sourceId AND itemId = :itemId LIMIT 1")
-    suspend fun getByItemId(sourceId: String, itemId: String): BookFormattingPreferencesEntity?
+    @Query(
+        "SELECT * FROM book_formatting_preferences " +
+            "WHERE sourceId = :sourceId AND itemId = :itemId AND scope = :scope LIMIT 1"
+    )
+    suspend fun getByItemId(sourceId: String, itemId: String, scope: String): BookFormattingPreferencesEntity?
 
-    @Query("DELETE FROM book_formatting_preferences WHERE sourceId = :sourceId AND itemId = :itemId")
-    suspend fun deleteByItemId(sourceId: String, itemId: String)
+    @Query(
+        "DELETE FROM book_formatting_preferences " +
+            "WHERE sourceId = :sourceId AND itemId = :itemId AND scope = :scope"
+    )
+    suspend fun deleteByItemId(sourceId: String, itemId: String, scope: String)
 }

--- a/core/database/src/main/kotlin/com/riffle/core/database/BookFormattingPreferencesEntity.kt
+++ b/core/database/src/main/kotlin/com/riffle/core/database/BookFormattingPreferencesEntity.kt
@@ -4,13 +4,15 @@ import androidx.room.Entity
 import androidx.room.ForeignKey
 import androidx.room.Index
 
-// Formatting stays per-device (never synced, never per-user), but the row must point at the *right*
-// book: once item ids collide across Sources, itemId alone would let two different books share one
-// formatting row (ADR 0025). sourceId is added for *identity*, not as a per-source feature; it
-// FK-cascades so a removed Source's formatting is cleared.
+// Formatting stays per-device (never synced, never per-user). The row must point at the *right*
+// book and the *right* reading context: once item ids collide across Sources, itemId alone would
+// let two different books share one formatting row (ADR 0025), and once the annotations reading
+// view got its own preferences chain, sourceId+itemId alone would let the annotations view and
+// full-book view collide on the same book. `sourceId` FK-cascades so a removed Source's
+// formatting is cleared. `scope` is the `FormattingScope` enum name ("FullBook" / "Highlights").
 @Entity(
     tableName = "book_formatting_preferences",
-    primaryKeys = ["sourceId", "itemId"],
+    primaryKeys = ["sourceId", "itemId", "scope"],
     foreignKeys = [
         ForeignKey(
             entity = SourceEntity::class,
@@ -24,6 +26,7 @@ import androidx.room.Index
 data class BookFormattingPreferencesEntity(
     val sourceId: String,
     val itemId: String,
+    val scope: String,
     val fontSize: Float? = null,
     val theme: String? = null,
     val fontFamily: String? = null,

--- a/core/database/src/main/kotlin/com/riffle/core/database/RiffleDatabase.kt
+++ b/core/database/src/main/kotlin/com/riffle/core/database/RiffleDatabase.kt
@@ -28,7 +28,7 @@ import androidx.sqlite.db.SupportSQLiteDatabase
         TocCacheEntity::class,
         AudiobookChapterCacheEntity::class,
     ],
-    version = 44,
+    version = 45,
     exportSchema = true,
 )
 abstract class RiffleDatabase : RoomDatabase() {
@@ -791,6 +791,53 @@ abstract class RiffleDatabase : RoomDatabase() {
         val MIGRATION_42_43 = object : Migration(42, 43) {
             override fun migrate(db: SupportSQLiteDatabase) {
                 db.execSQL("ALTER TABLE `annotations` ADD COLUMN `lastSyncedAt` INTEGER NOT NULL DEFAULT 0")
+            }
+        }
+
+        // Annotations reading view gets its own formatting-prefs chain, independent from the
+        // full-book reader. Add `scope` to book_formatting_preferences' PK so a book can carry
+        // two rows — one per FormattingScope. Existing rows are the full-book prefs, backfilled to
+        // scope='FullBook'. Rebuild the table (Room migration pattern for PK changes) preserving
+        // every other column verbatim. Runs after MIGRATION_43_44 (Server → Source rename), so
+        // the column is `sourceId` and the FK targets `sources(id)`.
+        val MIGRATION_44_45 = object : Migration(44, 45) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL(
+                    "CREATE TABLE IF NOT EXISTS `book_formatting_preferences_new` (" +
+                        "`sourceId` TEXT NOT NULL, " +
+                        "`itemId` TEXT NOT NULL, " +
+                        "`scope` TEXT NOT NULL, " +
+                        "`fontSize` REAL, " +
+                        "`theme` TEXT, " +
+                        "`fontFamily` TEXT, " +
+                        "`lineSpacing` REAL, " +
+                        "`margins` REAL, " +
+                        "`orientation` TEXT, " +
+                        "`showChapterMap` INTEGER, " +
+                        "`showReadingProgressLabels` INTEGER, " +
+                        "`showCurrentChapterLabel` INTEGER, " +
+                        "`doublePageSpread` INTEGER, " +
+                        "`justifyText` INTEGER, " +
+                        "`showReadingTimeEstimate` INTEGER, " +
+                        "PRIMARY KEY(`sourceId`, `itemId`, `scope`), " +
+                        "FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE)"
+                )
+                db.execSQL(
+                    "INSERT INTO `book_formatting_preferences_new` " +
+                        "(sourceId, itemId, scope, fontSize, theme, fontFamily, lineSpacing, margins, " +
+                        "orientation, showChapterMap, showReadingProgressLabels, showCurrentChapterLabel, " +
+                        "doublePageSpread, justifyText, showReadingTimeEstimate) " +
+                        "SELECT sourceId, itemId, 'FullBook', fontSize, theme, fontFamily, lineSpacing, " +
+                        "margins, orientation, showChapterMap, showReadingProgressLabels, " +
+                        "showCurrentChapterLabel, doublePageSpread, justifyText, showReadingTimeEstimate " +
+                        "FROM `book_formatting_preferences`"
+                )
+                db.execSQL("DROP TABLE `book_formatting_preferences`")
+                db.execSQL("ALTER TABLE `book_formatting_preferences_new` RENAME TO `book_formatting_preferences`")
+                db.execSQL(
+                    "CREATE INDEX IF NOT EXISTS `index_book_formatting_preferences_sourceId` " +
+                        "ON `book_formatting_preferences` (`sourceId`)"
+                )
             }
         }
 

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/BookFormattingPreferencesStore.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/BookFormattingPreferencesStore.kt
@@ -1,7 +1,7 @@
 package com.riffle.core.domain
 
 interface BookFormattingPreferencesStore {
-    suspend fun load(itemId: String): BookFormattingOverrides
-    suspend fun save(itemId: String, overrides: BookFormattingOverrides)
-    suspend fun clear(itemId: String)
+    suspend fun load(itemId: String, scope: FormattingScope): BookFormattingOverrides
+    suspend fun save(itemId: String, scope: FormattingScope, overrides: BookFormattingOverrides)
+    suspend fun clear(itemId: String, scope: FormattingScope)
 }

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/FormattingPreferencesStoreProvider.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/FormattingPreferencesStoreProvider.kt
@@ -1,0 +1,9 @@
+package com.riffle.core.domain
+
+// Selects the global formatting-preferences store for a given reading context. Full-book and
+// highlights each get their own DataStore instance so their global defaults are independent.
+// Consumers that only ever want the full-book prefs (e.g. Settings screen) inject
+// [FormattingPreferencesStore] directly and don't need this provider.
+interface FormattingPreferencesStoreProvider {
+    fun store(scope: FormattingScope): FormattingPreferencesStore
+}

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/FormattingScope.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/FormattingScope.kt
@@ -1,0 +1,8 @@
+package com.riffle.core.domain
+
+// Identifies which reading context the formatting preferences belong to. The full-book reader and
+// the annotations-view reader each have their own independent prefs chain (global defaults +
+// per-book overrides), so a tweak in one context never leaks into the other. Enum name values are
+// used verbatim as the `source` PK column in `book_formatting_preferences`, so renaming is a DB
+// migration.
+enum class FormattingScope { FullBook, Highlights }

--- a/docs/superpowers/specs/2026-07-07-annotations-view-accent-bar-tap-and-backdrop-design.md
+++ b/docs/superpowers/specs/2026-07-07-annotations-view-accent-bar-tap-and-backdrop-design.md
@@ -1,0 +1,76 @@
+# Annotations View — Accent-Bar Tap Target & Continuous Backdrop
+
+## Problems
+
+In the annotations reading view (`ReaderSource.Highlights`), three related defects:
+
+- **A.** In continuous mode, tapping *anywhere on highlighted text* opens the highlight edit menu. Only tapping the visible colored side line (the accent bar) should.
+- **B.** In paginated and vertical modes, tapping the accent bar does nothing. Nothing at all opens the menu today.
+- **C.** In continuous mode, when a chapter's synthesised body is short (few highlights), the area below the body renders as grey instead of the reader theme's background.
+
+FullBook mode is unaffected by any of these — it uses `HighlightTintStyle` + Readium's `onDecorationActivated`, a separate path that keeps on-text tinted highlights and tap-to-edit.
+
+## Goals
+
+- Highlights mode: taps on the accent bar open the highlight edit menu. Taps on the highlighted text do nothing (fall through to normal WebView tap → immersive toggle).
+- Uniform behavior across paginated, vertical, and continuous.
+- Continuous mode: backdrop below a short chapter matches the reader theme background.
+
+## Non-goals
+
+- No change to FullBook mode tap dispatch or highlight visuals.
+- No change to the visible accent-bar (border-left) styling in the synthesised HTML.
+- No change to note-glyph tap dispatch.
+
+## Design
+
+### Tap dispatch (Bugs A + B)
+
+The visible accent bar is a CSS `border-left: 4px solid <color>` on the `<p>` synthesised by `HighlightsPublicationFactory.renderChapterHtml`. That HTML is loaded by all three modes (paginated, vertical, and continuous — paginated/vertical via Readium's `EpubNavigatorFragment` on the synthesised `Publication`; continuous via `ContinuousReaderView` reading the same `Container`). We can therefore fix both bugs with a *single* mechanism inside that HTML.
+
+**In `renderChapterHtml`:** inside every synthesised highlight `<p>`, inject an absolutely-positioned transparent tap strip covering the border-left + padding-left gutter:
+
+```html
+<span class="riffle-hl-tap" data-ann-id="<id>"
+      onclick="location.href='riffle-annotation-tap:<id>'"></span>
+```
+
+CSS positions it `position:absolute; left:-16px; top:0; bottom:0; width:20px;` so it overlaps the visible 4px border and 12px padding. The `<p>` gets `position:relative` so the absolute child anchors correctly.
+
+**Dispatch:** `location.href='riffle-annotation-tap:<id>'` is intercepted before it navigates. The scheme string `riffle-annotation-tap:` is Riffle's convention for this feature.
+
+- **Paginated / vertical:** Readium's `EpubNavigatorFragment` exposes a `Navigator.Listener.onExternalLinkActivated` / `Navigator.Listener.onResourceLoadFailed` chain and a `WebViewClient.shouldOverrideUrlLoading` under the hood. We add an override that recognises the `riffle-annotation-tap:` scheme and routes the id to `ReadiumPresenter.feedAnnotationHighlightTap(href = currentHref, annotationId = id)`. Any other unknown scheme falls through to Readium's default handling.
+- **Continuous:** `ChapterWebView`'s existing `WebViewClient.shouldOverrideUrlLoading` gets the same check, routing to `ContinuousPresenter.feedAnnotationHighlightTap`.
+
+**In continuous mode's applied `<mark>` (`ContinuousStyleInjector.applyAnnotationHighlightsJs`):** remove the `click` listener from the `<mark>` when running in Highlights mode. The `<mark>` still wraps text (needed for locator resolution and any future color-change), but it no longer intercepts taps — the injected tap strip in the synthesised `<p>` owns clicks.
+
+`HighlightAccentBarStyle` (the invisible Readium decoration that was supposed to be the tap zone) is deleted along with its template + the `useAccentBarStyle=true` branch in `ContinuousHighlightRenderer` and `ReadiumHighlightRenderer`. Nothing else consumes it.
+
+### Continuous backdrop (Bug C)
+
+`ContinuousReaderView`'s root Composable currently paints no background, so a chapter whose body is shorter than the viewport shows the platform default (grey) beneath. Fix: apply `Modifier.background(readerBackgroundColor)` on the root, sourced from the effective reader theme the composable already observes for other purposes.
+
+Extract the theme→color mapping into a pure function `continuousBackdropColor(theme: ReaderTheme): Color` so it's JVM-testable.
+
+## Testing
+
+Every test below pins a specific behavior; reverting the fix flips at least one red.
+
+- **`HighlightsPublicationFactoryTest`** (extend existing):
+  - Each synthesised highlight `<p>` contains exactly one `<span class="riffle-hl-tap" data-ann-id="…">` and its `onclick` targets the `riffle-annotation-tap:` scheme with the annotation id.
+  - The `<p>` carries `position: relative` so the absolute tap strip anchors.
+- **`ContinuousStyleInjectorTest`** (new or extend existing):
+  - In Highlights mode, the emitted JS body wraps text in `<mark data-riffle-ann="…">` but no code path attaches a `click` listener on the mark.
+  - The FullBook branch is untouched (still attaches the listener).
+- **`AnnotationTapUrlSchemeTest`** (new):
+  - Introduce a pure decoder `parseAnnotationTapUrl(url: String): String?`. `parseAnnotationTapUrl("riffle-annotation-tap:abc-123") == "abc-123"`; `parseAnnotationTapUrl("https://example.com") == null`; empty id returns null.
+- **`ContinuousBackdropColorTest`** (new):
+  - `continuousBackdropColor(ReaderTheme.Light) == Color.White`; `Dark` / `DarkDim` / `Sepia` / `Auto` each map to the expected value.
+
+## Non-goals for tests
+
+- No instrumentation test forcing a real WebView tap — the JVM assertions above already flip if the injected HTML, injected JS, URL scheme decoder, or backdrop color function is reverted.
+
+## Rollout
+
+Single PR, additive at the DOM and dispatch layers. No data migration. No user-visible change to FullBook. Users in Highlights mode see the same visuals; only tap targets and (in continuous) the backdrop change.

--- a/docs/superpowers/specs/2026-07-07-annotations-view-separate-preferences-design.md
+++ b/docs/superpowers/specs/2026-07-07-annotations-view-separate-preferences-design.md
@@ -1,0 +1,85 @@
+# Annotations View — Separate Reading Preferences
+
+## Problem
+
+The annotations reading view (`EpubReaderScreen` in `ReaderSource.Highlights` mode) currently shares its reading preferences — font size, theme, margins, line spacing, everything — with the full-book view of the same book. Changing font size while skimming highlights mutates the book's reading experience, and vice versa. These are distinct reading contexts; the user wants them tuned independently.
+
+## Goals
+
+- Reading preferences applied in the annotations view are stored and read independently from the full-book view.
+- Applies at both layers today: **global defaults** (DataStore) and **per-book overrides** (Room).
+- No cross-talk: writing a pref in one mode never changes what the other mode reads back.
+
+## Non-goals
+
+- No import/copy button ("copy my book prefs to annotations view"). Add later if requested.
+- No annotations-mode-only extra settings — same schema, separate bucket.
+- No visual indicator ("these are annotations-view prefs") in the formatting sheet for v1. The user already knows which view they're in.
+- No change to per-book override UX beyond scoping — "Reset to global" behaves the same, just against the annotations-mode global defaults when in that mode.
+
+## Design
+
+Add a `source: ReaderSource` dimension to both preference layers. Full-book keeps its existing storage untouched; annotations mode gets a parallel, empty-by-default chain.
+
+Initial state on first open in annotations mode: **app defaults** — same starting point as a fresh install of the full-book view. No snapshot, no implicit fallback to the full-book prefs.
+
+### 1. Global prefs — two DataStore files
+
+Add a second DataStore file alongside the existing one:
+
+- `formatting_preferences.preferences_pb` (existing, unchanged) → full-book prefs.
+- `formatting_preferences_highlights.preferences_pb` (new) → annotations-mode prefs.
+
+Rationale over key-namespacing inside one file:
+
+- Zero migration on the existing file.
+- No risk of a bug reading the wrong bucket via a missing prefix.
+- Cleaner qualifier-based DI.
+
+Wiring: `FormattingPreferencesStore` gains a `source` parameter (or split into two injected instances behind a `ReaderSource`-keyed factory). `DataModule` exposes both DataStore instances via distinct `@FormattingPreferencesDataStore(source)` qualifiers.
+
+### 2. Per-book overrides — add `source` PK column
+
+`BookFormattingPreferencesEntity` today is keyed by `(serverId, itemId)`. Add `source: String` as a third PK column.
+
+- New PK: `(serverId, itemId, source)`
+- Column values: `"FullBook"` and `"Highlights"` (matches `ReaderSource` enum names).
+- Room migration bumps the DB schema version and backfills all existing rows with `source = "FullBook"`.
+
+Store API updates:
+
+- `BookFormattingPreferencesStore.load(itemId, source)`
+- `BookFormattingPreferencesStore.save(itemId, source, prefs)`
+- `BookFormattingPreferencesStore.clear(itemId, source)`
+
+Follow the AGENTS.md migration checklist: bump `@Database.version`, write `MIGRATION_N_(N+1)`, register in `DataModule`, generate schema JSON, add `MigrationTest.migrationNToN1()` + append to `migrateFullChain`.
+
+### 3. Effective prefs plumbing
+
+`FormattingSession.bindToBook(itemId)` becomes `bindToBook(itemId, source)`. It:
+
+1. Picks the global store instance for that source.
+2. Loads the per-book override for `(serverId, itemId, source)`.
+3. Merges (per-book overrides win) exactly as today.
+
+`EpubReaderViewModel` already knows `source` from the nav route; thread it into the session bind call.
+
+### 4. UI
+
+No new screens. The existing formatting sheet inside the reader binds to `FormattingSession.effectiveFormattingPreferences`; it automatically writes to the annotations chain when `source == Highlights`. "Reset to global" resets to the annotations-mode global defaults when in that mode.
+
+## Testing
+
+Regression tests must exist for each of the following (per AGENTS.md — the assertion must flip red if the fix is reverted):
+
+- **`FormattingPreferencesStoreImpl` isolation.** Writing a value in the `Highlights` store leaves the `FullBook` store's value unchanged, and vice versa.
+- **`BookFormattingPreferencesStoreImpl` isolation.** `save(itemId, Highlights, prefs)` followed by `load(itemId, FullBook)` returns whatever `FullBook` had (or null), not the `Highlights` value.
+- **`FormattingSession` correct chain.** Binding with `source = Highlights` yields effective prefs derived from the highlights global store + `(serverId, itemId, Highlights)` override — not the `FullBook` chain.
+- **Room `MigrationTest.migrationNToN1()`.** Pre-existing rows land with `source = "FullBook"`; a subsequent insert of `(serverId, itemId, "Highlights")` doesn't collide with the pre-existing row.
+- **End-to-end JVM regression.** Simulate: user changes font size in annotations view → assert full-book effective prefs for the same book unchanged.
+
+Every test above pins a specific behavior; reverting the split would flip at least one red.
+
+## Rollout
+
+Single PR. Migration is additive (new column, new DataStore file) — no data loss, no user-visible change to existing full-book prefs. Users opening the annotations view after the update see app defaults there, which matches the design intent.


### PR DESCRIPTION
## Summary

Annotations reading view (ADR 0041 elided reader) gets four related improvements bundled as one PR because they touch overlapping surfaces (VM open/delete paths, decoration templates, continuous WebView JS, and the reader's formatting-prefs chain).

### 1. Separate reading preferences per scope
- New `FormattingScope { FullBook, Highlights }`; the annotations view now keeps its own font-size / theme / margins / etc. independent from the full-book reader.
- Global prefs get a parallel DataStore file (via new `FormattingPreferencesStoreProvider`); per-book overrides get a `scope` PK column on `book_formatting_preferences` (Room migration **44 → 45**).
- `FormattingSession.bindToBook` now takes `(itemId, scope)` and the reader threads the scope from `ReaderSource`.

### 2. Accent-bar tap dispatch
- The elided reader's paragraph left-accent bar is now the tap-to-edit target across all three reader modes.
- Continuous mode routes the tap through the same `riffle://annotation-tap/<id>` URL as paginated/vertical (new `AnnotationTapUrl` parser).

### 3. Delete last annotation crash fix
- Deleting the last highlight in Highlights mode used to reload `openBook()` with an empty `readingOrder`, which crashes Readium's navigator. VM now emits `ReaderNavEvent.CloseEmptyHighlights` instead, and `MainScreen` pops the reader off the stack.

### 4. No highlight background on text (continuous)
- Paginated/vertical already route the annotations decoration through `HighlightAccentBarStyle` (no fill). Continuous's `ContinuousHighlightRenderer.applyAnnotations` used to ignore `useAccentBarStyle` and always paint the palette colour. Now emits `background: transparent` for the mark when `useAccentBarStyle == true` — the mark stays for locator resolution, but nothing paints over the text.

## Rebase note

Rebased over PR #451 (`Server → Source` DB rename). My per-scope migration was originally v44 (collided with #451's v44 sourceId rename), renumbered to **v45**, and my new column is now `scope` to avoid collision with the renamed `sourceId` column. Both migration test and full-chain test updated.

## Test plan
- [x] `./gradlew test` green locally
- [ ] CI green (unit + lint + `checkRiffleLogTags`)
- [ ] `MigrationTest.migration44To45_addsScopeToBookFormattingPreferencesPk` green on API-25 harness
- [ ] `MigrationTest.migrateFullChain` reaches v45 with sourceId + scope wiring intact
- [ ] Manual on-device: open annotations reader in continuous mode → text has no background fill, only left accent bar
- [ ] Manual on-device: tap accent bar in all three reader modes → highlight actions sheet opens
- [ ] Manual on-device: delete last highlight in annotations reader → reader closes cleanly (no crash)
- [ ] Manual on-device: change font size in annotations reader → full-book view unchanged and vice versa