### PR TITLE
feat(reader): smooth internal-link nav in Continuous and Vertical modes

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ColumnSnap.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ColumnSnap.kt
@@ -23,6 +23,47 @@ import org.json.JSONObject
 internal object ColumnSnap {
 
     /**
+     * A fixed-duration ease-out-cubic vertical scroll, in JS. Duration matches Continuous mode's
+     * [android.widget.NestedScrollView.smoothScrollTo] default (~250 ms) so both modes feel the
+     * same on internal-link taps — Chromium's `behavior:'smooth'` picks a distance-proportional
+     * duration that reads as sluggish on longer jumps and doesn't match the continuous curve.
+     *
+     * The emitted snippet expects the caller to have already declared these locals in the enclosing
+     * IIFE: `se` (scrolling element), `startV` (Number, the source scrollTop), and `targetV`
+     * (Number, the destination scrollTop). Callers do the pre-land (hard `se.scrollTop = pre`)
+     * first when the tail should ride only the last half-viewport under a nav cover; a same-doc
+     * link tap skips the pre-land and animates the full distance from where the user is.
+     *
+     * Uses `window.__riffleVsmoothGen` as a supersede counter so a later smooth scroll cancels the
+     * previous animation instead of fighting it — mirroring the `__riffleSnapGen` policy the
+     * paginated column-snap tracker already uses.
+     */
+    /**
+     * Stash the current scroll position and document URL on `window` so the post-`go(locator)`
+     * smooth-tail can decide whether the jump was same-doc (animate FROM the stashed origin, no
+     * visible pre-land) or cross-doc (stash is gone with the old document, pre-land under the nav
+     * cover). Called by [com.riffle.app.feature.reader.renderer.DefaultRendererBridge.snapAfterGoTo]
+     * BEFORE `frag.go(locator)`. Skipping this on a cross-doc jump is fine — the new document
+     * doesn't inherit the stash, and the JS reads `undefined`, which triggers the pre-land branch.
+     */
+    const val STASH_VERTICAL_ORIGIN_JS: String =
+        "(function(){var se=document.scrollingElement||document.documentElement;" +
+            "if(!se)return;" +
+            "window.__riffleOriginY=se.scrollTop;" +
+            "window.__riffleOriginHref=location.href;})()"
+
+    private const val VERTICAL_SMOOTH_TAIL_JS: String =
+        "var _dur=250,_t0=performance.now();" +
+            "var _gen=(window.__riffleVsmoothGen=(window.__riffleVsmoothGen||0)+1);" +
+            "var _delta=targetV-startV;" +
+            "function _step(now){if(_gen!==window.__riffleVsmoothGen)return;" +
+            "var _t=Math.min(1,(now-_t0)/_dur);" +
+            "var _e=1-Math.pow(1-_t,3);" + // ease-out cubic
+            "se.scrollTop=startV+_delta*_e;" +
+            "if(_t<1)requestAnimationFrame(_step);}" +
+            "requestAnimationFrame(_step);"
+
+    /**
      * The element id a TOC/search/resume locator points at (its href fragment), or null for a
      * jump to a resource start. Drives [snapToTargetColumnJs] so the landing snaps to the column
      * the target itself occupies — robust to where go() landed and to the post-load reflow.
@@ -313,8 +354,15 @@ internal object ColumnSnap {
             "if(se.scrollHeight > window.innerHeight + 4){" + // scroll (vertical) mode → no column grid
             "if(r.top>=0 && r.bottom<=window.innerHeight)return 'same';" + // already fully visible
             "var beforeTop=se.scrollTop;" +
-            "se.scrollTop=Math.max(0, r.top + se.scrollTop - Math.floor(window.innerHeight/2));" +
-            "return (Math.abs(se.scrollTop-beforeTop)>1)?'moved':'same';}" +
+            "var targetV=Math.max(0, r.top + se.scrollTop - Math.floor(window.innerHeight/2));" +
+            "if(Math.abs(targetV-beforeTop)<=1)return 'same';" +
+            // Fixed-duration JS animation to match Continuous mode's NestedScrollView.smoothScrollTo
+            // feel. `behavior:'smooth'` picks a distance-proportional duration that reads as
+            // sluggish on longer jumps and doesn't match the continuous curve; the JS tween keeps
+            // both modes at the same ~250 ms ease-out.
+            "var startV=beforeTop;" +
+            VERTICAL_SMOOTH_TAIL_JS +
+            "return 'moved';}" +
             "var iw=window.innerWidth;" +
             "var before=se.scrollLeft;" +
             "var abs=r.left+se.scrollLeft;" +
@@ -428,6 +476,35 @@ internal object ColumnSnap {
         val noTargetSnap = if (landAtStartWhenNoTarget) "se.scrollLeft=0;" else "se.scrollLeft=Math.round(se.scrollLeft/iw)*iw;"
         return "(function(){var id=$idLiteral;" +
             "var se=document.scrollingElement;" +
+            // Vertical (scroll-mode) smooth tail. Readium's `go(locator)` already teleported us to
+            // the target, so we compute `targetV` from either the fragment element's rect or the
+            // current scrollTop. The animation START point depends on whether the jump crossed
+            // documents: same-doc keeps the stashed pre-go scrollTop (no visible backward flash —
+            // return-to-position card + same-chapter TOC entries have no nav cover to hide a
+            // pre-land); cross-doc lost the stash with the old document, so we pre-land half a
+            // viewport short of target — the nav cover hides the pre-land, and the reveal shows
+            // the tail. Consuming the stash (setting to null) is important: a later same-doc
+            // background sync must not reuse a stale origin from an unrelated navigation.
+            // Skips the paginated rAF column-snap loop below — it only writes scrollLeft, which
+            // is a no-op in vertical, and the smooth animation is one-shot rather than a
+            // reflow-tracking loop.
+            "if(se && se.scrollHeight > window.innerHeight + 4){" +
+            "var targetV;" +
+            "if(id){var elV=document.getElementById(id);" +
+            "if(elV){var rV=elV.getBoundingClientRect();" +
+            "targetV=Math.max(0, rV.top + se.scrollTop - Math.floor(window.innerHeight/2));}" +
+            "else{targetV=se.scrollTop;}}" +
+            "else{targetV=se.scrollTop;}" +
+            "var _sameDoc=(typeof window.__riffleOriginY==='number')&&" +
+            "(window.__riffleOriginHref===location.href);" +
+            "var startV;" +
+            "if(_sameDoc){startV=window.__riffleOriginY;}" +
+            "else{startV=Math.max(0, targetV - Math.floor(window.innerHeight/2));}" +
+            "window.__riffleOriginY=null;window.__riffleOriginHref=null;" +
+            "if(Math.abs(targetV-startV)<=1)return;" + // origin already at target → no motion
+            "se.scrollTop=startV;" +
+            VERTICAL_SMOOTH_TAIL_JS +
+            "return;}" +
             "var gen=(window.__riffleSnapGen=(window.__riffleSnapGen||0)+1);" +
             "var lastW=-1,stable=0,frames=0;" +
             "function snap(){var iw=window.innerWidth;" +

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ColumnSnap.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ColumnSnap.kt
@@ -50,7 +50,13 @@ internal object ColumnSnap {
         "(function(){var se=document.scrollingElement||document.documentElement;" +
             "if(!se)return;" +
             "window.__riffleOriginY=se.scrollTop;" +
-            "window.__riffleOriginHref=location.href;})()"
+            // Store the document identity WITHOUT the fragment. Readium's `go(locator)` may
+            // append the target `#anchor` to `location.href` on same-doc jumps (browser-standard
+            // hash update on scroll-to-id), which would silently fail an `===` compare against
+            // the stashed value and drop the caller into the cross-doc pre-land branch. Same-doc
+            // is a document-identity question, not a URL-with-anchor one — strip the fragment on
+            // both sides so a hash change on the SAME document still matches.
+            "window.__riffleOriginHref=location.href.split('#')[0];})()"
 
     private const val VERTICAL_SMOOTH_TAIL_JS: String =
         "var _dur=250,_t0=performance.now();" +
@@ -346,8 +352,21 @@ internal object ColumnSnap {
     //    An element already fully on screen isn't moved.
     // Returns 'moved' when the snap changed the visible page (target was off-page → offer a return),
     // 'same' when it was already visible, or 'absent' when the id isn't in this document.
-    fun scrollToColumnJs(fragmentId: String): String =
-        "(function(){var el=document.getElementById(${JSONObject.quote(fragmentId)});" +
+    /**
+     * @param animated `true` for user-facing internal-link taps (return-to-position card,
+     * cross-reference "Figure X.Y") — animate the vertical scroll on a fixed 250 ms ease-out.
+     * `false` for readaloud cadence follow (`snapCadenceSpan`) which invokes this on every
+     * sentence tick and needs instant snap to stay in sync with the audio — a 250 ms tween
+     * per tick would visually drift and the supersede counter would cancel in-flight animations
+     * before they land.
+     */
+    fun scrollToColumnJs(fragmentId: String, animated: Boolean = true): String {
+        val verticalScroll = if (animated) {
+            "var startV=beforeTop;" + VERTICAL_SMOOTH_TAIL_JS
+        } else {
+            "se.scrollTop=targetV;"
+        }
+        return "(function(){var el=document.getElementById(${JSONObject.quote(fragmentId)});" +
             "if(!el)return 'absent';" +
             "var se=document.scrollingElement||document.documentElement;" +
             "var r=el.getBoundingClientRect();" +
@@ -356,18 +375,14 @@ internal object ColumnSnap {
             "var beforeTop=se.scrollTop;" +
             "var targetV=Math.max(0, r.top + se.scrollTop - Math.floor(window.innerHeight/2));" +
             "if(Math.abs(targetV-beforeTop)<=1)return 'same';" +
-            // Fixed-duration JS animation to match Continuous mode's NestedScrollView.smoothScrollTo
-            // feel. `behavior:'smooth'` picks a distance-proportional duration that reads as
-            // sluggish on longer jumps and doesn't match the continuous curve; the JS tween keeps
-            // both modes at the same ~250 ms ease-out.
-            "var startV=beforeTop;" +
-            VERTICAL_SMOOTH_TAIL_JS +
+            verticalScroll +
             "return 'moved';}" +
             "var iw=window.innerWidth;" +
             "var before=se.scrollLeft;" +
             "var abs=r.left+se.scrollLeft;" +
             "var target=Math.floor(abs/iw)*iw;se.scrollLeft=target;" +
             "return (Math.abs(target-before)>1)?'moved':'same';})()"
+    }
 
     // The AT-REST backstop: a debounced scroll-idle listener that, once horizontal scrolling has gone quiet
     // in paginated mode, rounds scrollLeft to the NEAREST column boundary so the page can never come to REST
@@ -496,7 +511,7 @@ internal object ColumnSnap {
             "else{targetV=se.scrollTop;}}" +
             "else{targetV=se.scrollTop;}" +
             "var _sameDoc=(typeof window.__riffleOriginY==='number')&&" +
-            "(window.__riffleOriginHref===location.href);" +
+            "(window.__riffleOriginHref===location.href.split('#')[0]);" +
             "var startV;" +
             "if(_sameDoc){startV=window.__riffleOriginY;}" +
             "else{startV=Math.max(0, targetV - Math.floor(window.innerHeight/2));}" +

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousNavigationView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousNavigationView.kt
@@ -21,6 +21,15 @@ internal interface ContinuousNavigationView {
         navigateTo(href, progression, alignToTop)
     }
 
+    /**
+     * Whether [href]'s chapter is currently loaded in the sliding window. The reader screen uses
+     * this to suppress the cross-resource nav-cover for an in-window jump — the cover otherwise
+     * hides the already-smooth [android.widget.NestedScrollView.smoothScrollTo] animation and the
+     * user sees a fade-to-snap instead of visible motion (the "back link feels abrupt" symptom).
+     * Default false so lightweight fakes for the presenter's JVM tests need not override.
+     */
+    fun isTargetInWindow(href: String): Boolean = false
+
     /** Page forward / backward; same semantics as [ContinuousReaderView.scrollByPage]. */
     fun scrollByPage(forward: Boolean)
 

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousPositionTracker.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousPositionTracker.kt
@@ -107,6 +107,33 @@ internal object ContinuousPositionTracker {
     }
 
     /**
+     * Whether [targetHref]'s chapter is currently loaded in the sliding window that spans
+     * `[topIndex, topIndex + loadedChapterCount)`. Used by the reader screen to suppress the
+     * cross-resource nav-cover for a navigation that stays in-window — the cover otherwise hides
+     * the already-smooth `NestedScrollView.smoothScrollTo` animation and the user only sees a
+     * fade-to-snap.
+     */
+    fun isTargetInWindow(
+        hrefs: List<String>,
+        targetHref: String,
+        topIndex: Int,
+        loadedChapterCount: Int,
+    ): Boolean {
+        val idx = chapterIndexForHref(hrefs, targetHref)
+        return idx in topIndex until (topIndex + loadedChapterCount)
+    }
+
+    /**
+     * Pre-landing scrollY for a cross-window navigation that wants a smooth-tail reveal: land half
+     * a viewport short of [targetY] under the still-showing nav cover, then the caller reveals
+     * the cover and animates the remaining half-viewport with `smoothScrollTo(targetY)`. That
+     * closes the "back button feels abrupt" gap in continuous mode without regressing the
+     * hard-landing paths (initial open, resume, annotation focus) that still call `scrollTo`.
+     */
+    fun preLandY(targetY: Int, viewportHeight: Int): Int =
+        (targetY - viewportHeight / 2).coerceAtLeast(0)
+
+    /**
      * Pixels to scroll for a volume-key "page" in continuous mode: one viewport minus overlap so the
      * line at the seam isn't skipped. Matches the 0·8-viewport delta the paginated/vertical volume-key
      * path uses via [ScrollBoundaryNavigationContainer.handleVolumeScroll] — keeping both modes on the

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
@@ -348,6 +348,8 @@ internal class ContinuousReaderView @JvmOverloads constructor(
     override fun navigateTo(href: String, progression: Float, alignToTop: Boolean, focusAnnotationId: String?) =
         controller.navigateTo(href, progression, alignToTop, focusAnnotationId)
 
+    override fun isTargetInWindow(href: String): Boolean = controller.isTargetInWindow(href)
+
     /**
      * Resolve the parent-viewport Y (in scrollY-space) of anchor [fragmentId] within [chapterHref].
      * See [ContinuousWindowController.anchorAbsoluteY]. Used to make an in-view same-document

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousWindowController.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousWindowController.kt
@@ -210,6 +210,16 @@ internal class ContinuousWindowController(
     /** Target chapter height used by the last re-applied landing; re-apply again when it changes. */
     private var reapplyTargetLastHeight: Int = -1
 
+    /**
+     * True while a smooth-tail initial land is running (set by [openWindowAt] when
+     * `smoothTail = true`). Used to suppress `reapplyLandingAfterFallback` — a target-chapter
+     * remeasure during the ~250 ms smooth animation would re-invoke the initial-scroll closure
+     * and hard-scrollTo mid-animation, chopping the tween. In smoothTail mode we accept a small
+     * position offset from late reflow rather than kill the visible motion. Cleared on
+     * [onTouchDown] and by any subsequent [navigateTo].
+     */
+    private var smoothTailInProgress: Boolean = false
+
     /** Annotation id to focus on initial open. See [ContinuousReaderView.pendingFocusAnnotationId]. */
     private var pendingFocusAnnotationId: String? = null
 
@@ -320,6 +330,7 @@ internal class ContinuousWindowController(
         pendingFallbackRunnable?.let { port.removeCallbacks(it) }
         pendingFallbackRunnable = null
         windowManager.reset()
+        smoothTailInProgress = smoothTail
         container.visibility = android.view.View.INVISIBLE
 
         val targetIndex = ContinuousPositionTracker
@@ -374,8 +385,15 @@ internal class ContinuousWindowController(
                         // reverting each frame back to `pre` until LANDING_HOLD_MS elapses.
                         landingHoldTargetY = -1
                         landingHoldUntilUptimeMs = 0L
-                        port.postOnAnimation { container.visibility = android.view.View.VISIBLE }
-                        port.post { port.smoothScrollTo(y) }
+                        // Reveal and start the tween on the SAME animation frame. Previously the
+                        // reveal used `postOnAnimation` (next vsync) and the smoothScrollTo used
+                        // `port.post` (next Handler drain — typically fires FIRST); the tween
+                        // began ~1 frame before the container became VISIBLE, so the user saw a
+                        // partial animation from wherever the scroll had already advanced.
+                        port.postOnAnimation {
+                            container.visibility = android.view.View.VISIBLE
+                            port.smoothScrollTo(y)
+                        }
                     } else {
                         port.scrollTo(y)
                         landingHoldTargetY = y
@@ -740,7 +758,12 @@ internal class ContinuousWindowController(
                     val scroll = pendingInitialScroll
                     pendingInitialScroll = null
                     scroll?.invoke()
-                    reapplyLandingAfterFallback = scroll
+                    // In smoothTail mode the closure launched a NestedScrollView smoothScrollTo;
+                    // arming the reapply here would let a late target-chapter remeasure fire the
+                    // closure again during the 250 ms tween, taking its ELSE branch (hard
+                    // port.scrollTo) and chopping the animation. Accept a small position offset
+                    // from late reflow rather than kill the visible motion.
+                    reapplyLandingAfterFallback = if (smoothTailInProgress) null else scroll
                     val targetIdx = pendingTargetHref?.let { webViewIndexFor(it) } ?: -1
                     reapplyTargetLastHeight = measuredHeights.getOrElse(targetIdx) { measuredPx }
                 } else if (webViews.getOrNull(i)?.chapterHref == pendingTargetHref &&
@@ -886,6 +909,7 @@ internal class ContinuousWindowController(
         pendingFocusAnnotationId = null
         landingHoldTargetY = -1
         landingHoldUntilUptimeMs = 0L
+        smoothTailInProgress = false
         // A manual scroll may leave [port.currentScrollY] far from the coalescer's pending target;
         // reset so the next volume press bases its animation on the user's new position.
         pageScrollCoalescer.reset()

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousWindowController.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousWindowController.kt
@@ -305,6 +305,17 @@ internal class ContinuousWindowController(
         anchorFragment: String = "",
         alignToTop: Boolean = false,
         focusAnnotationId: String? = null,
+        /**
+         * When true the first initial land pre-scrolls half a viewport short of the target under
+         * the still-showing nav-cover, then reveals the container and animates the remaining
+         * half-viewport with [ContinuousScrollPort.smoothScrollTo]. Used only by [navigateTo]'s
+         * cross-window branch so the "back link" (and any cross-chapter jump that rebuilds the
+         * window) arrives with visible motion instead of a hard snap on cover-reveal. Other
+         * callers (book open, resume, annotation focus, renderer-gone recovery) keep the hard
+         * land — a smooth tail on a cold open would just delay first content by ~300ms with no
+         * gesture to justify it.
+         */
+        smoothTail: Boolean = false,
     ) {
         pendingFallbackRunnable?.let { port.removeCallbacks(it) }
         pendingFallbackRunnable = null
@@ -331,6 +342,11 @@ internal class ContinuousWindowController(
         pendingInitialMeasureIndices.clear()
         pendingInitialMeasureIndices.addAll(0..targetWindowIndex)
         val targetHref = initialHref
+        // Only the FIRST invocation of the pending-initial-scroll closure runs the smooth-tail
+        // dance. Subsequent invocations from [reapplyLandingAfterFallback] on target-chapter
+        // remeasure are corrective micro-adjustments while the user is already looking at the
+        // destination — a smooth animation there would look like the page moved on its own.
+        var landCount = 0
         pendingInitialScroll = {
             fun postLandAt(offsetWithinTargetPx: Int?) {
                 port.post {
@@ -348,11 +364,24 @@ internal class ContinuousWindowController(
                             slot.top, slot.height, initialProgression, port.viewportHeightPx,
                         )
                     }
+                    val isFirstLand = landCount == 0
+                    landCount++
                     port.abortFling()
-                    port.scrollTo(y)
-                    landingHoldTargetY = y
-                    landingHoldUntilUptimeMs = android.os.SystemClock.uptimeMillis() + LANDING_HOLD_MS
-                    port.postOnAnimation { container.visibility = android.view.View.VISIBLE }
+                    if (smoothTail && isFirstLand) {
+                        val pre = ContinuousPositionTracker.preLandY(y, port.viewportHeightPx)
+                        port.scrollTo(pre)
+                        // Don't arm the landing hold: it would fight the tail animation by
+                        // reverting each frame back to `pre` until LANDING_HOLD_MS elapses.
+                        landingHoldTargetY = -1
+                        landingHoldUntilUptimeMs = 0L
+                        port.postOnAnimation { container.visibility = android.view.View.VISIBLE }
+                        port.post { port.smoothScrollTo(y) }
+                    } else {
+                        port.scrollTo(y)
+                        landingHoldTargetY = y
+                        landingHoldUntilUptimeMs = android.os.SystemClock.uptimeMillis() + LANDING_HOLD_MS
+                        port.postOnAnimation { container.visibility = android.view.View.VISIBLE }
+                    }
                 }
             }
             val targetWv = webViewIndexFor(targetHref)?.let { webViews.getOrNull(it) }
@@ -429,6 +458,14 @@ internal class ContinuousWindowController(
         navigateTo(href, progression, alignToTop, focusAnnotationId = null)
     }
 
+    override fun isTargetInWindow(href: String): Boolean =
+        ContinuousPositionTracker.isTargetInWindow(
+            hrefs = allChapters.map { it.link.href.toString() },
+            targetHref = href,
+            topIndex = topIndex,
+            loadedChapterCount = webViews.size,
+        )
+
     /**
      * Continuous-mode annotation navigation with mark-precise landing. When [focusAnnotationId] is
      * non-null and the chapter is in the sliding window, the landing anchors on the actual
@@ -470,6 +507,7 @@ internal class ContinuousWindowController(
                 anchorFragment = fragment,
                 alignToTop = alignToTop,
                 focusAnnotationId = focusAnnotationId,
+                smoothTail = true,
             )
         }
     }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -2096,7 +2096,15 @@ private fun EpubNavigatorView(
             // Continuous mode's view is created synchronously on first composition, so no wait needed.
             snapshotFlow { fragmentRef.value }.filterNotNull().first()
         }
-        val cover = href.substringBefore('#') != currentHrefHolder[0]?.substringBefore('#')
+        // Continuous mode: if the destination chapter is already in the sliding window,
+        // [ContinuousWindowController.navigateTo] takes the in-window smooth-scroll branch
+        // ([ContinuousScrollPort.smoothScrollTo]). Draping the cover over that hides the
+        // animation and the user only sees fade-to-snap — the "back link feels abrupt" symptom.
+        // Suppress the cover for the in-window case so the smoothScroll is visible; cross-window
+        // rebuilds still cover (and the controller does its own smooth-tail on reveal).
+        val inWindowContinuous = isContinuous && continuousViewRef.value?.isTargetInWindow(href) == true
+        val cover = href.substringBefore('#') != currentHrefHolder[0]?.substringBefore('#') &&
+            !inWindowContinuous
         navigating = cover
         try {
             readerPresenter.navigateTo(target, opts)

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/renderer/DefaultRendererBridge.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/renderer/DefaultRendererBridge.kt
@@ -118,7 +118,11 @@ internal class DefaultRendererBridge(
         fragment?.evaluateJavascript(ColumnSnap.scrollToColumnJs(fragmentId))?.trim('"') == "moved"
 
     override suspend fun snapCadenceSpan(fragmentId: String): String? =
-        fragment?.evaluateJavascript(ColumnSnap.scrollToColumnJs(fragmentId))?.trim('"')
+        // Readaloud follow ticks every sentence and needs the highlight to stay locked to the
+        // audio; a 250 ms tween per tick would visually drift because the supersede counter
+        // cancels in-flight animations before they land. Instant snap here (animated=false);
+        // internal-link taps still animate via [snapToElement].
+        fragment?.evaluateJavascript(ColumnSnap.scrollToColumnJs(fragmentId, animated = false))?.trim('"')
 
     override suspend fun landedAtEnd(): Boolean =
         fragment?.evaluateJavascript(ColumnSnap.LANDED_AT_END_JS)?.trim('"') == "true"

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/renderer/DefaultRendererBridge.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/renderer/DefaultRendererBridge.kt
@@ -81,6 +81,7 @@ internal class DefaultRendererBridge(
 
     override suspend fun snapAfterGoTo(link: Link) {
         val frag = fragment ?: return
+        frag.evaluateJavascript(ColumnSnap.STASH_VERTICAL_ORIGIN_JS)
         frag.go(link)
         frag.evaluateJavascript(ColumnSnap.snapToTargetColumnJs(navTargetFragmentId(link.href.toString())))
     }
@@ -96,6 +97,13 @@ internal class DefaultRendererBridge(
         // anchor on the DOM element directly.
         val fragmentId = locator.locations.fragments.firstOrNull()
             ?: navTargetFragmentId(locator.href.toString())
+        // Stash the pre-go scroll origin so the post-go smooth-tail can start from where the
+        // user actually was on same-doc jumps (return-to-position card, same-chapter TOC entry)
+        // instead of pre-landing half a viewport short — which flashes as "goes back a bit and
+        // then returns" because there is no nav cover to hide it on same-doc. Cross-doc jumps
+        // wipe the stash (new document, new JS context) and fall back to pre-land, which the
+        // cover hides.
+        frag.evaluateJavascript(ColumnSnap.STASH_VERTICAL_ORIGIN_JS)
         frag.go(locator)
         frag.evaluateJavascript(
             ColumnSnap.snapToTargetColumnJs(fragmentId, landAtStartWhenNoTarget),

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousPositionTrackerTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousPositionTrackerTest.kt
@@ -664,4 +664,64 @@ class ContinuousPositionTrackerTest {
             ),
         )
     }
+
+    // Reading order: 6 chapters; sliding window loaded is [topIndex=2, topIndex+4) = ch2..ch5.
+    private val readingOrder = listOf("ch0.xhtml", "ch1.xhtml", "ch2.xhtml", "ch3.xhtml", "ch4.xhtml", "ch5.xhtml")
+
+    @Test
+    fun `isTargetInWindow — chapter inside the window returns true`() {
+        assertTrue(
+            ContinuousPositionTracker.isTargetInWindow(
+                hrefs = readingOrder, targetHref = "ch3.xhtml", topIndex = 2, loadedChapterCount = 4,
+            ),
+        )
+    }
+
+    @Test
+    fun `isTargetInWindow — chapter before the window is false so cover shows during rebuild`() {
+        assertFalse(
+            ContinuousPositionTracker.isTargetInWindow(
+                hrefs = readingOrder, targetHref = "ch1.xhtml", topIndex = 2, loadedChapterCount = 4,
+            ),
+        )
+    }
+
+    @Test
+    fun `isTargetInWindow — chapter one past the window is false`() {
+        // topIndex=2, loadedChapterCount=4 → last in-window index = 5; but if only 3 loaded, ch5 is out.
+        assertFalse(
+            ContinuousPositionTracker.isTargetInWindow(
+                hrefs = readingOrder, targetHref = "ch5.xhtml", topIndex = 2, loadedChapterCount = 3,
+            ),
+        )
+    }
+
+    @Test
+    fun `isTargetInWindow — fragment on either side does not prevent match`() {
+        assertTrue(
+            ContinuousPositionTracker.isTargetInWindow(
+                hrefs = readingOrder, targetHref = "ch3.xhtml#fig-4-1", topIndex = 2, loadedChapterCount = 4,
+            ),
+        )
+    }
+
+    @Test
+    fun `isTargetInWindow — unknown href is false`() {
+        assertFalse(
+            ContinuousPositionTracker.isTargetInWindow(
+                hrefs = readingOrder, targetHref = "unknown.xhtml", topIndex = 0, loadedChapterCount = 6,
+            ),
+        )
+    }
+
+    @Test
+    fun `preLandY — subtracts half a viewport so smoothScrollTo has room to animate on reveal`() {
+        // targetY = 4000, viewport = 1200 → preLand = 4000 - 600 = 3400
+        assertEquals(3400, ContinuousPositionTracker.preLandY(targetY = 4000, viewportHeight = 1200))
+    }
+
+    @Test
+    fun `preLandY — clamps at zero when target is within half a viewport of the top`() {
+        assertEquals(0, ContinuousPositionTracker.preLandY(targetY = 200, viewportHeight = 1200))
+    }
 }

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ReaderWebViewScriptsTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ReaderWebViewScriptsTest.kt
@@ -88,8 +88,16 @@ class ReaderWebViewScriptsTest {
         assertTrue(
             "same-doc branch must start the animation from the stashed pre-go scrollTop",
             verticalBranch.contains("window.__riffleOriginY") &&
-                verticalBranch.contains("window.__riffleOriginHref===location.href") &&
                 verticalBranch.contains("startV=window.__riffleOriginY"),
+        )
+        // Fragment-stripped href compare: Readium's `go(locator)` on a same-doc jump often
+        // appends the target `#anchor` to `location.href` (browser-standard hash update). If the
+        // compare used bare `location.href` on both sides, EVERY same-doc jump would fail the
+        // same-doc check and default to the pre-land branch — the exact pre-land flash the
+        // stash+animate mechanism was written to eliminate.
+        assertTrue(
+            "same-doc href compare must strip the fragment on both sides",
+            verticalBranch.contains("location.href.split('#')[0]"),
         )
         // Cross-doc fallback: origin stash absent (new document), pre-land half a viewport short
         // under the nav cover so the tail rides visibly on cover-reveal.
@@ -121,10 +129,41 @@ class ReaderWebViewScriptsTest {
     // new document (undefined, harmless) — but if a future refactor keeps the stash across
     // resources, the href check is what still keeps cross-doc correct. Contract-pin both fields.
     @Test
-    fun `STASH_VERTICAL_ORIGIN_JS captures both scrollTop and href on window`() {
+    fun `STASH_VERTICAL_ORIGIN_JS captures scrollTop and fragment-stripped href on window`() {
         val js = ColumnSnap.STASH_VERTICAL_ORIGIN_JS
         assertTrue("stashes scrollTop", js.contains("window.__riffleOriginY=se.scrollTop"))
-        assertTrue("stashes location.href", js.contains("window.__riffleOriginHref=location.href"))
+        // Strips the fragment so a hash-only change on the SAME document (Readium's `go(locator)`
+        // appending `#anchor` to `location.href`) still compares equal in
+        // `snapToTargetColumnJs`'s same-doc branch. Without this strip, every same-doc back-nav
+        // hits the pre-land branch and flashes as "goes back a bit and then returns."
+        assertTrue(
+            "stashes fragment-stripped location.href",
+            js.contains("window.__riffleOriginHref=location.href.split('#')[0]"),
+        )
+    }
+
+    // The animated=false variant is what SentencePlaybackController's cadence follow needs: every
+    // narrated sentence tick calls snapCadenceSpan → scrollToColumnJs, and a 250 ms tween per
+    // tick would (a) drift because the supersede counter cancels in-flight tweens before they
+    // land and (b) desync from the audio. Verify the two variants emit different vertical
+    // behaviours so a future refactor can't silently make cadence follow animated.
+    @Test
+    fun `scrollToColumnJs animated=false uses instant scrollTop write in vertical mode`() {
+        val instant = ColumnSnap.scrollToColumnJs("cd-1", animated = false)
+        val animated = ColumnSnap.scrollToColumnJs("cd-1", animated = true)
+        val instantVertical = instant.substringAfter("scrollHeight > window.innerHeight")
+            .substringBefore("var iw=window.innerWidth")
+        val animatedVertical = animated.substringAfter("scrollHeight > window.innerHeight")
+            .substringBefore("var iw=window.innerWidth")
+        assertTrue(
+            "animated=false must write scrollTop synchronously (no rAF tween)",
+            instantVertical.contains("se.scrollTop=targetV") &&
+                !instantVertical.contains("requestAnimationFrame"),
+        )
+        assertTrue(
+            "animated=true must use the shared rAF tween",
+            animatedVertical.contains("requestAnimationFrame") && animatedVertical.contains("_dur=250"),
+        )
     }
 
     // Vertical (scroll) mode cross-reference tap must land the anchor at the VIEWPORT MIDPOINT, not

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ReaderWebViewScriptsTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ReaderWebViewScriptsTest.kt
@@ -41,8 +41,90 @@ class ReaderWebViewScriptsTest {
     fun `scrollToColumnJs scrolls vertically in scroll mode`() {
         val js = ColumnSnap.scrollToColumnJs("c04-fig-0001")
         assertTrue("detects scroll mode by content height", js.contains("scrollHeight > window.innerHeight"))
-        assertTrue("moves the vertical scroll", js.contains("se.scrollTop="))
+        assertTrue("moves the vertical scroll via se.scrollTop tween", js.contains("se.scrollTop=startV"))
         assertTrue("leaves an already-visible target alone", js.contains("r.bottom<=window.innerHeight"))
+    }
+
+    // Vertical (scroll) mode's cross-reference / return-to-position tap must animate the scroll
+    // with the SAME feel as Continuous mode's NestedScrollView.smoothScrollTo — a fixed ~250 ms
+    // ease-out, not Chromium's distance-proportional `behavior:'smooth'`. The distance-based curve
+    // reads as sluggish on longer jumps and doesn't match the continuous default; both modes need
+    // to feel identical on figure/back taps (the "make vertical as snappy as continuous" ask).
+    @Test
+    fun `scrollToColumnJs vertical branch uses fixed-duration JS animation not behavior smooth`() {
+        val js = ColumnSnap.scrollToColumnJs("c04-fig-0001")
+        val verticalBranch = js.substringAfter("scrollHeight > window.innerHeight")
+            .substringBefore("var iw=window.innerWidth")
+        assertTrue(
+            "vertical branch must drive the animation itself via requestAnimationFrame — in $verticalBranch",
+            verticalBranch.contains("requestAnimationFrame") && verticalBranch.contains("_dur=250"),
+        )
+        assertTrue(
+            "vertical branch must NOT delegate to Chromium's distance-proportional behavior:'smooth' — its curve doesn't match continuous mode's",
+            !verticalBranch.contains("behavior: 'smooth'") && !verticalBranch.contains("behavior:'smooth'"),
+        )
+    }
+
+    // Vertical mode return-to-position card and cross-resource internal links (which route through
+    // snapAfterGoTo → snapToTargetColumnJs) must animate, not hard-jump. Readium's `frag.go(locator)`
+    // already teleported the page to the target; without a vertical branch here, the entire snap
+    // JS is a no-op in scroll mode (it only manipulates scrollLeft) and the user sees the abrupt
+    // land the "back button feels abrupt in vertical" complaint pinned. The vertical branch has to
+    // (a) pre-scroll half a viewport short of the target under the nav cover, then (b) animate
+    // the tail with the same fixed-duration curve `scrollToColumnJs` uses, so both call sites feel
+    // identical.
+    @Test
+    fun `snapToTargetColumnJs animates in vertical mode from stashed origin on same-doc jumps`() {
+        val js = ColumnSnap.snapToTargetColumnJs("figure-4-1")
+        val verticalBranch = js.substringAfter("if(se && se.scrollHeight > window.innerHeight + 4)")
+            .substringBefore("var gen=(window.__riffleSnapGen")
+        assertTrue(
+            "vertical branch must be present in $js",
+            verticalBranch.contains("targetV=") && verticalBranch.contains("startV="),
+        )
+        // Same-doc branch: reads the pre-go scrollTop from window.__riffleOriginY. Without this,
+        // a return-to-position tap flashes as "goes back a bit and then returns" — the visible
+        // pre-land the user reported, because same-doc navigation has no nav cover to hide it.
+        assertTrue(
+            "same-doc branch must start the animation from the stashed pre-go scrollTop",
+            verticalBranch.contains("window.__riffleOriginY") &&
+                verticalBranch.contains("window.__riffleOriginHref===location.href") &&
+                verticalBranch.contains("startV=window.__riffleOriginY"),
+        )
+        // Cross-doc fallback: origin stash absent (new document), pre-land half a viewport short
+        // under the nav cover so the tail rides visibly on cover-reveal.
+        assertTrue(
+            "cross-doc branch must fall back to pre-landing half a viewport short",
+            verticalBranch.contains("Math.floor(window.innerHeight/2)") &&
+                verticalBranch.contains("se.scrollTop=startV"),
+        )
+        // Stash must be consumed so a later background sync doesn't reuse a stale origin from an
+        // unrelated navigation.
+        assertTrue(
+            "vertical branch must consume the stash after reading it",
+            verticalBranch.contains("window.__riffleOriginY=null") &&
+                verticalBranch.contains("window.__riffleOriginHref=null"),
+        )
+        assertTrue(
+            "vertical branch uses the shared fixed-duration ease-out animation",
+            verticalBranch.contains("requestAnimationFrame") && verticalBranch.contains("_dur=250"),
+        )
+        assertTrue(
+            "vertical branch skips the paginated rAF column-snap loop — no-op work in scroll mode",
+            verticalBranch.contains("return;"),
+        )
+    }
+
+    // The stash JS is the other half of the same-doc-origin contract: it must snapshot BOTH the
+    // scrollTop and the current href on `window` before Readium's `go(locator)` teleports the
+    // page. If the href isn't stashed, a cross-doc jump would read a stale __riffleOriginY on the
+    // new document (undefined, harmless) — but if a future refactor keeps the stash across
+    // resources, the href check is what still keeps cross-doc correct. Contract-pin both fields.
+    @Test
+    fun `STASH_VERTICAL_ORIGIN_JS captures both scrollTop and href on window`() {
+        val js = ColumnSnap.STASH_VERTICAL_ORIGIN_JS
+        assertTrue("stashes scrollTop", js.contains("window.__riffleOriginY=se.scrollTop"))
+        assertTrue("stashes location.href", js.contains("window.__riffleOriginHref=location.href"))
     }
 
     // Vertical (scroll) mode cross-reference tap must land the anchor at the VIEWPORT MIDPOINT, not


### PR DESCRIPTION
## Summary

Make cross-resource internal-link nav (return-to-position card, TOC entries, cross-references like "Figure X.Y") animate smoothly instead of hard-jumping. Continuous mode's back-link and Vertical mode's whole class of internal-link taps previously landed via `port.scrollTo(y)` after the cover fade — a snap the eye reads as abrupt.

Two independent fixes plus follow-up correctness pass from code review.

### Continuous mode
- `ContinuousWindowController.openWindowAt` grows a `smoothTail: Boolean` param, set true only from `navigateTo`'s out-of-window branch. The first initial land pre-scrolls half a viewport short of target under the still-showing nav-cover, reveals the container, and animates the remainder with `NestedScrollView.smoothScrollTo`. Cold open / resume / annotation focus / renderer recovery keep the hard land.
- `EpubReaderScreen.navigateWithCover` suppresses the cross-resource cover when the target chapter is already in the sliding window, so the existing in-window `smoothScrollTo` is visible motion instead of fade-to-snap.
- Pure helpers on `ContinuousPositionTracker` (`isTargetInWindow`, `preLandY`) make the decision JVM-testable.

### Vertical mode
- New shared `VERTICAL_SMOOTH_TAIL_JS`: a 250 ms ease-out-cubic `requestAnimationFrame` tween on `se.scrollTop`, matching Continuous mode's `NestedScrollView.smoothScrollTo` default. Chromium's `behavior:'smooth'` picks a distance-proportional duration that reads sluggish; the JS tween keeps both modes on the same feel. Uses `__riffleVsmoothGen` supersede counter.
- `scrollToColumnJs` vertical branch uses the shared tween. Grows an `animated: Boolean = true` param so `snapCadenceSpan` (readaloud follow) can stay instant — a 250 ms tween per cadence tick would drift.
- `snapToTargetColumnJs` gains a vertical branch that decides the animation start via a pre-`go(locator)` stash on `window`: same-doc jumps animate from the stashed origin (no visible backward flash — same-doc has no nav cover), cross-doc lost the stash with the old document and falls back to pre-landing half a viewport short under the nav cover. `DefaultRendererBridge` runs `STASH_VERTICAL_ORIGIN_JS` before every `frag.go(...)`.
- The stash + same-doc check strip the URL fragment on both sides. Readium's `go(locator)` updates `location.href` with the target `#anchor` on same-doc jumps, so an `===` compare against the stashed bare href would fail and default to pre-land.

### Correctness fixes from review
- `scrollToColumnJs(fragmentId, animated=false)` for cadence follow (readaloud regression fix).
- `smoothTailInProgress` flag on the controller suppresses `reapplyLandingAfterFallback` while a smooth tail is running — a target-chapter remeasure during the tween used to re-invoke the closure and hard-scroll mid-animation.
- Reveal + `smoothScrollTo` scheduled in the same `postOnAnimation` block so the tween doesn't start ~1 frame before the container becomes VISIBLE.

## Test plan
- [x] `./gradlew test` green (added ~10 assertions across `ContinuousPositionTrackerTest` and `ReaderWebViewScriptsTest` pinning the new helpers, JS shape, fragment-strip, and animated vs. instant contract).
- [x] Debug APK built and installed on an Android 13 AVD; opened a book in Continuous mode, swapped to Vertical, TOC nav and mode switches ran without crashes or logcat errors.
- [ ] Eyeball smoothness on the physical device: tap Back from a footnote/figure in both Continuous and Vertical; motion should ride the last half-viewport at 250 ms ease-out with no visible backward flash on same-doc jumps.

## Known deferred (surfaced in review, not fixed here)
- The `EpubReaderScreen.navigateWithCover` peek into `continuousViewRef.value?.isTargetInWindow(href)` leaks sliding-window internals into the screen. A follow-up could move that policy into `ContinuousNavigationView` as a higher-level `shouldShowCoverFor(href)` question.
- The `smoothTail: Boolean` flag on `openWindowAt` is set true from exactly one call site. A follow-up could move the smooth-tail dance into `navigateTo` itself and drop the plumbing.
- At chapter end, the vertical branch of `scrollToColumnJs` can return `'moved'` when the target is past `maxScrollY` — Chromium clamps the scroll but the pre-clamp target-vs-beforeTop compare misses it, capturing a phantom return anchor. Low frequency, low observable impact.