### PR TITLE
fix(reader): smoother volume-key page scroll in continuous mode

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousPositionTracker.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousPositionTracker.kt
@@ -107,11 +107,14 @@ internal object ContinuousPositionTracker {
     }
 
     /**
-     * Pixels to scroll for a volume-key "page" in continuous mode: one viewport minus a small overlap
-     * so the line at the seam isn't skipped. Returns 0 for a non-positive viewport.
+     * Pixels to scroll for a volume-key "page" in continuous mode: one viewport minus overlap so the
+     * line at the seam isn't skipped. Matches the 0·8-viewport delta the paginated/vertical volume-key
+     * path uses via [ScrollBoundaryNavigationContainer.handleVolumeScroll] — keeping both modes on the
+     * same step size is what makes rapid presses feel identical instead of "faster" in one mode.
+     * Returns 0 for a non-positive viewport.
      */
     fun pageScrollDelta(viewportHeightPx: Int): Int =
-        if (viewportHeightPx <= 0) 0 else (viewportHeightPx * 0.9f).toInt()
+        if (viewportHeightPx <= 0) 0 else (viewportHeightPx * 0.8f).toInt()
 
     /**
      * Resolve a text selection to the narrated-sentence id whose sentence contains it, for

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
@@ -62,6 +62,8 @@ internal class ContinuousReaderView @JvmOverloads constructor(
         override fun scrollBy(dy: Int) = this@ContinuousReaderView.scrollBy(0, dy)
         override fun smoothScrollTo(y: Int) = this@ContinuousReaderView.smoothScrollTo(0, y)
         override fun smoothScrollBy(dy: Int) = this@ContinuousReaderView.smoothScrollBy(0, dy)
+        override fun smoothScrollBy(dy: Int, durationMs: Int) =
+            this@ContinuousReaderView.smoothScrollBy(0, dy, durationMs)
         override fun abortFling() = this@ContinuousReaderView.abortFling()
         override fun post(block: () -> Unit) { this@ContinuousReaderView.post(block) }
         override fun postOnAnimation(block: () -> Unit) { this@ContinuousReaderView.postOnAnimation(block) }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
@@ -58,6 +58,8 @@ internal class ContinuousReaderView @JvmOverloads constructor(
     private val port = object : ContinuousScrollPort {
         override val viewportHeightPx: Int get() = height
         override val currentScrollY: Int get() = scrollY
+        override val maxScrollY: Int get() =
+            (computeVerticalScrollRange() - computeVerticalScrollExtent()).coerceAtLeast(0)
         override fun scrollTo(y: Int) = this@ContinuousReaderView.scrollTo(0, y)
         override fun scrollBy(dy: Int) = this@ContinuousReaderView.scrollBy(0, dy)
         override fun smoothScrollTo(y: Int) = this@ContinuousReaderView.smoothScrollTo(0, y)

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
@@ -58,8 +58,10 @@ internal class ContinuousReaderView @JvmOverloads constructor(
     private val port = object : ContinuousScrollPort {
         override val viewportHeightPx: Int get() = height
         override val currentScrollY: Int get() = scrollY
+        // computeVerticalScrollRange/Extent are @RestrictedApi on NestedScrollView; the equivalent
+        // for a NestedScrollView with a single vertical LinearLayout child is (child.height - viewport).
         override val maxScrollY: Int get() =
-            (computeVerticalScrollRange() - computeVerticalScrollExtent()).coerceAtLeast(0)
+            ((getChildAt(0)?.height ?: 0) - height).coerceAtLeast(0)
         override fun scrollTo(y: Int) = this@ContinuousReaderView.scrollTo(0, y)
         override fun scrollBy(dy: Int) = this@ContinuousReaderView.scrollBy(0, dy)
         override fun smoothScrollTo(y: Int) = this@ContinuousReaderView.smoothScrollTo(0, y)

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousWindowController.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousWindowController.kt
@@ -36,6 +36,9 @@ internal class ContinuousWindowController(
      * NOT be invoked from scroll callbacks — see the flake-avoidance rules in the issue.
      */
     private val onViewportFractionMeasured: (href: String, fraction: Double) -> Unit = { _, _ -> },
