### PR TITLE
chore(ci): checkNoServerReferences gradle task guards against Source/Server drift

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,3 +108,7 @@ Single-context repo — one `CONTEXT.md` + `docs/adr/` at the root. See `docs/ag
 ### Logger channels
 
 Production log tags are typed in `core/logging/src/main/kotlin/com/riffle/core/logging/LogChannel.kt` (`RIFFLE_RA`, `RIFFLE_AB`, `RIFFLE_HANDOFF`). Add a new channel by adding an enum entry; never introduce a new `Log.d("RIFFLE_*", …)` literal directly. Inject `Logger` (production: `AndroidLogger`; tests: `RecordingLogger`) and call `logger.d(LogChannel.X) { "msg" }`. The `checkRiffleLogTags` gradle task (wired into `check`) fails CI if a literal leaks back in.
+
+### Source/Service taxonomy (no new `Server`)
+
+The taxonomy is Source/Service (ADR 0041). The `checkNoServerReferences` gradle task (wired into `check`) fails CI if a Kotlin file outside the grandfathered allowlist introduces a `\bServer[A-Z]` identifier (e.g. `ServerType`, `ServerRepository`) or the bare literal `serverId`. New sites must use `SourceFoo` / `ServiceFoo` and `sourceId`; if a file legitimately belongs to Storyteller-adjacent internals or historical Room migration SQL, add it to `ServerReferenceLint.ALLOWLIST` in `buildSrc/` with a one-line justification. Detection logic lives in `buildSrc/src/main/kotlin/com/riffle/buildlogic/ServerReferenceLint.kt`.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,5 @@
 import com.riffle.buildlogic.RiffleLogTagLint
+import com.riffle.buildlogic.ServerReferenceLint
 
 plugins {
     alias(libs.plugins.android.application) apply false
@@ -160,11 +161,43 @@ tasks.register("checkRendererBridgeUsage") {
     }
 }
 
+// Enforces the Source/Service taxonomy (ADR 0041, #443): fails if a Kotlin file
+// outside the grandfathered allowlist introduces a `\bServer[A-Z]` identifier
+// (e.g. ServerType, ServerRepository) or the bare literal `serverId`. Test source
+// sets and comment-only lines are skipped. Detection logic lives in
+// buildSrc/.../ServerReferenceLint.kt so it's JUnit-testable.
+tasks.register("checkNoServerReferences") {
+    group = "verification"
+    description = "Fails if new `\\bServer[A-Z]` identifiers or bare `serverId` literals leak in outside the Source/Service allowlist."
+    notCompatibleWithConfigurationCache("reading the file system at execution time")
+
+    doLast {
+        val projectRoot = layout.projectDirectory.asFile
+        val offenders = ServerReferenceLint.findServerReferenceOffenders(
+            scanRoots = listOf(
+                layout.projectDirectory.dir("app/src").asFile,
+                layout.projectDirectory.dir("core").asFile,
+            ),
+            projectRoot = projectRoot,
+        )
+        if (offenders.isNotEmpty()) {
+            throw GradleException(
+                "The taxonomy is Source/Service (ADR 0041). Rename `ServerFoo` → `SourceFoo` / `ServiceFoo`\n" +
+                    "and `serverId` → `sourceId` at the introducing site, or (if the file legitimately\n" +
+                    "belongs to Storyteller-adjacent internals / historical migration SQL) add it to\n" +
+                    "ServerReferenceLint.ALLOWLIST with a one-line justification.\n" +
+                    offenders.joinToString("\n") { it.render(projectRoot) },
+            )
+        }
+    }
+}
+
 // Make it part of the normal `./gradlew check` run.
 allprojects {
     tasks.matching { it.name == "check" }.configureEach {
         dependsOn(rootProject.tasks.named("checkRiffleLogTags"))
         dependsOn(rootProject.tasks.named("checkRiffleInfraSeams"))
         dependsOn(rootProject.tasks.named("checkRendererBridgeUsage"))
+        dependsOn(rootProject.tasks.named("checkNoServerReferences"))
     }
 }

--- a/buildSrc/src/main/kotlin/com/riffle/buildlogic/ServerReferenceLint.kt
+++ b/buildSrc/src/main/kotlin/com/riffle/buildlogic/ServerReferenceLint.kt
@@ -1,0 +1,133 @@
+package com.riffle.buildlogic
+
+import java.io.File
+
+/**
+ * Pure detector for `Server`-typed identifiers (`\bServer[A-Z]…`) and the bare
+ * literal `serverId` outside a grandfathered allowlist. Analogue of
+ * `RiffleLogTagLint` — the gradle task `checkNoServerReferences` is a thin
+ * wrapper around [findServerReferenceOffenders].
+ *
+ * The taxonomy is now Source/Service (ADR 0041). New Kotlin sites introducing
+ * `ServerFoo` or `serverId` are treated as drift; the allowlist grandfathers
+ * every file that legitimately carries the old spelling today (Storyteller-
+ * adjacent internals, the `ServerType` enum, historical Room migration SQL
+ * that must remain verbatim, and the few identifier holdouts).
+ */
+object ServerReferenceLint {
+
+    val SERVER_IDENT_PATTERN: Regex = Regex("""\bServer[A-Z]""")
+    val SERVER_ID_PATTERN: Regex = Regex("""\bserverId\b""")
+
+    /**
+     * Project-relative paths grandfathered from the lint. Drop entries as follow-up
+     * PRs migrate each file to Source/Service spelling. Add a new entry only when a
+     * file legitimately refers to "server" (ABS URL forms, AbsServer HTTP client
+     * types, Storyteller service internals, or the ServerType enum itself).
+     */
+    val ALLOWLIST: Set<String> = setOf(
+        // The ServerType enum itself is the taxonomy hinge — the enum name stays.
+        "core/domain/src/main/kotlin/com/riffle/core/domain/ServerType.kt",
+        // Room database + migrations reference historical `serverId` columns and
+        // `servers` table in SQL that must remain verbatim to preserve migration
+        // history. Identifier holdouts (ServerRepository comment) live here too.
+        "core/database/src/main/kotlin/com/riffle/core/database/RiffleDatabase.kt",
+        // Domain models that still carry `serverType: ServerType` parameters.
+        "core/domain/src/main/kotlin/com/riffle/core/domain/Source.kt",
+        "core/domain/src/main/kotlin/com/riffle/core/domain/SourceRepository.kt",
+        "core/domain/src/main/kotlin/com/riffle/core/domain/PendingSource.kt",
+        "core/domain/src/main/kotlin/com/riffle/core/domain/ReadingSession.kt",
+        "core/domain/src/main/kotlin/com/riffle/core/domain/ProgressReconciler.kt",
+        "core/domain/src/main/kotlin/com/riffle/core/domain/ProgressSyncController.kt",
+        "core/domain/src/main/kotlin/com/riffle/core/domain/HighlightsResumeStore.kt",
+        // Data layer: Source repo carries the serverType field; Storyteller +
+        // WebDAV internals + reading-session repo pass `serverType` through.
+        "core/data/src/main/kotlin/com/riffle/core/data/SourceRepositoryImpl.kt",
+        "core/data/src/main/kotlin/com/riffle/core/data/StorytellerReadaloudSyncer.kt",
+        "core/data/src/main/kotlin/com/riffle/core/data/ReadaloudReviewRepositoryImpl.kt",
+        "core/data/src/main/kotlin/com/riffle/core/data/ReadaloudMatchingService.kt",
+        "core/data/src/main/kotlin/com/riffle/core/data/ReadingSessionRepositoryImpl.kt",
+        "core/data/src/main/kotlin/com/riffle/core/data/WebDavAnnotationSyncTarget.kt",
+        "core/data/src/main/kotlin/com/riffle/core/data/PreferenceStoreFactories.kt",
+        // Network clients — ABS and Storyteller HTTP surfaces carry `serverType`.
+        "core/network/src/main/kotlin/com/riffle/core/network/AbsApiClient.kt",
+        "core/network/src/main/kotlin/com/riffle/core/network/StorytellerApi.kt",
+        "core/network/src/main/kotlin/com/riffle/core/network/StorytellerApiClient.kt",
+        "core/network/src/main/kotlin/com/riffle/core/network/NetworkResult.kt",
+        // Catalog abs adapter carries ServerException.
+        "core/catalog/src/main/kotlin/com/riffle/core/catalog/abs/CatalogException.kt",
+        // App-side view-models + screens that thread ServerType through and the
+        // reader session `ServerJumpCoordinator` identifier holdout.
+        "app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt",
+        "app/src/main/kotlin/com/riffle/app/feature/reader/session/ServerJumpCoordinator.kt",
+        "app/src/main/kotlin/com/riffle/app/feature/reader/session/ReaderSessionLifecycle.kt",
+        "app/src/main/kotlin/com/riffle/app/feature/reader/session/PositionOrchestrator.kt",
+        "app/src/main/kotlin/com/riffle/app/feature/settings/SettingsViewModel.kt",
+        "app/src/main/kotlin/com/riffle/app/feature/settings/SettingsScreen.kt",
+        "app/src/main/kotlin/com/riffle/app/feature/settings/readaloud/ReadaloudMatchesViewModel.kt",
+        "app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModel.kt",
+        "app/src/main/kotlin/com/riffle/app/feature/navigation/NavigationDrawerViewModel.kt",
+        "app/src/main/kotlin/com/riffle/app/feature/navigation/NavigationDrawerComposable.kt",
+        "app/src/main/kotlin/com/riffle/app/feature/server/AddSourceViewModel.kt",
+        "app/src/main/kotlin/com/riffle/app/feature/annotations/AnnotationsListViewModel.kt",
+    )
+
+    data class Offender(
+        val file: File,
+        val lineNumber: Int,
+        val line: String,
+        val kind: Kind,
+    ) {
+        enum class Kind(val label: String) {
+            SERVER_IDENT("Server-typed identifier (\\bServer[A-Z])"),
+            SERVER_ID("bare `serverId` literal"),
+        }
+
+        fun render(projectRoot: File): String =
+            "${file.relativeTo(projectRoot)}:$lineNumber — ${kind.label} — ${line.trim()}"
+    }
+
+    /**
+     * Walks [scanRoots] and returns every offending line. Files in [allowlist]
+     * (paths relative to [projectRoot]) are skipped entirely. Test source sets
+     * (`/src/test/`, `/src/androidTest/`) are also skipped — fixtures legitimately
+     * reference the taxonomy under test.
+     */
+    fun findServerReferenceOffenders(
+        scanRoots: List<File>,
+        projectRoot: File,
+        allowlist: Set<String> = ALLOWLIST,
+    ): List<Offender> {
+        val offenders = mutableListOf<Offender>()
+        scanRoots
+            .asSequence()
+            .filter { it.exists() }
+            .flatMap { it.walkTopDown() }
+            .filter { it.isFile && it.extension == "kt" }
+            .filterNot {
+                val p = it.absolutePath
+                p.contains("/src/test/") || p.contains("/src/androidTest/")
+            }
+            .forEach { f ->
+                val rel = f.relativeTo(projectRoot).path
+                if (rel in allowlist) return@forEach
+                f.useLines { lines ->
+                    lines.forEachIndexed { idx, line ->
+                        val trimmed = line.trimStart()
+                        // Skip comment-only lines so KDoc / historical notes don't trip.
+                        if (trimmed.startsWith("//") ||
+                            trimmed.startsWith("*") ||
+                            trimmed.startsWith("/*")
+                        ) return@forEachIndexed
+                        if (SERVER_IDENT_PATTERN.containsMatchIn(line)) {
+                            offenders += Offender(f, idx + 1, line, Offender.Kind.SERVER_IDENT)
+                        }
+                        if (SERVER_ID_PATTERN.containsMatchIn(line)) {
+                            offenders += Offender(f, idx + 1, line, Offender.Kind.SERVER_ID)
+                        }
+                    }
+                }
+            }
+        return offenders
+    }
+}

--- a/buildSrc/src/test/kotlin/com/riffle/buildlogic/ServerReferenceLintTest.kt
+++ b/buildSrc/src/test/kotlin/com/riffle/buildlogic/ServerReferenceLintTest.kt
@@ -1,0 +1,151 @@
+package com.riffle.buildlogic
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+/**
+ * Regression tests for the `checkNoServerReferences` lint (#443).
+ *
+ * Guards:
+ *  1. Regex correctness — `\bServer[A-Z]` matches Server-typed identifiers but
+ *     not `AbsServer` (no boundary) or `Servers` (no [A-Z]); `\bserverId\b` matches
+ *     the bare literal but not `serverIdent` or `myserverId`.
+ *  2. Scan-scope correctness — test source sets are skipped; allowlisted files
+ *     are skipped; comment-only lines are skipped.
+ */
+class ServerReferenceLintTest {
+
+    @get:Rule
+    val tmp = TemporaryFolder()
+
+    private lateinit var root: File
+    private lateinit var scanRoots: List<File>
+
+    @Before
+    fun setUp() {
+        root = tmp.root
+        scanRoots = listOf(root.resolve("app/src"), root.resolve("core")).onEach { it.mkdirs() }
+    }
+
+    private fun writeKt(relative: String, body: String): File {
+        val f = root.resolve(relative)
+        f.parentFile.mkdirs()
+        f.writeText(body)
+        return f
+    }
+
+    private fun detect(allowlist: Set<String> = emptySet()) =
+        ServerReferenceLint.findServerReferenceOffenders(scanRoots, root, allowlist)
+
+    // --- Server[A-Z] regex ------------------------------------------------
+
+    @Test
+    fun `flags ServerType identifier`() {
+        writeKt("app/src/main/kotlin/Foo.kt", """val t: ServerType = ServerType.AUDIOBOOKSHELF""")
+        val offenders = detect()
+        // One offender per (line, kind) — a line with multiple identifier hits
+        // still surfaces as a single SERVER_IDENT record.
+        assertEquals(1, offenders.size)
+        assertEquals(ServerReferenceLint.Offender.Kind.SERVER_IDENT, offenders.single().kind)
+    }
+
+    @Test
+    fun `flags ServerRepository identifier`() {
+        writeKt("app/src/main/kotlin/Foo.kt", """class ServerRepository""")
+        assertEquals(1, detect().size)
+    }
+
+    @Test
+    fun `does not flag AbsServer — no word boundary before Server`() {
+        writeKt("app/src/main/kotlin/Foo.kt", """class AbsServerClient""")
+        assertTrue(detect().isEmpty())
+    }
+
+    @Test
+    fun `does not flag Servers — trailing s, no uppercase after Server`() {
+        writeKt("app/src/main/kotlin/Foo.kt", """val servers = listOf<Servers>()""")
+        // "servers" lowercase doesn't hit \bServer[A-Z]; "Servers" is Server + s (lowercase).
+        assertTrue(detect().isEmpty())
+    }
+
+    @Test
+    fun `does not flag lowercase server`() {
+        writeKt("app/src/main/kotlin/Foo.kt", """fun connect(server: String) {}""")
+        assertTrue(detect().isEmpty())
+    }
+
+    // --- serverId regex ---------------------------------------------------
+
+    @Test
+    fun `flags bare serverId identifier`() {
+        writeKt("app/src/main/kotlin/Foo.kt", """fun f(serverId: String) {}""")
+        val offenders = detect()
+        assertEquals(1, offenders.size)
+        assertEquals(ServerReferenceLint.Offender.Kind.SERVER_ID, offenders.single().kind)
+    }
+
+    @Test
+    fun `does not flag serverIdent`() {
+        writeKt("app/src/main/kotlin/Foo.kt", """val serverIdent = 1""")
+        assertTrue(detect().isEmpty())
+    }
+
+    @Test
+    fun `does not flag myserverId — no word boundary before`() {
+        writeKt("app/src/main/kotlin/Foo.kt", """val myserverId = 1""")
+        assertTrue(detect().isEmpty())
+    }
+
+    // --- Scan-scope + allowlist ------------------------------------------
+
+    @Test
+    fun `skips comment-only lines`() {
+        writeKt(
+            "app/src/main/kotlin/Foo.kt",
+            """
+            // ServerType used to live here
+             * Historical ServerRepository reference
+            /* serverId was the old column name */
+            """.trimIndent(),
+        )
+        assertTrue(detect().isEmpty())
+    }
+
+    @Test
+    fun `skips test source sets`() {
+        writeKt("app/src/test/kotlin/FooTest.kt", """val t: ServerType? = null""")
+        writeKt("app/src/androidTest/kotlin/FooAndroidTest.kt", """val id: String = serverId""")
+        assertTrue(detect().isEmpty())
+    }
+
+    @Test
+    fun `respects allowlist`() {
+        writeKt("core/domain/src/main/kotlin/ServerType.kt", """enum class ServerType { A }""")
+        writeKt("core/other/src/main/kotlin/Foo.kt", """val t: ServerType? = null""")
+        val allow = setOf("core/domain/src/main/kotlin/ServerType.kt")
+        val offenders = ServerReferenceLint.findServerReferenceOffenders(scanRoots, root, allow)
+        assertEquals(1, offenders.size)
+        assertEquals("Foo.kt", offenders.single().file.name)
+    }
+
+    @Test
+    fun `non-kt files are ignored`() {
+        writeKt("app/src/main/kotlin/Foo.txt", """ServerType""")
+        assertTrue(detect().isEmpty())
+    }
+
+    @Test
+    fun `flags both kinds on the same line`() {
+        writeKt("app/src/main/kotlin/Foo.kt", """fun f(serverId: String, type: ServerType) {}""")
+        val offenders = detect()
+        assertEquals(2, offenders.size)
+        val kinds = offenders.map { it.kind }.toSet()
+        assertTrue(ServerReferenceLint.Offender.Kind.SERVER_IDENT in kinds)
+        assertTrue(ServerReferenceLint.Offender.Kind.SERVER_ID in kinds)
+    }
+}


### PR DESCRIPTION
Closes #443.

Adds `checkNoServerReferences` — a drift-protection gate for ADR 0041's Source/Service taxonomy. Analogue of the existing `checkRiffleLogTags` gate. Fails `./gradlew check` if a Kotlin file outside the grandfathered allowlist introduces:

- A `\bServer[A-Z]` identifier (e.g. `ServerType`, `ServerRepository`), or
- The bare literal `serverId`.

Test source sets (`/src/test/`, `/src/androidTest/`) and comment-only lines are skipped — fixtures legitimately reference the taxonomy under test, and historical KDoc mentions shouldn't trip the gate.

## Approach

- Detection lives in `buildSrc/src/main/kotlin/com/riffle/buildlogic/ServerReferenceLint.kt` (JUnit-testable, matches the `RiffleLogTagLint` pattern).
- The gradle task in `build.gradle.kts` is a thin wrapper that walks `app/src` + `core` and throws on offenders.
- Files legitimately carrying the old spelling today are grandfathered in `ServerReferenceLint.ALLOWLIST` — the `ServerType` enum itself, historical Room migration SQL that must remain verbatim, and Source/Service-adjacent domain/data/network holdouts still threading `serverType: ServerType`. Follow-up PRs can drop entries as each file migrates.
- Wired into the `check` graph alongside the three existing lint tasks.
- AGENTS.md gets a one-liner mirroring the log-tag guidance.

## Verification

- `./gradlew :buildSrc:test --tests "com.riffle.buildlogic.ServerReferenceLintTest"` — 13 tests pass covering regex boundaries (`AbsServer` / `Servers` / `myserverId` don't trip; `ServerType` / `ServerRepository` / bare `serverId` do), scope skips (test source sets, comment-only lines, non-`.kt` files), and allowlist behaviour.
- `./gradlew checkNoServerReferences` — passes on the shipping tree (allowlist is complete, no false positives).
- Smoke test: introducing `internal class ServerFixture(val serverId: String)` in a random Kotlin file trips both detectors and fails the task locally. Removed after verification.