### PR TITLE
refactor(progress-sync): capability-gate peers; add CfiDialect marker

### DIFF
--- a/core/catalog/src/main/kotlin/com/riffle/core/catalog/CfiDialect.kt
+++ b/core/catalog/src/main/kotlin/com/riffle/core/catalog/CfiDialect.kt
@@ -1,0 +1,20 @@
+package com.riffle.core.catalog
+
+/**
+ * Which CFI dialect a [ProgressPeerCapability] stores its ebook position in (ADR 0013, ADR 0041).
+ *
+ * ABS stores epub.js-style `epubcfi(...)` — different from Readium's native CFI. When the peer
+ * uses [EPUB_JS], writes/reads must round-trip through the [com.riffle.core.domain.EbookCfiTranslator]
+ * at the Catalog boundary so the local store keeps a single canonical Locator JSON. When the peer
+ * uses [READIUM_NATIVE] the local Locator JSON is what the peer already speaks — no translation.
+ *
+ * A LocalFiles-style peer that never writes progress remotely is irrelevant here (it isn't a
+ * `ProgressPeerCapability` in the first place).
+ */
+enum class CfiDialect {
+    /** Peer stores epub.js `epubcfi(/6/4!/4)`; translation to/from Readium Locator JSON is required. */
+    EPUB_JS,
+
+    /** Peer stores the Readium Locator JSON as-is; the translator MUST be skipped. */
+    READIUM_NATIVE,
+}

