### PR TITLE
fix(annotations): figure inherits annotation only via single-selection; elided view + list polish

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/AnnotationsPanel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/AnnotationsPanel.kt
@@ -148,8 +148,12 @@ private fun AnnotationRow(
     onRename: () -> Unit,
 ) {
     val rowKind = rowKindFor(annotation)
+    // Bookmarks stay top-aligned (single-line title next to the icon); highlights + image rows
+    // centre vertically so a multi-line annotation (esp. text-figure-text) puts the colour dot
+    // in the middle of the card instead of pinned to the first line (fix 2026-07-10).
+    val leadingAlignment = if (rowKind == RowKind.Bookmark) Alignment.Top else Alignment.CenterVertically
     Row(
-        verticalAlignment = Alignment.Top,
+        verticalAlignment = leadingAlignment,
         modifier = Modifier
             .fillMaxWidth()
             .clickable(onClick = onClick)
@@ -234,9 +238,15 @@ private fun AnnotationContent(annotation: Annotation, rowKind: RowKind) {
             offsets = figures.map { it.charOffset },
         )
         textChunks.forEachIndexed { index, chunk ->
-            if (chunk.isNotBlank()) {
+            // Readium's textSnippet embeds "\n\n\n" between paragraphs on either side of a void
+            // figure to represent the block break. Compose's Text renders those newlines as
+            // blank lines, producing a wide gap in the annotations-list card (bug 2026-07-10).
+            // Trim ONLY leading/trailing whitespace runs — an intentional internal line-break
+            // still renders as a single visible break.
+            val trimmed = chunk.trim()
+            if (trimmed.isNotEmpty()) {
                 Text(
-                    text = chunk,
+                    text = trimmed,
                     style = MaterialTheme.typography.bodyLarge,
                     color = MaterialTheme.colorScheme.onSurface,
                 )

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -1571,15 +1571,11 @@ class EpubReaderViewModel @Inject constructor(
             }
             return
         }
-        if (current.type == AnnotationEntity.TYPE_IMAGE) {
-            // Symmetric with text-highlight dismiss (memory `annotations-text-graph-symmetric`):
-            // a dismissed TYPE_IMAGE popup checks for an adjacent same-colour no-note highlight
-            // that can absorb this figure. If one exists, the figure is absorbed and this row is
-            // deleted; otherwise no-op.
-            absorbFigureIntoAdjacentHighlight(current, effectiveColor, effectiveNote)
-            return
-        }
         if (current.type != AnnotationEntity.TYPE_HIGHLIGHT) {
+            // Standalone TYPE_IMAGE (long-press-created) popups dismiss without any merge check
+            // — a figure only becomes part of a highlight when the user's single selection
+            // covers text on both sides of the figure at creation time. Symmetric on the text
+            // side: [hasFigureInGap] rejects text-adjacency across a figure. (Revised 2026-07-10.)
             logger.d(LogChannel.HighlightMerge) { "edit-merge skip id=$id reason=type=${current.type}" }
             return
         }
@@ -1614,7 +1610,6 @@ class EpubReaderViewModel @Inject constructor(
             logger.d(LogChannel.HighlightMerge) { "edit-merge FAIL id=$id reason=no-html spine=${trialAnchor.spineIndex}" }
             return
         }
-        val toAbsorbImages = mutableListOf<Annotation>()
         while (true) {
             val match = findAnyMergeableNeighbor(
                 trialAnchor,
@@ -1626,33 +1621,15 @@ class EpubReaderViewModel @Inject constructor(
                 "edit-merge absorb neighborId=${match.neighbor.id} type=${match.neighbor.type} " +
                     "side=${match.side} neighborSnippet='${match.neighbor.textSnippet.take(30)}'"
             }
-            if (match.neighbor.type == com.riffle.core.database.AnnotationEntity.TYPE_IMAGE) {
-                toAbsorbImages += match.neighbor
-            } else {
-                when (match.side) {
-                    MergeSide.CANDIDATE_BEFORE_ANCHOR -> leftmost = match.neighbor.toMergeAnchor()
-                    MergeSide.CANDIDATE_AFTER_ANCHOR -> rightmost = match.neighbor.toMergeAnchor()
-                }
-                toAbsorb += match.neighbor
+            when (match.side) {
+                MergeSide.CANDIDATE_BEFORE_ANCHOR -> leftmost = match.neighbor.toMergeAnchor()
+                MergeSide.CANDIDATE_AFTER_ANCHOR -> rightmost = match.neighbor.toMergeAnchor()
             }
+            toAbsorb += match.neighbor
             absorbedIds += match.neighbor.id
             trialAnchor = applyMerge(trialAnchor, match)
         }
-        // Second-pass image absorption: catches TYPE_IMAGE annotations whose figure sits inside
-        // the highlight's (possibly expanded) range but wasn't picked up as a text-adjacent
-        // candidate. Combined with the trial-loop absorptions, this covers all "figure adjacent
-        // to highlight" cases symmetrically. See memory `annotations-text-graph-symmetric`.
-        val extraAbsorbableImages = findAbsorbableImageAnnotations(
-            html = html,
-            snippet = trialAnchor.textSnippet,
-            textBefore = trialAnchor.textBefore,
-            color = trialAnchor.color,
-            chapterHref = trialAnchor.chapterHref,
-            pool = pool,
-            excludeIds = absorbedIds,
-        )
-        val allAbsorbedImages = (toAbsorbImages + extraAbsorbableImages).distinctBy { it.id }
-        if (toAbsorb.isEmpty() && allAbsorbedImages.isEmpty()) {
+        if (toAbsorb.isEmpty()) {
             debugLogNoMergeReasons(trialAnchor, pool, id)
             return
         }
@@ -1712,24 +1689,20 @@ class EpubReaderViewModel @Inject constructor(
             return
         }
         val storedProgression = startChar.toDouble() / totalChars.toDouble()
-        // Build the merged highlight's embeddedFigures: figures enclosed by the merged range
-        // (walked here so positions are relative to the NEW range start) unioned with any bytes
-        // captured on absorbed TYPE_IMAGE annotations that map to those figures. This is what
-        // makes the merged highlight render correctly in the elided view + annotations panel
-        // even when the merge crossed a figure. Symmetric with the create-time embeddedFigures
-        // capture in createHighlight.
+        // Build the merged highlight's embeddedFigures by walking the merged range. Under the
+        // revised merge rule (2026-07-10) the merged range can only contain figures that were
+        // already inside one of the source highlights' individual ranges — [hasFigureInGap]
+        // rejects any merge that would newly annotate a figure. Bytes/svg are inherited from
+        // the anchor's own row if it carried them.
         val mergedEmbeddedFigures = buildMergedEmbeddedFigures(
             html = html,
             mergedStartChar = startChar,
             mergedEndChar = endChar,
-            absorbedImages = allAbsorbedImages,
             anchorId = id,
             pool = pool,
         )
         // All computations succeeded — commit: delete neighbours, then replace the anchor row.
-        // Redundant standalone TYPE_IMAGE annotations covered by the merged range also drop here.
         toAbsorb.forEach { annotationStore.delete(it.id) }
-        allAbsorbedImages.forEach { annotationStore.delete(it.id) }
         annotationStore.delete(id)
         val created = annotationStore.createHighlight(
             sourceId = sourceId,
@@ -1746,46 +1719,40 @@ class EpubReaderViewModel @Inject constructor(
         )
         logger.d(LogChannel.HighlightMerge) {
             "edit-merge done anchorReplaced=$id newId=${created.id} absorbedText=${toAbsorb.size} " +
-                "absorbedImages=${allAbsorbedImages.size} figures=${mergedEmbeddedFigures?.size ?: 0} " +
+                "figures=${mergedEmbeddedFigures?.size ?: 0} " +
                 "domLen=${domSnippet.length} startChar=$startChar"
         }
     }
 
     /**
      * Walk the merged range in the chapter DOM to compute embedded figures with position offsets
-     * relative to the merged start; then attach imageBytes/imageSvg from any absorbed TYPE_IMAGE
-     * annotations that identify the same figures (by [figureHrefFilename] correlation). Returns
-     * null iff no figures — normalized to null on the persisted entity by AnnotationStore.
+     * relative to the merged start. Under the revised merge rule (2026-07-10), the merged range
+     * can only contain figures that were already inside one of the source highlights, because
+     * [hasFigureInGap] blocks any merge whose gap would newly enclose a figure. Bytes/svg carried
+     * on the pre-merge anchor row (if any) are correlated back onto the walked figures by
+     * [figureHrefFilename] so a merge doesn't lose already-captured raster data.
      *
-     * The anchor's original embeddedFigures are NOT preserved verbatim — the merged range walk
-     * IS the authoritative source, and the merged range covers the anchor's range too, so any
-     * figure that WAS in the anchor gets re-walked here. Bytes preservation happens via the
-     * absorbed-image lookup (which includes the anchor's original TYPE_IMAGE neighbours).
+     * Returns null iff no figures — normalized to null on the persisted entity by AnnotationStore.
      */
     private fun buildMergedEmbeddedFigures(
         html: String,
         mergedStartChar: Long,
         mergedEndChar: Long,
-        absorbedImages: List<Annotation>,
         anchorId: String,
         pool: List<Annotation>,
     ): List<com.riffle.core.domain.EmbeddedFigure>? {
         val walked = findEnclosedFiguresInHtml(html, mergedStartChar, mergedEndChar - 1L)
-        if (walked.isEmpty() && absorbedImages.isEmpty()) return null
-        // Index absorbed image bytes by filename so a figure walked from the DOM picks up its
-        // captured raster bytes. Also include existing image annotations in the pool with a
-        // matching figure href — this catches the pre-existing anchor annotation's own image
-        // data when the anchor itself is TYPE_IMAGE (dismiss-of-image path).
+        if (walked.isEmpty()) return null
+        // Index bytes/svg from the anchor's existing embeddedFigures so a re-walk of the merged
+        // range doesn't drop image data that was already captured at create time.
         val bytesByFilename = mutableMapOf<String, String>()
         val svgByFilename = mutableMapOf<String, String>()
-        fun index(ann: Annotation) {
-            val href = ann.imageHref ?: return
-            val key = figureHrefFilename(href)
-            ann.imageBytes?.takeIf { it.isNotBlank() }?.let { bytesByFilename[key] = it }
-            ann.imageSvg?.takeIf { it.isNotBlank() }?.let { svgByFilename[key] = it }
+        val anchor = pool.firstOrNull { it.id == anchorId }
+        anchor?.embeddedFigures.orEmpty().forEach { fig ->
+            val key = fig.href?.let(::figureHrefFilename) ?: return@forEach
+            fig.imageBytes?.takeIf { it.isNotBlank() }?.let { bytesByFilename[key] = it }
+            fig.svg?.takeIf { it.isNotBlank() }?.let { svgByFilename[key] = it }
         }
-        absorbedImages.forEach(::index)
-        pool.firstOrNull { it.id == anchorId }?.let(::index)
         return walked.mapIndexed { i, fig ->
             val key = fig.href?.let(::figureHrefFilename)
             fig.copy(
@@ -1808,93 +1775,6 @@ class EpubReaderViewModel @Inject constructor(
         val na = a.filterNot { it.isWhitespace() }
         val nb = b.filterNot { it.isWhitespace() }
         return na.equals(nb, ignoreCase = true)
-    }
-
-    /**
-     * Dismiss-of-TYPE_IMAGE symmetric merge path (memory `annotations-text-graph-symmetric`).
-     * If a same-chapter same-colour no-note TYPE_HIGHLIGHT sits adjacent to this figure's DOM
-     * position, absorb the figure into that highlight and delete the standalone TYPE_IMAGE.
-     * "Adjacent" means the figure's char position falls inside the highlight's range widened by
-     * 1 char — same rule the reverse path uses.
-     *
-     * When multiple highlights are adjacent, the first-found wins; when none are adjacent, no-op.
-     * The absorbed highlight is recreated with the figure attached to its `embeddedFigures`
-     * (mirrors `buildMergedEmbeddedFigures`).
-     */
-    private suspend fun absorbFigureIntoAdjacentHighlight(
-        figure: Annotation,
-        effectiveColor: String,
-        effectiveNote: String?,
-    ) {
-        if (!effectiveNote.isNullOrBlank()) {
-            logger.d(LogChannel.HighlightMerge) { "image-dismiss skip id=${figure.id} reason=note-still-present" }
-            return
-        }
-        val sourceId = annotationServerId ?: run {
-            logger.d(LogChannel.HighlightMerge) { "image-dismiss skip id=${figure.id} reason=no-sourceId" }
-            return
-        }
-        val html = readChapterHtml(figure.spineIndex) ?: run {
-            logger.d(LogChannel.HighlightMerge) { "image-dismiss skip id=${figure.id} reason=no-html" }
-            return
-        }
-        val pool = annotationSession.annotations.value
-        // Same-chapter same-colour no-note text highlights in the pool.
-        val eligibleHighlights = pool.filter {
-            it.id != figure.id &&
-                it.type == AnnotationEntity.TYPE_HIGHLIGHT &&
-                it.spineIndex == figure.spineIndex &&
-                it.color.equals(effectiveColor, ignoreCase = true) &&
-                it.note.isNullOrBlank() &&
-                normalizeEpubHref(it.chapterHref) == normalizeEpubHref(figure.chapterHref)
-        }
-        // Find one whose (widened) range covers this figure's position — same rule as the
-        // TYPE_HIGHLIGHT absorb path in reverse.
-        val figureFilename = figure.imageHref?.let(::figureHrefFilename)
-        val target = eligibleHighlights.firstOrNull { hl ->
-            val start = locateSnippetInBody(html, hl.textSnippet, hl.textBefore) ?: return@firstOrNull false
-            val end = start + hl.textSnippet.length
-            val figs = findEnclosedFiguresInHtml(html, (start - 1L).coerceAtLeast(0L), end + 1L)
-            figs.any { it.href?.let(::figureHrefFilename) == figureFilename }
-        }
-        if (target == null) {
-            logger.d(LogChannel.HighlightMerge) {
-                "image-dismiss no-adjacent-highlight id=${figure.id} eligibleCount=${eligibleHighlights.size}"
-            }
-            return
-        }
-        // Recreate the target highlight with the figure absorbed into embeddedFigures. CFI + text
-        // are unchanged (the figure was already within the range).
-        val totalChars = com.riffle.core.domain.countBodyChars(org.jsoup.Jsoup.parse(html).body())
-        val startChar = locateSnippetInBody(html, target.textSnippet, target.textBefore) ?: return
-        val endChar = (startChar + target.textSnippet.length).coerceAtMost(totalChars)
-        val embeddedFigures = buildMergedEmbeddedFigures(
-            html = html,
-            mergedStartChar = startChar,
-            mergedEndChar = endChar,
-            absorbedImages = listOf(figure),
-            anchorId = target.id,
-            pool = pool,
-        )
-        annotationStore.delete(figure.id)
-        annotationStore.delete(target.id)
-        val created = annotationStore.createHighlight(
-            sourceId = sourceId,
-            itemId = itemId,
-            cfi = target.cfi,
-            textSnippet = target.textSnippet,
-            chapterHref = target.chapterHref,
-            textBefore = target.textBefore,
-            textAfter = target.textAfter,
-            color = target.color,
-            spineIndex = target.spineIndex,
-            progression = target.progression,
-            embeddedFigures = embeddedFigures,
-        )
-        logger.d(LogChannel.HighlightMerge) {
-            "image-dismiss absorbed figureId=${figure.id} intoHighlight=${target.id} newId=${created.id} " +
-                "figures=${embeddedFigures?.size ?: 0}"
-        }
     }
 
     /** Per-neighbour reason line, so a "why no merge?" can be answered from a single logcat grep. */

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -1700,6 +1700,7 @@ class EpubReaderViewModel @Inject constructor(
             mergedEndChar = endChar,
             anchorId = id,
             pool = pool,
+            absorbedHighlights = toAbsorb,
         )
         // All computations succeeded — commit: delete neighbours, then replace the anchor row.
         toAbsorb.forEach { annotationStore.delete(it.id) }
@@ -1740,19 +1741,25 @@ class EpubReaderViewModel @Inject constructor(
         mergedEndChar: Long,
         anchorId: String,
         pool: List<Annotation>,
+        absorbedHighlights: List<Annotation> = emptyList(),
     ): List<com.riffle.core.domain.EmbeddedFigure>? {
         val walked = findEnclosedFiguresInHtml(html, mergedStartChar, mergedEndChar - 1L)
         if (walked.isEmpty()) return null
-        // Index bytes/svg from the anchor's existing embeddedFigures so a re-walk of the merged
-        // range doesn't drop image data that was already captured at create time.
+        // Index bytes/svg from every source row's embeddedFigures so a re-walk of the merged
+        // range doesn't drop image data that was already captured at create time. Absorbed
+        // neighbours count: an absorbed text-figure-text highlight carries the figure's imageBytes
+        // even when the anchor row itself had none.
         val bytesByFilename = mutableMapOf<String, String>()
         val svgByFilename = mutableMapOf<String, String>()
-        val anchor = pool.firstOrNull { it.id == anchorId }
-        anchor?.embeddedFigures.orEmpty().forEach { fig ->
-            val key = fig.href?.let(::figureHrefFilename) ?: return@forEach
-            fig.imageBytes?.takeIf { it.isNotBlank() }?.let { bytesByFilename[key] = it }
-            fig.svg?.takeIf { it.isNotBlank() }?.let { svgByFilename[key] = it }
+        fun indexRow(ann: Annotation?) {
+            ann?.embeddedFigures.orEmpty().forEach { fig ->
+                val key = fig.href?.let(::figureHrefFilename) ?: return@forEach
+                fig.imageBytes?.takeIf { it.isNotBlank() }?.let { bytesByFilename.putIfAbsent(key, it) }
+                fig.svg?.takeIf { it.isNotBlank() }?.let { svgByFilename.putIfAbsent(key, it) }
+            }
         }
+        indexRow(pool.firstOrNull { it.id == anchorId })
+        absorbedHighlights.forEach(::indexRow)
         return walked.mapIndexed { i, fig ->
             val key = fig.href?.let(::figureHrefFilename)
             fig.copy(

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/FigureTapScript.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/FigureTapScript.kt
@@ -67,15 +67,21 @@ internal object FigureTapScript {
                 (document.head || document.documentElement).appendChild(style);
             } catch (e) {}
             function findFigure(target) {
-                // Walk up to body FIRST looking for an anchor-with-href ancestor. If we find one
-                // before we find a figure candidate, this tap is a link — return null so the
-                // existing footnote / cross-reference / external-link router handles it. Doing
-                // the walk in two passes fixes the anchor-wrapped-image bug where returning on
-                // the first <img> match happens BEFORE we ever see the wrapping <a>.
+                // Walk up to body FIRST looking for an anchor-with-href ancestor OR a synthesised
+                // Highlights-view figure block. If either is found before we find a figure
+                // candidate, the tap is not the reader-mode "open figure zoom" gesture and we
+                // return null so the appropriate downstream handler runs:
+                //   - <a href>: existing footnote / cross-reference / external-link router.
+                //   - <figure class="riffle-fig">: the accent-bar tap span's own onclick, which
+                //     dispatches to the annotation editor via the riffle:// URL scheme. Without
+                //     this skip, the capture-phase click here would swallow the tap and open the
+                //     figure-zoom overlay instead — the "tap accent bar → zoom instead of edit"
+                //     bug (fix 2026-07-10).
                 var scan = target;
                 while (scan && scan.nodeType === 1 && scan !== document.body) {
                     var stag = scan.tagName ? scan.tagName.toLowerCase() : '';
                     if (stag === 'a' && scan.getAttribute && scan.getAttribute('href')) return null;
+                    if (stag === 'figure' && scan.classList && scan.classList.contains('riffle-fig')) return null;
                     scan = scan.parentNode;
                 }
                 // Now walk up to find the actual figure candidate.

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/HighlightMerge.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/HighlightMerge.kt
@@ -52,17 +52,16 @@ internal fun Annotation.toMergeAnchor(): MergeAnchor = MergeAnchor(
 )
 
 /**
- * Static eligibility gate — same chapter, same colour, both notes empty/blank. Accepts either
- * TYPE_HIGHLIGHT or TYPE_IMAGE candidates: annotations do not distinguish text from graph — a
- * user's mental model treats them identically, so a figure adjacent to a same-colour highlight is
- * as eligible for absorption as another text highlight would be. See feedback memory
- * `annotations-text-graph-symmetric`. Adjacency (which decides WHERE in the range the candidate
- * sits) is a separate check in [findAdjacency] / [findFigureAdjacency].
+ * Static eligibility gate — same chapter, same colour, both notes empty/blank. Only TYPE_HIGHLIGHT
+ * candidates are eligible for auto-merge (revised 2026-07-10): a standalone TYPE_IMAGE annotation
+ * (long-press-created) represents distinct user intent and is never swept into an adjacent text
+ * highlight. Symmetric: two text highlights sitting either side of a figure are NOT merged either —
+ * see the figure-gap check in [findAnyMergeableNeighbor]. A figure only becomes part of a highlight
+ * when the user's single selection covers text on BOTH sides of the figure at creation time (see
+ * `createHighlight`'s `findEnclosedFiguresInHtml` walk).
  */
 internal fun isMergeEligible(anchor: MergeAnchor, candidate: Annotation): Boolean {
-    if (candidate.type != AnnotationEntity.TYPE_HIGHLIGHT &&
-        candidate.type != AnnotationEntity.TYPE_IMAGE
-    ) return false
+    if (candidate.type != AnnotationEntity.TYPE_HIGHLIGHT) return false
     if (anchor.spineIndex != candidate.spineIndex) return false
     if (!anchor.color.equals(candidate.color, ignoreCase = true)) return false
     if (!anchor.note.isNullOrBlank()) return false
@@ -83,12 +82,13 @@ internal fun isMergeEligible(anchor: MergeAnchor, candidate: Annotation): Boolea
  * "Modulo a single whitespace run" means zero-or-more whitespace chars, all contiguous. Any
  * non-whitespace character between = not adjacent.
  *
- * A void figure element (`<img>`) between the two counts as zero readable chars in the stream that
- * Readium uses to build `textBefore`/`textAfter`, so this same textual check catches figures that
- * sit visually between two adjacent same-colour text highlights — that's the desired behaviour
- * (feedback memory `annotations-text-graph-symmetric`): text-with-figure-between is still text-
- * adjacent. The figure gets absorbed as an embedded figure at merge time via
- * `findAbsorbableImageAnnotations` / the create-time range walk.
+ * Void figure elements (`<img>`) contribute zero readable chars, so this textual check ALONE
+ * would report "text-adjacent" even when a figure sits visually between the two highlights. That's
+ * not the intent: two separately-created highlights either side of a figure represent two
+ * independent user actions and must NOT merge (would silently pull the figure into the merged
+ * highlight's embedded figures). [findAnyMergeableNeighbor] runs a follow-up figure-gap check
+ * against the chapter HTML to reject that case; a figure only becomes part of a highlight when
+ * the user's single selection covers text on both sides of the figure at creation time.
  */
 internal fun findAdjacency(anchor: MergeAnchor, candidate: Annotation): MergeCandidate? {
     val anchorSnippet = anchor.textSnippet.takeIf { it.isNotBlank() } ?: return null
@@ -181,20 +181,11 @@ private const val MIN_MATCH_CHARS = 12
 
 /**
  * Apply a merge: produce a new anchor whose snippet spans both sides and whose text-before /
- * text-after / progression are inherited from the outermost endpoints.
- *
- * For a TYPE_IMAGE candidate the text is unchanged — the figure is absorbed into the merged
- * highlight's `embeddedFigures` later by the commit path, not into `textSnippet`. The anchor's
- * spatial extent still needs to grow so the merged CFI covers the figure position; that spatial
- * extension is done by the commit path via the figure's `charOffset`, not here.
+ * text-after / progression are inherited from the outermost endpoints. Only TYPE_HIGHLIGHT
+ * candidates reach here — [isMergeEligible] filters TYPE_IMAGE upstream.
  */
 internal fun applyMerge(anchor: MergeAnchor, match: MergeCandidate): MergeAnchor {
     val neighbor = match.neighbor
-    if (neighbor.type == AnnotationEntity.TYPE_IMAGE) {
-        // Text stays the same. Note stays empty (both sides eligibility-checked as no-note). No
-        // textBefore/textAfter change either — the figure is invisible in the readable-text stream.
-        return anchor
-    }
     return when (match.side) {
         MergeSide.CANDIDATE_AFTER_ANCHOR -> anchor.copy(
             textSnippet = anchor.textSnippet + match.whitespaceBetween + neighbor.textSnippet,
@@ -213,10 +204,12 @@ internal fun applyMerge(anchor: MergeAnchor, match: MergeCandidate): MergeAnchor
  * (chain-merge until no more matches). [excludeIds] carries the anchor's own id (if it already
  * exists) plus any neighbours already absorbed this round.
  *
- * TYPE_HIGHLIGHT candidates use [findAdjacency]'s text-context check. TYPE_IMAGE candidates use
- * [findFigureAdjacency], which needs the chapter [html] to locate the figure's DOM position and
- * compare it against the anchor's range endpoints; when [html] is null (unit-test paths without a
- * chapter body), TYPE_IMAGE candidates are silently skipped.
+ * When [html] is provided, an additional figure-gap check runs after [findAdjacency] succeeds: if
+ * ANY figure element (`<img>`/`<svg>`/`<picture>`/`<figure>`) sits in the DOM char-range between
+ * anchor and candidate, the pair is NOT merged. Rationale: two highlights created as separate
+ * selections either side of a figure represent independent user intent — merging them would
+ * silently annotate the figure. See the KDoc on [findAdjacency] for the void-figure motivation.
+ * When [html] is null (unit-test paths without a chapter body) the gap check is skipped.
  */
 internal fun findAnyMergeableNeighbor(
     anchor: MergeAnchor,
@@ -227,98 +220,54 @@ internal fun findAnyMergeableNeighbor(
     for (candidate in pool) {
         if (candidate.id in excludeIds) continue
         if (!isMergeEligible(anchor, candidate)) continue
-        val adjacency = when (candidate.type) {
-            AnnotationEntity.TYPE_HIGHLIGHT -> findAdjacency(anchor, candidate)
-            AnnotationEntity.TYPE_IMAGE ->
-                if (html != null) findFigureAdjacency(html, anchor, candidate) else null
-            else -> null
-        } ?: continue
+        val adjacency = findAdjacency(anchor, candidate) ?: continue
+        if (html != null && hasFigureInGap(html, anchor, candidate, adjacency.side)) continue
         return adjacency
     }
     return null
 }
 
 /**
- * Figure-adjacency: does the [imageCandidate]'s figure sit touching the [anchor]'s text range in
- * the chapter DOM? "Touching" means the figure's readable-text position (as counted by
- * `findEnclosedFiguresInHtml`) is at either endpoint of the anchor's range (widened by 1 char on
- * each side to catch void figures whose zero-char span coincides with the boundary), or strictly
- * inside the range.
+ * True when a figure element (`<img>`/`<svg>`/`<picture>`/`<figure>`) sits in the readable-text
+ * gap between [anchor] and [candidate] in [html]. Void figures contribute zero readable chars, so
+ * they're invisible to [findAdjacency]'s textual check — this walk over the gap catches them.
  *
- * Symmetric to [findAdjacency] for text neighbours — TYPE_IMAGE candidates are merged in the same
- * way (feedback memory `annotations-text-graph-symmetric`): the outcome absorbs the figure into
- * the merged highlight's embedded figures. Returns the [MergeCandidate] with an empty
- * whitespace-between run (figures are void — no whitespace to preserve).
+ * Falls back to `false` when either range can't be located in the DOM: without positions we can't
+ * verify there IS a figure between, so we don't block the merge. `findEnclosedFiguresInHtml`'s
+ * straddle check is strict (`start < elemPos < end`), so an empty gap or a figure at exactly one
+ * of the endpoints doesn't count.
  */
-internal fun findFigureAdjacency(
+internal fun hasFigureInGap(
     html: String,
     anchor: MergeAnchor,
-    imageCandidate: Annotation,
-): MergeCandidate? {
-    if (imageCandidate.type != AnnotationEntity.TYPE_IMAGE) return null
-    val figureHref = imageCandidate.imageHref ?: return null
-    val anchorStart = locateSnippetInBody(html, anchor.textSnippet, anchor.textBefore) ?: return null
+    candidate: Annotation,
+    side: MergeSide,
+): Boolean {
+    val anchorStart = locateSnippetInBody(html, anchor.textSnippet, anchor.textBefore) ?: return false
     val anchorEnd = anchorStart + anchor.textSnippet.length
-    val enclosed = findEnclosedFiguresInHtml(
-        html,
-        (anchorStart - 1L).coerceAtLeast(0L),
-        anchorEnd + 1L,
-    )
-    if (enclosed.isEmpty()) return null
-    val filename = figureHrefFilename(figureHref)
-    val match = enclosed.firstOrNull { it.href?.let(::figureHrefFilename) == filename } ?: return null
-    // Determine which side of the anchor the figure sits on so downstream commit logic can extend
-    // the merged range correctly. `charOffset` is measured from the anchor's start.
-    val offset = match.charOffset ?: 0L
-    val side = if (offset >= (anchor.textSnippet.length / 2).toLong()) {
-        MergeSide.CANDIDATE_AFTER_ANCHOR
-    } else {
-        MergeSide.CANDIDATE_BEFORE_ANCHOR
+    val candStart = locateSnippetInBody(html, candidate.textSnippet, candidate.textBefore) ?: return false
+    val candEnd = candStart + candidate.textSnippet.length
+    val rawGapStart: Long
+    val rawGapEnd: Long
+    when (side) {
+        MergeSide.CANDIDATE_AFTER_ANCHOR -> {
+            rawGapStart = anchorEnd
+            rawGapEnd = candStart
+        }
+        MergeSide.CANDIDATE_BEFORE_ANCHOR -> {
+            rawGapStart = candEnd
+            rawGapEnd = anchorStart
+        }
     }
-    return MergeCandidate(imageCandidate, side, whitespaceBetween = "")
-}
-
-/**
- * Standalone TYPE_IMAGE annotations that are absorbable by the text highlight anchored at
- * ([snippet], [textBefore]) — i.e. their figure sits inside (or immediately adjacent to) the
- * highlight's char range in [html] AND they share the highlight's [color] and [chapterHref] AND
- * carry no note. Called by `mergeAdjacentIntoHighlight` (fix #1, 2026-07-09) so a TYPE_IMAGE
- * annotated separately on a figure the highlight now covers gets collapsed on the next popup
- * dismiss — the same rule the create-time absorbedFilenames loop enforces, extended to edit-time.
- *
- * Adjacency uses a 1-char widening on each side of the range so a figure sitting exactly AT the
- * boundary (its position coincides with the range start or end) is still caught — void figures
- * contribute zero readable chars so their position equals the surrounding text position.
- *
- * [excludeIds] carries the anchor's own id plus any candidates already absorbed by the text-merge
- * pass, so we never re-consider the anchor or double-absorb the same row.
- */
-internal fun findAbsorbableImageAnnotations(
-    html: String,
-    snippet: String,
-    textBefore: String,
-    color: String,
-    chapterHref: String,
-    pool: List<Annotation>,
-    excludeIds: Set<String>,
-): List<Annotation> {
-    val start = locateSnippetInBody(html, snippet, textBefore) ?: return emptyList()
-    val end = start + snippet.length
-    val figures = findEnclosedFiguresInHtml(
-        html,
-        (start - 1L).coerceAtLeast(0L),
-        end + 1L,
-    )
-    if (figures.isEmpty()) return emptyList()
-    val enclosedFilenames = figures.mapNotNull { it.href }.map(::figureHrefFilename).toSet()
-    if (enclosedFilenames.isEmpty()) return emptyList()
-    return pool.filter { ann ->
-        ann.id !in excludeIds &&
-            ann.type == AnnotationEntity.TYPE_IMAGE &&
-            ann.color.equals(color, ignoreCase = true) &&
-            ann.note.isNullOrBlank() &&
-            normalizeEpubHref(ann.chapterHref) == normalizeEpubHref(chapterHref) &&
-            ann.imageHref?.let(::figureHrefFilename) in enclosedFilenames
-    }
+    // Widen the gap by 1 char on each side. Void figures (<img>) contribute zero readable chars,
+    // so a figure sitting exactly at the boundary between anchor and candidate would have
+    // `elemStart == rawGapStart == rawGapEnd` — the strict straddle in [findEnclosedFiguresInHtml]
+    // (`startChar < elemStart < endChar`) would then never fire without widening. Widening by 1 on
+    // each side is safe: the strict less-than still excludes figures sitting strictly inside
+    // anchor's or candidate's own range.
+    val gapStart = (rawGapStart - 1L).coerceAtLeast(0L)
+    val gapEnd = rawGapEnd + 1L
+    if (gapEnd <= gapStart) return false
+    return findEnclosedFiguresInHtml(html, gapStart, gapEnd).isNotEmpty()
 }
 

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/highlights/HighlightsDomPatch.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/highlights/HighlightsDomPatch.kt
@@ -50,9 +50,12 @@ sealed class HighlightsDomPatch {
 internal fun buildRecolorJs(annotationId: String, accentCssRgba: String): String {
     val idJs = jsQuoteString(annotationId)
     val colorJs = jsQuoteString(accentCssRgba)
-    // Update both the paragraph and any adjacent aside sharing the same data-ann-id — the note's
-    // border-left uses the same accent colour by design. Setting borderLeftColor is enough since
-    // the width/style are already inline (4px solid / 2px solid respectively, set at build time).
+    // Update the paragraph, adjacent aside, AND figure block sharing the same data-ann-id — the
+    // aside's and figure's border-left uses the same accent colour by design. Setting
+    // borderLeftColor is enough since the width/style are already inline (4px solid / 2px solid
+    // respectively, set at build time). `closest('p, figure')` covers text highlights (span inside
+    // <p>), embedded figures inside a highlight (span inside <figure class="riffle-fig">), and the
+    // <figure> itself now that we tag it with data-ann-id (fix 2026-07-10).
     return """
         |(function(){
         |  var id = $idJs;
@@ -60,7 +63,8 @@ internal fun buildRecolorJs(annotationId: String, accentCssRgba: String): String
         |  var nodes = document.querySelectorAll('[data-ann-id="' + id + '"]');
         |  for (var i = 0; i < nodes.length; i++) {
         |    var el = nodes[i];
-        |    var host = el.tagName === 'ASIDE' ? el : el.closest('p');
+        |    var host = el.tagName === 'ASIDE' || el.tagName === 'FIGURE'
+        |      ? el : el.closest('p, figure');
         |    if (host) host.style.setProperty('border-left-color', color, 'important');
         |  }
         |})();
@@ -73,9 +77,13 @@ internal fun buildSetNoteJs(annotationId: String, accentCssRgba: String, noteTex
     val noteJs = if (noteText == null) "null" else jsQuoteString(noteText)
     // Look up the aside by its own data-ann-id (not by sibling-adjacency to the paragraph);
     // Readium's HTMLInjector sometimes lands wrappers/text nodes between the two, so an
-    // adjacency-only check misses the pair. When creating a new aside we still need the
-    // paragraph to know WHERE to insert (right after it), so we resolve `p` via the highlight
-    // span; insertion uses `p.nextSibling` which is safe even when p has no next element.
+    // adjacency-only check misses the pair.
+    //
+    // For a text-figure-text (or more generally multi-chunk) annotation the aside must sit AFTER
+    // the LAST DOM node that belongs to this annotation, not after the FIRST paragraph — otherwise
+    // the note visually splits the annotation body (bug 2026-07-10: "adding a note to a grouped
+    // annotation shows the note under the first text"). Find every element with this data-ann-id
+    // and anchor the insertion to the last one's parent block (its <p> or <figure> host).
     return """
         |(function(){
         |  var id = $idJs;
@@ -87,17 +95,22 @@ internal fun buildSetNoteJs(annotationId: String, accentCssRgba: String, noteTex
         |    return;
         |  }
         |  if (!aside) {
-        |    var hlSpan = document.querySelector('span.riffle-hl[data-ann-id="' + id + '"]');
-        |    if (!hlSpan) return;
-        |    var p = hlSpan.closest('p');
-        |    if (!p) return;
+        |    var nodes = document.querySelectorAll('[data-ann-id="' + id + '"]');
+        |    var anchorHost = null;
+        |    for (var i = nodes.length - 1; i >= 0; i--) {
+        |      var el = nodes[i];
+        |      if (el.tagName === 'ASIDE') continue;
+        |      anchorHost = el.tagName === 'FIGURE' ? el : el.closest('p, figure');
+        |      if (anchorHost) break;
+        |    }
+        |    if (!anchorHost) return;
         |    aside = document.createElement('aside');
         |    aside.setAttribute('class', 'riffle-note');
         |    aside.setAttribute('data-ann-id', id);
         |    aside.setAttribute('style',
         |      'border-left: 2px solid ' + color + ' !important; padding-left: 12px; ' +
         |      'font-style: italic; opacity: 0.75;');
-        |    p.parentNode.insertBefore(aside, p.nextSibling);
+        |    anchorHost.parentNode.insertBefore(aside, anchorHost.nextSibling);
         |  } else {
         |    aside.style.setProperty('border-left-color', color, 'important');
         |  }
@@ -124,6 +137,8 @@ internal fun buildRemoveJs(annotationId: String): String {
         |    var p = hlSpan.closest('p');
         |    if (p) p.remove();
         |  }
+        |  var figs = document.querySelectorAll('figure.riffle-fig[data-ann-id="' + id + '"]');
+        |  for (var i = 0; i < figs.length; i++) figs[i].remove();
         |})();
     """.trimMargin()
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/highlights/HighlightsDomPatch.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/highlights/HighlightsDomPatch.kt
@@ -132,13 +132,17 @@ internal fun buildRemoveJs(annotationId: String): String {
         |  var id = $idJs;
         |  var aside = document.querySelector('aside.riffle-note[data-ann-id="' + id + '"]');
         |  if (aside) aside.remove();
-        |  var hlSpan = document.querySelector('span.riffle-hl[data-ann-id="' + id + '"]');
-        |  if (hlSpan) {
-        |    var p = hlSpan.closest('p');
-        |    if (p) p.remove();
+        |  // Multi-chunk (text-figure-text) annotations emit multiple <span class="riffle-hl">
+        |  // wrappers, one per chunk. Removing only the first <p> would leave the other chunk(s)
+        |  // orphaned in the DOM. Iterate every match and drop each host <p>.
+        |  var spans = document.querySelectorAll('span.riffle-hl[data-ann-id="' + id + '"]');
+        |  var seen = [];
+        |  for (var i = 0; i < spans.length; i++) {
+        |    var p = spans[i].closest('p');
+        |    if (p && seen.indexOf(p) === -1) { seen.push(p); p.remove(); }
         |  }
         |  var figs = document.querySelectorAll('figure.riffle-fig[data-ann-id="' + id + '"]');
-        |  for (var i = 0; i < figs.length; i++) figs[i].remove();
+        |  for (var j = 0; j < figs.length; j++) figs[j].remove();
         |})();
     """.trimMargin()
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/highlights/HighlightsPublicationFactory.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/highlights/HighlightsPublicationFactory.kt
@@ -419,7 +419,12 @@ private fun appendFigureFigure(
     val accent = highlightBackgroundCss(colorToken)
     val idEscaped = annotationId.xmlEscape()
     val tapUrl = buildAnnotationTapUrl(annotationId).xmlEscape()
-    sb.append("  <figure class=\"riffle-fig\" style=\"border-left: 4px solid ")
+    // `data-ann-id` on the <figure> itself so the live DOM-patch pipeline (buildRecolorJs /
+    // buildRemoveJs in HighlightsDomPatch) can find and recolour or delete the figure block
+    // when the owning highlight is edited — without it, `document.querySelectorAll('[data-ann-id]')`
+    // only matches the inner tap span, and `.closest('p')` returns null so recolour no-ops.
+    sb.append("  <figure class=\"riffle-fig\" data-ann-id=\"").append(idEscaped)
+    sb.append("\" style=\"border-left: 4px solid ")
     sb.append(accent)
     sb.append(" !important; padding-left: 12px;\">\n")
     // Tap-dispatch strip over the accent bar, matching the text-paragraph tap seam. `pointer-events`

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/FigureTapScriptTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/FigureTapScriptTest.kt
@@ -66,4 +66,23 @@ class FigureTapScriptTest {
         // Regression: extending the script for long-press must not disturb the existing tap wiring.
         assertTrue(script.contains("window.RiffleFigureBridge.onFigureTap(JSON.stringify(p))"))
     }
+
+    /**
+     * Fix 2026-07-10: the capture-phase click handler must NOT swallow taps inside a synthesised
+     * Highlights-view figure block (`<figure class="riffle-fig">`), otherwise the accent-bar tap
+     * span's onclick can't fire and tapping the coloured bar opens the figure-zoom overlay
+     * instead of the annotation editor. `findFigure` walks up looking for that class first and
+     * returns null when it sees it, letting the tap propagate to the span's own onclick.
+     */
+    @Test
+    fun `findFigure skips elided-view figure blocks so the accent-bar tap can fire`() {
+        assertTrue(
+            "findFigure must recognise the highlights-view figure class",
+            script.contains("'riffle-fig'"),
+        )
+        assertTrue(
+            "findFigure must bail out when it walks into a riffle-fig ancestor",
+            script.contains("classList.contains('riffle-fig')"),
+        )
+    }
 }

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/HighlightMergeTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/HighlightMergeTest.kt
@@ -316,240 +316,111 @@ class HighlightMergeTest {
         assertTrue(isMergeEligible(a, n))
     }
 
-    // -------- Cross-figure merge (symmetric with text): pin the current behaviour --------
+    // -------- Cross-figure merge (revised 2026-07-10): reject when a figure sits between --------
 
     /**
-     * Two same-colour no-note text highlights on either side of a figure MUST be mergeable — the
-     * figure between them counts as zero readable chars in Readium's textBefore/textAfter and the
-     * user's mental model treats text-across-figure the same as text-across-nothing (memory
-     * `annotations-text-graph-symmetric`). This test pins that pre-existing text adjacency wins.
-     * The old figureGuard reversed this and shipped the wrong fix; this assertion would flip red
-     * if a "reject cross-figure text merge" gate were reintroduced.
+     * Two same-colour no-note text highlights on either side of a figure MUST NOT be mergeable
+     * (revised rule 2026-07-10). Void figures contribute zero readable chars, so [findAdjacency]'s
+     * textual check would report "adjacent"; [hasFigureInGap] catches the figure via the DOM walk
+     * and rejects the merge in [findAnyMergeableNeighbor]. Rationale: two separately-created
+     * highlights represent independent user actions — merging them would silently annotate the
+     * figure between them. This assertion would flip red if the figure-gap check regressed.
      */
     @Test
-    fun `same-colour text highlights on either side of a figure merge as ordinary neighbours`() {
+    fun `same-colour text highlights on either side of a figure are NOT merged when html shows a figure in the gap`() {
+        val html = """
+            <html><body>
+              <p>To characterize this in a crude mathematical way:</p>
+              <div><img src="OEBPS/g.png" alt=""/></div>
+              <p>The overall complexity of a system.</p>
+            </body></html>
+        """.trimIndent()
         val anchor = anchor(
-            textSnippet = "The overall complexity of a system (C) is determined by the complexity",
-            textBefore = "characterize this in a crude mathematical way:",
-            textAfter = " of each part.",
+            textSnippet = "The overall complexity of a system.",
+            textBefore = "way:",
+            textAfter = "",
         )
         val neighbor = annotation(
             id = "before-fig",
             textSnippet = "To characterize this in a crude mathematical way:",
             textAfter = "The overall complexity of a system",
         )
-        val match = findAnyMergeableNeighbor(anchor, listOf(neighbor), excludeIds = emptySet())
-        assertNotNull("cross-figure text adjacency must merge — figure is invisible to the text stream", match)
+        val textOnlyMatch = findAdjacency(anchor, neighbor)
+        assertNotNull("text stream still reports adjacency — figure is void", textOnlyMatch)
+        val htmlAwareMatch = findAnyMergeableNeighbor(
+            anchor,
+            listOf(neighbor),
+            excludeIds = emptySet(),
+            html = html,
+        )
+        assertNull(
+            "with html available, a figure in the gap must block the merge",
+            htmlAwareMatch,
+        )
+    }
+
+    /**
+     * When no figure sits between the two ranges, [hasFigureInGap] returns false and the merge
+     * proceeds as before. Guards against over-eager rejection.
+     */
+    @Test
+    fun `text highlights with no figure between still merge when html is provided`() {
+        val html = """
+            <html><body>
+              <p>To characterize this in a crude mathematical way:The overall complexity of a system.</p>
+            </body></html>
+        """.trimIndent()
+        val anchor = anchor(
+            textSnippet = "The overall complexity of a system.",
+            textBefore = "way:",
+            textAfter = "",
+        )
+        val neighbor = annotation(
+            id = "adjacent",
+            textSnippet = "To characterize this in a crude mathematical way:",
+            textAfter = "The overall complexity of a system",
+        )
+        val match = findAnyMergeableNeighbor(
+            anchor,
+            listOf(neighbor),
+            excludeIds = emptySet(),
+            html = html,
+        )
+        assertNotNull("no figure in the gap → merge should still happen", match)
         assertEquals(MergeSide.CANDIDATE_BEFORE_ANCHOR, match!!.side)
     }
 
-    // -------- Figure absorption (2026-07-09) --------
+    // -------- Standalone TYPE_IMAGE candidates are never auto-merged (revised 2026-07-10) --------
 
     /**
-     * Text highlight covering a figure absorbs a redundant standalone TYPE_IMAGE annotation at
-     * that figure. Would flip red if [findAbsorbableImageAnnotations] stops matching enclosed
-     * figures by filename — the exact regression from removing the fix.
+     * A standalone TYPE_IMAGE annotation (long-press-created) is NOT eligible for auto-merge into
+     * an adjacent text highlight. Under the revised rule, the figure only becomes part of a
+     * highlight when the user's single selection covers text on both sides of the figure at
+     * creation time; long-press-created figure annotations represent distinct intent and stay
+     * separate.
      */
     @Test
-    fun `text highlight enclosing a figure absorbs the standalone image annotation on it`() {
-        val html = """
-            <html><body>
-              <p>Before figure text goes here.</p>
-              <div><img src="OEBPS/g.png" alt=""/></div>
-              <p>After figure text extends beyond.</p>
-            </body></html>
-        """.trimIndent()
-        val standaloneImage = annotation(
-            id = "img-1",
-            color = "yellow",
-            textSnippet = "the figure caption",
-            type = AnnotationEntity.TYPE_IMAGE,
-        ).copy(imageHref = "OEBPS/g.png")
-        val pool = listOf(standaloneImage)
-        val absorbable = findAbsorbableImageAnnotations(
-            html = html,
-            snippet = "Before figure text goes here.After figure text extends beyond.",
-            textBefore = "",
-            color = "yellow",
-            chapterHref = "ch1.xhtml",
-            pool = pool,
-            excludeIds = emptySet(),
-        )
-        assertEquals(listOf("img-1"), absorbable.map { it.id })
-    }
-
-    /**
-     * Figure sitting at the range endpoint (touching but not covered) is still absorbable — the
-     * widening by 1 char catches boundary figures. Removing the widening would flip this red.
-     */
-    @Test
-    fun `image annotation at range boundary is absorbable via widened check`() {
-        val html = """
-            <html><body>
-              <p>Only text here.</p>
-              <div><img src="OEBPS/g.png" alt=""/></div>
-              <p>More text.</p>
-            </body></html>
-        """.trimIndent()
-        val standaloneImage = annotation(
-            id = "img-1",
-            color = "yellow",
-            textSnippet = "",
-            type = AnnotationEntity.TYPE_IMAGE,
-        ).copy(imageHref = "OEBPS/g.png")
-        // Highlight snippet is "Only text here." — its end coincides with the figure position.
-        val absorbable = findAbsorbableImageAnnotations(
-            html = html,
-            snippet = "Only text here.",
-            textBefore = "",
-            color = "yellow",
-            chapterHref = "ch1.xhtml",
-            pool = listOf(standaloneImage),
-            excludeIds = emptySet(),
-        )
-        assertEquals(listOf("img-1"), absorbable.map { it.id })
-    }
-
-    /** Different colours are NOT absorbable — the same-colour eligibility rule applies. */
-    @Test
-    fun `image annotation with mismatching colour is not absorbable`() {
-        val html = """
-            <html><body>
-              <p>Text before.</p>
-              <div><img src="OEBPS/g.png" alt=""/></div>
-              <p>Text after.</p>
-            </body></html>
-        """.trimIndent()
-        val bluePool = listOf(
-            annotation(
-                id = "img-1",
-                color = "blue",
-                textSnippet = "",
-                type = AnnotationEntity.TYPE_IMAGE,
-            ).copy(imageHref = "OEBPS/g.png"),
-        )
-        val absorbable = findAbsorbableImageAnnotations(
-            html = html,
-            snippet = "Text before.Text after.",
-            textBefore = "",
-            color = "yellow",
-            chapterHref = "ch1.xhtml",
-            pool = bluePool,
-            excludeIds = emptySet(),
-        )
-        assertTrue(absorbable.isEmpty())
-    }
-
-    /** Image annotation with a note is NOT absorbable — user has meaningful data on it. */
-    @Test
-    fun `image annotation with a note is not absorbable`() {
-        val html = """
-            <html><body>
-              <p>Text before.</p>
-              <div><img src="OEBPS/g.png" alt=""/></div>
-              <p>Text after.</p>
-            </body></html>
-        """.trimIndent()
-        val notedPool = listOf(
-            annotation(
-                id = "img-1",
-                color = "yellow",
-                note = "Important observation about this graph",
-                textSnippet = "",
-                type = AnnotationEntity.TYPE_IMAGE,
-            ).copy(imageHref = "OEBPS/g.png"),
-        )
-        val absorbable = findAbsorbableImageAnnotations(
-            html = html,
-            snippet = "Text before.Text after.",
-            textBefore = "",
-            color = "yellow",
-            chapterHref = "ch1.xhtml",
-            pool = notedPool,
-            excludeIds = emptySet(),
-        )
-        assertTrue(absorbable.isEmpty())
-    }
-
-    // -------- Figure candidates (findFigureAdjacency + findAnyMergeableNeighbor with html) --------
-
-    /**
-     * A text highlight touching a figure absorbs the standalone TYPE_IMAGE candidate as a
-     * mergeable neighbour via [findFigureAdjacency]. Symmetric with text-neighbour merging: the
-     * candidate is returned by [findAnyMergeableNeighbor] when it's given the chapter HTML.
-     */
-    @Test
-    fun `TYPE_IMAGE candidate at highlight range boundary is returned as a mergeable neighbour`() {
-        val html = """
-            <html><body>
-              <p>The paragraph text before the figure.</p>
-              <div><img src="OEBPS/g.png" alt=""/></div>
-              <p>The paragraph after the figure.</p>
-            </body></html>
-        """.trimIndent()
-        val anchor = anchor(
-            color = "yellow",
-            textSnippet = "The paragraph text before the figure.",
-            textBefore = "",
-        )
-        val figureCandidate = annotation(
+    fun `standalone TYPE_IMAGE candidate is never eligible for auto-merge`() {
+        val a = anchor(color = "yellow", textSnippet = "Some text", textAfter = "")
+        val img = annotation(
             id = "img-1",
             color = "yellow",
             type = AnnotationEntity.TYPE_IMAGE,
         ).copy(imageHref = "OEBPS/g.png")
+        assertEquals(false, isMergeEligible(a, img))
+        val html = """
+            <html><body>
+              <p>Some text</p>
+              <div><img src="OEBPS/g.png" alt=""/></div>
+            </body></html>
+        """.trimIndent()
         val match = findAnyMergeableNeighbor(
-            anchor,
-            listOf(figureCandidate),
+            a,
+            listOf(img),
             excludeIds = emptySet(),
             html = html,
         )
-        assertNotNull("figure at range boundary must be mergeable when html is provided", match)
-        assertEquals("img-1", match!!.neighbor.id)
+        assertNull("TYPE_IMAGE candidates are not auto-merged, even with html", match)
     }
 
-    /** No chapter HTML → TYPE_IMAGE candidates are silently skipped, text-only pool works. */
-    @Test
-    fun `findAnyMergeableNeighbor without html skips TYPE_IMAGE candidates`() {
-        val anchor = anchor(color = "yellow", textSnippet = "Foo", textAfter = " Bar")
-        val figureCandidate = annotation(
-            id = "img-1",
-            color = "yellow",
-            type = AnnotationEntity.TYPE_IMAGE,
-        ).copy(imageHref = "OEBPS/g.png")
-        val match = findAnyMergeableNeighbor(anchor, listOf(figureCandidate), excludeIds = emptySet())
-        assertNull("no html → image candidate skipped", match)
-    }
-
-    /**
-     * A TYPE_IMAGE candidate whose figure sits neither inside nor touching the anchor's range is
-     * NOT adjacent. Would flip red if the widening in [findFigureAdjacency] were unbounded.
-     */
-    @Test
-    fun `TYPE_IMAGE candidate whose figure is far from the anchor's range is not adjacent`() {
-        val html = """
-            <html><body>
-              <p>Paragraph one with the highlight.</p>
-              <p>Paragraph two, unrelated.</p>
-              <div><img src="OEBPS/g.png" alt=""/></div>
-              <p>Paragraph three.</p>
-            </body></html>
-        """.trimIndent()
-        val anchor = anchor(
-            color = "yellow",
-            textSnippet = "Paragraph one",
-            textBefore = "",
-        )
-        val figureCandidate = annotation(
-            id = "img-1",
-            color = "yellow",
-            type = AnnotationEntity.TYPE_IMAGE,
-        ).copy(imageHref = "OEBPS/g.png")
-        val match = findAnyMergeableNeighbor(
-            anchor,
-            listOf(figureCandidate),
-            excludeIds = emptySet(),
-            html = html,
-        )
-        assertNull("figure far from anchor must NOT be adjacent", match)
-    }
 }

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/highlights/HighlightsDomPatchTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/highlights/HighlightsDomPatchTest.kt
@@ -18,7 +18,14 @@ class HighlightsDomPatchTest {
         // The recolour must touch BOTH the paragraph (via closest('p')) AND any aside that
         // carries the same data-ann-id — otherwise a note's border colour drifts from the bar.
         assertTrue("recolor JS must find nodes by data-ann-id", js.contains("data-ann-id="))
-        assertTrue("recolor JS must fall through to the paragraph via closest('p')", js.contains("closest('p')"))
+        assertTrue(
+            "recolor JS must fall through to the paragraph OR figure via closest('p, figure')",
+            js.contains("closest('p, figure')"),
+        )
+        assertTrue(
+            "recolor JS must treat a <figure> host as directly-target-able (fix 2026-07-10)",
+            js.contains("FIGURE"),
+        )
         assertTrue("recolor JS must set border-left-color", js.contains("border-left-color"))
         assertTrue("recolor JS must use setProperty with 'important' to defeat ReadiumCSS theming",
             js.contains("'important'") || js.contains("!important"))
@@ -37,6 +44,14 @@ class HighlightsDomPatchTest {
         assertTrue("must look up the existing aside by its own data-ann-id (adjacency is unreliable through Readium's HTMLInjector)",
             js.contains("aside.riffle-note[data-ann-id="))
         assertTrue("must update textContent (not innerHTML — avoid injection)", js.contains("textContent"))
+        // Fix 2026-07-10: for text-figure-text annotations the aside must sit after the LAST
+        // element carrying this data-ann-id, not the first — otherwise the note splits the
+        // annotation body. Loop from `nodes.length - 1` picks the last host block; the guard
+        // skips any existing aside with the same id so we don't chain a second aside onto the first.
+        assertTrue(
+            "SetNote must scan nodes from the END to place the aside after the last chunk",
+            js.contains("i = nodes.length - 1"),
+        )
     }
 
     @Test
@@ -66,6 +81,10 @@ class HighlightsDomPatchTest {
         assertTrue("Remove JS must look up the aside directly by data-ann-id",
             js.contains("aside.riffle-note[data-ann-id="))
         assertTrue(js.contains("closest('p')"))
+        assertTrue(
+            "Remove JS must also drop any figure.riffle-fig block carrying this id (fix 2026-07-10)",
+            js.contains("figure.riffle-fig[data-ann-id="),
+        )
     }
 
     @Test

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/highlights/HighlightsDomPatchTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/highlights/HighlightsDomPatchTest.kt
@@ -85,6 +85,13 @@ class HighlightsDomPatchTest {
             "Remove JS must also drop any figure.riffle-fig block carrying this id (fix 2026-07-10)",
             js.contains("figure.riffle-fig[data-ann-id="),
         )
+        // Multi-chunk annotations (text-figure-text) emit MULTIPLE <span class="riffle-hl"> — a
+        // querySelector would only drop the first chunk's <p>. Remove JS must loop over every
+        // match and drop each host paragraph.
+        assertTrue(
+            "Remove JS must iterate span.riffle-hl matches (querySelectorAll) to catch every chunk",
+            js.contains("querySelectorAll('span.riffle-hl["),
+        )
     }
 
     @Test

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/highlights/HighlightsPublicationFactoryImageTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/highlights/HighlightsPublicationFactoryImageTest.kt
@@ -257,7 +257,7 @@ class HighlightsPublicationFactoryImageTest {
         val yellowRgba = HighlightColor.YELLOW.argb.toCssRgba()
         assertTrue(
             "figure must carry coloured border-left in its inline style",
-            html.contains("<figure class=\"riffle-fig\" style=\"border-left: 4px solid $yellowRgba"),
+            html.contains("<figure class=\"riffle-fig\" data-ann-id=\"${ann.id}\" style=\"border-left: 4px solid $yellowRgba"),
         )
         assertTrue(
             "figure must carry the tap-dispatch span with the annotation id",
@@ -294,7 +294,7 @@ class HighlightsPublicationFactoryImageTest {
         val figureBlock = html.substring(figureBlockStart)
         assertTrue(
             "embedded figure must inherit owner's colour on border-left",
-            figureBlock.startsWith("<figure class=\"riffle-fig\" style=\"border-left: 4px solid $blueRgba"),
+            figureBlock.startsWith("<figure class=\"riffle-fig\" data-ann-id=\"hl-1\" style=\"border-left: 4px solid $blueRgba"),
         )
         assertTrue(
             "embedded figure's tap span must carry owning-highlight id",


### PR DESCRIPTION
## Summary

Reverses the "text↔graph symmetric" merge model shipped in #476. A figure now becomes part of a highlight **only** when the user's single selection spans it — two same-colour text highlights either side of a figure no longer auto-merge, and no longer absorb the figure between them. Standalone `TYPE_IMAGE` annotations are never auto-swept into a same-colour text highlight either.

Includes several elided-view + annotations-list rendering polish fixes that surfaced during the change:

- **Rule reversal (`HighlightMerge`, `EpubReaderViewModel`)**: `isMergeEligible` rejects `TYPE_IMAGE`; `findAnyMergeableNeighbor` runs `hasFigureInGap` after text-adjacency and blocks any merge whose DOM gap contains a figure; the old `findFigureAdjacency` / `findAbsorbableImageAnnotations` / `absorbFigureIntoAdjacentHighlight` paths are removed.
- **Merged bytes preservation**: `buildMergedEmbeddedFigures` now indexes every source row's `embeddedFigures` (anchor + all absorbed neighbours) so a merge that pulls in a text-figure-text highlight keeps the captured raster bytes.
- **Elided view — figure recolour on edit**: `<figure class="riffle-fig">` carries `data-ann-id`; `buildRecolorJs` handles `FIGURE` hosts via `closest('p, figure')`; `buildRemoveJs` drops matching figure blocks and iterates every chunk `<p>` (multi-chunk annotations no longer leave orphan paragraphs); `buildSetNoteJs` places the note aside after the last DOM element of the annotation instead of after the first `<p>`.
- **Elided view — tap dispatch**: `FigureTapScript.findFigure` returns null when it walks into a `.riffle-fig` ancestor, so the accent-bar tap span's `onclick` opens the annotation editor instead of the figure-zoom overlay.
- **Annotations list**: chunks are trimmed before rendering so Readium's `\n\n\n` paragraph-break marker doesn't manifest as blank lines around inline figures; colour dot is centre-aligned on non-bookmark rows so multi-line / text-figure-text annotations no longer pin it to the first line.

## Test plan

- [x] `./gradlew test` (all modules) green
- [x] `HighlightMergeTest`: cross-figure text-adjacency blocked when html shows a figure in the gap; no-figure gap still merges; TYPE_IMAGE never eligible
- [x] `HighlightsDomPatchTest`: Recolor JS targets `p, figure` hosts + `FIGURE` tags; Remove JS iterates `span.riffle-hl` matches + drops matching `figure.riffle-fig`; SetNote JS walks nodes from the end
- [x] `HighlightsPublicationFactoryImageTest`: figure element carries `data-ann-id`; embedded-figure `<figure>` inherits owner colour + id
- [x] `FigureTapScriptTest`: `findFigure` skips `riffle-fig` ancestors
- [ ] Device: verify grouped annotation edits repaint the figure border, deleting a text-figure-text annotation clears every chunk from the elided DOM, and tapping the figure's accent bar opens the editor (not the zoom overlay)

## Memory

- Updated `feedback_annotations_text_graph_symmetric.md` to reflect the 2026-07-10 reversal.