+    /** Injectable clock so [PageScrollCoalescer]'s validity window is testable without touching
+     *  Android SDK time APIs. Defaults to [android.os.SystemClock.uptimeMillis] in production. */
+    private val nowMs: () -> Long = { android.os.SystemClock.uptimeMillis() },
 ) : ContinuousHighlightTarget, ContinuousNavigationView {
 
     companion object {
@@ -58,6 +61,14 @@ internal class ContinuousWindowController(
         /** How long after the initial land to override framework smooth-scroll restoration of a
          *  stale scrollY. */
         private const val LANDING_HOLD_MS = 600L
+
+        /**
+         * Fixed animation duration for a volume-key page scroll. Matches the Chromium `behavior:
+         * 'smooth'` scroll duration used by paginated/vertical mode via [ScrollBoundaryNavigationContainer]
+         * closely enough that rapid presses feel the same in both modes. Also the validity window for
+         * [PageScrollCoalescer], so a new press coalesces iff its predecessor is still animating.
+         */
+        internal const val PAGE_SCROLL_DURATION_MS = 300
     }
 
     /** The [LinearLayout] the [ContinuousReaderView] wraps; controller owns and mutates its children. */
@@ -572,12 +583,20 @@ internal class ContinuousWindowController(
         }
     }
 
-    /** Scroll one viewport-page forward/backward (wired to the volume keys). */
+    /** Scroll one viewport-page forward/backward (wired to the volume keys). Rapid presses coalesce
+     *  through [pageScrollCoalescer] so each new press extends the in-flight animation's target
+     *  rather than restarting from the current (still-animating) position. */
     override fun scrollByPage(forward: Boolean) {
         val delta = ContinuousPositionTracker.pageScrollDelta(port.viewportHeightPx)
+        if (delta == 0) return
         clearLandingHold()
-        port.smoothScrollBy(if (forward) delta else -delta)
+        val signedDelta = if (forward) delta else -delta
+        val current = port.currentScrollY
+        val target = pageScrollCoalescer.computeTarget(current, signedDelta, nowMs())
+        port.smoothScrollBy(target - current, PAGE_SCROLL_DURATION_MS)
     }
+
+    private val pageScrollCoalescer = PageScrollCoalescer(PAGE_SCROLL_DURATION_MS.toLong())
 
     override fun highlightInChapter(href: String, fragmentId: String?, text: String, cssColor: String) {
         decorations.highlightInChapter(href, fragmentId, text, cssColor)
@@ -815,6 +834,9 @@ internal class ContinuousWindowController(
         pendingFocusAnnotationId = null
         landingHoldTargetY = -1
         landingHoldUntilUptimeMs = 0L
+        // A manual scroll may leave [port.currentScrollY] far from the coalescer's pending target;
+        // reset so the next volume press bases its animation on the user's new position.
+        pageScrollCoalescer.reset()
     }
 
     /**
@@ -897,6 +919,10 @@ internal interface ContinuousScrollPort {
     fun scrollBy(dy: Int)
     fun smoothScrollTo(y: Int)
     fun smoothScrollBy(dy: Int)
+    /** Fixed-duration variant used by the volume-key page-scroll path so consecutive presses share a
+     *  predictable animation length instead of NestedScrollView's velocity-derived default (which
+     *  makes rapid presses stutter as each new animation restarts from the current position). */
+    fun smoothScrollBy(dy: Int, durationMs: Int)
     fun abortFling()
     fun post(block: () -> Unit)
     fun postOnAnimation(block: () -> Unit)

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousWindowController.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousWindowController.kt
@@ -592,7 +592,13 @@ internal class ContinuousWindowController(
         clearLandingHold()
         val signedDelta = if (forward) delta else -delta
         val current = port.currentScrollY
-        val target = pageScrollCoalescer.computeTarget(current, signedDelta, nowMs())
+        val target = pageScrollCoalescer.computeTarget(
+            currentScrollY = current,
+            dy = signedDelta,
+            nowMs = nowMs(),
+            minScrollY = 0,
+            maxScrollY = port.maxScrollY,
+        )
         port.smoothScrollBy(target - current, PAGE_SCROLL_DURATION_MS)
     }
 
@@ -915,6 +921,10 @@ internal fun annotationFocusRelandClosure(
 internal interface ContinuousScrollPort {
     val viewportHeightPx: Int
     val currentScrollY: Int
+    /** Maximum scrollable Y (content height minus viewport, floor 0). Used to clamp coalesced
+     *  page-scroll targets so a run of volume presses at end-of-content doesn't leave a phantom
+     *  target far past the actual max, which would silently absorb the first reversal press. */
+    val maxScrollY: Int
     fun scrollTo(y: Int)
     fun scrollBy(dy: Int)
     fun smoothScrollTo(y: Int)

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/PageScrollCoalescer.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/PageScrollCoalescer.kt
@@ -1,0 +1,38 @@
+package com.riffle.app.feature.reader
+
+/**
+ * Merges consecutive volume-key page-scroll presses that land while a smooth-scroll animation is
+ * still in flight. Without coalescing, each new press restarts the animation from the current
+ * (still-animating) scroll position, so a run of quick taps stutters instead of gliding — the
+ * jankier feel that separates continuous mode from vertical mode's Chromium `behavior: 'smooth'`
+ * scroll (which coalesces natively).
+ *
+ * Not thread-safe; expected to be called from the main thread.
+ *
+ * @param validityWindowMs how long a computed target stays "in flight" — should match the smooth-
+ *   scroll animation duration passed to the port. A press arriving inside this window extends the
+ *   previous target; a press arriving after resets to the current scroll position.
+ */
+internal class PageScrollCoalescer(private val validityWindowMs: Long) {
+
+    private var pendingTargetY: Int = 0
+    private var validUntilMs: Long = Long.MIN_VALUE
+
+    /**
+     * Absolute scroll target for a new page-scroll press. If a previous press is still in flight
+     * (elapsed since it was computed < [validityWindowMs]), extends that target by [dy]; otherwise
+     * bases the target on [currentScrollY].
+     */
+    fun computeTarget(currentScrollY: Int, dy: Int, nowMs: Long): Int {
+        val base = if (nowMs < validUntilMs) pendingTargetY else currentScrollY
+        val target = base + dy
+        pendingTargetY = target
+        validUntilMs = nowMs + validityWindowMs
+        return target
+    }
+
+    /** Drop any pending target — e.g. the user touched the view so a manual scroll takes over. */
+    fun reset() {
+        validUntilMs = Long.MIN_VALUE
+    }
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/PageScrollCoalescer.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/PageScrollCoalescer.kt
@@ -21,11 +21,20 @@ internal class PageScrollCoalescer(private val validityWindowMs: Long) {
     /**
      * Absolute scroll target for a new page-scroll press. If a previous press is still in flight
      * (elapsed since it was computed < [validityWindowMs]), extends that target by [dy]; otherwise
-     * bases the target on [currentScrollY].
+     * bases the target on [currentScrollY]. The result is clamped to [[minScrollY], [maxScrollY]] so
+     * repeated presses at a content boundary cannot leave a phantom target beyond the scrollable
+     * range — otherwise the first reversal press would silently spend itself unwinding the phantom
+     * before the user saw any motion.
      */
-    fun computeTarget(currentScrollY: Int, dy: Int, nowMs: Long): Int {
+    fun computeTarget(
+        currentScrollY: Int,
+        dy: Int,
+        nowMs: Long,
+        minScrollY: Int = Int.MIN_VALUE,
+        maxScrollY: Int = Int.MAX_VALUE,
+    ): Int {
         val base = if (nowMs < validUntilMs) pendingTargetY else currentScrollY
-        val target = base + dy
+        val target = (base + dy).coerceIn(minScrollY, maxScrollY)
         pendingTargetY = target
         validUntilMs = nowMs + validityWindowMs
         return target

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousPositionTrackerTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousPositionTrackerTest.kt
@@ -375,7 +375,10 @@ class ContinuousPositionTrackerTest {
 
     @Test
     fun `pageScrollDelta is a viewport minus a small overlap`() {
-        assertEquals(900, ContinuousPositionTracker.pageScrollDelta(1000))
+        // 0·8 of the viewport — matches the paginated/vertical volume-key path so rapid presses
+        // travel the same distance in both reader modes. Regression pin: if this drifts back to
+        // 0·9, the assertion flips red.
+        assertEquals(800, ContinuousPositionTracker.pageScrollDelta(1000))
     }
 
     @Test

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/PageScrollCoalescerTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/PageScrollCoalescerTest.kt
@@ -39,6 +39,31 @@ class PageScrollCoalescerTest {
     }
 
     @Test
+    fun `pending target clamps at maxScrollY so end-of-content presses don't accumulate a phantom`() {
+        val c = PageScrollCoalescer(validityWindowMs = 300L)
+        // User is at end of content (currentScrollY == maxScrollY == 5000). Volume-forward presses
+        // fired rapidly must NOT accumulate a pending target past 5000 — otherwise a subsequent
+        // backward press would first have to unwind the phantom before the user saw any motion.
+        c.computeTarget(currentScrollY = 5000, dy = 800, nowMs = 0L, maxScrollY = 5000)
+        c.computeTarget(currentScrollY = 5000, dy = 800, nowMs = 50L, maxScrollY = 5000)
+        c.computeTarget(currentScrollY = 5000, dy = 800, nowMs = 100L, maxScrollY = 5000)
+        // First backward press: pending is clamped at 5000, so target = 5000 - 800 = 4200. Without
+        // the clamp, target would be 5000 + 3*800 - 800 = 6600 — still forward, no visible motion.
+        val target = c.computeTarget(currentScrollY = 5000, dy = -800, nowMs = 150L, maxScrollY = 5000)
+        assertEquals(4200, target)
+    }
+
+    @Test
+    fun `pending target clamps at minScrollY so start-of-content presses don't accumulate a phantom`() {
+        val c = PageScrollCoalescer(validityWindowMs = 300L)
+        // Symmetric to the end-of-content case, at scrollY=0.
+        c.computeTarget(currentScrollY = 0, dy = -800, nowMs = 0L, minScrollY = 0)
+        c.computeTarget(currentScrollY = 0, dy = -800, nowMs = 50L, minScrollY = 0)
+        val target = c.computeTarget(currentScrollY = 0, dy = 800, nowMs = 100L, minScrollY = 0)
+        assertEquals(800, target)
+    }
+
+    @Test
     fun `backward press inside validity window extends target backwards`() {
         val c = PageScrollCoalescer(validityWindowMs = 300L)
         // First backward press: pending target = 5000 - 800 = 4200.

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/PageScrollCoalescerTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/PageScrollCoalescerTest.kt
@@ -1,0 +1,49 @@
+package com.riffle.app.feature.reader
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class PageScrollCoalescerTest {
+
+    @Test
+    fun `first press bases target on current scroll position`() {
+        val c = PageScrollCoalescer(validityWindowMs = 300L)
+        assertEquals(1000 + 800, c.computeTarget(currentScrollY = 1000, dy = 800, nowMs = 0L))
+    }
+
+    @Test
+    fun `press inside validity window extends the previous target instead of restarting`() {
+        val c = PageScrollCoalescer(validityWindowMs = 300L)
+        c.computeTarget(currentScrollY = 1000, dy = 800, nowMs = 0L)
+        // Second press arrives mid-animation. Current scrollY has moved to 1400 (60% through the
+        // first animation). Without coalescing, target would be 1400 + 800 = 2200 — the animation
+        // "resets" and loses the queued extra viewport. With coalescing, target is 1800 + 800 = 2600
+        // so the smooth-scroll extends past the previous target without a restart.
+        assertEquals(2600, c.computeTarget(currentScrollY = 1400, dy = 800, nowMs = 100L))
+    }
+
+    @Test
+    fun `press after validity window resets base to current scroll position`() {
+        val c = PageScrollCoalescer(validityWindowMs = 300L)
+        c.computeTarget(currentScrollY = 1000, dy = 800, nowMs = 0L)
+        // First animation is long done; the user's finger position is authoritative again.
+        assertEquals(5000 + 800, c.computeTarget(currentScrollY = 5000, dy = 800, nowMs = 1000L))
+    }
+
+    @Test
+    fun `reset drops the pending target so next press restarts from current`() {
+        val c = PageScrollCoalescer(validityWindowMs = 300L)
+        c.computeTarget(currentScrollY = 1000, dy = 800, nowMs = 0L)
+        c.reset() // e.g. user touched the view to scroll manually
+        assertEquals(500 + 800, c.computeTarget(currentScrollY = 500, dy = 800, nowMs = 100L))
+    }
+
+    @Test
+    fun `backward press inside validity window extends target backwards`() {
+        val c = PageScrollCoalescer(validityWindowMs = 300L)
+        // First backward press: pending target = 5000 - 800 = 4200.
+        c.computeTarget(currentScrollY = 5000, dy = -800, nowMs = 0L)
+        // Second press extends from 4200, not from the mid-animation currentScrollY=4600.
+        assertEquals(3400, c.computeTarget(currentScrollY = 4600, dy = -800, nowMs = 100L))
+    }
+}


### PR DESCRIPTION
## Summary

Volume-key page scroll in continuous mode felt jankier than in vertical (scroll) mode. Traced the gap to three implementation differences:

- **Delta size**: continuous used 0·9 × viewport per press; vertical (through `ScrollBoundaryNavigationContainer.handleVolumeScroll`) uses 0·8 × viewport. Now 0·8 in both.
- **Animation duration**: continuous used `NestedScrollView.smoothScrollBy` with the default velocity-derived duration, which restarts from the current still-animating position on every subsequent press. Now uses the fixed-duration variant at `PAGE_SCROLL_DURATION_MS = 300` ms — same ballpark as Chromium's `behavior: 'smooth'` default that vertical mode's JS-injected scroll gets for free.
- **Coalescing**: Chromium's smooth-scroll natively merges in-flight targets; NestedScrollView doesn't. Added a small `PageScrollCoalescer` that extends the pending target when a new press arrives within the animation window, so rapid taps glide instead of stutter.

The coalescer clamps its pending target to the port's scroll range so a run of presses at end/start of content can't accumulate a phantom target past what the view can actually scroll — otherwise the first reversal press would silently spend itself unwinding the phantom before the user saw any motion.

Coalescer is reset on `onTouchDown` so a manual scroll can't leave a stale target behind.

Cannot be reused from vertical mode's path — vertical rides on Readium's WebView and injects `window.scrollBy({behavior: 'smooth'})`, while continuous is a native Android `NestedScrollView`. Different runtimes, different smoothing primitives.

## Test plan

- [x] `./gradlew :app:testDebugUnitTest` — new `PageScrollCoalescerTest` covers base-on-current, extend-in-flight target, reset-after-window, reset-on-manual-scroll, backward-direction, and clamp-at-max/min-scroll-bounds. Updated `ContinuousPositionTrackerTest.pageScrollDelta` regression-pin at 800 (would flip red if 0·9 came back).
- [ ] Device verification: install on AVD, open a book in continuous mode, hold volume-forward and volume-backward — should feel identical to vertical mode. Press-hold at start/end of content and confirm the first reversal press moves immediately (no dead phase from phantom accumulation).