### PR TITLE
refactor(storyteller): rename Storyteller Server → Storyteller Service (ADR 0041)

### DIFF
--- a/app/src/androidTest/kotlin/com/riffle/app/feature/reader/readaloud/ReadaloudStreamingSessionFactoryAndroidTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/reader/readaloud/ReadaloudStreamingSessionFactoryAndroidTest.kt
@@ -140,7 +140,7 @@ class ReadaloudStreamingSessionFactoryAndroidTest {
 
     private fun seed(withAudiobook: Boolean) = runBlocking {
         db.sourceDao().upsert(SourceEntity(ABS_SERVER, baseUrl, true, false, "u", ServerType.AUDIOBOOKSHELF.name))
-        db.sourceDao().upsert(SourceEntity(ST_SERVER, baseUrl, false, false, "u", ServerType.STORYTELLER.name))
+        db.sourceDao().upsert(SourceEntity(ST_SERVER, baseUrl, false, false, "u", ServerType.STORYTELLER_SERVICE.name))
         if (withAudiobook) {
             db.libraryItemDao().upsertAll(
                 listOf(

--- a/app/src/androidTest/kotlin/com/riffle/app/feature/settings/ServerSettingsExpansionTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/settings/ServerSettingsExpansionTest.kt
@@ -155,7 +155,7 @@ class ServerSettingsExpansionTest {
         var opened = false
         composeTestRule.setContent {
             ServerSettingsExpansion(
-                server = server(ServerType.STORYTELLER, active = true),
+                server = server(ServerType.STORYTELLER_SERVICE, active = true),
                 libraryItems = emptyList(),
                 summary = ReadaloudMatchSummary(unmatchedCount = 2, suggestedCount = 1, partiallyMatchedCount = 1, matchedCount = 3),
                 onSetLibraryVisible = { _, _ -> },

--- a/app/src/main/kotlin/com/riffle/app/feature/annotations/AnnotationsListViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/annotations/AnnotationsListViewModel.kt
@@ -31,7 +31,7 @@ data class AnnotationsListUiState(
  * Backs the per-Library Annotations tab in the Library Tab Bar — books with at least one live
  * highlight on the active server, scoped to [libraryId] read from `SavedStateHandle`, following the
  * same pattern as `LibraryItemsViewModel`. Follows the active-server derivation shape used by
- * `NavigationDrawerViewModel` (Storyteller servers are excluded there too, but they never carry
+ * `NavigationDrawerViewModel` (Storyteller services are excluded there too, but they never carry
  * annotations to begin with since annotation sync is ABS-server-scoped).
  */
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -47,7 +47,7 @@ class AnnotationsListViewModel @Inject constructor(
 
     private val activeServerId: kotlinx.coroutines.flow.Flow<String?> = sourceRepository.observeAll()
         .map { servers ->
-            servers.firstOrNull { it.isActive && it.serverType != ServerType.STORYTELLER }?.id
+            servers.firstOrNull { it.isActive && it.serverType != ServerType.STORYTELLER_SERVICE }?.id
         }
 
     val state: StateFlow<AnnotationsListUiState> = activeServerId

--- a/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModel.kt
@@ -393,8 +393,8 @@ class AudiobookPlayerViewModel @Inject constructor(
             // Readaloud is only actually offerable when the synced bundle is present — the same gate the
             // reader applies (readaloudControlState): a Storyteller book always qualifies, a matched ABS
             // book only once its bundle is downloaded, an unmatched ABS book never. The bundle is keyed by
-            // the linked Storyteller book (or this item, on a Storyteller server), NOT the ABS item id.
-            val isStoryteller = server?.serverType == com.riffle.core.domain.ServerType.STORYTELLER
+            // the linked Storyteller book (or this item, on a Storyteller service), NOT the ABS item id.
+            val isStoryteller = server?.serverType == com.riffle.core.domain.ServerType.STORYTELLER_SERVICE
             val audioServerId = link?.storytellerSourceId ?: sourceId
             val audioBookId = link?.storytellerBookId ?: itemId
             val readaloudAvailable = com.riffle.app.feature.reader.readaloudControlState(

--- a/app/src/main/kotlin/com/riffle/app/feature/navigation/NavigationDrawerViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/navigation/NavigationDrawerViewModel.kt
@@ -56,7 +56,7 @@ class NavigationDrawerViewModel @Inject constructor(
     // Storyteller is a Settings-only readaloud backend (ADR 0026): it never appears in the Source
     // Switcher and can never become the active browsable Source.
     val allServers: StateFlow<List<Source>> = sourceRepository.observeAll()
-        .map { servers -> servers.filter { it.serverType != ServerType.STORYTELLER } }
+        .map { servers -> servers.filter { it.serverType != ServerType.STORYTELLER_SERVICE } }
         .stateIn(viewModelScope, SharingStarted.Eagerly, emptyList())
 
     val activeServer: StateFlow<Source?> = allServers

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -690,8 +690,8 @@ class EpubReaderViewModel @Inject constructor(
 
     // ---- Readaloud (ADR 0023) ----------------------------------------------------------------
 
-    // isStorytellerServer and readerServerId now live on [lifecycle] (issue #376). The single
-    // remaining read site (annotation binding) captures activeServer + isStorytellerServer from
+    // isStorytellerService and readerServerId now live on [lifecycle] (issue #376). The single
+    // remaining read site (annotation binding) captures activeServer + isStorytellerService from
     // the Ready payload directly.
 
     // ---- Annotations (ADR 0024 / 0025) -------------------------------------------------------
@@ -1017,7 +1017,7 @@ class EpubReaderViewModel @Inject constructor(
         readaloud.bind(
             sourceId = o.resolvedReaderServerId ?: "",
             itemId = itemId,
-            isStorytellerServer = o.isStorytellerServer,
+            isStorytellerService = o.isStorytellerService,
             audioBookId = o.resolvedAudioBookId,
             audioServerId = o.resolvedAudioServerId,
             audioSettingsIdentity = o.resolvedAudioSettingsIdentity,
@@ -1072,7 +1072,7 @@ class EpubReaderViewModel @Inject constructor(
 
         // ── Annotation binding — ABS-side only (ADR 0024) ────────────────────────────
         val activeServer = o.activeServer
-        if (!o.isStorytellerServer && activeServer != null) {
+        if (!o.isStorytellerService && activeServer != null) {
             annotationServerId = activeServer.id
             // Bind the bookmarks controller so it can observe bookmarks and track the current
             // locator for page-bookmark detection.

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/session/ReadaloudSession.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/session/ReadaloudSession.kt
@@ -234,8 +234,8 @@ class ReadaloudSession @AssistedInject constructor(
     // --- Audio-source identity (bundle key) — set by VM init coroutine via property setters ---
     internal var audioBookId: String = ""
     internal var audioServerId: String = ""
-    // True when the active server is a Storyteller server; drives availability and sync behaviour.
-    internal var isStorytellerServer: Boolean = false
+    // True when the active server is a Storyteller service; drives availability and sync behaviour.
+    internal var isStorytellerService: Boolean = false
     // The reader's active server id, keys readaloud resume position (both seed-on-open and save-on-close).
     internal var readerServerId: String? = null
 
@@ -735,7 +735,7 @@ class ReadaloudSession @AssistedInject constructor(
     fun bind(
         sourceId: String,
         itemId: String,
-        isStorytellerServer: Boolean,
+        isStorytellerService: Boolean,
         audioBookId: String,
         audioServerId: String,
         audioSettingsIdentity: AudioIdentity,
@@ -752,7 +752,7 @@ class ReadaloudSession @AssistedInject constructor(
         // readerSyncServerId is derived from the VM's readerSyncServerId (same server as sourceId
         // for the ebook side). Wire it now so mirrorReadingToAudiobook is non-null immediately.
         this.readerSyncServerId = sourceId
-        this.isStorytellerServer = isStorytellerServer
+        this.isStorytellerService = isStorytellerService
         this.audioBookId = audioBookId
         this.audioServerId = audioServerId
         this.audioSettingsIdentity = audioSettingsIdentity
@@ -767,7 +767,7 @@ class ReadaloudSession @AssistedInject constructor(
         val isMatchedAbs = audioBookId != itemId
         val bundlePresent = readaloudAudioRepository.isAudioAvailable(audioServerId, audioBookId)
         val control = readaloudControlState(
-            isStoryteller = isStorytellerServer,
+            isStoryteller = isStorytellerService,
             isMatchedAbs = isMatchedAbs,
             bundlePresent = bundlePresent,
         )
@@ -1064,7 +1064,7 @@ class ReadaloudSession @AssistedInject constructor(
     }
 
     private fun startStorytellerSync() {
-        if (!isStorytellerServer) return
+        if (!isStorytellerService) return
         // A matched book runs the canonical reconciliation cycle; don't also run the standalone Storyteller loop.
         if (readerSyncProvider() != null) return
         if (storytellerSyncJob?.isActive == true) return

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/session/ReaderSessionLifecycle.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/session/ReaderSessionLifecycle.kt
@@ -112,11 +112,11 @@ class ReaderSessionLifecycle @AssistedInject constructor(
         _publication.value = pub
 
         val activeServer: Source? = sourceRepository.getActive()
-        val isStorytellerServer = activeServer?.serverType == ServerType.STORYTELLER
+        val isStorytellerService = activeServer?.serverType == ServerType.STORYTELLER_SERVICE
 
         // Matched ABS book → key the bundle by the linked Storyteller book id (the bundle is
         // stored under that id, not the ABS item id). Storyteller side keeps itemId.
-        val link = if (!isStorytellerServer && activeServer != null) {
+        val link = if (!isStorytellerService && activeServer != null) {
             readaloudLinkRepository.findByAbsItem(activeServer.id, params.itemId)
         } else {
             null
@@ -210,7 +210,7 @@ class ReaderSessionLifecycle @AssistedInject constructor(
             effectiveInitialLocator = effectiveInitial,
             openAtLocator = openAtLocator,
             activeServer = activeServer,
-            isStorytellerServer = isStorytellerServer,
+            isStorytellerService = isStorytellerService,
             resolvedAudioBookId = resolvedAudioBookId,
             resolvedAudioServerId = resolvedAudioServerId,
             resolvedReaderServerId = resolvedReaderServerId,
@@ -278,7 +278,7 @@ class ReaderSessionLifecycle @AssistedInject constructor(
             val effectiveInitialLocator: Locator?,
             val openAtLocator: Locator?,
             val activeServer: Source?,
-            val isStorytellerServer: Boolean,
+            val isStorytellerService: Boolean,
             val resolvedAudioBookId: String,
             val resolvedAudioServerId: String,
             val resolvedReaderServerId: String?,

--- a/app/src/main/kotlin/com/riffle/app/feature/server/AddSourceViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/server/AddSourceViewModel.kt
@@ -248,7 +248,7 @@ class AddSourceViewModel @Inject constructor(
                         editingServerId?.let { repository.remove(it) }
                         when (val c = repository.commit(pending, hiddenLibraryIds = emptySet())) {
                             is CommitSourceResult.Success -> {
-                                if (serverType == ServerType.STORYTELLER) {
+                                if (serverType == ServerType.STORYTELLER_SERVICE) {
                                     runCatching { storytellerSyncer.syncStale() }
                                     runCatching { readaloudMatcher.reconcileLinks() }
                                 }
@@ -374,6 +374,6 @@ private fun parseBackend(raw: String?): AddSourceBackend = when (raw?.lowercase(
 
 private fun AddSourceBackend.toServerType(): ServerType? = when (this) {
     AddSourceBackend.AUDIOBOOKSHELF -> ServerType.AUDIOBOOKSHELF
-    AddSourceBackend.STORYTELLER -> ServerType.STORYTELLER
+    AddSourceBackend.STORYTELLER -> ServerType.STORYTELLER_SERVICE
     AddSourceBackend.WEBDAV -> null
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsScreen.kt
@@ -343,7 +343,7 @@ fun SettingsScreen(
                     modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
                 )
                 HorizontalDivider()
-                val storytellerServers = servers.filter { it.serverType == ServerType.STORYTELLER }
+                val storytellerServers = servers.filter { it.serverType == ServerType.STORYTELLER_SERVICE }
                 if (storytellerServers.isEmpty()) {
                     ListItem(
                         modifier = Modifier.clickable { onNavigateToAddSource(AddSourceBackend.STORYTELLER, null) },
@@ -847,7 +847,7 @@ private fun ServerRow(
 
 /**
  * The settings revealed when a server row is expanded: ABS servers show their library visibility
- * switches; Storyteller servers show a readaloud-matches summary that opens the full matches screen.
+ * switches; Storyteller services show a readaloud-matches summary that opens the full matches screen.
  */
 @Composable
 internal fun ServerSettingsExpansion(
@@ -877,7 +877,7 @@ internal fun ServerSettingsExpansion(
                     )
                 }
             }
-            ServerType.STORYTELLER -> {
+            ServerType.STORYTELLER_SERVICE -> {
                 ExpansionHeader("Readaloud matches")
                 val counts = summary ?: ReadaloudMatchSummary(0, 0, 0, 0)
                 ListItem(

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsViewModel.kt
@@ -274,9 +274,9 @@ class SettingsViewModel @Inject constructor(
         folderHealthRefreshTicks.value = folderHealthRefreshTicks.value + 1L
     }
 
-    /** Ids of the configured Storyteller servers, feeding the per-server readaloud summaries. */
+    /** Ids of the configured Storyteller services, feeding the per-server readaloud summaries. */
     private val storytellerServerIds: StateFlow<List<String>> = servers
-        .map { list -> list.filter { it.serverType == ServerType.STORYTELLER }.map { it.id } }
+        .map { list -> list.filter { it.serverType == ServerType.STORYTELLER_SERVICE }.map { it.id } }
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
 
     /** Readaloud-matches counts (unmatched / suggested / partially matched / matched) per server. */
@@ -420,7 +420,7 @@ class SettingsViewModel @Inject constructor(
             if (removing.isActive) {
                 // Promote the next browsable server. A Storyteller Source is never browsable
                 // (ADR 0026) and can never be active, so skip it when choosing the successor.
-                val next = current.firstOrNull { it.id != sourceId && it.serverType != ServerType.STORYTELLER }
+                val next = current.firstOrNull { it.id != sourceId && it.serverType != ServerType.STORYTELLER_SERVICE }
                 if (next != null) {
                     sourceRepository.setActive(next.id)
                 } else {
@@ -478,7 +478,7 @@ class SettingsViewModel @Inject constructor(
     // endregion
 }
 
-/** Counts shown in a Storyteller server's expanded "Readaloud matches" summary (gradient order). */
+/** Counts shown in a Storyteller service's expanded "Readaloud matches" summary (gradient order). */
 data class ReadaloudMatchSummary(
     val unmatchedCount: Int,
     val suggestedCount: Int,

--- a/app/src/test/kotlin/com/riffle/app/feature/navigation/NavigationDrawerViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/navigation/NavigationDrawerViewModelTest.kt
@@ -256,12 +256,12 @@ class NavigationDrawerViewModelTest {
     }
 
     @Test
-    fun `allServers excludes Storyteller servers from the switcher`() = runTest {
+    fun `allServers excludes Storyteller services from the switcher`() = runTest {
         // Storyteller is a Settings-only readaloud backend (ADR 0026) — it must never appear in the
         // drawer's Source Switcher, so it can never become the active browsable server.
         serversFlow.value = listOf(
             server("abs-1", active = true),
-            server("st-1", serverType = ServerType.STORYTELLER),
+            server("st-1", serverType = ServerType.STORYTELLER_SERVICE),
         )
 
         val vm = makeVm()

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/session/ReadaloudSessionTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/session/ReadaloudSessionTest.kt
@@ -628,7 +628,7 @@ class ReadaloudSessionTest {
             )
             // Make available
             session._readaloudAvailable.value = true
-            // isStorytellerServer=false → no storyteller sync; connectivityObserver.isOnline returns true
+            // isStorytellerService=false → no storyteller sync; connectivityObserver.isOnline returns true
             // No bundle and no streaming session → shows download prompt (probeSizeBytes=500)
             session.audioBookId = "book1"
             session.audioServerId = "srv1"
@@ -1011,7 +1011,7 @@ class ReadaloudSessionTest {
             session.bind(
                 sourceId = "srv-reader",
                 itemId = "ebook-abc",
-                isStorytellerServer = true,
+                isStorytellerService = true,
                 audioBookId = "styteller-book-99",
                 audioServerId = "srv-st",
                 audioSettingsIdentity = expectedIdentity,
@@ -1026,12 +1026,12 @@ class ReadaloudSessionTest {
             assertEquals("itemId must be stored", "ebook-abc", session.itemId)
             assertEquals("readerServerId must be stored", "srv-reader", session.readerServerId)
             assertEquals("readerSyncServerId must be stored", "srv-reader", session.readerSyncServerId)
-            assertEquals("isStorytellerServer must be stored", true, session.isStorytellerServer)
+            assertEquals("isStorytellerService must be stored", true, session.isStorytellerService)
             assertEquals("audioBookId must be stored", "styteller-book-99", session.audioBookId)
             assertEquals("audioServerId must be stored", "srv-st", session.audioServerId)
             assertEquals("audioSettingsIdentity must be stored", expectedIdentity, session.audioSettingsIdentity)
             assertEquals("audiobookItemId must be stored", "abs-audiobook-777", session.audiobookItemId.value)
-            // Storyteller server → readaloud is always available and visible
+            // Storyteller service → readaloud is always available and visible
             assertTrue("readaloudAvailable must be true for Storyteller", session.readaloudAvailable.value)
             assertTrue("readaloudVisible must be true for Storyteller", session.readaloudVisible.value)
         } finally {
@@ -1045,7 +1045,7 @@ class ReadaloudSessionTest {
         try {
             val bundle = java.io.File.createTempFile("bundle", ".zip")
             bundle.deleteOnExit()
-            // Use a Storyteller server (always available) so the pre-warm path is reached
+            // Use a Storyteller service (always available) so the pre-warm path is reached
             val fakeRepo = FakeReadaloudAudioRepository(bundleFileVal = bundle)
             val session = makeSessionForBind(scope = sessionScope, audioRepository = fakeRepo)
 
@@ -1057,7 +1057,7 @@ class ReadaloudSessionTest {
             session.bind(
                 sourceId = "srv1",
                 itemId = "book1",
-                isStorytellerServer = true,
+                isStorytellerService = true,
                 audioBookId = "book1",
                 audioServerId = "srv1",
                 audioSettingsIdentity = com.riffle.core.domain.AudioIdentity("srv1", "book1"),
@@ -1134,7 +1134,7 @@ class ReadaloudSessionTest {
             session.bind(
                 sourceId = "srv1",
                 itemId = "book1",
-                isStorytellerServer = true,
+                isStorytellerService = true,
                 audioBookId = "book1",
                 audioServerId = "srv1",
                 audioSettingsIdentity = AudioIdentity("srv1", "book1"),
@@ -1222,7 +1222,7 @@ class ReadaloudSessionTest {
             session.bind(
                 sourceId = "srv-reader",
                 itemId = "abs-book",
-                isStorytellerServer = false,
+                isStorytellerService = false,
                 audioBookId = "st-book",
                 audioServerId = "srv-st",
                 audioSettingsIdentity = AudioIdentity("srv-st", "st-book"),

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/session/ReaderSessionLifecycleTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/session/ReaderSessionLifecycleTest.kt
@@ -189,7 +189,7 @@ class ReaderSessionLifecycleTest {
         serverType = ServerType.AUDIOBOOKSHELF,
     )
 
-    private val storytellerServer = activeServer.copy(id = "srv-st", serverType = ServerType.STORYTELLER)
+    private val storytellerServer = activeServer.copy(id = "srv-st", serverType = ServerType.STORYTELLER_SERVICE)
 
     private val ebookItem = LibraryItem(
         id = "item-1",
@@ -286,7 +286,7 @@ class ReaderSessionLifecycleTest {
         val (lifecycle, _) = makeLifecycle(openReconcileTargets = reconcile)
         val outcome = lifecycle.open(params()) as ReaderSessionLifecycle.OpenOutcome.Ready
 
-        assertFalse(outcome.isStorytellerServer)
+        assertFalse(outcome.isStorytellerService)
         assertEquals("item-1", outcome.resolvedAudioBookId)
         assertEquals("srv-abs", outcome.resolvedAudioServerId)
         assertEquals("srv-abs", outcome.resolvedReaderServerId)
@@ -333,13 +333,13 @@ class ReaderSessionLifecycleTest {
     }
 
     @Test
-    fun `open on Storyteller server keeps itemId as audio ids`() = runTest {
+    fun `open on Storyteller service keeps itemId as audio ids`() = runTest {
         val (lifecycle, _) = makeLifecycle(
             sourceRepository = FakeServerRepository(storytellerServer),
         )
         val outcome = lifecycle.open(params()) as ReaderSessionLifecycle.OpenOutcome.Ready
 
-        assertTrue(outcome.isStorytellerServer)
+        assertTrue(outcome.isStorytellerService)
         assertEquals("item-1", outcome.resolvedAudioBookId)
         assertEquals("srv-st", outcome.resolvedAudioServerId)
     }

--- a/app/src/test/kotlin/com/riffle/app/feature/server/AddSourceViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/server/AddSourceViewModelTest.kt
@@ -350,7 +350,7 @@ class AddSourceViewModelTest {
             isActive = false,
             insecureConnectionAllowed = true,
             username = "plamen",
-            serverType = com.riffle.core.domain.ServerType.STORYTELLER,
+            serverType = com.riffle.core.domain.ServerType.STORYTELLER_SERVICE,
         )
         val repo = RecordingRepository(
             authResult = AuthenticateResult.WrongCredentials("x"),
@@ -620,7 +620,7 @@ class AddSourceViewModelTest {
             isActive = false,
             insecureConnectionAllowed = false,
             username = "plamen",
-            serverType = com.riffle.core.domain.ServerType.STORYTELLER,
+            serverType = com.riffle.core.domain.ServerType.STORYTELLER_SERVICE,
         )
         val repo = RecordingRepository(
             authResult = AuthenticateResult.WrongCredentials("Bad creds"),
@@ -646,7 +646,7 @@ class AddSourceViewModelTest {
             isActive = false,
             insecureConnectionAllowed = true,
             username = "plamen",
-            serverType = com.riffle.core.domain.ServerType.STORYTELLER,
+            serverType = com.riffle.core.domain.ServerType.STORYTELLER_SERVICE,
         )
         val repo = RecordingRepository(
             authResult = AuthenticateResult.WrongCredentials("x"),

--- a/app/src/test/kotlin/com/riffle/app/feature/settings/SettingsViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/settings/SettingsViewModelTest.kt
@@ -395,7 +395,7 @@ class SettingsViewModelTest {
         // the active ABS server must skip the Storyteller and promote the next ABS server.
         serversFlow.value = listOf(
             server("abs-1", active = true),
-            server("st-1", serverType = ServerType.STORYTELLER),
+            server("st-1", serverType = ServerType.STORYTELLER_SERVICE),
             server("abs-2"),
         )
         val vm = makeViewModel()
@@ -528,7 +528,7 @@ class SettingsViewModelTest {
 
     @Test
     fun `readaloudSummaries reports per-server unmatched suggested partially-matched and matched counts`() = runTest {
-        serversFlow.value = listOf(server("st-1", active = true, serverType = ServerType.STORYTELLER))
+        serversFlow.value = listOf(server("st-1", active = true, serverType = ServerType.STORYTELLER_SERVICE))
         reviewsFlow.value = mapOf(
             "st-1" to ReadaloudReview(
                 pending = listOf(pending("b1")),
@@ -549,7 +549,7 @@ class SettingsViewModelTest {
     }
 
     @Test
-    fun `readaloudSummaries is empty when there are no Storyteller servers`() = runTest {
+    fun `readaloudSummaries is empty when there are no Storyteller services`() = runTest {
         serversFlow.value = listOf(server("abs-1", active = true))
         val vm = makeViewModel()
         backgroundScope.launch { vm.readaloudSummaries.collect {} }

--- a/core/data/src/main/kotlin/com/riffle/core/data/LocalStoreImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/LocalStoreImpl.kt
@@ -8,7 +8,7 @@ import java.io.File
 import java.io.InputStream
 
 // Files live under dir/<sourceId>/<itemId><ext> so item ids that collide across Servers
-// (e.g. two Storyteller Servers each emitting "1") never overwrite each other (ADR 0025).
+// (e.g. two Storyteller Services each emitting "1") never overwrite each other (ADR 0025).
 class LocalStoreImpl(
     private val dir: File,
     private val extension: String,

--- a/core/data/src/main/kotlin/com/riffle/core/data/ReadaloudMatchingService.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/ReadaloudMatchingService.kt
@@ -49,7 +49,7 @@ open class ReadaloudMatchingService(
     ) : this(libraryItemDao, readaloudLinkDao, readaloudCandidateDao, readaloudDismissalDao, System::currentTimeMillis)
 
     override suspend fun reconcileLinks() {
-        val storytellerBooks = libraryItemDao.listMatchableBySourceType(ServerType.STORYTELLER.name)
+        val storytellerBooks = libraryItemDao.listMatchableBySourceType(ServerType.STORYTELLER_SERVICE.name)
         val absItems = libraryItemDao.listMatchableBySourceType(ServerType.AUDIOBOOKSHELF.name)
 
         // Match each ABS server (= one user login on one ABS instance) independently: a

--- a/core/data/src/main/kotlin/com/riffle/core/data/ReadaloudReviewRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/ReadaloudReviewRepositoryImpl.kt
@@ -73,7 +73,7 @@ class ReadaloudReviewRepositoryImpl(
         allLinks: List<ReadaloudLinkEntity>,
         candidates: List<ReadaloudCandidateEntity>,
     ): ReadaloudReview {
-        val books = libraryItemDao.listMatchableBySourceType(ServerType.STORYTELLER.name)
+        val books = libraryItemDao.listMatchableBySourceType(ServerType.STORYTELLER_SERVICE.name)
             .filter { it.sourceId == storytellerSourceId }
 
         val linksForServer = allLinks.filter { it.storytellerSourceId == storytellerSourceId }

--- a/core/data/src/main/kotlin/com/riffle/core/data/SourceRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/SourceRepositoryImpl.kt
@@ -57,7 +57,7 @@ class SourceRepositoryImpl @Inject constructor(
         serverType: ServerType,
     ): AuthenticateResult = when (serverType) {
         ServerType.AUDIOBOOKSHELF -> authenticateAbs(url, username, password, insecureAllowed)
-        ServerType.STORYTELLER -> authenticateStoryteller(url, username, password, insecureAllowed)
+        ServerType.STORYTELLER_SERVICE -> authenticateStoryteller(url, username, password, insecureAllowed)
     }
 
     private suspend fun authenticateAbs(
@@ -119,7 +119,7 @@ class SourceRepositoryImpl @Inject constructor(
                 // readaloud backend. The local namespace row that hosts its books as matcher input
                 // is created in [commit], not surfaced to the user.
                 libraries = emptyList(),
-                serverType = ServerType.STORYTELLER,
+                serverType = ServerType.STORYTELLER_SERVICE,
             )
         )
         else -> AuthenticateResult.NetworkError(result.errorAsThrowable())
@@ -146,7 +146,7 @@ class SourceRepositoryImpl @Inject constructor(
         // A Storyteller Source is a Settings-only readaloud backend (ADR 0026) — it must never
         // become the active browsable Source, not even as the first source added. ABS sources keep
         // the "first source becomes active" convenience.
-        val inserted = if (pending.serverType == ServerType.STORYTELLER) {
+        val inserted = if (pending.serverType == ServerType.STORYTELLER_SERVICE) {
             dao.upsert(entity)
             entity
         } else {
@@ -162,7 +162,7 @@ class SourceRepositoryImpl @Inject constructor(
         // matcher's library→source join resolves their serverType and the source-removal cascade
         // cleans them up. This row is never surfaced in the drawer or any library picker — the
         // Source is never the active browsable Source.
-        if (pending.serverType == ServerType.STORYTELLER) {
+        if (pending.serverType == ServerType.STORYTELLER_SERVICE) {
             libraryRows += LibraryEntity(
                 id = readaloudLibraryId(id),
                 name = "Readalouds",
@@ -181,7 +181,7 @@ class SourceRepositoryImpl @Inject constructor(
         // A Storyteller Source is a Settings-only readaloud backend (ADR 0026) — it can never be the
         // active browsable Source. Enforce the invariant here so no caller (source removal, deep
         // links, future UI) can promote one, and a stale DB row can't be re-activated.
-        if (dao.getById(sourceId)?.serverType == ServerType.STORYTELLER.name) return
+        if (dao.getById(sourceId)?.serverType == ServerType.STORYTELLER_SERVICE.name) return
         dao.setActiveAtomic(sourceId)
     }
 
@@ -203,7 +203,7 @@ class SourceRepositoryImpl @Inject constructor(
     override suspend fun getSourceVersion(sourceId: String): String? {
         val source = dao.getById(sourceId)?.toDomain() ?: return null
         // Storyteller exposes no /server-info endpoint; the UI deliberately shows no version for it.
-        if (source.serverType == ServerType.STORYTELLER) return null
+        if (source.serverType == ServerType.STORYTELLER_SERVICE) return null
         val token = tokenStorage.getToken(sourceId) ?: return null
         return serverInfoApi.getServerInfo(
             baseUrl = source.url.value,
@@ -225,7 +225,7 @@ class SourceRepositoryImpl @Inject constructor(
 
     override suspend fun ensureAbsUserId(sourceId: String): String? {
         val row = dao.getById(sourceId) ?: return null
-        if (row.serverType == ServerType.STORYTELLER.name) return null
+        if (row.serverType == ServerType.STORYTELLER_SERVICE.name) return null
         row.absUserId?.takeIf { it.isNotBlank() }?.let { return it }
         // Legacy row (added before the column existed) — backfill from /api/me.
         val token = tokenStorage.getToken(sourceId) ?: return null

--- a/core/data/src/main/kotlin/com/riffle/core/data/StorytellerReadaloudSyncer.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/StorytellerReadaloudSyncer.kt
@@ -71,10 +71,10 @@ open class StorytellerReadaloudSyncer(
 ) : com.riffle.core.domain.StorytellerReadaloudCacheSyncer {
     private val lastSyncedAt = ConcurrentHashMap<String, Long>()
 
-    /** Best-effort: fetch+store readalouds for each stale Storyteller server. Never throws. */
+    /** Best-effort: fetch+store readalouds for each stale Storyteller service. Never throws. */
     override suspend fun syncStale() {
         val servers = runCatching { sourceRepository.observeAll().first() }.getOrNull().orEmpty()
-            .filter { it.serverType == ServerType.STORYTELLER }
+            .filter { it.serverType == ServerType.STORYTELLER_SERVICE }
         val now = clock()
         for (source in servers) {
             val last = lastSyncedAt[source.id]

--- a/core/data/src/main/kotlin/com/riffle/core/data/di/DatabaseModule.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/di/DatabaseModule.kt
@@ -85,6 +85,7 @@ object DatabaseModule {
                 RiffleDatabase.MIGRATION_45_46,
                 RiffleDatabase.MIGRATION_46_47,
                 RiffleDatabase.MIGRATION_47_48,
+                RiffleDatabase.MIGRATION_48_49,
             )
             .build()
 

--- a/core/data/src/test/kotlin/com/riffle/core/data/LibraryRepositoryTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/LibraryRepositoryTest.kt
@@ -1057,7 +1057,7 @@ class LibraryRepositoryTest {
         isActive = true,
         insecureConnectionAllowed = false,
         username = "plamen",
-        serverType = com.riffle.core.domain.ServerType.STORYTELLER,
+        serverType = com.riffle.core.domain.ServerType.STORYTELLER_SERVICE,
     )
 
     // Storyteller is never the active/browsable source (ADR 0026), so refreshLibraryItems/

--- a/core/data/src/test/kotlin/com/riffle/core/data/ReadaloudMatchingServiceTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/ReadaloudMatchingServiceTest.kt
@@ -374,7 +374,7 @@ class ReadaloudMatchingServiceTest {
         private val byId = entities.associateBy { it.id }
 
         override suspend fun listMatchableBySourceType(serverType: String): List<MatchableItemRow> = when (serverType) {
-            "STORYTELLER" -> storyteller
+            "STORYTELLER_SERVICE" -> storyteller
             "AUDIOBOOKSHELF" -> abs
             else -> emptyList()
         }

--- a/core/data/src/test/kotlin/com/riffle/core/data/ReadaloudReviewRepositoryTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/ReadaloudReviewRepositoryTest.kt
@@ -401,7 +401,7 @@ class ReadaloudReviewRepositoryTest {
         override suspend fun listMatchableBySourceType(serverType: String): List<MatchableItemRow> {
             val serverIds = when (serverType) {
                 ServerType.AUDIOBOOKSHELF.name -> absServerIds
-                ServerType.STORYTELLER.name -> storytellerServerIds
+                ServerType.STORYTELLER_SERVICE.name -> storytellerServerIds
                 else -> emptySet()
             }
             return items.filter { it.sourceId in serverIds }

--- a/core/data/src/test/kotlin/com/riffle/core/data/SourceRepositoryTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/SourceRepositoryTest.kt
@@ -310,13 +310,13 @@ class ServerRepositoryTest {
 
         val result = repo.authenticate(
             SourceUrl.parse("http://media-source:8001")!!, "plamen", "pw", insecureAllowed = false,
-            serverType = ServerType.STORYTELLER,
+            serverType = ServerType.STORYTELLER_SERVICE,
         )
 
         assertTrue(result is AuthenticateResult.Success)
         val pending = (result as AuthenticateResult.Success).pending
         assertEquals("tok-st", pending.token)
-        assertEquals(ServerType.STORYTELLER, pending.serverType)
+        assertEquals(ServerType.STORYTELLER_SERVICE, pending.serverType)
         // Storyteller contributes no browsable Library (ADR 0026) — the namespace row is created
         // at commit time, not surfaced as a pending library.
         assertTrue(pending.libraries.isEmpty())
@@ -333,14 +333,14 @@ class ServerRepositoryTest {
 
         val result = repo.authenticate(
             SourceUrl.parse("http://media-source:8001")!!, "plamen", "wrong", insecureAllowed = false,
-            serverType = ServerType.STORYTELLER,
+            serverType = ServerType.STORYTELLER_SERVICE,
         )
 
         assertTrue(result is AuthenticateResult.WrongCredentials)
     }
 
     @Test
-    fun `two Storyteller servers commit independently, each with their own Readaloud library row`() = runTest {
+    fun `two Storyteller services commit independently, each with their own Readaloud library row`() = runTest {
         val dao = fakeDao(); val tokens = fakeTokenStorage()
         val libDao = fakeLibraryDao(); val visibility = fakeVisibilityStore()
         val absApi = AbsApi { _, _, _, _ -> error("not called") }
@@ -352,14 +352,14 @@ class ServerRepositoryTest {
             username = "plamen", userId = "", token = "tok-A", password = "",
             insecureConnectionAllowed = false,
             libraries = emptyList(),
-            serverType = ServerType.STORYTELLER,
+            serverType = ServerType.STORYTELLER_SERVICE,
         )
         val pendingB = PendingSource(
             url = SourceUrl.parse("https://readalouds.example.com")!!,
             username = "plamen", userId = "", token = "tok-B", password = "",
             insecureConnectionAllowed = false,
             libraries = emptyList(),
-            serverType = ServerType.STORYTELLER,
+            serverType = ServerType.STORYTELLER_SERVICE,
         )
 
         val resultA = repo.commit(pendingA, hiddenLibraryIds = emptySet())
@@ -371,8 +371,8 @@ class ServerRepositoryTest {
         val serverB = (resultB as CommitSourceResult.Success).source
 
         assertEquals(2, dao.allCount())
-        assertEquals(ServerType.STORYTELLER, serverA.serverType)
-        assertEquals(ServerType.STORYTELLER, serverB.serverType)
+        assertEquals(ServerType.STORYTELLER_SERVICE, serverA.serverType)
+        assertEquals(ServerType.STORYTELLER_SERVICE, serverB.serverType)
         // Each source gets its own Readaloud library row with a distinct source-scoped id —
         // the disambiguation requested in #34's acceptance criterion. The library name itself
         // remains the working "Readalouds" label; the active-source context (drawer header /
@@ -400,7 +400,7 @@ class ServerRepositoryTest {
             username = "plamen", userId = "", token = "tok-st", password = "",
             insecureConnectionAllowed = false,
             libraries = emptyList(),
-            serverType = ServerType.STORYTELLER,
+            serverType = ServerType.STORYTELLER_SERVICE,
         )
 
         val result = repo.commit(pending, hiddenLibraryIds = emptySet())
@@ -425,7 +425,7 @@ class ServerRepositoryTest {
             username = "plamen", userId = "", token = "tok-st", password = "",
             insecureConnectionAllowed = false,
             libraries = emptyList(),
-            serverType = ServerType.STORYTELLER,
+            serverType = ServerType.STORYTELLER_SERVICE,
         )
 
         val result = repo.commit(pending, hiddenLibraryIds = emptySet())
@@ -449,14 +449,14 @@ class ServerRepositoryTest {
             username = "plamen", userId = "uid-1", token = "tok-st", password = "",
             insecureConnectionAllowed = false,
             libraries = emptyList(),
-            serverType = com.riffle.core.domain.ServerType.STORYTELLER,
+            serverType = com.riffle.core.domain.ServerType.STORYTELLER_SERVICE,
         )
 
         val result = repo.commit(pending, hiddenLibraryIds = emptySet())
 
         assertTrue(result is CommitSourceResult.Success)
         val source = (result as CommitSourceResult.Success).source
-        assertEquals(com.riffle.core.domain.ServerType.STORYTELLER, source.serverType)
+        assertEquals(com.riffle.core.domain.ServerType.STORYTELLER_SERVICE, source.serverType)
     }
 
     @Test
@@ -528,7 +528,7 @@ class ServerRepositoryTest {
 
     @Test
     fun `remove cascades libraries and library_items for a Storyteller source`() = runTest {
-        val entity = SourceEntity("st-1", "http://media-source:8001", true, false, username = "plamen", serverType = "STORYTELLER")
+        val entity = SourceEntity("st-1", "http://media-source:8001", true, false, username = "plamen", serverType = "STORYTELLER_SERVICE")
         val dao = fakeDao(entity)
         val tokens = fakeTokenStorage()
         tokens.tokens["st-1"] = "tok-st"
@@ -596,7 +596,7 @@ class ServerRepositoryTest {
     @Test
     fun `setActive ignores a Storyteller source so it never becomes the active browsable source`() = runTest {
         val abs = SourceEntity("abs", "https://abs.example.com", true, false, username = "")
-        val st = SourceEntity("st", "http://media-source:8001", false, false, username = "", serverType = ServerType.STORYTELLER.name)
+        val st = SourceEntity("st", "http://media-source:8001", false, false, username = "", serverType = ServerType.STORYTELLER_SERVICE.name)
         val dao = fakeDao(abs, st)
         val absApi = AbsApi { _, _, _, _ -> NetworkResult.Auth }
         val repo = SourceRepositoryImpl(
@@ -655,7 +655,7 @@ class ServerRepositoryTest {
                 username = "plamen", userId = "", token = "tok-st", password = "",
                 insecureConnectionAllowed = false,
                 libraries = emptyList(),
-                serverType = ServerType.STORYTELLER,
+                serverType = ServerType.STORYTELLER_SERVICE,
             ),
             hiddenLibraryIds = emptySet(),
         )
@@ -722,7 +722,7 @@ class ServerRepositoryTest {
 
     @Test
     fun `ensureAbsUserId returns null for a Storyteller source without fetching api me`() = runTest {
-        val entity = SourceEntity("st-1", "http://media-source:8001", false, false, username = "u", serverType = ServerType.STORYTELLER.name)
+        val entity = SourceEntity("st-1", "http://media-source:8001", false, false, username = "u", serverType = ServerType.STORYTELLER_SERVICE.name)
         val infoApi = RecordingServerInfoApi(userId = "should-not-be-called")
         val repo = SourceRepositoryImpl(
             fakeDao(entity), fakeTokenStorage(), AbsApi { _, _, _, _ -> error("not called") },

--- a/core/data/src/test/kotlin/com/riffle/core/data/StorytellerReadaloudSyncerTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/StorytellerReadaloudSyncerTest.kt
@@ -27,7 +27,7 @@ private fun stServer(id: String) = Source(
     isActive = true,
     insecureConnectionAllowed = false,
     username = "user",
-    serverType = ServerType.STORYTELLER,
+    serverType = ServerType.STORYTELLER_SERVICE,
 )
 
 private fun absServer(id: String) = Source(

--- a/core/database/schemas/com.riffle.core.database.RiffleDatabase/49.json
+++ b/core/database/schemas/com.riffle.core.database.RiffleDatabase/49.json
@@ -1,0 +1,1606 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 49,
+    "identityHash": "e2c5f526725585147b466a5044bd1385",
+    "entities": [
+      {
+        "tableName": "sources",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `url` TEXT NOT NULL, `isActive` INTEGER NOT NULL, `insecureConnectionAllowed` INTEGER NOT NULL, `username` TEXT NOT NULL, `serverType` TEXT NOT NULL, `absUserId` TEXT, `type` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "isActive",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "insecureConnectionAllowed",
+            "columnName": "insecureConnectionAllowed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "username",
+            "columnName": "username",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverType",
+            "columnName": "serverType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absUserId",
+            "columnName": "absUserId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "libraries",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `mediaType` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `isUnsupported` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `id`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaType",
+            "columnName": "mediaType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isUnsupported",
+            "columnName": "isUnsupported",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_libraries_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_libraries_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "library_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `id` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `title` TEXT NOT NULL, `author` TEXT NOT NULL, `coverUrl` TEXT, `readingProgress` REAL NOT NULL, `ebookFileIno` TEXT, `ebookFormat` TEXT NOT NULL, `hasAudio` INTEGER NOT NULL, `audioDurationSec` REAL NOT NULL, `description` TEXT, `seriesName` TEXT, `publishedYear` TEXT, `genres` TEXT NOT NULL, `publisher` TEXT, `language` TEXT, `lastOpenedAt` INTEGER, `addedAt` INTEGER, `isbn` TEXT, `asin` TEXT, `finishedAt` INTEGER, PRIMARY KEY(`sourceId`, `id`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "coverUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "readingProgress",
+            "columnName": "readingProgress",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ebookFileIno",
+            "columnName": "ebookFileIno",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "ebookFormat",
+            "columnName": "ebookFormat",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hasAudio",
+            "columnName": "hasAudio",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "audioDurationSec",
+            "columnName": "audioDurationSec",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seriesName",
+            "columnName": "seriesName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "publishedYear",
+            "columnName": "publishedYear",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "genres",
+            "columnName": "genres",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "publisher",
+            "columnName": "publisher",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "language",
+            "columnName": "language",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastOpenedAt",
+            "columnName": "lastOpenedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "isbn",
+            "columnName": "isbn",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "asin",
+            "columnName": "asin",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "finishedAt",
+            "columnName": "finishedAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_library_items_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_library_items_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "series",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `name` TEXT NOT NULL, `coverUrl` TEXT, `bookCount` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "coverUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "bookCount",
+            "columnName": "bookCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "collections",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `name` TEXT NOT NULL, `bookCount` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookCount",
+            "columnName": "bookCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "series_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`seriesId` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `sequenceOrder` REAL NOT NULL, PRIMARY KEY(`seriesId`, `sourceId`, `itemId`))",
+        "fields": [
+          {
+            "fieldPath": "seriesId",
+            "columnName": "seriesId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sequenceOrder",
+            "columnName": "sequenceOrder",
+            "affinity": "REAL",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "seriesId",
+            "sourceId",
+            "itemId"
+          ]
+        }
+      },
+      {
+        "tableName": "collection_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`collectionId` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, PRIMARY KEY(`collectionId`, `sourceId`, `itemId`))",
+        "fields": [
+          {
+            "fieldPath": "collectionId",
+            "columnName": "collectionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "collectionId",
+            "sourceId",
+            "itemId"
+          ]
+        }
+      },
+      {
+        "tableName": "reading_positions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `cfi` TEXT NOT NULL, `localUpdatedAt` INTEGER NOT NULL, `lastSyncedAt` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `itemId`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cfi",
+            "columnName": "cfi",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localUpdatedAt",
+            "columnName": "localUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncedAt",
+            "columnName": "lastSyncedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "itemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_reading_positions_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_reading_positions_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "book_formatting_preferences",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `scope` TEXT NOT NULL, `fontSize` REAL, `theme` TEXT, `fontFamily` TEXT, `lineSpacing` REAL, `margins` REAL, `orientation` TEXT, `showChapterMap` INTEGER, `showReadingProgressLabels` INTEGER, `showCurrentChapterLabel` INTEGER, `doublePageSpread` INTEGER, `justifyText` INTEGER, `showReadingTimeEstimate` INTEGER, PRIMARY KEY(`sourceId`, `itemId`, `scope`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scope",
+            "columnName": "scope",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fontSize",
+            "columnName": "fontSize",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "theme",
+            "columnName": "theme",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "fontFamily",
+            "columnName": "fontFamily",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lineSpacing",
+            "columnName": "lineSpacing",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "margins",
+            "columnName": "margins",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "orientation",
+            "columnName": "orientation",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "showChapterMap",
+            "columnName": "showChapterMap",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "showReadingProgressLabels",
+            "columnName": "showReadingProgressLabels",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "showCurrentChapterLabel",
+            "columnName": "showCurrentChapterLabel",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "doublePageSpread",
+            "columnName": "doublePageSpread",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "justifyText",
+            "columnName": "justifyText",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "showReadingTimeEstimate",
+            "columnName": "showReadingTimeEstimate",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "itemId",
+            "scope"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_book_formatting_preferences_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_book_formatting_preferences_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "readaloud_links",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`absSourceId` TEXT NOT NULL, `absLibraryItemId` TEXT NOT NULL, `storytellerSourceId` TEXT NOT NULL, `storytellerBookId` TEXT NOT NULL, `state` TEXT NOT NULL, `userConfirmed` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `identityResult` TEXT NOT NULL, PRIMARY KEY(`absSourceId`, `absLibraryItemId`), FOREIGN KEY(`storytellerSourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`absSourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "absSourceId",
+            "columnName": "absSourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absLibraryItemId",
+            "columnName": "absLibraryItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerSourceId",
+            "columnName": "storytellerSourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerBookId",
+            "columnName": "storytellerBookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userConfirmed",
+            "columnName": "userConfirmed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityResult",
+            "columnName": "identityResult",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "absSourceId",
+            "absLibraryItemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_readaloud_links_storytellerSourceId_storytellerBookId",
+            "unique": false,
+            "columnNames": [
+              "storytellerSourceId",
+              "storytellerBookId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_readaloud_links_storytellerSourceId_storytellerBookId` ON `${TABLE_NAME}` (`storytellerSourceId`, `storytellerBookId`)"
+          },
+          {
+            "name": "index_readaloud_links_storytellerSourceId",
+            "unique": false,
+            "columnNames": [
+              "storytellerSourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_readaloud_links_storytellerSourceId` ON `${TABLE_NAME}` (`storytellerSourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "storytellerSourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "absSourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "readaloud_candidates",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`storytellerSourceId` TEXT NOT NULL, `storytellerBookId` TEXT NOT NULL, `absSourceId` TEXT NOT NULL, `absLibraryItemId` TEXT NOT NULL, `score` REAL NOT NULL, PRIMARY KEY(`storytellerSourceId`, `storytellerBookId`, `absSourceId`, `absLibraryItemId`), FOREIGN KEY(`storytellerSourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`absSourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "storytellerSourceId",
+            "columnName": "storytellerSourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerBookId",
+            "columnName": "storytellerBookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absSourceId",
+            "columnName": "absSourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absLibraryItemId",
+            "columnName": "absLibraryItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "score",
+            "columnName": "score",
+            "affinity": "REAL",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "storytellerSourceId",
+            "storytellerBookId",
+            "absSourceId",
+            "absLibraryItemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_readaloud_candidates_absSourceId",
+            "unique": false,
+            "columnNames": [
+              "absSourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_readaloud_candidates_absSourceId` ON `${TABLE_NAME}` (`absSourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "storytellerSourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "absSourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "readaloud_dismissals",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`storytellerSourceId` TEXT NOT NULL, `storytellerBookId` TEXT NOT NULL, `scope` TEXT NOT NULL, `absSourceId` TEXT NOT NULL, `absLibraryItemId` TEXT NOT NULL, PRIMARY KEY(`storytellerSourceId`, `storytellerBookId`, `absSourceId`, `absLibraryItemId`), FOREIGN KEY(`storytellerSourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "storytellerSourceId",
+            "columnName": "storytellerSourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerBookId",
+            "columnName": "storytellerBookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scope",
+            "columnName": "scope",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absSourceId",
+            "columnName": "absSourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absLibraryItemId",
+            "columnName": "absLibraryItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "storytellerSourceId",
+            "storytellerBookId",
+            "absSourceId",
+            "absLibraryItemId"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "storytellerSourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "cross_epub_index",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`absEpubChecksum` TEXT NOT NULL, `storytellerEpubChecksum` TEXT NOT NULL, `perChapterMapsBlob` TEXT NOT NULL, `builtAt` INTEGER NOT NULL, PRIMARY KEY(`absEpubChecksum`, `storytellerEpubChecksum`))",
+        "fields": [
+          {
+            "fieldPath": "absEpubChecksum",
+            "columnName": "absEpubChecksum",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerEpubChecksum",
+            "columnName": "storytellerEpubChecksum",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "perChapterMapsBlob",
+            "columnName": "perChapterMapsBlob",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "builtAt",
+            "columnName": "builtAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "absEpubChecksum",
+            "storytellerEpubChecksum"
+          ]
+        }
+      },
+      {
+        "tableName": "annotations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `type` TEXT NOT NULL, `cfi` TEXT NOT NULL, `color` TEXT NOT NULL, `note` TEXT, `textSnippet` TEXT NOT NULL, `textBefore` TEXT NOT NULL, `textAfter` TEXT NOT NULL, `chapterHref` TEXT NOT NULL, `spineIndex` INTEGER NOT NULL, `progression` REAL NOT NULL, `bookmarkTitle` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `originDeviceId` TEXT NOT NULL, `lastModifiedByDeviceId` TEXT NOT NULL, `deleted` INTEGER NOT NULL, `lastSyncedAt` INTEGER NOT NULL, `embeddedFigures` TEXT, `imageHref` TEXT, `imageSvg` TEXT, `imageBytes` TEXT, PRIMARY KEY(`id`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cfi",
+            "columnName": "cfi",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "color",
+            "columnName": "color",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "note",
+            "columnName": "note",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "textSnippet",
+            "columnName": "textSnippet",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "textBefore",
+            "columnName": "textBefore",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "textAfter",
+            "columnName": "textAfter",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chapterHref",
+            "columnName": "chapterHref",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "spineIndex",
+            "columnName": "spineIndex",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "progression",
+            "columnName": "progression",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookmarkTitle",
+            "columnName": "bookmarkTitle",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "originDeviceId",
+            "columnName": "originDeviceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastModifiedByDeviceId",
+            "columnName": "lastModifiedByDeviceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deleted",
+            "columnName": "deleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncedAt",
+            "columnName": "lastSyncedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "embeddedFigures",
+            "columnName": "embeddedFigures",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "imageHref",
+            "columnName": "imageHref",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "imageSvg",
+            "columnName": "imageSvg",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "imageBytes",
+            "columnName": "imageBytes",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_annotations_sourceId_itemId",
+            "unique": false,
+            "columnNames": [
+              "sourceId",
+              "itemId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_annotations_sourceId_itemId` ON `${TABLE_NAME}` (`sourceId`, `itemId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "readaloud_resume_positions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `href` TEXT NOT NULL, `progression` REAL, `fragmentRef` TEXT, `localUpdatedAt` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `itemId`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "href",
+            "columnName": "href",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "progression",
+            "columnName": "progression",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "fragmentRef",
+            "columnName": "fragmentRef",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localUpdatedAt",
+            "columnName": "localUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "itemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_readaloud_resume_positions_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_readaloud_resume_positions_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "audio_playback_preferences",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `bookId` TEXT NOT NULL, `speed` REAL, PRIMARY KEY(`sourceId`, `bookId`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "speed",
+            "columnName": "speed",
+            "affinity": "REAL"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "bookId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_audio_playback_preferences_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_audio_playback_preferences_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "audiobook_positions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `positionSec` REAL NOT NULL, `localUpdatedAt` INTEGER NOT NULL, `lastSyncedAt` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `itemId`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "positionSec",
+            "columnName": "positionSec",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localUpdatedAt",
+            "columnName": "localUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncedAt",
+            "columnName": "lastSyncedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "itemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_audiobook_positions_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_audiobook_positions_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "audiobook_bookmarks",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `positionSec` REAL NOT NULL, `title` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `localUpdatedAt` INTEGER NOT NULL, `lastSyncedAt` INTEGER NOT NULL, `deleted` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "positionSec",
+            "columnName": "positionSec",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localUpdatedAt",
+            "columnName": "localUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncedAt",
+            "columnName": "lastSyncedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deleted",
+            "columnName": "deleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_audiobook_bookmarks_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_audiobook_bookmarks_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          },
+          {
+            "name": "index_audiobook_bookmarks_sourceId_itemId",
+            "unique": false,
+            "columnNames": [
+              "sourceId",
+              "itemId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_audiobook_bookmarks_sourceId_itemId` ON `${TABLE_NAME}` (`sourceId`, `itemId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "toc_cache",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `ebookFileIno` TEXT NOT NULL, `entriesJson` TEXT NOT NULL, PRIMARY KEY(`sourceId`, `itemId`))",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ebookFileIno",
+            "columnName": "ebookFileIno",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entriesJson",
+            "columnName": "entriesJson",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "itemId"
+          ]
+        }
+      },
+      {
+        "tableName": "audiobook_chapter_cache",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `chaptersJson` TEXT NOT NULL, PRIMARY KEY(`sourceId`, `itemId`))",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chaptersJson",
+            "columnName": "chaptersJson",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "itemId"
+          ]
+        }
+      },
+      {
+        "tableName": "local_files_folders",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `treeUri` TEXT NOT NULL, `displayName` TEXT NOT NULL, `addedAtEpochMs` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `treeUri`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "treeUri",
+            "columnName": "treeUri",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAtEpochMs",
+            "columnName": "addedAtEpochMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "treeUri"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_files_folders_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_files_folders_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "local_files_files",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `sourceItemId` TEXT NOT NULL, `folderTreeUri` TEXT NOT NULL, `originalUri` TEXT NOT NULL, `copiedPath` TEXT NOT NULL, `coverPath` TEXT, `format` TEXT NOT NULL, `sizeBytes` INTEGER NOT NULL, `mtimeEpochMs` INTEGER NOT NULL, `lastSeenAtEpochMs` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `sourceItemId`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceItemId",
+            "columnName": "sourceItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "folderTreeUri",
+            "columnName": "folderTreeUri",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "originalUri",
+            "columnName": "originalUri",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "copiedPath",
+            "columnName": "copiedPath",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverPath",
+            "columnName": "coverPath",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "format",
+            "columnName": "format",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sizeBytes",
+            "columnName": "sizeBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mtimeEpochMs",
+            "columnName": "mtimeEpochMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSeenAtEpochMs",
+            "columnName": "lastSeenAtEpochMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "sourceItemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_files_files_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_files_files_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'e2c5f526725585147b466a5044bd1385')"
+    ]
+  }
+}

--- a/core/database/src/androidTest/kotlin/com/riffle/core/database/MigrationTest.kt
+++ b/core/database/src/androidTest/kotlin/com/riffle/core/database/MigrationTest.kt
@@ -1919,7 +1919,7 @@ class MigrationTest {
         }
 
         val db = helper.runMigrationsAndValidate(
-            TEST_DB, 47, true,
+            TEST_DB, 49, true,
             RiffleDatabase.MIGRATION_1_2,
             RiffleDatabase.MIGRATION_2_3,
             RiffleDatabase.MIGRATION_3_4,
@@ -1966,6 +1966,8 @@ class MigrationTest {
             RiffleDatabase.MIGRATION_44_45,
             RiffleDatabase.MIGRATION_45_46,
             RiffleDatabase.MIGRATION_46_47,
+            RiffleDatabase.MIGRATION_47_48,
+            RiffleDatabase.MIGRATION_48_49,
         )
 
         db.query("SELECT url, username, serverType, absUserId, type FROM sources WHERE id = 's1'").use { cursor ->
@@ -2121,6 +2123,34 @@ class MigrationTest {
             assertTrue(c.isNull(1))
             assertTrue(c.isNull(2))
             assertTrue(c.isNull(3))
+        }
+        db.close()
+    }
+
+    // Rename Storyteller Server → Storyteller Service per ADR 0041. Legacy Storyteller rows
+    // must be rewritten from serverType='STORYTELLER' to 'STORYTELLER_SERVICE'; ABS rows and
+    // any other value stay untouched.
+    @Test
+    fun migration48To49_rewritesStorytellerServerTypeToStorytellerService() {
+        helper.createDatabase(TEST_DB, 48).apply {
+            execSQL(
+                "INSERT INTO sources (id, url, isActive, insecureConnectionAllowed, username, serverType, absUserId, type) " +
+                    "VALUES ('st-1', 'http://storyteller', 1, 0, 'test', 'STORYTELLER', NULL, 'ABS')"
+            )
+            execSQL(
+                "INSERT INTO sources (id, url, isActive, insecureConnectionAllowed, username, serverType, absUserId, type) " +
+                    "VALUES ('abs-1', 'http://abs', 1, 0, 'test', 'AUDIOBOOKSHELF', 'u1', 'ABS')"
+            )
+            close()
+        }
+        val db = helper.runMigrationsAndValidate(TEST_DB, 49, true, RiffleDatabase.MIGRATION_48_49)
+        db.query("SELECT serverType FROM sources WHERE id = 'st-1'").use { c ->
+            assertTrue(c.moveToFirst())
+            assertEquals("STORYTELLER_SERVICE", c.getString(0))
+        }
+        db.query("SELECT serverType FROM sources WHERE id = 'abs-1'").use { c ->
+            assertTrue(c.moveToFirst())
+            assertEquals("AUDIOBOOKSHELF", c.getString(0))
         }
         db.close()
     }

--- a/core/database/src/main/kotlin/com/riffle/core/database/RiffleDatabase.kt
+++ b/core/database/src/main/kotlin/com/riffle/core/database/RiffleDatabase.kt
@@ -30,7 +30,7 @@ import androidx.sqlite.db.SupportSQLiteDatabase
         LocalFilesFolderEntity::class,
         LocalFilesFileEntity::class,
     ],
-    version = 48,
+    version = 49,
     exportSchema = true,
 )
 abstract class RiffleDatabase : RoomDatabase() {
@@ -359,7 +359,7 @@ abstract class RiffleDatabase : RoomDatabase() {
         //    server columns FK-cascade so candidates clear when either Server is removed.
         // 2. `readaloud_dismissals` records sticky user decisions: a per-book "don't ask again"
         //    (BOOK scope, empty ABS ids) and per-candidate dismissals (CANDIDATE scope). Only
-        //    the Storyteller server FK-cascades; the ABS id is a sentinel for book scope.
+        //    the Storyteller service FK-cascades; the ABS id is a sentinel for book scope.
         val MIGRATION_22_23 = object : Migration(22, 23) {
             override fun migrate(db: SupportSQLiteDatabase) {
                 db.execSQL(
@@ -446,7 +446,7 @@ abstract class RiffleDatabase : RoomDatabase() {
         }
 
         // 25 → 26: key Library Items by (serverId, itemId) end-to-end (issue #81, ADR 0025).
-        // Item ids are unique only within a Server — two Storyteller Servers each emit "1", "2", …
+        // Item ids are unique only within a Server — two Storyteller Services each emit "1", "2", …
         // — so itemId-alone keying collides. Recreate `library_items` with a `serverId` column and
         // a composite PK (serverId, id), backfilling serverId from each item's owning library
         // (libraryId → libraries.serverId); an FK to servers cascade-deletes a Server's items.
@@ -1304,6 +1304,16 @@ abstract class RiffleDatabase : RoomDatabase() {
         val MIGRATION_47_48 = object : Migration(47, 48) {
             override fun migrate(db: SupportSQLiteDatabase) {
                 db.execSQL("ALTER TABLE annotations ADD COLUMN imageBytes TEXT")
+            }
+        }
+
+        // Rename Storyteller Server → Storyteller Service per ADR 0041: Storyteller is a
+        // Service (a sidecar that enriches items), not a Server or Source. The row stays in
+        // the `sources` table for zero-cost storage — only the enum-encoded discriminator
+        // in the `serverType` column changes from "STORYTELLER" to "STORYTELLER_SERVICE".
+        val MIGRATION_48_49 = object : Migration(48, 49) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("UPDATE sources SET serverType = 'STORYTELLER_SERVICE' WHERE serverType = 'STORYTELLER'")
             }
         }
     }

--- a/core/database/src/main/kotlin/com/riffle/core/database/SourceEntity.kt
+++ b/core/database/src/main/kotlin/com/riffle/core/database/SourceEntity.kt
@@ -15,7 +15,7 @@ data class SourceEntity(
      * Cross-device-stable identity for this ABS account, taken from `/api/me`'s `user.id`.
      * Used by annotation sync as the WebDAV path namespace so two devices pointing at the same
      * ABS server see each other's files (the primary-key [id] is a per-device random UUID and
-     * cannot serve this purpose). Null on Storyteller servers and on ABS rows that were added
+     * cannot serve this purpose). Null on Storyteller services and on ABS rows that were added
      * before this column existed — backfilled lazily on the next successful `/api/me` call.
      */
     val absUserId: String? = null,

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/CanonicalSyncCycle.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/CanonicalSyncCycle.kt
@@ -95,7 +95,7 @@ sealed interface WriteResult {
  * Note: the local Room store is **not** a `ProgressPeer` — it is the canonical authority the cycle
  * is reconciling toward, and its write semantics are compare-and-swap (`ifLocalUpdatedAt` guarded
  * via [SyncPositionStore]) rather than push-then-stamp. Storyteller is also not a peer: there is
- * no progress-write endpoint on the Storyteller server. Both are intentionally absent; do not add
+ * no progress-write endpoint on the Storyteller service. Both are intentionally absent; do not add
  * a no-op peer to satisfy a symmetry that doesn't exist.
  */
 interface ProgressPeer {

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/Library.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/Library.kt
@@ -8,7 +8,7 @@ data class Library(
 )
 
 /**
- * Media type of the local-only "Readalouds" library row that namespaces a Storyteller Server's
+ * Media type of the local-only "Readalouds" library row that namespaces a Storyteller Service's
  * readaloud books as matcher input. Per ADR 0026 this row is never browsable — it must be excluded
  * from any Server Switcher or library picker.
  */

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/ReadaloudAudioRepository.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/ReadaloudAudioRepository.kt
@@ -15,7 +15,7 @@ sealed interface AudioDownloadResult {
  * cache-size cap (ADR 0024).
  */
 interface ReadaloudAudioRepository {
-    // The bundle lives on the Storyteller Server; [sourceId] is that Server (ADR 0025) — which on
+    // The bundle lives on the Storyteller Service; [sourceId] is that Server (ADR 0025) — which on
     // the ABS item-detail screen is NOT the active Server.
 
     /** True when the synced bundle is present locally (Downloads or Cache). */

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/ReadaloudReview.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/ReadaloudReview.kt
@@ -1,8 +1,8 @@
 package com.riffle.core.domain
 
 /**
- * The full review surface for one Storyteller Server's readalouds (ADR 0021): the three sections
- * shown under Settings → [Storyteller Server] → Readaloud matches.
+ * The full review surface for one Storyteller Service's readalouds (ADR 0021): the three sections
+ * shown under Settings → [Storyteller Service] → Readaloud matches.
  */
 data class ReadaloudReview(
     val pending: List<PendingReadaloud>,

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/ReadaloudReviewRepository.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/ReadaloudReviewRepository.kt
@@ -10,7 +10,7 @@ import kotlinx.coroutines.flow.Flow
 interface ReadaloudReviewRepository {
 
     /**
-     * The live three-section review for one Storyteller Server. [absSourceId] scopes the
+     * The live three-section review for one Storyteller Service. [absSourceId] scopes the
      * pending-candidate suggestions to a single ABS Server — the one the user is currently
      * matching against — so two ABS accounts pointing at the same library don't produce
      * duplicate suggestions for every readaloud. Pass `null` to keep the legacy cross-server

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/ServerType.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/ServerType.kt
@@ -2,11 +2,14 @@ package com.riffle.core.domain
 
 enum class ServerType(val label: String) {
     AUDIOBOOKSHELF("Audiobookshelf"),
-    STORYTELLER("Storyteller"),
+    STORYTELLER_SERVICE("Storyteller"),
     ;
 
     companion object {
         fun fromStorageString(value: String): ServerType =
-            entries.firstOrNull { it.name == value } ?: AUDIOBOOKSHELF
+            entries.firstOrNull { it.name == value }
+                ?: if (value == LEGACY_STORYTELLER_NAME) STORYTELLER_SERVICE else AUDIOBOOKSHELF
+
+        private const val LEGACY_STORYTELLER_NAME = "STORYTELLER"
     }
 }

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/Source.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/Source.kt
@@ -11,7 +11,7 @@ data class Source(
     /**
      * ABS-side stable user identity (the `/api/me` `user.id`). Used by annotation sync as the
      * cross-device path namespace — see [com.riffle.core.domain.AnnotationSyncTarget]. Null on
-     * Storyteller servers and on legacy rows that haven't been backfilled yet.
+     * Storyteller services and on legacy rows that haven't been backfilled yet.
      */
     val absUserId: String? = null,
 )

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/SourceRepository.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/SourceRepository.kt
@@ -38,7 +38,7 @@ interface SourceRepository {
     /**
      * Return the ABS-side stable user identity for this source, fetching it from `/api/me` if
      * it hasn't been persisted yet (legacy rows created before the column existed). Returns
-     * null for Storyteller servers, for unknown source ids, and when the fetch fails (offline,
+     * null for Storyteller services, for unknown source ids, and when the fetch fails (offline,
      * server down, invalid token). A successful fetch is persisted so subsequent calls are
      * a single DB lookup.
      */

--- a/core/domain/src/test/kotlin/com/riffle/core/domain/ServerTypeTest.kt
+++ b/core/domain/src/test/kotlin/com/riffle/core/domain/ServerTypeTest.kt
@@ -1,0 +1,35 @@
+package com.riffle.core.domain
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ServerTypeTest {
+
+    @Test
+    fun `new writes serialise Storyteller as STORYTELLER_SERVICE`() {
+        assertEquals("STORYTELLER_SERVICE", ServerType.STORYTELLER_SERVICE.name)
+    }
+
+    // Legacy alias — pre-migration rows written before the ADR 0041 rename used "STORYTELLER".
+    // If MIGRATION_48_49 fails to run for any reason (e.g. downgrade + re-upgrade path), this
+    // fallback keeps such rows readable and identifies them as the same Storyteller Service.
+    @Test
+    fun `fromStorageString maps legacy STORYTELLER value to STORYTELLER_SERVICE`() {
+        assertEquals(ServerType.STORYTELLER_SERVICE, ServerType.fromStorageString("STORYTELLER"))
+    }
+
+    @Test
+    fun `fromStorageString round-trips STORYTELLER_SERVICE`() {
+        assertEquals(ServerType.STORYTELLER_SERVICE, ServerType.fromStorageString("STORYTELLER_SERVICE"))
+    }
+
+    @Test
+    fun `fromStorageString returns AUDIOBOOKSHELF for unknown values`() {
+        assertEquals(ServerType.AUDIOBOOKSHELF, ServerType.fromStorageString("BOGUS"))
+    }
+
+    @Test
+    fun `fromStorageString round-trips AUDIOBOOKSHELF`() {
+        assertEquals(ServerType.AUDIOBOOKSHELF, ServerType.fromStorageString("AUDIOBOOKSHELF"))
+    }
+}

--- a/core/network/src/main/kotlin/com/riffle/core/network/InsecureTls.kt
+++ b/core/network/src/main/kotlin/com/riffle/core/network/InsecureTls.kt
@@ -10,7 +10,7 @@ import javax.net.ssl.X509TrustManager
  * Returns a copy of this client that accepts self-signed / untrusted TLS certificates.
  *
  * Callers gate this on the per-server `insecureAllowed` flag (self-hosted Audiobookshelf and
- * Storyteller servers commonly run behind self-signed certs on homelab domains). Never call
+ * Storyteller services commonly run behind self-signed certs on homelab domains). Never call
  * unconditionally: the returned client bypasses certificate validation entirely.
  */
 internal fun OkHttpClient.withInsecureTls(): OkHttpClient {


### PR DESCRIPTION
Closes #441. Amends ADR 0020 and ADR 0026 (both already superseded by ADR 0041 in header).

Storyteller is a **Service** (a sidecar that enriches items regardless of Source), not a Server or Source per [ADR 0041](../blob/main/docs/adr/0041-source-and-service-abstractions-replace-server.md). This PR catches the code up to that taxonomy.

## Kotlin renames

- `ServerType.STORYTELLER` → `ServerType.STORYTELLER_SERVICE`. Human-readable label (`"Storyteller"`) unchanged.
- `isStorytellerServer` property/param → `isStorytellerService` in `ReadaloudSession`, `ReaderSessionLifecycle`, `EpubReaderViewModel`, and their tests.
- KDoc/comments referencing "Storyteller Server(s)" now say "Storyteller Service(s)". Historical migration-test comments (which describe pre-rename state) are left alone.

## Config storage

Per the ADR 0041 recommendation, Storyteller config **stays in the `sources` table** — zero-cost storage. Only the encoded discriminator changes:

- `MIGRATION_48_49` rewrites `sources.serverType='STORYTELLER'` → `'STORYTELLER_SERVICE'`.
- `ServerType.fromStorageString` also treats the old `"STORYTELLER"` string as a legacy alias mapping to `STORYTELLER_SERVICE`, so any row that ever escapes the migration (mid-migration crash, downgrade + re-upgrade) still reads correctly.
- Storyteller entries continue to be excluded from the Source Switcher / Nav Drawer via the existing `serverType == STORYTELLER_SERVICE` checks (was previously `== STORYTELLER`).

Schema `49.json` exported by KSP.

## Tests

Regression tests that flip red if this refactor were reverted line-for-line:

- **`ServerTypeTest`** — pins `.name == "STORYTELLER_SERVICE"` (new stored value) and `fromStorageString("STORYTELLER") == STORYTELLER_SERVICE` (legacy alias). Reverting the enum rename fails both.
- **`MigrationTest.migration48To49_rewritesStorytellerServerTypeToStorytellerService`** — seeds a v48 DB with one `STORYTELLER` and one `AUDIOBOOKSHELF` row, runs the migration, and asserts the Storyteller row now reads `STORYTELLER_SERVICE` while the ABS row is untouched. Reverting `MIGRATION_48_49` fails this test.
- **`MigrationTest.migrateFullChain`** — extended to v49, so any regression that breaks the full 1→49 chain trips here.
- Existing Storyteller integration tests updated to the new identifiers and still pass.

No user-visible strings changed — there were none referencing "Storyteller Server" to begin with.

## Verification

- `./gradlew test` — green (all JVM unit tests across every module).
- `./gradlew :core:database:kspDebugKotlin` — new `49.json` schema exported and committed.