### PR TITLE
feat(ui): Source Switcher, Add Source flow, Source Type picker

### DIFF
--- a/app/src/androidTest/kotlin/com/riffle/app/feature/reader/AnnotationFocusHarnessTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/reader/AnnotationFocusHarnessTest.kt
@@ -329,6 +329,12 @@ class AnnotationFocusHarnessTest {
     // ── UI driving (mirrors NavigationSnapHarnessTest) ─────────────────────────
 
     private fun addServerAndBrowseLibrary() {
+        // With no sources, HomeScreen navigates to the Source Type picker (#435).
+        // Tap the Audiobookshelf card to advance to the connect form.
+        composeTestRule.waitUntil(timeoutMillis = 5_000) {
+            composeTestRule.onAllNodesWithText("Audiobookshelf").fetchSemanticsNodes().isNotEmpty()
+        }
+        composeTestRule.onNodeWithText("Audiobookshelf").performClick()
         composeTestRule.waitUntil(timeoutMillis = 5_000) {
             composeTestRule.onAllNodesWithText("Connect").fetchSemanticsNodes().isNotEmpty()
         }

--- a/app/src/androidTest/kotlin/com/riffle/app/feature/reader/ContinuousAnnotationRenderHarnessTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/reader/ContinuousAnnotationRenderHarnessTest.kt
@@ -185,6 +185,12 @@ class ContinuousAnnotationRenderHarnessTest {
     }
 
     private fun addServerAndBrowseLibrary() {
+        // With no sources, HomeScreen navigates to the Source Type picker (#435).
+        // Tap the Audiobookshelf card to advance to the connect form.
+        composeTestRule.waitUntil(timeoutMillis = 5_000) {
+            composeTestRule.onAllNodesWithText("Audiobookshelf").fetchSemanticsNodes().isNotEmpty()
+        }
+        composeTestRule.onNodeWithText("Audiobookshelf").performClick()
         composeTestRule.waitUntil(timeoutMillis = 5_000) {
             composeTestRule.onAllNodesWithText("Connect").fetchSemanticsNodes().isNotEmpty()
         }

--- a/app/src/androidTest/kotlin/com/riffle/app/feature/reader/OrientationFlipAnnotationHarnessTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/reader/OrientationFlipAnnotationHarnessTest.kt
@@ -244,6 +244,12 @@ class OrientationFlipAnnotationHarnessTest {
     }
 
     private fun addServerAndBrowseLibrary() {
+        // With no sources, HomeScreen navigates to the Source Type picker (#435).
+        // Tap the Audiobookshelf card to advance to the connect form.
+        composeTestRule.waitUntil(timeoutMillis = 5_000) {
+            composeTestRule.onAllNodesWithText("Audiobookshelf").fetchSemanticsNodes().isNotEmpty()
+        }
+        composeTestRule.onNodeWithText("Audiobookshelf").performClick()
         composeTestRule.waitUntil(timeoutMillis = 5_000) {
             composeTestRule.onAllNodesWithText("Connect").fetchSemanticsNodes().isNotEmpty()
         }

--- a/app/src/androidTest/kotlin/com/riffle/app/feature/server/SourceTypePickerScreenTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/server/SourceTypePickerScreenTest.kt
@@ -1,0 +1,61 @@
+package com.riffle.app.feature.server
+
+import androidx.activity.ComponentActivity
+import androidx.compose.material3.windowsizeclass.calculateWindowSizeClass
+import androidx.compose.ui.test.assertHasClickAction
+import androidx.compose.ui.test.assertHasNoClickAction
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Instrumentation coverage for #435's SourceTypePickerScreen. Locks the ABS-enabled +
+ * LocalFiles-disabled contract at the composable level; JVM-side data-model pinning
+ * lives in [SourceTypePickerTest].
+ */
+@RunWith(AndroidJUnit4::class)
+class SourceTypePickerScreenTest {
+
+    @get:Rule
+    val composeRule = createAndroidComposeRule<ComponentActivity>()
+
+    @Test
+    fun bothCards_areDisplayed() {
+        setContent()
+        composeRule.onNodeWithText("Audiobookshelf").assertIsDisplayed()
+        composeRule.onNodeWithText("Local files").assertIsDisplayed()
+    }
+
+    @Test
+    fun audiobookshelfCard_click_invokesCallback() {
+        var pickCount = 0
+        setContent(onPick = { pickCount++ })
+        composeRule.onNodeWithTag("SourceTypeCard.Audiobookshelf").assertHasClickAction().performClick()
+        assertEquals(1, pickCount)
+    }
+
+    @Test
+    fun localFilesCard_isDisabled_showsComingSoon() {
+        setContent()
+        composeRule.onNodeWithText("Coming soon").assertIsDisplayed()
+        composeRule.onNodeWithTag("SourceTypeCard.LocalFiles").assertHasNoClickAction()
+    }
+
+    private fun setContent(onPick: () -> Unit = {}) {
+        composeRule.setContent {
+            val wsc = calculateWindowSizeClass(composeRule.activity)
+            SourceTypePickerScreen(
+                windowSizeClass = wsc,
+                onNavigateBack = {},
+                onPickAudiobookshelf = onPick,
+            )
+        }
+    }
+}

--- a/app/src/androidTest/kotlin/com/riffle/app/feature/server/SourceTypePickerScreenTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/server/SourceTypePickerScreenTest.kt
@@ -1,6 +1,7 @@
 package com.riffle.app.feature.server
 
 import androidx.activity.ComponentActivity
+import androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSizeClassApi
 import androidx.compose.material3.windowsizeclass.calculateWindowSizeClass
 import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.assertHasNoClickAction
@@ -20,6 +21,7 @@ import org.junit.runner.RunWith
  * LocalFiles-disabled contract at the composable level; JVM-side data-model pinning
  * lives in [SourceTypePickerTest].
  */
+@OptIn(ExperimentalMaterial3WindowSizeClassApi::class)
 @RunWith(AndroidJUnit4::class)
 class SourceTypePickerScreenTest {
 

--- a/app/src/androidTest/kotlin/com/riffle/app/harness/EpubHarnessTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/harness/EpubHarnessTest.kt
@@ -201,8 +201,12 @@ class EpubHarnessTest {
     // ── Helpers ─────────────────────────────────────────────────────────────
 
     private fun addServerAndBrowseLibrary() {
-        // With no servers, HomeScreen automatically navigates to AddSourceScreen.
-        // Wait for the form to appear before filling it in.
+        // With no sources, HomeScreen navigates to the Source Type picker (#435).
+        // Tap the Audiobookshelf card to advance to the connect form.
+        composeTestRule.waitUntil(timeoutMillis = 5_000) {
+            composeTestRule.onAllNodesWithText("Audiobookshelf").fetchSemanticsNodes().isNotEmpty()
+        }
+        composeTestRule.onNodeWithText("Audiobookshelf").performClick()
         composeTestRule.waitUntil(timeoutMillis = 5_000) {
             composeTestRule.onAllNodesWithText("Connect").fetchSemanticsNodes().isNotEmpty()
         }

--- a/app/src/androidTest/kotlin/com/riffle/app/harness/EpubHarnessTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/harness/EpubHarnessTest.kt
@@ -201,7 +201,7 @@ class EpubHarnessTest {
     // ── Helpers ─────────────────────────────────────────────────────────────
 
     private fun addServerAndBrowseLibrary() {
-        // With no servers, HomeScreen automatically navigates to AddServerScreen.
+        // With no servers, HomeScreen automatically navigates to AddSourceScreen.
         // Wait for the form to appear before filling it in.
         composeTestRule.waitUntil(timeoutMillis = 5_000) {
             composeTestRule.onAllNodesWithText("Connect").fetchSemanticsNodes().isNotEmpty()

--- a/app/src/androidTest/kotlin/com/riffle/app/harness/NavigationSnapHarnessTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/harness/NavigationSnapHarnessTest.kt
@@ -372,6 +372,12 @@ class NavigationSnapHarnessTest {
     }
 
     private fun addServerAndBrowseLibrary() {
+        // With no sources, HomeScreen navigates to the Source Type picker (#435).
+        // Tap the Audiobookshelf card to advance to the connect form.
+        composeTestRule.waitUntil(timeoutMillis = 5_000) {
+            composeTestRule.onAllNodesWithText("Audiobookshelf").fetchSemanticsNodes().isNotEmpty()
+        }
+        composeTestRule.onNodeWithText("Audiobookshelf").performClick()
         composeTestRule.waitUntil(timeoutMillis = 5_000) {
             composeTestRule.onAllNodesWithText("Connect").fetchSemanticsNodes().isNotEmpty()
         }

--- a/app/src/androidTest/kotlin/com/riffle/app/harness/PdfHarnessTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/harness/PdfHarnessTest.kt
@@ -145,7 +145,7 @@ class PdfHarnessTest {
     // ── Helpers ─────────────────────────────────────────────────────────────
 
     private fun addServerAndBrowseLibrary() {
-        // With no servers, HomeScreen automatically navigates to AddServerScreen.
+        // With no servers, HomeScreen automatically navigates to AddSourceScreen.
         // Wait for the form to appear before filling it in.
         composeTestRule.waitUntil(timeoutMillis = 5_000) {
             composeTestRule.onAllNodesWithText("Connect").fetchSemanticsNodes().isNotEmpty()

--- a/app/src/androidTest/kotlin/com/riffle/app/harness/PdfHarnessTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/harness/PdfHarnessTest.kt
@@ -145,8 +145,12 @@ class PdfHarnessTest {
     // ── Helpers ─────────────────────────────────────────────────────────────
 
     private fun addServerAndBrowseLibrary() {
-        // With no servers, HomeScreen automatically navigates to AddSourceScreen.
-        // Wait for the form to appear before filling it in.
+        // With no sources, HomeScreen navigates to the Source Type picker (#435).
+        // Tap the Audiobookshelf card to advance to the connect form.
+        composeTestRule.waitUntil(timeoutMillis = 5_000) {
+            composeTestRule.onAllNodesWithText("Audiobookshelf").fetchSemanticsNodes().isNotEmpty()
+        }
+        composeTestRule.onNodeWithText("Audiobookshelf").performClick()
         composeTestRule.waitUntil(timeoutMillis = 5_000) {
             composeTestRule.onAllNodesWithText("Connect").fetchSemanticsNodes().isNotEmpty()
         }

--- a/app/src/androidTest/kotlin/com/riffle/app/harness/SearchHarnessTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/harness/SearchHarnessTest.kt
@@ -196,6 +196,12 @@ class SearchHarnessTest {
     // ── Helpers ─────────────────────────────────────────────────────────────
 
     private fun addServerAndBrowseLibrary() {
+        // With no sources, HomeScreen navigates to the Source Type picker (#435).
+        // Tap the Audiobookshelf card to advance to the connect form.
+        composeTestRule.waitUntil(timeoutMillis = 5_000) {
+            composeTestRule.onAllNodesWithText("Audiobookshelf").fetchSemanticsNodes().isNotEmpty()
+        }
+        composeTestRule.onNodeWithText("Audiobookshelf").performClick()
         composeTestRule.waitUntil(timeoutMillis = 5_000) {
             composeTestRule.onAllNodesWithText("Connect").fetchSemanticsNodes().isNotEmpty()
         }

--- a/app/src/androidTest/kotlin/com/riffle/app/harness/WakeLockHarnessTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/harness/WakeLockHarnessTest.kt
@@ -125,6 +125,12 @@ class WakeLockHarnessTest {
     }
 
     private fun addServerAndBrowseToReader() {
+        // With no sources, HomeScreen navigates to the Source Type picker (#435).
+        // Tap the Audiobookshelf card to advance to the connect form.
+        composeTestRule.waitUntil(timeoutMillis = 5_000) {
+            composeTestRule.onAllNodesWithText("Audiobookshelf").fetchSemanticsNodes().isNotEmpty()
+        }
+        composeTestRule.onNodeWithText("Audiobookshelf").performClick()
         composeTestRule.waitUntil(timeoutMillis = 5_000) {
             composeTestRule.onAllNodesWithText("Connect").fetchSemanticsNodes().isNotEmpty()
         }
@@ -157,6 +163,12 @@ class WakeLockHarnessTest {
     }
 
     private fun addServerAndBrowseToPdfReader() {
+        // With no sources, HomeScreen navigates to the Source Type picker (#435).
+        // Tap the Audiobookshelf card to advance to the connect form.
+        composeTestRule.waitUntil(timeoutMillis = 5_000) {
+            composeTestRule.onAllNodesWithText("Audiobookshelf").fetchSemanticsNodes().isNotEmpty()
+        }
+        composeTestRule.onNodeWithText("Audiobookshelf").performClick()
         composeTestRule.waitUntil(timeoutMillis = 5_000) {
             composeTestRule.onAllNodesWithText("Connect").fetchSemanticsNodes().isNotEmpty()
         }
@@ -189,6 +201,12 @@ class WakeLockHarnessTest {
     }
 
     private fun addServerAndNavigateToSettings() {
+        // With no sources, HomeScreen navigates to the Source Type picker (#435).
+        // Tap the Audiobookshelf card to advance to the connect form.
+        composeTestRule.waitUntil(timeoutMillis = 5_000) {
+            composeTestRule.onAllNodesWithText("Audiobookshelf").fetchSemanticsNodes().isNotEmpty()
+        }
+        composeTestRule.onNodeWithText("Audiobookshelf").performClick()
         composeTestRule.waitUntil(timeoutMillis = 5_000) {
             composeTestRule.onAllNodesWithText("Connect").fetchSemanticsNodes().isNotEmpty()
         }

--- a/app/src/main/kotlin/com/riffle/app/feature/annotationsync/AnnotationSyncStatus.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/annotationsync/AnnotationSyncStatus.kt
@@ -7,7 +7,7 @@ import com.riffle.core.domain.AnnotationSyncConfig
  * Single source of truth for the WebDAV sync "kind" (Local / Synced / Pending / Error) rendered by
  * the main Settings row ([com.riffle.app.feature.settings.SettingsViewModel.annotationSyncRow]) and
  * the AddServer WebDAV banner
- * ([com.riffle.app.feature.server.AddServerViewModel.webdavBanner]).
+ * ([com.riffle.app.feature.server.AddSourceViewModel.webdavBanner]).
  *
  * Both surfaces observe the same singleton [com.riffle.core.data.AnnotationSyncStatusStore] and the
  * same pending-book count, and both call this function to decide their badge/kind — so the two

--- a/app/src/main/kotlin/com/riffle/app/feature/navigation/HomeScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/navigation/HomeScreen.kt
@@ -25,7 +25,7 @@ import kotlinx.coroutines.withContext
 
 @Composable
 fun HomeScreen(
-    onNavigateToAddServer: () -> Unit,
+    onNavigateToAddSource: () -> Unit,
     onNavigateToLibrary: (libraryId: String, libraryName: String) -> Unit,
     viewModel: HomeViewModel = hiltViewModel(),
 ) {
@@ -41,7 +41,7 @@ fun HomeScreen(
         // LifecycleRegistry.setCurrentState() which requires the main thread.
         withContext(viewModel.dispatchers.mainImmediate) {
             when (dest) {
-                is HomeViewModel.StartDestination.AddServer -> onNavigateToAddServer()
+                is HomeViewModel.StartDestination.AddSource -> onNavigateToAddSource()
                 is HomeViewModel.StartDestination.Library -> onNavigateToLibrary(dest.libraryId, dest.libraryName)
                 is HomeViewModel.StartDestination.NoLibraries -> showRetry = true
             }

--- a/app/src/main/kotlin/com/riffle/app/feature/navigation/HomeViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/navigation/HomeViewModel.kt
@@ -24,14 +24,14 @@ class HomeViewModel @Inject constructor(
 ) : ViewModel() {
 
     sealed class StartDestination {
-        data object AddServer : StartDestination()
+        data object AddSource : StartDestination()
         data object NoLibraries : StartDestination()
         data class Library(val libraryId: String, val libraryName: String) : StartDestination()
     }
 
     suspend fun getStartDestination(): StartDestination = withContext(dispatchers.io) {
         val servers = sourceRepository.observeAll().first()
-        if (servers.isEmpty()) return@withContext StartDestination.AddServer
+        if (servers.isEmpty()) return@withContext StartDestination.AddSource
 
         val activeServer = servers.firstOrNull { it.isActive } ?: servers.first()
         var libraries = libraryObserver.observeLibraries().first()
@@ -41,7 +41,7 @@ class HomeViewModel @Inject constructor(
             libraries = libraryObserver.observeLibraries().first()
             if (libraries.isEmpty()) {
                 return@withContext when (refreshResult) {
-                    LibraryRefreshResult.Success -> StartDestination.AddServer
+                    LibraryRefreshResult.Success -> StartDestination.AddSource
                     else -> StartDestination.NoLibraries
                 }
             }

--- a/app/src/main/kotlin/com/riffle/app/feature/navigation/NavigationDrawerComposable.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/navigation/NavigationDrawerComposable.kt
@@ -197,7 +197,7 @@ private fun DrawerHeader(
     ) {
         ListItem(
             headlineContent = {
-                val name = activeServer?.serverType?.label ?: "No server"
+                val name = activeServer?.serverType?.label ?: "No source"
                 val username = activeServer?.username?.takeIf { it.isNotEmpty() }
                 if (username != null) {
                     Text(
@@ -224,7 +224,7 @@ private fun DrawerHeader(
             trailingContent = {
                 Icon(
                     imageVector = if (switcherExpanded) Icons.Default.KeyboardArrowUp else Icons.Default.KeyboardArrowDown,
-                    contentDescription = "Toggle server switcher",
+                    contentDescription = "Toggle source switcher",
                 )
             },
             modifier = Modifier.clickable { switcherExpanded = !switcherExpanded },

--- a/app/src/main/kotlin/com/riffle/app/feature/server/AddSourceScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/server/AddSourceScreen.kt
@@ -200,14 +200,14 @@ fun AddSourceScreen(
     }
 }
 
-private fun screenTitle(backend: AddSourceBackend, isEditing: Boolean): String = when (backend) {
-    AddSourceBackend.AUDIOBOOKSHELF -> if (isEditing) "Edit Audiobookshelf server" else "Add Audiobookshelf server"
+internal fun screenTitle(backend: AddSourceBackend, isEditing: Boolean): String = when (backend) {
+    AddSourceBackend.AUDIOBOOKSHELF -> if (isEditing) "Edit Audiobookshelf" else "Add Audiobookshelf"
     AddSourceBackend.STORYTELLER -> if (isEditing) "Edit Storyteller" else "Add Storyteller"
     AddSourceBackend.WEBDAV -> if (isEditing) "Edit WebDAV" else "Add WebDAV"
 }
 
-private fun removeButtonLabel(backend: AddSourceBackend): String = when (backend) {
-    AddSourceBackend.AUDIOBOOKSHELF -> "Remove server"
+internal fun removeButtonLabel(backend: AddSourceBackend): String = when (backend) {
+    AddSourceBackend.AUDIOBOOKSHELF -> "Remove source"
     AddSourceBackend.STORYTELLER -> "Remove Storyteller"
     AddSourceBackend.WEBDAV -> "Disable sync"
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/server/AddSourceScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/server/AddSourceScreen.kt
@@ -55,12 +55,12 @@ import com.riffle.core.domain.PendingSource
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun AddServerScreen(
+fun AddSourceScreen(
     windowSizeClass: WindowSizeClass,
     onNavigateBack: () -> Unit,
     onAuthenticated: (PendingSource) -> Unit,
     onAutoCompleted: () -> Unit,
-    viewModel: AddServerViewModel = hiltViewModel(),
+    viewModel: AddSourceViewModel = hiltViewModel(),
 ) {
     LaunchedEffect(Unit) {
         viewModel.navigateToSelectLibraries.collect { onAuthenticated(it) }
@@ -72,9 +72,9 @@ fun AddServerScreen(
     val backend = viewModel.backend
     val isEditing = viewModel.isEditing
     val title = screenTitle(backend, isEditing)
-    val urlLabel = if (backend == AddServerBackend.WEBDAV) "WebDAV URL" else "Source URL"
+    val urlLabel = if (backend == AddSourceBackend.WEBDAV) "WebDAV URL" else "Source URL"
     val urlPlaceholder = when (backend) {
-        AddServerBackend.WEBDAV -> "server.example.com/dav/annotations"
+        AddSourceBackend.WEBDAV -> "server.example.com/dav/annotations"
         else -> "abs.example.com"
     }
     val submitLabel = if (isEditing) "Save" else "Connect"
@@ -118,7 +118,7 @@ fun AddServerScreen(
                     )
                 }
                 val webdavBanner by viewModel.webdavBanner.collectAsState()
-                if (backend == AddServerBackend.WEBDAV) {
+                if (backend == AddSourceBackend.WEBDAV) {
                     webdavBanner?.let { WebdavStatusCard(it) }
                 }
                 Row(verticalAlignment = Alignment.CenterVertically) {
@@ -200,27 +200,27 @@ fun AddServerScreen(
     }
 }
 
-private fun screenTitle(backend: AddServerBackend, isEditing: Boolean): String = when (backend) {
-    AddServerBackend.AUDIOBOOKSHELF -> if (isEditing) "Edit Audiobookshelf server" else "Add Audiobookshelf server"
-    AddServerBackend.STORYTELLER -> if (isEditing) "Edit Storyteller" else "Add Storyteller"
-    AddServerBackend.WEBDAV -> if (isEditing) "Edit WebDAV" else "Add WebDAV"
+private fun screenTitle(backend: AddSourceBackend, isEditing: Boolean): String = when (backend) {
+    AddSourceBackend.AUDIOBOOKSHELF -> if (isEditing) "Edit Audiobookshelf server" else "Add Audiobookshelf server"
+    AddSourceBackend.STORYTELLER -> if (isEditing) "Edit Storyteller" else "Add Storyteller"
+    AddSourceBackend.WEBDAV -> if (isEditing) "Edit WebDAV" else "Add WebDAV"
 }
 
-private fun removeButtonLabel(backend: AddServerBackend): String = when (backend) {
-    AddServerBackend.AUDIOBOOKSHELF -> "Remove server"
-    AddServerBackend.STORYTELLER -> "Remove Storyteller"
-    AddServerBackend.WEBDAV -> "Disable sync"
+private fun removeButtonLabel(backend: AddSourceBackend): String = when (backend) {
+    AddSourceBackend.AUDIOBOOKSHELF -> "Remove server"
+    AddSourceBackend.STORYTELLER -> "Remove Storyteller"
+    AddSourceBackend.WEBDAV -> "Disable sync"
 }
 
 // User-facing description of what Riffle does with each backend. Keep in sync
 // with what the app actually supports — when a backend gains/loses a capability
 // (e.g. audiobook streaming, readaloud sync), revisit this copy.
-private fun backendHelpText(backend: AddServerBackend): String = when (backend) {
-    AddServerBackend.AUDIOBOOKSHELF ->
+private fun backendHelpText(backend: AddSourceBackend): String = when (backend) {
+    AddSourceBackend.AUDIOBOOKSHELF ->
         "Stream ebooks and audiobooks from your Audiobookshelf server, with progress synced across devices."
-    AddServerBackend.STORYTELLER ->
+    AddSourceBackend.STORYTELLER ->
         "Storyteller hosts aligned ebook + audiobook \"readalouds.\" Riffle matches each readaloud to a book on your Audiobookshelf server, enabling synchronized text + audio playback inside the reader."
-    AddServerBackend.WEBDAV ->
+    AddSourceBackend.WEBDAV ->
         "Sync highlights, notes, and bookmarks between your devices via a WebDAV server."
 }
 

--- a/app/src/main/kotlin/com/riffle/app/feature/server/AddSourceViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/server/AddSourceViewModel.kt
@@ -42,14 +42,14 @@ import javax.inject.Inject
 import javax.inject.Named
 
 /**
- * Backend kind selectable in [AddServerScreen]. Distinct from [ServerType] because WebDAV is
+ * Backend kind selectable in [AddSourceScreen]. Distinct from [ServerType] because WebDAV is
  * not a content "server" in the domain sense — it just shares the same URL+username+password
  * shape — and we want a single screen for adding any of them.
  */
-enum class AddServerBackend { AUDIOBOOKSHELF, STORYTELLER, WEBDAV }
+enum class AddSourceBackend { AUDIOBOOKSHELF, STORYTELLER, WEBDAV }
 
 @HiltViewModel
-class AddServerViewModel @Inject constructor(
+class AddSourceViewModel @Inject constructor(
     private val repository: SourceRepository,
     private val webdavConfigStore: AnnotationSyncConfigStore,
     private val webdavTargetFactory: WebDavAnnotationSyncTargetFactory,
@@ -64,7 +64,7 @@ class AddServerViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
 ) : ViewModel() {
 
-    var backend by mutableStateOf(AddServerBackend.AUDIOBOOKSHELF)
+    var backend by mutableStateOf(AddSourceBackend.AUDIOBOOKSHELF)
         private set
     /** Source id when editing an existing Storyteller/ABS server; null for add or for WebDAV. */
     var editingServerId by mutableStateOf<String?>(null)
@@ -116,14 +116,14 @@ class AddServerViewModel @Inject constructor(
 
     private suspend fun initFromRoute() {
         when (backend) {
-            AddServerBackend.AUDIOBOOKSHELF, AddServerBackend.STORYTELLER -> {
+            AddSourceBackend.AUDIOBOOKSHELF, AddSourceBackend.STORYTELLER -> {
                 val id = editingServerId ?: return
                 val server = repository.getById(id) ?: return
                 applyUrl(server.url.value)
                 username = server.username
                 password = tokenStorage.getPassword(id).orEmpty()
             }
-            AddServerBackend.WEBDAV -> {
+            AddSourceBackend.WEBDAV -> {
                 val existing = webdavConfigStore.observe().first()
                 if (existing != null) {
                     isEditingWebdav = true
@@ -176,8 +176,8 @@ class AddServerViewModel @Inject constructor(
     fun onConnect() {
         error = null
         when (backend) {
-            AddServerBackend.AUDIOBOOKSHELF, AddServerBackend.STORYTELLER -> connectServer()
-            AddServerBackend.WEBDAV -> connectWebdav()
+            AddSourceBackend.AUDIOBOOKSHELF, AddSourceBackend.STORYTELLER -> connectServer()
+            AddSourceBackend.WEBDAV -> connectWebdav()
         }
     }
 
@@ -275,9 +275,9 @@ class AddServerViewModel @Inject constructor(
     fun onRemove() {
         viewModelScope.launch {
             when (backend) {
-                AddServerBackend.AUDIOBOOKSHELF, AddServerBackend.STORYTELLER ->
+                AddSourceBackend.AUDIOBOOKSHELF, AddSourceBackend.STORYTELLER ->
                     editingServerId?.let { repository.remove(it) }
-                AddServerBackend.WEBDAV -> webdavConfigStore.clear()
+                AddSourceBackend.WEBDAV -> webdavConfigStore.clear()
             }
             _navigateHome.send(Unit)
         }
@@ -348,7 +348,7 @@ class AddServerViewModel @Inject constructor(
     companion object {
         /**
          * Hilt qualifier for the [webdavBanner]'s wall-clock ticker. See [WebdavBannerTickerModule]
-         * for the production ticker (once a minute), and [AddServerViewModelTest] for the test
+         * for the production ticker (once a minute), and [AddSourceViewModelTest] for the test
          * override.
          */
         const val WEBDAV_BANNER_TICKER = "webdavBannerTicker"
@@ -366,14 +366,14 @@ data class WebdavBanner(
     val prescription: String?,
 )
 
-private fun parseBackend(raw: String?): AddServerBackend = when (raw?.lowercase()) {
-    "storyteller" -> AddServerBackend.STORYTELLER
-    "webdav" -> AddServerBackend.WEBDAV
-    else -> AddServerBackend.AUDIOBOOKSHELF
+private fun parseBackend(raw: String?): AddSourceBackend = when (raw?.lowercase()) {
+    "storyteller" -> AddSourceBackend.STORYTELLER
+    "webdav" -> AddSourceBackend.WEBDAV
+    else -> AddSourceBackend.AUDIOBOOKSHELF
 }
 
-private fun AddServerBackend.toServerType(): ServerType? = when (this) {
-    AddServerBackend.AUDIOBOOKSHELF -> ServerType.AUDIOBOOKSHELF
-    AddServerBackend.STORYTELLER -> ServerType.STORYTELLER
-    AddServerBackend.WEBDAV -> null
+private fun AddSourceBackend.toServerType(): ServerType? = when (this) {
+    AddSourceBackend.AUDIOBOOKSHELF -> ServerType.AUDIOBOOKSHELF
+    AddSourceBackend.STORYTELLER -> ServerType.STORYTELLER
+    AddSourceBackend.WEBDAV -> null
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/server/SourceSetupViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/server/SourceSetupViewModel.kt
@@ -7,11 +7,11 @@ import javax.inject.Inject
 
 /**
  * Scoped to the `server_setup` nested navigation graph. Holds the
- * authenticated-but-not-yet-persisted PendingSource so AddServerScreen and
+ * authenticated-but-not-yet-persisted PendingSource so AddSourceScreen and
  * SelectLibrariesScreen can share it without routing the auth token through
  * nav arguments.
  */
 @HiltViewModel
-class ServerSetupViewModel @Inject constructor() : ViewModel() {
+class SourceSetupViewModel @Inject constructor() : ViewModel() {
     var pendingServer: PendingSource? = null
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/server/SourceTypePickerScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/server/SourceTypePickerScreen.kt
@@ -32,6 +32,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.disabled
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import com.riffle.app.ui.TabletContentWidthContainer
 
@@ -118,9 +120,15 @@ fun SourceTypePickerScreen(
 
 @Composable
 private fun SourceTypeCardRow(card: SourceTypeCard, onClick: (() -> Unit)?) {
+    // Merge descendants so the whole card presents as one semantic node — TalkBack reads
+    // title+subtitle+"Coming soon" together, and Compose UI tests can find the click action
+    // via `onNodeWithText(card.title)` (not only via the test tag).
     val baseModifier = Modifier
         .fillMaxWidth()
         .testTag(testTagFor(card.type))
+        .semantics(mergeDescendants = true) {
+            if (!card.enabled) disabled()
+        }
     val cardModifier = if (onClick != null) baseModifier.clickable(onClick = onClick) else baseModifier
     Card(
         modifier = cardModifier,

--- a/app/src/main/kotlin/com/riffle/app/feature/server/SourceTypePickerScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/server/SourceTypePickerScreen.kt
@@ -1,0 +1,167 @@
+package com.riffle.app.feature.server
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Cloud
+import androidx.compose.material.icons.filled.Folder
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.windowsizeclass.WindowSizeClass
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+import com.riffle.app.ui.TabletContentWidthContainer
+
+sealed interface SourceTypeChoice {
+    data object Audiobookshelf : SourceTypeChoice
+    data object LocalFiles : SourceTypeChoice
+}
+
+data class SourceTypeCard(
+    val type: SourceTypeChoice,
+    val title: String,
+    val subtitle: String,
+    val enabled: Boolean,
+    val comingSoon: Boolean,
+)
+
+internal fun sourceTypeCards(): List<SourceTypeCard> = listOf(
+    SourceTypeCard(
+        type = SourceTypeChoice.Audiobookshelf,
+        title = "Audiobookshelf",
+        subtitle = "Stream ebooks and audiobooks from your Audiobookshelf server.",
+        enabled = true,
+        comingSoon = false,
+    ),
+    SourceTypeCard(
+        type = SourceTypeChoice.LocalFiles,
+        title = "Local files",
+        subtitle = "Read EPUBs and PDFs from a folder on this device.",
+        enabled = false,
+        comingSoon = true,
+    ),
+)
+
+private fun iconFor(type: SourceTypeChoice): ImageVector = when (type) {
+    SourceTypeChoice.Audiobookshelf -> Icons.Default.Cloud
+    SourceTypeChoice.LocalFiles -> Icons.Default.Folder
+}
+
+private fun testTagFor(type: SourceTypeChoice): String = when (type) {
+    SourceTypeChoice.Audiobookshelf -> "SourceTypeCard.Audiobookshelf"
+    SourceTypeChoice.LocalFiles -> "SourceTypeCard.LocalFiles"
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SourceTypePickerScreen(
+    windowSizeClass: WindowSizeClass,
+    onNavigateBack: () -> Unit,
+    onPickAudiobookshelf: () -> Unit,
+) {
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Add source") },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        TabletContentWidthContainer(
+            windowSizeClass = windowSizeClass,
+            modifier = Modifier.fillMaxSize().padding(padding),
+        ) {
+            Column(
+                modifier = Modifier.fillMaxSize().padding(24.dp),
+                verticalArrangement = Arrangement.spacedBy(16.dp),
+            ) {
+                sourceTypeCards().forEach { card ->
+                    SourceTypeCardRow(
+                        card = card,
+                        onClick = when (card.type) {
+                            SourceTypeChoice.Audiobookshelf -> onPickAudiobookshelf
+                            SourceTypeChoice.LocalFiles -> null
+                        },
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun SourceTypeCardRow(card: SourceTypeCard, onClick: (() -> Unit)?) {
+    val baseModifier = Modifier
+        .fillMaxWidth()
+        .testTag(testTagFor(card.type))
+    val cardModifier = if (onClick != null) baseModifier.clickable(onClick = onClick) else baseModifier
+    Card(
+        modifier = cardModifier,
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surface,
+        ),
+    ) {
+        Row(
+            modifier = Modifier.padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            val contentAlpha = if (card.enabled) 1f else 0.5f
+            Icon(
+                imageVector = iconFor(card.type),
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.size(40.dp).alpha(contentAlpha),
+            )
+            Column(
+                modifier = Modifier.weight(1f).alpha(contentAlpha),
+            ) {
+                Text(card.title, style = MaterialTheme.typography.titleMedium)
+                Spacer(Modifier.size(2.dp))
+                Text(
+                    card.subtitle,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            if (card.comingSoon) {
+                Surface(
+                    shape = RoundedCornerShape(8.dp),
+                    color = MaterialTheme.colorScheme.tertiaryContainer,
+                    contentColor = MaterialTheme.colorScheme.onTertiaryContainer,
+                ) {
+                    Box(modifier = Modifier.padding(horizontal = 10.dp, vertical = 4.dp)) {
+                        Text("Coming soon", style = MaterialTheme.typography.labelMedium)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/server/WebdavBannerTickerModule.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/server/WebdavBannerTickerModule.kt
@@ -1,6 +1,6 @@
 package com.riffle.app.feature.server
 
-import com.riffle.app.feature.server.AddServerViewModel.Companion.WEBDAV_BANNER_TICKER
+import com.riffle.app.feature.server.AddSourceViewModel.Companion.WEBDAV_BANNER_TICKER
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -12,7 +12,7 @@ import javax.inject.Named
 import javax.inject.Singleton
 
 /**
- * Wall-clock ticker driving the [AddServerViewModel.webdavBanner] combine — emits Unit once a
+ * Wall-clock ticker driving the [AddSourceViewModel.webdavBanner] combine — emits Unit once a
  * minute so the "Last sync N ago" relative label advances even while nothing upstream changes.
  * Without it the banner freezes whenever offline: WorkManager gates the sweep on CONNECTED, so
  * no CycleOutcome reports fire, and the label sticks at whatever value was computed when

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsNavEvent.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsNavEvent.kt
@@ -1,6 +1,6 @@
 package com.riffle.app.feature.settings
 
 sealed class SettingsNavEvent {
-    data object NavigateToAddServer : SettingsNavEvent()
+    data object NavigateToAddSource : SettingsNavEvent()
     data class NavigateToReadaloudMatches(val sourceId: String) : SettingsNavEvent()
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsScreen.kt
@@ -73,7 +73,7 @@ import com.riffle.app.feature.reader.behaviorSummary
 import com.riffle.app.feature.reader.displaySummary
 import com.riffle.app.feature.reader.formattingSummary
 import com.riffle.app.ui.TabletContentWidthContainer
-import com.riffle.app.feature.server.AddServerBackend
+import com.riffle.app.feature.server.AddSourceBackend
 import com.riffle.core.domain.AppTheme
 import com.riffle.core.domain.HighlightColor
 import com.riffle.core.domain.Source
@@ -89,7 +89,7 @@ internal fun crashReportShareSubject(timestamp: String): String =
 fun SettingsScreen(
     windowSizeClass: WindowSizeClass,
     onNavigateBack: () -> Unit,
-    onNavigateToAddServer: (backend: AddServerBackend, editId: String?) -> Unit,
+    onNavigateToAddSource: (backend: AddSourceBackend, editId: String?) -> Unit,
     onNavigateToReadaloudMatches: (String) -> Unit = {},
     onNavigateToAnnotationSyncMaintenance: () -> Unit = {},
     onNavigateToDebugLogs: () -> Unit = {},
@@ -124,7 +124,7 @@ fun SettingsScreen(
     LaunchedEffect(Unit) {
         viewModel.navigationEvents.collect { event ->
             when (event) {
-                is SettingsNavEvent.NavigateToAddServer -> onNavigateToAddServer(AddServerBackend.AUDIOBOOKSHELF, null)
+                is SettingsNavEvent.NavigateToAddSource -> onNavigateToAddSource(AddSourceBackend.AUDIOBOOKSHELF, null)
                 is SettingsNavEvent.NavigateToReadaloudMatches -> onNavigateToReadaloudMatches(event.sourceId)
             }
         }
@@ -181,7 +181,7 @@ fun SettingsScreen(
                     )
                 }
                 Button(
-                    onClick = { onNavigateToAddServer(AddServerBackend.AUDIOBOOKSHELF, null) },
+                    onClick = { onNavigateToAddSource(AddSourceBackend.AUDIOBOOKSHELF, null) },
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(horizontal = 16.dp, vertical = 8.dp),
@@ -308,7 +308,7 @@ fun SettingsScreen(
                 val storytellerServers = servers.filter { it.serverType == ServerType.STORYTELLER }
                 if (storytellerServers.isEmpty()) {
                     ListItem(
-                        modifier = Modifier.clickable { onNavigateToAddServer(AddServerBackend.STORYTELLER, null) },
+                        modifier = Modifier.clickable { onNavigateToAddSource(AddSourceBackend.STORYTELLER, null) },
                         leadingContent = { StorytellerBadge(configured = false) },
                         headlineContent = { Text("Configure Storyteller") },
                         supportingContent = { Text("Not configured") },
@@ -336,7 +336,7 @@ fun SettingsScreen(
                         }
                         ListItem(
                             modifier = Modifier.clickable {
-                                onNavigateToAddServer(AddServerBackend.STORYTELLER, server.id)
+                                onNavigateToAddSource(AddSourceBackend.STORYTELLER, server.id)
                             },
                             leadingContent = { StorytellerBadge(configured = true) },
                             headlineContent = { Text("Storyteller") },
@@ -463,7 +463,7 @@ fun SettingsScreen(
                 val annotationSyncRow by viewModel.annotationSyncRow.collectAsState()
                 ListItem(
                     modifier = Modifier.clickable {
-                        onNavigateToAddServer(AddServerBackend.WEBDAV, null)
+                        onNavigateToAddSource(AddSourceBackend.WEBDAV, null)
                     },
                     leadingContent = { AnnotationSyncBadge(annotationSyncRow.badge) },
                     headlineContent = { Text("Configure WebDAV") },

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsScreen.kt
@@ -154,7 +154,7 @@ fun SettingsScreen(
                 HorizontalDivider()
 
                 Text(
-                    text = "Audiobookshelf servers",
+                    text = "Sources",
                     style = MaterialTheme.typography.titleSmall,
                     fontWeight = FontWeight.Bold,
                     modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
@@ -186,7 +186,7 @@ fun SettingsScreen(
                         .fillMaxWidth()
                         .padding(horizontal = 16.dp, vertical = 8.dp),
                 ) {
-                    Text("Add server")
+                    Text("Add source")
                 }
                 HorizontalDivider()
 

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsViewModel.kt
@@ -366,7 +366,7 @@ class SettingsViewModel @Inject constructor(
                 if (next != null) {
                     sourceRepository.setActive(next.id)
                 } else {
-                    _navigationEvents.send(SettingsNavEvent.NavigateToAddServer)
+                    _navigationEvents.send(SettingsNavEvent.NavigateToAddSource)
                 }
             }
         }

--- a/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
@@ -37,9 +37,9 @@ import com.riffle.app.feature.navigation.NavigationDrawerViewModel
 import com.riffle.app.feature.navigation.RiffleNavigationDrawer
 import com.riffle.app.feature.reader.EpubReaderScreen
 import com.riffle.app.feature.reader.PdfReaderScreen
-import com.riffle.app.feature.server.AddServerScreen
+import com.riffle.app.feature.server.AddSourceScreen
 import com.riffle.app.feature.server.SelectLibrariesScreen
-import com.riffle.app.feature.server.ServerSetupViewModel
+import com.riffle.app.feature.server.SourceSetupViewModel
 import com.riffle.app.feature.settings.SettingsScreen
 import com.riffle.app.feature.settings.annotationsync.AnnotationSyncMaintenanceScreen
 import com.riffle.app.feature.settings.debug.DebugLogScreen
@@ -165,7 +165,7 @@ fun MainScreen(
         NavHost(navController = navController, startDestination = HOME) {
             composable(HOME) {
                 HomeScreen(
-                    onNavigateToAddServer = {
+                    onNavigateToAddSource = {
                         navController.navigateAsRoot("$ADD_SERVER?type=audiobookshelf")
                     },
                     onNavigateToLibrary = { libraryId, libraryName ->
@@ -192,10 +192,10 @@ fun MainScreen(
                     val parentEntry = remember(backStackEntry) {
                         navController.getBackStackEntry(SERVER_SETUP_GRAPH)
                     }
-                    val setupVm: ServerSetupViewModel = hiltViewModel(parentEntry)
+                    val setupVm: SourceSetupViewModel = hiltViewModel(parentEntry)
                     val cameFromSettings = navController.previousBackStackEntry
                         ?.destination?.route == SETTINGS
-                    AddServerScreen(
+                    AddSourceScreen(
                         windowSizeClass = windowSizeClass,
                         onNavigateBack = {
                             if (cameFromSettings) navController.popBackStack()
@@ -215,7 +215,7 @@ fun MainScreen(
                     val parentEntry = remember(backStackEntry) {
                         navController.getBackStackEntry(SERVER_SETUP_GRAPH)
                     }
-                    val setupVm: ServerSetupViewModel = hiltViewModel(parentEntry)
+                    val setupVm: SourceSetupViewModel = hiltViewModel(parentEntry)
                     val pending = setupVm.pendingServer
                     if (pending == null) {
                         LaunchedEffect(Unit) { navController.popBackStack() }
@@ -235,7 +235,7 @@ fun MainScreen(
                 SettingsScreen(
                     windowSizeClass = windowSizeClass,
                     onNavigateBack = { navController.popBackStack() },
-                    onNavigateToAddServer = { backend, editId ->
+                    onNavigateToAddSource = { backend, editId ->
                         val params = buildList {
                             add("type=${backend.name.lowercase()}")
                             if (!editId.isNullOrEmpty()) add("editId=${URLEncoder.encode(editId, "UTF-8")}")

--- a/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
@@ -51,9 +51,10 @@ import java.net.URLDecoder
 import java.net.URLEncoder
 
 private const val HOME = "home"
-private const val SERVER_SETUP_GRAPH = "server_setup"
-private const val ADD_SERVER = "add_server"
-private const val ADD_SERVER_ROUTE = "add_server?type={type}&editId={editId}"
+private const val SOURCE_SETUP_GRAPH = "source_setup"
+private const val ADD_SOURCE_TYPE_PICKER = "add_source_type_picker"
+private const val ADD_SOURCE = "add_source"
+private const val ADD_SOURCE_ROUTE = "add_source?type={type}&editId={editId}"
 private const val SELECT_LIBRARIES = "select_libraries"
 private const val SETTINGS = "settings"
 private const val ANNOTATION_SYNC_MAINTENANCE = "settings/annotation_sync/maintenance"
@@ -166,7 +167,7 @@ fun MainScreen(
             composable(HOME) {
                 HomeScreen(
                     onNavigateToAddSource = {
-                        navController.navigateAsRoot("$ADD_SERVER?type=audiobookshelf")
+                        navController.navigateAsRoot(ADD_SOURCE_TYPE_PICKER)
                     },
                     onNavigateToLibrary = { libraryId, libraryName ->
                         viewModel.setActiveLibrary(libraryId)
@@ -175,9 +176,25 @@ fun MainScreen(
                     },
                 )
             }
-            navigation(startDestination = ADD_SERVER_ROUTE, route = SERVER_SETUP_GRAPH) {
+            navigation(startDestination = ADD_SOURCE_TYPE_PICKER, route = SOURCE_SETUP_GRAPH) {
+                composable(ADD_SOURCE_TYPE_PICKER) {
+                    val cameFromSettings = navController.previousBackStackEntry
+                        ?.destination?.route == SETTINGS
+                    com.riffle.app.feature.server.SourceTypePickerScreen(
+                        windowSizeClass = windowSizeClass,
+                        onNavigateBack = {
+                            if (cameFromSettings) navController.popBackStack()
+                            else navController.navigateAsRoot(HOME)
+                        },
+                        onPickAudiobookshelf = {
+                            navController.navigate("$ADD_SOURCE?type=audiobookshelf") {
+                                popUpTo(ADD_SOURCE_TYPE_PICKER) { inclusive = true }
+                            }
+                        },
+                    )
+                }
                 composable(
-                    route = ADD_SERVER_ROUTE,
+                    route = ADD_SOURCE_ROUTE,
                     arguments = listOf(
                         navArgument("type") {
                             type = NavType.StringType
@@ -190,7 +207,7 @@ fun MainScreen(
                     ),
                 ) { backStackEntry ->
                     val parentEntry = remember(backStackEntry) {
-                        navController.getBackStackEntry(SERVER_SETUP_GRAPH)
+                        navController.getBackStackEntry(SOURCE_SETUP_GRAPH)
                     }
                     val setupVm: SourceSetupViewModel = hiltViewModel(parentEntry)
                     val cameFromSettings = navController.previousBackStackEntry
@@ -213,7 +230,7 @@ fun MainScreen(
                 }
                 composable(SELECT_LIBRARIES) { backStackEntry ->
                     val parentEntry = remember(backStackEntry) {
-                        navController.getBackStackEntry(SERVER_SETUP_GRAPH)
+                        navController.getBackStackEntry(SOURCE_SETUP_GRAPH)
                     }
                     val setupVm: SourceSetupViewModel = hiltViewModel(parentEntry)
                     val pending = setupVm.pendingServer
@@ -236,11 +253,20 @@ fun MainScreen(
                     windowSizeClass = windowSizeClass,
                     onNavigateBack = { navController.popBackStack() },
                     onNavigateToAddSource = { backend, editId ->
-                        val params = buildList {
-                            add("type=${backend.name.lowercase()}")
-                            if (!editId.isNullOrEmpty()) add("editId=${URLEncoder.encode(editId, "UTF-8")}")
-                        }.joinToString("&")
-                        navController.navigate("$ADD_SERVER?$params")
+                        // The Source Type picker only fronts the "add a fresh ABS Source" flow.
+                        // Storyteller/WebDAV are Services (not Sources) and deep-link straight
+                        // to the form; editing an existing ABS Source also skips the picker
+                        // (Source Type is already known).
+                        val isNewAbs = backend == com.riffle.app.feature.server.AddSourceBackend.AUDIOBOOKSHELF && editId.isNullOrEmpty()
+                        if (isNewAbs) {
+                            navController.navigate(ADD_SOURCE_TYPE_PICKER)
+                        } else {
+                            val params = buildList {
+                                add("type=${backend.name.lowercase()}")
+                                if (!editId.isNullOrEmpty()) add("editId=${URLEncoder.encode(editId, "UTF-8")}")
+                            }.joinToString("&")
+                            navController.navigate("$ADD_SOURCE?$params")
+                        }
                     },
                     onNavigateToReadaloudMatches = { sourceId ->
                         val encoded = URLEncoder.encode(sourceId, "UTF-8")

--- a/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
@@ -176,23 +176,30 @@ fun MainScreen(
                     },
                 )
             }
-            navigation(startDestination = ADD_SOURCE_TYPE_PICKER, route = SOURCE_SETUP_GRAPH) {
-                composable(ADD_SOURCE_TYPE_PICKER) {
-                    val cameFromSettings = navController.previousBackStackEntry
-                        ?.destination?.route == SETTINGS
-                    com.riffle.app.feature.server.SourceTypePickerScreen(
-                        windowSizeClass = windowSizeClass,
-                        onNavigateBack = {
-                            if (cameFromSettings) navController.popBackStack()
-                            else navController.navigateAsRoot(HOME)
-                        },
-                        onPickAudiobookshelf = {
-                            navController.navigate("$ADD_SOURCE?type=audiobookshelf") {
-                                popUpTo(ADD_SOURCE_TYPE_PICKER) { inclusive = true }
-                            }
-                        },
-                    )
-                }
+            // The Source Type picker lives at NavHost level (not inside SOURCE_SETUP_GRAPH) so
+            // that entering the setup graph directly for Storyteller/WebDAV/edit paths does NOT
+            // implicitly push the picker as the graph's start destination onto the back stack.
+            // With this shape the back stack for those flows stays [caller, ADD_SOURCE], and
+            // `previousBackStackEntry.route == SETTINGS` remains the right predicate for
+            // "should top-app-bar back pop to Settings?".
+            composable(ADD_SOURCE_TYPE_PICKER) {
+                val cameFromSettings = navController.previousBackStackEntry
+                    ?.destination?.route == SETTINGS
+                com.riffle.app.feature.server.SourceTypePickerScreen(
+                    windowSizeClass = windowSizeClass,
+                    onNavigateBack = {
+                        if (cameFromSettings) navController.popBackStack()
+                        else navController.navigateAsRoot(HOME)
+                    },
+                    onPickAudiobookshelf = {
+                        navController.navigate("$ADD_SOURCE?type=audiobookshelf") {
+                            // Drop the picker so back from the form returns to the caller.
+                            popUpTo(ADD_SOURCE_TYPE_PICKER) { inclusive = true }
+                        }
+                    },
+                )
+            }
+            navigation(startDestination = ADD_SOURCE_ROUTE, route = SOURCE_SETUP_GRAPH) {
                 composable(
                     route = ADD_SOURCE_ROUTE,
                     arguments = listOf(

--- a/app/src/test/kotlin/com/riffle/app/feature/navigation/HomeViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/navigation/HomeViewModelTest.kt
@@ -127,9 +127,9 @@ class HomeViewModelTest {
     )
 
     @Test
-    fun `getStartDestination returns AddServer when no servers`() = runTest {
+    fun `getStartDestination returns AddSource when no servers`() = runTest {
         val result = makeVm().getStartDestination()
-        assertEquals(HomeViewModel.StartDestination.AddServer, result)
+        assertEquals(HomeViewModel.StartDestination.AddSource, result)
     }
 
     @Test
@@ -154,13 +154,13 @@ class HomeViewModelTest {
     }
 
     @Test
-    fun `getStartDestination returns AddServer when server exists but refresh yields no libraries`() = runTest {
+    fun `getStartDestination returns AddSource when server exists but refresh yields no libraries`() = runTest {
         serversFlow.value = listOf(server("srv-1", active = true))
         // libraries remain empty even after a successful refresh — server has no book libraries
 
         val result = makeVm().getStartDestination()
 
-        assertEquals(HomeViewModel.StartDestination.AddServer, result)
+        assertEquals(HomeViewModel.StartDestination.AddSource, result)
     }
 
     @Test

--- a/app/src/test/kotlin/com/riffle/app/feature/server/AddSourceCopyTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/server/AddSourceCopyTest.kt
@@ -1,0 +1,40 @@
+package com.riffle.app.feature.server
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Pins the ABS-variant AddSource copy after the #435 Server → Source rename. If any of
+ * these assertions flip, the fix has been reverted line-for-line. Storyteller/WebDAV
+ * strings are pinned untouched — Storyteller's rename is #441's job, WebDAV is a Service.
+ */
+class AddSourceCopyTest {
+    @Test
+    fun `ABS add title is Add Audiobookshelf`() {
+        assertEquals("Add Audiobookshelf", screenTitle(AddSourceBackend.AUDIOBOOKSHELF, isEditing = false))
+    }
+
+    @Test
+    fun `ABS edit title is Edit Audiobookshelf`() {
+        assertEquals("Edit Audiobookshelf", screenTitle(AddSourceBackend.AUDIOBOOKSHELF, isEditing = true))
+    }
+
+    @Test
+    fun `ABS remove label is Remove source`() {
+        assertEquals("Remove source", removeButtonLabel(AddSourceBackend.AUDIOBOOKSHELF))
+    }
+
+    @Test
+    fun `Storyteller strings unchanged (kept for #441)`() {
+        assertEquals("Add Storyteller", screenTitle(AddSourceBackend.STORYTELLER, isEditing = false))
+        assertEquals("Edit Storyteller", screenTitle(AddSourceBackend.STORYTELLER, isEditing = true))
+        assertEquals("Remove Storyteller", removeButtonLabel(AddSourceBackend.STORYTELLER))
+    }
+
+    @Test
+    fun `WebDAV strings unchanged (Service not Source)`() {
+        assertEquals("Add WebDAV", screenTitle(AddSourceBackend.WEBDAV, isEditing = false))
+        assertEquals("Edit WebDAV", screenTitle(AddSourceBackend.WEBDAV, isEditing = true))
+        assertEquals("Disable sync", removeButtonLabel(AddSourceBackend.WEBDAV))
+    }
+}

--- a/app/src/test/kotlin/com/riffle/app/feature/server/AddSourceViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/server/AddSourceViewModelTest.kt
@@ -42,7 +42,7 @@ import org.junit.Before
 import org.junit.Test
 
 @OptIn(ExperimentalCoroutinesApi::class)
-class AddServerViewModelTest {
+class AddSourceViewModelTest {
 
     private val testDispatcher = StandardTestDispatcher()
 
@@ -167,7 +167,7 @@ class AddServerViewModelTest {
         clock: com.riffle.core.domain.Clock = MutableClock(),
         annotationDao: AnnotationDao = stubAnnotationDao(pendingBookCount = 0),
         bannerTicker: Flow<Unit> = flowOf(Unit),
-    ): AddServerViewModel = AddServerViewModel(
+    ): AddSourceViewModel = AddSourceViewModel(
         repository = repository,
         webdavConfigStore = configStore,
         webdavTargetFactory = WebDavAnnotationSyncTargetFactory(OkHttpClient(), com.riffle.core.domain.DefaultDispatcherProvider),
@@ -355,7 +355,7 @@ class AddServerViewModelTest {
         val vm = makeVm(repo, savedState = savedState, tokenStorage = tokens)
         testDispatcher.scheduler.advanceUntilIdle()
 
-        assertEquals(AddServerBackend.STORYTELLER, vm.backend)
+        assertEquals(AddSourceBackend.STORYTELLER, vm.backend)
         assertTrue(vm.isEditing)
         assertEquals("http://", vm.scheme)
         assertEquals("media-server:8001", vm.host)
@@ -380,7 +380,7 @@ class AddServerViewModelTest {
         )
         testDispatcher.scheduler.advanceUntilIdle()
 
-        assertEquals(AddServerBackend.WEBDAV, vm.backend)
+        assertEquals(AddSourceBackend.WEBDAV, vm.backend)
         assertTrue(vm.isEditingWebdav)
         assertEquals("https://", vm.scheme)
         assertEquals("dav.example.com/store", vm.host)
@@ -399,7 +399,7 @@ class AddServerViewModelTest {
         )
         testDispatcher.scheduler.advanceUntilIdle()
 
-        assertEquals(AddServerBackend.WEBDAV, vm.backend)
+        assertEquals(AddSourceBackend.WEBDAV, vm.backend)
         assertFalse(vm.isEditingWebdav)
         assertEquals("", vm.host)
         assertEquals("", vm.username)

--- a/app/src/test/kotlin/com/riffle/app/feature/server/SourceTypePickerTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/server/SourceTypePickerTest.kt
@@ -1,0 +1,38 @@
+package com.riffle.app.feature.server
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pins the SourceType picker's data model (#435). LocalFiles must stay disabled with a
+ * "Coming soon" flag until #7 lands. If any of these assertions flip, the picker's
+ * contract has changed and the change must be intentional.
+ */
+class SourceTypePickerTest {
+
+    @Test
+    fun `cards are ordered ABS first then LocalFiles`() {
+        val cards = sourceTypeCards()
+        assertEquals(2, cards.size)
+        assertEquals(SourceTypeChoice.Audiobookshelf, cards[0].type)
+        assertEquals(SourceTypeChoice.LocalFiles, cards[1].type)
+    }
+
+    @Test
+    fun `ABS card is enabled and not coming soon`() {
+        val abs = sourceTypeCards().first { it.type is SourceTypeChoice.Audiobookshelf }
+        assertTrue(abs.enabled)
+        assertFalse(abs.comingSoon)
+        assertEquals("Audiobookshelf", abs.title)
+    }
+
+    @Test
+    fun `LocalFiles card is disabled and coming soon`() {
+        val lf = sourceTypeCards().first { it.type is SourceTypeChoice.LocalFiles }
+        assertFalse(lf.enabled)
+        assertTrue(lf.comingSoon)
+        assertEquals("Local files", lf.title)
+    }
+}

--- a/app/src/test/kotlin/com/riffle/app/feature/settings/SettingsViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/settings/SettingsViewModelTest.kt
@@ -376,7 +376,7 @@ class SettingsViewModelTest {
     }
 
     @Test
-    fun `removeServer last server emits NavigateToAddServer event`() = runTest {
+    fun `removeServer last server emits NavigateToAddSource event`() = runTest {
         serversFlow.value = listOf(server("srv-1", active = true))
         val vm = makeViewModel()
         backgroundScope.launch { vm.servers.collect {} }
@@ -386,7 +386,7 @@ class SettingsViewModelTest {
         testDispatcher.scheduler.advanceUntilIdle()
 
         val event = vm.navigationEvents.first()
-        assertTrue(event is SettingsNavEvent.NavigateToAddServer)
+        assertTrue(event is SettingsNavEvent.NavigateToAddSource)
     }
 
     // --- library visibility ---

--- a/docs/superpowers/plans/2026-07-09-source-switcher-and-add-source-picker.md
+++ b/docs/superpowers/plans/2026-07-09-source-switcher-and-add-source-picker.md
@@ -1,0 +1,966 @@
+# Source Switcher, Add Source flow, Source Type picker — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Issue:** [#435](https://github.com/pkmetski/riffle/issues/435) — Phase 3 of the ADR 0041 Source/Service re-root.
+
+**Goal:** Rename user-facing surfaces from **Server** to **Source** in the Nav Drawer, Add flow, and Settings, and insert a **Source Type picker** as the first step of Add-Source for ABS entry points (Audiobookshelf enabled, Local files disabled placeholder).
+
+**Architecture:** Symbol renames are mechanical (file `git mv` + IDE-safe rename). Copy renames are literal-string edits in three Composables (`NavigationDrawerComposable`, `SettingsScreen`, `AddSourceScreen`). The picker is a new stateless Composable driven by a pure JVM-testable list — no ViewModel, no side effects beyond a navigation callback. Nav-graph rewiring inserts one new destination between the ABS entry points and the connect form; Storyteller and WebDAV keep their existing direct entry.
+
+**Tech Stack:** Kotlin, Jetpack Compose (Material 3), Compose Navigation, Hilt, JUnit4, Compose UI Test.
+
+**Design spec:** `docs/superpowers/specs/2026-07-09-source-switcher-and-add-source-picker-design.md`.
+
+## Global Constraints
+
+- No user-visible change to Storyteller or WebDAV copy — those are #441's job.
+- No domain-layer changes: `SourceType` enum stays at `{ ABS }` (adding `LOCAL_FILES` is #7's job). The picker uses a local sealed interface `SourceTypeChoice` to represent LocalFiles without polluting the domain.
+- No `Source.serverType` field changes: the `AUDIOBOOKSHELF`/`STORYTELLER` split is what #441 collapses.
+- ABS product-referencing copy stays as-is ("your Audiobookshelf server" in help text, "Couldn't reach the server" errors) — those refer to ABS the product, not Riffle's domain.
+- Directory `app/feature/server/` stays — package rename is churn without user impact.
+- `AddSourceBackend` enum values stay `AUDIOBOOKSHELF` / `STORYTELLER` / `WEBDAV` — internal, keeps diff small.
+- Every rename step uses `git mv` (preserves blame) followed by content edits.
+- Follow AGENTS.md: regression tests required, no docstring-as-test, verify on AVD before /finalize.
+
+---
+
+## File Structure
+
+**Renames (file moves via `git mv`):**
+- `app/src/main/kotlin/com/riffle/app/feature/server/AddServerScreen.kt` → `AddSourceScreen.kt`
+- `app/src/main/kotlin/com/riffle/app/feature/server/AddServerViewModel.kt` → `AddSourceViewModel.kt`
+- `app/src/main/kotlin/com/riffle/app/feature/server/ServerSetupViewModel.kt` → `SourceSetupViewModel.kt`
+- `app/src/test/kotlin/com/riffle/app/feature/server/AddServerViewModelTest.kt` → `AddSourceViewModelTest.kt`
+
+**New files:**
+- `app/src/main/kotlin/com/riffle/app/feature/server/SourceTypePickerScreen.kt` — Composable + pure data (`SourceTypeChoice`, `SourceTypeCard`, `sourceTypeCards()`).
+- `app/src/test/kotlin/com/riffle/app/feature/server/SourceTypePickerTest.kt` — JVM test over `sourceTypeCards()`.
+- `app/src/androidTest/kotlin/com/riffle/app/feature/server/SourceTypePickerScreenTest.kt` — Compose UI test.
+
+**Modified files:**
+- `app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt` — nav-route consts, new picker destination, wire ABS entry points through it.
+- `app/src/main/kotlin/com/riffle/app/feature/navigation/NavigationDrawerComposable.kt` — drawer copy (`"No server"` → `"No source"`, contentDescription).
+- `app/src/main/kotlin/com/riffle/app/feature/settings/SettingsScreen.kt` — section header, button label, callback rename.
+- `app/src/main/kotlin/com/riffle/app/feature/navigation/HomeScreen.kt` — callback param rename.
+- `app/src/main/kotlin/com/riffle/app/feature/navigation/HomeViewModel.kt` — `StartDestination.AddServer` → `StartDestination.AddSource`.
+- `app/src/test/kotlin/com/riffle/app/feature/navigation/HomeViewModelTest.kt` — sealed-class symbol reference.
+- Harness tests that traverse HomeScreen → AddSource: add one tap on the "Audiobookshelf" card.
+
+---
+
+## Task 1: Rename `AddServer*` symbols and files (mechanical, no behavior change)
+
+**Files:**
+- Rename: `app/src/main/kotlin/com/riffle/app/feature/server/AddServerScreen.kt` → `AddSourceScreen.kt`
+- Rename: `app/src/main/kotlin/com/riffle/app/feature/server/AddServerViewModel.kt` → `AddSourceViewModel.kt`
+- Rename: `app/src/main/kotlin/com/riffle/app/feature/server/ServerSetupViewModel.kt` → `SourceSetupViewModel.kt`
+- Rename: `app/src/test/kotlin/com/riffle/app/feature/server/AddServerViewModelTest.kt` → `AddSourceViewModelTest.kt`
+- Modify: `app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt:40-42,178,193,195,198,214,218` (imports + references)
+- Modify: `app/src/main/kotlin/com/riffle/app/feature/settings/SettingsScreen.kt:76,92,127,184,311,339,466` (imports + `AddServerBackend` → `AddSourceBackend`, callback param name)
+- Modify: `app/src/main/kotlin/com/riffle/app/feature/navigation/HomeScreen.kt:28,44` (callback param name)
+- Modify: `app/src/main/kotlin/com/riffle/app/feature/navigation/HomeViewModel.kt:27,34,44` (`StartDestination.AddServer` → `StartDestination.AddSource`)
+- Modify: `app/src/test/kotlin/com/riffle/app/feature/navigation/HomeViewModelTest.kt:130` (test symbol reference)
+
+**Interfaces produced:**
+- `AddSourceScreen(windowSizeClass, onNavigateBack, onAuthenticated, onAutoCompleted, viewModel: AddSourceViewModel = hiltViewModel())`
+- `AddSourceViewModel`
+- `SourceSetupViewModel`
+- `enum class AddSourceBackend { AUDIOBOOKSHELF, STORYTELLER, WEBDAV }`
+- `HomeViewModel.StartDestination.AddSource`
+- Callback: `onNavigateToAddSource: (backend: AddSourceBackend, editId: String?) -> Unit` in `SettingsScreen`.
+- Callback: `onNavigateToAddSource: () -> Unit` in `HomeScreen`.
+
+- [ ] **Step 1: Move files with `git mv` (preserves blame)**
+
+```bash
+cd app/src/main/kotlin/com/riffle/app/feature/server
+git mv AddServerScreen.kt AddSourceScreen.kt
+git mv AddServerViewModel.kt AddSourceViewModel.kt
+git mv ServerSetupViewModel.kt SourceSetupViewModel.kt
+cd -
+git mv app/src/test/kotlin/com/riffle/app/feature/server/AddServerViewModelTest.kt \
+       app/src/test/kotlin/com/riffle/app/feature/server/AddSourceViewModelTest.kt
+```
+
+- [ ] **Step 2: In each renamed file, rewrite symbol names**
+
+Replace inside `AddSourceScreen.kt`:
+- Composable function `AddServerScreen` → `AddSourceScreen`
+- Enum `AddServerBackend` → `AddSourceBackend`
+- Every reference to `AddServerBackend.` → `AddSourceBackend.`
+
+Replace inside `AddSourceViewModel.kt`:
+- Class `AddServerViewModel` → `AddSourceViewModel`
+- Every internal reference to `AddServerBackend` → `AddSourceBackend`
+
+Replace inside `SourceSetupViewModel.kt`:
+- Class `ServerSetupViewModel` → `SourceSetupViewModel`
+- Field name `pendingServer` stays (it's a `PendingSource` — the field-name refactor is orthogonal and out of scope).
+
+Replace inside `AddSourceViewModelTest.kt`:
+- Class `AddServerViewModelTest` → `AddSourceViewModelTest`
+- `AddServerViewModel(` constructor calls → `AddSourceViewModel(`
+- `AddServerBackend.` → `AddSourceBackend.`
+
+- [ ] **Step 3: Update `MainScreen.kt` imports and references**
+
+Change lines 40-42 imports from:
+```kotlin
+import com.riffle.app.feature.server.AddServerScreen
+import com.riffle.app.feature.server.SelectLibrariesScreen
+import com.riffle.app.feature.server.ServerSetupViewModel
+```
+to:
+```kotlin
+import com.riffle.app.feature.server.AddSourceScreen
+import com.riffle.app.feature.server.SelectLibrariesScreen
+import com.riffle.app.feature.server.SourceSetupViewModel
+```
+
+Change references in the nav-graph body:
+- Line 195: `val setupVm: ServerSetupViewModel = hiltViewModel(parentEntry)` → `val setupVm: SourceSetupViewModel = hiltViewModel(parentEntry)`
+- Line 198: `AddServerScreen(` → `AddSourceScreen(`
+- Line 218: same (second occurrence)
+
+Change callback name at line 168 and line 238 (in the composable body):
+- `onNavigateToAddServer =` → `onNavigateToAddSource =`
+
+- [ ] **Step 4: Update `SettingsScreen.kt`**
+
+Change import at line 76:
+```kotlin
+import com.riffle.app.feature.server.AddServerBackend
+```
+to:
+```kotlin
+import com.riffle.app.feature.server.AddSourceBackend
+```
+
+Change signature at line 92:
+```kotlin
+onNavigateToAddServer: (backend: AddServerBackend, editId: String?) -> Unit,
+```
+to:
+```kotlin
+onNavigateToAddSource: (backend: AddSourceBackend, editId: String?) -> Unit,
+```
+
+Replace every call-site `AddServerBackend.` → `AddSourceBackend.` (lines 127, 184, 311, 339, 466).
+Replace every call `onNavigateToAddServer(` → `onNavigateToAddSource(` (same lines).
+
+Also rename the internal sealed-class member if present — `SettingsNavEvent.NavigateToAddServer` → `SettingsNavEvent.NavigateToAddSource`. Search the file for `NavigateToAddServer` and rename in `SettingsScreen.kt` and `SettingsViewModel.kt` together.
+
+- [ ] **Step 5: Update `HomeScreen.kt`**
+
+Change line 28 signature:
+```kotlin
+onNavigateToAddServer: () -> Unit,
+```
+to:
+```kotlin
+onNavigateToAddSource: () -> Unit,
+```
+
+Change line 44 branch:
+```kotlin
+is HomeViewModel.StartDestination.AddServer -> onNavigateToAddServer()
+```
+to:
+```kotlin
+is HomeViewModel.StartDestination.AddSource -> onNavigateToAddSource()
+```
+
+- [ ] **Step 6: Update `HomeViewModel.kt`**
+
+In the sealed class at line 26:
+```kotlin
+sealed class StartDestination {
+    data object AddServer : StartDestination()
+```
+becomes:
+```kotlin
+sealed class StartDestination {
+    data object AddSource : StartDestination()
+```
+
+Every `StartDestination.AddServer` reference in this file (lines 34, 44) → `StartDestination.AddSource`.
+
+- [ ] **Step 7: Update `HomeViewModelTest.kt`**
+
+Line 130 test name/body:
+```kotlin
+fun `getStartDestination returns AddServer when no servers`() = runTest {
+```
+becomes:
+```kotlin
+fun `getStartDestination returns AddSource when no servers`() = runTest {
+```
+And any `StartDestination.AddServer` in this test → `StartDestination.AddSource`.
+
+- [ ] **Step 8: Compile and run all JVM tests to confirm mechanical rename is behavior-preserving**
+
+Run:
+```bash
+export JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"
+./gradlew :app:test :app:compileDebugKotlin --no-daemon
+```
+Expected: PASS. No behavior change; only symbol renames.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add -A
+git commit -m "refactor(app): rename AddServer* symbols to AddSource* (#435)"
+```
+
+---
+
+## Task 2: Update user-facing copy in Nav Drawer + Settings + AddSourceScreen
+
+**Files:**
+- Modify: `app/src/main/kotlin/com/riffle/app/feature/navigation/NavigationDrawerComposable.kt:200,227`
+- Modify: `app/src/main/kotlin/com/riffle/app/feature/settings/SettingsScreen.kt:157,189`
+- Modify: `app/src/main/kotlin/com/riffle/app/feature/server/AddSourceScreen.kt:203-213`
+- Test: `app/src/test/kotlin/com/riffle/app/feature/server/AddSourceCopyTest.kt` (new, JVM)
+
+**Interfaces produced:** none (literal-string edits + `internal` visibility bump on two helper functions).
+
+- [ ] **Step 1: Write the failing JVM regression test that pins the AddSourceScreen ABS strings**
+
+`screenTitle()` and `removeButtonLabel()` are currently `private fun` at `AddSourceScreen.kt:203` and `:209`. Bump them to `internal fun` so the JVM test in the same package can reach them.
+
+Create `app/src/test/kotlin/com/riffle/app/feature/server/AddSourceCopyTest.kt`:
+
+```kotlin
+package com.riffle.app.feature.server
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class AddSourceCopyTest {
+    @Test
+    fun `ABS add title = 'Add Audiobookshelf'`() {
+        assertEquals("Add Audiobookshelf", screenTitle(AddSourceBackend.AUDIOBOOKSHELF, isEditing = false))
+    }
+
+    @Test
+    fun `ABS edit title = 'Edit Audiobookshelf'`() {
+        assertEquals("Edit Audiobookshelf", screenTitle(AddSourceBackend.AUDIOBOOKSHELF, isEditing = true))
+    }
+
+    @Test
+    fun `ABS remove label = 'Remove source'`() {
+        assertEquals("Remove source", removeButtonLabel(AddSourceBackend.AUDIOBOOKSHELF))
+    }
+
+    @Test
+    fun `Storyteller strings unchanged (kept for #441)`() {
+        assertEquals("Add Storyteller", screenTitle(AddSourceBackend.STORYTELLER, isEditing = false))
+        assertEquals("Remove Storyteller", removeButtonLabel(AddSourceBackend.STORYTELLER))
+    }
+}
+```
+
+`screenTitle` and `removeButtonLabel` need to be visible to this test — bump them from `private fun` to `internal fun` in `AddSourceScreen.kt`.
+
+Run:
+```bash
+./gradlew :app:test --tests "com.riffle.app.feature.server.AddSourceCopyTest" --no-daemon
+```
+Expected: FAIL — three assertions on `AUDIOBOOKSHELF` fail because current strings still say "Add Audiobookshelf server" / "Edit Audiobookshelf server" / "Remove server".
+
+- [ ] **Step 2: Update `AddSourceScreen.kt` strings (ABS variant only)**
+
+At `AddSourceScreen.kt:204` replace:
+```kotlin
+AddSourceBackend.AUDIOBOOKSHELF -> if (isEditing) "Edit Audiobookshelf server" else "Add Audiobookshelf server"
+```
+with:
+```kotlin
+AddSourceBackend.AUDIOBOOKSHELF -> if (isEditing) "Edit Audiobookshelf" else "Add Audiobookshelf"
+```
+
+At `AddSourceScreen.kt:210` replace:
+```kotlin
+AddSourceBackend.AUDIOBOOKSHELF -> "Remove server"
+```
+with:
+```kotlin
+AddSourceBackend.AUDIOBOOKSHELF -> "Remove source"
+```
+
+Also change the two `private fun` declarations at lines 203 and 209 to `internal fun` so the JVM test can reach them.
+
+- [ ] **Step 3: Update `NavigationDrawerComposable.kt` strings**
+
+At line 200 replace:
+```kotlin
+val name = activeServer?.serverType?.label ?: "No server"
+```
+with:
+```kotlin
+val name = activeServer?.serverType?.label ?: "No source"
+```
+
+At line 227 replace:
+```kotlin
+contentDescription = "Toggle server switcher",
+```
+with:
+```kotlin
+contentDescription = "Toggle source switcher",
+```
+
+- [ ] **Step 4: Update `SettingsScreen.kt` strings**
+
+At line 157 replace:
+```kotlin
+text = "Audiobookshelf servers",
+```
+with:
+```kotlin
+text = "Sources",
+```
+
+At line 189 replace:
+```kotlin
+Text("Add server")
+```
+with:
+```kotlin
+Text("Add source")
+```
+
+- [ ] **Step 5: Re-run JVM tests — they should now pass**
+
+```bash
+./gradlew :app:test --tests "com.riffle.app.feature.server.AddSourceCopyTest" --no-daemon
+```
+Expected: PASS on all four assertions.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add -A
+git commit -m "feat(app): rename user-facing Server → Source copy (#435)"
+```
+
+---
+
+## Task 3: Create `SourceTypePickerScreen` (Composable + pure data model + JVM test)
+
+**Files:**
+- Create: `app/src/main/kotlin/com/riffle/app/feature/server/SourceTypePickerScreen.kt`
+- Test: `app/src/test/kotlin/com/riffle/app/feature/server/SourceTypePickerTest.kt`
+
+**Interfaces produced:**
+- `sealed interface SourceTypeChoice { data object Audiobookshelf; data object LocalFiles }`
+- `data class SourceTypeCard(val type: SourceTypeChoice, val title: String, val subtitle: String, val enabled: Boolean, val comingSoon: Boolean)`
+- `internal fun sourceTypeCards(): List<SourceTypeCard>`
+- `@Composable fun SourceTypePickerScreen(windowSizeClass: WindowSizeClass, onNavigateBack: () -> Unit, onPickAudiobookshelf: () -> Unit)`
+
+- [ ] **Step 1: Write the failing JVM test**
+
+Create `app/src/test/kotlin/com/riffle/app/feature/server/SourceTypePickerTest.kt`:
+
+```kotlin
+package com.riffle.app.feature.server
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SourceTypePickerTest {
+
+    @Test
+    fun `cards are ordered ABS first then LocalFiles`() {
+        val cards = sourceTypeCards()
+        assertEquals(2, cards.size)
+        assertEquals(SourceTypeChoice.Audiobookshelf, cards[0].type)
+        assertEquals(SourceTypeChoice.LocalFiles, cards[1].type)
+    }
+
+    @Test
+    fun `ABS card is enabled and not coming soon`() {
+        val abs = sourceTypeCards().first { it.type is SourceTypeChoice.Audiobookshelf }
+        assertTrue(abs.enabled)
+        assertFalse(abs.comingSoon)
+        assertEquals("Audiobookshelf", abs.title)
+    }
+
+    @Test
+    fun `LocalFiles card is disabled and coming soon`() {
+        val lf = sourceTypeCards().first { it.type is SourceTypeChoice.LocalFiles }
+        assertFalse(lf.enabled)
+        assertTrue(lf.comingSoon)
+        assertEquals("Local files", lf.title)
+    }
+}
+```
+
+Run:
+```bash
+./gradlew :app:test --tests "com.riffle.app.feature.server.SourceTypePickerTest" --no-daemon
+```
+Expected: FAIL — unresolved reference `sourceTypeCards` / `SourceTypeChoice`.
+
+- [ ] **Step 2: Create the picker Composable + data model**
+
+Create `app/src/main/kotlin/com/riffle/app/feature/server/SourceTypePickerScreen.kt`:
+
+```kotlin
+package com.riffle.app.feature.server
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Cloud
+import androidx.compose.material.icons.filled.Folder
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.windowsizeclass.WindowSizeClass
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.testTag
+import androidx.compose.ui.unit.dp
+import com.riffle.app.ui.TabletContentWidthContainer
+
+sealed interface SourceTypeChoice {
+    data object Audiobookshelf : SourceTypeChoice
+    data object LocalFiles : SourceTypeChoice
+}
+
+data class SourceTypeCard(
+    val type: SourceTypeChoice,
+    val title: String,
+    val subtitle: String,
+    val enabled: Boolean,
+    val comingSoon: Boolean,
+)
+
+internal fun sourceTypeCards(): List<SourceTypeCard> = listOf(
+    SourceTypeCard(
+        type = SourceTypeChoice.Audiobookshelf,
+        title = "Audiobookshelf",
+        subtitle = "Stream ebooks and audiobooks from your Audiobookshelf server.",
+        enabled = true,
+        comingSoon = false,
+    ),
+    SourceTypeCard(
+        type = SourceTypeChoice.LocalFiles,
+        title = "Local files",
+        subtitle = "Read EPUBs and PDFs from a folder on this device.",
+        enabled = false,
+        comingSoon = true,
+    ),
+)
+
+private fun iconFor(type: SourceTypeChoice): ImageVector = when (type) {
+    SourceTypeChoice.Audiobookshelf -> Icons.Default.Cloud
+    SourceTypeChoice.LocalFiles -> Icons.Default.Folder
+}
+
+private fun testTagFor(type: SourceTypeChoice): String = when (type) {
+    SourceTypeChoice.Audiobookshelf -> "SourceTypeCard.Audiobookshelf"
+    SourceTypeChoice.LocalFiles -> "SourceTypeCard.LocalFiles"
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SourceTypePickerScreen(
+    windowSizeClass: WindowSizeClass,
+    onNavigateBack: () -> Unit,
+    onPickAudiobookshelf: () -> Unit,
+) {
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Add source") },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        TabletContentWidthContainer(
+            windowSizeClass = windowSizeClass,
+            modifier = Modifier.fillMaxSize().padding(padding),
+        ) {
+            Column(
+                modifier = Modifier.fillMaxSize().padding(24.dp),
+                verticalArrangement = Arrangement.spacedBy(16.dp),
+            ) {
+                sourceTypeCards().forEach { card ->
+                    SourceTypeCardRow(
+                        card = card,
+                        onClick = when (card.type) {
+                            SourceTypeChoice.Audiobookshelf -> onPickAudiobookshelf
+                            SourceTypeChoice.LocalFiles -> null
+                        },
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun SourceTypeCardRow(card: SourceTypeCard, onClick: (() -> Unit)?) {
+    val cardModifier = Modifier
+        .fillMaxWidth()
+        .semantics { testTag = testTagFor(card.type) }
+        .let { if (onClick != null) it.clickable(onClick = onClick) else it }
+    Card(
+        modifier = cardModifier,
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surface,
+        ),
+    ) {
+        Row(
+            modifier = Modifier.padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            val contentAlpha = if (card.enabled) 1f else 0.5f
+            Icon(
+                imageVector = iconFor(card.type),
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.size(40.dp).alpha(contentAlpha),
+            )
+            Column(modifier = Modifier.weight(1f).alpha(contentAlpha)) {
+                Text(card.title, style = MaterialTheme.typography.titleMedium)
+                Spacer(Modifier.size(2.dp))
+                Text(
+                    card.subtitle,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            if (card.comingSoon) {
+                Surface(
+                    shape = RoundedCornerShape(8.dp),
+                    color = MaterialTheme.colorScheme.tertiaryContainer,
+                    contentColor = MaterialTheme.colorScheme.onTertiaryContainer,
+                ) {
+                    Box(modifier = Modifier.padding(horizontal = 10.dp, vertical = 4.dp)) {
+                        Text("Coming soon", style = MaterialTheme.typography.labelMedium)
+                    }
+                }
+            }
+        }
+    }
+}
+```
+
+Note the `weight(1f)` inside a `Row` — this is valid because `Row`'s children have `RowScope`. If Kotlin complains, replace with `Modifier.weight(1f, fill = true)` explicitly or use the `RowScope` import.
+
+- [ ] **Step 3: Re-run JVM tests to confirm they pass**
+
+```bash
+./gradlew :app:test --tests "com.riffle.app.feature.server.SourceTypePickerTest" --no-daemon
+```
+Expected: PASS on all three tests.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add -A
+git commit -m "feat(app): SourceTypePickerScreen with ABS + LocalFiles-disabled placeholder (#435)"
+```
+
+---
+
+## Task 4: Wire the picker into the nav graph and route ABS entry points through it
+
+**Files:**
+- Modify: `app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt` — rename route consts, add picker composable, redirect ABS entry points.
+
+**Interfaces consumed:**
+- `SourceTypePickerScreen(windowSizeClass, onNavigateBack, onPickAudiobookshelf)` from Task 3.
+- `AddSourceScreen`, `SourceSetupViewModel`, `AddSourceBackend` from Task 1.
+- `StartDestination.AddSource` from Task 1.
+
+**Interfaces produced:**
+- Nav route consts `ADD_SOURCE = "add_source"`, `ADD_SOURCE_ROUTE = "add_source?type={type}&editId={editId}"`, `ADD_SOURCE_TYPE_PICKER = "add_source_type_picker"`, `SOURCE_SETUP_GRAPH = "source_setup"`.
+
+- [ ] **Step 1: Rename nav-route constants in `MainScreen.kt:54-57`**
+
+Replace:
+```kotlin
+private const val SERVER_SETUP_GRAPH = "server_setup"
+private const val ADD_SERVER = "add_server"
+private const val ADD_SERVER_ROUTE = "add_server?type={type}&editId={editId}"
+private const val SELECT_LIBRARIES = "select_libraries"
+```
+with:
+```kotlin
+private const val SOURCE_SETUP_GRAPH = "source_setup"
+private const val ADD_SOURCE_TYPE_PICKER = "add_source_type_picker"
+private const val ADD_SOURCE = "add_source"
+private const val ADD_SOURCE_ROUTE = "add_source?type={type}&editId={editId}"
+private const val SELECT_LIBRARIES = "select_libraries"
+```
+
+Update every reference in this file (search `SERVER_SETUP_GRAPH` → `SOURCE_SETUP_GRAPH`, `ADD_SERVER_ROUTE` → `ADD_SOURCE_ROUTE`, `ADD_SERVER` → `ADD_SOURCE`).
+
+- [ ] **Step 2: Insert the picker composable into the setup nav graph**
+
+Inside `navigation(startDestination = ..., route = SOURCE_SETUP_GRAPH) { ... }`, change the `startDestination` to `ADD_SOURCE_TYPE_PICKER` and add a composable block for it. The end result of that navigation block:
+
+```kotlin
+navigation(startDestination = ADD_SOURCE_TYPE_PICKER, route = SOURCE_SETUP_GRAPH) {
+    composable(ADD_SOURCE_TYPE_PICKER) {
+        val cameFromSettings = navController.previousBackStackEntry
+            ?.destination?.route == SETTINGS
+        SourceTypePickerScreen(
+            windowSizeClass = windowSizeClass,
+            onNavigateBack = {
+                if (cameFromSettings) navController.popBackStack()
+                else navController.navigateAsRoot(HOME)
+            },
+            onPickAudiobookshelf = {
+                navController.navigate("$ADD_SOURCE?type=audiobookshelf") {
+                    popUpTo(ADD_SOURCE_TYPE_PICKER) { inclusive = true }
+                }
+            },
+        )
+    }
+    composable(
+        route = ADD_SOURCE_ROUTE,
+        arguments = listOf(
+            navArgument("type") {
+                type = NavType.StringType
+                defaultValue = ""
+            },
+            navArgument("editId") {
+                type = NavType.StringType
+                defaultValue = ""
+            },
+        ),
+    ) { backStackEntry ->
+        val parentEntry = remember(backStackEntry) {
+            navController.getBackStackEntry(SOURCE_SETUP_GRAPH)
+        }
+        val setupVm: SourceSetupViewModel = hiltViewModel(parentEntry)
+        val cameFromSettings = navController.previousBackStackEntry
+            ?.destination?.route == SETTINGS
+        AddSourceScreen(
+            windowSizeClass = windowSizeClass,
+            onNavigateBack = {
+                if (cameFromSettings) navController.popBackStack()
+                else navController.navigateAsRoot(HOME)
+            },
+            onAuthenticated = { pending ->
+                setupVm.pendingServer = pending
+                navController.navigate(SELECT_LIBRARIES)
+            },
+            onAutoCompleted = {
+                if (cameFromSettings) navController.popBackStack()
+                else navController.navigateAsRoot(HOME)
+            },
+        )
+    }
+    composable(SELECT_LIBRARIES) { /* unchanged */ }
+}
+```
+
+- [ ] **Step 3: Route the ABS entry points through the picker**
+
+At `MainScreen.kt` line 168 (HomeScreen callback), replace:
+```kotlin
+onNavigateToAddSource = {
+    navController.navigateAsRoot("$ADD_SOURCE?type=audiobookshelf")
+},
+```
+with:
+```kotlin
+onNavigateToAddSource = {
+    navController.navigateAsRoot(ADD_SOURCE_TYPE_PICKER)
+},
+```
+
+At `MainScreen.kt` line ~238 (SettingsScreen callback):
+```kotlin
+onNavigateToAddSource = { backend, editId ->
+    val params = buildList {
+        add("type=${backend.name.lowercase()}")
+        if (!editId.isNullOrEmpty()) add("editId=${URLEncoder.encode(editId, "UTF-8")}")
+    }.joinToString("&")
+    navController.navigate("$ADD_SOURCE?$params")
+},
+```
+becomes:
+```kotlin
+onNavigateToAddSource = { backend, editId ->
+    // Only the "add ABS from scratch" flow shows the type picker. Storyteller/WebDAV are
+    // Services (not Sources) and still deep-link straight to the form. Editing an existing
+    // ABS source also skips the picker (Source Type is already known).
+    val isNewAbs = backend == AddSourceBackend.AUDIOBOOKSHELF && editId.isNullOrEmpty()
+    if (isNewAbs) {
+        navController.navigate(ADD_SOURCE_TYPE_PICKER)
+    } else {
+        val params = buildList {
+            add("type=${backend.name.lowercase()}")
+            if (!editId.isNullOrEmpty()) add("editId=${URLEncoder.encode(editId, "UTF-8")}")
+        }.joinToString("&")
+        navController.navigate("$ADD_SOURCE?$params")
+    }
+},
+```
+
+- [ ] **Step 4: Compile and run all JVM tests**
+
+```bash
+./gradlew :app:test :app:compileDebugKotlin --no-daemon
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A
+git commit -m "feat(app): route ABS entry points through Source Type picker (#435)"
+```
+
+---
+
+## Task 5: Instrumentation test for `SourceTypePickerScreen`
+
+**Files:**
+- Create: `app/src/androidTest/kotlin/com/riffle/app/feature/server/SourceTypePickerScreenTest.kt`
+
+**Interfaces consumed:**
+- `SourceTypePickerScreen` Composable.
+
+- [ ] **Step 1: Write the instrumentation test**
+
+Create `app/src/androidTest/kotlin/com/riffle/app/feature/server/SourceTypePickerScreenTest.kt`:
+
+```kotlin
+package com.riffle.app.feature.server
+
+import androidx.activity.ComponentActivity
+import androidx.compose.material3.windowsizeclass.calculateWindowSizeClass
+import androidx.compose.ui.test.assertHasClickAction
+import androidx.compose.ui.test.assertHasNoClickAction
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class SourceTypePickerScreenTest {
+
+    @get:Rule
+    val composeRule = createAndroidComposeRule<ComponentActivity>()
+
+    @Test
+    fun bothCards_areDisplayed() {
+        composeRule.setContent {
+            val wsc = calculateWindowSizeClass(composeRule.activity)
+            SourceTypePickerScreen(
+                windowSizeClass = wsc,
+                onNavigateBack = {},
+                onPickAudiobookshelf = {},
+            )
+        }
+        composeRule.onNodeWithText("Audiobookshelf").assertIsDisplayed()
+        composeRule.onNodeWithText("Local files").assertIsDisplayed()
+    }
+
+    @Test
+    fun audiobookshelfCard_click_invokesCallback() {
+        var pickCount = 0
+        composeRule.setContent {
+            val wsc = calculateWindowSizeClass(composeRule.activity)
+            SourceTypePickerScreen(
+                windowSizeClass = wsc,
+                onNavigateBack = {},
+                onPickAudiobookshelf = { pickCount++ },
+            )
+        }
+        composeRule.onNodeWithTag("SourceTypeCard.Audiobookshelf").assertHasClickAction().performClick()
+        assertEquals(1, pickCount)
+    }
+
+    @Test
+    fun localFilesCard_isDisabled_showsComingSoon() {
+        composeRule.setContent {
+            val wsc = calculateWindowSizeClass(composeRule.activity)
+            SourceTypePickerScreen(
+                windowSizeClass = wsc,
+                onNavigateBack = {},
+                onPickAudiobookshelf = {},
+            )
+        }
+        composeRule.onNodeWithText("Coming soon").assertIsDisplayed()
+        composeRule.onNodeWithTag("SourceTypeCard.LocalFiles").assertHasNoClickAction()
+    }
+}
+```
+
+- [ ] **Step 2: Run the harness test**
+
+```bash
+make harness-test
+```
+Then filter output for `SourceTypePickerScreenTest` — all three tests PASS.
+
+Expected: PASS. If a test is skipped because the phone-form-factor filter excludes it, add no `@TabletLayout` annotation (this test is form-factor-agnostic; the default filter includes it).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add -A
+git commit -m "test(app): instrumentation tests for SourceTypePickerScreen (#435)"
+```
+
+---
+
+## Task 6: Update harness tests that traverse HomeScreen → Add flow
+
+**Files:**
+- Modify: `app/src/androidTest/kotlin/com/riffle/app/harness/EpubHarnessTest.kt`
+- Modify: `app/src/androidTest/kotlin/com/riffle/app/harness/PdfHarnessTest.kt`
+- Modify: `app/src/androidTest/kotlin/com/riffle/app/harness/SearchHarnessTest.kt`
+- Modify: `app/src/androidTest/kotlin/com/riffle/app/harness/WakeLockHarnessTest.kt`
+- Modify: `app/src/androidTest/kotlin/com/riffle/app/harness/NavigationSnapHarnessTest.kt`
+- Modify: `app/src/androidTest/kotlin/com/riffle/app/feature/reader/OrientationFlipAnnotationHarnessTest.kt`
+- Modify: `app/src/androidTest/kotlin/com/riffle/app/feature/reader/ContinuousAnnotationRenderHarnessTest.kt`
+- Modify: `app/src/androidTest/kotlin/com/riffle/app/feature/reader/AnnotationFocusHarnessTest.kt`
+
+Any other harness test that opens `HomeScreen` with zero configured sources: same treatment.
+
+- [ ] **Step 1: In each affected harness test, add a picker-tap step before the "Source URL" field appears**
+
+Find the block that comments about HomeScreen auto-navigating to AddServerScreen, e.g. in `EpubHarnessTest.kt:204`:
+
+```kotlin
+// With no servers, HomeScreen automatically navigates to AddServerScreen.
+```
+
+Change the comment and add a tap step:
+
+```kotlin
+// With no sources, HomeScreen automatically navigates to the Source Type picker.
+// Tap the Audiobookshelf card to advance to the connect form.
+composeTestRule.onNodeWithText("Audiobookshelf")
+    .assertIsDisplayed()
+    .performClick()
+composeTestRule.waitUntil(timeoutMillis = 5_000) {
+    composeTestRule.onAllNodesWithText("Source URL").fetchSemanticsNodes().isNotEmpty()
+}
+```
+
+Do the same edit in each file listed above. Grep with:
+
+```bash
+grep -rn "HomeScreen automatically navigates to AddServerScreen" app/src/androidTest/
+```
+to find every occurrence (there are ~8).
+
+- [ ] **Step 2: Run the harness suite**
+
+```bash
+make harness-test
+```
+Expected: PASS. If any fail with `Audiobookshelf` node not found, verify that HomeScreen's `onNavigateToAddSource` really navigates to `ADD_SOURCE_TYPE_PICKER` (Task 4 Step 3).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add -A
+git commit -m "test(harness): tap through Source Type picker in Add flow (#435)"
+```
+
+---
+
+## Task 7: Verify on AVD and open PR
+
+- [ ] **Step 1: Ask the user to build and install the APK**
+
+Say to the user: "Please build and install the debug APK on your device or the harness AVD so I can verify the picker + drawer + settings copy end-to-end."
+
+Wait for confirmation. Do not `assembleDebug` or `adb install` yourself (AGENTS.md).
+
+- [ ] **Step 2: Drive the flow yourself with `adb`**
+
+With the installed APK running on the AVD (serial captured via `adb devices`):
+
+1. `adb shell am start -n com.riffle/.MainActivity` — launch the app.
+2. Fresh-install state: HomeScreen should redirect to the Source Type picker. Capture: `adb exec-out screencap -p > /tmp/435-picker-fresh.png`.
+3. Configure an ABS source, then open the Nav Drawer → verify header reads `"No source"` (with no active source) or the source-type label (with one) and the trailing-icon contentDescription reads `"Toggle source switcher"` (announced by TalkBack; also visible via UI Automator dump).
+4. Open Settings → verify the section header reads `"Sources"` and the button reads `"Add source"`. Capture.
+5. Tap Settings → Sources → "Add source" → verify picker screen shown; capture.
+6. Tap "Audiobookshelf" card → verify the connect form appears with title `"Add Audiobookshelf"`. Capture.
+7. Edit an existing ABS source (Settings → the row → tap) → verify the picker is BYPASSED; the connect form appears directly with title `"Edit Audiobookshelf"` and remove button `"Remove source"`. Capture.
+8. Tap Settings → Readaloud → "Configure Storyteller" → verify the connect form appears with title `"Add Storyteller"` (unchanged). Capture.
+
+Store captures under `.context/435-verification/`.
+
+- [ ] **Step 3: Fetch logcat for any error markers**
+
+```bash
+adb logcat -d | grep -E "AndroidRuntime|FATAL|RIFFLE_" | tail -60
+```
+Expected: no crashes, no unexpected errors.
+
+- [ ] **Step 4: Confirm every AGENTS.md verification checklist item is green**
+
+- [ ] Fresh install → picker shown (Step 2.2).
+- [ ] Drawer copy renamed (Step 2.3).
+- [ ] Settings section + button renamed (Step 2.4).
+- [ ] Picker → ABS card advances to renamed form (Step 2.5–2.6).
+- [ ] Edit skips picker (Step 2.7).
+- [ ] Storyteller unchanged (Step 2.8).
+
+- [ ] **Step 5: Invoke `/finalize`**
+
+Do NOT push manually. `/finalize` rebases on main, addresses any lint/CI feedback, and opens the PR with the required `Closes #435` line.
+
+---
+
+## Regression pinning summary — what stops a revert
+
+- `SourceTypePickerTest.localFiles_isDisabled_showsComingSoon()` (JVM) — locks the LocalFiles-disabled contract until #7 lands.
+- `SourceTypePickerTest.cards_orderIsAbsThenLocalFiles()` (JVM) — locks card order.
+- `SourceTypePickerScreenTest.localFilesCard_isDisabled_showsComingSoon()` (instrumentation) — locks the `"Coming soon"` label + no-click contract.
+- `AddSourceCopyTest.'ABS add title = Add Audiobookshelf'` (JVM) — locks the ABS form title rename.
+- `AddSourceCopyTest.'ABS remove label = Remove source'` (JVM) — locks the ABS remove-button rename.
+- Harness `Audiobookshelf` card tap — locks the picker's presence in the ABS entry-point flow. If someone reverts the nav-graph rewiring (Task 4 Step 3), every harness test flips red on "Audiobookshelf node not found".
+
+Each of these assertions flips red if the corresponding fix were reverted line-for-line.

--- a/docs/superpowers/specs/2026-07-09-source-switcher-and-add-source-picker-design.md
+++ b/docs/superpowers/specs/2026-07-09-source-switcher-and-add-source-picker-design.md
@@ -1,0 +1,162 @@
+# Source Switcher, Add Source flow, Source Type picker
+
+Issue: [#435](https://github.com/pkmetski/riffle/issues/435). Phase 3 of the [ADR 0041](../../adr/0041-source-and-service-abstractions-replace-server.md) Source/Service re-root. Amends [ADR 0007](../../adr/0007-navigation-drawer-replaces-server-and-library-screens.md).
+
+## Goal
+
+Rename user-facing surfaces from **Server** to **Source** and introduce a **Source Type picker** as the first step of the Add flow (Audiobookshelf enabled, LocalFiles a disabled placeholder until #7).
+
+## Scope
+
+### In scope
+
+- New `SourceTypePickerScreen` inserted before the ABS Add-Source entry points.
+- File and symbol renames:
+  - `AddServerScreen` → `AddSourceScreen`
+  - `AddServerViewModel` → `AddSourceViewModel`
+  - `AddServerBackend` → `AddSourceBackend` (enum values `AUDIOBOOKSHELF` / `STORYTELLER` / `WEBDAV` unchanged)
+  - `ServerSetupViewModel` → `SourceSetupViewModel`
+  - Nav-route consts `ADD_SERVER*` → `ADD_SOURCE*`; new `ADD_SOURCE_TYPE_PICKER`
+  - Callback params `onNavigateToAddServer` → `onNavigateToAddSource`
+- User-visible string changes:
+  - Drawer: `"No server"` → `"No source"`; `"Toggle server switcher"` contentDescription → `"Toggle source switcher"`
+  - Settings: section header `"Audiobookshelf servers"` → `"Sources"`; button `"Add server"` → `"Add source"`
+  - AddSourceScreen (ABS variant only): title `"Add Audiobookshelf server"` / `"Edit Audiobookshelf server"` → `"Add Audiobookshelf"` / `"Edit Audiobookshelf"`; remove-button `"Remove server"` → `"Remove source"`
+- Instrumentation snapshot tests regenerated where affected.
+
+### Out of scope
+
+- Storyteller user-facing strings (`"Add Storyteller"`, "Edit Storyteller", etc.) stay unchanged — issue #441 renames them.
+- WebDAV strings stay — WebDAV is a Service (annotation sync target), not a Source.
+- `Source.serverType` domain field stays (the `AUDIOBOOKSHELF` / `STORYTELLER` split is what #441 collapses).
+- ABS product-referencing copy stays ("your Audiobookshelf server" in help text; "Couldn't reach the server" errors) — these refer to ABS the product.
+- Directory `app/feature/server/` stays — package rename is churn without user impact.
+
+## Non-goals
+
+- No behavioral change to the ABS or Storyteller connection flows.
+- No LocalFiles wiring; the card is a visible placeholder only.
+- No Storyteller-as-Service copy shift (issue #441).
+
+## Design
+
+### Source Type picker screen
+
+**Route:** `add_source_type_picker`, inside the source-setup nav graph. Reachable only from ABS entry points (see wiring below). Storyteller and WebDAV deep-link straight into `AddSourceScreen` with their preset backend.
+
+**Composable:** `SourceTypePickerScreen(onPickAudiobookshelf: () -> Unit, onNavigateBack: () -> Unit)`
+
+- `Scaffold` + `TopAppBar` titled `"Add source"` with back arrow.
+- `TabletContentWidthContainer` (matches existing Add-Source screens).
+- Vertical stack of two `Card`s.
+
+**Card 1 — Audiobookshelf**
+
+- Leading icon: cloud/storage placeholder.
+- Headline: `"Audiobookshelf"`.
+- Supporting: `"Stream ebooks and audiobooks from your Audiobookshelf server."`
+- `enabled = true`; `onClick` → `onPickAudiobookshelf()`.
+
+**Card 2 — Local files**
+
+- Leading icon: folder placeholder.
+- Headline: `"Local files"`.
+- Supporting: `"Read EPUBs and PDFs from a folder on this device."`
+- Trailing: plain rounded label (`Surface` with `RoundedCornerShape` + `tertiaryContainer` background) reading `"Coming soon"`.
+- `enabled = false`; no `onClick` modifier. Content dimmed via `alpha 0.5f` on the leading icon + text.
+
+**Data model** — pure Kotlin, JVM-testable. `SourceType` currently only has `ABS`; adding `LOCAL_FILES` belongs to #7 / #438. This PR uses a picker-local sealed interface so the LocalFiles row exists without dragging a domain-model change:
+
+```kotlin
+sealed interface SourceTypeChoice {
+    data object Audiobookshelf : SourceTypeChoice
+    data object LocalFiles : SourceTypeChoice
+}
+
+data class SourceTypeCard(
+    val type: SourceTypeChoice,
+    val title: String,
+    val subtitle: String,
+    val enabled: Boolean,
+    val comingSoon: Boolean,
+)
+
+internal fun sourceTypeCards(): List<SourceTypeCard> = listOf(
+    SourceTypeCard(
+        type = SourceTypeChoice.Audiobookshelf,
+        title = "Audiobookshelf",
+        subtitle = "Stream ebooks and audiobooks from your Audiobookshelf server.",
+        enabled = true,
+        comingSoon = false,
+    ),
+    SourceTypeCard(
+        type = SourceTypeChoice.LocalFiles,
+        title = "Local files",
+        subtitle = "Read EPUBs and PDFs from a folder on this device.",
+        enabled = false,
+        comingSoon = true,
+    ),
+)
+```
+
+### Nav-graph wiring
+
+**Entry points routed through the picker** (change from direct → picker):
+
+1. Nav Drawer `+ Add source` button (drawer copy: `"Add server"` → `"Add source"`).
+2. Settings `"Sources"` section `"Add source"` button.
+3. `HomeViewModel.StartDestination.AddSource` (fresh install with no configured sources).
+
+**Entry points that keep deep-linking directly** (unchanged):
+
+1. Settings → Readaloud → `"Configure Storyteller"` → `AddSourceScreen(backend=STORYTELLER)`.
+2. Settings → Sync → WebDAV row → `AddSourceScreen(backend=WEBDAV)`.
+3. Editing an existing ABS Source (Settings row → tap) → `AddSourceScreen(backend=AUDIOBOOKSHELF, editId=<id>)`.
+
+**In `MainScreen.kt`:**
+
+- Rename `SERVER_SETUP_GRAPH` → `SOURCE_SETUP_GRAPH`, `ADD_SERVER` → `ADD_SOURCE`, `ADD_SERVER_ROUTE` → `ADD_SOURCE_ROUTE`.
+- Add const `ADD_SOURCE_TYPE_PICKER = "add_source_type_picker"` and a composable inside the setup graph.
+- Picker's `onPickAudiobookshelf` navigates to `AddSourceScreen(backend=AUDIOBOOKSHELF, editId=null)` with `popUpTo(ADD_SOURCE_TYPE_PICKER) { inclusive = true }` so back from the form returns to the caller (drawer/settings), not the picker.
+
+## Test plan
+
+### JVM unit tests
+
+**`SourceTypePickerTest`** (new)
+
+- `cards_orderIsAbsThenLocalFiles()` — `sourceTypeCards()` returns two items, ABS first, LocalFiles second. Reverting the order flips red.
+- `abs_isEnabled_notComingSoon()` — ABS card `enabled=true, comingSoon=false`.
+- `localFiles_isDisabled_showsComingSoon()` — LocalFiles card `enabled=false, comingSoon=true`. Reverting LocalFiles to enabled flips red — this is the pinned contract until #7 lands.
+
+**`AddSourceViewModelTest`** (existing, renamed from `AddServerViewModelTest`) — symbol-only rename; behavior unchanged.
+
+### Instrumentation tests
+
+**`SourceTypePickerScreenTest`** (new)
+
+- `bothCards_areDisplayed()` — asserts `"Audiobookshelf"` and `"Local files"` headline text render.
+- `audiobookshelfCard_click_invokesCallback()` — tap on the Audiobookshelf card fires `onPickAudiobookshelf` exactly once.
+- `localFilesCard_isDisabled_showsComingSoon()` — asserts `"Coming soon"` text is visible; asserts the LocalFiles card `.assertHasNoClickAction()`.
+
+**Existing drawer/settings tests updated for renamed copy:**
+
+- `NavigationDrawerGestureTest`
+- `PermanentNavigationDrawerTest`
+- `NavigationDrawerViewModelTest` (if it asserts on copy)
+- Any harness test that traverses the Add flow needs the extra picker tap.
+
+### Regression pinning (what stops a revert)
+
+- `SourceTypePickerTest.localFiles_isDisabled_showsComingSoon()` and `SourceTypePickerScreenTest.localFilesCard_isDisabled_showsComingSoon()` — pin the LocalFiles-disabled state.
+- Drawer/settings copy assertions in updated instrumentation tests — pin the string rename.
+
+## Verification (per AGENTS.md)
+
+This is a UI-visible change: verification path is **AVD build + install** with before/after frames of the Nav Drawer header, Settings → Sources section, and the new Source Type picker screen at phone and tablet form factors, plus one edit-flow trip (deep-link into an existing ABS source) to confirm the picker is bypassed on edit.
+
+## Risks and mitigations
+
+- **Snapshot test churn:** many drawer/settings snapshot tests may need regeneration. Mitigation: run harness suite, regen failing snapshots, review each diff to confirm the only changed pixels are the copy rename.
+- **Nav route rename breaking deep links:** nav routes are ephemeral (in-memory backstack); no persisted state references them. No migration needed.
+- **AddSourceBackend enum retains `STORYTELLER`/`WEBDAV`:** internal name is inconsistent with the ADR (Storyteller/WebDAV are Services). Deliberately deferred to #441; documented above.


### PR DESCRIPTION
Closes #435. Phase 3 of the [ADR 0041](../blob/main/docs/adr/0041-source-and-service-abstractions-replace-server.md) Source/Service re-root.

## Summary

- Rename user-facing surfaces from **Server** to **Source** in the Nav Drawer, Add flow, and Settings.
- Add a **Source Type picker** as the first step of Add-Source for ABS entry points (Audiobookshelf enabled, Local files disabled placeholder until #7 lands).
- Storyteller and WebDAV entry points and edit-existing-ABS bypass the picker and deep-link to the connect form as today. Storyteller/WebDAV copy is untouched — Storyteller's rename is #441's job.

## Key strings changed

| Surface | Before | After |
|---|---|---|
| Drawer header | `No server` | `No source` |
| Drawer switcher a11y | `Toggle server switcher` | `Toggle source switcher` |
| Settings section | `Audiobookshelf servers` | `Sources` |
| Settings button | `Add server` | `Add source` |
| ABS form title | `Add Audiobookshelf server` / `Edit Audiobookshelf server` | `Add Audiobookshelf` / `Edit Audiobookshelf` |
| ABS remove button | `Remove server` | `Remove source` |

ABS product-referencing copy (`"your Audiobookshelf server"`, `"Couldn't reach the server"`) stays — those refer to the ABS product, not Riffle's domain.

## Nav-graph shape

The picker lives at the top-level `NavHost` — deliberately **not** inside `SOURCE_SETUP_GRAPH` — so direct-entry flows (Storyteller / WebDAV / edit-existing) don't implicitly push it on the back stack. Only fresh-install and Settings "Add source" navigate to the picker; the picker's `onPickAudiobookshelf` calls `navigate` with `popUpTo(picker) { inclusive = true }` so back from the form returns to the caller.

## Testing

- `SourceTypePickerTest` (JVM) — pins card order + LocalFiles-disabled contract.
- `AddSourceCopyTest` (JVM) — pins the renamed ABS titles and remove-button label; asserts Storyteller/WebDAV strings are untouched.
- `SourceTypePickerScreenTest` (instrumentation) — both cards displayed, ABS card triggers callback, LocalFiles has no click action + "Coming soon" chip.
- Card uses `semantics(mergeDescendants = true)` so `onNodeWithText(title)` resolves to the clickable Card node in tests (and TalkBack reads title+subtitle+chip together).
- 8 existing harness tests updated to tap the "Audiobookshelf" card before hitting the connect form.

## Test plan

- [x] `./gradlew :app:test :app:compileDebugAndroidTestKotlin` passes locally.
- [ ] Fresh install → Source Type picker shown; tap Audiobookshelf → connect form with title "Add Audiobookshelf".
- [ ] Settings → Sources → "Add source" → picker → back returns to Settings.
- [ ] Edit existing ABS source → picker is bypassed; form title reads "Edit Audiobookshelf".
- [ ] Settings → Readaloud → Configure Storyteller → form title reads "Add Storyteller" (unchanged).
- [ ] Drawer header reads "No source" with no active source; TalkBack announces "Toggle source switcher".
- [ ] Local files card: dimmed, shows "Coming soon", tap does nothing.