--- a/core/catalog/src/main/kotlin/com/riffle/core/catalog/ProgressPeerCapability.kt
+++ b/core/catalog/src/main/kotlin/com/riffle/core/catalog/ProgressPeerCapability.kt
@@ -12,6 +12,14 @@ package com.riffle.core.catalog
  */
 interface ProgressPeerCapability : CatalogCapability {
     /**
+     * Which CFI dialect this peer stores its ebook position in — see [CfiDialect]. Callers on the
+     * ebook path gate translator invocation on this: [CfiDialect.EPUB_JS] round-trips through the
+     * translator, [CfiDialect.READIUM_NATIVE] passes the local Locator JSON straight through.
+     * Defaults to [CfiDialect.EPUB_JS] since ABS is the reference impl today (ADR 0013).
+     */
+    val cfiDialect: CfiDialect get() = CfiDialect.EPUB_JS
+
+    /**
      * [isFinished] is tri-state: `null` = leave the item-level finished flag untouched (this is
      * the common case — routine reader-position saves must not touch the audio dimension of ABS's
      * shared media-progress record); `true`/`false` = explicitly set/clear it (only mark-finished

--- a/core/catalog/src/main/kotlin/com/riffle/core/catalog/abs/AbsCatalog.kt
+++ b/core/catalog/src/main/kotlin/com/riffle/core/catalog/abs/AbsCatalog.kt
@@ -21,6 +21,7 @@ import com.riffle.core.catalog.CatalogSeries
 import com.riffle.core.catalog.CatalogSeriesEntry
 import com.riffle.core.catalog.CatalogSessionHandle
 import com.riffle.core.catalog.CatalogStats
+import com.riffle.core.catalog.CfiDialect
 import com.riffle.core.catalog.CollectionsCapability
 import com.riffle.core.catalog.OfflineBrowseCapability
 import com.riffle.core.catalog.PlaylistsCapability
@@ -270,6 +271,8 @@ class AbsCatalog(
     // endregion
 
     // region ProgressPeerCapability
+
+    override val cfiDialect: CfiDialect = CfiDialect.EPUB_JS
 
     override suspend fun pushEbookProgress(
         itemId: String,

--- a/core/data/src/main/kotlin/com/riffle/core/data/AbsProgressRemotes.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/AbsProgressRemotes.kt
@@ -1,5 +1,6 @@
 package com.riffle.core.data
 
+import com.riffle.core.catalog.CfiDialect
 import com.riffle.core.catalog.ProgressPeerCapability
 import com.riffle.core.domain.Clock
 import com.riffle.core.domain.EbookCfiTranslator
@@ -8,10 +9,16 @@ import com.riffle.core.domain.RemoteProgress
 
 /**
  * An ebook media-progress record as one reconcilable target (ADR 0030), routed through the
- * Source's [ProgressPeerCapability]. Position is stored locally as Readium Locator JSON, but ABS
- * stores it as epub.js `epubcfi(...)`; [translator] converts between the two (ADR 0013). When the
- * cached EPUB isn't available the translator is null: GET returns null (Offline — row left dirty)
- * and PATCH is skipped (PushFailed — row left dirty) so no corrupt value ever enters either side.
+ * Source's [ProgressPeerCapability]. Position is stored locally as Readium Locator JSON. Whether
+ * the peer stores that same JSON verbatim ([CfiDialect.READIUM_NATIVE]) or a foreign epub.js
+ * `epubcfi(...)` string ([CfiDialect.EPUB_JS]) is decided by [ProgressPeerCapability.cfiDialect]:
+ *
+ *  - [CfiDialect.EPUB_JS] (ABS today, ADR 0013): [translator] converts at the Catalog boundary.
+ *    When the cached EPUB isn't available the translator is null — GET returns null (Offline, row
+ *    left dirty) and PATCH is skipped (PushFailed, row left dirty) so no corrupt value ever
+ *    enters either side.
+ *  - [CfiDialect.READIUM_NATIVE]: the peer already speaks Locator JSON, so the translator MUST
+ *    NOT run — even when supplied — and a null translator is normal, not "not cached yet".
  *
  * The PATCH also needs the `ebookProgress` fraction (ABS's library % + finished-detection); since
  * the local store keeps only the Locator JSON, the fraction is supplied by [readingProgress] —
@@ -26,22 +33,32 @@ class CatalogEbookProgressRemote(
 ) : ProgressRemote<String> {
 
     override suspend fun get(): RemoteProgress<String>? {
-        val t = translator ?: return null
         val r = runCatching { peer.pullProgress(itemId) }.getOrNull() ?: return null
         val raw = r.ebookLocation.orEmpty()
-        // ABS returns blank when the book has never been opened; skip translation so the
-        // reconciler can still compare timestamps and push local progress if it's newer.
-        val locatorJson = if (raw.isBlank()) "" else t.cfiToLocatorJson(raw) ?: return null
+        val locatorJson = when (peer.cfiDialect) {
+            CfiDialect.READIUM_NATIVE -> raw
+            CfiDialect.EPUB_JS -> {
+                val t = translator ?: return null
+                // ABS returns blank when the book has never been opened; skip translation so the
+                // reconciler can still compare timestamps and push local progress if it's newer.
+                if (raw.isBlank()) "" else t.cfiToLocatorJson(raw) ?: return null
+            }
+        }
         return RemoteProgress(locatorJson, r.lastUpdate)
     }
 
     override suspend fun patch(position: String): Long? {
-        val t = translator ?: return null
-        val cfi = t.locatorJsonToCfi(position) ?: return null
+        val payload = when (peer.cfiDialect) {
+            CfiDialect.READIUM_NATIVE -> position
+            CfiDialect.EPUB_JS -> {
+                val t = translator ?: return null
+                t.locatorJsonToCfi(position) ?: return null
+            }
+        }
         return runCatching {
             val stamp = peer.pushEbookProgress(
                 itemId = itemId,
-                location = cfi,
+                location = payload,
                 progress = readingProgress(),
                 isFinished = null,
                 lastUpdateEpochMs = clock.nowMs(),

--- a/core/data/src/main/kotlin/com/riffle/core/data/ProgressSweep.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/ProgressSweep.kt
@@ -1,6 +1,7 @@
 package com.riffle.core.data
 
 import com.riffle.core.catalog.CatalogRegistry
+import com.riffle.core.catalog.ProgressPeerCapability
 import com.riffle.core.domain.ProgressReconciler
 import com.riffle.core.domain.ProgressRemote
 import com.riffle.core.domain.RemoteKind
@@ -59,8 +60,14 @@ class ProgressSweep(
         for (sourceId in sources) {
             // Skip sources whose catalog can't be resolved right now (no row, no token, or no
             // registered factory) — rows stay dirty for the next sweep.
-            if (catalogRegistry.forSourceId(sourceId) == null) continue
-            for (itemId in ledger.dirtyEbookItems(sourceId)) {
+            val catalog = catalogRegistry.forSourceId(sourceId) ?: continue
+            // Progress reconciliation is only defined for sources whose Catalog is a
+            // ProgressPeerCapability (ADR 0041). Zero-peer sources (LocalFiles) still get their
+            // dirty position rows enumerated, but the loops below no-op — the rows are legal
+            // zero-peer entries and drain without work. Bookmarks are gated separately, further
+            // down, on their own capability by the underlying reconciler.
+            val isProgressPeer = catalog is ProgressPeerCapability
+            if (isProgressPeer) for (itemId in ledger.dirtyEbookItems(sourceId)) {
                 // Skip a book a live surface is driving — its own cycle owns inbound jumps (ADR 0030).
                 if (openTargets.isOpen(sourceId, itemId)) continue
                 val remote = remoteFactory.ebook(sourceId, itemId) ?: continue
@@ -68,7 +75,7 @@ class ProgressSweep(
                     ebookReconciler.reconcile(sourceId, itemId, remote)
                 }
             }
-            for (itemId in ledger.dirtyAudioItems(sourceId)) {
+            if (isProgressPeer) for (itemId in ledger.dirtyAudioItems(sourceId)) {
                 if (openTargets.isOpen(sourceId, itemId)) continue
                 val remote = remoteFactory.audio(sourceId, itemId) ?: continue
                 locks.withLock(sourceId, itemId, RemoteKind.ABS_AUDIO) {

--- a/core/data/src/test/kotlin/com/riffle/core/data/AbsProgressRemoteTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/AbsProgressRemoteTest.kt
@@ -1,6 +1,7 @@
 package com.riffle.core.data
 
 import com.riffle.core.catalog.CatalogProgress
+import com.riffle.core.catalog.CfiDialect
 import com.riffle.core.catalog.ProgressPeerCapability
 import com.riffle.core.domain.Clock
 import com.riffle.core.domain.EbookCfiTranslator
@@ -21,6 +22,7 @@ class AbsProgressRemoteTest {
         var progress: CatalogProgress? = null,
         var failGet: Boolean = false,
         var failPush: Boolean = false,
+        override val cfiDialect: CfiDialect = CfiDialect.EPUB_JS,
     ) : ProgressPeerCapability {
         data class Ebook(val itemId: String, val location: String, val progress: Float, val isFinished: Boolean?, val ts: Long)
         data class Audio(val itemId: String, val currentTimeSec: Double, val durationSec: Double, val isFinished: Boolean?, val ts: Long)
@@ -140,6 +142,40 @@ class AbsProgressRemoteTest {
         val peer = FakePeer(failPush = true)
         val translator = FakeTranslator(cfiResult = { it }, locatorResult = { it })
         assertNull(ebookRemote(peer, translator).patch("epubcfi(/6/4!/4)"))
+    }
+
+    // --- ebook, READIUM_NATIVE dialect: translator MUST be skipped ---
+
+    @Test
+    fun `ebook get - READIUM_NATIVE dialect passes ebookLocation through verbatim without translator`() = runTest {
+        val peer = FakePeer(
+            progress = CatalogProgress("item-1", ebookLocation = locatorJson, lastUpdate = 1700L),
+            cfiDialect = CfiDialect.READIUM_NATIVE,
+        )
+        val translator = FakeTranslator(cfiResult = { error("must not translate for READIUM_NATIVE") }, locatorResult = { error("must not translate") })
+        val read = ebookRemote(peer, translator).get()
+        assertEquals(locatorJson, read?.position)
+        assertEquals(1700L, read?.lastUpdate)
+    }
+
+    @Test
+    fun `ebook get - READIUM_NATIVE dialect succeeds even without a translator`() = runTest {
+        val peer = FakePeer(
+            progress = CatalogProgress("item-1", ebookLocation = locatorJson, lastUpdate = 1700L),
+            cfiDialect = CfiDialect.READIUM_NATIVE,
+        )
+        val read = ebookRemote(peer, translator = null).get()
+        assertEquals(locatorJson, read?.position)
+    }
+
+    @Test
+    fun `ebook patch - READIUM_NATIVE dialect sends Locator JSON verbatim and stamps`() = runTest {
+        val peer = FakePeer(cfiDialect = CfiDialect.READIUM_NATIVE)
+        val translator = FakeTranslator(cfiResult = { error("must not translate") }, locatorResult = { error("must not translate") })
+        val stamp = ebookRemote(peer, translator, progress = 0.42f).patch(locatorJson)
+        assertEquals(1800L, stamp)
+        assertEquals(locatorJson, peer.lastEbook?.location)
+        assertEquals(0.42f, peer.lastEbook?.progress)
     }
 
     // --- audio ---

--- a/core/data/src/test/kotlin/com/riffle/core/data/ProgressSweepTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/ProgressSweepTest.kt
@@ -1,13 +1,15 @@
 package com.riffle.core.data
 
+import com.riffle.core.catalog.BookFormat
 import com.riffle.core.catalog.Catalog
-import com.riffle.core.catalog.CatalogRegistry
 import com.riffle.core.catalog.CatalogFileHandle
 import com.riffle.core.catalog.CatalogFileStream
-import com.riffle.core.catalog.BookFormat
 import com.riffle.core.catalog.CatalogHealth
 import com.riffle.core.catalog.CatalogItem
+import com.riffle.core.catalog.CatalogProgress
+import com.riffle.core.catalog.CatalogRegistry
 import com.riffle.core.catalog.CatalogRoot
+import com.riffle.core.catalog.ProgressPeerCapability
 import com.riffle.core.catalog.SortKey
 import com.riffle.core.domain.PositionSnapshot
 import com.riffle.core.domain.ProgressReconciler
@@ -89,12 +91,17 @@ class ProgressSweepTest {
      */
     private class FakeRegistry(private val available: Set<String>) : CatalogRegistry {
         override suspend fun forActive(): Catalog? = null
-        override suspend fun forSource(source: Source): Catalog? = if (source.id in available) DummyCatalog else null
-        override suspend fun forSourceId(sourceId: String): Catalog? = if (sourceId in available) DummyCatalog else null
+        override suspend fun forSource(source: Source): Catalog? = if (source.id in available) DummyCatalog.PEER else null
+        override suspend fun forSourceId(sourceId: String): Catalog? = if (sourceId in available) DummyCatalog.PEER else null
     }
 
-    /** No-op Catalog — sweep never invokes its methods; only presence/absence matters. */
-    private object DummyCatalog : Catalog {
+    /**
+     * A Catalog that implements [ProgressPeerCapability] — sweep gates sources on the capability
+     * (ADR 0041), so the fake registry's presence-check maps 1:1 to "is a progress peer" for these
+     * tests. All methods no-op; only presence/absence matters. The [asPeer] flag lets a test opt out
+     * of the capability to simulate a zero-peer source (LocalFiles).
+     */
+    private open class DummyCatalog(val asPeer: Boolean = true) : Catalog {
         override val sourceType = SourceType.ABS
         override suspend fun listRoots() = emptyList<CatalogRoot>()
         override suspend fun browse(rootId: String, sort: SortKey, page: Int, pageSize: Int) = emptyList<CatalogItem>()
@@ -105,6 +112,18 @@ class ProgressSweepTest {
         override suspend fun openFile(itemId: String, format: BookFormat, handleHint: String?): CatalogFileStream =
             throw UnsupportedOperationException()
         override suspend fun connectivityCheck() = CatalogHealth(isReachable = false)
+
+        companion object {
+            val PEER: Catalog = PeerCatalog()
+            val NON_PEER: Catalog = DummyCatalog(asPeer = false)
+        }
+
+        private class PeerCatalog : DummyCatalog(asPeer = true), ProgressPeerCapability {
+            override suspend fun pushEbookProgress(itemId: String, location: String, progress: Float, isFinished: Boolean?, lastUpdateEpochMs: Long) = null
+            override suspend fun pushAudiobookProgress(itemId: String, currentTimeSec: Double, durationSec: Double, isFinished: Boolean?, lastUpdateEpochMs: Long) = null
+            override suspend fun pullProgress(itemId: String): CatalogProgress? = null
+            override suspend fun pullAllProgress(): List<CatalogProgress> = emptyList()
+        }
     }
 
     private fun ledger(
@@ -211,6 +230,28 @@ class ProgressSweepTest {
 
         assertFalse(ebookStore.dirty("s1", "i1"))
         assertFalse(audioStore.dirty("s1", "i1"))
+    }
+
+    @Test
+    fun `skips sources whose Catalog is not a ProgressPeerCapability, leaving their rows dirty`() = runTest {
+        // A LocalFiles Source has a Catalog but no ProgressPeerCapability (ADR 0041). Its dirty
+        // position rows are legal zero-peer entries — the sweep must drain them immediately (no
+        // work) and never build a remote for them. `localUpdatedAt` stays as the reader wrote it.
+        val store = FakeStore<String>().apply { rows["local-fs" to "book"] = Triple("local", 300L, 100L) }
+        val factory = RecordingFactory()
+        val registry = object : CatalogRegistry {
+            override suspend fun forActive(): Catalog? = null
+            override suspend fun forSource(source: Source): Catalog? = DummyCatalog.NON_PEER
+            override suspend fun forSourceId(sourceId: String): Catalog? = DummyCatalog.NON_PEER
+        }
+
+        sweep(
+            ledger(listOf("local-fs"), ebook = mapOf("local-fs" to listOf("book"))),
+            registry, store, FakeStore(), factory,
+        ).run()
+
+        assertTrue("row remains at its local timestamp — nothing to sync against", store.dirty("local-fs", "book"))
+        assertFalse("no remote must be built for a zero-peer source", factory.ebookBuilt.contains("local-fs" to "book"))
     }
 
     @Test

--- a/core/domain/src/test/kotlin/com/riffle/core/domain/CanonicalSyncCycleTest.kt
+++ b/core/domain/src/test/kotlin/com/riffle/core/domain/CanonicalSyncCycleTest.kt
@@ -109,6 +109,24 @@ class CanonicalSyncCycleTest {
     }
 
     @Test
+    fun `zero-peer cycle no-ops on both directions and preserves local lastUpdate`() = runTest {
+        // A LocalFiles-only book has no ProgressPeerCapability sources → empty peer list.
+        // The reconciler must run cleanly, never jump, never patch, and leave localUpdatedAt
+        // untouched so on-device activity keeps advancing it (ADR 0041 zero-peer contract).
+        val local = LocalCanonical(pos("L"), lastUpdate = 4242)
+
+        val result = CanonicalSyncCycle.run(local, emptyList())
+
+        assertNull("no remotes → no jump", result.jumpTo)
+        assertTrue("no remotes → nothing patched", result.patched.isEmpty())
+        assertEquals(
+            "local lastUpdate is preserved verbatim so the reader keeps advancing it",
+            4242L,
+            result.canonicalLastUpdate,
+        )
+    }
+
+    @Test
     fun `a peer that skips its PATCH is treated identically to one that fails`() = runTest {
         // WriteResult.Skipped models a deliberate no-op (e.g. translator couldn't place the
         // canonical position, or an inbound-only wrapper suppressed the outbound). The cycle must


### PR DESCRIPTION
Closes #440

## Summary

Progress Sync peer selection now flows from `ProgressPeerCapability` rather than assuming an ABS-shaped source. Phase 7 of the ADR 0041 rearchitecture.

- **CFI dialect marker.** New `CfiDialect { EPUB_JS, READIUM_NATIVE }` on `ProgressPeerCapability` (default `EPUB_JS`). `CatalogEbookProgressRemote` gates the CFI translator on this — `READIUM_NATIVE` peers round-trip Readium Locator JSON verbatim, so a null translator is a normal state for them, not "not cached yet". `AbsCatalog` explicitly declares `CfiDialect.EPUB_JS` (ADR 0013).
- **Zero-peer sweep.** `ProgressSweep` explicitly skips the ebook/audio loops for a source whose Catalog is not a `ProgressPeerCapability` (LocalFiles). Dirty position rows on such sources are legal zero-peer entries per ADR 0041 and drain immediately without work. Bookmarks stay gated separately by their own capability, unchanged.
- **Zero-peer cycle.** `CanonicalSyncCycle` already no-ops on an empty peer list; that contract is now pinned by a regression test so it can't silently regress.
- **Preserved behavior.** All existing ABS-matched-book Progress Sync tests are untouched; only tests directly asserting the new capability gate are added.

## Test plan

- [x] `./gradlew test` — full JVM suite green
- [x] New JVM tests: zero-peer `CanonicalSyncCycle`, zero-peer `ProgressSweep`, `CatalogEbookProgressRemote` `READIUM_NATIVE` round-trip (with and without translator)
- [ ] Instrumentation on a LocalFiles reader session with progress advancement across close/reopen (blocked on #7, which this issue unblocks)