### PR TITLE
fix(reader): honour openAtCfi target when opening from Annotations View

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -2637,7 +2637,11 @@ private fun EpubNavigatorView(
                         publication = state.publication,
                         configuration = sharedEpubNavigatorConfig,
                     ).createFragmentFactory(
-                        initialLocator = latestLocator() ?: state.initialLocator,
+                        initialLocator = pickInitialLocator(
+                            focusAnnotationId = state.initialFocusAnnotationId,
+                            latest = latestLocator(),
+                            initial = state.initialLocator,
+                        ),
                         initialPreferences = formattingPrefs.toEpubPreferences(isLandscape, isFixedLayout),
                         configuration = formattingPrefs.toFragmentConfiguration(isLandscape, isFixedLayout).apply {
                             registerBundledFonts()

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/InitialLocatorSelection.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/InitialLocatorSelection.kt
@@ -1,0 +1,25 @@
+package com.riffle.app.feature.reader
+
+import org.readium.r2.shared.publication.Locator
+
+/**
+ * Picks the initial locator handed to Readium's `EpubNavigatorFragment` when the reader
+ * boots (paginated + vertical modes).
+ *
+ * Normally the last-known reading position wins so reopens land where the user left off.
+ * But when the reader was opened from an annotation tap (Annotations View → "Open in book"),
+ * [focusAnnotationId] is populated from the openAtCfi resolver, and the last-locator snapshot
+ * is unreliable — `runReaderSyncCycle` inside `openBook` writes the ABS server's last-read
+ * position into it before first composition, which then shadows the annotation target and
+ * lands the reader in the wrong chapter. The continuous renderer escapes this because its
+ * `focusAnnotationId` path centres on the actual `<mark>` element; paginated/vertical have
+ * no equivalent rescue, so we must honour [initial] directly for that flow.
+ */
+internal fun pickInitialLocator(
+    focusAnnotationId: String?,
+    latest: Locator?,
+    initial: Locator?,
+): Locator? = when {
+    focusAnnotationId != null -> initial
+    else -> latest ?: initial
+}

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/InitialLocatorSelectionTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/InitialLocatorSelectionTest.kt
@@ -1,0 +1,109 @@
+package com.riffle.app.feature.reader
+
+import android.net.FakeUri
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Test
+import org.readium.r2.shared.publication.Locator
+import org.readium.r2.shared.util.AbsoluteUrl
+import org.readium.r2.shared.util.mediatype.MediaType
+
+/**
+ * Regression coverage for the Annotations View → paginated/vertical "wrong chapter" bug.
+ *
+ * The chapter-landing symptom happened because `runReaderSyncCycle` writes the ABS last-read
+ * position into the last-locator snapshot BEFORE the AndroidView factory runs, so the older
+ * `latestLocator() ?: state.initialLocator` expression always shadowed the openAtCfi target
+ * when opening from an annotation.
+ *
+ * The assertion that flips red on revert: with a non-null focusAnnotationId, the helper must
+ * return `initial`, never `latest`.
+ */
+class InitialLocatorSelectionTest {
+
+    @Suppress("UNCHECKED_CAST")
+    private fun makeAbsoluteUrl(urlString: String): AbsoluteUrl {
+        val unsafe = Class.forName("sun.misc.Unsafe")
+            .getDeclaredField("theUnsafe")
+            .also { it.isAccessible = true }
+            .get(null) as sun.misc.Unsafe
+        val instance = unsafe.allocateInstance(AbsoluteUrl::class.java) as AbsoluteUrl
+        val uriField = AbsoluteUrl::class.java.getDeclaredField("uri")
+            .also { it.isAccessible = true }
+        uriField.set(instance, FakeUri(urlString))
+        return instance
+    }
+
+    private fun locator(href: String): Locator = Locator(
+        href = makeAbsoluteUrl("https://example.com/$href"),
+        mediaType = MediaType.XHTML,
+    )
+
+    @Test
+    fun `focus annotation forces initial locator over latest`() {
+        val latest = locator("ch5.xhtml")
+        val initial = locator("ch2.xhtml")
+        val picked = pickInitialLocator(
+            focusAnnotationId = "ann-1",
+            latest = latest,
+            initial = initial,
+        )
+        assertSame(initial, picked)
+    }
+
+    @Test
+    fun `focus annotation still returns initial when latest is null`() {
+        val initial = locator("ch2.xhtml")
+        val picked = pickInitialLocator(
+            focusAnnotationId = "ann-1",
+            latest = null,
+            initial = initial,
+        )
+        assertSame(initial, picked)
+    }
+
+    @Test
+    fun `focus annotation returns null initial as-is`() {
+        val latest = locator("ch5.xhtml")
+        val picked = pickInitialLocator(
+            focusAnnotationId = "ann-1",
+            latest = latest,
+            initial = null,
+        )
+        assertNull(picked)
+    }
+
+    @Test
+    fun `no focus annotation prefers latest over initial`() {
+        val latest = locator("ch5.xhtml")
+        val initial = locator("ch2.xhtml")
+        val picked = pickInitialLocator(
+            focusAnnotationId = null,
+            latest = latest,
+            initial = initial,
+        )
+        assertSame(latest, picked)
+    }
+
+    @Test
+    fun `no focus annotation falls back to initial when latest is null`() {
+        val initial = locator("ch2.xhtml")
+        val picked = pickInitialLocator(
+            focusAnnotationId = null,
+            latest = null,
+            initial = initial,
+        )
+        assertSame(initial, picked)
+    }
+
+    @Test
+    fun `no focus annotation and no locators returns null`() {
+        assertNull(
+            pickInitialLocator(
+                focusAnnotationId = null,
+                latest = null,
+                initial = null,
+            )
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Tapping **Open in book** from the **Annotations View** (the elided view — the reader running on `HighlightsPublicationFactory`'s synthesised publication) landed the paginated and vertical reader in the **wrong chapter**. Continuous mode was unaffected.

## Root cause

`runReaderSyncCycle` inside `openBook` writes the ABS server's last-read position into `PositionOrchestrator.lastLocator` **before** the reader's first composition. `EpubReaderScreen`'s paginated/vertical branch then booted the `EpubNavigatorFragment` at `latestLocator() ?: state.initialLocator` — so the sync-cycle-written locator shadowed the `openAtCfi` target, and the fragment opened at the user's last-read position instead of the annotation's chapter.

Continuous escaped this because its `focusAnnotationId` path in `ContinuousReaderView.openWindowAt` centres the viewport on the actual `<mark data-riffle-ann>` element and overrides the initial href/progression fallback. Paginated/vertical have no equivalent rescue.

## Fix

Extract the initial-locator decision into `pickInitialLocator(focusAnnotationId, latest, initial)` and prefer `state.initialLocator` when `state.initialFocusAnnotationId` is non-null. That id is populated exclusively by `ReaderSessionLifecycle` for `openAtCfi` targets (see `ReaderSessionLifecycle.kt:161-167`), so the change is scoped to the annotation-nav flow and leaves the normal-reopen path untouched.

## Test plan

- [x] `InitialLocatorSelectionTest` — 6 JVM tests covering the decision matrix. The load-bearing assertion (*focus annotation forces initial locator over latest*) flips red on revert.
- [ ] Install the branch on an AVD and open a highlight from Annotations View in paginated, vertical, and continuous modes — reader must land in the correct chapter in all three.