### PR TITLE
refactor(storage): scope Cache/Download tiers per Source; skip Cache tier for LocalFiles

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/downloads/DownloadsScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/downloads/DownloadsScreen.kt
@@ -112,26 +112,28 @@ fun DownloadsScreen(
                     }
                 }
 
-                item {
-                    SectionHeader(
-                        title = "Cached",
-                        totalLabel = if (uiState.cachedItems.isNotEmpty()) formatBytes(uiState.cachedTotalBytes) else null,
-                        actionLabel = if (uiState.cachedItems.isNotEmpty()) "Clear all" else null,
-                        onAction = { viewModel.clearAllCached() },
-                    )
-                }
-                if (uiState.cachedItems.isEmpty()) {
+                if (uiState.showCachedSection) {
                     item {
-                        EmptySection("No cached books")
-                    }
-                } else {
-                    items(uiState.cachedItems, key = { it.sourceId + "/" + it.item.id }) { entry ->
-                        LocalItemRow(
-                            entry = entry,
-                            pillColor = PillColor.Cached,
-                            onClick = { onItemSelected(entry.item) },
-                            onRemove = { viewModel.removeCachedItem(entry.sourceId, entry.item.id) },
+                        SectionHeader(
+                            title = "Cached",
+                            totalLabel = if (uiState.cachedItems.isNotEmpty()) formatBytes(uiState.cachedTotalBytes) else null,
+                            actionLabel = if (uiState.cachedItems.isNotEmpty()) "Clear all" else null,
+                            onAction = { viewModel.clearAllCached() },
                         )
+                    }
+                    if (uiState.cachedItems.isEmpty()) {
+                        item {
+                            EmptySection("No cached books")
+                        }
+                    } else {
+                        items(uiState.cachedItems, key = { it.sourceId + "/" + it.item.id }) { entry ->
+                            LocalItemRow(
+                                entry = entry,
+                                pillColor = PillColor.Cached,
+                                onClick = { onItemSelected(entry.item) },
+                                onRemove = { viewModel.removeCachedItem(entry.sourceId, entry.item.id) },
+                            )
+                        }
                     }
                 }
 

--- a/app/src/main/kotlin/com/riffle/app/feature/downloads/DownloadsViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/downloads/DownloadsViewModel.kt
@@ -5,6 +5,8 @@ import androidx.lifecycle.viewModelScope
 import com.riffle.core.domain.DownloadsRepository
 import com.riffle.core.domain.LibraryItem
 import com.riffle.core.domain.LibraryObserver
+import com.riffle.core.domain.SourceRepository
+import com.riffle.core.domain.showCachedSectionFor
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -22,6 +24,11 @@ data class DownloadsUiState(
     val downloadedItems: List<LocalItemUi> = emptyList(),
     val cachedItems: List<LocalItemUi> = emptyList(),
     val readaloudSidecars: List<LocalItemUi> = emptyList(),
+    /**
+     * Whether the active Source's storage model exposes a separate Cache tier. When false (e.g.
+     * LocalFiles, single-tier), the Downloads Screen renders one section instead of two.
+     */
+    val showCachedSection: Boolean = true,
 ) {
     val downloadedTotalBytes: Long get() = downloadedItems.sumOf { it.sizeBytes }
     val cachedTotalBytes: Long get() = cachedItems.sumOf { it.sizeBytes }
@@ -33,6 +40,7 @@ class DownloadsViewModel @Inject constructor(
     private val downloadsRepository: DownloadsRepository,
     private val libraryObserver: LibraryObserver,
     private val sidecarStore: com.riffle.core.data.ReadaloudSidecarStore,
+    private val sourceRepository: SourceRepository,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(DownloadsUiState())
@@ -69,6 +77,7 @@ class DownloadsViewModel @Inject constructor(
                 downloadedItems = downloadedItems,
                 cachedItems = cachedItems,
                 readaloudSidecars = readaloudSidecars,
+                showCachedSection = showCachedSectionFor(sourceRepository.getActive()),
             )
         }
     }

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/SourceStorageModel.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/SourceStorageModel.kt
@@ -1,0 +1,23 @@
+package com.riffle.core.domain
+
+/**
+ * Whether the Source's storage model includes an implicit, evictable **Cache** tier alongside the
+ * explicit **Download** tier (ADR 0011 / ADR 0041).
+ *
+ * Sources with a remote catalog (ABS today, OPDS/Kavita/… later) keep the two-tier split — cache is
+ * populated on open, downloads are populated by the user. LocalFiles is single-tier: bytes are
+ * copied in permanently on scan, so there's no Cache concept to expose.
+ *
+ * Consumers use this to gate cache-on-open writes and to decide the Downloads Screen section count.
+ */
+fun SourceType.hasCacheTier(): Boolean = when (this) {
+    SourceType.ABS -> true
+}
+
+/**
+ * Whether the Downloads Screen should render a separate **Cached** section for the given active
+ * Source. Null (no active source yet) preserves the current two-section layout — a UI without an
+ * active Source is transient and shouldn't flicker.
+ */
+fun showCachedSectionFor(activeSource: Source?): Boolean =
+    activeSource?.type?.hasCacheTier() ?: true

--- a/core/domain/src/test/kotlin/com/riffle/core/domain/SourceStorageModelTest.kt
+++ b/core/domain/src/test/kotlin/com/riffle/core/domain/SourceStorageModelTest.kt
@@ -1,0 +1,53 @@
+package com.riffle.core.domain
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SourceStorageModelTest {
+
+    private fun source(type: SourceType) = Source(
+        id = "s",
+        url = SourceUrl.parse("https://example.test")!!,
+        isActive = true,
+        insecureConnectionAllowed = false,
+        username = "",
+        type = type,
+    )
+
+    // ─── hasCacheTier ────────────────────────────────────────────────────────────────────────────
+    //
+    // ABS sources have a remote catalog, so cache-on-open is the two-tier storage model from
+    // ADR 0011. When LocalFiles lands (#437 / #438), it must return false here so cache-on-open is
+    // skipped and the Downloads Screen collapses to a single section. A flip on ABS would be a
+    // silent regression — the whole two-tier design assumes true.
+
+    @Test fun `ABS has a cache tier`() {
+        assertTrue(SourceType.ABS.hasCacheTier())
+    }
+
+    // ─── showCachedSectionFor ────────────────────────────────────────────────────────────────────
+
+    @Test fun `showCachedSectionFor ABS active source returns true`() {
+        assertTrue(showCachedSectionFor(source(SourceType.ABS)))
+    }
+
+    @Test fun `showCachedSectionFor null active source defaults to true`() {
+        // A null active source is a transient UI state (bootstrapping / just cleared). Defaulting
+        // to true preserves the pre-#436 two-section layout so the screen doesn't flicker sections
+        // in/out during activation.
+        assertTrue(showCachedSectionFor(null))
+    }
+
+    // Guard so a future SourceType addition can't silently reuse the ABS branch. The `when` below
+    // is exhaustive on SourceType — a new value forces the compiler to fail this file, prompting
+    // an explicit cache-tier decision alongside the enum change.
+    @Test fun `every SourceType has an explicit cache-tier decision`() {
+        for (type in SourceType.entries) {
+            val expected = when (type) {
+                SourceType.ABS -> true
+            }
+            assertEquals("SourceType.$type disagrees with hasCacheTier()", expected, type.hasCacheTier())
+        }
+    }
+}


### PR DESCRIPTION
Closes #436.

## Summary

Phase 4 of the ABS-independence rearchitecture (ADR 0041). Introduces the Source-shaped storage-model predicate that gates the two-tier Cache/Download storage model, and wires it into the Downloads Screen so LocalFiles will render a single Downloaded section when it lands in #437 / #438.

- **`SourceType.hasCacheTier()`** in `core/domain`. ABS = `true`. LocalFiles will flip to `false` when the enum grows in #438; the exhaustive `when` compile-fails to force the decision alongside the enum change.
- **`showCachedSectionFor(activeSource)`** — pure JVM-testable helper the Downloads Screen uses to decide one-vs-two sections. Null active source defaults to `true` so the screen doesn't flicker sections during activation.
- **Wire through `DownloadsViewModel`** — inject `SourceRepository`, expose `showCachedSection` on `DownloadsUiState`.
- **Gate the Cached section** in `DownloadsScreen`.
- **Per-`sourceId` file-store keying** is already in place from #451; audited and no changes needed to `LocalStoreImpl` (`dir/<sourceId>/<itemId><ext>`) or the cache-write paths in `EpubRepositoryImpl` / `PdfRepositoryImpl` (both key by `item.sourceId`).

For ABS users this is invisible — `hasCacheTier()` returns `true` and the Downloads Screen renders the same two-section layout. LocalFiles verification lands with #438.

## Regression test

`SourceStorageModelTest`:
- `ABS has a cache tier` — pins `SourceType.ABS.hasCacheTier() == true`. Flipping ABS to false would break the whole two-tier design and trip this assertion.
- `showCachedSectionFor ABS active source returns true` / `null active source defaults to true` — pin the section-count decision the Downloads Screen consumes.
- `every SourceType has an explicit cache-tier decision` — exhaustive `when` on `SourceType.entries` fails to compile when a new value is added without a matching branch, forcing an explicit choice.

## Test plan

- [x] `./gradlew :core:domain:test` green.
- [x] `./gradlew :app:compileDebugKotlin :core:data:compileDebugKotlin` green.
- [ ] CI green.