### PR TITLE
fix(reader): re-land on focused annotation across every target remeasure in continuous mode

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousWindowController.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousWindowController.kt
@@ -588,21 +588,35 @@ internal class ContinuousWindowController(
             "onAnnotationHighlightsApplied href='${wv.chapterHref}' matchesPendingTarget=$matches pendingTargetHref='$pendingTargetHref'"
         }
         if (!matches) return
-        reapplyLandingAfterFallback?.invoke()
-        scrollToPendingFocusAnnotation(wv.chapterHref)
+        val annotationReland = annotationFocusRelandClosure(
+            pendingFocusAnnotationId = pendingFocusAnnotationId,
+            chapterHref = wv.chapterHref,
+            landOnAnnotation = ::scrollToFocusAnnotation,
+        )
+        if (annotationReland != null) {
+            // Promote the annotation-focus landing to be the re-land closure so subsequent
+            // target-height remeasures (typography settle, late image decodes, style re-injection)
+            // re-land on the annotation's current offset rather than on the paragraph anchor.
+            // Without this, the anchor-based `reapplyLandingAfterFallback` invoked from
+            // appendChapter's onHeightMeasured loop yanks the scroll off the annotation whenever
+            // the target chapter reflows.
+            reapplyLandingAfterFallback = annotationReland
+            annotationReland()
+            pendingFocusAnnotationId = null
+        } else {
+            reapplyLandingAfterFallback?.invoke()
+        }
     }
 
