### PR TITLE
fix(reader): live-update Annotations View in continuous mode

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousNavigationView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousNavigationView.kt
@@ -26,4 +26,13 @@ internal interface ContinuousNavigationView {
 
     /** Live-update typography for the running continuous session. */
     fun updatePreferences(prefs: FormattingPreferences)
+
+    /**
+     * Apply one [com.riffle.app.feature.reader.highlights.HighlightsDomPatch] (ADR 0041) to every
+     * currently loaded chapter WebView in the sliding window. Each patch's JS looks up its target
+     * by `data-ann-id` and no-ops on chapters that don't contain it, so a fan-out broadcast is
+     * safe and works regardless of which chapter is scrolled into view. Default is a no-op so
+     * lightweight fakes for the presenter's JVM tests need not override.
+     */
+    fun applyHighlightDomPatch(patch: com.riffle.app.feature.reader.highlights.HighlightsDomPatch) {}
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
@@ -364,6 +364,10 @@ internal class ContinuousReaderView @JvmOverloads constructor(
 
     override fun scrollByPage(forward: Boolean) = controller.scrollByPage(forward)
 
+    override fun applyHighlightDomPatch(
+        patch: com.riffle.app.feature.reader.highlights.HighlightsDomPatch,
+    ) = controller.applyHighlightDomPatch(patch)
+
     override fun highlightInChapter(href: String, fragmentId: String?, text: String, cssColor: String) =
         controller.highlightInChapter(href, fragmentId, text, cssColor)
 

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousWindowController.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousWindowController.kt
@@ -141,6 +141,20 @@ internal class ContinuousWindowController(
         decorations.setCadenceOnChapterLoaded(hook)
     }
 
+    /**
+     * Fan an ADR-0041 Highlights-mode DOM patch out to every loaded chapter WebView in the sliding
+     * window. Each patch's JS resolves its target via `data-ann-id` and no-ops on chapters that
+     * don't hold the annotation, so the broadcast is safe. Paginated / vertical mode route this
+     * through [com.riffle.app.feature.reader.renderer.RendererBridge]; continuous mode must fan
+     * out here because the Readium fragment is parked at height=0 and holds no elided DOM.
+     */
+    override fun applyHighlightDomPatch(patch: com.riffle.app.feature.reader.highlights.HighlightsDomPatch) {
+        val js = patch.applyJs()
+        for (wv in webViews) {
+            wv.evaluateJavascript(js, null as ((String?) -> Unit)?)
+        }
+    }
+
 
     /** True while a window-shift operation (removeTop/removeBottom/prependChapter) is in progress. */
     private var shiftInProgress = false

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -1422,15 +1422,18 @@ private fun EpubNavigatorView(
     }
 
     // Highlights mode (ADR 0041) live DOM patches — recolour / note edit / delete of a single
-    // annotation is applied as a targeted `document.querySelector(...)` mutation on the Readium
-    // WebView, so the Annotations View refreshes IN PLACE instead of transitioning through
+    // annotation is applied as a targeted `document.querySelector(...)` mutation on the reader's
+    // WebView(s), so the Annotations View refreshes IN PLACE instead of transitioning through
     // Loading and rebuilding the whole Publication. Bytes for the affected chapter are rewritten
     // in the InMemoryContainer by the VM, so navigating chapter-back-and-forth still shows the
-    // updated HTML. Patch is a no-op in continuous mode (the fragment is null and the bridge
-    // short-circuits); continuous keeps falling back to the observer's structural reload path.
-    LaunchedEffect(rendererBridge, highlightDomPatches) {
+    // updated HTML. Dispatched via the presenter so continuous mode fans the patch out to every
+    // loaded chapter WebView (in paginated/vertical the presenter delegates to the renderer
+    // bridge). Routing through the bridge directly would silently drop the patch in continuous
+    // because its fragment is parked at height=0 — issue: Annotations View live-update was dead
+    // in continuous mode for recolour / note edit / delete.
+    LaunchedEffect(readerPresenter, highlightDomPatches) {
         highlightDomPatches.collect { patch ->
-            rendererBridge.applyHighlightDomPatch(patch)
+            readerPresenter.applyHighlightDomPatch(patch)
         }
     }
 

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/presenter/ContinuousPresenter.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/presenter/ContinuousPresenter.kt
@@ -163,6 +163,15 @@ internal class ContinuousPresenter : ReaderPresenter {
     override suspend fun measureCadenceColumns(fragmentId: String): List<Double> = emptyList()
     override suspend fun snapCadenceColumn(fragmentId: String, columnIndex: Int) = Unit
 
+    override suspend fun applyHighlightDomPatch(
+        patch: com.riffle.app.feature.reader.highlights.HighlightsDomPatch,
+    ) {
+        // Fan out to every loaded chapter WebView. The patch's `querySelector('[data-ann-id=…]')`
+        // is a no-op on chapters that don't contain the annotation, so an untargeted broadcast is
+        // safe and lets a mid-scroll patch land on whichever chapter currently owns the DOM.
+        view?.applyHighlightDomPatch(patch)
+    }
+
     // Continuous mode's chapter boundaries are tracked internally by ContinuousReaderView (window
     // shifting, infinite-scroll math), so the screen's ScrollBoundaryNavigationContainer is bypassed
     // entirely in this mode. The seam returns None so the (vertical-only) boundary-poll loop in

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/presenter/ReaderPresenter.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/presenter/ReaderPresenter.kt
@@ -124,6 +124,22 @@ internal interface ReaderPresenter {
     suspend fun snapCadenceColumn(fragmentId: String, columnIndex: Int)
 
     /**
+     * Apply one [com.riffle.app.feature.reader.highlights.HighlightsDomPatch] to the currently
+     * loaded elided-reader chapter. Idempotent by design: an unrecognised `data-ann-id` is a
+     * no-op, so it's safe to invoke against any live document.
+     *
+     * Implementations:
+     * - Paginated / vertical (Readium): delegates to
+     *   [com.riffle.app.feature.reader.renderer.RendererBridge.applyHighlightDomPatch], which
+     *   evaluates the patch JS in the single attached fragment WebView.
+     * - Continuous: fans the patch out to every loaded chapter WebView in the sliding window.
+     *   The Readium fragment is parked at height=0 in continuous mode, so routing through the
+     *   bridge would silently drop the patch — which is exactly why the Annotations View stopped
+     *   live-updating in continuous mode.
+     */
+    suspend fun applyHighlightDomPatch(patch: com.riffle.app.feature.reader.highlights.HighlightsDomPatch)
+
+    /**
      * Current native-scroll boundary state for the rendered content. Used by the vertical-mode
      * chapter-boundary gesture (ADR 0014) and by volume-key navigation to decide whether the
      * next page-step should turn the chapter or scroll within it.

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/presenter/ReadiumPresenter.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/presenter/ReadiumPresenter.kt
@@ -280,6 +280,13 @@ internal class ReadiumPresenter(
         bridge.snapCadenceColumn(fragmentId, columnIndex)
     }
 
+    override suspend fun applyHighlightDomPatch(
+        patch: com.riffle.app.feature.reader.highlights.HighlightsDomPatch,
+    ) {
+        if (fragment == null) return
+        bridge.applyHighlightDomPatch(patch)
+    }
+
     override suspend fun scrollBoundary(): ScrollBoundary {
         if (fragment == null) return ScrollBoundary.None
         val (atForward, atBackward) = bridge.scrollBoundary()

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/HighlightsLiveUpdateObserverTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/HighlightsLiveUpdateObserverTest.kt
@@ -106,6 +106,28 @@ class HighlightsLiveUpdateObserverTest {
     }
 
     @Test
+    fun `screen dispatches DOM patches through the presenter, not the renderer bridge`() {
+        // Regression guard for the "Annotations View live-update dead in continuous mode" bug.
+        // RendererBridge wraps only Readium's EpubNavigatorFragment; in continuous mode the
+        // fragment is parked at height=0 and holds no elided DOM, so a bridge-only dispatch
+        // silently drops every non-structural patch. Routing through ReaderPresenter lets
+        // ContinuousPresenter fan the patch out to its live chapter WebViews.
+        val screen = File("src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt")
+            .let { if (it.exists()) it else File("app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt") }
+        val text = screen.readText()
+        assertTrue(
+            "EpubReaderScreen must dispatch highlightDomPatches through readerPresenter." +
+                "applyHighlightDomPatch — a bridge-only dispatch drops the patch in continuous mode.",
+            text.contains("readerPresenter.applyHighlightDomPatch("),
+        )
+        assertFalse(
+            "EpubReaderScreen must NOT dispatch highlightDomPatches via rendererBridge directly; " +
+                "the bridge is Readium-only and silently drops patches in continuous mode.",
+            text.contains("rendererBridge.applyHighlightDomPatch("),
+        )
+    }
+
+    @Test
     fun `mutation methods do not fire reloadHighlightsView directly anymore`() {
         val source = vmSource()
         val names = listOf(

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/presenter/ContinuousPresenterTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/presenter/ContinuousPresenterTest.kt
@@ -1,6 +1,7 @@
 package com.riffle.app.feature.reader.presenter
 
 import com.riffle.app.feature.reader.ContinuousNavigationView
+import com.riffle.app.feature.reader.highlights.HighlightsDomPatch
 import com.riffle.core.domain.FormattingPreferences
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.launch
@@ -27,6 +28,7 @@ class ContinuousPresenterTest {
         data class NavCall(val href: String, val progression: Float, val alignToTop: Boolean)
         val navCalls: MutableList<NavCall> = mutableListOf()
         val pageCalls: MutableList<Boolean> = mutableListOf()
+        val domPatches: MutableList<HighlightsDomPatch> = mutableListOf()
         override fun navigateTo(href: String, progression: Float, alignToTop: Boolean) {
             navCalls += NavCall(href, progression, alignToTop)
         }
@@ -34,6 +36,9 @@ class ContinuousPresenterTest {
             pageCalls += forward
         }
         override fun updatePreferences(prefs: FormattingPreferences) = Unit
+        override fun applyHighlightDomPatch(patch: HighlightsDomPatch) {
+            domPatches += patch
+        }
     }
 
     @Test
@@ -246,6 +251,38 @@ class ContinuousPresenterTest {
 
         assertEquals(listOf("ch2.xhtml" to 0.25), collected)
         job.cancel()
+    }
+
+    // Regression guard for the "Annotations View live-update dead in continuous mode" bug.
+    // Before this fix, DOM patches from EpubReaderViewModel's Highlights-mode observer were
+    // dispatched via RendererBridge only, which wraps Readium's EpubNavigatorFragment. In
+    // continuous mode the fragment is parked at height=0 and holds no elided DOM, so patches
+    // silently disappeared and recolour / note-edit / delete never repainted the Annotations
+    // View. The presenter now owns the seam and continuous mode fans out to its live chapter
+    // WebViews — reverting to a bridge-only dispatch would break this test.
+    @Test
+    fun `applyHighlightDomPatch forwards patches to the attached continuous view`() = runTest {
+        val presenter = ContinuousPresenter()
+        val view = FakeView()
+        presenter.attach(view)
+
+        val recolor = HighlightsDomPatch.Recolor("ann-1", "rgba(255,255,0,0.4)")
+        val setNote = HighlightsDomPatch.SetNote("ann-2", "rgba(255,255,0,0.4)", "hello")
+        val remove = HighlightsDomPatch.Remove("ann-3")
+
+        presenter.applyHighlightDomPatch(recolor)
+        presenter.applyHighlightDomPatch(setNote)
+        presenter.applyHighlightDomPatch(remove)
+
+        assertEquals(listOf(recolor, setNote, remove), view.domPatches)
+    }
+
+    @Test
+    fun `applyHighlightDomPatch is a no-op before attach`() = runTest {
+        val presenter = ContinuousPresenter()
+        // No exception, no observable effect when the view isn't bound yet — mirrors the
+        // navigate/scrollByPage safety contract elsewhere on the presenter.
+        presenter.applyHighlightDomPatch(HighlightsDomPatch.Remove("ann-1"))
     }
 
     @Test

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/presenter/FakeReaderPresenter.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/presenter/FakeReaderPresenter.kt
@@ -92,6 +92,14 @@ internal class FakeReaderPresenter : ReaderPresenter {
     var scrollBoundaryResult: ScrollBoundary = ScrollBoundary.None
     override suspend fun scrollBoundary(): ScrollBoundary = scrollBoundaryResult
 
+    val recordedHighlightDomPatches: MutableList<com.riffle.app.feature.reader.highlights.HighlightsDomPatch> =
+        mutableListOf()
+    override suspend fun applyHighlightDomPatch(
+        patch: com.riffle.app.feature.reader.highlights.HighlightsDomPatch,
+    ) {
+        recordedHighlightDomPatches += patch
+    }
+
     // ----- Event drivers (for tests) -------------------------------------------------------
 
     suspend fun emitPosition(position: ReaderPosition) {


### PR DESCRIPTION
## Summary

Recolour / note-edit / delete in the Annotations View (ADR 0041) stopped repainting live in **continuous** reading mode after #464. Paginated and vertical modes were fine — the bug was continuous-only.

**Root cause.** `EpubReaderScreen`'s `LaunchedEffect` dispatched every `HighlightsDomPatch` through `RendererBridge.applyHighlightDomPatch`, which is a thin wrapper around `fragment?.evaluateJavascript(...)` on Readium's `EpubNavigatorFragment`. In continuous mode the Readium fragment is parked at height=0 and holds no elided DOM, so every non-structural patch became a silent no-op. The comment above the effect claimed "continuous keeps falling back to the observer's structural reload path" — but the observer only falls back on **structural** diffs (add / chapter-emptied / cross-chapter move). Recolour, note-edit, and delete-with-peers-remaining emit `HighlightsDomPatch`es and no reload — so in continuous mode those edits stayed invisible until the user scrolled the chapter out and back in (fresh HTML fetch from the rewritten bytes).

**Fix.** Move the dispatch onto `ReaderPresenter` so each mode picks its own sink:

- `ReadiumPresenter` delegates to `RendererBridge` (unchanged path).
- `ContinuousPresenter` forwards to `ContinuousNavigationView.applyHighlightDomPatch`, which delegates through `ContinuousReaderView` into `ContinuousWindowController`; the controller fans `patch.applyJs()` out to every loaded `ChapterWebView` in the sliding window. The patch JS resolves its target by `data-ann-id`, so a broadcast is safe — chapters that don't hold the annotation no-op.

The Readium-only rendering seam (RendererBridge) stays Readium-only, matching the file's own docstring; the mode fork lives where the interface already forks (ReaderPresenter).

## Tests

- `ContinuousPresenterTest` gains two tests: `applyHighlightDomPatch` forwards `Recolor` / `SetNote` / `Remove` patches to the attached `ContinuousNavigationView`; it's a safe no-op before attach.
- `HighlightsLiveUpdateObserverTest` gains a source-scan assertion that `EpubReaderScreen` dispatches via `readerPresenter.applyHighlightDomPatch(` and does NOT call `rendererBridge.applyHighlightDomPatch(` — a revert to the bridge-only dispatch fails at build time.

Full `:app:testDebugUnitTest` green.

## Test plan

- [ ] Continuous mode: open Annotations View; recolour a highlight → colour bar updates in place, no Loading flash.
- [ ] Continuous mode: edit a note on a highlight → aside text/border updates in place.
- [ ] Continuous mode: delete a highlight (not the last one on its chapter) → the paragraph and aside disappear in place.
- [ ] Continuous mode: delete the last highlight in a chapter → spine shrinks (structural fallback path, existing behaviour).
- [ ] Paginated + vertical modes: same three operations still work (no regression on the unchanged path).