### PR TITLE
fix(settings): pin BehaviorSection row height to 48dp

### DIFF
--- a/app/src/androidTest/kotlin/com/riffle/app/feature/reader/BehaviorSectionRowHeightTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/reader/BehaviorSectionRowHeightTest.kt
@@ -1,10 +1,12 @@
 package com.riffle.app.feature.reader
 
 import androidx.activity.ComponentActivity
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -28,7 +30,9 @@ class BehaviorSectionRowHeightTest {
 
     @Test
     fun allThreeRowsHaveEqualHeight() {
+        var pxPerDp = 0f
         composeTestRule.setContent {
+            pxPerDp = LocalDensity.current.density
             BehaviorSection(
                 keepScreenOn = true,
                 onKeepScreenOnChange = {},
@@ -58,5 +62,16 @@ class BehaviorSectionRowHeightTest {
             gap12, gap23, 1f,
         )
         assert(abs(gap12 - gap23) <= 1f)
+
+        // Regression: the label→next-label pitch must be ≥ 48dp so rows read
+        // as 48dp-tall touch targets. Reproduces the PR #474 tightness: with
+        // `onCheckedChange = null` on the Switch, Material3 skips the Switch's
+        // `minimumInteractiveComponentSize` wrapper, and without an explicit
+        // `heightIn(48.dp)` on the Row the labels sit ~32dp apart.
+        val minPitchPx = 48f * pxPerDp
+        val pitch12 = volumeKeys.top - keepScreen.top
+        val pitch23 = invertKeys.top - volumeKeys.top
+        assertTrue("Row 1→2 pitch $pitch12 px < 48dp ($minPitchPx px)", pitch12 >= minPitchPx)
+        assertTrue("Row 2→3 pitch $pitch23 px < 48dp ($minPitchPx px)", pitch23 >= minPitchPx)
     }
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/BehaviorSection.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/BehaviorSection.kt
@@ -3,6 +3,7 @@ package com.riffle.app.feature.reader
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.selection.toggleable
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Switch
@@ -12,14 +13,17 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.unit.dp
 
 /**
  * Device-behavior toggles that apply to all books. Global in both hosts (reader sheet Behavior tab
  * and Settings → Behavior) — never per-book. Row rhythm mirrors [DisplaySection]'s on-screen-info
- * toggles: single-line label + Switch, no per-row supporting text, no explicit spacers — the
- * Switch's 48dp minimum interactive size dictates row height uniformly. The row itself is the
- * toggle target (Role.Switch) so tapping the label toggles, matching the pre-existing UX and the
- * `WakeLockHarnessTest` which drives the wake-lock preference via a label tap.
+ * toggles: single-line label + Switch, no per-row supporting text, no explicit spacers. Row height
+ * is pinned to a 48dp minimum on the [Row] itself — the Switch here uses `onCheckedChange = null`
+ * (the whole row is the tap target via [toggleable], required by `WakeLockHarnessTest` which taps
+ * the label), and Material3 only applies `minimumInteractiveComponentSize` to a Switch when its
+ * `onCheckedChange` is non-null, so without the explicit `heightIn` the row would collapse to the
+ * Switch's ~32dp intrinsic height.
  */
 @Composable
 fun BehaviorSection(
@@ -53,6 +57,7 @@ private fun ToggleRow(
         verticalAlignment = Alignment.CenterVertically,
         modifier = Modifier
             .fillMaxWidth()
+            .heightIn(min = 48.dp)
             .toggleable(value = checked, enabled = enabled, role = Role.Switch, onValueChange = onChange)
             .alpha(if (enabled) 1f else 0.38f),
     ) {


### PR DESCRIPTION
## Root cause

PR #474 (\"align Behavior row spacing with Display view\") replaced BehaviorSection's rows with a bare \`Row { Text; Switch(onCheckedChange = null) }\`, with the whole row as the tap target via \`.toggleable\` (required by \`WakeLockHarnessTest\`, which taps the label). The PR claimed row height would still be dictated by \"the Switch's 48dp minimum interactive size\" — but Material3 only applies \`minimumInteractiveComponentSize\` to a \`Switch\` when its \`onCheckedChange\` is non-null. With \`null\`, the Switch renders at its intrinsic ~32dp and, because nothing else set a min height, each row collapsed to ~32dp — hence the \"practically no spacing\" between the Keep-screen-on / Volume-key-navigation / Invert-volume-keys rows.

\`DisplaySection.ToggleRow\` isn't affected because it passes a real callback to \`Switch\`, so its rows still get the 48dp minimum.

## Fix

- \`BehaviorSection.kt\`: pin \`Modifier.heightIn(min = 48.dp)\` on the Row so height no longer relies on Switch internals. Updated the KDoc to explain the Material3 gotcha so the trap doesn't get re-set.
- \`BehaviorSectionRowHeightTest.kt\`: the existing \`allThreeRowsHaveEqualHeight\` regression only asserted equal gaps — three uniformly-tight rows still passed. Added a label-to-label pitch assertion (each ≥ 48dp in px) that flips red on revert.

## Test plan

- [ ] \`make harness-test\` on Harness Medium Phone AVD — new pitch assertion passes; \`WakeLockHarnessTest\` still passes (label taps toggle wake lock).
- [ ] Open Settings → Behavior on device: three rows read as evenly-spaced 48dp-tall touch targets.