-    private fun scrollToPendingFocusAnnotation(href: String) {
-        val id = pendingFocusAnnotationId ?: return
+    private fun scrollToFocusAnnotation(href: String, id: String) {
         val wv = webViewIndexFor(href)?.let { webViews.getOrNull(it) } ?: return
         wv.annotationOffsetTopDevicePx(id) { annOffset ->
             if (annOffset == null) return@annotationOffsetTopDevicePx
-            val i = pendingTargetHref?.let { webViewIndexFor(it) } ?: return@annotationOffsetTopDevicePx
+            val i = webViewIndexFor(href) ?: return@annotationOffsetTopDevicePx
             val slot = buildWindow().getOrNull(i) ?: return@annotationOffsetTopDevicePx
             val y = (slot.top + annOffset).coerceAtLeast(0)
             clearLandingHold()
             port.post { port.scrollTo(y) }
-            pendingFocusAnnotationId = null
         }
     }
 
@@ -832,6 +846,30 @@ internal class ContinuousWindowController(
         if (href.isEmpty()) return
         onViewportFractionMeasured(href, vh.toDouble() / measuredPx)
     }
+}
+
+/**
+ * Given the state at `onAnnotationHighlightsApplied`, produce the closure that
+ * [ContinuousWindowController] should install as `reapplyLandingAfterFallback` so subsequent
+ * target-height remeasures re-land on the annotation's current offset (typography settle, late
+ * image decodes, style re-injection can all shift the annotation after the initial land).
+ *
+ * Returns:
+ *  - a closure that invokes [landOnAnnotation] when a focus id is pending — the caller installs
+ *    it AND invokes it once immediately; the height-change loop in `appendChapter.onHeightMeasured`
+ *    then re-invokes it on every subsequent remeasure of the target chapter until height stabilises.
+ *  - `null` when no focus id is pending — the caller keeps the existing paragraph-anchor closure.
+ *
+ * Extracted as a top-level `internal` function so the decision is JVM-testable:
+ * [ContinuousWindowController] requires an Android `Context` to construct.
+ */
+internal fun annotationFocusRelandClosure(
+    pendingFocusAnnotationId: String?,
+    chapterHref: String,
+    landOnAnnotation: (href: String, id: String) -> Unit,
+): (() -> Unit)? {
+    val id = pendingFocusAnnotationId ?: return null
+    return { landOnAnnotation(chapterHref, id) }
 }
 
 /**

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/session/regressions/ContinuousAnnotationFocusReflowRaceTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/session/regressions/ContinuousAnnotationFocusReflowRaceTest.kt
@@ -1,7 +1,10 @@
 package com.riffle.app.feature.reader.session.regressions
 
 import com.riffle.app.feature.reader.ContinuousPositionTracker
+import com.riffle.app.feature.reader.annotationFocusRelandClosure
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -232,6 +235,113 @@ class ContinuousAnnotationFocusReflowRaceTest {
         val fired = sm.onHeightMeasured("ch1.xhtml", 800)
         assertEquals("Re-land must NOT fire after disarm", false, fired)
         assertEquals(0, fireCount)
+    }
+
+    // ---------------------------------------------------------------------------
+    // 3. Annotation-focus reland decision
+    //
+    // Regression coverage for the one-shot bug in `onAnnotationHighlightsApplied`:
+    // before the fix, the focus-annotation scroll fired once and nulled
+    // `pendingFocusAnnotationId`, leaving `reapplyLandingAfterFallback` pointed at the
+    // paragraph-anchor closure. Any subsequent target-height remeasure then re-landed
+    // on the paragraph anchor and knocked the reader off the annotation.
+    //
+    // Post-fix, `annotationFocusRelandClosure` returns a NEW closure (calling
+    // `landOnAnnotation` with the target chapter's href + the focus id) that the caller
+    // installs as `reapplyLandingAfterFallback`, so the existing height-change loop in
+    // `appendChapter.onHeightMeasured` re-lands on the annotation offset on every
+    // target remeasure until height stabilises.
+    // ---------------------------------------------------------------------------
+
+    @Test
+    fun `annotationFocusRelandClosure returns null when no focus id is pending`() {
+        val closure = annotationFocusRelandClosure(
+            pendingFocusAnnotationId = null,
+            chapterHref = "ch1.xhtml",
+            landOnAnnotation = { _, _ -> },
+        )
+        assertNull("With no focus id the anchor reland must be left in place", closure)
+    }
+
+    @Test
+    fun `annotationFocusRelandClosure returns a closure that lands on the annotation when a focus id is pending`() {
+        val calls = mutableListOf<Pair<String, String>>()
+        val closure = annotationFocusRelandClosure(
+            pendingFocusAnnotationId = "ann-42",
+            chapterHref = "ch1.xhtml",
+            landOnAnnotation = { href, id -> calls.add(href to id) },
+        )
+        assertNotNull("With a focus id, must return a non-null reland closure", closure)
+        closure!!.invoke()
+        assertEquals(1, calls.size)
+        assertEquals("ch1.xhtml" to "ann-42", calls[0])
+    }
+
+    @Test
+    fun `annotationFocusRelandClosure is NOT one-shot — repeated invocations each land on the annotation`() {
+        val calls = mutableListOf<Pair<String, String>>()
+        val closure = annotationFocusRelandClosure(
+            pendingFocusAnnotationId = "ann-42",
+            chapterHref = "ch1.xhtml",
+            landOnAnnotation = { href, id -> calls.add(href to id) },
+        )!!
+        // The remeasure loop invokes the closure on every target-height change. If the closure
+        // is one-shot (the pre-fix bug) the loop stops re-landing on the annotation after the
+        // first fire and the reader drifts off the annotation as the target reflows.
+        closure()
+        closure()
+        closure()
+        assertEquals("Every remeasure must re-land on the annotation", 3, calls.size)
+        assertTrue(
+            "Every invocation must land on the same annotation on the same chapter",
+            calls.all { it == "ch1.xhtml" to "ann-42" },
+        )
+    }
+
+    /**
+     * End-to-end model of the fix: an anchor-based reland is initially armed. When highlights
+     * apply for the target chapter with a focus id pending, the reland closure is swapped for
+     * the annotation-based one. A subsequent target-height remeasure invokes the NEW closure,
+     * which calls `landOnAnnotation` — proving the anchor reland has been replaced.
+     *
+     * Before the fix, `reapplyLandingAfterFallback` was NOT swapped; the height-change loop
+     * kept invoking the anchor closure, and `landOnAnnotation` was never called on remeasure.
+     */
+    @Test
+    fun `after highlights apply with focus id, the height-change loop re-lands on the annotation`() {
+        val anchorLandings = mutableListOf<Int>()
+        val annotationLandings = mutableListOf<Pair<String, String>>()
+        val sm = ReapplyStateMachine(
+            targetHref = "ch1.xhtml",
+            initialHeightPx = 400,
+            onReland = { h -> anchorLandings.add(h) },
+        )
+
+        // Simulate onAnnotationHighlightsApplied: focus id is pending, compute the new reland
+        // closure and swap it into place (mirrors ContinuousWindowController lines 591-603).
+        val annotationReland = annotationFocusRelandClosure(
+            pendingFocusAnnotationId = "ann-42",
+            chapterHref = "ch1.xhtml",
+            landOnAnnotation = { href, id -> annotationLandings.add(href to id) },
+        )!!
+        sm.reapplyLandingAfterFallback = annotationReland
+        annotationReland()  // initial invocation
+
+        // Target chapter reflows further after highlights applied.
+        assertTrue(sm.onHeightMeasured("ch1.xhtml", 650))
+        assertTrue(sm.onHeightMeasured("ch1.xhtml", 800))
+
+        assertEquals(
+            "The anchor closure MUST NOT be invoked after highlights apply — the swap replaces it",
+            0,
+            anchorLandings.size,
+        )
+        assertEquals(
+            "Every remeasure of the target must re-land on the annotation (1 initial + 2 remeasures)",
+            3,
+            annotationLandings.size,
+        )
+        assertTrue(annotationLandings.all { it == "ch1.xhtml" to "ann-42" })
     }
 
     @Test


