### PR TITLE
debug(reader): instrument highlight-merge dismiss path

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,8 @@ Always run harness tests via `make harness-test` (phone-form-factor tests) or `m
 
 When debugging with `[DEBUG-<tag>]` logs the user is reproducing for you, **fetch the logcat yourself** — don't ask the user to paste it. The user's device is connected via `adb`; run e.g. `adb logcat -d | grep DEBUG-<tag>` (use `-d` to dump and exit, not stream). Clear the buffer with `adb logcat -c` before they reproduce so the output isn't drowned in history. If multiple devices/emulators are connected, pick the right one with `-s <serial>` (`adb devices`). Trust the user when they say "reproduced" — go fetch.
 
+Assume the user is testing on the correct/latest version of the app. Don't diagnose a reported bug as "wrong APK installed" based on the emulator's build SHA, the drawer version string, or a missing symbol in the installed commit — the user is typically reproducing on their physical device (or a fresh install), not on the emulator you're driving. Treat the bug as real and dig into the code.
+
 ## Reader mode changes
 
 The reader has three modes: **paginated**, **vertical**, and **continuous**.

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -1415,6 +1415,11 @@ class EpubReaderViewModel @Inject constructor(
                 spineIndex = spineIndex,
                 progression = progression,
             )
+            logger.d(LogChannel.HighlightMerge) {
+                "create id=${created.id} snippet='${snippet.take(30)}' " +
+                    "beforeTail='${textBeforeCaptured.takeLast(30)}' afterHead='${newAfter.take(30)}' " +
+                    "poolSizeAtCreate=${annotationSession.annotations.value.size}"
+            }
             openHighlightActions(created.id, anchorRect)
             scheduleAnnotationSync()
             // observeHighlights re-emits → highlightRenders updates → the screen re-applies decorations.

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/session/AnnotationSession.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/session/AnnotationSession.kt
@@ -9,6 +9,8 @@ import com.riffle.core.domain.Annotation
 import com.riffle.core.domain.AnnotationStore
 import com.riffle.core.domain.HighlightColor
 import com.riffle.core.domain.HighlightColorPreferencesStore
+import com.riffle.core.logging.LogChannel
+import com.riffle.core.logging.Logger
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
@@ -60,6 +62,7 @@ class AnnotationSession @AssistedInject constructor(
     private val annotationStatusStore: AnnotationSyncStatusStore,
     private val highlightColorPreferencesStore: HighlightColorPreferencesStore,
     private val progressFlushScope: ProgressFlushScope,
+    private val logger: Logger,
     /** Called on [bind] after [syncOnOpen]; returns the [Job] backing the live-pull loop. */
     @Assisted private val startLiveSync: (sourceId: String, namespace: String, itemId: String) -> Job,
     /** Called on each annotation mutation to schedule a debounced push. */
@@ -352,10 +355,26 @@ class AnnotationSession @AssistedInject constructor(
     fun dismissHighlightActions() {
         val target = _highlightToEdit.value
         _highlightToEdit.value = null
-        if (_noteEditorTarget.value != null) return
-        val id = target?.id ?: return
-        val row = _annotations.value.firstOrNull { it.id == id } ?: return
-        if (row.type != AnnotationEntity.TYPE_HIGHLIGHT) return
+        logger.d(LogChannel.HighlightMerge) { "dismiss entry targetId=${target?.id} noteEditorOpen=${_noteEditorTarget.value != null}" }
+        if (_noteEditorTarget.value != null) {
+            logger.d(LogChannel.HighlightMerge) { "dismiss skip reason=note-editor-transition" }
+            return
+        }
+        val id = target?.id ?: run {
+            logger.d(LogChannel.HighlightMerge) { "dismiss skip reason=no-target" }
+            return
+        }
+        val row = _annotations.value.firstOrNull { it.id == id } ?: run {
+            logger.d(LogChannel.HighlightMerge) {
+                "dismiss skip reason=row-not-in-annotations id=$id poolSize=${_annotations.value.size} poolIds=${_annotations.value.take(5).joinToString { it.id.take(6) }}"
+            }
+            return
+        }
+        if (row.type != AnnotationEntity.TYPE_HIGHLIGHT) {
+            logger.d(LogChannel.HighlightMerge) { "dismiss skip reason=type=${row.type} id=$id" }
+            return
+        }
+        logger.d(LogChannel.HighlightMerge) { "dismiss → mergeAfterEdit id=$id color=${row.color} note=${row.note?.let { "'${it.take(20)}'" }}" }
         scope.launch { mergeAfterEdit(id, row.color, row.note) }
     }
 

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/session/AnnotationSessionTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/session/AnnotationSessionTest.kt
@@ -203,6 +203,7 @@ class AnnotationSessionTest {
         annotationStatusStore = statusStore,
         highlightColorPreferencesStore = colorPrefsStore,
         progressFlushScope = flushScope,
+        logger = com.riffle.core.logging.RecordingLogger(),
         startLiveSync = syncOps.makeStartLiveSync(scope),
         scheduleSync = syncOps.makeScheduleDebounce(),
         syncOnOpen = syncOps.makeSyncOnOpen(),


### PR DESCRIPTION
## Summary

Auto-merge of adjacent same-colour highlights (added in #452) is reported not to fire when the user creates two adjacent highlights and dismisses each popup. Which gate silently swallows the merge is not visible in the current `RIFFLE_HL_MERGE` stream — `dismissHighlightActions` returns without logging when the target is null, when the row is missing from `_annotations`, or when the type is wrong. `mergeAdjacentIntoHighlight` only starts logging after a non-null lookup, so an entire class of race/state failures is invisible.

This PR adds instrumentation only; no behaviour change.

- `dismissHighlightActions` now logs at entry and at every early-return branch (`note-editor-transition`, `no-target`, `row-not-in-annotations` with pool size + first 5 ids, `type=…`).
- `createHighlight` logs the created id + snippet + textBefore-tail + textAfter-head + `poolSizeAtCreate` — so the Room-flow race hypothesis (row not yet in `_annotations` when dismiss fires) is directly observable.
- `AnnotationSession` gains a `Logger` dep (auto-injected non-`@Assisted` param); the JVM test now passes `RecordingLogger()`.

Also updates `AGENTS.md` to spell out that the user tests on the correct/latest version — blocks the "wrong APK installed" mis-diagnosis path when the emulator's drawer SHA differs from HEAD.

## Test plan

- [x] `./gradlew :app:compileDebugKotlin` — BUILD SUCCESSFUL
- [x] `./gradlew :app:testDebugUnitTest --tests AnnotationSessionTest` — BUILD SUCCESSFUL
- [ ] Reproduce on device: highlight adjacent word A, dismiss; highlight word B, dismiss; grep `RIFFLE_HL_MERGE` — a follow-up PR will fix the failing gate the logs identify.

No tests added — this diff is pure diagnostic logging; there is no new behaviour to pin. Per `AGENTS.md` "Tests are required before opening a PR", docstring/log-only changes cannot fail an assertion. The actual regression test lands with the fix once the failing gate is known.