### PR TITLE
fix(reader): guard createTreeWalker injections against a null document.body

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ColumnSnap.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ColumnSnap.kt
@@ -74,6 +74,10 @@ internal object ColumnSnap {
           }
           needle=needle.replace(/ ${'$'}/,"");
           if(!needle) return "off";
+          // #428 guard: chapter injections can fire before document.body is populated
+          // (e.g. right after a sandboxed WebView restart); createTreeWalker throws
+          // "parameter 1 is not of type 'Node'" and wedges follow-up injections.
+          if(!document.body) return "off";
           var w=document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT, null, false), n;
           var buf="", bn=[], bo=[], bsp=false;
           while(n=w.nextNode()){
@@ -135,6 +139,8 @@ internal object ColumnSnap {
         return """
           var full=$full; if(!full) return "off";
           var key=full.slice(0,12);
+          // #428 guard: see autoFollowSnapJs.
+          if(!document.body) return "off";
           var w=document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT, null, false), n, sn=null, so=0;
           while(n=w.nextNode()){ var i=n.nodeValue.indexOf(key); if(i>=0){ sn=n; so=i; break; } }
           if(!sn) return "off";

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjector.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjector.kt
@@ -501,6 +501,11 @@ internal object ContinuousStyleInjector {
                 var buildFlat = function() {
                     var fullText = '';
                     var nodes = [];
+                    // #428 guard: chapter injections can fire before document.body is populated
+                    // (e.g. right after a sandboxed WebView restart); createTreeWalker throws
+                    // "parameter 1 is not of type 'Node'" and silently wedges highlight
+                    // rendering for the rest of the session.
+                    if (!document.body) return { fullText: '', nodes: [] };
                     var w = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT, null, false);
                     var n;
                     while (n = w.nextNode()) {

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderWebViewScripts.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderWebViewScripts.kt
@@ -396,6 +396,10 @@ internal fun resolveSelectionSentenceJs(sentences: List<Pair<String, String>>): 
       var sents=$sents;
       var iw=window.innerWidth, ih=window.innerHeight;
       var LH=Math.max(8, sel.bottom - sel.top);
+      // #428 guard: chapter injections can fire before document.body is populated
+      // (e.g. right after a sandboxed WebView restart); createTreeWalker throws
+      // "parameter 1 is not of type 'Node'" and wedges the highlight pipeline.
+      if(!document.body) return "";
       var w=document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT, null, false), n;
       var bestId="", bestTop=-1e9, bestLeft=-1e9;
       while(n=w.nextNode()){
@@ -442,6 +446,8 @@ internal fun firstVisibleSentenceJs(highlights: List<String>): String {
     return """
     (function(){
       var keys=$keys;
+      // #428 guard: see sentenceIdAtSelectionJs.
+      if(!document.body) return "";
       var w=document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT, null, false), n;
       var TOL=24;
       while(n=w.nextNode()){

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjectorTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjectorTest.kt
@@ -797,4 +797,19 @@ class ContinuousStyleInjectorTest {
         assertTrue(ContinuousStyleInjector.CLEAR_SEARCH_HIGHLIGHTS_JS.contains("data-riffle-si"))
         assertTrue(ContinuousStyleInjector.CLEAR_SEARCH_HIGHLIGHTS_JS.contains("data-riffle-sa"))
     }
+
+    // Regression for #428: chapter injections can fire before document.body is populated (observed
+    // right after a sandboxed WebView process restart). An unguarded
+    // `document.createTreeWalker(document.body, ...)` throws "parameter 1 is not of type 'Node'",
+    // wedges buildFlat's index build, and the highlight-application pipeline silently no-ops for
+    // the rest of the session ("create highlight; nothing appears; app restart fixes it"). Pin the
+    // guard so a future edit can't remove it without turning this red.
+    @Test
+    fun `applyAnnotationHighlightsJs guards buildFlat against a missing document body (issue 428)`() {
+        val js = applyJs(AnnotationHighlight("id1", "hello", "#ff0000"))
+        assertTrue(
+            "buildFlat must early-return when document.body is null (issue #428)",
+            js.contains("if (!document.body) return { fullText: '', nodes: [] };"),
+        )
+    }
 }

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ReaderWebViewScriptsTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ReaderWebViewScriptsTest.kt
@@ -198,4 +198,50 @@ class ReaderWebViewScriptsTest {
         val gateIdx = js.indexOf("if (hadSel) return;")
         assertTrue("click skips onTap when a selection was live at touchstart", gateIdx in 0 until onTapIdx)
     }
+
+    // Regression for #428: chapter injections can fire before document.body is populated
+    // (observed on a running session after a sandboxed WebView process restart). Every
+    // `document.createTreeWalker(document.body, ...)` call site must early-return so the
+    // injection doesn't throw "parameter 1 is not of type 'Node'" and wedge the reader.
+    @Test
+    fun `resolveSelectionSentenceJs guards createTreeWalker against a null document body (issue 428)`() {
+        val js = resolveSelectionSentenceJs(listOf("s1" to "Hello world hello world"))
+        val guardIdx = js.indexOf("if(!document.body) return \"\";")
+        val walkerIdx = js.indexOf("document.createTreeWalker(document.body")
+        assertTrue("guard present", guardIdx >= 0)
+        assertTrue("walker present", walkerIdx >= 0)
+        assertTrue("guard sits BEFORE the walker call", guardIdx < walkerIdx)
+    }
+
+    @Test
+    fun `firstVisibleSentenceJs guards createTreeWalker against a null document body (issue 428)`() {
+        val js = firstVisibleSentenceJs(listOf("Hello world hello world"))
+        val guardIdx = js.indexOf("if(!document.body) return \"\";")
+        val walkerIdx = js.indexOf("document.createTreeWalker(document.body")
+        assertTrue("guard present", guardIdx >= 0)
+        assertTrue("walker present", walkerIdx >= 0)
+        assertTrue("guard sits BEFORE the walker call", guardIdx < walkerIdx)
+    }
+
+    @Test
+    fun `autoFollowSnapJs guards createTreeWalker against a null document body (issue 428)`() {
+        val js = ColumnSnap.autoFollowSnapJs("Hello world.")
+        val guardIdx = js.indexOf("if(!document.body) return \"off\";")
+        val walkerIdx = js.indexOf("document.createTreeWalker(document.body")
+        assertTrue("guard present", guardIdx >= 0)
+        assertTrue("walker present", walkerIdx >= 0)
+        assertTrue("guard sits BEFORE the walker call", guardIdx < walkerIdx)
+    }
+
+    @Test
+    fun `measureNarratedColumnsJs guards createTreeWalker against a null document body (issue 428)`() {
+        // measureNarratedColumnsJs inlines narratedColumnsPreludeJs (private), so this exercises the
+        // shared prelude's guard from the public surface.
+        val js = ColumnSnap.measureNarratedColumnsJs("Hello world.")
+        val guardIdx = js.indexOf("if(!document.body) return \"off\";")
+        val walkerIdx = js.indexOf("document.createTreeWalker(document.body")
+        assertTrue("guard present", guardIdx >= 0)
+        assertTrue("walker present", walkerIdx >= 0)
+        assertTrue("guard sits BEFORE the walker call", guardIdx < walkerIdx)
+    }
 }


### PR DESCRIPTION
Closes #428

## Summary

- Every reader JS injection that calls `document.createTreeWalker(document.body, …)` now early-returns when `document.body` is null. Right after a sandboxed WebView process restart the body can still be missing, and the unguarded walker throws `"parameter 1 is not of type 'Node'"` — wedging follow-up injections and silently no-oping the highlight-application pipeline for the rest of the session (matches the reported "create highlight → nothing appears → app restart fixes it" symptom).
- Guarded call sites: `ColumnSnap.autoFollowSnapJs`, the shared `narratedColumnsPreludeJs`, `resolveSelectionSentenceJs`, `firstVisibleSentenceJs`, and `ContinuousStyleInjector.applyAnnotationHighlightsJs` (`buildFlat`).
- Cadence's tokeniser already sits inside an outer `try/catch` that returns an empty `supported:false` payload, so it's not affected.

## Regression tests

One JVM test per guarded site (in `ReaderWebViewScriptsTest` and `ContinuousStyleInjectorTest`) asserts the guard string is present in the returned JS and sits before the walker call. Removing any guard flips the corresponding test red.

## Test plan
- [x] `./gradlew :app:testDebugUnitTest --tests ReaderWebViewScriptsTest --tests ContinuousStyleInjectorTest` → green
- [ ] Root cause is transient and not reproducible on demand (per the issue); this ships as defensive hardening backed by JVM pins rather than an on-device repro.