### PR DESCRIPTION
## Why

Post-merge harness run [28960174301](https://github.com/pkmetski/riffle/actions/runs/28960174301) failed on `AnnotationFocusHarnessTest.continuousMode_annotationTap_focusesAnnotationOnScreen`:

```
Continuous attempt 3: annotated phrase not focused on screen.
phraseScreen=(52.4, 4925.7) content=[0,0 +1080x1920]
wvLoc=(0,-3462) rect=(20.0,3198.0) iw/ih=(412.0,684.0) wv=1080x1794
```

The phrase ended up ~3000 px below the viewport bottom after focus — a classic reflow race. In continuous mode, `ContinuousWindowController.onAnnotationHighlightsApplied` scrolled once to the focus annotation and nulled `pendingFocusAnnotationId`, but left `reapplyLandingAfterFallback` pointed at the paragraph-anchor closure from the initial land. Any subsequent target-chapter remeasure (typography settle, late image decode, style re-injection) then invoked the anchor closure via the reland loop in `appendChapter.onHeightMeasured`, yanking the reader off the annotation.

`ChapterWebView.annotationOffsetTopDevicePx`'s docstring even states the intended contract: *"the reflow-tracking re-land re-fires this query on every target remeasure so once the mark appears, the landing snaps onto it"* — but the controller only wired this for the initial (anchor) land, not for the annotation land.

## What

When `onAnnotationHighlightsApplied` fires with a focus id pending, install a new annotation-focus closure into `reapplyLandingAfterFallback` so every subsequent target remeasure re-lands on the annotation's current offset until height stabilises. Decision extracted as a top-level `internal fun annotationFocusRelandClosure(...)` — `ContinuousWindowController` needs an Android `Context` and can't be JVM-constructed, so the branch decision is tested in isolation.

## Tests

`ContinuousAnnotationFocusReflowRaceTest` gains four cases:

- `null` when no focus id pending → caller keeps the anchor closure.
- Non-null closure that calls `landOnAnnotation("ch1.xhtml", "ann-42")` when invoked.
- Closure is NOT one-shot — three invocations produce three landings.
- End-to-end model using the existing `ReapplyStateMachine` mirror: after highlights apply with focus id, target-height changes fire the annotation closure, not the anchor.

Full JVM suite green locally (`./gradlew test`). The instrumentation test that flaked will exercise the fixed path on CI.

## Blast radius

Continuous-mode annotation focus only. Non-annotation resumes (progression/anchor) fall through the `null` branch and use the existing anchor closure unchanged. Mid-session `scrollToLoadedChapter` (lines 544-555) has an analogous one-shot annotation branch that this PR doesn't touch — a candidate follow-up. Paginated & vertical modes use Readium's `EpubNavigatorFragment`, entirely separate code.

Not opened from a GitHub Issue, so no `Closes #N`.