### PR TITLE
feat(library): move progress bar under cover on item detail

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemDetailScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemDetailScreen.kt
@@ -385,6 +385,14 @@ private fun LibraryItemDetailContent(
             )
         }
 
+        if (item.isListenable && item.audioDurationSec > 0) {
+            AudiobookDurationLine(item.audioDurationSec, item.readingProgress)
+        }
+
+        if (item.readingProgress > 0f) {
+            ReadingProgressIndicator(progress = item.readingProgress, listened = item.isListenable && !item.isReadable)
+        }
+
         ActionRow(
             item = item,
             isInToRead = isInToRead,
@@ -465,14 +473,6 @@ private fun LibraryItemDetailContent(
                     onClick = { showChaptersSheet = true },
                 ),
             )
-        }
-
-        if (item.isListenable && item.audioDurationSec > 0) {
-            AudiobookDurationLine(item.audioDurationSec, item.readingProgress)
-        }
-
-        if (item.readingProgress > 0f) {
-            ReadingProgressIndicator(progress = item.readingProgress, listened = item.isListenable && !item.isReadable)
         }
 
         item.description?.takeIf { it.isNotBlank() }?.let { desc ->


### PR DESCRIPTION
Moves the audiobook duration line and reading-progress bar from below the Chapters/TOC rows up to directly under the cover image (between the cover and the ActionRow). Progress is now visible at a glance without scrolling past the metadata.

No behavior change beyond visual ordering; no test added — the change is pure Compose source-order in a Column, with no logic to pin.