### PR TITLE
feat(reader): pause auto-scroll and Cadence while selecting text

### DIFF
--- a/app/src/androidTest/kotlin/com/riffle/app/feature/reader/ContinuousReaderViewSelectionInterceptTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/reader/ContinuousReaderViewSelectionInterceptTest.kt
@@ -103,6 +103,25 @@ class ContinuousReaderViewSelectionInterceptTest {
     }
 
     @Test
+    fun onSelectionActiveChanged_firesOnlyOnCountTransitionEdges() {
+        // Regression: the reader hooks this to pause Auto-Scroll / Cadence while the user is
+        // selecting text (handles are invisible if the viewport keeps moving under them). The
+        // callback MUST fire only on 0↔1 transitions of the counter — never on inner increments
+        // during an overlapping-selection recycle race — otherwise a mid-drag re-entry would
+        // toggle pause and resume within one drag.
+        val v = view()
+        val events = mutableListOf<Boolean>()
+        onMain { v.onSelectionActiveChanged = { events += it } }
+        onMain {
+            v.onSelectionActiveForTest(true)       // 0 → 1: fire true
+            v.onSelectionActiveForTest(true)       // 1 → 2: no-op
+            v.onSelectionActiveForTest(false)      // 2 → 1: no-op
+            v.onSelectionActiveForTest(false)      // 1 → 0: fire false
+        }
+        assertEquals(listOf(true, false), events)
+    }
+
+    @Test
     fun overlappingSelections_decrementOnlyClearsWhenAllEnd() {
         val v = view()
         onMain {

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
@@ -185,13 +185,24 @@ internal class ContinuousReaderView @JvmOverloads constructor(
      */
     private var selectionActiveCount = 0
 
+    /**
+     * Called on the main thread with the current selection-active state whenever it transitions
+     * (i.e. on every 0↔1 boundary of [selectionActiveCount]). Distinct from [onSelectionEnded],
+     * which only fires on the falling edge — the reader uses this to also pause Auto-Scroll /
+     * Cadence the moment a selection begins.
+     */
+    var onSelectionActiveChanged: ((Boolean) -> Unit)? = null
+
     private fun onChildSelectionActiveChanged(active: Boolean) {
+        val wasActive = selectionActiveCount > 0
         if (active) {
             selectionActiveCount++
         } else if (selectionActiveCount > 0) {
             selectionActiveCount--
             if (selectionActiveCount == 0) onSelectionEnded?.invoke()
         }
+        val nowActive = selectionActiveCount > 0
+        if (nowActive != wasActive) onSelectionActiveChanged?.invoke(nowActive)
     }
 
     /** Test seam: drives the same counter the production [ChapterWebView] callback does, without

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -276,6 +276,10 @@ fun EpubReaderScreen(
 
     val annotationsAvailable by viewModel.annotationsAvailable.collectAsState()
     val annotationsPanelVisible by viewModel.annotationsPanelVisible.collectAsState()
+    // Set by [EpubNavigatorView]'s onSelectionActiveChanged callback (paged/vertical fire the
+    // Readium selectionActionModeCallback; continuous fires ContinuousReaderView's own callback).
+    // Combined with [highlightToEdit] / [noteEditorTarget] below to gate Auto-Scroll / Cadence.
+    var readerSelectionActive by remember { mutableStateOf(false) }
     val annotations by viewModel.annotations.collectAsState()
     val isCurrentPageBookmarked by viewModel.isCurrentPageBookmarked.collectAsState()
     val highlightRenders by viewModel.highlightRenders.collectAsState()
@@ -391,6 +395,25 @@ fun EpubReaderScreen(
                             cause = com.riffle.core.domain.autoscroll.PauseCause.PanelOpen,
                         )
                     }
+                    // Pause Auto-Scroll AND Cadence while text is being selected or the resulting
+                    // annotation popup / note editor is open — selection handles are invisible if
+                    // the viewport keeps advancing under them. Scoped resume (see
+                    // FormattingSession.setAutoScrollPaused / EpubReaderViewModel.setCadencePaused)
+                    // guarantees this can't un-park a longer-lived cause (e.g. PanelOpen) that
+                    // started mid-selection. Applies to all three reader modes.
+                    LaunchedEffect(readerSelectionActive, highlightToEdit, noteEditorTarget) {
+                        val anyOn = readerSelectionActive ||
+                            highlightToEdit != null ||
+                            noteEditorTarget != null
+                        viewModel.setAutoScrollPaused(
+                            paused = anyOn,
+                            cause = com.riffle.core.domain.autoscroll.PauseCause.TextSelection,
+                        )
+                        viewModel.setCadencePaused(
+                            paused = anyOn,
+                            cause = com.riffle.core.domain.cadence.PauseCause.TextSelection,
+                        )
+                    }
                     val spinePositions by viewModel.spinePositionCounts.collectAsState()
                     // Mutual-exclusion OR for the sentence-highlight pipeline (issue #403): when
                     // Cadence is running, its currentFragment / quotes / colour replace
@@ -461,6 +484,7 @@ fun EpubReaderScreen(
                             // transition on pre-R.
                             if (immersiveState.isImmersive) immersiveState.hide(force = true)
                         },
+                        onSelectionActiveChanged = { active -> readerSelectionActive = active },
                         latestLocator = { viewModel.latestLocator },
                         onFootnoteTapped = viewModel::showFootnotePopup,
                         returnNavEvents = viewModel.returnNavEvents,
@@ -1266,6 +1290,7 @@ private fun EpubNavigatorView(
     volumeNavEvents: Flow<VolumeNavEvent>,
     onTap: () -> Unit,
     onSelectionEnded: () -> Unit,
+    onSelectionActiveChanged: (Boolean) -> Unit,
     latestLocator: () -> Locator?,
     onFootnoteTapped: (content: FootnoteContent) -> Unit,
     returnNavEvents: Flow<Locator>,
@@ -1492,6 +1517,7 @@ private fun EpubNavigatorView(
     // without needing to be re-created when onTap changes.
     val currentOnTap by rememberUpdatedState(onTap)
     val currentOnSelectionEnded by rememberUpdatedState(onSelectionEnded)
+    val currentOnSelectionActiveChanged by rememberUpdatedState(onSelectionActiveChanged)
     val currentOnFootnoteTapped by rememberUpdatedState(onFootnoteTapped)
     val currentLatestLocator by rememberUpdatedState(latestLocator)
     val currentOnCaptureReturnTarget by rememberUpdatedState(onCaptureReturnTarget)
@@ -1577,6 +1603,11 @@ private fun EpubNavigatorView(
     val playFromHereActionMode = remember {
         object : android.view.ActionMode.Callback {
             override fun onCreateActionMode(mode: android.view.ActionMode, menu: android.view.Menu): Boolean {
+                // Selection begins here in paged/vertical mode: pause Auto-Scroll / Cadence so the
+                // selection handles are visible while the user drags them. Paired with the
+                // onDestroyActionMode → onSelectionActiveChanged(false) below. Continuous mode has
+                // its own selection-active plumbing on ContinuousReaderView.
+                currentOnSelectionActiveChanged(true)
                 menu.add(0, copyMenuId, 0, android.R.string.copy)
                 if (currentAnnotationsAvailable) {
                     menu.add(0, highlightMenuId, 1, "Highlight")
@@ -1691,6 +1722,7 @@ private fun EpubNavigatorView(
                 // the OS leaves the system bars in a transparent-overlay state that the topInset
                 // watcher can't see. Force-re-hide restores true immersive.
                 currentOnSelectionEnded()
+                currentOnSelectionActiveChanged(false)
             }
         }
     }
@@ -2704,6 +2736,7 @@ private fun EpubNavigatorView(
                         view.readaloudAvailable = currentReadaloudAvailable
                         view.onFigureTap = { payload -> onFigureTap(payload) }
                         view.onSelectionEnded = { currentOnSelectionEnded() }
+                        view.onSelectionActiveChanged = { active -> currentOnSelectionActiveChanged(active) }
                     }
                 },
                 // Availability flags can flip mid-session; keep the selection menu gates in sync.

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -1601,6 +1601,11 @@ private fun EpubNavigatorView(
     val searchMenuId = remember { View.generateViewId() }
     val shareMenuId = remember { View.generateViewId() }
     val playFromHereActionMode = remember {
+        // See [SelectionHandoffLatch]. Latched by the highlightMenuId branch and cleared by the
+        // coroutine's `finally`, this bridges the frame-scale gap between mode.finish() (which
+        // synchronously fires onDestroyActionMode and would otherwise resume Auto-Scroll) and
+        // `highlightToEdit` becoming non-null (which re-latches the LaunchedEffect's pause).
+        val handoff = SelectionHandoffLatch()
         object : android.view.ActionMode.Callback {
             override fun onCreateActionMode(mode: android.view.ActionMode, menu: android.view.Menu): Boolean {
                 // Selection begins here in paged/vertical mode: pause Auto-Scroll / Cadence so the
@@ -1608,6 +1613,7 @@ private fun EpubNavigatorView(
                 // onDestroyActionMode → onSelectionActiveChanged(false) below. Continuous mode has
                 // its own selection-active plumbing on ContinuousReaderView.
                 currentOnSelectionActiveChanged(true)
+                handoff.reset()
                 menu.add(0, copyMenuId, 0, android.R.string.copy)
                 if (currentAnnotationsAvailable) {
                     menu.add(0, highlightMenuId, 1, "Highlight")
@@ -1655,13 +1661,27 @@ private fun EpubNavigatorView(
                         val selectable = fragmentRef.value as? org.readium.r2.navigator.SelectableNavigator
                             ?: return false
                         val container = containerRef.value ?: return false
+                        // Suppress the synchronous selection-active clear in onDestroyActionMode
+                        // below; defer it to the coroutine's `finally` so `highlightToEdit` has a
+                        // chance to become non-null (which re-latches the pause via
+                        // [LaunchedEffect]) before selection-active flips off.
+                        handoff.beginHighlightHandoff()
                         coroutineScope.launch {
-                            val selection = selectable.currentSelection() ?: return@launch
-                            val rawRect = selection.rect
-                                ?: run { selectable.clearSelection(); return@launch }
-                            val rect = rawRect.toWindowIntRect(container)
-                            currentOnHighlight(selection.locator, rect)
-                            selectable.clearSelection()
+                            try {
+                                val selection = selectable.currentSelection() ?: return@launch
+                                val rawRect = selection.rect
+                                    ?: run { selectable.clearSelection(); return@launch }
+                                val rect = rawRect.toWindowIntRect(container)
+                                currentOnHighlight(selection.locator, rect)
+                                selectable.clearSelection()
+                            } finally {
+                                // Runs on all exits — success, early-out on null selection/rect,
+                                // and cancellation. If `currentOnHighlight` populated
+                                // `highlightToEdit`, the LaunchedEffect stays paused; if not (the
+                                // early-out paths), the pause resumes here as intended.
+                                handoff.endHighlightHandoff()
+                                currentOnSelectionActiveChanged(false)
+                            }
                         }
                     }
                     playFromHereMenuId -> {
@@ -1722,7 +1742,9 @@ private fun EpubNavigatorView(
                 // the OS leaves the system bars in a transparent-overlay state that the topInset
                 // watcher can't see. Force-re-hide restores true immersive.
                 currentOnSelectionEnded()
-                currentOnSelectionActiveChanged(false)
+                // Skip the selection-active clear when a highlight is in flight — the
+                // highlightMenuId coroutine's `finally` owns it. See [SelectionHandoffLatch].
+                if (handoff.shouldClearOnDestroy()) currentOnSelectionActiveChanged(false)
             }
         }
     }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -599,6 +599,11 @@ class EpubReaderViewModel @Inject constructor(
     fun resumeCadenceIfPaused() =
         cadenceController.dispatch(com.riffle.core.domain.cadence.CadenceEvent.Resume)
 
+    fun setCadencePaused(
+        paused: Boolean,
+        cause: com.riffle.core.domain.cadence.PauseCause,
+    ) = cadenceController.setPaused(paused, cause)
+
     /**
      * Snapshot the currently-running feature and apply [com.riffle.core.domain.cadence.onStart]'s
      * pause fan-out. Called before dispatching a Start event to [starting]'s own controller.

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/SelectionHandoffLatch.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/SelectionHandoffLatch.kt
@@ -1,0 +1,52 @@
+package com.riffle.app.feature.reader
+
+/**
+ * Two-state latch that bridges the frame-scale gap between the Readium selection ActionMode's
+ * synchronous `onDestroyActionMode` and the asynchronous "highlight-actions popup opens" event
+ * driven by [com.riffle.app.feature.reader.session.AnnotationSession].
+ *
+ * When the user taps the "Highlight" item, `onActionItemClicked` launches a coroutine that
+ * eventually calls the highlight-creation flow (a Room write + StateFlow update), then finishes
+ * the ActionMode. `mode.finish()` synchronously fires `onDestroyActionMode`, which would clear
+ * the reader's `selectionActive` signal before the popup has had a chance to latch the pause via
+ * `highlightToEdit != null`. Auto-Scroll would then resume for one or more frames while the popup
+ * is materialising — the exact state the pause was introduced to prevent.
+ *
+ * Usage: call [beginHighlightHandoff] from the highlight branch of `onActionItemClicked`, call
+ * [shouldClearOnDestroy] from `onDestroyActionMode`, and call [endHighlightHandoff] from the
+ * coroutine's `finally`. Call [reset] from `onCreateActionMode` to be safe against a callback
+ * instance being reused across successive selections without a pairing coroutine run.
+ */
+internal class SelectionHandoffLatch {
+    private var pending: Boolean = false
+
+    /** Fresh state — no highlight tap seen since the last reset. */
+    fun reset() {
+        pending = false
+    }
+
+    /** Called from the Highlight menu-item branch before mode.finish() launches the coroutine. */
+    fun beginHighlightHandoff() {
+        pending = true
+    }
+
+    /**
+     * Called from the highlight-creation coroutine's `finally`. Always safe — clears the latch so
+     * a subsequent onDestroyActionMode without a highlight tap goes through the normal clear path.
+     */
+    fun endHighlightHandoff() {
+        pending = false
+    }
+
+    /**
+     * Returns true if `onDestroyActionMode` should synchronously clear the selection-active signal
+     * (no handoff is in flight). Returns false if a highlight tap started a coroutine whose
+     * `finally` will call [endHighlightHandoff] and the clear itself. Clears the latch on true
+     * so the callback instance is usable across successive selections.
+     */
+    fun shouldClearOnDestroy(): Boolean {
+        val clearNow = !pending
+        if (clearNow) pending = false
+        return clearNow
+    }
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/cadence/CadenceController.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/cadence/CadenceController.kt
@@ -163,6 +163,25 @@ open class CadenceController internal constructor(
         dispatch(CadenceEvent.Pause(cause))
     }
 
+    /**
+     * Scoped pause/resume — mirrors `FormattingSession.setAutoScrollPaused`.
+     * `paused = true` dispatches [CadenceEvent.Pause] with [cause].
+     * `paused = false` only dispatches [CadenceEvent.Resume] when the current pause cause matches
+     * [cause], so a short-lived cause (e.g. [PauseCause.TextSelection]) can't silently un-park a
+     * longer-lived one (e.g. [PauseCause.PanelOpen]) that started while the selection was still
+     * active. Called from the reader ViewModel.
+     */
+    fun setPaused(paused: Boolean, cause: PauseCause) {
+        if (paused) {
+            dispatch(CadenceEvent.Pause(cause))
+        } else {
+            val current = _state.value
+            if (current is CadenceState.Paused && current.cause == cause) {
+                dispatch(CadenceEvent.Resume)
+            }
+        }
+    }
+
     /** Called on the ticker itself, once a fragment lookup succeeds and we can position at it. */
     fun goTo(fragment: FragmentRef) {
         ticker?.goTo(fragment)

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/SelectionHandoffLatchTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/SelectionHandoffLatchTest.kt
@@ -1,0 +1,56 @@
+package com.riffle.app.feature.reader
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SelectionHandoffLatchTest {
+
+    // Plain dismiss (no Highlight tap): destroy must clear selection immediately, otherwise the
+    // pause would leak past the ActionMode dismissal.
+    @Test
+    fun `no handoff — destroy clears synchronously`() {
+        val latch = SelectionHandoffLatch()
+        assertTrue(latch.shouldClearOnDestroy())
+    }
+
+    // Regression: without this deferral, mode.finish() in onActionItemClicked(Highlight) fires
+    // onDestroyActionMode synchronously, which would flip selection-active to false BEFORE the
+    // highlight-creation coroutine reaches `currentOnHighlight` (which sets `highlightToEdit`).
+    // Auto-Scroll would resume for one or more frames until `highlightToEdit != null` re-latches
+    // the pause. The latch defers the clear to the coroutine's `finally`.
+    @Test
+    fun `highlight handoff — destroy defers clear`() {
+        val latch = SelectionHandoffLatch()
+        latch.beginHighlightHandoff()
+        assertFalse(
+            "onDestroyActionMode must NOT clear selection-active while a highlight coroutine is in flight",
+            latch.shouldClearOnDestroy(),
+        )
+        // Coroutine finally runs → latch is clear. A subsequent (unrelated) destroy clears again.
+        latch.endHighlightHandoff()
+        assertTrue(latch.shouldClearOnDestroy())
+    }
+
+    // Coroutine finally fires BEFORE onDestroyActionMode (fast-return path where currentSelection
+    // is null): destroy still needs to clear, since the handoff already ended.
+    @Test
+    fun `handoff ended before destroy — destroy still clears`() {
+        val latch = SelectionHandoffLatch()
+        latch.beginHighlightHandoff()
+        latch.endHighlightHandoff()
+        assertTrue(latch.shouldClearOnDestroy())
+    }
+
+    // The same ActionMode.Callback instance is reused across successive selections. After a
+    // deferred destroy, the next onCreateActionMode → reset() must restore the "no handoff"
+    // baseline so a subsequent plain dismiss clears synchronously.
+    @Test
+    fun `reset from onCreateActionMode restores fresh state`() {
+        val latch = SelectionHandoffLatch()
+        latch.beginHighlightHandoff()
+        // Callback instance reused for the next selection before the coroutine finished.
+        latch.reset()
+        assertTrue(latch.shouldClearOnDestroy())
+    }
+}

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/cadence/CadenceControllerTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/cadence/CadenceControllerTest.kt
@@ -194,4 +194,49 @@ class CadenceControllerTest {
         assertNull(c.currentFragment.value)
         assertEquals(CadenceState.Idle, c.state.value)
     }
+
+    // setPaused(true, cause) → setPaused(false, cause) resumes; setPaused(false, otherCause)
+    // does NOT. Backs the pause-while-selecting behaviour so a `TextSelection` resume can't
+    // silently un-park a longer-lived cause (e.g. `PanelOpen`) that started mid-selection.
+    @Test
+    fun `setPaused with matching cause resumes`() = runController { c ->
+        c.bind(FakeSource(listOf("c#s0" to "one two three four five six seven eight")))
+        c.dispatch(CadenceEvent.Start)
+        runCurrent()
+        c.setPaused(paused = true, cause = PauseCause.TextSelection)
+        assertTrue(c.state.value is CadenceState.Paused)
+        assertEquals(PauseCause.TextSelection, (c.state.value as CadenceState.Paused).cause)
+
+        c.setPaused(paused = false, cause = PauseCause.TextSelection)
+        assertTrue(c.state.value is CadenceState.Running)
+    }
+
+    @Test
+    fun `setPaused with non-matching resume cause does not resume`() = runController { c ->
+        c.bind(FakeSource(listOf("c#s0" to "one two three four five six seven eight")))
+        c.dispatch(CadenceEvent.Start)
+        runCurrent()
+        c.setPaused(paused = true, cause = PauseCause.PanelOpen)
+
+        // Selection ended → attempts a scoped resume with TextSelection. The reducer's current
+        // cause is PanelOpen, so this MUST be ignored — otherwise closing a selection would
+        // un-park a panel-open pause that started while the selection was still active.
+        c.setPaused(paused = false, cause = PauseCause.TextSelection)
+        assertTrue(c.state.value is CadenceState.Paused)
+        assertEquals(PauseCause.PanelOpen, (c.state.value as CadenceState.Paused).cause)
+    }
+
+    @Test
+    fun `setPaused pausing while already paused updates the cause`() = runController { c ->
+        c.bind(FakeSource(listOf("c#s0" to "one two three four five six seven eight")))
+        c.dispatch(CadenceEvent.Start)
+        runCurrent()
+        c.setPaused(paused = true, cause = PauseCause.TextSelection)
+        // A panel opens during the selection: pause carrier flips to PanelOpen.
+        c.setPaused(paused = true, cause = PauseCause.PanelOpen)
+        assertEquals(PauseCause.PanelOpen, (c.state.value as CadenceState.Paused).cause)
+        // The selection then ends: a scoped TextSelection resume must NOT un-park.
+        c.setPaused(paused = false, cause = PauseCause.TextSelection)
+        assertTrue(c.state.value is CadenceState.Paused)
+    }
 }


### PR DESCRIPTION
## Summary

Selection handles were invisible while Auto-Scroll or Cadence kept the viewport advancing, making text selection effectively impossible. This PR pauses both features the moment a selection begins in any of the three reader modes (paginated, vertical, continuous) and resumes when both the annotation-actions popup and the note editor are dismissed.

## Changes

- **`ContinuousReaderView.onSelectionActiveChanged`**: new callback fires on 0↔1 transitions of the existing `selectionActiveCount`, symmetric with `onSelectionEnded` but firing on the rising edge too.
- **Paged + vertical**: share Readium's `selectionActionModeCallback` in `EpubReaderScreen`; `onCreateActionMode` / `onDestroyActionMode` drive the same signal.
- **`CadenceController.setPaused(paused, cause)`**: scoped pause/resume mirroring `FormattingSession.setAutoScrollPaused` so a `TextSelection` resume can't silently un-park a longer-lived cause (e.g. `PanelOpen`) that started mid-selection.
- **One `LaunchedEffect`** in `EpubReaderScreen` combines `readerSelectionActive || highlightToEdit != null || noteEditorTarget != null` and drives `setAutoScrollPaused` + `setCadencePaused` with `PauseCause.TextSelection`.
- **`SelectionHandoffLatch`** (second commit): bridges the frame-scale gap between `mode.finish()` (synchronous `onDestroyActionMode`) and `highlightToEdit` becoming non-null. Without it, tapping "Highlight" resumed Auto-Scroll for the frames it took the highlight-creation coroutine to reach `currentOnHighlight` — the exact state the pause was introduced to prevent.

## Tests

- `CadenceControllerTest`: three new tests pinning `setPaused` scoped resume + cross-cause protection.
- `ContinuousReaderViewSelectionInterceptTest`: new test pinning the transition-edge callback (fires only on 0↔1 counter changes).
- `SelectionHandoffLatchTest`: four new tests pinning the handoff state machine.
- AutoScroll's `TextSelection` scoped-resume is already covered by the existing `panel open then close leaves UserPausedPill parked` test — same code path.

## Test plan

- [ ] Continuous mode: start Auto-Scroll → long-press to select text → verify scroll pauses and handles are visible; dismiss selection → scroll resumes.
- [ ] Paginated mode: start Cadence → long-press to select → same behaviour.
- [ ] Vertical (Readium scroll) mode: same behaviour.
- [ ] From an active selection, tap "Highlight" → verify no scroll-blip between the ActionMode teardown and the highlight-actions popup opening.
- [ ] Tap-outside dismiss (all three modes): pause lifts cleanly.
- [ ] Open note editor from highlight popup → scroll stays paused; close note editor → scroll resumes.