### PR TITLE
fix(reader): auto-merge adjacent highlights on dismiss — await Room Flow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,8 @@ Always run harness tests via `make harness-test` (phone-form-factor tests) or `m
 
 When debugging with `[DEBUG-<tag>]` logs the user is reproducing for you, **fetch the logcat yourself** — don't ask the user to paste it. The user's device is connected via `adb`; run e.g. `adb logcat -d | grep DEBUG-<tag>` (use `-d` to dump and exit, not stream). Clear the buffer with `adb logcat -c` before they reproduce so the output isn't drowned in history. If multiple devices/emulators are connected, pick the right one with `-s <serial>` (`adb devices`). Trust the user when they say "reproduced" — go fetch.
 
+Assume the user is testing on the correct/latest version of the app. Don't diagnose a reported bug as "wrong APK installed" based on the emulator's build SHA, the drawer version string, or a missing symbol in the installed commit — the user is typically reproducing on their physical device (or a fresh install), not on the emulator you're driving. Treat the bug as real and dig into the code.
+
 ## Reader mode changes
 
 The reader has three modes: **paginated**, **vertical**, and **continuous**.

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/session/AnnotationSession.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/session/AnnotationSession.kt
@@ -19,10 +19,12 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeoutOrNull
 import org.readium.r2.shared.publication.Locator
 
 /**
@@ -354,10 +356,30 @@ class AnnotationSession @AssistedInject constructor(
         _highlightToEdit.value = null
         if (_noteEditorTarget.value != null) return
         val id = target?.id ?: return
-        val row = _annotations.value.firstOrNull { it.id == id } ?: return
-        if (row.type != AnnotationEntity.TYPE_HIGHLIGHT) return
-        scope.launch { mergeAfterEdit(id, row.color, row.note) }
+        scope.launch {
+            // If the popup was opened right after a create, the observed-annotations Room Flow
+            // may not have re-emitted with the new row yet — a synchronous firstOrNull would
+            // return null and silently drop the merge. Suspend until the row shows up (bounded
+            // so a genuinely-missing id doesn't hang the coroutine). Fixed the "two adjacent
+            // fresh highlights don't merge on dismiss" race — spec:
+            // 2026-07-05-highlight-auto-merge-design.md.
+            val row = awaitAnnotation(id) ?: return@launch
+            if (row.type != AnnotationEntity.TYPE_HIGHLIGHT) return@launch
+            mergeAfterEdit(id, row.color, row.note)
+        }
     }
+
+    /**
+     * Suspend until [_annotations] contains a row with [id], or [timeoutMs] elapses. Returns the
+     * row, or null if it never showed up within the window (unknown id, deletion race).
+     *
+     * Extracted so the flow-race fix is JVM-testable and reused wherever a just-created annotation
+     * is looked up by id — see [dismissHighlightActions] and callers of [mergeAfterEdit].
+     */
+    internal suspend fun awaitAnnotation(id: String, timeoutMs: Long = 500): Annotation? =
+        withTimeoutOrNull(timeoutMs) {
+            _annotations.first { list -> list.any { it.id == id } }.first { it.id == id }
+        }
 
     /**
      * Emit a locator directly to the annotation navigation channel. Used by the VM's

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/session/AnnotationSessionTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/session/AnnotationSessionTest.kt
@@ -424,6 +424,47 @@ class AnnotationSessionTest {
     }
 
     /**
+     * Regression: [AnnotationSession.dismissHighlightActions] must wait for the observed-
+     * annotations Flow to include the just-created row before firing [mergeAfterEdit], because
+     * Room's InvalidationTracker emits on a background executor and can lag the insert. Before
+     * this fix, a synchronous `firstOrNull { it.id == id }` returned null and the dismiss
+     * silently early-returned — so highlighting two adjacent words in quick succession never
+     * merged them on the second popup's dismiss. This test asserts merge still fires when the
+     * flow is populated AFTER dismiss but before the timeout elapses.
+     */
+    @Test
+    fun `dismissHighlightActions awaits the annotations flow when the row is not yet present`() = runTest {
+        val dispatcher = UnconfinedTestDispatcher(testScheduler)
+        val sessionScope = CoroutineScope(dispatcher)
+        val store = FakeAnnotationStore()
+        val syncOps = FakeSyncOps()
+        val mergeCalls = mutableListOf<Triple<String, String, String?>>()
+        val session = makeSession(
+            store = store, syncOps = syncOps, scope = sessionScope,
+            mergeAfterEdit = { id, color, note -> mergeCalls += Triple(id, color, note) },
+        )
+        defaultBind(session)
+        // Row is NOT yet in the observed flow — simulating the Room emission lag.
+        store.allAnnotations.value = emptyList()
+        session.openHighlightActions("h1", androidx.compose.ui.unit.IntRect(0, 0, 0, 0))
+
+        session.dismissHighlightActions()
+
+        // Merge hasn't fired yet — the coroutine is suspended awaiting the flow.
+        assertEquals(0, mergeCalls.size)
+
+        // Now the Room observer catches up.
+        store.allAnnotations.value = listOf(makeAnnotation(id = "h1", color = "green").copy(note = null))
+
+        // Merge fires with the observed row's state.
+        assertEquals(1, mergeCalls.size)
+        assertEquals("h1", mergeCalls[0].first)
+        assertEquals("green", mergeCalls[0].second)
+        assertNull(mergeCalls[0].third)
+        sessionScope.coroutineContext[Job]?.cancel()
+    }
+
+    /**
      * Regression: tapping "Add note" transitions the actions popup into the note editor. The
      * actions popup closes, but this MUST NOT fire mergeAfterEdit — the row is about to receive
      * a note. A merge fired here would (a) absorb the row into a same-colour neighbour and (b)


### PR DESCRIPTION
## Summary

Auto-merge of adjacent same-colour highlights (added in #452) never fired when the user created two adjacent highlights in quick succession and dismissed each popup — the second dismiss silently dropped the merge.

**Root cause.** On popup dismiss, `AnnotationSession.dismissHighlightActions` looked up the target row synchronously in the observed-annotations `StateFlow`:

```kotlin
val row = _annotations.value.firstOrNull { it.id == id } ?: return
```

That flow is fed by Room's `InvalidationTracker`, which emits on a background executor and can lag the insert by tens of ms. For the just-created second highlight, the row wasn't yet in the snapshot at dismiss time — `firstOrNull` returned null and the merge branch was skipped without a log line. Neither `dismissHighlightActions` nor `mergeAdjacentIntoHighlight` logged this early-return, so the failure was invisible.

**Fix.** New `internal suspend fun awaitAnnotation(id, timeoutMs = 500)` suspends on `_annotations` until the row appears (or the timeout elapses, so a genuinely-missing id doesn't hang the coroutine). `dismissHighlightActions` now runs its lookup on `scope.launch` and awaits the flow, so the merge fires as soon as the row lands.

## Test plan

- [x] New regression test `dismissHighlightActions awaits the annotations flow when the row is not yet present` in `AnnotationSessionTest`:
  - opens the popup for `id="h1"` with an empty `_annotations` flow,
  - dismisses,
  - asserts `mergeAfterEdit` has NOT yet fired,
  - populates the flow with `id="h1"`,
  - asserts `mergeAfterEdit` now fires with the observed row's colour + note.
  - This assertion flips red if `awaitAnnotation` is reverted to `firstOrNull`.
- [x] Existing tests unchanged (`./gradlew :app:testDebugUnitTest --tests AnnotationSessionTest` — BUILD SUCCESSFUL).
- [ ] Manual verification on device: highlight word A, dismiss popup; highlight adjacent word B, dismiss popup → single merged highlight spanning "A B".

## Other

- `AGENTS.md` gains a "assume the user is testing on the correct/latest version" note under Debugging, preventing the "wrong APK installed" mis-diagnosis path when the emulator's drawer SHA differs from HEAD.