### PR TITLE
feat(localfiles): ingestion pipeline (SAF folder picker + scanner + copy-in)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -164,6 +164,10 @@ dependencies {
     implementation(libs.readium.streamer)
     implementation(libs.readium.navigator)
     implementation(libs.readium.adapter.pdfium)
+    // Readium 3.3.0 ships marain87's PdfiumAndroid fork (namespace `com.shockwave.pdfium`) at
+    // runtime. We just need the class on the compile classpath to bind our metadata extractor,
+    // so use compileOnly to avoid a manifest namespace clash between the two forks.
+    compileOnly(libs.pdfium.android)
 
     implementation(libs.acra.core)
     implementation(libs.acra.toast)

--- a/app/src/main/kotlin/com/riffle/app/feature/source/localfiles/LocalFilesAppModule.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/source/localfiles/LocalFilesAppModule.kt
@@ -1,0 +1,17 @@
+package com.riffle.app.feature.source.localfiles
+
+import com.riffle.core.domain.PdfMetadataExtractor
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class LocalFilesAppModule {
+
+    @Binds
+    @Singleton
+    abstract fun bindPdfMetadataExtractor(impl: PdfiumPdfMetadataExtractor): PdfMetadataExtractor
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/source/localfiles/PdfiumPdfMetadataExtractor.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/source/localfiles/PdfiumPdfMetadataExtractor.kt
@@ -6,6 +6,8 @@ import com.riffle.core.domain.PdfMetadata
 import com.riffle.core.domain.PdfMetadataExtractor
 import com.shockwave.pdfium.PdfiumCore
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import java.io.File
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -19,26 +21,28 @@ class PdfiumPdfMetadataExtractor @Inject constructor(
     @ApplicationContext private val context: Context,
 ) : PdfMetadataExtractor {
 
-    override suspend fun extract(file: File): PdfMetadata = try {
+    override suspend fun extract(file: File): PdfMetadata = withContext(Dispatchers.IO) {
         val core = PdfiumCore(context)
-        val pfd = ParcelFileDescriptor.open(file, ParcelFileDescriptor.MODE_READ_ONLY)
-        val doc = core.newDocument(pfd)
-        try {
-            val meta = core.getDocumentMeta(doc)
-            PdfMetadata(
-                title = (meta.title as String?)?.takeIf { it.isNotBlank() },
-                author = (meta.author as String?)?.takeIf { it.isNotBlank() },
-                subject = (meta.subject as String?)?.takeIf { it.isNotBlank() },
-                keywords = (meta.keywords as String?)
-                    ?.split(',', ';')
-                    ?.map { it.trim() }
-                    ?.filter { it.isNotEmpty() }
-                    ?: emptyList(),
-            )
-        } finally {
-            core.closeDocument(doc)
+        // ParcelFileDescriptor and the Pdfium document handle are two separate native resources:
+        // closeDocument releases only the doc handle, not the underlying fd. Both must be closed
+        // for every PDF or we leak an fd per file — EMFILE after hundreds of scanned books.
+        ParcelFileDescriptor.open(file, ParcelFileDescriptor.MODE_READ_ONLY).use { pfd ->
+            val doc = core.newDocument(pfd)
+            try {
+                val meta = core.getDocumentMeta(doc)
+                PdfMetadata(
+                    title = (meta.title as String?)?.takeIf { it.isNotBlank() },
+                    author = (meta.author as String?)?.takeIf { it.isNotBlank() },
+                    subject = (meta.subject as String?)?.takeIf { it.isNotBlank() },
+                    keywords = (meta.keywords as String?)
+                        ?.split(',', ';')
+                        ?.map { it.trim() }
+                        ?.filter { it.isNotEmpty() }
+                        ?: emptyList(),
+                )
+            } finally {
+                core.closeDocument(doc)
+            }
         }
-    } catch (_: Exception) {
-        PdfMetadata.EMPTY
     }
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/source/localfiles/PdfiumPdfMetadataExtractor.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/source/localfiles/PdfiumPdfMetadataExtractor.kt
@@ -1,0 +1,44 @@
+package com.riffle.app.feature.source.localfiles
+
+import android.content.Context
+import android.os.ParcelFileDescriptor
+import com.riffle.core.domain.PdfMetadata
+import com.riffle.core.domain.PdfMetadataExtractor
+import com.shockwave.pdfium.PdfiumCore
+import dagger.hilt.android.qualifiers.ApplicationContext
+import java.io.File
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Pdfium-backed [PdfMetadataExtractor]. Only implementation on Android — JVM tests inject
+ * [com.riffle.core.domain.NoOpPdfMetadataExtractor] via the scanner constructor.
+ */
+@Singleton
+class PdfiumPdfMetadataExtractor @Inject constructor(
+    @ApplicationContext private val context: Context,
+) : PdfMetadataExtractor {
+
+    override suspend fun extract(file: File): PdfMetadata = try {
+        val core = PdfiumCore(context)
+        val pfd = ParcelFileDescriptor.open(file, ParcelFileDescriptor.MODE_READ_ONLY)
+        val doc = core.newDocument(pfd)
+        try {
+            val meta = core.getDocumentMeta(doc)
+            PdfMetadata(
+                title = (meta.title as String?)?.takeIf { it.isNotBlank() },
+                author = (meta.author as String?)?.takeIf { it.isNotBlank() },
+                subject = (meta.subject as String?)?.takeIf { it.isNotBlank() },
+                keywords = (meta.keywords as String?)
+                    ?.split(',', ';')
+                    ?.map { it.trim() }
+                    ?.filter { it.isNotEmpty() }
+                    ?: emptyList(),
+            )
+        } finally {
+            core.closeDocument(doc)
+        }
+    } catch (_: Exception) {
+        PdfMetadata.EMPTY
+    }
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/source/localfiles/PickFolderContract.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/source/localfiles/PickFolderContract.kt
@@ -1,0 +1,23 @@
+package com.riffle.app.feature.source.localfiles
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import androidx.activity.result.contract.ActivityResultContract
+
+/**
+ * SAF folder picker: launches [Intent.ACTION_OPEN_DOCUMENT_TREE] with persistable-URI grant flags
+ * and returns the picked tree URI, or `null` if the user cancelled. Callers must then invoke
+ * `ContentResolver.takePersistableUriPermission(...)` to keep read access across process death.
+ */
+class PickFolderContract : ActivityResultContract<Unit, Uri?>() {
+
+    override fun createIntent(context: Context, input: Unit): Intent =
+        Intent(Intent.ACTION_OPEN_DOCUMENT_TREE)
+            .addFlags(
+                Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION,
+            )
+
+    override fun parseResult(resultCode: Int, intent: Intent?): Uri? =
+        intent?.data.takeIf { resultCode == android.app.Activity.RESULT_OK }
+}

--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -43,6 +43,7 @@ dependencies {
     implementation(libs.androidx.work.runtime.ktx)
     implementation(libs.androidx.lifecycle.process)
     implementation(libs.androidx.datastore.preferences)
+    implementation(libs.androidx.documentfile)
     implementation(libs.androidx.security.crypto)
     implementation(libs.hilt.android)
     ksp(libs.hilt.compiler)

--- a/core/data/src/main/kotlin/com/riffle/core/data/di/DatabaseModule.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/di/DatabaseModule.kt
@@ -10,6 +10,8 @@ import com.riffle.core.database.BookFormattingPreferencesDao
 import com.riffle.core.database.CollectionDao
 import com.riffle.core.database.LibraryDao
 import com.riffle.core.database.LibraryItemDao
+import com.riffle.core.database.LocalFilesFileDao
+import com.riffle.core.database.LocalFilesFolderDao
 import com.riffle.core.database.CrossEpubIndexDao
 import com.riffle.core.database.ReadaloudCandidateDao
 import com.riffle.core.database.ReadaloudDismissalDao
@@ -80,6 +82,7 @@ object DatabaseModule {
                 RiffleDatabase.MIGRATION_42_43,
                 RiffleDatabase.MIGRATION_43_44,
                 RiffleDatabase.MIGRATION_44_45,
+                RiffleDatabase.MIGRATION_45_46,
             )
             .build()
 
@@ -156,4 +159,12 @@ object DatabaseModule {
     @Singleton
     fun provideAudiobookChapterCacheDao(db: RiffleDatabase): AudiobookChapterCacheDao =
         db.audiobookChapterCacheDao()
+
+    @Provides
+    @Singleton
+    fun provideLocalFilesFolderDao(db: RiffleDatabase): LocalFilesFolderDao = db.localFilesFolderDao()
+
+    @Provides
+    @Singleton
+    fun provideLocalFilesFileDao(db: RiffleDatabase): LocalFilesFileDao = db.localFilesFileDao()
 }

--- a/core/data/src/main/kotlin/com/riffle/core/data/di/LocalFilesModule.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/di/LocalFilesModule.kt
@@ -1,0 +1,24 @@
+package com.riffle.core.data.di
+
+import com.riffle.core.data.localfiles.AndroidCopyInService
+import com.riffle.core.data.localfiles.CopyInService
+import com.riffle.core.data.localfiles.FolderWalker
+import com.riffle.core.data.localfiles.SafFolderWalker
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class LocalFilesModule {
+
+    @Binds
+    @Singleton
+    abstract fun bindFolderWalker(impl: SafFolderWalker): FolderWalker
+
+    @Binds
+    @Singleton
+    abstract fun bindCopyInService(impl: AndroidCopyInService): CopyInService
+}

--- a/core/data/src/main/kotlin/com/riffle/core/data/localfiles/AndroidCopyInService.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/localfiles/AndroidCopyInService.kt
@@ -1,0 +1,65 @@
+package com.riffle.core.data.localfiles
+
+import android.content.Context
+import dagger.hilt.android.qualifiers.ApplicationContext
+import java.io.File
+import java.io.InputStream
+import javax.inject.Inject
+
+/**
+ * Copies bytes into `filesDir/localfiles/<sourceId>/`. Books land as `<hash>.<ext>`; covers as
+ * `covers/<hash>.<ext>`. Partial writes on aborted copies are deleted before returning.
+ */
+class AndroidCopyInService @Inject constructor(
+    @ApplicationContext private val context: Context,
+) : CopyInService {
+
+    override suspend fun copyBook(
+        sourceId: String,
+        sourceItemId: String,
+        extension: String,
+        stream: InputStream,
+    ): File {
+        val out = bookFile(sourceId, sourceItemId, extension)
+        out.parentFile?.mkdirs()
+        try {
+            out.outputStream().use { dst -> stream.copyTo(dst) }
+        } catch (e: Exception) {
+            out.delete()
+            throw e
+        }
+        return out
+    }
+
+    override suspend fun writeCover(
+        sourceId: String,
+        sourceItemId: String,
+        extension: String,
+        bytes: ByteArray,
+    ): File {
+        val out = coverFile(sourceId, sourceItemId, extension)
+        out.parentFile?.mkdirs()
+        out.writeBytes(bytes)
+        return out
+    }
+
+    override suspend fun deleteBook(sourceId: String, sourceItemId: String) {
+        val dir = sourceDir(sourceId)
+        if (!dir.exists()) return
+        dir.listFiles { f -> f.isFile && f.nameWithoutExtension == sourceItemId }
+            ?.forEach { it.delete() }
+    }
+
+    override suspend fun deleteCover(sourceId: String, sourceItemId: String) {
+        val dir = File(sourceDir(sourceId), "covers")
+        if (!dir.exists()) return
+        dir.listFiles { f -> f.isFile && f.nameWithoutExtension == sourceItemId }
+            ?.forEach { it.delete() }
+    }
+
+    private fun sourceDir(sourceId: String): File = File(context.filesDir, "localfiles/$sourceId")
+    private fun bookFile(sourceId: String, sourceItemId: String, extension: String): File =
+        File(sourceDir(sourceId), "$sourceItemId.$extension")
+    private fun coverFile(sourceId: String, sourceItemId: String, extension: String): File =
+        File(sourceDir(sourceId), "covers/$sourceItemId.$extension")
+}

--- a/core/data/src/main/kotlin/com/riffle/core/data/localfiles/AndroidCopyInService.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/localfiles/AndroidCopyInService.kt
@@ -2,6 +2,8 @@ package com.riffle.core.data.localfiles
 
 import android.content.Context
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import java.io.File
 import java.io.InputStream
 import javax.inject.Inject
@@ -19,7 +21,7 @@ class AndroidCopyInService @Inject constructor(
         sourceItemId: String,
         extension: String,
         stream: InputStream,
-    ): File {
+    ): File = withContext(Dispatchers.IO) {
         val out = bookFile(sourceId, sourceItemId, extension)
         out.parentFile?.mkdirs()
         try {
@@ -28,7 +30,7 @@ class AndroidCopyInService @Inject constructor(
             out.delete()
             throw e
         }
-        return out
+        out
     }
 
     override suspend fun writeCover(
@@ -36,23 +38,30 @@ class AndroidCopyInService @Inject constructor(
         sourceItemId: String,
         extension: String,
         bytes: ByteArray,
-    ): File {
+    ): File = withContext(Dispatchers.IO) {
         val out = coverFile(sourceId, sourceItemId, extension)
         out.parentFile?.mkdirs()
-        out.writeBytes(bytes)
-        return out
+        try {
+            out.writeBytes(bytes)
+        } catch (e: Exception) {
+            // A partial-write file would otherwise be surfaced to the library grid as a broken
+            // cover on subsequent scans (identity is unchanged so no re-extraction happens).
+            out.delete()
+            throw e
+        }
+        out
     }
 
-    override suspend fun deleteBook(sourceId: String, sourceItemId: String) {
+    override suspend fun deleteBook(sourceId: String, sourceItemId: String): Unit = withContext(Dispatchers.IO) {
         val dir = sourceDir(sourceId)
-        if (!dir.exists()) return
+        if (!dir.exists()) return@withContext
         dir.listFiles { f -> f.isFile && f.nameWithoutExtension == sourceItemId }
             ?.forEach { it.delete() }
     }
 
-    override suspend fun deleteCover(sourceId: String, sourceItemId: String) {
+    override suspend fun deleteCover(sourceId: String, sourceItemId: String): Unit = withContext(Dispatchers.IO) {
         val dir = File(sourceDir(sourceId), "covers")
-        if (!dir.exists()) return
+        if (!dir.exists()) return@withContext
         dir.listFiles { f -> f.isFile && f.nameWithoutExtension == sourceItemId }
             ?.forEach { it.delete() }
     }

--- a/core/data/src/main/kotlin/com/riffle/core/data/localfiles/CopyInService.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/localfiles/CopyInService.kt
@@ -1,0 +1,22 @@
+package com.riffle.core.data.localfiles
+
+import java.io.File
+import java.io.InputStream
+
+/**
+ * Copies book bytes and cover bytes into Riffle-owned private storage. Abstracted so JVM tests
+ * can substitute a fake that writes to a temp dir.
+ */
+interface CopyInService {
+    /** Copy [stream] into private storage, returning the absolute path of the written file. */
+    suspend fun copyBook(sourceId: String, sourceItemId: String, extension: String, stream: InputStream): File
+
+    /** Write [bytes] as a cover image, returning the absolute path. */
+    suspend fun writeCover(sourceId: String, sourceItemId: String, extension: String, bytes: ByteArray): File
+
+    /** Delete the copied book bytes for [sourceItemId], if present. */
+    suspend fun deleteBook(sourceId: String, sourceItemId: String)
+
+    /** Delete the cover bytes for [sourceItemId], if present. */
+    suspend fun deleteCover(sourceId: String, sourceItemId: String)
+}

--- a/core/data/src/main/kotlin/com/riffle/core/data/localfiles/FileClassifier.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/localfiles/FileClassifier.kt
@@ -11,27 +11,26 @@ object FileClassifier {
 
     private val EPUB_ZIP_MAGIC = byteArrayOf(0x50, 0x4B, 0x03, 0x04) // "PK\x03\x04"
     private val PDF_MAGIC = "%PDF-".toByteArray(Charsets.US_ASCII)
-    private const val EPUB_MIMETYPE = "application/epub+zip"
 
     fun classify(name: String, head: ByteArray): Kind {
         val ext = name.substringAfterLast('.', "").lowercase()
         return when (ext) {
-            "epub" -> if (isEpub(head)) Kind.EPUB else Kind.UNKNOWN
+            "epub" -> if (isZip(head)) Kind.EPUB else Kind.UNKNOWN
             "pdf" -> if (isPdf(head)) Kind.PDF else Kind.UNKNOWN
             else -> Kind.UNKNOWN
         }
     }
 
-    private fun isEpub(head: ByteArray): Boolean {
+    // Extension `.epub` + zip magic classifies as EPUB. We deliberately don't try to verify the
+    // uncompressed `mimetype` local-file-header here — many archivers deviate from the strict
+    // offset-30 layout, so a byte-scan would produce false negatives. The downstream
+    // EpubMetadataExtractor is the source of truth for actual EPUB validity; a zip that turns
+    // out not to be an EPUB gets an EpubMetadata.EMPTY result and the scanner falls back to the
+    // filename as title — safe degradation, no data loss.
+    private fun isZip(head: ByteArray): Boolean {
         if (head.size < 4) return false
         for (i in 0..3) if (head[i] != EPUB_ZIP_MAGIC[i]) return false
-        // EPUB requires a `mimetype` file starting at zip local-file-header data offset 30 (name
-        // length = 8, extra length = 0). We accept the mimetype string appearing at that offset
-        // as a strong indicator; some archivers deviate slightly (extra fields, etc.), so if the
-        // magic PK header is present but the mimetype check fails we still accept it.
-        if (head.size < 30 + EPUB_MIMETYPE.length) return true
-        val slice = head.copyOfRange(30, 30 + EPUB_MIMETYPE.length)
-        return slice.toString(Charsets.US_ASCII) == EPUB_MIMETYPE || true
+        return true
     }
 
     private fun isPdf(head: ByteArray): Boolean {

--- a/core/data/src/main/kotlin/com/riffle/core/data/localfiles/FileClassifier.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/localfiles/FileClassifier.kt
@@ -1,0 +1,42 @@
+package com.riffle.core.data.localfiles
+
+/**
+ * Classifies a local file by extension + magic bytes. Extension alone would misclassify anything
+ * renamed on-disk; magic bytes alone would classify anything that happens to be a zip. Both must
+ * agree.
+ */
+object FileClassifier {
+
+    enum class Kind { EPUB, PDF, UNKNOWN }
+
+    private val EPUB_ZIP_MAGIC = byteArrayOf(0x50, 0x4B, 0x03, 0x04) // "PK\x03\x04"
+    private val PDF_MAGIC = "%PDF-".toByteArray(Charsets.US_ASCII)
+    private const val EPUB_MIMETYPE = "application/epub+zip"
+
+    fun classify(name: String, head: ByteArray): Kind {
+        val ext = name.substringAfterLast('.', "").lowercase()
+        return when (ext) {
+            "epub" -> if (isEpub(head)) Kind.EPUB else Kind.UNKNOWN
+            "pdf" -> if (isPdf(head)) Kind.PDF else Kind.UNKNOWN
+            else -> Kind.UNKNOWN
+        }
+    }
+
+    private fun isEpub(head: ByteArray): Boolean {
+        if (head.size < 4) return false
+        for (i in 0..3) if (head[i] != EPUB_ZIP_MAGIC[i]) return false
+        // EPUB requires a `mimetype` file starting at zip local-file-header data offset 30 (name
+        // length = 8, extra length = 0). We accept the mimetype string appearing at that offset
+        // as a strong indicator; some archivers deviate slightly (extra fields, etc.), so if the
+        // magic PK header is present but the mimetype check fails we still accept it.
+        if (head.size < 30 + EPUB_MIMETYPE.length) return true
+        val slice = head.copyOfRange(30, 30 + EPUB_MIMETYPE.length)
+        return slice.toString(Charsets.US_ASCII) == EPUB_MIMETYPE || true
+    }
+
+    private fun isPdf(head: ByteArray): Boolean {
+        if (head.size < PDF_MAGIC.size) return false
+        for (i in PDF_MAGIC.indices) if (head[i] != PDF_MAGIC[i]) return false
+        return true
+    }
+}

--- a/core/data/src/main/kotlin/com/riffle/core/data/localfiles/FolderWalker.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/localfiles/FolderWalker.kt
@@ -1,0 +1,28 @@
+package com.riffle.core.data.localfiles
+
+/**
+ * Walks a SAF tree URI (or, in tests, an in-memory fake filesystem) and yields every candidate
+ * file. Recursion depth is unbounded but callers filter by extension before opening bytes.
+ *
+ * Implementations are cheap to construct and stateless per call.
+ */
+interface FolderWalker {
+
+    /**
+     * @param treeUri the persistable SAF tree URI, or an arbitrary string the test walker understands.
+     * @return a sequence-like list of walked files, root-first, in a stable order.
+     */
+    suspend fun walk(treeUri: String): List<WalkedFile>
+}
+
+data class WalkedFile(
+    val originalUri: String,
+    val displayName: String,
+    val sizeBytes: Long,
+    val mtimeEpochMs: Long,
+    /**
+     * A callback to open the file's bytes. Called at most twice per file (once to sniff the
+     * head, once to copy). Real impls stream from `ContentResolver.openInputStream(uri)`.
+     */
+    val openStream: suspend () -> java.io.InputStream,
+)

--- a/core/data/src/main/kotlin/com/riffle/core/data/localfiles/IdentityHasher.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/localfiles/IdentityHasher.kt
@@ -1,0 +1,34 @@
+package com.riffle.core.data.localfiles
+
+import java.io.InputStream
+import java.security.MessageDigest
+
+/**
+ * Content-based identity for an ingested file — SHA-1 of the first 64KB combined with the file
+ * size. Cheap (single read of the prefix), stable across path changes and renames, tolerant of
+ * SAF re-mounts. Full-file hashing would be prohibitive for large PDFs; a prefix hash is enough
+ * to distinguish user libraries in practice.
+ */
+object IdentityHasher {
+
+    private const val PREFIX_BYTES = 64 * 1024
+
+    fun hash(prefix: ByteArray, sizeBytes: Long): String {
+        val md = MessageDigest.getInstance("SHA-1")
+        md.update(prefix, 0, minOf(prefix.size, PREFIX_BYTES))
+        md.update(sizeBytes.toString().toByteArray(Charsets.US_ASCII))
+        return md.digest().joinToString("") { "%02x".format(it) }
+    }
+
+    /** Reads up to [PREFIX_BYTES] from [input] and hashes with [sizeBytes]. */
+    fun hash(input: InputStream, sizeBytes: Long): String {
+        val buf = ByteArray(PREFIX_BYTES)
+        var total = 0
+        while (total < buf.size) {
+            val read = input.read(buf, total, buf.size - total)
+            if (read <= 0) break
+            total += read
+        }
+        return hash(if (total == buf.size) buf else buf.copyOf(total), sizeBytes)
+    }
+}

--- a/core/data/src/main/kotlin/com/riffle/core/data/localfiles/LocalFilesFolderRepository.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/localfiles/LocalFilesFolderRepository.kt
@@ -1,0 +1,56 @@
+package com.riffle.core.data.localfiles
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import androidx.documentfile.provider.DocumentFile
+import com.riffle.core.database.LocalFilesFolderDao
+import com.riffle.core.database.LocalFilesFolderEntity
+import com.riffle.core.domain.Clock
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Adds/removes configured LocalFiles folders. On add, takes persistable read permission on the
+ * tree URI so the folder survives process death; on remove, releases the grant.
+ */
+@Singleton
+class LocalFilesFolderRepository @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val folderDao: LocalFilesFolderDao,
+    private val clock: Clock,
+) {
+
+    suspend fun addFolder(sourceId: String, treeUri: Uri) {
+        context.contentResolver.takePersistableUriPermission(
+            treeUri,
+            Intent.FLAG_GRANT_READ_URI_PERMISSION,
+        )
+        val displayName = DocumentFile.fromTreeUri(context, treeUri)?.name
+            ?: treeUri.lastPathSegment
+            ?: treeUri.toString()
+        folderDao.upsert(
+            LocalFilesFolderEntity(
+                sourceId = sourceId,
+                treeUri = treeUri.toString(),
+                displayName = displayName,
+                addedAtEpochMs = clock.nowMs(),
+            ),
+        )
+    }
+
+    suspend fun removeFolder(sourceId: String, treeUri: String) {
+        try {
+            context.contentResolver.releasePersistableUriPermission(
+                Uri.parse(treeUri),
+                Intent.FLAG_GRANT_READ_URI_PERMISSION,
+            )
+        } catch (_: SecurityException) {
+            // Grant may already be gone (e.g. user cleared app data). Fall through to db delete.
+        }
+        folderDao.delete(sourceId, treeUri)
+    }
+
+    suspend fun folders(sourceId: String): List<LocalFilesFolderEntity> = folderDao.forSource(sourceId)
+}

--- a/core/data/src/main/kotlin/com/riffle/core/data/localfiles/LocalFilesScanner.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/localfiles/LocalFilesScanner.kt
@@ -10,6 +10,8 @@ import com.riffle.core.domain.EpubMetadata
 import com.riffle.core.domain.EpubMetadataExtractor
 import com.riffle.core.domain.PdfMetadata
 import com.riffle.core.domain.PdfMetadataExtractor
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 /**
@@ -44,18 +46,25 @@ class LocalFilesScanner @Inject constructor(
 
     data class ScanFailure(val displayName: String, val reason: String)
 
-    suspend fun scan(sourceId: String): ScanReport {
+    suspend fun scan(sourceId: String): ScanReport = withContext(Dispatchers.IO) {
         val scanStart = clock.nowMs()
         val folders = folderDao.forSource(sourceId)
         var added = 0
         var refreshed = 0
         val failures = mutableListOf<ScanFailure>()
+        // We only prune stale rows when every folder walked cleanly AND every ingest succeeded.
+        // A single transient walk/ingest failure suppresses the sweep for this pass — otherwise a
+        // DocumentsProvider hiccup on a folder full of previously-ingested books would wipe every
+        // one of them (their lastSeenAt never gets touched because the walk aborts). We accept
+        // that a mixed-success scan doesn't reclaim deleted books until the next fully-clean scan.
+        var completed = true
 
         for (folder in folders) {
             val files = try {
                 walker.walk(folder.treeUri)
             } catch (e: Exception) {
                 failures += ScanFailure(folder.displayName, "walk-failed: ${e.message ?: e::class.simpleName}")
+                completed = false
                 continue
             }
             for (file in files) {
@@ -63,6 +72,7 @@ class LocalFilesScanner @Inject constructor(
                     ingest(sourceId, folder.treeUri, file, scanStart)
                 } catch (e: Exception) {
                     failures += ScanFailure(file.displayName, "ingest-failed: ${e.message ?: e::class.simpleName}")
+                    completed = false
                     continue
                 }
                 when (outcome) {
@@ -73,6 +83,11 @@ class LocalFilesScanner @Inject constructor(
             }
         }
 
+        val removed = if (completed) sweepStale(sourceId, scanStart) else 0
+        ScanReport(added = added, refreshed = refreshed, removed = removed, failures = failures)
+    }
+
+    private suspend fun sweepStale(sourceId: String, scanStart: Long): Int {
         val stale = fileDao.stale(sourceId, scanStart)
         for (row in stale) {
             libraryItemDao.deleteById(row.sourceId, row.sourceItemId)
@@ -80,8 +95,7 @@ class LocalFilesScanner @Inject constructor(
             if (row.coverPath != null) copyIn.deleteCover(row.sourceId, row.sourceItemId)
             fileDao.delete(row.sourceId, row.sourceItemId)
         }
-
-        return ScanReport(added = added, refreshed = refreshed, removed = stale.size, failures = failures)
+        return stale.size
     }
 
     private enum class Outcome { ADDED, REFRESHED, SKIPPED }

--- a/core/data/src/main/kotlin/com/riffle/core/data/localfiles/LocalFilesScanner.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/localfiles/LocalFilesScanner.kt
@@ -1,0 +1,225 @@
+package com.riffle.core.data.localfiles
+
+import com.riffle.core.database.LibraryItemDao
+import com.riffle.core.database.LibraryItemEntity
+import com.riffle.core.database.LocalFilesFileDao
+import com.riffle.core.database.LocalFilesFileEntity
+import com.riffle.core.database.LocalFilesFolderDao
+import com.riffle.core.domain.Clock
+import com.riffle.core.domain.EpubMetadata
+import com.riffle.core.domain.EpubMetadataExtractor
+import com.riffle.core.domain.PdfMetadata
+import com.riffle.core.domain.PdfMetadataExtractor
+import javax.inject.Inject
+
+/**
+ * Walks the LocalFiles Source's configured folders, classifies EPUB/PDF files by extension +
+ * magic bytes, computes a content-identity hash, and idempotently upserts:
+ *   - a `library_items` row per unique file (title/author/…, cover URL where extractable),
+ *   - a `local_files_files` row per unique file (originalUri, copiedPath, coverPath, lastSeenAt).
+ *
+ * A single scan pass runs across *all* configured folders of the source; rows whose
+ * `lastSeenAtEpochMs` predates `scanStart` after the pass are hard-deleted along with their copied
+ * bytes and library rows. This unifies "file removed from folder" with "folder permission revoked"
+ * — both surface as absence during the walk.
+ *
+ * Not thread-safe: only one scan should be in-flight per source at a time.
+ */
+class LocalFilesScanner @Inject constructor(
+    private val folderDao: LocalFilesFolderDao,
+    private val fileDao: LocalFilesFileDao,
+    private val libraryItemDao: LibraryItemDao,
+    private val walker: FolderWalker,
+    private val copyIn: CopyInService,
+    private val pdfMetadata: PdfMetadataExtractor,
+    private val clock: Clock,
+) {
+
+    data class ScanReport(
+        val added: Int,
+        val refreshed: Int,
+        val removed: Int,
+        val failures: List<ScanFailure>,
+    )
+
+    data class ScanFailure(val displayName: String, val reason: String)
+
+    suspend fun scan(sourceId: String): ScanReport {
+        val scanStart = clock.nowMs()
+        val folders = folderDao.forSource(sourceId)
+        var added = 0
+        var refreshed = 0
+        val failures = mutableListOf<ScanFailure>()
+
+        for (folder in folders) {
+            val files = try {
+                walker.walk(folder.treeUri)
+            } catch (e: Exception) {
+                failures += ScanFailure(folder.displayName, "walk-failed: ${e.message ?: e::class.simpleName}")
+                continue
+            }
+            for (file in files) {
+                val outcome = try {
+                    ingest(sourceId, folder.treeUri, file, scanStart)
+                } catch (e: Exception) {
+                    failures += ScanFailure(file.displayName, "ingest-failed: ${e.message ?: e::class.simpleName}")
+                    continue
+                }
+                when (outcome) {
+                    Outcome.ADDED -> added += 1
+                    Outcome.REFRESHED -> refreshed += 1
+                    Outcome.SKIPPED -> {}
+                }
+            }
+        }
+
+        val stale = fileDao.stale(sourceId, scanStart)
+        for (row in stale) {
+            libraryItemDao.deleteById(row.sourceId, row.sourceItemId)
+            copyIn.deleteBook(row.sourceId, row.sourceItemId)
+            if (row.coverPath != null) copyIn.deleteCover(row.sourceId, row.sourceItemId)
+            fileDao.delete(row.sourceId, row.sourceItemId)
+        }
+
+        return ScanReport(added = added, refreshed = refreshed, removed = stale.size, failures = failures)
+    }
+
+    private enum class Outcome { ADDED, REFRESHED, SKIPPED }
+
+    private suspend fun ingest(
+        sourceId: String,
+        folderTreeUri: String,
+        file: WalkedFile,
+        scanStart: Long,
+    ): Outcome {
+        val head = file.openStream().use { s ->
+            val buf = ByteArray(HEAD_BYTES)
+            var total = 0
+            while (total < buf.size) {
+                val r = s.read(buf, total, buf.size - total)
+                if (r <= 0) break
+                total += r
+            }
+            if (total == buf.size) buf else buf.copyOf(total)
+        }
+        val kind = FileClassifier.classify(file.displayName, head)
+        if (kind == FileClassifier.Kind.UNKNOWN) return Outcome.SKIPPED
+
+        val identity = IdentityHasher.hash(head, file.sizeBytes)
+        val existing = fileDao.findById(sourceId, identity)
+        if (existing != null) {
+            fileDao.touchLastSeen(sourceId, identity, folderTreeUri, scanStart)
+            return Outcome.REFRESHED
+        }
+
+        val extension = when (kind) {
+            FileClassifier.Kind.EPUB -> "epub"
+            FileClassifier.Kind.PDF -> "pdf"
+            FileClassifier.Kind.UNKNOWN -> return Outcome.SKIPPED
+        }
+        val copied = file.openStream().use { s -> copyIn.copyBook(sourceId, identity, extension, s) }
+
+        val (item, coverPath) = when (kind) {
+            FileClassifier.Kind.EPUB -> buildEpubItem(sourceId, identity, file, copied)
+            FileClassifier.Kind.PDF -> buildPdfItem(sourceId, identity, file, copied)
+            FileClassifier.Kind.UNKNOWN -> return Outcome.SKIPPED
+        }
+        libraryItemDao.upsertAll(listOf(item))
+        fileDao.upsert(
+            LocalFilesFileEntity(
+                sourceId = sourceId,
+                sourceItemId = identity,
+                folderTreeUri = folderTreeUri,
+                originalUri = file.originalUri,
+                copiedPath = copied.absolutePath,
+                coverPath = coverPath?.absolutePath,
+                format = ebookFormatOf(kind),
+                sizeBytes = file.sizeBytes,
+                mtimeEpochMs = file.mtimeEpochMs,
+                lastSeenAtEpochMs = scanStart,
+            ),
+        )
+        return Outcome.ADDED
+    }
+
+    private suspend fun buildEpubItem(
+        sourceId: String,
+        identity: String,
+        file: WalkedFile,
+        copied: java.io.File,
+    ): Pair<LibraryItemEntity, java.io.File?> {
+        val metadata = EpubMetadataExtractor.extract(copied)
+        val coverBytes = metadata.coverBytes
+        val coverFile = if (coverBytes != null) {
+            copyIn.writeCover(sourceId, identity, metadata.coverExtension ?: "jpg", coverBytes)
+        } else null
+        return libraryItemFromEpub(sourceId, identity, file, metadata, coverFile) to coverFile
+    }
+
+    private suspend fun buildPdfItem(
+        sourceId: String,
+        identity: String,
+        file: WalkedFile,
+        copied: java.io.File,
+    ): Pair<LibraryItemEntity, java.io.File?> {
+        val metadata = try { pdfMetadata.extract(copied) } catch (_: Exception) { PdfMetadata.EMPTY }
+        val entity = LibraryItemEntity(
+            sourceId = sourceId,
+            id = identity,
+            libraryId = LOCAL_ROOT_LIBRARY_ID,
+            title = metadata.title?.ifBlank { null } ?: stripExtension(file.displayName),
+            author = metadata.author?.ifBlank { null } ?: "",
+            coverUrl = null,
+            readingProgress = 0f,
+            ebookFormat = EBOOK_FORMAT_PDF,
+            description = metadata.subject,
+            addedAt = clock.nowMs(),
+        )
+        return entity to null
+    }
+
+    private fun libraryItemFromEpub(
+        sourceId: String,
+        identity: String,
+        file: WalkedFile,
+        metadata: EpubMetadata,
+        coverFile: java.io.File?,
+    ): LibraryItemEntity = LibraryItemEntity(
+        sourceId = sourceId,
+        id = identity,
+        libraryId = LOCAL_ROOT_LIBRARY_ID,
+        title = metadata.title?.ifBlank { null } ?: stripExtension(file.displayName),
+        author = metadata.author?.ifBlank { null } ?: "",
+        coverUrl = coverFile?.toURI()?.toString(),
+        readingProgress = 0f,
+        ebookFormat = EBOOK_FORMAT_EPUB,
+        description = metadata.description,
+        seriesName = metadata.seriesName,
+        publishedYear = metadata.publishedYear,
+        genres = metadata.genres.joinToString(","),
+        publisher = metadata.publisher,
+        language = metadata.language,
+        isbn = metadata.isbn,
+        asin = metadata.asin,
+        addedAt = clock.nowMs(),
+    )
+
+    private fun ebookFormatOf(kind: FileClassifier.Kind): String = when (kind) {
+        FileClassifier.Kind.EPUB -> EBOOK_FORMAT_EPUB
+        FileClassifier.Kind.PDF -> EBOOK_FORMAT_PDF
+        FileClassifier.Kind.UNKNOWN -> EBOOK_FORMAT_UNSUPPORTED
+    }
+
+    private fun stripExtension(name: String): String {
+        val dot = name.lastIndexOf('.')
+        return if (dot > 0) name.substring(0, dot) else name
+    }
+
+    companion object {
+        const val LOCAL_ROOT_LIBRARY_ID: String = "local:root"
+        const val EBOOK_FORMAT_EPUB: String = "epub"
+        const val EBOOK_FORMAT_PDF: String = "pdf"
+        const val EBOOK_FORMAT_UNSUPPORTED: String = "unsupported"
+        private const val HEAD_BYTES: Int = 64 * 1024
+    }
+}

--- a/core/data/src/main/kotlin/com/riffle/core/data/localfiles/SafFolderWalker.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/localfiles/SafFolderWalker.kt
@@ -1,0 +1,44 @@
+package com.riffle.core.data.localfiles
+
+import android.content.Context
+import android.net.Uri
+import androidx.documentfile.provider.DocumentFile
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+
+/**
+ * Real [FolderWalker] backed by SAF `DocumentFile`. Walks recursively; yields every non-directory
+ * child file with a stream opener that reads from the shared `ContentResolver`.
+ */
+class SafFolderWalker @Inject constructor(
+    @ApplicationContext private val context: Context,
+) : FolderWalker {
+
+    override suspend fun walk(treeUri: String): List<WalkedFile> {
+        val root = DocumentFile.fromTreeUri(context, Uri.parse(treeUri))
+            ?: throw IllegalStateException("Cannot open tree URI: $treeUri")
+        val out = mutableListOf<WalkedFile>()
+        walkInto(root, out)
+        return out
+    }
+
+    private fun walkInto(node: DocumentFile, out: MutableList<WalkedFile>) {
+        for (child in node.listFiles()) {
+            if (child.isDirectory) {
+                walkInto(child, out)
+            } else if (child.isFile) {
+                val name = child.name ?: continue
+                out += WalkedFile(
+                    originalUri = child.uri.toString(),
+                    displayName = name,
+                    sizeBytes = child.length(),
+                    mtimeEpochMs = child.lastModified(),
+                    openStream = {
+                        context.contentResolver.openInputStream(child.uri)
+                            ?: throw IllegalStateException("Cannot open input stream: ${child.uri}")
+                    },
+                )
+            }
+        }
+    }
+}

--- a/core/data/src/main/kotlin/com/riffle/core/data/localfiles/SafFolderWalker.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/localfiles/SafFolderWalker.kt
@@ -4,6 +4,8 @@ import android.content.Context
 import android.net.Uri
 import androidx.documentfile.provider.DocumentFile
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 /**
@@ -14,12 +16,12 @@ class SafFolderWalker @Inject constructor(
     @ApplicationContext private val context: Context,
 ) : FolderWalker {
 
-    override suspend fun walk(treeUri: String): List<WalkedFile> {
+    override suspend fun walk(treeUri: String): List<WalkedFile> = withContext(Dispatchers.IO) {
         val root = DocumentFile.fromTreeUri(context, Uri.parse(treeUri))
             ?: throw IllegalStateException("Cannot open tree URI: $treeUri")
         val out = mutableListOf<WalkedFile>()
         walkInto(root, out)
-        return out
+        out
     }
 
     private fun walkInto(node: DocumentFile, out: MutableList<WalkedFile>) {
@@ -34,6 +36,9 @@ class SafFolderWalker @Inject constructor(
                     sizeBytes = child.length(),
                     mtimeEpochMs = child.lastModified(),
                     openStream = {
+                        // Called on whatever dispatcher the caller (the scanner) uses. The scanner's
+                        // head-read + copy-in wraps their own IO in withContext(IO), so we don't
+                        // need to redispatch here.
                         context.contentResolver.openInputStream(child.uri)
                             ?: throw IllegalStateException("Cannot open input stream: ${child.uri}")
                     },

--- a/core/data/src/test/kotlin/com/riffle/core/data/FakeLibraryItemDao.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/FakeLibraryItemDao.kt
@@ -109,6 +109,12 @@ internal class FakeLibraryItemDao : LibraryItemDao {
         roomData[libraryId]!!.value = current.filterNot { it.sourceId == sourceId }
     }
 
+    override suspend fun deleteById(sourceId: String, itemId: String) {
+        roomData.forEach { (_, flow) ->
+            flow.value = flow.value.filterNot { it.sourceId == sourceId && it.id == itemId }
+        }
+    }
+
     override suspend fun updateLastOpenedAt(sourceId: String, itemId: String, timestamp: Long) {}
 
     override suspend fun getLastOpenedAtMap(sourceId: String, libraryId: String): List<LastOpenedAtRow> =

--- a/core/data/src/test/kotlin/com/riffle/core/data/NoopLibraryDaos.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/NoopLibraryDaos.kt
@@ -26,6 +26,7 @@ internal object ThrowingLibraryItemDao : LibraryItemDao {
     override fun observeById(sourceId: String, itemId: String): Flow<LibraryItemEntity?> = flowOf(null)
     override suspend fun findSourceIdForItem(itemId: String): String? = null
     override suspend fun deleteByLibraryId(sourceId: String, libraryId: String) = Unit
+    override suspend fun deleteById(sourceId: String, itemId: String) = Unit
     override suspend fun deleteRemovedFromLibrary(sourceId: String, libraryId: String, serverItemIds: List<String>) = Unit
     override suspend fun updateLastOpenedAt(sourceId: String, itemId: String, timestamp: Long) = Unit
     override suspend fun updateReadingProgress(sourceId: String, itemId: String, progress: Float) = Unit

--- a/core/data/src/test/kotlin/com/riffle/core/data/ReadaloudMatchingServiceTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/ReadaloudMatchingServiceTest.kt
@@ -391,6 +391,7 @@ class ReadaloudMatchingServiceTest {
         override fun observeById(sourceId: String, itemId: String): Flow<LibraryItemEntity?> = flowOf(byId[itemId])
         override suspend fun findSourceIdForItem(itemId: String): String? = byId[itemId]?.sourceId
         override suspend fun deleteByLibraryId(sourceId: String, libraryId: String) = Unit
+        override suspend fun deleteById(sourceId: String, itemId: String) = Unit
         override suspend fun deleteRemovedFromLibrary(sourceId: String, libraryId: String, serverItemIds: List<String>) = Unit
         override suspend fun updateLastOpenedAt(sourceId: String, itemId: String, timestamp: Long) = Unit
         override suspend fun updateReadingProgress(sourceId: String, itemId: String, progress: Float) = Unit

--- a/core/data/src/test/kotlin/com/riffle/core/data/SeriesIntegrationTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/SeriesIntegrationTest.kt
@@ -122,6 +122,7 @@ class SeriesIntegrationTest {
         override suspend fun insertOrIgnore(items: List<LibraryItemEntity>) {}
         override suspend fun updateMetadata(metadata: com.riffle.core.database.LibraryItemMetadata) {}
         override suspend fun deleteByLibraryId(sourceId: String, libraryId: String) {}
+        override suspend fun deleteById(sourceId: String, itemId: String) {}
         override suspend fun deleteRemovedFromLibrary(sourceId: String, libraryId: String, serverItemIds: List<String>) {}
         override suspend fun updateLastOpenedAt(sourceId: String, itemId: String, timestamp: Long) {}
         override suspend fun getLastOpenedAtMap(sourceId: String, libraryId: String): List<LastOpenedAtRow> = emptyList()

--- a/core/data/src/test/kotlin/com/riffle/core/data/SourceRepositoryTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/SourceRepositoryTest.kt
@@ -158,6 +158,9 @@ class ServerRepositoryTest {
             rows[libraryId]?.removeAll { it.sourceId == sourceId }
             if (rows[libraryId]?.isEmpty() == true) rows.remove(libraryId)
         }
+        override suspend fun deleteById(sourceId: String, itemId: String) {
+            rows.forEach { (_, v) -> v.removeAll { it.sourceId == sourceId && it.id == itemId } }
+        }
         override suspend fun deleteRemovedFromLibrary(sourceId: String, libraryId: String, serverItemIds: List<String>) = Unit
         override suspend fun updateLastOpenedAt(sourceId: String, itemId: String, timestamp: Long) {}
         override suspend fun getLastOpenedAtMap(sourceId: String, libraryId: String) = emptyList<com.riffle.core.database.LastOpenedAtRow>()

--- a/core/data/src/test/kotlin/com/riffle/core/data/localfiles/FileClassifierTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/localfiles/FileClassifierTest.kt
@@ -1,0 +1,47 @@
+package com.riffle.core.data.localfiles
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class FileClassifierTest {
+
+    private val epubMagic = byteArrayOf(0x50, 0x4B, 0x03, 0x04) + ByteArray(200)
+    private val pdfMagic = "%PDF-1.7".toByteArray()
+
+    @Test
+    fun `classifies epub extension with zip magic as EPUB`() {
+        assertEquals(FileClassifier.Kind.EPUB, FileClassifier.classify("book.epub", epubMagic))
+    }
+
+    @Test
+    fun `classifies EPUB extension case-insensitively`() {
+        assertEquals(FileClassifier.Kind.EPUB, FileClassifier.classify("Book.EPUB", epubMagic))
+    }
+
+    @Test
+    fun `classifies pdf extension with pdf magic as PDF`() {
+        assertEquals(FileClassifier.Kind.PDF, FileClassifier.classify("book.pdf", pdfMagic))
+    }
+
+    @Test
+    fun `unknown extension returns UNKNOWN even if bytes look valid`() {
+        assertEquals(FileClassifier.Kind.UNKNOWN, FileClassifier.classify("book.txt", epubMagic))
+        assertEquals(FileClassifier.Kind.UNKNOWN, FileClassifier.classify("book", pdfMagic))
+    }
+
+    @Test
+    fun `epub extension with wrong magic returns UNKNOWN`() {
+        assertEquals(FileClassifier.Kind.UNKNOWN, FileClassifier.classify("book.epub", "not a zip".toByteArray()))
+    }
+
+    @Test
+    fun `pdf extension with wrong magic returns UNKNOWN`() {
+        assertEquals(FileClassifier.Kind.UNKNOWN, FileClassifier.classify("book.pdf", "not a pdf".toByteArray()))
+    }
+
+    @Test
+    fun `empty head returns UNKNOWN`() {
+        assertEquals(FileClassifier.Kind.UNKNOWN, FileClassifier.classify("book.epub", ByteArray(0)))
+        assertEquals(FileClassifier.Kind.UNKNOWN, FileClassifier.classify("book.pdf", ByteArray(0)))
+    }
+}

--- a/core/data/src/test/kotlin/com/riffle/core/data/localfiles/IdentityHasherTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/localfiles/IdentityHasherTest.kt
@@ -1,0 +1,52 @@
+package com.riffle.core.data.localfiles
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Test
+import java.io.ByteArrayInputStream
+
+class IdentityHasherTest {
+
+    @Test
+    fun `identical prefix and size produces identical hash`() {
+        val prefix = "hello world".toByteArray()
+        assertEquals(IdentityHasher.hash(prefix, 42L), IdentityHasher.hash(prefix, 42L))
+    }
+
+    @Test
+    fun `different sizes produce different hashes for the same prefix`() {
+        val prefix = "hello".toByteArray()
+        assertNotEquals(IdentityHasher.hash(prefix, 100L), IdentityHasher.hash(prefix, 200L))
+    }
+
+    @Test
+    fun `different prefixes produce different hashes for the same size`() {
+        assertNotEquals(
+            IdentityHasher.hash("hello".toByteArray(), 5L),
+            IdentityHasher.hash("world".toByteArray(), 5L),
+        )
+    }
+
+    @Test
+    fun `stream and prefix overloads agree at the 64KB boundary`() {
+        val prefix = ByteArray(64 * 1024) { (it % 251).toByte() }
+        val byArray = IdentityHasher.hash(prefix, prefix.size.toLong())
+        val byStream = IdentityHasher.hash(ByteArrayInputStream(prefix), prefix.size.toLong())
+        assertEquals(byArray, byStream)
+    }
+
+    @Test
+    fun `stream overload handles inputs shorter than 64KB`() {
+        val bytes = ByteArray(1024) { (it % 97).toByte() }
+        val byArray = IdentityHasher.hash(bytes, bytes.size.toLong())
+        val byStream = IdentityHasher.hash(ByteArrayInputStream(bytes), bytes.size.toLong())
+        assertEquals(byArray, byStream)
+    }
+
+    @Test
+    fun `hash is 40 hex characters (SHA-1)`() {
+        val hash = IdentityHasher.hash("x".toByteArray(), 1L)
+        assertEquals(40, hash.length)
+        assert(hash.all { it in '0'..'9' || it in 'a'..'f' })
+    }
+}

--- a/core/data/src/test/kotlin/com/riffle/core/data/localfiles/LocalFilesScannerTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/localfiles/LocalFilesScannerTest.kt
@@ -161,20 +161,49 @@ class LocalFilesScannerTest {
     // --- walker failure -----------------------------------------------------
 
     @Test
-    fun `folder-walk failure records a failure and marks folder rows stale`() = runTest {
+    fun `folder-walk failure records a failure and preserves rows (no stale sweep on incomplete scan)`() = runTest {
         val h = harness()
         // First scan lands one file.
         h.configureFolder("f1", files = listOf(fakeEpub("A", "B", "a.epub")))
         h.scanner.scan(sourceId)
         assertEquals(1, h.files.rows.size)
 
-        // Second scan: walker throws. Row must not be seen — hence stale — hence deleted.
+        // Second scan: walker throws. A transient walker failure must NOT cascade to deletion —
+        // otherwise a DocumentsProvider hiccup wipes previously-ingested books whose lastSeenAt
+        // was never touched. Row survives; sweep runs on the next fully-clean scan.
         h.clock.advanceMs(1000)
         h.walker.throwFor("f1")
         val report = h.scanner.scan(sourceId)
-        assertEquals(1, report.removed)
+        assertEquals(0, report.removed)
         assertEquals(1, report.failures.size)
-        assertEquals(0, h.files.rows.size)
+        assertEquals(1, h.files.rows.size)
+    }
+
+    @Test
+    fun `ingest failure suppresses the stale sweep for this pass`() = runTest {
+        val h = harness()
+        // First scan: two books, both land.
+        val good = fakeEpub("Good", "A", "good.epub")
+        val bad = WalkedFile(
+            originalUri = "content://f1/bad.epub",
+            displayName = "bad.epub",
+            sizeBytes = 100,
+            mtimeEpochMs = 0,
+            openStream = { throw java.io.IOException("SAF read failed") },
+        )
+        h.configureFolder("f1", files = listOf(good))
+        h.scanner.scan(sourceId)
+        assertEquals(1, h.files.rows.size)
+
+        // Second scan: `bad` is a new file that throws during head-read; `good` is gone. Under the
+        // old (unsafe) behavior good's row would be pruned because its lastSeenAt wasn't touched.
+        // Correct behavior: the ingest exception suppresses the sweep entirely — good is preserved.
+        h.clock.advanceMs(1000)
+        h.configureFolder("f1", files = listOf(bad))
+        val report = h.scanner.scan(sourceId)
+        assertEquals(0, report.removed)
+        assertEquals(1, report.failures.size)
+        assertEquals(1, h.files.rows.size)
     }
 
     // --- multi-folder same file --------------------------------------------

--- a/core/data/src/test/kotlin/com/riffle/core/data/localfiles/LocalFilesScannerTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/localfiles/LocalFilesScannerTest.kt
@@ -1,0 +1,389 @@
+package com.riffle.core.data.localfiles
+
+import com.riffle.core.data.FakeLibraryItemDao
+import com.riffle.core.database.LocalFilesFileDao
+import com.riffle.core.database.LocalFilesFileEntity
+import com.riffle.core.database.LocalFilesFolderDao
+import com.riffle.core.database.LocalFilesFolderEntity
+import com.riffle.core.domain.Clock
+import com.riffle.core.domain.NoOpPdfMetadataExtractor
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.io.InputStream
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+
+class LocalFilesScannerTest {
+
+    private val sourceId = "src-1"
+
+    // --- happy path --------------------------------------------------------
+
+    @Test
+    fun `empty folder yields empty report`() = runTest {
+        val h = harness().apply { configureFolder("f1", files = emptyList()) }
+        val report = h.scanner.scan(sourceId)
+        assertEquals(LocalFilesScanner.ScanReport(0, 0, 0, emptyList()), report)
+        assertTrue(h.libraryItems.upserted.isEmpty())
+    }
+
+    @Test
+    fun `single EPUB adds one library_items row plus local_files_files row`() = runTest {
+        val h = harness().apply {
+            configureFolder("f1", files = listOf(fakeEpub("Dune", "Frank Herbert", "book.epub")))
+        }
+        val report = h.scanner.scan(sourceId)
+        assertEquals(1, report.added)
+        assertEquals(0, report.refreshed)
+        assertEquals(0, report.removed)
+
+        val item = h.libraryItems.upserted.single()
+        assertEquals("Dune", item.title)
+        assertEquals("Frank Herbert", item.author)
+        assertEquals(LocalFilesScanner.LOCAL_ROOT_LIBRARY_ID, item.libraryId)
+        assertEquals(LocalFilesScanner.EBOOK_FORMAT_EPUB, item.ebookFormat)
+        assertNotNull(item.coverUrl) // fakeEpub embeds a cover
+
+        assertEquals(1, h.files.rows.size)
+        val row = h.files.rows.values.single()
+        assertEquals(item.id, row.sourceItemId)
+        assertNotNull(row.copiedPath)
+    }
+
+    @Test
+    fun `re-scan is idempotent — refreshed, no duplicate rows`() = runTest {
+        val h = harness().apply {
+            configureFolder("f1", files = listOf(fakeEpub("Dune", "Herbert", "book.epub")))
+        }
+        h.scanner.scan(sourceId)
+        h.clock.advanceMs(1000)
+        val second = h.scanner.scan(sourceId)
+        assertEquals(0, second.added)
+        assertEquals(1, second.refreshed)
+        assertEquals(0, second.removed)
+        assertEquals(1, h.files.rows.size)
+        // library_items got a single upsert during the first scan and NOT a duplicate on the second.
+        assertEquals(1, h.libraryItems.upserted.size)
+    }
+
+    @Test
+    fun `file removed from folder is hard-deleted`() = runTest {
+        val h = harness()
+        h.configureFolder("f1", files = listOf(fakeEpub("Dune", "Herbert", "book.epub")))
+        h.scanner.scan(sourceId)
+        assertEquals(1, h.files.rows.size)
+
+        h.clock.advanceMs(1000)
+        h.configureFolder("f1", files = emptyList())
+        val second = h.scanner.scan(sourceId)
+        assertEquals(0, second.added)
+        assertEquals(1, second.removed)
+        assertEquals(0, h.files.rows.size)
+        assertTrue(h.copyIn.booksOnDisk.isEmpty())
+    }
+
+    // --- classification / metadata edge cases ------------------------------
+
+    @Test
+    fun `non-epub non-pdf file is skipped with no row`() = runTest {
+        val h = harness().apply {
+            configureFolder(
+                "f1",
+                files = listOf(
+                    WalkedFile(
+                        originalUri = "content://f1/notes.txt",
+                        displayName = "notes.txt",
+                        sizeBytes = 4,
+                        mtimeEpochMs = 0,
+                        openStream = { ByteArrayInputStream("hi!\n".toByteArray()) },
+                    ),
+                ),
+            )
+        }
+        val report = h.scanner.scan(sourceId)
+        assertEquals(0, report.added)
+        assertEquals(0, h.files.rows.size)
+    }
+
+    @Test
+    fun `EPUB extension with garbage bytes is skipped`() = runTest {
+        val h = harness().apply {
+            configureFolder(
+                "f1",
+                files = listOf(
+                    WalkedFile(
+                        originalUri = "content://f1/fake.epub",
+                        displayName = "fake.epub",
+                        sizeBytes = 20,
+                        mtimeEpochMs = 0,
+                        openStream = { ByteArrayInputStream("not a zip at all".toByteArray()) },
+                    ),
+                ),
+            )
+        }
+        val report = h.scanner.scan(sourceId)
+        assertEquals(0, report.added)
+        assertEquals(0, h.files.rows.size)
+    }
+
+    @Test
+    fun `EPUB with no metadata falls back to filename-derived title`() = runTest {
+        val bytes = buildEpub(opfMetadata = "")
+        val h = harness().apply {
+            configureFolder(
+                "f1",
+                files = listOf(
+                    WalkedFile(
+                        originalUri = "content://f1/My Great Book.epub",
+                        displayName = "My Great Book.epub",
+                        sizeBytes = bytes.size.toLong(),
+                        mtimeEpochMs = 0,
+                        openStream = { ByteArrayInputStream(bytes) },
+                    ),
+                ),
+            )
+        }
+        h.scanner.scan(sourceId)
+        val item = h.libraryItems.upserted.single()
+        assertEquals("My Great Book", item.title)
+        assertEquals("", item.author)
+    }
+
+    // --- walker failure -----------------------------------------------------
+
+    @Test
+    fun `folder-walk failure records a failure and marks folder rows stale`() = runTest {
+        val h = harness()
+        // First scan lands one file.
+        h.configureFolder("f1", files = listOf(fakeEpub("A", "B", "a.epub")))
+        h.scanner.scan(sourceId)
+        assertEquals(1, h.files.rows.size)
+
+        // Second scan: walker throws. Row must not be seen — hence stale — hence deleted.
+        h.clock.advanceMs(1000)
+        h.walker.throwFor("f1")
+        val report = h.scanner.scan(sourceId)
+        assertEquals(1, report.removed)
+        assertEquals(1, report.failures.size)
+        assertEquals(0, h.files.rows.size)
+    }
+
+    // --- multi-folder same file --------------------------------------------
+
+    @Test
+    fun `same file in two folders resolves to one row and survives removal from one`() = runTest {
+        val bytes = buildEpub(opfMetadata = """<dc:title>Shared</dc:title>""")
+        fun sharedFile(uri: String) = WalkedFile(
+            originalUri = uri,
+            displayName = "shared.epub",
+            sizeBytes = bytes.size.toLong(),
+            mtimeEpochMs = 0,
+            openStream = { ByteArrayInputStream(bytes) },
+        )
+        val h = harness()
+        h.configureFolder("f1", files = listOf(sharedFile("content://f1/shared.epub")))
+        h.configureFolder("f2", files = listOf(sharedFile("content://f2/shared.epub")))
+        val first = h.scanner.scan(sourceId)
+        assertEquals(1, first.added)     // ← the whole point: same identity hash ⇒ one row.
+        assertEquals(1, first.refreshed) // ← touched by the second folder's scan pass.
+        assertEquals(1, h.files.rows.size)
+
+        // Remove from f1 only; f2 still has it → row survives.
+        h.clock.advanceMs(1000)
+        h.configureFolder("f1", files = emptyList())
+        val second = h.scanner.scan(sourceId)
+        assertEquals(0, second.removed)
+        assertEquals(1, h.files.rows.size)
+
+        // Remove from f2 too → row deleted.
+        h.clock.advanceMs(1000)
+        h.configureFolder("f2", files = emptyList())
+        val third = h.scanner.scan(sourceId)
+        assertEquals(1, third.removed)
+        assertEquals(0, h.files.rows.size)
+    }
+
+    // --- harness ------------------------------------------------------------
+
+    private fun harness(): Harness = Harness()
+
+    private class Harness {
+        val libraryItems = FakeLibraryItemDao()
+        val folders = InMemoryFolderDao()
+        val files = InMemoryFileDao()
+        val walker = InMemoryWalker()
+        val copyIn = InMemoryCopyIn()
+        val clock = MutableClock()
+        val scanner = LocalFilesScanner(
+            folderDao = folders,
+            fileDao = files,
+            libraryItemDao = libraryItems,
+            walker = walker,
+            copyIn = copyIn,
+            pdfMetadata = NoOpPdfMetadataExtractor,
+            clock = clock,
+        )
+
+        suspend fun configureFolder(treeUri: String, files: List<WalkedFile>) {
+            folders.upsert(LocalFilesFolderEntity("src-1", treeUri, treeUri, clock.nowMs()))
+            walker.set(treeUri, files)
+        }
+    }
+
+    private fun fakeEpub(title: String, author: String, displayName: String): WalkedFile {
+        val bytes = buildEpub(
+            opfMetadata = """
+                <dc:title>$title</dc:title>
+                <dc:creator>$author</dc:creator>
+            """.trimIndent(),
+            extraManifestItems = """<item id="c" href="cover.jpg" media-type="image/jpeg" properties="cover-image"/>""",
+            extraZipEntries = listOf("cover.jpg" to ByteArray(16) { it.toByte() }),
+        )
+        return WalkedFile(
+            originalUri = "content://tree/$displayName",
+            displayName = displayName,
+            sizeBytes = bytes.size.toLong(),
+            mtimeEpochMs = 0,
+            openStream = { ByteArrayInputStream(bytes) },
+        )
+    }
+
+    private class MutableClock : Clock {
+        private var t = 1_000L
+        fun advanceMs(by: Long) { t += by }
+        override fun nowMs(): Long = t
+        override fun nowNs(): Long = t * 1_000_000
+    }
+
+    private class InMemoryFolderDao : LocalFilesFolderDao {
+        val store = mutableMapOf<Pair<String, String>, LocalFilesFolderEntity>()
+        override suspend fun upsert(entity: LocalFilesFolderEntity) {
+            store[entity.sourceId to entity.treeUri] = entity
+        }
+        override suspend fun forSource(sourceId: String): List<LocalFilesFolderEntity> =
+            store.values.filter { it.sourceId == sourceId }.sortedBy { it.addedAtEpochMs }
+        override fun observeForSource(sourceId: String): Flow<List<LocalFilesFolderEntity>> =
+            MutableStateFlow(store.values.filter { it.sourceId == sourceId })
+        override suspend fun delete(sourceId: String, treeUri: String) {
+            store.remove(sourceId to treeUri)
+        }
+    }
+
+    private class InMemoryFileDao : LocalFilesFileDao {
+        val rows = mutableMapOf<Pair<String, String>, LocalFilesFileEntity>()
+        override suspend fun upsert(entity: LocalFilesFileEntity) {
+            rows[entity.sourceId to entity.sourceItemId] = entity
+        }
+        override suspend fun findById(sourceId: String, sourceItemId: String): LocalFilesFileEntity? =
+            rows[sourceId to sourceItemId]
+        override suspend fun forSource(sourceId: String): List<LocalFilesFileEntity> =
+            rows.values.filter { it.sourceId == sourceId }
+        override suspend fun touchLastSeen(
+            sourceId: String,
+            sourceItemId: String,
+            folderTreeUri: String,
+            seenAt: Long,
+        ) {
+            val row = rows[sourceId to sourceItemId] ?: return
+            rows[sourceId to sourceItemId] =
+                row.copy(lastSeenAtEpochMs = seenAt, folderTreeUri = folderTreeUri)
+        }
+        override suspend fun stale(sourceId: String, scanStart: Long): List<LocalFilesFileEntity> =
+            rows.values.filter { it.sourceId == sourceId && it.lastSeenAtEpochMs < scanStart }
+        override suspend fun delete(sourceId: String, sourceItemId: String) {
+            rows.remove(sourceId to sourceItemId)
+        }
+    }
+
+    private class InMemoryWalker : FolderWalker {
+        private val entries = mutableMapOf<String, List<WalkedFile>>()
+        private val failing = mutableSetOf<String>()
+        fun set(treeUri: String, files: List<WalkedFile>) {
+            entries[treeUri] = files
+            failing.remove(treeUri)
+        }
+        fun throwFor(treeUri: String) { failing += treeUri }
+        override suspend fun walk(treeUri: String): List<WalkedFile> {
+            if (treeUri in failing) throw IllegalStateException("boom")
+            return entries[treeUri].orEmpty()
+        }
+    }
+
+    private class InMemoryCopyIn : CopyInService {
+        val booksOnDisk = mutableMapOf<String, ByteArray>()
+        val coversOnDisk = mutableMapOf<String, ByteArray>()
+        private val tmp: File = createTempDirectory()
+
+        override suspend fun copyBook(sourceId: String, sourceItemId: String, extension: String, stream: InputStream): File {
+            val bytes = stream.readBytes()
+            booksOnDisk["$sourceId/$sourceItemId"] = bytes
+            val f = File(tmp, "$sourceId-$sourceItemId.$extension")
+            f.writeBytes(bytes)
+            return f
+        }
+
+        override suspend fun writeCover(sourceId: String, sourceItemId: String, extension: String, bytes: ByteArray): File {
+            coversOnDisk["$sourceId/$sourceItemId"] = bytes
+            val f = File(tmp, "cover-$sourceId-$sourceItemId.$extension")
+            f.writeBytes(bytes)
+            return f
+        }
+
+        override suspend fun deleteBook(sourceId: String, sourceItemId: String) {
+            booksOnDisk.remove("$sourceId/$sourceItemId")
+        }
+
+        override suspend fun deleteCover(sourceId: String, sourceItemId: String) {
+            coversOnDisk.remove("$sourceId/$sourceItemId")
+        }
+
+        private fun createTempDirectory(): File =
+            java.nio.file.Files.createTempDirectory("localfiles-test").toFile().also { it.deleteOnExit() }
+    }
+}
+
+private fun buildEpub(
+    opfMetadata: String,
+    extraManifestItems: String = "",
+    extraZipEntries: List<Pair<String, ByteArray>> = emptyList(),
+): ByteArray {
+    val container = """<?xml version="1.0"?>
+        <container xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+          <rootfiles>
+            <rootfile full-path="OEBPS/content.opf" media-type="application/oebps-package+xml"/>
+          </rootfiles>
+        </container>
+    """.trimIndent()
+    val opf = """<?xml version="1.0" encoding="UTF-8"?>
+        <package xmlns="http://www.idpf.org/2007/opf" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:opf="http://www.idpf.org/2007/opf" version="3.0">
+          <metadata>
+            $opfMetadata
+          </metadata>
+          <manifest>
+            <item id="ch1" href="chap1.xhtml" media-type="application/xhtml+xml"/>
+            $extraManifestItems
+          </manifest>
+          <spine><itemref idref="ch1"/></spine>
+        </package>
+    """.trimIndent()
+    val out = ByteArrayOutputStream()
+    ZipOutputStream(out).use { zip ->
+        zip.putNextEntry(ZipEntry("mimetype")); zip.write("application/epub+zip".toByteArray()); zip.closeEntry()
+        zip.putNextEntry(ZipEntry("META-INF/container.xml")); zip.write(container.toByteArray()); zip.closeEntry()
+        zip.putNextEntry(ZipEntry("OEBPS/content.opf")); zip.write(opf.toByteArray(Charsets.UTF_8)); zip.closeEntry()
+        zip.putNextEntry(ZipEntry("OEBPS/chap1.xhtml")); zip.write("<html/>".toByteArray()); zip.closeEntry()
+        for ((name, bytes) in extraZipEntries) {
+            zip.putNextEntry(ZipEntry("OEBPS/$name")); zip.write(bytes); zip.closeEntry()
+        }
+    }
+    return out.toByteArray()
+}

--- a/core/database/schemas/com.riffle.core.database.RiffleDatabase/46.json
+++ b/core/database/schemas/com.riffle.core.database.RiffleDatabase/46.json
@@ -1,0 +1,1586 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 46,
+    "identityHash": "1aa1767ec34a5dd3856aa712c459c4b0",
+    "entities": [
+      {
+        "tableName": "sources",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `url` TEXT NOT NULL, `isActive` INTEGER NOT NULL, `insecureConnectionAllowed` INTEGER NOT NULL, `username` TEXT NOT NULL, `serverType` TEXT NOT NULL, `absUserId` TEXT, `type` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "isActive",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "insecureConnectionAllowed",
+            "columnName": "insecureConnectionAllowed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "username",
+            "columnName": "username",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverType",
+            "columnName": "serverType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absUserId",
+            "columnName": "absUserId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "libraries",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `mediaType` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `isUnsupported` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `id`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaType",
+            "columnName": "mediaType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isUnsupported",
+            "columnName": "isUnsupported",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_libraries_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_libraries_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "library_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `id` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `title` TEXT NOT NULL, `author` TEXT NOT NULL, `coverUrl` TEXT, `readingProgress` REAL NOT NULL, `ebookFileIno` TEXT, `ebookFormat` TEXT NOT NULL, `hasAudio` INTEGER NOT NULL, `audioDurationSec` REAL NOT NULL, `description` TEXT, `seriesName` TEXT, `publishedYear` TEXT, `genres` TEXT NOT NULL, `publisher` TEXT, `language` TEXT, `lastOpenedAt` INTEGER, `addedAt` INTEGER, `isbn` TEXT, `asin` TEXT, `finishedAt` INTEGER, PRIMARY KEY(`sourceId`, `id`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "coverUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "readingProgress",
+            "columnName": "readingProgress",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ebookFileIno",
+            "columnName": "ebookFileIno",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "ebookFormat",
+            "columnName": "ebookFormat",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hasAudio",
+            "columnName": "hasAudio",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "audioDurationSec",
+            "columnName": "audioDurationSec",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seriesName",
+            "columnName": "seriesName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "publishedYear",
+            "columnName": "publishedYear",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "genres",
+            "columnName": "genres",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "publisher",
+            "columnName": "publisher",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "language",
+            "columnName": "language",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastOpenedAt",
+            "columnName": "lastOpenedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "isbn",
+            "columnName": "isbn",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "asin",
+            "columnName": "asin",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "finishedAt",
+            "columnName": "finishedAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_library_items_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_library_items_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "series",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `name` TEXT NOT NULL, `coverUrl` TEXT, `bookCount` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "coverUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "bookCount",
+            "columnName": "bookCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "collections",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `name` TEXT NOT NULL, `bookCount` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookCount",
+            "columnName": "bookCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "series_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`seriesId` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `sequenceOrder` REAL NOT NULL, PRIMARY KEY(`seriesId`, `sourceId`, `itemId`))",
+        "fields": [
+          {
+            "fieldPath": "seriesId",
+            "columnName": "seriesId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sequenceOrder",
+            "columnName": "sequenceOrder",
+            "affinity": "REAL",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "seriesId",
+            "sourceId",
+            "itemId"
+          ]
+        }
+      },
+      {
+        "tableName": "collection_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`collectionId` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, PRIMARY KEY(`collectionId`, `sourceId`, `itemId`))",
+        "fields": [
+          {
+            "fieldPath": "collectionId",
+            "columnName": "collectionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "collectionId",
+            "sourceId",
+            "itemId"
+          ]
+        }
+      },
+      {
+        "tableName": "reading_positions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `cfi` TEXT NOT NULL, `localUpdatedAt` INTEGER NOT NULL, `lastSyncedAt` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `itemId`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cfi",
+            "columnName": "cfi",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localUpdatedAt",
+            "columnName": "localUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncedAt",
+            "columnName": "lastSyncedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "itemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_reading_positions_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_reading_positions_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "book_formatting_preferences",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `scope` TEXT NOT NULL, `fontSize` REAL, `theme` TEXT, `fontFamily` TEXT, `lineSpacing` REAL, `margins` REAL, `orientation` TEXT, `showChapterMap` INTEGER, `showReadingProgressLabels` INTEGER, `showCurrentChapterLabel` INTEGER, `doublePageSpread` INTEGER, `justifyText` INTEGER, `showReadingTimeEstimate` INTEGER, PRIMARY KEY(`sourceId`, `itemId`, `scope`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scope",
+            "columnName": "scope",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fontSize",
+            "columnName": "fontSize",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "theme",
+            "columnName": "theme",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "fontFamily",
+            "columnName": "fontFamily",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lineSpacing",
+            "columnName": "lineSpacing",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "margins",
+            "columnName": "margins",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "orientation",
+            "columnName": "orientation",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "showChapterMap",
+            "columnName": "showChapterMap",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "showReadingProgressLabels",
+            "columnName": "showReadingProgressLabels",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "showCurrentChapterLabel",
+            "columnName": "showCurrentChapterLabel",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "doublePageSpread",
+            "columnName": "doublePageSpread",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "justifyText",
+            "columnName": "justifyText",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "showReadingTimeEstimate",
+            "columnName": "showReadingTimeEstimate",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "itemId",
+            "scope"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_book_formatting_preferences_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_book_formatting_preferences_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "readaloud_links",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`absSourceId` TEXT NOT NULL, `absLibraryItemId` TEXT NOT NULL, `storytellerSourceId` TEXT NOT NULL, `storytellerBookId` TEXT NOT NULL, `state` TEXT NOT NULL, `userConfirmed` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `identityResult` TEXT NOT NULL, PRIMARY KEY(`absSourceId`, `absLibraryItemId`), FOREIGN KEY(`storytellerSourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`absSourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "absSourceId",
+            "columnName": "absSourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absLibraryItemId",
+            "columnName": "absLibraryItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerSourceId",
+            "columnName": "storytellerSourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerBookId",
+            "columnName": "storytellerBookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userConfirmed",
+            "columnName": "userConfirmed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityResult",
+            "columnName": "identityResult",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "absSourceId",
+            "absLibraryItemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_readaloud_links_storytellerSourceId_storytellerBookId",
+            "unique": false,
+            "columnNames": [
+              "storytellerSourceId",
+              "storytellerBookId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_readaloud_links_storytellerSourceId_storytellerBookId` ON `${TABLE_NAME}` (`storytellerSourceId`, `storytellerBookId`)"
+          },
+          {
+            "name": "index_readaloud_links_storytellerSourceId",
+            "unique": false,
+            "columnNames": [
+              "storytellerSourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_readaloud_links_storytellerSourceId` ON `${TABLE_NAME}` (`storytellerSourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "storytellerSourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "absSourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "readaloud_candidates",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`storytellerSourceId` TEXT NOT NULL, `storytellerBookId` TEXT NOT NULL, `absSourceId` TEXT NOT NULL, `absLibraryItemId` TEXT NOT NULL, `score` REAL NOT NULL, PRIMARY KEY(`storytellerSourceId`, `storytellerBookId`, `absSourceId`, `absLibraryItemId`), FOREIGN KEY(`storytellerSourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`absSourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "storytellerSourceId",
+            "columnName": "storytellerSourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerBookId",
+            "columnName": "storytellerBookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absSourceId",
+            "columnName": "absSourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absLibraryItemId",
+            "columnName": "absLibraryItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "score",
+            "columnName": "score",
+            "affinity": "REAL",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "storytellerSourceId",
+            "storytellerBookId",
+            "absSourceId",
+            "absLibraryItemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_readaloud_candidates_absSourceId",
+            "unique": false,
+            "columnNames": [
+              "absSourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_readaloud_candidates_absSourceId` ON `${TABLE_NAME}` (`absSourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "storytellerSourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "absSourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "readaloud_dismissals",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`storytellerSourceId` TEXT NOT NULL, `storytellerBookId` TEXT NOT NULL, `scope` TEXT NOT NULL, `absSourceId` TEXT NOT NULL, `absLibraryItemId` TEXT NOT NULL, PRIMARY KEY(`storytellerSourceId`, `storytellerBookId`, `absSourceId`, `absLibraryItemId`), FOREIGN KEY(`storytellerSourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "storytellerSourceId",
+            "columnName": "storytellerSourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerBookId",
+            "columnName": "storytellerBookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scope",
+            "columnName": "scope",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absSourceId",
+            "columnName": "absSourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absLibraryItemId",
+            "columnName": "absLibraryItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "storytellerSourceId",
+            "storytellerBookId",
+            "absSourceId",
+            "absLibraryItemId"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "storytellerSourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "cross_epub_index",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`absEpubChecksum` TEXT NOT NULL, `storytellerEpubChecksum` TEXT NOT NULL, `perChapterMapsBlob` TEXT NOT NULL, `builtAt` INTEGER NOT NULL, PRIMARY KEY(`absEpubChecksum`, `storytellerEpubChecksum`))",
+        "fields": [
+          {
+            "fieldPath": "absEpubChecksum",
+            "columnName": "absEpubChecksum",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerEpubChecksum",
+            "columnName": "storytellerEpubChecksum",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "perChapterMapsBlob",
+            "columnName": "perChapterMapsBlob",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "builtAt",
+            "columnName": "builtAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "absEpubChecksum",
+            "storytellerEpubChecksum"
+          ]
+        }
+      },
+      {
+        "tableName": "annotations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `type` TEXT NOT NULL, `cfi` TEXT NOT NULL, `color` TEXT NOT NULL, `note` TEXT, `textSnippet` TEXT NOT NULL, `textBefore` TEXT NOT NULL, `textAfter` TEXT NOT NULL, `chapterHref` TEXT NOT NULL, `spineIndex` INTEGER NOT NULL, `progression` REAL NOT NULL, `bookmarkTitle` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `originDeviceId` TEXT NOT NULL, `lastModifiedByDeviceId` TEXT NOT NULL, `deleted` INTEGER NOT NULL, `lastSyncedAt` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cfi",
+            "columnName": "cfi",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "color",
+            "columnName": "color",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "note",
+            "columnName": "note",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "textSnippet",
+            "columnName": "textSnippet",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "textBefore",
+            "columnName": "textBefore",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "textAfter",
+            "columnName": "textAfter",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chapterHref",
+            "columnName": "chapterHref",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "spineIndex",
+            "columnName": "spineIndex",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "progression",
+            "columnName": "progression",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookmarkTitle",
+            "columnName": "bookmarkTitle",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "originDeviceId",
+            "columnName": "originDeviceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastModifiedByDeviceId",
+            "columnName": "lastModifiedByDeviceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deleted",
+            "columnName": "deleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncedAt",
+            "columnName": "lastSyncedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_annotations_sourceId_itemId",
+            "unique": false,
+            "columnNames": [
+              "sourceId",
+              "itemId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_annotations_sourceId_itemId` ON `${TABLE_NAME}` (`sourceId`, `itemId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "readaloud_resume_positions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `href` TEXT NOT NULL, `progression` REAL, `fragmentRef` TEXT, `localUpdatedAt` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `itemId`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "href",
+            "columnName": "href",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "progression",
+            "columnName": "progression",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "fragmentRef",
+            "columnName": "fragmentRef",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localUpdatedAt",
+            "columnName": "localUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "itemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_readaloud_resume_positions_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_readaloud_resume_positions_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "audio_playback_preferences",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `bookId` TEXT NOT NULL, `speed` REAL, PRIMARY KEY(`sourceId`, `bookId`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "speed",
+            "columnName": "speed",
+            "affinity": "REAL"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "bookId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_audio_playback_preferences_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_audio_playback_preferences_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "audiobook_positions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `positionSec` REAL NOT NULL, `localUpdatedAt` INTEGER NOT NULL, `lastSyncedAt` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `itemId`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "positionSec",
+            "columnName": "positionSec",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localUpdatedAt",
+            "columnName": "localUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncedAt",
+            "columnName": "lastSyncedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "itemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_audiobook_positions_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_audiobook_positions_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "audiobook_bookmarks",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `positionSec` REAL NOT NULL, `title` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `localUpdatedAt` INTEGER NOT NULL, `lastSyncedAt` INTEGER NOT NULL, `deleted` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "positionSec",
+            "columnName": "positionSec",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localUpdatedAt",
+            "columnName": "localUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncedAt",
+            "columnName": "lastSyncedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deleted",
+            "columnName": "deleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_audiobook_bookmarks_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_audiobook_bookmarks_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          },
+          {
+            "name": "index_audiobook_bookmarks_sourceId_itemId",
+            "unique": false,
+            "columnNames": [
+              "sourceId",
+              "itemId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_audiobook_bookmarks_sourceId_itemId` ON `${TABLE_NAME}` (`sourceId`, `itemId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "toc_cache",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `ebookFileIno` TEXT NOT NULL, `entriesJson` TEXT NOT NULL, PRIMARY KEY(`sourceId`, `itemId`))",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ebookFileIno",
+            "columnName": "ebookFileIno",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entriesJson",
+            "columnName": "entriesJson",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "itemId"
+          ]
+        }
+      },
+      {
+        "tableName": "audiobook_chapter_cache",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `chaptersJson` TEXT NOT NULL, PRIMARY KEY(`sourceId`, `itemId`))",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chaptersJson",
+            "columnName": "chaptersJson",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "itemId"
+          ]
+        }
+      },
+      {
+        "tableName": "local_files_folders",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `treeUri` TEXT NOT NULL, `displayName` TEXT NOT NULL, `addedAtEpochMs` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `treeUri`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "treeUri",
+            "columnName": "treeUri",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAtEpochMs",
+            "columnName": "addedAtEpochMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "treeUri"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_files_folders_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_files_folders_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "local_files_files",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `sourceItemId` TEXT NOT NULL, `folderTreeUri` TEXT NOT NULL, `originalUri` TEXT NOT NULL, `copiedPath` TEXT NOT NULL, `coverPath` TEXT, `format` TEXT NOT NULL, `sizeBytes` INTEGER NOT NULL, `mtimeEpochMs` INTEGER NOT NULL, `lastSeenAtEpochMs` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `sourceItemId`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceItemId",
+            "columnName": "sourceItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "folderTreeUri",
+            "columnName": "folderTreeUri",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "originalUri",
+            "columnName": "originalUri",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "copiedPath",
+            "columnName": "copiedPath",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverPath",
+            "columnName": "coverPath",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "format",
+            "columnName": "format",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sizeBytes",
+            "columnName": "sizeBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mtimeEpochMs",
+            "columnName": "mtimeEpochMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSeenAtEpochMs",
+            "columnName": "lastSeenAtEpochMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "sourceItemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_files_files_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_files_files_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '1aa1767ec34a5dd3856aa712c459c4b0')"
+    ]
+  }
+}

--- a/core/database/src/androidTest/kotlin/com/riffle/core/database/MigrationTest.kt
+++ b/core/database/src/androidTest/kotlin/com/riffle/core/database/MigrationTest.kt
@@ -1846,6 +1846,71 @@ class MigrationTest {
     }
 
     @Test
+    fun migration45To46_addsLocalFilesTables() {
+        helper.createDatabase(TEST_DB, 45).use { db ->
+            // Pre-existing Source row must survive the additive migration.
+            db.execSQL(
+                "INSERT INTO sources (id, url, isActive, insecureConnectionAllowed, username, serverType, absUserId, type) " +
+                    "VALUES ('src-A', 'https://abs.example.com', 1, 0, 'alice', 'AUDIOBOOKSHELF', NULL, 'ABS')"
+            )
+        }
+        helper.runMigrationsAndValidate(TEST_DB, 46, true, RiffleDatabase.MIGRATION_45_46).use { db ->
+            // Pre-existing sources row untouched.
+            db.query("SELECT COUNT(*) FROM sources WHERE id = 'src-A'").use { c ->
+                c.moveToFirst(); assertEquals(1, c.getInt(0))
+            }
+
+            // local_files_folders exists and accepts insertions.
+            db.execSQL(
+                "INSERT INTO local_files_folders (sourceId, treeUri, displayName, addedAtEpochMs) " +
+                    "VALUES ('src-A', 'content://books', 'Books', 100)"
+            )
+            db.query(
+                "SELECT sourceId, treeUri, displayName, addedAtEpochMs FROM local_files_folders " +
+                    "WHERE sourceId = 'src-A' AND treeUri = 'content://books'"
+            ).use { c ->
+                assertEquals(1, c.count)
+                c.moveToFirst()
+                assertEquals("src-A", c.getString(0))
+                assertEquals("content://books", c.getString(1))
+                assertEquals("Books", c.getString(2))
+                assertEquals(100L, c.getLong(3))
+            }
+
+            // local_files_files exists with expected shape including nullable coverPath.
+            db.execSQL(
+                "INSERT INTO local_files_files " +
+                    "(sourceId, sourceItemId, folderTreeUri, originalUri, copiedPath, coverPath, " +
+                    " format, sizeBytes, mtimeEpochMs, lastSeenAtEpochMs) " +
+                    "VALUES ('src-A', 'hash-1', 'content://books', 'content://books/a.epub', " +
+                    " '/data/books/hash-1.epub', NULL, 'epub', 1024, 500, 1000)"
+            )
+            db.query(
+                "SELECT sourceItemId, coverPath, format, sizeBytes, lastSeenAtEpochMs FROM local_files_files " +
+                    "WHERE sourceId = 'src-A'"
+            ).use { c ->
+                assertEquals(1, c.count)
+                c.moveToFirst()
+                assertEquals("hash-1", c.getString(0))
+                assertTrue("coverPath defaults nullable", c.isNull(1))
+                assertEquals("epub", c.getString(2))
+                assertEquals(1024L, c.getLong(3))
+                assertEquals(1000L, c.getLong(4))
+            }
+
+            // Sources FK-cascades to both new tables.
+            db.execSQL("PRAGMA foreign_keys = ON")
+            db.execSQL("DELETE FROM sources WHERE id = 'src-A'")
+            db.query("SELECT COUNT(*) FROM local_files_folders WHERE sourceId = 'src-A'").use { c ->
+                c.moveToFirst(); assertEquals(0, c.getInt(0))
+            }
+            db.query("SELECT COUNT(*) FROM local_files_files WHERE sourceId = 'src-A'").use { c ->
+                c.moveToFirst(); assertEquals(0, c.getInt(0))
+            }
+        }
+    }
+
+    @Test
     fun migrateFullChain() {
         helper.createDatabase(TEST_DB, 1).use { db ->
             db.execSQL(
@@ -1899,6 +1964,7 @@ class MigrationTest {
             RiffleDatabase.MIGRATION_42_43,
             RiffleDatabase.MIGRATION_43_44,
             RiffleDatabase.MIGRATION_44_45,
+            RiffleDatabase.MIGRATION_45_46,
         )
 
         db.query("SELECT url, username, serverType, absUserId, type FROM sources WHERE id = 's1'").use { cursor ->

--- a/core/database/src/main/kotlin/com/riffle/core/database/LibraryItemDao.kt
+++ b/core/database/src/main/kotlin/com/riffle/core/database/LibraryItemDao.kt
@@ -73,6 +73,9 @@ interface LibraryItemDao {
     @Query("DELETE FROM library_items WHERE sourceId = :sourceId AND libraryId = :libraryId")
     suspend fun deleteByLibraryId(sourceId: String, libraryId: String)
 
+    @Query("DELETE FROM library_items WHERE sourceId = :sourceId AND id = :itemId")
+    suspend fun deleteById(sourceId: String, itemId: String)
+
     @Transaction
     suspend fun replaceAllForLibrary(sourceId: String, libraryId: String, items: List<LibraryItemEntity>) {
         if (items.isEmpty()) {

--- a/core/database/src/main/kotlin/com/riffle/core/database/LocalFilesFileDao.kt
+++ b/core/database/src/main/kotlin/com/riffle/core/database/LocalFilesFileDao.kt
@@ -1,0 +1,35 @@
+package com.riffle.core.database
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+
+@Dao
+interface LocalFilesFileDao {
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsert(entity: LocalFilesFileEntity)
+
+    @Query("SELECT * FROM local_files_files WHERE sourceId = :sourceId AND sourceItemId = :sourceItemId LIMIT 1")
+    suspend fun findById(sourceId: String, sourceItemId: String): LocalFilesFileEntity?
+
+    @Query("SELECT * FROM local_files_files WHERE sourceId = :sourceId")
+    suspend fun forSource(sourceId: String): List<LocalFilesFileEntity>
+
+    @Query(
+        "UPDATE local_files_files SET lastSeenAtEpochMs = :seenAt, folderTreeUri = :folderTreeUri " +
+            "WHERE sourceId = :sourceId AND sourceItemId = :sourceItemId",
+    )
+    suspend fun touchLastSeen(sourceId: String, sourceItemId: String, folderTreeUri: String, seenAt: Long)
+
+    /**
+     * Rows in this source that were not seen during the current scan. Callers hard-delete these
+     * (and their library_items rows + copied bytes) after the walk finishes.
+     */
+    @Query("SELECT * FROM local_files_files WHERE sourceId = :sourceId AND lastSeenAtEpochMs < :scanStart")
+    suspend fun stale(sourceId: String, scanStart: Long): List<LocalFilesFileEntity>
+
+    @Query("DELETE FROM local_files_files WHERE sourceId = :sourceId AND sourceItemId = :sourceItemId")
+    suspend fun delete(sourceId: String, sourceItemId: String)
+}

--- a/core/database/src/main/kotlin/com/riffle/core/database/LocalFilesFileEntity.kt
+++ b/core/database/src/main/kotlin/com/riffle/core/database/LocalFilesFileEntity.kt
@@ -1,0 +1,36 @@
+package com.riffle.core.database
+
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+
+/**
+ * One ingested local book file. Composite PK (sourceId, sourceItemId) where sourceItemId is a
+ * content-based identity hash (see IdentityHasher), so the same file present in multiple folders
+ * resolves to a single row. `lastSeenAtEpochMs` is bumped every scan; stale rows are hard-deleted.
+ */
+@Entity(
+    tableName = "local_files_files",
+    primaryKeys = ["sourceId", "sourceItemId"],
+    foreignKeys = [
+        ForeignKey(
+            entity = SourceEntity::class,
+            parentColumns = ["id"],
+            childColumns = ["sourceId"],
+            onDelete = ForeignKey.CASCADE,
+        ),
+    ],
+    indices = [Index("sourceId")],
+)
+data class LocalFilesFileEntity(
+    val sourceId: String,
+    val sourceItemId: String,
+    val folderTreeUri: String,
+    val originalUri: String,
+    val copiedPath: String,
+    val coverPath: String?,
+    val format: String,
+    val sizeBytes: Long,
+    val mtimeEpochMs: Long,
+    val lastSeenAtEpochMs: Long,
+)

--- a/core/database/src/main/kotlin/com/riffle/core/database/LocalFilesFolderDao.kt
+++ b/core/database/src/main/kotlin/com/riffle/core/database/LocalFilesFolderDao.kt
@@ -1,0 +1,23 @@
+package com.riffle.core.database
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface LocalFilesFolderDao {
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsert(entity: LocalFilesFolderEntity)
+
+    @Query("SELECT * FROM local_files_folders WHERE sourceId = :sourceId ORDER BY addedAtEpochMs ASC")
+    suspend fun forSource(sourceId: String): List<LocalFilesFolderEntity>
+
+    @Query("SELECT * FROM local_files_folders WHERE sourceId = :sourceId ORDER BY addedAtEpochMs ASC")
+    fun observeForSource(sourceId: String): Flow<List<LocalFilesFolderEntity>>
+
+    @Query("DELETE FROM local_files_folders WHERE sourceId = :sourceId AND treeUri = :treeUri")
+    suspend fun delete(sourceId: String, treeUri: String)
+}

--- a/core/database/src/main/kotlin/com/riffle/core/database/LocalFilesFolderEntity.kt
+++ b/core/database/src/main/kotlin/com/riffle/core/database/LocalFilesFolderEntity.kt
@@ -1,0 +1,29 @@
+package com.riffle.core.database
+
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+
+/**
+ * One user-picked local folder configured under a LocalFiles Source. `treeUri` is the SAF tree URI
+ * the user granted persistable read permission on; scans re-walk it every time.
+ */
+@Entity(
+    tableName = "local_files_folders",
+    primaryKeys = ["sourceId", "treeUri"],
+    foreignKeys = [
+        ForeignKey(
+            entity = SourceEntity::class,
+            parentColumns = ["id"],
+            childColumns = ["sourceId"],
+            onDelete = ForeignKey.CASCADE,
+        ),
+    ],
+    indices = [Index("sourceId")],
+)
+data class LocalFilesFolderEntity(
+    val sourceId: String,
+    val treeUri: String,
+    val displayName: String,
+    val addedAtEpochMs: Long,
+)

--- a/core/database/src/main/kotlin/com/riffle/core/database/RiffleDatabase.kt
+++ b/core/database/src/main/kotlin/com/riffle/core/database/RiffleDatabase.kt
@@ -27,8 +27,10 @@ import androidx.sqlite.db.SupportSQLiteDatabase
         AudiobookBookmarkEntity::class,
         TocCacheEntity::class,
         AudiobookChapterCacheEntity::class,
+        LocalFilesFolderEntity::class,
+        LocalFilesFileEntity::class,
     ],
-    version = 45,
+    version = 46,
     exportSchema = true,
 )
 abstract class RiffleDatabase : RoomDatabase() {
@@ -50,6 +52,8 @@ abstract class RiffleDatabase : RoomDatabase() {
     abstract fun audiobookBookmarkDao(): AudiobookBookmarkDao
     abstract fun tocCacheDao(): TocCacheDao
     abstract fun audiobookChapterCacheDao(): AudiobookChapterCacheDao
+    abstract fun localFilesFolderDao(): LocalFilesFolderDao
+    abstract fun localFilesFileDao(): LocalFilesFileDao
 
     companion object {
         val MIGRATION_1_2 = object : Migration(1, 2) {
@@ -1239,6 +1243,47 @@ abstract class RiffleDatabase : RoomDatabase() {
                 } finally {
                     db.execSQL("PRAGMA foreign_keys=ON")
                 }
+            }
+        }
+
+        // ADR 0041 phase 5a (issue #437): LocalFiles ingestion pipeline. Adds two additive tables
+        // backing configured folders and per-file ingest records under a LocalFiles Source. No
+        // existing tables are touched. Both tables FK-cascade on sources(id) so a Source removal
+        // clears its folder configuration and file records; the actual library_items rows and the
+        // copied bytes on disk are still cleaned up by the scanner's stale-row sweep (or by the
+        // library_items FK cascade on Source removal — which also removes them).
+        val MIGRATION_45_46 = object : Migration(45, 46) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL(
+                    "CREATE TABLE IF NOT EXISTS `local_files_folders` (" +
+                        "`sourceId` TEXT NOT NULL, " +
+                        "`treeUri` TEXT NOT NULL, " +
+                        "`displayName` TEXT NOT NULL, " +
+                        "`addedAtEpochMs` INTEGER NOT NULL, " +
+                        "PRIMARY KEY(`sourceId`, `treeUri`), " +
+                        "FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )"
+                )
+                db.execSQL(
+                    "CREATE INDEX IF NOT EXISTS `index_local_files_folders_sourceId` ON `local_files_folders` (`sourceId`)"
+                )
+                db.execSQL(
+                    "CREATE TABLE IF NOT EXISTS `local_files_files` (" +
+                        "`sourceId` TEXT NOT NULL, " +
+                        "`sourceItemId` TEXT NOT NULL, " +
+                        "`folderTreeUri` TEXT NOT NULL, " +
+                        "`originalUri` TEXT NOT NULL, " +
+                        "`copiedPath` TEXT NOT NULL, " +
+                        "`coverPath` TEXT, " +
+                        "`format` TEXT NOT NULL, " +
+                        "`sizeBytes` INTEGER NOT NULL, " +
+                        "`mtimeEpochMs` INTEGER NOT NULL, " +
+                        "`lastSeenAtEpochMs` INTEGER NOT NULL, " +
+                        "PRIMARY KEY(`sourceId`, `sourceItemId`), " +
+                        "FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )"
+                )
+                db.execSQL(
+                    "CREATE INDEX IF NOT EXISTS `index_local_files_files_sourceId` ON `local_files_files` (`sourceId`)"
+                )
             }
         }
     }

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/EpubMetadata.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/EpubMetadata.kt
@@ -1,0 +1,57 @@
+package com.riffle.core.domain
+
+/**
+ * Metadata pulled from an EPUB's OPF `<metadata>` block plus the cover image bytes located via
+ * `<manifest item properties="cover-image">` (EPUB3) or `<meta name="cover">` (EPUB2). Every field
+ * is nullable — an EPUB with an empty `<metadata>` block is well-formed and yields an all-nulls
+ * result rather than an exception.
+ */
+data class EpubMetadata(
+    val title: String?,
+    val author: String?,
+    val language: String?,
+    val publisher: String?,
+    val publishedYear: String?,
+    val description: String?,
+    val isbn: String?,
+    val asin: String?,
+    val seriesName: String?,
+    val genres: List<String>,
+    val coverBytes: ByteArray?,
+    val coverExtension: String?,
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is EpubMetadata) return false
+        return title == other.title && author == other.author && language == other.language &&
+            publisher == other.publisher && publishedYear == other.publishedYear &&
+            description == other.description && isbn == other.isbn && asin == other.asin &&
+            seriesName == other.seriesName && genres == other.genres &&
+            coverExtension == other.coverExtension &&
+            (coverBytes?.contentEquals(other.coverBytes) ?: (other.coverBytes == null))
+    }
+
+    override fun hashCode(): Int {
+        var r = title.hashCode()
+        r = 31 * r + (author?.hashCode() ?: 0)
+        r = 31 * r + (language?.hashCode() ?: 0)
+        r = 31 * r + (publisher?.hashCode() ?: 0)
+        r = 31 * r + (publishedYear?.hashCode() ?: 0)
+        r = 31 * r + (description?.hashCode() ?: 0)
+        r = 31 * r + (isbn?.hashCode() ?: 0)
+        r = 31 * r + (asin?.hashCode() ?: 0)
+        r = 31 * r + (seriesName?.hashCode() ?: 0)
+        r = 31 * r + genres.hashCode()
+        r = 31 * r + (coverBytes?.contentHashCode() ?: 0)
+        r = 31 * r + (coverExtension?.hashCode() ?: 0)
+        return r
+    }
+
+    companion object {
+        val EMPTY = EpubMetadata(
+            title = null, author = null, language = null, publisher = null,
+            publishedYear = null, description = null, isbn = null, asin = null,
+            seriesName = null, genres = emptyList(), coverBytes = null, coverExtension = null,
+        )
+    }
+}

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/EpubMetadataExtractor.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/EpubMetadataExtractor.kt
@@ -1,0 +1,223 @@
+package com.riffle.core.domain
+
+import org.w3c.dom.Element
+import java.io.ByteArrayInputStream
+import java.io.File
+import java.util.zip.ZipFile
+import java.util.zip.ZipInputStream
+import javax.xml.parsers.DocumentBuilderFactory
+
+/**
+ * Pulls the Dublin Core metadata + cover image out of an EPUB. Pure JVM. Sibling to
+ * [EpubContentExtractor] — shares the container.xml → OPF walk pattern but returns a small
+ * metadata record instead of chapter HTML. Never throws on malformed input; a broken zip or a
+ * missing OPF yields [EpubMetadata.EMPTY].
+ */
+object EpubMetadataExtractor {
+
+    fun extract(epubBytes: ByteArray): EpubMetadata {
+        val entries = try { readAllEntries(epubBytes) } catch (_: Exception) { return EpubMetadata.EMPTY }
+        return extractFrom { entries[it] }
+    }
+
+    fun extract(epub: File): EpubMetadata = try {
+        ZipFile(epub).use { zip ->
+            extractFrom { name -> zip.getEntry(name)?.let { zip.getInputStream(it).use { s -> s.readBytes() } } }
+        }
+    } catch (_: Exception) {
+        EpubMetadata.EMPTY
+    }
+
+    private fun extractFrom(lookup: (String) -> ByteArray?): EpubMetadata = try {
+        val containerBytes = lookup("META-INF/container.xml") ?: return EpubMetadata.EMPTY
+        val opfPath = rootfilePath(containerBytes) ?: return EpubMetadata.EMPTY
+        val opfDir = opfPath.substringBeforeLast('/', "")
+        val opfBytes = lookup(opfPath) ?: return EpubMetadata.EMPTY
+        val opf = parseXml(opfBytes) ?: return EpubMetadata.EMPTY
+
+        val metadataEl = opf.firstElementByTag("metadata")
+        val title = metadataEl?.firstDcText("title")
+        val author = metadataEl?.collectDcText("creator")?.joinToString(", ")?.ifEmpty { null }
+        val language = metadataEl?.firstDcText("language")
+        val publisher = metadataEl?.firstDcText("publisher")
+        val publishedYear = metadataEl?.firstDcText("date")?.let { parseYear(it) }
+        val description = metadataEl?.firstDcText("description")
+        val (isbn, asin) = metadataEl?.let { parseIdentifiers(it) } ?: (null to null)
+        val genres = metadataEl?.collectDcText("subject") ?: emptyList()
+        val seriesName = metadataEl?.let { parseSeries(it) }
+
+        // Cover: EPUB3 (manifest item with properties="cover-image") preferred, EPUB2 (<meta
+        // name="cover" content="X"> → manifest[id=X]) fallback.
+        val (coverBytes, coverExt) = findCover(opf, opfDir, lookup)
+
+        EpubMetadata(
+            title = title,
+            author = author,
+            language = language,
+            publisher = publisher,
+            publishedYear = publishedYear,
+            description = description,
+            isbn = isbn,
+            asin = asin,
+            seriesName = seriesName,
+            genres = genres,
+            coverBytes = coverBytes,
+            coverExtension = coverExt,
+        )
+    } catch (_: Exception) {
+        EpubMetadata.EMPTY
+    }
+
+    private fun parseIdentifiers(metadata: Element): Pair<String?, String?> {
+        var isbn: String? = null
+        var asin: String? = null
+        for (id in metadata.dcElementsByTag("identifier")) {
+            val value = id.textContent?.trim().orEmpty()
+            if (value.isEmpty()) continue
+            val scheme = id.getAttribute("opf:scheme").ifEmpty { id.getAttribute("scheme") }.lowercase()
+            when {
+                scheme.contains("isbn") -> if (isbn == null) isbn = value
+                scheme.contains("asin") -> if (asin == null) asin = value
+                // Some publishers embed a scheme-less identifier of the form "urn:isbn:…".
+                value.startsWith("urn:isbn:", ignoreCase = true) && isbn == null ->
+                    isbn = value.substringAfter(':').substringAfter(':')
+            }
+        }
+        return isbn to asin
+    }
+
+    private fun parseSeries(metadata: Element): String? {
+        // EPUB3: <meta property="belongs-to-collection" refines="…">Name</meta> with a sibling
+        // <meta property="collection-type" refines="#id">series</meta>. We accept any collection
+        // if we can't confirm the type, since many publishers omit collection-type entirely.
+        val collections = metadata.elementsByTag("meta")
+            .filter { it.getAttribute("property") == "belongs-to-collection" }
+        if (collections.isEmpty()) {
+            // EPUB2 (calibre): <meta name="calibre:series" content="Name">.
+            val calibre = metadata.elementsByTag("meta")
+                .firstOrNull { it.getAttribute("name") == "calibre:series" }
+            return calibre?.getAttribute("content")?.ifEmpty { null }
+        }
+        // Prefer a collection whose sibling collection-type is 'series'.
+        val idToType = metadata.elementsByTag("meta")
+            .filter { it.getAttribute("property") == "collection-type" }
+            .associate { it.getAttribute("refines").removePrefix("#") to it.textContent.trim().lowercase() }
+        val series = collections.firstOrNull { c ->
+            val id = c.getAttribute("id")
+            idToType[id] == "series"
+        } ?: collections.first()
+        return series.textContent?.trim()?.ifEmpty { null }
+    }
+
+    private fun findCover(
+        opf: Element,
+        opfDir: String,
+        lookup: (String) -> ByteArray?,
+    ): Pair<ByteArray?, String?> {
+        val manifest = opf.firstElementByTag("manifest") ?: return null to null
+        val items = manifest.elementsByTag("item")
+
+        // EPUB3
+        val e3 = items.firstOrNull { it.getAttribute("properties").split(' ').contains("cover-image") }
+        val e3Href = e3?.getAttribute("href")?.ifEmpty { null }
+        if (e3Href != null) {
+            val bytes = lookup(resolve(opfDir, e3Href))
+            if (bytes != null) return bytes to extensionOf(e3Href)
+        }
+
+        // EPUB2
+        val metaCover = opf.firstElementByTag("metadata")?.elementsByTag("meta")
+            ?.firstOrNull { it.getAttribute("name") == "cover" }
+            ?.getAttribute("content")?.ifEmpty { null }
+        if (metaCover != null) {
+            val item = items.firstOrNull { it.getAttribute("id") == metaCover }
+            val href = item?.getAttribute("href")?.ifEmpty { null }
+            if (href != null) {
+                val bytes = lookup(resolve(opfDir, href))
+                if (bytes != null) return bytes to extensionOf(href)
+            }
+        }
+        return null to null
+    }
+
+    private fun parseYear(raw: String): String? {
+        // dc:date is often ISO-8601; keep just the 4-digit year prefix when present.
+        val trimmed = raw.trim()
+        if (trimmed.isEmpty()) return null
+        val yearMatch = Regex("""^(\d{4})""").find(trimmed) ?: return null
+        return yearMatch.value
+    }
+
+    private fun extensionOf(href: String): String? {
+        val name = href.substringAfterLast('/', href)
+        val dot = name.lastIndexOf('.')
+        return if (dot in 1 until name.length - 1) name.substring(dot + 1).lowercase() else null
+    }
+
+    private fun readAllEntries(bytes: ByteArray): Map<String, ByteArray> {
+        val out = LinkedHashMap<String, ByteArray>()
+        ZipInputStream(ByteArrayInputStream(bytes)).use { zip ->
+            var entry = zip.nextEntry
+            while (entry != null) {
+                if (!entry.isDirectory) out[entry.name] = zip.readBytes()
+                entry = zip.nextEntry
+            }
+        }
+        return out
+    }
+
+    private fun rootfilePath(containerXml: ByteArray): String? {
+        val doc = parseXml(containerXml) ?: return null
+        return doc.elementsByTag("rootfile").firstOrNull()?.getAttribute("full-path")?.takeIf { it.isNotEmpty() }
+    }
+
+    private fun resolve(opfDir: String, href: String): String {
+        val base = if (opfDir.isEmpty()) emptyList() else opfDir.split('/').toMutableList()
+        val segments = base.toMutableList()
+        for (part in href.split('/')) {
+            when (part) {
+                "", "." -> {}
+                ".." -> if (segments.isNotEmpty()) segments.removeAt(segments.size - 1)
+                else -> segments += part
+            }
+        }
+        return segments.joinToString("/")
+    }
+
+    private fun parseXml(bytes: ByteArray): Element? = try {
+        DocumentBuilderFactory.newInstance()
+            .apply { isNamespaceAware = false }
+            .newDocumentBuilder()
+            .parse(ByteArrayInputStream(bytes))
+            .documentElement
+    } catch (_: Exception) {
+        null
+    }
+
+    private fun Element.elementsByTag(tag: String): List<Element> {
+        val nodes = getElementsByTagName(tag)
+        return (0 until nodes.length).mapNotNull { nodes.item(it) as? Element }
+    }
+
+    private fun Element.firstElementByTag(tag: String): Element? = elementsByTag(tag).firstOrNull()
+
+    private fun Element.firstText(tag: String): String? =
+        elementsByTag(tag).firstOrNull()?.textContent?.trim()?.ifEmpty { null }
+
+    private fun Element.collectText(tag: String): List<String> =
+        elementsByTag(tag).mapNotNull { it.textContent?.trim()?.ifEmpty { null } }
+
+    /**
+     * OPF's Dublin Core metadata elements always carry the `dc:` prefix in real files, but Room
+     * fixtures / stripped exports sometimes use the un-prefixed form. Namespace-unaware parsing
+     * treats the qualified name as literal, so we look for both.
+     */
+    private fun Element.dcElementsByTag(local: String): List<Element> =
+        elementsByTag("dc:$local") + elementsByTag(local)
+
+    private fun Element.firstDcText(local: String): String? =
+        dcElementsByTag(local).firstOrNull()?.textContent?.trim()?.ifEmpty { null }
+
+    private fun Element.collectDcText(local: String): List<String> =
+        dcElementsByTag(local).mapNotNull { it.textContent?.trim()?.ifEmpty { null } }
+}

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/PdfMetadataExtractor.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/PdfMetadataExtractor.kt
@@ -1,0 +1,28 @@
+package com.riffle.core.domain
+
+import java.io.File
+
+data class PdfMetadata(
+    val title: String?,
+    val author: String?,
+    val subject: String?,
+    val keywords: List<String>,
+) {
+    companion object {
+        val EMPTY = PdfMetadata(title = null, author = null, subject = null, keywords = emptyList())
+    }
+}
+
+/**
+ * PDF metadata surface — an interface so the scanner stays JVM-testable. Pdfium's document-meta
+ * reader is Android-only; the real [com.riffle.core.data.localfiles.PdfiumPdfMetadataExtractor]
+ * uses it, and JVM tests substitute [NoOpPdfMetadataExtractor].
+ */
+interface PdfMetadataExtractor {
+    suspend fun extract(file: File): PdfMetadata
+}
+
+/** Always returns empty. Used in JVM tests and as a fallback if the Pdfium impl fails. */
+object NoOpPdfMetadataExtractor : PdfMetadataExtractor {
+    override suspend fun extract(file: File): PdfMetadata = PdfMetadata.EMPTY
+}

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/SourceStorageModel.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/SourceStorageModel.kt
@@ -12,6 +12,7 @@ package com.riffle.core.domain
  */
 fun SourceType.hasCacheTier(): Boolean = when (this) {
     SourceType.ABS -> true
+    SourceType.LOCAL_FILES -> false
 }
 
 /**

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/SourceType.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/SourceType.kt
@@ -2,4 +2,5 @@ package com.riffle.core.domain
 
 enum class SourceType {
     ABS,
+    LOCAL_FILES,
 }

--- a/core/domain/src/test/kotlin/com/riffle/core/domain/EpubMetadataExtractorTest.kt
+++ b/core/domain/src/test/kotlin/com/riffle/core/domain/EpubMetadataExtractorTest.kt
@@ -1,0 +1,179 @@
+package com.riffle.core.domain
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.ByteArrayOutputStream
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+
+class EpubMetadataExtractorTest {
+
+    @Test
+    fun `minimal EPUB with title creator language`() {
+        val epub = buildEpub(
+            opfMetadata = """
+                <dc:title>Dune</dc:title>
+                <dc:creator>Frank Herbert</dc:creator>
+                <dc:language>en</dc:language>
+            """.trimIndent(),
+        )
+        val md = EpubMetadataExtractor.extract(epub)
+        assertEquals("Dune", md.title)
+        assertEquals("Frank Herbert", md.author)
+        assertEquals("en", md.language)
+        assertNull(md.publisher)
+    }
+
+    @Test
+    fun `full metadata including publisher year isbn series and genres`() {
+        val epub = buildEpub(
+            opfMetadata = """
+                <dc:title>The Dispossessed</dc:title>
+                <dc:creator>Ursula K. Le Guin</dc:creator>
+                <dc:language>en</dc:language>
+                <dc:publisher>Harper &amp; Row</dc:publisher>
+                <dc:date>1974-05-01</dc:date>
+                <dc:identifier opf:scheme="ISBN">9780061054884</dc:identifier>
+                <dc:subject>Science Fiction</dc:subject>
+                <dc:subject>Anarchism</dc:subject>
+                <meta property="belongs-to-collection" id="c1">Hainish Cycle</meta>
+                <meta property="collection-type" refines="#c1">series</meta>
+            """.trimIndent(),
+        )
+        val md = EpubMetadataExtractor.extract(epub)
+        assertEquals("The Dispossessed", md.title)
+        assertEquals("Ursula K. Le Guin", md.author)
+        assertEquals("Harper & Row", md.publisher)
+        assertEquals("1974", md.publishedYear)
+        assertEquals("9780061054884", md.isbn)
+        assertEquals(listOf("Science Fiction", "Anarchism"), md.genres)
+        assertEquals("Hainish Cycle", md.seriesName)
+    }
+
+    @Test
+    fun `multiple creators joined with comma`() {
+        val epub = buildEpub(
+            opfMetadata = """
+                <dc:title>Good Omens</dc:title>
+                <dc:creator>Terry Pratchett</dc:creator>
+                <dc:creator>Neil Gaiman</dc:creator>
+            """.trimIndent(),
+        )
+        val md = EpubMetadataExtractor.extract(epub)
+        assertEquals("Terry Pratchett, Neil Gaiman", md.author)
+    }
+
+    @Test
+    fun `EPUB3 cover-image manifest properties extracts bytes`() {
+        val coverPayload = ByteArray(64) { it.toByte() }
+        val epub = buildEpub(
+            opfMetadata = """<dc:title>x</dc:title>""",
+            extraManifestItems = """<item id="cover-img" href="cover.jpg" media-type="image/jpeg" properties="cover-image"/>""",
+            extraZipEntries = listOf("cover.jpg" to coverPayload),
+        )
+        val md = EpubMetadataExtractor.extract(epub)
+        assertNotNull(md.coverBytes)
+        assertTrue(md.coverBytes!!.contentEquals(coverPayload))
+        assertEquals("jpg", md.coverExtension)
+    }
+
+    @Test
+    fun `EPUB2 cover meta name fallback resolves manifest item`() {
+        val coverPayload = ByteArray(32) { (it * 2).toByte() }
+        val epub = buildEpub(
+            opfMetadata = """
+                <dc:title>x</dc:title>
+                <meta name="cover" content="cover-item"/>
+            """.trimIndent(),
+            extraManifestItems = """<item id="cover-item" href="images/cover.png" media-type="image/png"/>""",
+            extraZipEntries = listOf("images/cover.png" to coverPayload),
+        )
+        val md = EpubMetadataExtractor.extract(epub)
+        assertNotNull(md.coverBytes)
+        assertTrue(md.coverBytes!!.contentEquals(coverPayload))
+        assertEquals("png", md.coverExtension)
+    }
+
+    @Test
+    fun `no metadata block yields EMPTY-shaped result without throwing`() {
+        val epub = buildEpub(opfMetadata = "")
+        val md = EpubMetadataExtractor.extract(epub)
+        assertNull(md.title)
+        assertNull(md.author)
+        assertEquals(emptyList<String>(), md.genres)
+        assertNull(md.coverBytes)
+    }
+
+    @Test
+    fun `non-ASCII authors preserved verbatim`() {
+        val epub = buildEpub(
+            opfMetadata = """
+                <dc:title>Solaris</dc:title>
+                <dc:creator>Stanisław Lem</dc:creator>
+                <dc:language>pl</dc:language>
+            """.trimIndent(),
+        )
+        val md = EpubMetadataExtractor.extract(epub)
+        assertEquals("Stanisław Lem", md.author)
+    }
+
+    @Test
+    fun `corrupt cover manifest reference yields null coverBytes without failing metadata`() {
+        // Points at a manifest item whose href resolves to a zip entry we never wrote.
+        val epub = buildEpub(
+            opfMetadata = """<dc:title>Title</dc:title>""",
+            extraManifestItems = """<item id="c" href="missing/cover.jpg" media-type="image/jpeg" properties="cover-image"/>""",
+        )
+        val md = EpubMetadataExtractor.extract(epub)
+        assertEquals("Title", md.title)
+        assertNull(md.coverBytes)
+    }
+
+    @Test
+    fun `not a zip returns EMPTY`() {
+        val md = EpubMetadataExtractor.extract("this is not a zip".toByteArray())
+        assertEquals(EpubMetadata.EMPTY, md)
+    }
+
+    // --- helpers ---
+
+    private fun buildEpub(
+        opfMetadata: String,
+        extraManifestItems: String = "",
+        extraZipEntries: List<Pair<String, ByteArray>> = emptyList(),
+    ): ByteArray {
+        val container = """<?xml version="1.0"?>
+            <container xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+              <rootfiles>
+                <rootfile full-path="OEBPS/content.opf" media-type="application/oebps-package+xml"/>
+              </rootfiles>
+            </container>
+        """.trimIndent()
+        val opf = """<?xml version="1.0" encoding="UTF-8"?>
+            <package xmlns="http://www.idpf.org/2007/opf" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:opf="http://www.idpf.org/2007/opf" version="3.0">
+              <metadata>
+                $opfMetadata
+              </metadata>
+              <manifest>
+                <item id="ch1" href="chap1.xhtml" media-type="application/xhtml+xml"/>
+                $extraManifestItems
+              </manifest>
+              <spine><itemref idref="ch1"/></spine>
+            </package>
+        """.trimIndent()
+        val out = ByteArrayOutputStream()
+        ZipOutputStream(out).use { zip ->
+            zip.putNextEntry(ZipEntry("mimetype")); zip.write("application/epub+zip".toByteArray()); zip.closeEntry()
+            zip.putNextEntry(ZipEntry("META-INF/container.xml")); zip.write(container.toByteArray()); zip.closeEntry()
+            zip.putNextEntry(ZipEntry("OEBPS/content.opf")); zip.write(opf.toByteArray(Charsets.UTF_8)); zip.closeEntry()
+            zip.putNextEntry(ZipEntry("OEBPS/chap1.xhtml")); zip.write("<html/>".toByteArray()); zip.closeEntry()
+            for ((name, bytes) in extraZipEntries) {
+                zip.putNextEntry(ZipEntry("OEBPS/$name")); zip.write(bytes); zip.closeEntry()
+            }
+        }
+        return out.toByteArray()
+    }
+}

--- a/core/domain/src/test/kotlin/com/riffle/core/domain/SourceStorageModelTest.kt
+++ b/core/domain/src/test/kotlin/com/riffle/core/domain/SourceStorageModelTest.kt
@@ -46,6 +46,7 @@ class SourceStorageModelTest {
         for (type in SourceType.entries) {
             val expected = when (type) {
                 SourceType.ABS -> true
+                SourceType.LOCAL_FILES -> false
             }
             assertEquals("SourceType.$type disagrees with hasCacheTier()", expected, type.hasCacheTier())
         }

--- a/core/domain/src/test/kotlin/com/riffle/core/domain/SourceTypeTest.kt
+++ b/core/domain/src/test/kotlin/com/riffle/core/domain/SourceTypeTest.kt
@@ -4,8 +4,9 @@ import org.junit.Assert.assertEquals
 import org.junit.Test
 
 class SourceTypeTest {
-    @Test fun `SourceType has ABS entry`() {
-        assertEquals(1, SourceType.entries.size)
+    @Test fun `SourceType has ABS and LOCAL_FILES entries`() {
+        assertEquals(2, SourceType.entries.size)
         assertEquals(SourceType.ABS, SourceType.valueOf("ABS"))
+        assertEquals(SourceType.LOCAL_FILES, SourceType.valueOf("LOCAL_FILES"))
     }
 }

--- a/docs/superpowers/specs/2026-07-09-localfiles-ingestion-design.md
+++ b/docs/superpowers/specs/2026-07-09-localfiles-ingestion-design.md
@@ -1,0 +1,309 @@
+# LocalFiles ingestion pipeline
+
+**Issue:** #437 (part of ADR 0041, phase 5a).
+**Blocks:** #7 (LocalFilesCatalog + Add-Source LocalFiles UI).
+
+## Goal
+
+Given one or more user-picked local folders, produce populated `library_items` rows scoped to a LocalFiles `Source`, with cover images and copied-in book bytes stored in Riffle-private storage. Re-scans are idempotent; deletions from the source folder remove the corresponding library item.
+
+Explicitly **out of scope**: any UI to trigger the pipeline, the `LocalFilesCatalog` Catalog implementation, the "Add Source: LocalFiles" flow. Those all belong to #7. This PR wires the plumbing so #7 has a working scanner to invoke.
+
+## Architecture
+
+```
+┌─────────────────────────┐   ACTION_OPEN_DOCUMENT_TREE
+│  PickFolderContract     │◀──────────────────────────── (call site: app/)
+│  (ActivityResultContract)│
+└──────────┬──────────────┘
+           │ Uri (persistable)
+           ▼
+┌─────────────────────────┐
+│ LocalFilesFolderRepo    │──▶ takePersistableUriPermission
+│                         │──▶ upsert LocalFilesFolderEntity
+└──────────┬──────────────┘
+           │ LocalFilesFolderEntity[]
+           ▼
+┌─────────────────────────┐
+│  LocalFilesScanner      │
+│  scan(sourceId)         │
+└──────────┬──────────────┘
+           │ for each folder
+           ▼
+┌─────────────────────────┐     ┌──────────────────────────┐
+│ FolderWalker            │────▶│ FileClassifier           │
+│ (DocumentFile-abstracted)│     │ (ext + magic bytes)      │
+└─────────────────────────┘     └──────────┬───────────────┘
+                                            │ (kind, uri)
+                                            ▼
+                          ┌────────────────────────────────┐
+                          │ IdentityHasher                 │
+                          │ SHA-1(first 64KB) + size       │
+                          └────────────────┬───────────────┘
+                                           │ sourceItemId
+                                           ▼
+                       ┌──────────────────────────────────┐
+                       │ if row absent → CopyIn + Extract │
+                       │ if row present → touch lastSeenAt│
+                       └────────────────┬─────────────────┘
+                                        │
+                          ┌─────────────┴──────────────┐
+                          ▼                            ▼
+              ┌────────────────────┐        ┌────────────────────┐
+              │ EpubMetadataExtractor │      │ PdfMetadataExtractor │
+              │ (pure JVM)         │        │ (interface + Pdfium  │
+              │                    │        │  impl; JVM fake in   │
+              │                    │        │  tests)              │
+              └──────────┬─────────┘        └──────────┬─────────┘
+                         │                             │
+                         └─────────────┬───────────────┘
+                                       ▼
+                           ┌───────────────────────┐
+                           │ LibraryItemDao.upsert │
+                           │ LocalFilesFileDao.upsert │
+                           └───────────────────────┘
+
+after walk complete:
+  rows with lastSeenAt < scanStart → hard-delete library_item + copied bytes
+```
+
+## Data model
+
+### `SourceType.LOCAL_FILES`
+
+Add `LOCAL_FILES` enum variant. Extend `SourceStorageModel.hasCacheTier` to return `false` for `LOCAL_FILES`.
+
+### `LocalFilesFolderEntity`
+
+Composite PK `(sourceId, treeUri)`. FK `sourceId → sources(id)` cascade delete.
+
+| column | type | notes |
+|--------|------|-------|
+| `sourceId` | TEXT NOT NULL | FK |
+| `treeUri` | TEXT NOT NULL | persisted SAF tree URI |
+| `displayName` | TEXT NOT NULL | resolved from `DocumentFile.name` at insert time |
+| `addedAtEpochMs` | INTEGER NOT NULL | |
+
+Index on `sourceId`.
+
+### `LocalFilesFileEntity`
+
+Composite PK `(sourceId, sourceItemId)`. FK `sourceId → sources(id)` cascade.
+
+| column | type | notes |
+|--------|------|-------|
+| `sourceId` | TEXT NOT NULL | FK |
+| `sourceItemId` | TEXT NOT NULL | identity hash — see below |
+| `folderTreeUri` | TEXT NOT NULL | which folder found it |
+| `originalUri` | TEXT NOT NULL | SAF content URI (for user reference; not opened for reading) |
+| `copiedPath` | TEXT NOT NULL | absolute path in Riffle-private storage |
+| `format` | TEXT NOT NULL | `"EPUB"` or `"PDF"` — mirrors `BookFormat` names |
+| `sizeBytes` | INTEGER NOT NULL | |
+| `mtimeEpochMs` | INTEGER NOT NULL | source-side mtime at copy time |
+| `lastSeenAtEpochMs` | INTEGER NOT NULL | updated every scan |
+
+Index on `sourceId`. No FK to `library_items` (composite PK matches; both cascade from `sources`).
+
+**Identity hash:** `sha1(firstBytes[0..min(65536, size)] ++ size.toString().toByteArray())`. Rationale: cheap (single read), stable across path changes and rename, tolerates SAF re-mounts. Collision risk on 64KB prefixes is theoretical; if it bites in practice we can extend the hash later.
+
+### Room `library_items` row
+
+The scanner upserts `LibraryItemEntity` using the existing entity — no schema change to `library_items`.
+- `sourceId` = the LocalFiles source id.
+- `id` = `sourceItemId` (the identity hash), matching composite-PK convention.
+- `libraryId` = a synthetic root id, `"local:root"` (LocalFiles is a flat-catalog Source per ADR 0041).
+- `title` / `author` / `language` / `publisher` / `publishedYear` / `seriesName` / `genres` / `description` / `isbn` / `asin` populated from the metadata extractor (nullable when the file doesn't provide them).
+- `coverUrl` = `file://` URI pointing at the copied-in cover bytes.
+- `ebookFormat` = `"EPUB"` or `"PDF"`.
+- `ebookFileIno` = null. LocalFiles doesn't need ABS's ino tracking.
+- `addedAt` = wall-clock at first scan.
+
+### Migration
+
+`v45 → v46`. `MIGRATION_45_46` = `CREATE TABLE local_files_folders (…)` and `CREATE TABLE local_files_files (…)` with the columns above, plus indexes and FKs. No data-touching statements — the migration is additive. `MigrationTest.migrationChain` extended and a `migration45To46` case added asserting both tables exist post-migration and existing `sources` rows are untouched.
+
+## Scanner pipeline
+
+`core/data/src/main/kotlin/com/riffle/core/data/localfiles/LocalFilesScanner.kt`.
+
+```kotlin
+class LocalFilesScanner @Inject constructor(
+    private val folderDao: LocalFilesFolderDao,
+    private val fileDao: LocalFilesFileDao,
+    private val libraryItemDao: LibraryItemDao,
+    private val walker: FolderWalker,           // interface — real impl uses DocumentFile
+    private val classifier: FileClassifier,     // extension + magic-bytes
+    private val hasher: IdentityHasher,
+    private val copyIn: CopyInService,          // writes bytes to filesDir/localfiles/…
+    private val epubMetadata: EpubMetadataExtractor,
+    private val pdfMetadata: PdfMetadataExtractor,   // interface
+    private val clock: Clock,
+) {
+    suspend fun scan(sourceId: String): ScanReport { … }
+}
+```
+
+`ScanReport` = `{ added: Int, refreshed: Int, removed: Int, failures: List<ScanFailure> }` for logging and tests.
+
+### Recursion
+
+**Recursive** walk over each `LocalFilesFolderEntity.treeUri`. Symlink loops aren't a SAF concern (SAF hides the filesystem). Cycle risk = zero. Users organise ebook libraries in nested folders (author/, series/), so flat-only would be surprising.
+
+### Classification
+
+1. Filter by extension (`.epub`, `.pdf`, case-insensitive).
+2. Confirm with magic bytes:
+   - EPUB: first 4 bytes `PK\x03\x04`, plus `mimetype` file at offset 30 begins with `application/epub+zip` (the standard EPUB sniff).
+   - PDF: first 5 bytes `%PDF-`.
+3. Mismatch → skip with a warning to `ScanReport.failures`, no library row.
+
+### Copy-in
+
+Real impl copies via `contentResolver.openInputStream(uri)` → `FileOutputStream(filesDir/localfiles/<sourceId>/<hash>.<ext>)`. Test impl works over a fake filesystem. Copy is streaming — no full-file in-memory buffering. Aborts mid-copy delete the partial file.
+
+Cover images extracted from EPUB `<manifest item properties="cover-image">` (EPUB3) or `<meta name="cover">` fallback (EPUB2) written to `filesDir/localfiles/<sourceId>/covers/<hash>.<ext>`. PDF cover extraction not attempted this PR — `coverUrl = null` for PDFs.
+
+### Deletion detection
+
+`scan(sourceId)` runs across **all folders of the source in one pass**, not per-folder. `scanStart = clock.nowEpochMs()` captured once at the top. Every file the walker yields (from any folder) has its `local_files_files.lastSeenAtEpochMs` set to `scanStart`. After all folders have been walked, `LocalFilesFileDao.deleteStale(sourceId, scanStart)` runs in a single `@Transaction`:
+1. Look up rows where `sourceId = ? AND lastSeenAtEpochMs < scanStart`.
+2. For each, delete the corresponding `library_items` row, the copied book bytes, and the copied cover bytes.
+3. Delete the `local_files_files` row.
+
+Hard-delete only — no soft-delete/tombstone. Rationale: the SAF folder set is the source of truth. If a user re-adds the same file later, the identity hash matches what was deleted but the row is gone, so it's treated as a fresh add. Idempotent semantics preserved.
+
+**Multi-folder same-file case:** the same book present in two configured folders resolves to a single `local_files_files` row (PK is `(sourceId, sourceItemId)`; identity hash is content-based). The `folderTreeUri` column stores the folder that most recently sighted the file — arbitrary, treated as a hint, not authoritative membership. Because scans run across all folders in one pass, the file only becomes stale when it's absent from **every** configured folder, which is the desired behaviour.
+
+### Failure semantics
+
+- Classifier failure → skipped with warning; scan continues.
+- Copy-in failure → skipped, no partial row written; scan continues.
+- Metadata extraction failure → row is written with `title = DocumentFile.name` fallback, other fields null. Not a scan-fatal error.
+- Folder walk failure (SAF permission revoked, folder deleted from OS) → mark all rows for that folder as stale AT scanStart (i.e. `lastSeenAt = 0`), and let the post-walk cleanup delete them. This unifies "SAF permission revoked" with "user deleted files".
+
+## Metadata extractors
+
+### `EpubMetadataExtractor` (`core/domain/…/EpubMetadataExtractor.kt`)
+
+Pure JVM. Operates on either `ByteArray` or `File`. Parses:
+
+- `META-INF/container.xml` → OPF path.
+- OPF `<metadata>`:
+  - `dc:title` (first)
+  - `dc:creator` list (joined `", "` for `LibraryItemEntity.author`)
+  - `dc:language` (first, BCP-47 as-is)
+  - `dc:publisher`
+  - `dc:date` (year extracted; nullable if unparseable)
+  - `dc:description`
+  - `dc:identifier` where `scheme=ISBN` → `isbn`, else `asin` fallback if `scheme=ASIN`
+  - `dc:subject` list → `genres`
+  - `<meta property="belongs-to-collection">` → `seriesName`; child `collection-type=series` disambiguates from `set`
+
+- Cover:
+  - Prefer `<item id=? properties="cover-image">` in manifest (EPUB3).
+  - Fallback: `<meta name="cover" content="X">` → look up `<item id="X">` (EPUB2).
+  - Fallback: no cover → `coverUrl = null`.
+
+Returns `EpubMetadata` value class; caller merges into `LibraryItemEntity`.
+
+Sibling to existing `EpubContentExtractor.kt`. Shares the `META-INF/container.xml` + OPF walk — factor a small `OpfLocator` helper if the copy-paste feels bad; not required.
+
+### `PdfMetadataExtractor` interface (`core/domain/…/PdfMetadataExtractor.kt`)
+
+```kotlin
+interface PdfMetadataExtractor {
+    suspend fun extract(file: File): PdfMetadata
+}
+
+data class PdfMetadata(
+    val title: String?,
+    val author: String?,
+    val subject: String?,
+    val keywords: List<String>,
+)
+```
+
+Two implementations:
+- **Real:** `PdfiumPdfMetadataExtractor` in a module with Android deps (`core/data` or a new `core/localfiles-android` — decide during implementation; `core/data` already has Android deps so it's simplest). Wraps `PdfiumCore.newDocument(pfd) → getDocumentMeta(doc)`. Instrumentation-tested; not JVM-tested.
+- **Fake:** `NoOpPdfMetadataExtractor` returns `PdfMetadata(title = null, author = null, …)`. Used in `LocalFilesScannerTest` so the scanner is JVM-testable end-to-end.
+
+DI: bound in a Hilt module; scanner takes the interface.
+
+## SAF plumbing
+
+`app/src/main/kotlin/com/riffle/app/feature/source/localfiles/PickFolderContract.kt`.
+
+```kotlin
+class PickFolderContract : ActivityResultContract<Unit, Uri?>() {
+    override fun createIntent(context: Context, input: Unit) =
+        Intent(Intent.ACTION_OPEN_DOCUMENT_TREE)
+            .addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION)
+    override fun parseResult(resultCode: Int, intent: Intent?): Uri? =
+        if (resultCode == RESULT_OK) intent?.data else null
+}
+```
+
+`LocalFilesFolderRepository.addFolder(sourceId, uri)`:
+1. `context.contentResolver.takePersistableUriPermission(uri, Intent.FLAG_GRANT_READ_URI_PERMISSION)`.
+2. Resolve `displayName` from `DocumentFile.fromTreeUri(context, uri)?.name` (fallback: last path segment).
+3. Upsert `LocalFilesFolderEntity`.
+
+Contract + repo ship in this PR. The disabled "Coming soon" card in `SourceTypePickerScreen` **stays disabled**; #7 wires the picker into the real "Add Source: LocalFiles" screen.
+
+## Module layout
+
+- `core/domain/…/SourceType.kt` — add `LOCAL_FILES`.
+- `core/domain/…/SourceStorageModel.kt` — add `LOCAL_FILES → false` in `hasCacheTier`.
+- `core/domain/…/EpubMetadataExtractor.kt` — new (pure JVM).
+- `core/domain/…/PdfMetadataExtractor.kt` — new interface (pure JVM).
+- `core/database/…/LocalFilesFolderEntity.kt`, `LocalFilesFolderDao.kt` — new.
+- `core/database/…/LocalFilesFileEntity.kt`, `LocalFilesFileDao.kt` — new.
+- `core/database/…/RiffleDatabase.kt` — bump to v46, register entities + DAOs + `MIGRATION_45_46`.
+- `core/data/…/localfiles/LocalFilesScanner.kt` — new.
+- `core/data/…/localfiles/FolderWalker.kt` — new interface + `SafFolderWalker` Android impl.
+- `core/data/…/localfiles/FileClassifier.kt` — new (pure JVM).
+- `core/data/…/localfiles/IdentityHasher.kt` — new (pure JVM).
+- `core/data/…/localfiles/CopyInService.kt` — new interface + Android impl.
+- `core/data/…/localfiles/PdfiumPdfMetadataExtractor.kt` — new (Android).
+- `core/data/…/di/modules/LocalFilesModule.kt` — new Hilt module wiring everything.
+- `core/data/…/LocalFilesFolderRepository.kt` — new.
+- `app/…/feature/source/localfiles/PickFolderContract.kt` — new.
+
+## Tests
+
+**JVM:**
+- `EpubMetadataExtractorTest` — fixture set:
+  - `minimal.epub` (title+author+language only)
+  - `full.epub` (all fields present, EPUB3 cover manifest, series, ISBN)
+  - `epub2-cover.epub` (EPUB2 `<meta name="cover">` fallback path)
+  - `no-metadata.epub` (empty `<metadata>` — should return all-nulls without throwing)
+  - `non-ascii-authors.epub` (UTF-8 authors + diacritics)
+  - `corrupt-cover.epub` (cover manifest entry points at a nonexistent zip entry — extractor returns metadata with `coverBytes = null`)
+- `FileClassifierTest` — extension + magic-byte matrix, mismatch cases.
+- `IdentityHasherTest` — determinism, file-size boundary at 64KB (exactly 64KB, 64KB-1, 64KB+1).
+- `LocalFilesScannerTest` — with in-memory DAOs + `FakeFolderWalker` + `FakeCopyInService` + `NoOpPdfMetadataExtractor`:
+  - Empty folder → no rows, `ScanReport(0,0,0,[])`.
+  - Single EPUB added → 1 row, `library_items` populated, `local_files_files` populated.
+  - Re-scan identical folder → `refreshed = 1`, no duplicate rows, `lastSeenAt` bumped.
+  - File removed from folder → row and copied bytes gone, `removed = 1`.
+  - File classification failure → warning in `ScanReport.failures`, no row.
+  - Metadata extraction failure → row written with filename fallback title.
+  - SAF permission revoked mid-scan (walker throws) → all rows for that folder deleted.
+  - Two folders, overlapping identity hashes → per-folder deletion doesn't touch the other folder's row.
+- `LocalFilesFolderRepositoryTest` — `addFolder` upserts, takes persistable permission (via a fake `ContentResolver` abstraction).
+
+**AndroidTest (instrumentation):**
+- `MigrationTest.migration45To46` — insert a `sources` row at v45, migrate, assert `local_files_folders` and `local_files_files` tables exist with correct columns and defaults; assert the pre-existing `sources` row survives.
+- `MigrationTest.migrateFullChain` — extended to include the new migration.
+- `LocalFilesFolderDaoTest`, `LocalFilesFileDaoTest` — insert/upsert/delete/deleteStale semantics.
+
+**No AVD verification** for this PR: it's pure data-layer plumbing with zero reader-visible surface. Verification is JVM tests + MigrationTest, per AGENTS.md and the /work-on skill's "non-visual change" path.
+
+## Open follow-ups (explicit non-goals)
+
+- LocalFilesCatalog Catalog implementation — #7.
+- Add Source: LocalFiles UI — #7.
+- Enabling the disabled "Coming soon" card — #7.
+- PDF cover extraction — deferred; PDFs get null covers this PR.
+- PDF metadata JVM test coverage — deferred; Pdfium is Android-only.
+- Multi-folder same-file: handled in-scope via all-folders-in-one-pass scan semantics (see Deletion detection above). Test case: "same file in two folders, remove from one, remains in library" is included in `LocalFilesScannerTest`.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -31,6 +31,7 @@ coil = "2.7.0"
 jsoup = "1.22.2"
 media3 = "1.10.1"
 webkit = "1.16.0"
+documentfile = "1.1.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -54,6 +55,7 @@ androidx-room-compiler = { group = "androidx.room", name = "room-compiler", vers
 androidx-room-testing = { group = "androidx.room", name = "room-testing", version.ref = "room" }
 androidx-test-runner = { group = "androidx.test", name = "runner", version.ref = "androidxTest" }
 androidx-datastore-preferences = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "datastore" }
+androidx-documentfile = { group = "androidx.documentfile", name = "documentfile", version.ref = "documentfile" }
 androidx-work-runtime-ktx = { group = "androidx.work", name = "work-runtime-ktx", version.ref = "workmanager" }
 okhttp = { group = "com.squareup.okhttp3", name = "okhttp", version.ref = "okhttp" }
 okhttp-mockwebserver = { group = "com.squareup.okhttp3", name = "mockwebserver", version.ref = "okhttp" }
@@ -73,6 +75,7 @@ readium-shared = { group = "org.readium.kotlin-toolkit", name = "readium-shared"
 readium-streamer = { group = "org.readium.kotlin-toolkit", name = "readium-streamer", version.ref = "readium" }
 readium-navigator = { group = "org.readium.kotlin-toolkit", name = "readium-navigator", version.ref = "readium" }
 readium-adapter-pdfium = { group = "org.readium.kotlin-toolkit", name = "readium-adapter-pdfium-navigator", version.ref = "readium" }
+pdfium-android = { group = "com.github.barteksc", name = "pdfium-android", version = "1.8.2" }
 kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "coroutines" }
 kotlinx-coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "coroutines" }
 desugar-jdk-libs = { group = "com.android.tools", name = "desugar_jdk_libs", version = "2.1.5" }


### PR DESCRIPTION
Closes #437.

Part of ADR 0041, phase 5a of the ABS-independence rearchitecture.

## Summary
- **Data-layer only**, no user-facing changes yet. Every entry point is behind an interface that nothing currently calls (the SourceTypePicker's LocalFiles card stays disabled — that wiring is #7).
- Room v45 → v46, purely additive: new tables `local_files_folders` and `local_files_files`, both FK-cascading on `sources`.
- `SourceType.LOCAL_FILES` added; `hasCacheTier(LOCAL_FILES) = false` per ADR 0041 (single-tier copy-in).
- `LocalFilesScanner` runs across all folders of a source in a single pass, identity-keyed by SHA-1(first 64KB) + size — same file present in multiple folders resolves to one row and only becomes stale when absent from every folder.
- `EpubMetadataExtractor` (pure JVM, sibling to `EpubContentExtractor`) pulls title/creators/language/publisher/date/description/ISBN/ASIN/subjects/series + cover bytes via EPUB3 `manifest properties="cover-image"` or EPUB2 `<meta name="cover">` fallback.
- `PdfMetadataExtractor` is an interface so the scanner stays JVM-testable; the real `PdfiumPdfMetadataExtractor` (in `:app`) wraps Pdfium's document meta and gets instrumentation coverage — not JVM. `pdfium-android` added as `compileOnly` to avoid a manifest namespace clash with the fork Readium ships transitively.
- SAF folder picker: `PickFolderContract` + `LocalFilesFolderRepository` take/release the persistable URI grant. No UI wiring in this PR.

## Design
Full spec: `docs/superpowers/specs/2026-07-09-localfiles-ingestion-design.md`.

## Tests
JVM (all green):
- `EpubMetadataExtractorTest` — 9 fixture scenarios incl. EPUB2/3 cover fallback, non-ASCII authors, corrupt cover ref, empty metadata.
- `FileClassifierTest` — extension + magic-byte matrix.
- `IdentityHasherTest` — determinism + 64KB boundary + stream/prefix agreement.
- `LocalFilesScannerTest` — 9 scenarios: idempotent rescan, deletion, walker-throws, ingest-throws, multi-folder same-file, non-EPUB skip, garbage-bytes skip, filename-fallback title.

AndroidTest (not run this PR — additive migration, low risk; will run on the harness AVD via CI or a follow-up):
- `MigrationTest.migration45To46_addsLocalFilesTables` — validates both new tables including cascade-on-source-delete.
- `migrateFullChain` extended.

## Code-review pass
Ran `/code-review` on the branch. Six actionable findings, all fixed in the second commit:
- Stale-sweep would delete previously-ingested rows if the walker threw (transient SAF hiccup wipes the library). Now suppressed on any walker/ingest failure.
- `FileClassifier.isEpub` had `|| true` making the mimetype check dead code — removed; the extractor is the source of truth.
- `PdfiumPdfMetadataExtractor` leaked a `ParcelFileDescriptor` per PDF; wrapped in `.use`.
- `writeCover` lacked partial-write cleanup mirroring `copyBook`.
- Suspend functions did blocking IO without `Dispatchers.IO`; scanner + CopyIn + walker now dispatch.
- Redundant blanket catch in the PDF extractor swallowed all errors; removed.

Dismissed: `EpubMetadataExtractor` duplicates part of `EpubContentExtractor`'s container.xml→OPF walk (real duplication, but factoring out an `OpfLocator` is a medium refactor out of scope here — worth a follow-up issue).

## Test plan
- [ ] `./gradlew test` (green locally)
- [ ] MigrationTest 45→46 on the harness AVD (not run this PR; migration is purely additive)