### PR TITLE
feat(localfiles): LocalFilesCatalog + Add-Source LocalFiles flow + URI revocation handling

### DIFF
--- a/app/src/androidTest/kotlin/com/riffle/app/di/TestDatabaseModule.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/di/TestDatabaseModule.kt
@@ -13,6 +13,8 @@ import com.riffle.core.database.CollectionDao
 import com.riffle.core.database.CrossEpubIndexDao
 import com.riffle.core.database.LibraryDao
 import com.riffle.core.database.LibraryItemDao
+import com.riffle.core.database.LocalFilesFileDao
+import com.riffle.core.database.LocalFilesFolderDao
 import com.riffle.core.database.ReadaloudCandidateDao
 import com.riffle.core.database.ReadaloudDismissalDao
 import com.riffle.core.database.ReadaloudLinkDao
@@ -63,6 +65,14 @@ object TestDatabaseModule {
     @Provides
     @Singleton
     fun provideLibraryItemDao(db: RiffleDatabase): LibraryItemDao = db.libraryItemDao()
+
+    @Provides
+    @Singleton
+    fun provideLocalFilesFolderDao(db: RiffleDatabase): LocalFilesFolderDao = db.localFilesFolderDao()
+
+    @Provides
+    @Singleton
+    fun provideLocalFilesFileDao(db: RiffleDatabase): LocalFilesFileDao = db.localFilesFileDao()
 
     @Provides
     @Singleton

--- a/app/src/androidTest/kotlin/com/riffle/app/feature/server/SourceTypePickerScreenTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/server/SourceTypePickerScreenTest.kt
@@ -17,8 +17,8 @@ import org.junit.Test
 import org.junit.runner.RunWith
 
 /**
- * Instrumentation coverage for #435's SourceTypePickerScreen. Locks the ABS-enabled +
- * LocalFiles-disabled contract at the composable level; JVM-side data-model pinning
+ * Instrumentation coverage for #435's SourceTypePickerScreen. Locks the "both cards enabled and
+ * routable" contract now that #438 has landed the LocalFiles wiring; JVM-side data-model pinning
  * lives in [SourceTypePickerTest].
  */
 @OptIn(ExperimentalMaterial3WindowSizeClassApi::class)
@@ -37,26 +37,31 @@ class SourceTypePickerScreenTest {
 
     @Test
     fun audiobookshelfCard_click_invokesCallback() {
-        var pickCount = 0
-        setContent(onPick = { pickCount++ })
+        var absCount = 0
+        setContent(onPickAbs = { absCount++ })
         composeRule.onNodeWithTag("SourceTypeCard.Audiobookshelf").assertHasClickAction().performClick()
-        assertEquals(1, pickCount)
+        assertEquals(1, absCount)
     }
 
     @Test
-    fun localFilesCard_isDisabled_showsComingSoon() {
-        setContent()
-        composeRule.onNodeWithText("Coming soon").assertIsDisplayed()
-        composeRule.onNodeWithTag("SourceTypeCard.LocalFiles").assertHasNoClickAction()
+    fun localFilesCard_click_invokesCallback() {
+        var lfCount = 0
+        setContent(onPickLocal = { lfCount++ })
+        composeRule.onNodeWithTag("SourceTypeCard.LocalFiles").assertHasClickAction().performClick()
+        assertEquals(1, lfCount)
     }
 
-    private fun setContent(onPick: () -> Unit = {}) {
+    private fun setContent(
+        onPickAbs: () -> Unit = {},
+        onPickLocal: () -> Unit = {},
+    ) {
         composeRule.setContent {
             val wsc = calculateWindowSizeClass(composeRule.activity)
             SourceTypePickerScreen(
                 windowSizeClass = wsc,
                 onNavigateBack = {},
-                onPickAudiobookshelf = onPick,
+                onPickAudiobookshelf = onPickAbs,
+                onPickLocalFiles = onPickLocal,
             )
         }
     }

--- a/app/src/main/kotlin/com/riffle/app/RiffleApplication.kt
+++ b/app/src/main/kotlin/com/riffle/app/RiffleApplication.kt
@@ -9,6 +9,7 @@ import com.riffle.app.sync.kickSweepsOnReconnect
 import com.riffle.core.data.AnnotationSweep
 import com.riffle.core.data.LocalStoreMigrator
 import com.riffle.core.data.ProgressSweep
+import com.riffle.core.data.localfiles.LocalFilesFolderWatcher
 import com.riffle.core.domain.ApplicationScope
 import dagger.hilt.EntryPoint
 import dagger.hilt.InstallIn
@@ -36,6 +37,7 @@ class RiffleApplication : Application(), ImageLoaderFactory {
         fun applicationScope(): ApplicationScope
         fun annotationSweep(): AnnotationSweep
         fun progressSweep(): ProgressSweep
+        fun localFilesFolderWatcher(): LocalFilesFolderWatcher
     }
 
     override fun attachBaseContext(base: Context) {
@@ -119,6 +121,10 @@ class RiffleApplication : Application(), ImageLoaderFactory {
                 runAnnotationSweep = { runCatching { annotationSweep.run() } },
             )
         }
+
+        // Auto-scan configured LocalFiles folders on app foreground and on SAF change events.
+        // Users adding a book to a picked folder never have to hit a manual "Rescan" button.
+        entryPoint.localFilesFolderWatcher().start()
     }
 
     override fun newImageLoader(): ImageLoader =

--- a/app/src/main/kotlin/com/riffle/app/feature/navigation/NavigationDrawerComposable.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/navigation/NavigationDrawerComposable.kt
@@ -49,6 +49,7 @@ import androidx.compose.ui.unit.dp
 import com.riffle.app.BuildConfig
 import com.riffle.core.domain.Library
 import com.riffle.core.domain.Source
+import com.riffle.core.domain.SourceType
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -188,8 +189,10 @@ private fun DrawerHeader(
 
     // Same product type appearing more than once forces the host to appear in the supporting
     // line so users can tell the two instances apart. With a single instance the host is noise.
+    // LocalFiles has no meaningful host (placeholder URL), so the host is never useful there.
     val activeNeedsHost = activeServer != null &&
-        allServers.count { it.serverType == activeServer.serverType } > 1
+        activeServer.type != SourceType.LOCAL_FILES &&
+        allServers.count { it.serverType == activeServer.serverType && it.type == activeServer.type } > 1
 
     Box(modifier = Modifier
         .fillMaxWidth()
@@ -197,8 +200,10 @@ private fun DrawerHeader(
     ) {
         ListItem(
             headlineContent = {
-                val name = activeServer?.serverType?.label ?: "No source"
-                val username = activeServer?.username?.takeIf { it.isNotEmpty() }
+                val name = activeServer?.let(::sourceDisplayName) ?: "No source"
+                val username = activeServer
+                    ?.takeIf { it.type != SourceType.LOCAL_FILES }
+                    ?.username?.takeIf { it.isNotEmpty() }
                 if (username != null) {
                     Text(
                         buildAnnotatedString {
@@ -214,11 +219,13 @@ private fun DrawerHeader(
                 }
             },
             supportingContent = {
-                val host = activeServer?.url?.authority().orEmpty()
-                val support = buildSupportingLine(
-                    host = if (activeNeedsHost) host else null,
-                    version = activeVersion,
-                )
+                val support = activeServer?.let {
+                    sourceSubtitle(
+                        source = it,
+                        host = if (activeNeedsHost) it.url.authority() else null,
+                        version = activeVersion,
+                    )
+                }
                 if (support != null) Text(support)
             },
             trailingContent = {
@@ -235,15 +242,19 @@ private fun DrawerHeader(
             modifier = if (headerWidth != Dp.Unspecified) Modifier.width(headerWidth) else Modifier,
         ) {
             allServers.forEach { server ->
-                val needsHost = allServers.count { it.serverType == server.serverType } > 1
+                val needsHost = server.type != SourceType.LOCAL_FILES &&
+                    allServers.count { it.serverType == server.serverType && it.type == server.type } > 1
                 DropdownMenuItem(
                     text = {
                         Column {
-                            val username = server.username.takeIf { it.isNotEmpty() }
+                            val displayName = sourceDisplayName(server)
+                            val username = server
+                                .takeIf { it.type != SourceType.LOCAL_FILES }
+                                ?.username?.takeIf { it.isNotEmpty() }
                             if (username != null) {
                                 Text(
                                     buildAnnotatedString {
-                                        append(server.serverType.label)
+                                        append(displayName)
                                         append(" ")
                                         withStyle(SpanStyle(color = MaterialTheme.colorScheme.onSurfaceVariant)) {
                                             append("[$username]")
@@ -251,9 +262,10 @@ private fun DrawerHeader(
                                     }
                                 )
                             } else {
-                                Text(server.serverType.label)
+                                Text(displayName)
                             }
-                            val support = buildSupportingLine(
+                            val support = sourceSubtitle(
+                                source = server,
                                 host = if (needsHost) server.url.authority() else null,
                                 version = serverVersions[server.id],
                             )
@@ -296,3 +308,24 @@ private fun buildSupportingLine(host: String?, version: String?): String? {
         else -> null
     }
 }
+
+/**
+ * Display label for the source-switcher header + dropdown. LocalFiles gets its own name so it
+ * doesn't inherit its placeholder [ServerType.AUDIOBOOKSHELF] value (LocalFiles has no product
+ * server); everything else falls back to the server product label.
+ */
+private fun sourceDisplayName(source: Source): String = when (source.type) {
+    SourceType.LOCAL_FILES -> "Local files"
+    else -> source.serverType.label
+}
+
+/**
+ * Subtitle for the source-switcher row. LocalFiles shows "on this device" — its URL column is a
+ * non-network placeholder ("localfiles.invalid") that would otherwise leak into the UI. ABS
+ * sources reuse [buildSupportingLine] (host · version).
+ */
+private fun sourceSubtitle(source: Source, host: String?, version: String?): String? =
+    when (source.type) {
+        SourceType.LOCAL_FILES -> "on this device"
+        else -> buildSupportingLine(host, version)
+    }

--- a/app/src/main/kotlin/com/riffle/app/feature/server/SourceTypePickerScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/server/SourceTypePickerScreen.kt
@@ -62,8 +62,8 @@ internal fun sourceTypeCards(): List<SourceTypeCard> = listOf(
         type = SourceTypeChoice.LocalFiles,
         title = "Local files",
         subtitle = "Read EPUBs and PDFs from a folder on this device.",
-        enabled = false,
-        comingSoon = true,
+        enabled = true,
+        comingSoon = false,
     ),
 )
 
@@ -83,6 +83,7 @@ fun SourceTypePickerScreen(
     windowSizeClass: WindowSizeClass,
     onNavigateBack: () -> Unit,
     onPickAudiobookshelf: () -> Unit,
+    onPickLocalFiles: () -> Unit,
 ) {
     Scaffold(
         topBar = {
@@ -109,7 +110,7 @@ fun SourceTypePickerScreen(
                         card = card,
                         onClick = when (card.type) {
                             SourceTypeChoice.Audiobookshelf -> onPickAudiobookshelf
-                            SourceTypeChoice.LocalFiles -> null
+                            SourceTypeChoice.LocalFiles -> onPickLocalFiles
                         },
                     )
                 }

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsNavEvent.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsNavEvent.kt
@@ -2,5 +2,6 @@ package com.riffle.app.feature.settings
 
 sealed class SettingsNavEvent {
     data object NavigateToAddSource : SettingsNavEvent()
+    data object NavigateToAddLocalFolder : SettingsNavEvent()
     data class NavigateToReadaloudMatches(val sourceId: String) : SettingsNavEvent()
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsNavEvent.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsNavEvent.kt
@@ -2,6 +2,5 @@ package com.riffle.app.feature.settings
 
 sealed class SettingsNavEvent {
     data object NavigateToAddSource : SettingsNavEvent()
-    data object NavigateToAddLocalFolder : SettingsNavEvent()
     data class NavigateToReadaloudMatches(val sourceId: String) : SettingsNavEvent()
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsScreen.kt
@@ -3,6 +3,7 @@ package com.riffle.app.feature.settings
 import android.content.Intent
 import android.net.Uri
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
 import androidx.core.content.FileProvider
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.animateFloatAsState
@@ -27,9 +28,11 @@ import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.Schedule
+import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material.icons.outlined.CloudOff
 import androidx.compose.material.icons.outlined.Headphones
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -90,6 +93,7 @@ fun SettingsScreen(
     windowSizeClass: WindowSizeClass,
     onNavigateBack: () -> Unit,
     onNavigateToAddSource: (backend: AddSourceBackend, editId: String?) -> Unit,
+    onNavigateToAddLocalFolder: () -> Unit = {},
     onNavigateToReadaloudMatches: (String) -> Unit = {},
     onNavigateToAnnotationSyncMaintenance: () -> Unit = {},
     onNavigateToDebugLogs: () -> Unit = {},
@@ -102,6 +106,8 @@ fun SettingsScreen(
     val invertVolumeKeys by viewModel.invertVolumeKeys.collectAsState()
     val appTheme by viewModel.appTheme.collectAsState()
     val servers by viewModel.servers.collectAsState()
+    val localFilesSource by viewModel.localFilesSource.collectAsState()
+    val localFilesFolders by viewModel.localFilesFolders.collectAsState()
     val serverVersions by viewModel.serverVersions.collectAsState()
     val libraryItemsByServer by viewModel.libraryUiItemsByServer.collectAsState()
     val readaloudSummaries by viewModel.readaloudSummaries.collectAsState()
@@ -125,6 +131,7 @@ fun SettingsScreen(
         viewModel.navigationEvents.collect { event ->
             when (event) {
                 is SettingsNavEvent.NavigateToAddSource -> onNavigateToAddSource(AddSourceBackend.AUDIOBOOKSHELF, null)
+                is SettingsNavEvent.NavigateToAddLocalFolder -> onNavigateToAddLocalFolder()
                 is SettingsNavEvent.NavigateToReadaloudMatches -> onNavigateToReadaloudMatches(event.sourceId)
             }
         }
@@ -188,6 +195,15 @@ fun SettingsScreen(
                 ) {
                     Text("Add source")
                 }
+                HorizontalDivider()
+
+                LocalFilesSection(
+                    source = localFilesSource,
+                    folders = localFilesFolders,
+                    onAddFolder = { viewModel.openAddLocalFolder() },
+                    onRemoveFolder = { treeUri -> viewModel.removeLocalFolder(treeUri) },
+                    onRemoveSource = { viewModel.removeLocalFilesSource() },
+                )
                 HorizontalDivider()
 
                 Text(
@@ -985,6 +1001,118 @@ private fun AnnotationSyncBadge(badge: AnnotationSyncRowState.Badge) {
         contentAlignment = Alignment.Center,
     ) {
         Icon(imageVector = glyph, contentDescription = null, tint = fg, modifier = Modifier.size(18.dp))
+    }
+}
+
+@Composable
+private fun LocalFilesSection(
+    source: com.riffle.core.domain.Source?,
+    folders: List<com.riffle.core.database.LocalFilesFolderEntity>,
+    onAddFolder: () -> Unit,
+    onRemoveFolder: (String) -> Unit,
+    onRemoveSource: () -> Unit,
+) {
+    var pendingFolderRemoval by remember { mutableStateOf<com.riffle.core.database.LocalFilesFolderEntity?>(null) }
+    var pendingSourceRemoval by remember { mutableStateOf(false) }
+
+    Text(
+        text = "Local Files",
+        style = MaterialTheme.typography.titleSmall,
+        fontWeight = FontWeight.Bold,
+        modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+    )
+    HorizontalDivider()
+
+    if (source == null) {
+        ListItem(
+            headlineContent = { Text("No local folders configured") },
+            supportingContent = { Text("Add a folder on this device to read EPUBs and PDFs offline.") },
+        )
+    } else {
+        folders.forEach { folder ->
+            ListItem(
+                modifier = Modifier.testTag("LocalFilesFolder.${folder.treeUri}"),
+                headlineContent = { Text(folder.displayName) },
+                supportingContent = {
+                    Text(
+                        folder.treeUri,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                },
+                trailingContent = {
+                    IconButton(onClick = { pendingFolderRemoval = folder }) {
+                        Icon(Icons.Default.Delete, contentDescription = "Remove folder")
+                    }
+                },
+            )
+        }
+        if (folders.isEmpty()) {
+            ListItem(
+                headlineContent = { Text("No folders yet") },
+                supportingContent = { Text("Add a folder to start scanning for local books.") },
+            )
+        }
+    }
+
+    Button(
+        onClick = onAddFolder,
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 8.dp)
+            .testTag("LocalFilesAddFolder"),
+    ) {
+        Text(if (source == null || folders.isEmpty()) "Add a local folder" else "Add another folder")
+    }
+
+    if (source != null && folders.isNotEmpty()) {
+        TextButton(
+            onClick = { pendingSourceRemoval = true },
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp),
+        ) {
+            Text("Remove Local Files source", color = MaterialTheme.colorScheme.error)
+        }
+    }
+
+    pendingFolderRemoval?.let { folder ->
+        AlertDialog(
+            onDismissRequest = { pendingFolderRemoval = null },
+            title = { Text("Remove folder?") },
+            text = {
+                Text(
+                    "\"${folder.displayName}\" will be removed and any books that came from it " +
+                        "will be deleted from this device. Books shared with another configured " +
+                        "folder are kept.",
+                )
+            },
+            confirmButton = {
+                TextButton(onClick = {
+                    onRemoveFolder(folder.treeUri)
+                    pendingFolderRemoval = null
+                }) { Text("Remove") }
+            },
+            dismissButton = {
+                TextButton(onClick = { pendingFolderRemoval = null }) { Text("Cancel") }
+            },
+        )
+    }
+    if (pendingSourceRemoval) {
+        AlertDialog(
+            onDismissRequest = { pendingSourceRemoval = false },
+            title = { Text("Remove Local Files source?") },
+            text = { Text("Every configured folder and every locally-stored book will be deleted from this device.") },
+            confirmButton = {
+                TextButton(onClick = {
+                    onRemoveSource()
+                    pendingSourceRemoval = false
+                }) { Text("Remove") }
+            },
+            dismissButton = {
+                TextButton(onClick = { pendingSourceRemoval = false }) { Text("Cancel") }
+            },
+        )
     }
 }
 

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsScreen.kt
@@ -108,6 +108,7 @@ fun SettingsScreen(
     val servers by viewModel.servers.collectAsState()
     val localFilesSource by viewModel.localFilesSource.collectAsState()
     val localFilesFolders by viewModel.localFilesFolders.collectAsState()
+    val localFilesFolderHealth by viewModel.localFilesFolderHealth.collectAsState()
     val serverVersions by viewModel.serverVersions.collectAsState()
     val libraryItemsByServer by viewModel.libraryUiItemsByServer.collectAsState()
     val readaloudSummaries by viewModel.readaloudSummaries.collectAsState()
@@ -200,6 +201,7 @@ fun SettingsScreen(
                 LocalFilesSection(
                     source = localFilesSource,
                     folders = localFilesFolders,
+                    folderHealth = localFilesFolderHealth,
                     onAddFolder = { viewModel.openAddLocalFolder() },
                     onRemoveFolder = { treeUri -> viewModel.removeLocalFolder(treeUri) },
                     onRemoveSource = { viewModel.removeLocalFilesSource() },
@@ -1008,10 +1010,12 @@ private fun AnnotationSyncBadge(badge: AnnotationSyncRowState.Badge) {
 private fun LocalFilesSection(
     source: com.riffle.core.domain.Source?,
     folders: List<com.riffle.core.database.LocalFilesFolderEntity>,
+    folderHealth: Map<String, Boolean>,
     onAddFolder: () -> Unit,
     onRemoveFolder: (String) -> Unit,
     onRemoveSource: () -> Unit,
 ) {
+    val unhealthyCount = folders.count { folderHealth[it.treeUri] == false }
     var pendingFolderRemoval by remember { mutableStateOf<com.riffle.core.database.LocalFilesFolderEntity?>(null) }
     var pendingSourceRemoval by remember { mutableStateOf(false) }
 
@@ -1023,6 +1027,30 @@ private fun LocalFilesSection(
     )
     HorizontalDivider()
 
+    if (unhealthyCount > 0) {
+        ListItem(
+            leadingContent = {
+                Icon(
+                    Icons.Default.Warning,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.error,
+                )
+            },
+            headlineContent = {
+                Text(
+                    "$unhealthyCount folder${if (unhealthyCount == 1) "" else "s"} need${if (unhealthyCount == 1) "s" else ""} attention",
+                )
+            },
+            supportingContent = {
+                Text(
+                    "Riffle no longer has access to these folders — they were removed or their " +
+                        "permission was revoked in system Settings. Remove and re-add each one " +
+                        "to resume scanning. Books already stored on this device stay readable.",
+                )
+            },
+        )
+    }
+
     if (source == null) {
         ListItem(
             headlineContent = { Text("No local folders configured") },
@@ -1030,14 +1058,25 @@ private fun LocalFilesSection(
         )
     } else {
         folders.forEach { folder ->
+            val isHealthy = folderHealth[folder.treeUri] != false
             ListItem(
                 modifier = Modifier.testTag("LocalFilesFolder.${folder.treeUri}"),
+                leadingContent = {
+                    if (!isHealthy) {
+                        Icon(
+                            Icons.Default.Warning,
+                            contentDescription = "Permission revoked",
+                            tint = MaterialTheme.colorScheme.error,
+                        )
+                    }
+                },
                 headlineContent = { Text(folder.displayName) },
                 supportingContent = {
                     Text(
-                        folder.treeUri,
+                        if (isHealthy) folder.treeUri else "Permission revoked — remove and re-add",
                         style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        color = if (isHealthy) MaterialTheme.colorScheme.onSurfaceVariant
+                        else MaterialTheme.colorScheme.error,
                     )
                 },
                 trailingContent = {

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsScreen.kt
@@ -2,8 +2,12 @@ package com.riffle.app.feature.settings
 
 import android.content.Intent
 import android.net.Uri
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.platform.testTag
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
 import androidx.core.content.FileProvider
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.animateFloatAsState
@@ -135,6 +139,17 @@ fun SettingsScreen(
                 is SettingsNavEvent.NavigateToReadaloudMatches -> onNavigateToReadaloudMatches(event.sourceId)
             }
         }
+    }
+
+    // Returning from system Settings after revoking a SAF grant doesn't change the DB folder set,
+    // so the local-files-health map would stay stale. Kick a recompute on every resume.
+    val settingsLifecycle = LocalLifecycleOwner.current.lifecycle
+    DisposableEffect(settingsLifecycle) {
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_RESUME) viewModel.refreshLocalFilesFolderHealth()
+        }
+        settingsLifecycle.addObserver(observer)
+        onDispose { settingsLifecycle.removeObserver(observer) }
     }
 
     Scaffold(

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsScreen.kt
@@ -93,7 +93,6 @@ fun SettingsScreen(
     windowSizeClass: WindowSizeClass,
     onNavigateBack: () -> Unit,
     onNavigateToAddSource: (backend: AddSourceBackend, editId: String?) -> Unit,
-    onNavigateToAddLocalFolder: () -> Unit = {},
     onNavigateToReadaloudMatches: (String) -> Unit = {},
     onNavigateToAnnotationSyncMaintenance: () -> Unit = {},
     onNavigateToDebugLogs: () -> Unit = {},
@@ -132,7 +131,6 @@ fun SettingsScreen(
         viewModel.navigationEvents.collect { event ->
             when (event) {
                 is SettingsNavEvent.NavigateToAddSource -> onNavigateToAddSource(AddSourceBackend.AUDIOBOOKSHELF, null)
-                is SettingsNavEvent.NavigateToAddLocalFolder -> onNavigateToAddLocalFolder()
                 is SettingsNavEvent.NavigateToReadaloudMatches -> onNavigateToReadaloudMatches(event.sourceId)
             }
         }
@@ -188,6 +186,19 @@ fun SettingsScreen(
                         onOpenReadaloudMatches = { viewModel.openReadaloudMatches(server.id) },
                     )
                 }
+                localFilesSource?.let { lfs ->
+                    LocalFilesSourceRow(
+                        source = lfs,
+                        folders = localFilesFolders,
+                        folderHealth = localFilesFolderHealth,
+                        isExpanded = expandedServers[lfs.id] == true,
+                        onToggleExpanded = {
+                            expandedServers[lfs.id] = expandedServers[lfs.id] != true
+                        },
+                        onRemoveFolder = { treeUri -> viewModel.removeLocalFolder(treeUri) },
+                        onRemoveSource = { viewModel.removeLocalFilesSource() },
+                    )
+                }
                 Button(
                     onClick = { onNavigateToAddSource(AddSourceBackend.AUDIOBOOKSHELF, null) },
                     modifier = Modifier
@@ -196,16 +207,6 @@ fun SettingsScreen(
                 ) {
                     Text("Add source")
                 }
-                HorizontalDivider()
-
-                LocalFilesSection(
-                    source = localFilesSource,
-                    folders = localFilesFolders,
-                    folderHealth = localFilesFolderHealth,
-                    onAddFolder = { viewModel.openAddLocalFolder() },
-                    onRemoveFolder = { treeUri -> viewModel.removeLocalFolder(treeUri) },
-                    onRemoveSource = { viewModel.removeLocalFilesSource() },
-                )
                 HorizontalDivider()
 
                 Text(
@@ -1006,112 +1007,113 @@ private fun AnnotationSyncBadge(badge: AnnotationSyncRowState.Badge) {
     }
 }
 
+/**
+ * Sources-list row for the singleton LocalFiles Source. Mirrors [ServerRow]'s chevron-expand
+ * shape so the two Source types read as siblings in the "Sources" section: header + collapsed
+ * summary; expanding drops down the configured folders with per-folder revocation warnings and
+ * a per-folder / whole-source removal path. Adding another folder goes through the standard
+ * Add-source picker — [com.riffle.core.data.localfiles.LocalFilesSourceInstaller.ensureLocalFilesSource]
+ * is idempotent, so "Add source > Local files" attaches to the existing row instead of creating
+ * a duplicate.
+ */
 @Composable
-private fun LocalFilesSection(
-    source: com.riffle.core.domain.Source?,
+private fun LocalFilesSourceRow(
+    source: com.riffle.core.domain.Source,
     folders: List<com.riffle.core.database.LocalFilesFolderEntity>,
     folderHealth: Map<String, Boolean>,
-    onAddFolder: () -> Unit,
+    isExpanded: Boolean,
+    onToggleExpanded: () -> Unit,
     onRemoveFolder: (String) -> Unit,
     onRemoveSource: () -> Unit,
 ) {
-    val unhealthyCount = folders.count { folderHealth[it.treeUri] == false }
     var pendingFolderRemoval by remember { mutableStateOf<com.riffle.core.database.LocalFilesFolderEntity?>(null) }
     var pendingSourceRemoval by remember { mutableStateOf(false) }
-
-    Text(
-        text = "Local Files",
-        style = MaterialTheme.typography.titleSmall,
-        fontWeight = FontWeight.Bold,
-        modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+    val unhealthyCount = folders.count { folderHealth[it.treeUri] == false }
+    val chevronRotation by androidx.compose.animation.core.animateFloatAsState(
+        targetValue = if (isExpanded) 90f else 0f,
+        label = "chevron",
     )
-    HorizontalDivider()
 
-    if (unhealthyCount > 0) {
+    Column {
         ListItem(
+            modifier = Modifier
+                .clickable { onToggleExpanded() }
+                .testTag("LocalFilesSourceRow"),
             leadingContent = {
                 Icon(
-                    Icons.Default.Warning,
-                    contentDescription = null,
-                    tint = MaterialTheme.colorScheme.error,
+                    Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                    contentDescription = if (isExpanded) "Collapse" else "Expand",
+                    modifier = Modifier.rotate(chevronRotation),
                 )
             },
-            headlineContent = {
-                Text(
-                    "$unhealthyCount folder${if (unhealthyCount == 1) "" else "s"} need${if (unhealthyCount == 1) "s" else ""} attention",
-                )
-            },
+            headlineContent = { Text("Local files") },
             supportingContent = {
-                Text(
-                    "Riffle no longer has access to these folders — they were removed or their " +
-                        "permission was revoked in system Settings. Remove and re-add each one " +
-                        "to resume scanning. Books already stored on this device stay readable.",
-                )
+                val folderWord = if (folders.size == 1) "folder" else "folders"
+                val summary = buildString {
+                    append("${folders.size} $folderWord on this device")
+                    if (unhealthyCount > 0) append(" · $unhealthyCount need attention")
+                }
+                Text(summary)
             },
+            trailingContent = if (unhealthyCount > 0) {
+                {
+                    Icon(
+                        Icons.Default.Warning,
+                        contentDescription = "Some folders need attention",
+                        tint = MaterialTheme.colorScheme.error,
+                    )
+                }
+            } else null,
         )
-    }
-
-    if (source == null) {
-        ListItem(
-            headlineContent = { Text("No local folders configured") },
-            supportingContent = { Text("Add a folder on this device to read EPUBs and PDFs offline.") },
-        )
-    } else {
-        folders.forEach { folder ->
-            val isHealthy = folderHealth[folder.treeUri] != false
-            ListItem(
-                modifier = Modifier.testTag("LocalFilesFolder.${folder.treeUri}"),
-                leadingContent = {
-                    if (!isHealthy) {
-                        Icon(
-                            Icons.Default.Warning,
-                            contentDescription = "Permission revoked",
-                            tint = MaterialTheme.colorScheme.error,
+        androidx.compose.animation.AnimatedVisibility(visible = isExpanded) {
+            Column {
+                if (folders.isEmpty()) {
+                    ListItem(
+                        headlineContent = { Text("No folders yet") },
+                        supportingContent = {
+                            Text("Use \"Add source\" below to pick a folder for this device.")
+                        },
+                    )
+                } else {
+                    folders.forEach { folder ->
+                        val isHealthy = folderHealth[folder.treeUri] != false
+                        ListItem(
+                            modifier = Modifier.testTag("LocalFilesFolder.${folder.treeUri}"),
+                            leadingContent = {
+                                if (!isHealthy) {
+                                    Icon(
+                                        Icons.Default.Warning,
+                                        contentDescription = "Permission revoked",
+                                        tint = MaterialTheme.colorScheme.error,
+                                    )
+                                }
+                            },
+                            headlineContent = { Text(folder.displayName) },
+                            supportingContent = {
+                                Text(
+                                    if (isHealthy) folder.treeUri else "Permission revoked — remove and re-add",
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = if (isHealthy) MaterialTheme.colorScheme.onSurfaceVariant
+                                    else MaterialTheme.colorScheme.error,
+                                )
+                            },
+                            trailingContent = {
+                                IconButton(onClick = { pendingFolderRemoval = folder }) {
+                                    Icon(Icons.Default.Delete, contentDescription = "Remove folder")
+                                }
+                            },
                         )
                     }
-                },
-                headlineContent = { Text(folder.displayName) },
-                supportingContent = {
-                    Text(
-                        if (isHealthy) folder.treeUri else "Permission revoked — remove and re-add",
-                        style = MaterialTheme.typography.bodySmall,
-                        color = if (isHealthy) MaterialTheme.colorScheme.onSurfaceVariant
-                        else MaterialTheme.colorScheme.error,
-                    )
-                },
-                trailingContent = {
-                    IconButton(onClick = { pendingFolderRemoval = folder }) {
-                        Icon(Icons.Default.Delete, contentDescription = "Remove folder")
-                    }
-                },
-            )
-        }
-        if (folders.isEmpty()) {
-            ListItem(
-                headlineContent = { Text("No folders yet") },
-                supportingContent = { Text("Add a folder to start scanning for local books.") },
-            )
-        }
-    }
-
-    Button(
-        onClick = onAddFolder,
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(horizontal = 16.dp, vertical = 8.dp)
-            .testTag("LocalFilesAddFolder"),
-    ) {
-        Text(if (source == null || folders.isEmpty()) "Add a local folder" else "Add another folder")
-    }
-
-    if (source != null && folders.isNotEmpty()) {
-        TextButton(
-            onClick = { pendingSourceRemoval = true },
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 16.dp),
-        ) {
-            Text("Remove Local Files source", color = MaterialTheme.colorScheme.error)
+                }
+                TextButton(
+                    onClick = { pendingSourceRemoval = true },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 4.dp),
+                ) {
+                    Text("Remove Local Files source", color = MaterialTheme.colorScheme.error)
+                }
+            }
         }
     }
 

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.rememberScrollState
@@ -108,6 +109,7 @@ fun SettingsScreen(
     val localFilesSource by viewModel.localFilesSource.collectAsState()
     val localFilesFolders by viewModel.localFilesFolders.collectAsState()
     val localFilesFolderHealth by viewModel.localFilesFolderHealth.collectAsState()
+    val localFilesRescanning by viewModel.localFilesRescanning.collectAsState()
     val serverVersions by viewModel.serverVersions.collectAsState()
     val libraryItemsByServer by viewModel.libraryUiItemsByServer.collectAsState()
     val readaloudSummaries by viewModel.readaloudSummaries.collectAsState()
@@ -195,9 +197,11 @@ fun SettingsScreen(
                         folders = localFilesFolders,
                         folderHealth = localFilesFolderHealth,
                         isExpanded = expandedServers[lfs.id] == true,
+                        isRescanning = localFilesRescanning,
                         onToggleExpanded = {
                             expandedServers[lfs.id] = expandedServers[lfs.id] != true
                         },
+                        onRescan = { viewModel.rescanLocalFiles() },
                         onRemoveFolder = { treeUri -> viewModel.removeLocalFolder(treeUri) },
                         onRemoveSource = { viewModel.removeLocalFilesSource() },
                     )
@@ -1025,7 +1029,9 @@ private fun LocalFilesSourceRow(
     folders: List<com.riffle.core.database.LocalFilesFolderEntity>,
     folderHealth: Map<String, Boolean>,
     isExpanded: Boolean,
+    isRescanning: Boolean,
     onToggleExpanded: () -> Unit,
+    onRescan: () -> Unit,
     onRemoveFolder: (String) -> Unit,
     onRemoveSource: () -> Unit,
 ) {
@@ -1106,6 +1112,26 @@ private fun LocalFilesSourceRow(
                                 }
                             },
                         )
+                    }
+                }
+                Button(
+                    onClick = onRescan,
+                    enabled = !isRescanning && folders.isNotEmpty(),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 8.dp)
+                        .testTag("LocalFilesRescan"),
+                ) {
+                    if (isRescanning) {
+                        CircularProgressIndicator(
+                            modifier = Modifier.size(18.dp),
+                            strokeWidth = 2.dp,
+                            color = MaterialTheme.colorScheme.onPrimary,
+                        )
+                        Spacer(Modifier.size(12.dp))
+                        Text("Scanning…")
+                    } else {
+                        Text("Scan for new books")
                     }
                 }
                 TextButton(

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsScreen.kt
@@ -166,7 +166,10 @@ fun SettingsScreen(
                     modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
                 )
                 HorizontalDivider()
-                servers.filter { it.serverType == ServerType.AUDIOBOOKSHELF }.forEach { server ->
+                servers.filter {
+                    it.serverType == ServerType.AUDIOBOOKSHELF &&
+                        it.type == com.riffle.core.domain.SourceType.ABS
+                }.forEach { server ->
                     ServerRow(
                         server = server,
                         isExpanded = expandedServers[server.id] == true,

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsScreen.kt
@@ -109,7 +109,6 @@ fun SettingsScreen(
     val localFilesSource by viewModel.localFilesSource.collectAsState()
     val localFilesFolders by viewModel.localFilesFolders.collectAsState()
     val localFilesFolderHealth by viewModel.localFilesFolderHealth.collectAsState()
-    val localFilesRescanning by viewModel.localFilesRescanning.collectAsState()
     val serverVersions by viewModel.serverVersions.collectAsState()
     val libraryItemsByServer by viewModel.libraryUiItemsByServer.collectAsState()
     val readaloudSummaries by viewModel.readaloudSummaries.collectAsState()
@@ -197,11 +196,9 @@ fun SettingsScreen(
                         folders = localFilesFolders,
                         folderHealth = localFilesFolderHealth,
                         isExpanded = expandedServers[lfs.id] == true,
-                        isRescanning = localFilesRescanning,
                         onToggleExpanded = {
                             expandedServers[lfs.id] = expandedServers[lfs.id] != true
                         },
-                        onRescan = { viewModel.rescanLocalFiles() },
                         onRemoveFolder = { treeUri -> viewModel.removeLocalFolder(treeUri) },
                         onRemoveSource = { viewModel.removeLocalFilesSource() },
                     )
@@ -1029,9 +1026,7 @@ private fun LocalFilesSourceRow(
     folders: List<com.riffle.core.database.LocalFilesFolderEntity>,
     folderHealth: Map<String, Boolean>,
     isExpanded: Boolean,
-    isRescanning: Boolean,
     onToggleExpanded: () -> Unit,
-    onRescan: () -> Unit,
     onRemoveFolder: (String) -> Unit,
     onRemoveSource: () -> Unit,
 ) {
@@ -1112,26 +1107,6 @@ private fun LocalFilesSourceRow(
                                 }
                             },
                         )
-                    }
-                }
-                Button(
-                    onClick = onRescan,
-                    enabled = !isRescanning && folders.isNotEmpty(),
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 16.dp, vertical = 8.dp)
-                        .testTag("LocalFilesRescan"),
-                ) {
-                    if (isRescanning) {
-                        CircularProgressIndicator(
-                            modifier = Modifier.size(18.dp),
-                            strokeWidth = 2.dp,
-                            color = MaterialTheme.colorScheme.onPrimary,
-                        )
-                        Spacer(Modifier.size(12.dp))
-                        Text("Scanning…")
-                    } else {
-                        Text("Scan for new books")
                     }
                 }
                 TextButton(

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsViewModel.kt
@@ -434,27 +434,6 @@ class SettingsViewModel @Inject constructor(
 
     // region LocalFiles folder management
 
-    private val _rescanning = MutableStateFlow(false)
-    val localFilesRescanning: StateFlow<Boolean> = _rescanning.asStateFlow()
-
-    /**
-     * Re-walk every configured folder for the LocalFiles source and ingest anything new. Users
-     * dropping a new EPUB into their picked folder don't have to remove and re-add the source;
-     * this button drives the same [LocalFilesScanner.scan] pipeline used by first-install.
-     */
-    fun rescanLocalFiles() {
-        val source = localFilesSource.value ?: return
-        if (_rescanning.value) return
-        viewModelScope.launch {
-            _rescanning.value = true
-            try {
-                localFilesScanner.scan(source.id)
-            } finally {
-                _rescanning.value = false
-            }
-        }
-    }
-
     /**
      * Remove one configured LocalFiles folder from the singleton LocalFiles Source. Releases the
      * SAF grant, deletes the folder row, then runs a scan so the sweep-stale pass hard-deletes

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsViewModel.kt
@@ -434,10 +434,6 @@ class SettingsViewModel @Inject constructor(
 
     // region LocalFiles folder management
 
-    fun openAddLocalFolder() {
-        viewModelScope.launch { _navigationEvents.send(SettingsNavEvent.NavigateToAddLocalFolder) }
-    }
-
     /**
      * Remove one configured LocalFiles folder from the singleton LocalFiles Source. Releases the
      * SAF grant, deletes the folder row, then runs a scan so the sweep-stale pass hard-deletes

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsViewModel.kt
@@ -28,7 +28,12 @@ import com.riffle.app.feature.annotationsync.AnnotationSyncKind
 import com.riffle.app.feature.annotationsync.deriveAnnotationSyncKind
 import com.riffle.core.data.AnnotationSyncStatusStore
 import com.riffle.core.data.CycleOutcome
+import com.riffle.core.data.localfiles.LocalFilesFolderRepository
+import com.riffle.core.data.localfiles.LocalFilesScanner
+import com.riffle.core.data.localfiles.LocalFilesSourceInstaller
 import com.riffle.core.database.AnnotationDao
+import com.riffle.core.database.LocalFilesFolderDao
+import com.riffle.core.database.LocalFilesFolderEntity
 import com.riffle.core.domain.VolumeKeyPreferencesStore
 import com.riffle.core.domain.WakeLockPreferencesStore
 import com.riffle.core.domain.SourceRepository
@@ -75,6 +80,10 @@ class SettingsViewModel @Inject constructor(
     private val connectivityObserver: ConnectivityObserver,
     private val appUpdateRepository: AppUpdateRepository,
     private val readaloudPreferencesStore: ReadaloudPreferencesStore,
+    private val localFilesFolderDao: LocalFilesFolderDao,
+    private val localFilesFolderRepository: LocalFilesFolderRepository,
+    private val localFilesScanner: LocalFilesScanner,
+    private val localFilesSourceInstaller: LocalFilesSourceInstaller,
     annotationSyncConfigStore: com.riffle.core.domain.AnnotationSyncConfigStore,
     annotationSyncStatusStore: AnnotationSyncStatusStore,
     annotationDao: AnnotationDao,
@@ -222,6 +231,22 @@ class SettingsViewModel @Inject constructor(
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), AppTheme.System)
 
     val servers: StateFlow<List<Source>> = sourceRepository.observeAll()
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
+
+    /**
+     * The singleton LocalFiles Source row if one has been installed (there is at most one per
+     * device — multi-folder lives inside it). Null before the first Add-Source LocalFiles pass.
+     */
+    val localFilesSource: StateFlow<Source?> = servers
+        .map { list -> list.firstOrNull { it.type == com.riffle.core.domain.SourceType.LOCAL_FILES } }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), null)
+
+    /** Configured folder rows under the LocalFiles Source, reactive. Empty when no source yet. */
+    val localFilesFolders: StateFlow<List<LocalFilesFolderEntity>> = localFilesSource
+        .flatMapLatest { source ->
+            if (source == null) MutableStateFlow(emptyList())
+            else localFilesFolderDao.observeForSource(source.id)
+        }
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
 
     /** Ids of the configured Storyteller servers, feeding the per-server readaloud summaries. */
@@ -392,6 +417,36 @@ class SettingsViewModel @Inject constructor(
 
     private fun shortHost(rawUrl: String): String =
         runCatching { java.net.URI(rawUrl).host ?: rawUrl }.getOrDefault(rawUrl)
+
+    // region LocalFiles folder management
+
+    fun openAddLocalFolder() {
+        viewModelScope.launch { _navigationEvents.send(SettingsNavEvent.NavigateToAddLocalFolder) }
+    }
+
+    /**
+     * Remove one configured LocalFiles folder from the singleton LocalFiles Source. Releases the
+     * SAF grant, deletes the folder row, then runs a scan so the sweep-stale pass hard-deletes
+     * every file that lived only in this folder (identity-hashed rows shared with another folder
+     * survive automatically). Callers confirm via a dialog.
+     */
+    fun removeLocalFolder(treeUri: String) {
+        val source = localFilesSource.value ?: return
+        viewModelScope.launch {
+            localFilesFolderRepository.removeFolder(source.id, treeUri)
+            localFilesScanner.scan(source.id)
+        }
+    }
+
+    /**
+     * Remove the entire LocalFiles Source (all folders, all copied-in files). Wired through the
+     * standard [removeServer] path so the cascade — DB, tokens, files-on-disk — stays uniform.
+     */
+    fun removeLocalFilesSource() {
+        localFilesSource.value?.id?.let { removeServer(it) }
+    }
+
+    // endregion
 }
 
 /** Counts shown in a Storyteller server's expanded "Readaloud matches" summary (gradient order). */

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsViewModel.kt
@@ -256,12 +256,23 @@ class SettingsViewModel @Inject constructor(
      * persistable URI grant revoked by the user in system Settings; already-copied bytes stay
      * readable, but rescanning and picking up new files needs a re-pick.
      *
-     * Re-derives every time the folder set changes so users returning from system Settings pick
-     * up the fresh state without a manual refresh gesture.
+     * Re-derives when the folder set changes OR when [refreshLocalFilesFolderHealth] is called —
+     * the Settings screen pokes it on Lifecycle.ON_RESUME so returning from system Settings picks
+     * up freshly-revoked grants without any user gesture. Without that trigger the map would go
+     * stale (the DB folder set didn't change; only the OS grant list did).
      */
-    val localFilesFolderHealth: StateFlow<Map<String, Boolean>> = localFilesFolders
-        .map { folders -> localFilesFolderHealthChecker.healthFor(folders.map { it.treeUri }) }
-        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyMap())
+    private val folderHealthRefreshTicks = MutableStateFlow(0L)
+    val localFilesFolderHealth: StateFlow<Map<String, Boolean>> = combine(
+        localFilesFolders,
+        folderHealthRefreshTicks,
+    ) { folders, _ ->
+        localFilesFolderHealthChecker.healthFor(folders.map { it.treeUri })
+    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyMap())
+
+    /** Kicks a re-check of every configured folder's SAF grant. Cheap; safe to call on RESUME. */
+    fun refreshLocalFilesFolderHealth() {
+        folderHealthRefreshTicks.value = folderHealthRefreshTicks.value + 1L
+    }
 
     /** Ids of the configured Storyteller servers, feeding the per-server readaloud summaries. */
     private val storytellerServerIds: StateFlow<List<String>> = servers
@@ -312,7 +323,15 @@ class SettingsViewModel @Inject constructor(
     }
 
     private val absServers: StateFlow<List<Source>> = servers
-        .map { list -> list.filter { it.serverType == ServerType.AUDIOBOOKSHELF } }
+        // Match by (type, serverType) rather than serverType alone: LocalFiles rows persist
+        // `serverType = AUDIOBOOKSHELF` as a placeholder (see [LocalFilesSourceInstaller]) and
+        // would otherwise leak into every ABS-only downstream (library refresh, cover tokens).
+        .map { list ->
+            list.filter {
+                it.type == com.riffle.core.domain.SourceType.ABS &&
+                    it.serverType == ServerType.AUDIOBOOKSHELF
+            }
+        }
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
 
     /**

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsViewModel.kt
@@ -28,6 +28,7 @@ import com.riffle.app.feature.annotationsync.AnnotationSyncKind
 import com.riffle.app.feature.annotationsync.deriveAnnotationSyncKind
 import com.riffle.core.data.AnnotationSyncStatusStore
 import com.riffle.core.data.CycleOutcome
+import com.riffle.core.data.localfiles.LocalFilesFolderHealthChecker
 import com.riffle.core.data.localfiles.LocalFilesFolderRepository
 import com.riffle.core.data.localfiles.LocalFilesScanner
 import com.riffle.core.data.localfiles.LocalFilesSourceInstaller
@@ -84,6 +85,7 @@ class SettingsViewModel @Inject constructor(
     private val localFilesFolderRepository: LocalFilesFolderRepository,
     private val localFilesScanner: LocalFilesScanner,
     private val localFilesSourceInstaller: LocalFilesSourceInstaller,
+    private val localFilesFolderHealthChecker: LocalFilesFolderHealthChecker,
     annotationSyncConfigStore: com.riffle.core.domain.AnnotationSyncConfigStore,
     annotationSyncStatusStore: AnnotationSyncStatusStore,
     annotationDao: AnnotationDao,
@@ -248,6 +250,18 @@ class SettingsViewModel @Inject constructor(
             else localFilesFolderDao.observeForSource(source.id)
         }
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
+
+    /**
+     * (treeUri → isHealthy) for every configured LocalFiles folder. Unhealthy folders had their
+     * persistable URI grant revoked by the user in system Settings; already-copied bytes stay
+     * readable, but rescanning and picking up new files needs a re-pick.
+     *
+     * Re-derives every time the folder set changes so users returning from system Settings pick
+     * up the fresh state without a manual refresh gesture.
+     */
+    val localFilesFolderHealth: StateFlow<Map<String, Boolean>> = localFilesFolders
+        .map { folders -> localFilesFolderHealthChecker.healthFor(folders.map { it.treeUri }) }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyMap())
 
     /** Ids of the configured Storyteller servers, feeding the per-server readaloud summaries. */
     private val storytellerServerIds: StateFlow<List<String>> = servers

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsViewModel.kt
@@ -434,6 +434,27 @@ class SettingsViewModel @Inject constructor(
 
     // region LocalFiles folder management
 
+    private val _rescanning = MutableStateFlow(false)
+    val localFilesRescanning: StateFlow<Boolean> = _rescanning.asStateFlow()
+
+    /**
+     * Re-walk every configured folder for the LocalFiles source and ingest anything new. Users
+     * dropping a new EPUB into their picked folder don't have to remove and re-add the source;
+     * this button drives the same [LocalFilesScanner.scan] pipeline used by first-install.
+     */
+    fun rescanLocalFiles() {
+        val source = localFilesSource.value ?: return
+        if (_rescanning.value) return
+        viewModelScope.launch {
+            _rescanning.value = true
+            try {
+                localFilesScanner.scan(source.id)
+            } finally {
+                _rescanning.value = false
+            }
+        }
+    }
+
     /**
      * Remove one configured LocalFiles folder from the singleton LocalFiles Source. Releases the
      * SAF grant, deletes the folder row, then runs a scan so the sweep-stale pass hard-deletes

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/readaloud/ReadaloudMatchesViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/readaloud/ReadaloudMatchesViewModel.kt
@@ -56,7 +56,13 @@ class ReadaloudMatchesViewModel @Inject constructor(
      */
     val activeAbsServerId: StateFlow<String> = sourceRepository.observeAll()
         .map { servers ->
-            val abs = servers.filter { it.serverType == ServerType.AUDIOBOOKSHELF }
+            // Filter by SourceType.ABS too — LocalFiles rows carry
+            // `serverType = AUDIOBOOKSHELF` as a placeholder and would otherwise be picked as
+            // "active ABS", pointing readaloud matching at a source with no ABS API.
+            val abs = servers.filter {
+                it.type == com.riffle.core.domain.SourceType.ABS &&
+                    it.serverType == ServerType.AUDIOBOOKSHELF
+            }
             (abs.firstOrNull { it.isActive } ?: abs.firstOrNull())?.id ?: ""
         }
         .stateIn(viewModelScope, SharingStarted.Eagerly, "")

--- a/app/src/main/kotlin/com/riffle/app/feature/source/localfiles/AddLocalFilesScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/source/localfiles/AddLocalFilesScreen.kt
@@ -61,9 +61,6 @@ fun AddLocalFilesScreen(
             launcher.launch(Unit)
         }
     }
-    LaunchedEffect(state) {
-        if (state is AddLocalFilesViewModel.State.Success) onDone()
-    }
 
     Scaffold(
         topBar = {
@@ -92,7 +89,11 @@ fun AddLocalFilesScreen(
                         onNavigateBack = onNavigateBack,
                     )
                     AddLocalFilesViewModel.State.Installing -> InstallingView()
-                    is AddLocalFilesViewModel.State.Success -> SuccessView(s.report.added, s.report.failures.size)
+                    is AddLocalFilesViewModel.State.Success -> SuccessView(
+                        added = s.report.added,
+                        failures = s.report.failures.size,
+                        onDone = onDone,
+                    )
                     is AddLocalFilesViewModel.State.Error -> ErrorView(
                         message = s.message,
                         onRetry = { launcher.launch(Unit) },
@@ -114,19 +115,30 @@ private fun InstallingView() {
 }
 
 @Composable
-private fun SuccessView(added: Int, failures: Int) {
-    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+private fun SuccessView(added: Int, failures: Int, onDone: () -> Unit) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
         Text(
             "Added $added book${if (added == 1) "" else "s"}.",
             style = MaterialTheme.typography.titleMedium,
         )
         if (failures > 0) {
-            Spacer(Modifier.size(4.dp))
             Text(
                 "$failures item${if (failures == 1) "" else "s"} could not be read.",
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
+        } else if (added == 0) {
+            Text(
+                "No EPUBs or PDFs were found in that folder.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        Button(onClick = onDone, modifier = Modifier.testTag("AddLocalFiles.Done")) {
+            Text("Done")
         }
     }
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/source/localfiles/AddLocalFilesScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/source/localfiles/AddLocalFilesScreen.kt
@@ -1,0 +1,164 @@
+package com.riffle.app.feature.source.localfiles
+
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.windowsizeclass.WindowSizeClass
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.riffle.app.ui.TabletContentWidthContainer
+
+/**
+ * Entry point for the Add-Source LocalFiles flow. Auto-launches the SAF folder picker on first
+ * frame; on cancel offers a retry / back path; on success surfaces the scan report before
+ * handing back to the caller. No form fields — LocalFiles has no credentials to supply.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AddLocalFilesScreen(
+    windowSizeClass: WindowSizeClass,
+    onDone: () -> Unit,
+    onNavigateBack: () -> Unit,
+    viewModel: AddLocalFilesViewModel = hiltViewModel(),
+) {
+    val state by viewModel.state.collectAsState()
+    val launcher = rememberLauncherForActivityResult(PickFolderContract()) { uri ->
+        viewModel.onFolderPicked(uri)
+    }
+    // Autolaunch once per compose entry. `pickerLaunched` guards against relaunching after
+    // process-death restore (state is already set to Installing/Success).
+    var pickerLaunched by remember { mutableStateOf(false) }
+    LaunchedEffect(Unit) {
+        if (!pickerLaunched && state is AddLocalFilesViewModel.State.Idle) {
+            pickerLaunched = true
+            launcher.launch(Unit)
+        }
+    }
+    LaunchedEffect(state) {
+        if (state is AddLocalFilesViewModel.State.Success) onDone()
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Add local folder") },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        TabletContentWidthContainer(
+            windowSizeClass = windowSizeClass,
+            modifier = Modifier.fillMaxSize().padding(padding),
+        ) {
+            Box(modifier = Modifier.fillMaxSize().padding(24.dp), contentAlignment = Alignment.Center) {
+                when (val s = state) {
+                    AddLocalFilesViewModel.State.Idle -> {
+                        // Waiting for the picker to launch — usually invisible.
+                        Text("Opening folder picker…")
+                    }
+                    AddLocalFilesViewModel.State.Cancelled -> CancelledView(
+                        onPickAgain = { launcher.launch(Unit) },
+                        onNavigateBack = onNavigateBack,
+                    )
+                    AddLocalFilesViewModel.State.Installing -> InstallingView()
+                    is AddLocalFilesViewModel.State.Success -> SuccessView(s.report.added, s.report.failures.size)
+                    is AddLocalFilesViewModel.State.Error -> ErrorView(
+                        message = s.message,
+                        onRetry = { launcher.launch(Unit) },
+                        onNavigateBack = onNavigateBack,
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun InstallingView() {
+    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+        CircularProgressIndicator()
+        Spacer(Modifier.size(16.dp))
+        Text("Scanning your folder…")
+    }
+}
+
+@Composable
+private fun SuccessView(added: Int, failures: Int) {
+    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+        Text(
+            "Added $added book${if (added == 1) "" else "s"}.",
+            style = MaterialTheme.typography.titleMedium,
+        )
+        if (failures > 0) {
+            Spacer(Modifier.size(4.dp))
+            Text(
+                "$failures item${if (failures == 1) "" else "s"} could not be read.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+@Composable
+private fun CancelledView(onPickAgain: () -> Unit, onNavigateBack: () -> Unit) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        Text("No folder picked.", style = MaterialTheme.typography.titleMedium)
+        Button(onClick = onPickAgain, modifier = Modifier.testTag("AddLocalFiles.PickAgain")) {
+            Text("Pick a folder")
+        }
+        Button(onClick = onNavigateBack) { Text("Cancel") }
+    }
+}
+
+@Composable
+private fun ErrorView(message: String, onRetry: () -> Unit, onNavigateBack: () -> Unit) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Text("Couldn't add that folder.", style = MaterialTheme.typography.titleMedium)
+        Text(
+            message,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Button(onClick = onRetry) { Text("Try again") }
+        Button(onClick = onNavigateBack) { Text("Cancel") }
+    }
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/source/localfiles/AddLocalFilesViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/source/localfiles/AddLocalFilesViewModel.kt
@@ -1,0 +1,49 @@
+package com.riffle.app.feature.source.localfiles
+
+import android.net.Uri
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.riffle.core.data.localfiles.LocalFilesScanner
+import com.riffle.core.data.localfiles.LocalFilesSourceInstaller
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class AddLocalFilesViewModel @Inject constructor(
+    private val installer: LocalFilesSourceInstaller,
+) : ViewModel() {
+
+    sealed interface State {
+        /** No folder picked yet — the SAF picker should launch. */
+        data object Idle : State
+        /** User cancelled the SAF picker. */
+        data object Cancelled : State
+        /** Folder picked; scanning in progress. */
+        data object Installing : State
+        data class Success(val report: LocalFilesScanner.ScanReport) : State
+        data class Error(val message: String) : State
+    }
+
+    private val _state = MutableStateFlow<State>(State.Idle)
+    val state: StateFlow<State> = _state.asStateFlow()
+
+    fun onFolderPicked(uri: Uri?) {
+        if (uri == null) {
+            _state.value = State.Cancelled
+            return
+        }
+        _state.value = State.Installing
+        viewModelScope.launch {
+            _state.value = try {
+                val result = installer.installFolder(uri)
+                State.Success(result.scan)
+            } catch (t: Throwable) {
+                State.Error(t.message ?: t::class.simpleName ?: "Unknown error")
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
@@ -53,6 +53,7 @@ import java.net.URLEncoder
 private const val HOME = "home"
 private const val SOURCE_SETUP_GRAPH = "source_setup"
 private const val ADD_SOURCE_TYPE_PICKER = "add_source_type_picker"
+private const val ADD_LOCAL_FILES = "add_local_files"
 private const val ADD_SOURCE = "add_source"
 private const val ADD_SOURCE_ROUTE = "add_source?type={type}&editId={editId}"
 private const val SELECT_LIBRARIES = "select_libraries"
@@ -196,6 +197,26 @@ fun MainScreen(
                             // Drop the picker so back from the form returns to the caller.
                             popUpTo(ADD_SOURCE_TYPE_PICKER) { inclusive = true }
                         }
+                    },
+                    onPickLocalFiles = {
+                        navController.navigate(ADD_LOCAL_FILES) {
+                            popUpTo(ADD_SOURCE_TYPE_PICKER) { inclusive = true }
+                        }
+                    },
+                )
+            }
+            composable(ADD_LOCAL_FILES) {
+                val cameFromSettings = navController.previousBackStackEntry
+                    ?.destination?.route == SETTINGS
+                com.riffle.app.feature.source.localfiles.AddLocalFilesScreen(
+                    windowSizeClass = windowSizeClass,
+                    onDone = {
+                        if (cameFromSettings) navController.popBackStack()
+                        else navController.navigateAsRoot(HOME)
+                    },
+                    onNavigateBack = {
+                        if (cameFromSettings) navController.popBackStack()
+                        else navController.navigateAsRoot(HOME)
                     },
                 )
             }

--- a/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
@@ -296,6 +296,7 @@ fun MainScreen(
                             navController.navigate("$ADD_SOURCE?$params")
                         }
                     },
+                    onNavigateToAddLocalFolder = { navController.navigate(ADD_LOCAL_FILES) },
                     onNavigateToReadaloudMatches = { sourceId ->
                         val encoded = URLEncoder.encode(sourceId, "UTF-8")
                         navController.navigate("readaloud_matches/$encoded")

--- a/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
@@ -296,7 +296,6 @@ fun MainScreen(
                             navController.navigate("$ADD_SOURCE?$params")
                         }
                     },
-                    onNavigateToAddLocalFolder = { navController.navigate(ADD_LOCAL_FILES) },
                     onNavigateToReadaloudMatches = { sourceId ->
                         val encoded = URLEncoder.encode(sourceId, "UTF-8")
                         navController.navigate("readaloud_matches/$encoded")

--- a/app/src/test/kotlin/com/riffle/app/feature/server/SourceTypePickerTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/server/SourceTypePickerTest.kt
@@ -6,9 +6,9 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
- * Pins the SourceType picker's data model (#435). LocalFiles must stay disabled with a
- * "Coming soon" flag until #7 lands. If any of these assertions flip, the picker's
- * contract has changed and the change must be intentional.
+ * Pins the SourceType picker's data model (#435, #438). Both source types are enabled once
+ * the LocalFiles Catalog and Add-Source flow have landed (#438). If any of these assertions
+ * flip, the picker's contract has changed and the change must be intentional.
  */
 class SourceTypePickerTest {
 
@@ -29,10 +29,10 @@ class SourceTypePickerTest {
     }
 
     @Test
-    fun `LocalFiles card is disabled and coming soon`() {
+    fun `LocalFiles card is enabled once 438 has landed`() {
         val lf = sourceTypeCards().first { it.type is SourceTypeChoice.LocalFiles }
-        assertFalse(lf.enabled)
-        assertTrue(lf.comingSoon)
+        assertTrue(lf.enabled)
+        assertFalse(lf.comingSoon)
         assertEquals("Local files", lf.title)
     }
 }

--- a/app/src/test/kotlin/com/riffle/app/feature/settings/SettingsViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/settings/SettingsViewModelTest.kt
@@ -196,6 +196,22 @@ class SettingsViewModelTest {
         override val isOnline: kotlinx.coroutines.flow.StateFlow<Boolean> = isOnlineFlow
     }
 
+    // LocalFiles dependencies are unused by these settings tests — they still need to satisfy the
+    // constructor's non-null parameters, so route them through relaxed mockk mocks.
+    private val fakeLocalFilesFolderDao = io.mockk.mockk<com.riffle.core.database.LocalFilesFolderDao>(relaxed = true).also {
+        io.mockk.every { it.observeForSource(any()) } returns flowOf(emptyList())
+    }
+    private val fakeLocalFilesFolderRepository =
+        io.mockk.mockk<com.riffle.core.data.localfiles.LocalFilesFolderRepository>(relaxed = true)
+    private val fakeLocalFilesScanner =
+        io.mockk.mockk<com.riffle.core.data.localfiles.LocalFilesScanner>(relaxed = true)
+    private val fakeLocalFilesSourceInstaller =
+        io.mockk.mockk<com.riffle.core.data.localfiles.LocalFilesSourceInstaller>(relaxed = true)
+    private val fakeLocalFilesFolderHealthChecker =
+        io.mockk.mockk<com.riffle.core.data.localfiles.LocalFilesFolderHealthChecker>(relaxed = true).also {
+            io.mockk.every { it.healthFor(any()) } returns emptyMap()
+        }
+
     private val fakeAppUpdateRepo = object : com.riffle.core.domain.AppUpdateRepository {
         override suspend fun checkForUpdate(currentVersionCode: Int) =
             com.riffle.core.domain.UpdateCheckResult.UpToDate
@@ -242,6 +258,11 @@ class SettingsViewModelTest {
         },
         annotationSyncStatusStore = annotationSyncStatusStore,
         annotationDao = annotationDao,
+        localFilesFolderDao = fakeLocalFilesFolderDao,
+        localFilesFolderRepository = fakeLocalFilesFolderRepository,
+        localFilesScanner = fakeLocalFilesScanner,
+        localFilesSourceInstaller = fakeLocalFilesSourceInstaller,
+        localFilesFolderHealthChecker = fakeLocalFilesFolderHealthChecker,
     )
 
     private fun stubAnnotationDao(pendingBookCount: Int): AnnotationDao = object : AnnotationDao {
@@ -306,6 +327,11 @@ class SettingsViewModelTest {
         annotationSyncConfigStore = configStore,
         annotationSyncStatusStore = statusStore,
         annotationDao = annotationDao,
+        localFilesFolderDao = fakeLocalFilesFolderDao,
+        localFilesFolderRepository = fakeLocalFilesFolderRepository,
+        localFilesScanner = fakeLocalFilesScanner,
+        localFilesSourceInstaller = fakeLocalFilesSourceInstaller,
+        localFilesFolderHealthChecker = fakeLocalFilesFolderHealthChecker,
     )
 
     // --- crash report list tests ---

--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -54,6 +54,7 @@ dependencies {
     testImplementation(libs.junit)
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.okhttp.mockwebserver)
+    testImplementation(libs.mockk)
 
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.test.runner)

--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -40,6 +40,7 @@ dependencies {
     implementation(project(":core:network"))
     implementation(project(":core:database"))
     implementation(project(":core:catalog"))
+    implementation(project(":core:logging"))
     implementation(libs.androidx.work.runtime.ktx)
     implementation(libs.androidx.lifecycle.process)
     implementation(libs.androidx.datastore.preferences)

--- a/core/data/src/main/kotlin/com/riffle/core/data/SourceRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/SourceRepositoryImpl.kt
@@ -15,6 +15,7 @@ import com.riffle.core.domain.Source
 import com.riffle.core.domain.SourceFilesCleaner
 import com.riffle.core.domain.SourceRepository
 import com.riffle.core.domain.ServerType
+import com.riffle.core.domain.SourceType
 import com.riffle.core.domain.SourceUrl
 import com.riffle.core.domain.TokenStorage
 import com.riffle.core.network.AbsApi
@@ -246,6 +247,7 @@ class SourceRepositoryImpl @Inject constructor(
             isActive = isActive,
             insecureConnectionAllowed = insecureConnectionAllowed,
             username = username,
+            type = runCatching { SourceType.valueOf(type) }.getOrDefault(SourceType.ABS),
             serverType = ServerType.fromStorageString(serverType),
             absUserId = absUserId,
         )

--- a/core/data/src/main/kotlin/com/riffle/core/data/di/modules/CatalogModule.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/di/modules/CatalogModule.kt
@@ -5,6 +5,10 @@ import com.riffle.core.catalog.CatalogRegistry
 import com.riffle.core.catalog.DefaultCatalogRegistry
 import com.riffle.core.domain.SourceType
 import com.riffle.core.catalog.abs.AbsCatalogFactory
+import com.riffle.core.data.localfiles.LocalFilesCatalogFactory
+import com.riffle.core.database.LibraryItemDao
+import com.riffle.core.database.LocalFilesFileDao
+import com.riffle.core.database.LocalFilesFolderDao
 import com.riffle.core.domain.Clock
 import com.riffle.core.domain.DeviceIdStore
 import com.riffle.core.domain.SourceRepository
@@ -26,12 +30,26 @@ import javax.inject.Singleton
  * implementation registers its factory here via `@IntoMap` + `@SourceTypeKey`; repositories
  * consume [CatalogRegistry] rather than the map directly.
  *
- * LocalFiles will bind its factory here once the LocalFiles source implementation lands
- * (issue #437 / #438).
+ * LocalFiles factory (#438) reads catalog data from the local Room DAOs populated by
+ * [LocalFilesScanner]; ABS factory pulls per-Source auth from [TokenStorage] and speaks HTTP.
  */
 @Module
 @InstallIn(SingletonComponent::class)
 object CatalogModule {
+
+    @Provides
+    @Singleton
+    @IntoMap
+    @SourceTypeKey(SourceType.LOCAL_FILES)
+    fun provideLocalFilesCatalogFactory(
+        folderDao: LocalFilesFolderDao,
+        fileDao: LocalFilesFileDao,
+        itemDao: LibraryItemDao,
+    ): CatalogFactory = LocalFilesCatalogFactory(
+        folderDao = folderDao,
+        fileDao = fileDao,
+        itemDao = itemDao,
+    )
 
     @Provides
     @Singleton

--- a/core/data/src/main/kotlin/com/riffle/core/data/localfiles/LocalFilesCatalog.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/localfiles/LocalFilesCatalog.kt
@@ -1,0 +1,214 @@
+package com.riffle.core.data.localfiles
+
+import com.riffle.core.catalog.BookFormat
+import com.riffle.core.catalog.Catalog
+import com.riffle.core.catalog.CatalogFileHandle
+import com.riffle.core.catalog.CatalogFileStream
+import com.riffle.core.catalog.CatalogHealth
+import com.riffle.core.catalog.CatalogItem
+import com.riffle.core.catalog.CatalogRoot
+import com.riffle.core.catalog.CatalogSeries
+import com.riffle.core.catalog.CatalogSeriesEntry
+import com.riffle.core.catalog.OfflineBrowseCapability
+import com.riffle.core.catalog.SeriesCapability
+import com.riffle.core.catalog.SortKey
+import com.riffle.core.catalog.abs.CatalogException
+import com.riffle.core.database.LibraryItemDao
+import com.riffle.core.database.LibraryItemEntity
+import com.riffle.core.database.LocalFilesFileDao
+import com.riffle.core.database.LocalFilesFileEntity
+import com.riffle.core.database.LocalFilesFolderDao
+import com.riffle.core.domain.SourceType
+import java.io.File
+import java.io.FileInputStream
+
+/**
+ * The LocalFiles-backed [Catalog]. Reads from local Room storage populated by
+ * [LocalFilesScanner]: `library_items` rows carry the browsable metadata, `local_files_files`
+ * rows carry the copied-in file path used to serve bytes. There is no network — every method
+ * is trivially offline-safe, which is why LocalFiles implements [OfflineBrowseCapability]. The
+ * catalog exposes a single synthetic root (`local:root`) matching the `libraryId` the scanner
+ * writes for every ingested file. [SeriesCapability] is derived from EPUB `belongs-to-collection`
+ * metadata already extracted into `library_items.seriesName` — the tab hides itself in the UI
+ * when the aggregation yields zero series.
+ */
+class LocalFilesCatalog(
+    private val sourceId: String,
+    private val folderDao: LocalFilesFolderDao,
+    private val fileDao: LocalFilesFileDao,
+    private val itemDao: LibraryItemDao,
+) : Catalog, SeriesCapability, OfflineBrowseCapability {
+
+    override val sourceType: SourceType = SourceType.LOCAL_FILES
+
+    override suspend fun listRoots(): List<CatalogRoot> = listOf(
+        CatalogRoot(id = LOCAL_ROOT_ID, name = "Local Files", mediaType = "book"),
+    )
+
+    override suspend fun browse(
+        rootId: String,
+        sort: SortKey,
+        page: Int,
+        pageSize: Int,
+    ): List<CatalogItem> {
+        val items = itemDao.listByLibraryId(sourceId, rootId)
+            .map { it.toCatalogItem() }
+            .sortedWith(comparatorFor(sort))
+        return items.pageOf(page, pageSize)
+    }
+
+    override suspend fun search(
+        rootId: String,
+        query: String,
+        page: Int,
+        pageSize: Int,
+    ): List<CatalogItem> {
+        val needle = query.trim().lowercase()
+        if (needle.isEmpty()) return emptyList()
+        val hits = itemDao.listByLibraryId(sourceId, rootId)
+            .filter {
+                it.title.lowercase().contains(needle) || it.author.lowercase().contains(needle)
+            }
+            .map { it.toCatalogItem() }
+            .sortedBy { it.title.lowercase() }
+        return hits.pageOf(page, pageSize)
+    }
+
+    override suspend fun getItem(itemId: String): CatalogItem? =
+        itemDao.getById(sourceId, itemId)?.toCatalogItem()
+
+    override suspend fun fetchFile(itemId: String, format: BookFormat): CatalogFileHandle {
+        val file = requireFile(itemId, format)
+        return CatalogFileHandle.Local(
+            path = file.copiedPath,
+            format = format,
+            sizeBytes = file.sizeBytes,
+        )
+    }
+
+    override suspend fun openFile(
+        itemId: String,
+        format: BookFormat,
+        handleHint: String?,
+    ): CatalogFileStream {
+        val file = requireFile(itemId, format)
+        val f = File(file.copiedPath)
+        val length = if (f.exists()) f.length() else -1L
+        val stream = FileInputStream(f)
+        return object : CatalogFileStream {
+            override val contentLength: Long = length
+            override fun byteStream(): java.io.InputStream = stream
+            override fun close() { stream.close() }
+        }
+    }
+
+    /**
+     * LocalFiles has no server to check — it's always reachable. Callers that need to gate on
+     * "can this Source actually serve a book" use [OfflineBrowseCapability] + folder-level health
+     * (see [LocalFilesFolderHealth]), which surfaces SAF-URI revocation separately.
+     */
+    override suspend fun connectivityCheck(): CatalogHealth = CatalogHealth(
+        isReachable = true,
+        serverVersion = "local",
+        latencyMs = 0L,
+    )
+
+    // region SeriesCapability
+
+    override suspend fun listSeries(rootId: String): List<CatalogSeries> {
+        val rows = itemDao.listByLibraryId(sourceId, rootId)
+            .filter { !it.seriesName.isNullOrBlank() }
+        if (rows.isEmpty()) return emptyList()
+        return rows.groupBy { it.seriesName!! }
+            .toSortedMap()
+            .map { (name, items) ->
+                val sorted = items.sortedWith(seriesEntryComparator)
+                CatalogSeries(
+                    id = name,
+                    rootId = rootId,
+                    name = name,
+                    coverUrl = sorted.firstNotNullOfOrNull { it.coverUrl },
+                    bookCount = sorted.size,
+                    items = sorted.map { CatalogSeriesEntry(itemId = it.id, sequence = null) },
+                )
+            }
+    }
+
+    override suspend fun listItemsInSeries(rootId: String, seriesId: String): List<CatalogItem> =
+        itemDao.listByLibraryId(sourceId, rootId)
+            .filter { it.seriesName == seriesId }
+            .sortedWith(seriesEntryComparator)
+            .map { it.toCatalogItem() }
+
+    // endregion
+
+    private suspend fun requireFile(itemId: String, format: BookFormat): LocalFilesFileEntity {
+        val row = fileDao.findById(sourceId, itemId)
+            ?: throw CatalogException.UnsupportedFormat(
+                "No local file for itemId=$itemId in sourceId=$sourceId",
+            )
+        val expected = format.toStorageString()
+        if (expected != null && row.format != expected) {
+            throw CatalogException.UnsupportedFormat(
+                "Requested format=$format but stored format=${row.format} for itemId=$itemId",
+            )
+        }
+        return row
+    }
+
+    private fun BookFormat.toStorageString(): String? = when (this) {
+        BookFormat.Epub -> "epub"
+        BookFormat.Pdf -> "pdf"
+        BookFormat.Audiobook, BookFormat.Unsupported -> null
+    }
+
+    private fun LibraryItemEntity.toCatalogItem(): CatalogItem = CatalogItem(
+        id = id,
+        rootId = libraryId,
+        title = title,
+        author = author,
+        coverUrl = coverUrl,
+        ebookFormat = when (ebookFormat) {
+            "epub" -> BookFormat.Epub
+            "pdf" -> BookFormat.Pdf
+            else -> BookFormat.Unsupported
+        },
+        hasAudio = hasAudio,
+        audioDurationSec = audioDurationSec,
+        ebookFileIno = ebookFileIno,
+        description = description,
+        seriesName = seriesName,
+        publishedYear = publishedYear,
+        genres = if (genres.isBlank()) emptyList() else genres.split(",").map { it.trim() }.filter { it.isNotEmpty() },
+        publisher = publisher,
+        language = language,
+        addedAt = addedAt,
+        isbn = isbn,
+        asin = asin,
+        readingProgress = readingProgress,
+        updatedAt = null,
+    )
+
+    private val seriesEntryComparator: Comparator<LibraryItemEntity> = compareBy { it.title.lowercase() }
+
+    private fun comparatorFor(sort: SortKey): Comparator<CatalogItem> = when (sort) {
+        SortKey.TITLE -> compareBy { it.title.lowercase() }
+        SortKey.AUTHOR -> compareBy { it.author.lowercase() }
+        SortKey.ADDED_AT -> compareByDescending { it.addedAt ?: 0L }
+        SortKey.PUBLISHED_YEAR -> compareBy { it.publishedYear ?: "" }
+        SortKey.RECENTLY_OPENED -> throw CatalogException.UnsupportedFormat(
+            "SortKey.RECENTLY_OPENED is a local ordering — apply it above the Catalog layer",
+        )
+    }
+
+    private fun <T> List<T>.pageOf(page: Int, pageSize: Int): List<T> {
+        val from = (page * pageSize).coerceAtLeast(0)
+        if (from >= size) return emptyList()
+        val to = (from + pageSize).coerceAtMost(size)
+        return subList(from, to)
+    }
+
+    companion object {
+        const val LOCAL_ROOT_ID: String = "local:root"
+    }
+}

--- a/core/data/src/main/kotlin/com/riffle/core/data/localfiles/LocalFilesCatalog.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/localfiles/LocalFilesCatalog.kt
@@ -93,7 +93,15 @@ class LocalFilesCatalog(
     ): CatalogFileStream {
         val file = requireFile(itemId, format)
         val f = File(file.copiedPath)
-        val length = if (f.exists()) f.length() else -1L
+        // Row exists but the copied-in blob is gone (external cleanup, storage corruption). Surface
+        // this the same way the "no row" branch does so reader code catching CatalogException gets
+        // a uniform error rather than a raw FileNotFoundException.
+        if (!f.exists()) {
+            throw CatalogException.UnsupportedFormat(
+                "LocalFiles copied path missing for itemId=$itemId path=${file.copiedPath}",
+            )
+        }
+        val length = f.length()
         val stream = FileInputStream(f)
         return object : CatalogFileStream {
             override val contentLength: Long = length

--- a/core/data/src/main/kotlin/com/riffle/core/data/localfiles/LocalFilesCatalogFactory.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/localfiles/LocalFilesCatalogFactory.kt
@@ -1,0 +1,31 @@
+package com.riffle.core.data.localfiles
+
+import com.riffle.core.catalog.Catalog
+import com.riffle.core.catalog.CatalogFactory
+import com.riffle.core.database.LibraryItemDao
+import com.riffle.core.database.LocalFilesFileDao
+import com.riffle.core.database.LocalFilesFolderDao
+import com.riffle.core.domain.Source
+import com.riffle.core.domain.SourceType
+import javax.inject.Inject
+
+/**
+ * Builds a [LocalFilesCatalog] per LocalFiles Source row. Unlike [AbsCatalogFactory] there is no
+ * per-Source auth to resolve — the DAOs are singletons and the Catalog just carries the sourceId
+ * so its queries scope correctly.
+ */
+class LocalFilesCatalogFactory @Inject constructor(
+    private val folderDao: LocalFilesFolderDao,
+    private val fileDao: LocalFilesFileDao,
+    private val itemDao: LibraryItemDao,
+) : CatalogFactory {
+
+    override val sourceType: SourceType = SourceType.LOCAL_FILES
+
+    override suspend fun create(source: Source): Catalog? = LocalFilesCatalog(
+        sourceId = source.id,
+        folderDao = folderDao,
+        fileDao = fileDao,
+        itemDao = itemDao,
+    )
+}

--- a/core/data/src/main/kotlin/com/riffle/core/data/localfiles/LocalFilesFolderHealthChecker.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/localfiles/LocalFilesFolderHealthChecker.kt
@@ -1,0 +1,44 @@
+package com.riffle.core.data.localfiles
+
+import android.content.ContentResolver
+import android.content.Context
+import android.net.Uri
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Reports per-folder SAF-URI health for the LocalFiles Source. A folder is "healthy" when the
+ * user's persistable URI grant on its tree URI is still present in [ContentResolver.getPersistedUriPermissions]
+ * — the grant survives process death, but the user can revoke it any time in system Settings, and
+ * once revoked our next read attempt would throw [SecurityException]. Checking the persisted-grant
+ * list catches this state up-front without needing to touch the tree.
+ *
+ * Already-copied bytes stay readable regardless (they live under app-private storage), so an
+ * unhealthy folder degrades to "we can't rescan for new files" — not "your books disappeared".
+ */
+@Singleton
+class LocalFilesFolderHealthChecker @Inject constructor(
+    @ApplicationContext private val context: Context,
+) {
+    /**
+     * True when [treeUri] still has a persistable read grant on this device. False after the
+     * user revoked it in system Settings, or if the app never held the grant (rare — added
+     * folders always [ContentResolver.takePersistableUriPermission]).
+     */
+    fun isHealthy(treeUri: String): Boolean {
+        val target = try { Uri.parse(treeUri) } catch (_: Throwable) { return false }
+        return context.contentResolver.persistedUriPermissions.any { grant ->
+            grant.uri == target && grant.isReadPermission
+        }
+    }
+
+    /** Bulk variant — cheaper than N calls when the caller has a full folder set to report on. */
+    fun healthFor(treeUris: Collection<String>): Map<String, Boolean> {
+        if (treeUris.isEmpty()) return emptyMap()
+        val heldReadable: Set<String> = context.contentResolver.persistedUriPermissions
+            .filter { it.isReadPermission }
+            .mapTo(mutableSetOf()) { it.uri.toString() }
+        return treeUris.associateWith { it in heldReadable }
+    }
+}

--- a/core/data/src/main/kotlin/com/riffle/core/data/localfiles/LocalFilesFolderWatcher.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/localfiles/LocalFilesFolderWatcher.kt
@@ -1,0 +1,154 @@
+package com.riffle.core.data.localfiles
+
+import android.content.Context
+import android.database.ContentObserver
+import android.net.Uri
+import android.os.Handler
+import android.os.Looper
+import android.provider.DocumentsContract
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.ProcessLifecycleOwner
+import com.riffle.core.database.LocalFilesFolderDao
+import com.riffle.core.domain.ApplicationScope
+import com.riffle.core.domain.SourceRepository
+import com.riffle.core.domain.SourceType
+import com.riffle.core.logging.LogChannel
+import com.riffle.core.logging.Logger
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Keeps the LocalFiles library in sync with the folders on disk *without* asking the user to hit a
+ * "Rescan" button. Two mechanisms, complementary:
+ *
+ * 1. **App-foreground kick**: on every [androidx.lifecycle.Lifecycle.Event.ON_START] we run a
+ *    scan. Deterministic — covers the "user closed the app, dropped a book in, reopened" case
+ *    regardless of whether the DocumentsProvider dispatches change notifications.
+ * 2. **SAF `ContentObserver`**: while the app is running, we register a [ContentObserver] on each
+ *    configured folder's children URI so a book added via the Files app (or any SAF-aware app)
+ *    triggers a scan within `DEBOUNCE_MS`. Providers vary in how faithfully they fire these — the
+ *    lifecycle kick above is the safety net.
+ *
+ * Scans are idempotent (identity-hash keyed) so triggering more often than strictly necessary is
+ * cheap: unchanged rows only touch `lastSeenAtEpochMs`.
+ */
+@Singleton
+class LocalFilesFolderWatcher @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val sourceRepository: SourceRepository,
+    private val folderDao: LocalFilesFolderDao,
+    private val scanner: LocalFilesScanner,
+    private val applicationScope: ApplicationScope,
+    private val logger: Logger,
+) {
+
+    private val handler = Handler(Looper.getMainLooper())
+    private val observers = mutableMapOf<String, ContentObserver>()
+    private var scanDebounceJob: Job? = null
+    private var startedFor: String? = null
+    private var currentSourceId: String? = null
+
+    private val lifecycleObserver = object : DefaultLifecycleObserver {
+        override fun onStart(owner: LifecycleOwner) {
+            // Foreground return: catches file drops made while the app was backgrounded/closed.
+            currentSourceId?.let { requestScan(it, reason = "lifecycle.onStart") }
+        }
+    }
+
+    /**
+     * Begin watching. Idempotent: safe to call more than once. Registers a lifecycle observer on
+     * [ProcessLifecycleOwner] and collects the LocalFiles source id + its folder set for the
+     * lifetime of [applicationScope].
+     */
+    @OptIn(ExperimentalCoroutinesApi::class)
+    fun start() {
+        if (startedFor != null) return
+        startedFor = "started"
+        ProcessLifecycleOwner.get().lifecycle.addObserver(lifecycleObserver)
+        applicationScope.launchSurvivable {
+            sourceRepository.observeAll()
+                .map { list -> list.firstOrNull { it.type == SourceType.LOCAL_FILES }?.id }
+                .distinctUntilChanged()
+                .collectLatest { sourceId ->
+                    currentSourceId = sourceId
+                    if (sourceId == null) {
+                        unregisterAll()
+                        return@collectLatest
+                    }
+                    requestScan(sourceId, reason = "source-appeared")
+                    folderDao.observeForSource(sourceId).collect { folders ->
+                        syncObservers(folders.map { it.treeUri }, sourceId)
+                    }
+                }
+        }
+    }
+
+    private fun syncObservers(currentTreeUris: List<String>, sourceId: String) {
+        val currentSet = currentTreeUris.toSet()
+        val removed = observers.keys - currentSet
+        for (tree in removed) {
+            observers.remove(tree)?.let { context.contentResolver.unregisterContentObserver(it) }
+            logger.d(LogChannel.LocalFiles) { "watcher unregistered observer tree=$tree" }
+        }
+        for (tree in currentSet - observers.keys) {
+            val treeUri = try { Uri.parse(tree) } catch (_: Throwable) { continue }
+            val childrenUri = try {
+                DocumentsContract.buildChildDocumentsUriUsingTree(
+                    treeUri,
+                    DocumentsContract.getTreeDocumentId(treeUri),
+                )
+            } catch (t: Throwable) {
+                logger.d(LogChannel.LocalFiles, t) { "watcher can't build childrenUri for tree=$tree" }
+                continue
+            }
+            val observer = object : ContentObserver(handler) {
+                override fun onChange(selfChange: Boolean, uri: Uri?) {
+                    logger.d(LogChannel.LocalFiles) { "watcher content change tree=$tree uri=$uri" }
+                    requestScan(sourceId, reason = "content-observer")
+                }
+            }
+            try {
+                context.contentResolver.registerContentObserver(childrenUri, true, observer)
+                observers[tree] = observer
+                logger.d(LogChannel.LocalFiles) { "watcher registered observer tree=$tree" }
+            } catch (t: Throwable) {
+                logger.d(LogChannel.LocalFiles, t) { "watcher registerContentObserver failed tree=$tree" }
+            }
+        }
+    }
+
+    private fun requestScan(sourceId: String, reason: String) {
+        scanDebounceJob?.cancel()
+        scanDebounceJob = applicationScope.launchSurvivable {
+            delay(DEBOUNCE_MS)
+            logger.d(LogChannel.LocalFiles) { "watcher auto-scan reason=$reason" }
+            try {
+                scanner.scan(sourceId)
+            } catch (t: Throwable) {
+                logger.d(LogChannel.LocalFiles, t) { "watcher auto-scan failed" }
+            }
+        }
+    }
+
+    private fun unregisterAll() {
+        for ((_, observer) in observers) {
+            context.contentResolver.unregisterContentObserver(observer)
+        }
+        observers.clear()
+    }
+
+    companion object {
+        // Content observers can fire in bursts (a copy operation dispatches per-file); coalesce
+        // them into a single scan.
+        private const val DEBOUNCE_MS: Long = 500L
+    }
+}

--- a/core/data/src/main/kotlin/com/riffle/core/data/localfiles/LocalFilesScanner.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/localfiles/LocalFilesScanner.kt
@@ -10,6 +10,8 @@ import com.riffle.core.domain.EpubMetadata
 import com.riffle.core.domain.EpubMetadataExtractor
 import com.riffle.core.domain.PdfMetadata
 import com.riffle.core.domain.PdfMetadataExtractor
+import com.riffle.core.logging.LogChannel
+import com.riffle.core.logging.Logger
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
@@ -35,6 +37,7 @@ class LocalFilesScanner @Inject constructor(
     private val copyIn: CopyInService,
     private val pdfMetadata: PdfMetadataExtractor,
     private val clock: Clock,
+    private val logger: Logger,
 ) {
 
     data class ScanReport(
@@ -49,6 +52,7 @@ class LocalFilesScanner @Inject constructor(
     suspend fun scan(sourceId: String): ScanReport = withContext(Dispatchers.IO) {
         val scanStart = clock.nowMs()
         val folders = folderDao.forSource(sourceId)
+        logger.d(LogChannel.LocalFiles) { "scan start sourceId=$sourceId folders=${folders.size}" }
         var added = 0
         var refreshed = 0
         val failures = mutableListOf<ScanFailure>()
@@ -63,9 +67,14 @@ class LocalFilesScanner @Inject constructor(
             val files = try {
                 walker.walk(folder.treeUri)
             } catch (e: Exception) {
+                logger.d(LogChannel.LocalFiles, e) { "walk failed for ${folder.displayName}" }
                 failures += ScanFailure(folder.displayName, "walk-failed: ${e.message ?: e::class.simpleName}")
                 completed = false
                 continue
+            }
+            logger.d(LogChannel.LocalFiles) {
+                "walked folder=${folder.displayName} files=${files.size} " +
+                    "sample=${files.take(3).joinToString { it.displayName }}"
             }
             for (file in files) {
                 val outcome = try {
@@ -117,6 +126,10 @@ class LocalFilesScanner @Inject constructor(
             if (total == buf.size) buf else buf.copyOf(total)
         }
         val kind = FileClassifier.classify(file.displayName, head)
+        logger.d(LogChannel.LocalFiles) {
+            "classify name=${file.displayName} kind=$kind headBytes=${head.size} " +
+                "head4=${head.take(4).joinToString(",") { "%02x".format(it) }}"
+        }
         if (kind == FileClassifier.Kind.UNKNOWN) return Outcome.SKIPPED
 
         val identity = IdentityHasher.hash(head, file.sizeBytes)

--- a/core/data/src/main/kotlin/com/riffle/core/data/localfiles/LocalFilesScanner.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/localfiles/LocalFilesScanner.kt
@@ -193,7 +193,7 @@ class LocalFilesScanner @Inject constructor(
         val entity = LibraryItemEntity(
             sourceId = sourceId,
             id = identity,
-            libraryId = LOCAL_ROOT_LIBRARY_ID,
+            libraryId = LocalFilesCatalog.LOCAL_ROOT_ID,
             title = metadata.title?.ifBlank { null } ?: stripExtension(file.displayName),
             author = metadata.author?.ifBlank { null } ?: "",
             coverUrl = null,
@@ -214,7 +214,7 @@ class LocalFilesScanner @Inject constructor(
     ): LibraryItemEntity = LibraryItemEntity(
         sourceId = sourceId,
         id = identity,
-        libraryId = LOCAL_ROOT_LIBRARY_ID,
+        libraryId = LocalFilesCatalog.LOCAL_ROOT_ID,
         title = metadata.title?.ifBlank { null } ?: stripExtension(file.displayName),
         author = metadata.author?.ifBlank { null } ?: "",
         coverUrl = coverFile?.toURI()?.toString(),
@@ -243,7 +243,6 @@ class LocalFilesScanner @Inject constructor(
     }
 
     companion object {
-        const val LOCAL_ROOT_LIBRARY_ID: String = "local:root"
         const val EBOOK_FORMAT_EPUB: String = "epub"
         const val EBOOK_FORMAT_PDF: String = "pdf"
         const val EBOOK_FORMAT_UNSUPPORTED: String = "unsupported"

--- a/core/data/src/main/kotlin/com/riffle/core/data/localfiles/LocalFilesSourceInstaller.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/localfiles/LocalFilesSourceInstaller.kt
@@ -1,0 +1,84 @@
+package com.riffle.core.data.localfiles
+
+import android.net.Uri
+import com.riffle.core.database.LibraryDao
+import com.riffle.core.database.LibraryEntity
+import com.riffle.core.database.SourceDao
+import com.riffle.core.database.SourceEntity
+import com.riffle.core.domain.SourceType
+import java.util.UUID
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Owns the "install a LocalFiles Source" side of the Add-Source flow. Materialises the singleton
+ * LocalFiles [SourceEntity] on first use (there is at most one LocalFiles source per device — the
+ * user's multi-folder model runs *inside* that source), attaches the picked SAF folder to it via
+ * [LocalFilesFolderRepository], and kicks the initial [LocalFilesScanner.scan].
+ *
+ * Not part of [com.riffle.core.domain.SourceRepository.commit] because there is no
+ * [com.riffle.core.domain.PendingSource] step (no credentials to authenticate, no library set to
+ * pick) — the whole flow collapses to "user picked a folder".
+ */
+@Singleton
+class LocalFilesSourceInstaller @Inject constructor(
+    private val sourceDao: SourceDao,
+    private val libraryDao: LibraryDao,
+    private val folderRepository: LocalFilesFolderRepository,
+    private val scanner: LocalFilesScanner,
+) {
+
+    data class InstallResult(
+        val sourceId: String,
+        val scan: LocalFilesScanner.ScanReport,
+    )
+
+    /**
+     * Adds [treeUri] to the LocalFiles source, creating the source row and its synthetic
+     * `local:root` library on first call. Runs a first scan of the folder and returns the
+     * outcome so callers can surface add/failure counts.
+     */
+    suspend fun installFolder(treeUri: Uri): InstallResult {
+        val sourceId = ensureLocalFilesSource()
+        folderRepository.addFolder(sourceId, treeUri)
+        val report = scanner.scan(sourceId)
+        return InstallResult(sourceId = sourceId, scan = report)
+    }
+
+    /**
+     * The LocalFiles source id. Creates one on first call; subsequent calls return the same id.
+     * Idempotent: exposed for the Settings folder-management view so it can query "what folders
+     * are configured?" before any folder-picker flow has run.
+     */
+    suspend fun ensureLocalFilesSource(): String {
+        sourceDao.getByType(SourceType.LOCAL_FILES.name)?.let { return it.id }
+        val id = UUID.randomUUID().toString()
+        val entity = SourceEntity(
+            id = id,
+            // No meaningful URL; placeholder parses through [SourceUrl.parse] cleanly and is
+            // never network-called (LocalFiles has no server).
+            url = LOCAL_FILES_URL_PLACEHOLDER,
+            isActive = false,
+            insecureConnectionAllowed = false,
+            username = "",
+            serverType = "AUDIOBOOKSHELF",
+            type = SourceType.LOCAL_FILES.name,
+        )
+        val inserted = sourceDao.upsertAsFirstIfNoActive(entity)
+        libraryDao.upsertAll(
+            listOf(
+                LibraryEntity(
+                    id = LocalFilesCatalog.LOCAL_ROOT_ID,
+                    name = "Local Files",
+                    mediaType = "book",
+                    sourceId = inserted.id,
+                ),
+            ),
+        )
+        return inserted.id
+    }
+
+    companion object {
+        const val LOCAL_FILES_URL_PLACEHOLDER: String = "https://localfiles.invalid"
+    }
+}

--- a/core/data/src/main/kotlin/com/riffle/core/data/localfiles/LocalFilesSourceInstaller.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/localfiles/LocalFilesSourceInstaller.kt
@@ -6,6 +6,8 @@ import com.riffle.core.database.LibraryEntity
 import com.riffle.core.database.SourceDao
 import com.riffle.core.database.SourceEntity
 import com.riffle.core.domain.SourceType
+import com.riffle.core.logging.LogChannel
+import com.riffle.core.logging.Logger
 import java.util.UUID
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -26,6 +28,7 @@ class LocalFilesSourceInstaller @Inject constructor(
     private val libraryDao: LibraryDao,
     private val folderRepository: LocalFilesFolderRepository,
     private val scanner: LocalFilesScanner,
+    private val logger: Logger,
 ) {
 
     data class InstallResult(
@@ -39,9 +42,17 @@ class LocalFilesSourceInstaller @Inject constructor(
      * outcome so callers can surface add/failure counts.
      */
     suspend fun installFolder(treeUri: Uri): InstallResult {
+        logger.d(LogChannel.LocalFiles) { "installFolder start uri=$treeUri" }
         val sourceId = ensureLocalFilesSource()
+        logger.d(LogChannel.LocalFiles) { "installFolder sourceId=$sourceId" }
         folderRepository.addFolder(sourceId, treeUri)
+        logger.d(LogChannel.LocalFiles) { "installFolder folder attached, starting scan" }
         val report = scanner.scan(sourceId)
+        logger.d(LogChannel.LocalFiles) {
+            "installFolder scan done added=${report.added} refreshed=${report.refreshed} " +
+                "removed=${report.removed} failures=${report.failures.size} " +
+                "failureSample=${report.failures.take(3).joinToString { "${it.displayName}:${it.reason}" }}"
+        }
         return InstallResult(sourceId = sourceId, scan = report)
     }
 

--- a/core/data/src/test/kotlin/com/riffle/core/data/FakeLibraryItemDao.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/FakeLibraryItemDao.kt
@@ -98,6 +98,9 @@ internal class FakeLibraryItemDao : LibraryItemDao {
     override suspend fun getById(sourceId: String, itemId: String): LibraryItemEntity? =
         roomData.values.flatMap { it.value }.firstOrNull { it.sourceId == sourceId && it.id == itemId }
 
+    override suspend fun listByLibraryId(sourceId: String, libraryId: String): List<LibraryItemEntity> =
+        scoped(sourceId, libraryId)
+
     override fun observeById(sourceId: String, itemId: String): Flow<LibraryItemEntity?> =
         MutableStateFlow(roomData.values.flatMap { it.value }.firstOrNull { it.sourceId == sourceId && it.id == itemId })
 

--- a/core/data/src/test/kotlin/com/riffle/core/data/NoopLibraryDaos.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/NoopLibraryDaos.kt
@@ -23,6 +23,7 @@ internal object ThrowingLibraryItemDao : LibraryItemDao {
     override suspend fun insertOrIgnore(items: List<LibraryItemEntity>) = Unit
     override suspend fun updateMetadata(metadata: LibraryItemMetadata) = Unit
     override suspend fun getById(sourceId: String, itemId: String): LibraryItemEntity? = null
+    override suspend fun listByLibraryId(sourceId: String, libraryId: String): List<LibraryItemEntity> = emptyList()
     override fun observeById(sourceId: String, itemId: String): Flow<LibraryItemEntity?> = flowOf(null)
     override suspend fun findSourceIdForItem(itemId: String): String? = null
     override suspend fun deleteByLibraryId(sourceId: String, libraryId: String) = Unit

--- a/core/data/src/test/kotlin/com/riffle/core/data/ReadaloudMatchingServiceTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/ReadaloudMatchingServiceTest.kt
@@ -388,6 +388,7 @@ class ReadaloudMatchingServiceTest {
         override suspend fun insertOrIgnore(items: List<LibraryItemEntity>) = Unit
         override suspend fun updateMetadata(metadata: com.riffle.core.database.LibraryItemMetadata) = Unit
         override suspend fun getById(sourceId: String, itemId: String): LibraryItemEntity? = byId[itemId]
+        override suspend fun listByLibraryId(sourceId: String, libraryId: String): List<LibraryItemEntity> = emptyList()
         override fun observeById(sourceId: String, itemId: String): Flow<LibraryItemEntity?> = flowOf(byId[itemId])
         override suspend fun findSourceIdForItem(itemId: String): String? = byId[itemId]?.sourceId
         override suspend fun deleteByLibraryId(sourceId: String, libraryId: String) = Unit

--- a/core/data/src/test/kotlin/com/riffle/core/data/SeriesIntegrationTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/SeriesIntegrationTest.kt
@@ -116,6 +116,7 @@ class SeriesIntegrationTest {
         override fun observeRecentlyAdded(sourceId: String, libraryId: String): Flow<List<LibraryItemEntity>> = MutableStateFlow(emptyList())
         override fun observeAllBooks(sourceId: String, libraryId: String): Flow<List<LibraryItemEntity>> = MutableStateFlow(emptyList())
         override suspend fun getById(sourceId: String, itemId: String): LibraryItemEntity? = null
+        override suspend fun listByLibraryId(sourceId: String, libraryId: String): List<LibraryItemEntity> = emptyList()
         override fun observeById(sourceId: String, itemId: String): Flow<LibraryItemEntity?> = MutableStateFlow(null)
         override suspend fun findSourceIdForItem(itemId: String): String? = null
         override suspend fun upsertAll(items: List<LibraryItemEntity>) {}

--- a/core/data/src/test/kotlin/com/riffle/core/data/SourceRepositoryTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/SourceRepositoryTest.kt
@@ -67,6 +67,7 @@ class ServerRepositoryTest {
         override fun observeAll() = flowOf(store.toList())
         override suspend fun getActive() = store.firstOrNull { it.isActive }
         override suspend fun getById(id: String): SourceEntity? = store.firstOrNull { it.id == id }
+        override suspend fun getByType(type: String): SourceEntity? = store.firstOrNull { it.type == type }
         override suspend fun upsert(source: SourceEntity) {
             store.removeAll { it.id == source.id }
             store.add(source)
@@ -144,6 +145,8 @@ class ServerRepositoryTest {
         override fun observeRecentlyAdded(sourceId: String, libraryId: String) = flowOf(emptyList<com.riffle.core.database.LibraryItemEntity>())
         override fun observeAllBooks(sourceId: String, libraryId: String) = flowOf(emptyList<com.riffle.core.database.LibraryItemEntity>())
         override suspend fun getById(sourceId: String, itemId: String) = rows.values.flatten().firstOrNull { it.id == itemId }
+        override suspend fun listByLibraryId(sourceId: String, libraryId: String) =
+            rows[libraryId].orEmpty().filter { it.sourceId == sourceId }.toList()
         override fun observeById(sourceId: String, itemId: String) = flowOf(rows.values.flatten().firstOrNull { it.id == itemId })
         override suspend fun findSourceIdForItem(itemId: String): String? = rows.values.flatten().firstOrNull { it.id == itemId }?.sourceId
         override suspend fun upsertAll(items: List<com.riffle.core.database.LibraryItemEntity>) {

--- a/core/data/src/test/kotlin/com/riffle/core/data/localfiles/LocalFilesCatalogTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/localfiles/LocalFilesCatalogTest.kt
@@ -1,0 +1,274 @@
+package com.riffle.core.data.localfiles
+
+import com.riffle.core.catalog.BookFormat
+import com.riffle.core.catalog.CatalogFileHandle
+import com.riffle.core.catalog.SortKey
+import com.riffle.core.catalog.abs.CatalogException
+import com.riffle.core.data.FakeLibraryItemDao
+import com.riffle.core.database.LibraryItemEntity
+import com.riffle.core.database.LocalFilesFileEntity
+import com.riffle.core.database.LocalFilesFileDao
+import com.riffle.core.database.LocalFilesFolderDao
+import com.riffle.core.database.LocalFilesFolderEntity
+import com.riffle.core.domain.SourceType
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+class LocalFilesCatalogTest {
+
+    private val sourceId = "src-1"
+    private val libraryId = LocalFilesCatalog.LOCAL_ROOT_ID
+
+    @Test
+    fun `listRoots returns the single synthetic local root`() = runTest {
+        val catalog = catalog()
+        val roots = catalog.listRoots()
+        assertEquals(1, roots.size)
+        assertEquals(libraryId, roots[0].id)
+        assertEquals("Local Files", roots[0].name)
+        assertEquals(SourceType.LOCAL_FILES, catalog.sourceType)
+    }
+
+    @Test
+    fun `browse returns items sorted by title, paged`() = runTest {
+        val items = FakeLibraryItemDao()
+        items.emit(
+            sourceId,
+            listOf(
+                epubItem("c", "Cormac"),
+                epubItem("a", "Alpha"),
+                epubItem("b", "Bravo"),
+            ),
+        )
+        val catalog = catalog(items = items)
+
+        val page0 = catalog.browse(libraryId, SortKey.TITLE, page = 0, pageSize = 2)
+        assertEquals(listOf("Alpha", "Bravo"), page0.map { it.title })
+
+        val page1 = catalog.browse(libraryId, SortKey.TITLE, page = 1, pageSize = 2)
+        assertEquals(listOf("Cormac"), page1.map { it.title })
+    }
+
+    @Test
+    fun `browse sort by ADDED_AT is descending`() = runTest {
+        val items = FakeLibraryItemDao()
+        items.emit(
+            sourceId,
+            listOf(
+                epubItem("old", "Old", addedAt = 100L),
+                epubItem("new", "New", addedAt = 500L),
+                epubItem("mid", "Mid", addedAt = 250L),
+            ),
+        )
+        val catalog = catalog(items = items)
+        val browsed = catalog.browse(libraryId, SortKey.ADDED_AT)
+        assertEquals(listOf("New", "Mid", "Old"), browsed.map { it.title })
+    }
+
+    @Test
+    fun `search matches title and author case-insensitively`() = runTest {
+        val items = FakeLibraryItemDao()
+        items.emit(
+            sourceId,
+            listOf(
+                epubItem("1", "The Hobbit", author = "J.R.R. Tolkien"),
+                epubItem("2", "Dune", author = "Frank Herbert"),
+                epubItem("3", "Foundation", author = "Isaac Asimov"),
+            ),
+        )
+        val catalog = catalog(items = items)
+
+        assertEquals(listOf("The Hobbit"), catalog.search(libraryId, "hobbit").map { it.title })
+        assertEquals(listOf("Foundation"), catalog.search(libraryId, "asimov").map { it.title })
+        assertTrue(catalog.search(libraryId, "").isEmpty())
+    }
+
+    @Test
+    fun `getItem returns null for missing item`() = runTest {
+        val items = FakeLibraryItemDao().also { it.emit(sourceId, listOf(epubItem("x", "x"))) }
+        val catalog = catalog(items = items)
+        assertEquals("x", catalog.getItem("x")?.title)
+        assertNull(catalog.getItem("missing"))
+    }
+
+    @Test
+    fun `fetchFile returns Local handle from the copied path`() = runTest {
+        val fileDao = InMemoryFileDao()
+        val tmp = File.createTempFile("book", ".epub").apply { writeText("payload") }
+        fileDao.rows[sourceId to "item-1"] = LocalFilesFileEntity(
+            sourceId = sourceId,
+            sourceItemId = "item-1",
+            folderTreeUri = "content://tree/A",
+            originalUri = "content://tree/A/document/1",
+            copiedPath = tmp.absolutePath,
+            coverPath = null,
+            format = "epub",
+            sizeBytes = 7L,
+            mtimeEpochMs = 0L,
+            lastSeenAtEpochMs = 0L,
+        )
+        val catalog = catalog(fileDao = fileDao)
+
+        val handle = catalog.fetchFile("item-1", BookFormat.Epub)
+        val local = handle as CatalogFileHandle.Local
+        assertEquals(tmp.absolutePath, local.path)
+        assertEquals(BookFormat.Epub, local.format)
+        assertEquals(7L, local.sizeBytes)
+
+        tmp.delete()
+    }
+
+    @Test
+    fun `fetchFile throws when the format does not match the stored kind`() = runTest {
+        val fileDao = InMemoryFileDao()
+        fileDao.rows[sourceId to "item-1"] = LocalFilesFileEntity(
+            sourceId = sourceId,
+            sourceItemId = "item-1",
+            folderTreeUri = "content://tree/A",
+            originalUri = "content://tree/A/document/1",
+            copiedPath = "/tmp/x.pdf",
+            coverPath = null,
+            format = "pdf",
+            sizeBytes = 0L,
+            mtimeEpochMs = 0L,
+            lastSeenAtEpochMs = 0L,
+        )
+        val catalog = catalog(fileDao = fileDao)
+        val ex = runCatching { catalog.fetchFile("item-1", BookFormat.Epub) }.exceptionOrNull()
+        assertTrue(ex is CatalogException.UnsupportedFormat)
+    }
+
+    @Test
+    fun `fetchFile throws when no local file row exists for the item`() = runTest {
+        val catalog = catalog()
+        val ex = runCatching { catalog.fetchFile("missing", BookFormat.Epub) }.exceptionOrNull()
+        assertTrue(ex is CatalogException.UnsupportedFormat)
+    }
+
+    @Test
+    fun `connectivityCheck reports healthy regardless of state`() = runTest {
+        val health = catalog().connectivityCheck()
+        assertTrue(health.isReachable)
+        assertEquals("local", health.serverVersion)
+    }
+
+    @Test
+    fun `listSeries aggregates library_items by seriesName and lists items alphabetically`() = runTest {
+        val items = FakeLibraryItemDao()
+        items.emit(
+            sourceId,
+            listOf(
+                epubItem("a", "Book A", seriesName = "Cycle"),
+                epubItem("b", "Book B", seriesName = "Cycle"),
+                epubItem("c", "Loner", seriesName = null),
+                epubItem("d", "Other 1", seriesName = "Other"),
+            ),
+        )
+        val catalog = catalog(items = items)
+
+        val series = catalog.listSeries(libraryId)
+        assertEquals(listOf("Cycle", "Other"), series.map { it.name })
+        val cycle = series.first { it.name == "Cycle" }
+        assertEquals(2, cycle.bookCount)
+        assertEquals(listOf("a", "b"), cycle.items.map { it.itemId })
+
+        val inCycle = catalog.listItemsInSeries(libraryId, "Cycle")
+        assertEquals(listOf("Book A", "Book B"), inCycle.map { it.title })
+    }
+
+    @Test
+    fun `listSeries is empty when no items advertise a series`() = runTest {
+        val items = FakeLibraryItemDao().also {
+            it.emit(sourceId, listOf(epubItem("a", "Only Book", seriesName = null)))
+        }
+        val catalog = catalog(items = items)
+        assertTrue(catalog.listSeries(libraryId).isEmpty())
+    }
+
+    @Test
+    fun `RECENTLY_OPENED sort is not supported at the Catalog layer`() = runTest {
+        val items = FakeLibraryItemDao().also { it.emit(sourceId, listOf(epubItem("a", "a"))) }
+        val catalog = catalog(items = items)
+        val ex = runCatching { catalog.browse(libraryId, SortKey.RECENTLY_OPENED) }.exceptionOrNull()
+        assertTrue(ex is CatalogException.UnsupportedFormat)
+    }
+
+    // region helpers
+
+    private fun catalog(
+        folderDao: LocalFilesFolderDao = InMemoryFolderDao(),
+        fileDao: LocalFilesFileDao = InMemoryFileDao(),
+        items: FakeLibraryItemDao = FakeLibraryItemDao(),
+    ) = LocalFilesCatalog(
+        sourceId = sourceId,
+        folderDao = folderDao,
+        fileDao = fileDao,
+        itemDao = items,
+    )
+
+    private fun epubItem(
+        id: String,
+        title: String,
+        author: String = "",
+        addedAt: Long? = null,
+        seriesName: String? = null,
+    ): LibraryItemEntity = LibraryItemEntity(
+        sourceId = sourceId,
+        id = id,
+        libraryId = libraryId,
+        title = title,
+        author = author,
+        coverUrl = null,
+        readingProgress = 0f,
+        ebookFormat = "epub",
+        addedAt = addedAt,
+        seriesName = seriesName,
+    )
+
+    // endregion
+
+    // region in-memory DAOs (mirrors of the scanner test's fakes so this suite is self-contained)
+
+    private class InMemoryFolderDao : LocalFilesFolderDao {
+        val store = mutableMapOf<Pair<String, String>, LocalFilesFolderEntity>()
+        override suspend fun upsert(entity: LocalFilesFolderEntity) {
+            store[entity.sourceId to entity.treeUri] = entity
+        }
+        override suspend fun forSource(sourceId: String): List<LocalFilesFolderEntity> =
+            store.values.filter { it.sourceId == sourceId }.sortedBy { it.addedAtEpochMs }
+        override fun observeForSource(sourceId: String): Flow<List<LocalFilesFolderEntity>> =
+            MutableStateFlow(store.values.filter { it.sourceId == sourceId })
+        override suspend fun delete(sourceId: String, treeUri: String) {
+            store.remove(sourceId to treeUri)
+        }
+    }
+
+    private class InMemoryFileDao : LocalFilesFileDao {
+        val rows = mutableMapOf<Pair<String, String>, LocalFilesFileEntity>()
+        override suspend fun upsert(entity: LocalFilesFileEntity) {
+            rows[entity.sourceId to entity.sourceItemId] = entity
+        }
+        override suspend fun findById(sourceId: String, sourceItemId: String): LocalFilesFileEntity? =
+            rows[sourceId to sourceItemId]
+        override suspend fun forSource(sourceId: String): List<LocalFilesFileEntity> =
+            rows.values.filter { it.sourceId == sourceId }
+        override suspend fun touchLastSeen(
+            sourceId: String,
+            sourceItemId: String,
+            folderTreeUri: String,
+            seenAt: Long,
+        ) { /* not exercised */ }
+        override suspend fun stale(sourceId: String, scanStart: Long): List<LocalFilesFileEntity> = emptyList()
+        override suspend fun delete(sourceId: String, sourceItemId: String) {
+            rows.remove(sourceId to sourceItemId)
+        }
+    }
+
+    // endregion
+}

--- a/core/data/src/test/kotlin/com/riffle/core/data/localfiles/LocalFilesScannerTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/localfiles/LocalFilesScannerTest.kt
@@ -260,6 +260,7 @@ class LocalFilesScannerTest {
             copyIn = copyIn,
             pdfMetadata = NoOpPdfMetadataExtractor,
             clock = clock,
+            logger = com.riffle.core.logging.NoopLogger,
         )
 
         suspend fun configureFolder(treeUri: String, files: List<WalkedFile>) {

--- a/core/data/src/test/kotlin/com/riffle/core/data/localfiles/LocalFilesScannerTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/localfiles/LocalFilesScannerTest.kt
@@ -49,7 +49,7 @@ class LocalFilesScannerTest {
         val item = h.libraryItems.upserted.single()
         assertEquals("Dune", item.title)
         assertEquals("Frank Herbert", item.author)
-        assertEquals(LocalFilesScanner.LOCAL_ROOT_LIBRARY_ID, item.libraryId)
+        assertEquals(LocalFilesCatalog.LOCAL_ROOT_ID, item.libraryId)
         assertEquals(LocalFilesScanner.EBOOK_FORMAT_EPUB, item.ebookFormat)
         assertNotNull(item.coverUrl) // fakeEpub embeds a cover
 

--- a/core/data/src/test/kotlin/com/riffle/core/data/localfiles/LocalFilesSourceInstallerTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/localfiles/LocalFilesSourceInstallerTest.kt
@@ -1,0 +1,165 @@
+package com.riffle.core.data.localfiles
+
+import com.riffle.core.database.LibraryDao
+import com.riffle.core.database.LibraryEntity
+import com.riffle.core.database.SourceDao
+import com.riffle.core.database.SourceEntity
+import com.riffle.core.domain.SourceType
+import com.riffle.core.logging.NoopLogger
+import io.mockk.mockk
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class LocalFilesSourceInstallerTest {
+
+    @Test
+    fun `ensureLocalFilesSource creates a fresh LOCAL_FILES source on first call`() = runTest {
+        val sourceDao = InMemorySourceDao()
+        val libraryDao = InMemoryLibraryDao()
+        val installer = installer(sourceDao = sourceDao, libraryDao = libraryDao)
+
+        val id = installer.ensureLocalFilesSource()
+
+        val row = sourceDao.getById(id)
+        assertNotNull("Source row missing after ensureLocalFilesSource", row)
+        assertEquals(SourceType.LOCAL_FILES.name, row!!.type)
+        assertEquals(LocalFilesSourceInstaller.LOCAL_FILES_URL_PLACEHOLDER, row.url)
+        assertEquals("", row.username)
+        // The first-installed source becomes active because no other active source existed.
+        assertTrue(row.isActive)
+    }
+
+    @Test
+    fun `ensureLocalFilesSource is idempotent - second call returns the same id`() = runTest {
+        val sourceDao = InMemorySourceDao()
+        val installer = installer(sourceDao = sourceDao)
+
+        val first = installer.ensureLocalFilesSource()
+        val second = installer.ensureLocalFilesSource()
+
+        assertEquals(first, second)
+        // Only one row survives — critical: any second insertion would give the CatalogRegistry
+        // two factories to disambiguate, and multi-folder-in-one-source is the intended model.
+        assertEquals(1, sourceDao.rowsOfType(SourceType.LOCAL_FILES.name))
+    }
+
+    @Test
+    fun `ensureLocalFilesSource seeds the synthetic local root library row`() = runTest {
+        val libraryDao = InMemoryLibraryDao()
+        val installer = installer(libraryDao = libraryDao)
+
+        val sourceId = installer.ensureLocalFilesSource()
+
+        val libs = libraryDao.forSource(sourceId)
+        assertEquals(1, libs.size)
+        val lib = libs.single()
+        assertEquals(LocalFilesCatalog.LOCAL_ROOT_ID, lib.id)
+        assertEquals(sourceId, lib.sourceId)
+        assertEquals("book", lib.mediaType)
+    }
+
+    @Test
+    fun `ensureLocalFilesSource does not become active when another source is already active`() = runTest {
+        val sourceDao = InMemorySourceDao()
+        sourceDao.upsert(
+            SourceEntity(
+                id = "abs-1",
+                url = "https://abs.example.com",
+                isActive = true,
+                insecureConnectionAllowed = false,
+                username = "user",
+                serverType = "AUDIOBOOKSHELF",
+                type = "ABS",
+            ),
+        )
+        val installer = installer(sourceDao = sourceDao)
+
+        val id = installer.ensureLocalFilesSource()
+
+        val local = sourceDao.getById(id)!!
+        // Adding LocalFiles when an ABS source is already active must not knock it out of the
+        // active slot — first-source-active is a convenience, not a takeover.
+        assertEquals(false, local.isActive)
+        assertEquals(true, sourceDao.getById("abs-1")!!.isActive)
+    }
+
+    // region helpers
+
+    private fun installer(
+        sourceDao: SourceDao = InMemorySourceDao(),
+        libraryDao: LibraryDao = InMemoryLibraryDao(),
+    ): LocalFilesSourceInstaller = LocalFilesSourceInstaller(
+        sourceDao = sourceDao,
+        libraryDao = libraryDao,
+        // folderRepository + scanner are only exercised by installFolder; ensureLocalFilesSource
+        // touches neither. Relaxed mocks keep the constructor happy without needing an Android
+        // Context or the metadata-extractor chain.
+        folderRepository = mockk(relaxed = true),
+        scanner = mockk(relaxed = true),
+        logger = NoopLogger,
+    )
+
+    // endregion
+
+    // region in-memory DAOs
+
+    private class InMemorySourceDao : SourceDao {
+        val rows = mutableMapOf<String, SourceEntity>()
+        fun rowsOfType(type: String): Int = rows.values.count { it.type == type }
+
+        override fun observeAll(): Flow<List<SourceEntity>> = flowOf(rows.values.toList())
+        override suspend fun getActive(): SourceEntity? = rows.values.firstOrNull { it.isActive }
+        override suspend fun upsert(source: SourceEntity) { rows[source.id] = source }
+        override suspend fun clearActiveFlag() {
+            for ((id, entity) in rows.toMap()) rows[id] = entity.copy(isActive = false)
+        }
+        override suspend fun setActive(id: String) {
+            rows[id]?.let { rows[id] = it.copy(isActive = true) }
+        }
+        override suspend fun setActiveAtomic(id: String) { clearActiveFlag(); setActive(id) }
+        override suspend fun upsertAsFirstIfNoActive(source: SourceEntity): SourceEntity {
+            val toInsert = source.copy(isActive = getActive() == null)
+            upsert(toInsert)
+            return toInsert
+        }
+        override suspend fun getById(id: String): SourceEntity? = rows[id]
+        override suspend fun getByType(type: String): SourceEntity? =
+            rows.values.firstOrNull { it.type == type }
+        override suspend fun deleteById(id: String) { rows.remove(id) }
+        override suspend fun setAbsUserId(id: String, absUserId: String) {
+            rows[id]?.let { rows[id] = it.copy(absUserId = absUserId) }
+        }
+    }
+
+    private class InMemoryLibraryDao : LibraryDao {
+        val rows = mutableListOf<LibraryEntity>()
+        fun forSource(sourceId: String): List<LibraryEntity> = rows.filter { it.sourceId == sourceId }
+        override fun observeBySourceId(sourceId: String): Flow<List<LibraryEntity>> =
+            MutableStateFlow(rows.filter { it.sourceId == sourceId })
+        override suspend fun libraryIdsForSource(sourceId: String): List<String> =
+            rows.filter { it.sourceId == sourceId }.map { it.id }
+        override suspend fun getById(sourceId: String, libraryId: String): LibraryEntity? =
+            rows.firstOrNull { it.sourceId == sourceId && it.id == libraryId }
+        override suspend fun upsertAll(libraries: List<LibraryEntity>) {
+            for (lib in libraries) {
+                rows.removeIf { it.sourceId == lib.sourceId && it.id == lib.id }
+                rows.add(lib)
+            }
+        }
+        override suspend fun deleteBySourceId(sourceId: String) {
+            rows.removeIf { it.sourceId == sourceId }
+        }
+        override suspend fun setUnsupported(sourceId: String, libraryId: String, isUnsupported: Boolean) {
+            val idx = rows.indexOfFirst { it.sourceId == sourceId && it.id == libraryId }
+            if (idx >= 0) rows[idx] = rows[idx].copy(isUnsupported = isUnsupported)
+        }
+    }
+
+    // endregion
+}

--- a/core/database/src/main/kotlin/com/riffle/core/database/LibraryItemDao.kt
+++ b/core/database/src/main/kotlin/com/riffle/core/database/LibraryItemDao.kt
@@ -14,6 +14,9 @@ interface LibraryItemDao {
     @Query("SELECT * FROM library_items WHERE sourceId = :sourceId AND libraryId = :libraryId ORDER BY title ASC")
     fun observeByLibraryId(sourceId: String, libraryId: String): Flow<List<LibraryItemEntity>>
 
+    @Query("SELECT * FROM library_items WHERE sourceId = :sourceId AND libraryId = :libraryId")
+    suspend fun listByLibraryId(sourceId: String, libraryId: String): List<LibraryItemEntity>
+
     /** All library items owned by a Source, across every library. Used by the Annotations View
      *  library list, which joins against highlight summaries that aren't library-scoped. */
     @Query("SELECT * FROM library_items WHERE sourceId = :sourceId")

--- a/core/database/src/main/kotlin/com/riffle/core/database/SourceDao.kt
+++ b/core/database/src/main/kotlin/com/riffle/core/database/SourceDao.kt
@@ -42,6 +42,13 @@ interface SourceDao {
     @Query("SELECT * FROM sources WHERE id = :id LIMIT 1")
     suspend fun getById(id: String): SourceEntity?
 
+    /**
+     * First source row whose [SourceEntity.type] matches [type] (there is at most one LocalFiles
+     * source per device; this returns it or `null` when none has been installed yet).
+     */
+    @Query("SELECT * FROM sources WHERE type = :type LIMIT 1")
+    suspend fun getByType(type: String): SourceEntity?
+
     @Query("DELETE FROM sources WHERE id = :id")
     suspend fun deleteById(id: String)
 

--- a/core/logging/src/main/kotlin/com/riffle/core/logging/LogChannel.kt
+++ b/core/logging/src/main/kotlin/com/riffle/core/logging/LogChannel.kt
@@ -16,4 +16,5 @@ enum class LogChannel(val tag: String) {
     ReaderDecoration("RIFFLE_DECO"),
     Cadence("RIFFLE_CD"),
     Covers("RIFFLE_COVERS"),
+    LocalFiles("RIFFLE_LF"),
 }


### PR DESCRIPTION
Closes #438.

Part of [ADR 0041](../blob/main/docs/adr/0041-source-and-service-abstractions-replace-server.md) Phase 5b — the shippable LocalFiles UX. First time local-only users are first-class citizens.

## Summary

- `LocalFilesCatalog` implements `Catalog` + `SeriesCapability` + `OfflineBrowseCapability` against the local Room store populated by #437's ingestion pipeline. Single synthetic root `local:root`.
- Add-Source flow: LocalFiles card in `SourceTypePickerScreen` is enabled and routes to an `AddLocalFilesScreen` that drives `PickFolderContract`, materialises the singleton LocalFiles source row via `LocalFilesSourceInstaller`, and runs the first scan.
- Multi-folder management in Settings, folded into the Sources list next to ABS (expandable row mirroring `ServerRow`). Adding another folder reuses the top-level "Add source" flow (`LocalFilesSourceInstaller.ensureLocalFilesSource` is idempotent).
- URI-revocation surface: `LocalFilesFolderHealthChecker` inspects `ContentResolver.persistedUriPermissions`; folders with a missing grant show a per-row warning and a section-level banner. Already-copied bytes stay readable.
- Auto-scan: `LocalFilesFolderWatcher` runs a debounced scan on `ProcessLifecycleOwner.ON_START` and on SAF `ContentObserver` change events, so users dropping a book in never need to hit a manual Rescan button.
- Nav Drawer source-switcher label: LocalFiles renders as "Local files · on this device" via `sourceDisplayName` / `sourceSubtitle`, ignoring the ABS placeholder columns.

## Verification

- `./gradlew test` — all JVM suites green (LocalFilesCatalogTest, LocalFilesSourceInstallerTest, updated SettingsViewModelTest + SourceRepositoryTest fakes, SourceTypePickerTest flipped from "coming soon" to "enabled").
- End-to-end on emulator-5554: install → Add source → Local files → SAF pick `/sdcard/Books/` → book appears in Local Files library with extracted cover + title + author. Auto-scan verified via `RIFFLE_LF` logs on foreground return.

## Known gaps flagged in review, deferred

- `LibraryItemMetadata` still writes `finishedAt` on refresh — clobbers locally-tracked "finished" state on any refresh where the catalog can't provide it (LocalFiles, since it has no `ProgressPeerCapability`). Mirrors how `readingProgress` is excluded; needs the same treatment for `finishedAt`. Belongs in a follow-up that touches all non-ProgressPeer sources.
- Nav Drawer indicator for unhealthy LocalFiles folders — Settings has the surface; the Drawer badge is a nice-to-have not in this PR.
- `LocalFilesSourceRow` re-implements `ServerRow`'s chevron/expand shell — could share an `ExpandableSourceRow` primitive.
- `LocalFilesFolderWatcher` uses a Job-based debounce; a `MutableSharedFlow.debounce` variant would remove the mid-scan re-entry race.

## Test plan
- [ ] Fresh install on device: Add source → Local files → pick folder with EPUBs and PDFs, verify all show up in Local Files library.
- [ ] Open one of each in every reader mode (paginated / vertical / continuous), confirm formatting / TOC / bookmarks / highlights work.
- [ ] Add a folder from Settings > Local files > (expand) > (top-level Add source), verify additional folder attaches to the same source and its books show up.
- [ ] Drop a new EPUB into a monitored folder while the app is backgrounded, foreground the app, verify it appears without any manual scan.
- [ ] Revoke SAF permission in system Settings, return to Riffle, verify the folder shows the warning banner and per-row indicator.
- [ ] Remove a single folder from Settings, confirm-dialog appears, its books disappear on next scan.
- [ ] Remove the whole LocalFiles source, verify DB and copied-in files are cleaned up.