### PR TITLE
refactor(data): repositories consume Catalog + capability mixins (#434)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -130,6 +130,7 @@ dependencies {
     implementation(project(":core:logging"))
     // Three-peer reader sync constructs SyncRemotes over the position APIs directly (issue #38).
     implementation(project(":core:network"))
+    implementation(project(":core:catalog"))
 
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.webkit)

--- a/app/src/androidTest/kotlin/com/riffle/app/feature/reader/readaloud/ReadaloudStreamingSessionFactoryAndroidTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/reader/readaloud/ReadaloudStreamingSessionFactoryAndroidTest.kt
@@ -175,10 +175,33 @@ class ReadaloudStreamingSessionFactoryAndroidTest {
                     sidecarScope.async(block = block).await()
             },
         )
+        val absApiClient = AbsApiClient(OkHttpClient(), DefaultDispatcherProvider)
+        val testClock = object : com.riffle.core.domain.Clock {
+            override fun nowMs() = System.currentTimeMillis()
+            override fun nowNs() = System.nanoTime()
+        }
+        val catalogRegistry = object : com.riffle.core.catalog.CatalogRegistry {
+            override suspend fun forActive() = repo.getActive()?.let { forSource(it) }
+            override suspend fun forSourceId(sourceId: String) = repo.getById(sourceId)?.let { forSource(it) }
+            override suspend fun forSource(source: com.riffle.core.domain.Source) = com.riffle.core.catalog.abs.AbsCatalog(
+                config = com.riffle.core.catalog.abs.AbsCatalogConfig(
+                    baseUrl = source.url.value,
+                    token = "tok",
+                    insecureAllowed = source.insecureConnectionAllowed,
+                    deviceId = "test-device",
+                ),
+                libraryApi = absApiClient,
+                playbackApi = absApiClient,
+                sessionApi = absApiClient,
+                bookmarkApi = absApiClient,
+                serverInfoApi = absApiClient,
+                clock = testClock,
+            )
+        }
         return ReadaloudStreamingSessionFactory(
             context = ctx,
             audioIdentityResolver = AudioIdentityResolverImpl(db.readaloudLinkDao(), db.libraryItemDao()),
-            absApi = AbsApiClient(OkHttpClient(), DefaultDispatcherProvider),
+            catalogRegistry = catalogRegistry,
             storytellerApi = StorytellerApiClient(OkHttpClient(), DefaultDispatcherProvider),
             sidecarStore = sidecarStore,
             sourceRepository = repo,

--- a/app/src/main/kotlin/com/riffle/app/feature/library/FetchAudiobookChaptersUseCase.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/FetchAudiobookChaptersUseCase.kt
@@ -3,33 +3,17 @@ package com.riffle.app.feature.library
 import com.riffle.core.domain.AudiobookChapter
 import com.riffle.core.domain.AudiobookChapterCacheRepository
 import com.riffle.core.domain.LibraryItem
-import com.riffle.core.domain.SourceRepository
-import com.riffle.core.domain.TokenStorage
 import javax.inject.Inject
 
 class FetchAudiobookChaptersUseCase @Inject constructor(
     private val chapterCacheRepository: AudiobookChapterCacheRepository,
-    private val sourceRepository: SourceRepository,
-    private val tokenStorage: TokenStorage,
 ) {
     suspend operator fun invoke(item: LibraryItem): List<AudiobookChapter> {
         val cached = chapterCacheRepository.getCachedChapters(item.sourceId, item.id)
         if (cached != null) return cached
-
-        val server = sourceRepository.getById(item.sourceId) ?: return emptyList()
-        val token = tokenStorage.getToken(item.sourceId) ?: return emptyList()
-
-        val baseUrl = server.url.value
-
         return try {
-            chapterCacheRepository.fetchAndCacheChapters(
-                sourceId = item.sourceId,
-                itemId = item.id,
-                baseUrl = baseUrl,
-                token = token,
-                insecureAllowed = server.insecureConnectionAllowed,
-            )
-        } catch (e: Exception) {
+            chapterCacheRepository.fetchAndCacheChapters(sourceId = item.sourceId, itemId = item.id)
+        } catch (_: Exception) {
             emptyList()
         }
     }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderSync.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderSync.kt
@@ -1,7 +1,9 @@
 package com.riffle.app.feature.reader
 
+import com.riffle.core.catalog.ProgressPeerCapability
 import com.riffle.core.domain.BookSyncState
 import com.riffle.core.domain.CanonicalReaderPosition
+import com.riffle.core.domain.Clock
 import com.riffle.core.domain.LocalCanonical
 import com.riffle.core.domain.PositionTranslator
 import com.riffle.core.domain.ProgressPeer
@@ -9,50 +11,55 @@ import com.riffle.core.domain.ProgressSyncStrategy
 import com.riffle.core.domain.RemoteKind
 import com.riffle.core.domain.RemoteRead
 import com.riffle.core.domain.WriteResult
-import com.riffle.core.network.AbsSessionApi
-import com.riffle.core.network.NetworkAudiobookProgressPayload
-import com.riffle.core.network.NetworkEbookProgressPayload
-import com.riffle.core.network.NetworkResult
 
 /**
- * Resolved ABS endpoint for a matched ABS Library Item (its media-progress record). [durationSec]
- * is the item's total audio length, sent with audiobook progress so ABS reports a real percentage;
- * 0 for the ebook endpoint.
+ * Resolved sync endpoint for a matched Library Item (its media-progress record). [durationSec] is
+ * the item's total audio length, sent with audiobook progress so ABS reports a real percentage;
+ * 0 for the ebook endpoint. [peer] is the Source's [ProgressPeerCapability] — sourced from the
+ * Catalog for the item's Source.
  */
-data class AbsSyncEndpoint(val baseUrl: String, val token: String, val insecure: Boolean, val itemId: String, val durationSec: Double = 0.0)
+data class CatalogSyncEndpoint(
+    val peer: ProgressPeerCapability,
+    val itemId: String,
+    val durationSec: Double = 0.0,
+)
 
 // A reachable peer that has no position yet: it never wins (timestamp 0) but is stale relative
 // to any local progress, so the cycle still pushes the reader's first position to it.
 internal val EMPTY_PEER_READ = RemoteRead(CanonicalReaderPosition(""), 0L)
 
-// ABS's progress PATCH replies "OK" with no timestamp, so after a write we GET the record back to
-// learn the server time it was stored under. Callers record it as the local timestamp; without it a
-// write reads back next cycle as a "newer remote" and overwrites local progress (the feedback loop).
-internal suspend fun AbsSessionApi.serverStamp(ep: AbsSyncEndpoint): Long? =
-    (getProgress(ep.baseUrl, ep.itemId, ep.token, ep.insecure) as? NetworkResult.Success)?.value?.lastUpdate
+/**
+ * Push the matched audiobook's currentTime through [ProgressPeerCapability] and return the stamp
+ * the caller should adopt. Historically ABS's PATCH replied with no timestamp so a follow-up GET
+ * read back `lastUpdate`; that read-back is redundant when the caller controls the write time.
+ */
+internal suspend fun ProgressPeerCapability.writeAudiobookSeconds(
+    ep: CatalogSyncEndpoint,
+    seconds: Double,
+    clock: Clock,
+): Long? = runCatching {
+    val now = clock.nowMs()
+    pushAudiobookProgress(
+        itemId = ep.itemId,
+        currentTimeSec = seconds.coerceAtLeast(0.0),
+        durationSec = ep.durationSec,
+        isFinished = false,
+        lastUpdateEpochMs = now,
+    )
+    now
+}.getOrNull()
 
-// Write the matched audiobook's currentTime and read back the server timestamp it was stored under.
-// One definition for both the cycle peer's outbound patch and the responsive follow-loop push, so the
-// payload shape and the stamp read-back can never drift apart. `null` on failure.
-internal suspend fun AbsSessionApi.writeAudiobookSeconds(ep: AbsSyncEndpoint, seconds: Double): Long? {
-    val payload = NetworkAudiobookProgressPayload(seconds.coerceAtLeast(0.0), ep.durationSec)
-    if (syncAudiobookProgress(ep.baseUrl, ep.itemId, payload, ep.token, ep.insecure) !is NetworkResult.Success) return null
-    return serverStamp(ep)
-}
-
-/** ABS ebook progress as a [ProgressPeer]: an ebookLocation CFI on the ABS EPUB. */
+/** Ebook progress as a [ProgressPeer]: an ebookLocation CFI on the ABS EPUB. */
 internal class AbsEbookProgressPeer(
-    private val api: AbsSessionApi,
-    private val ep: AbsSyncEndpoint,
+    private val ep: CatalogSyncEndpoint,
     private val translator: PositionTranslator,
+    private val clock: Clock,
 ) : ProgressPeer {
     override val id = RemoteKind.ABS_EBOOK.name
 
     override suspend fun tryGet(): RemoteRead? {
-        // NetworkError → null (unreachable, excluded); 404/no-CFI → reachable-empty placeholder.
-        val p = (api.getProgress(ep.baseUrl, ep.itemId, ep.token, ep.insecure) as? NetworkResult.Success)
-            ?.value ?: return null
-        val cfi = p.ebookLocation.takeIf { it.startsWith("epubcfi(") }
+        val p = runCatching { ep.peer.pullProgress(ep.itemId) }.getOrNull() ?: return null
+        val cfi = p.ebookLocation?.takeIf { it.startsWith("epubcfi(") }
         if (p.lastUpdate <= 0L || cfi == null) return EMPTY_PEER_READ
         val canonical = translator.absCfiToCanonical(cfi) ?: return EMPTY_PEER_READ
         return RemoteRead(CanonicalReaderPosition(canonical), p.lastUpdate)
@@ -60,133 +67,85 @@ internal class AbsEbookProgressPeer(
 
     override suspend fun tryPatch(canonical: CanonicalReaderPosition): WriteResult {
         val cfi = translator.canonicalToAbsCfi(canonical.value)
-            ?: return WriteResult.Skipped // canonical can't be placed in the ABS EPUB this cycle
-        val payload = NetworkEbookProgressPayload(cfi, translator.canonicalBookProgress(canonical.value))
-        if (api.syncEbookProgress(ep.baseUrl, ep.itemId, payload, ep.token, ep.insecure) !is NetworkResult.Success)
-            return WriteResult.Failed("ABS ebook PATCH network error")
-        val stamp = api.serverStamp(ep) ?: return WriteResult.Failed("ABS ebook stamp read-back failed")
-        return WriteResult.Ok(stamp)
+            ?: return WriteResult.Skipped
+        val progress = translator.canonicalBookProgress(canonical.value)
+        return runCatching {
+            val now = clock.nowMs()
+            ep.peer.pushEbookProgress(
+                itemId = ep.itemId,
+                location = cfi,
+                progress = progress,
+                isFinished = false,
+                lastUpdateEpochMs = now,
+            )
+            WriteResult.Ok(now)
+        }.getOrElse { WriteResult.Failed("ABS ebook PATCH network error") }
     }
 }
 
 /**
- * ABS audiobook progress as a sync remote, translated through the readaloud bundle's SMIL media
+ * Audiobook progress as a sync remote, translated through the readaloud bundle's SMIL media
  * overlay — the exact page↔audio-timestamp mapping. [tryGet] turns the audiobook `currentTime` into a
  * reading position (so a newer listen on another device moves the reader); [tryPatch] turns the
- * winning reading position into an audiobook `currentTime` (so reading advances the audiobook). The
- * SMIL times are made absolute over the concatenated audio files in [PositionTranslator], so
- * `currentTime` matches the ABS audiobook's single-file timeline rather than a per-file offset.
- *
- * The raw audio *clock* is never written here — only positions derived from the canonical reading
- * position — so a behind/early playback clock cannot drive the ebook. The feedback loop is closed by
- * adopting the server timestamp each write returns (the cycle / push records it as the local time).
+ * winning reading position into an audiobook `currentTime` (so reading advances the audiobook).
  */
 internal class AbsAudiobookProgressPeer(
-    private val api: AbsSessionApi,
-    private val ep: AbsSyncEndpoint,
+    private val ep: CatalogSyncEndpoint,
     private val translator: PositionTranslator,
+    private val clock: Clock,
 ) : ProgressPeer {
     override val id = RemoteKind.ABS_AUDIO.name
 
     override suspend fun tryGet(): RemoteRead? {
-        val p = (api.getProgress(ep.baseUrl, ep.itemId, ep.token, ep.insecure) as? NetworkResult.Success)
-            ?.value ?: return null
-        if (p.lastUpdate <= 0L || p.currentTime <= 0.0) return EMPTY_PEER_READ // no audiobook position yet
-        val canonical = translator.audioSecondsToCanonical(p.currentTime) ?: return EMPTY_PEER_READ
+        val p = runCatching { ep.peer.pullProgress(ep.itemId) }.getOrNull() ?: return null
+        if (p.lastUpdate <= 0L || p.audioCurrentTime <= 0.0) return EMPTY_PEER_READ
+        val canonical = translator.audioSecondsToCanonical(p.audioCurrentTime) ?: return EMPTY_PEER_READ
         return RemoteRead(CanonicalReaderPosition(canonical), p.lastUpdate)
     }
 
     override suspend fun tryPatch(canonical: CanonicalReaderPosition): WriteResult {
         val seconds = translator.canonicalToAudioSeconds(canonical.value)
-            ?: return WriteResult.Skipped // canonical can't be placed on the audio timeline this cycle
-        val stamp = api.writeAudiobookSeconds(ep, seconds)
-            ?: return WriteResult.Failed("ABS audiobook PATCH or stamp read-back failed")
+            ?: return WriteResult.Skipped
+        val stamp = ep.peer.writeAudiobookSeconds(ep, seconds, clock)
+            ?: return WriteResult.Failed("ABS audiobook PATCH failed")
         return WriteResult.Ok(stamp)
     }
 }
 
-/**
- * Wraps a peer so the cycle still READS it (a genuinely-newer remote still wins inbound) but never
- * PATCHes it. Used while the reader is parked on the sentence readaloud stopped on: readaloud already
- * wrote the precise audiobook position on close, so the cycle's page-derived outbound push must not
- * regress it to the page top (ADR 0031). Outbound resumes once the user navigates off that page.
- */
 private class InboundOnlyPeer(private val inner: ProgressPeer) : ProgressPeer {
     override val id = inner.id
     override suspend fun tryGet(): RemoteRead? = inner.tryGet()
     override suspend fun tryPatch(canonical: CanonicalReaderPosition): WriteResult = WriteResult.Skipped
 }
 
-/**
- * Drives one matched readaloud book's two-ABS-peer reconciliation (ADR 0019, as amended by ADR 0029
- * which dropped the Storyteller position peer). Builds the live
- * [ProgressPeer]s for the applicable peer set and runs the unified [ProgressSyncStrategy] each
- * cycle. The canonical position is the displayed-EPUB Locator JSON; [runCycle] returns the
- * Locator JSON the reader should jump to, or `null` for no jump.
- *
- * The ABS ebook and audiobook remotes target their own matched ABS Library Item — the same item
- * when it is a combined ebook+audiobook, or two separate items when a library splits ebooks and
- * audiobooks (ADR 0019). A peer that can't be built (missing endpoint) is simply skipped.
- */
-/**
- * @param jumpLocatorJson the displayed-EPUB Locator JSON to jump the reader to, or `null` for
- *   no jump. @param canonicalLastUpdate the winning timestamp to persist as `localUpdatedAt`.
- */
 data class ReaderSyncCycleResult(val jumpLocatorJson: String?, val canonicalLastUpdate: Long)
 
-/**
- * Outcome of an audio-led reconciliation cycle (ADR 0029). [jumpToAudioSec] is the book-absolute
- * second the [Audiobook Player] should seek to when a genuinely-newer remote won, else `null`;
- * [canonicalLastUpdate] is the winning timestamp the caller adopts as `localUpdatedAt`.
- */
 data class AudioLedCycleResult(val jumpToAudioSec: Double?, val canonicalLastUpdate: Long)
 
 class ReaderSyncCoordinator(
     private val state: BookSyncState,
     private val translator: PositionTranslator,
-    private val absApi: AbsSessionApi,
-    // The ABS ebook and audiobook remotes target their own matched Library Item: one combined item
-    // (same endpoint) or two separate items when a library splits ebooks and audiobooks (ADR 0019).
-    private val absEbookEndpoint: AbsSyncEndpoint?,
-    private val absAudioEndpoint: AbsSyncEndpoint?,
+    private val clock: Clock,
+    private val absEbookEndpoint: CatalogSyncEndpoint?,
+    private val absAudioEndpoint: CatalogSyncEndpoint?,
 ) {
-    /**
-     * @param pushAudio when `false`, the audiobook peer is reconciled **inbound-only** (read, never
-     *   patched) — readaloud owns the precise audiobook write while the reader is parked on the
-     *   sentence it stopped on, so the page-derived outbound can't regress it (ADR 0031).
-     */
     suspend fun runCycle(displayedLocatorJson: String, localUpdatedAt: Long, pushAudio: Boolean = true): ReaderSyncCycleResult {
         val strategy = ProgressSyncStrategy { kind ->
             when (kind) {
-                RemoteKind.ABS_EBOOK -> absEbookEndpoint?.let { AbsEbookProgressPeer(absApi, it, translator) }
+                RemoteKind.ABS_EBOOK -> absEbookEndpoint?.let { AbsEbookProgressPeer(it, translator, clock) }
                 RemoteKind.ABS_AUDIO -> absAudioEndpoint?.let {
-                    val peer = AbsAudiobookProgressPeer(absApi, it, translator)
+                    val peer = AbsAudiobookProgressPeer(it, translator, clock)
                     if (pushAudio) peer else InboundOnlyPeer(peer)
                 }
-                // Bookmarks are not a position peer — they reconcile via the sweep, not this cycle.
                 RemoteKind.ABS_BOOKMARK -> null
             }
         }
         val local = LocalCanonical(CanonicalReaderPosition(displayedLocatorJson), localUpdatedAt)
         val result = strategy.runCycle(state, local)
-        // Guard the empty-remote placeholder: it never legitimately wins, but never jump to "".
         val jump = result.jumpTo?.value?.takeIf { it.isNotEmpty() }
         return ReaderSyncCycleResult(jump, result.canonicalLastUpdate)
     }
 
-    /**
-     * The same two-ABS-peer reconciliation, but **audio-led** for the [Audiobook Player] (ADR 0029):
-     * the local position is the live listen position in book-absolute seconds rather than a displayed
-     * EPUB locator. The seconds are translated to the canonical text position through the bundle's SMIL
-     * (so a winning listen propagates to the ebook CFI), and any inbound winner is translated back to
-     * seconds so the caller can seek the player. The bridge stays encapsulated — the audiobook player
-     * never sees a Locator.
-     *
-     * Returns [AudioLedCycleResult.jumpToAudioSec] (non-null only when a genuinely-newer remote won, so
-     * the player seeks there) and the winning timestamp to adopt as `localUpdatedAt`. When the audio
-     * position can't be translated yet (prerequisites mid-cache), the cycle is skipped — local time
-     * unchanged, no jump.
-     */
     suspend fun runAudioLedCycle(currentAudioSec: Double, localUpdatedAt: Long): AudioLedCycleResult {
         val localCanonical = translator.audioSecondsToCanonical(currentAudioSec)
             ?: return AudioLedCycleResult(jumpToAudioSec = null, canonicalLastUpdate = localUpdatedAt)
@@ -195,48 +154,25 @@ class ReaderSyncCoordinator(
         return AudioLedCycleResult(jumpToAudioSec = jumpAudio, canonicalLastUpdate = result.canonicalLastUpdate)
     }
 
-    /** The narrated fragment a canonical reading position falls in, so readaloud can start exactly
-     *  where a server-sync jump placed the reader rather than at the page top. */
     fun fragmentForCanonical(canonicalLocatorJson: String): String? =
         translator.canonicalToFragmentRef(canonicalLocatorJson)
 
-    /** Whether this matched book carries an audiobook ABS record (the dual-write sibling, ADR 0030). */
     val hasAudioTarget: Boolean get() = absAudioEndpoint != null
-
-    /** The ABS item id of the audiobook record — the audio store key for the dual-write. May differ
-     *  from the ebook item id when a library splits ebooks and audiobooks (ADR 0019). */
     val audioItemId: String? get() = absAudioEndpoint?.itemId
-
-    /** The ABS item id of the ebook record — the reading store key for the dual-write (ADR 0030). */
     val ebookItemId: String? get() = absEbookEndpoint?.itemId
 
-    /** The audiobook second a reading position maps to (bundle SMIL) — the value the cycle already
-     *  pushes to ABS_AUDIO; the dual-write persists it locally too. `null` if untranslatable. */
     fun audioSecondsForCanonical(canonicalLocatorJson: String): Double? =
         translator.canonicalToAudioSeconds(canonicalLocatorJson)
 
-    /** The audiobook second the **narrated sentence** maps to (bundle SMIL, sentence-precise), falling
-     *  back to the page-derived position. Used to persist the local audiobook position on readaloud
-     *  close/pause (ADR 0031). `null` if neither can be translated. */
     fun audioSecondsForFragment(fragmentRef: String, fallbackCanonicalJson: String?): Double? =
         translator.audioSecondsForFragment(fragmentRef)
             ?: fallbackCanonicalJson?.let { translator.canonicalToAudioSeconds(it) }
 
-    /** The narrated sentence an absolute audio second falls in (bundle SMIL, index-free) — seeds the
-     *  readaloud start from a local listen position (ADR 0031). */
     fun fragmentForAudioSeconds(seconds: Double): String? = translator.fragmentForAudioSeconds(seconds)
 
-    /** The reading-position locator JSON an audiobook second maps to (bundle SMIL) — the counterpart
-     *  for the audiobook player's dual-write onto the reading store. `null` if untranslatable. */
     fun canonicalForAudioSeconds(seconds: Double): String? =
         translator.audioSecondsToCanonical(seconds)
 
-    /**
-     * The readaloud resume anchor (reader href + column progression + narrated sentence) an audiobook
-     * second maps to, via the bundle's SMIL (ADR 0031). Lets the audiobook player write the readaloud
-     * resume so reopening the reader and starting readaloud lands where the listen got to. `null` when
-     * the seconds can't be translated (prerequisites mid-cache).
-     */
     fun readaloudAnchorForAudioSeconds(seconds: Double): com.riffle.core.domain.ReadaloudResumePosition? {
         val canonicalJson = translator.audioSecondsToCanonical(seconds) ?: return null
         val pos = CanonicalReaderPosition(canonicalJson)
@@ -248,41 +184,15 @@ class ReaderSyncCoordinator(
         )
     }
 
-    /**
-     * Re-keys a "Play from here" selection ref (the displayed ABS `href#spanId`) onto the Storyteller
-     * bundle chapter the selection sits in, so the player resolves the clip in THAT chapter rather than
-     * the first book-wide occurrence of the span id (ids recur across chapters — the "Play-from-here
-     * reset my progress" bug). Returns the bundle-href ref, or `null` when the chapter can't be mapped
-     * or the ref carries no span id; the caller then plays the original ref unchanged.
-     */
     fun bundleFragmentRefForSelection(displayedRef: String): String? {
         val spanId = displayedRef.substringAfter('#', "").takeIf { it.isNotEmpty() } ?: return null
         val bundleHref = translator.displayedHrefToBundleHref(displayedRef.substringBefore('#')) ?: return null
         return "$bundleHref#$spanId"
     }
 
-    /**
-     * Responsive update of the matched ABS audiobook's `currentTime` from the current **reading
-     * position**, translated through the bundle's SMIL ([PositionTranslator.canonicalToAudioSeconds],
-     * absolute over the concatenated audio files). Used by the audiobook-follow loop while readaloud
-     * plays (the page tracks the audio) so the audiobook reaches the server between reconcile cycles.
-     * Writes ONLY the audiobook item, from a page-derived position — never the raw audio clock — so it
-     * can never erase or override reading progress.
-     *
-     * Returns the server's `lastUpdate` for the write, or `null` on no-op / failure. The caller must
-     * record it as the local timestamp: the audiobook remote reads this same record back next cycle,
-     * and only an equal-or-older read keeps the reading position the winner — this closes the feedback
-     * loop without dropping inbound audiobook sync. ABS's PATCH carries no timestamp, so we GET it back.
-     */
     suspend fun pushAudiobookProgress(canonicalLocatorJson: String): Long? =
         pushAudiobookAtSeconds(translator.canonicalToAudioSeconds(canonicalLocatorJson))
 
-    /**
-     * Responsive audiobook update from the **exact narrated sentence** (the player's active fragment),
-     * not the page — so while readaloud plays, the audiobook `currentTime` matches the sentence the
-     * user hears, instead of lagging to the top of the page. Falls back to the page-derived position
-     * when the fragment can't be placed.
-     */
     suspend fun pushAudiobookForFragment(fragmentRef: String, fallbackCanonicalJson: String?): Long? {
         val seconds = translator.audioSecondsForFragment(fragmentRef)
             ?: fallbackCanonicalJson?.let { translator.canonicalToAudioSeconds(it) }
@@ -292,58 +202,33 @@ class ReaderSyncCoordinator(
     private suspend fun pushAudiobookAtSeconds(seconds: Double?): Long? {
         val ep = absAudioEndpoint ?: return null
         if (seconds == null) return null
-        return absApi.writeAudiobookSeconds(ep, seconds)
+        return ep.peer.writeAudiobookSeconds(ep, seconds, clock)
     }
 }
 
-/**
- * Bundle-SMIL-only audiobook follow (ADR 0031): translates a narrated fragment to its absolute audio
- * second and pushes the matched ABS audiobook record — using **only** the Storyteller bundle's SMIL,
- * with no cross-EPUB index or ABS EPUB. This lets readaloud sync to the audiobook even when the full
- * [ReaderSyncCoordinator] can't be built (e.g. the cross-EPUB index isn't ready or a multi-link guard
- * trips). It also produces the **ebook** position for an audio second — a text-anchored locator built
- * from the bundle's own sentence text ([ebookItemId]/[sourceId] key the stores), so audiobook→ebook
- * sync also works index-free (ADR 0031: both directions go via the bundle, never the cross-EPUB index).
- */
 class AudiobookFollow(
-    private val absApi: AbsSessionApi,
-    private val endpoint: AbsSyncEndpoint,
+    private val endpoint: CatalogSyncEndpoint,
     private val translator: PositionTranslator,
+    private val clock: Clock,
     val sourceId: String,
     val audioItemId: String,
     val ebookItemId: String? = null,
     private val quotes: Map<String, com.riffle.core.domain.SentenceQuote> = emptyMap(),
 ) {
-    /** The absolute audio second the narrated sentence begins (bundle SMIL), or `null` if unknown. */
     fun secondsForFragment(fragmentRef: String): Double? = translator.fragmentRefToAudioSeconds(fragmentRef)
 
-    /** The narrated sentence an absolute audio second falls in (bundle SMIL, index-free) — seeds the
-     *  readaloud start from a local listen position even with no cross-EPUB index (ADR 0031). */
     fun fragmentForAudioSeconds(seconds: Double): String? =
         translator.audioSecondsToStorytellerProgression(seconds)?.let { translator.fragmentAt(it) }
 
-    /** The **ebook** reading position (a text-anchored Readium locator JSON) for an audio second —
-     *  index-free: maps seconds → narrated sentence (SMIL), then anchors that sentence by its bundle
-     *  text so it resolves on the ABS EPUB (the same text-anchoring the highlight uses). `null` when
-     *  the seconds can't be placed or the sentence has no quote. */
     fun ebookLocatorForAudioSeconds(seconds: Double): String? {
         val ref = fragmentForAudioSeconds(seconds) ?: return null
         val quote = quotes[ref.substringAfter('#')] ?: return null
         return readaloudLocatorJson(ref, quote).toString()
     }
 
-    /** PATCH the ABS audiobook record from the narrated sentence; returns the server stamp or `null`. */
     suspend fun pushFragment(fragmentRef: String): Long? =
-        secondsForFragment(fragmentRef)?.let { absApi.writeAudiobookSeconds(endpoint, it) }
+        secondsForFragment(fragmentRef)?.let { endpoint.peer.writeAudiobookSeconds(endpoint, it, clock) }
 
-    /**
-     * The readaloud resume anchor for an audio second, index-free via the bundle SMIL (ADR 0031): maps
-     * seconds → narrated sentence and carries that sentence ref. Lets the audiobook player persist the
-     * readaloud resume so reopening the reader and pressing Play lands on the listened sentence instead
-     * of a stale one — even without the cross-EPUB index. Unlike [ebookLocatorForAudioSeconds] it needs
-     * no quote: the readaloud start only needs the sentence ref, not a text anchor. `null` when the
-     * seconds narrate no sentence.
-     */
     fun readaloudAnchorForAudioSeconds(seconds: Double): com.riffle.core.domain.ReadaloudResumePosition? {
         val ref = fragmentForAudioSeconds(seconds) ?: return null
         val href = ref.substringBefore('#').takeIf { it.isNotEmpty() } ?: return null

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderSync.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderSync.kt
@@ -43,7 +43,7 @@ internal suspend fun ProgressPeerCapability.writeAudiobookSeconds(
         itemId = ep.itemId,
         currentTimeSec = seconds.coerceAtLeast(0.0),
         durationSec = ep.durationSec,
-        isFinished = false,
+        isFinished = null,
         lastUpdateEpochMs = now,
     )
     stamp?.takeIf { it > 0L } ?: now
@@ -75,7 +75,7 @@ internal class AbsEbookProgressPeer(
                 itemId = ep.itemId,
                 location = cfi,
                 progress = progress,
-                isFinished = false,
+                isFinished = null,
                 lastUpdateEpochMs = now,
             )
             // Adopt the source stamp when it reported one so a fresh write can't read back as newer

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderSync.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderSync.kt
@@ -39,14 +39,14 @@ internal suspend fun ProgressPeerCapability.writeAudiobookSeconds(
     clock: Clock,
 ): Long? = runCatching {
     val now = clock.nowMs()
-    pushAudiobookProgress(
+    val stamp = pushAudiobookProgress(
         itemId = ep.itemId,
         currentTimeSec = seconds.coerceAtLeast(0.0),
         durationSec = ep.durationSec,
         isFinished = false,
         lastUpdateEpochMs = now,
     )
-    now
+    stamp?.takeIf { it > 0L } ?: now
 }.getOrNull()
 
 /** Ebook progress as a [ProgressPeer]: an ebookLocation CFI on the ABS EPUB. */
@@ -71,14 +71,16 @@ internal class AbsEbookProgressPeer(
         val progress = translator.canonicalBookProgress(canonical.value)
         return runCatching {
             val now = clock.nowMs()
-            ep.peer.pushEbookProgress(
+            val stamp = ep.peer.pushEbookProgress(
                 itemId = ep.itemId,
                 location = cfi,
                 progress = progress,
                 isFinished = false,
                 lastUpdateEpochMs = now,
             )
-            WriteResult.Ok(now)
+            // Adopt the source stamp when it reported one so a fresh write can't read back as newer
+            // next cycle (feedback loop). A `null`/`0L` reply falls back to the client clock.
+            WriteResult.Ok(stamp?.takeIf { it > 0L } ?: now)
         }.getOrElse { WriteResult.Failed("ABS ebook PATCH network error") }
     }
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderSyncFactory.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderSyncFactory.kt
@@ -1,11 +1,14 @@
 package com.riffle.app.feature.reader
 
+import com.riffle.core.catalog.CatalogRegistry
+import com.riffle.core.catalog.ProgressPeerCapability
 import com.riffle.core.data.CrossEpubIndexBuildTrigger
 import com.riffle.core.data.di.EpubCacheStore
 import com.riffle.core.data.di.EpubDownloadsStore
 import com.riffle.core.domain.BookSyncState
-import com.riffle.core.domain.DefaultPositionTranslator
+import com.riffle.core.domain.Clock
 import com.riffle.core.domain.CrossEpubIndexStore
+import com.riffle.core.domain.DefaultPositionTranslator
 import com.riffle.core.domain.EpubChecksum
 import com.riffle.core.domain.EpubContentExtractor
 import com.riffle.core.domain.ExtractedEpub
@@ -15,40 +18,26 @@ import com.riffle.core.domain.ReadaloudLinkRepository
 import com.riffle.core.domain.ReadaloudSidecarCache
 import com.riffle.core.domain.SourceRepository
 import com.riffle.core.domain.StorytellerFragmentIndexBuilder
-import com.riffle.core.domain.TokenStorage
 import com.riffle.core.logging.LogChannel
 import com.riffle.core.logging.Logger
-import com.riffle.core.network.AbsSessionApi
 import javax.inject.Inject
 
-/**
- * Assembles a [ReaderSyncCoordinator] for the open book when, and only when, all of
- * ADR 0019's reconciliation prerequisites are met: the book is a Confirmed match with **exactly
- * one** ABS link, both EPUBs are cached, and the cross-EPUB index for their current checksums
- * is built. Any miss returns `null`, leaving the reader on its existing single-peer path — so
- * the reconciliation cycle is strictly additive and never degrades the non-matched case.
- */
 open class ReaderSyncFactory @Inject constructor(
     private val linkRepository: ReadaloudLinkRepository,
     private val sourceRepository: SourceRepository,
-    private val tokenStorage: TokenStorage,
+    private val catalogRegistry: CatalogRegistry,
     private val indexStore: CrossEpubIndexStore,
-    private val absSessionApi: AbsSessionApi,
     private val libraryObserver: LibraryObserver,
     @EpubCacheStore private val cacheStore: LocalStore,
     @EpubDownloadsStore private val downloadsStore: LocalStore,
     private val crossEpubIndexBuildTrigger: CrossEpubIndexBuildTrigger,
     private val sidecarCache: ReadaloudSidecarCache,
+    private val clock: Clock,
     private val logger: Logger,
 ) {
-    /**
-     * @param itemId the ABS Library Item id the reader opened. A book is always read from the ABS
-     *   side (ADR 0026), so the link is resolved by ABS item.
-     */
     open suspend fun createIfApplicable(itemId: String): ReaderSyncCoordinator? {
         val active = sourceRepository.getActive() ?: return null
 
-        // The readaloud bundle is the hub: route progress to whichever ABS items are matched to it.
         val openedLink = linkRepository.findByAbsItem(active.id, itemId) ?: return null
         val allLinks = linkRepository.findByStorytellerBook(openedLink.storytellerSourceId, openedLink.storytellerBookId)
         val linkedMedia = allLinks.mapNotNull { l ->
@@ -56,23 +45,12 @@ open class ReaderSyncFactory @Inject constructor(
             AbsLinkMedia(l, isReadable = item.isReadable, hasAudio = item.hasAudio, audioDurationSec = item.audioDurationSec)
         }
         val targets = resolveAbsTargets(itemId, linkedMedia)
-        // The reader displays the ABS EPUB (ADR 0026): no matched ebook item ⇒ nothing to display
-        // and no frame for the cross-EPUB index, so the reconciliation cycle can't apply.
         val ebookLink = targets.ebook ?: return null
 
         val absFile = cachedFile(ebookLink.absSourceId, ebookLink.absLibraryItemId) ?: return null
         val storytellerFile = cachedFile(openedLink.storytellerSourceId, openedLink.storytellerBookId) ?: return null
 
-        // The index must already be built for these exact bytes (checksum-keyed); otherwise the
-        // background builder hasn't caught up — stay single-peer until it has. Checksums stream the
-        // file (the synced bundle is hundreds of MB — never read it into memory; ADR 0023).
         val index = indexStore.load(EpubChecksum.of(absFile), EpubChecksum.of(storytellerFile)) ?: run {
-            // An operation requiring the cross-EPUB index, reached before the index exists. Both EPUBs
-            // are cached (above), so the build's prerequisites are all present — self-heal by enqueueing
-            // it (idempotent), and leave a trace explaining why this book's position sync just degraded
-            // to single-peer. This is the reader-open AND player-open retry path in one place; it also
-            // catches a deferred/failed download-time build, an EPUB re-upload (checksum change), or a
-            // bundle present from outside the in-app download flow (ADR 0031).
             logger.w(LogChannel.Readaloud) {
                 "cross-EPUB index missing for matched item $itemId (ebook=${ebookLink.absLibraryItemId}); " +
                     "position sync degraded to single-peer — enqueued a build"
@@ -97,10 +75,10 @@ open class ReaderSyncFactory @Inject constructor(
             storytellerChapterHtml = storytellerExtract.htmlAt(),
         )
 
-        val absEbookEndpoint = absEndpointFor(ebookLink.absSourceId, ebookLink.absLibraryItemId)
+        val absEbookEndpoint = endpointFor(ebookLink.absSourceId, ebookLink.absLibraryItemId)
         val absAudioEndpoint = targets.audio?.let { a ->
             val durationSec = linkedMedia.firstOrNull { it.link.absLibraryItemId == a.absLibraryItemId }?.audioDurationSec ?: 0.0
-            absEndpointFor(a.absSourceId, a.absLibraryItemId, durationSec)
+            endpointFor(a.absSourceId, a.absLibraryItemId, durationSec)
         }
 
         return ReaderSyncCoordinator(
@@ -111,18 +89,12 @@ open class ReaderSyncFactory @Inject constructor(
                 prerequisitesCached = true,
             ),
             translator = translator,
-            absApi = absSessionApi,
+            clock = clock,
             absEbookEndpoint = absEbookEndpoint,
             absAudioEndpoint = absAudioEndpoint,
         )
     }
 
-    /**
-     * Builds a bundle-SMIL-only [AudiobookFollow] for a matched book that has an audiobook target and a
-     * cached Storyteller bundle — **without** requiring the ABS EPUB or the cross-EPUB index that
-     * [createIfApplicable] needs (ADR 0031). Lets readaloud sync to the audiobook in the window before
-     * the index is built (or when it can't be). `null` when there is no audio target or no cached bundle.
-     */
     open suspend fun createAudiobookFollowIfApplicable(itemId: String): AudiobookFollow? {
         val active = sourceRepository.getActive() ?: return null
         val openedLink = linkRepository.findByAbsItem(active.id, itemId) ?: return null
@@ -133,34 +105,26 @@ open class ReaderSyncFactory @Inject constructor(
         }
         val targets = resolveAbsTargets(itemId, linkedMedia)
         val audioTarget = targets.audio ?: return null
-        // For the streaming path (ADR 0028) the sidecar stands in for the full bundle: it carries the
-        // SMIL clips and chapter HTML needed by DefaultPositionTranslator and ReadaloudTextQuotes, so
-        // AudiobookFollow can be built without a downloaded bundle. createIfApplicable() still requires
-        // the full bundle (for cross-EPUB index checksums), so the coordinator stays on the sidecar-only
-        // path until the bundle is downloaded.
         val storytellerFile = cachedFile(openedLink.storytellerSourceId, openedLink.storytellerBookId)
             ?: sidecarCache.cachedFile(openedLink.storytellerSourceId, openedLink.storytellerBookId)
             ?: return null
         val storytellerExtract = EpubContentExtractor.extract(storytellerFile) ?: return null
         val durationSec = linkedMedia.firstOrNull { it.link.absLibraryItemId == audioTarget.absLibraryItemId }?.audioDurationSec ?: 0.0
-        val endpoint = absEndpointFor(audioTarget.absSourceId, audioTarget.absLibraryItemId, durationSec) ?: return null
+        val endpoint = endpointFor(audioTarget.absSourceId, audioTarget.absLibraryItemId, durationSec) ?: return null
         return AudiobookFollow(
-            absApi = absSessionApi,
             endpoint = endpoint,
             translator = DefaultPositionTranslator(smilClips = storytellerExtract.smilClips),
+            clock = clock,
             sourceId = audioTarget.absSourceId,
             audioItemId = audioTarget.absLibraryItemId,
-            // The ebook target + the bundle's sentence quotes let audiobook→ebook resolve index-free,
-            // text-anchored on the ABS EPUB (ADR 0031).
             ebookItemId = targets.ebook?.absLibraryItemId,
             quotes = com.riffle.core.domain.ReadaloudTextQuotes.build(storytellerExtract.chapters),
         )
     }
 
-    private suspend fun absEndpointFor(sourceId: String, itemId: String, durationSec: Double = 0.0): AbsSyncEndpoint? {
-        val server = sourceRepository.getById(sourceId) ?: return null
-        val token = tokenStorage.getToken(sourceId) ?: return null
-        return AbsSyncEndpoint(server.url.value, token, server.insecureConnectionAllowed, itemId, durationSec)
+    private suspend fun endpointFor(sourceId: String, itemId: String, durationSec: Double = 0.0): CatalogSyncEndpoint? {
+        val peer = catalogRegistry.forSourceId(sourceId) as? ProgressPeerCapability ?: return null
+        return CatalogSyncEndpoint(peer, itemId, durationSec)
     }
 
     private fun cachedFile(sourceId: String, itemId: String): java.io.File? =

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/ReadaloudStreamingSessionFactory.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/ReadaloudStreamingSessionFactory.kt
@@ -72,12 +72,16 @@ class ReadaloudStreamingSessionFactory @Inject constructor(
                 else -> Result.failure(RuntimeException("storyteller fingerprint fetch failed"))
             }
             val absFingerprint: Result<AudiobookFingerprint?> = runCatching {
-                val fp = audioCap.getFingerprint(audiobook.bookId)
-                AudiobookFingerprint(
-                    fileSizeBytes = fp.fileSizeBytes,
-                    durationSec = fp.totalDurationSec,
-                    trackDurationsSec = fp.trackDurations,
-                )
+                // Null fingerprint = "no audiobook on this item" (a Source-Success result). Preserve
+                // it so AudiobookIdentityResolver returns the definitive NO_AUDIOBOOK verdict rather
+                // than treating it as an UNKNOWN retry-forever state.
+                audioCap.getFingerprint(audiobook.bookId)?.let { fp ->
+                    AudiobookFingerprint(
+                        fileSizeBytes = fp.fileSizeBytes,
+                        durationSec = fp.totalDurationSec,
+                        trackDurationsSec = fp.trackDurations,
+                    )
+                }
             }
             val verdict = AudiobookIdentityResolver.resolve(stFingerprint, absFingerprint)
             linkRepository.updateIdentityResult(audiobook.sourceId, audiobook.bookId, verdict)

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/ReadaloudStreamingSessionFactory.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/readaloud/ReadaloudStreamingSessionFactory.kt
@@ -1,18 +1,20 @@
 package com.riffle.app.feature.reader.readaloud
 
 import android.content.Context
+import com.riffle.core.catalog.AudiobookMediaCapability
+import com.riffle.core.catalog.CatalogRegistry
 import com.riffle.core.data.AudiobookIdentityResolver
 import com.riffle.core.data.MediaOverlayReader
 import com.riffle.core.data.ReadaloudSidecarStore
 import com.riffle.core.data.StreamingSetupBuilder
 import com.riffle.core.domain.AudioIdentityResolver
+import com.riffle.core.domain.AudiobookFingerprint
 import com.riffle.core.domain.AudiobookIdentityResult
 import com.riffle.core.domain.DispatcherProvider
 import com.riffle.core.domain.ReadaloudLinkRepository
 import com.riffle.core.domain.ReadaloudTrack
 import com.riffle.core.domain.SourceRepository
 import com.riffle.core.domain.TokenStorage
-import com.riffle.core.network.AbsLibraryApi
 import com.riffle.core.network.NetworkResult
 import com.riffle.core.network.StorytellerLibraryApi
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -22,13 +24,14 @@ import javax.inject.Inject
 
 /**
  * Assembles a streaming Readaloud session (ADR 0028) for a matched book, or returns null so the
- * caller falls back to the bundle. Streaming is built only when an ABS audiobook is linked AND its
- * recording identity is VERIFIED against Storyteller's ingested source — so a mismatch never streams.
+ * caller falls back to the bundle. Streaming is built only when a Source-side audiobook is linked
+ * AND its recording identity is VERIFIED against Storyteller's ingested source — so a mismatch
+ * never streams.
  */
 class ReadaloudStreamingSessionFactory @Inject constructor(
     @ApplicationContext private val context: Context,
     private val audioIdentityResolver: AudioIdentityResolver,
-    private val absApi: AbsLibraryApi,
+    private val catalogRegistry: CatalogRegistry,
     private val storytellerApi: StorytellerLibraryApi,
     private val sidecarStore: ReadaloudSidecarStore,
     private val sourceRepository: SourceRepository,
@@ -36,14 +39,8 @@ class ReadaloudStreamingSessionFactory @Inject constructor(
     private val linkRepository: ReadaloudLinkRepository,
     private val dispatchers: DispatcherProvider,
 ) {
-    // Guard against an evict-and-refetch loop when the Storyteller bundle is still partially aligned:
-    // we attempt one fresh fetch per session, but if the re-fetched sidecar is also partial we stop.
     private val evictedPartialSidecars = mutableSetOf<String>()
 
-    /**
-     * [sidecarFile] stands in for the bundle for the track, highlight quotes, and cross-EPUB index;
-     * [absToken] lets the caller eager-complete the audio download while playing (ADR 0028).
-     */
     data class Session(
         val track: ReadaloudTrack,
         val streaming: SharedBundle.Streaming,
@@ -52,7 +49,6 @@ class ReadaloudStreamingSessionFactory @Inject constructor(
     )
 
     suspend fun tryBuild(storytellerSourceId: String, storytellerBookId: String): Session? = withContext(dispatchers.io) {
-        // 1. Resolve the ABS audiobook linked to this readaloud. No audiobook → not streamable.
         val audiobook = audioIdentityResolver.resolveForStorytellerBook(storytellerSourceId, storytellerBookId)
         if (audiobook.sourceId == storytellerSourceId && audiobook.bookId == storytellerBookId) {
             return@withContext null
@@ -60,13 +56,9 @@ class ReadaloudStreamingSessionFactory @Inject constructor(
 
         val absServer = sourceRepository.getById(audiobook.sourceId) ?: return@withContext null
         val absToken = tokenStorage.getToken(audiobook.sourceId) ?: return@withContext null
+        val catalog = catalogRegistry.forSourceId(audiobook.sourceId) ?: return@withContext null
+        val audioCap = catalog as? AudiobookMediaCapability ?: return@withContext null
 
-        // 2. Recording-identity gate: only stream when ABS audio is provably Storyteller's source.
-        // Reuse the persisted verdict (ADR 0028) so a re-open doesn't re-fetch both fingerprints: a stored
-        // VERIFIED is trusted as-is; a stored definitive negative (MISMATCH/NO_AUDIOBOOK) stays on the
-        // bundle without a network round-trip. Only an as-yet-UNKNOWN link runs the fingerprint check —
-        // and because it persists the verdict, a transient failure leaves it UNKNOWN so a later attempt
-        // retries rather than being stuck (the source decision never trusts a non-VERIFIED result).
         val persisted = linkRepository.findByAbsItem(audiobook.sourceId, audiobook.bookId)?.identityResult
         if (persisted != null && persisted != AudiobookIdentityResult.UNKNOWN) {
             if (persisted != AudiobookIdentityResult.VERIFIED) return@withContext null
@@ -74,25 +66,38 @@ class ReadaloudStreamingSessionFactory @Inject constructor(
             val stServer = sourceRepository.getById(storytellerSourceId) ?: return@withContext null
             val stToken = tokenStorage.getToken(storytellerSourceId) ?: return@withContext null
             val bookId = storytellerBookId.toLongOrNull() ?: return@withContext null
-            val stFp = storytellerApi.getAudiobookFingerprint(stServer.url.value, bookId, stToken, stServer.insecureConnectionAllowed)
-            val absFp = absApi.getAudiobookFingerprint(absServer.url.value, audiobook.bookId, absToken, absServer.insecureConnectionAllowed)
-            val verdict = AudiobookIdentityResolver.resolve(stFp, absFp)
+            val stFpRes = storytellerApi.getAudiobookFingerprint(stServer.url.value, bookId, stToken, stServer.insecureConnectionAllowed)
+            val stFingerprint: Result<AudiobookFingerprint?> = when (stFpRes) {
+                is NetworkResult.Success -> Result.success(stFpRes.value)
+                else -> Result.failure(RuntimeException("storyteller fingerprint fetch failed"))
+            }
+            val absFingerprint: Result<AudiobookFingerprint?> = runCatching {
+                val fp = audioCap.getFingerprint(audiobook.bookId)
+                AudiobookFingerprint(
+                    fileSizeBytes = fp.fileSizeBytes,
+                    durationSec = fp.totalDurationSec,
+                    trackDurationsSec = fp.trackDurations,
+                )
+            }
+            val verdict = AudiobookIdentityResolver.resolve(stFingerprint, absFingerprint)
             linkRepository.updateIdentityResult(audiobook.sourceId, audiobook.bookId, verdict)
             if (verdict != AudiobookIdentityResult.VERIFIED) return@withContext null
         }
 
-        // 3. ABS audiobook tracks (ino + duration).
-        val tracksResult = absApi.getAudiobookTracks(absServer.url.value, audiobook.bookId, absToken, absServer.insecureConnectionAllowed)
-        val tracks = (tracksResult as? NetworkResult.Success)?.value?.takeIf { it.isNotEmpty() } ?: return@withContext null
+        val tracks = runCatching { audioCap.getTracks(audiobook.bookId) }.getOrNull()?.takeIf { it.isNotEmpty() }
+            ?: return@withContext null
 
-        // 4. The sidecar (SMIL + text). Use ONLY the already-cached copy — the slow /synced fetch is done
-        //    ahead of time by ReadaloudSidecarStore.prepare() when the book is opened (ADR 0028), so the
-        //    Play path never blocks on it. Not prepared yet → null → the caller surfaces "Preparing…".
         val sidecarFile = sidecarStore.cachedFile(storytellerSourceId, storytellerBookId)
             ?: return@withContext null
 
-        // 5. Reconcile segments to tracks; null when timelines disagree → bundle.
-        val setup = StreamingSetupBuilder().build(sidecarFile, tracks, absServer.url.value, audiobook.bookId, absToken)
+        val networkTracks = tracks.map { t ->
+            com.riffle.core.network.NetworkAbsAudioTrack(
+                ino = t.ino,
+                index = t.index,
+                durationSec = t.durationSec,
+            )
+        }
+        val setup = StreamingSetupBuilder().build(sidecarFile, networkTracks, absServer.url.value, audiobook.bookId, absToken)
         if (setup == null) {
             evictStaleOrPartialSidecar(storytellerSourceId, storytellerBookId, sidecarFile, tracks.sumOf { it.durationSec })
             return@withContext null
@@ -101,13 +106,6 @@ class ReadaloudStreamingSessionFactory @Inject constructor(
         Session(setup.track, SharedBundle.Streaming(setup.items.associateBy { it.audioSrc }), sidecarFile, absToken)
     }
 
-    /**
-     * When [StreamingSetupBuilder] returns null, inspect the sidecar to decide whether it's a stale
-     * intermediate artifact (no clips, or covers only part of the book) and evict it so the next
-     * prepare() fetches from the now-complete Storyteller bundle. Partial-sidecar eviction is guarded
-     * to one attempt per session — if the re-fetched sidecar is also partial, alignment is still in
-     * progress on the server and we stop trying until the next app launch.
-     */
     private fun evictStaleOrPartialSidecar(sourceId: String, bookId: String, sidecarFile: File, absTotalSec: Double) {
         val sidecarTrack = runCatching { MediaOverlayReader.readTrack(sidecarFile) }.getOrNull() ?: return
         val clips = sidecarTrack.clips

--- a/app/src/test/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModelBookmarkTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModelBookmarkTest.kt
@@ -727,18 +727,24 @@ class AudiobookPlayerViewModelBookmarkTest {
     private class TestReaderSyncFactory : ReaderSyncFactory(
         FakeLinkRepository,
         StubServer,
-        FakeTokenStorage,
+        StubCatalogRegistry,
         StubIndexStore,
-        StubAbsApi,
         StubLibrary,
         StubLocalStore,
         StubLocalStore,
         StubBuildTrigger,
         sidecarCache = { _, _ -> null },
+        clock = object : com.riffle.core.domain.Clock { override fun nowMs() = 0L; override fun nowNs() = 0L },
         logger = RecordingLogger(),
     ) {
         override suspend fun createIfApplicable(itemId: String): ReaderSyncCoordinator? = null
         override suspend fun createAudiobookFollowIfApplicable(itemId: String): AudiobookFollow? = null
+    }
+
+    private object StubCatalogRegistry : com.riffle.core.catalog.CatalogRegistry {
+        override suspend fun forActive(): com.riffle.core.catalog.Catalog? = null
+        override suspend fun forSource(source: Source): com.riffle.core.catalog.Catalog? = null
+        override suspend fun forSourceId(sourceId: String): com.riffle.core.catalog.Catalog? = null
     }
 
     private object StubServer : SourceRepository {

--- a/app/src/test/kotlin/com/riffle/app/feature/audiobook/SleepTimerTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/audiobook/SleepTimerTest.kt
@@ -549,18 +549,24 @@ class SleepTimerTest {
     private class TestReaderSyncFactory : ReaderSyncFactory(
         FakeLinkRepository,
         StubServer,
-        FakeTokenStorage,
+        StubCatalogRegistry,
         StubIndexStore,
-        StubAbsApi,
         StubLibrary,
         StubLocalStore,
         StubLocalStore,
         StubBuildTrigger,
         sidecarCache = { _, _ -> null },
+        clock = object : com.riffle.core.domain.Clock { override fun nowMs() = 0L; override fun nowNs() = 0L },
         logger = RecordingLogger(),
     ) {
         override suspend fun createIfApplicable(itemId: String): ReaderSyncCoordinator? = null
         override suspend fun createAudiobookFollowIfApplicable(itemId: String): AudiobookFollow? = null
+    }
+
+    private object StubCatalogRegistry : com.riffle.core.catalog.CatalogRegistry {
+        override suspend fun forActive(): com.riffle.core.catalog.Catalog? = null
+        override suspend fun forSource(source: Source): com.riffle.core.catalog.Catalog? = null
+        override suspend fun forSourceId(sourceId: String): com.riffle.core.catalog.Catalog? = null
     }
 
     private object StubServer : SourceRepository {

--- a/app/src/test/kotlin/com/riffle/app/feature/library/FetchAudiobookChaptersUseCaseTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/FetchAudiobookChaptersUseCaseTest.kt
@@ -4,10 +4,6 @@ import com.riffle.core.domain.AudiobookChapter
 import com.riffle.core.domain.AudiobookChapterCacheRepository
 import com.riffle.core.domain.EbookFormat
 import com.riffle.core.domain.LibraryItem
-import com.riffle.core.domain.Source
-import com.riffle.core.domain.SourceRepository
-import com.riffle.core.domain.SourceUrl
-import com.riffle.core.domain.TokenStorage
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
@@ -18,22 +14,12 @@ import org.junit.Test
 
 class FetchAudiobookChaptersUseCaseTest {
     private val chapterRepo = mockk<AudiobookChapterCacheRepository>()
-    private val serverRepo = mockk<SourceRepository>()
-    private val tokenStorage = mockk<TokenStorage>()
-    private val useCase = FetchAudiobookChaptersUseCase(chapterRepo, serverRepo, tokenStorage)
+    private val useCase = FetchAudiobookChaptersUseCase(chapterRepo)
 
     private fun makeItem() = LibraryItem(
         id = "item1", libraryId = "lib1", title = "Book", author = "Author",
         coverUrl = null, readingProgress = 0f, isCached = false, isDownloaded = false,
         ebookFormat = EbookFormat.Unsupported, hasAudio = true, sourceId = "srv1",
-    )
-
-    private fun makeServer(baseUrl: String = "http://base") = Source(
-        id = "srv1",
-        url = SourceUrl.parse(baseUrl)!!,
-        isActive = true,
-        insecureConnectionAllowed = false,
-        username = "user",
     )
 
     @Test
@@ -44,18 +30,14 @@ class FetchAudiobookChaptersUseCaseTest {
         val result = useCase(makeItem())
 
         assertEquals(chapters, result)
-        coVerify(exactly = 0) { chapterRepo.fetchAndCacheChapters(any(), any(), any(), any(), any()) }
+        coVerify(exactly = 0) { chapterRepo.fetchAndCacheChapters(any(), any()) }
     }
 
     @Test
     fun `fetches from network when no cache`() = runTest {
         val chapters = listOf(AudiobookChapter(0, 0.0, 300.0, "Intro"))
         coEvery { chapterRepo.getCachedChapters("srv1", "item1") } returns null
-        coEvery { serverRepo.getById("srv1") } returns makeServer("http://base")
-        coEvery { tokenStorage.getToken("srv1") } returns "tok"
-        coEvery {
-            chapterRepo.fetchAndCacheChapters("srv1", "item1", "http://base", "tok", false)
-        } returns chapters
+        coEvery { chapterRepo.fetchAndCacheChapters("srv1", "item1") } returns chapters
 
         val result = useCase(makeItem())
 
@@ -63,9 +45,9 @@ class FetchAudiobookChaptersUseCaseTest {
     }
 
     @Test
-    fun `returns empty list when server not found`() = runTest {
+    fun `returns empty list on repository error`() = runTest {
         coEvery { chapterRepo.getCachedChapters("srv1", "item1") } returns null
-        coEvery { serverRepo.getById("srv1") } returns null
+        coEvery { chapterRepo.fetchAndCacheChapters("srv1", "item1") } throws RuntimeException("boom")
 
         val result = useCase(makeItem())
 

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/AbsProgressPeerTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/AbsProgressPeerTest.kt
@@ -1,30 +1,26 @@
 package com.riffle.app.feature.reader
 
-import com.riffle.core.network.NetworkResult
-
-import com.riffle.core.domain.DefaultPositionTranslator
+import com.riffle.core.catalog.CatalogProgress
+import com.riffle.core.catalog.ProgressPeerCapability
 import com.riffle.core.domain.CanonicalReaderPosition
 import com.riffle.core.domain.ChapterCharMap
 import com.riffle.core.domain.ChapterProgression
+import com.riffle.core.domain.Clock
 import com.riffle.core.domain.CrossEpubIndex
+import com.riffle.core.domain.DefaultPositionTranslator
 import com.riffle.core.domain.MediaOverlayClip
 import com.riffle.core.domain.WriteResult
-import com.riffle.core.network.AbsSessionApi
-import com.riffle.core.network.NetworkAudiobookProgressPayload
-import com.riffle.core.network.NetworkEbookProgressPayload
-import com.riffle.core.network.NetworkServerProgress
 import kotlinx.coroutines.test.runTest
 import org.json.JSONObject
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
-import java.io.IOException
 
 /**
- * Pins the new [WriteResult] contract on the ABS peer adapters (#302): a translator boundary that
- * can't place the canonical position is a deliberate [WriteResult.Skipped], not a [WriteResult.Failed]
- * — the row is left for a later cycle, never marked as a sync failure to act on. Network errors
- * remain Failed.
+ * Pins the [WriteResult] contract on the Catalog-backed peer adapters (#302 / #434): a translator
+ * boundary that can't place the canonical position is a deliberate [WriteResult.Skipped], not a
+ * [WriteResult.Failed] — the row is left for a later cycle, never marked as a sync failure to act
+ * on. Network errors remain Failed.
  */
 class AbsProgressPeerTest {
 
@@ -38,86 +34,65 @@ class AbsProgressPeerTest {
         storytellerSpineHrefs = listOf("c1.xhtml"),
         storytellerChapterHtml = { if (it == 0) absHtml else null },
     )
-    private val ep = AbsSyncEndpoint("http://abs", "t", false, "i", durationSec = 100.0)
+    private val clock = object : Clock {
+        override fun nowMs() = 9000L
+        override fun nowNs() = 0L
+    }
+
+    private fun endpoint(peer: ProgressPeerCapability) = CatalogSyncEndpoint(peer, "i", durationSec = 100.0)
 
     private fun locator(href: String, progression: Double): String = JSONObject()
         .put("href", href)
         .put("locations", JSONObject().put("progression", progression))
         .toString()
 
-    /** PATCH succeeds and the GET stamp read-back is what gets adopted by the cycle. */
-    private class OkAbs(private val stamp: Long) : AbsSessionApi {
-        override suspend fun syncEbookProgress(baseUrl: String, libraryItemId: String, payload: NetworkEbookProgressPayload, token: String, insecureAllowed: Boolean) =
-            NetworkResult.Success(stamp)
-        override suspend fun syncAudiobookProgress(baseUrl: String, libraryItemId: String, payload: NetworkAudiobookProgressPayload, token: String, insecureAllowed: Boolean) =
-            NetworkResult.Success(stamp)
-        override suspend fun getProgress(baseUrl: String, libraryItemId: String, token: String, insecureAllowed: Boolean) =
-            NetworkResult.Success(NetworkServerProgress(ebookLocation = "", lastUpdate = stamp))
+    /** PATCH succeeds — peer echoes the stamp back mirroring ABS's PATCH response. */
+    private class OkPeer(private val stamp: Long) : ProgressPeerCapability {
+        override suspend fun pushEbookProgress(itemId: String, location: String, progress: Float, isFinished: Boolean, lastUpdateEpochMs: Long) = stamp
+        override suspend fun pushAudiobookProgress(itemId: String, currentTimeSec: Double, durationSec: Double, isFinished: Boolean, lastUpdateEpochMs: Long) = stamp
+        override suspend fun pullProgress(itemId: String): CatalogProgress? = null
+        override suspend fun pullAllProgress(): List<CatalogProgress> = emptyList()
     }
 
     /** PATCH fails at the network. */
-    private class PatchFailAbs : AbsSessionApi {
-        override suspend fun syncEbookProgress(baseUrl: String, libraryItemId: String, payload: NetworkEbookProgressPayload, token: String, insecureAllowed: Boolean) =
-            NetworkResult.Offline(IOException("boom"))
-        override suspend fun syncAudiobookProgress(baseUrl: String, libraryItemId: String, payload: NetworkAudiobookProgressPayload, token: String, insecureAllowed: Boolean) =
-            NetworkResult.Offline(IOException("boom"))
-        override suspend fun getProgress(baseUrl: String, libraryItemId: String, token: String, insecureAllowed: Boolean) =
-            NetworkResult.Offline(IOException("boom"))
-    }
-
-    /** PATCH OK but the follow-up GET (the stamp read-back) fails. */
-    private class StampReadbackFailAbs : AbsSessionApi {
-        override suspend fun syncEbookProgress(baseUrl: String, libraryItemId: String, payload: NetworkEbookProgressPayload, token: String, insecureAllowed: Boolean) =
-            NetworkResult.Success(0L)
-        override suspend fun syncAudiobookProgress(baseUrl: String, libraryItemId: String, payload: NetworkAudiobookProgressPayload, token: String, insecureAllowed: Boolean) =
-            NetworkResult.Success(0L)
-        override suspend fun getProgress(baseUrl: String, libraryItemId: String, token: String, insecureAllowed: Boolean) =
-            NetworkResult.Offline(IOException("stamp read-back failed"))
+    private class FailPeer : ProgressPeerCapability {
+        override suspend fun pushEbookProgress(itemId: String, location: String, progress: Float, isFinished: Boolean, lastUpdateEpochMs: Long): Long? = throw java.io.IOException("boom")
+        override suspend fun pushAudiobookProgress(itemId: String, currentTimeSec: Double, durationSec: Double, isFinished: Boolean, lastUpdateEpochMs: Long): Long? = throw java.io.IOException("boom")
+        override suspend fun pullProgress(itemId: String): CatalogProgress? = null
+        override suspend fun pullAllProgress(): List<CatalogProgress> = emptyList()
     }
 
     @Test
     fun `ebook peer Ok when network PATCH succeeds and stamp comes back`() = runTest {
-        val peer = AbsEbookProgressPeer(OkAbs(stamp = 1234L), ep, translator)
+        val peer = AbsEbookProgressPeer(endpoint(OkPeer(stamp = 1234L)), translator, clock)
         val result = peer.tryPatch(CanonicalReaderPosition(locator("c1.xhtml", 0.5)))
         assertEquals(WriteResult.Ok(1234L), result)
     }
 
     @Test
     fun `ebook peer Skipped when canonical can't be translated to a CFI (deliberate no-op)`() = runTest {
-        // href not in the spine → translator.canonicalToAbsCfi returns null → Skipped (not Failed): the
-        // peer made no network attempt; the row is not dirty, the cycle will retry next pass.
-        val peer = AbsEbookProgressPeer(OkAbs(stamp = 1234L), ep, translator)
+        val peer = AbsEbookProgressPeer(endpoint(OkPeer(stamp = 1234L)), translator, clock)
         val result = peer.tryPatch(CanonicalReaderPosition(locator("nonexistent.xhtml", 0.5)))
         assertEquals(WriteResult.Skipped, result)
     }
 
     @Test
-    fun `ebook peer Failed when ABS PATCH errors`() = runTest {
-        val peer = AbsEbookProgressPeer(PatchFailAbs(), ep, translator)
+    fun `ebook peer Failed when Catalog push errors`() = runTest {
+        val peer = AbsEbookProgressPeer(endpoint(FailPeer()), translator, clock)
         val result = peer.tryPatch(CanonicalReaderPosition(locator("c1.xhtml", 0.5)))
         assertTrue("expected Failed, was $result", result is WriteResult.Failed)
     }
 
     @Test
-    fun `ebook peer Failed when stamp read-back fails (PATCH stored, stamp unknown)`() = runTest {
-        // ABS itself returns Success with no stamp; the read-back GET fails. The cycle needs the stamp
-        // to break the feedback loop, so report Failed — not Ok with a fake stamp.
-        val peer = AbsEbookProgressPeer(StampReadbackFailAbs(), ep, translator)
-        val result = peer.tryPatch(CanonicalReaderPosition(locator("c1.xhtml", 0.5)))
-        assertTrue("expected Failed, was $result", result is WriteResult.Failed)
-    }
-
-    @Test
-    fun `audiobook peer Ok when SMIL placement + PATCH + stamp succeed`() = runTest {
-        val peer = AbsAudiobookProgressPeer(OkAbs(stamp = 9000L), ep, translator)
-        // progression 0.2 places inside the SMIL clip f1 (5–10s) — translates to a valid audio second
+    fun `audiobook peer Ok when SMIL placement + PATCH succeed`() = runTest {
+        val peer = AbsAudiobookProgressPeer(endpoint(OkPeer(stamp = 9000L)), translator, clock)
         val result = peer.tryPatch(CanonicalReaderPosition(locator("c1.xhtml", 0.2)))
         assertEquals(WriteResult.Ok(9000L), result)
     }
 
     @Test
-    fun `audiobook peer Failed when ABS PATCH errors`() = runTest {
-        val peer = AbsAudiobookProgressPeer(PatchFailAbs(), ep, translator)
+    fun `audiobook peer Failed when Catalog push errors`() = runTest {
+        val peer = AbsAudiobookProgressPeer(endpoint(FailPeer()), translator, clock)
         val result = peer.tryPatch(CanonicalReaderPosition(locator("c1.xhtml", 0.2)))
         assertTrue("expected Failed, was $result", result is WriteResult.Failed)
     }

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/AbsProgressPeerTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/AbsProgressPeerTest.kt
@@ -48,16 +48,16 @@ class AbsProgressPeerTest {
 
     /** PATCH succeeds — peer echoes the stamp back mirroring ABS's PATCH response. */
     private class OkPeer(private val stamp: Long) : ProgressPeerCapability {
-        override suspend fun pushEbookProgress(itemId: String, location: String, progress: Float, isFinished: Boolean, lastUpdateEpochMs: Long) = stamp
-        override suspend fun pushAudiobookProgress(itemId: String, currentTimeSec: Double, durationSec: Double, isFinished: Boolean, lastUpdateEpochMs: Long) = stamp
+        override suspend fun pushEbookProgress(itemId: String, location: String, progress: Float, isFinished: Boolean?, lastUpdateEpochMs: Long) = stamp
+        override suspend fun pushAudiobookProgress(itemId: String, currentTimeSec: Double, durationSec: Double, isFinished: Boolean?, lastUpdateEpochMs: Long) = stamp
         override suspend fun pullProgress(itemId: String): CatalogProgress? = null
         override suspend fun pullAllProgress(): List<CatalogProgress> = emptyList()
     }
 
     /** PATCH fails at the network. */
     private class FailPeer : ProgressPeerCapability {
-        override suspend fun pushEbookProgress(itemId: String, location: String, progress: Float, isFinished: Boolean, lastUpdateEpochMs: Long): Long? = throw java.io.IOException("boom")
-        override suspend fun pushAudiobookProgress(itemId: String, currentTimeSec: Double, durationSec: Double, isFinished: Boolean, lastUpdateEpochMs: Long): Long? = throw java.io.IOException("boom")
+        override suspend fun pushEbookProgress(itemId: String, location: String, progress: Float, isFinished: Boolean?, lastUpdateEpochMs: Long): Long? = throw java.io.IOException("boom")
+        override suspend fun pushAudiobookProgress(itemId: String, currentTimeSec: Double, durationSec: Double, isFinished: Boolean?, lastUpdateEpochMs: Long): Long? = throw java.io.IOException("boom")
         override suspend fun pullProgress(itemId: String): CatalogProgress? = null
         override suspend fun pullAllProgress(): List<CatalogProgress> = emptyList()
     }

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/AudiobookFollowTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/AudiobookFollowTest.kt
@@ -1,14 +1,11 @@
 package com.riffle.app.feature.reader
 
-import com.riffle.core.network.NetworkResult
-
-import com.riffle.core.domain.DefaultPositionTranslator
+import com.riffle.core.catalog.CatalogProgress
+import com.riffle.core.catalog.ProgressPeerCapability
 import com.riffle.core.domain.ChapterProgression
+import com.riffle.core.domain.Clock
+import com.riffle.core.domain.DefaultPositionTranslator
 import com.riffle.core.domain.MediaOverlayClip
-import com.riffle.core.network.AbsSessionApi
-import com.riffle.core.network.NetworkAudiobookProgressPayload
-import com.riffle.core.network.NetworkEbookProgressPayload
-import com.riffle.core.network.NetworkServerProgress
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
@@ -18,7 +15,7 @@ import org.junit.Test
 
 /**
  * The bundle-SMIL-only [AudiobookFollow] (ADR 0031): readaloud→audiobook works from the bundle alone
- * (no cross-EPUB index). Verifies fragment↔seconds translation and the ABS push, over a fake API.
+ * (no cross-EPUB index). Verifies fragment↔seconds translation and the Catalog push, over a fake peer.
  */
 class AudiobookFollowTest {
 
@@ -34,85 +31,84 @@ class AudiobookFollowTest {
     )
     private fun translator() = DefaultPositionTranslator(clips, fragmentProgressions = fragmentProgressions)
 
-    private class FakeApi(val stamp: Long = 4242L) : AbsSessionApi {
+    private class FakePeer(val stamp: Long = 4242L) : ProgressPeerCapability {
         var sentSeconds: Double? = null
-        override suspend fun syncEbookProgress(baseUrl: String, libraryItemId: String, payload: NetworkEbookProgressPayload, token: String, insecureAllowed: Boolean) =
-            NetworkResult.Success(0L)
-        override suspend fun syncAudiobookProgress(baseUrl: String, libraryItemId: String, payload: NetworkAudiobookProgressPayload, token: String, insecureAllowed: Boolean): NetworkResult<Long> {
-            sentSeconds = payload.currentTime; return NetworkResult.Success(stamp)
+        override suspend fun pushEbookProgress(itemId: String, location: String, progress: Float, isFinished: Boolean, lastUpdateEpochMs: Long) = 0L
+        override suspend fun pushAudiobookProgress(itemId: String, currentTimeSec: Double, durationSec: Double, isFinished: Boolean, lastUpdateEpochMs: Long): Long {
+            sentSeconds = currentTimeSec
+            return stamp
         }
-        override suspend fun getProgress(baseUrl: String, libraryItemId: String, token: String, insecureAllowed: Boolean) =
-            NetworkResult.Success(NetworkServerProgress(ebookLocation = "", currentTime = 0.0, lastUpdate = stamp))
+        override suspend fun pullProgress(itemId: String): CatalogProgress? = null
+        override suspend fun pullAllProgress(): List<CatalogProgress> = emptyList()
     }
 
     private val quotes = mapOf(
         "s2" to com.riffle.core.domain.SentenceQuote(before = "before words", highlight = "the narrated sentence", after = "after words"),
     )
-    private fun follow(api: AbsSessionApi) = AudiobookFollow(
-        absApi = api,
-        endpoint = AbsSyncEndpoint("http://abs", "tok", false, "audio-item", durationSec = 3600.0),
+
+    private val clock = object : Clock {
+        override fun nowMs() = 1_000L
+        override fun nowNs() = 0L
+    }
+
+    private fun follow(peer: ProgressPeerCapability) = AudiobookFollow(
+        endpoint = CatalogSyncEndpoint(peer, "audio-item", durationSec = 3600.0),
         translator = translator(),
+        clock = clock,
         sourceId = "s1",
         audioItemId = "audio-item",
         ebookItemId = "ebook-item",
         quotes = quotes,
     )
 
-    // c2's clips live at 4..8s absolute (after a.mp3's 0..10) — concatenation is exercised.
-
     @Test
     fun `secondsForFragment returns the sentence's absolute clip-begin`() {
-        val f = follow(FakeApi())
+        val f = follow(FakePeer())
         assertEquals(5.0, f.secondsForFragment("c1.html#s2")!!, 0.0001)
-        assertEquals(10.0, f.secondsForFragment("c2.html#s1")!!, 0.0001) // 0.0 + a.mp3 duration 10
+        assertEquals(10.0, f.secondsForFragment("c2.html#s1")!!, 0.0001)
     }
 
     @Test
     fun `secondsForFragment is null for an unknown fragment`() {
-        assertNull(follow(FakeApi()).secondsForFragment("c1.html#nope"))
+        assertNull(follow(FakePeer()).secondsForFragment("c1.html#nope"))
     }
 
     @Test
     fun `fragmentForAudioSeconds maps an absolute second back to the narrated sentence`() {
-        val f = follow(FakeApi())
-        assertEquals("c1.html#s2", f.fragmentForAudioSeconds(7.0))   // 7s is within s2's 5..10
+        val f = follow(FakePeer())
+        assertEquals("c1.html#s2", f.fragmentForAudioSeconds(7.0))
     }
 
     @Test
-    fun `pushFragment sends the fragment's seconds to ABS and returns the server stamp`() = runTest {
-        val api = FakeApi(stamp = 9999L)
-        val stamp = follow(api).pushFragment("c1.html#s2")
+    fun `pushFragment sends the fragment's seconds through the Catalog and returns the source stamp`() = runTest {
+        val peer = FakePeer(stamp = 9999L)
+        val stamp = follow(peer).pushFragment("c1.html#s2")
         assertEquals(9999L, stamp)
-        assertEquals(5.0, api.sentSeconds!!, 0.0001)
+        assertEquals(5.0, peer.sentSeconds!!, 0.0001)
     }
 
     @Test
     fun `pushFragment does nothing for an unresolvable fragment`() = runTest {
-        val api = FakeApi()
-        assertNull(follow(api).pushFragment("c1.html#nope"))
-        assertNull(api.sentSeconds)
+        val peer = FakePeer()
+        assertNull(follow(peer).pushFragment("c1.html#nope"))
+        assertNull(peer.sentSeconds)
     }
 
     @Test
     fun `ebookLocatorForAudioSeconds yields a TEXT-anchored locator (index-free audiobook to ebook)`() {
-        // 7s -> sentence s2; its quote text anchors the locator so it resolves on the ABS EPUB
-        // by text search — no cross-EPUB index needed (ADR 0031).
-        val json = follow(FakeApi()).ebookLocatorForAudioSeconds(7.0)
+        val json = follow(FakePeer()).ebookLocatorForAudioSeconds(7.0)
         assertNotNull(json)
         assertTrue("must carry the sentence text for anchoring", json!!.contains("the narrated sentence"))
     }
 
     @Test
     fun `ebookLocatorForAudioSeconds is null when the sentence has no quote`() {
-        // 2s -> sentence s1, which has no quote entry -> cannot text-anchor -> null (no coarse write).
-        assertNull(follow(FakeApi()).ebookLocatorForAudioSeconds(2.0))
+        assertNull(follow(FakePeer()).ebookLocatorForAudioSeconds(2.0))
     }
 
     @Test
     fun `readaloudAnchorForAudioSeconds yields the narrated sentence (index-free)`() {
-        // 7s -> sentence s2; the readaloud resume is the sentence ref, so reopening the reader and
-        // pressing Play lands on the listened sentence rather than a stale one (ADR 0031).
-        val anchor = follow(FakeApi()).readaloudAnchorForAudioSeconds(7.0)
+        val anchor = follow(FakePeer()).readaloudAnchorForAudioSeconds(7.0)
         assertNotNull(anchor)
         assertEquals("c1.html#s2", anchor!!.fragmentRef)
         assertEquals("c1.html", anchor.href)
@@ -120,17 +116,13 @@ class AudiobookFollowTest {
 
     @Test
     fun `readaloudAnchorForAudioSeconds resolves even without a quote (the sentence ref is the anchor)`() {
-        // 2s -> sentence s1, which has NO quote. Unlike ebookLocatorForAudioSeconds (which needs the
-        // quote to text-anchor), the readaloud resume only needs the sentence ref to start narration,
-        // so it must still resolve — else the audiobook can't move the readaloud resume here.
-        val anchor = follow(FakeApi()).readaloudAnchorForAudioSeconds(2.0)
+        val anchor = follow(FakePeer()).readaloudAnchorForAudioSeconds(2.0)
         assertNotNull(anchor)
         assertEquals("c1.html#s1", anchor!!.fragmentRef)
     }
 
     @Test
     fun `readaloudAnchorForAudioSeconds is null when the second has no narrated sentence`() {
-        // A second past the last clip maps to no fragment -> nothing to anchor.
-        assertNull(follow(FakeApi()).readaloudAnchorForAudioSeconds(99_999.0))
+        assertNull(follow(FakePeer()).readaloudAnchorForAudioSeconds(99_999.0))
     }
 }

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/AudiobookFollowTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/AudiobookFollowTest.kt
@@ -33,8 +33,8 @@ class AudiobookFollowTest {
 
     private class FakePeer(val stamp: Long = 4242L) : ProgressPeerCapability {
         var sentSeconds: Double? = null
-        override suspend fun pushEbookProgress(itemId: String, location: String, progress: Float, isFinished: Boolean, lastUpdateEpochMs: Long) = 0L
-        override suspend fun pushAudiobookProgress(itemId: String, currentTimeSec: Double, durationSec: Double, isFinished: Boolean, lastUpdateEpochMs: Long): Long {
+        override suspend fun pushEbookProgress(itemId: String, location: String, progress: Float, isFinished: Boolean?, lastUpdateEpochMs: Long) = 0L
+        override suspend fun pushAudiobookProgress(itemId: String, currentTimeSec: Double, durationSec: Double, isFinished: Boolean?, lastUpdateEpochMs: Long): Long {
             sentSeconds = currentTimeSec
             return stamp
         }

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ReaderSyncCoordinatorTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ReaderSyncCoordinatorTest.kt
@@ -69,7 +69,7 @@ class ReaderSyncCoordinatorTest {
         private fun nextStamp(): Long { clock += 1_000; return clock }
 
         override suspend fun pushEbookProgress(
-            itemId: String, location: String, progress: Float, isFinished: Boolean, lastUpdateEpochMs: Long,
+            itemId: String, location: String, progress: Float, isFinished: Boolean?, lastUpdateEpochMs: Long,
         ): Long {
             ebookLocation = location
             ebookProgress = progress
@@ -79,7 +79,7 @@ class ReaderSyncCoordinatorTest {
         }
 
         override suspend fun pushAudiobookProgress(
-            itemId: String, currentTimeSec: Double, durationSec: Double, isFinished: Boolean, lastUpdateEpochMs: Long,
+            itemId: String, currentTimeSec: Double, durationSec: Double, isFinished: Boolean?, lastUpdateEpochMs: Long,
         ): Long {
             audioCurrentTime = currentTimeSec
             audioDuration = durationSec

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ReaderSyncCoordinatorTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ReaderSyncCoordinatorTest.kt
@@ -1,18 +1,15 @@
 package com.riffle.app.feature.reader
 
-import com.riffle.core.network.NetworkResult
-
 import com.riffle.app.testing.TestApplicationScope
+import com.riffle.core.catalog.CatalogProgress
+import com.riffle.core.catalog.ProgressPeerCapability
 import com.riffle.core.domain.BookSyncState
-import com.riffle.core.domain.DefaultPositionTranslator
 import com.riffle.core.domain.ChapterCharMap
 import com.riffle.core.domain.ChapterProgression
+import com.riffle.core.domain.Clock
 import com.riffle.core.domain.CrossEpubIndex
+import com.riffle.core.domain.DefaultPositionTranslator
 import com.riffle.core.domain.MediaOverlayClip
-import com.riffle.core.network.AbsSessionApi
-import com.riffle.core.network.NetworkAudiobookProgressPayload
-import com.riffle.core.network.NetworkEbookProgressPayload
-import com.riffle.core.network.NetworkServerProgress
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
@@ -33,9 +30,6 @@ import org.junit.Test
 @OptIn(ExperimentalCoroutinesApi::class)
 class ReaderSyncCoordinatorTest {
 
-    // Identity cross-EPUB index → Storyteller and ABS progressions coincide. The SMIL maps both ways:
-    // clip f1 (5–10s) narrates progression 0.2, clip f9 (90–100s) narrates progression 0.9. Single
-    // audio file, so absolute == per-file here (the multi-file offsetting is tested in the translator).
     private val absHtml = "<html><body><p>${"x".repeat(100)}</p></body></html>"
     private val translator = DefaultPositionTranslator(
         smilClips = listOf(
@@ -53,56 +47,66 @@ class ReaderSyncCoordinatorTest {
     private val state = BookSyncState(
         isMatched = true, hasAbsEbookTarget = true, hasAbsAudioTarget = true, prerequisitesCached = true,
     )
-    private val absEp = AbsSyncEndpoint("http://abs", "t", false, "abs-item", durationSec = 100.0)
 
     private fun locator(progression: Double) = JSONObject()
         .put("href", "c1.xhtml")
         .put("locations", JSONObject().put("progression", progression))
         .toString()
 
-    // A minimal in-memory ABS server modelled on the REAL one: a write stores the record stamped with
-    // a fresh, monotonically-increasing server `lastUpdate`, but the PATCH response is "OK" with NO
-    // timestamp (Success(0)) — exactly as ABS replies. The stored stamp is observable only via a
-    // follow-up GET. This is what makes the timestamp-adoption / feedback-loop logic real: code that
-    // relies on the PATCH returning a usable stamp will (correctly) fail here.
-    private class FakeAbs(initial: NetworkServerProgress) : AbsSessionApi {
+    /**
+     * An in-memory Catalog peer that mimics ABS's PATCH semantics: writes bump a monotonic server
+     * `lastUpdate` and pushEbook/pushAudio return that fresh stamp — the same shape the ABS session
+     * API returns in production after PR #434.
+     */
+    private class FakePeer(initial: CatalogProgress) : ProgressPeerCapability {
         var progress = initial
         private var clock = initial.lastUpdate
-        var ebookPatch: NetworkEbookProgressPayload? = null
-        var ebookPatchItemId: String? = null
-        var audioPatch: NetworkAudiobookProgressPayload? = null
-        var audioPatchItemId: String? = null
-        val getProgressItemIds = mutableListOf<String>()
+        var ebookLocation: String? = null
+        var ebookProgress: Float? = null
+        var audioCurrentTime: Double? = null
+        var audioDuration: Double? = null
 
         private fun nextStamp(): Long { clock += 1_000; return clock }
 
-        override suspend fun syncEbookProgress(baseUrl: String, libraryItemId: String, payload: NetworkEbookProgressPayload, token: String, insecureAllowed: Boolean): NetworkResult<Long> {
-            ebookPatch = payload; ebookPatchItemId = libraryItemId
-            progress = progress.copy(ebookLocation = payload.ebookLocation, ebookProgress = payload.ebookProgress, lastUpdate = nextStamp())
-            return NetworkResult.Success(0L) // ABS replies "OK" — no timestamp in the body
+        override suspend fun pushEbookProgress(
+            itemId: String, location: String, progress: Float, isFinished: Boolean, lastUpdateEpochMs: Long,
+        ): Long {
+            ebookLocation = location
+            ebookProgress = progress
+            val stamp = nextStamp()
+            this.progress = this.progress.copy(ebookLocation = location, ebookProgress = progress, lastUpdate = stamp)
+            return stamp
         }
-        override suspend fun syncAudiobookProgress(baseUrl: String, libraryItemId: String, payload: NetworkAudiobookProgressPayload, token: String, insecureAllowed: Boolean): NetworkResult<Long> {
-            audioPatch = payload; audioPatchItemId = libraryItemId
-            progress = progress.copy(currentTime = payload.currentTime, duration = payload.duration, lastUpdate = nextStamp())
-            return NetworkResult.Success(0L) // ABS replies "OK" — no timestamp in the body
+
+        override suspend fun pushAudiobookProgress(
+            itemId: String, currentTimeSec: Double, durationSec: Double, isFinished: Boolean, lastUpdateEpochMs: Long,
+        ): Long {
+            audioCurrentTime = currentTimeSec
+            audioDuration = durationSec
+            val stamp = nextStamp()
+            this.progress = this.progress.copy(audioCurrentTime = currentTimeSec, audioDuration = durationSec, lastUpdate = stamp)
+            return stamp
         }
-        override suspend fun getProgress(baseUrl: String, libraryItemId: String, token: String, insecureAllowed: Boolean): NetworkResult<com.riffle.core.network.NetworkServerProgress> {
-            getProgressItemIds += libraryItemId; return NetworkResult.Success(progress)
-        }
+
+        override suspend fun pullProgress(itemId: String): CatalogProgress? = progress
+        override suspend fun pullAllProgress(): List<CatalogProgress> = emptyList()
     }
 
-    private fun coordinator(abs: FakeAbs, ebookEp: AbsSyncEndpoint = absEp, audioEp: AbsSyncEndpoint? = absEp) =
-        ReaderSyncCoordinator(state, translator, abs, ebookEp, audioEp)
+    private val clock = object : Clock {
+        override fun nowMs() = 0L
+        override fun nowNs() = 0L
+    }
 
-    // ── reading-only / cross-device ebook ────────────────────────────────────────────
+    private fun coordinator(
+        peer: FakePeer,
+        ebookEp: CatalogSyncEndpoint = CatalogSyncEndpoint(peer, "abs-item", durationSec = 100.0),
+        audioEp: CatalogSyncEndpoint? = CatalogSyncEndpoint(peer, "abs-item", durationSec = 100.0),
+    ) = ReaderSyncCoordinator(state, translator, clock, ebookEp, audioEp)
 
     @Test
     fun `a newer audiobook position wins the cycle and the reader jumps to it`() = runTest {
-        // The two ABS peers reconcile (no Storyteller). A fresher audiobook position (95s → 0.9) wins
-        // over an older local reading position and jumps the reader (ADR 0029).
-        val abs = FakeAbs(NetworkServerProgress(ebookLocation = "", currentTime = 95.0, duration = 100.0, lastUpdate = 5_000L))
-
-        val result = coordinator(abs).runCycle(locator(0.2), localUpdatedAt = 1_000L)
+        val peer = FakePeer(CatalogProgress("abs-item", ebookLocation = "", audioCurrentTime = 95.0, audioDuration = 100.0, lastUpdate = 5_000L))
+        val result = coordinator(peer).runCycle(locator(0.2), localUpdatedAt = 1_000L)
 
         assertNotNull(result.jumpLocatorJson)
         assertEquals(0.9, JSONObject(result.jumpLocatorJson!!).getJSONObject("locations").getDouble("progression"), 1e-9)
@@ -110,121 +114,84 @@ class ReaderSyncCoordinatorTest {
     }
 
     @Test
-    fun `when local is newest there is no jump and every ABS peer gets the reading position`() = runTest {
-        val abs = FakeAbs(NetworkServerProgress(ebookLocation = "", lastUpdate = 0L))
-
-        val result = coordinator(abs).runCycle(locator(0.3), localUpdatedAt = 9_000L)
+    fun `when local is newest there is no jump and every peer gets the reading position`() = runTest {
+        val peer = FakePeer(CatalogProgress("abs-item", ebookLocation = "", lastUpdate = 0L))
+        val result = coordinator(peer).runCycle(locator(0.3), localUpdatedAt = 9_000L)
 
         assertNull(result.jumpLocatorJson)
-        assertNotNull("ABS ebook received the first write", abs.ebookPatch)
-        assertTrue(abs.ebookPatch!!.ebookLocation.startsWith("epubcfi("))
-        // Reading advances the audiobook too: the page (0.3) translates through the bundle SMIL to the
-        // fragment narrated at 0.2 → its absolute clip start (5s). The raw audio clock is never used.
-        assertNotNull("the cycle writes the audiobook from the page", abs.audioPatch)
-        assertEquals(5.0, abs.audioPatch!!.currentTime, 1e-9)
+        assertNotNull("ebook peer received a write", peer.ebookLocation)
+        assertTrue(peer.ebookLocation!!.startsWith("epubcfi("))
+        assertNotNull("the cycle writes the audiobook from the page", peer.audioCurrentTime)
+        assertEquals(5.0, peer.audioCurrentTime!!, 1e-9)
     }
-
-    // ── inbound audiobook (the feature) ─────────────────────────────────────────────
 
     @Test
     fun `a genuinely newer audiobook listened elsewhere wins and jumps the reader to the bundle page`() = runTest {
-        // Another device left the audiobook at 95s (→ progression 0.9) with a fresh timestamp; the
-        // local reading position is at the start and older. Inbound audiobook must win and move the
-        // reader to the bundle-translated page — "server updates reflected locally".
-        val abs = FakeAbs(NetworkServerProgress(ebookLocation = "", currentTime = 95.0, duration = 100.0, lastUpdate = 9_999L))
-
-        val result = coordinator(abs).runCycle(locator(0.0), localUpdatedAt = 1_000L)
+        val peer = FakePeer(CatalogProgress("abs-item", ebookLocation = "", audioCurrentTime = 95.0, audioDuration = 100.0, lastUpdate = 9_999L))
+        val result = coordinator(peer).runCycle(locator(0.0), localUpdatedAt = 1_000L)
 
         assertNotNull("a newer audiobook must move the reader", result.jumpLocatorJson)
         assertEquals(0.9, JSONObject(result.jumpLocatorJson!!).getJSONObject("locations").getDouble("progression"), 1e-9)
-        // The win propagates to the ebook, whose write the server stamps even later; the cycle adopts
-        // that stamp so the propagated ebook doesn't bounce back next cycle.
         assertTrue("the winning timestamp is at least the audiobook's", result.canonicalLastUpdate >= 9_999L)
-        assertNotNull("the ebook is moved to the listened position", abs.ebookPatch)
-        // The ebook progress is computed from the chapter char weights (0.9 here), NOT cleared to 0 —
-        // a remote-sourced position has no totalProgression on it.
-        assertEquals("ebook progress must not be cleared", 0.9, abs.ebookPatch!!.ebookProgress.toDouble(), 1e-6)
+        assertNotNull("the ebook is moved to the listened position", peer.ebookLocation)
+        assertEquals("ebook progress must not be cleared", 0.9, peer.ebookProgress?.toDouble() ?: 0.0, 1e-6)
     }
 
     @Test
     fun `our own audiobook push does not read back as a newer remote (feedback loop closed)`() = runTest {
-        // The exact erase mechanism: we push the audiobook (here for a near-end reading position), then
-        // a cycle runs. Without the timestamp-recording fix the audiobook reads back newer than the
-        // page and drives the ebook. With it, the caller records the push's server timestamp as
-        // localUpdatedAt, so the read comes back EQUAL and the reading position wins.
-        val abs = FakeAbs(NetworkServerProgress(ebookLocation = "", lastUpdate = 1_000L))
-        val coordinator = coordinator(abs)
+        val peer = FakePeer(CatalogProgress("abs-item", ebookLocation = "", lastUpdate = 1_000L))
+        val coordinator = coordinator(peer)
 
-        val pushStamp = coordinator.pushAudiobookProgress(locator(0.9)) // → audio 90s
+        val pushStamp = coordinator.pushAudiobookProgress(locator(0.9))
         assertNotNull(pushStamp)
-        // The caller (the ViewModel) records pushStamp as the local timestamp; simulate that here.
         val result = coordinator.runCycle(locator(0.0), localUpdatedAt = pushStamp!!)
 
         assertNull("our own push must not jump the reader", result.jumpLocatorJson)
-        // The ebook keeps the reading position (start), never the audio's near-end.
-        assertEquals("ebook stays at the reading position", 0.0, abs.ebookPatch?.ebookProgress?.toDouble() ?: 0.0, 1e-9)
+        assertEquals("ebook stays at the reading position", 0.0, peer.ebookProgress?.toDouble() ?: 0.0, 1e-9)
     }
 
     @Test
-    fun `a page written outbound must not read back as a newer server position next cycle`() = runTest {
-        // The "server always overwrites local" bug, ebook-specific: ABS stamps our ebook write with a
-        // server time LATER than the local page-turn time. If we don't adopt that timestamp, the next
-        // cycle reads our own write back as "newer" and bounces the reader to the position it just
-        // wrote. The cycle must fold the server's returned write timestamp into canonicalLastUpdate.
-        val abs = FakeAbs(NetworkServerProgress(ebookLocation = "", lastUpdate = 0L)) // server stamps writes 1000, 2000, …
-        val coordinator = coordinator(abs)
+    fun `a page written outbound must not read back as a newer position next cycle`() = runTest {
+        val peer = FakePeer(CatalogProgress("abs-item", ebookLocation = "", lastUpdate = 0L))
+        val coordinator = coordinator(peer)
 
-        // Cycle 1: local (ts 500) is newer than the empty server, so the page is written out; ABS
-        // stamps that write 1000 (> 500).
         val r1 = coordinator.runCycle(locator(0.3), localUpdatedAt = 500L)
         assertNull(r1.jumpLocatorJson)
 
-        // The ViewModel records the cycle's returned timestamp as the new local timestamp.
         val newLocal = maxOf(500L, r1.canonicalLastUpdate)
-        // Cycle 2: same reading position. Our own just-written ebook must NOT win and jump.
         val r2 = coordinator.runCycle(locator(0.3), localUpdatedAt = newLocal)
         assertNull("the just-written ebook must not read back as newer and bounce the reader", r2.jumpLocatorJson)
     }
 
-    // ── responsive audiobook-follow push (from the reading position) ─────────────────
-
     @Test
-    fun `pushAudiobookProgress writes only the audiobook item from the page and returns the server timestamp`() = runTest {
-        val abs = FakeAbs(NetworkServerProgress(ebookLocation = "", lastUpdate = 0L))
-        val ebookEp = AbsSyncEndpoint("http://abs", "t", false, "ebook-item")
-        val audioEp = AbsSyncEndpoint("http://abs", "t", false, "audiobook-item", durationSec = 39214.0)
-        val coordinator = coordinator(abs, ebookEp, audioEp)
+    fun `pushAudiobookProgress writes only the audiobook item from the page and returns the source stamp`() = runTest {
+        val peer = FakePeer(CatalogProgress("abs-item", ebookLocation = "", lastUpdate = 0L))
+        val ebookEp = CatalogSyncEndpoint(peer, "ebook-item")
+        val audioEp = CatalogSyncEndpoint(peer, "audiobook-item", durationSec = 39214.0)
+        val coordinator = coordinator(peer, ebookEp, audioEp)
 
-        val stamp = coordinator.pushAudiobookProgress(locator(0.9)) // page 0.9 → fragment f9 → 90s
+        val stamp = coordinator.pushAudiobookProgress(locator(0.9))
 
         assertNotNull("a successful push returns the server timestamp", stamp)
-        assertEquals(90.0, abs.audioPatch!!.currentTime, 1e-9)
-        assertEquals(39214.0, abs.audioPatch!!.duration, 1e-9)
-        assertEquals("audiobook-item", abs.audioPatchItemId)
-        // Derived from the page, never the raw audio clock; the ebook is never touched.
-        assertNull(abs.ebookPatch)
-        assertNull(abs.ebookPatchItemId)
+        assertEquals(90.0, peer.audioCurrentTime!!, 1e-9)
+        assertEquals(39214.0, peer.audioDuration!!, 1e-9)
+        assertNull(peer.ebookLocation)
     }
 
     @Test
     fun `pushAudiobookProgress is a no-op when there is no matched audiobook`() = runTest {
-        val abs = FakeAbs(NetworkServerProgress(ebookLocation = "", lastUpdate = 0L))
-        val ebookEp = AbsSyncEndpoint("http://abs", "t", false, "ebook-item")
-        val coordinator = coordinator(abs, ebookEp, audioEp = null)
+        val peer = FakePeer(CatalogProgress("abs-item", ebookLocation = "", lastUpdate = 0L))
+        val ebookEp = CatalogSyncEndpoint(peer, "ebook-item")
+        val coordinator = coordinator(peer, ebookEp, audioEp = null)
 
         assertNull(coordinator.pushAudiobookProgress(locator(0.9)))
-        assertNull(abs.audioPatch)
+        assertNull(peer.audioCurrentTime)
     }
-
-    // ── audio-led cycle (the audiobook player drives it; ADR 0029) ───────────────────
 
     @Test
     fun `audio-led — a newer position elsewhere wins and the player seeks to its audio second`() = runTest {
-        // Another device left the audiobook at 95s (→ progression 0.9) with a fresh timestamp; the
-        // local listen is near the start (5s) and stale. The audio-led cycle must surface
-        // jumpToAudioSec so the player seeks there — 0.9 maps back through the SMIL to the f9 clip (90s).
-        val abs = FakeAbs(NetworkServerProgress(ebookLocation = "", currentTime = 95.0, duration = 100.0, lastUpdate = 9_999L))
-        val coordinator = coordinator(abs)
+        val peer = FakePeer(CatalogProgress("abs-item", ebookLocation = "", audioCurrentTime = 95.0, audioDuration = 100.0, lastUpdate = 9_999L))
+        val coordinator = coordinator(peer)
 
         val r = coordinator.runAudioLedCycle(currentAudioSec = 5.0, localUpdatedAt = 1_000L)
 
@@ -234,88 +201,59 @@ class ReaderSyncCoordinatorTest {
     }
 
     @Test
-    fun `audio-led — when the listen is newest there is no seek and both ABS peers get the listen position`() = runTest {
-        val abs = FakeAbs(NetworkServerProgress(ebookLocation = "", lastUpdate = 0L))
-        val coordinator = coordinator(abs)
+    fun `audio-led — when the listen is newest there is no seek and both peers get the listen position`() = runTest {
+        val peer = FakePeer(CatalogProgress("abs-item", ebookLocation = "", lastUpdate = 0L))
+        val coordinator = coordinator(peer)
 
-        // Listening at 90s (→ fragment f9 → progression 0.9), local is the freshest.
         val r = coordinator.runAudioLedCycle(currentAudioSec = 90.0, localUpdatedAt = 9_000L)
 
         assertNull("our own listen must not seek the player", r.jumpToAudioSec)
-        assertNotNull("the ebook is advanced from the listen position", abs.ebookPatch)
-        assertTrue(abs.ebookPatch!!.ebookLocation.startsWith("epubcfi("))
-        assertNotNull("the audiobook is written from the listen position", abs.audioPatch)
-        assertEquals(90.0, abs.audioPatch!!.currentTime, 1e-9)
+        assertNotNull("the ebook is advanced from the listen position", peer.ebookLocation)
+        assertTrue(peer.ebookLocation!!.startsWith("epubcfi("))
+        assertNotNull("the audiobook is written from the listen position", peer.audioCurrentTime)
+        assertEquals(90.0, peer.audioCurrentTime!!, 1e-9)
     }
 
     @Test
     fun `audio-led — our own write does not read back as newer and re-seek next cycle (feedback closed)`() = runTest {
-        val abs = FakeAbs(NetworkServerProgress(ebookLocation = "", lastUpdate = 0L))
-        val coordinator = coordinator(abs)
+        val peer = FakePeer(CatalogProgress("abs-item", ebookLocation = "", lastUpdate = 0L))
+        val coordinator = coordinator(peer)
 
         val r1 = coordinator.runAudioLedCycle(currentAudioSec = 90.0, localUpdatedAt = 500L)
         assertNull(r1.jumpToAudioSec)
-        // The ViewModel adopts the returned timestamp; our just-written position must not bounce back.
         val r2 = coordinator.runAudioLedCycle(currentAudioSec = 90.0, localUpdatedAt = maxOf(500L, r1.canonicalLastUpdate))
         assertNull("our own just-written position must not re-seek the player", r2.jumpToAudioSec)
     }
 
-    // ── split libraries (distinct ebook / audiobook items) ──────────────────────────
-
     @Test
-    fun `split libraries route ebook progress and the push to their own item ids`() = runTest {
-        val abs = FakeAbs(NetworkServerProgress(ebookLocation = "", lastUpdate = 0L))
-        val ebookEp = AbsSyncEndpoint("http://abs", "t", false, "ebook-item")
-        val audioEp = AbsSyncEndpoint("http://abs", "t", false, "audiobook-item", durationSec = 100.0)
-        val coordinator = coordinator(abs, ebookEp, audioEp)
-
-        coordinator.runCycle(locator(0.3), localUpdatedAt = 9_000L)
-        coordinator.pushAudiobookProgress(locator(0.3))
-
-        assertEquals("ebook progress goes to the ebook item", "ebook-item", abs.ebookPatchItemId)
-        assertTrue("the cycle reads the ebook item", "ebook-item" in abs.getProgressItemIds)
-        assertTrue("the cycle reconciles the audiobook item", "audiobook-item" in abs.getProgressItemIds)
-        assertEquals("audiobook writes target the audiobook item", "audiobook-item", abs.audioPatchItemId)
-    }
-
-    // ── teardown-time flush survives "close, then leave right away" ──────────────────
-    // The bug: the close/pause audiobook push was launched on the screen's viewModelScope, so leaving
-    // the book / player the instant after closing cancelled the in-flight ABS PATCH and nothing
-    // reached the server. Routed through ProgressFlushScope, the PATCH must complete regardless.
-
-    @Test
-    fun `closing readaloud flushes the exact narrated sentence to ABS even when the reader is torn down at once`() = runTest {
-        val abs = FakeAbs(NetworkServerProgress(ebookLocation = "", lastUpdate = 0L))
-        val coordinator = coordinator(abs)
+    fun `closing readaloud flushes the exact narrated sentence to the source even when the reader is torn down at once`() = runTest {
+        val peer = FakePeer(CatalogProgress("abs-item", ebookLocation = "", lastUpdate = 0L))
+        val coordinator = coordinator(peer)
         val flusher = ProgressFlushScope(TestApplicationScope(CoroutineScope(StandardTestDispatcher(testScheduler) + SupervisorJob())))
 
-        // closeReadaloud(): fire the precise audiobook push (narrated fragment f9 → 90s) on the flush
-        // scope, then the user immediately leaves the book — cancelling the reader's viewModelScope.
         val viewModelScope = CoroutineScope(StandardTestDispatcher(testScheduler) + Job())
         viewModelScope.launch { flusher.flush { coordinator.pushAudiobookForFragment("f9", null) } }
         advanceTimeBy(1)
         viewModelScope.cancel()
 
         advanceUntilIdle()
-        assertNotNull("the audiobook position must reach ABS despite teardown", abs.audioPatch)
-        assertEquals("the precise narrated sentence (f9 clip start) is synced", 90.0, abs.audioPatch!!.currentTime, 1e-9)
+        assertNotNull("the audiobook position must reach the source despite teardown", peer.audioCurrentTime)
+        assertEquals("the precise narrated sentence (f9 clip start) is synced", 90.0, peer.audioCurrentTime!!, 1e-9)
     }
 
     @Test
-    fun `the audiobook player's stop flush reaches ABS through the survivable scope after onCleared`() = runTest {
-        val abs = FakeAbs(NetworkServerProgress(ebookLocation = "", lastUpdate = 0L))
-        val coordinator = coordinator(abs)
+    fun `the audiobook player's stop flush reaches the source through the survivable scope after onCleared`() = runTest {
+        val peer = FakePeer(CatalogProgress("abs-item", ebookLocation = "", lastUpdate = 0L))
+        val coordinator = coordinator(peer)
         val flusher = ProgressFlushScope(TestApplicationScope(CoroutineScope(StandardTestDispatcher(testScheduler) + SupervisorJob())))
 
-        // The audiobook player's pushProgressOnStop runs an audio-led cycle (listen at 90s). On the
-        // player's onCleared the viewModelScope is already cancelled, so it must run on the flush scope.
         val viewModelScope = CoroutineScope(StandardTestDispatcher(testScheduler) + Job())
         viewModelScope.launch { flusher.flush { coordinator.runAudioLedCycle(currentAudioSec = 90.0, localUpdatedAt = 9_000L) } }
         advanceTimeBy(1)
         viewModelScope.cancel()
 
         advanceUntilIdle()
-        assertNotNull("the listen position must reach ABS despite teardown", abs.audioPatch)
-        assertEquals(90.0, abs.audioPatch!!.currentTime, 1e-9)
+        assertNotNull("the listen position must reach the source despite teardown", peer.audioCurrentTime)
+        assertEquals(90.0, peer.audioCurrentTime!!, 1e-9)
     }
 }

--- a/core/catalog/src/main/kotlin/com/riffle/core/catalog/AudiobookMediaCapability.kt
+++ b/core/catalog/src/main/kotlin/com/riffle/core/catalog/AudiobookMediaCapability.kt
@@ -4,6 +4,21 @@ interface AudiobookMediaCapability : CatalogCapability {
     suspend fun getTracks(itemId: String): List<CatalogAudioTrack>
     suspend fun getFingerprint(itemId: String): CatalogAudioFingerprint
 
-    /** Direct streaming URL for a specific track. Independent of any open reading session. */
+    /** Direct streaming URL for a specific track. Includes any auth token needed for playback. */
     fun buildStreamUrl(itemId: String, trackIno: String): String
+
+    /**
+     * Open a playable audiobook session for [itemId]. Returns tracks (with playable URLs baked in),
+     * chapters, and the server's last-known position + lastUpdate stamp — one composite call so a
+     * repository can spin up a media3 stream + last-update-wins reconciler in one round-trip.
+     * Returns `null` when the item has no audiobook or the session cannot be opened.
+     */
+    suspend fun openAudiobook(itemId: String, deviceLabel: String): CatalogAudiobookStream?
+
+    /**
+     * Chapter markers for [itemId]'s audiobook, without opening a playback session. Populates the
+     * local chapter cache eagerly on the library detail screen. Returns empty when the item has no
+     * audiobook chapters (rare — most audiobooks carry at least one).
+     */
+    suspend fun getAudiobookChapters(itemId: String): List<CatalogAudiobookChapter>
 }

--- a/core/catalog/src/main/kotlin/com/riffle/core/catalog/AudiobookMediaCapability.kt
+++ b/core/catalog/src/main/kotlin/com/riffle/core/catalog/AudiobookMediaCapability.kt
@@ -2,7 +2,9 @@ package com.riffle.core.catalog
 
 interface AudiobookMediaCapability : CatalogCapability {
     suspend fun getTracks(itemId: String): List<CatalogAudioTrack>
-    suspend fun getFingerprint(itemId: String): CatalogAudioFingerprint
+    /** Returns `null` when the item carries no audiobook on this Source (distinct from a fetch
+     *  failure, which throws). Callers persist the NO_AUDIOBOOK verdict definitively on null. */
+    suspend fun getFingerprint(itemId: String): CatalogAudioFingerprint?
 
     /** Direct streaming URL for a specific track. Includes any auth token needed for playback. */
     fun buildStreamUrl(itemId: String, trackIno: String): String

--- a/core/catalog/src/main/kotlin/com/riffle/core/catalog/BookmarksCapability.kt
+++ b/core/catalog/src/main/kotlin/com/riffle/core/catalog/BookmarksCapability.kt
@@ -1,0 +1,19 @@
+package com.riffle.core.catalog
+
+/**
+ * Server-side audiobook bookmarks. Sources that keep bookmarks per-item on the server (ABS)
+ * implement this so the local set-reconciler can pull the remote set and push local mutations.
+ */
+interface BookmarksCapability : CatalogCapability {
+    /** All bookmarks the current user has on this Source across every item. */
+    suspend fun listAllBookmarks(): List<CatalogBookmark>
+
+    /** Create a new bookmark on [itemId] at [timeSec] with [title]. */
+    suspend fun createBookmark(itemId: String, timeSec: Int, title: String): CatalogBookmark
+
+    /** Delete the bookmark on [itemId] at [timeSec]. */
+    suspend fun deleteBookmark(itemId: String, timeSec: Int)
+
+    /** Rename the bookmark on [itemId] at [timeSec]. */
+    suspend fun renameBookmark(itemId: String, timeSec: Int, newTitle: String): CatalogBookmark
+}

--- a/core/catalog/src/main/kotlin/com/riffle/core/catalog/Catalog.kt
+++ b/core/catalog/src/main/kotlin/com/riffle/core/catalog/Catalog.kt
@@ -45,6 +45,21 @@ interface Catalog {
     /** Openable handle for [itemId] in [format]. Throws on unsupported [format]. */
     suspend fun fetchFile(itemId: String, format: BookFormat): CatalogFileHandle
 
+    /**
+     * Open a byte stream over [itemId] in [format]. Encapsulates Source-specific transport
+     * concerns (auth headers, self-signed TLS trust, local file access) so callers only see bytes.
+     * Caller must [CatalogFileStream.close] the returned stream. Throws on unsupported [format].
+     *
+     * [handleHint] is a Source-specific opaque identifier that lets the Catalog skip a lookup when
+     * the caller already knows it (e.g. ABS's `ebookFileIno` persisted on the local library row).
+     * `null` means "resolve it yourself".
+     */
+    suspend fun openFile(
+        itemId: String,
+        format: BookFormat,
+        handleHint: String? = null,
+    ): CatalogFileStream
+
     /** Reachability + server-side identifiers; safe to call unauthenticated. */
     suspend fun connectivityCheck(): CatalogHealth
 }

--- a/core/catalog/src/main/kotlin/com/riffle/core/catalog/CatalogAudioFingerprint.kt
+++ b/core/catalog/src/main/kotlin/com/riffle/core/catalog/CatalogAudioFingerprint.kt
@@ -3,10 +3,12 @@ package com.riffle.core.catalog
 /**
  * A stable identity for an item's audio content. Used by cross-Source audio identity resolution
  * (matching a Storyteller bundle to an ABS audiobook, for instance). Shape mirrors ABS's audio
- * fingerprint payload; other backends fill what they can.
+ * fingerprint payload; other backends fill what they can (LocalFiles reports the concatenated file
+ * size, streaming-only backends may report 0 and rely on duration alone).
  */
 data class CatalogAudioFingerprint(
     val itemId: String,
+    val fileSizeBytes: Long,
     val totalDurationSec: Double,
     val trackDurations: List<Double>,
 )

--- a/core/catalog/src/main/kotlin/com/riffle/core/catalog/CatalogAudiobookStream.kt
+++ b/core/catalog/src/main/kotlin/com/riffle/core/catalog/CatalogAudiobookStream.kt
@@ -1,0 +1,21 @@
+package com.riffle.core.catalog
+
+/**
+ * A playable audiobook stream: track URLs (auth baked in), chapter markers, current server-side
+ * position, and the last-update timestamp for last-writer-wins reconciliation (ADR 0029).
+ */
+data class CatalogAudiobookStream(
+    val trackUrls: List<String>,
+    val tracks: List<CatalogAudioTrack>,
+    val chapters: List<CatalogAudiobookChapter>,
+    val totalDurationSec: Double,
+    val serverCurrentTimeSec: Double,
+    val serverLastUpdate: Long,
+)
+
+data class CatalogAudiobookChapter(
+    val index: Int,
+    val startSec: Double,
+    val endSec: Double,
+    val title: String,
+)

--- a/core/catalog/src/main/kotlin/com/riffle/core/catalog/CatalogBookmark.kt
+++ b/core/catalog/src/main/kotlin/com/riffle/core/catalog/CatalogBookmark.kt
@@ -1,0 +1,12 @@
+package com.riffle.core.catalog
+
+/**
+ * A named audiobook bookmark on a Source. Cross-source, cross-device set semantics; the reconciler
+ * unions this Source's set with the local set (last-writer-wins on delete conflicts).
+ */
+data class CatalogBookmark(
+    val itemId: String,
+    val timeSec: Int,
+    val title: String,
+    val createdAt: Long,
+)

--- a/core/catalog/src/main/kotlin/com/riffle/core/catalog/CatalogCollection.kt
+++ b/core/catalog/src/main/kotlin/com/riffle/core/catalog/CatalogCollection.kt
@@ -5,4 +5,6 @@ data class CatalogCollection(
     val rootId: String,
     val name: String,
     val bookCount: Int,
+    /** Ordered item ids in the collection; empty when the caller asked for summary only. */
+    val itemIds: List<String> = emptyList(),
 )

--- a/core/catalog/src/main/kotlin/com/riffle/core/catalog/CatalogFactory.kt
+++ b/core/catalog/src/main/kotlin/com/riffle/core/catalog/CatalogFactory.kt
@@ -1,0 +1,23 @@
+package com.riffle.core.catalog
+
+import com.riffle.core.domain.Source
+import com.riffle.core.domain.SourceType
+
+/**
+ * Builds a [Catalog] for a specific [Source] row. Because per-Source configuration (base URL, auth
+ * token, insecure-connection flag) is bound at construction time (see e.g. `AbsCatalogConfig`), a
+ * single Hilt map entry (`Map<SourceType, CatalogFactory>`) cannot itself be `Map<SourceType, Catalog>`
+ * — one factory per SourceType is registered, and [CatalogRegistry] materialises the per-Source
+ * instance when the active Source is known.
+ */
+interface CatalogFactory {
+    /** Which Source type this factory serves. Mirrors [Catalog.sourceType]. */
+    val sourceType: SourceType
+
+    /**
+     * Build a Catalog for [source]. Returns `null` when the Source cannot yet be spoken to (e.g. an
+     * ABS Source with no stored token because login hasn't completed) — a first-class state that
+     * repositories translate into an empty result.
+     */
+    suspend fun create(source: Source): Catalog?
+}

--- a/core/catalog/src/main/kotlin/com/riffle/core/catalog/CatalogFileStream.kt
+++ b/core/catalog/src/main/kotlin/com/riffle/core/catalog/CatalogFileStream.kt
@@ -1,0 +1,16 @@
+package com.riffle.core.catalog
+
+import java.io.Closeable
+import java.io.InputStream
+
+/**
+ * A byte stream over a Catalog item's file, returned by [Catalog.openFile]. Owns the underlying
+ * transport resource (network socket, file handle) — the caller must [close] it once done.
+ *
+ * [contentLength] is `-1` when the source cannot report a length up-front (chunked HTTP responses,
+ * pipes) — callers that need a total for progress reporting should treat that as "unknown".
+ */
+interface CatalogFileStream : Closeable {
+    val contentLength: Long
+    fun byteStream(): InputStream
+}

--- a/core/catalog/src/main/kotlin/com/riffle/core/catalog/CatalogItem.kt
+++ b/core/catalog/src/main/kotlin/com/riffle/core/catalog/CatalogItem.kt
@@ -19,6 +19,8 @@ data class CatalogItem(
     val ebookFileIno: String? = null,
     val description: String? = null,
     val seriesName: String? = null,
+    /** Position within [seriesName] when the item belongs to a series (e.g. "1", "2.5"). */
+    val seriesSequence: String? = null,
     val publishedYear: String? = null,
     val genres: List<String> = emptyList(),
     val publisher: String? = null,
@@ -26,4 +28,12 @@ data class CatalogItem(
     val addedAt: Long? = null,
     val isbn: String? = null,
     val asin: String? = null,
+    /**
+     * Optional server-reported "how far through" fraction (0..1). Only populated by non-progress
+     * paths that return items with server-side progress joined (e.g. some catalog list endpoints).
+     * Repositories that need authoritative progress consult [ProgressPeerCapability] instead.
+     */
+    val readingProgress: Float? = null,
+    /** Last time this item was updated on the source (used to bust cover-image CDN caches). */
+    val updatedAt: Long? = null,
 )

--- a/core/catalog/src/main/kotlin/com/riffle/core/catalog/CatalogPlaylist.kt
+++ b/core/catalog/src/main/kotlin/com/riffle/core/catalog/CatalogPlaylist.kt
@@ -5,4 +5,6 @@ data class CatalogPlaylist(
     val rootId: String,
     val name: String,
     val bookCount: Int,
+    /** Ordered item ids in the playlist; empty when the caller asked for summary only. */
+    val itemIds: List<String> = emptyList(),
 )

--- a/core/catalog/src/main/kotlin/com/riffle/core/catalog/CatalogProgress.kt
+++ b/core/catalog/src/main/kotlin/com/riffle/core/catalog/CatalogProgress.kt
@@ -3,6 +3,9 @@ package com.riffle.core.catalog
 /**
  * A progress record returned by a [ProgressPeerCapability] peer. Ebook and audiobook progress
  * share the same envelope so callers can reconcile against one stream.
+ *
+ * [finishedAt] carries the "when did this book finish" timestamp so the library UI's "Finished"
+ * badge stays server-accurate; [isFinished] is the derived boolean.
  */
 data class CatalogProgress(
     val itemId: String,
@@ -11,5 +14,6 @@ data class CatalogProgress(
     val audioCurrentTime: Double = 0.0,
     val audioDuration: Double = 0.0,
     val isFinished: Boolean = false,
+    val finishedAt: Long? = null,
     val lastUpdate: Long,
 )

--- a/core/catalog/src/main/kotlin/com/riffle/core/catalog/CatalogRegistry.kt
+++ b/core/catalog/src/main/kotlin/com/riffle/core/catalog/CatalogRegistry.kt
@@ -1,0 +1,24 @@
+package com.riffle.core.catalog
+
+import com.riffle.core.domain.Source
+
+/**
+ * Resolves the [Catalog] to consult for a given [Source]. Backed by a `Map<SourceType, CatalogFactory>`
+ * registered at Hilt time (see `CatalogModule`) — every SourceType is served by exactly one
+ * factory, and each factory builds one [Catalog] per Source row.
+ *
+ * Repositories call [forActive] for the browsing-scoped default (the Source the user is currently
+ * viewing) or [forSource] / [forSourceId] to target a specific Source (e.g. an open reader that
+ * outlives a Source switch, an item pinned to a particular Source). Returns `null` when the target
+ * Source no longer exists, is missing credentials, or has no factory registered for its type.
+ */
+interface CatalogRegistry {
+    /** Catalog for the active Source, or `null` when there is none or credentials are missing. */
+    suspend fun forActive(): Catalog?
+
+    /** Catalog for a specific Source row. */
+    suspend fun forSource(source: Source): Catalog?
+
+    /** Catalog for a Source resolved by id, or `null` when the row no longer exists. */
+    suspend fun forSourceId(sourceId: String): Catalog?
+}

--- a/core/catalog/src/main/kotlin/com/riffle/core/catalog/CatalogSeries.kt
+++ b/core/catalog/src/main/kotlin/com/riffle/core/catalog/CatalogSeries.kt
@@ -1,9 +1,21 @@
 package com.riffle.core.catalog
 
+/**
+ * An entry in a [CatalogSeries]: an item id paired with its position within the series (e.g. "1",
+ * "2.5"). Kept flat rather than embedding a full [CatalogItem] because the refresher pairs entries
+ * against the already-materialised item rows.
+ */
+data class CatalogSeriesEntry(
+    val itemId: String,
+    val sequence: String?,
+)
+
 data class CatalogSeries(
     val id: String,
     val rootId: String,
     val name: String,
     val coverUrl: String?,
     val bookCount: Int,
+    /** Ordered entries in the series (server-order); empty when the caller asked for summary only. */
+    val items: List<CatalogSeriesEntry> = emptyList(),
 )

--- a/core/catalog/src/main/kotlin/com/riffle/core/catalog/DefaultCatalogRegistry.kt
+++ b/core/catalog/src/main/kotlin/com/riffle/core/catalog/DefaultCatalogRegistry.kt
@@ -1,0 +1,29 @@
+package com.riffle.core.catalog
+
+import com.riffle.core.domain.Source
+import com.riffle.core.domain.SourceRepository
+import com.riffle.core.domain.SourceType
+
+/**
+ * Default [CatalogRegistry] implementation: looks the active/target [Source] up in
+ * [SourceRepository] and delegates to the [CatalogFactory] registered for the Source's
+ * [Source.type]. Catalogs are cheap and stateless; we build a fresh one per call rather than cache,
+ * so credential changes (token rotation on re-login, insecure-connection toggle) always take effect
+ * on the next resolution without any cache-invalidation bookkeeping.
+ */
+class DefaultCatalogRegistry(
+    private val factories: Map<SourceType, CatalogFactory>,
+    private val sourceRepository: SourceRepository,
+) : CatalogRegistry {
+
+    override suspend fun forActive(): Catalog? =
+        sourceRepository.getActive()?.let { forSource(it) }
+
+    override suspend fun forSourceId(sourceId: String): Catalog? =
+        sourceRepository.getById(sourceId)?.let { forSource(it) }
+
+    override suspend fun forSource(source: Source): Catalog? {
+        val factory = factories[source.type] ?: return null
+        return factory.create(source)
+    }
+}

--- a/core/catalog/src/main/kotlin/com/riffle/core/catalog/ProgressPeerCapability.kt
+++ b/core/catalog/src/main/kotlin/com/riffle/core/catalog/ProgressPeerCapability.kt
@@ -4,6 +4,11 @@ package com.riffle.core.catalog
  * A peer that stores per-item reading/listening progress and can be synced against. Ebook and
  * audiobook progress use separate push endpoints because backends model them separately (ADR 0029);
  * pull returns a unified [CatalogProgress] envelope for reconciliation.
+ *
+ * Push methods return the source-side timestamp the write was stored under (mirrors ABS's PATCH
+ * response) so callers can adopt it as `localUpdatedAt` — critical for last-update-wins
+ * reconciliation (ADR 0008 / 0030). Returns `null` (or `0L`) if the source can't report a stamp;
+ * callers substitute the client clock.
  */
 interface ProgressPeerCapability : CatalogCapability {
     suspend fun pushEbookProgress(
@@ -12,7 +17,7 @@ interface ProgressPeerCapability : CatalogCapability {
         progress: Float,
         isFinished: Boolean,
         lastUpdateEpochMs: Long,
-    )
+    ): Long?
 
     suspend fun pushAudiobookProgress(
         itemId: String,
@@ -20,7 +25,7 @@ interface ProgressPeerCapability : CatalogCapability {
         durationSec: Double,
         isFinished: Boolean,
         lastUpdateEpochMs: Long,
-    )
+    ): Long?
 
     suspend fun pullProgress(itemId: String): CatalogProgress?
 

--- a/core/catalog/src/main/kotlin/com/riffle/core/catalog/ProgressPeerCapability.kt
+++ b/core/catalog/src/main/kotlin/com/riffle/core/catalog/ProgressPeerCapability.kt
@@ -11,11 +11,17 @@ package com.riffle.core.catalog
  * callers substitute the client clock.
  */
 interface ProgressPeerCapability : CatalogCapability {
+    /**
+     * [isFinished] is tri-state: `null` = leave the item-level finished flag untouched (this is
+     * the common case — routine reader-position saves must not touch the audio dimension of ABS's
+     * shared media-progress record); `true`/`false` = explicitly set/clear it (only mark-finished
+     * / mark-unread callers pass a non-null value).
+     */
     suspend fun pushEbookProgress(
         itemId: String,
         location: String,
         progress: Float,
-        isFinished: Boolean,
+        isFinished: Boolean?,
         lastUpdateEpochMs: Long,
     ): Long?
 
@@ -23,7 +29,7 @@ interface ProgressPeerCapability : CatalogCapability {
         itemId: String,
         currentTimeSec: Double,
         durationSec: Double,
-        isFinished: Boolean,
+        isFinished: Boolean?,
         lastUpdateEpochMs: Long,
     ): Long?
 

--- a/core/catalog/src/main/kotlin/com/riffle/core/catalog/abs/AbsCatalog.kt
+++ b/core/catalog/src/main/kotlin/com/riffle/core/catalog/abs/AbsCatalog.kt
@@ -2,17 +2,23 @@ package com.riffle.core.catalog.abs
 
 import com.riffle.core.catalog.AudiobookMediaCapability
 import com.riffle.core.catalog.BookFormat
+import com.riffle.core.catalog.BookmarksCapability
 import com.riffle.core.catalog.Catalog
 import com.riffle.core.catalog.CatalogAudioFingerprint
 import com.riffle.core.catalog.CatalogAudioTrack
+import com.riffle.core.catalog.CatalogAudiobookChapter
+import com.riffle.core.catalog.CatalogAudiobookStream
+import com.riffle.core.catalog.CatalogBookmark
 import com.riffle.core.catalog.CatalogCollection
 import com.riffle.core.catalog.CatalogFileHandle
+import com.riffle.core.catalog.CatalogFileStream
 import com.riffle.core.catalog.CatalogHealth
 import com.riffle.core.catalog.CatalogItem
 import com.riffle.core.catalog.CatalogPlaylist
 import com.riffle.core.catalog.CatalogProgress
 import com.riffle.core.catalog.CatalogRoot
 import com.riffle.core.catalog.CatalogSeries
+import com.riffle.core.catalog.CatalogSeriesEntry
 import com.riffle.core.catalog.CatalogSessionHandle
 import com.riffle.core.catalog.CatalogStats
 import com.riffle.core.catalog.CollectionsCapability
@@ -35,14 +41,17 @@ import com.riffle.core.network.AbsPlaybackApi
 import com.riffle.core.network.AbsServerInfoApi
 import com.riffle.core.network.AbsSessionApi
 import com.riffle.core.network.NetworkAbsAudioTrack
+import com.riffle.core.network.NetworkAbsBookmark
 import com.riffle.core.network.NetworkAudiobookProgressPayload
 import com.riffle.core.network.NetworkCollection
 import com.riffle.core.network.NetworkEbookProgressPayload
 import com.riffle.core.network.NetworkLibrary
 import com.riffle.core.network.NetworkLibraryItem
 import com.riffle.core.network.NetworkPlaylist
+import com.riffle.core.network.NetworkResult
 import com.riffle.core.network.NetworkSeries
 import com.riffle.core.network.NetworkServerProgress
+import com.riffle.core.network.errorAsThrowable
 
 /**
  * The ABS-backed [Catalog] implementation. Wraps the existing ABS HTTP client (split across
@@ -71,6 +80,7 @@ class AbsCatalog(
     ReadingSessionsCapability,
     StatsCapability,
     AudiobookMediaCapability,
+    BookmarksCapability,
     OfflineBrowseCapability {
 
     override val sourceType: SourceType = SourceType.ABS
@@ -134,6 +144,32 @@ class AbsCatalog(
         }
     }
 
+    override suspend fun openFile(
+        itemId: String,
+        format: BookFormat,
+        handleHint: String?,
+    ): CatalogFileStream {
+        return when (format) {
+            BookFormat.Epub, BookFormat.Pdf -> {
+                val ino = handleHint?.takeIf { it.isNotEmpty() }
+                    ?: libraryApi.getItemEbookFileIno(config.baseUrl, itemId, config.token, config.insecureAllowed).unwrap()
+                val body = when (val r = libraryApi.downloadEpub(config.baseUrl, itemId, ino, config.token, config.insecureAllowed)) {
+                    is NetworkResult.Success -> r.value
+                    else -> throw CatalogException.Unknown(r.errorAsThrowable())
+                }
+                object : CatalogFileStream {
+                    override val contentLength: Long = body.contentLength()
+                    override fun byteStream(): java.io.InputStream = body.byteStream()
+                    override fun close() { body.close() }
+                }
+            }
+            BookFormat.Audiobook -> throw CatalogException.UnsupportedFormat(
+                "Audiobook file streams are per-track — use AudiobookMediaCapability.buildStreamUrl",
+            )
+            BookFormat.Unsupported -> throw CatalogException.UnsupportedFormat("Cannot open Unsupported format")
+        }
+    }
+
     override suspend fun connectivityCheck(): CatalogHealth {
         // AbsApiClient.getServerInfo swallows failures and returns null on any error, so we can't
         // surface a specific error string — reachability collapses to (version != null).
@@ -173,9 +209,12 @@ class AbsCatalog(
                 ebookFileIno = book.ebookFileIno,
                 description = book.description,
                 seriesName = book.seriesName,
+                seriesSequence = book.sequence,
                 publishedYear = book.publishedYear,
                 genres = book.genres,
                 publisher = book.publisher,
+                readingProgress = book.readingProgress,
+                updatedAt = book.updatedAt,
             )
         }
     }
@@ -286,6 +325,7 @@ class AbsCatalog(
                     audioCurrentTime = 0.0,
                     audioDuration = 0.0,
                     isFinished = p.finishedAt != null,
+                    finishedAt = p.finishedAt,
                     lastUpdate = p.lastUpdate ?: 0L,
                 )
             }
@@ -346,13 +386,99 @@ class AbsCatalog(
             ?: throw CatalogException.Unknown(IllegalStateException("Item $itemId has no audiobook"))
         return CatalogAudioFingerprint(
             itemId = itemId,
+            fileSizeBytes = fp.fileSizeBytes,
             totalDurationSec = fp.durationSec,
             trackDurations = fp.trackDurationsSec,
         )
     }
 
-    override fun buildStreamUrl(itemId: String, trackIno: String): String =
-        AbsAudioUrl.track(config.baseUrl, itemId, trackIno)
+    override suspend fun getAudiobookChapters(itemId: String): List<CatalogAudiobookChapter> {
+        val detail = when (val r = libraryApi.getItemDetail(config.baseUrl, itemId, config.token, config.insecureAllowed)) {
+            is NetworkResult.Success -> r.value
+            else -> return emptyList()
+        }
+        return detail.media.chapters.mapIndexed { i, c ->
+            CatalogAudiobookChapter(index = i, startSec = c.startSec, endSec = c.endSec, title = c.title)
+        }
+    }
+
+    override fun buildStreamUrl(itemId: String, trackIno: String): String {
+        val base = AbsAudioUrl.track(config.baseUrl, itemId, trackIno)
+        val sep = if (base.contains("?")) "&" else "?"
+        return "$base${sep}token=${config.token}"
+    }
+
+    override suspend fun openAudiobook(itemId: String, deviceLabel: String): CatalogAudiobookStream? {
+        val session = when (
+            val r = playbackApi.openPlaybackSession(config.baseUrl, itemId, config.deviceId, config.token, config.insecureAllowed)
+        ) {
+            is NetworkResult.Success -> r.value
+            else -> return null
+        }
+        if (session.tracks.isEmpty()) return null
+
+        val baseTrimmed = config.baseUrl.trimEnd('/')
+        val trackUrls = session.tracks.map { t ->
+            val path = if (t.contentUrl.startsWith("/")) t.contentUrl else "/${t.contentUrl}"
+            val sep = if (t.contentUrl.contains("?")) "&" else "?"
+            "$baseTrimmed$path${sep}token=${config.token}"
+        }
+        val tracks = session.tracks.map { t ->
+            CatalogAudioTrack(
+                ino = t.contentUrl.substringAfterLast("/"),
+                index = t.index,
+                startOffsetSec = t.startOffsetSec,
+                durationSec = t.durationSec,
+                contentUrl = "$baseTrimmed${if (t.contentUrl.startsWith("/")) t.contentUrl else "/${t.contentUrl}"}",
+                mimeType = t.mimeType,
+            )
+        }
+        val chapters = session.chapters.mapIndexed { i, c ->
+            CatalogAudiobookChapter(index = i, startSec = c.startSec, endSec = c.endSec, title = c.title)
+        }
+        val serverLastUpdate = (
+            sessionApi.getProgress(config.baseUrl, itemId, config.token, config.insecureAllowed) as? NetworkResult.Success
+        )?.value?.lastUpdate ?: 0L
+
+        return CatalogAudiobookStream(
+            trackUrls = trackUrls,
+            tracks = tracks,
+            chapters = chapters,
+            totalDurationSec = session.durationSec,
+            serverCurrentTimeSec = session.currentTimeSec,
+            serverLastUpdate = serverLastUpdate,
+        )
+    }
+
+    // endregion
+
+    // region BookmarksCapability
+
+    override suspend fun listAllBookmarks(): List<CatalogBookmark> =
+        bookmarkApi.listBookmarks(config.baseUrl, config.token, config.insecureAllowed)
+            .unwrap()
+            .map { it.toCatalogBookmark() }
+
+    override suspend fun createBookmark(itemId: String, timeSec: Int, title: String): CatalogBookmark =
+        bookmarkApi.createBookmark(config.baseUrl, itemId, timeSec, title, config.token, config.insecureAllowed)
+            .unwrap()
+            .toCatalogBookmark()
+
+    override suspend fun deleteBookmark(itemId: String, timeSec: Int) {
+        bookmarkApi.deleteBookmark(config.baseUrl, itemId, timeSec, config.token, config.insecureAllowed).unwrap()
+    }
+
+    override suspend fun renameBookmark(itemId: String, timeSec: Int, newTitle: String): CatalogBookmark =
+        bookmarkApi.updateBookmark(config.baseUrl, itemId, timeSec, newTitle, config.token, config.insecureAllowed)
+            .unwrap()
+            .toCatalogBookmark()
+
+    private fun NetworkAbsBookmark.toCatalogBookmark(): CatalogBookmark = CatalogBookmark(
+        itemId = libraryItemId,
+        timeSec = timeSec,
+        title = title,
+        createdAt = createdAt,
+    )
 
     // endregion
 
@@ -387,6 +513,8 @@ class AbsCatalog(
         addedAt = addedAt,
         isbn = isbn,
         asin = asin,
+        readingProgress = readingProgress,
+        updatedAt = updatedAt,
     )
 
     private fun NetworkSeries.toCatalogSeries(): CatalogSeries = CatalogSeries(
@@ -395,6 +523,7 @@ class AbsCatalog(
         name = name,
         coverUrl = items.firstOrNull()?.let { coverUrl(it.id, it.updatedAt) },
         bookCount = bookCount,
+        items = items.map { CatalogSeriesEntry(itemId = it.id, sequence = it.sequence) },
     )
 
     private fun NetworkCollection.toCatalogCollection(): CatalogCollection = CatalogCollection(
@@ -402,6 +531,7 @@ class AbsCatalog(
         rootId = libraryId,
         name = name,
         bookCount = bookCount,
+        itemIds = items.map { it.id },
     )
 
     private fun NetworkPlaylist.toCatalogPlaylist(): CatalogPlaylist = CatalogPlaylist(
@@ -409,6 +539,7 @@ class AbsCatalog(
         rootId = libraryId,
         name = name,
         bookCount = bookCount,
+        itemIds = items.map { it.id },
     )
 
     private fun NetworkServerProgress.toCatalogProgress(itemId: String): CatalogProgress = CatalogProgress(

--- a/core/catalog/src/main/kotlin/com/riffle/core/catalog/abs/AbsCatalog.kt
+++ b/core/catalog/src/main/kotlin/com/riffle/core/catalog/abs/AbsCatalog.kt
@@ -277,15 +277,13 @@ class AbsCatalog(
         progress: Float,
         isFinished: Boolean,
         lastUpdateEpochMs: Long,
-    ) {
-        sessionApi.syncEbookProgress(
-            config.baseUrl,
-            itemId,
-            NetworkEbookProgressPayload(ebookLocation = location, ebookProgress = progress, isFinished = isFinished),
-            config.token,
-            config.insecureAllowed,
-        ).unwrap()
-    }
+    ): Long? = sessionApi.syncEbookProgress(
+        config.baseUrl,
+        itemId,
+        NetworkEbookProgressPayload(ebookLocation = location, ebookProgress = progress, isFinished = isFinished),
+        config.token,
+        config.insecureAllowed,
+    ).unwrap()
 
     override suspend fun pushAudiobookProgress(
         itemId: String,
@@ -293,13 +291,10 @@ class AbsCatalog(
         durationSec: Double,
         isFinished: Boolean,
         lastUpdateEpochMs: Long,
-    ) {
+    ): Long? {
         // ABS derives finished-state server-side from progress==1.0 for audiobook records (ADR 0029),
-        // so the `isFinished` param is captured for capability parity but not forwarded here. A
-        // Source that needs to explicitly signal "mark finished at t<duration" would have to send
-        // the ebook side of the shared media-progress record (see `pushEbookProgress`) with the
-        // same itemId — see project_mark_read_unread_audiobook_bug for the shape of that path.
-        sessionApi.syncAudiobookProgress(
+        // so the `isFinished` param is captured for capability parity but not forwarded here.
+        return sessionApi.syncAudiobookProgress(
             config.baseUrl,
             itemId,
             NetworkAudiobookProgressPayload(currentTime = currentTimeSec, duration = durationSec),

--- a/core/catalog/src/main/kotlin/com/riffle/core/catalog/abs/AbsCatalog.kt
+++ b/core/catalog/src/main/kotlin/com/riffle/core/catalog/abs/AbsCatalog.kt
@@ -275,11 +275,14 @@ class AbsCatalog(
         itemId: String,
         location: String,
         progress: Float,
-        isFinished: Boolean,
+        isFinished: Boolean?,
         lastUpdateEpochMs: Long,
     ): Long? = sessionApi.syncEbookProgress(
         config.baseUrl,
         itemId,
+        // Leave `isFinished` nullable through to the payload: null = leave the audio dimension of
+        // ABS's shared media-progress record untouched. Non-null zeroes the audio side per
+        // NetworkEbookProgressPayload's contract — only mark-read/mark-unread callers do that.
         NetworkEbookProgressPayload(ebookLocation = location, ebookProgress = progress, isFinished = isFinished),
         config.token,
         config.insecureAllowed,
@@ -289,7 +292,7 @@ class AbsCatalog(
         itemId: String,
         currentTimeSec: Double,
         durationSec: Double,
-        isFinished: Boolean,
+        isFinished: Boolean?,
         lastUpdateEpochMs: Long,
     ): Long? {
         // ABS derives finished-state server-side from progress==1.0 for audiobook records (ADR 0029),
@@ -304,8 +307,12 @@ class AbsCatalog(
     }
 
     override suspend fun pullProgress(itemId: String): CatalogProgress? {
+        // A successful GET always yields a CatalogProgress (fields may all be empty for a
+        // never-touched item — callers detect that via `lastUpdate <= 0L`). A network failure
+        // surfaces as a thrown [CatalogException] from `unwrap()`; the peer-adapter's runCatching
+        // treats that as "unreachable" and returns null. Collapsing "reachable-empty" to null here
+        // would make the two states indistinguishable and drop the first push on a fresh book.
         val p = sessionApi.getProgress(config.baseUrl, itemId, config.token, config.insecureAllowed).unwrap()
-        if (p.lastUpdate == 0L && p.ebookLocation.isEmpty() && p.currentTime == 0.0) return null
         return p.toCatalogProgress(itemId)
     }
 
@@ -376,9 +383,12 @@ class AbsCatalog(
         }
     }
 
-    override suspend fun getFingerprint(itemId: String): CatalogAudioFingerprint {
+    override suspend fun getFingerprint(itemId: String): CatalogAudioFingerprint? {
+        // A successful GET with no audiobook is a first-class outcome (Success(null) on the
+        // network layer) — surface it as null so the caller persists a definitive NO_AUDIOBOOK
+        // verdict rather than re-fingerprinting on every open. Network failures still throw.
         val fp: AudiobookFingerprint = libraryApi.getAudiobookFingerprint(config.baseUrl, itemId, config.token, config.insecureAllowed).unwrap()
-            ?: throw CatalogException.Unknown(IllegalStateException("Item $itemId has no audiobook"))
+            ?: return null
         return CatalogAudioFingerprint(
             itemId = itemId,
             fileSizeBytes = fp.fileSizeBytes,

--- a/core/catalog/src/main/kotlin/com/riffle/core/catalog/abs/AbsCatalogFactory.kt
+++ b/core/catalog/src/main/kotlin/com/riffle/core/catalog/abs/AbsCatalogFactory.kt
@@ -1,0 +1,54 @@
+package com.riffle.core.catalog.abs
+
+import com.riffle.core.catalog.Catalog
+import com.riffle.core.catalog.CatalogFactory
+import com.riffle.core.domain.SourceType
+import com.riffle.core.domain.Clock
+import com.riffle.core.domain.DeviceIdStore
+import com.riffle.core.domain.Source
+import com.riffle.core.domain.TokenStorage
+import com.riffle.core.network.AbsBookmarkApi
+import com.riffle.core.network.AbsLibraryApi
+import com.riffle.core.network.AbsPlaybackApi
+import com.riffle.core.network.AbsServerInfoApi
+import com.riffle.core.network.AbsSessionApi
+
+/**
+ * Builds an [AbsCatalog] per ABS Source row. The token comes from [TokenStorage]; if the row has
+ * no stored token (fresh Source that hasn't completed login yet, credentials wiped) [create]
+ * returns null so callers up the chain treat the Source as unreachable without crashing.
+ */
+class AbsCatalogFactory(
+    private val libraryApi: AbsLibraryApi,
+    private val playbackApi: AbsPlaybackApi,
+    private val sessionApi: AbsSessionApi,
+    private val bookmarkApi: AbsBookmarkApi,
+    private val serverInfoApi: AbsServerInfoApi,
+    private val tokenStorage: TokenStorage,
+    private val deviceIdStore: DeviceIdStore,
+    private val clock: Clock,
+) : CatalogFactory {
+
+    override val sourceType: SourceType = SourceType.ABS
+
+    override suspend fun create(source: Source): Catalog? {
+        val token = tokenStorage.getToken(source.id) ?: return null
+        val deviceId = deviceIdStore.getOrCreate()
+        val config = AbsCatalogConfig(
+            baseUrl = source.url.value,
+            token = token,
+            insecureAllowed = source.insecureConnectionAllowed,
+            deviceId = deviceId,
+        )
+        return AbsCatalog(
+            config = config,
+            libraryApi = libraryApi,
+            playbackApi = playbackApi,
+            sessionApi = sessionApi,
+            bookmarkApi = bookmarkApi,
+            serverInfoApi = serverInfoApi,
+            clock = clock,
+        )
+    }
+}
+

--- a/core/catalog/src/test/kotlin/com/riffle/core/catalog/abs/AbsCatalogTest.kt
+++ b/core/catalog/src/test/kotlin/com/riffle/core/catalog/abs/AbsCatalogTest.kt
@@ -595,10 +595,10 @@ class AbsCatalogTest {
         }
     }
 
-    @Test fun `buildStreamUrl mirrors AbsAudioUrl track pattern`() {
+    @Test fun `buildStreamUrl mirrors AbsAudioUrl track pattern and bakes the auth token in`() {
         val url = catalog.buildStreamUrl(itemId = "it-1", trackIno = "a")
 
-        assertEquals("https://abs.example.com/api/items/it-1/file/a", url)
+        assertEquals("https://abs.example.com/api/items/it-1/file/a?token=T", url)
     }
 
     // endregion

--- a/core/catalog/src/test/kotlin/com/riffle/core/catalog/abs/AbsCatalogTest.kt
+++ b/core/catalog/src/test/kotlin/com/riffle/core/catalog/abs/AbsCatalogTest.kt
@@ -381,12 +381,15 @@ class AbsCatalogTest {
 
     // region ProgressPeerCapability
 
-    @Test fun `pushEbookProgress sends location progress and isFinished`() = runTest {
+    @Test fun `pushEbookProgress with isFinished=null leaves the audio dimension untouched (routine save)`() = runTest {
+        // Regression: forwarding `false` here would zero ABS's audio currentTime+progress per
+        // NetworkEbookProgressPayload's contract, clobbering audiobook progress on every ordinary
+        // reader position save. Only mark-finished / mark-unread callers pass a non-null value.
         catalog.pushEbookProgress(
             itemId = "it-1",
             location = "epubcfi(/6/4)",
             progress = 0.5f,
-            isFinished = false,
+            isFinished = null,
             lastUpdateEpochMs = 42L,
         )
 
@@ -394,7 +397,18 @@ class AbsCatalogTest {
         val payload = sessionApi.lastEbookPushPayload!!
         assertEquals("epubcfi(/6/4)", payload.ebookLocation)
         assertEquals(0.5f, payload.ebookProgress)
-        assertEquals(false, payload.isFinished)
+        assertEquals(null, payload.isFinished)
+    }
+
+    @Test fun `pushEbookProgress with isFinished=true forwards the flag (mark-finished)`() = runTest {
+        catalog.pushEbookProgress(
+            itemId = "it-1",
+            location = "epubcfi(/6/4)",
+            progress = 1.0f,
+            isFinished = true,
+            lastUpdateEpochMs = 42L,
+        )
+        assertEquals(true, sessionApi.lastEbookPushPayload!!.isFinished)
     }
 
     @Test fun `pushAudiobookProgress sends currentTime and duration`() = runTest {
@@ -402,7 +416,7 @@ class AbsCatalogTest {
             itemId = "it-1",
             currentTimeSec = 120.5,
             durationSec = 3600.0,
-            isFinished = false,
+            isFinished = null,
             lastUpdateEpochMs = 42L,
         )
 
@@ -411,12 +425,15 @@ class AbsCatalogTest {
         assertEquals(3600.0, sessionApi.lastAudiobookPushPayload!!.duration, 0.0)
     }
 
-    @Test fun `pullProgress returns null on empty ABS record`() = runTest {
+    @Test fun `pullProgress returns a reachable-empty CatalogProgress (lastUpdate=0) rather than null`() = runTest {
+        // Distinct from a null on network failure — an empty record means "reachable but never
+        // touched", so the caller can push the first position on this device instead of skipping.
         sessionApi.progressForItem["it-1"] = NetworkServerProgress(ebookLocation = "", lastUpdate = 0L)
 
-        val result = catalog.pullProgress(itemId = "it-1")
+        val result = catalog.pullProgress(itemId = "it-1")!!
 
-        assertNull(result)
+        assertEquals(0L, result.lastUpdate)
+        assertEquals(null, result.ebookLocation) // toCatalogProgress collapses "" → null
     }
 
     @Test fun `pullProgress maps a non-empty ABS record`() = runTest {
@@ -580,19 +597,15 @@ class AbsCatalogTest {
 
         val fp = catalog.getFingerprint(itemId = "it-1")
 
-        assertEquals("it-1", fp.itemId)
+        assertEquals("it-1", fp!!.itemId)
         assertEquals(3600.0, fp.totalDurationSec, 0.0)
         assertEquals(listOf(1800.0, 1800.0), fp.trackDurations)
     }
 
-    @Test fun `getFingerprint throws Unknown when item has no audiobook`() = runTest {
+    @Test fun `getFingerprint returns null when item has no audiobook (definitive NO_AUDIOBOOK verdict)`() = runTest {
         libraryApi.fingerprints["it-1"] = null
 
-        try {
-            catalog.getFingerprint(itemId = "it-1")
-            fail("expected CatalogException.Unknown")
-        } catch (_: CatalogException.Unknown) {
-        }
+        assertEquals(null, catalog.getFingerprint(itemId = "it-1"))
     }
 
     @Test fun `buildStreamUrl mirrors AbsAudioUrl track pattern and bakes the auth token in`() {

--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -39,6 +39,7 @@ dependencies {
     implementation(project(":core:domain"))
     implementation(project(":core:network"))
     implementation(project(":core:database"))
+    implementation(project(":core:catalog"))
     implementation(libs.androidx.work.runtime.ktx)
     implementation(libs.androidx.lifecycle.process)
     implementation(libs.androidx.datastore.preferences)

--- a/core/data/src/main/kotlin/com/riffle/core/data/AbsProgressRemoteFactory.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/AbsProgressRemoteFactory.kt
@@ -1,16 +1,18 @@
 package com.riffle.core.data
 
+import com.riffle.core.catalog.CatalogRegistry
+import com.riffle.core.catalog.ProgressPeerCapability
 import com.riffle.core.database.LibraryItemDao
+import com.riffle.core.domain.Clock
 import com.riffle.core.domain.EbookCfiTranslatorFactory
 import com.riffle.core.domain.ProgressRemote
-import com.riffle.core.domain.Source
-import com.riffle.core.network.AbsSessionApi
 import javax.inject.Inject
 
 /**
- * Builds the ABS [ProgressRemote]s, sourcing the auxiliary metadata each PATCH needs from the
- * locally-persisted `library_items` row (the ebook progress fraction / the audio duration), so the
- * sweep can push without re-reading it from the network (ADR 0030).
+ * Builds the [ProgressRemote]s the sweep consumes, resolving each Source's Catalog through
+ * [CatalogRegistry] and demanding [ProgressPeerCapability] before returning a remote. Sources
+ * without a capability (LocalFiles today) are non-syncable — the factory returns null and the
+ * sweep drops the (source, item) pair.
  *
  * For ebook items, [translatorFactory] produces a per-item CFI↔Locator converter (ADR 0013): the
  * converter translates ABS's `epubcfi(...)` to Readium Locator JSON on GET and back on PATCH, so
@@ -18,21 +20,30 @@ import javax.inject.Inject
  * returns null and the remote defers (leaves the row dirty) rather than writing a raw CFI.
  */
 class AbsProgressRemoteFactory @Inject constructor(
-    private val api: AbsSessionApi,
+    private val catalogRegistry: CatalogRegistry,
     private val libraryItemDao: LibraryItemDao,
     private val translatorFactory: EbookCfiTranslatorFactory,
+    private val clock: Clock,
 ) : ProgressRemoteFactory {
 
-    override fun ebook(source: Source, token: String, itemId: String): ProgressRemote<String> =
-        AbsEbookProgressRemote(
-            api, source.url.value, token, source.insecureConnectionAllowed, itemId,
-            translator = translatorFactory.forItem(source.id, itemId),
-        ) {
-            libraryItemDao.getById(source.id, itemId)?.readingProgress ?: 0f
-        }
+    override suspend fun ebook(sourceId: String, itemId: String): ProgressRemote<String>? {
+        val peer = catalogRegistry.forSourceId(sourceId) as? ProgressPeerCapability ?: return null
+        return CatalogEbookProgressRemote(
+            peer = peer,
+            itemId = itemId,
+            translator = translatorFactory.forItem(sourceId, itemId),
+            readingProgress = { libraryItemDao.getById(sourceId, itemId)?.readingProgress ?: 0f },
+            clock = clock,
+        )
+    }
 
-    override fun audio(source: Source, token: String, itemId: String): ProgressRemote<Double> =
-        AbsAudioProgressRemote(api, source.url.value, token, source.insecureConnectionAllowed, itemId) {
-            libraryItemDao.getById(source.id, itemId)?.audioDurationSec ?: 0.0
-        }
+    override suspend fun audio(sourceId: String, itemId: String): ProgressRemote<Double>? {
+        val peer = catalogRegistry.forSourceId(sourceId) as? ProgressPeerCapability ?: return null
+        return CatalogAudioProgressRemote(
+            peer = peer,
+            itemId = itemId,
+            duration = { libraryItemDao.getById(sourceId, itemId)?.audioDurationSec ?: 0.0 },
+            clock = clock,
+        )
+    }
 }

--- a/core/data/src/main/kotlin/com/riffle/core/data/AbsProgressRemotes.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/AbsProgressRemotes.kt
@@ -39,15 +39,14 @@ class CatalogEbookProgressRemote(
         val t = translator ?: return null
         val cfi = t.locatorJsonToCfi(position) ?: return null
         return runCatching {
-            val now = clock.nowMs()
-            peer.pushEbookProgress(
+            val stamp = peer.pushEbookProgress(
                 itemId = itemId,
                 location = cfi,
                 progress = readingProgress(),
                 isFinished = false,
-                lastUpdateEpochMs = now,
+                lastUpdateEpochMs = clock.nowMs(),
             )
-            now
+            stamp?.takeIf { it > 0L } ?: clock.nowMs()
         }.getOrNull()
     }
 }
@@ -72,14 +71,13 @@ class CatalogAudioProgressRemote(
 
     override suspend fun patch(position: Double): Long? =
         runCatching {
-            val now = clock.nowMs()
-            peer.pushAudiobookProgress(
+            val stamp = peer.pushAudiobookProgress(
                 itemId = itemId,
                 currentTimeSec = position,
                 durationSec = duration(),
                 isFinished = false,
-                lastUpdateEpochMs = now,
+                lastUpdateEpochMs = clock.nowMs(),
             )
-            now
+            stamp?.takeIf { it > 0L } ?: clock.nowMs()
         }.getOrNull()
 }

--- a/core/data/src/main/kotlin/com/riffle/core/data/AbsProgressRemotes.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/AbsProgressRemotes.kt
@@ -1,77 +1,85 @@
 package com.riffle.core.data
 
+import com.riffle.core.catalog.ProgressPeerCapability
+import com.riffle.core.domain.Clock
 import com.riffle.core.domain.EbookCfiTranslator
 import com.riffle.core.domain.ProgressRemote
 import com.riffle.core.domain.RemoteProgress
-import com.riffle.core.network.AbsSessionApi
-import com.riffle.core.network.NetworkAudiobookProgressPayload
-import com.riffle.core.network.NetworkEbookProgressPayload
-import com.riffle.core.network.NetworkResult
 
 /**
- * The ABS ebook media-progress record as one reconcilable target (ADR 0030). Position is stored
- * locally as Readium Locator JSON but ABS uses the epub.js `epubcfi(...)` format; [translator]
- * converts between the two at this boundary (ADR 0013). When the cached EPUB isn't available the
- * translator is null: GET returns null (Offline — row left dirty) and PATCH is skipped (PushFailed
- * — row left dirty) so no corrupt value ever enters the local store or ABS.
+ * An ebook media-progress record as one reconcilable target (ADR 0030), routed through the
+ * Source's [ProgressPeerCapability]. Position is stored locally as Readium Locator JSON, but ABS
+ * stores it as epub.js `epubcfi(...)`; [translator] converts between the two (ADR 0013). When the
+ * cached EPUB isn't available the translator is null: GET returns null (Offline — row left dirty)
+ * and PATCH is skipped (PushFailed — row left dirty) so no corrupt value ever enters either side.
  *
  * The PATCH also needs the `ebookProgress` fraction (ABS's library % + finished-detection); since
  * the local store keeps only the Locator JSON, the fraction is supplied by [readingProgress] —
  * wired by the caller to the locally-persisted `library_items.readingProgress`.
  */
-class AbsEbookProgressRemote(
-    private val api: AbsSessionApi,
-    private val baseUrl: String,
-    private val token: String,
-    private val insecureAllowed: Boolean,
+class CatalogEbookProgressRemote(
+    private val peer: ProgressPeerCapability,
     private val itemId: String,
     private val translator: EbookCfiTranslator?,
     private val readingProgress: suspend () -> Float,
+    private val clock: Clock,
 ) : ProgressRemote<String> {
 
     override suspend fun get(): RemoteProgress<String>? {
         val t = translator ?: return null
-        val r = api.getProgress(baseUrl, itemId, token, insecureAllowed)
-        if (r !is NetworkResult.Success) return null
-        val raw = r.value.ebookLocation
+        val r = runCatching { peer.pullProgress(itemId) }.getOrNull() ?: return null
+        val raw = r.ebookLocation.orEmpty()
         // ABS returns blank when the book has never been opened; skip translation so the
         // reconciler can still compare timestamps and push local progress if it's newer.
         val locatorJson = if (raw.isBlank()) "" else t.cfiToLocatorJson(raw) ?: return null
-        return RemoteProgress(locatorJson, r.value.lastUpdate)
+        return RemoteProgress(locatorJson, r.lastUpdate)
     }
 
     override suspend fun patch(position: String): Long? {
         val t = translator ?: return null
         val cfi = t.locatorJsonToCfi(position) ?: return null
-        val payload = NetworkEbookProgressPayload(ebookLocation = cfi, ebookProgress = readingProgress())
-        val r = api.syncEbookProgress(baseUrl, itemId, payload, token, insecureAllowed)
-        return (r as? NetworkResult.Success)?.value
+        return runCatching {
+            val now = clock.nowMs()
+            peer.pushEbookProgress(
+                itemId = itemId,
+                location = cfi,
+                progress = readingProgress(),
+                isFinished = false,
+                lastUpdateEpochMs = now,
+            )
+            now
+        }.getOrNull()
     }
 }
 
 /**
- * The ABS audiobook media-progress record as one reconcilable target (ADR 0030). Position is the
- * book-absolute `currentTime` in seconds. The PATCH needs the track [duration]; the local store keeps
- * only seconds, so duration is supplied by the caller from `library_items.audioDurationSec`.
+ * An audiobook media-progress record as one reconcilable target (ADR 0030), routed through the
+ * Source's [ProgressPeerCapability]. Position is the book-absolute `currentTime` in seconds. The
+ * PATCH needs the track [duration]; the local store keeps only seconds, so duration is supplied
+ * by the caller from `library_items.audioDurationSec`.
  */
-class AbsAudioProgressRemote(
-    private val api: AbsSessionApi,
-    private val baseUrl: String,
-    private val token: String,
-    private val insecureAllowed: Boolean,
+class CatalogAudioProgressRemote(
+    private val peer: ProgressPeerCapability,
     private val itemId: String,
     private val duration: suspend () -> Double,
+    private val clock: Clock,
 ) : ProgressRemote<Double> {
 
     override suspend fun get(): RemoteProgress<Double>? {
-        val r = api.getProgress(baseUrl, itemId, token, insecureAllowed)
-        if (r !is NetworkResult.Success) return null
-        return RemoteProgress(r.value.currentTime, r.value.lastUpdate)
+        val r = runCatching { peer.pullProgress(itemId) }.getOrNull() ?: return null
+        return RemoteProgress(r.audioCurrentTime, r.lastUpdate)
     }
 
-    override suspend fun patch(position: Double): Long? {
-        val payload = NetworkAudiobookProgressPayload(currentTime = position, duration = duration())
-        val r = api.syncAudiobookProgress(baseUrl, itemId, payload, token, insecureAllowed)
-        return (r as? NetworkResult.Success)?.value
-    }
+    override suspend fun patch(position: Double): Long? =
+        runCatching {
+            val now = clock.nowMs()
+            peer.pushAudiobookProgress(
+                itemId = itemId,
+                currentTimeSec = position,
+                durationSec = duration(),
+                isFinished = false,
+                lastUpdateEpochMs = now,
+            )
+            now
+        }.getOrNull()
 }

--- a/core/data/src/main/kotlin/com/riffle/core/data/AbsProgressRemotes.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/AbsProgressRemotes.kt
@@ -43,7 +43,7 @@ class CatalogEbookProgressRemote(
                 itemId = itemId,
                 location = cfi,
                 progress = readingProgress(),
-                isFinished = false,
+                isFinished = null,
                 lastUpdateEpochMs = clock.nowMs(),
             )
             stamp?.takeIf { it > 0L } ?: clock.nowMs()
@@ -75,7 +75,7 @@ class CatalogAudioProgressRemote(
                 itemId = itemId,
                 currentTimeSec = position,
                 durationSec = duration(),
-                isFinished = false,
+                isFinished = null,
                 lastUpdateEpochMs = clock.nowMs(),
             )
             stamp?.takeIf { it > 0L } ?: clock.nowMs()

--- a/core/data/src/main/kotlin/com/riffle/core/data/AudiobookBookmarkReconciler.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/AudiobookBookmarkReconciler.kt
@@ -1,18 +1,18 @@
 package com.riffle.core.data
 
+import com.riffle.core.catalog.BookmarksCapability
+import com.riffle.core.catalog.CatalogRegistry
 import com.riffle.core.database.AudiobookBookmarkDao
 import com.riffle.core.database.AudiobookBookmarkEntity
-import com.riffle.core.network.AbsBookmarkApi
-import com.riffle.core.network.NetworkResult
 import javax.inject.Inject
 import kotlin.math.roundToInt
 
 /**
- * Set-reconciler for audiobook bookmarks against Audiobookshelf (ADR 0030).
+ * Set-reconciler for audiobook bookmarks against the Source's [BookmarksCapability] (ADR 0030).
  *
- * Unlike positions (one value per item), bookmarks are a COLLECTION per (sourceId, itemId),
- * so this is a set-reconcile. ABS identity for a bookmark is (libraryItemId, time) where time
- * is INTEGER seconds — there is NO per-bookmark id, so we key local<->server matches on
+ * Unlike positions (one value per item), bookmarks are a COLLECTION per (sourceId, itemId), so
+ * this is a set-reconcile. Source identity for a bookmark is (itemId, time) where time is INTEGER
+ * seconds — there is NO per-bookmark id, so we key local<->server matches on
  * `positionSec.roundToInt() == timeSec`.
  *
  * Policy: PUSH local intent first (creates / renames / deletes), then PULL the server set to
@@ -21,7 +21,7 @@ import kotlin.math.roundToInt
  */
 class AudiobookBookmarkReconciler(
     private val dao: AudiobookBookmarkDao,
-    private val api: AbsBookmarkApi,
+    private val catalogRegistry: CatalogRegistry,
     private val now: () -> Long = System::currentTimeMillis,
     private val newId: () -> String = { java.util.UUID.randomUUID().toString() },
 ) {
@@ -30,48 +30,38 @@ class AudiobookBookmarkReconciler(
     // established pattern in this codebase (e.g. AudiobookPlayerViewModel). Tests use the primary
     // constructor with deterministic fakes.
     @Inject
-    constructor(dao: AudiobookBookmarkDao, api: AbsBookmarkApi) : this(
+    constructor(dao: AudiobookBookmarkDao, catalogRegistry: CatalogRegistry) : this(
         dao,
-        api,
+        catalogRegistry,
         System::currentTimeMillis,
         { java.util.UUID.randomUUID().toString() },
     )
 
-    suspend fun reconcile(
-        sourceId: String,
-        itemId: String,
-        baseUrl: String,
-        token: String,
-        insecureAllowed: Boolean,
-    ) {
+    suspend fun reconcile(sourceId: String, itemId: String) {
+        val catalog = catalogRegistry.forSourceId(sourceId) ?: return
+        val cap = catalog as? BookmarksCapability ?: return
+
         // --- PUSH: send each dirty row's local intent. Capture ifStamp BEFORE the network call. ---
         val dirty = dao.allForItem(sourceId, itemId).filter { it.localUpdatedAt > it.lastSyncedAt }
         for (row in dirty) {
             val ifStamp = row.localUpdatedAt
             if (row.deleted) {
-                val res = api.deleteBookmark(baseUrl, itemId, row.positionSec.roundToInt(), token, insecureAllowed)
-                if (res is NetworkResult.Success) {
-                    dao.hardDeleteIfUnchanged(row.id, ifLocalUpdatedAt = ifStamp)
-                }
+                val ok = runCatching { cap.deleteBookmark(itemId, row.positionSec.roundToInt()) }.isSuccess
+                if (ok) dao.hardDeleteIfUnchanged(row.id, ifLocalUpdatedAt = ifStamp)
                 // Any error -> leave the tombstone (retries next sweep).
             } else {
-                val res = if (row.lastSyncedAt == 0L) {
-                    api.createBookmark(baseUrl, itemId, row.positionSec.roundToInt(), row.title, token, insecureAllowed)
-                } else {
-                    api.updateBookmark(baseUrl, itemId, row.positionSec.roundToInt(), row.title, token, insecureAllowed)
-                }
-                if (res is NetworkResult.Success) {
-                    dao.confirmPushedIfUnchanged(row.id, serverStamp = now(), ifLocalUpdatedAt = ifStamp)
-                }
+                val ok = runCatching {
+                    if (row.lastSyncedAt == 0L) cap.createBookmark(itemId, row.positionSec.roundToInt(), row.title)
+                    else cap.renameBookmark(itemId, row.positionSec.roundToInt(), row.title)
+                }.isSuccess
+                if (ok) dao.confirmPushedIfUnchanged(row.id, serverStamp = now(), ifLocalUpdatedAt = ifStamp)
                 // Any error -> leave dirty.
             }
         }
 
         // --- PULL: only if we can read the server. ---
-        val listResult = api.listBookmarks(baseUrl, token, insecureAllowed)
-        val serverBookmarks = (listResult as? NetworkResult.Success)?.value ?: return
-
-        val serverForItem = serverBookmarks.filter { it.libraryItemId == itemId }
+        val remoteAll = runCatching { cap.listAllBookmarks() }.getOrNull() ?: return
+        val serverForItem = remoteAll.filter { it.itemId == itemId }
         val serverTimes = serverForItem.map { it.timeSec }.toSet()
         // Re-read local AFTER push so confirmed deletes are already gone.
         val local = dao.allForItem(sourceId, itemId)

--- a/core/data/src/main/kotlin/com/riffle/core/data/AudiobookChapterCacheRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/AudiobookChapterCacheRepositoryImpl.kt
@@ -1,18 +1,18 @@
 package com.riffle.core.data
 
+import com.riffle.core.catalog.AudiobookMediaCapability
+import com.riffle.core.catalog.CatalogRegistry
 import com.riffle.core.database.AudiobookChapterCacheDao
 import com.riffle.core.database.AudiobookChapterCacheEntity
 import com.riffle.core.domain.AudiobookChapter
 import com.riffle.core.domain.AudiobookChapterCacheRepository
-import com.riffle.core.network.AbsLibraryApi
-import com.riffle.core.network.NetworkResult
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import javax.inject.Inject
 
 class AudiobookChapterCacheRepositoryImpl @Inject constructor(
     private val dao: AudiobookChapterCacheDao,
-    private val api: AbsLibraryApi,
+    private val catalogRegistry: CatalogRegistry,
 ) : AudiobookChapterCacheRepository {
 
     private val json = Json { ignoreUnknownKeys = true }
@@ -22,23 +22,11 @@ class AudiobookChapterCacheRepositoryImpl @Inject constructor(
         return json.decodeFromString<List<AudiobookChapter>>(entity.chaptersJson)
     }
 
-    override suspend fun fetchAndCacheChapters(
-        sourceId: String,
-        itemId: String,
-        baseUrl: String,
-        token: String,
-        insecureAllowed: Boolean,
-    ): List<AudiobookChapter> {
-        val result = api.getItemDetail(baseUrl, itemId, token, insecureAllowed)
-        val response = (result as? NetworkResult.Success)?.value ?: return emptyList()
-        val chapters = response.media.chapters.mapIndexed { index, dto ->
-            AudiobookChapter(
-                index = index,
-                startSec = dto.startSec,
-                endSec = dto.endSec,
-                title = dto.title,
-            )
-        }
+    override suspend fun fetchAndCacheChapters(sourceId: String, itemId: String): List<AudiobookChapter> {
+        val catalog = catalogRegistry.forSourceId(sourceId) ?: return emptyList()
+        val audioCap = catalog as? AudiobookMediaCapability ?: return emptyList()
+        val chapters = runCatching { audioCap.getAudiobookChapters(itemId) }.getOrElse { return emptyList() }
+            .map { c -> AudiobookChapter(index = c.index, startSec = c.startSec, endSec = c.endSec, title = c.title) }
         dao.upsert(AudiobookChapterCacheEntity(sourceId, itemId, json.encodeToString(chapters)))
         return chapters
     }

--- a/core/data/src/main/kotlin/com/riffle/core/data/AudiobookIdentityResolver.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/AudiobookIdentityResolver.kt
@@ -3,17 +3,17 @@ package com.riffle.core.data
 import com.riffle.core.domain.AudiobookFingerprint
 import com.riffle.core.domain.AudiobookIdentity
 import com.riffle.core.domain.AudiobookIdentityResult
-import com.riffle.core.network.NetworkResult
 
 /**
  * Resolves the two fetched fingerprints into an [AudiobookIdentityResult] (ADR 0028). A fetch
  * failure resolves to [AudiobookIdentityResult.UNKNOWN] — never a false VERIFIED — so an offline
- * or flaky check can only ever keep a book on the (safe) bundle path.
+ * or flaky check can only ever keep a book on the (safe) bundle path. A successful fetch with no
+ * audiobook attached resolves to [AudiobookIdentityResult.NO_AUDIOBOOK].
  */
 object AudiobookIdentityResolver {
     fun resolve(
-        storyteller: NetworkResult<AudiobookFingerprint?>,
-        abs: NetworkResult<AudiobookFingerprint?>,
+        storyteller: Result<AudiobookFingerprint?>,
+        abs: Result<AudiobookFingerprint?>,
     ): AudiobookIdentityResult {
         val storytellerFp = storyteller.fingerprintOr { return it }
         val absFp = abs.fingerprintOr { return it }
@@ -24,11 +24,10 @@ object AudiobookIdentityResolver {
         }
     }
 
-    /** Either the fingerprint, or an early-return verdict for the non-success cases. */
-    private inline fun NetworkResult<AudiobookFingerprint?>.fingerprintOr(
+    private inline fun Result<AudiobookFingerprint?>.fingerprintOr(
         onNonSuccess: (AudiobookIdentityResult) -> Nothing,
-    ): AudiobookFingerprint = when (this) {
-        is NetworkResult.Success -> value ?: onNonSuccess(AudiobookIdentityResult.NO_AUDIOBOOK)
-        else -> onNonSuccess(AudiobookIdentityResult.UNKNOWN)
-    }
+    ): AudiobookFingerprint = fold(
+        onSuccess = { it ?: onNonSuccess(AudiobookIdentityResult.NO_AUDIOBOOK) },
+        onFailure = { onNonSuccess(AudiobookIdentityResult.UNKNOWN) },
+    )
 }

--- a/core/data/src/main/kotlin/com/riffle/core/data/AudiobookRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/AudiobookRepositoryImpl.kt
@@ -1,88 +1,60 @@
 package com.riffle.core.data
 
+import com.riffle.core.catalog.AudiobookMediaCapability
+import com.riffle.core.catalog.CatalogRegistry
+import com.riffle.core.catalog.ProgressPeerCapability
 import com.riffle.core.domain.AudiobookChapter
 import com.riffle.core.domain.AudiobookRepository
 import com.riffle.core.domain.AudiobookSession
 import com.riffle.core.domain.AudiobookTimeline
 import com.riffle.core.domain.AudiobookTrackSpan
-import com.riffle.core.domain.SourceRepository
-import com.riffle.core.domain.TokenStorage
-import com.riffle.core.network.AbsPlaybackApi
-import com.riffle.core.network.AbsSessionApi
-import com.riffle.core.network.NetworkAudiobookProgressPayload
-import com.riffle.core.network.NetworkResult
+import com.riffle.core.domain.Clock
 import javax.inject.Inject
 
 /**
- * Opens an ABS direct-play session (ADR 0029) and maps it to a playable [AudiobookSession]: each
- * track's server-relative `contentUrl` is turned into an absolute, token-bearing URL Media3 can
- * stream (ABS accepts the auth token as a `?token=` query param, so no custom auth data source is
- * needed). Chapter markers and durations pass straight through to the [AudiobookTimeline].
+ * Opens a Source-native direct-play audiobook session (ADR 0029) and maps it to a playable
+ * [AudiobookSession]. Track URLs come from the Source's [AudiobookMediaCapability] with any auth
+ * headers/tokens baked in. Chapter markers and durations pass straight through to [AudiobookTimeline].
  */
 class AudiobookRepositoryImpl @Inject constructor(
-    private val playbackApi: AbsPlaybackApi,
-    private val sessionApi: AbsSessionApi,
-    private val sourceRepository: SourceRepository,
-    private val tokenStorage: TokenStorage,
+    private val catalogRegistry: CatalogRegistry,
+    private val clock: Clock,
 ) : AudiobookRepository {
 
     override suspend fun openSession(sourceId: String, itemId: String): AudiobookSession? {
-        val source = sourceRepository.getById(sourceId) ?: return null
-        val token = tokenStorage.getToken(sourceId) ?: return null
-        val result = playbackApi.openPlaybackSession(
-            baseUrl = source.url.value,
-            libraryItemId = itemId,
-            deviceId = sourceId, // stable per-server device id; ABS only needs it non-empty
-            token = token,
-            insecureAllowed = source.insecureConnectionAllowed,
-        )
-        val session = (result as? NetworkResult.Success)?.value ?: return null
-        if (session.tracks.isEmpty()) return null
-
-        val base = source.url.value.trimEnd('/')
-        val trackUrls = session.tracks.map { t ->
-            val path = if (t.contentUrl.startsWith("/")) t.contentUrl else "/${t.contentUrl}"
-            val sep = if (t.contentUrl.contains("?")) "&" else "?"
-            "$base$path${sep}token=$token"
-        }
-        val spans = session.tracks.map { t ->
+        val catalog = catalogRegistry.forSourceId(sourceId) ?: return null
+        val audioCap = catalog as? AudiobookMediaCapability ?: return null
+        // deviceLabel is opaque to Riffle — ABS treats it as the session's device id.
+        val stream = audioCap.openAudiobook(itemId, deviceLabel = sourceId) ?: return null
+        val spans = stream.tracks.map { t ->
             AudiobookTrackSpan(index = t.index, startOffsetSec = t.startOffsetSec, durationSec = t.durationSec)
         }
         val timeline = AudiobookTimeline(
-            durationSec = session.durationSec,
-            chapters = session.chapters.mapIndexed { i, c ->
-                AudiobookChapter(index = i, startSec = c.startSec, endSec = c.endSec, title = c.title)
+            durationSec = stream.totalDurationSec,
+            chapters = stream.chapters.map { c ->
+                AudiobookChapter(index = c.index, startSec = c.startSec, endSec = c.endSec, title = c.title)
             },
         )
-        // Read ABS's server-side lastUpdate so the player can last-update-wins resume against the
-        // durable local store. A failed read leaves it 0 (the play-session currentTime still resumes).
-        val serverLastUpdate = (
-            sessionApi.getProgress(
-                baseUrl = source.url.value,
-                libraryItemId = itemId,
-                token = token,
-                insecureAllowed = source.insecureConnectionAllowed,
-            ) as? NetworkResult.Success
-        )?.value?.lastUpdate ?: 0L
-
         return AudiobookSession(
-            trackUrls = trackUrls,
+            trackUrls = stream.trackUrls,
             tracks = spans,
             timeline = timeline,
-            serverCurrentTimeSec = session.currentTimeSec,
-            serverLastUpdate = serverLastUpdate,
+            serverCurrentTimeSec = stream.serverCurrentTimeSec,
+            serverLastUpdate = stream.serverLastUpdate,
         )
     }
 
     override suspend fun saveProgress(sourceId: String, itemId: String, positionSec: Double, durationSec: Double) {
-        val source = sourceRepository.getById(sourceId) ?: return
-        val token = tokenStorage.getToken(sourceId) ?: return
-        sessionApi.syncAudiobookProgress(
-            baseUrl = source.url.value,
-            libraryItemId = itemId,
-            payload = NetworkAudiobookProgressPayload(currentTime = positionSec, duration = durationSec),
-            token = token,
-            insecureAllowed = source.insecureConnectionAllowed,
-        )
+        val catalog = catalogRegistry.forSourceId(sourceId) ?: return
+        val peer = catalog as? ProgressPeerCapability ?: return
+        runCatching {
+            peer.pushAudiobookProgress(
+                itemId = itemId,
+                currentTimeSec = positionSec,
+                durationSec = durationSec,
+                isFinished = durationSec > 0.0 && positionSec >= durationSec,
+                lastUpdateEpochMs = clock.nowMs(),
+            )
+        }
     }
 }

--- a/core/data/src/main/kotlin/com/riffle/core/data/AudiobookRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/AudiobookRepositoryImpl.kt
@@ -52,7 +52,9 @@ class AudiobookRepositoryImpl @Inject constructor(
                 itemId = itemId,
                 currentTimeSec = positionSec,
                 durationSec = durationSec,
-                isFinished = durationSec > 0.0 && positionSec >= durationSec,
+                // ABS derives audiobook finished-state from progress==1.0 server-side; sending
+                // isFinished here would only touch the ebook dimension of the shared record.
+                isFinished = null,
                 lastUpdateEpochMs = clock.nowMs(),
             )
         }

--- a/core/data/src/main/kotlin/com/riffle/core/data/CrossEpubIndexBuilderService.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/CrossEpubIndexBuilderService.kt
@@ -1,5 +1,7 @@
 package com.riffle.core.data
 
+import com.riffle.core.catalog.BookFormat
+import com.riffle.core.catalog.CatalogRegistry
 import com.riffle.core.data.di.EpubCacheStore
 import com.riffle.core.data.di.EpubDownloadsStore
 import com.riffle.core.domain.ApplicationScope
@@ -11,11 +13,6 @@ import com.riffle.core.domain.EpubChecksum
 import com.riffle.core.domain.EpubContentExtractor
 import com.riffle.core.domain.LocalStore
 import com.riffle.core.domain.ReadaloudLink
-import com.riffle.core.domain.Source
-import com.riffle.core.domain.SourceRepository
-import com.riffle.core.domain.TokenStorage
-import com.riffle.core.network.AbsLibraryApi
-import com.riffle.core.network.NetworkResult
 import kotlinx.coroutines.launch
 import java.io.File
 import java.util.Collections
@@ -30,20 +27,14 @@ import javax.inject.Singleton
  * checksums already exists) and degrades to *deferred* — never a partial/wrong index — when
  * a prerequisite EPUB isn't available yet.
  *
- * The ABS publisher EPUB is small and is downloaded-then-cached on the first build. The Storyteller
- * side, however, is the *synced bundle* (ADR 0023) — the full readaloud audio, hundreds of MB — so
- * this service never downloads it proactively: it builds only once that bundle is already present
- * locally (i.e. after the user has downloaded readaloud for the book). Pulling and caching one synced
- * bundle per Confirmed match in the background would fill the device's storage, starving real user
- * downloads and truncating in-flight ones. This isn't a functional regression: the canonical reconciliation cycle
- * ([ReaderSyncFactory]) already gates on that same locally-present bundle, so an index built
- * before the bundle exists could never be used anyway.
+ * The Source-side publisher EPUB is small and is downloaded-then-cached on the first build. The
+ * Storyteller side, however, is the *synced bundle* (ADR 0023) — the full readaloud audio, hundreds
+ * of MB — so this service never downloads it proactively: it builds only once that bundle is already
+ * present locally (i.e. after the user has downloaded readaloud for the book).
  */
 @Singleton
 class CrossEpubIndexBuilderService(
-    private val sourceRepository: SourceRepository,
-    private val tokenStorage: TokenStorage,
-    private val absApi: AbsLibraryApi,
+    private val catalogRegistry: CatalogRegistry,
     @EpubCacheStore private val cacheStore: LocalStore,
     @EpubDownloadsStore private val downloadsStore: LocalStore,
     private val store: CrossEpubIndexStore,
@@ -52,15 +43,13 @@ class CrossEpubIndexBuilderService(
     applicationScope: ApplicationScope,
 ) : CrossEpubIndexBuildTrigger {
     @Inject constructor(
-        sourceRepository: SourceRepository,
-        tokenStorage: TokenStorage,
-        absApi: AbsLibraryApi,
+        catalogRegistry: CatalogRegistry,
         @EpubCacheStore cacheStore: LocalStore,
         @EpubDownloadsStore downloadsStore: LocalStore,
         store: CrossEpubIndexStore,
         sidecarStore: ReadaloudSidecarStore,
         applicationScope: ApplicationScope,
-    ) : this(sourceRepository, tokenStorage, absApi, cacheStore, downloadsStore, store, sidecarStore, System::currentTimeMillis, applicationScope)
+    ) : this(catalogRegistry, cacheStore, downloadsStore, store, sidecarStore, System::currentTimeMillis, applicationScope)
 
     private val scope = applicationScope.coroutineScope
     private val inFlight = Collections.synchronizedSet(mutableSetOf<Pair<String, String>>())
@@ -88,19 +77,12 @@ class CrossEpubIndexBuilderService(
 
     private suspend fun loadInputs(link: ReadaloudLink): CrossEpubBuildInputs? {
         // Storyteller text for the index: the downloaded bundle if present, otherwise the ~1 MB sidecar
-        // (ADR 0028) — the sidecar is the Storyteller EPUB minus audio, so it feeds the index identically
-        // and lets a streamed book (no bundle) get the same three-peer sync as a bundle book. Use ONLY the
-        // already-prepared sidecar (cachedFile, non-blocking) — never fetch it here: enqueueBuild fires for
-        // every Confirmed match, so a fetch would hammer /synced with one full-bundle generation per match
-        // concurrently (observed: ~18 at once, all failing). The /synced fetch belongs to prepare-on-open,
-        // which runs one book at a time. Absent both → defer; the build re-runs once the sidecar is prepared.
+        // (ADR 0028). Use ONLY the already-prepared sidecar (cachedFile, non-blocking) — never fetch here.
         val storytellerFile = cachedFile(link.storytellerSourceId, link.storytellerBookId)
             ?: sidecarStore.cachedFile(link.storytellerSourceId, link.storytellerBookId)
             ?: return null
 
-        val absServer = sourceRepository.getById(link.absSourceId) ?: return null
-        val absToken = tokenStorage.getToken(link.absSourceId) ?: return null
-        val absFile = absEpubFile(absServer, absToken, link.absLibraryItemId) ?: return null
+        val absFile = absEpubFile(link.absSourceId, link.absLibraryItemId) ?: return null
 
         // extract() reads only the OPF + spine chapters + SMIL from the zip, and of() streams the
         // file — so the hundreds-of-MB synced bundle (ADR 0023) is never held in memory.
@@ -118,11 +100,13 @@ class CrossEpubIndexBuilderService(
     private fun cachedFile(sourceId: String, itemId: String): File? =
         downloadsStore.get(sourceId, itemId) ?: cacheStore.get(sourceId, itemId)
 
-    private suspend fun absEpubFile(source: Source, token: String, itemId: String): File? {
-        cachedFile(source.id, itemId)?.let { return it }
-        val ino = (absApi.getItemEbookFileIno(source.url.value, itemId, token, source.insecureConnectionAllowed)
-            as? NetworkResult.Success)?.value ?: return null
-        val download = absApi.downloadEpub(source.url.value, itemId, ino, token, source.insecureConnectionAllowed)
-        return (download as? NetworkResult.Success)?.value?.use { cacheStore.save(source.id, itemId, it.byteStream()) }
+    private suspend fun absEpubFile(sourceId: String, itemId: String): File? {
+        cachedFile(sourceId, itemId)?.let { return it }
+        val catalog = catalogRegistry.forSourceId(sourceId) ?: return null
+        return runCatching {
+            catalog.openFile(itemId, BookFormat.Epub).use { stream ->
+                cacheStore.save(sourceId, itemId, stream.byteStream())
+            }
+        }.getOrNull()
     }
 }

--- a/core/data/src/main/kotlin/com/riffle/core/data/EpubRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/EpubRepositoryImpl.kt
@@ -1,5 +1,7 @@
 package com.riffle.core.data
 
+import com.riffle.core.catalog.BookFormat
+import com.riffle.core.catalog.CatalogRegistry
 import com.riffle.core.domain.EpubDownloadResult
 import com.riffle.core.domain.EpubOpenResult
 import com.riffle.core.domain.EpubRepository
@@ -7,44 +9,37 @@ import com.riffle.core.domain.LibraryItem
 import com.riffle.core.domain.LocalStore
 import com.riffle.core.domain.ReadingPositionStore
 import com.riffle.core.domain.SourceRepository
-import com.riffle.core.domain.TokenStorage
-import com.riffle.core.network.AbsLibraryApi
-import com.riffle.core.network.NetworkResult
-import com.riffle.core.network.errorAsThrowable
 
 class EpubRepositoryImpl(
-    private val api: AbsLibraryApi,
+    private val catalogRegistry: CatalogRegistry,
     private val cacheStore: LocalStore,
     private val downloadsStore: LocalStore,
     private val positionStore: ReadingPositionStore,
     private val sourceRepository: SourceRepository,
-    private val tokenStorage: TokenStorage,
 ) : EpubRepository {
 
     override suspend fun openEpub(item: LibraryItem): EpubOpenResult {
-        // Resolve the item's OWN server row, not `getActive()`. A user-switch on the same URL mints
-        // a fresh server row (ServerRepositoryImpl.commit → UUID.randomUUID), leaving the previous
-        // row (and its cached files under cacheDir/epubs/<oldId>/) in place. Keying by activeServer
-        // here made the opener look under the new row's dir, miss the truly-cached file, and fall
-        // into the network branch — surfacing "unable to resolve host" when offline even though the
+        // Resolve the item's OWN Source, not the active one. A user-switch on the same URL mints a
+        // fresh source row (SourceRepositoryImpl.commit → UUID.randomUUID), leaving the previous
+        // row's cached files under cacheDir/epubs/<oldId>/ in place. Keying by activeSource here
+        // made the opener look under the new row's dir, miss the truly-cached file, and fall into
+        // the network branch — surfacing "unable to resolve host" when offline even though the
         // library detail badge (which correctly keys by item.sourceId) said the book was cached.
-        val source = sourceRepository.getById(item.sourceId)
-            ?: return EpubOpenResult.NetworkError(IllegalStateException("No server for item"))
         val local = downloadsStore.get(item.sourceId, item.id) ?: cacheStore.get(item.sourceId, item.id)
         val epubFile = if (local != null) {
             local
         } else {
-            val token = tokenStorage.getToken(source.id)
-                ?: return EpubOpenResult.NetworkError(IllegalStateException("No token for server"))
-            val ino = item.ebookFileIno ?: run {
-                val r = api.getItemEbookFileIno(source.url.value, item.id, token, source.insecureConnectionAllowed)
-                if (r is NetworkResult.Success) r.value else return EpubOpenResult.NetworkError(r.errorAsThrowable())
+            val catalog = catalogRegistry.forSourceId(item.sourceId)
+                ?: return EpubOpenResult.NetworkError(IllegalStateException("No catalog for item"))
+            try {
+                catalog.openFile(item.id, BookFormat.Epub, handleHint = item.ebookFileIno).use { stream ->
+                    cacheStore.save(item.sourceId, item.id, stream.byteStream())
+                }
+            } catch (t: Throwable) {
+                return EpubOpenResult.NetworkError(t)
             }
-            val download = api.downloadEpub(source.url.value, item.id, ino, token, source.insecureConnectionAllowed)
-            if (download !is NetworkResult.Success) return EpubOpenResult.NetworkError(download.errorAsThrowable())
-            download.value.use { body -> cacheStore.save(item.sourceId, item.id, body.byteStream()) }
         }
-        // Position load intentionally stays keyed by activeServer.id — [saveReadingPosition] also
+        // Position load intentionally stays keyed by activeSource.id — [saveReadingPosition] also
         // uses it, so this pair stays consistent within a session. Round-trip across a user-switch
         // is a separate concern tracked apart from this fix.
         val activeSource = sourceRepository.getActive()
@@ -66,23 +61,17 @@ class EpubRepositoryImpl(
             cacheStore.delete(item.sourceId, item.id)
             return EpubDownloadResult.Success
         }
-        // Same rationale as [openEpub]: resolve by item.sourceId so a user-switch (or any second
-        // ServerEntity row for the same URL) still fetches from the item's owning server.
-        val source = sourceRepository.getById(item.sourceId)
-            ?: return EpubDownloadResult.NetworkError(IllegalStateException("No server for item"))
-        val token = tokenStorage.getToken(source.id)
-            ?: return EpubDownloadResult.NetworkError(IllegalStateException("No token for server"))
-        val ino = item.ebookFileIno ?: run {
-            val r = api.getItemEbookFileIno(source.url.value, item.id, token, source.insecureConnectionAllowed)
-            if (r is NetworkResult.Success) r.value else return EpubDownloadResult.NetworkError(r.errorAsThrowable())
+        val catalog = catalogRegistry.forSourceId(item.sourceId)
+            ?: return EpubDownloadResult.NetworkError(IllegalStateException("No catalog for item"))
+        return try {
+            catalog.openFile(item.id, BookFormat.Epub, handleHint = item.ebookFileIno).use { stream ->
+                val progressStream = ProgressReportingInputStream(stream.byteStream(), stream.contentLength, onProgress)
+                downloadsStore.save(item.sourceId, item.id, progressStream)
+            }
+            EpubDownloadResult.Success
+        } catch (t: Throwable) {
+            EpubDownloadResult.NetworkError(t)
         }
-        val result = api.downloadEpub(source.url.value, item.id, ino, token, source.insecureConnectionAllowed)
-        if (result !is NetworkResult.Success) return EpubDownloadResult.NetworkError(result.errorAsThrowable())
-        result.value.use { body ->
-            val stream = ProgressReportingInputStream(body.byteStream(), body.contentLength(), onProgress)
-            downloadsStore.save(item.sourceId, item.id, stream)
-        }
-        return EpubDownloadResult.Success
     }
 
     override suspend fun removeDownload(sourceId: String, itemId: String) {

--- a/core/data/src/main/kotlin/com/riffle/core/data/LibraryRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/LibraryRepositoryImpl.kt
@@ -1,6 +1,8 @@
 package com.riffle.core.data
 
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import com.riffle.core.catalog.CatalogRegistry
+import com.riffle.core.catalog.ProgressPeerCapability
 import com.riffle.core.database.CollectionDao
 import com.riffle.core.database.CollectionEntity
 import com.riffle.core.database.CollectionItemEntity
@@ -22,11 +24,6 @@ import com.riffle.core.domain.LibraryRefreshResult
 import com.riffle.core.domain.LibraryRefresher
 import com.riffle.core.domain.Series
 import com.riffle.core.domain.SourceRepository
-import com.riffle.core.domain.TokenStorage
-import com.riffle.core.network.AbsCoverUrl
-import com.riffle.core.network.AbsLibraryApi
-import com.riffle.core.network.NetworkResult
-import com.riffle.core.network.errorAsThrowable
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
@@ -37,18 +34,17 @@ import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 
 /**
- * Slim Room/API wrapper that satisfies the three segregated library role interfaces. Cross-cutting
- * choreography (readaloud matcher / Storyteller catalogue sync / reading-session push) lives in
- * use-cases under `com.riffle.core.domain.usecase`, NOT here.
+ * Slim Room/Catalog wrapper that satisfies the three segregated library role interfaces.
+ * Cross-cutting choreography (readaloud matcher / Storyteller catalogue sync / reading-session
+ * push) lives in use-cases under `com.riffle.core.domain.usecase`, NOT here.
  */
 class LibraryRepositoryImpl @Inject constructor(
-    private val api: AbsLibraryApi,
+    private val catalogRegistry: CatalogRegistry,
     private val libraryDao: LibraryDao,
     private val libraryItemDao: LibraryItemDao,
     private val seriesDao: SeriesDao,
     private val collectionDao: CollectionDao,
     private val sourceRepository: SourceRepository,
-    private val tokenStorage: TokenStorage,
     private val clock: Clock,
 ) : LibraryObserver, LibraryMutator, LibraryRefresher {
 
@@ -65,17 +61,17 @@ class LibraryRepositoryImpl @Inject constructor(
     override fun observeLibraries(sourceId: String): Flow<List<Library>> =
         libraryDao.observeBySourceId(sourceId).map { list -> list.map { it.toDomain() } }
 
-    // Id of the Server whose libraries the user is currently browsing. The nav drawer only ever
-    // lists the active Server's libraries, so the visible library always belongs to it.
+    // Id of the Source whose libraries the user is currently browsing. The nav drawer only ever
+    // lists the active Source's libraries, so the visible library always belongs to it.
     private val activeServerId: Flow<String?> =
         sourceRepository.observeAll()
             .map { servers -> servers.firstOrNull { it.isActive }?.id }
             .distinctUntilChanged()
 
-    // Library-scoped item flows resolve the active Server's id and pass it as the DAO's primary
+    // Library-scoped item flows resolve the active Source's id and pass it as the DAO's primary
     // scope. library_items is keyed by (sourceId, id) (ADR 0025), so the query itself enforces
-    // server isolation — no post-query filter required. With no active Server the screen has
-    // nothing to show, so we emit an empty list rather than mixing data across Servers.
+    // source isolation — no post-query filter required. With no active Source the screen has
+    // nothing to show, so we emit an empty list rather than mixing data across Sources.
     @OptIn(ExperimentalCoroutinesApi::class)
     private fun scopedItemFlow(
         query: (String) -> Flow<List<LibraryItemEntity>>,
@@ -118,8 +114,8 @@ class LibraryRepositoryImpl @Inject constructor(
     override fun observeCollectionItems(collectionId: String): Flow<List<LibraryItem>> =
         scopedItemFlow { sourceId -> collectionDao.observeItemsByCollectionId(sourceId, collectionId) }
 
-    // Item ids are only unique within a Server (ADR 0025); reads/writes here target the active
-    // Server's copy, mirroring how reading positions are keyed. No active Server → nothing to do.
+    // Item ids are only unique within a Source (ADR 0025); reads/writes here target the active
+    // Source's copy, mirroring how reading positions are keyed. No active Source → nothing to do.
     override suspend fun getItem(itemId: String): LibraryItem? {
         val sourceId = sourceRepository.getActive()?.id ?: return null
         return libraryItemDao.getById(sourceId, itemId)?.toDomain()
@@ -138,8 +134,8 @@ class LibraryRepositoryImpl @Inject constructor(
     override suspend fun getItem(sourceId: String, itemId: String): LibraryItem? =
         libraryItemDao.getById(sourceId, itemId)?.toDomain()
 
-    // Library ids are only unique within a Server (issue #113); resolve against the active Server's
-    // copy, mirroring how [getItem] keys item reads. No active Server → nothing to resolve.
+    // Library ids are only unique within a Source (issue #113); resolve against the active Source's
+    // copy, mirroring how [getItem] keys item reads. No active Source → nothing to resolve.
     override suspend fun getLibrary(libraryId: String): Library? {
         val sourceId = sourceRepository.getActive()?.id ?: return null
         return libraryDao.getById(sourceId, libraryId)?.toDomain()
@@ -163,42 +159,55 @@ class LibraryRepositoryImpl @Inject constructor(
     }
 
     override suspend fun refreshLibraries(): LibraryRefreshResult {
-        val server = sourceRepository.getActive() ?: return LibraryRefreshResult.NoActiveServer
-        val token = tokenStorage.getToken(server.id) ?: return LibraryRefreshResult.NoActiveServer
-        val result = api.getLibraries(server.url.value, token, server.insecureConnectionAllowed)
-        if (result !is NetworkResult.Success) return LibraryRefreshResult.NetworkError(result.errorAsThrowable())
-        val entities = result.value
+        val source = sourceRepository.getActive() ?: return LibraryRefreshResult.NoActiveServer
+        val catalog = catalogRegistry.forSource(source) ?: return LibraryRefreshResult.NoActiveServer
+        val roots = try {
+            catalog.listRoots()
+        } catch (t: Throwable) {
+            return LibraryRefreshResult.NetworkError(t)
+        }
+        val entities = roots
             .filter { it.mediaType == "book" }
-            .map { LibraryEntity(id = it.id, name = it.name, mediaType = it.mediaType, sourceId = server.id) }
-        libraryDao.replaceAllForSource(server.id, entities)
+            .map { LibraryEntity(id = it.id, name = it.name, mediaType = it.mediaType, sourceId = source.id) }
+        libraryDao.replaceAllForSource(source.id, entities)
         return LibraryRefreshResult.Success
     }
 
     override suspend fun refreshLibraryItems(libraryId: String): LibraryRefreshResult {
-        val server = sourceRepository.getActive() ?: return LibraryRefreshResult.NoActiveServer
-        val token = tokenStorage.getToken(server.id) ?: return LibraryRefreshResult.NoActiveServer
+        val source = sourceRepository.getActive() ?: return LibraryRefreshResult.NoActiveServer
+        val catalog = catalogRegistry.forSource(source) ?: return LibraryRefreshResult.NoActiveServer
+        val progressPeer = catalog as? ProgressPeerCapability
         return coroutineScope {
             // Fire both calls simultaneously: user-progress and library items are independent
-            // requests. Total latency = max(getUserProgress, getLibraryItems) instead of their sum.
-            val progressDeferred = async { api.getUserProgress(server.url.value, token, server.insecureConnectionAllowed) }
-            val itemsDeferred = async { api.getLibraryItems(server.url.value, libraryId, token, server.insecureConnectionAllowed) }
+            // requests. Total latency = max(pullAllProgress, browse) instead of their sum.
+            val progressDeferred = async {
+                try {
+                    progressPeer?.pullAllProgress().orEmpty()
+                } catch (_: Throwable) {
+                    emptyList()
+                }
+            }
+            val itemsDeferred = async {
+                // Ask for one un-paged sweep of the library — refresh replaces the whole set.
+                runCatching { catalog.browse(libraryId, pageSize = Int.MAX_VALUE) }
+            }
 
-            val serverProgressMap = (progressDeferred.await() as? NetworkResult.Success)?.value ?: emptyMap()
-            val result = itemsDeferred.await()
-            if (result !is NetworkResult.Success) return@coroutineScope LibraryRefreshResult.NetworkError(result.errorAsThrowable())
-            val lastOpenedAtMap = libraryItemDao.getLastOpenedAtMap(server.id, libraryId).associate { it.id to it.lastOpenedAt }
-            val entities = result.value
-                .sortedByDescending { it.isSupported }
+            val serverProgressMap = progressDeferred.await().associateBy { it.itemId }
+            val itemsResult = itemsDeferred.await()
+            val items = itemsResult.getOrElse { return@coroutineScope LibraryRefreshResult.NetworkError(it) }
+            val lastOpenedAtMap = libraryItemDao.getLastOpenedAtMap(source.id, libraryId).associate { it.id to it.lastOpenedAt }
+            val entities = items
+                .sortedByDescending { it.ebookFormat != com.riffle.core.catalog.BookFormat.Unsupported }
                 .distinctBy { it.title.trim().lowercase() }
                 .map { item ->
                     val serverProgress = serverProgressMap[item.id]
                     LibraryItemEntity(
-                        sourceId = server.id,
+                        sourceId = source.id,
                         id = item.id,
-                        libraryId = item.libraryId,
+                        libraryId = item.rootId,
                         title = item.title,
                         author = item.author,
-                        coverUrl = absCoverUrl(server.url.value, item.id, item.updatedAt),
+                        coverUrl = item.coverUrl ?: "",
                         // For an audiobook-only item the ABS user-progress fallback already maps
                         // its listen fraction into `ebookProgress` (AbsApiClient: ebookProgress ?:
                         // progress), so this single field is the unified "how far through this
@@ -208,7 +217,7 @@ class LibraryRepositoryImpl @Inject constructor(
                         // new item for the first time.
                         readingProgress = serverProgress?.ebookProgress ?: item.readingProgress ?: 0f,
                         ebookFileIno = item.ebookFileIno,
-                        ebookFormat = item.ebookFormat.toStorageString(),
+                        ebookFormat = item.ebookFormat.toEbookFormat().toStorageString(),
                         hasAudio = item.hasAudio,
                         audioDurationSec = item.audioDurationSec,
                         description = item.description,
@@ -228,36 +237,38 @@ class LibraryRepositoryImpl @Inject constructor(
                         finishedAt = serverProgress?.finishedAt,
                     )
                 }
-            libraryItemDao.replaceAllForLibrary(server.id, libraryId, entities)
+            libraryItemDao.replaceAllForLibrary(source.id, libraryId, entities)
             val isUnsupported = entities.isNotEmpty() && entities.none { it.ebookFormat != EbookFormat.Unsupported.toStorageString() }
-            libraryDao.setUnsupported(server.id, libraryId, isUnsupported)
+            libraryDao.setUnsupported(source.id, libraryId, isUnsupported)
             LibraryRefreshResult.Success
         }
     }
 
     override suspend fun refreshSeries(libraryId: String): LibraryRefreshResult {
-        val server = sourceRepository.getActive() ?: return LibraryRefreshResult.NoActiveServer
-        val token = tokenStorage.getToken(server.id) ?: return LibraryRefreshResult.NoActiveServer
-        val result = api.getSeries(server.url.value, libraryId, token, server.insecureConnectionAllowed)
-        if (result !is NetworkResult.Success) return LibraryRefreshResult.NetworkError(result.errorAsThrowable())
-        val seriesEntities = result.value.map { s ->
+        val source = sourceRepository.getActive() ?: return LibraryRefreshResult.NoActiveServer
+        val catalog = catalogRegistry.forSource(source) ?: return LibraryRefreshResult.NoActiveServer
+        val seriesCap = catalog as? com.riffle.core.catalog.SeriesCapability ?: return LibraryRefreshResult.Success
+        val series = try {
+            seriesCap.listSeries(libraryId)
+        } catch (t: Throwable) {
+            return LibraryRefreshResult.NetworkError(t)
+        }
+        val seriesEntities = series.map { s ->
             SeriesEntity(
                 id = s.id,
-                libraryId = s.libraryId,
+                libraryId = s.rootId,
                 name = s.name,
-                coverUrl = s.items.firstOrNull()?.let { first ->
-                    absCoverUrl(server.url.value, first.id, first.updatedAt)
-                },
+                coverUrl = s.coverUrl,
                 bookCount = s.bookCount,
             )
         }
-        val seriesItemEntities = result.value.flatMap { s ->
-            s.items.mapIndexed { index, item ->
+        val seriesItemEntities = series.flatMap { s ->
+            s.items.mapIndexed { index, entry ->
                 SeriesItemEntity(
                     seriesId = s.id,
-                    sourceId = server.id,
-                    itemId = item.id,
-                    sequenceOrder = item.sequence?.toFloatOrNull() ?: (index + 1).toFloat(),
+                    sourceId = source.id,
+                    itemId = entry.itemId,
+                    sequenceOrder = entry.sequence?.toFloatOrNull() ?: (index + 1).toFloat(),
                 )
             }
         }
@@ -266,21 +277,25 @@ class LibraryRepositoryImpl @Inject constructor(
     }
 
     override suspend fun refreshCollections(libraryId: String): LibraryRefreshResult {
-        val server = sourceRepository.getActive() ?: return LibraryRefreshResult.NoActiveServer
-        val token = tokenStorage.getToken(server.id) ?: return LibraryRefreshResult.NoActiveServer
-        val result = api.getCollections(server.url.value, libraryId, token, server.insecureConnectionAllowed)
-        if (result !is NetworkResult.Success) return LibraryRefreshResult.NetworkError(result.errorAsThrowable())
-        val collectionEntities = result.value.map { c ->
+        val source = sourceRepository.getActive() ?: return LibraryRefreshResult.NoActiveServer
+        val catalog = catalogRegistry.forSource(source) ?: return LibraryRefreshResult.NoActiveServer
+        val collectionsCap = catalog as? com.riffle.core.catalog.CollectionsCapability ?: return LibraryRefreshResult.Success
+        val collections = try {
+            collectionsCap.listCollections(libraryId)
+        } catch (t: Throwable) {
+            return LibraryRefreshResult.NetworkError(t)
+        }
+        val collectionEntities = collections.map { c ->
             CollectionEntity(
                 id = c.id,
-                libraryId = c.libraryId,
+                libraryId = c.rootId,
                 name = c.name,
                 bookCount = c.bookCount,
             )
         }
-        val collectionItemEntities = result.value.flatMap { c ->
-            c.items.map { item ->
-                CollectionItemEntity(collectionId = c.id, sourceId = server.id, itemId = item.id)
+        val collectionItemEntities = collections.flatMap { c ->
+            c.itemIds.map { itemId ->
+                CollectionItemEntity(collectionId = c.id, sourceId = source.id, itemId = itemId)
             }
         }
         collectionDao.replaceAllForLibrary(libraryId, collectionEntities, collectionItemEntities)
@@ -330,13 +345,18 @@ class LibraryRepositoryImpl @Inject constructor(
         bookCount = bookCount,
     )
 
-    private fun absCoverUrl(baseUrl: String, itemId: String, updatedAt: Long?) =
-        AbsCoverUrl.of(baseUrl, itemId, updatedAt)
-
     private fun CollectionEntity.toDomain() = Collection(
         id = id,
         libraryId = libraryId,
         name = name,
         bookCount = bookCount,
     )
+
+    private fun com.riffle.core.catalog.BookFormat.toEbookFormat(): EbookFormat = when (this) {
+        com.riffle.core.catalog.BookFormat.Epub -> EbookFormat.Epub
+        com.riffle.core.catalog.BookFormat.Pdf -> EbookFormat.Pdf
+        com.riffle.core.catalog.BookFormat.Audiobook -> EbookFormat.Unsupported
+        com.riffle.core.catalog.BookFormat.Unsupported -> EbookFormat.Unsupported
+    }
+
 }

--- a/core/data/src/main/kotlin/com/riffle/core/data/PdfRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/PdfRepositoryImpl.kt
@@ -1,5 +1,7 @@
 package com.riffle.core.data
 
+import com.riffle.core.catalog.BookFormat
+import com.riffle.core.catalog.CatalogRegistry
 import com.riffle.core.domain.LibraryItem
 import com.riffle.core.domain.LocalStore
 import com.riffle.core.domain.PdfDownloadResult
@@ -7,26 +9,19 @@ import com.riffle.core.domain.PdfOpenResult
 import com.riffle.core.domain.PdfRepository
 import com.riffle.core.domain.ReadingPositionStore
 import com.riffle.core.domain.SourceRepository
-import com.riffle.core.domain.TokenStorage
-import com.riffle.core.network.AbsLibraryApi
-import com.riffle.core.network.NetworkResult
-import com.riffle.core.network.errorAsThrowable
 import java.io.File
 
 class PdfRepositoryImpl(
-    private val api: AbsLibraryApi,
+    private val catalogRegistry: CatalogRegistry,
     private val cacheStore: LocalStore,
     private val downloadsStore: LocalStore,
     private val positionStore: ReadingPositionStore,
     private val sourceRepository: SourceRepository,
-    private val tokenStorage: TokenStorage,
 ) : PdfRepository {
 
     override suspend fun openPdf(item: LibraryItem): PdfOpenResult {
-        // Resolve the item's OWN server row, not `getActive()`. See EpubRepositoryImpl.openEpub
+        // Resolve the item's OWN source, not the active one. See EpubRepositoryImpl.openEpub
         // for the rationale — this is the same bug on the PDF side.
-        val source = sourceRepository.getById(item.sourceId)
-            ?: return PdfOpenResult.NetworkError(IllegalStateException("No server for item"))
         val local = (downloadsStore.get(item.sourceId, item.id) ?: cacheStore.get(item.sourceId, item.id))?.takeIf { it.isValidPdf() }
         if (local == null) {
             cacheStore.delete(item.sourceId, item.id)
@@ -34,15 +29,15 @@ class PdfRepositoryImpl(
         val pdfFile = if (local != null) {
             local
         } else {
-            val token = tokenStorage.getToken(source.id)
-                ?: return PdfOpenResult.NetworkError(IllegalStateException("No token for server"))
-            val ino = item.ebookFileIno ?: run {
-                val r = api.getItemEbookFileIno(source.url.value, item.id, token, source.insecureConnectionAllowed)
-                if (r is NetworkResult.Success) r.value else return PdfOpenResult.NetworkError(r.errorAsThrowable())
+            val catalog = catalogRegistry.forSourceId(item.sourceId)
+                ?: return PdfOpenResult.NetworkError(IllegalStateException("No catalog for item"))
+            try {
+                catalog.openFile(item.id, BookFormat.Pdf, handleHint = item.ebookFileIno).use { stream ->
+                    cacheStore.save(item.sourceId, item.id, stream.byteStream())
+                }
+            } catch (t: Throwable) {
+                return PdfOpenResult.NetworkError(t)
             }
-            val result = api.downloadEpub(source.url.value, item.id, ino, token, source.insecureConnectionAllowed)
-            if (result !is NetworkResult.Success) return PdfOpenResult.NetworkError(result.errorAsThrowable())
-            result.value.use { body -> cacheStore.save(item.sourceId, item.id, body.byteStream()) }
         }
         val activeSource = sourceRepository.getActive()
         val lastPosition = activeSource?.let { positionStore.load(it.id, item.id) }
@@ -63,23 +58,17 @@ class PdfRepositoryImpl(
             cacheStore.delete(item.sourceId, item.id)
             return PdfDownloadResult.Success
         }
-        // Same rationale as [openPdf]: resolve by item.sourceId so a user-switch (or any second
-        // SourceEntity row for the same URL) still fetches from the item's owning server.
-        val source = sourceRepository.getById(item.sourceId)
-            ?: return PdfDownloadResult.NetworkError(IllegalStateException("No server for item"))
-        val token = tokenStorage.getToken(source.id)
-            ?: return PdfDownloadResult.NetworkError(IllegalStateException("No token for server"))
-        val ino = item.ebookFileIno ?: run {
-            val r = api.getItemEbookFileIno(source.url.value, item.id, token, source.insecureConnectionAllowed)
-            if (r is NetworkResult.Success) r.value else return PdfDownloadResult.NetworkError(r.errorAsThrowable())
+        val catalog = catalogRegistry.forSourceId(item.sourceId)
+            ?: return PdfDownloadResult.NetworkError(IllegalStateException("No catalog for item"))
+        return try {
+            catalog.openFile(item.id, BookFormat.Pdf, handleHint = item.ebookFileIno).use { stream ->
+                val progressStream = ProgressReportingInputStream(stream.byteStream(), stream.contentLength, onProgress)
+                downloadsStore.save(item.sourceId, item.id, progressStream)
+            }
+            PdfDownloadResult.Success
+        } catch (t: Throwable) {
+            PdfDownloadResult.NetworkError(t)
         }
-        val result = api.downloadEpub(source.url.value, item.id, ino, token, source.insecureConnectionAllowed)
-        if (result !is NetworkResult.Success) return PdfDownloadResult.NetworkError(result.errorAsThrowable())
-        result.value.use { body ->
-            val stream = ProgressReportingInputStream(body.byteStream(), body.contentLength(), onProgress)
-            downloadsStore.save(item.sourceId, item.id, stream)
-        }
-        return PdfDownloadResult.Success
     }
 
     override suspend fun removeDownload(sourceId: String, itemId: String) {

--- a/core/data/src/main/kotlin/com/riffle/core/data/ProgressSweep.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/ProgressSweep.kt
@@ -1,9 +1,9 @@
 package com.riffle.core.data
 
+import com.riffle.core.catalog.CatalogRegistry
 import com.riffle.core.domain.ProgressReconciler
 import com.riffle.core.domain.ProgressRemote
 import com.riffle.core.domain.RemoteKind
-import com.riffle.core.domain.Source
 
 /** Enumerates the dirty position rows (localUpdatedAt > lastSyncedAt) the sweep must reconcile. */
 interface DirtyProgressLedger {
@@ -12,16 +12,10 @@ interface DirtyProgressLedger {
     suspend fun dirtyAudioItems(sourceId: String): List<String>
 }
 
-/** Resolves a sourceId to its [Source] + auth token, or `null` when the source is unknown or has no
- *  valid token — in which case the sweep skips it and its rows stay dirty for a later run. */
-fun interface ServerTokenResolver {
-    suspend fun resolve(sourceId: String): Pair<Source, String>?
-}
-
-/** Builds the per-target ABS [ProgressRemote] for one (source, item). */
+/** Builds the per-target [ProgressRemote] for one (sourceId, itemId), or null when unavailable. */
 interface ProgressRemoteFactory {
-    fun ebook(source: Source, token: String, itemId: String): ProgressRemote<String>
-    fun audio(source: Source, token: String, itemId: String): ProgressRemote<Double>
+    suspend fun ebook(sourceId: String, itemId: String): ProgressRemote<String>?
+    suspend fun audio(sourceId: String, itemId: String): ProgressRemote<Double>?
 }
 
 /** Enumerates the (source, item) pairs with at least one dirty audiobook-bookmark row to reconcile. */
@@ -31,23 +25,25 @@ interface DirtyBookmarkLedger {
 }
 
 /**
- * The set-reconcile of one item's audiobook bookmarks against ABS — the sweep's seam over
- * `AudiobookBookmarkReconciler` so its orchestration stays testable without Room or the network.
+ * The set-reconcile of one item's audiobook bookmarks against the Source's bookmarks capability —
+ * the sweep's seam over `AudiobookBookmarkReconciler` so its orchestration stays testable without
+ * Room or the network.
  */
 fun interface BookmarkReconcile {
-    suspend fun reconcile(sourceId: String, itemId: String, baseUrl: String, token: String, insecureAllowed: Boolean)
+    suspend fun reconcile(sourceId: String, itemId: String)
 }
 
 /**
  * The durable, book-independent dirty sweep of ADR 0030: reconcile every dirty position row across
- * **all** servers when online, so offline progress is pushed without the book being reopened — while
+ * **all** sources when online, so offline progress is pushed without the book being reopened — while
  * a newer server position still wins (each reconcile is GET-before-PATCH). Single-target: it pushes
- * one ABS record per dirty row, never translating. Each target reconciles under its per-target lock
- * (shared with the live paths) so the worker and an open book never double-reconcile the same target.
+ * one media record per dirty row, never translating. Each target reconciles under its per-target
+ * lock (shared with the live paths) so the worker and an open book never double-reconcile the same
+ * target.
  */
 class ProgressSweep(
     private val ledger: DirtyProgressLedger,
-    private val resolver: ServerTokenResolver,
+    private val catalogRegistry: CatalogRegistry,
     private val ebookReconciler: ProgressReconciler<String>,
     private val audioReconciler: ProgressReconciler<Double>,
     private val remoteFactory: ProgressRemoteFactory,
@@ -61,29 +57,31 @@ class ProgressSweep(
         // positions) must still be reconciled, so process the union of both dirty sets (ADR 0030).
         val sources = (ledger.serversWithDirty() + bookmarkLedger.serversWithDirty()).distinct()
         for (sourceId in sources) {
-            val (source, token) = resolver.resolve(sourceId) ?: continue
+            // Skip sources whose catalog can't be resolved right now (no row, no token, or no
+            // registered factory) — rows stay dirty for the next sweep.
+            if (catalogRegistry.forSourceId(sourceId) == null) continue
             for (itemId in ledger.dirtyEbookItems(sourceId)) {
                 // Skip a book a live surface is driving — its own cycle owns inbound jumps (ADR 0030).
                 if (openTargets.isOpen(sourceId, itemId)) continue
+                val remote = remoteFactory.ebook(sourceId, itemId) ?: continue
                 locks.withLock(sourceId, itemId, RemoteKind.ABS_EBOOK) {
-                    ebookReconciler.reconcile(sourceId, itemId, remoteFactory.ebook(source, token, itemId))
+                    ebookReconciler.reconcile(sourceId, itemId, remote)
                 }
             }
             for (itemId in ledger.dirtyAudioItems(sourceId)) {
                 if (openTargets.isOpen(sourceId, itemId)) continue
+                val remote = remoteFactory.audio(sourceId, itemId) ?: continue
                 locks.withLock(sourceId, itemId, RemoteKind.ABS_AUDIO) {
-                    audioReconciler.reconcile(sourceId, itemId, remoteFactory.audio(source, token, itemId))
+                    audioReconciler.reconcile(sourceId, itemId, remote)
                 }
             }
             for (itemId in bookmarkLedger.dirtyItems(sourceId)) {
-                // Same open-book discipline as the audio pass: an open book's bookmarks reconcile once
-                // it closes. ABS_BOOKMARK is its own lock kind, so it never contends with the position
-                // passes for the same item.
+                // Same open-book discipline as the audio pass: an open book's bookmarks reconcile
+                // once it closes. ABS_BOOKMARK is its own lock kind, so it never contends with the
+                // position passes for the same item.
                 if (openTargets.isOpen(sourceId, itemId)) continue
                 locks.withLock(sourceId, itemId, RemoteKind.ABS_BOOKMARK) {
-                    bookmarkReconcile.reconcile(
-                        sourceId, itemId, source.url.value, token, source.insecureConnectionAllowed,
-                    )
+                    bookmarkReconcile.reconcile(sourceId, itemId)
                 }
             }
         }

--- a/core/data/src/main/kotlin/com/riffle/core/data/ReadingSessionRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/ReadingSessionRepositoryImpl.kt
@@ -65,7 +65,7 @@ class ReadingSessionRepositoryImpl @Inject constructor(
                 )
             }
             localUpdatedAt > serverLastUpdate -> {
-                val ok = runCatching {
+                val stamp = runCatching {
                     peer.pushEbookProgress(
                         itemId = itemId,
                         location = payload.ebookLocation,
@@ -73,8 +73,13 @@ class ReadingSessionRepositoryImpl @Inject constructor(
                         isFinished = false,
                         lastUpdateEpochMs = clock.nowMs(),
                     )
-                }.isSuccess
-                if (ok) positionStore.updateLocalTimestamp(source.id, itemId, clock.nowMs())
+                }.getOrNull()
+                if (stamp != null) {
+                    // Adopt the source-derived stamp; a zero/absent stamp falls back to clock so the
+                    // row still marks clean (matches the old sessionApi.syncEbookProgress path).
+                    val ts = stamp.takeIf { it > 0L } ?: clock.nowMs()
+                    positionStore.updateLocalTimestamp(source.id, itemId, ts)
+                }
                 ProgressSyncCycleResult.LocalWins
             }
             else -> ProgressSyncCycleResult.InSync

--- a/core/data/src/main/kotlin/com/riffle/core/data/ReadingSessionRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/ReadingSessionRepositoryImpl.kt
@@ -1,5 +1,8 @@
 package com.riffle.core.data
 
+import com.riffle.core.catalog.Catalog
+import com.riffle.core.catalog.CatalogRegistry
+import com.riffle.core.catalog.ProgressPeerCapability
 import com.riffle.core.database.LibraryItemDao
 import com.riffle.core.domain.AudiobookPositionStore
 import com.riffle.core.domain.Clock
@@ -7,22 +10,15 @@ import com.riffle.core.domain.ProgressSyncCycleResult
 import com.riffle.core.domain.ReadaloudResumeStore
 import com.riffle.core.domain.ReadingPositionStore
 import com.riffle.core.domain.ReadingSessionRepository
-import com.riffle.core.domain.Source
 import com.riffle.core.domain.ServerProgress
-import com.riffle.core.domain.SourceRepository
 import com.riffle.core.domain.SessionPayload
+import com.riffle.core.domain.SourceRepository
 import com.riffle.core.domain.SyncSessionResult
-import com.riffle.core.domain.TokenStorage
-import com.riffle.core.network.AbsSessionApi
-import com.riffle.core.network.NetworkEbookProgressPayload
-import com.riffle.core.network.NetworkResult
-import com.riffle.core.network.errorAsThrowable
 import javax.inject.Inject
 
 class ReadingSessionRepositoryImpl @Inject constructor(
-    private val api: AbsSessionApi,
+    private val catalogRegistry: CatalogRegistry,
     private val sourceRepository: SourceRepository,
-    private val tokenStorage: TokenStorage,
     private val positionStore: ReadingPositionStore,
     private val audiobookPositionStore: AudiobookPositionStore,
     private val readaloudResumeStore: ReadaloudResumeStore,
@@ -31,41 +27,54 @@ class ReadingSessionRepositoryImpl @Inject constructor(
 ) : ReadingSessionRepository {
 
     override suspend fun syncProgress(itemId: String, payload: SessionPayload): SyncSessionResult {
-        val resolved = resolveSourceAndToken() ?: return SyncSessionResult.NetworkError(
-            IllegalStateException("No active server or token")
+        val peer = activeProgressPeer() ?: return SyncSessionResult.NetworkError(
+            IllegalStateException("No active source or capability")
         )
-        val (source, token) = resolved
-        val r = api.syncEbookProgress(source.url.value, itemId, payload.toNetwork(), token, source.insecureConnectionAllowed)
-        return if (r is NetworkResult.Success) SyncSessionResult.Success else SyncSessionResult.NetworkError(r.errorAsThrowable())
+        return try {
+            peer.pushEbookProgress(
+                itemId = itemId,
+                location = payload.ebookLocation,
+                progress = payload.ebookProgress,
+                isFinished = false,
+                lastUpdateEpochMs = clock.nowMs(),
+            )
+            SyncSessionResult.Success
+        } catch (t: Throwable) {
+            SyncSessionResult.NetworkError(t)
+        }
     }
 
     override suspend fun runSyncCycle(itemId: String, payload: SessionPayload): ProgressSyncCycleResult {
-        val resolved = resolveSourceAndToken() ?: return ProgressSyncCycleResult.Offline
-        val (source, token) = resolved
+        val source = sourceRepository.getActive() ?: return ProgressSyncCycleResult.Offline
+        val catalog = catalogRegistry.forSource(source) ?: return ProgressSyncCycleResult.Offline
+        val peer = catalog as? ProgressPeerCapability ?: return ProgressSyncCycleResult.Offline
 
-        val getRes = api.getProgress(source.url.value, itemId, token, source.insecureConnectionAllowed)
-        if (getRes !is NetworkResult.Success) return ProgressSyncCycleResult.Offline
-        val serverProgress = getRes.value
-
+        val serverProgress = runCatching { peer.pullProgress(itemId) }.getOrElse { return ProgressSyncCycleResult.Offline }
+        val serverLastUpdate = serverProgress?.lastUpdate ?: 0L
         val localUpdatedAt = positionStore.loadLocalUpdatedAt(source.id, itemId)
 
         return when {
-            serverProgress.lastUpdate > localUpdatedAt -> {
-                positionStore.updateLocalTimestamp(source.id, itemId, serverProgress.lastUpdate)
+            serverLastUpdate > localUpdatedAt && serverProgress != null -> {
+                positionStore.updateLocalTimestamp(source.id, itemId, serverLastUpdate)
                 ProgressSyncCycleResult.ServerWins(
                     ServerProgress(
-                        ebookLocation = serverProgress.ebookLocation,
+                        ebookLocation = serverProgress.ebookLocation.orEmpty(),
                         ebookProgress = serverProgress.ebookProgress,
-                        lastUpdate = serverProgress.lastUpdate,
+                        lastUpdate = serverLastUpdate,
                     )
                 )
             }
-            localUpdatedAt > serverProgress.lastUpdate -> {
-                val patchResult = api.syncEbookProgress(source.url.value, itemId, payload.toNetwork(), token, source.insecureConnectionAllowed)
-                if (patchResult is NetworkResult.Success) {
-                    val ts = patchResult.value.takeIf { it > 0L } ?: clock.nowMs()
-                    positionStore.updateLocalTimestamp(source.id, itemId, ts)
-                }
+            localUpdatedAt > serverLastUpdate -> {
+                val ok = runCatching {
+                    peer.pushEbookProgress(
+                        itemId = itemId,
+                        location = payload.ebookLocation,
+                        progress = payload.ebookProgress,
+                        isFinished = false,
+                        lastUpdateEpochMs = clock.nowMs(),
+                    )
+                }.isSuccess
+                if (ok) positionStore.updateLocalTimestamp(source.id, itemId, clock.nowMs())
                 ProgressSyncCycleResult.LocalWins
             }
             else -> ProgressSyncCycleResult.InSync
@@ -73,11 +82,10 @@ class ReadingSessionRepositoryImpl @Inject constructor(
     }
 
     override suspend fun touchOpenTimestamp(itemId: String) {
-        val resolved = resolveSourceAndToken() ?: return
-        val (source, token) = resolved
-        val getRes = api.getProgress(source.url.value, itemId, token, source.insecureConnectionAllowed)
-        if (getRes !is NetworkResult.Success) return
-        val serverProgress = getRes.value
+        val source = sourceRepository.getActive() ?: return
+        val catalog = catalogRegistry.forSource(source) ?: return
+        val peer = catalog as? ProgressPeerCapability ?: return
+        val serverProgress = runCatching { peer.pullProgress(itemId) }.getOrNull() ?: return
         // Deliberately do NOT bump positionStore.localUpdatedAt here. Matching the server's
         // post-PATCH lastUpdate without also writing the server's cfi locally would create a
         // "local in sync but cfi empty" state: the next runSyncCycle would see equal stamps
@@ -85,14 +93,15 @@ class ReadingSessionRepositoryImpl @Inject constructor(
         // PATCH first-page state over the real server position. Leaving local untouched lets
         // the first runSyncCycle after this call see server > local and trigger ServerWins,
         // restoring the saved position to the navigator.
-        api.syncEbookProgress(
-            source.url.value, itemId,
-            NetworkEbookProgressPayload(
-                ebookLocation = serverProgress.ebookLocation,
-                ebookProgress = serverProgress.ebookProgress,
-            ),
-            token, source.insecureConnectionAllowed,
-        )
+        runCatching {
+            peer.pushEbookProgress(
+                itemId = itemId,
+                location = serverProgress.ebookLocation.orEmpty(),
+                progress = serverProgress.ebookProgress,
+                isFinished = false,
+                lastUpdateEpochMs = clock.nowMs(),
+            )
+        }
     }
 
     override suspend fun markFinished(itemId: String, finished: Boolean) {
@@ -111,33 +120,28 @@ class ReadingSessionRepositoryImpl @Inject constructor(
             audiobookPositionStore.updateLocalTimestamp(source.id, itemId, now)
             readaloudResumeStore.clear(source.id, itemId)
         }
-        // Bump before token check: marks the record dirty so the sync cycle pushes it
-        // even if the token is missing right now.
+        // Bump before catalog lookup: marks the record dirty so the sync cycle pushes it
+        // even if the catalog is unavailable right now.
         positionStore.updateLocalTimestamp(source.id, itemId, now)
         libraryItemDao.updateFinishedAt(source.id, itemId, if (finished) now else null)
-        val token = tokenStorage.getToken(source.id) ?: return
-        api.syncEbookProgress(
-            source.url.value, itemId,
-            // isFinished resets the audio half of the record too: true→progress 1, false→currentTime
-            // and progress 0. Both halves move together so neither can re-shadow the other.
-            NetworkEbookProgressPayload(
-                ebookLocation = ebookLocation,
-                ebookProgress = if (finished) 1.0f else 0.0f,
+        val peer = catalogRegistry.forSource(source) as? ProgressPeerCapability ?: return
+        // isFinished resets the audio half of the record too: true→progress 1, false→currentTime
+        // and progress 0. Both halves move together so neither can re-shadow the other.
+        runCatching {
+            peer.pushEbookProgress(
+                itemId = itemId,
+                location = ebookLocation,
+                progress = if (finished) 1.0f else 0.0f,
                 isFinished = finished,
-            ),
-            token, source.insecureConnectionAllowed,
-        )
+                lastUpdateEpochMs = now,
+            )
+        }
         // PATCH failure intentionally ignored — next sync cycle will push
     }
 
-    private suspend fun resolveSourceAndToken(): Pair<Source, String>? {
+    private suspend fun activeProgressPeer(): ProgressPeerCapability? {
         val source = sourceRepository.getActive() ?: return null
-        val token = tokenStorage.getToken(source.id) ?: return null
-        return source to token
+        val catalog: Catalog = catalogRegistry.forSource(source) ?: return null
+        return catalog as? ProgressPeerCapability
     }
-
-    private fun SessionPayload.toNetwork() = NetworkEbookProgressPayload(
-        ebookLocation = ebookLocation,
-        ebookProgress = ebookProgress,
-    )
 }

--- a/core/data/src/main/kotlin/com/riffle/core/data/ReadingSessionRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/ReadingSessionRepositoryImpl.kt
@@ -35,7 +35,7 @@ class ReadingSessionRepositoryImpl @Inject constructor(
                 itemId = itemId,
                 location = payload.ebookLocation,
                 progress = payload.ebookProgress,
-                isFinished = false,
+                isFinished = null,
                 lastUpdateEpochMs = clock.nowMs(),
             )
             SyncSessionResult.Success
@@ -70,7 +70,7 @@ class ReadingSessionRepositoryImpl @Inject constructor(
                         itemId = itemId,
                         location = payload.ebookLocation,
                         progress = payload.ebookProgress,
-                        isFinished = false,
+                        isFinished = null,
                         lastUpdateEpochMs = clock.nowMs(),
                     )
                 }.getOrNull()
@@ -103,7 +103,7 @@ class ReadingSessionRepositoryImpl @Inject constructor(
                 itemId = itemId,
                 location = serverProgress.ebookLocation.orEmpty(),
                 progress = serverProgress.ebookProgress,
-                isFinished = false,
+                isFinished = null,
                 lastUpdateEpochMs = clock.nowMs(),
             )
         }

--- a/core/data/src/main/kotlin/com/riffle/core/data/ToReadRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/ToReadRepositoryImpl.kt
@@ -1,9 +1,8 @@
 package com.riffle.core.data
 
-import com.riffle.core.domain.SourceRepository
-import com.riffle.core.domain.TokenStorage
-import com.riffle.core.network.AbsLibraryApi
-import com.riffle.core.network.NetworkResult
+import com.riffle.core.catalog.Catalog
+import com.riffle.core.catalog.CatalogRegistry
+import com.riffle.core.catalog.PlaylistsCapability
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.map
@@ -20,9 +19,7 @@ private data class ToReadSnapshot(val playlistId: String?, val itemIds: Set<Stri
 
 @Singleton
 class ToReadRepositoryImpl @Inject constructor(
-    private val api: AbsLibraryApi,
-    private val sourceRepository: SourceRepository,
-    private val tokenStorage: TokenStorage,
+    private val catalogRegistry: CatalogRegistry,
 ) : ToReadRepository {
 
     private val cache = MutableStateFlow<Map<String, ToReadSnapshot>>(emptyMap())
@@ -31,13 +28,12 @@ class ToReadRepositoryImpl @Inject constructor(
         cache.map { it[libraryId]?.itemIds ?: emptySet() }
 
     override suspend fun refresh(libraryId: String): Boolean {
-        val session = resolveSession() ?: return false
-        val result = api.getPlaylists(session.baseUrl, libraryId, session.token, session.insecureAllowed)
-        if (result !is NetworkResult.Success) return false
-        val match = result.value.firstOrNull { it.name == TO_READ_PLAYLIST_NAME }
+        val cap = activePlaylistsCap() ?: return false
+        val playlists = runCatching { cap.listPlaylists(libraryId) }.getOrElse { return false }
+        val match = playlists.firstOrNull { it.name == TO_READ_PLAYLIST_NAME }
         val snapshot = ToReadSnapshot(
             playlistId = match?.id,
-            itemIds = match?.bookIds ?: emptySet(),
+            itemIds = match?.itemIds?.toSet() ?: emptySet(),
         )
         cache.value = cache.value + (libraryId to snapshot)
         return true
@@ -47,35 +43,27 @@ class ToReadRepositoryImpl @Inject constructor(
         cache.value[libraryId]?.itemIds?.contains(libraryItemId) == true
 
     override suspend fun addToToRead(libraryItemId: String, libraryId: String): Boolean {
-        val session = resolveSession() ?: return false
+        val cap = activePlaylistsCap() ?: return false
         val before = cache.value[libraryId] ?: ToReadSnapshot(playlistId = null, itemIds = emptySet())
         // Optimistic update
         cache.value = cache.value + (libraryId to before.copy(itemIds = before.itemIds + libraryItemId))
         val playlistId = before.playlistId
         val ok = if (playlistId == null) {
-            val r = api.createPlaylist(
-                session.baseUrl, libraryId, TO_READ_PLAYLIST_NAME, libraryItemId,
-                session.token, session.insecureAllowed,
-            )
-            if (r is NetworkResult.Success) {
-                val newId = r.value?.id
-                if (newId != null) {
-                    cache.value = cache.value + (libraryId to ToReadSnapshot(newId, before.itemIds + libraryItemId))
-                }
+            runCatching {
+                val created = cap.createPlaylist(libraryId, TO_READ_PLAYLIST_NAME)
+                cap.addItemToPlaylist(created.id, libraryItemId)
+                cache.value = cache.value + (libraryId to ToReadSnapshot(created.id, before.itemIds + libraryItemId))
                 true
-            } else false
+            }.getOrDefault(false)
         } else {
-            val r = api.addBookToPlaylist(
-                session.baseUrl, playlistId, libraryItemId, session.token, session.insecureAllowed,
-            )
-            r is NetworkResult.Success
+            runCatching { cap.addItemToPlaylist(playlistId, libraryItemId); true }.getOrDefault(false)
         }
         if (!ok) cache.value = cache.value + (libraryId to before)
         return ok
     }
 
     override suspend fun removeFromToRead(libraryItemId: String, libraryId: String): Boolean {
-        val session = resolveSession() ?: return false
+        val cap = activePlaylistsCap() ?: return false
         val before = cache.value[libraryId] ?: return true
         val playlistId = before.playlistId ?: return true
         if (libraryItemId !in before.itemIds) return true
@@ -88,19 +76,13 @@ class ToReadRepositoryImpl @Inject constructor(
             before.copy(itemIds = remainingIds)
         }
         cache.value = cache.value + (libraryId to optimistic)
-        val r = api.removeBookFromPlaylist(
-            session.baseUrl, playlistId, libraryItemId, session.token, session.insecureAllowed,
-        )
-        val ok = r is NetworkResult.Success
+        val ok = runCatching { cap.removeItemFromPlaylist(playlistId, libraryItemId); true }.getOrDefault(false)
         if (!ok) cache.value = cache.value + (libraryId to before)
         return ok
     }
 
-    private suspend fun resolveSession(): Session? {
-        val server = sourceRepository.getActive() ?: return null
-        val token = tokenStorage.getToken(server.id) ?: return null
-        return Session(server.url.value, token, server.insecureConnectionAllowed)
+    private suspend fun activePlaylistsCap(): PlaylistsCapability? {
+        val catalog: Catalog = catalogRegistry.forActive() ?: return null
+        return catalog as? PlaylistsCapability
     }
-
-    private data class Session(val baseUrl: String, val token: String, val insecureAllowed: Boolean)
 }

--- a/core/data/src/main/kotlin/com/riffle/core/data/di/modules/CatalogModule.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/di/modules/CatalogModule.kt
@@ -1,0 +1,66 @@
+package com.riffle.core.data.di.modules
+
+import com.riffle.core.catalog.CatalogFactory
+import com.riffle.core.catalog.CatalogRegistry
+import com.riffle.core.catalog.DefaultCatalogRegistry
+import com.riffle.core.domain.SourceType
+import com.riffle.core.catalog.abs.AbsCatalogFactory
+import com.riffle.core.domain.Clock
+import com.riffle.core.domain.DeviceIdStore
+import com.riffle.core.domain.SourceRepository
+import com.riffle.core.domain.TokenStorage
+import com.riffle.core.network.AbsBookmarkApi
+import com.riffle.core.network.AbsLibraryApi
+import com.riffle.core.network.AbsPlaybackApi
+import com.riffle.core.network.AbsServerInfoApi
+import com.riffle.core.network.AbsSessionApi
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import dagger.multibindings.IntoMap
+import javax.inject.Singleton
+
+/**
+ * Wires the `Map<SourceType, CatalogFactory>` used by [CatalogRegistry]. Every SourceType
+ * implementation registers its factory here via `@IntoMap` + `@SourceTypeKey`; repositories
+ * consume [CatalogRegistry] rather than the map directly.
+ *
+ * LocalFiles will bind its factory here once the LocalFiles source implementation lands
+ * (issue #437 / #438).
+ */
+@Module
+@InstallIn(SingletonComponent::class)
+object CatalogModule {
+
+    @Provides
+    @Singleton
+    @IntoMap
+    @SourceTypeKey(SourceType.ABS)
+    fun provideAbsCatalogFactory(
+        libraryApi: AbsLibraryApi,
+        playbackApi: AbsPlaybackApi,
+        sessionApi: AbsSessionApi,
+        bookmarkApi: AbsBookmarkApi,
+        serverInfoApi: AbsServerInfoApi,
+        tokenStorage: TokenStorage,
+        deviceIdStore: DeviceIdStore,
+        clock: Clock,
+    ): CatalogFactory = AbsCatalogFactory(
+        libraryApi = libraryApi,
+        playbackApi = playbackApi,
+        sessionApi = sessionApi,
+        bookmarkApi = bookmarkApi,
+        serverInfoApi = serverInfoApi,
+        tokenStorage = tokenStorage,
+        deviceIdStore = deviceIdStore,
+        clock = clock,
+    )
+
+    @Provides
+    @Singleton
+    fun provideCatalogRegistry(
+        factories: Map<SourceType, @JvmSuppressWildcards CatalogFactory>,
+        sourceRepository: SourceRepository,
+    ): CatalogRegistry = DefaultCatalogRegistry(factories, sourceRepository)
+}

--- a/core/data/src/main/kotlin/com/riffle/core/data/di/modules/RepositoriesModule.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/di/modules/RepositoriesModule.kt
@@ -35,8 +35,7 @@ import com.riffle.core.domain.ReadingPositionStore
 import com.riffle.core.domain.ReadingSessionRepository
 import com.riffle.core.domain.SourceRepository
 import com.riffle.core.domain.TocRepository
-import com.riffle.core.domain.TokenStorage
-import com.riffle.core.network.AbsLibraryApi
+import com.riffle.core.catalog.CatalogRegistry
 import dagger.Binds
 import dagger.Module
 import dagger.Provides
@@ -100,24 +99,22 @@ abstract class RepositoriesModule {
         @Provides
         @Singleton
         fun provideEpubRepository(
-            api: AbsLibraryApi,
+            catalogRegistry: CatalogRegistry,
             @EpubCacheStore cacheStore: LocalStore,
             @EpubDownloadsStore downloadsStore: LocalStore,
             positionStore: ReadingPositionStore,
             sourceRepository: SourceRepository,
-            tokenStorage: TokenStorage,
-        ): EpubRepository = EpubRepositoryImpl(api, cacheStore, downloadsStore, positionStore, sourceRepository, tokenStorage)
+        ): EpubRepository = EpubRepositoryImpl(catalogRegistry, cacheStore, downloadsStore, positionStore, sourceRepository)
 
         @Provides
         @Singleton
         fun providePdfRepository(
-            api: AbsLibraryApi,
+            catalogRegistry: CatalogRegistry,
             @PdfCacheStore cacheStore: LocalStore,
             @PdfDownloadsStore downloadsStore: LocalStore,
             positionStore: ReadingPositionStore,
             sourceRepository: SourceRepository,
-            tokenStorage: TokenStorage,
-        ): PdfRepository = PdfRepositoryImpl(api, cacheStore, downloadsStore, positionStore, sourceRepository, tokenStorage)
+        ): PdfRepository = PdfRepositoryImpl(catalogRegistry, cacheStore, downloadsStore, positionStore, sourceRepository)
 
         @Provides
         @Singleton

--- a/core/data/src/main/kotlin/com/riffle/core/data/di/modules/SourceTypeKey.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/di/modules/SourceTypeKey.kt
@@ -1,0 +1,8 @@
+package com.riffle.core.data.di.modules
+
+import com.riffle.core.domain.SourceType
+import dagger.MapKey
+
+/** Hilt map key for `Map<SourceType, CatalogFactory>` — see [CatalogModule]. */
+@MapKey
+annotation class SourceTypeKey(val value: SourceType)

--- a/core/data/src/main/kotlin/com/riffle/core/data/di/modules/SyncModule.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/di/modules/SyncModule.kt
@@ -1,5 +1,6 @@
 package com.riffle.core.data.di.modules
 
+import com.riffle.core.catalog.CatalogRegistry
 import com.riffle.core.data.AnnotationSyncConfigStoreImpl
 import com.riffle.core.data.AudiobookPositionStoreImpl
 import com.riffle.core.data.ReadaloudMatchingService
@@ -59,25 +60,14 @@ abstract class SyncModule {
     abstract fun bindStorytellerReadaloudCacheSyncer(impl: StorytellerReadaloudSyncer): com.riffle.core.domain.StorytellerReadaloudCacheSyncer
 
     companion object {
-        // Durable offline progress reconcile (ADR 0030): resolve a sourceId to its server+token
-        // (null ⇒ skip), and assemble the multi-server dirty sweep over the single-target primitive.
-        @Provides
-        @Singleton
-        fun provideServerTokenResolver(
-            sourceRepository: SourceRepository,
-            tokenStorage: TokenStorage,
-        ): com.riffle.core.data.ServerTokenResolver =
-            com.riffle.core.data.ServerTokenResolver { sourceId ->
-                val server = sourceRepository.getById(sourceId) ?: return@ServerTokenResolver null
-                val token = tokenStorage.getToken(sourceId) ?: return@ServerTokenResolver null
-                server to token
-            }
-
+        // Durable offline progress reconcile (ADR 0030): assemble the multi-source dirty sweep
+        // over the single-target primitive. Skipping unresolvable sources (no row / no token /
+        // no factory) is baked into ProgressSweep via CatalogRegistry.forSourceId.
         @Provides
         @Singleton
         fun provideProgressSweep(
             ledger: com.riffle.core.data.DirtyProgressLedger,
-            resolver: com.riffle.core.data.ServerTokenResolver,
+            catalogRegistry: CatalogRegistry,
             remoteFactory: com.riffle.core.data.ProgressRemoteFactory,
             locks: com.riffle.core.data.ReconcileLocks,
             openTargets: com.riffle.core.data.OpenReconcileTargets,
@@ -87,19 +77,20 @@ abstract class SyncModule {
             bookmarkReconciler: com.riffle.core.data.AudiobookBookmarkReconciler,
         ): com.riffle.core.data.ProgressSweep =
             com.riffle.core.data.ProgressSweep(
-                ledger, resolver,
+                ledger,
+                catalogRegistry,
                 com.riffle.core.domain.ProgressReconciler(ebookStore),
                 com.riffle.core.domain.ProgressReconciler(audioStore),
                 remoteFactory, locks, openTargets,
                 // Bookmarks ride the sweep at the same cadence as positions: enumerate dirty
-                // (server, item) pairs straight off the bookmark DAO (ADR 0030, Task 12).
+                // (source, item) pairs straight off the bookmark DAO (ADR 0030, Task 12).
                 object : com.riffle.core.data.DirtyBookmarkLedger {
                     override suspend fun serversWithDirty() = bookmarkDao.sourcesWithDirtyRows()
                     override suspend fun dirtyItems(sourceId: String) =
                         bookmarkDao.dirtyForSource(sourceId).map { it.itemId }.distinct()
                 },
-                com.riffle.core.data.BookmarkReconcile { sourceId, itemId, baseUrl, token, insecureAllowed ->
-                    bookmarkReconciler.reconcile(sourceId, itemId, baseUrl, token, insecureAllowed)
+                com.riffle.core.data.BookmarkReconcile { sourceId, itemId ->
+                    bookmarkReconciler.reconcile(sourceId, itemId)
                 },
             )
 

--- a/core/data/src/test/kotlin/com/riffle/core/data/AbsProgressRemoteTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/AbsProgressRemoteTest.kt
@@ -1,44 +1,54 @@
 package com.riffle.core.data
 
-import com.riffle.core.network.NetworkResult
-
+import com.riffle.core.catalog.CatalogProgress
+import com.riffle.core.catalog.ProgressPeerCapability
+import com.riffle.core.domain.Clock
 import com.riffle.core.domain.EbookCfiTranslator
-import com.riffle.core.network.AbsSessionApi
-import com.riffle.core.network.NetworkAudiobookProgressPayload
-import com.riffle.core.network.NetworkEbookProgressPayload
-import com.riffle.core.network.NetworkServerProgress
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Test
 
 /**
- * The ABS [com.riffle.core.domain.ProgressRemote] adapters (ADR 0030 / ADR 0013): translate ABS
- * `epubcfi(...)` ↔ Riffle Locator JSON at the ABS boundary so the local store is never polluted
- * with a foreign format. A null translator defers (returns null) — row stays dirty for the next
- * sweep once the EPUB is cached.
+ * Catalog-backed [com.riffle.core.domain.ProgressRemote] adapters (ADR 0030 / ADR 0013): translate
+ * ABS `epubcfi(...)` ↔ Riffle Locator JSON at the Catalog boundary so the local store is never
+ * polluted with a foreign format. A null translator defers (returns null) — row stays dirty for
+ * the next sweep once the EPUB is cached.
  */
 class AbsProgressRemoteTest {
 
-    private class FakeSessionApi(
-        private val getResult: NetworkResult<NetworkServerProgress>,
-        private val syncResult: NetworkResult<Long>,
-    ) : AbsSessionApi {
-        var ebookPayload: NetworkEbookProgressPayload? = null
-        var audioPayload: NetworkAudiobookProgressPayload? = null
-        var getItemId: String? = null
+    private class FakePeer(
+        var progress: CatalogProgress? = null,
+        var failGet: Boolean = false,
+        var failPush: Boolean = false,
+    ) : ProgressPeerCapability {
+        data class Ebook(val itemId: String, val location: String, val progress: Float, val isFinished: Boolean, val ts: Long)
+        data class Audio(val itemId: String, val currentTimeSec: Double, val durationSec: Double, val isFinished: Boolean, val ts: Long)
+        var lastEbook: Ebook? = null
+        var lastAudio: Audio? = null
 
-        override suspend fun syncEbookProgress(
-            baseUrl: String, libraryItemId: String, payload: NetworkEbookProgressPayload, token: String, insecureAllowed: Boolean,
-        ): NetworkResult<Long> { ebookPayload = payload; return syncResult }
+        override suspend fun pushEbookProgress(
+            itemId: String, location: String, progress: Float, isFinished: Boolean, lastUpdateEpochMs: Long,
+        ): Long? {
+            if (failPush) throw RuntimeException("down")
+            lastEbook = Ebook(itemId, location, progress, isFinished, lastUpdateEpochMs)
+            return null
+        }
 
-        override suspend fun syncAudiobookProgress(
-            baseUrl: String, libraryItemId: String, payload: NetworkAudiobookProgressPayload, token: String, insecureAllowed: Boolean,
-        ): NetworkResult<Long> { audioPayload = payload; return syncResult }
+        override suspend fun pushAudiobookProgress(
+            itemId: String, currentTimeSec: Double, durationSec: Double, isFinished: Boolean, lastUpdateEpochMs: Long,
+        ): Long? {
+            if (failPush) throw RuntimeException("down")
+            lastAudio = Audio(itemId, currentTimeSec, durationSec, isFinished, lastUpdateEpochMs)
+            return null
+        }
 
-        override suspend fun getProgress(
-            baseUrl: String, libraryItemId: String, token: String, insecureAllowed: Boolean,
-        ): NetworkResult<NetworkServerProgress> { getItemId = libraryItemId; return getResult }
+        override suspend fun pullProgress(itemId: String): CatalogProgress? {
+            if (failGet) throw RuntimeException("down")
+            return progress
+        }
+
+        override suspend fun pullAllProgress(): List<CatalogProgress> = emptyList()
     }
 
     private class FakeTranslator(
@@ -49,173 +59,112 @@ class AbsProgressRemoteTest {
         override suspend fun locatorJsonToCfi(locatorJson: String) = locatorResult(locatorJson)
     }
 
-    private fun serverProgress(cfi: String = "", progress: Float = 0f, currentTime: Double = 0.0, lastUpdate: Long = 0L) =
-        NetworkServerProgress(ebookLocation = cfi, ebookProgress = progress, currentTime = currentTime, lastUpdate = lastUpdate)
-
+    private val clock = object : Clock { override fun nowMs() = 1800L; override fun nowNs() = 0L }
     private val locatorJson = """{"href":"OPS/ch1.xhtml","type":"application/xhtml+xml","locations":{"progression":0.5}}"""
+
+    private fun ebookRemote(peer: ProgressPeerCapability, translator: EbookCfiTranslator?, progress: Float = 0.5f) =
+        CatalogEbookProgressRemote(peer, "item-1", translator, { progress }, clock)
+
+    private fun audioRemote(peer: ProgressPeerCapability, duration: Double = 3600.0) =
+        CatalogAudioProgressRemote(peer, "item-1", { duration }, clock)
 
     // --- ebook get ---
 
     @Test
     fun `ebook get - null translator returns null (EPUB not cached, defers row)`() = runTest {
-        val api = FakeSessionApi(
-            NetworkResult.Success(serverProgress(cfi = "epubcfi(/6/4!/4)", lastUpdate = 1700L)),
-            NetworkResult.Success(0L),
-        )
-        val remote = AbsEbookProgressRemote(api, "http://abs", "tok", false, "item-1", translator = null) { 0.5f }
-        assertNull(remote.get())
+        val peer = FakePeer(progress = CatalogProgress("item-1", ebookLocation = "epubcfi(/6/4!/4)", lastUpdate = 1700L))
+        assertNull(ebookRemote(peer, translator = null).get())
     }
 
     @Test
     fun `ebook get - translates epubcfi to Locator JSON and preserves lastUpdate`() = runTest {
-        val api = FakeSessionApi(
-            NetworkResult.Success(serverProgress(cfi = "epubcfi(/6/4!/4)", lastUpdate = 1700L)),
-            NetworkResult.Success(0L),
-        )
+        val peer = FakePeer(progress = CatalogProgress("item-1", ebookLocation = "epubcfi(/6/4!/4)", lastUpdate = 1700L))
         val translator = FakeTranslator(cfiResult = { locatorJson }, locatorResult = { it })
-        val remote = AbsEbookProgressRemote(api, "http://abs", "tok", false, "item-1", translator) { 0.5f }
-        val read = remote.get()
+        val read = ebookRemote(peer, translator).get()
         assertEquals(locatorJson, read?.position)
         assertEquals(1700L, read?.lastUpdate)
-        assertEquals("item-1", api.getItemId)
     }
 
     @Test
     fun `ebook get - returns null when translation fails (CFI unresolvable)`() = runTest {
-        val api = FakeSessionApi(
-            NetworkResult.Success(serverProgress(cfi = "epubcfi(/6/4!/4)", lastUpdate = 1700L)),
-            NetworkResult.Success(0L),
-        )
+        val peer = FakePeer(progress = CatalogProgress("item-1", ebookLocation = "epubcfi(/6/4!/4)", lastUpdate = 1700L))
         val translator = FakeTranslator(cfiResult = { null }, locatorResult = { null })
-        val remote = AbsEbookProgressRemote(api, "http://abs", "tok", false, "item-1", translator) { 0.5f }
-        assertNull(remote.get())
+        assertNull(ebookRemote(peer, translator).get())
     }
 
     @Test
-    fun `ebook get - blank ebookLocation (never-opened book) passes through as empty without translation`() = runTest {
-        val api = FakeSessionApi(
-            NetworkResult.Success(serverProgress(cfi = "", lastUpdate = 0L)),
-            NetworkResult.Success(0L),
-        )
+    fun `ebook get - blank ebookLocation passes through as empty without translation`() = runTest {
+        val peer = FakePeer(progress = CatalogProgress("item-1", ebookLocation = "", lastUpdate = 0L))
         val translator = FakeTranslator(cfiResult = { error("should not be called") }, locatorResult = { it })
-        val remote = AbsEbookProgressRemote(api, "http://abs", "tok", false, "item-1", translator) { 0.5f }
-        val read = remote.get()
+        val read = ebookRemote(peer, translator).get()
         assertEquals("", read?.position)
         assertEquals(0L, read?.lastUpdate)
     }
 
     @Test
     fun `ebook get - returns null on network error`() = runTest {
-        val api = FakeSessionApi(
-            NetworkResult.Offline(RuntimeException("down")),
-            NetworkResult.Success(0L),
-        )
+        val peer = FakePeer(failGet = true)
         val translator = FakeTranslator(cfiResult = { locatorJson }, locatorResult = { it })
-        val remote = AbsEbookProgressRemote(api, "http://abs", "tok", false, "item-1", translator) { 0.5f }
-        assertNull(remote.get())
+        assertNull(ebookRemote(peer, translator).get())
     }
 
     // --- ebook patch ---
 
     @Test
     fun `ebook patch - null translator returns null without sending PATCH`() = runTest {
-        val api = FakeSessionApi(
-            NetworkResult.Success(serverProgress()),
-            NetworkResult.Success(1800L),
-        )
-        val remote = AbsEbookProgressRemote(api, "http://abs", "tok", false, "item-1", translator = null) { 0.73f }
-        assertNull(remote.patch(locatorJson))
-        assertNull(api.ebookPayload)
+        val peer = FakePeer()
+        assertNull(ebookRemote(peer, translator = null, progress = 0.73f).patch(locatorJson))
+        assertNull(peer.lastEbook)
     }
 
     @Test
     fun `ebook patch - translates Locator JSON to epubcfi and sends it with progress fraction`() = runTest {
-        val api = FakeSessionApi(
-            NetworkResult.Success(serverProgress()),
-            NetworkResult.Success(1800L),
-        )
+        val peer = FakePeer()
         val translator = FakeTranslator(cfiResult = { it }, locatorResult = { "epubcfi(/6/8!/2)" })
-        val remote = AbsEbookProgressRemote(api, "http://abs", "tok", false, "item-1", translator) { 0.73f }
-        val stamp = remote.patch(locatorJson)
+        val stamp = ebookRemote(peer, translator, progress = 0.73f).patch(locatorJson)
         assertEquals(1800L, stamp)
-        assertEquals("epubcfi(/6/8!/2)", api.ebookPayload?.ebookLocation)
-        assertEquals(0.73f, api.ebookPayload?.ebookProgress)
+        assertEquals("epubcfi(/6/8!/2)", peer.lastEbook?.location)
+        assertEquals(0.73f, peer.lastEbook?.progress)
     }
 
     @Test
     fun `ebook patch - returns null without sending PATCH when translation fails`() = runTest {
-        val api = FakeSessionApi(
-            NetworkResult.Success(serverProgress()),
-            NetworkResult.Success(1800L),
-        )
+        val peer = FakePeer()
         val translator = FakeTranslator(cfiResult = { it }, locatorResult = { null })
-        val remote = AbsEbookProgressRemote(api, "http://abs", "tok", false, "item-1", translator) { 0.5f }
-        assertNull(remote.patch(locatorJson))
-        assertNull(api.ebookPayload)
+        assertNull(ebookRemote(peer, translator).patch(locatorJson))
+        assertNull(peer.lastEbook)
     }
 
     @Test
     fun `ebook patch - returns null on network error`() = runTest {
-        val api = FakeSessionApi(
-            NetworkResult.Success(serverProgress()),
-            NetworkResult.Offline(RuntimeException("down")),
-        )
+        val peer = FakePeer(failPush = true)
         val translator = FakeTranslator(cfiResult = { it }, locatorResult = { it })
-        val remote = AbsEbookProgressRemote(api, "http://abs", "tok", false, "item-1", translator) { 0.5f }
-        assertNull(remote.patch("epubcfi(/6/4!/4)"))
-    }
-
-    @Test
-    fun `ebook patch - passes through a legacy raw epubcfi unchanged`() = runTest {
-        val api = FakeSessionApi(
-            NetworkResult.Success(serverProgress()),
-            NetworkResult.Success(1800L),
-        )
-        // Simulates EbookCfiTranslatorImpl.locatorJsonToCfi: raw epubcfi passes through
-        val translator = FakeTranslator(cfiResult = { it }, locatorResult = { input ->
-            if (input.startsWith("epubcfi(")) input else null
-        })
-        val remote = AbsEbookProgressRemote(api, "http://abs", "tok", false, "item-1", translator) { 0.5f }
-        val stamp = remote.patch("epubcfi(/6/8!/2)")
-        assertEquals(1800L, stamp)
-        assertEquals("epubcfi(/6/8!/2)", api.ebookPayload?.ebookLocation)
+        assertNull(ebookRemote(peer, translator).patch("epubcfi(/6/4!/4)"))
     }
 
     // --- audio ---
 
     @Test
     fun `audio get maps currentTime and lastUpdate`() = runTest {
-        val api = FakeSessionApi(
-            NetworkResult.Success(serverProgress(currentTime = 942.0, lastUpdate = 1700L)),
-            NetworkResult.Success(0L),
-        )
-        val remote = AbsAudioProgressRemote(api, "http://abs", "tok", false, "item-1") { 3600.0 }
-        val read = remote.get()
+        val peer = FakePeer(progress = CatalogProgress("item-1", audioCurrentTime = 942.0, lastUpdate = 1700L))
+        val read = audioRemote(peer).get()
         assertEquals(942.0, read?.position!!, 0.0001)
         assertEquals(1700L, read.lastUpdate)
     }
 
     @Test
-    fun `audio patch sends seconds with the supplied duration and returns the source stamp`() = runTest {
-        val api = FakeSessionApi(
-            NetworkResult.Success(serverProgress()),
-            NetworkResult.Success(1900L),
-        )
-        val remote = AbsAudioProgressRemote(api, "http://abs", "tok", false, "item-1") { 3600.0 }
-        val stamp = remote.patch(1234.5)
-        assertEquals(1900L, stamp)
-        assertEquals(1234.5, api.audioPayload?.currentTime!!, 0.0001)
-        assertEquals(3600.0, api.audioPayload?.duration!!, 0.0001)
+    fun `audio patch sends seconds with the supplied duration and returns the write stamp`() = runTest {
+        val peer = FakePeer()
+        val stamp = audioRemote(peer).patch(1234.5)
+        assertEquals(1800L, stamp)
+        assertEquals(1234.5, peer.lastAudio?.currentTimeSec!!, 0.0001)
+        assertEquals(3600.0, peer.lastAudio?.durationSec!!, 0.0001)
     }
 
     @Test
     fun `audio get and patch return null on network error`() = runTest {
-        val api = FakeSessionApi(
-            NetworkResult.Offline(RuntimeException("down")),
-            NetworkResult.Offline(RuntimeException("down")),
-        )
-        val remote = AbsAudioProgressRemote(api, "http://abs", "tok", false, "item-1") { 3600.0 }
-        assertNull(remote.get())
-        assertNull(remote.patch(10.0))
+        val peer = FakePeer(failGet = true, failPush = true)
+        assertNull(audioRemote(peer).get())
+        assertNull(audioRemote(peer).patch(10.0))
     }
 }

--- a/core/data/src/test/kotlin/com/riffle/core/data/AbsProgressRemoteTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/AbsProgressRemoteTest.kt
@@ -22,13 +22,13 @@ class AbsProgressRemoteTest {
         var failGet: Boolean = false,
         var failPush: Boolean = false,
     ) : ProgressPeerCapability {
-        data class Ebook(val itemId: String, val location: String, val progress: Float, val isFinished: Boolean, val ts: Long)
-        data class Audio(val itemId: String, val currentTimeSec: Double, val durationSec: Double, val isFinished: Boolean, val ts: Long)
+        data class Ebook(val itemId: String, val location: String, val progress: Float, val isFinished: Boolean?, val ts: Long)
+        data class Audio(val itemId: String, val currentTimeSec: Double, val durationSec: Double, val isFinished: Boolean?, val ts: Long)
         var lastEbook: Ebook? = null
         var lastAudio: Audio? = null
 
         override suspend fun pushEbookProgress(
-            itemId: String, location: String, progress: Float, isFinished: Boolean, lastUpdateEpochMs: Long,
+            itemId: String, location: String, progress: Float, isFinished: Boolean?, lastUpdateEpochMs: Long,
         ): Long? {
             if (failPush) throw RuntimeException("down")
             lastEbook = Ebook(itemId, location, progress, isFinished, lastUpdateEpochMs)
@@ -36,7 +36,7 @@ class AbsProgressRemoteTest {
         }
 
         override suspend fun pushAudiobookProgress(
-            itemId: String, currentTimeSec: Double, durationSec: Double, isFinished: Boolean, lastUpdateEpochMs: Long,
+            itemId: String, currentTimeSec: Double, durationSec: Double, isFinished: Boolean?, lastUpdateEpochMs: Long,
         ): Long? {
             if (failPush) throw RuntimeException("down")
             lastAudio = Audio(itemId, currentTimeSec, durationSec, isFinished, lastUpdateEpochMs)

--- a/core/data/src/test/kotlin/com/riffle/core/data/AudiobookBookmarkReconcilerTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/AudiobookBookmarkReconcilerTest.kt
@@ -1,11 +1,20 @@
 package com.riffle.core.data
 
-import com.riffle.core.network.NetworkResult
-
+import com.riffle.core.catalog.BookFormat
+import com.riffle.core.catalog.BookmarksCapability
+import com.riffle.core.catalog.Catalog
+import com.riffle.core.catalog.CatalogBookmark
+import com.riffle.core.catalog.CatalogFileHandle
+import com.riffle.core.catalog.CatalogFileStream
+import com.riffle.core.catalog.CatalogHealth
+import com.riffle.core.catalog.CatalogItem
+import com.riffle.core.catalog.CatalogRegistry
+import com.riffle.core.catalog.CatalogRoot
+import com.riffle.core.catalog.SortKey
 import com.riffle.core.database.AudiobookBookmarkDao
 import com.riffle.core.database.AudiobookBookmarkEntity
-import com.riffle.core.network.AbsBookmarkApi
-import com.riffle.core.network.NetworkAbsBookmark
+import com.riffle.core.domain.Source
+import com.riffle.core.domain.SourceType
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.map
@@ -18,8 +27,6 @@ import org.junit.Test
 
 class AudiobookBookmarkReconcilerTest {
 
-    // A fake DAO that faithfully implements the compare-and-clear / hard-delete semantics
-    // so the reconciler's clean/dirty transitions can be asserted end-to-end.
     private class FakeDao : AudiobookBookmarkDao {
         val rows = MutableStateFlow<List<AudiobookBookmarkEntity>>(emptyList())
 
@@ -72,56 +79,48 @@ class AudiobookBookmarkReconcilerTest {
         }
     }
 
-    private class FakeApi(
-        var listResult: NetworkResult<List<NetworkAbsBookmark>> = NetworkResult.Success(emptyList()),
-    ) : AbsBookmarkApi {
+    private class FakeCatalog(
+        var listResult: Result<List<CatalogBookmark>> = Result.success(emptyList()),
+    ) : Catalog, BookmarksCapability {
         data class Call(val kind: String, val itemId: String, val timeSec: Int, val title: String)
-
         val calls = mutableListOf<Call>()
-        var createResult: NetworkResult<NetworkAbsBookmark> = NetworkResult.Success(NetworkAbsBookmark("", "", 0, 0))
-        var updateResult: NetworkResult<NetworkAbsBookmark> = NetworkResult.Success(NetworkAbsBookmark("", "", 0, 0))
-        var deleteResult: NetworkResult<NetworkAbsBookmark> = NetworkResult.Success(NetworkAbsBookmark("", "", 0, 0))
+        var createOk: Boolean = true
+        var renameOk: Boolean = true
+        var deleteOk: Boolean = true
 
-        override suspend fun createBookmark(
-            baseUrl: String,
-            itemId: String,
-            timeSec: Int,
-            title: String,
-            token: String,
-            insecureAllowed: Boolean,
-        ): NetworkResult<NetworkAbsBookmark> {
+        override val sourceType = SourceType.ABS
+        override suspend fun listRoots() = emptyList<CatalogRoot>()
+        override suspend fun browse(rootId: String, sort: SortKey, page: Int, pageSize: Int) = emptyList<CatalogItem>()
+        override suspend fun search(rootId: String, query: String, page: Int, pageSize: Int) = emptyList<CatalogItem>()
+        override suspend fun getItem(itemId: String): CatalogItem? = null
+        override suspend fun fetchFile(itemId: String, format: BookFormat): CatalogFileHandle = throw UnsupportedOperationException()
+        override suspend fun openFile(itemId: String, format: BookFormat, handleHint: String?): CatalogFileStream = throw UnsupportedOperationException()
+        override suspend fun connectivityCheck() = CatalogHealth(isReachable = true)
+
+        override suspend fun listAllBookmarks(): List<CatalogBookmark> = listResult.getOrThrow()
+
+        override suspend fun createBookmark(itemId: String, timeSec: Int, title: String): CatalogBookmark {
             calls += Call("create", itemId, timeSec, title)
-            return createResult
+            if (!createOk) throw RuntimeException("boom")
+            return CatalogBookmark(itemId, timeSec, title, createdAt = 0L)
         }
 
-        override suspend fun updateBookmark(
-            baseUrl: String,
-            itemId: String,
-            timeSec: Int,
-            title: String,
-            token: String,
-            insecureAllowed: Boolean,
-        ): NetworkResult<NetworkAbsBookmark> {
-            calls += Call("update", itemId, timeSec, title)
-            return updateResult
-        }
-
-        override suspend fun deleteBookmark(
-            baseUrl: String,
-            itemId: String,
-            timeSec: Int,
-            token: String,
-            insecureAllowed: Boolean,
-        ): NetworkResult<NetworkAbsBookmark> {
+        override suspend fun deleteBookmark(itemId: String, timeSec: Int) {
             calls += Call("delete", itemId, timeSec, "")
-            return deleteResult
+            if (!deleteOk) throw RuntimeException("boom")
         }
 
-        override suspend fun listBookmarks(
-            baseUrl: String,
-            token: String,
-            insecureAllowed: Boolean,
-        ): NetworkResult<List<NetworkAbsBookmark>> = listResult
+        override suspend fun renameBookmark(itemId: String, timeSec: Int, newTitle: String): CatalogBookmark {
+            calls += Call("update", itemId, timeSec, newTitle)
+            if (!renameOk) throw RuntimeException("boom")
+            return CatalogBookmark(itemId, timeSec, newTitle, createdAt = 0L)
+        }
+    }
+
+    private class FakeRegistry(private val catalog: Catalog) : CatalogRegistry {
+        override suspend fun forActive(): Catalog = catalog
+        override suspend fun forSource(source: Source): Catalog = catalog
+        override suspend fun forSourceId(sourceId: String): Catalog = catalog
     }
 
     private val now = { 1000L }
@@ -130,11 +129,10 @@ class AudiobookBookmarkReconcilerTest {
         return { "gen-${n++}" }
     }
 
-    private fun reconciler(dao: FakeDao, api: FakeApi) =
-        AudiobookBookmarkReconciler(dao, api, now = now, newId = counterIds())
+    private fun reconciler(dao: FakeDao, catalog: FakeCatalog) =
+        AudiobookBookmarkReconciler(dao, FakeRegistry(catalog), now = now, newId = counterIds())
 
-    private suspend fun AudiobookBookmarkReconciler.run() =
-        reconcile("s1", "i1", "http://abs", "tok", insecureAllowed = false)
+    private suspend fun AudiobookBookmarkReconciler.run() = reconcile("s1", "i1")
 
     @Test fun pushCreate() = runTest {
         val dao = FakeDao()
@@ -144,11 +142,10 @@ class AudiobookBookmarkReconcilerTest {
                 createdAt = 500L, localUpdatedAt = 800L, lastSyncedAt = 0L, deleted = false,
             ),
         )
-        // Source echoes the bookmark back so the pull doesn't remove the now-clean row.
-        val api = FakeApi(listResult = NetworkResult.Success(listOf(NetworkAbsBookmark("i1", "Intro", 12, 500L))))
-        reconciler(dao, api).run()
+        val cat = FakeCatalog(listResult = Result.success(listOf(CatalogBookmark("i1", 12, "Intro", 500L))))
+        reconciler(dao, cat).run()
 
-        assertEquals(listOf(FakeApi.Call("create", "i1", 12, "Intro")), api.calls.filter { it.kind == "create" })
+        assertEquals(listOf(FakeCatalog.Call("create", "i1", 12, "Intro")), cat.calls.filter { it.kind == "create" })
         val row = dao.getById("a")!!
         assertTrue("created row must become clean", row.localUpdatedAt <= row.lastSyncedAt)
     }
@@ -161,11 +158,11 @@ class AudiobookBookmarkReconcilerTest {
                 createdAt = 500L, localUpdatedAt = 900L, lastSyncedAt = 600L, deleted = false,
             ),
         )
-        val api = FakeApi(listResult = NetworkResult.Success(listOf(NetworkAbsBookmark("i1", "New name", 30, 500L))))
-        reconciler(dao, api).run()
+        val cat = FakeCatalog(listResult = Result.success(listOf(CatalogBookmark("i1", 30, "New name", 500L))))
+        reconciler(dao, cat).run()
 
-        assertEquals(listOf(FakeApi.Call("update", "i1", 30, "New name")), api.calls.filter { it.kind == "update" })
-        assertTrue(api.calls.none { it.kind == "create" })
+        assertEquals(listOf(FakeCatalog.Call("update", "i1", 30, "New name")), cat.calls.filter { it.kind == "update" })
+        assertTrue(cat.calls.none { it.kind == "create" })
         val row = dao.getById("a")!!
         assertTrue("renamed row must become clean", row.localUpdatedAt <= row.lastSyncedAt)
     }
@@ -178,10 +175,10 @@ class AudiobookBookmarkReconcilerTest {
                 createdAt = 500L, localUpdatedAt = 900L, lastSyncedAt = 600L, deleted = true,
             ),
         )
-        val api = FakeApi()
-        reconciler(dao, api).run()
+        val cat = FakeCatalog()
+        reconciler(dao, cat).run()
 
-        assertEquals(listOf(FakeApi.Call("delete", "i1", 45, "")), api.calls.filter { it.kind == "delete" })
+        assertEquals(listOf(FakeCatalog.Call("delete", "i1", 45, "")), cat.calls.filter { it.kind == "delete" })
         assertNull("confirmed delete must be hard-removed", dao.getById("a"))
     }
 
@@ -193,9 +190,8 @@ class AudiobookBookmarkReconcilerTest {
                 createdAt = 500L, localUpdatedAt = 900L, lastSyncedAt = 600L, deleted = true,
             ),
         )
-        val api = FakeApi()
-        api.deleteResult = NetworkResult.Offline(RuntimeException("boom"))
-        reconciler(dao, api).run()
+        val cat = FakeCatalog().apply { deleteOk = false }
+        reconciler(dao, cat).run()
 
         val row = dao.getById("a")!!
         assertEquals(true, row.deleted)
@@ -204,8 +200,8 @@ class AudiobookBookmarkReconcilerTest {
 
     @Test fun pullInsert() = runTest {
         val dao = FakeDao()
-        val api = FakeApi(listResult = NetworkResult.Success(listOf(NetworkAbsBookmark("i1", "From source", 77, 1234L))))
-        reconciler(dao, api).run()
+        val cat = FakeCatalog(listResult = Result.success(listOf(CatalogBookmark("i1", 77, "From source", 1234L))))
+        reconciler(dao, cat).run()
 
         val row = dao.allForItem("s1", "i1").single()
         assertEquals(77.0, row.positionSec, 0.0001)
@@ -223,37 +219,30 @@ class AudiobookBookmarkReconcilerTest {
                 createdAt = 500L, localUpdatedAt = 600L, lastSyncedAt = 600L, deleted = false,
             ),
         )
-        val api = FakeApi(listResult = NetworkResult.Success(emptyList<NetworkAbsBookmark>()))
-        reconciler(dao, api).run()
+        val cat = FakeCatalog(listResult = Result.success(emptyList()))
+        reconciler(dao, cat).run()
 
         assertNull("clean row missing from source must be removed", dao.getById("a"))
     }
 
     @Test fun pullDoesNotClobberDirtyRows() = runTest {
         val dao = FakeDao()
-        // Dirty local create whose time is absent source-side -> must NOT be removed.
         dao.upsert(
             AudiobookBookmarkEntity(
                 id = "create", sourceId = "s1", itemId = "i1", positionSec = 20.0, title = "pending",
                 createdAt = 500L, localUpdatedAt = 900L, lastSyncedAt = 0L, deleted = false,
             ),
         )
-        // Dirty rename whose source title differs -> source title must NOT be applied.
         dao.upsert(
             AudiobookBookmarkEntity(
                 id = "rename", sourceId = "s1", itemId = "i1", positionSec = 50.0, title = "local title",
                 createdAt = 500L, localUpdatedAt = 900L, lastSyncedAt = 600L, deleted = false,
             ),
         )
-        // Source returns the rename's time with a DIFFERENT title; the create's time is absent.
-        val api = FakeApi(
-            listResult = NetworkResult.Success(listOf(NetworkAbsBookmark("i1", "source title", 50, 500L))),
-        )
-        // Pushes fail (network) so both rows stay DIRTY through the pull — that's the scenario
-        // under test: the pull must not clobber pending local intent.
-        api.createResult = NetworkResult.Offline(RuntimeException("down"))
-        api.updateResult = NetworkResult.Offline(RuntimeException("down"))
-        reconciler(dao, api).run()
+        val cat = FakeCatalog(listResult = Result.success(listOf(CatalogBookmark("i1", 50, "source title", 500L))))
+        cat.createOk = false
+        cat.renameOk = false
+        reconciler(dao, cat).run()
 
         val createRow = dao.getById("create")
         assertNotNull("dirty pending create must survive pull", createRow)
@@ -263,43 +252,40 @@ class AudiobookBookmarkReconcilerTest {
 
     @Test fun listBookmarksNetworkErrorSkipsPullButPushesHappen() = runTest {
         val dao = FakeDao()
-        // A dirty create to push.
         dao.upsert(
             AudiobookBookmarkEntity(
                 id = "a", sourceId = "s1", itemId = "i1", positionSec = 12.0, title = "Intro",
                 createdAt = 500L, localUpdatedAt = 800L, lastSyncedAt = 0L, deleted = false,
             ),
         )
-        // A clean row that, if the pull ran, would be removed (absent source-side). It must survive.
         dao.upsert(
             AudiobookBookmarkEntity(
                 id = "clean", sourceId = "s1", itemId = "i1", positionSec = 99.0, title = "keep",
                 createdAt = 500L, localUpdatedAt = 600L, lastSyncedAt = 600L, deleted = false,
             ),
         )
-        val api = FakeApi(listResult = NetworkResult.Offline(RuntimeException("down")))
-        reconciler(dao, api).run()
+        val cat = FakeCatalog(listResult = Result.failure(RuntimeException("down")))
+        reconciler(dao, cat).run()
 
-        assertEquals(listOf(FakeApi.Call("create", "i1", 12, "Intro")), api.calls.filter { it.kind == "create" })
+        assertEquals(listOf(FakeCatalog.Call("create", "i1", 12, "Intro")), cat.calls.filter { it.kind == "create" })
         assertNotNull("pull skipped: clean row must NOT be removed", dao.getById("clean"))
     }
 
     @Test fun crossItemIsolation() = runTest {
         val dao = FakeDao()
-        val api = FakeApi(
-            listResult = NetworkResult.Success(
+        val cat = FakeCatalog(
+            listResult = Result.success(
                 listOf(
-                    NetworkAbsBookmark("OTHER", "other item", 10, 1L),
-                    NetworkAbsBookmark("i1", "ours", 20, 2L),
+                    CatalogBookmark("OTHER", 10, "other item", 1L),
+                    CatalogBookmark("i1", 20, "ours", 2L),
                 ),
             ),
         )
-        reconciler(dao, api).run()
+        reconciler(dao, cat).run()
 
         val rows = dao.allForItem("s1", "i1")
         assertEquals(1, rows.size)
         assertEquals("ours", rows.single().title)
-        // No row inserted for the OTHER item.
         assertTrue(dao.rows.value.none { it.itemId == "OTHER" })
     }
 }

--- a/core/data/src/test/kotlin/com/riffle/core/data/AudiobookChapterCacheRepositoryImplTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/AudiobookChapterCacheRepositoryImplTest.kt
@@ -48,7 +48,7 @@ class AudiobookChapterCacheRepositoryImplTest {
         override suspend fun openFile(itemId: String, format: BookFormat, handleHint: String?): CatalogFileStream = throw UnsupportedOperationException()
         override suspend fun connectivityCheck() = CatalogHealth(isReachable = true)
         override suspend fun getTracks(itemId: String): List<CatalogAudioTrack> = emptyList()
-        override suspend fun getFingerprint(itemId: String) = CatalogAudioFingerprint(itemId, 0L, 0.0, emptyList())
+        override suspend fun getFingerprint(itemId: String): CatalogAudioFingerprint? = CatalogAudioFingerprint(itemId, 0L, 0.0, emptyList())
         override fun buildStreamUrl(itemId: String, trackIno: String) = ""
         override suspend fun openAudiobook(itemId: String, deviceLabel: String): CatalogAudiobookStream? = null
         override suspend fun getAudiobookChapters(itemId: String): List<CatalogAudiobookChapter> {

--- a/core/data/src/test/kotlin/com/riffle/core/data/AudiobookChapterCacheRepositoryImplTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/AudiobookChapterCacheRepositoryImplTest.kt
@@ -1,14 +1,24 @@
 package com.riffle.core.data
 
-import com.riffle.core.network.NetworkResult
-
+import com.riffle.core.catalog.AudiobookMediaCapability
+import com.riffle.core.catalog.BookFormat
+import com.riffle.core.catalog.Catalog
+import com.riffle.core.catalog.CatalogAudioFingerprint
+import com.riffle.core.catalog.CatalogAudioTrack
+import com.riffle.core.catalog.CatalogAudiobookChapter
+import com.riffle.core.catalog.CatalogAudiobookStream
+import com.riffle.core.catalog.CatalogFileHandle
+import com.riffle.core.catalog.CatalogFileStream
+import com.riffle.core.catalog.CatalogHealth
+import com.riffle.core.catalog.CatalogItem
+import com.riffle.core.catalog.CatalogRegistry
+import com.riffle.core.catalog.CatalogRoot
+import com.riffle.core.catalog.SortKey
 import com.riffle.core.database.AudiobookChapterCacheDao
 import com.riffle.core.database.AudiobookChapterCacheEntity
 import com.riffle.core.domain.AudiobookChapter
-import com.riffle.core.network.AbsLibraryApi
-import com.riffle.core.network.model.AbsItemChapterDto
-import com.riffle.core.network.model.AbsItemDetailMediaDto
-import com.riffle.core.network.model.AbsItemDetailResponse
+import com.riffle.core.domain.Source
+import com.riffle.core.domain.SourceType
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
@@ -28,24 +38,35 @@ class AudiobookChapterCacheRepositoryImplTest {
         }
     }
 
-    private fun fakeApiReturning(result: NetworkResult<com.riffle.core.network.model.AbsItemDetailResponse>) = object : AbsLibraryApi {
-        override suspend fun getLibraries(baseUrl: String, token: String, insecureAllowed: Boolean): NetworkResult<List<com.riffle.core.network.NetworkLibrary>> =
-            throw NotImplementedError()
-        override suspend fun getLibraryItems(baseUrl: String, libraryId: String, token: String, insecureAllowed: Boolean): NetworkResult<List<com.riffle.core.network.NetworkLibraryItem>> =
-            throw NotImplementedError()
-        override suspend fun getSeries(baseUrl: String, libraryId: String, token: String, insecureAllowed: Boolean): NetworkResult<List<com.riffle.core.network.NetworkSeries>> =
-            throw NotImplementedError()
-        override suspend fun getCollections(baseUrl: String, libraryId: String, token: String, insecureAllowed: Boolean): NetworkResult<List<com.riffle.core.network.NetworkCollection>> =
-            throw NotImplementedError()
-        override suspend fun getItemDetail(baseUrl: String, itemId: String, token: String, insecureAllowed: Boolean): NetworkResult<com.riffle.core.network.model.AbsItemDetailResponse> =
-            result
+    private class FakeCatalog(val chapters: List<CatalogAudiobookChapter>?, val fail: Boolean = false) : Catalog, AudiobookMediaCapability {
+        override val sourceType = SourceType.ABS
+        override suspend fun listRoots() = emptyList<CatalogRoot>()
+        override suspend fun browse(rootId: String, sort: SortKey, page: Int, pageSize: Int) = emptyList<CatalogItem>()
+        override suspend fun search(rootId: String, query: String, page: Int, pageSize: Int) = emptyList<CatalogItem>()
+        override suspend fun getItem(itemId: String): CatalogItem? = null
+        override suspend fun fetchFile(itemId: String, format: BookFormat): CatalogFileHandle = throw UnsupportedOperationException()
+        override suspend fun openFile(itemId: String, format: BookFormat, handleHint: String?): CatalogFileStream = throw UnsupportedOperationException()
+        override suspend fun connectivityCheck() = CatalogHealth(isReachable = true)
+        override suspend fun getTracks(itemId: String): List<CatalogAudioTrack> = emptyList()
+        override suspend fun getFingerprint(itemId: String) = CatalogAudioFingerprint(itemId, 0L, 0.0, emptyList())
+        override fun buildStreamUrl(itemId: String, trackIno: String) = ""
+        override suspend fun openAudiobook(itemId: String, deviceLabel: String): CatalogAudiobookStream? = null
+        override suspend fun getAudiobookChapters(itemId: String): List<CatalogAudiobookChapter> {
+            if (fail) throw RuntimeException("boom")
+            return chapters!!
+        }
+    }
+
+    private class FakeRegistry(private val catalog: Catalog?) : CatalogRegistry {
+        override suspend fun forActive(): Catalog? = catalog
+        override suspend fun forSource(source: Source): Catalog? = catalog
+        override suspend fun forSourceId(sourceId: String): Catalog? = catalog
     }
 
     @Test
     fun `getCachedChapters returns null when no cache`() = runTest {
         val dao = FakeAudiobookChapterCacheDao()
-        val api = fakeApiReturning(NetworkResult.Offline(RuntimeException("not called")))
-        val repo = AudiobookChapterCacheRepositoryImpl(dao, api)
+        val repo = AudiobookChapterCacheRepositoryImpl(dao, FakeRegistry(null))
 
         assertNull(repo.getCachedChapters("srv", "item"))
     }
@@ -55,8 +76,7 @@ class AudiobookChapterCacheRepositoryImplTest {
         val dao = FakeAudiobookChapterCacheDao()
         val json = """[{"index":0,"startSec":0.0,"endSec":300.0,"title":"Intro"}]"""
         dao.store["srv" to "item"] = AudiobookChapterCacheEntity("srv", "item", json)
-        val api = fakeApiReturning(NetworkResult.Offline(RuntimeException("not called")))
-        val repo = AudiobookChapterCacheRepositoryImpl(dao, api)
+        val repo = AudiobookChapterCacheRepositoryImpl(dao, FakeRegistry(null))
 
         val result = repo.getCachedChapters("srv", "item")
         assertNotNull(result)
@@ -66,23 +86,12 @@ class AudiobookChapterCacheRepositoryImplTest {
     }
 
     @Test
-    fun `fetchAndCacheChapters calls api, maps chapters, and upserts`() = runTest {
+    fun `fetchAndCacheChapters calls catalog, maps chapters, and upserts`() = runTest {
         val dao = FakeAudiobookChapterCacheDao()
-        val api = fakeApiReturning(
-            NetworkResult.Success(
-                AbsItemDetailResponse(
-                    id = "item",
-                    media = AbsItemDetailMediaDto(
-                        chapters = listOf(
-                            AbsItemChapterDto(id = 0, startSec = 0.0, endSec = 600.0, title = "Ch 1")
-                        )
-                    ),
-                )
-            )
-        )
-        val repo = AudiobookChapterCacheRepositoryImpl(dao, api)
+        val catalog = FakeCatalog(listOf(CatalogAudiobookChapter(0, 0.0, 600.0, "Ch 1")))
+        val repo = AudiobookChapterCacheRepositoryImpl(dao, FakeRegistry(catalog))
 
-        val result = repo.fetchAndCacheChapters("srv", "item", "http://base", "tok", false)
+        val result = repo.fetchAndCacheChapters("srv", "item")
 
         assertEquals(1, result.size)
         assertEquals("Ch 1", result[0].title)
@@ -99,10 +108,9 @@ class AudiobookChapterCacheRepositoryImplTest {
     @Test
     fun `fetchAndCacheChapters returns empty list on network error`() = runTest {
         val dao = FakeAudiobookChapterCacheDao()
-        val api = fakeApiReturning(NetworkResult.Offline(RuntimeException("network fail")))
-        val repo = AudiobookChapterCacheRepositoryImpl(dao, api)
+        val repo = AudiobookChapterCacheRepositoryImpl(dao, FakeRegistry(FakeCatalog(chapters = null, fail = true)))
 
-        val result = repo.fetchAndCacheChapters("srv", "item", "http://base", "tok", false)
+        val result = repo.fetchAndCacheChapters("srv", "item")
 
         assertEquals(emptyList<AudiobookChapter>(), result)
         assert(!dao.upsertCalled) { "dao.upsert should NOT have been called on error" }
@@ -111,22 +119,13 @@ class AudiobookChapterCacheRepositoryImplTest {
     @Test
     fun `fetchAndCacheChapters round-trips through getCachedChapters`() = runTest {
         val dao = FakeAudiobookChapterCacheDao()
-        val api = fakeApiReturning(
-            NetworkResult.Success(
-                AbsItemDetailResponse(
-                    id = "item",
-                    media = AbsItemDetailMediaDto(
-                        chapters = listOf(
-                            AbsItemChapterDto(id = 0, startSec = 0.0, endSec = 300.0, title = "Prologue"),
-                            AbsItemChapterDto(id = 1, startSec = 300.0, endSec = 900.0, title = "Chapter 1"),
-                        )
-                    ),
-                )
-            )
-        )
-        val repo = AudiobookChapterCacheRepositoryImpl(dao, api)
+        val catalog = FakeCatalog(listOf(
+            CatalogAudiobookChapter(0, 0.0, 300.0, "Prologue"),
+            CatalogAudiobookChapter(1, 300.0, 900.0, "Chapter 1"),
+        ))
+        val repo = AudiobookChapterCacheRepositoryImpl(dao, FakeRegistry(catalog))
 
-        repo.fetchAndCacheChapters("srv", "item", "http://base", "tok", false)
+        repo.fetchAndCacheChapters("srv", "item")
         val cached = repo.getCachedChapters("srv", "item")
 
         assertNotNull(cached)

--- a/core/data/src/test/kotlin/com/riffle/core/data/AudiobookIdentityResolverTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/AudiobookIdentityResolverTest.kt
@@ -1,7 +1,5 @@
 package com.riffle.core.data
 
-import com.riffle.core.network.NetworkResult
-
 import com.riffle.core.domain.AudiobookFingerprint
 import com.riffle.core.domain.AudiobookIdentityResult
 import org.junit.Assert.assertEquals
@@ -15,8 +13,8 @@ class AudiobookIdentityResolverTest {
 
     private val martian = AudiobookFingerprint(313_869_927, 39_214.464, listOf(39_214.464))
 
-    private fun ok(fp: AudiobookFingerprint): NetworkResult<AudiobookFingerprint?> = NetworkResult.Success(fp)
-    private val noAudiobook: NetworkResult<AudiobookFingerprint?> = NetworkResult.Success(null)
+    private fun ok(fp: AudiobookFingerprint?): Result<AudiobookFingerprint?> = Result.success(fp)
+    private val noAudiobook: Result<AudiobookFingerprint?> = Result.success(null)
 
     @Test
     fun `matching fingerprints verify`() {
@@ -41,7 +39,7 @@ class AudiobookIdentityResolverTest {
     fun `a fetch error resolves to UNKNOWN, never a false verify`() {
         assertEquals(
             AudiobookIdentityResult.UNKNOWN,
-            AudiobookIdentityResolver.resolve(ok(martian), NetworkResult.Offline(RuntimeException())),
+            AudiobookIdentityResolver.resolve(ok(martian), Result.failure(RuntimeException())),
         )
     }
 }

--- a/core/data/src/test/kotlin/com/riffle/core/data/AudiobookRepositoryImplTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/AudiobookRepositoryImplTest.kt
@@ -1,20 +1,22 @@
 package com.riffle.core.data
 
-import com.riffle.core.network.NetworkResult
-
+import com.riffle.core.catalog.AudiobookMediaCapability
+import com.riffle.core.catalog.BookFormat
+import com.riffle.core.catalog.Catalog
+import com.riffle.core.catalog.CatalogAudioFingerprint
+import com.riffle.core.catalog.CatalogAudioTrack
+import com.riffle.core.catalog.CatalogAudiobookChapter
+import com.riffle.core.catalog.CatalogAudiobookStream
+import com.riffle.core.catalog.CatalogFileHandle
+import com.riffle.core.catalog.CatalogFileStream
+import com.riffle.core.catalog.CatalogHealth
+import com.riffle.core.catalog.CatalogItem
+import com.riffle.core.catalog.CatalogRegistry
+import com.riffle.core.catalog.CatalogRoot
+import com.riffle.core.catalog.SortKey
+import com.riffle.core.domain.Clock
 import com.riffle.core.domain.Source
-import com.riffle.core.domain.SourceRepository
-import com.riffle.core.domain.SourceUrl
-import com.riffle.core.domain.TokenStorage
-import com.riffle.core.network.AbsPlaybackApi
-import com.riffle.core.network.AbsSessionApi
-import com.riffle.core.network.NetworkAudioChapter
-import com.riffle.core.network.NetworkAudioTrack
-import com.riffle.core.network.NetworkAudiobookProgressPayload
-import com.riffle.core.network.NetworkEbookProgressPayload
-import com.riffle.core.network.NetworkPlaybackSession
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.emptyFlow
+import com.riffle.core.domain.SourceType
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
@@ -22,44 +24,32 @@ import org.junit.Test
 
 class AudiobookRepositoryImplTest {
 
-    private val source = Source(
-        id = "srv", url = SourceUrl.parse("http://host:13378")!!, isActive = true,
-        insecureConnectionAllowed = false, username = "u",
-    )
-
-    private fun repo(
-        playback: AbsPlaybackApi,
-        session: AbsSessionApi = NoopSessionApi,
-        serverById: Source? = source,
-        token: String? = "TKN",
-    ) = AudiobookRepositoryImpl(
-        playbackApi = playback,
-        sessionApi = session,
-        sourceRepository = FakeSourceRepository(serverById),
-        tokenStorage = FakeTokenStorage(token),
+    private fun repo(catalog: Catalog?) = AudiobookRepositoryImpl(
+        catalogRegistry = FakeRegistry(catalog),
+        clock = object : Clock { override fun nowMs() = 0L; override fun nowNs() = 0L },
     )
 
     @Test
-    fun `openSession builds absolute tokenised track URLs and maps timeline`() = runTest {
-        val playback = FakePlaybackApi(
-            NetworkResult.Success(
-                NetworkPlaybackSession(
-                    sessionId = "ps",
-                    tracks = listOf(
-                        NetworkAudioTrack(0, 0.0, 100.0, "/api/items/it/file/1", "audio/mpeg"),
-                        NetworkAudioTrack(1, 100.0, 200.0, "/api/items/it/file/2", "audio/mpeg"),
-                    ),
-                    chapters = listOf(
-                        NetworkAudioChapter(0, 0.0, 100.0, "One"),
-                        NetworkAudioChapter(1, 100.0, 300.0, "Two"),
-                    ),
-                    currentTimeSec = 42.0,
-                    durationSec = 300.0,
-                ),
+    fun `openSession maps stream tracks, chapters and timeline`() = runTest {
+        val stream = CatalogAudiobookStream(
+            trackUrls = listOf(
+                "http://host:13378/api/items/it/file/1?token=TKN",
+                "http://host:13378/api/items/it/file/2?token=TKN",
             ),
+            tracks = listOf(
+                CatalogAudioTrack(ino = "1", index = 0, startOffsetSec = 0.0, durationSec = 100.0, contentUrl = ""),
+                CatalogAudioTrack(ino = "2", index = 1, startOffsetSec = 100.0, durationSec = 200.0, contentUrl = ""),
+            ),
+            chapters = listOf(
+                CatalogAudiobookChapter(0, 0.0, 100.0, "One"),
+                CatalogAudiobookChapter(1, 100.0, 300.0, "Two"),
+            ),
+            totalDurationSec = 300.0,
+            serverCurrentTimeSec = 42.0,
+            serverLastUpdate = 1_700_000_000_000L,
         )
 
-        val s = repo(playback).openSession("srv", "it")!!
+        val s = repo(FakeAudioCatalog(stream)).openSession("srv", "it")!!
 
         assertEquals(
             listOf(
@@ -73,113 +63,55 @@ class AudiobookRepositoryImplTest {
         assertEquals(300.0, s.timeline.durationSec, 0.0)
         assertEquals(listOf("One", "Two"), s.timeline.chapters.map { it.title })
         assertEquals(42.0, s.serverCurrentTimeSec, 0.0)
+        assertEquals(1_700_000_000_000L, s.serverLastUpdate)
     }
 
     @Test
-    fun `openSession carries the source lastUpdate from the progress record`() = runTest {
-        val playback = FakePlaybackApi(
-            NetworkResult.Success(
-                NetworkPlaybackSession(
-                    sessionId = "ps",
-                    tracks = listOf(NetworkAudioTrack(0, 0.0, 100.0, "/api/items/it/file/1", "audio/mpeg")),
-                    chapters = emptyList(),
-                    currentTimeSec = 42.0,
-                    durationSec = 100.0,
-                ),
-            ),
-        )
-        val session = object : AbsSessionApi by NoopSessionApi {
-            override suspend fun getProgress(
-                baseUrl: String, libraryItemId: String, token: String, insecureAllowed: Boolean,
-            ) = NetworkResult.Success(
-                com.riffle.core.network.NetworkServerProgress(
-                    ebookLocation = "", ebookProgress = 0f, currentTime = 42.0, duration = 100.0,
-                    lastUpdate = 1700000000000L,
-                ),
-            )
-        }
-
-        val s = repo(playback, session).openSession("srv", "it")!!
-
-        assertEquals(1700000000000L, s.serverLastUpdate)
+    fun `openSession returns null when the stream cannot be opened`() = runTest {
+        assertNull(repo(FakeAudioCatalog(stream = null)).openSession("srv", "it"))
     }
 
     @Test
-    fun `openSession defaults serverLastUpdate to zero when the progress read fails`() = runTest {
-        val playback = FakePlaybackApi(
-            NetworkResult.Success(
-                NetworkPlaybackSession(
-                    sessionId = "ps",
-                    tracks = listOf(NetworkAudioTrack(0, 0.0, 100.0, "/api/items/it/file/1", "audio/mpeg")),
-                    chapters = emptyList(),
-                    currentTimeSec = 42.0,
-                    durationSec = 100.0,
-                ),
-            ),
-        )
-        // NoopSessionApi.getProgress returns NetworkError → no stamp available.
-        val s = repo(playback).openSession("srv", "it")!!
-        assertEquals(0L, s.serverLastUpdate)
+    fun `openSession returns null when there is no catalog for the source`() = runTest {
+        assertNull(repo(catalog = null).openSession("srv", "it"))
     }
 
     @Test
-    fun `openSession returns null when the play session has no tracks`() = runTest {
-        val playback = FakePlaybackApi(
-            NetworkResult.Success(
-                NetworkPlaybackSession("ps", emptyList(), emptyList(), 0.0, 0.0),
-            ),
-        )
-        assertNull(repo(playback).openSession("srv", "it"))
+    fun `openSession returns null when the catalog has no audiobook capability`() = runTest {
+        assertNull(repo(PlainCatalog).openSession("srv", "it"))
     }
 
-    @Test
-    fun `openSession returns null on a network error`() = runTest {
-        val playback = FakePlaybackApi(NetworkResult.Offline(RuntimeException("boom")))
-        assertNull(repo(playback).openSession("srv", "it"))
+    private class FakeRegistry(private val catalog: Catalog?) : CatalogRegistry {
+        override suspend fun forActive(): Catalog? = catalog
+        override suspend fun forSource(source: Source): Catalog? = catalog
+        override suspend fun forSourceId(sourceId: String): Catalog? = catalog
     }
 
-    @Test
-    fun `openSession returns null when there is no token`() = runTest {
-        val playback = FakePlaybackApi(NetworkResult.Offline(RuntimeException("unused")))
-        assertNull(repo(playback, token = null).openSession("srv", "it"))
+    private class FakeAudioCatalog(private val stream: CatalogAudiobookStream?) : Catalog, AudiobookMediaCapability {
+        override val sourceType = SourceType.ABS
+        override suspend fun listRoots() = emptyList<CatalogRoot>()
+        override suspend fun browse(rootId: String, sort: SortKey, page: Int, pageSize: Int) = emptyList<CatalogItem>()
+        override suspend fun search(rootId: String, query: String, page: Int, pageSize: Int) = emptyList<CatalogItem>()
+        override suspend fun getItem(itemId: String): CatalogItem? = null
+        override suspend fun fetchFile(itemId: String, format: BookFormat): CatalogFileHandle = throw UnsupportedOperationException()
+        override suspend fun openFile(itemId: String, format: BookFormat, handleHint: String?): CatalogFileStream = throw UnsupportedOperationException()
+        override suspend fun connectivityCheck() = CatalogHealth(isReachable = true)
+        override suspend fun getTracks(itemId: String): List<CatalogAudioTrack> = emptyList()
+        override suspend fun getFingerprint(itemId: String) = CatalogAudioFingerprint(itemId, 0L, 0.0, emptyList())
+        override fun buildStreamUrl(itemId: String, trackIno: String) = ""
+        override suspend fun openAudiobook(itemId: String, deviceLabel: String) = stream
+        override suspend fun getAudiobookChapters(itemId: String) = emptyList<CatalogAudiobookChapter>()
     }
 
-    private class FakePlaybackApi(private val result: NetworkResult<com.riffle.core.network.NetworkPlaybackSession>) : AbsPlaybackApi {
-        override suspend fun openPlaybackSession(
-            baseUrl: String, libraryItemId: String, deviceId: String, token: String, insecureAllowed: Boolean,
-        ) = result
-    }
-
-    private class FakeTokenStorage(private val token: String?) : TokenStorage {
-        override suspend fun saveToken(sourceId: String, token: String) = Unit
-        override suspend fun getToken(sourceId: String): String? = token
-        override suspend fun deleteToken(sourceId: String) = Unit
-    }
-
-    private class FakeSourceRepository(private val byId: Source?) : SourceRepository {
-        override fun observeAll(): Flow<List<Source>> = emptyFlow()
-        override suspend fun getActive(): Source? = byId
-        override suspend fun getById(sourceId: String): Source? = byId
-        override suspend fun authenticate(
-            url: SourceUrl, username: String, password: String, insecureAllowed: Boolean,
-            serverType: com.riffle.core.domain.ServerType,
-        ) = throw UnsupportedOperationException()
-        override suspend fun commit(pending: com.riffle.core.domain.PendingSource, hiddenLibraryIds: Set<String>) =
-            throw UnsupportedOperationException()
-        override suspend fun setActive(sourceId: String) = Unit
-        override suspend fun remove(sourceId: String) = Unit
-        override suspend fun getSourceVersion(sourceId: String): String? = null
-    }
-
-    private object NoopSessionApi : AbsSessionApi {
-        override suspend fun syncEbookProgress(
-            baseUrl: String, libraryItemId: String, payload: NetworkEbookProgressPayload, token: String, insecureAllowed: Boolean,
-        ) = NetworkResult.Success(0L)
-        override suspend fun syncAudiobookProgress(
-            baseUrl: String, libraryItemId: String, payload: NetworkAudiobookProgressPayload, token: String, insecureAllowed: Boolean,
-        ) = NetworkResult.Success(0L)
-        override suspend fun getProgress(
-            baseUrl: String, libraryItemId: String, token: String, insecureAllowed: Boolean,
-        ) = NetworkResult.Offline(RuntimeException("unused"))
+    /** A Catalog without AudiobookMediaCapability. */
+    private object PlainCatalog : Catalog {
+        override val sourceType = SourceType.ABS
+        override suspend fun listRoots() = emptyList<CatalogRoot>()
+        override suspend fun browse(rootId: String, sort: SortKey, page: Int, pageSize: Int) = emptyList<CatalogItem>()
+        override suspend fun search(rootId: String, query: String, page: Int, pageSize: Int) = emptyList<CatalogItem>()
+        override suspend fun getItem(itemId: String): CatalogItem? = null
+        override suspend fun fetchFile(itemId: String, format: BookFormat): CatalogFileHandle = throw UnsupportedOperationException()
+        override suspend fun openFile(itemId: String, format: BookFormat, handleHint: String?): CatalogFileStream = throw UnsupportedOperationException()
+        override suspend fun connectivityCheck() = CatalogHealth(isReachable = true)
     }
 }

--- a/core/data/src/test/kotlin/com/riffle/core/data/AudiobookRepositoryImplTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/AudiobookRepositoryImplTest.kt
@@ -97,7 +97,7 @@ class AudiobookRepositoryImplTest {
         override suspend fun openFile(itemId: String, format: BookFormat, handleHint: String?): CatalogFileStream = throw UnsupportedOperationException()
         override suspend fun connectivityCheck() = CatalogHealth(isReachable = true)
         override suspend fun getTracks(itemId: String): List<CatalogAudioTrack> = emptyList()
-        override suspend fun getFingerprint(itemId: String) = CatalogAudioFingerprint(itemId, 0L, 0.0, emptyList())
+        override suspend fun getFingerprint(itemId: String): CatalogAudioFingerprint? = CatalogAudioFingerprint(itemId, 0L, 0.0, emptyList())
         override fun buildStreamUrl(itemId: String, trackIno: String) = ""
         override suspend fun openAudiobook(itemId: String, deviceLabel: String) = stream
         override suspend fun getAudiobookChapters(itemId: String) = emptyList<CatalogAudiobookChapter>()

--- a/core/data/src/test/kotlin/com/riffle/core/data/EpubPositionIntegrationTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/EpubPositionIntegrationTest.kt
@@ -61,12 +61,8 @@ class EpubPositionIntegrationTest {
         source.shutdown()
     }
 
-    private fun buildRepo(): EpubRepositoryImpl = EpubRepositoryImpl(
-        api = AbsApiClient(OkHttpClient(), DefaultDispatcherProvider),
-        cacheStore = cacheStore,
-        downloadsStore = LocalStoreImpl(tmp.newFolder("downloads-${System.nanoTime()}"), ".epub", com.riffle.core.domain.DefaultDispatcherProvider),
-        positionStore = ReadingPositionStoreImpl(sharedPositionDao, com.riffle.core.domain.TestClock(System.currentTimeMillis())),
-        sourceRepository = object : SourceRepository {
+    private fun buildRepo(): EpubRepositoryImpl {
+        val sourceRepo = object : SourceRepository {
             val activeServer = Source(
                 id = "source-1",
                 url = SourceUrl.parse(source.url("/").toString().trimEnd('/'))!!,
@@ -84,13 +80,15 @@ class EpubPositionIntegrationTest {
             override suspend fun setActive(sourceId: String) = Unit
             override suspend fun remove(sourceId: String) = Unit
             override suspend fun getSourceVersion(sourceId: String): String? = null
-        },
-        tokenStorage = object : TokenStorage {
-            override suspend fun saveToken(sourceId: String, token: String) = Unit
-            override suspend fun getToken(sourceId: String): String? = "test-token"
-            override suspend fun deleteToken(sourceId: String) = Unit
-        },
-    )
+        }
+        return EpubRepositoryImpl(
+            catalogRegistry = TestCatalogRegistry(sourceRepo, mapOf("source-1" to "test-token")),
+            cacheStore = cacheStore,
+            downloadsStore = LocalStoreImpl(tmp.newFolder("downloads-${System.nanoTime()}"), ".epub", com.riffle.core.domain.DefaultDispatcherProvider),
+            positionStore = ReadingPositionStoreImpl(sharedPositionDao, com.riffle.core.domain.TestClock(System.currentTimeMillis())),
+            sourceRepository = sourceRepo,
+        )
+    }
 
     private fun item() = LibraryItem(
         id = "item-1",

--- a/core/data/src/test/kotlin/com/riffle/core/data/EpubRepositoryTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/EpubRepositoryTest.kt
@@ -58,13 +58,13 @@ class EpubRepositoryTest {
         cacheStore = LocalStoreImpl(tmp.newFolder("cache"), ".epub", com.riffle.core.domain.DefaultDispatcherProvider)
         downloadsStore = LocalStoreImpl(tmp.newFolder("downloads"), ".epub", com.riffle.core.domain.DefaultDispatcherProvider)
         positionStore = FakePositionStore()
+        val sourceRepo = fakeServerRepository(source.url("/").toString().trimEnd('/'))
         repo = EpubRepositoryImpl(
-            api = AbsApiClient(OkHttpClient(), DefaultDispatcherProvider),
+            catalogRegistry = TestCatalogRegistry(sourceRepo, mapOf("source-1" to "test-token")),
             cacheStore = cacheStore,
             downloadsStore = downloadsStore,
             positionStore = positionStore,
-            sourceRepository = fakeServerRepository(source.url("/").toString().trimEnd('/')),
-            tokenStorage = fakeTokenStorage("test-token"),
+            sourceRepository = sourceRepo,
         )
     }
 
@@ -268,12 +268,6 @@ class EpubRepositoryTest {
     // directory, misses the truly-cached file, and falls into the network branch. That's the
     // "unable to resolve host" symptom on a cached book while offline.
 
-    private fun multiTokenStorage(tokens: Map<String, String>): TokenStorage = object : TokenStorage {
-        override suspend fun saveToken(sourceId: String, token: String) = Unit
-        override suspend fun getToken(sourceId: String): String? = tokens[sourceId]
-        override suspend fun deleteToken(sourceId: String) = Unit
-    }
-
     private fun serverRow(id: String, baseUrl: String, isActive: Boolean) = Source(
         id = id,
         url = SourceUrl.parse(baseUrl)!!,
@@ -283,14 +277,13 @@ class EpubRepositoryTest {
         serverType = ServerType.AUDIOBOOKSHELF,
     )
 
-    private fun repoWith(sourceRepository: SourceRepository, tokenStorage: TokenStorage): EpubRepository =
+    private fun repoWith(sourceRepository: SourceRepository, tokens: Map<String, String>): EpubRepository =
         EpubRepositoryImpl(
-            api = AbsApiClient(OkHttpClient(), DefaultDispatcherProvider),
+            catalogRegistry = TestCatalogRegistry(sourceRepository, tokens),
             cacheStore = cacheStore,
             downloadsStore = downloadsStore,
             positionStore = positionStore,
             sourceRepository = sourceRepository,
-            tokenStorage = tokenStorage,
         )
 
     @Test
@@ -306,7 +299,7 @@ class EpubRepositoryTest {
                 ),
                 activeId = newId,
             ),
-            multiTokenStorage(mapOf(oldId to "old-token", newId to "new-token")),
+            (mapOf(oldId to "old-token", newId to "new-token")),
         )
         cacheStore.save(oldId, "item-1", epubBytes.inputStream())
 
@@ -329,7 +322,7 @@ class EpubRepositoryTest {
                 ),
                 activeId = newId,
             ),
-            multiTokenStorage(mapOf(oldId to "old-token", newId to "new-token")),
+            (mapOf(oldId to "old-token", newId to "new-token")),
         )
         downloadsStore.save(oldId, "item-1", epubBytes.inputStream())
 
@@ -355,7 +348,7 @@ class EpubRepositoryTest {
                     ),
                     activeId = activeId,
                 ),
-                multiTokenStorage(mapOf(itemId to "item-token", activeId to "active-token")),
+                (mapOf(itemId to "item-token", activeId to "active-token")),
             )
             source.enqueue(MockResponse().setResponseCode(200).setBody(Buffer().write(epubBytes)))
 
@@ -379,7 +372,7 @@ class EpubRepositoryTest {
                 servers = listOf(serverRow("some-other-source", baseUrl, isActive = true)),
                 activeId = "some-other-source",
             ),
-            multiTokenStorage(mapOf("some-other-source" to "some-token")),
+            (mapOf("some-other-source" to "some-token")),
         )
 
         val result = repo.openEpub(item(sourceId = "orphaned-source"))
@@ -401,7 +394,7 @@ class EpubRepositoryTest {
                 ),
                 activeId = newId,
             ),
-            multiTokenStorage(mapOf(oldId to "old-token", newId to "new-token")),
+            (mapOf(oldId to "old-token", newId to "new-token")),
         )
         source.enqueue(MockResponse().setResponseCode(200).setBody(Buffer().write(epubBytes)))
 
@@ -424,7 +417,7 @@ class EpubRepositoryTest {
                 ),
                 activeId = newId,
             ),
-            multiTokenStorage(mapOf(oldId to "old-token", newId to "new-token")),
+            (mapOf(oldId to "old-token", newId to "new-token")),
         )
         cacheStore.save(oldId, "item-1", epubBytes.inputStream())
 
@@ -452,7 +445,7 @@ class EpubRepositoryTest {
                     ),
                     activeId = activeId,
                 ),
-                multiTokenStorage(mapOf(itemId to "item-token", activeId to "active-token")),
+                (mapOf(itemId to "item-token", activeId to "active-token")),
             )
             source.enqueue(MockResponse().setResponseCode(200).setBody(Buffer().write(epubBytes)))
 
@@ -477,7 +470,7 @@ class EpubRepositoryTest {
                 servers = listOf(serverRow("some-other-source", baseUrl, isActive = true)),
                 activeId = "some-other-source",
             ),
-            multiTokenStorage(mapOf("some-other-source" to "some-token")),
+            (mapOf("some-other-source" to "some-token")),
         )
 
         val result = repo.downloadEpub(item(sourceId = "orphaned-source"))

--- a/core/data/src/test/kotlin/com/riffle/core/data/LibraryRepositoryTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/LibraryRepositoryTest.kt
@@ -197,8 +197,12 @@ class LibraryRepositoryTest {
                 NetworkResult.Success(emptyList())
         },
     ) = LibraryRepositoryImpl(
-        api, libraryDao, libraryItemDao, seriesDao, collectionDao,
-        fakeServerRepository, fakeTokenStorage, com.riffle.core.domain.TestClock(),
+        InlineCatalogRegistry(testAbsCatalog(
+            libraryApi = api,
+            baseUrl = fakeServerRepository.activeServer?.url?.value ?: "http://abs",
+        )),
+        libraryDao, libraryItemDao, seriesDao, collectionDao,
+        fakeServerRepository, com.riffle.core.domain.TestClock(),
     )
 
     private fun activeServer(id: String = "s1") = Source(

--- a/core/data/src/test/kotlin/com/riffle/core/data/MarkUnreadServerResetTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/MarkUnreadServerResetTest.kt
@@ -89,9 +89,8 @@ class MarkUnreadServerResetTest {
         }
     }
 
-    private fun repo(api: AbsSessionApi) = ReadingSessionRepositoryImpl(
-        api = api,
-        sourceRepository = object : SourceRepository {
+    private fun repo(api: AbsSessionApi): ReadingSessionRepositoryImpl {
+        val sourceRepo = object : SourceRepository {
             val source = Source("s1", SourceUrl.parse("http://localhost")!!, true, false, "")
             override fun observeAll(): Flow<List<Source>> = flowOf(listOf(source))
             override suspend fun getActive(): Source = source
@@ -100,13 +99,11 @@ class MarkUnreadServerResetTest {
             override suspend fun setActive(sourceId: String) = Unit
             override suspend fun remove(sourceId: String) = Unit
             override suspend fun getSourceVersion(sourceId: String): String? = null
-        },
-        tokenStorage = object : TokenStorage {
-            override suspend fun saveToken(sourceId: String, token: String) = Unit
-            override suspend fun getToken(sourceId: String): String? = "tok"
-            override suspend fun deleteToken(sourceId: String) = Unit
-        },
-        positionStore = object : ReadingPositionStore {
+        }
+        return ReadingSessionRepositoryImpl(
+            catalogRegistry = InlineCatalogRegistry(testAbsCatalog(sessionApi = api, libraryApi = com.riffle.core.data.NoopLibraryApi)),
+            sourceRepository = sourceRepo,
+            positionStore = object : ReadingPositionStore {
             override suspend fun save(sourceId: String, itemId: String, payload: String) = Unit
             override suspend fun load(sourceId: String, itemId: String): String? = null
             override suspend fun loadLocalUpdatedAt(sourceId: String, itemId: String): Long = 0L
@@ -125,7 +122,8 @@ class MarkUnreadServerResetTest {
         },
         libraryItemDao = FakeLibraryItemDao(),
             clock = com.riffle.core.domain.TestClock(),
-    )
+        )
+    }
 
     // The crux of the phantom: an audiobook item read to the middle. After mark-unread the source's
     // currentTime/progress MUST be 0, or the reader's audiobook peer reads currentTime>0 on reopen and

--- a/core/data/src/test/kotlin/com/riffle/core/data/PdfRepositoryTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/PdfRepositoryTest.kt
@@ -52,13 +52,13 @@ class PdfRepositoryTest {
         cacheStore = LocalStoreImpl(tmp.newFolder("pdf-cache"), ".pdf", com.riffle.core.domain.DefaultDispatcherProvider)
         downloadsStore = LocalStoreImpl(tmp.newFolder("pdf-downloads"), ".pdf", com.riffle.core.domain.DefaultDispatcherProvider)
         positionStore = FakePdfPositionStore()
+        val sourceRepo = fakeServerRepository(source.url("/").toString().trimEnd('/'))
         repo = PdfRepositoryImpl(
-            api = AbsApiClient(OkHttpClient(), DefaultDispatcherProvider),
+            catalogRegistry = TestCatalogRegistry(sourceRepo, mapOf("source-1" to "test-token")),
             cacheStore = cacheStore,
             downloadsStore = downloadsStore,
             positionStore = positionStore,
-            sourceRepository = fakeServerRepository(source.url("/").toString().trimEnd('/')),
-            tokenStorage = fakeTokenStorage("test-token"),
+            sourceRepository = sourceRepo,
         )
     }
 
@@ -253,12 +253,6 @@ class PdfRepositoryTest {
     // rationale — a user-switch on the same URL leaves the previous source row (and its cached
     // files) in place; the opener must key by item.sourceId, not activeServer.id.
 
-    private fun multiTokenStorage(tokens: Map<String, String>): TokenStorage = object : TokenStorage {
-        override suspend fun saveToken(sourceId: String, token: String) = Unit
-        override suspend fun getToken(sourceId: String): String? = tokens[sourceId]
-        override suspend fun deleteToken(sourceId: String) = Unit
-    }
-
     private fun serverRow(id: String, baseUrl: String, isActive: Boolean) = Source(
         id = id,
         url = SourceUrl.parse(baseUrl)!!,
@@ -268,14 +262,13 @@ class PdfRepositoryTest {
         serverType = ServerType.AUDIOBOOKSHELF,
     )
 
-    private fun repoWith(sourceRepository: SourceRepository, tokenStorage: TokenStorage): PdfRepository =
+    private fun repoWith(sourceRepository: SourceRepository, tokens: Map<String, String>): PdfRepository =
         PdfRepositoryImpl(
-            api = AbsApiClient(OkHttpClient(), com.riffle.core.domain.DefaultDispatcherProvider),
+            catalogRegistry = TestCatalogRegistry(sourceRepository, tokens),
             cacheStore = cacheStore,
             downloadsStore = downloadsStore,
             positionStore = positionStore,
             sourceRepository = sourceRepository,
-            tokenStorage = tokenStorage,
         )
 
     @Test
@@ -291,7 +284,7 @@ class PdfRepositoryTest {
                 ),
                 activeId = newId,
             ),
-            multiTokenStorage(mapOf(oldId to "old-token", newId to "new-token")),
+            (mapOf(oldId to "old-token", newId to "new-token")),
         )
         cacheStore.save(oldId, "item-1", pdfBytes.inputStream())
 
@@ -314,7 +307,7 @@ class PdfRepositoryTest {
                 ),
                 activeId = newId,
             ),
-            multiTokenStorage(mapOf(oldId to "old-token", newId to "new-token")),
+            (mapOf(oldId to "old-token", newId to "new-token")),
         )
         downloadsStore.save(oldId, "item-1", pdfBytes.inputStream())
 
@@ -340,7 +333,7 @@ class PdfRepositoryTest {
                     ),
                     activeId = activeId,
                 ),
-                multiTokenStorage(mapOf(itemId to "item-token", activeId to "active-token")),
+                (mapOf(itemId to "item-token", activeId to "active-token")),
             )
             source.enqueue(MockResponse().setResponseCode(200).setBody(Buffer().write(pdfBytes)))
 
@@ -364,7 +357,7 @@ class PdfRepositoryTest {
                 servers = listOf(serverRow("some-other-source", baseUrl, isActive = true)),
                 activeId = "some-other-source",
             ),
-            multiTokenStorage(mapOf("some-other-source" to "some-token")),
+            (mapOf("some-other-source" to "some-token")),
         )
 
         val result = repo.openPdf(item(sourceId = "orphaned-source"))
@@ -386,7 +379,7 @@ class PdfRepositoryTest {
                 ),
                 activeId = newId,
             ),
-            multiTokenStorage(mapOf(oldId to "old-token", newId to "new-token")),
+            (mapOf(oldId to "old-token", newId to "new-token")),
         )
         source.enqueue(MockResponse().setResponseCode(200).setBody(Buffer().write(pdfBytes)))
 
@@ -409,7 +402,7 @@ class PdfRepositoryTest {
                 ),
                 activeId = newId,
             ),
-            multiTokenStorage(mapOf(oldId to "old-token", newId to "new-token")),
+            (mapOf(oldId to "old-token", newId to "new-token")),
         )
         cacheStore.save(oldId, "item-1", pdfBytes.inputStream())
 
@@ -437,7 +430,7 @@ class PdfRepositoryTest {
                     ),
                     activeId = activeId,
                 ),
-                multiTokenStorage(mapOf(itemId to "item-token", activeId to "active-token")),
+                (mapOf(itemId to "item-token", activeId to "active-token")),
             )
             source.enqueue(MockResponse().setResponseCode(200).setBody(Buffer().write(pdfBytes)))
 
@@ -462,7 +455,7 @@ class PdfRepositoryTest {
                 servers = listOf(serverRow("some-other-source", baseUrl, isActive = true)),
                 activeId = "some-other-source",
             ),
-            multiTokenStorage(mapOf("some-other-source" to "some-token")),
+            (mapOf("some-other-source" to "some-token")),
         )
 
         val result = repo.downloadPdf(item(sourceId = "orphaned-source"))

--- a/core/data/src/test/kotlin/com/riffle/core/data/ProgressSweepBookmarkTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/ProgressSweepBookmarkTest.kt
@@ -1,12 +1,21 @@
 package com.riffle.core.data
 
+import com.riffle.core.catalog.BookFormat
+import com.riffle.core.catalog.Catalog
+import com.riffle.core.catalog.CatalogFileHandle
+import com.riffle.core.catalog.CatalogFileStream
+import com.riffle.core.catalog.CatalogHealth
+import com.riffle.core.catalog.CatalogItem
+import com.riffle.core.catalog.CatalogRegistry
+import com.riffle.core.catalog.CatalogRoot
+import com.riffle.core.catalog.SortKey
+import com.riffle.core.domain.PositionSnapshot
 import com.riffle.core.domain.ProgressReconciler
 import com.riffle.core.domain.ProgressRemote
 import com.riffle.core.domain.RemoteProgress
 import com.riffle.core.domain.Source
-import com.riffle.core.domain.SourceUrl
+import com.riffle.core.domain.SourceType
 import com.riffle.core.domain.SyncPositionStore
-import com.riffle.core.domain.PositionSnapshot
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -14,7 +23,7 @@ import org.junit.Test
 
 /**
  * The bookmark pass of the durable dirty sweep (ADR 0030, Task 12): bookmarks reconcile on the SAME
- * cadence as positions. Per source (unioned with position-dirty servers), every itemId with at least
+ * cadence as positions. Per source (unioned with position-dirty sources), every itemId with at least
  * one dirty bookmark row reconciles once under its own per-target lock. Exercised over fakes.
  */
 class ProgressSweepBookmarkTest {
@@ -28,23 +37,37 @@ class ProgressSweepBookmarkTest {
     }
 
     private class NoopFactory : ProgressRemoteFactory {
-        override fun ebook(source: Source, token: String, itemId: String): ProgressRemote<String> =
+        override suspend fun ebook(sourceId: String, itemId: String): ProgressRemote<String> =
             object : ProgressRemote<String> { override suspend fun get() = RemoteProgress("noop", 0L); override suspend fun patch(position: String) = 0L }
-        override fun audio(source: Source, token: String, itemId: String): ProgressRemote<Double> =
+        override suspend fun audio(sourceId: String, itemId: String): ProgressRemote<Double> =
             object : ProgressRemote<Double> { override suspend fun get() = RemoteProgress(0.0, 0L); override suspend fun patch(position: Double) = 0L }
     }
 
-    /** Records every reconcile call's full arg tuple. */
+    /** Records every reconcile call. */
     private class RecordingBookmarkReconcile : BookmarkReconcile {
-        data class Call(val sourceId: String, val itemId: String, val baseUrl: String, val token: String, val insecure: Boolean)
+        data class Call(val sourceId: String, val itemId: String)
         val calls = mutableListOf<Call>()
-        override suspend fun reconcile(sourceId: String, itemId: String, baseUrl: String, token: String, insecureAllowed: Boolean) {
-            calls += Call(sourceId, itemId, baseUrl, token, insecureAllowed)
+        override suspend fun reconcile(sourceId: String, itemId: String) {
+            calls += Call(sourceId, itemId)
         }
     }
 
-    private fun source(id: String) =
-        Source(id, SourceUrl.parse("http://$id")!!, isActive = false, insecureConnectionAllowed = false, username = "u")
+    private class FakeRegistry(private val available: Set<String>) : CatalogRegistry {
+        override suspend fun forActive(): Catalog? = null
+        override suspend fun forSource(source: Source): Catalog? = if (source.id in available) DummyCatalog else null
+        override suspend fun forSourceId(sourceId: String): Catalog? = if (sourceId in available) DummyCatalog else null
+    }
+
+    private object DummyCatalog : Catalog {
+        override val sourceType = SourceType.ABS
+        override suspend fun listRoots() = emptyList<CatalogRoot>()
+        override suspend fun browse(rootId: String, sort: SortKey, page: Int, pageSize: Int) = emptyList<CatalogItem>()
+        override suspend fun search(rootId: String, query: String, page: Int, pageSize: Int) = emptyList<CatalogItem>()
+        override suspend fun getItem(itemId: String): CatalogItem? = null
+        override suspend fun fetchFile(itemId: String, format: BookFormat): CatalogFileHandle = throw UnsupportedOperationException()
+        override suspend fun openFile(itemId: String, format: BookFormat, handleHint: String?): CatalogFileStream = throw UnsupportedOperationException()
+        override suspend fun connectivityCheck() = CatalogHealth(isReachable = false)
+    }
 
     private fun positionLedger(servers: List<String>) = object : DirtyProgressLedger {
         override suspend fun serversWithDirty() = servers
@@ -64,44 +87,37 @@ class ProgressSweepBookmarkTest {
         positionLedger: DirtyProgressLedger,
         bookmarkLedger: DirtyBookmarkLedger,
         bookmarkReconcile: BookmarkReconcile,
-        resolver: ServerTokenResolver,
+        registry: CatalogRegistry,
         openTargets: OpenReconcileTargets = OpenReconcileTargets(),
     ) = ProgressSweep(
-        positionLedger, resolver,
+        positionLedger, registry,
         ProgressReconciler(NoopStore<String>()), ProgressReconciler(NoopStore<Double>()),
         NoopFactory(), ReconcileLocks(), openTargets,
         bookmarkLedger, bookmarkReconcile,
     )
 
     @Test
-    fun `reconciles a dirty bookmark item with the resolved base url, token and insecure flag`() = runTest {
+    fun `reconciles a dirty bookmark item on a resolvable source`() = runTest {
         val rec = RecordingBookmarkReconcile()
-        val resolver = ServerTokenResolver { id ->
-            Source(id, SourceUrl.parse("https://$id")!!, isActive = false, insecureConnectionAllowed = true, username = "u") to "tok-$id"
-        }
 
         sweep(
             positionLedger(listOf("s1")),
             bookmarkLedger(listOf("s1"), items = mapOf("s1" to listOf("i1"))),
-            rec, resolver,
+            rec, FakeRegistry(setOf("s1")),
         ).run()
 
         assertEquals(1, rec.calls.size)
-        assertEquals(
-            RecordingBookmarkReconcile.Call("s1", "i1", "https://s1", "tok-s1", true),
-            rec.calls.single(),
-        )
+        assertEquals(RecordingBookmarkReconcile.Call("s1", "i1"), rec.calls.single())
     }
 
     @Test
     fun `a source with only dirty bookmarks and no dirty positions is still processed`() = runTest {
         val rec = RecordingBookmarkReconcile()
-        val resolver = ServerTokenResolver { id -> source(id) to "tok" }
 
         sweep(
-            positionLedger(emptyList()), // no position-dirty servers at all
+            positionLedger(emptyList()),
             bookmarkLedger(listOf("s9"), items = mapOf("s9" to listOf("i9"))),
-            rec, resolver,
+            rec, FakeRegistry(setOf("s9")),
         ).run()
 
         assertEquals(listOf("s9" to "i9"), rec.calls.map { it.sourceId to it.itemId })
@@ -115,7 +131,7 @@ class ProgressSweepBookmarkTest {
         sweep(
             positionLedger(emptyList()),
             bookmarkLedger(listOf("s1"), items = mapOf("s1" to listOf("open", "closed"))),
-            rec, ServerTokenResolver { id -> source(id) to "tok" }, openTargets,
+            rec, FakeRegistry(setOf("s1")), openTargets,
         ).run()
 
         assertEquals(listOf("closed"), rec.calls.map { it.itemId })
@@ -123,14 +139,13 @@ class ProgressSweepBookmarkTest {
     }
 
     @Test
-    fun `skips a bookmark-dirty source with no token, leaving it for a later sweep`() = runTest {
+    fun `skips a bookmark-dirty source whose Catalog cannot be resolved, leaving it for a later sweep`() = runTest {
         val rec = RecordingBookmarkReconcile()
-        val resolver = ServerTokenResolver { id -> if (id == "s2") null else source(id) to "tok" }
 
         sweep(
             positionLedger(emptyList()),
             bookmarkLedger(listOf("s1", "s2"), items = mapOf("s1" to listOf("i1"), "s2" to listOf("i2"))),
-            rec, resolver,
+            rec, FakeRegistry(setOf("s1")),
         ).run()
 
         assertEquals(listOf("s1" to "i1"), rec.calls.map { it.sourceId to it.itemId })

--- a/core/data/src/test/kotlin/com/riffle/core/data/ProgressSweepTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/ProgressSweepTest.kt
@@ -1,11 +1,20 @@
 package com.riffle.core.data
 
+import com.riffle.core.catalog.Catalog
+import com.riffle.core.catalog.CatalogRegistry
+import com.riffle.core.catalog.CatalogFileHandle
+import com.riffle.core.catalog.CatalogFileStream
+import com.riffle.core.catalog.BookFormat
+import com.riffle.core.catalog.CatalogHealth
+import com.riffle.core.catalog.CatalogItem
+import com.riffle.core.catalog.CatalogRoot
+import com.riffle.core.catalog.SortKey
 import com.riffle.core.domain.PositionSnapshot
 import com.riffle.core.domain.ProgressReconciler
 import com.riffle.core.domain.ProgressRemote
 import com.riffle.core.domain.RemoteProgress
 import com.riffle.core.domain.Source
-import com.riffle.core.domain.SourceUrl
+import com.riffle.core.domain.SourceType
 import com.riffle.core.domain.SyncPositionStore
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
@@ -15,8 +24,9 @@ import org.junit.Test
 
 /**
  * The durable multi-source dirty sweep (ADR 0030 slice 5): enumerate dirty rows across every source,
- * skip servers with no valid token, and reconcile each dirty target once under its per-target lock.
- * Orchestration is exercised over fakes — no Android, Room, or network.
+ * skip sources whose Catalog can't be resolved (missing token / unknown source), and reconcile each
+ * dirty target once under its per-target lock. Orchestration is exercised over fakes — no Android,
+ * Room, or network.
  */
 class ProgressSweepTest {
 
@@ -63,18 +73,39 @@ class ProgressSweepTest {
     ) : ProgressRemoteFactory {
         val ebookBuilt = mutableListOf<Pair<String, String>>()
         val audioBuilt = mutableListOf<Pair<String, String>>()
-        override fun ebook(source: Source, token: String, itemId: String): ProgressRemote<String> {
-            ebookBuilt += source.id to itemId
-            return ebookRemotes[source.id to itemId] ?: FakeRemote(RemoteProgress("noop", 0L), 0L)
+        override suspend fun ebook(sourceId: String, itemId: String): ProgressRemote<String>? {
+            ebookBuilt += sourceId to itemId
+            return ebookRemotes[sourceId to itemId] ?: FakeRemote(RemoteProgress("noop", 0L), 0L)
         }
-        override fun audio(source: Source, token: String, itemId: String): ProgressRemote<Double> {
-            audioBuilt += source.id to itemId
-            return audioRemotes[source.id to itemId] ?: FakeRemote(RemoteProgress(0.0, 0L), 0L)
+        override suspend fun audio(sourceId: String, itemId: String): ProgressRemote<Double>? {
+            audioBuilt += sourceId to itemId
+            return audioRemotes[sourceId to itemId] ?: FakeRemote(RemoteProgress(0.0, 0L), 0L)
         }
     }
 
-    private fun source(id: String) =
-        Source(id, SourceUrl.parse("http://$id")!!, isActive = false, insecureConnectionAllowed = false, username = "u")
+    /**
+     * A minimal [CatalogRegistry] that treats "unknown source" as absent — mirrors the production
+     * behaviour when a Source row exists but its token is missing (Catalog can't be built).
+     */
+    private class FakeRegistry(private val available: Set<String>) : CatalogRegistry {
+        override suspend fun forActive(): Catalog? = null
+        override suspend fun forSource(source: Source): Catalog? = if (source.id in available) DummyCatalog else null
+        override suspend fun forSourceId(sourceId: String): Catalog? = if (sourceId in available) DummyCatalog else null
+    }
+
+    /** No-op Catalog — sweep never invokes its methods; only presence/absence matters. */
+    private object DummyCatalog : Catalog {
+        override val sourceType = SourceType.ABS
+        override suspend fun listRoots() = emptyList<CatalogRoot>()
+        override suspend fun browse(rootId: String, sort: SortKey, page: Int, pageSize: Int) = emptyList<CatalogItem>()
+        override suspend fun search(rootId: String, query: String, page: Int, pageSize: Int) = emptyList<CatalogItem>()
+        override suspend fun getItem(itemId: String): CatalogItem? = null
+        override suspend fun fetchFile(itemId: String, format: BookFormat): CatalogFileHandle =
+            throw UnsupportedOperationException()
+        override suspend fun openFile(itemId: String, format: BookFormat, handleHint: String?): CatalogFileStream =
+            throw UnsupportedOperationException()
+        override suspend fun connectivityCheck() = CatalogHealth(isReachable = false)
+    }
 
     private fun ledger(
         servers: List<String>,
@@ -88,24 +119,24 @@ class ProgressSweepTest {
 
     private fun sweep(
         ledger: DirtyProgressLedger,
-        resolver: ServerTokenResolver,
+        registry: CatalogRegistry,
         ebookStore: SyncPositionStore<String>,
         audioStore: SyncPositionStore<Double>,
         factory: ProgressRemoteFactory,
         openTargets: OpenReconcileTargets = OpenReconcileTargets(),
     ) = ProgressSweep(
-        ledger, resolver,
+        ledger, registry,
         ProgressReconciler(ebookStore), ProgressReconciler(audioStore),
         factory, ReconcileLocks(), openTargets,
         object : DirtyBookmarkLedger {
             override suspend fun serversWithDirty() = emptyList<String>()
             override suspend fun dirtyItems(sourceId: String) = emptyList<String>()
         },
-        BookmarkReconcile { _, _, _, _, _ -> },
+        BookmarkReconcile { _, _ -> },
     )
 
     @Test
-    fun `reconciles dirty ebook rows across multiple servers`() = runTest {
+    fun `reconciles dirty ebook rows across multiple sources`() = runTest {
         val store = FakeStore<String>().apply {
             rows["s1" to "i1"] = Triple("local1", 300L, 100L)
             rows["s2" to "i2"] = Triple("local2", 300L, 100L)
@@ -116,19 +147,18 @@ class ProgressSweepTest {
                 ("s2" to "i2") to FakeRemote(RemoteProgress("srv", 200L), stamp = 305L),
             ),
         )
-        val resolver = ServerTokenResolver { id -> source(id) to "tok-$id" }
 
         sweep(
             ledger(listOf("s1", "s2"), ebook = mapOf("s1" to listOf("i1"), "s2" to listOf("i2"))),
-            resolver, store, FakeStore(), factory,
+            FakeRegistry(setOf("s1", "s2")), store, FakeStore(), factory,
         ).run()
 
-        assertFalse(store.dirty("s1", "i1")) // pushed + cleaned
+        assertFalse(store.dirty("s1", "i1"))
         assertFalse(store.dirty("s2", "i2"))
     }
 
     @Test
-    fun `skips servers with no token, leaving their rows dirty`() = runTest {
+    fun `skips sources whose Catalog cannot be resolved, leaving their rows dirty`() = runTest {
         val store = FakeStore<String>().apply {
             rows["s1" to "i1"] = Triple("local1", 300L, 100L)
             rows["s2" to "i2"] = Triple("local2", 300L, 100L)
@@ -136,16 +166,15 @@ class ProgressSweepTest {
         val factory = RecordingFactory(
             ebookRemotes = mapOf(("s1" to "i1") to FakeRemote(RemoteProgress("srv", 200L), stamp = 305L)),
         )
-        // s2 has no token → skipped.
-        val resolver = ServerTokenResolver { id -> if (id == "s2") null else source(id) to "tok" }
 
+        // s2's Catalog cannot be resolved → skipped by the sweep.
         sweep(
             ledger(listOf("s1", "s2"), ebook = mapOf("s1" to listOf("i1"), "s2" to listOf("i2"))),
-            resolver, store, FakeStore(), factory,
+            FakeRegistry(setOf("s1")), store, FakeStore(), factory,
         ).run()
 
         assertFalse(store.dirty("s1", "i1"))
-        assertTrue(store.dirty("s2", "i2")) // untouched
+        assertTrue(store.dirty("s2", "i2"))
         assertFalse("s2 must never be contacted", factory.ebookBuilt.contains("s2" to "i2"))
     }
 
@@ -159,11 +188,11 @@ class ProgressSweepTest {
 
         sweep(
             ledger(listOf("s1"), ebook = mapOf("s1" to listOf("open"))),
-            ServerTokenResolver { id -> source(id) to "tok" }, store, FakeStore(), factory, openTargets,
+            FakeRegistry(setOf("s1")), store, FakeStore(), factory, openTargets,
         ).run()
 
-        assertTrue("open book is left to its own live cycle", store.dirty("s1", "open"))
-        assertFalse("open book is never contacted by the sweep", factory.ebookBuilt.contains("s1" to "open"))
+        assertTrue(store.dirty("s1", "open"))
+        assertFalse(factory.ebookBuilt.contains("s1" to "open"))
     }
 
     @Test
@@ -177,7 +206,7 @@ class ProgressSweepTest {
 
         sweep(
             ledger(listOf("s1"), ebook = mapOf("s1" to listOf("i1")), audio = mapOf("s1" to listOf("i1"))),
-            ServerTokenResolver { id -> source(id) to "tok" }, ebookStore, audioStore, factory,
+            FakeRegistry(setOf("s1")), ebookStore, audioStore, factory,
         ).run()
 
         assertFalse(ebookStore.dirty("s1", "i1"))
@@ -193,11 +222,11 @@ class ProgressSweepTest {
 
         sweep(
             ledger(listOf("s1"), ebook = mapOf("s1" to listOf("i1"))),
-            ServerTokenResolver { id -> source(id) to "tok" }, store, FakeStore(), factory,
+            FakeRegistry(setOf("s1")), store, FakeStore(), factory,
         ).run()
 
         val row = store.rows["s1" to "i1"]!!
-        assertEquals("source-newer", row.first) // persisted locally, no reader needed
+        assertEquals("source-newer", row.first)
         assertFalse(store.dirty("s1", "i1"))
     }
 }

--- a/core/data/src/test/kotlin/com/riffle/core/data/ProgressSyncCycleTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/ProgressSyncCycleTest.kt
@@ -104,7 +104,7 @@ class ProgressSyncCycleTest {
         readaloudResumeStore: com.riffle.core.domain.ReadaloudResumeStore = FakeReadaloudResumeStore(),
     ) =
         ReadingSessionRepositoryImpl(
-            api = api,
+            catalogRegistry = InlineCatalogRegistry(testAbsCatalog(sessionApi = api, libraryApi = NoopLibraryApi)),
             sourceRepository = object : SourceRepository {
                 val source = Source("s1", SourceUrl.parse("http://localhost")!!, true, false, "")
                 override fun observeAll(): Flow<List<Source>> = flowOf(listOf(source))
@@ -114,11 +114,6 @@ class ProgressSyncCycleTest {
                 override suspend fun setActive(sourceId: String) = Unit
                 override suspend fun remove(sourceId: String) = Unit
                 override suspend fun getSourceVersion(sourceId: String): String? = null
-            },
-            tokenStorage = object : TokenStorage {
-                override suspend fun saveToken(sourceId: String, token: String) = Unit
-                override suspend fun getToken(sourceId: String): String? = "tok"
-                override suspend fun deleteToken(sourceId: String) = Unit
             },
             positionStore = positionStore,
             audiobookPositionStore = audiobookPositionStore,

--- a/core/data/src/test/kotlin/com/riffle/core/data/ProgressSyncIntegrationTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/ProgressSyncIntegrationTest.kt
@@ -48,9 +48,8 @@ class ProgressSyncIntegrationTest {
         override suspend fun updateLocalTimestamp(sourceId: String, itemId: String, millis: Long) { updatedTimestamp = millis }
     }
 
-    private fun buildRepo() = ReadingSessionRepositoryImpl(
-        api = AbsApiClient(OkHttpClient(), DefaultDispatcherProvider),
-        sourceRepository = object : SourceRepository {
+    private fun buildRepo(): ReadingSessionRepositoryImpl {
+        val sourceRepo = object : SourceRepository {
             val activeServer = Source(
                 id = "source-1",
                 url = SourceUrl.parse(source.url("/").toString().trimEnd('/'))!!,
@@ -67,13 +66,11 @@ class ProgressSyncIntegrationTest {
             override suspend fun setActive(sourceId: String) = Unit
             override suspend fun remove(sourceId: String) = Unit
             override suspend fun getSourceVersion(sourceId: String): String? = null
-        },
-        tokenStorage = object : TokenStorage {
-            override suspend fun saveToken(sourceId: String, token: String) = Unit
-            override suspend fun getToken(sourceId: String): String? = "test-token"
-            override suspend fun deleteToken(sourceId: String) = Unit
-        },
-        positionStore = positionStore,
+        }
+        return ReadingSessionRepositoryImpl(
+            catalogRegistry = TestCatalogRegistry(sourceRepo, mapOf("source-1" to "test-token")),
+            sourceRepository = sourceRepo,
+            positionStore = positionStore,
         audiobookPositionStore = object : com.riffle.core.domain.AudiobookPositionStore {
             override suspend fun save(sourceId: String, itemId: String, payload: Double) = Unit
             override suspend fun load(sourceId: String, itemId: String): Double? = null
@@ -87,7 +84,8 @@ class ProgressSyncIntegrationTest {
         },
         libraryItemDao = FakeLibraryItemDao(),
             clock = com.riffle.core.domain.TestClock(initialMs = 5_000L),
-    )
+        )
+    }
 
     private fun json(code: Int, body: String) = MockResponse()
         .setResponseCode(code)

--- a/core/data/src/test/kotlin/com/riffle/core/data/ReadingSessionIntegrationTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/ReadingSessionIntegrationTest.kt
@@ -37,9 +37,8 @@ class ReadingSessionIntegrationTest {
     @After
     fun tearDown() = source.shutdown()
 
-    private fun buildRepo() = ReadingSessionRepositoryImpl(
-        api = AbsApiClient(OkHttpClient(), DefaultDispatcherProvider),
-        sourceRepository = object : SourceRepository {
+    private fun buildRepo(): ReadingSessionRepositoryImpl {
+        val sourceRepo = object : SourceRepository {
             val activeServer = Source(
                 id = "source-1",
                 url = SourceUrl.parse(source.url("/").toString().trimEnd('/'))!!,
@@ -56,13 +55,11 @@ class ReadingSessionIntegrationTest {
             override suspend fun setActive(sourceId: String) = Unit
             override suspend fun remove(sourceId: String) = Unit
             override suspend fun getSourceVersion(sourceId: String): String? = null
-        },
-        tokenStorage = object : TokenStorage {
-            override suspend fun saveToken(sourceId: String, token: String) = Unit
-            override suspend fun getToken(sourceId: String): String? = "test-token"
-            override suspend fun deleteToken(sourceId: String) = Unit
-        },
-        positionStore = object : ReadingPositionStore {
+        }
+        return ReadingSessionRepositoryImpl(
+            catalogRegistry = TestCatalogRegistry(sourceRepo, mapOf("source-1" to "test-token")),
+            sourceRepository = sourceRepo,
+            positionStore = object : ReadingPositionStore {
             override suspend fun save(sourceId: String, itemId: String, payload: String) = Unit
             override suspend fun load(sourceId: String, itemId: String): String? = null
             override suspend fun loadLocalUpdatedAt(sourceId: String, itemId: String): Long = 0L
@@ -81,7 +78,8 @@ class ReadingSessionIntegrationTest {
         },
         libraryItemDao = FakeLibraryItemDao(),
             clock = com.riffle.core.domain.TestClock(),
-    )
+        )
+    }
 
     @Test
     fun `syncProgress sends PATCH to correct path with payload`() = runTest {

--- a/core/data/src/test/kotlin/com/riffle/core/data/SeriesIntegrationTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/SeriesIntegrationTest.kt
@@ -144,13 +144,12 @@ class SeriesIntegrationTest {
     private fun makeRepo(seriesDao: FakeSeriesDao = FakeSeriesDao()): LibraryRepositoryImpl {
         val itemDao = FakeLibraryItemDao()
         return LibraryRepositoryImpl(
-            api = AbsApiClient(OkHttpClient(), DefaultDispatcherProvider),
+            catalogRegistry = TestCatalogRegistry(fakeServerRepository, mapOf("s1" to "test-token")),
             libraryDao = FakeLibraryDao(),
             libraryItemDao = itemDao,
             seriesDao = seriesDao,
             collectionDao = FakeCollectionDao(),
             sourceRepository = fakeServerRepository,
-            tokenStorage = fakeTokenStorage,
             clock = com.riffle.core.domain.TestClock(),
         )
     }

--- a/core/data/src/test/kotlin/com/riffle/core/data/TestCatalogRegistry.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/TestCatalogRegistry.kt
@@ -1,0 +1,152 @@
+package com.riffle.core.data
+
+import com.riffle.core.catalog.Catalog
+import com.riffle.core.catalog.CatalogRegistry
+import com.riffle.core.catalog.abs.AbsCatalog
+import com.riffle.core.catalog.abs.AbsCatalogConfig
+import com.riffle.core.domain.Clock
+import com.riffle.core.domain.DefaultDispatcherProvider
+import com.riffle.core.domain.Source
+import com.riffle.core.domain.SourceRepository
+import com.riffle.core.network.AbsApiClient
+import com.riffle.core.network.AbsBookmarkApi
+import com.riffle.core.network.AbsLibraryApi
+import com.riffle.core.network.AbsPlaybackApi
+import com.riffle.core.network.AbsServerInfoApi
+import com.riffle.core.network.AbsSessionApi
+import okhttp3.OkHttpClient
+
+private val defaultTestClock = object : Clock {
+    override fun nowMs() = System.currentTimeMillis()
+    override fun nowNs() = System.nanoTime()
+}
+
+/**
+ * Test helper that wraps a shared [AbsApiClient] behind [CatalogRegistry], resolving each Source to
+ * a fresh [AbsCatalog] bound to that Source's URL + a per-Source token. Lets the ABS-shaped
+ * repository tests keep their MockWebServer setup while consuming the same Catalog surface as
+ * production.
+ */
+class TestCatalogRegistry(
+    private val sourceRepository: SourceRepository,
+    private val tokens: Map<String, String>,
+    private val apiClient: AbsApiClient = AbsApiClient(OkHttpClient(), DefaultDispatcherProvider),
+    private val clock: Clock = defaultTestClock,
+    private val deviceId: String = "test-device",
+) : CatalogRegistry {
+    override suspend fun forActive(): Catalog? =
+        sourceRepository.getActive()?.let { forSource(it) }
+
+    override suspend fun forSourceId(sourceId: String): Catalog? =
+        sourceRepository.getById(sourceId)?.let { forSource(it) }
+
+    override suspend fun forSource(source: Source): Catalog? {
+        val token = tokens[source.id] ?: return null
+        val config = AbsCatalogConfig(
+            baseUrl = source.url.value,
+            token = token,
+            insecureAllowed = source.insecureConnectionAllowed,
+            deviceId = deviceId,
+        )
+        return AbsCatalog(
+            config = config,
+            libraryApi = apiClient,
+            playbackApi = apiClient,
+            sessionApi = apiClient,
+            bookmarkApi = apiClient,
+            serverInfoApi = apiClient,
+            clock = clock,
+        )
+    }
+}
+
+/**
+ * A registry that always returns the same catalog, for tests that construct a bespoke Catalog
+ * (e.g. an [AbsCatalog] pointed at fake in-process APIs).
+ */
+class InlineCatalogRegistry(private val catalog: Catalog?) : CatalogRegistry {
+    override suspend fun forActive(): Catalog? = catalog
+    override suspend fun forSource(source: Source): Catalog? = catalog
+    override suspend fun forSourceId(sourceId: String): Catalog? = catalog
+}
+
+/**
+ * Assemble an [AbsCatalog] over caller-supplied API fakes. Any API left null becomes a no-op that
+ * throws on call — pass what the test exercises.
+ */
+fun testAbsCatalog(
+    baseUrl: String = "http://abs",
+    token: String = "tok",
+    insecureAllowed: Boolean = false,
+    deviceId: String = "test-device",
+    libraryApi: AbsLibraryApi,
+    playbackApi: AbsPlaybackApi = NoopAbsPlaybackApi,
+    sessionApi: AbsSessionApi = NoopAbsSessionApi,
+    bookmarkApi: AbsBookmarkApi = NoopAbsBookmarkApi,
+    serverInfoApi: AbsServerInfoApi = NoopAbsServerInfoApi,
+    clock: Clock = defaultTestClock,
+): Catalog = AbsCatalog(
+    config = AbsCatalogConfig(baseUrl, token, insecureAllowed, deviceId),
+    libraryApi = libraryApi,
+    playbackApi = playbackApi,
+    sessionApi = sessionApi,
+    bookmarkApi = bookmarkApi,
+    serverInfoApi = serverInfoApi,
+    clock = clock,
+)
+
+/** A minimal [AbsLibraryApi] whose methods all return empty results — useful in tests that only
+ *  exercise the sessionApi / playback path via [AbsCatalog]. */
+object NoopLibraryApi : AbsLibraryApi {
+    override suspend fun getLibraries(baseUrl: String, token: String, insecureAllowed: Boolean) =
+        com.riffle.core.network.NetworkResult.Success(emptyList<com.riffle.core.network.NetworkLibrary>())
+    override suspend fun getLibraryItems(baseUrl: String, libraryId: String, token: String, insecureAllowed: Boolean) =
+        com.riffle.core.network.NetworkResult.Success(emptyList<com.riffle.core.network.NetworkLibraryItem>())
+    override suspend fun getSeries(baseUrl: String, libraryId: String, token: String, insecureAllowed: Boolean) =
+        com.riffle.core.network.NetworkResult.Success(emptyList<com.riffle.core.network.NetworkSeries>())
+    override suspend fun getCollections(baseUrl: String, libraryId: String, token: String, insecureAllowed: Boolean) =
+        com.riffle.core.network.NetworkResult.Success(emptyList<com.riffle.core.network.NetworkCollection>())
+}
+
+private object NoopAbsPlaybackApi : AbsPlaybackApi {
+    override suspend fun openPlaybackSession(
+        baseUrl: String, libraryItemId: String, deviceId: String, token: String, insecureAllowed: Boolean,
+    ) = com.riffle.core.network.NetworkResult.Offline(RuntimeException("noop"))
+}
+
+private object NoopAbsSessionApi : AbsSessionApi {
+    override suspend fun syncEbookProgress(
+        baseUrl: String, libraryItemId: String,
+        payload: com.riffle.core.network.NetworkEbookProgressPayload, token: String, insecureAllowed: Boolean,
+    ) = com.riffle.core.network.NetworkResult.Success(0L)
+
+    override suspend fun syncAudiobookProgress(
+        baseUrl: String, libraryItemId: String,
+        payload: com.riffle.core.network.NetworkAudiobookProgressPayload, token: String, insecureAllowed: Boolean,
+    ) = com.riffle.core.network.NetworkResult.Success(0L)
+
+    override suspend fun getProgress(
+        baseUrl: String, libraryItemId: String, token: String, insecureAllowed: Boolean,
+    ) = com.riffle.core.network.NetworkResult.Offline(RuntimeException("noop"))
+}
+
+private object NoopAbsBookmarkApi : AbsBookmarkApi {
+    override suspend fun createBookmark(
+        baseUrl: String, itemId: String, timeSec: Int, title: String, token: String, insecureAllowed: Boolean,
+    ) = com.riffle.core.network.NetworkResult.Offline(RuntimeException("noop"))
+    override suspend fun updateBookmark(
+        baseUrl: String, itemId: String, timeSec: Int, title: String, token: String, insecureAllowed: Boolean,
+    ) = com.riffle.core.network.NetworkResult.Offline(RuntimeException("noop"))
+    override suspend fun deleteBookmark(
+        baseUrl: String, itemId: String, timeSec: Int, token: String, insecureAllowed: Boolean,
+    ) = com.riffle.core.network.NetworkResult.Offline(RuntimeException("noop"))
+    override suspend fun listBookmarks(baseUrl: String, token: String, insecureAllowed: Boolean) =
+        com.riffle.core.network.NetworkResult.Success(emptyList<com.riffle.core.network.NetworkAbsBookmark>())
+}
+
+private object NoopAbsServerInfoApi : AbsServerInfoApi {
+    override suspend fun getServerInfo(baseUrl: String, token: String, insecureAllowed: Boolean): String? = null
+    override suspend fun getCurrentUserId(baseUrl: String, token: String, insecureAllowed: Boolean): String? = null
+    override suspend fun getListeningStats(baseUrl: String, token: String, insecureAllowed: Boolean) =
+        com.riffle.core.network.NetworkResult.Success(com.riffle.core.network.NetworkListeningStats(totalTimeSec = 0.0))
+}

--- a/core/data/src/test/kotlin/com/riffle/core/data/ToReadRepositoryTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/ToReadRepositoryTest.kt
@@ -1,82 +1,60 @@
 package com.riffle.core.data
 
-import com.riffle.core.network.NetworkResult
-
-import com.riffle.core.domain.AuthenticateResult
-import com.riffle.core.domain.CommitSourceResult
-import com.riffle.core.domain.EbookFormat
-import com.riffle.core.domain.PendingSource
+import com.riffle.core.catalog.BookFormat
+import com.riffle.core.catalog.Catalog
+import com.riffle.core.catalog.CatalogCollection
+import com.riffle.core.catalog.CatalogFileHandle
+import com.riffle.core.catalog.CatalogFileStream
+import com.riffle.core.catalog.CatalogHealth
+import com.riffle.core.catalog.CatalogItem
+import com.riffle.core.catalog.CatalogPlaylist
+import com.riffle.core.catalog.CatalogRegistry
+import com.riffle.core.catalog.CatalogRoot
+import com.riffle.core.catalog.PlaylistsCapability
+import com.riffle.core.catalog.SortKey
 import com.riffle.core.domain.Source
-import com.riffle.core.domain.SourceRepository
-import com.riffle.core.domain.SourceUrl
-import com.riffle.core.domain.TokenStorage
-import com.riffle.core.network.AbsLibraryApi
-import com.riffle.core.network.NetworkLibraryItem
-import com.riffle.core.network.NetworkPlaylist
-import kotlinx.coroutines.flow.MutableStateFlow
+import com.riffle.core.domain.SourceType
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
-import java.io.IOException
 
 class ToReadRepositoryTest {
 
-    private val activeServer = Source(
-        id = "s1",
-        url = SourceUrl.parse("http://abs.local")!!,
-        isActive = true,
-        insecureConnectionAllowed = false,
-        username = "u",
-    )
-
-    private fun makeRepo(
-        api: AbsLibraryApi = FakeAbsApi(),
-        sourceRepository: SourceRepository = FakeSourceRepository(activeServer),
-        tokenStorage: TokenStorage = FakeTokenStorage(mutableMapOf("s1" to "tok")),
-    ) = ToReadRepositoryImpl(api, sourceRepository, tokenStorage)
+    private fun makeRepo(catalog: Catalog?) = ToReadRepositoryImpl(FakeRegistry(catalog))
 
     // ── refresh + observeToReadItemIds ────────────────────────────────────────
 
     @Test
     fun `refresh populates cache from source`() = runTest {
-        val api = FakeAbsApi(
-            playlistsByLibrary = mapOf("lib-1" to listOf(playlist("pl-A", "To Read", listOf("item-1", "item-2")))),
-        )
-        val repo = makeRepo(api)
+        val cap = FakeCatalog(mapOf("lib-1" to listOf(playlist("pl-A", "To Read", listOf("item-1", "item-2")))))
+        val repo = makeRepo(cap)
         assertTrue(repo.refresh("lib-1"))
         assertEquals(setOf("item-1", "item-2"), repo.observeToReadItemIds("lib-1").first())
     }
 
     @Test
     fun `refresh populates empty when no To Read playlist exists`() = runTest {
-        val api = FakeAbsApi(playlistsByLibrary = mapOf("lib-1" to emptyList()))
-        val repo = makeRepo(api)
+        val cap = FakeCatalog(mapOf("lib-1" to emptyList()))
+        val repo = makeRepo(cap)
         assertTrue(repo.refresh("lib-1"))
         assertEquals(emptySet<String>(), repo.observeToReadItemIds("lib-1").first())
     }
 
     @Test
     fun `refresh returns false on network error and leaves cache untouched`() = runTest {
-        val api = object : FakeAbsApi() {
-            override suspend fun getPlaylists(baseUrl: String, libraryId: String, token: String, insecureAllowed: Boolean): NetworkResult<List<NetworkPlaylist>> =
-                NetworkResult.Offline(IOException("HTTP 500"))
-        }
-        val repo = makeRepo(api)
+        val cap = FakeCatalog(mapOf("lib-1" to emptyList()), listFails = true)
+        val repo = makeRepo(cap)
         assertFalse(repo.refresh("lib-1"))
         assertEquals(emptySet<String>(), repo.observeToReadItemIds("lib-1").first())
     }
 
-    // ── isInToRead ────────────────────────────────────────────────────────────
-
     @Test
     fun `isInToRead reads from cache after refresh`() = runTest {
-        val api = FakeAbsApi(
-            playlistsByLibrary = mapOf("lib-1" to listOf(playlist("pl-A", "To Read", listOf("item-1")))),
-        )
-        val repo = makeRepo(api)
+        val cap = FakeCatalog(mapOf("lib-1" to listOf(playlist("pl-A", "To Read", listOf("item-1")))))
+        val repo = makeRepo(cap)
         repo.refresh("lib-1")
         assertTrue(repo.isInToRead("item-1", "lib-1"))
         assertFalse(repo.isInToRead("item-9", "lib-1"))
@@ -84,58 +62,42 @@ class ToReadRepositoryTest {
 
     @Test
     fun `isInToRead returns false before any refresh`() = runTest {
-        val api = FakeAbsApi(
-            playlistsByLibrary = mapOf("lib-1" to listOf(playlist("pl-A", "To Read", listOf("item-1")))),
-        )
-        assertFalse(makeRepo(api).isInToRead("item-1", "lib-1"))
+        val cap = FakeCatalog(mapOf("lib-1" to listOf(playlist("pl-A", "To Read", listOf("item-1")))))
+        assertFalse(makeRepo(cap).isInToRead("item-1", "lib-1"))
     }
-
-    // ── addToToRead ───────────────────────────────────────────────────────────
 
     @Test
     fun `addToToRead appends to existing playlist and updates cache optimistically`() = runTest {
-        val api = FakeAbsApi(
-            playlistsByLibrary = mapOf("lib-1" to listOf(playlist("pl-A", "To Read", emptyList()))),
-        )
-        val repo = makeRepo(api)
+        val cap = FakeCatalog(mapOf("lib-1" to listOf(playlist("pl-A", "To Read", emptyList()))))
+        val repo = makeRepo(cap)
         repo.refresh("lib-1")
         assertTrue(repo.addToToRead("item-1", "lib-1"))
-        assertTrue(api.createCalls.isEmpty())
-        assertEquals(listOf("pl-A" to "item-1"), api.addCalls)
+        assertTrue(cap.createCalls.isEmpty())
+        assertEquals(listOf("pl-A" to "item-1"), cap.addCalls)
         assertEquals(setOf("item-1"), repo.observeToReadItemIds("lib-1").first())
     }
 
     @Test
     fun `addToToRead creates playlist when cache is empty + no playlist on source`() = runTest {
-        val api = FakeAbsApi(playlistsByLibrary = mapOf("lib-1" to emptyList()))
-        val repo = makeRepo(api)
+        val cap = FakeCatalog(mapOf("lib-1" to emptyList()))
+        val repo = makeRepo(cap)
         repo.refresh("lib-1")
         assertTrue(repo.addToToRead("item-1", "lib-1"))
-        assertEquals(listOf(Triple("lib-1", "To Read", "item-1")), api.createCalls)
-        assertTrue(api.addCalls.isEmpty())
+        assertEquals(listOf("lib-1" to "To Read"), cap.createCalls)
+        assertEquals(listOf("pl-new" to "item-1"), cap.addCalls)
         assertEquals(setOf("item-1"), repo.observeToReadItemIds("lib-1").first())
     }
 
     @Test
-    fun `addToToRead returns false when no active source`() = runTest {
-        val repo = makeRepo(
-            sourceRepository = FakeSourceRepository(activeServer = null),
-            tokenStorage = FakeTokenStorage(mutableMapOf()),
-        )
+    fun `addToToRead returns false when no catalog for active source`() = runTest {
+        val repo = makeRepo(catalog = null)
         assertFalse(repo.addToToRead("item-1", "lib-1"))
     }
 
     @Test
     fun `addToToRead reverts cache when add fails`() = runTest {
-        val api = object : FakeAbsApi(
-            playlistsByLibrary = mapOf("lib-1" to listOf(playlist("pl-A", "To Read", emptyList()))),
-        ) {
-            override suspend fun addBookToPlaylist(
-                baseUrl: String, playlistId: String, libraryItemId: String,
-                token: String, insecureAllowed: Boolean,
-            ): NetworkResult<NetworkPlaylist?> = NetworkResult.Offline(IOException("HTTP 500"))
-        }
-        val repo = makeRepo(api)
+        val cap = FakeCatalog(mapOf("lib-1" to listOf(playlist("pl-A", "To Read", emptyList()))), addFails = true)
+        val repo = makeRepo(cap)
         repo.refresh("lib-1")
         assertFalse(repo.addToToRead("item-1", "lib-1"))
         assertEquals(emptySet<String>(), repo.observeToReadItemIds("lib-1").first())
@@ -143,146 +105,101 @@ class ToReadRepositoryTest {
 
     @Test
     fun `addToToRead reverts cache when create fails`() = runTest {
-        val api = object : FakeAbsApi(playlistsByLibrary = mapOf("lib-1" to emptyList())) {
-            override suspend fun createPlaylist(
-                baseUrl: String, libraryId: String, name: String, initialBookId: String?,
-                token: String, insecureAllowed: Boolean,
-            ): NetworkResult<NetworkPlaylist?> = NetworkResult.Offline(IOException("HTTP 500"))
-        }
-        val repo = makeRepo(api)
+        val cap = FakeCatalog(mapOf("lib-1" to emptyList()), createFails = true)
+        val repo = makeRepo(cap)
         repo.refresh("lib-1")
         assertFalse(repo.addToToRead("item-1", "lib-1"))
         assertEquals(emptySet<String>(), repo.observeToReadItemIds("lib-1").first())
     }
 
-    // ── removeFromToRead ──────────────────────────────────────────────────────
-
     @Test
     fun `removeFromToRead calls DELETE and updates cache`() = runTest {
-        val api = FakeAbsApi(
-            playlistsByLibrary = mapOf("lib-1" to listOf(playlist("pl-A", "To Read", listOf("item-1")))),
-        )
-        val repo = makeRepo(api)
+        val cap = FakeCatalog(mapOf("lib-1" to listOf(playlist("pl-A", "To Read", listOf("item-1")))))
+        val repo = makeRepo(cap)
         repo.refresh("lib-1")
         assertTrue(repo.removeFromToRead("item-1", "lib-1"))
-        assertEquals(listOf("pl-A" to "item-1"), api.removeCalls)
+        assertEquals(listOf("pl-A" to "item-1"), cap.removeCalls)
         assertEquals(emptySet<String>(), repo.observeToReadItemIds("lib-1").first())
     }
 
     @Test
     fun `removeFromToRead clears cached playlistId when last item is removed`() = runTest {
-        // ABS auto-deletes empty playlists source-side, so the cached id must be invalidated
-        // or the next add will POST to a dead playlist id.
-        val api = FakeAbsApi(
-            playlistsByLibrary = mapOf("lib-1" to listOf(playlist("pl-A", "To Read", listOf("item-1")))),
-        )
-        val repo = makeRepo(api)
+        val cap = FakeCatalog(mapOf("lib-1" to listOf(playlist("pl-A", "To Read", listOf("item-1")))))
+        val repo = makeRepo(cap)
         repo.refresh("lib-1")
         assertTrue(repo.removeFromToRead("item-1", "lib-1"))
         // Next add must create a new playlist, not POST to the dead pl-A.
         assertTrue(repo.addToToRead("item-2", "lib-1"))
-        assertEquals(listOf(Triple("lib-1", "To Read", "item-2")), api.createCalls)
-        assertTrue(api.addCalls.isEmpty())
+        assertEquals(listOf("lib-1" to "To Read"), cap.createCalls)
     }
 
     @Test
     fun `removeFromToRead returns true and makes no call when cache empty`() = runTest {
-        val api = FakeAbsApi(playlistsByLibrary = mapOf("lib-1" to emptyList()))
-        val repo = makeRepo(api)
+        val cap = FakeCatalog(mapOf("lib-1" to emptyList()))
+        val repo = makeRepo(cap)
         repo.refresh("lib-1")
         assertTrue(repo.removeFromToRead("item-1", "lib-1"))
-        assertTrue(api.removeCalls.isEmpty())
+        assertTrue(cap.removeCalls.isEmpty())
     }
 
     @Test
     fun `removeFromToRead reverts cache when DELETE fails`() = runTest {
-        val api = object : FakeAbsApi(
-            playlistsByLibrary = mapOf("lib-1" to listOf(playlist("pl-A", "To Read", listOf("item-1")))),
-        ) {
-            override suspend fun removeBookFromPlaylist(
-                baseUrl: String, playlistId: String, libraryItemId: String,
-                token: String, insecureAllowed: Boolean,
-            ): NetworkResult<NetworkPlaylist?> = NetworkResult.Offline(IOException("HTTP 500"))
-        }
-        val repo = makeRepo(api)
+        val cap = FakeCatalog(mapOf("lib-1" to listOf(playlist("pl-A", "To Read", listOf("item-1")))), removeFails = true)
+        val repo = makeRepo(cap)
         repo.refresh("lib-1")
         assertFalse(repo.removeFromToRead("item-1", "lib-1"))
         assertEquals(setOf("item-1"), repo.observeToReadItemIds("lib-1").first())
     }
 
-    // ── helpers ───────────────────────────────────────────────────────────────
-
-    private fun playlist(id: String, name: String, itemIds: List<String>) = NetworkPlaylist(
-        id = id, libraryId = "lib-1", name = name,
-        items = itemIds.map { NetworkLibraryItem(
-            id = it, libraryId = "lib-1", title = "T", author = "A",
-            readingProgress = 0f, ebookFormat = EbookFormat.Epub,
-        ) },
-        bookIds = itemIds.toSet(),
+    private fun playlist(id: String, name: String, itemIds: List<String>) = CatalogPlaylist(
+        id = id, rootId = "lib-1", name = name, bookCount = itemIds.size, itemIds = itemIds,
     )
-}
 
-private class FakeSourceRepository(private val activeServer: Source?) : SourceRepository {
-    override fun observeAll() = MutableStateFlow(listOfNotNull(activeServer))
-    override suspend fun getActive(): Source? = activeServer
-    override suspend fun authenticate(url: SourceUrl, username: String, password: String, insecureAllowed: Boolean, serverType: com.riffle.core.domain.ServerType): AuthenticateResult =
-        AuthenticateResult.NetworkError(IOException())
-    override suspend fun commit(pending: PendingSource, hiddenLibraryIds: Set<String>): CommitSourceResult =
-        CommitSourceResult.Failure(IOException())
-    override suspend fun setActive(sourceId: String) {}
-    override suspend fun remove(sourceId: String) {}
-    override suspend fun getSourceVersion(sourceId: String): String? = null
-}
-
-private class FakeTokenStorage(private val tokens: MutableMap<String, String>) : TokenStorage {
-    override suspend fun saveToken(sourceId: String, token: String) { tokens[sourceId] = token }
-    override suspend fun getToken(sourceId: String): String? = tokens[sourceId]
-    override suspend fun deleteToken(sourceId: String) { tokens.remove(sourceId) }
-}
-
-private open class FakeAbsApi(
-    val playlistsByLibrary: Map<String, List<NetworkPlaylist>> = emptyMap(),
-) : AbsLibraryApi {
-    val createCalls = mutableListOf<Triple<String, String, String?>>()
-    val addCalls = mutableListOf<Pair<String, String>>()
-    val removeCalls = mutableListOf<Pair<String, String>>()
-
-    override suspend fun getLibraries(baseUrl: String, token: String, insecureAllowed: Boolean): NetworkResult<List<com.riffle.core.network.NetworkLibrary>> =
-        NetworkResult.Success(emptyList())
-
-    override suspend fun getLibraryItems(baseUrl: String, libraryId: String, token: String, insecureAllowed: Boolean): NetworkResult<List<com.riffle.core.network.NetworkLibraryItem>> =
-        NetworkResult.Success(emptyList())
-
-    override suspend fun getSeries(baseUrl: String, libraryId: String, token: String, insecureAllowed: Boolean): NetworkResult<List<com.riffle.core.network.NetworkSeries>> =
-        NetworkResult.Success(emptyList())
-
-    override suspend fun getCollections(baseUrl: String, libraryId: String, token: String, insecureAllowed: Boolean): NetworkResult<List<com.riffle.core.network.NetworkCollection>> =
-        NetworkResult.Success(emptyList())
-
-    override suspend fun getPlaylists(baseUrl: String, libraryId: String, token: String, insecureAllowed: Boolean): NetworkResult<List<NetworkPlaylist>> =
-        NetworkResult.Success(playlistsByLibrary[libraryId].orEmpty())
-
-    override suspend fun createPlaylist(
-        baseUrl: String, libraryId: String, name: String, initialBookId: String?,
-        token: String, insecureAllowed: Boolean,
-    ): NetworkResult<NetworkPlaylist?> {
-        createCalls += Triple(libraryId, name, initialBookId)
-        return NetworkResult.Success(NetworkPlaylist("pl-new", libraryId, name, emptyList(), emptySet()))
+    private class FakeRegistry(private val catalog: Catalog?) : CatalogRegistry {
+        override suspend fun forActive(): Catalog? = catalog
+        override suspend fun forSource(source: Source): Catalog? = catalog
+        override suspend fun forSourceId(sourceId: String): Catalog? = catalog
     }
 
-    override suspend fun addBookToPlaylist(
-        baseUrl: String, playlistId: String, libraryItemId: String,
-        token: String, insecureAllowed: Boolean,
-    ): NetworkResult<NetworkPlaylist?> {
-        addCalls += playlistId to libraryItemId
-        return NetworkResult.Success(null)
-    }
+    private class FakeCatalog(
+        val playlistsByLibrary: Map<String, List<CatalogPlaylist>> = emptyMap(),
+        val listFails: Boolean = false,
+        val createFails: Boolean = false,
+        val addFails: Boolean = false,
+        val removeFails: Boolean = false,
+    ) : Catalog, PlaylistsCapability {
+        val createCalls = mutableListOf<Pair<String, String>>()
+        val addCalls = mutableListOf<Pair<String, String>>()
+        val removeCalls = mutableListOf<Pair<String, String>>()
 
-    override suspend fun removeBookFromPlaylist(
-        baseUrl: String, playlistId: String, libraryItemId: String,
-        token: String, insecureAllowed: Boolean,
-    ): NetworkResult<NetworkPlaylist?> {
-        removeCalls += playlistId to libraryItemId
-        return NetworkResult.Success(null)
+        override val sourceType = SourceType.ABS
+        override suspend fun listRoots() = emptyList<CatalogRoot>()
+        override suspend fun browse(rootId: String, sort: SortKey, page: Int, pageSize: Int) = emptyList<CatalogItem>()
+        override suspend fun search(rootId: String, query: String, page: Int, pageSize: Int) = emptyList<CatalogItem>()
+        override suspend fun getItem(itemId: String): CatalogItem? = null
+        override suspend fun fetchFile(itemId: String, format: BookFormat): CatalogFileHandle = throw UnsupportedOperationException()
+        override suspend fun openFile(itemId: String, format: BookFormat, handleHint: String?): CatalogFileStream = throw UnsupportedOperationException()
+        override suspend fun connectivityCheck() = CatalogHealth(isReachable = true)
+
+        override suspend fun listPlaylists(rootId: String): List<CatalogPlaylist> {
+            if (listFails) throw RuntimeException("boom")
+            return playlistsByLibrary[rootId].orEmpty()
+        }
+
+        override suspend fun createPlaylist(rootId: String, name: String): CatalogPlaylist {
+            if (createFails) throw RuntimeException("boom")
+            createCalls += rootId to name
+            return CatalogPlaylist(id = "pl-new", rootId = rootId, name = name, bookCount = 0)
+        }
+
+        override suspend fun addItemToPlaylist(playlistId: String, itemId: String) {
+            if (addFails) throw RuntimeException("boom")
+            addCalls += playlistId to itemId
+        }
+
+        override suspend fun removeItemFromPlaylist(playlistId: String, itemId: String) {
+            if (removeFails) throw RuntimeException("boom")
+            removeCalls += playlistId to itemId
+        }
     }
 }

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/AudiobookChapterCacheRepository.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/AudiobookChapterCacheRepository.kt
@@ -2,11 +2,10 @@ package com.riffle.core.domain
 
 interface AudiobookChapterCacheRepository {
     suspend fun getCachedChapters(sourceId: String, itemId: String): List<AudiobookChapter>?
-    suspend fun fetchAndCacheChapters(
-        sourceId: String,
-        itemId: String,
-        baseUrl: String,
-        token: String,
-        insecureAllowed: Boolean,
-    ): List<AudiobookChapter>
+
+    /**
+     * Fetch chapter markers for [itemId] from the Source identified by [sourceId] and upsert them
+     * into the local cache. Returns the fetched chapters (possibly empty on a network error).
+     */
+    suspend fun fetchAndCacheChapters(sourceId: String, itemId: String): List<AudiobookChapter>
 }


### PR DESCRIPTION
Closes #434.

## Summary

Phase 2b of the ABS-independence rearchitecture (ADR 0041). Every repository that previously talked ABS-specific HTTP APIs now consumes the [\`Catalog\`](../blob/main/core/catalog/src/main/kotlin/com/riffle/core/catalog/Catalog.kt) abstraction + capability mixins via a new \`CatalogRegistry\`. \`AbsCatalog\` is the only ABS-shaped implementation; every other production ABS call site has moved behind it.

### DI foundation

- \`CatalogFactory\` (per-Source \`Catalog\` construction, since \`AbsCatalog\` is per-Source-row) + \`CatalogRegistry\` + \`DefaultCatalogRegistry\`.
- Hilt \`CatalogModule\` binds \`Map<SourceType, @JvmSuppressWildcards CatalogFactory>\` with \`ABS -> AbsCatalogFactory\`. LocalFiles will slot in the same way once #437 / #438 land.

### Repositories migrated

| Repository | Uses |
|---|---|
| \`LibraryRepositoryImpl\` | \`Catalog.listRoots\` / \`browse\` + \`ProgressPeerCapability.pullAllProgress\` + \`SeriesCapability\` + \`CollectionsCapability\` |
| \`EpubRepositoryImpl\` / \`PdfRepositoryImpl\` | \`Catalog.openFile(BookFormat, handleHint)\` (hint preserves the local-ino skip-lookup optimization) |
| \`AudiobookRepositoryImpl\` | \`AudiobookMediaCapability.openAudiobook\` + \`ProgressPeerCapability.pushAudiobookProgress\` |
| \`AudiobookChapterCacheRepositoryImpl\` | \`AudiobookMediaCapability.getAudiobookChapters\` (interface simplified to \`sourceId, itemId\`) |
| \`AudiobookBookmarkReconciler\` | \`BookmarksCapability\` (new) |
| \`ToReadRepositoryImpl\` | \`PlaylistsCapability\` |
| \`ReadingSessionRepositoryImpl\` | \`ProgressPeerCapability\` (adopts the returned stamp to close the feedback loop) |
| \`AbsProgressRemoteFactory\` / \`AbsProgressRemotes\` | Rebuilt over \`ProgressPeerCapability\` |
| \`ProgressSweep\` | \`ServerTokenResolver\` dropped; \`CatalogRegistry.forSourceId\` doubles as the reachability gate |
| \`CrossEpubIndexBuilderService\` | \`Catalog.openFile\` |
| App-layer \`ReaderSync\` / \`ReaderSyncFactory\` / \`AudiobookFollow\` / \`ReadaloudStreamingSessionFactory\` | Route through \`ProgressPeerCapability\` + \`AudiobookMediaCapability\`. \`AbsSyncEndpoint\` → \`CatalogSyncEndpoint\` |

### Catalog surface additions

- \`Catalog.openFile(itemId, format, handleHint)\` + \`CatalogFileStream\` — byte-stream open (encapsulates auth/TLS).
- \`AudiobookMediaCapability.openAudiobook\` (composite session open) + \`getAudiobookChapters\` + \`CatalogAudiobookStream\` / \`CatalogAudiobookChapter\`.
- \`BookmarksCapability\` + \`CatalogBookmark\`.
- \`CatalogItem\`: \`seriesSequence\`, \`readingProgress\`, \`updatedAt\` fields (so refresh can rebuild join tables in one round-trip).
- \`CatalogSeries.items\` (with sequence), \`CatalogCollection.itemIds\`, \`CatalogPlaylist.itemIds\`.
- \`CatalogProgress.finishedAt\`, \`CatalogAudioFingerprint.fileSizeBytes\`.
- \`ProgressPeerCapability.push*\` now returns the source-side \`Long?\` stamp so callers can adopt it as \`localUpdatedAt\` — closes the last-update-wins feedback loop (ADR 0008 / 0030).
- \`buildStreamUrl\` bakes the auth token into the ABS audio URL.

### Not migrated

\`SourceRepositoryImpl\` retains \`AbsApi\` / \`AbsLibraryApi\` / \`AbsServerInfoApi\` for the **pre-Catalog auth bootstrap** — login/authenticate cannot route through a Source's own Catalog because the Source doesn't exist yet, and \`getCurrentUserId\` (\`/api/me\`) has no Catalog equivalent. Every other production ABS call site has moved.

### Review pass

\`/code-review\` after rebase surfaced three real bugs (all fixed in commit \`aeb2b7fcc\`):

1. Non-null \`isFinished\` on routine ebook saves zeroed ABS's audio dimension — widened to \`Boolean?\`; \`null\` for routine saves, \`true\`/\`false\` only for mark-finished.
2. \`AbsCatalog.pullProgress\` collapsed reachable-empty to null, dropping the first push on fresh books — restored a CatalogProgress with \`lastUpdate=0\`.
3. \`AbsCatalog.getFingerprint\` threw on Success(null) — widened to \`CatalogAudioFingerprint?\` so \`NO_AUDIOBOOK\` persists definitively instead of re-fingerprinting every open.

## Test plan

- [x] \`./gradlew test\` — full suite green (1,562 tests, 0 failed).
- [ ] Smoke test on a fresh AVD — library refresh, open EPUB, page-turn saves progress, close reader, reopen and verify position restored, mark unread, open audiobook, verify playback + progress sync.
- [ ] Regression checks on adjacent flows: readaloud (matched book), download EPUB, bookmarks, To Read add/remove.