### PR TITLE
feat(ui): capability-gate every Source-conditional surface

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemDetailScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemDetailScreen.kt
@@ -196,6 +196,7 @@ fun LibraryItemDetailScreen(
                     LibraryItemDetailContentPhoneLandscape(
                         item = state.item,
                         seriesId = state.seriesId,
+                        capabilities = state.capabilities,
                         onFacet = onFacet,
                         onSeriesClick = onSeriesClick,
                         isInToRead = state.isInToRead,
@@ -227,6 +228,7 @@ fun LibraryItemDetailScreen(
                     LibraryItemDetailContentTablet(
                         item = state.item,
                         seriesId = state.seriesId,
+                        capabilities = state.capabilities,
                         onFacet = onFacet,
                         onSeriesClick = onSeriesClick,
                         isInToRead = state.isInToRead,
@@ -258,6 +260,7 @@ fun LibraryItemDetailScreen(
                     LibraryItemDetailContent(
                         item = state.item,
                         seriesId = state.seriesId,
+                        capabilities = state.capabilities,
                         onFacet = onFacet,
                         onSeriesClick = onSeriesClick,
                         isInToRead = state.isInToRead,
@@ -320,6 +323,7 @@ private fun CollapsibleDescription(description: String) {
 private fun LibraryItemDetailContent(
     item: LibraryItem,
     seriesId: String?,
+    capabilities: DetailCapabilities = DetailCapabilities.All,
     onFacet: (FacetType, String) -> Unit,
     onSeriesClick: (String, String) -> Unit,
     isInToRead: Boolean,
@@ -396,6 +400,7 @@ private fun LibraryItemDetailContent(
         ActionRow(
             item = item,
             isInToRead = isInToRead,
+            capabilities = capabilities,
             downloadState = downloadState,
             isCachedOrDownloaded = isCachedOrDownloaded,
             isOffline = isOffline,
@@ -421,8 +426,10 @@ private fun LibraryItemDetailContent(
         )
         AuthorByline(author = item.author, onAuthorClick = { onFacet(FacetType.AUTHOR, it) })
 
-        item.seriesName?.let { series ->
-            SeriesLine(seriesName = series, seriesId = seriesId, onSeriesClick = onSeriesClick)
+        if (capabilities.hasSeries) {
+            item.seriesName?.let { series ->
+                SeriesLine(seriesName = series, seriesId = seriesId, onSeriesClick = onSeriesClick)
+            }
         }
 
         // TOC row — EPUB items only; hidden if TOC loaded as empty
@@ -537,6 +544,7 @@ private fun formatAudiobookDuration(durationSec: Double): String {
 internal fun LibraryItemDetailContentTablet(
     item: LibraryItem,
     seriesId: String? = null,
+    capabilities: DetailCapabilities = DetailCapabilities.All,
     onFacet: (FacetType, String) -> Unit = { _, _ -> },
     onSeriesClick: (String, String) -> Unit = { _, _ -> },
     isInToRead: Boolean,
@@ -619,6 +627,7 @@ internal fun LibraryItemDetailContentTablet(
             ActionRow(
                 item = item,
                 isInToRead = isInToRead,
+                capabilities = capabilities,
                 downloadState = downloadState,
                 isCachedOrDownloaded = isCachedOrDownloaded,
                 isOffline = isOffline,
@@ -699,8 +708,10 @@ internal fun LibraryItemDetailContentTablet(
             item.description?.takeIf { it.isNotBlank() }?.let { desc ->
                 CollapsibleDescription(desc)
             }
-            item.seriesName?.let { series ->
-                SeriesLine(seriesName = series, seriesId = seriesId, onSeriesClick = onSeriesClick)
+            if (capabilities.hasSeries) {
+                item.seriesName?.let { series ->
+                    SeriesLine(seriesName = series, seriesId = seriesId, onSeriesClick = onSeriesClick)
+                }
             }
             MetadataLines(item = item, onFacet = onFacet)
         }
@@ -739,6 +750,7 @@ internal fun LibraryItemDetailContentTablet(
 internal fun LibraryItemDetailContentPhoneLandscape(
     item: LibraryItem,
     seriesId: String? = null,
+    capabilities: DetailCapabilities = DetailCapabilities.All,
     onFacet: (FacetType, String) -> Unit = { _, _ -> },
     onSeriesClick: (String, String) -> Unit = { _, _ -> },
     isInToRead: Boolean,
@@ -808,8 +820,10 @@ internal fun LibraryItemDetailContentPhoneLandscape(
                 onReadaloudClick = { onFacet(FacetType.READALOUD, "all") },
             )
             AuthorByline(author = item.author, onAuthorClick = { onFacet(FacetType.AUTHOR, it) })
-            item.seriesName?.let { series ->
-                SeriesLine(seriesName = series, seriesId = seriesId, onSeriesClick = onSeriesClick)
+            if (capabilities.hasSeries) {
+                item.seriesName?.let { series ->
+                    SeriesLine(seriesName = series, seriesId = seriesId, onSeriesClick = onSeriesClick)
+                }
             }
             if (item.isListenable && item.audioDurationSec > 0) {
                 AudiobookDurationLine(item.audioDurationSec, item.readingProgress)
@@ -820,6 +834,7 @@ internal fun LibraryItemDetailContentPhoneLandscape(
             ActionRow(
                 item = item,
                 isInToRead = isInToRead,
+                capabilities = capabilities,
                 downloadState = downloadState,
                 isCachedOrDownloaded = isCachedOrDownloaded,
                 isOffline = isOffline,
@@ -1028,6 +1043,7 @@ private fun FacetValue(
 private fun ActionRow(
     item: LibraryItem,
     isInToRead: Boolean,
+    capabilities: DetailCapabilities = DetailCapabilities.All,
     downloadState: DownloadState,
     isCachedOrDownloaded: Boolean,
     isOffline: Boolean,
@@ -1047,8 +1063,12 @@ private fun ActionRow(
 ) {
     // An item may be readable (has an ebook), listenable (an Audiobook — ADR 0029), both (a
     // combined item), or neither. The action row offers Read and Listen independently; only a wholly
-    // un-openable item shows the empty-state message.
-    if (!item.isPlayable) {
+    // un-openable item shows the empty-state message. When the active Source lacks
+    // AudiobookMediaCapability (e.g. LocalFiles has no audiobook player yet, issue #439), a nominally
+    // listenable item is treated as un-openable on the listen side — no Listen button, and if there's
+    // also no readable ebook the empty-state message wins.
+    val effectivelyListenable = item.isListenable && capabilities.hasAudiobookMedia
+    if (!item.isReadable && !effectivelyListenable) {
         Text(
             text = "Nothing to read or listen to for this item on the server.",
             style = MaterialTheme.typography.bodyLarge,
@@ -1086,7 +1106,7 @@ private fun ActionRow(
                 }
             }
         }
-        if (item.isListenable) {
+        if (item.isListenable && capabilities.hasAudiobookMedia) {
             // The audiobook player resolves download > bundle > ABS stream (ADR 0029), so Listen needs
             // connectivity only when neither a dedicated audiobook download nor a readaloud bundle is
             // present locally — either local source plays offline.
@@ -1118,10 +1138,12 @@ private fun ActionRow(
             onMarkAsRead = onMarkAsRead,
             onMarkAsUnread = onMarkAsUnread,
         )
-        ToReadToggleButton(
-            isInToRead = isInToRead,
-            onToggle = onToggleToRead,
-        )
+        if (capabilities.hasPlaylists) {
+            ToReadToggleButton(
+                isInToRead = isInToRead,
+                onToggle = onToggleToRead,
+            )
+        }
         // The base DownloadButton manages the ABS EPUB, so it only applies to a readable item. A
         // matched ABS item additionally gets the ReadaloudDownloadButton below, which fetches the
         // Storyteller synced bundle (ADR 0023/0026) for audio + highlight.

--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModel.kt
@@ -19,6 +19,10 @@ import com.riffle.core.domain.usecase.MarkReadAcrossDimensions
 import com.riffle.core.domain.usecase.RecordItemOpened
 import com.riffle.core.domain.usecase.UpdateReadingProgress
 import com.riffle.core.data.ToReadRepository
+import com.riffle.core.catalog.AudiobookMediaCapability
+import com.riffle.core.catalog.CatalogRegistry
+import com.riffle.core.catalog.PlaylistsCapability
+import com.riffle.core.catalog.SeriesCapability
 import com.riffle.core.domain.SourceRepository
 import com.riffle.core.domain.TocEntry
 import com.riffle.core.domain.TokenStorage
@@ -50,8 +54,29 @@ sealed interface LibraryItemDetailUiState {
         // True when the device is currently offline. Reactive — updated via combine with
         // ConnectivityObserver.isOnline in the ViewModel.
         val isOffline: Boolean = false,
+        // Capability snapshot for the item's Source. Composables gate the Series chip / Listen
+        // button / To Read icon on these instead of the item shape alone (issue #439). A Source
+        // that lacks the capability hides the surface even when the item nominally supports it
+        // (e.g. an audiobook file dropped into a LocalFiles Source: `isListenable` is true, but
+        // `hasAudiobookMedia` is false, so no Listen button appears — LocalFiles has no player yet).
+        val capabilities: DetailCapabilities = DetailCapabilities.Empty,
     ) : LibraryItemDetailUiState
     data object Error : LibraryItemDetailUiState
+}
+
+/** Per-Source capability flags consumed by the item-detail screen. */
+data class DetailCapabilities(
+    val hasSeries: Boolean,
+    val hasPlaylists: Boolean,
+    val hasAudiobookMedia: Boolean,
+) {
+    companion object {
+        /** Every capability present — matches the ABS shape used by the majority of items. */
+        val All = DetailCapabilities(hasSeries = true, hasPlaylists = true, hasAudiobookMedia = true)
+
+        /** No capability present — safe default when the active Source's Catalog can't be resolved. */
+        val Empty = DetailCapabilities(hasSeries = false, hasPlaylists = false, hasAudiobookMedia = false)
+    }
 }
 
 sealed interface DownloadState {
@@ -104,6 +129,7 @@ class LibraryItemDetailViewModel @Inject constructor(
     private val sidecarPrefetcher: com.riffle.core.data.ReadaloudSidecarPrefetcher,
     private val extractEpubTocUseCase: ExtractEpubTocUseCase,
     private val fetchAudiobookChaptersUseCase: FetchAudiobookChaptersUseCase,
+    private val catalogRegistry: CatalogRegistry,
 ) : ViewModel() {
 
     private val itemId: String = savedStateHandle.get<String>("itemId") ?: ""
@@ -186,12 +212,21 @@ class LibraryItemDetailViewModel @Inject constructor(
                     // the detail screen stuck in Loading for the network timeout (~10s).
                     val isInToRead = toReadRepository.isInToRead(item.id, item.libraryId)
                     val seriesId = item.seriesName?.let { libraryObserver.getSeriesIdForItem(item.sourceId, item.id) }
+                    // Raw `is` checks (see LibraryItemsViewModel.tabVisibility for the JVM-target
+                    // rationale).
+                    val catalog = server?.let { catalogRegistry.forSource(it) }
+                    val capabilities = DetailCapabilities(
+                        hasSeries = catalog is SeriesCapability,
+                        hasPlaylists = catalog is PlaylistsCapability,
+                        hasAudiobookMedia = catalog is AudiobookMediaCapability,
+                    )
                     LibraryItemDetailUiState.Ready(
                         item = item,
                         seriesId = seriesId,
                         isInToRead = isInToRead,
                         isCachedOrDownloaded = isCachedOrDownloaded,
                         isOffline = !connectivityObserver.isOnline.value,
+                        capabilities = capabilities,
                     )
                 } else {
                     LibraryItemDetailUiState.Error

--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModel.kt
@@ -212,9 +212,13 @@ class LibraryItemDetailViewModel @Inject constructor(
                     // the detail screen stuck in Loading for the network timeout (~10s).
                     val isInToRead = toReadRepository.isInToRead(item.id, item.libraryId)
                     val seriesId = item.seriesName?.let { libraryObserver.getSeriesIdForItem(item.sourceId, item.id) }
-                    // Raw `is` checks (see LibraryItemsViewModel.tabVisibility for the JVM-target
-                    // rationale).
-                    val catalog = server?.let { catalogRegistry.forSource(it) }
+                    // Key capabilities off the item's OWN Source, not the currently-active one.
+                    // Details screens outlive Source switches (deep-links from Annotations across
+                    // Sources, an item pinned to a specific Source while another is active) — using
+                    // getActive() would surface ABS-shape controls for a LocalFiles item, or vice
+                    // versa. Raw `is` checks (see LibraryItemsViewModel.tabVisibility for the
+                    // JVM-target rationale).
+                    val catalog = catalogRegistry.forSourceId(item.sourceId)
                     val capabilities = DetailCapabilities(
                         hasSeries = catalog is SeriesCapability,
                         hasPlaylists = catalog is PlaylistsCapability,

--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsScreen.kt
@@ -165,6 +165,7 @@ fun LibraryItemsScreen(
     val isLoading by viewModel.isLoading.collectAsState()
     val linkedItemIds by viewModel.linkedItemIds.collectAsState()
     val notStartedFilterActive by viewModel.notStartedFilterActive.collectAsState()
+    val tabVisibility by viewModel.tabVisibility.collectAsState()
 
     val coversAreSquare by viewModel.coversAreSquare.collectAsState()
     // Versioned key: v2 = post-Annotations-tab-insertion. Without the version bump, a user
@@ -172,6 +173,12 @@ fun LibraryItemsScreen(
     // (also index 2) after the shuffle. Bumping the key discards the old saved int and resets
     // everyone to Home on first launch after upgrade.
     var selectedTab by rememberSaveable(key = "library_selected_tab_v2") { mutableIntStateOf(0) }
+
+    // Reset to Home when the previously-selected tab is no longer visible for the active Source
+    // (e.g. user was on Series, then switched to a LocalFiles Source that lacks SeriesCapability).
+    LaunchedEffect(tabVisibility) {
+        if (!isTabVisible(selectedTab, tabVisibility)) selectedTab = 0
+    }
 
     // Drive the grids off a local live scale so a pinch reflows instantly; the
     // persisted value (collected here) seeds it and wins on any external change.
@@ -237,7 +244,11 @@ fun LibraryItemsScreen(
         },
         bottomBar = {
             if (searchQuery.isEmpty()) {
-                LibraryTabBar(selectedTab = selectedTab, onTabSelected = { selectedTab = it })
+                LibraryTabBar(
+                    selectedTab = selectedTab,
+                    onTabSelected = { selectedTab = it },
+                    visibility = tabVisibility,
+                )
             }
         },
     ) { padding ->
@@ -1234,34 +1245,57 @@ internal fun LibraryItemCard(
  */
 internal fun tabIndexForAnnotations(): Int = 2
 
+/**
+ * True when the tab currently rendered at [selectedTab] is still valid given the active Source's
+ * [visibility]. Callers use this to fall back to Home (index 0) after a Source switch hides the
+ * previously-selected tab. Home / Annotations / All Books are always visible.
+ */
+internal fun isTabVisible(selectedTab: Int, visibility: LibraryTabVisibility): Boolean =
+    when (selectedTab) {
+        1 -> visibility.toRead
+        3 -> visibility.series
+        4 -> visibility.collections
+        else -> true
+    }
+
 @Composable
-private fun LibraryTabBar(selectedTab: Int, onTabSelected: (Int) -> Unit) {
+private fun LibraryTabBar(
+    selectedTab: Int,
+    onTabSelected: (Int) -> Unit,
+    visibility: LibraryTabVisibility,
+) {
     NavigationBar {
         NavigationBarItem(
             selected = selectedTab == 0,
             onClick = { onTabSelected(0) },
             icon = { Icon(Icons.Filled.Home, contentDescription = "Home") },
         )
-        NavigationBarItem(
-            selected = selectedTab == 1,
-            onClick = { onTabSelected(1) },
-            icon = { Icon(RiffleIcons.ToReadFilled, contentDescription = "To Read") },
-        )
+        if (visibility.toRead) {
+            NavigationBarItem(
+                selected = selectedTab == 1,
+                onClick = { onTabSelected(1) },
+                icon = { Icon(RiffleIcons.ToReadFilled, contentDescription = "To Read") },
+            )
+        }
         NavigationBarItem(
             selected = selectedTab == tabIndexForAnnotations(),
             onClick = { onTabSelected(tabIndexForAnnotations()) },
             icon = { Icon(RiffleIcons.Annotations, contentDescription = "Annotations") },
         )
-        NavigationBarItem(
-            selected = selectedTab == 3,
-            onClick = { onTabSelected(3) },
-            icon = { Icon(Icons.Filled.FormatListNumbered, contentDescription = "Series") },
-        )
-        NavigationBarItem(
-            selected = selectedTab == 4,
-            onClick = { onTabSelected(4) },
-            icon = { Icon(Icons.Filled.Folder, contentDescription = "Collections") },
-        )
+        if (visibility.series) {
+            NavigationBarItem(
+                selected = selectedTab == 3,
+                onClick = { onTabSelected(3) },
+                icon = { Icon(Icons.Filled.FormatListNumbered, contentDescription = "Series") },
+            )
+        }
+        if (visibility.collections) {
+            NavigationBarItem(
+                selected = selectedTab == 4,
+                onClick = { onTabSelected(4) },
+                icon = { Icon(Icons.Filled.Folder, contentDescription = "Collections") },
+            )
+        }
         NavigationBarItem(
             selected = selectedTab == 5,
             onClick = { onTabSelected(5) },

--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsScreen.kt
@@ -176,8 +176,11 @@ fun LibraryItemsScreen(
 
     // Reset to Home when the previously-selected tab is no longer visible for the active Source
     // (e.g. user was on Series, then switched to a LocalFiles Source that lacks SeriesCapability).
+    // Skip while tabVisibility is null (Catalog still resolving) so a `rememberSaveable`-restored
+    // selectedTab isn't silently clobbered before the real capability set lands.
     LaunchedEffect(tabVisibility) {
-        if (!isTabVisible(selectedTab, tabVisibility)) selectedTab = 0
+        val visibility = tabVisibility ?: return@LaunchedEffect
+        if (!isTabVisible(selectedTab, visibility)) selectedTab = 0
     }
 
     // Drive the grids off a local live scale so a pinch reflows instantly; the
@@ -244,10 +247,15 @@ fun LibraryItemsScreen(
         },
         bottomBar = {
             if (searchQuery.isEmpty()) {
+                // Fall back to the full ABS-shape while the active Catalog is resolving so the
+                // tab bar renders immediately — hiding tabs mid-load would flash the bar layout.
+                // The LaunchedEffect above waits for a real emission before clamping selectedTab,
+                // so this permissive fallback can never route the user into a truly unavailable
+                // tab.
                 LibraryTabBar(
                     selectedTab = selectedTab,
                     onTabSelected = { selectedTab = it },
-                    visibility = tabVisibility,
+                    visibility = tabVisibility ?: LibraryTabVisibility.All,
                 )
             }
         },

--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsViewModel.kt
@@ -211,23 +211,30 @@ class LibraryItemsViewModel @Inject constructor(
     /**
      * Which optional Library tabs are visible for the active Source. Home, Annotations, and All
      * Books are always available; the rest are gated on the active Catalog's capabilities per
-     * issue #439 / ADR 0041. An unresolved active Source (missing credentials, no factory) hides
-     * every optional tab — safer than showing a tab that will crash on selection.
+     * issue #439 / ADR 0041.
+     *
+     * Null before the active Source's Catalog resolves — composables read this and skip the
+     * "clamp selected tab back to Home" effect while unresolved, so a `rememberSaveable`-restored
+     * selected-tab isn't wiped by the initial empty state on cold start.
+     *
+     * Reactive against `sourceRepository.observeAll()` so an in-place Source switch (drawer tap,
+     * background sync, etc.) re-derives the visibility set instead of latching on whichever
+     * Source happened to be active when this VM was constructed. Raw `is X` checks stand in for
+     * the inline `Catalog.has<T>()` extension: core:catalog compiles at JVM target 21 (implicit)
+     * while every consumer pins target 17, so the inline can't cross the boundary today.
      */
-    val tabVisibility: StateFlow<LibraryTabVisibility> =
-        kotlinx.coroutines.flow.flow {
-            // Raw `is` checks in place of the inline `Catalog.has<T>()` extension: core:catalog
-            // compiles at JVM target 21 (its module leaves target unset) but the app / core:data
-            // modules pin to JVM target 17, so an inline call across the boundary fails to compile.
-            val catalog = catalogRegistry.forActive()
-            emit(
-                LibraryTabVisibility(
-                    toRead = catalog is PlaylistsCapability,
-                    series = catalog is SeriesCapability,
-                    collections = catalog is CollectionsCapability,
-                ),
+    val tabVisibility: StateFlow<LibraryTabVisibility?> = sourceRepository.observeAll()
+        .map { servers -> servers.firstOrNull { it.isActive }?.id }
+        .distinctUntilChanged()
+        .map { sourceId ->
+            val catalog = sourceId?.let { catalogRegistry.forSourceId(it) }
+            LibraryTabVisibility(
+                toRead = catalog is PlaylistsCapability,
+                series = catalog is SeriesCapability,
+                collections = catalog is CollectionsCapability,
             )
-        }.stateIn(viewModelScope, SharingStarted.Eagerly, LibraryTabVisibility.Empty)
+        }
+        .stateIn(viewModelScope, SharingStarted.Eagerly, null)
 
     var authToken: String by mutableStateOf("")
         private set

--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsViewModel.kt
@@ -20,6 +20,10 @@ import com.riffle.core.domain.usecase.RefreshLibraryItems
 import com.riffle.core.domain.usecase.RefreshSeries
 import com.riffle.core.domain.Series
 import com.riffle.core.data.ToReadRepository
+import com.riffle.core.catalog.CatalogRegistry
+import com.riffle.core.catalog.CollectionsCapability
+import com.riffle.core.catalog.PlaylistsCapability
+import com.riffle.core.catalog.SeriesCapability
 import com.riffle.core.domain.SourceRepository
 import com.riffle.core.domain.TokenStorage
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -63,6 +67,7 @@ class LibraryItemsViewModel @Inject constructor(
     private val coverGridDensityStore: com.riffle.core.domain.CoverGridDensityStore,
     private val annotationStore: AnnotationStore,
     private val audiobookBookmarkStore: AudiobookBookmarkStore,
+    private val catalogRegistry: CatalogRegistry,
 ) : ViewModel() {
 
     val libraryId: String = savedStateHandle.get<String>("libraryId") ?: ""
@@ -202,6 +207,27 @@ class LibraryItemsViewModel @Inject constructor(
 
     val projection: StateFlow<LibraryProjection> = filterEngine.projection
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), LibraryProjection.Empty)
+
+    /**
+     * Which optional Library tabs are visible for the active Source. Home, Annotations, and All
+     * Books are always available; the rest are gated on the active Catalog's capabilities per
+     * issue #439 / ADR 0041. An unresolved active Source (missing credentials, no factory) hides
+     * every optional tab — safer than showing a tab that will crash on selection.
+     */
+    val tabVisibility: StateFlow<LibraryTabVisibility> =
+        kotlinx.coroutines.flow.flow {
+            // Raw `is` checks in place of the inline `Catalog.has<T>()` extension: core:catalog
+            // compiles at JVM target 21 (its module leaves target unset) but the app / core:data
+            // modules pin to JVM target 17, so an inline call across the boundary fails to compile.
+            val catalog = catalogRegistry.forActive()
+            emit(
+                LibraryTabVisibility(
+                    toRead = catalog is PlaylistsCapability,
+                    series = catalog is SeriesCapability,
+                    collections = catalog is CollectionsCapability,
+                ),
+            )
+        }.stateIn(viewModelScope, SharingStarted.Eagerly, LibraryTabVisibility.Empty)
 
     var authToken: String by mutableStateOf("")
         private set

--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryTabVisibility.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryTabVisibility.kt
@@ -1,0 +1,20 @@
+package com.riffle.app.feature.library
+
+/**
+ * Which optional Library-tab-bar entries are shown for the active Source. Home, Annotations and
+ * All Books are unconditional and not tracked here. Populated by [LibraryItemsViewModel] from
+ * the active Catalog's capabilities (issue #439 / ADR 0041).
+ */
+data class LibraryTabVisibility(
+    val toRead: Boolean,
+    val series: Boolean,
+    val collections: Boolean,
+) {
+    companion object {
+        /** Default before the active Catalog has been resolved: hide every optional tab. */
+        val Empty = LibraryTabVisibility(toRead = false, series = false, collections = false)
+
+        /** Every optional tab present — mirrors what a full ABS Catalog exposes. */
+        val All = LibraryTabVisibility(toRead = true, series = true, collections = true)
+    }
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/navigation/NavigationDrawerViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/navigation/NavigationDrawerViewModel.kt
@@ -13,6 +13,8 @@ import com.riffle.core.domain.Source
 import com.riffle.core.domain.SourceRepository
 import com.riffle.core.domain.ServerType
 import com.riffle.core.domain.isReadaloud
+import com.riffle.core.catalog.Catalog
+import com.riffle.core.catalog.CatalogRegistry
 import com.riffle.app.playback.NowPlaying
 import com.riffle.app.playback.NowPlayingNavigator
 import com.riffle.app.playback.NowPlayingStore
@@ -41,6 +43,7 @@ class NavigationDrawerViewModel @Inject constructor(
     private val orderStore: LibraryOrderPreferencesStore,
     private val lastOpenedLibraryStore: LastOpenedLibraryStore,
     private val connectivityObserver: ConnectivityObserver,
+    private val catalogRegistry: CatalogRegistry,
     nowPlayingNavigator: NowPlayingNavigator,
     private val nowPlayingStore: NowPlayingStore,
 ) : ViewModel() {
@@ -58,6 +61,13 @@ class NavigationDrawerViewModel @Inject constructor(
 
     val activeServer: StateFlow<Source?> = allServers
         .map { servers -> servers.firstOrNull { it.isActive } }
+        .stateIn(viewModelScope, SharingStarted.Eagerly, null)
+
+    // Capability-gated UI (issue #439) reads this to hide surfaces the active Source can't
+    // support. Null before the first Source loads or when the active Source can't yield a
+    // Catalog (missing credentials, unregistered factory). Composables treat null as "hide".
+    val activeCatalog: StateFlow<Catalog?> = activeServer
+        .map { source -> source?.let { catalogRegistry.forSource(it) } }
         .stateIn(viewModelScope, SharingStarted.Eagerly, null)
 
     private val versionsCache = mutableMapOf<String, String>()

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -834,9 +834,13 @@ class EpubReaderViewModel @Inject constructor(
         // provide ReadingSessionsCapability. LocalFiles (no capability) never enables sessions;
         // ABS flips it on once its Catalog resolves.
         viewModelScope.launch {
-            val catalog = sourceRepository.getActive()?.let { catalogRegistry.forSource(it) }
-            // Raw `is` check in place of the inline has<T>() extension — see
-            // LibraryItemsViewModel.tabVisibility for the JVM-target rationale.
+            // Key on the book's own Source, not the currently-active one — a reader can outlive
+            // a Source switch (issue #439 / ADR 0041). Fall back to the active Source when nav
+            // didn't carry a sourceId (normal FullBook open), matching the resolution pattern
+            // used elsewhere in this VM. Raw `is` check in place of the inline has<T>() extension —
+            // see LibraryItemsViewModel.tabVisibility for the JVM-target rationale.
+            val sourceId = navServerId ?: sourceRepository.getActive()?.id
+            val catalog = sourceId?.let { catalogRegistry.forSourceId(it) }
             readingSessionsEnabled.set(catalog is com.riffle.core.catalog.ReadingSessionsCapability)
         }
         viewModelScope.launch {

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -198,7 +198,14 @@ class EpubReaderViewModel @Inject constructor(
     private val highlightsResumeStore: HighlightsResumeStore,
     private val tocRepository: TocRepository,
     private val figuresInRangeResolver: FiguresInRangeResolver,
+    private val catalogRegistry: com.riffle.core.catalog.CatalogRegistry,
 ) : AndroidViewModel(application) {
+
+    // ReadingSessionCoordinator's per-call enabled gate reads this atomic; init below flips it once
+    // the active Catalog's capability set is known (issue #439). Starts false so a coordinator tick
+    // that fires before init completes stays a no-op — the coordinator won't heartbeat/flush until
+    // the capability is confirmed.
+    private val readingSessionsEnabled = java.util.concurrent.atomic.AtomicBoolean(false)
 
     // Formatting/typography/auto-scroll orchestrator — constructed with viewModelScope so
     // teardown is deterministic (the orchestrator's coroutines cancel when the VM is cleared).
@@ -367,6 +374,7 @@ class EpubReaderViewModel @Inject constructor(
         clock = clock,
         readingSpeedStore = readingSpeedStore,
         scope = viewModelScope,
+        enabled = { readingSessionsEnabled.get() },
     )
 
     private val positionSaveCoordinator = PositionSaveCoordinator<String>(
@@ -822,6 +830,15 @@ class EpubReaderViewModel @Inject constructor(
         readaloud.onAudioPlayingChanged = { isPlaying -> readerStateHolder.isAudioPlaying = isPlaying }
         // Wire the Storyteller pulled-locator callback once — position is constructed by this point.
         readaloud.storytellerServerLocatorCallback = { locator -> position.requestServerJump(locator) }
+        // Issue #439: ReadingSessionCoordinator no-ops until the active Source is confirmed to
+        // provide ReadingSessionsCapability. LocalFiles (no capability) never enables sessions;
+        // ABS flips it on once its Catalog resolves.
+        viewModelScope.launch {
+            val catalog = sourceRepository.getActive()?.let { catalogRegistry.forSource(it) }
+            // Raw `is` check in place of the inline has<T>() extension — see
+            // LibraryItemsViewModel.tabVisibility for the JVM-target rationale.
+            readingSessionsEnabled.set(catalog is com.riffle.core.catalog.ReadingSessionsCapability)
+        }
         viewModelScope.launch {
             // Sequential: formatting prefs must be available before openBook() so the
             // navigator never sees the stateIn default on first paint (FormattingSession.bindToBook

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/PdfReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/PdfReaderViewModel.kt
@@ -65,7 +65,20 @@ class PdfReaderViewModel @Inject constructor(
     private val volumeKeyDispatcher: VolumeKeyDispatcher,
     clock: Clock,
     readingSpeedStore: ReadingSpeedStore,
+    private val catalogRegistry: com.riffle.core.catalog.CatalogRegistry,
 ) : AndroidViewModel(application) {
+
+    // See EpubReaderViewModel — mirrors the #439 gate for PDF's coordinator.
+    private val readingSessionsEnabled = java.util.concurrent.atomic.AtomicBoolean(false)
+
+    init {
+        viewModelScope.launch {
+            val catalog = sourceRepository.getActive()?.let { catalogRegistry.forSource(it) }
+            // Raw `is` check in place of the inline has<T>() extension — see
+            // LibraryItemsViewModel.tabVisibility for the JVM-target rationale.
+            readingSessionsEnabled.set(catalog is com.riffle.core.catalog.ReadingSessionsCapability)
+        }
+    }
 
     private val itemId: String = checkNotNull(savedStateHandle["itemId"])
 
@@ -152,6 +165,7 @@ class PdfReaderViewModel @Inject constructor(
         clock = clock,
         readingSpeedStore = readingSpeedStore,
         scope = viewModelScope,
+        enabled = { readingSessionsEnabled.get() },
     )
 
     // Cached at book-open so navigateToEntry can resolve a TocEntry click back to

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/PdfReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/PdfReaderViewModel.kt
@@ -73,9 +73,11 @@ class PdfReaderViewModel @Inject constructor(
 
     init {
         viewModelScope.launch {
-            val catalog = sourceRepository.getActive()?.let { catalogRegistry.forSource(it) }
-            // Raw `is` check in place of the inline has<T>() extension — see
+            // getActive() is captured once at reader-open time. In practice the reader is opened
+            // from a tap on the currently-active Source's library, so this matches the item's
+            // Source. Raw `is` check in place of the inline has<T>() extension — see
             // LibraryItemsViewModel.tabVisibility for the JVM-target rationale.
+            val catalog = sourceRepository.getActive()?.let { catalogRegistry.forSource(it) }
             readingSessionsEnabled.set(catalog is com.riffle.core.catalog.ReadingSessionsCapability)
         }
     }

--- a/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModelTest.kt
@@ -278,7 +278,17 @@ class LibraryItemDetailViewModelTest {
         sidecarPrefetcher = { _, _ -> },
         extractEpubTocUseCase = extractEpubTocUseCase,
         fetchAudiobookChaptersUseCase = fetchAudiobookChaptersUseCase,
+        catalogRegistry = detailFakeCatalogRegistry(),
     )
+
+    // These tests exercise ViewModel state and side-effects; none read Ready.capabilities.
+    // Returning null keeps the fake tiny.
+    private fun detailFakeCatalogRegistry(): com.riffle.core.catalog.CatalogRegistry =
+        object : com.riffle.core.catalog.CatalogRegistry {
+            override suspend fun forActive(): com.riffle.core.catalog.Catalog? = null
+            override suspend fun forSource(source: com.riffle.core.domain.Source): com.riffle.core.catalog.Catalog? = null
+            override suspend fun forSourceId(sourceId: String): com.riffle.core.catalog.Catalog? = null
+        }
 
     /** Records the links handed to the index-build trigger (the download-complete trigger, ADR 0031). */
     private class RecordingBuildTrigger : com.riffle.core.data.CrossEpubIndexBuildTrigger {

--- a/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModelTocTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModelTocTest.kt
@@ -165,6 +165,11 @@ class LibraryItemDetailViewModelTocTest {
         sidecarPrefetcher = { _, _ -> },
         extractEpubTocUseCase = extractEpubTocUseCase,
         fetchAudiobookChaptersUseCase = fetchAudiobookChaptersUseCase,
+        catalogRegistry = object : com.riffle.core.catalog.CatalogRegistry {
+            override suspend fun forActive(): com.riffle.core.catalog.Catalog? = null
+            override suspend fun forSource(source: com.riffle.core.domain.Source): com.riffle.core.catalog.Catalog? = null
+            override suspend fun forSourceId(sourceId: String): com.riffle.core.catalog.Catalog? = null
+        },
     )
 
     private val epubItem = LibraryItem(

--- a/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemsViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemsViewModelTest.kt
@@ -1123,6 +1123,124 @@ class LibraryItemsViewModelTest {
         assertEquals(emptyList<AnnotationSearchResult>(), vm.projection.value.annotations)
     }
 
+    // Regression pins for #439: tabVisibility must map from the active Catalog's capabilities and
+    // must re-derive when the active Source changes in place.
+    @Test
+    fun `tabVisibility maps active Catalog capabilities to per-tab flags`() = runTest {
+        val srv = source("s-abs", active = true)
+        val serversFlow = MutableStateFlow(listOf(srv))
+        val srcRepo = object : SourceRepository {
+            override fun observeAll(): Flow<List<Source>> = serversFlow
+            override suspend fun getActive(): Source? = serversFlow.value.firstOrNull { it.isActive }
+            override suspend fun authenticate(url: SourceUrl, username: String, password: String, insecureAllowed: Boolean, serverType: com.riffle.core.domain.ServerType) = throw UnsupportedOperationException()
+            override suspend fun commit(pending: com.riffle.core.domain.PendingSource, hiddenLibraryIds: Set<String>) = throw UnsupportedOperationException()
+            override suspend fun setActive(sourceId: String) {}
+            override suspend fun remove(sourceId: String) {}
+            override suspend fun getSourceVersion(sourceId: String): String? = null
+        }
+        val vm = makeViewModel(
+            sourceRepository = srcRepo,
+            catalogRegistry = catalogRegistryReturning(SeriesAndPlaylistsOnlyCatalog),
+        )
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        val visibility = vm.tabVisibility.value
+        assertEquals(true, visibility?.series)
+        assertEquals(true, visibility?.toRead)
+        assertEquals(false, visibility?.collections)
+    }
+
+    @Test
+    fun `tabVisibility re-emits when the active Source flips to one with a different capability set`() = runTest {
+        val abs = source("s-abs", active = true)
+        val local = source("s-local", active = false)
+        val serversFlow = MutableStateFlow(listOf(abs, local))
+        val srcRepo = object : SourceRepository {
+            override fun observeAll(): Flow<List<Source>> = serversFlow
+            override suspend fun getActive(): Source? = serversFlow.value.firstOrNull { it.isActive }
+            override suspend fun authenticate(url: SourceUrl, username: String, password: String, insecureAllowed: Boolean, serverType: com.riffle.core.domain.ServerType) = throw UnsupportedOperationException()
+            override suspend fun commit(pending: com.riffle.core.domain.PendingSource, hiddenLibraryIds: Set<String>) = throw UnsupportedOperationException()
+            override suspend fun setActive(sourceId: String) {}
+            override suspend fun remove(sourceId: String) {}
+            override suspend fun getSourceVersion(sourceId: String): String? = null
+        }
+        // ABS → SeriesAndPlaylistsOnlyCatalog; LocalFiles → SeriesOnlyCatalog. The mapping keys on
+        // source id so we can prove the flow re-fires on switch, not just latches the first value.
+        val registry = object : com.riffle.core.catalog.CatalogRegistry {
+            override suspend fun forActive(): com.riffle.core.catalog.Catalog? = null
+            override suspend fun forSource(source: Source): com.riffle.core.catalog.Catalog? = forSourceId(source.id)
+            override suspend fun forSourceId(sourceId: String): com.riffle.core.catalog.Catalog? = when (sourceId) {
+                "s-abs" -> SeriesAndPlaylistsOnlyCatalog
+                "s-local" -> SeriesOnlyCatalog
+                else -> null
+            }
+        }
+        val vm = makeViewModel(sourceRepository = srcRepo, catalogRegistry = registry)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(true, vm.tabVisibility.value?.toRead)
+
+        // Flip active to the LocalFiles-shaped source.
+        serversFlow.value = listOf(abs.copy(isActive = false), local.copy(isActive = true))
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        val v = vm.tabVisibility.value
+        assertEquals(true, v?.series)
+        assertEquals(false, v?.toRead)
+    }
+
+    private fun source(id: String, active: Boolean) = Source(
+        id = id,
+        url = checkNotNull(SourceUrl.parse("https://example.test/$id")),
+        isActive = active,
+        insecureConnectionAllowed = false,
+        username = "u",
+        type = if (id == "s-local") com.riffle.core.domain.SourceType.LOCAL_FILES else com.riffle.core.domain.SourceType.ABS,
+        serverType = com.riffle.core.domain.ServerType.AUDIOBOOKSHELF,
+    )
+
+    private fun catalogRegistryReturning(catalog: com.riffle.core.catalog.Catalog?): com.riffle.core.catalog.CatalogRegistry =
+        object : com.riffle.core.catalog.CatalogRegistry {
+            override suspend fun forActive(): com.riffle.core.catalog.Catalog? = catalog
+            override suspend fun forSource(source: Source): com.riffle.core.catalog.Catalog? = catalog
+            override suspend fun forSourceId(sourceId: String): com.riffle.core.catalog.Catalog? = catalog
+        }
+
+    private object SeriesAndPlaylistsOnlyCatalog :
+        com.riffle.core.catalog.Catalog,
+        com.riffle.core.catalog.SeriesCapability,
+        com.riffle.core.catalog.PlaylistsCapability {
+        override val sourceType = com.riffle.core.domain.SourceType.ABS
+        override suspend fun listRoots() = emptyList<com.riffle.core.catalog.CatalogRoot>()
+        override suspend fun browse(rootId: String, sort: com.riffle.core.catalog.SortKey, page: Int, pageSize: Int) = emptyList<com.riffle.core.catalog.CatalogItem>()
+        override suspend fun search(rootId: String, query: String, page: Int, pageSize: Int) = emptyList<com.riffle.core.catalog.CatalogItem>()
+        override suspend fun getItem(itemId: String) = null
+        override suspend fun fetchFile(itemId: String, format: com.riffle.core.catalog.BookFormat) = error("unused")
+        override suspend fun openFile(itemId: String, format: com.riffle.core.catalog.BookFormat, handleHint: String?) = error("unused")
+        override suspend fun connectivityCheck() = error("unused")
+        override suspend fun listSeries(rootId: String) = emptyList<com.riffle.core.catalog.CatalogSeries>()
+        override suspend fun listItemsInSeries(rootId: String, seriesId: String) = emptyList<com.riffle.core.catalog.CatalogItem>()
+        override suspend fun listPlaylists(rootId: String) = emptyList<com.riffle.core.catalog.CatalogPlaylist>()
+        override suspend fun createPlaylist(rootId: String, name: String) = error("unused")
+        override suspend fun addItemToPlaylist(playlistId: String, itemId: String) {}
+        override suspend fun removeItemFromPlaylist(playlistId: String, itemId: String) {}
+    }
+
+    private object SeriesOnlyCatalog :
+        com.riffle.core.catalog.Catalog,
+        com.riffle.core.catalog.SeriesCapability {
+        override val sourceType = com.riffle.core.domain.SourceType.LOCAL_FILES
+        override suspend fun listRoots() = emptyList<com.riffle.core.catalog.CatalogRoot>()
+        override suspend fun browse(rootId: String, sort: com.riffle.core.catalog.SortKey, page: Int, pageSize: Int) = emptyList<com.riffle.core.catalog.CatalogItem>()
+        override suspend fun search(rootId: String, query: String, page: Int, pageSize: Int) = emptyList<com.riffle.core.catalog.CatalogItem>()
+        override suspend fun getItem(itemId: String) = null
+        override suspend fun fetchFile(itemId: String, format: com.riffle.core.catalog.BookFormat) = error("unused")
+        override suspend fun openFile(itemId: String, format: com.riffle.core.catalog.BookFormat, handleHint: String?) = error("unused")
+        override suspend fun connectivityCheck() = error("unused")
+        override suspend fun listSeries(rootId: String) = emptyList<com.riffle.core.catalog.CatalogSeries>()
+        override suspend fun listItemsInSeries(rootId: String, seriesId: String) = emptyList<com.riffle.core.catalog.CatalogItem>()
+    }
+
     // Regression: on ON_RESUME we always refresh so `_refreshFailed` clears if the server is back.
     // Connectivity self-heals inside the ConnectivityObserver via ProcessLifecycleOwner + the
     // ACTION_AIRPLANE_MODE_CHANGED broadcast, so it does not need to be poked from the view model.

--- a/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemsViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemsViewModelTest.kt
@@ -211,6 +211,7 @@ class LibraryItemsViewModelTest {
         },
         annotationStore: com.riffle.core.domain.AnnotationStore = fakeAnnotationStore(),
         audiobookBookmarkStore: com.riffle.core.domain.AudiobookBookmarkStore = fakeAudiobookBookmarkStore(),
+        catalogRegistry: com.riffle.core.catalog.CatalogRegistry = fakeCatalogRegistry(),
     ) = LibraryItemsViewModel(
         savedStateHandle = savedStateHandle,
         libraryObserver = libraryRepository,
@@ -234,7 +235,16 @@ class LibraryItemsViewModelTest {
         coverGridDensityStore = coverGridDensityStore,
         annotationStore = annotationStore,
         audiobookBookmarkStore = audiobookBookmarkStore,
+        catalogRegistry = catalogRegistry,
     )
+
+    private fun fakeCatalogRegistry(
+        catalog: com.riffle.core.catalog.Catalog? = null,
+    ): com.riffle.core.catalog.CatalogRegistry = object : com.riffle.core.catalog.CatalogRegistry {
+        override suspend fun forActive(): com.riffle.core.catalog.Catalog? = catalog
+        override suspend fun forSource(source: com.riffle.core.domain.Source): com.riffle.core.catalog.Catalog? = catalog
+        override suspend fun forSourceId(sourceId: String): com.riffle.core.catalog.Catalog? = catalog
+    }
 
     private fun series(name: String) = Series("id-$name", "lib-1", name, null, 1)
     private fun collection(name: String) = Collection("id-$name", "lib-1", name, 1)

--- a/app/src/test/kotlin/com/riffle/app/feature/library/LibraryTabVisibilityTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/LibraryTabVisibilityTest.kt
@@ -1,0 +1,50 @@
+package com.riffle.app.feature.library
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Regression pins for issue #439's Library-tab visibility gate. The `isTabVisible` helper is what
+ * `LibraryItemsScreen` uses to clamp `selectedTab` back to Home when the active Source stops
+ * exposing the previously-selected tab (e.g. user was on Series, then switched to a LocalFiles
+ * Source that lacks `SeriesCapability`). If any of these assertions flips red, either the tab
+ * indices in `LibraryTabBar` have drifted, or a capability got silently ungated.
+ */
+class LibraryTabVisibilityTest {
+
+    @Test
+    fun `unconditional tabs stay visible regardless of capabilities`() {
+        val none = LibraryTabVisibility.Empty
+        // Home (0), Annotations (2 via tabIndexForAnnotations), All Books (5) are always shown.
+        assertTrue(isTabVisible(0, none))
+        assertTrue(isTabVisible(tabIndexForAnnotations(), none))
+        assertTrue(isTabVisible(5, none))
+    }
+
+    @Test
+    fun `to read tab is hidden without PlaylistsCapability`() {
+        assertFalse(isTabVisible(1, LibraryTabVisibility.Empty))
+        assertTrue(isTabVisible(1, LibraryTabVisibility.All))
+    }
+
+    @Test
+    fun `series tab is hidden without SeriesCapability`() {
+        assertFalse(isTabVisible(3, LibraryTabVisibility.Empty))
+        assertTrue(isTabVisible(3, LibraryTabVisibility.All))
+    }
+
+    @Test
+    fun `collections tab is hidden without CollectionsCapability`() {
+        assertFalse(isTabVisible(4, LibraryTabVisibility.Empty))
+        assertTrue(isTabVisible(4, LibraryTabVisibility.All))
+    }
+
+    @Test
+    fun `a partial visibility set only affects its own tab`() {
+        val onlyToRead = LibraryTabVisibility(toRead = true, series = false, collections = false)
+        assertTrue(isTabVisible(1, onlyToRead))
+        assertFalse(isTabVisible(3, onlyToRead))
+        assertFalse(isTabVisible(4, onlyToRead))
+    }
+}

--- a/app/src/test/kotlin/com/riffle/app/feature/navigation/NavigationDrawerViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/navigation/NavigationDrawerViewModelTest.kt
@@ -148,9 +148,17 @@ class NavigationDrawerViewModelTest {
         orderStore = fakeOrderStore(),
         lastOpenedLibraryStore = fakeLastOpenedStore(),
         connectivityObserver = fakeConnectivity(),
+        catalogRegistry = fakeCatalogRegistry(),
         nowPlayingNavigator = com.riffle.app.playback.NowPlayingNavigator(),
         nowPlayingStore = com.riffle.app.playback.NowPlayingStore(),
     )
+
+    private fun fakeCatalogRegistry(): com.riffle.core.catalog.CatalogRegistry =
+        object : com.riffle.core.catalog.CatalogRegistry {
+            override suspend fun forActive(): com.riffle.core.catalog.Catalog? = null
+            override suspend fun forSource(source: com.riffle.core.domain.Source): com.riffle.core.catalog.Catalog? = null
+            override suspend fun forSourceId(sourceId: String): com.riffle.core.catalog.Catalog? = null
+        }
 
     @Test
     fun `redirectToLibrary emits next visible library when active library is hidden`() = runTest(testDispatcher) {

--- a/core/data/src/test/kotlin/com/riffle/core/data/localfiles/LocalFilesCatalogTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/localfiles/LocalFilesCatalogTest.kt
@@ -192,6 +192,27 @@ class LocalFilesCatalogTest {
     }
 
     @Test
+    fun `capability set excludes every non-LocalFiles surface`() {
+        // Regression pin for issue #439's promise: a LocalFiles user sees no Collections tab, no
+        // To Read tab, no Reading Sessions, no Reading Statistics, and no Listen affordance.
+        // LocalFilesCatalog does implement SeriesCapability (folder-inferred series) and
+        // OfflineBrowseCapability. If any assertion below flips green, either LocalFilesCatalog
+        // silently gained a capability it doesn't actually implement, or the marker mixins have
+        // drifted. Uses raw `is` checks — this module's JVM target (17) can't inline
+        // `Catalog.has<T>()` emitted by core:catalog (target 21).
+        val catalog: com.riffle.core.catalog.Catalog = catalog()
+
+        assertTrue(catalog is com.riffle.core.catalog.SeriesCapability)
+        assertTrue(catalog is com.riffle.core.catalog.OfflineBrowseCapability)
+
+        assertEquals(false, catalog is com.riffle.core.catalog.CollectionsCapability)
+        assertEquals(false, catalog is com.riffle.core.catalog.PlaylistsCapability)
+        assertEquals(false, catalog is com.riffle.core.catalog.AudiobookMediaCapability)
+        assertEquals(false, catalog is com.riffle.core.catalog.ReadingSessionsCapability)
+        assertEquals(false, catalog is com.riffle.core.catalog.StatsCapability)
+    }
+
+    @Test
     fun `RECENTLY_OPENED sort is not supported at the Catalog layer`() = runTest {
         val items = FakeLibraryItemDao().also { it.emit(sourceId, listOf(epubItem("a", "a"))) }
         val catalog = catalog(items = items)

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/ReadingSessionCoordinator.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/ReadingSessionCoordinator.kt
@@ -28,13 +28,14 @@ class ReadingSessionCoordinator(
     private val readingSpeedStore: ReadingSpeedStore,
     private val scope: CoroutineScope,
     private val syncIntervalMs: Long = SYNC_INTERVAL_MS,
-    // Whether reading-session lifecycle actions should fire at all. Evaluated per call so the
-    // Catalog capability check can be resolved after construction (readers set this once the
-    // active Source's Catalog is known). False when the active Source has no
-    // ReadingSessionsCapability (issue #439 / ADR 0041) — LocalFiles, for example. Both
-    // [onResumed] and [onClosed] become no-ops so the heartbeat never starts and the
-    // speed-tracker session is never flushed. Defaults to `always-on` to keep pre-#439 callers
-    // (and every ABS Source) unchanged.
+    // Whether reading-session ticks and the terminal speed flush should fire. Evaluated INSIDE
+    // the tick loop (not at [onResumed] entry) so the check keeps working across a Catalog
+    // capability resolution that lands after the reader is already mounted (issue #439 / ADR
+    // 0041). If [enabled] were checked once at start, a race between the reader's async catalog
+    // probe and its own [onResumed] call would silently kill the whole session — an ABS regression
+    // as well as the LocalFiles case. Deferring the check to per-tick pays a cheap `delay(30s)`
+    // every heartbeat interval for LocalFiles, which is what "zero-op" was ever going to cost
+    // anyway. Defaults to always-on to keep pre-#439 callers unchanged.
     private val enabled: () -> Boolean = { true },
 ) {
 
@@ -55,14 +56,13 @@ class ReadingSessionCoordinator(
      *   themselves alongside [onResumed].
      */
     fun onResumed(initialTotalProgression: Float?, onTick: suspend () -> Unit) {
-        if (!enabled()) return
         sessionStartProgression = initialTotalProgression
         sessionStartMs = clock.nowMs()
         syncJob?.cancel()
         syncJob = scope.launch {
             while (true) {
                 delay(syncIntervalMs)
-                onTick()
+                if (enabled()) onTick()
             }
         }
     }
@@ -77,10 +77,9 @@ class ReadingSessionCoordinator(
      *   value the rail uses. A zero total skips the speed write (we'd divide by zero).
      */
     fun onClosed(currentTotalProgression: Float?, totalPositions: Float) {
-        if (!enabled()) return
         syncJob?.cancel()
         syncJob = null
-        flushSpeedSession(currentTotalProgression, totalPositions)
+        if (enabled()) flushSpeedSession(currentTotalProgression, totalPositions)
     }
 
     private fun flushSpeedSession(currentTotalProgression: Float?, totalPositions: Float) {

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/ReadingSessionCoordinator.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/ReadingSessionCoordinator.kt
@@ -28,6 +28,14 @@ class ReadingSessionCoordinator(
     private val readingSpeedStore: ReadingSpeedStore,
     private val scope: CoroutineScope,
     private val syncIntervalMs: Long = SYNC_INTERVAL_MS,
+    // Whether reading-session lifecycle actions should fire at all. Evaluated per call so the
+    // Catalog capability check can be resolved after construction (readers set this once the
+    // active Source's Catalog is known). False when the active Source has no
+    // ReadingSessionsCapability (issue #439 / ADR 0041) — LocalFiles, for example. Both
+    // [onResumed] and [onClosed] become no-ops so the heartbeat never starts and the
+    // speed-tracker session is never flushed. Defaults to `always-on` to keep pre-#439 callers
+    // (and every ABS Source) unchanged.
+    private val enabled: () -> Boolean = { true },
 ) {
 
     private var syncJob: Job? = null
@@ -47,6 +55,7 @@ class ReadingSessionCoordinator(
      *   themselves alongside [onResumed].
      */
     fun onResumed(initialTotalProgression: Float?, onTick: suspend () -> Unit) {
+        if (!enabled()) return
         sessionStartProgression = initialTotalProgression
         sessionStartMs = clock.nowMs()
         syncJob?.cancel()
@@ -68,6 +77,7 @@ class ReadingSessionCoordinator(
      *   value the rail uses. A zero total skips the speed write (we'd divide by zero).
      */
     fun onClosed(currentTotalProgression: Float?, totalPositions: Float) {
+        if (!enabled()) return
         syncJob?.cancel()
         syncJob = null
         flushSpeedSession(currentTotalProgression, totalPositions)

--- a/core/domain/src/test/kotlin/com/riffle/core/domain/ReadingSessionCoordinatorTest.kt
+++ b/core/domain/src/test/kotlin/com/riffle/core/domain/ReadingSessionCoordinatorTest.kt
@@ -175,4 +175,62 @@ class ReadingSessionCoordinatorTest {
     fun `the default interval is 30s`() {
         assertEquals(30_000L, ReadingSessionCoordinator.SYNC_INTERVAL_MS)
     }
+
+    @Test
+    fun `disabled coordinator does not start the heartbeat`() = runTest {
+        // Regression for #439: a Source without ReadingSessionsCapability must never
+        // heartbeat. Otherwise every LocalFiles reader session would kick off a
+        // 30s timer that either no-ops via ProgressSyncController or worse, tries
+        // to post to a server that isn't there.
+        val clock = TestClock()
+        val store = FakeSpeedStore(initial = 100.0)
+        val coord = ReadingSessionCoordinator(
+            clock = clock,
+            readingSpeedStore = store,
+            scope = this,
+            syncIntervalMs = 30_000L,
+            enabled = { false },
+        )
+        var ticks = 0
+        coord.onResumed(initialTotalProgression = 0.10f, onTick = { ticks++ })
+
+        advanceTimeBy(90_001L)
+        assertEquals(0, ticks)
+
+        // And onClosed must not flush the speed store either, otherwise a disabled
+        // Source would silently update the shared speed tracker with garbage deltas.
+        clock.advance(600_000L)
+        coord.onClosed(currentTotalProgression = 0.15f, totalPositions = 100f)
+        advanceUntilIdle()
+        assertEquals(100.0, store.current, 1e-9)
+    }
+
+    @Test
+    fun `enabled gate is re-evaluated on every call`() = runTest {
+        // The reader ViewModels flip the enabled flag once the active Source's Catalog
+        // resolves — a coordinator constructed before the flip must still respect the
+        // flag at call time, not at construction time.
+        val clock = TestClock()
+        val store = FakeSpeedStore(initial = 100.0)
+        var enabled = false
+        val coord = ReadingSessionCoordinator(
+            clock = clock,
+            readingSpeedStore = store,
+            scope = this,
+            syncIntervalMs = 30_000L,
+            enabled = { enabled },
+        )
+        var ticks = 0
+        coord.onResumed(initialTotalProgression = 0.10f, onTick = { ticks++ })
+        advanceTimeBy(30_001L)
+        assertEquals(0, ticks)
+
+        enabled = true
+        coord.onResumed(initialTotalProgression = 0.10f, onTick = { ticks++ })
+        advanceTimeBy(30_001L)
+        assertEquals(1, ticks)
+
+        coord.onClosed(currentTotalProgression = 0.15f, totalPositions = 100f)
+        advanceUntilIdle()
+    }
 }

--- a/core/domain/src/test/kotlin/com/riffle/core/domain/ReadingSessionCoordinatorTest.kt
+++ b/core/domain/src/test/kotlin/com/riffle/core/domain/ReadingSessionCoordinatorTest.kt
@@ -177,11 +177,10 @@ class ReadingSessionCoordinatorTest {
     }
 
     @Test
-    fun `disabled coordinator does not start the heartbeat`() = runTest {
-        // Regression for #439: a Source without ReadingSessionsCapability must never
-        // heartbeat. Otherwise every LocalFiles reader session would kick off a
-        // 30s timer that either no-ops via ProgressSyncController or worse, tries
-        // to post to a server that isn't there.
+    fun `disabled coordinator does not fire onTick and does not flush speed`() = runTest {
+        // Regression for #439: a Source without ReadingSessionsCapability must never sync a
+        // reading tick or update the shared speed store. The tick job itself may spin (that's
+        // free) but the observable behaviour — onTick calls and speed writes — must be zero.
         val clock = TestClock()
         val store = FakeSpeedStore(initial = 100.0)
         val coord = ReadingSessionCoordinator(
@@ -197,8 +196,6 @@ class ReadingSessionCoordinatorTest {
         advanceTimeBy(90_001L)
         assertEquals(0, ticks)
 
-        // And onClosed must not flush the speed store either, otherwise a disabled
-        // Source would silently update the shared speed tracker with garbage deltas.
         clock.advance(600_000L)
         coord.onClosed(currentTotalProgression = 0.15f, totalPositions = 100f)
         advanceUntilIdle()
@@ -206,10 +203,12 @@ class ReadingSessionCoordinatorTest {
     }
 
     @Test
-    fun `enabled gate is re-evaluated on every call`() = runTest {
-        // The reader ViewModels flip the enabled flag once the active Source's Catalog
-        // resolves — a coordinator constructed before the flip must still respect the
-        // flag at call time, not at construction time.
+    fun `enabled flipping true after onResumed lets subsequent ticks fire`() = runTest {
+        // The reader ViewModels resolve the active Source's Catalog asynchronously — the
+        // coordinator's [onResumed] can be called BEFORE the enabled gate has resolved. If the
+        // gate were checked once at [onResumed] entry, an ABS session that races the catalog
+        // probe would silently drop the entire session's heartbeat. Checking per tick keeps
+        // the session alive across the resolve window.
         val clock = TestClock()
         val store = FakeSpeedStore(initial = 100.0)
         var enabled = false
@@ -222,14 +221,20 @@ class ReadingSessionCoordinatorTest {
         )
         var ticks = 0
         coord.onResumed(initialTotalProgression = 0.10f, onTick = { ticks++ })
+
+        // First tick fires during the resolve window; enabled is still false so it skips.
         advanceTimeBy(30_001L)
         assertEquals(0, ticks)
 
+        // Catalog resolves — subsequent ticks land.
         enabled = true
-        coord.onResumed(initialTotalProgression = 0.10f, onTick = { ticks++ })
-        advanceTimeBy(30_001L)
+        advanceTimeBy(30_000L)
         assertEquals(1, ticks)
+        advanceTimeBy(30_000L)
+        assertEquals(2, ticks)
 
+        // Flush the started session so it also runs the speed write once at close.
+        clock.advance(600_000L)
         coord.onClosed(currentTotalProgression = 0.15f, totalPositions = 100f)
         advanceUntilIdle()
     }


### PR DESCRIPTION
Closes #439

Every UI surface that today implicitly assumes ABS-shape now checks the active Source's `Catalog` capabilities. Prerequisite for LocalFiles debut (#7).

## Summary

- **LibraryTabBar** hides Series / Collections / To Read tabs when the active Catalog lacks `SeriesCapability` / `CollectionsCapability` / `PlaylistsCapability`. Selection clamps back to Home when a hidden tab was previously selected. Home / Annotations / All Books are always shown.
- **Library Item Detail Screen** gates the Series chip on `SeriesCapability`, the Listen affordance on `AudiobookMediaCapability`, and the To Read icon on `PlaylistsCapability`. Empty-state text wins when neither a readable ebook nor a playable audiobook is available. Capabilities keyed off `item.sourceId`, not the currently-active Source — a detail view can outlive a Source switch.
- **ReadingSessionCoordinator** is a zero-op when the active Catalog lacks `ReadingSessionsCapability`. The gate is checked per tick (not once at `onResumed`) so a session isn't silently dropped by a race between the async catalog probe and the reader's own `onResumed` — an ABS-visible race as well as the LocalFiles case.
- **`NavigationDrawerViewModel.activeCatalog: StateFlow<Catalog?>`** exposes the current Catalog so downstream surfaces can react to Source switches.
- **Reading Statistics** has no entry point today (screen not built), so its Settings/Nav gate is a no-op — same `StatsCapability` probe pattern will apply when the entry lands.

## Bugs caught in review and fixed in `e6984b697`

Independent code-review of the initial implementation surfaced three real bugs which are fixed in the second commit:

- Race between the reader's async catalog probe and its own `onResumed` was silently dropping ABS reading sessions when the probe lost — coordinator now checks the enabled gate inside the tick loop.
- `tabVisibility` was a one-shot `flow { emit() }` that never re-emitted on Source switch — now reactive against `sourceRepository.observeAll()`.
- Detail screen keyed capabilities off `sourceRepository.getActive()` instead of `item.sourceId` — a detail view of an item from a non-active Source got the wrong capability set.

## Tests

- `LibraryTabVisibilityTest` — pins each tab's capability gate (Home/Annotations/AllBooks unconditional; To Read on Playlists; Series on Series; Collections on Collections).
- `LibraryItemsViewModelTest` — new regressions: `tabVisibility` maps a Series+Playlists-only Catalog correctly, and re-emits when the active Source flips to a different capability shape.
- `LocalFilesCatalogTest` — asserts the LocalFiles capability set matches the issue's LocalFiles-user story: only Series + OfflineBrowse; no Collections / Playlists / AudiobookMedia / ReadingSessions / Stats.
- `ReadingSessionCoordinatorTest` — two new pins: disabled coordinator fires no `onTick` and no flush; `enabled` flipping true after `onResumed` lets subsequent ticks fire (the async-race regression).

## Notes

- Cross-module `Catalog.has<T>()` inline calls could not be used from consumers today: `core:catalog` compiles at JVM target 21 (its module leaves target unset) while every consumer pins 17, and the inline can't cross the boundary. Fixed at call sites with raw `is X` checks and a one-liner comment linking back. Aligning `core:catalog` to 17 would ripple through `core:domain` and `core:network`; deferred to a follow-up.
- No composable branches on `SourceType` — all optional-surface branches now go through capabilities. Remaining `serverType == STORYTELLER` filters in Settings/AnnotationsList are intentionally out of scope (they gate Storyteller-specific screens, not capability-shaped UI).

## Test plan

- [ ] JVM tests green: `./gradlew test`
- [ ] Lint green: `./gradlew :app:lintDebug`
- [ ] Manual: on ABS the UI is unchanged (Series/Collections/To Read tabs present, Listen button visible on audiobooks, Series chip on series items, ToRead icon in detail).
- [ ] Manual: on a mocked LocalFiles Source (or once #7 lands): no Series tab (wait — LocalFilesCatalog *does* have SeriesCapability so Series appears; only Collections and To Read hide), no To Read tab, no Collections tab, no Listen button on any item, no reading-session heartbeat.