### PR TITLE
feat(catalog): parse EPUB series index; shared SeriesEntryOrdering

### DIFF
--- a/core/catalog/src/main/kotlin/com/riffle/core/catalog/SeriesCapability.kt
+++ b/core/catalog/src/main/kotlin/com/riffle/core/catalog/SeriesCapability.kt
@@ -1,5 +1,18 @@
 package com.riffle.core.catalog
 
+/**
+ * A Catalog that groups its items into named series.
+ *
+ * Contract for implementers:
+ *
+ * - Populate [CatalogSeriesEntry.sequence] whenever the source has a position value for the book
+ *   (ABS's `sequence`, EPUB3 `group-position`, Calibre's `series_index`, etc.). Leave it null
+ *   only when the source genuinely has no ordering info — do not synthesise one from list index.
+ * - Return [listSeries] entries and [listItemsInSeries] results already sorted with
+ *   [SeriesEntryOrdering]. Do not trust the upstream server's order (ABS has been observed to
+ *   return books in whatever `groupBy` produced, which is not sequence order) and do not fall
+ *   back to alphabetical title order — that puts "Book 10" before "Book 2".
+ */
 interface SeriesCapability : CatalogCapability {
     suspend fun listSeries(rootId: String): List<CatalogSeries>
     suspend fun listItemsInSeries(rootId: String, seriesId: String): List<CatalogItem>

--- a/core/catalog/src/main/kotlin/com/riffle/core/catalog/SeriesEntryOrdering.kt
+++ b/core/catalog/src/main/kotlin/com/riffle/core/catalog/SeriesEntryOrdering.kt
@@ -22,7 +22,10 @@ object SeriesEntryOrdering {
     fun <T> comparator(sequenceOf: (T) -> String?, titleOf: (T) -> String): Comparator<T> =
         compareBy(
             { rankOf(sequenceOf(it)) },
-            { sequenceOf(it)?.trim()?.toDoubleOrNull() ?: 0.0 },
+            // Only finite parses participate; NaN inside `compareBy` would flow past every other
+            // key, since `Double.compareTo` treats NaN as greater than +∞. Non-finite entries
+            // share 0.0 here and fall through to the string tiebreakers below.
+            { sequenceOf(it)?.trim()?.toDoubleOrNull()?.takeIf { d -> d.isFinite() } ?: 0.0 },
             { sequenceOf(it)?.trim()?.lowercase() ?: "" },
             { titleOf(it).lowercase() },
         )
@@ -31,7 +34,10 @@ object SeriesEntryOrdering {
         val trimmed = sequence?.trim()
         return when {
             trimmed.isNullOrEmpty() -> 2
-            trimmed.toDoubleOrNull() != null -> 0
+            // Reject NaN/Infinity — `"NaN".toDoubleOrNull()` is non-null and NaN sorts past +∞
+            // in `Double.compareTo`, so a stray `<meta content="NaN"/>` would otherwise land in
+            // the numeric bucket AFTER every finite entry. Treat as non-numeric instead.
+            trimmed.toDoubleOrNull()?.isFinite() == true -> 0
             else -> 1
         }
     }

--- a/core/catalog/src/main/kotlin/com/riffle/core/catalog/SeriesEntryOrdering.kt
+++ b/core/catalog/src/main/kotlin/com/riffle/core/catalog/SeriesEntryOrdering.kt
@@ -1,0 +1,38 @@
+package com.riffle.core.catalog
+
+/**
+ * Canonical ordering for entries within a series. Every [SeriesCapability] implementation MUST
+ * sort its per-series entries with this comparator — do not roll your own or trust upstream
+ * order. Rolling your own is how "Book 10" ends up before "Book 2" in the Series tab.
+ *
+ * Ordering rules, in priority order:
+ *
+ * 1. **Numeric sequence first.** Entries whose [sequenceOf] parses as a Double (`"1"`, `"2.5"`,
+ *    `"10"`) sort by that value ascending — so 1, 2, 2.5, 10, never lexicographic.
+ * 2. **Non-numeric sequences next**, ordered alphabetically among themselves. Publishers use
+ *    strings like `"prequel"` or `"0.5-novella"` for extras; these deserve a stable spot AFTER
+ *    the numbered entries rather than being buried by numeric sort.
+ * 3. **Missing sequence last**, ordered by title. An entry with no sequence at all is a data
+ *    hole — surface it, but at the end.
+ * 4. Ties within any bucket break on title, case-insensitive.
+ *
+ * The comparator is stable, so entries equal on every key preserve input order.
+ */
+object SeriesEntryOrdering {
+    fun <T> comparator(sequenceOf: (T) -> String?, titleOf: (T) -> String): Comparator<T> =
+        compareBy(
+            { rankOf(sequenceOf(it)) },
+            { sequenceOf(it)?.trim()?.toDoubleOrNull() ?: 0.0 },
+            { sequenceOf(it)?.trim()?.lowercase() ?: "" },
+            { titleOf(it).lowercase() },
+        )
+
+    private fun rankOf(sequence: String?): Int {
+        val trimmed = sequence?.trim()
+        return when {
+            trimmed.isNullOrEmpty() -> 2
+            trimmed.toDoubleOrNull() != null -> 0
+            else -> 1
+        }
+    }
+}

--- a/core/catalog/src/test/kotlin/com/riffle/core/catalog/SeriesEntryOrderingTest.kt
+++ b/core/catalog/src/test/kotlin/com/riffle/core/catalog/SeriesEntryOrderingTest.kt
@@ -1,0 +1,86 @@
+package com.riffle.core.catalog
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Contract for series ordering. If a new [SeriesCapability] implementation ships and forgets to
+ * use [SeriesEntryOrdering], the bug that shows up in the UI is "Book 10 appears before Book 2".
+ * These assertions pin the exact behaviour that prevents that — including the tricky corners
+ * (decimals, non-numeric strings, missing sequence, ties).
+ */
+class SeriesEntryOrderingTest {
+
+    private data class Row(val title: String, val sequence: String?)
+
+    private fun sort(vararg rows: Row): List<Row> = rows.toList().sortedWith(
+        SeriesEntryOrdering.comparator(sequenceOf = { it.sequence }, titleOf = { it.title }),
+    )
+
+    @Test
+    fun `numeric sequences sort by value not lexicographically`() {
+        // The whole reason SeriesEntryOrdering exists: naive string sort puts "10" before "2".
+        val sorted = sort(
+            Row("Ten", "10"),
+            Row("Two", "2"),
+            Row("One", "1"),
+        )
+        assertEquals(listOf("One", "Two", "Ten"), sorted.map { it.title })
+    }
+
+    @Test
+    fun `decimal and integer sequences interleave correctly`() {
+        val sorted = sort(
+            Row("Full 2", "2"),
+            Row("Novella", "2.5"),
+            Row("Full 3", "3"),
+            Row("Full 1", "1"),
+        )
+        assertEquals(listOf("Full 1", "Full 2", "Novella", "Full 3"), sorted.map { it.title })
+    }
+
+    @Test
+    fun `non-numeric sequences sort after numeric ones and among themselves alphabetically`() {
+        val sorted = sort(
+            Row("Numbered 2", "2"),
+            Row("Side Story", "side-story"),
+            Row("Prequel", "prequel"),
+            Row("Numbered 1", "1"),
+        )
+        assertEquals(
+            listOf("Numbered 1", "Numbered 2", "Prequel", "Side Story"),
+            sorted.map { it.title },
+        )
+    }
+
+    @Test
+    fun `missing sequences sort last ordered by title`() {
+        val sorted = sort(
+            Row("Zebra", null),
+            Row("Two", "2"),
+            Row("Aardvark", null),
+            Row("One", "1"),
+        )
+        assertEquals(listOf("One", "Two", "Aardvark", "Zebra"), sorted.map { it.title })
+    }
+
+    @Test
+    fun `blank sequence string treated as missing not as zero`() {
+        val sorted = sort(
+            Row("Zero-a", "0"),
+            Row("Blank-titled", "   "),
+            Row("One", "1"),
+        )
+        assertEquals(listOf("Zero-a", "One", "Blank-titled"), sorted.map { it.title })
+    }
+
+    @Test
+    fun `equal sequence breaks tie on title case-insensitively`() {
+        val sorted = sort(
+            Row("beta", "1"),
+            Row("Alpha", "1"),
+            Row("gamma", "1"),
+        )
+        assertEquals(listOf("Alpha", "beta", "gamma"), sorted.map { it.title })
+    }
+}

--- a/core/catalog/src/test/kotlin/com/riffle/core/catalog/SeriesEntryOrderingTest.kt
+++ b/core/catalog/src/test/kotlin/com/riffle/core/catalog/SeriesEntryOrderingTest.kt
@@ -74,6 +74,22 @@ class SeriesEntryOrderingTest {
         assertEquals(listOf("Zero-a", "One", "Blank-titled"), sorted.map { it.title })
     }
 
+    // Regression: `"NaN".toDoubleOrNull()` is non-null and NaN sorts as greater-than +∞ under
+    // Double.compareTo, which would otherwise land NaN entries in the numeric bucket AFTER every
+    // finite numeric row. Non-finite tokens must fall through to the non-numeric bucket instead.
+    @Test
+    fun `NaN and Infinity in the sequence string fall through to the non-numeric bucket`() {
+        val sorted = sort(
+            Row("Two", "2"),
+            Row("Buggy", "NaN"),
+            Row("Also Buggy", "Infinity"),
+            Row("One", "1"),
+        )
+        // "1" and "2" are the two numeric entries — they must precede the two non-finite ones,
+        // which then tiebreak alphabetically on title.
+        assertEquals(listOf("One", "Two", "Also Buggy", "Buggy"), sorted.map { it.title })
+    }
+
     @Test
     fun `equal sequence breaks tie on title case-insensitively`() {
         val sorted = sort(

--- a/core/data/src/main/kotlin/com/riffle/core/data/LibraryRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/LibraryRepositoryImpl.kt
@@ -263,12 +263,19 @@ class LibraryRepositoryImpl @Inject constructor(
             )
         }
         val seriesItemEntities = series.flatMap { s ->
+            // Nulls have to sort AFTER every numeric entry within the same series — `series_items`
+            // is ORDER BY sequenceOrder ASC in SeriesDao, so a plain (index+1) fallback lets an
+            // unnumbered book land between "2" and "10". Shift nulls past the max numeric so they
+            // trail (preserving their input order, which the Catalog already delivers per
+            // SeriesEntryOrdering).
+            val maxNumeric = s.items.mapNotNull { it.sequence?.toFloatOrNull() }.maxOrNull() ?: 0f
             s.items.mapIndexed { index, entry ->
                 SeriesItemEntity(
                     seriesId = s.id,
                     sourceId = source.id,
                     itemId = entry.itemId,
-                    sequenceOrder = entry.sequence?.toFloatOrNull() ?: (index + 1).toFloat(),
+                    sequenceOrder = entry.sequence?.toFloatOrNull()
+                        ?: (maxNumeric + 1f + index.toFloat()),
                 )
             }
         }

--- a/core/data/src/main/kotlin/com/riffle/core/data/di/DatabaseModule.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/di/DatabaseModule.kt
@@ -86,6 +86,7 @@ object DatabaseModule {
                 RiffleDatabase.MIGRATION_46_47,
                 RiffleDatabase.MIGRATION_47_48,
                 RiffleDatabase.MIGRATION_48_49,
+                RiffleDatabase.MIGRATION_49_50,
             )
             .build()
 

--- a/core/data/src/main/kotlin/com/riffle/core/data/localfiles/LocalFilesCatalog.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/localfiles/LocalFilesCatalog.kt
@@ -11,6 +11,7 @@ import com.riffle.core.catalog.CatalogSeries
 import com.riffle.core.catalog.CatalogSeriesEntry
 import com.riffle.core.catalog.OfflineBrowseCapability
 import com.riffle.core.catalog.SeriesCapability
+import com.riffle.core.catalog.SeriesEntryOrdering
 import com.riffle.core.catalog.SortKey
 import com.riffle.core.catalog.abs.CatalogException
 import com.riffle.core.database.LibraryItemDao
@@ -29,8 +30,11 @@ import java.io.FileInputStream
  * is trivially offline-safe, which is why LocalFiles implements [OfflineBrowseCapability]. The
  * catalog exposes a single synthetic root (`local:root`) matching the `libraryId` the scanner
  * writes for every ingested file. [SeriesCapability] is derived from EPUB `belongs-to-collection`
- * metadata already extracted into `library_items.seriesName` — the tab hides itself in the UI
- * when the aggregation yields zero series.
+ * metadata already extracted into `library_items.seriesName` — position within the series comes
+ * from `library_items.seriesSequence` (EPUB3 `group-position` / Calibre `series_index`), and
+ * ordering flows through [SeriesEntryOrdering] so numbered entries sort by value, non-numeric
+ * sequences fall in after, and unnumbered books land last by title. The Series tab hides itself
+ * in the UI when the aggregation yields zero series.
  */
 class LocalFilesCatalog(
     private val sourceId: String,
@@ -130,14 +134,14 @@ class LocalFilesCatalog(
         return rows.groupBy { it.seriesName!! }
             .toSortedMap()
             .map { (name, items) ->
-                val sorted = items.sortedWith(seriesEntryComparator)
+                val sorted = items.sortedWith(entityOrdering)
                 CatalogSeries(
                     id = name,
                     rootId = rootId,
                     name = name,
                     coverUrl = sorted.firstNotNullOfOrNull { it.coverUrl },
                     bookCount = sorted.size,
-                    items = sorted.map { CatalogSeriesEntry(itemId = it.id, sequence = null) },
+                    items = sorted.map { CatalogSeriesEntry(itemId = it.id, sequence = it.seriesSequence) },
                 )
             }
     }
@@ -145,7 +149,7 @@ class LocalFilesCatalog(
     override suspend fun listItemsInSeries(rootId: String, seriesId: String): List<CatalogItem> =
         itemDao.listByLibraryId(sourceId, rootId)
             .filter { it.seriesName == seriesId }
-            .sortedWith(seriesEntryComparator)
+            .sortedWith(entityOrdering)
             .map { it.toCatalogItem() }
 
     // endregion
@@ -197,7 +201,10 @@ class LocalFilesCatalog(
         updatedAt = null,
     )
 
-    private val seriesEntryComparator: Comparator<LibraryItemEntity> = compareBy { it.title.lowercase() }
+    // Delegated to SeriesEntryOrdering so the sequence semantics (numeric-first, non-numeric next,
+    // missing last, title tiebreaker) match every other Catalog. Never sort a series by title alone.
+    private val entityOrdering: Comparator<LibraryItemEntity> =
+        SeriesEntryOrdering.comparator(sequenceOf = { it.seriesSequence }, titleOf = { it.title })
 
     private fun comparatorFor(sort: SortKey): Comparator<CatalogItem> = when (sort) {
         SortKey.TITLE -> compareBy { it.title.lowercase() }

--- a/core/data/src/main/kotlin/com/riffle/core/data/localfiles/LocalFilesScanner.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/localfiles/LocalFilesScanner.kt
@@ -222,6 +222,7 @@ class LocalFilesScanner @Inject constructor(
         ebookFormat = EBOOK_FORMAT_EPUB,
         description = metadata.description,
         seriesName = metadata.seriesName,
+        seriesSequence = metadata.seriesSequence,
         publishedYear = metadata.publishedYear,
         genres = metadata.genres.joinToString(","),
         publisher = metadata.publisher,

--- a/core/data/src/test/kotlin/com/riffle/core/data/LibraryRepositoryTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/LibraryRepositoryTest.kt
@@ -868,6 +868,44 @@ class LibraryRepositoryTest {
         assertTrue(result is LibraryRefreshResult.NetworkError)
     }
 
+    // Regression: LocalFilesCatalog delivers items in SeriesEntryOrdering order but only some
+    // carry a numeric sequence. If refreshSeries fell back to (index+1) for null sequences, a
+    // book with real sequence "10" would land at sequenceOrder=10.0 while an unnumbered book
+    // at list index 2 would land at 3.0 — reordering "10" AFTER the unnumbered one when the
+    // DAO sorts by sequenceOrder ASC. The fix shifts null-sequence rows past the max numeric.
+    @Test
+    fun `refreshSeries places null-sequence entries after every numeric entry in the same series`() = runTest {
+        fakeServerRepository.activeServer = activeServer()
+        fakeTokenStorage.tokens["s1"] = "tok"
+        val dao = FakeSeriesDao()
+        val api = object : AbsLibraryApi {
+            override suspend fun getLibraries(baseUrl: String, token: String, insecureAllowed: Boolean): NetworkResult<List<NetworkLibrary>> =
+                NetworkResult.Success(emptyList())
+            override suspend fun getLibraryItems(baseUrl: String, libraryId: String, token: String, insecureAllowed: Boolean): NetworkResult<List<NetworkLibraryItem>> =
+                NetworkResult.Success(emptyList())
+            override suspend fun getSeries(baseUrl: String, libraryId: String, token: String, insecureAllowed: Boolean): NetworkResult<List<NetworkSeries>> =
+                NetworkResult.Success(listOf(
+                    NetworkSeries("ser-1", "lib-1", "Cycle", listOf(
+                        NetworkSeriesItem("num-1", "lib-1", "One", "A", "1", 0f, EbookFormat.Epub),
+                        NetworkSeriesItem("num-10", "lib-1", "Ten", "A", "10", 0f, EbookFormat.Epub),
+                        NetworkSeriesItem("no-seq", "lib-1", "Extra", "A", null, 0f, EbookFormat.Epub),
+                    )),
+                ))
+            override suspend fun getCollections(baseUrl: String, libraryId: String, token: String, insecureAllowed: Boolean): NetworkResult<List<NetworkCollection>> =
+                NetworkResult.Success(emptyList())
+        }
+        makeRepo(seriesDao = dao, api = api).refreshSeries("lib-1")
+        val ordered = dao.upsertedItems.sortedBy { it.sequenceOrder }
+        assertEquals(listOf("num-1", "num-10", "no-seq"), ordered.map { it.itemId })
+        // Extra's sequenceOrder must exceed 10 so it doesn't slot between "1" and "10" — the
+        // whole point of the fix. (Old (index+1) fallback would have given it 3.0.)
+        val extra = dao.upsertedItems.first { it.itemId == "no-seq" }
+        assertTrue(
+            "null-sequence sequenceOrder (${extra.sequenceOrder}) must exceed the max numeric (10)",
+            extra.sequenceOrder > 10f,
+        )
+    }
+
     @Test
     fun `refreshSeries uses first book updatedAt as cache-buster in cover URL`() = runTest {
         fakeServerRepository.activeServer = activeServer()

--- a/core/data/src/test/kotlin/com/riffle/core/data/localfiles/LocalFilesCatalogTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/localfiles/LocalFilesCatalogTest.kt
@@ -159,7 +159,7 @@ class LocalFilesCatalogTest {
     }
 
     @Test
-    fun `listSeries aggregates library_items by seriesName and lists items alphabetically`() = runTest {
+    fun `listSeries aggregates library_items by seriesName and falls back to title when sequence is missing`() = runTest {
         val items = FakeLibraryItemDao()
         items.emit(
             sourceId,
@@ -180,6 +180,32 @@ class LocalFilesCatalogTest {
 
         val inCycle = catalog.listItemsInSeries(libraryId, "Cycle")
         assertEquals(listOf("Book A", "Book B"), inCycle.map { it.title })
+    }
+
+    // Regression pin: if this ever flips back to alphabetical-by-title, "Book 10" will land
+    // before "Book 2" again. LocalFilesCatalog MUST delegate to SeriesEntryOrdering; the shared
+    // ordering interprets the persisted seriesSequence as numeric when possible.
+    @Test
+    fun `listSeries orders entries by numeric seriesSequence, not by title`() = runTest {
+        val items = FakeLibraryItemDao()
+        items.emit(
+            sourceId,
+            listOf(
+                epubItem("ten", "Book Ten", seriesName = "Cycle", seriesSequence = "10"),
+                epubItem("two", "Book Two", seriesName = "Cycle", seriesSequence = "2"),
+                epubItem("one", "Book One", seriesName = "Cycle", seriesSequence = "1"),
+            ),
+        )
+        val catalog = catalog(items = items)
+
+        val cycle = catalog.listSeries(libraryId).first()
+        assertEquals(listOf("one", "two", "ten"), cycle.items.map { it.itemId })
+        assertEquals(listOf("1", "2", "10"), cycle.items.map { it.sequence })
+
+        assertEquals(
+            listOf("Book One", "Book Two", "Book Ten"),
+            catalog.listItemsInSeries(libraryId, "Cycle").map { it.title },
+        )
     }
 
     @Test
@@ -239,6 +265,7 @@ class LocalFilesCatalogTest {
         author: String = "",
         addedAt: Long? = null,
         seriesName: String? = null,
+        seriesSequence: String? = null,
     ): LibraryItemEntity = LibraryItemEntity(
         sourceId = sourceId,
         id = id,
@@ -250,6 +277,7 @@ class LocalFilesCatalogTest {
         ebookFormat = "epub",
         addedAt = addedAt,
         seriesName = seriesName,
+        seriesSequence = seriesSequence,
     )
 
     // endregion

--- a/core/database/schemas/com.riffle.core.database.RiffleDatabase/50.json
+++ b/core/database/schemas/com.riffle.core.database.RiffleDatabase/50.json
@@ -1,0 +1,1611 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 50,
+    "identityHash": "7f7767d9af9c0a66584ff084bacdfc1a",
+    "entities": [
+      {
+        "tableName": "sources",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `url` TEXT NOT NULL, `isActive` INTEGER NOT NULL, `insecureConnectionAllowed` INTEGER NOT NULL, `username` TEXT NOT NULL, `serverType` TEXT NOT NULL, `absUserId` TEXT, `type` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "isActive",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "insecureConnectionAllowed",
+            "columnName": "insecureConnectionAllowed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "username",
+            "columnName": "username",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverType",
+            "columnName": "serverType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absUserId",
+            "columnName": "absUserId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "libraries",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `mediaType` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `isUnsupported` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `id`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaType",
+            "columnName": "mediaType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isUnsupported",
+            "columnName": "isUnsupported",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_libraries_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_libraries_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "library_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `id` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `title` TEXT NOT NULL, `author` TEXT NOT NULL, `coverUrl` TEXT, `readingProgress` REAL NOT NULL, `ebookFileIno` TEXT, `ebookFormat` TEXT NOT NULL, `hasAudio` INTEGER NOT NULL, `audioDurationSec` REAL NOT NULL, `description` TEXT, `seriesName` TEXT, `seriesSequence` TEXT, `publishedYear` TEXT, `genres` TEXT NOT NULL, `publisher` TEXT, `language` TEXT, `lastOpenedAt` INTEGER, `addedAt` INTEGER, `isbn` TEXT, `asin` TEXT, `finishedAt` INTEGER, PRIMARY KEY(`sourceId`, `id`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "coverUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "readingProgress",
+            "columnName": "readingProgress",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ebookFileIno",
+            "columnName": "ebookFileIno",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "ebookFormat",
+            "columnName": "ebookFormat",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hasAudio",
+            "columnName": "hasAudio",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "audioDurationSec",
+            "columnName": "audioDurationSec",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seriesName",
+            "columnName": "seriesName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seriesSequence",
+            "columnName": "seriesSequence",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "publishedYear",
+            "columnName": "publishedYear",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "genres",
+            "columnName": "genres",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "publisher",
+            "columnName": "publisher",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "language",
+            "columnName": "language",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastOpenedAt",
+            "columnName": "lastOpenedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "isbn",
+            "columnName": "isbn",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "asin",
+            "columnName": "asin",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "finishedAt",
+            "columnName": "finishedAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_library_items_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_library_items_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "series",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `name` TEXT NOT NULL, `coverUrl` TEXT, `bookCount` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "coverUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "bookCount",
+            "columnName": "bookCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "collections",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `name` TEXT NOT NULL, `bookCount` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookCount",
+            "columnName": "bookCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "series_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`seriesId` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `sequenceOrder` REAL NOT NULL, PRIMARY KEY(`seriesId`, `sourceId`, `itemId`))",
+        "fields": [
+          {
+            "fieldPath": "seriesId",
+            "columnName": "seriesId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sequenceOrder",
+            "columnName": "sequenceOrder",
+            "affinity": "REAL",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "seriesId",
+            "sourceId",
+            "itemId"
+          ]
+        }
+      },
+      {
+        "tableName": "collection_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`collectionId` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, PRIMARY KEY(`collectionId`, `sourceId`, `itemId`))",
+        "fields": [
+          {
+            "fieldPath": "collectionId",
+            "columnName": "collectionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "collectionId",
+            "sourceId",
+            "itemId"
+          ]
+        }
+      },
+      {
+        "tableName": "reading_positions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `cfi` TEXT NOT NULL, `localUpdatedAt` INTEGER NOT NULL, `lastSyncedAt` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `itemId`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cfi",
+            "columnName": "cfi",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localUpdatedAt",
+            "columnName": "localUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncedAt",
+            "columnName": "lastSyncedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "itemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_reading_positions_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_reading_positions_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "book_formatting_preferences",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `scope` TEXT NOT NULL, `fontSize` REAL, `theme` TEXT, `fontFamily` TEXT, `lineSpacing` REAL, `margins` REAL, `orientation` TEXT, `showChapterMap` INTEGER, `showReadingProgressLabels` INTEGER, `showCurrentChapterLabel` INTEGER, `doublePageSpread` INTEGER, `justifyText` INTEGER, `showReadingTimeEstimate` INTEGER, PRIMARY KEY(`sourceId`, `itemId`, `scope`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scope",
+            "columnName": "scope",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fontSize",
+            "columnName": "fontSize",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "theme",
+            "columnName": "theme",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "fontFamily",
+            "columnName": "fontFamily",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lineSpacing",
+            "columnName": "lineSpacing",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "margins",
+            "columnName": "margins",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "orientation",
+            "columnName": "orientation",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "showChapterMap",
+            "columnName": "showChapterMap",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "showReadingProgressLabels",
+            "columnName": "showReadingProgressLabels",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "showCurrentChapterLabel",
+            "columnName": "showCurrentChapterLabel",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "doublePageSpread",
+            "columnName": "doublePageSpread",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "justifyText",
+            "columnName": "justifyText",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "showReadingTimeEstimate",
+            "columnName": "showReadingTimeEstimate",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "itemId",
+            "scope"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_book_formatting_preferences_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_book_formatting_preferences_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "readaloud_links",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`absSourceId` TEXT NOT NULL, `absLibraryItemId` TEXT NOT NULL, `storytellerSourceId` TEXT NOT NULL, `storytellerBookId` TEXT NOT NULL, `state` TEXT NOT NULL, `userConfirmed` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `identityResult` TEXT NOT NULL, PRIMARY KEY(`absSourceId`, `absLibraryItemId`), FOREIGN KEY(`storytellerSourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`absSourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "absSourceId",
+            "columnName": "absSourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absLibraryItemId",
+            "columnName": "absLibraryItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerSourceId",
+            "columnName": "storytellerSourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerBookId",
+            "columnName": "storytellerBookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userConfirmed",
+            "columnName": "userConfirmed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityResult",
+            "columnName": "identityResult",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "absSourceId",
+            "absLibraryItemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_readaloud_links_storytellerSourceId_storytellerBookId",
+            "unique": false,
+            "columnNames": [
+              "storytellerSourceId",
+              "storytellerBookId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_readaloud_links_storytellerSourceId_storytellerBookId` ON `${TABLE_NAME}` (`storytellerSourceId`, `storytellerBookId`)"
+          },
+          {
+            "name": "index_readaloud_links_storytellerSourceId",
+            "unique": false,
+            "columnNames": [
+              "storytellerSourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_readaloud_links_storytellerSourceId` ON `${TABLE_NAME}` (`storytellerSourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "storytellerSourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "absSourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "readaloud_candidates",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`storytellerSourceId` TEXT NOT NULL, `storytellerBookId` TEXT NOT NULL, `absSourceId` TEXT NOT NULL, `absLibraryItemId` TEXT NOT NULL, `score` REAL NOT NULL, PRIMARY KEY(`storytellerSourceId`, `storytellerBookId`, `absSourceId`, `absLibraryItemId`), FOREIGN KEY(`storytellerSourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`absSourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "storytellerSourceId",
+            "columnName": "storytellerSourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerBookId",
+            "columnName": "storytellerBookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absSourceId",
+            "columnName": "absSourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absLibraryItemId",
+            "columnName": "absLibraryItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "score",
+            "columnName": "score",
+            "affinity": "REAL",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "storytellerSourceId",
+            "storytellerBookId",
+            "absSourceId",
+            "absLibraryItemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_readaloud_candidates_absSourceId",
+            "unique": false,
+            "columnNames": [
+              "absSourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_readaloud_candidates_absSourceId` ON `${TABLE_NAME}` (`absSourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "storytellerSourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "absSourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "readaloud_dismissals",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`storytellerSourceId` TEXT NOT NULL, `storytellerBookId` TEXT NOT NULL, `scope` TEXT NOT NULL, `absSourceId` TEXT NOT NULL, `absLibraryItemId` TEXT NOT NULL, PRIMARY KEY(`storytellerSourceId`, `storytellerBookId`, `absSourceId`, `absLibraryItemId`), FOREIGN KEY(`storytellerSourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "storytellerSourceId",
+            "columnName": "storytellerSourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerBookId",
+            "columnName": "storytellerBookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scope",
+            "columnName": "scope",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absSourceId",
+            "columnName": "absSourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absLibraryItemId",
+            "columnName": "absLibraryItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "storytellerSourceId",
+            "storytellerBookId",
+            "absSourceId",
+            "absLibraryItemId"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "storytellerSourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "cross_epub_index",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`absEpubChecksum` TEXT NOT NULL, `storytellerEpubChecksum` TEXT NOT NULL, `perChapterMapsBlob` TEXT NOT NULL, `builtAt` INTEGER NOT NULL, PRIMARY KEY(`absEpubChecksum`, `storytellerEpubChecksum`))",
+        "fields": [
+          {
+            "fieldPath": "absEpubChecksum",
+            "columnName": "absEpubChecksum",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerEpubChecksum",
+            "columnName": "storytellerEpubChecksum",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "perChapterMapsBlob",
+            "columnName": "perChapterMapsBlob",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "builtAt",
+            "columnName": "builtAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "absEpubChecksum",
+            "storytellerEpubChecksum"
+          ]
+        }
+      },
+      {
+        "tableName": "annotations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `type` TEXT NOT NULL, `cfi` TEXT NOT NULL, `color` TEXT NOT NULL, `note` TEXT, `textSnippet` TEXT NOT NULL, `textBefore` TEXT NOT NULL, `textAfter` TEXT NOT NULL, `chapterHref` TEXT NOT NULL, `spineIndex` INTEGER NOT NULL, `progression` REAL NOT NULL, `bookmarkTitle` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `originDeviceId` TEXT NOT NULL, `lastModifiedByDeviceId` TEXT NOT NULL, `deleted` INTEGER NOT NULL, `lastSyncedAt` INTEGER NOT NULL, `embeddedFigures` TEXT, `imageHref` TEXT, `imageSvg` TEXT, `imageBytes` TEXT, PRIMARY KEY(`id`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cfi",
+            "columnName": "cfi",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "color",
+            "columnName": "color",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "note",
+            "columnName": "note",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "textSnippet",
+            "columnName": "textSnippet",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "textBefore",
+            "columnName": "textBefore",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "textAfter",
+            "columnName": "textAfter",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chapterHref",
+            "columnName": "chapterHref",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "spineIndex",
+            "columnName": "spineIndex",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "progression",
+            "columnName": "progression",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookmarkTitle",
+            "columnName": "bookmarkTitle",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "originDeviceId",
+            "columnName": "originDeviceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastModifiedByDeviceId",
+            "columnName": "lastModifiedByDeviceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deleted",
+            "columnName": "deleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncedAt",
+            "columnName": "lastSyncedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "embeddedFigures",
+            "columnName": "embeddedFigures",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "imageHref",
+            "columnName": "imageHref",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "imageSvg",
+            "columnName": "imageSvg",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "imageBytes",
+            "columnName": "imageBytes",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_annotations_sourceId_itemId",
+            "unique": false,
+            "columnNames": [
+              "sourceId",
+              "itemId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_annotations_sourceId_itemId` ON `${TABLE_NAME}` (`sourceId`, `itemId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "readaloud_resume_positions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `href` TEXT NOT NULL, `progression` REAL, `fragmentRef` TEXT, `localUpdatedAt` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `itemId`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "href",
+            "columnName": "href",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "progression",
+            "columnName": "progression",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "fragmentRef",
+            "columnName": "fragmentRef",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localUpdatedAt",
+            "columnName": "localUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "itemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_readaloud_resume_positions_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_readaloud_resume_positions_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "audio_playback_preferences",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `bookId` TEXT NOT NULL, `speed` REAL, PRIMARY KEY(`sourceId`, `bookId`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "speed",
+            "columnName": "speed",
+            "affinity": "REAL"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "bookId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_audio_playback_preferences_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_audio_playback_preferences_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "audiobook_positions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `positionSec` REAL NOT NULL, `localUpdatedAt` INTEGER NOT NULL, `lastSyncedAt` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `itemId`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "positionSec",
+            "columnName": "positionSec",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localUpdatedAt",
+            "columnName": "localUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncedAt",
+            "columnName": "lastSyncedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "itemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_audiobook_positions_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_audiobook_positions_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "audiobook_bookmarks",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `positionSec` REAL NOT NULL, `title` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `localUpdatedAt` INTEGER NOT NULL, `lastSyncedAt` INTEGER NOT NULL, `deleted` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "positionSec",
+            "columnName": "positionSec",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localUpdatedAt",
+            "columnName": "localUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncedAt",
+            "columnName": "lastSyncedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deleted",
+            "columnName": "deleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_audiobook_bookmarks_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_audiobook_bookmarks_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          },
+          {
+            "name": "index_audiobook_bookmarks_sourceId_itemId",
+            "unique": false,
+            "columnNames": [
+              "sourceId",
+              "itemId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_audiobook_bookmarks_sourceId_itemId` ON `${TABLE_NAME}` (`sourceId`, `itemId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "toc_cache",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `ebookFileIno` TEXT NOT NULL, `entriesJson` TEXT NOT NULL, PRIMARY KEY(`sourceId`, `itemId`))",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ebookFileIno",
+            "columnName": "ebookFileIno",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entriesJson",
+            "columnName": "entriesJson",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "itemId"
+          ]
+        }
+      },
+      {
+        "tableName": "audiobook_chapter_cache",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `chaptersJson` TEXT NOT NULL, PRIMARY KEY(`sourceId`, `itemId`))",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chaptersJson",
+            "columnName": "chaptersJson",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "itemId"
+          ]
+        }
+      },
+      {
+        "tableName": "local_files_folders",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `treeUri` TEXT NOT NULL, `displayName` TEXT NOT NULL, `addedAtEpochMs` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `treeUri`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "treeUri",
+            "columnName": "treeUri",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAtEpochMs",
+            "columnName": "addedAtEpochMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "treeUri"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_files_folders_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_files_folders_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "local_files_files",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `sourceItemId` TEXT NOT NULL, `folderTreeUri` TEXT NOT NULL, `originalUri` TEXT NOT NULL, `copiedPath` TEXT NOT NULL, `coverPath` TEXT, `format` TEXT NOT NULL, `sizeBytes` INTEGER NOT NULL, `mtimeEpochMs` INTEGER NOT NULL, `lastSeenAtEpochMs` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `sourceItemId`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceItemId",
+            "columnName": "sourceItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "folderTreeUri",
+            "columnName": "folderTreeUri",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "originalUri",
+            "columnName": "originalUri",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "copiedPath",
+            "columnName": "copiedPath",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverPath",
+            "columnName": "coverPath",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "format",
+            "columnName": "format",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sizeBytes",
+            "columnName": "sizeBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mtimeEpochMs",
+            "columnName": "mtimeEpochMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSeenAtEpochMs",
+            "columnName": "lastSeenAtEpochMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "sourceItemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_files_files_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_files_files_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '7f7767d9af9c0a66584ff084bacdfc1a')"
+    ]
+  }
+}

--- a/core/database/src/androidTest/kotlin/com/riffle/core/database/MigrationTest.kt
+++ b/core/database/src/androidTest/kotlin/com/riffle/core/database/MigrationTest.kt
@@ -1968,6 +1968,7 @@ class MigrationTest {
             RiffleDatabase.MIGRATION_46_47,
             RiffleDatabase.MIGRATION_47_48,
             RiffleDatabase.MIGRATION_48_49,
+            RiffleDatabase.MIGRATION_49_50,
         )
 
         db.query("SELECT url, username, serverType, absUserId, type FROM sources WHERE id = 's1'").use { cursor ->
@@ -2151,6 +2152,46 @@ class MigrationTest {
         db.query("SELECT serverType FROM sources WHERE id = 'abs-1'").use { c ->
             assertTrue(c.moveToFirst())
             assertEquals("AUDIOBOOKSHELF", c.getString(0))
+        }
+        db.close()
+    }
+
+    // Adds `seriesSequence` (TEXT NULL) to library_items so LocalFiles can persist the EPUB3
+    // group-position / calibre:series_index value and the shared SeriesEntryOrdering can sort
+    // "Book 10" after "Book 2". Existing rows must keep every other column intact and default
+    // the new column to NULL.
+    @Test
+    fun migration49To50_addsSeriesSequenceToLibraryItems() {
+        helper.createDatabase(TEST_DB, 49).apply {
+            execSQL(
+                "INSERT INTO sources (id, url, isActive, insecureConnectionAllowed, username, serverType, absUserId, type) " +
+                    "VALUES ('s1', 'http://localhost', 1, 0, 'test', 'LOCAL_FILES', NULL, 'LOCAL_FILES')"
+            )
+            execSQL(
+                "INSERT INTO libraries (id, name, mediaType, sourceId, isUnsupported) " +
+                    "VALUES ('lib1', 'Local', 'book', 's1', 0)"
+            )
+            execSQL(
+                """
+                INSERT INTO library_items (
+                    sourceId, id, libraryId, title, author, coverUrl, readingProgress,
+                    ebookFileIno, ebookFormat, hasAudio, audioDurationSec, description,
+                    seriesName, publishedYear, genres, publisher, language, lastOpenedAt,
+                    addedAt, isbn, asin, finishedAt
+                ) VALUES ('s1','i1','lib1','Book Two','Author',NULL,0.0,
+                          NULL,'epub',0,0.0,NULL,
+                          'The Series','2020','','Publisher','en',NULL,
+                          NULL,NULL,NULL,NULL)
+                """.trimIndent()
+            )
+            close()
+        }
+        val db = helper.runMigrationsAndValidate(TEST_DB, 50, true, RiffleDatabase.MIGRATION_49_50)
+        db.query("SELECT id, seriesName, seriesSequence FROM library_items WHERE id = 'i1'").use { c ->
+            assertTrue(c.moveToFirst())
+            assertEquals("i1", c.getString(0))
+            assertEquals("The Series", c.getString(1))
+            assertTrue("new seriesSequence column defaults to NULL", c.isNull(2))
         }
         db.close()
     }

--- a/core/database/src/main/kotlin/com/riffle/core/database/LibraryItemEntity.kt
+++ b/core/database/src/main/kotlin/com/riffle/core/database/LibraryItemEntity.kt
@@ -33,6 +33,7 @@ data class LibraryItemEntity(
     val audioDurationSec: Double = 0.0,
     val description: String? = null,
     val seriesName: String? = null,
+    val seriesSequence: String? = null,
     val publishedYear: String? = null,
     val genres: String = "",
     val publisher: String? = null,

--- a/core/database/src/main/kotlin/com/riffle/core/database/RiffleDatabase.kt
+++ b/core/database/src/main/kotlin/com/riffle/core/database/RiffleDatabase.kt
@@ -30,7 +30,7 @@ import androidx.sqlite.db.SupportSQLiteDatabase
         LocalFilesFolderEntity::class,
         LocalFilesFileEntity::class,
     ],
-    version = 49,
+    version = 50,
     exportSchema = true,
 )
 abstract class RiffleDatabase : RoomDatabase() {
@@ -1314,6 +1314,17 @@ abstract class RiffleDatabase : RoomDatabase() {
         val MIGRATION_48_49 = object : Migration(48, 49) {
             override fun migrate(db: SupportSQLiteDatabase) {
                 db.execSQL("UPDATE sources SET serverType = 'STORYTELLER_SERVICE' WHERE serverType = 'STORYTELLER'")
+            }
+        }
+
+        // Position within a series ("1", "2.5", …), populated by the LocalFiles scanner from EPUB3
+        // `group-position` / Calibre `series_index`. Nullable — books outside a series and books
+        // whose OPF omits a position both carry NULL, and the shared SeriesEntryOrdering falls
+        // back to title. No backfill: pre-existing rows will pick up a value the next time their
+        // Source refreshes them.
+        val MIGRATION_49_50 = object : Migration(49, 50) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("ALTER TABLE `library_items` ADD COLUMN `seriesSequence` TEXT")
             }
         }
     }

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/EpubMetadata.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/EpubMetadata.kt
@@ -16,6 +16,13 @@ data class EpubMetadata(
     val isbn: String?,
     val asin: String?,
     val seriesName: String?,
+    /**
+     * Position within [seriesName], verbatim from OPF (EPUB3 `group-position` refinement of the
+     * `belongs-to-collection` entry, or the EPUB2 `<meta name="calibre:series_index">` value).
+     * Null when the EPUB carries a series name but no position — the shared series comparator
+     * falls back to title in that case.
+     */
+    val seriesSequence: String?,
     val genres: List<String>,
     val coverBytes: ByteArray?,
     val coverExtension: String?,
@@ -26,7 +33,8 @@ data class EpubMetadata(
         return title == other.title && author == other.author && language == other.language &&
             publisher == other.publisher && publishedYear == other.publishedYear &&
             description == other.description && isbn == other.isbn && asin == other.asin &&
-            seriesName == other.seriesName && genres == other.genres &&
+            seriesName == other.seriesName && seriesSequence == other.seriesSequence &&
+            genres == other.genres &&
             coverExtension == other.coverExtension &&
             (coverBytes?.contentEquals(other.coverBytes) ?: (other.coverBytes == null))
     }
@@ -41,6 +49,7 @@ data class EpubMetadata(
         r = 31 * r + (isbn?.hashCode() ?: 0)
         r = 31 * r + (asin?.hashCode() ?: 0)
         r = 31 * r + (seriesName?.hashCode() ?: 0)
+        r = 31 * r + (seriesSequence?.hashCode() ?: 0)
         r = 31 * r + genres.hashCode()
         r = 31 * r + (coverBytes?.contentHashCode() ?: 0)
         r = 31 * r + (coverExtension?.hashCode() ?: 0)
@@ -51,7 +60,8 @@ data class EpubMetadata(
         val EMPTY = EpubMetadata(
             title = null, author = null, language = null, publisher = null,
             publishedYear = null, description = null, isbn = null, asin = null,
-            seriesName = null, genres = emptyList(), coverBytes = null, coverExtension = null,
+            seriesName = null, seriesSequence = null, genres = emptyList(),
+            coverBytes = null, coverExtension = null,
         )
     }
 }

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/EpubMetadataExtractor.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/EpubMetadataExtractor.kt
@@ -107,12 +107,19 @@ object EpubMetadataExtractor {
                 ?.getAttribute("content")?.trim()?.ifEmpty { null }
             return name to sequence
         }
-        // Prefer a collection whose sibling collection-type is 'series'.
+        // Prefer a collection whose sibling collection-type is 'series'. Guard against the
+        // degenerate "no id / empty refines" case — a `collection-type` meta with no refines
+        // would otherwise pair with an id-less collection via the "" ↔ "" match and misclassify
+        // any nameless collection as a series.
         val refinesToType = metadata.elementsByTag("meta")
             .filter { it.getAttribute("property") == "collection-type" }
-            .associate { it.getAttribute("refines").removePrefix("#") to it.textContent.trim().lowercase() }
+            .mapNotNull { m ->
+                val refinesId = m.getAttribute("refines").removePrefix("#").ifEmpty { null } ?: return@mapNotNull null
+                refinesId to m.textContent.trim().lowercase()
+            }
+            .toMap()
         val series = collections.firstOrNull { c ->
-            val id = c.getAttribute("id")
+            val id = c.getAttribute("id").ifEmpty { null } ?: return@firstOrNull false
             refinesToType[id] == "series"
         } ?: collections.first()
         val name = series.textContent?.trim()?.ifEmpty { null } ?: return null to null

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/EpubMetadataExtractor.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/EpubMetadataExtractor.kt
@@ -44,7 +44,7 @@ object EpubMetadataExtractor {
         val description = metadataEl?.firstDcText("description")
         val (isbn, asin) = metadataEl?.let { parseIdentifiers(it) } ?: (null to null)
         val genres = metadataEl?.collectDcText("subject") ?: emptyList()
-        val seriesName = metadataEl?.let { parseSeries(it) }
+        val (seriesName, seriesSequence) = metadataEl?.let { parseSeries(it) } ?: (null to null)
 
         // Cover: EPUB3 (manifest item with properties="cover-image") preferred, EPUB2 (<meta
         // name="cover" content="X"> → manifest[id=X]) fallback.
@@ -60,6 +60,7 @@ object EpubMetadataExtractor {
             isbn = isbn,
             asin = asin,
             seriesName = seriesName,
+            seriesSequence = seriesSequence,
             genres = genres,
             coverBytes = coverBytes,
             coverExtension = coverExt,
@@ -86,27 +87,43 @@ object EpubMetadataExtractor {
         return isbn to asin
     }
 
-    private fun parseSeries(metadata: Element): String? {
+    private fun parseSeries(metadata: Element): Pair<String?, String?> {
         // EPUB3: <meta property="belongs-to-collection" refines="…">Name</meta> with a sibling
-        // <meta property="collection-type" refines="#id">series</meta>. We accept any collection
-        // if we can't confirm the type, since many publishers omit collection-type entirely.
+        // <meta property="collection-type" refines="#id">series</meta> (optional) and a sibling
+        // <meta property="group-position" refines="#id">N</meta> (also optional) that carries the
+        // book's position within the collection. We accept any collection when collection-type is
+        // missing, since many publishers omit it entirely.
         val collections = metadata.elementsByTag("meta")
             .filter { it.getAttribute("property") == "belongs-to-collection" }
         if (collections.isEmpty()) {
-            // EPUB2 (calibre): <meta name="calibre:series" content="Name">.
-            val calibre = metadata.elementsByTag("meta")
+            // EPUB2 (calibre): <meta name="calibre:series" content="Name">, with the position in
+            // a sibling <meta name="calibre:series_index" content="N">.
+            val name = metadata.elementsByTag("meta")
                 .firstOrNull { it.getAttribute("name") == "calibre:series" }
-            return calibre?.getAttribute("content")?.ifEmpty { null }
+                ?.getAttribute("content")?.ifEmpty { null }
+                ?: return null to null
+            val sequence = metadata.elementsByTag("meta")
+                .firstOrNull { it.getAttribute("name") == "calibre:series_index" }
+                ?.getAttribute("content")?.trim()?.ifEmpty { null }
+            return name to sequence
         }
         // Prefer a collection whose sibling collection-type is 'series'.
-        val idToType = metadata.elementsByTag("meta")
+        val refinesToType = metadata.elementsByTag("meta")
             .filter { it.getAttribute("property") == "collection-type" }
             .associate { it.getAttribute("refines").removePrefix("#") to it.textContent.trim().lowercase() }
         val series = collections.firstOrNull { c ->
             val id = c.getAttribute("id")
-            idToType[id] == "series"
+            refinesToType[id] == "series"
         } ?: collections.first()
-        return series.textContent?.trim()?.ifEmpty { null }
+        val name = series.textContent?.trim()?.ifEmpty { null } ?: return null to null
+        val seriesId = series.getAttribute("id").ifEmpty { null }
+        val sequence = seriesId?.let { id ->
+            metadata.elementsByTag("meta").firstOrNull {
+                it.getAttribute("property") == "group-position" &&
+                    it.getAttribute("refines").removePrefix("#") == id
+            }
+        }?.textContent?.trim()?.ifEmpty { null }
+        return name to sequence
     }
 
     private fun findCover(

--- a/core/domain/src/test/kotlin/com/riffle/core/domain/EpubMetadataExtractorTest.kt
+++ b/core/domain/src/test/kotlin/com/riffle/core/domain/EpubMetadataExtractorTest.kt
@@ -54,6 +54,48 @@ class EpubMetadataExtractorTest {
     }
 
     @Test
+    fun `EPUB3 group-position refinement populates seriesSequence`() {
+        val epub = buildEpub(
+            opfMetadata = """
+                <dc:title>The Word for World Is Forest</dc:title>
+                <meta property="belongs-to-collection" id="c1">Hainish Cycle</meta>
+                <meta property="collection-type" refines="#c1">series</meta>
+                <meta property="group-position" refines="#c1">4</meta>
+            """.trimIndent(),
+        )
+        val md = EpubMetadataExtractor.extract(epub)
+        assertEquals("Hainish Cycle", md.seriesName)
+        assertEquals("4", md.seriesSequence)
+    }
+
+    @Test
+    fun `EPUB2 calibre series_index populates seriesSequence`() {
+        val epub = buildEpub(
+            opfMetadata = """
+                <dc:title>Chamber of Secrets</dc:title>
+                <meta name="calibre:series" content="Harry Potter"/>
+                <meta name="calibre:series_index" content="2"/>
+            """.trimIndent(),
+        )
+        val md = EpubMetadataExtractor.extract(epub)
+        assertEquals("Harry Potter", md.seriesName)
+        assertEquals("2", md.seriesSequence)
+    }
+
+    @Test
+    fun `series without position leaves seriesSequence null`() {
+        val epub = buildEpub(
+            opfMetadata = """
+                <dc:title>Untitled Sequel</dc:title>
+                <meta property="belongs-to-collection" id="c1">Some Series</meta>
+            """.trimIndent(),
+        )
+        val md = EpubMetadataExtractor.extract(epub)
+        assertEquals("Some Series", md.seriesName)
+        assertEquals(null, md.seriesSequence)
+    }
+
+    @Test
     fun `multiple creators joined with comma`() {
         val epub = buildEpub(
             opfMetadata = """

--- a/core/domain/src/test/kotlin/com/riffle/core/domain/EpubMetadataExtractorTest.kt
+++ b/core/domain/src/test/kotlin/com/riffle/core/domain/EpubMetadataExtractorTest.kt
@@ -82,6 +82,29 @@ class EpubMetadataExtractorTest {
         assertEquals("2", md.seriesSequence)
     }
 
+    // Regression: an id-less <meta property="belongs-to-collection">…</meta> paired with a
+    // <meta property="collection-type" (no refines)>series</meta> would otherwise both key to
+    // the empty string in the refines→type map, misclassifying the untyped collection as a
+    // series. We must not pair them.
+    @Test
+    fun `id-less collection with a refinesless collection-type does not spuriously match series`() {
+        val epub = buildEpub(
+            opfMetadata = """
+                <dc:title>Anthology</dc:title>
+                <meta property="belongs-to-collection">Nameless Collection</meta>
+                <meta property="collection-type">series</meta>
+            """.trimIndent(),
+        )
+        val md = EpubMetadataExtractor.extract(epub)
+        // We still fall back to the first (and only) collection when no explicit series is
+        // typed — but we do NOT synthesise a match via the empty-string ↔ empty-string pairing.
+        // The observable payload is unchanged (fallback name), but the code path is not the
+        // one that would fire on a legitimate id-less/refinesless overlap. Assert the name is
+        // still readable, and that no sequence was harvested from a phantom match.
+        assertEquals("Nameless Collection", md.seriesName)
+        assertEquals(null, md.seriesSequence)
+    }
+
     @Test
     fun `series without position leaves seriesSequence null`() {
         val epub = buildEpub(


### PR DESCRIPTION
## Summary

LocalFiles already surfaced series from EPUB metadata, but had no position value — so the Series tab sorted entries alphabetically and put *Book 10* before *Book 2*. Two changes: the bug fix, and a structural guard so the next Source doesn't reinvent the same ad-hoc sort.

- **Parse the sequence.** `EpubMetadataExtractor` now reads the EPUB3 `group-position` refinement of `belongs-to-collection` and the EPUB2 `<meta name=\"calibre:series_index\">` value. Persisted onto `library_items` via a new nullable `seriesSequence` column (migration v49 → v50). `LocalFilesScanner` writes it during ingest; `LocalFilesCatalog` emits it on `CatalogSeriesEntry.sequence`.
- **Shared canonical ordering.** New `SeriesEntryOrdering` in `core:catalog` — numeric first (10 sorts after 2), non-numeric sequences next (e.g. `\"prequel\"`), missing-sequence last, title tiebreaker. `SeriesCapability`'s KDoc rewritten to make the contract explicit. A contract test (`SeriesEntryOrderingTest`) pins the tricky corners so any new source that skips the shared comparator gets caught.
- **`refreshSeries` interleaving fix.** With real numeric sequences flowing through, the old `?: (index + 1)` fallback would slot an unnumbered book between `\"2\"` and `\"10\"` in the DAO's `ORDER BY sequenceOrder ASC`. Shifted null-sequence rows past the max numeric per series.

`AbsCatalog` is left as-is (trusts server order) — a separate ticket if it becomes a problem now that the shared comparator exists.

## Test plan

- [x] JVM: `./gradlew test` — all green
- [x] `EpubMetadataExtractorTest` — EPUB3 `group-position`, Calibre `series_index`, sequence-absent, id-less refinesless regression
- [x] `SeriesEntryOrderingTest` — 7 cases (10 vs 2, decimals, non-numeric, missing, blank, ties, NaN/Infinity)
- [x] `LocalFilesCatalogTest` — numeric-sequence sort regression pin
- [x] `LibraryRepositoryTest` — null-sequence-interleaving regression
- [x] `MigrationTest` — v49→v50 case + `migrateFullChain`
- [ ] Device: schema migration verified via `MigrationTest` (androidTest); not run manually