### PR TITLE
fix(debug-log): prevent duplicate LazyColumn key crash from identical log entries

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/settings/debug/DebugLogScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/debug/DebugLogScreen.kt
@@ -139,7 +139,7 @@ fun DebugLogScreen(
                     modifier = Modifier.fillMaxSize(),
                     reverseLayout = true,
                 ) {
-                    items(filtered, key = { it.hashCode() }) { entry ->
+                    items(filtered, key = { it.seq }) { entry ->
                         LogRow(entry)
                         HorizontalDivider(color = Color(0x11000000))
                     }

--- a/core/logging/src/main/kotlin/com/riffle/core/logging/InMemoryLogBuffer.kt
+++ b/core/logging/src/main/kotlin/com/riffle/core/logging/InMemoryLogBuffer.kt
@@ -3,6 +3,7 @@ package com.riffle.core.logging
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import java.util.concurrent.atomic.AtomicLong
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -24,20 +25,27 @@ class InMemoryLogBuffer @Inject constructor() {
         val channel: LogChannel,
         val message: String,
         val throwableSummary: String?,
+        // Monotonic, process-wide unique id assigned in [append]. Callers may leave it at 0L;
+        // the buffer stamps a fresh value on insertion so consumers (e.g. the debug log
+        // LazyColumn) always have a stable, unique key even when two entries share
+        // timestamp/level/channel/message.
+        val seq: Long = 0L,
     ) {
         enum class Level { D, W, E }
     }
 
     private val lock = Any()
     private val ring = ArrayDeque<Entry>(CAPACITY)
+    private val seqGen = AtomicLong(0L)
     private val _entries = MutableStateFlow<List<Entry>>(emptyList())
 
     val entries: StateFlow<List<Entry>> = _entries.asStateFlow()
 
     fun append(entry: Entry) {
+        val stamped = entry.copy(seq = seqGen.incrementAndGet())
         val snapshot: List<Entry> = synchronized(lock) {
             if (ring.size >= CAPACITY) ring.removeFirst()
-            ring.addLast(entry)
+            ring.addLast(stamped)
             ring.toList()
         }
         _entries.value = snapshot

--- a/core/logging/src/test/kotlin/com/riffle/core/logging/InMemoryLogBufferTest.kt
+++ b/core/logging/src/test/kotlin/com/riffle/core/logging/InMemoryLogBufferTest.kt
@@ -54,6 +54,25 @@ class InMemoryLogBufferTest {
     }
 
     @Test
+    fun `append stamps monotonically increasing unique seq even for identical entries`() {
+        // Regression: DebugLogScreen's LazyColumn crashed with "Key was already used" when
+        // two log entries hashed to the same value (same timestamp/level/channel/message).
+        // Every appended entry must carry a distinct seq so it can serve as the LazyColumn key.
+        val buf = InMemoryLogBuffer()
+        val duplicate = InMemoryLogBuffer.Entry(
+            timestampMs = 42L,
+            level = InMemoryLogBuffer.Entry.Level.D,
+            channel = LogChannel.ReaderDecoration,
+            message = "same",
+            throwableSummary = null,
+        )
+        repeat(3) { buf.append(duplicate) }
+        val seqs = buf.snapshot().map { it.seq }
+        assertEquals(3, seqs.toSet().size)
+        assertEquals(seqs.sorted(), seqs)
+    }
+
+    @Test
     fun `snapshot is independent of subsequent appends`() {
         val buf = InMemoryLogBuffer()
         buf.append(entry(1))


### PR DESCRIPTION
## Summary

Two production crash reports (same stack, same key `-1464473254`, ASUS_AI2302 / Android 15 / app 2.19.0) traced to `DebugLogScreen.kt:142`:

```kotlin
items(filtered, key = { it.hashCode() }) { entry -> ... }
```

`InMemoryLogBuffer.Entry` is a `data class`, so two log emissions in the same millisecond with identical `level`/`channel`/`message`/`throwableSummary` produce identical `hashCode()`s → LazyColumn throws `IllegalArgumentException: Key "…" was already used`.

Fix: stamp a process-wide monotonic `seq: Long` on every entry inside `InMemoryLogBuffer.append`, and use `it.seq` as the LazyColumn key.

## Test plan

- [x] `./gradlew :core:logging:test` — new regression test `append stamps monotonically increasing unique seq even for identical entries` asserts three appends of an identical `Entry` receive three distinct, monotonically increasing seqs. Would flip red if the buffer stopped stamping unique seqs (the load-bearing invariant behind the LazyColumn key).