### PR TITLE
feat(reader): elided view inherits book font, per-annotation origin capture

### DIFF
--- a/app/src/androidTest/kotlin/com/riffle/app/feature/reader/AnnotationFocusHarnessTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/reader/AnnotationFocusHarnessTest.kt
@@ -302,6 +302,7 @@ class AnnotationFocusHarnessTest {
             cfi = cfi,
             textSnippet = targetPhrase,
             chapterHref = "chapter1.xhtml",
+            originFontFamily = "Georgia, serif",
         )
     }
 

--- a/app/src/androidTest/kotlin/com/riffle/app/feature/reader/AnnotationReopenInstrumentedTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/reader/AnnotationReopenInstrumentedTest.kt
@@ -104,6 +104,7 @@ class AnnotationReopenInstrumentedTest {
             cfi = cfiRange,
             textSnippet = selectedText,
             chapterHref = link.href.toString(),
+            originFontFamily = "Georgia, serif",
         )
 
         // Reopen: read back what's stored and re-anchor it, exactly as the ViewModel does.

--- a/app/src/androidTest/kotlin/com/riffle/app/feature/reader/BookmarkIndicatorReopenInstrumentedTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/reader/BookmarkIndicatorReopenInstrumentedTest.kt
@@ -79,6 +79,7 @@ class BookmarkIndicatorReopenInstrumentedTest {
             spineIndex = 0,
             progression = 0.30,
             bookmarkTitle = "Test",
+            originFontFamily = "Georgia, serif",
         )
 
         // Session B: same chapter, different port.
@@ -107,6 +108,7 @@ class BookmarkIndicatorReopenInstrumentedTest {
             spineIndex = 0,
             progression = 0.30,
             bookmarkTitle = "Test",
+            originFontFamily = "Georgia, serif",
         )
 
         val reopened = store.observeBookmarks("abs1", "item-1").first()
@@ -132,6 +134,7 @@ class BookmarkIndicatorReopenInstrumentedTest {
             spineIndex = 0,
             progression = 0.10,
             bookmarkTitle = "Test",
+            originFontFamily = "Georgia, serif",
         )
 
         val reopened = store.observeBookmarks("abs1", "item-1").first()

--- a/app/src/androidTest/kotlin/com/riffle/app/feature/reader/ContinuousAnnotationRenderHarnessTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/reader/ContinuousAnnotationRenderHarnessTest.kt
@@ -162,6 +162,7 @@ class ContinuousAnnotationRenderHarnessTest {
             cfi = cfi,
             textSnippet = targetPhrase,
             chapterHref = "chapter1.xhtml",
+            originFontFamily = "Georgia, serif",
         )
     }
 

--- a/app/src/androidTest/kotlin/com/riffle/app/feature/reader/OrientationFlipAnnotationHarnessTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/reader/OrientationFlipAnnotationHarnessTest.kt
@@ -221,6 +221,7 @@ class OrientationFlipAnnotationHarnessTest {
             cfi = cfi,
             textSnippet = targetPhrase,
             chapterHref = "chapter1.xhtml",
+            originFontFamily = "Georgia, serif",
         )
     }
 

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ChapterWebView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ChapterWebView.kt
@@ -624,6 +624,9 @@ internal class ChapterWebView(context: Context) : WebView(context), ChapterWebVi
                     (obj.optDouble("r", 0.0) * dpr).toInt(),
                     (obj.optDouble("b", 0.0) * dpr).toInt(),
                 )
+                // Origin font-family at the selection's start element (issue #484). Stashed for
+                // EpubReaderViewModel.createHighlight/toggleBookmark to persist onto the entity.
+                SelectionFontStash.set(obj.optString("ff", ""))
                 // Figures enclosed by the selection range — captured by SELECTION_SPAN_TRACKER_JS
                 // while the range was still live (raster figures rasterised via canvas to a data
                 // URI; SVG serialised verbatim). Stashed here so EpubReaderViewModel.createHighlight

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ChapterWebView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ChapterWebView.kt
@@ -46,6 +46,16 @@ internal class ChapterWebView(context: Context) : WebView(context), ChapterWebVi
     var onPageFinished: (() -> Unit)? = null
 
     /**
+     * Fires once per chapter page load with the source book's computed body `font-family`.
+     * Continuous-mode counterpart to [RiffleSelectionRectBridge.onBookBodyFont] — populates
+     * `window.__riffleBookBodyFont` from `SELECTION_SPAN_TRACKER_JS`'s install branch, then a
+     * `evaluateJavascript` reads it out and invokes this. Consumers use it as the elided-view
+     * fallback + to backfill legacy null-font annotation rows (issue #484). Empty string is
+     * skipped (probe found no body). See [EpubReaderViewModel.noteBookBodyFontFamily].
+     */
+    var onBookBodyFont: ((String) -> Unit)? = null
+
+    /**
      * Called on the main thread when the user taps the chapter (no scroll movement).
      * Wire this to the reader's chrome toggle so taps in Continuous mode show/hide the
      * top/bottom bars, matching the behaviour of the standard Readium navigator.
@@ -267,6 +277,19 @@ internal class ChapterWebView(context: Context) : WebView(context), ChapterWebVi
         webViewClient = object : WebViewClient() {
             override fun onPageFinished(view: WebView?, url: String?) {
                 this@ChapterWebView.onPageFinished?.invoke()
+                // Body-font probe (issue #484): read the value the SELECTION_SPAN_TRACKER_JS
+                // installer stashed on `window.__riffleBookBodyFont` and route to the VM via
+                // [onBookBodyFont]. Empty means the probe found no body; skip.
+                if (onBookBodyFont != null) {
+                    try {
+                        evaluateJavascript(
+                            "(function(){return window.__riffleBookBodyFont || '';})()",
+                        ) { raw ->
+                            val ff = decodeJsString(raw)
+                            if (ff.isNotBlank()) onBookBodyFont?.invoke(ff)
+                        }
+                    } catch (_: Throwable) {}
+                }
             }
 
             override fun shouldOverrideUrlLoading(view: WebView, request: WebResourceRequest): Boolean {

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
@@ -102,6 +102,14 @@ internal class ContinuousReaderView @JvmOverloads constructor(
         set(value) { controller.onPlayFromHereSelection = value }
 
     /**
+     * Set with the VM callback that consumes the source book's computed body font on chapter
+     * load (issue #484). Forwarded onto every chapter WebView the controller manages.
+     */
+    var onBookBodyFont: ((String) -> Unit)?
+        get() = controller.onBookBodyFont
+        set(value) { controller.onBookBodyFont = value }
+
+    /**
      * Called on the main thread with the raw JSON payload emitted by figure-tap.js when the user
      * taps a figure. The host parses it via [FigureTapMessageParser] and pushes the result into
      * the ViewModel's figureZoom state, causing [FigureZoomOverlay] to open above the reader.

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousWindowController.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousWindowController.kt
@@ -96,6 +96,13 @@ internal class ContinuousWindowController(
      */
     var onPlayFromHereSelection: ((href: String, selectedText: String, evalJs: (String, (String?) -> Unit) -> Unit) -> Unit)? = null
 
+    /**
+     * Set once by the parent [ContinuousReaderView] with the VM callback that consumes the
+     * source book's computed body `font-family` on chapter load (issue #484). Chapter WebViews
+     * created after this is set forward their probe callback here.
+     */
+    var onBookBodyFont: ((String) -> Unit)? = null
+
     /** Set once via [install]. */
     private lateinit var binder: ChapterWebViewBinder
 
@@ -775,6 +782,7 @@ internal class ContinuousWindowController(
                 }
             }
         }
+        wv.onBookBodyFont = { ff -> onBookBodyFont?.invoke(ff) }
         wv.onPageFinished = {
             val styleJs = ContinuousStyleInjector.buildStyleInjectionJs(formattingPrefs)
             wv.injectStylesAndMeasure(styleJs)
@@ -804,6 +812,7 @@ internal class ContinuousWindowController(
                 if (delta != 0) port.scrollBy(delta)
             }
         }
+        wv.onBookBodyFont = { ff -> onBookBodyFont?.invoke(ff) }
         wv.onPageFinished = {
             val styleJs = ContinuousStyleInjector.buildStyleInjectionJs(formattingPrefs)
             wv.injectStylesAndMeasure(styleJs)

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -3215,4 +3215,17 @@ internal class RiffleSelectionRectBridge(
         }
         SelectionFiguresStash.set(figures)
     }
+
+    /**
+     * Called from [ReaderWebViewScripts.SELECTION_SPAN_TRACKER_JS] on every selectionchange with
+     * the computed `font-family` at the range's start element (issue #484). Stashed so the
+     * paginated action-mode's Highlight handler ([EpubReaderViewModel.createHighlight]) can
+     * persist it onto the annotation — the paginated path doesn't route through
+     * [ChapterWebView.withSelectionTextAndProgression], which is where continuous mode reads
+     * `ff` out of the stashed JSON payload.
+     */
+    @android.webkit.JavascriptInterface
+    fun onFontFamily(fontFamily: String) {
+        SelectionFontStash.set(fontFamily)
+    }
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -592,6 +592,7 @@ fun EpubReaderScreen(
                         onFigureLongPress = { payload, anchorRect ->
                             viewModel.viewModelScope.launch { viewModel.onFigureLongPress(payload, anchorRect) }
                         },
+                        onBookBodyFontFamily = viewModel::noteBookBodyFontFamily,
                         dispatchers = viewModel.dispatchers,
                         logger = viewModel.logger,
                         modifier = Modifier
@@ -1337,6 +1338,10 @@ private fun EpubNavigatorView(
     onAutoScrollResume: () -> Unit,
     onFigureTap: (payload: String) -> Unit,
     onFigureLongPress: (FigureLongPressPayload, androidx.compose.ui.unit.IntRect) -> Unit,
+    // Called once per chapter install with the source book's computed `document.body`
+    // font-family (issue #484). Routed from the JS tracker via both the paginated
+    // RiffleSelBridge and the continuous ChapterWebView probe.
+    onBookBodyFontFamily: (String) -> Unit,
     dispatchers: com.riffle.core.domain.DispatcherProvider,
     logger: com.riffle.core.logging.Logger,
     // Cadence per-chapter hook (issue #403). Non-null in the outer caller when Cadence is enabled;
@@ -1501,7 +1506,14 @@ private fun EpubNavigatorView(
     // immersive mode. Written on the JS background thread; consumed on the main thread.
     val pagedSelectionActiveAtDown = remember { AtomicBoolean(false) }
     val pagedSelectionRectBridge = remember {
-        RiffleSelectionRectBridge(pagedSelectionRectCss, pagedSelectionActiveAtDown)
+        RiffleSelectionRectBridge(
+            store = pagedSelectionRectCss,
+            activeAtDown = pagedSelectionActiveAtDown,
+            // Feeds the source book's computed body font to the VM once per chapter install
+            // (issue #484). VM caches it as the elided-view fallback and backfills every legacy
+            // null-font row on this book so old annotations render in the origin's face.
+            onBodyFont = onBookBodyFontFamily,
+        )
     }
     // Tracks whether Readium is currently in vertical-scroll mode (scroll=true). Read from the
     // startActionModeForChild wrapper to route the selection popup differently — the JS-captured
@@ -2824,6 +2836,10 @@ private fun EpubNavigatorView(
                         view.onFigureLongPress = { payload, anchorRect -> onFigureLongPress(payload, anchorRect) }
                         view.onSelectionEnded = { currentOnSelectionEnded() }
                         view.onSelectionActiveChanged = { active -> currentOnSelectionActiveChanged(active) }
+                        // Continuous-mode body-font probe (issue #484). Fires once per chapter
+                        // load with the source book's computed body `font-family`; the VM caches
+                        // it as the elided-view fallback and backfills legacy null-font rows.
+                        view.onBookBodyFont = onBookBodyFontFamily
                     }
                 },
                 // Availability flags can flip mid-session; keep the selection menu gates in sync.
@@ -3170,6 +3186,7 @@ internal fun createPagedDirectionalNavigationAdapter(
 internal class RiffleSelectionRectBridge(
     private val store: java.util.concurrent.atomic.AtomicReference<android.graphics.RectF?>,
     private val activeAtDown: java.util.concurrent.atomic.AtomicBoolean,
+    private val onBodyFont: ((String) -> Unit)? = null,
 ) {
     @android.webkit.JavascriptInterface
     fun onRect(left: Double, top: Double, right: Double, bottom: Double) {
@@ -3227,5 +3244,18 @@ internal class RiffleSelectionRectBridge(
     @android.webkit.JavascriptInterface
     fun onFontFamily(fontFamily: String) {
         SelectionFontStash.set(fontFamily)
+    }
+
+    /**
+     * Called from the SELECTION_SPAN_TRACKER_JS installer once per chapter load with the source
+     * book's computed body `font-family` (issue #484). Routes into
+     * [EpubReaderViewModel.noteBookBodyFontFamily] via [onBodyFont] — the VM caches it as the
+     * elided-view fallback and backfills every legacy null-font row on this book at the DB
+     * layer so legacy annotations render in the origin's face without waiting for the user to
+     * create a new one first.
+     */
+    @android.webkit.JavascriptInterface
+    fun onBookBodyFont(fontFamily: String) {
+        onBodyFont?.invoke(fontFamily)
     }
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -109,6 +109,33 @@ import javax.inject.Inject
 // Debounce window for persisting a playback-speed change, so a granular scrub/slide settles to a
 // single write rather than one per intermediate 0.05× value.
 private const val SPEED_SAVE_DEBOUNCE_MS = 400L
+
+/**
+ * Placeholder `font-family` value written on the entity when a live WebView probe returned
+ * nothing at annotation-create time (rare selection-teardown race, or bookmarks toggled without
+ * a prior selection). Deliberately plain "serif" so the elided view still declares a
+ * font-family — [HighlightsPublicationFactory]'s sanitizer will let this pass through while
+ * anything the DB coughs up beyond the safe allowlist is dropped. Issue #484.
+ */
+private const val FALLBACK_ORIGIN_FONT_FAMILY = "serif"
+
+/** Convenience for the merge-inherit path: returns [Annotation.originFontFamily] on the
+ *  domain projection, or null when the annotation predates issue #484 and hasn't been touched
+ *  by lazy backfill yet. Callers fall back to [FALLBACK_ORIGIN_FONT_FAMILY]. */
+private fun entityFontFamily(annotation: Annotation): String? =
+    annotation.originFontFamily?.takeIf { it.isNotBlank() }
+
+/** Plurality (mode) `originFontFamily` across every annotation in [chapters], skipping blanks.
+ *  Returns null when nothing has a value yet — callers use that to mean "emit no `font-family`
+ *  at all" (falls through to ReadiumCSS default). Ties broken by first-seen order. Issue #484. */
+private fun pluralityOriginFont(chapters: List<ChapterElision>): String? =
+    chapters.asSequence()
+        .flatMap { it.highlights.asSequence() }
+        .mapNotNull { it.originFontFamily?.takeIf { f -> f.isNotBlank() } }
+        .groupingBy { it }
+        .eachCount()
+        .maxByOrNull { it.value }
+        ?.key
 // Characters of textAfter used to build each highlight's context window for position
 // disambiguation in the overlap-detection logic (see createHighlight).
 private const val OVERLAP_CONTEXT_LEN = 60
@@ -407,6 +434,13 @@ class EpubReaderViewModel @Inject constructor(
     // locator update back to a highlight id without rebuilding the Publication. Null in FullBook mode.
     private var highlightsResumeChapters: List<ChapterElision>? = null
     private var highlightsResumeServerId: String? = null
+    // Plurality [AnnotationEntity.originFontFamily] across the currently-loaded elided chapters
+    // (issue #484). Recomputed on every full elided rebuild in [loadHighlightsPublication] and
+    // re-used as the `bookBodyFontFamily` fallback on partial re-renders (post-edit setChapterBytes)
+    // so a chapter refreshed after a recolour keeps the same fallback face as its neighbours. Null
+    // when no annotation on the book has a captured font yet — factory then emits no
+    // font-family and the elided reader falls back to ReadiumCSS default (pre-fix behaviour).
+    private var elidedBodyFontFamily: String? = null
     // Highlights mode only: subscription to annotationStore.observeAnnotations so the elided
     // reader updates live when annotations change (colour/note/delete edits from anywhere, and
     // additions arriving via AnnotationSyncController's remote pull). Kept alive across the
@@ -934,11 +968,19 @@ class EpubReaderViewModel @Inject constructor(
             // label makes clear which book's highlights are shown. Falls back to plain "Annotations"
             // when the local library_items row is gone (orphaned book).
             val realBookTitle = libraryItemDao.getById(sourceId, itemId)?.title
+            // Fallback body-font for excerpts whose annotation has null `originFontFamily`
+            // (legacy rows, W3C sync ingest). Pick the plurality font across the captured set —
+            // it converges to the book's dominant face as the user creates new annotations.
+            // Null (no captured fonts anywhere) → factory emits no `font-family`, falls all the
+            // way back to ReadiumCSS default (pre-issue-484 behaviour). See issue #484 and
+            // [HighlightsPublicationFactory.buildHandle].
+            elidedBodyFontFamily = pluralityOriginFont(chapters)
             val handle = highlightsPublicationFactory.buildHandle(
                 sourceId = sourceId,
                 itemId = itemId,
                 bookTitle = realBookTitle?.let { "$it — Annotations" },
                 chapters = chapters,
+                bookBodyFontFamily = elidedBodyFontFamily,
             )
             highlightsPublicationHandle = handle
             val pub = handle.publication
@@ -1542,6 +1584,11 @@ class EpubReaderViewModel @Inject constructor(
                     .filter { it.imageHref?.let(::figureHrefFilename) in absorbedFilenames }
                     .forEach { annotationStore.delete(it.id) }
             }
+            // Origin font-family at the selection start (issue #484). Non-blank contract on the
+            // store — fall back to the store's plain-serif default when the WebView side happened
+            // to return empty (rare selection-teardown race). The lazy backfill on chapter-load
+            // rewrites approximated values as they get corrected against the real DOM.
+            val originFont = SelectionFontStash.consume().takeIf { it.isNotBlank() } ?: FALLBACK_ORIGIN_FONT_FAMILY
             val created = annotationStore.createHighlight(
                 sourceId = sourceId,
                 itemId = itemId,
@@ -1554,6 +1601,7 @@ class EpubReaderViewModel @Inject constructor(
                 spineIndex = spineIndex,
                 progression = progression,
                 embeddedFigures = embeddedFigures,
+                originFontFamily = originFont,
             )
             openHighlightActions(created.id, anchorRect)
             scheduleAnnotationSync()
@@ -1726,6 +1774,13 @@ class EpubReaderViewModel @Inject constructor(
         // All computations succeeded — commit: delete neighbours, then replace the anchor row.
         toAbsorb.forEach { annotationStore.delete(it.id) }
         annotationStore.delete(id)
+        // The merged row inherits the anchor's origin font-family (issue #484); if the anchor was
+        // a legacy row with none, fall back to the first non-null neighbour, then to the plain
+        // serif default the elided view falls through to anyway.
+        val anchorRow = pool.firstOrNull { it.id == id }
+        val mergedOriginFont = anchorRow?.let { entityFontFamily(it) }
+            ?: toAbsorb.firstNotNullOfOrNull { entityFontFamily(it) }
+            ?: FALLBACK_ORIGIN_FONT_FAMILY
         val created = annotationStore.createHighlight(
             sourceId = sourceId,
             itemId = itemId,
@@ -1738,6 +1793,7 @@ class EpubReaderViewModel @Inject constructor(
             spineIndex = trialAnchor.spineIndex,
             progression = storedProgression,
             embeddedFigures = mergedEmbeddedFigures,
+            originFontFamily = mergedOriginFont,
         )
         logger.d(LogChannel.HighlightMerge) {
             "edit-merge done anchorReplaced=$id newId=${created.id} absorbedText=${toAbsorb.size} " +
@@ -1869,6 +1925,11 @@ class EpubReaderViewModel @Inject constructor(
                 }
                 val cfi = locator.toPayload().ebookLocation
                 val snippet = locator.text.before?.take(200).orEmpty()
+                // Bookmarks have no live text selection to read a range font from — fall back to
+                // the last captured selection font when one is pending, else the plain-serif
+                // placeholder (issue #484). Backfill will refine legacy rows on chapter-load.
+                val bookmarkFont = SelectionFontStash.consume().takeIf { it.isNotBlank() }
+                    ?: FALLBACK_ORIGIN_FONT_FAMILY
                 annotationStore.createBookmark(
                     sourceId = sourceId,
                     itemId = itemId,
@@ -1878,6 +1939,7 @@ class EpubReaderViewModel @Inject constructor(
                     spineIndex = spineIdx,
                     progression = prog,
                     bookmarkTitle = title,
+                    originFontFamily = bookmarkFont,
                 )
                 scheduleAnnotationSync()
             }
@@ -2114,7 +2176,7 @@ class EpubReaderViewModel @Inject constructor(
                             title = titleByHref[chapterHref] ?: chapterHref,
                             highlights = livePeers,
                         )
-                        val freshHtml = highlightsPublicationFactory.renderChapterHtml(chapter)
+                        val freshHtml = highlightsPublicationFactory.renderChapterHtml(chapter, elidedBodyFontFamily)
                         handle.setChapterBytes(chapterHref, freshHtml)
                     }
                 }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -1460,6 +1460,41 @@ class EpubReaderViewModel @Inject constructor(
 
     // ---- Annotations -------------------------------------------------------------------------
 
+    // Set by the WebView-side body-font probe injected in [SELECTION_SPAN_TRACKER_JS] (issue
+    // #484). Set-once — the first non-blank value the reader reports for the current book,
+    // triggers a DB backfill of every legacy null-font row for the same book, and is cached so
+    // subsequent chapter loads (which re-fire the tracker install) don't re-write the DB.
+    private val bookBodyFontFamilyReported = java.util.concurrent.atomic.AtomicReference<String>("")
+
+    /**
+     * Called by [RiffleSelectionRectBridge.onBookBodyFont] on chapter install. Caches the value
+     * on the VM (used as `bookBodyFontFamily` on subsequent elided-view opens) and, on the FIRST
+     * non-blank report for the current book, backfills every legacy null-font row on this book
+     * (issue #484). Only runs in FullBook mode — the elided view is a synthesised publication
+     * whose body font is what we WROTE, not the origin's face.
+     */
+    fun noteBookBodyFontFamily(fontFamily: String) {
+        if (source == ReaderSource.Highlights) return
+        val trimmed = fontFamily.trim()
+        if (trimmed.isBlank()) return
+        // Set-once per (VM lifecycle, book). AtomicReference.compareAndSet returns false when
+        // we've already stored a non-blank font — cheap no-op on the many repeat reports the
+        // JS tracker fires as chapters install across a reading session.
+        if (!bookBodyFontFamilyReported.compareAndSet("", trimmed)) return
+        val sourceId = annotationServerId ?: return
+        viewModelScope.launch {
+            val updated = runCatching {
+                annotationStore.backfillNullOriginFontFamily(sourceId, itemId, trimmed)
+            }.getOrElse { 0 }
+            if (updated > 0) {
+                logger.d(LogChannel.HighlightMerge) {
+                    "originFontFamily backfill sourceId=$sourceId itemId=$itemId font='$trimmed' updated=$updated"
+                }
+                scheduleAnnotationSync()
+            }
+        }
+    }
+
     // Create a highlight at the current text selection in the user's last-used colour (see
     // [AnnotationSession.lastUsedHighlightColor]; falls back to yellow first-run). Anchors on a CFI range built from
     // the selection's start progression + selected text (ADR 0024), capturing the snippet + href.

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/PdfReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/PdfReaderViewModel.kt
@@ -440,6 +440,11 @@ class PdfReaderViewModel @Inject constructor(
                     spineIndex = 0,
                     progression = totalProg,
                     bookmarkTitle = "Page $position",
+                    // PDFs have no HTML DOM to sample a font from — the excerpt in the elided view
+                    // shows "" for a PDF bookmark's textSnippet anyway (issue #484 render is a
+                    // no-op on blank snippets). Plain serif placeholder satisfies the store's
+                    // non-null contract.
+                    originFontFamily = "serif",
                 )
             }
         }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderWebViewScripts.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderWebViewScripts.kt
@@ -274,6 +274,27 @@ internal val SELECTION_SPAN_TRACKER_JS = """
     (function () {
       if (window.__riffleSelTrackerInstalled) return;
       window.__riffleSelTrackerInstalled = true;
+      // One-shot body-font probe (issue #484). Fires once per chapter install: reads the source
+      // book's computed body `font-family` and (a) stashes it in `window.__riffleBookBodyFont`
+      // so continuous mode can pull it via evaluateJavascript from onPageFinished, and (b)
+      // bridges it out to Kotlin directly for paginated mode via RiffleSelBridge — the elided
+      // view uses this as the fallback for legacy null-font rows AND to backfill them in the DB.
+      try {
+        var bodyEl = document.body || document.documentElement;
+        var bodyFont = '';
+        if (bodyEl) {
+          var bcs = window.getComputedStyle(bodyEl);
+          if (bcs) bodyFont = bcs.fontFamily || '';
+        }
+        window.__riffleBookBodyFont = bodyFont;
+        if (bodyFont) {
+          try {
+            if (window.RiffleSelBridge && window.RiffleSelBridge.onBookBodyFont) {
+              window.RiffleSelBridge.onBookBodyFont(bodyFont);
+            }
+          } catch (e) {}
+        }
+      } catch (e) { window.__riffleBookBodyFont = ''; }
       // Snapshot selection state at touchstart, BEFORE the browser processes the up-gesture
       // that would dismiss an active selection. Readium's InputListener.onTap fires from the
       // WebView's click event and can race with the selectionchange that clears the selection

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderWebViewScripts.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderWebViewScripts.kt
@@ -224,14 +224,15 @@ internal val CONTINUOUS_SELECTION_READ_JS = """
             return JSON.stringify({
                 text: stash.text, p: stash.p,
                 l: stash.l, t: stash.t, r: stash.r, b: stash.b,
-                bef: stash.bef || '', aft: stash.aft || ''
+                bef: stash.bef || '', aft: stash.aft || '',
+                ff: stash.ff || ''
             });
         }
         var sel = window.getSelection ? window.getSelection() : null;
         var text = sel ? sel.toString() : '';
         var prog = 0.0;
         var l = 0, t = 0, r = 0, b = 0;
-        var bef = '', aft = '';
+        var bef = '', aft = '', ff = '';
         if (sel && sel.rangeCount > 0) {
             var range = sel.getRangeAt(0);
             var rect = range.getBoundingClientRect();
@@ -256,8 +257,16 @@ internal val CONTINUOUS_SELECTION_READ_JS = """
                     aft = afterR.toString().slice(0, 60);
                 } catch (e) { aft = ''; }
             }
+            try {
+                var startEl = range.startContainer;
+                if (startEl && startEl.nodeType === 3) startEl = startEl.parentElement;
+                if (startEl && startEl.nodeType === 1) {
+                    var cs = window.getComputedStyle(startEl);
+                    if (cs) ff = cs.fontFamily || '';
+                }
+            } catch (e) { ff = ''; }
         }
-        return JSON.stringify({text: text, p: prog, l: l, t: t, r: r, b: b, bef: bef, aft: aft});
+        return JSON.stringify({text: text, p: prog, l: l, t: t, r: r, b: b, bef: bef, aft: aft, ff: ff});
     })()
 """.trimIndent()
 
@@ -414,12 +423,25 @@ internal val SELECTION_SPAN_TRACKER_JS = """
                 figures.push(entry);
               }
             } catch (e) { figures = []; }
+            // Origin font-family at the selection's start element (issue #484). Read from the
+            // start container walked up to its parent Element (text nodes have no computed
+            // style). Empty string on failure — Kotlin side falls back to the book's body font.
+            var ff = '';
+            try {
+              var startEl = rng.startContainer;
+              if (startEl && startEl.nodeType === 3) startEl = startEl.parentElement;
+              if (startEl && startEl.nodeType === 1) {
+                var cs = window.getComputedStyle(startEl);
+                if (cs) ff = cs.fontFamily || '';
+              }
+            } catch (e) { ff = ''; }
             window.__riffleSelData = {
               text: text,
               p: Math.max(0, Math.min(1, br2.top / docH)),
               l: br2.left, t: br2.top, r: br2.right, b: br2.bottom,
               bef: bef, aft: aft,
-              figures: figures
+              figures: figures,
+              ff: ff
             };
             // Also bridge figures to Kotlin directly. Continuous mode reads them out of
             // window.__riffleSelData in ChapterWebView.withSelectionTextAndProgression, but
@@ -429,6 +451,13 @@ internal val SELECTION_SPAN_TRACKER_JS = """
             try {
               if (window.RiffleSelBridge && window.RiffleSelBridge.onFigures) {
                 window.RiffleSelBridge.onFigures(JSON.stringify(figures));
+              }
+            } catch (e) {}
+            // Bridge origin font-family too (issue #484), same reasoning as figures — paginated
+            // Readium mode never reads window.__riffleSelData, so the bridge is the only path.
+            try {
+              if (window.RiffleSelBridge && window.RiffleSelBridge.onFontFamily) {
+                window.RiffleSelBridge.onFontFamily(ff);
               }
             } catch (e) {}
           }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/SelectionFontStash.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/SelectionFontStash.kt
@@ -1,0 +1,25 @@
+package com.riffle.app.feature.reader
+
+import java.util.concurrent.atomic.AtomicReference
+
+/**
+ * Process-wide singleton that carries the computed `font-family` at the most recent live text
+ * selection's start element from a reader WebView to [EpubReaderViewModel.createHighlight] /
+ * `toggleBookmark`. Populated by both selection readers (continuous [ChapterWebView] and
+ * paginated action-mode in [EpubReaderScreen]) whenever they read a completed selection payload
+ * (`ff` field of the JSON stashed by [ReaderWebViewScripts.SELECTION_SPAN_TRACKER_JS]).
+ *
+ * Mirrors [SelectionFiguresStash]'s shape — only one reader session is active at a time, so a
+ * singleton is safe. Contents cleared by the ViewModel after consumption. Empty string means
+ * the JS side had no value (e.g. no live selection at read time); callers fall back to the
+ * publication's body font (issue #484 backfill path).
+ */
+internal object SelectionFontStash {
+    private val current = AtomicReference<String>("")
+
+    fun set(fontFamily: String) {
+        current.set(fontFamily)
+    }
+
+    fun consume(): String = current.getAndSet("")
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/highlights/HighlightsPublicationFactory.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/highlights/HighlightsPublicationFactory.kt
@@ -87,14 +87,21 @@ class HighlightsPublicationFactory @Inject constructor() {
         chapters: List<ChapterElision>,
         urlFactory: (String) -> Url? = { Url(it) },
         resourceFetcher: ResourceFetcher = ResourceFetcher { null },
+        bookBodyFontFamily: String? = null,
     ): Publication =
-        buildHandle(sourceId, itemId, bookTitle, chapters, urlFactory, resourceFetcher).publication
+        buildHandle(sourceId, itemId, bookTitle, chapters, urlFactory, resourceFetcher, bookBodyFontFamily)
+            .publication
 
     /**
      * Same as [build] but returns the handle that lets the caller rewrite a chapter's bytes in
      * place. The elided reader ([EpubReaderViewModel]) uses this so per-annotation edits patch the
      * DOM live via [RendererBridge.applyHighlightDomPatch] AND persist to the container — so a
      * subsequent chapter-back navigation reads the fresh HTML.
+     *
+     * [bookBodyFontFamily] is the source book's computed body-font (issue #484), used as the
+     * per-excerpt fallback when an annotation has no [AnnotationEntity.originFontFamily] of its
+     * own (legacy row, or one that hasn't been touched by the lazy-backfill yet). Null falls
+     * back all the way to ReadiumCSS's default.
      */
     fun buildHandle(
         sourceId: String,
@@ -103,6 +110,7 @@ class HighlightsPublicationFactory @Inject constructor() {
         chapters: List<ChapterElision>,
         urlFactory: (String) -> Url? = { Url(it) },
         resourceFetcher: ResourceFetcher = ResourceFetcher { null },
+        bookBodyFontFamily: String? = null,
     ): HighlightsPublicationHandle {
         val nonEmptyChapters = chapters.filter { it.highlights.isNotEmpty() }
 
@@ -134,7 +142,7 @@ class HighlightsPublicationFactory @Inject constructor() {
         nonEmptyChapters.forEachIndexed { index, chapter ->
             val href = "highlights/ch$index.xhtml"
             val url = requireNotNull(urlFactory(href)) { "Failed to build synthetic Url for $href" }
-            entries[url] = renderChapterHtml(chapter).toByteArray(Charsets.UTF_8)
+            entries[url] = renderChapterHtml(chapter, bookBodyFontFamily).toByteArray(Charsets.UTF_8)
             chapterUrls[chapter.href] = url
             readingOrder += Link(
                 href = url,
@@ -170,7 +178,7 @@ class HighlightsPublicationFactory @Inject constructor() {
      * chapter's bytes after a per-annotation edit and write them back through
      * [HighlightsPublicationHandle.setChapterBytes] without rebuilding the whole Publication.
      */
-    internal fun renderChapterHtml(chapter: ChapterElision): String {
+    internal fun renderChapterHtml(chapter: ChapterElision, bookBodyFontFamily: String? = null): String {
         val body = buildString {
             for (annotation in chapter.highlights) {
                 when (annotation.type) {
@@ -184,7 +192,7 @@ class HighlightsPublicationFactory @Inject constructor() {
                         // whole highlight falls back to "text first, then figures" — the v1
                         // behaviour matches what shipped before offsets existed. See
                         // appendInterleavedHighlight's KDoc.
-                        appendInterleavedHighlight(this, annotation)
+                        appendInterleavedHighlight(this, annotation, bookBodyFontFamily)
                     }
                 }
             }
@@ -241,10 +249,14 @@ internal const val FIGURE_CENTERING_CSS =
  * The fallback keeps the shipped elided-reader semantics intact for annotations that predate this
  * change.
  */
-private fun appendInterleavedHighlight(sb: StringBuilder, highlight: com.riffle.core.database.AnnotationEntity) {
+private fun appendInterleavedHighlight(
+    sb: StringBuilder,
+    highlight: com.riffle.core.database.AnnotationEntity,
+    bookBodyFontFamily: String?,
+) {
     val figures = highlight.decodedEmbeddedFigures()?.sortedBy { it.order }.orEmpty()
     if (figures.isEmpty() || figures.any { it.charOffset == null }) {
-        appendTextHighlight(sb, highlight)
+        appendTextHighlight(sb, highlight, bookBodyFontFamily)
         figures.forEach { appendFigureBlock(sb, it, highlight.id, highlight.color) }
         return
     }
@@ -255,7 +267,7 @@ private fun appendInterleavedHighlight(sb: StringBuilder, highlight: com.riffle.
     // Emit alternating: chunk[0], figure[0], chunk[1], figure[1], ..., chunk[last].
     chunks.forEachIndexed { index, chunk ->
         if (chunk.isNotEmpty()) {
-            appendHighlightTextChunk(sb, highlight, chunk)
+            appendHighlightTextChunk(sb, highlight, chunk, bookBodyFontFamily)
         }
         figures.getOrNull(index)?.let { fig ->
             appendFigureBlock(sb, fig, highlight.id, highlight.color)
@@ -285,6 +297,7 @@ private fun appendHighlightTextChunk(
     sb: StringBuilder,
     highlight: com.riffle.core.database.AnnotationEntity,
     chunk: String,
+    bookBodyFontFamily: String?,
 ) {
     val accent = highlightBackgroundCss(highlight.color)
     val idEscaped = highlight.id.xmlEscape()
@@ -293,7 +306,9 @@ private fun appendHighlightTextChunk(
     sb.append(PARAGRAPH_GAP_STYLE)
     sb.append("; position: relative; border-left: 4px solid ")
     sb.append(accent)
-    sb.append(" !important; padding-left: 12px;\"><span class=\"")
+    sb.append(" !important; padding-left: 12px;")
+    appendOriginFontFamilyStyle(sb, highlight.originFontFamily, bookBodyFontFamily)
+    sb.append("\"><span class=\"")
     sb.append(ACCENT_BAR_TAP_CLASS)
     sb.append("\" data-ann-id=\"")
     sb.append(idEscaped)
@@ -312,7 +327,7 @@ private fun appendHighlightTextChunk(
  * emission (TYPE_IMAGE, embedded figures) can be dispatched independently. Now also serves as the
  * `charOffset == null` fallback path from [appendInterleavedHighlight].
  */
-private fun appendTextHighlight(sb: StringBuilder, highlight: AnnotationEntity) {
+private fun appendTextHighlight(sb: StringBuilder, highlight: AnnotationEntity, bookBodyFontFamily: String?) {
     // The highlight is presented as a left accent bar in the palette colour, matching
     // Riffle's [Book Search] results card style — the text itself renders in the
     // theme's normal body colour so dense highlights don't fatigue the eye. `!important`
@@ -329,7 +344,9 @@ private fun appendTextHighlight(sb: StringBuilder, highlight: AnnotationEntity) 
     sb.append(PARAGRAPH_GAP_STYLE)
     sb.append("; position: relative; border-left: 4px solid ")
     sb.append(accent)
-    sb.append(" !important; padding-left: 12px;\"><span class=\"")
+    sb.append(" !important; padding-left: 12px;")
+    appendOriginFontFamilyStyle(sb, highlight.originFontFamily, bookBodyFontFamily)
+    sb.append("\"><span class=\"")
     sb.append(ACCENT_BAR_TAP_CLASS)
     sb.append("\" data-ann-id=\"")
     sb.append(idEscaped)
@@ -350,6 +367,47 @@ private fun appendTextHighlight(sb: StringBuilder, highlight: AnnotationEntity) 
         sb.append(note.xmlEscape())
         sb.append("</aside>\n")
     }
+}
+
+/**
+ * Appends `; font-family: <sanitized>;` to a `<p style="…">` builder when either the annotation
+ * has a captured [AnnotationEntity.originFontFamily] (preferred) or the caller supplied a
+ * publication-wide [bookBodyFontFamily] fallback. No-op when both are null/blank — the excerpt
+ * then inherits ReadiumCSS's default face, matching the pre-issue-484 behaviour.
+ *
+ * The value is defensively sanitized (see [sanitizeCssFontFamily]) before being XML-escaped
+ * into the `style` attribute — `getComputedStyle().fontFamily` is normally well-formed, but a
+ * DB row (including a lazy backfill) is not a trust boundary and CSS injection via
+ * `};color:red;` would otherwise be trivially possible.
+ */
+private fun appendOriginFontFamilyStyle(
+    sb: StringBuilder,
+    originFontFamily: String?,
+    bookBodyFontFamily: String?,
+) {
+    val raw = originFontFamily?.takeIf { it.isNotBlank() } ?: bookBodyFontFamily?.takeIf { it.isNotBlank() }
+    val safe = sanitizeCssFontFamily(raw) ?: return
+    sb.append(" font-family: ")
+    sb.append(safe.xmlEscape())
+    sb.append(";")
+}
+
+/**
+ * Returns [value] unchanged if it only contains characters legal in a CSS `font-family` list
+ * (letters, digits, spaces, single/double quotes, dashes, underscores, commas, dots) — else
+ * null. This is a paranoia check: `getComputedStyle().fontFamily` from a modern browser is
+ * always a serialized CSS identifier list, but the DB is not a trust boundary and a malformed
+ * value must not be able to escape the `font-family` declaration.
+ */
+internal fun sanitizeCssFontFamily(value: String?): String? {
+    if (value.isNullOrBlank()) return null
+    val trimmed = value.trim()
+    // Reject any character outside a safe allowlist.
+    if (trimmed.any { c ->
+            !(c.isLetterOrDigit() || c == ' ' || c == '-' || c == '_' || c == ',' || c == '.' ||
+                c == '\'' || c == '"')
+        }) return null
+    return trimmed
 }
 
 /**

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/highlights/HighlightsPublicationFactory.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/highlights/HighlightsPublicationFactory.kt
@@ -198,18 +198,24 @@ class HighlightsPublicationFactory @Inject constructor() {
             }
         }
         val title = chapter.title.xmlEscape()
-        // Apply the book's body font to `<body>` so `<h1>` (chapter title), `<aside>` (notes) and
-        // anything else in the synthesised document inherits the origin's face instead of
-        // ReadiumCSS's serif default. Per-excerpt `<p>` inline `font-family` from
-        // [appendOriginFontFamilyStyle] still overrides for annotations that captured their own
-        // per-range font. Issue #484.
+        // Apply the book's body font to `<body>`, every heading, and `<aside>` so the whole
+        // synthesised document inherits the origin's face instead of ReadiumCSS's serif default.
+        // `!important` is load-bearing: ReadiumCSS-default.css sets its own `font-family` on
+        // headings (via `--RS__*Font*` variables) with equal-or-higher specificity, so a plain
+        // inline `<body>` style loses on `<h1>`. Per-excerpt `<p>` inline styles from
+        // [appendOriginFontFamilyStyle] still override this — inline `!important` beats
+        // stylesheet `!important` at equal specificity. Issue #484.
         val safeBodyFont = sanitizeCssFontFamily(bookBodyFontFamily)
-        val bodyStyle = if (safeBodyFont != null) " style=\"font-family: ${safeBodyFont.xmlEscape()};\"" else ""
+        val bodyFontStyleBlock = if (safeBodyFont != null) {
+            val escaped = safeBodyFont.xmlEscape()
+            "body, h1, h2, h3, h4, h5, h6, aside, figcaption, .riffle-fig { font-family: $escaped !important; }"
+        } else ""
         return """
             |<?xml version="1.0" encoding="UTF-8"?>
             |<html xmlns="http://www.w3.org/1999/xhtml"><head><title>$title</title>$READIUM_DEFAULT_CSS_LINK<style>$ACCENT_BAR_TAP_CSS
-            |$FIGURE_CENTERING_CSS</style></head>
-            |<body$bodyStyle>
+            |$FIGURE_CENTERING_CSS
+            |$bodyFontStyleBlock</style></head>
+            |<body>
             |  <h1>$title</h1>
             |${body.trimEnd('\n')}
             |</body></html>
@@ -394,9 +400,12 @@ private fun appendOriginFontFamilyStyle(
 ) {
     val raw = originFontFamily?.takeIf { it.isNotBlank() } ?: bookBodyFontFamily?.takeIf { it.isNotBlank() }
     val safe = sanitizeCssFontFamily(raw) ?: return
+    // `!important` needed to win against the equally-important body/heading override rule
+    // emitted by [renderChapterHtml] — inline `!important` beats stylesheet `!important`
+    // at equal specificity, so the per-excerpt annotation font wins.
     sb.append(" font-family: ")
     sb.append(safe.xmlEscape())
-    sb.append(";")
+    sb.append(" !important;")
 }
 
 /**

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/highlights/HighlightsPublicationFactory.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/highlights/HighlightsPublicationFactory.kt
@@ -198,11 +198,18 @@ class HighlightsPublicationFactory @Inject constructor() {
             }
         }
         val title = chapter.title.xmlEscape()
+        // Apply the book's body font to `<body>` so `<h1>` (chapter title), `<aside>` (notes) and
+        // anything else in the synthesised document inherits the origin's face instead of
+        // ReadiumCSS's serif default. Per-excerpt `<p>` inline `font-family` from
+        // [appendOriginFontFamilyStyle] still overrides for annotations that captured their own
+        // per-range font. Issue #484.
+        val safeBodyFont = sanitizeCssFontFamily(bookBodyFontFamily)
+        val bodyStyle = if (safeBodyFont != null) " style=\"font-family: ${safeBodyFont.xmlEscape()};\"" else ""
         return """
             |<?xml version="1.0" encoding="UTF-8"?>
             |<html xmlns="http://www.w3.org/1999/xhtml"><head><title>$title</title>$READIUM_DEFAULT_CSS_LINK<style>$ACCENT_BAR_TAP_CSS
             |$FIGURE_CENTERING_CSS</style></head>
-            |<body>
+            |<body$bodyStyle>
             |  <h1>$title</h1>
             |${body.trimEnd('\n')}
             |</body></html>

--- a/app/src/test/kotlin/com/riffle/app/feature/library/AnnotationSearchViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/AnnotationSearchViewModelTest.kt
@@ -83,6 +83,7 @@ class AnnotationSearchViewModelTest {
         override suspend fun findImageAnnotationForFigure(
             sourceId: String, itemId: String, chapterHref: String, imageHref: String?, imageSvg: String?,
         ): Annotation? = null
+        override suspend fun backfillNullOriginFontFamily(sourceId: String, itemId: String, fontFamily: String) = error("unused")
     }
 
     private fun fakeAudiobookBookmarkStore(): com.riffle.core.domain.AudiobookBookmarkStore =

--- a/app/src/test/kotlin/com/riffle/app/feature/library/AnnotationSearchViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/AnnotationSearchViewModelTest.kt
@@ -72,8 +72,8 @@ class AnnotationSearchViewModelTest {
         override fun observeAnnotations(sourceId: String, itemId: String) = MutableStateFlow(emptyList<Annotation>())
         override fun observeAnnotationsForSource(sourceId: String) =
             annotationsFlow.map { all -> all.filter { it.sourceId == sourceId } }
-        override suspend fun createHighlight(sourceId: String, itemId: String, cfi: String, textSnippet: String, chapterHref: String, textBefore: String, textAfter: String, color: String, spineIndex: Int, progression: Double, embeddedFigures: List<com.riffle.core.domain.EmbeddedFigure>?) = error("unused")
-        override suspend fun createBookmark(sourceId: String, itemId: String, cfi: String, textSnippet: String, chapterHref: String, spineIndex: Int, progression: Double, bookmarkTitle: String) = error("unused")
+        override suspend fun createHighlight(sourceId: String, itemId: String, cfi: String, textSnippet: String, chapterHref: String, textBefore: String, textAfter: String, color: String, spineIndex: Int, progression: Double, embeddedFigures: List<com.riffle.core.domain.EmbeddedFigure>?, originFontFamily: String) = error("unused")
+        override suspend fun createBookmark(sourceId: String, itemId: String, cfi: String, textSnippet: String, chapterHref: String, spineIndex: Int, progression: Double, bookmarkTitle: String, originFontFamily: String) = error("unused")
         override suspend fun createImageAnnotation(sourceId: String, itemId: String, cfi: String, textSnippet: String, chapterHref: String, spineIndex: Int, progression: Double, imageHref: String?, imageSvg: String?, imageBytes: String?, color: String) = error("unused")
         override suspend fun delete(id: String) = error("unused")
         override suspend fun recolor(id: String, color: String) = error("unused")

--- a/app/src/test/kotlin/com/riffle/app/feature/library/LibraryFilterEngineTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/LibraryFilterEngineTest.kt
@@ -91,6 +91,7 @@ class LibraryFilterEngineTest {
         override suspend fun findImageAnnotationForFigure(
             sourceId: String, itemId: String, chapterHref: String, imageHref: String?, imageSvg: String?,
         ): com.riffle.core.domain.Annotation? = null
+        override suspend fun backfillNullOriginFontFamily(sourceId: String, itemId: String, fontFamily: String) = error("unused")
     }
 
     private fun fakeBookmarkStore(): AudiobookBookmarkStore = object : AudiobookBookmarkStore {

--- a/app/src/test/kotlin/com/riffle/app/feature/library/LibraryFilterEngineTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/LibraryFilterEngineTest.kt
@@ -80,8 +80,8 @@ class LibraryFilterEngineTest {
         override fun observeAnnotations(sourceId: String, itemId: String) = MutableStateFlow(emptyList<com.riffle.core.domain.Annotation>())
         override fun observeAnnotationsForSource(sourceId: String) =
             annotationsFlow.map { all -> all.filter { it.sourceId == sourceId } }
-        override suspend fun createHighlight(sourceId: String, itemId: String, cfi: String, textSnippet: String, chapterHref: String, textBefore: String, textAfter: String, color: String, spineIndex: Int, progression: Double, embeddedFigures: List<com.riffle.core.domain.EmbeddedFigure>?) = error("unused")
-        override suspend fun createBookmark(sourceId: String, itemId: String, cfi: String, textSnippet: String, chapterHref: String, spineIndex: Int, progression: Double, bookmarkTitle: String) = error("unused")
+        override suspend fun createHighlight(sourceId: String, itemId: String, cfi: String, textSnippet: String, chapterHref: String, textBefore: String, textAfter: String, color: String, spineIndex: Int, progression: Double, embeddedFigures: List<com.riffle.core.domain.EmbeddedFigure>?, originFontFamily: String) = error("unused")
+        override suspend fun createBookmark(sourceId: String, itemId: String, cfi: String, textSnippet: String, chapterHref: String, spineIndex: Int, progression: Double, bookmarkTitle: String, originFontFamily: String) = error("unused")
         override suspend fun createImageAnnotation(sourceId: String, itemId: String, cfi: String, textSnippet: String, chapterHref: String, spineIndex: Int, progression: Double, imageHref: String?, imageSvg: String?, imageBytes: String?, color: String) = error("unused")
         override suspend fun delete(id: String) = error("unused")
         override suspend fun recolor(id: String, color: String) = error("unused")

--- a/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemsViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemsViewModelTest.kt
@@ -87,6 +87,7 @@ class LibraryItemsViewModelTest {
             override suspend fun findImageAnnotationForFigure(
                 sourceId: String, itemId: String, chapterHref: String, imageHref: String?, imageSvg: String?,
             ): com.riffle.core.domain.Annotation? = null
+            override suspend fun backfillNullOriginFontFamily(sourceId: String, itemId: String, fontFamily: String) = error("unused")
         }
 
     private fun fakeAudiobookBookmarkStore(): com.riffle.core.domain.AudiobookBookmarkStore =

--- a/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemsViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemsViewModelTest.kt
@@ -76,8 +76,8 @@ class LibraryItemsViewModelTest {
             override fun observeAnnotations(sourceId: String, itemId: String) = MutableStateFlow(emptyList<com.riffle.core.domain.Annotation>())
             override fun observeAnnotationsForSource(sourceId: String) =
                 annotationsFlow.map { all -> all.filter { it.sourceId == sourceId } }
-            override suspend fun createHighlight(sourceId: String, itemId: String, cfi: String, textSnippet: String, chapterHref: String, textBefore: String, textAfter: String, color: String, spineIndex: Int, progression: Double, embeddedFigures: List<com.riffle.core.domain.EmbeddedFigure>?) = error("unused")
-            override suspend fun createBookmark(sourceId: String, itemId: String, cfi: String, textSnippet: String, chapterHref: String, spineIndex: Int, progression: Double, bookmarkTitle: String) = error("unused")
+            override suspend fun createHighlight(sourceId: String, itemId: String, cfi: String, textSnippet: String, chapterHref: String, textBefore: String, textAfter: String, color: String, spineIndex: Int, progression: Double, embeddedFigures: List<com.riffle.core.domain.EmbeddedFigure>?, originFontFamily: String) = error("unused")
+            override suspend fun createBookmark(sourceId: String, itemId: String, cfi: String, textSnippet: String, chapterHref: String, spineIndex: Int, progression: Double, bookmarkTitle: String, originFontFamily: String) = error("unused")
             override suspend fun createImageAnnotation(sourceId: String, itemId: String, cfi: String, textSnippet: String, chapterHref: String, spineIndex: Int, progression: Double, imageHref: String?, imageSvg: String?, imageBytes: String?, color: String) = error("unused")
             override suspend fun delete(id: String) = error("unused")
             override suspend fun recolor(id: String, color: String) = error("unused")

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/EpubReaderViewModelEmbeddedFiguresTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/EpubReaderViewModelEmbeddedFiguresTest.kt
@@ -152,6 +152,7 @@ class EpubReaderViewModelEmbeddedFiguresTest {
         spineIndex = 0,
         progression = 0.2,
         embeddedFigures = resolver.resolve(cfiRange),
+        originFontFamily = "Georgia, serif",
     )
 
     @Test

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/EpubReaderViewModelEmbeddedFiguresTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/EpubReaderViewModelEmbeddedFiguresTest.kt
@@ -120,6 +120,23 @@ class EpubReaderViewModelEmbeddedFiguresTest {
 
         override suspend fun purgeAgedTombstones(sourceId: String, itemId: String, cutoff: Long): Int = 0
 
+        override suspend fun backfillNullOriginFontFamily(
+            sourceId: String,
+            itemId: String,
+            fontFamily: String,
+            updatedAt: Long,
+            deviceId: String,
+        ): Int {
+            var changed = 0
+            rows.value = rows.value.map {
+                if (it.sourceId == sourceId && it.itemId == itemId && !it.deleted && it.originFontFamily == null) {
+                    changed++
+                    it.copy(originFontFamily = fontFamily, updatedAt = updatedAt, lastModifiedByDeviceId = deviceId)
+                } else it
+            }
+            return changed
+        }
+
         override fun observeBooksWithHighlights(sourceId: String): Flow<List<BookHighlightSummary>> =
             flowOf(emptyList())
     }

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/EpubReaderViewModelImageAnnotationTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/EpubReaderViewModelImageAnnotationTest.kt
@@ -119,6 +119,23 @@ class EpubReaderViewModelImageAnnotationTest {
 
         override suspend fun purgeAgedTombstones(sourceId: String, itemId: String, cutoff: Long): Int = 0
 
+        override suspend fun backfillNullOriginFontFamily(
+            sourceId: String,
+            itemId: String,
+            fontFamily: String,
+            updatedAt: Long,
+            deviceId: String,
+        ): Int {
+            var changed = 0
+            rows.value = rows.value.map {
+                if (it.sourceId == sourceId && it.itemId == itemId && !it.deleted && it.originFontFamily == null) {
+                    changed++
+                    it.copy(originFontFamily = fontFamily, updatedAt = updatedAt, lastModifiedByDeviceId = deviceId)
+                } else it
+            }
+            return changed
+        }
+
         override fun observeBooksWithHighlights(sourceId: String): Flow<List<com.riffle.core.database.BookHighlightSummary>> =
             flowOf(emptyList())
     }

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/controllers/BookmarksControllerTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/controllers/BookmarksControllerTest.kt
@@ -107,6 +107,11 @@ class BookmarksControllerTest {
         override suspend fun findImageAnnotationForFigure(
             sourceId: String, itemId: String, chapterHref: String, imageHref: String?, imageSvg: String?,
         ): Annotation? = null
+        override suspend fun backfillNullOriginFontFamily(
+            sourceId: String,
+            itemId: String,
+            fontFamily: String,
+        ): Int = 0
     }
 
     private fun makeAnnotation(

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/controllers/BookmarksControllerTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/controllers/BookmarksControllerTest.kt
@@ -41,6 +41,7 @@ class BookmarksControllerTest {
             chapterHref: String, textBefore: String, textAfter: String, color: String,
             spineIndex: Int, progression: Double,
             embeddedFigures: List<com.riffle.core.domain.EmbeddedFigure>?,
+            originFontFamily: String,
         ): Annotation {
             val a = Annotation(
                 id = "highlight-${created.size}",
@@ -59,6 +60,7 @@ class BookmarksControllerTest {
         override suspend fun createBookmark(
             sourceId: String, itemId: String, cfi: String, textSnippet: String,
             chapterHref: String, spineIndex: Int, progression: Double, bookmarkTitle: String,
+            originFontFamily: String,
         ): Annotation {
             val a = Annotation(
                 id = "bm-${created.size}",

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/highlights/HighlightsPublicationFactoryTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/highlights/HighlightsPublicationFactoryTest.kt
@@ -320,7 +320,7 @@ class HighlightsPublicationFactoryTest {
         val html = readChapterHtml(pub, index = 0)
         assertTrue(
             "excerpt <p> carries an inline font-family with the captured value; html was: $html",
-            html.contains("font-family: &quot;Fira Sans&quot;, sans-serif;")
+            html.contains("font-family: &quot;Fira Sans&quot;, sans-serif !important;")
         )
     }
 
@@ -343,15 +343,17 @@ class HighlightsPublicationFactoryTest {
         val html = readChapterHtml(pub, index = 0)
         assertTrue(
             "excerpt <p> falls back to book body font; html was: $html",
-            html.contains("font-family: Georgia, serif;")
+            html.contains("font-family: Georgia, serif !important;")
         )
     }
 
-    // The `bookBodyFontFamily` is also applied to `<body>` so chapter titles (`<h1>`), notes
-    // (`<aside>`), and anything else non-`<p>` inherits the origin's face — matches "the elided
-    // view must inherit the origin's font" for the whole document, not just excerpts.
+    // The `bookBodyFontFamily` is applied via a `<style>` block that targets `<body>` + every
+    // heading tag so the chapter title, notes, and figcaptions inherit the origin's face —
+    // matches "the elided view must inherit the origin's font" for the whole document, not just
+    // excerpts. `!important` is load-bearing because ReadiumCSS-default.css sets its own
+    // font-family on headings via `--RS__*Font*` CSS variables.
     @Test
-    fun bookBodyFontFamily_isSetOnBodyElementForTitleAndNotes() {
+    fun bookBodyFontFamily_isAppliedToHeadingsAndAsideViaStyleBlock() {
         val pub = factory.build(
             sourceId = "S1", itemId = "B1", bookTitle = null,
             chapters = listOf(
@@ -365,8 +367,11 @@ class HighlightsPublicationFactoryTest {
         )
         val html = readChapterHtml(pub, index = 0)
         assertTrue(
-            "<body> must carry the book body font-family so <h1>/<aside> inherit it; html was: $html",
-            html.contains("<body style=\"font-family: Georgia, serif;\">")
+            "<style> block must set the book body font on body + headings + aside; html was: $html",
+            html.contains(
+                "body, h1, h2, h3, h4, h5, h6, aside, figcaption, .riffle-fig " +
+                    "{ font-family: Georgia, serif !important; }"
+            )
         )
     }
 

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/highlights/HighlightsPublicationFactoryTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/highlights/HighlightsPublicationFactoryTest.kt
@@ -347,6 +347,29 @@ class HighlightsPublicationFactoryTest {
         )
     }
 
+    // The `bookBodyFontFamily` is also applied to `<body>` so chapter titles (`<h1>`), notes
+    // (`<aside>`), and anything else non-`<p>` inherits the origin's face — matches "the elided
+    // view must inherit the origin's font" for the whole document, not just excerpts.
+    @Test
+    fun bookBodyFontFamily_isSetOnBodyElementForTitleAndNotes() {
+        val pub = factory.build(
+            sourceId = "S1", itemId = "B1", bookTitle = null,
+            chapters = listOf(
+                ChapterElision(
+                    "ch0.xhtml", "Chapter Title Here",
+                    listOf(hl("h1", "excerpt", note = "my note")),
+                ),
+            ),
+            urlFactory = ::testUrlFactory,
+            bookBodyFontFamily = "Georgia, serif",
+        )
+        val html = readChapterHtml(pub, index = 0)
+        assertTrue(
+            "<body> must carry the book body font-family so <h1>/<aside> inherit it; html was: $html",
+            html.contains("<body style=\"font-family: Georgia, serif;\">")
+        )
+    }
+
     // Both null → no font-family declaration at all → ReadiumCSS's default applies. Preserves
     // the pre-issue-484 behaviour for callers that don't (yet) supply a fallback.
     @Test

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/highlights/HighlightsPublicationFactoryTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/highlights/HighlightsPublicationFactoryTest.kt
@@ -302,6 +302,88 @@ class HighlightsPublicationFactoryTest {
         assertTrue(html.contains("font-style: italic; opacity: 0.75;\">my thought</aside>"))
     }
 
+    // Issue #484: an annotation with a captured `originFontFamily` renders its excerpt `<p>` with
+    // an inline `font-family` declaration, so the elided view matches the face the reader saw at
+    // the source range instead of falling back to ReadiumCSS's default serif.
+    @Test
+    fun originFontFamily_isInlinedOnExcerptParagraph() {
+        val pub = factory.build(
+            sourceId = "S1", itemId = "B1", bookTitle = null,
+            chapters = listOf(
+                ChapterElision(
+                    "ch0.xhtml", "One",
+                    listOf(hl("h1", "sans excerpt", originFontFamily = "\"Fira Sans\", sans-serif")),
+                ),
+            ),
+            urlFactory = ::testUrlFactory,
+        )
+        val html = readChapterHtml(pub, index = 0)
+        assertTrue(
+            "excerpt <p> carries an inline font-family with the captured value; html was: $html",
+            html.contains("font-family: &quot;Fira Sans&quot;, sans-serif;")
+        )
+    }
+
+    // When the annotation has no captured font, the caller-supplied publication-wide body-font
+    // is used as fallback. Preserves the "match the book, at least approximately" experience for
+    // legacy rows written before issue #484 shipped.
+    @Test
+    fun bookBodyFontFamily_fallsBackWhenAnnotationHasNoOwnFont() {
+        val pub = factory.build(
+            sourceId = "S1", itemId = "B1", bookTitle = null,
+            chapters = listOf(
+                ChapterElision(
+                    "ch0.xhtml", "One",
+                    listOf(hl("h1", "legacy row", originFontFamily = null)),
+                ),
+            ),
+            urlFactory = ::testUrlFactory,
+            bookBodyFontFamily = "Georgia, serif",
+        )
+        val html = readChapterHtml(pub, index = 0)
+        assertTrue(
+            "excerpt <p> falls back to book body font; html was: $html",
+            html.contains("font-family: Georgia, serif;")
+        )
+    }
+
+    // Both null → no font-family declaration at all → ReadiumCSS's default applies. Preserves
+    // the pre-issue-484 behaviour for callers that don't (yet) supply a fallback.
+    @Test
+    fun noFontFamilyDeclaredWhenBothAnnotationAndBookAreNull() {
+        val pub = factory.build(
+            sourceId = "S1", itemId = "B1", bookTitle = null,
+            chapters = listOf(
+                ChapterElision("ch0.xhtml", "One", listOf(hl("h1", "no font"))),
+            ),
+            urlFactory = ::testUrlFactory,
+        )
+        val html = readChapterHtml(pub, index = 0)
+        assertTrue("no inline font-family emitted", !html.contains("font-family:"))
+    }
+
+    // A font-family value whose bytes contain something outside the safe allowlist (e.g. an
+    // injected `};color:red;`) must be dropped, not written into the excerpt style attribute —
+    // the DB is not a trust boundary and CSS injection must not be possible.
+    @Test
+    fun maliciousFontFamily_isDroppedNotWritten() {
+        val pub = factory.build(
+            sourceId = "S1", itemId = "B1", bookTitle = null,
+            chapters = listOf(
+                ChapterElision(
+                    "ch0.xhtml", "One",
+                    listOf(hl("h1", "hi", originFontFamily = "serif;} body{color:red")),
+                ),
+            ),
+            urlFactory = ::testUrlFactory,
+        )
+        val html = readChapterHtml(pub, index = 0)
+        assertTrue(
+            "malicious font-family value must be dropped; html was: $html",
+            !html.contains("body{color:red") && !html.contains("font-family:")
+        )
+    }
+
     private fun hl(
         id: String,
         snippet: String,
@@ -309,6 +391,7 @@ class HighlightsPublicationFactoryTest {
         spineIndex: Int = 0,
         progression: Double = 0.0,
         color: String = AnnotationEntity.COLOR_YELLOW,
+        originFontFamily: String? = null,
     ): AnnotationEntity =
         AnnotationEntity(
             id = id,
@@ -326,6 +409,7 @@ class HighlightsPublicationFactoryTest {
             updatedAt = 0L,
             originDeviceId = "test",
             lastModifiedByDeviceId = "test",
+            originFontFamily = originFontFamily,
         )
 
     private fun readChapterHtml(pub: Publication, index: Int): String {

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/session/AnnotationSessionTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/session/AnnotationSessionTest.kt
@@ -94,6 +94,11 @@ class AnnotationSessionTest {
         override suspend fun findImageAnnotationForFigure(
             sourceId: String, itemId: String, chapterHref: String, imageHref: String?, imageSvg: String?,
         ): Annotation? = null
+        override suspend fun backfillNullOriginFontFamily(
+            sourceId: String,
+            itemId: String,
+            fontFamily: String,
+        ): Int = 0
     }
 
     /**

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/session/AnnotationSessionTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/session/AnnotationSessionTest.kt
@@ -49,6 +49,7 @@ class AnnotationSessionTest {
         val color: String,
         val spineIndex: Int,
         val progression: Double,
+        val originFontFamily: String,
     )
 
     private class FakeAnnotationStore : AnnotationStore {
@@ -69,15 +70,17 @@ class AnnotationSessionTest {
             chapterHref: String, textBefore: String, textAfter: String, color: String,
             spineIndex: Int, progression: Double,
             embeddedFigures: List<com.riffle.core.domain.EmbeddedFigure>?,
+            originFontFamily: String,
         ): Annotation {
             createHighlightCalls.add(
-                CreateHighlightArgs(sourceId, itemId, cfi, textSnippet, chapterHref, textBefore, textAfter, color, spineIndex, progression)
+                CreateHighlightArgs(sourceId, itemId, cfi, textSnippet, chapterHref, textBefore, textAfter, color, spineIndex, progression, originFontFamily)
             )
             return makeAnnotation(id = "h1", type = "highlight", cfi = cfi, color = color)
         }
         override suspend fun createBookmark(
             sourceId: String, itemId: String, cfi: String, textSnippet: String,
             chapterHref: String, spineIndex: Int, progression: Double, bookmarkTitle: String,
+            originFontFamily: String,
         ): Annotation = makeAnnotation(id = "b1", type = "bookmark", cfi = cfi)
         override suspend fun createImageAnnotation(
             sourceId: String, itemId: String, cfi: String, textSnippet: String, chapterHref: String,
@@ -908,6 +911,7 @@ class AnnotationSessionTest {
             color = "yellow",
             spineIndex = 0,
             progression = 0.5,
+            originFontFamily = "Georgia, serif",
         )
 
         val captured = store.createHighlightCalls.single()
@@ -915,6 +919,7 @@ class AnnotationSessionTest {
         assertEquals("hello", captured.textSnippet)
         assertEquals("say ", captured.textBefore)
         assertEquals(" world", captured.textAfter)
+        assertEquals("Georgia, serif", captured.originFontFamily)
         // Verify the returned annotation carries the expected identity.
         assertEquals("yellow", created.color)
     }

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/session/ReaderSessionLifecycleTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/session/ReaderSessionLifecycleTest.kt
@@ -178,6 +178,11 @@ class ReaderSessionLifecycleTest {
         override suspend fun findImageAnnotationForFigure(
             sourceId: String, itemId: String, chapterHref: String, imageHref: String?, imageSvg: String?,
         ): Annotation? = null
+        override suspend fun backfillNullOriginFontFamily(
+            sourceId: String,
+            itemId: String,
+            fontFamily: String,
+        ): Int = 0
     }
 
     // ── Helpers ──────────────────────────────────────────────────────────────────────────

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/session/ReaderSessionLifecycleTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/session/ReaderSessionLifecycleTest.kt
@@ -158,10 +158,12 @@ class ReaderSessionLifecycleTest {
             sourceId: String, itemId: String, cfi: String, textSnippet: String, chapterHref: String,
             textBefore: String, textAfter: String, color: String, spineIndex: Int, progression: Double,
             embeddedFigures: List<com.riffle.core.domain.EmbeddedFigure>?,
+            originFontFamily: String,
         ): Annotation = error("not needed")
         override suspend fun createBookmark(
             sourceId: String, itemId: String, cfi: String, textSnippet: String, chapterHref: String,
             spineIndex: Int, progression: Double, bookmarkTitle: String,
+            originFontFamily: String,
         ): Annotation = error("not needed")
         override suspend fun createImageAnnotation(
             sourceId: String, itemId: String, cfi: String, textSnippet: String, chapterHref: String,

--- a/app/src/test/kotlin/com/riffle/app/feature/server/AddSourceViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/server/AddSourceViewModelTest.kt
@@ -208,6 +208,13 @@ class AddSourceViewModelTest {
         override suspend fun dirtySourceItems() = emptyList<AnnotationDao.DirtySourceItem>()
         override suspend fun markSynced(ids: List<String>, syncedAt: Long) {}
         override suspend fun purgeAgedTombstones(sourceId: String, itemId: String, cutoff: Long): Int = 0
+        override suspend fun backfillNullOriginFontFamily(
+            sourceId: String,
+            itemId: String,
+            fontFamily: String,
+            updatedAt: Long,
+            deviceId: String,
+        ): Int = 0
         override fun observeBooksWithHighlights(sourceId: String) =
             flowOf(emptyList<com.riffle.core.database.BookHighlightSummary>())
     }
@@ -529,6 +536,13 @@ class AddSourceViewModelTest {
             override suspend fun dirtySourceItems() = emptyList<AnnotationDao.DirtySourceItem>()
             override suspend fun markSynced(ids: List<String>, syncedAt: Long) {}
             override suspend fun purgeAgedTombstones(sourceId: String, itemId: String, cutoff: Long): Int = 0
+            override suspend fun backfillNullOriginFontFamily(
+                sourceId: String,
+                itemId: String,
+                fontFamily: String,
+                updatedAt: Long,
+                deviceId: String,
+            ): Int = 0
             override fun observeBooksWithHighlights(sourceId: String) =
                 flowOf(emptyList<com.riffle.core.database.BookHighlightSummary>())
         }

--- a/app/src/test/kotlin/com/riffle/app/feature/settings/SettingsViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/settings/SettingsViewModelTest.kt
@@ -291,6 +291,13 @@ class SettingsViewModelTest {
         override suspend fun dirtySourceItems() = emptyList<AnnotationDao.DirtySourceItem>()
         override suspend fun markSynced(ids: List<String>, syncedAt: Long) {}
         override suspend fun purgeAgedTombstones(sourceId: String, itemId: String, cutoff: Long): Int = 0
+        override suspend fun backfillNullOriginFontFamily(
+            sourceId: String,
+            itemId: String,
+            fontFamily: String,
+            updatedAt: Long,
+            deviceId: String,
+        ): Int = 0
         override fun observeBooksWithHighlights(sourceId: String) =
             flowOf(emptyList<com.riffle.core.database.BookHighlightSummary>())
     }

--- a/core/data/src/main/kotlin/com/riffle/core/data/AnnotationStoreImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/AnnotationStoreImpl.kt
@@ -57,7 +57,11 @@ class AnnotationStoreImpl(
         spineIndex: Int,
         progression: Double,
         embeddedFigures: List<EmbeddedFigure>?,
+        originFontFamily: String,
     ): Annotation {
+        require(originFontFamily.isNotBlank()) {
+            "originFontFamily must be non-blank for locally-created highlights (issue #484)"
+        }
         val deviceId = deviceIdStore.getOrCreate()
         val now = clock()
         val entity = AnnotationEntity(
@@ -81,6 +85,7 @@ class AnnotationStoreImpl(
             lastModifiedByDeviceId = deviceId,
             deleted = false,
             embeddedFigures = embeddedFigures.toEntityJson(),
+            originFontFamily = originFontFamily,
         )
         dao.upsert(entity)
         return entity.toDomain()
@@ -95,7 +100,11 @@ class AnnotationStoreImpl(
         spineIndex: Int,
         progression: Double,
         bookmarkTitle: String,
+        originFontFamily: String,
     ): Annotation {
+        require(originFontFamily.isNotBlank()) {
+            "originFontFamily must be non-blank for locally-created bookmarks (issue #484)"
+        }
         val deviceId = deviceIdStore.getOrCreate()
         val now = clock()
         val entity = AnnotationEntity(
@@ -116,6 +125,7 @@ class AnnotationStoreImpl(
             originDeviceId = deviceId,
             lastModifiedByDeviceId = deviceId,
             deleted = false,
+            originFontFamily = originFontFamily,
         )
         dao.upsert(entity)
         return entity.toDomain()
@@ -235,6 +245,7 @@ internal fun Annotation.toEntity() = AnnotationEntity(
     imageHref = imageHref,
     imageSvg = imageSvg,
     imageBytes = imageBytes,
+    originFontFamily = originFontFamily,
 )
 
 internal fun AnnotationEntity.toDomain() = Annotation(
@@ -258,4 +269,5 @@ internal fun AnnotationEntity.toDomain() = Annotation(
     imageHref = imageHref,
     imageSvg = imageSvg,
     imageBytes = imageBytes,
+    originFontFamily = originFontFamily,
 )

--- a/core/data/src/main/kotlin/com/riffle/core/data/AnnotationStoreImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/AnnotationStoreImpl.kt
@@ -173,6 +173,21 @@ class AnnotationStoreImpl(
         return entity.toDomain()
     }
 
+    override suspend fun backfillNullOriginFontFamily(
+        sourceId: String,
+        itemId: String,
+        fontFamily: String,
+    ): Int {
+        if (fontFamily.isBlank()) return 0
+        return dao.backfillNullOriginFontFamily(
+            sourceId = sourceId,
+            itemId = itemId,
+            fontFamily = fontFamily,
+            updatedAt = clock(),
+            deviceId = deviceIdStore.getOrCreate(),
+        )
+    }
+
     override suspend fun delete(id: String) {
         dao.tombstone(id, updatedAt = clock(), deviceId = deviceIdStore.getOrCreate())
     }

--- a/core/data/src/main/kotlin/com/riffle/core/data/di/DatabaseModule.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/di/DatabaseModule.kt
@@ -87,6 +87,7 @@ object DatabaseModule {
                 RiffleDatabase.MIGRATION_47_48,
                 RiffleDatabase.MIGRATION_48_49,
                 RiffleDatabase.MIGRATION_49_50,
+                RiffleDatabase.MIGRATION_50_51,
             )
             .build()
 

--- a/core/data/src/test/kotlin/com/riffle/core/data/AnnotationStoreImplTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/AnnotationStoreImplTest.kt
@@ -68,6 +68,27 @@ class AnnotationStoreImplTest {
             }
         }
 
+        override suspend fun backfillNullOriginFontFamily(
+            sourceId: String,
+            itemId: String,
+            fontFamily: String,
+            updatedAt: Long,
+            deviceId: String,
+        ): Int {
+            var updated = 0
+            rows.value = rows.value.map { row ->
+                if (row.sourceId == sourceId && row.itemId == itemId && !row.deleted && row.originFontFamily == null) {
+                    updated++
+                    row.copy(
+                        originFontFamily = fontFamily,
+                        updatedAt = updatedAt,
+                        lastModifiedByDeviceId = deviceId,
+                    )
+                } else row
+            }
+            return updated
+        }
+
         override suspend fun updateNote(id: String, note: String?, updatedAt: Long, deviceId: String) {
             rows.value = rows.value.map {
                 if (it.id == id) it.copy(note = note, updatedAt = updatedAt, lastModifiedByDeviceId = deviceId) else it

--- a/core/data/src/test/kotlin/com/riffle/core/data/AnnotationStoreImplTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/AnnotationStoreImplTest.kt
@@ -13,6 +13,8 @@ import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
+private const val TEST_FONT = "Georgia, serif"
+
 class AnnotationStoreImplTest {
 
     private val rows = MutableStateFlow<List<AnnotationEntity>>(emptyList())
@@ -126,16 +128,59 @@ class AnnotationStoreImplTest {
         val created = store().createHighlight(
             sourceId = "abs1", itemId = "item1", cfi = "epubcfi(/6/4!/4/2,/1:0,/1:10)",
             textSnippet = "t", chapterHref = "c.xhtml", color = "green",
+            originFontFamily = TEST_FONT,
         )
         assertEquals("green", created.color)
         assertEquals("green", dao.getById(created.id)?.color)
+    }
+
+    // Issue #484: `originFontFamily` must round-trip from the createHighlight/createBookmark call
+    // to the persisted entity — non-null contract on the local write path.
+    @Test
+    fun `createHighlight persists originFontFamily to the entity`() = runTest {
+        val created = store().createHighlight(
+            sourceId = "abs1", itemId = "item1", cfi = "epubcfi(/6/4!/4/2,/1:0,/1:10)",
+            textSnippet = "t", chapterHref = "c.xhtml",
+            originFontFamily = "\"Fira Sans\", sans-serif",
+        )
+        assertEquals("\"Fira Sans\", sans-serif", created.let { dao.getById(it.id)?.originFontFamily })
+    }
+
+    @Test
+    fun `createBookmark persists originFontFamily to the entity`() = runTest {
+        val created = store().createBookmark(
+            sourceId = "abs1", itemId = "item1", cfi = "epubcfi(/6/6!/4/1:0)",
+            textSnippet = "", chapterHref = "ch2.xhtml",
+            spineIndex = 0, progression = 0.0, bookmarkTitle = "x",
+            originFontFamily = "\"Merriweather\", serif",
+        )
+        assertEquals("\"Merriweather\", serif", dao.getById(created.id)?.originFontFamily)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `createHighlight rejects blank originFontFamily`() = runTest {
+        store().createHighlight(
+            sourceId = "abs1", itemId = "item1", cfi = "epubcfi(/6/4!/4/2,/1:0,/1:10)",
+            textSnippet = "t", chapterHref = "c.xhtml",
+            originFontFamily = "  ",
+        )
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `createBookmark rejects blank originFontFamily`() = runTest {
+        store().createBookmark(
+            sourceId = "abs1", itemId = "item1", cfi = "epubcfi(/6/6!/4/1:0)",
+            textSnippet = "", chapterHref = "c.xhtml",
+            spineIndex = 0, progression = 0.0, bookmarkTitle = "",
+            originFontFamily = "",
+        )
     }
 
     @Test
     fun `findByItemAndCfi returns the matching live annotation`() = runTest {
         val s = store()
         val cfi = "epubcfi(/6/4!/4/26[s3],/1:0,/1:24)"
-        val created = s.createHighlight("abs1", "item1", cfi, "Section 1.3", "c.xhtml")
+        val created = s.createHighlight("abs1", "item1", cfi, "Section 1.3", "c.xhtml", originFontFamily = TEST_FONT)
         val found = s.findByItemAndCfi("abs1", "item1", cfi)
         assertEquals(created.id, found?.id)
     }
@@ -143,7 +188,7 @@ class AnnotationStoreImplTest {
     @Test
     fun `findByItemAndCfi returns null on CFI mismatch`() = runTest {
         val s = store()
-        s.createHighlight("abs1", "item1", "epubcfi(/6/4!/4/26[s3],/1:0,/1:24)", "t", "c.xhtml")
+        s.createHighlight("abs1", "item1", "epubcfi(/6/4!/4/26[s3],/1:0,/1:24)", "t", "c.xhtml", originFontFamily = TEST_FONT)
         assertNull(s.findByItemAndCfi("abs1", "item1", "epubcfi(/6/4!/4/22,/1:0,/1:5)"))
     }
 
@@ -151,7 +196,7 @@ class AnnotationStoreImplTest {
     fun `findByItemAndCfi scopes by sourceId and itemId`() = runTest {
         val s = store()
         val cfi = "epubcfi(/6/4!/4/2,/1:0,/1:10)"
-        s.createHighlight("abs1", "item1", cfi, "t", "c.xhtml")
+        s.createHighlight("abs1", "item1", cfi, "t", "c.xhtml", originFontFamily = TEST_FONT)
         // Same CFI but different source / item — must NOT match.
         assertNull(s.findByItemAndCfi("abs2", "item1", cfi))
         assertNull(s.findByItemAndCfi("abs1", "item2", cfi))
@@ -161,7 +206,7 @@ class AnnotationStoreImplTest {
     fun `findByItemAndCfi skips tombstoned annotations`() = runTest {
         val s = store()
         val cfi = "epubcfi(/6/4!/4/2,/1:0,/1:10)"
-        val created = s.createHighlight("abs1", "item1", cfi, "t", "c.xhtml")
+        val created = s.createHighlight("abs1", "item1", cfi, "t", "c.xhtml", originFontFamily = TEST_FONT)
         s.delete(created.id) // tombstones the row
         assertNull(s.findByItemAndCfi("abs1", "item1", cfi))
     }
@@ -169,7 +214,7 @@ class AnnotationStoreImplTest {
     @Test
     fun `recolor updates the colour and bumps updatedAt and device`() = runTest {
         val s = store()
-        val created = s.createHighlight("abs1", "item1", "epubcfi(/6/4!/4/2,/1:0,/1:10)", "t", "c.xhtml")
+        val created = s.createHighlight("abs1", "item1", "epubcfi(/6/4!/4/2,/1:0,/1:10)", "t", "c.xhtml", originFontFamily = TEST_FONT)
         now = 5000L
 
         s.recolor(created.id, "blue")
@@ -183,7 +228,7 @@ class AnnotationStoreImplTest {
     @Test
     fun `updateNote adds a note and bumps updatedAt and device`() = runTest {
         val s = store()
-        val created = s.createHighlight("abs1", "item1", "epubcfi(/6/4!/4/2,/1:0,/1:10)", "t", "c.xhtml")
+        val created = s.createHighlight("abs1", "item1", "epubcfi(/6/4!/4/2,/1:0,/1:10)", "t", "c.xhtml", originFontFamily = TEST_FONT)
         now = 7000L
 
         s.updateNote(created.id, "My note")
@@ -197,7 +242,7 @@ class AnnotationStoreImplTest {
     @Test
     fun `updateNote edits an existing note`() = runTest {
         val s = store()
-        val created = s.createHighlight("abs1", "item1", "epubcfi(/6/4!/4/2,/1:0,/1:10)", "t", "c.xhtml")
+        val created = s.createHighlight("abs1", "item1", "epubcfi(/6/4!/4/2,/1:0,/1:10)", "t", "c.xhtml", originFontFamily = TEST_FONT)
         s.updateNote(created.id, "First")
         now = 8000L
 
@@ -210,7 +255,7 @@ class AnnotationStoreImplTest {
     @Test
     fun `updateNote with null clears the note and leaves the highlight intact`() = runTest {
         val s = store()
-        val created = s.createHighlight("abs1", "item1", "epubcfi(/6/4!/4/2,/1:0,/1:10)", "t", "c.xhtml")
+        val created = s.createHighlight("abs1", "item1", "epubcfi(/6/4!/4/2,/1:0,/1:10)", "t", "c.xhtml", originFontFamily = TEST_FONT)
         s.updateNote(created.id, "To be removed")
 
         s.updateNote(created.id, null)
@@ -224,7 +269,7 @@ class AnnotationStoreImplTest {
     @Test
     fun `tombstoned highlights are excluded from observeHighlights (and thus from rendering)`() = runTest {
         val s = store()
-        val created = s.createHighlight("abs1", "item1", "epubcfi(/6/4!/4/2,/1:0,/1:10)", "t", "c.xhtml")
+        val created = s.createHighlight("abs1", "item1", "epubcfi(/6/4!/4/2,/1:0,/1:10)", "t", "c.xhtml", originFontFamily = TEST_FONT)
         assertEquals(1, s.observeHighlights("abs1", "item1").first().size)
 
         s.delete(created.id)
@@ -239,6 +284,7 @@ class AnnotationStoreImplTest {
             cfi = "epubcfi(/6/6!/4/1:0)",
             textSnippet = "", chapterHref = "ch2.xhtml",
             spineIndex = 3, progression = 0.42, bookmarkTitle = "The Egg · 42%",
+            originFontFamily = TEST_FONT,
         )
         assertEquals(3, created.spineIndex)
         assertEquals(0.42, created.progression, 0.001)
@@ -251,6 +297,7 @@ class AnnotationStoreImplTest {
         val created = s.createBookmark(
             "abs1", "item1", "epubcfi(/6/6!/4/1:0)", "", "ch2.xhtml",
             spineIndex = 0, progression = 0.0, bookmarkTitle = "42%",
+            originFontFamily = TEST_FONT,
         )
         s.renameBookmark(created.id, "Where it gets weird")
         val updated = dao.getById(created.id)
@@ -269,12 +316,12 @@ class AnnotationStoreImplTest {
         val s = storeWithUniqueIds()
         // Insert out-of-order
         s.createHighlight("abs1", "item1", "cfi1", "text", "ch3.xhtml",
-            textBefore = "", textAfter = "")
+            textBefore = "", textAfter = "", originFontFamily = TEST_FONT)
             .also { rows.value = rows.value.map { e -> if (e.id == it.id) e.copy(spineIndex = 2, progression = 0.1) else e } }
         s.createBookmark("abs1", "item1", "cfi2", "", "ch1.xhtml",
-            spineIndex = 0, progression = 0.9, bookmarkTitle = "bm1")
+            spineIndex = 0, progression = 0.9, bookmarkTitle = "bm1", originFontFamily = TEST_FONT)
         s.createHighlight("abs1", "item1", "cfi3", "text2", "ch1.xhtml",
-            textBefore = "", textAfter = "")
+            textBefore = "", textAfter = "", originFontFamily = TEST_FONT)
             .also { rows.value = rows.value.map { e -> if (e.id == it.id) e.copy(spineIndex = 0, progression = 0.2) else e } }
 
         val result = storeWithUniqueIds().observeAnnotations("abs1", "item1").first()
@@ -289,7 +336,7 @@ class AnnotationStoreImplTest {
     fun `observeAnnotations excludes tombstoned annotations`() = runTest {
         val s = store()
         val bm = s.createBookmark("abs1", "item1", "cfi", "", "ch.xhtml",
-            spineIndex = 0, progression = 0.0, bookmarkTitle = "x")
+            spineIndex = 0, progression = 0.0, bookmarkTitle = "x", originFontFamily = TEST_FONT)
         s.delete(bm.id)
         val result = s.observeAnnotations("abs1", "item1").first()
         assertTrue(result.isEmpty())
@@ -299,9 +346,9 @@ class AnnotationStoreImplTest {
     fun observeAnnotationsForServerReturnsAllNonDeletedForServer() = runTest {
         var idSeq = 0
         val store = AnnotationStoreImpl(dao, deviceIdStore, clock = { 0L }, idGenerator = { "id-${idSeq++}" })
-        store.createHighlight("srv1", "b1", "epubcfi(/6/4!/4)", "snippet", "ch.html")
-        store.createBookmark("srv1", "b2", "epubcfi(/6/6!/2)", "top", "ch2.html", 1, 0.1, "mark")
-        store.createHighlight("srv2", "b9", "epubcfi(/6/4!/4)", "other source", "ch.html")
+        store.createHighlight("srv1", "b1", "epubcfi(/6/4!/4)", "snippet", "ch.html", originFontFamily = TEST_FONT)
+        store.createBookmark("srv1", "b2", "epubcfi(/6/6!/2)", "top", "ch2.html", 1, 0.1, "mark", originFontFamily = TEST_FONT)
+        store.createHighlight("srv2", "b9", "epubcfi(/6/4!/4)", "other source", "ch.html", originFontFamily = TEST_FONT)
 
         val forSrv1 = store.observeAnnotationsForSource("srv1").first()
         assertEquals(setOf("b1", "b2"), forSrv1.map { it.itemId }.toSet())

--- a/core/data/src/test/kotlin/com/riffle/core/data/AnnotationStoreTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/AnnotationStoreTest.kt
@@ -63,6 +63,26 @@ class AnnotationStoreTest {
                 if (it.id == id) it.copy(color = color, updatedAt = updatedAt, lastModifiedByDeviceId = deviceId) else it
             }
         }
+        override suspend fun backfillNullOriginFontFamily(
+            sourceId: String,
+            itemId: String,
+            fontFamily: String,
+            updatedAt: Long,
+            deviceId: String,
+        ): Int {
+            var updated = 0
+            rows.value = rows.value.map { row ->
+                if (row.sourceId == sourceId && row.itemId == itemId && !row.deleted && row.originFontFamily == null) {
+                    updated++
+                    row.copy(
+                        originFontFamily = fontFamily,
+                        updatedAt = updatedAt,
+                        lastModifiedByDeviceId = deviceId,
+                    )
+                } else row
+            }
+            return updated
+        }
         override suspend fun updateNote(id: String, note: String?, updatedAt: Long, deviceId: String) {
             rows.value = rows.value.map {
                 if (it.id == id) it.copy(note = note, updatedAt = updatedAt, lastModifiedByDeviceId = deviceId) else it

--- a/core/data/src/test/kotlin/com/riffle/core/data/AnnotationStoreTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/AnnotationStoreTest.kt
@@ -14,6 +14,8 @@ import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
+private const val TEST_FONT = "Georgia, serif"
+
 class AnnotationStoreTest {
 
     private class FakeAnnotationDao : AnnotationDao {
@@ -124,6 +126,7 @@ class AnnotationStoreTest {
             cfi = "epubcfi(/6/4!/4/2,/1:0,/1:10)",
             textSnippet = "selected words",
             chapterHref = "chap01.xhtml",
+            originFontFamily = TEST_FONT,
         )
 
         val saved = dao.getById("uuid-1")!!
@@ -146,7 +149,7 @@ class AnnotationStoreTest {
     fun `createHighlight returns the created annotation`() = runTest {
         val store = buildStore(idGenerator = { "uuid-1" })
 
-        val created = store.createHighlight("abs1", "item1", "epubcfi(x)", "snip", "c.xhtml")
+        val created = store.createHighlight("abs1", "item1", "epubcfi(x)", "snip", "c.xhtml", originFontFamily = TEST_FONT)
 
         assertEquals("uuid-1", created.id)
         assertEquals("epubcfi(x)", created.cfi)
@@ -159,8 +162,8 @@ class AnnotationStoreTest {
         var n = 0
         val store = buildStore(dao = dao, idGenerator = { "id-${n++}" })
 
-        store.createHighlight("abs1", "item1", "epubcfi(a)", "s", "c")
-        store.createHighlight("abs1", "item2", "epubcfi(b)", "s", "c")
+        store.createHighlight("abs1", "item1", "epubcfi(a)", "s", "c", originFontFamily = TEST_FONT)
+        store.createHighlight("abs1", "item2", "epubcfi(b)", "s", "c", originFontFamily = TEST_FONT)
 
         val list = store.observeHighlights("abs1", "item1").first()
         assertEquals(1, list.size)
@@ -171,7 +174,7 @@ class AnnotationStoreTest {
     fun `delete tombstones the annotation so it leaves the live query`() = runTest {
         val dao = FakeAnnotationDao()
         val store = buildStore(dao = dao, deviceId = "device-A", clock = { 7000L }, idGenerator = { "uuid-1" })
-        store.createHighlight("abs1", "item1", "epubcfi(a)", "s", "c")
+        store.createHighlight("abs1", "item1", "epubcfi(a)", "s", "c", originFontFamily = TEST_FONT)
 
         store.delete("uuid-1")
 
@@ -195,6 +198,7 @@ class AnnotationStoreTest {
             spineIndex = 0,
             progression = 0.0,
             bookmarkTitle = "",
+            originFontFamily = TEST_FONT,
         )
 
         val saved = dao.getById("bm-1")!!
@@ -216,7 +220,7 @@ class AnnotationStoreTest {
         val store = buildStore(idGenerator = { "bm-1" })
 
         val created = store.createBookmark("abs1", "item1", "epubcfi(/6/4!/4/2)", "snip", "c.xhtml",
-            spineIndex = 0, progression = 0.0, bookmarkTitle = "")
+            spineIndex = 0, progression = 0.0, bookmarkTitle = "", originFontFamily = TEST_FONT)
 
         assertEquals("bm-1", created.id)
         assertEquals(AnnotationEntity.TYPE_BOOKMARK, created.type)
@@ -228,11 +232,11 @@ class AnnotationStoreTest {
         var n = 0
         val store = buildStore(dao = dao, idGenerator = { "id-${n++}" })
 
-        store.createHighlight("abs1", "item1", "epubcfi(a)", "h", "c")
+        store.createHighlight("abs1", "item1", "epubcfi(a)", "h", "c", originFontFamily = TEST_FONT)
         store.createBookmark("abs1", "item1", "epubcfi(b)", "snip", "c",
-            spineIndex = 0, progression = 0.0, bookmarkTitle = "")
+            spineIndex = 0, progression = 0.0, bookmarkTitle = "", originFontFamily = TEST_FONT)
         store.createBookmark("abs1", "item2", "epubcfi(c)", "snip", "c",
-            spineIndex = 0, progression = 0.0, bookmarkTitle = "")  // different item
+            spineIndex = 0, progression = 0.0, bookmarkTitle = "", originFontFamily = TEST_FONT)  // different item
 
         val list = store.observeBookmarks("abs1", "item1").first()
         assertEquals(1, list.size)
@@ -244,7 +248,7 @@ class AnnotationStoreTest {
         val dao = FakeAnnotationDao()
         val store = buildStore(dao = dao, idGenerator = { "bm-1" })
         store.createBookmark("abs1", "item1", "epubcfi(/6/4!/4/2)", "snip", "c",
-            spineIndex = 0, progression = 0.0, bookmarkTitle = "")
+            spineIndex = 0, progression = 0.0, bookmarkTitle = "", originFontFamily = TEST_FONT)
 
         store.delete("bm-1")
 
@@ -257,9 +261,9 @@ class AnnotationStoreTest {
         var n = 0
         val store = buildStore(dao = dao, idGenerator = { "id-${n++}" })
 
-        store.createHighlight("abs1", "item1", "epubcfi(a)", "h", "c")
+        store.createHighlight("abs1", "item1", "epubcfi(a)", "h", "c", originFontFamily = TEST_FONT)
         store.createBookmark("abs1", "item1", "epubcfi(b)", "snip", "c",
-            spineIndex = 0, progression = 0.0, bookmarkTitle = "")
+            spineIndex = 0, progression = 0.0, bookmarkTitle = "", originFontFamily = TEST_FONT)
 
         val highlights = store.observeHighlights("abs1", "item1").first()
         assertEquals(1, highlights.size)

--- a/core/data/src/test/kotlin/com/riffle/core/data/AnnotationSweepTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/AnnotationSweepTest.kt
@@ -349,5 +349,12 @@ abstract class StubAnnotationDao : AnnotationDao {
     override suspend fun dirtySourceItems() = emptyList<AnnotationDao.DirtySourceItem>()
     override suspend fun markSynced(ids: List<String>, syncedAt: Long) {}
     override suspend fun purgeAgedTombstones(sourceId: String, itemId: String, cutoff: Long): Int = 0
+    override suspend fun backfillNullOriginFontFamily(
+        sourceId: String,
+        itemId: String,
+        fontFamily: String,
+        updatedAt: Long,
+        deviceId: String,
+    ): Int = 0
     override fun observeBooksWithHighlights(sourceId: String) = kotlinx.coroutines.flow.flowOf(emptyList<com.riffle.core.database.BookHighlightSummary>())
 }

--- a/core/data/src/test/kotlin/com/riffle/core/data/AnnotationSyncControllerLifecycleTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/AnnotationSyncControllerLifecycleTest.kt
@@ -1024,6 +1024,28 @@ private class LifecycleInMemoryAnnotationDao : AnnotationDao {
         return before - localAnnotations.size
     }
 
+    override suspend fun backfillNullOriginFontFamily(
+        sourceId: String,
+        itemId: String,
+        fontFamily: String,
+        updatedAt: Long,
+        deviceId: String,
+    ): Int {
+        var changed = 0
+        for (i in localAnnotations.indices) {
+            val row = localAnnotations[i]
+            if (row.sourceId == sourceId && row.itemId == itemId && !row.deleted && row.originFontFamily == null) {
+                localAnnotations[i] = row.copy(
+                    originFontFamily = fontFamily,
+                    updatedAt = updatedAt,
+                    lastModifiedByDeviceId = deviceId,
+                )
+                changed++
+            }
+        }
+        return changed
+    }
+
     override fun observeBooksWithHighlights(sourceId: String) =
         kotlinx.coroutines.flow.flowOf(emptyList<com.riffle.core.database.BookHighlightSummary>())
 }

--- a/core/data/src/test/kotlin/com/riffle/core/data/AnnotationSyncControllerReactiveTargetTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/AnnotationSyncControllerReactiveTargetTest.kt
@@ -98,5 +98,12 @@ private class NoOpAnnotationDao : AnnotationDao {
     override suspend fun dirtySourceItems(): List<AnnotationDao.DirtySourceItem> = emptyList()
     override suspend fun markSynced(ids: List<String>, syncedAt: Long) = Unit
     override suspend fun purgeAgedTombstones(sourceId: String, itemId: String, cutoff: Long): Int = 0
+    override suspend fun backfillNullOriginFontFamily(
+        sourceId: String,
+        itemId: String,
+        fontFamily: String,
+        updatedAt: Long,
+        deviceId: String,
+    ): Int = 0
     override fun observeBooksWithHighlights(sourceId: String): Flow<List<com.riffle.core.database.BookHighlightSummary>> = flowOf(emptyList())
 }

--- a/core/data/src/test/kotlin/com/riffle/core/data/FakeAnnotationDao.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/FakeAnnotationDao.kt
@@ -77,4 +77,12 @@ internal class FakeAnnotationDao : AnnotationDao {
 
     override suspend fun purgeAgedTombstones(sourceId: String, itemId: String, cutoff: Long): Int =
         error("not used by this fake")
+
+    override suspend fun backfillNullOriginFontFamily(
+        sourceId: String,
+        itemId: String,
+        fontFamily: String,
+        updatedAt: Long,
+        deviceId: String,
+    ): Int = error("not used by this fake")
 }

--- a/core/database/schemas/com.riffle.core.database.RiffleDatabase/50.json
+++ b/core/database/schemas/com.riffle.core.database.RiffleDatabase/50.json
@@ -2,7 +2,7 @@
   "formatVersion": 1,
   "database": {
     "version": 50,
-    "identityHash": "fb0c262bdff854d0b018d034368d39ce",
+    "identityHash": "7f7767d9af9c0a66584ff084bacdfc1a",
     "entities": [
       {
         "tableName": "sources",
@@ -132,7 +132,7 @@
       },
       {
         "tableName": "library_items",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `id` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `title` TEXT NOT NULL, `author` TEXT NOT NULL, `coverUrl` TEXT, `readingProgress` REAL NOT NULL, `ebookFileIno` TEXT, `ebookFormat` TEXT NOT NULL, `hasAudio` INTEGER NOT NULL, `audioDurationSec` REAL NOT NULL, `description` TEXT, `seriesName` TEXT, `publishedYear` TEXT, `genres` TEXT NOT NULL, `publisher` TEXT, `language` TEXT, `lastOpenedAt` INTEGER, `addedAt` INTEGER, `isbn` TEXT, `asin` TEXT, `finishedAt` INTEGER, PRIMARY KEY(`sourceId`, `id`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `id` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `title` TEXT NOT NULL, `author` TEXT NOT NULL, `coverUrl` TEXT, `readingProgress` REAL NOT NULL, `ebookFileIno` TEXT, `ebookFormat` TEXT NOT NULL, `hasAudio` INTEGER NOT NULL, `audioDurationSec` REAL NOT NULL, `description` TEXT, `seriesName` TEXT, `seriesSequence` TEXT, `publishedYear` TEXT, `genres` TEXT NOT NULL, `publisher` TEXT, `language` TEXT, `lastOpenedAt` INTEGER, `addedAt` INTEGER, `isbn` TEXT, `asin` TEXT, `finishedAt` INTEGER, PRIMARY KEY(`sourceId`, `id`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
         "fields": [
           {
             "fieldPath": "sourceId",
@@ -206,6 +206,11 @@
           {
             "fieldPath": "seriesName",
             "columnName": "seriesName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seriesSequence",
+            "columnName": "seriesSequence",
             "affinity": "TEXT"
           },
           {
@@ -906,7 +911,7 @@
       },
       {
         "tableName": "annotations",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `type` TEXT NOT NULL, `cfi` TEXT NOT NULL, `color` TEXT NOT NULL, `note` TEXT, `textSnippet` TEXT NOT NULL, `textBefore` TEXT NOT NULL, `textAfter` TEXT NOT NULL, `chapterHref` TEXT NOT NULL, `spineIndex` INTEGER NOT NULL, `progression` REAL NOT NULL, `bookmarkTitle` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `originDeviceId` TEXT NOT NULL, `lastModifiedByDeviceId` TEXT NOT NULL, `deleted` INTEGER NOT NULL, `lastSyncedAt` INTEGER NOT NULL, `embeddedFigures` TEXT, `imageHref` TEXT, `imageSvg` TEXT, `imageBytes` TEXT, `originFontFamily` TEXT, PRIMARY KEY(`id`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `type` TEXT NOT NULL, `cfi` TEXT NOT NULL, `color` TEXT NOT NULL, `note` TEXT, `textSnippet` TEXT NOT NULL, `textBefore` TEXT NOT NULL, `textAfter` TEXT NOT NULL, `chapterHref` TEXT NOT NULL, `spineIndex` INTEGER NOT NULL, `progression` REAL NOT NULL, `bookmarkTitle` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `originDeviceId` TEXT NOT NULL, `lastModifiedByDeviceId` TEXT NOT NULL, `deleted` INTEGER NOT NULL, `lastSyncedAt` INTEGER NOT NULL, `embeddedFigures` TEXT, `imageHref` TEXT, `imageSvg` TEXT, `imageBytes` TEXT, PRIMARY KEY(`id`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
         "fields": [
           {
             "fieldPath": "id",
@@ -1045,11 +1050,6 @@
           {
             "fieldPath": "imageBytes",
             "columnName": "imageBytes",
-            "affinity": "TEXT"
-          },
-          {
-            "fieldPath": "originFontFamily",
-            "columnName": "originFontFamily",
             "affinity": "TEXT"
           }
         ],
@@ -1605,7 +1605,7 @@
     ],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'fb0c262bdff854d0b018d034368d39ce')"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '7f7767d9af9c0a66584ff084bacdfc1a')"
     ]
   }
 }

--- a/core/database/schemas/com.riffle.core.database.RiffleDatabase/50.json
+++ b/core/database/schemas/com.riffle.core.database.RiffleDatabase/50.json
@@ -2,7 +2,7 @@
   "formatVersion": 1,
   "database": {
     "version": 50,
-    "identityHash": "7f7767d9af9c0a66584ff084bacdfc1a",
+    "identityHash": "fb0c262bdff854d0b018d034368d39ce",
     "entities": [
       {
         "tableName": "sources",
@@ -132,7 +132,7 @@
       },
       {
         "tableName": "library_items",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `id` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `title` TEXT NOT NULL, `author` TEXT NOT NULL, `coverUrl` TEXT, `readingProgress` REAL NOT NULL, `ebookFileIno` TEXT, `ebookFormat` TEXT NOT NULL, `hasAudio` INTEGER NOT NULL, `audioDurationSec` REAL NOT NULL, `description` TEXT, `seriesName` TEXT, `seriesSequence` TEXT, `publishedYear` TEXT, `genres` TEXT NOT NULL, `publisher` TEXT, `language` TEXT, `lastOpenedAt` INTEGER, `addedAt` INTEGER, `isbn` TEXT, `asin` TEXT, `finishedAt` INTEGER, PRIMARY KEY(`sourceId`, `id`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `id` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `title` TEXT NOT NULL, `author` TEXT NOT NULL, `coverUrl` TEXT, `readingProgress` REAL NOT NULL, `ebookFileIno` TEXT, `ebookFormat` TEXT NOT NULL, `hasAudio` INTEGER NOT NULL, `audioDurationSec` REAL NOT NULL, `description` TEXT, `seriesName` TEXT, `publishedYear` TEXT, `genres` TEXT NOT NULL, `publisher` TEXT, `language` TEXT, `lastOpenedAt` INTEGER, `addedAt` INTEGER, `isbn` TEXT, `asin` TEXT, `finishedAt` INTEGER, PRIMARY KEY(`sourceId`, `id`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
         "fields": [
           {
             "fieldPath": "sourceId",
@@ -206,11 +206,6 @@
           {
             "fieldPath": "seriesName",
             "columnName": "seriesName",
-            "affinity": "TEXT"
-          },
-          {
-            "fieldPath": "seriesSequence",
-            "columnName": "seriesSequence",
             "affinity": "TEXT"
           },
           {
@@ -911,7 +906,7 @@
       },
       {
         "tableName": "annotations",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `type` TEXT NOT NULL, `cfi` TEXT NOT NULL, `color` TEXT NOT NULL, `note` TEXT, `textSnippet` TEXT NOT NULL, `textBefore` TEXT NOT NULL, `textAfter` TEXT NOT NULL, `chapterHref` TEXT NOT NULL, `spineIndex` INTEGER NOT NULL, `progression` REAL NOT NULL, `bookmarkTitle` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `originDeviceId` TEXT NOT NULL, `lastModifiedByDeviceId` TEXT NOT NULL, `deleted` INTEGER NOT NULL, `lastSyncedAt` INTEGER NOT NULL, `embeddedFigures` TEXT, `imageHref` TEXT, `imageSvg` TEXT, `imageBytes` TEXT, PRIMARY KEY(`id`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `type` TEXT NOT NULL, `cfi` TEXT NOT NULL, `color` TEXT NOT NULL, `note` TEXT, `textSnippet` TEXT NOT NULL, `textBefore` TEXT NOT NULL, `textAfter` TEXT NOT NULL, `chapterHref` TEXT NOT NULL, `spineIndex` INTEGER NOT NULL, `progression` REAL NOT NULL, `bookmarkTitle` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `originDeviceId` TEXT NOT NULL, `lastModifiedByDeviceId` TEXT NOT NULL, `deleted` INTEGER NOT NULL, `lastSyncedAt` INTEGER NOT NULL, `embeddedFigures` TEXT, `imageHref` TEXT, `imageSvg` TEXT, `imageBytes` TEXT, `originFontFamily` TEXT, PRIMARY KEY(`id`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
         "fields": [
           {
             "fieldPath": "id",
@@ -1050,6 +1045,11 @@
           {
             "fieldPath": "imageBytes",
             "columnName": "imageBytes",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originFontFamily",
+            "columnName": "originFontFamily",
             "affinity": "TEXT"
           }
         ],
@@ -1605,7 +1605,7 @@
     ],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '7f7767d9af9c0a66584ff084bacdfc1a')"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'fb0c262bdff854d0b018d034368d39ce')"
     ]
   }
 }

--- a/core/database/schemas/com.riffle.core.database.RiffleDatabase/51.json
+++ b/core/database/schemas/com.riffle.core.database.RiffleDatabase/51.json
@@ -1,0 +1,1616 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 51,
+    "identityHash": "d42e29a27b98668020137c11c18fe488",
+    "entities": [
+      {
+        "tableName": "sources",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `url` TEXT NOT NULL, `isActive` INTEGER NOT NULL, `insecureConnectionAllowed` INTEGER NOT NULL, `username` TEXT NOT NULL, `serverType` TEXT NOT NULL, `absUserId` TEXT, `type` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "isActive",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "insecureConnectionAllowed",
+            "columnName": "insecureConnectionAllowed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "username",
+            "columnName": "username",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverType",
+            "columnName": "serverType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absUserId",
+            "columnName": "absUserId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "libraries",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `mediaType` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `isUnsupported` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `id`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaType",
+            "columnName": "mediaType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isUnsupported",
+            "columnName": "isUnsupported",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_libraries_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_libraries_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "library_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `id` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `title` TEXT NOT NULL, `author` TEXT NOT NULL, `coverUrl` TEXT, `readingProgress` REAL NOT NULL, `ebookFileIno` TEXT, `ebookFormat` TEXT NOT NULL, `hasAudio` INTEGER NOT NULL, `audioDurationSec` REAL NOT NULL, `description` TEXT, `seriesName` TEXT, `seriesSequence` TEXT, `publishedYear` TEXT, `genres` TEXT NOT NULL, `publisher` TEXT, `language` TEXT, `lastOpenedAt` INTEGER, `addedAt` INTEGER, `isbn` TEXT, `asin` TEXT, `finishedAt` INTEGER, PRIMARY KEY(`sourceId`, `id`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "coverUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "readingProgress",
+            "columnName": "readingProgress",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ebookFileIno",
+            "columnName": "ebookFileIno",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "ebookFormat",
+            "columnName": "ebookFormat",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hasAudio",
+            "columnName": "hasAudio",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "audioDurationSec",
+            "columnName": "audioDurationSec",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seriesName",
+            "columnName": "seriesName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seriesSequence",
+            "columnName": "seriesSequence",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "publishedYear",
+            "columnName": "publishedYear",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "genres",
+            "columnName": "genres",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "publisher",
+            "columnName": "publisher",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "language",
+            "columnName": "language",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastOpenedAt",
+            "columnName": "lastOpenedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "isbn",
+            "columnName": "isbn",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "asin",
+            "columnName": "asin",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "finishedAt",
+            "columnName": "finishedAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_library_items_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_library_items_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "series",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `name` TEXT NOT NULL, `coverUrl` TEXT, `bookCount` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "coverUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "bookCount",
+            "columnName": "bookCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "collections",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `name` TEXT NOT NULL, `bookCount` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookCount",
+            "columnName": "bookCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "series_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`seriesId` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `sequenceOrder` REAL NOT NULL, PRIMARY KEY(`seriesId`, `sourceId`, `itemId`))",
+        "fields": [
+          {
+            "fieldPath": "seriesId",
+            "columnName": "seriesId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sequenceOrder",
+            "columnName": "sequenceOrder",
+            "affinity": "REAL",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "seriesId",
+            "sourceId",
+            "itemId"
+          ]
+        }
+      },
+      {
+        "tableName": "collection_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`collectionId` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, PRIMARY KEY(`collectionId`, `sourceId`, `itemId`))",
+        "fields": [
+          {
+            "fieldPath": "collectionId",
+            "columnName": "collectionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "collectionId",
+            "sourceId",
+            "itemId"
+          ]
+        }
+      },
+      {
+        "tableName": "reading_positions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `cfi` TEXT NOT NULL, `localUpdatedAt` INTEGER NOT NULL, `lastSyncedAt` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `itemId`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cfi",
+            "columnName": "cfi",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localUpdatedAt",
+            "columnName": "localUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncedAt",
+            "columnName": "lastSyncedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "itemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_reading_positions_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_reading_positions_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "book_formatting_preferences",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `scope` TEXT NOT NULL, `fontSize` REAL, `theme` TEXT, `fontFamily` TEXT, `lineSpacing` REAL, `margins` REAL, `orientation` TEXT, `showChapterMap` INTEGER, `showReadingProgressLabels` INTEGER, `showCurrentChapterLabel` INTEGER, `doublePageSpread` INTEGER, `justifyText` INTEGER, `showReadingTimeEstimate` INTEGER, PRIMARY KEY(`sourceId`, `itemId`, `scope`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scope",
+            "columnName": "scope",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fontSize",
+            "columnName": "fontSize",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "theme",
+            "columnName": "theme",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "fontFamily",
+            "columnName": "fontFamily",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lineSpacing",
+            "columnName": "lineSpacing",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "margins",
+            "columnName": "margins",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "orientation",
+            "columnName": "orientation",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "showChapterMap",
+            "columnName": "showChapterMap",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "showReadingProgressLabels",
+            "columnName": "showReadingProgressLabels",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "showCurrentChapterLabel",
+            "columnName": "showCurrentChapterLabel",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "doublePageSpread",
+            "columnName": "doublePageSpread",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "justifyText",
+            "columnName": "justifyText",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "showReadingTimeEstimate",
+            "columnName": "showReadingTimeEstimate",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "itemId",
+            "scope"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_book_formatting_preferences_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_book_formatting_preferences_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "readaloud_links",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`absSourceId` TEXT NOT NULL, `absLibraryItemId` TEXT NOT NULL, `storytellerSourceId` TEXT NOT NULL, `storytellerBookId` TEXT NOT NULL, `state` TEXT NOT NULL, `userConfirmed` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `identityResult` TEXT NOT NULL, PRIMARY KEY(`absSourceId`, `absLibraryItemId`), FOREIGN KEY(`storytellerSourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`absSourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "absSourceId",
+            "columnName": "absSourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absLibraryItemId",
+            "columnName": "absLibraryItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerSourceId",
+            "columnName": "storytellerSourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerBookId",
+            "columnName": "storytellerBookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userConfirmed",
+            "columnName": "userConfirmed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityResult",
+            "columnName": "identityResult",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "absSourceId",
+            "absLibraryItemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_readaloud_links_storytellerSourceId_storytellerBookId",
+            "unique": false,
+            "columnNames": [
+              "storytellerSourceId",
+              "storytellerBookId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_readaloud_links_storytellerSourceId_storytellerBookId` ON `${TABLE_NAME}` (`storytellerSourceId`, `storytellerBookId`)"
+          },
+          {
+            "name": "index_readaloud_links_storytellerSourceId",
+            "unique": false,
+            "columnNames": [
+              "storytellerSourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_readaloud_links_storytellerSourceId` ON `${TABLE_NAME}` (`storytellerSourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "storytellerSourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "absSourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "readaloud_candidates",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`storytellerSourceId` TEXT NOT NULL, `storytellerBookId` TEXT NOT NULL, `absSourceId` TEXT NOT NULL, `absLibraryItemId` TEXT NOT NULL, `score` REAL NOT NULL, PRIMARY KEY(`storytellerSourceId`, `storytellerBookId`, `absSourceId`, `absLibraryItemId`), FOREIGN KEY(`storytellerSourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`absSourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "storytellerSourceId",
+            "columnName": "storytellerSourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerBookId",
+            "columnName": "storytellerBookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absSourceId",
+            "columnName": "absSourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absLibraryItemId",
+            "columnName": "absLibraryItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "score",
+            "columnName": "score",
+            "affinity": "REAL",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "storytellerSourceId",
+            "storytellerBookId",
+            "absSourceId",
+            "absLibraryItemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_readaloud_candidates_absSourceId",
+            "unique": false,
+            "columnNames": [
+              "absSourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_readaloud_candidates_absSourceId` ON `${TABLE_NAME}` (`absSourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "storytellerSourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "absSourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "readaloud_dismissals",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`storytellerSourceId` TEXT NOT NULL, `storytellerBookId` TEXT NOT NULL, `scope` TEXT NOT NULL, `absSourceId` TEXT NOT NULL, `absLibraryItemId` TEXT NOT NULL, PRIMARY KEY(`storytellerSourceId`, `storytellerBookId`, `absSourceId`, `absLibraryItemId`), FOREIGN KEY(`storytellerSourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "storytellerSourceId",
+            "columnName": "storytellerSourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerBookId",
+            "columnName": "storytellerBookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scope",
+            "columnName": "scope",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absSourceId",
+            "columnName": "absSourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absLibraryItemId",
+            "columnName": "absLibraryItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "storytellerSourceId",
+            "storytellerBookId",
+            "absSourceId",
+            "absLibraryItemId"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "storytellerSourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "cross_epub_index",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`absEpubChecksum` TEXT NOT NULL, `storytellerEpubChecksum` TEXT NOT NULL, `perChapterMapsBlob` TEXT NOT NULL, `builtAt` INTEGER NOT NULL, PRIMARY KEY(`absEpubChecksum`, `storytellerEpubChecksum`))",
+        "fields": [
+          {
+            "fieldPath": "absEpubChecksum",
+            "columnName": "absEpubChecksum",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerEpubChecksum",
+            "columnName": "storytellerEpubChecksum",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "perChapterMapsBlob",
+            "columnName": "perChapterMapsBlob",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "builtAt",
+            "columnName": "builtAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "absEpubChecksum",
+            "storytellerEpubChecksum"
+          ]
+        }
+      },
+      {
+        "tableName": "annotations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `type` TEXT NOT NULL, `cfi` TEXT NOT NULL, `color` TEXT NOT NULL, `note` TEXT, `textSnippet` TEXT NOT NULL, `textBefore` TEXT NOT NULL, `textAfter` TEXT NOT NULL, `chapterHref` TEXT NOT NULL, `spineIndex` INTEGER NOT NULL, `progression` REAL NOT NULL, `bookmarkTitle` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `originDeviceId` TEXT NOT NULL, `lastModifiedByDeviceId` TEXT NOT NULL, `deleted` INTEGER NOT NULL, `lastSyncedAt` INTEGER NOT NULL, `embeddedFigures` TEXT, `imageHref` TEXT, `imageSvg` TEXT, `imageBytes` TEXT, `originFontFamily` TEXT, PRIMARY KEY(`id`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cfi",
+            "columnName": "cfi",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "color",
+            "columnName": "color",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "note",
+            "columnName": "note",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "textSnippet",
+            "columnName": "textSnippet",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "textBefore",
+            "columnName": "textBefore",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "textAfter",
+            "columnName": "textAfter",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chapterHref",
+            "columnName": "chapterHref",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "spineIndex",
+            "columnName": "spineIndex",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "progression",
+            "columnName": "progression",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookmarkTitle",
+            "columnName": "bookmarkTitle",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "originDeviceId",
+            "columnName": "originDeviceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastModifiedByDeviceId",
+            "columnName": "lastModifiedByDeviceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deleted",
+            "columnName": "deleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncedAt",
+            "columnName": "lastSyncedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "embeddedFigures",
+            "columnName": "embeddedFigures",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "imageHref",
+            "columnName": "imageHref",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "imageSvg",
+            "columnName": "imageSvg",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "imageBytes",
+            "columnName": "imageBytes",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originFontFamily",
+            "columnName": "originFontFamily",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_annotations_sourceId_itemId",
+            "unique": false,
+            "columnNames": [
+              "sourceId",
+              "itemId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_annotations_sourceId_itemId` ON `${TABLE_NAME}` (`sourceId`, `itemId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "readaloud_resume_positions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `href` TEXT NOT NULL, `progression` REAL, `fragmentRef` TEXT, `localUpdatedAt` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `itemId`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "href",
+            "columnName": "href",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "progression",
+            "columnName": "progression",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "fragmentRef",
+            "columnName": "fragmentRef",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localUpdatedAt",
+            "columnName": "localUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "itemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_readaloud_resume_positions_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_readaloud_resume_positions_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "audio_playback_preferences",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `bookId` TEXT NOT NULL, `speed` REAL, PRIMARY KEY(`sourceId`, `bookId`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "speed",
+            "columnName": "speed",
+            "affinity": "REAL"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "bookId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_audio_playback_preferences_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_audio_playback_preferences_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "audiobook_positions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `positionSec` REAL NOT NULL, `localUpdatedAt` INTEGER NOT NULL, `lastSyncedAt` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `itemId`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "positionSec",
+            "columnName": "positionSec",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localUpdatedAt",
+            "columnName": "localUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncedAt",
+            "columnName": "lastSyncedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "itemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_audiobook_positions_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_audiobook_positions_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "audiobook_bookmarks",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `positionSec` REAL NOT NULL, `title` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `localUpdatedAt` INTEGER NOT NULL, `lastSyncedAt` INTEGER NOT NULL, `deleted` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "positionSec",
+            "columnName": "positionSec",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localUpdatedAt",
+            "columnName": "localUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncedAt",
+            "columnName": "lastSyncedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deleted",
+            "columnName": "deleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_audiobook_bookmarks_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_audiobook_bookmarks_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          },
+          {
+            "name": "index_audiobook_bookmarks_sourceId_itemId",
+            "unique": false,
+            "columnNames": [
+              "sourceId",
+              "itemId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_audiobook_bookmarks_sourceId_itemId` ON `${TABLE_NAME}` (`sourceId`, `itemId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "toc_cache",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `ebookFileIno` TEXT NOT NULL, `entriesJson` TEXT NOT NULL, PRIMARY KEY(`sourceId`, `itemId`))",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ebookFileIno",
+            "columnName": "ebookFileIno",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entriesJson",
+            "columnName": "entriesJson",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "itemId"
+          ]
+        }
+      },
+      {
+        "tableName": "audiobook_chapter_cache",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `chaptersJson` TEXT NOT NULL, PRIMARY KEY(`sourceId`, `itemId`))",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chaptersJson",
+            "columnName": "chaptersJson",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "itemId"
+          ]
+        }
+      },
+      {
+        "tableName": "local_files_folders",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `treeUri` TEXT NOT NULL, `displayName` TEXT NOT NULL, `addedAtEpochMs` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `treeUri`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "treeUri",
+            "columnName": "treeUri",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAtEpochMs",
+            "columnName": "addedAtEpochMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "treeUri"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_files_folders_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_files_folders_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "local_files_files",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `sourceItemId` TEXT NOT NULL, `folderTreeUri` TEXT NOT NULL, `originalUri` TEXT NOT NULL, `copiedPath` TEXT NOT NULL, `coverPath` TEXT, `format` TEXT NOT NULL, `sizeBytes` INTEGER NOT NULL, `mtimeEpochMs` INTEGER NOT NULL, `lastSeenAtEpochMs` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `sourceItemId`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceItemId",
+            "columnName": "sourceItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "folderTreeUri",
+            "columnName": "folderTreeUri",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "originalUri",
+            "columnName": "originalUri",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "copiedPath",
+            "columnName": "copiedPath",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverPath",
+            "columnName": "coverPath",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "format",
+            "columnName": "format",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sizeBytes",
+            "columnName": "sizeBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mtimeEpochMs",
+            "columnName": "mtimeEpochMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSeenAtEpochMs",
+            "columnName": "lastSeenAtEpochMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "sourceItemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_files_files_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_files_files_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'd42e29a27b98668020137c11c18fe488')"
+    ]
+  }
+}

--- a/core/database/src/androidTest/kotlin/com/riffle/core/database/AnnotationDaoTest.kt
+++ b/core/database/src/androidTest/kotlin/com/riffle/core/database/AnnotationDaoTest.kt
@@ -101,6 +101,21 @@ class AnnotationDaoTest {
         assertEquals("the selected text", a.textSnippet)
     }
 
+    // The captured `originFontFamily` (per-annotation, from getComputedStyle at the source
+    // range) round-trips intact; legacy rows without a value read back as null. Pins that the
+    // Annotations View can retrieve the origin's font-family for each excerpt.
+    @Test
+    fun originFontFamily_roundTripsAndDefaultsNull() = runTest {
+        dao.upsert(highlight("h1"))
+        dao.upsert(highlight("h2").copy(originFontFamily = "\"Fira Sans\", sans-serif"))
+
+        val legacy = requireNotNull(dao.getById("h1")) { "h1 must exist" }
+        val captured = requireNotNull(dao.getById("h2")) { "h2 must exist" }
+
+        assertEquals(null, legacy.originFontFamily)
+        assertEquals("\"Fira Sans\", sans-serif", captured.originFontFamily)
+    }
+
     // A CFI *range* string must survive storage byte-for-byte — it is the load-bearing anchor.
     @Test
     fun cfiRange_persistsIntact() = runTest {

--- a/core/database/src/androidTest/kotlin/com/riffle/core/database/MigrationTest.kt
+++ b/core/database/src/androidTest/kotlin/com/riffle/core/database/MigrationTest.kt
@@ -1919,7 +1919,7 @@ class MigrationTest {
         }
 
         val db = helper.runMigrationsAndValidate(
-            TEST_DB, 49, true,
+            TEST_DB, 51, true,
             RiffleDatabase.MIGRATION_1_2,
             RiffleDatabase.MIGRATION_2_3,
             RiffleDatabase.MIGRATION_3_4,
@@ -1969,6 +1969,7 @@ class MigrationTest {
             RiffleDatabase.MIGRATION_47_48,
             RiffleDatabase.MIGRATION_48_49,
             RiffleDatabase.MIGRATION_49_50,
+            RiffleDatabase.MIGRATION_50_51,
         )
 
         db.query("SELECT url, username, serverType, absUserId, type FROM sources WHERE id = 's1'").use { cursor ->
@@ -2192,6 +2193,65 @@ class MigrationTest {
             assertEquals("i1", c.getString(0))
             assertEquals("The Series", c.getString(1))
             assertTrue("new seriesSequence column defaults to NULL", c.isNull(2))
+        }
+        db.close()
+    }
+
+    // Origin-font capture: adds a single nullable `originFontFamily` column to `annotations`
+    // for per-annotation font-family (from `getComputedStyle` at the source range) so the
+    // Annotations View can render each excerpt in the origin's face. Pre-existing rows must
+    // survive with the new column defaulting to NULL; new rows must round-trip a value.
+    @Test
+    fun migration50To51_addsOriginFontFamilyColumnToAnnotations() {
+        helper.createDatabase(TEST_DB, 50).apply {
+            execSQL(
+                "INSERT INTO sources (id, url, isActive, insecureConnectionAllowed, username, serverType, absUserId, type) " +
+                    "VALUES ('s1', 'http://abs', 1, 0, 'test', 'AUDIOBOOKSHELF', 'u1', 'ABS')"
+            )
+            execSQL(
+                """
+                INSERT INTO annotations
+                  (id, sourceId, itemId, type, cfi, color, note, textSnippet, textBefore, textAfter,
+                   chapterHref, spineIndex, progression, bookmarkTitle, createdAt, updatedAt,
+                   originDeviceId, lastModifiedByDeviceId, deleted, lastSyncedAt,
+                   embeddedFigures, imageHref, imageSvg, imageBytes)
+                VALUES
+                  ('a-legacy','s1','i1','HIGHLIGHT','epubcfi(/6/2!/4/2,/1:0,/1:5)','yellow',NULL,
+                   'meaning','','','ch1.xhtml',0,0.5,'',1000,1000,'d1','d1',0,0,
+                   NULL,NULL,NULL,NULL)
+                """.trimIndent()
+            )
+            close()
+        }
+
+        val db = helper.runMigrationsAndValidate(TEST_DB, 51, true, RiffleDatabase.MIGRATION_50_51)
+
+        // Pre-existing row preserved; new column defaults to NULL.
+        db.query("SELECT id, textSnippet, originFontFamily FROM annotations WHERE id = 'a-legacy'").use { c ->
+            assertEquals(1, c.count)
+            assertTrue(c.moveToFirst())
+            assertEquals("a-legacy", c.getString(0))
+            assertEquals("meaning", c.getString(1))
+            assertTrue("legacy row's originFontFamily defaults to NULL", c.isNull(2))
+        }
+
+        // New rows round-trip a captured font-family.
+        db.execSQL(
+            """
+            INSERT INTO annotations
+              (id, sourceId, itemId, type, cfi, color, note, textSnippet, textBefore, textAfter,
+               chapterHref, spineIndex, progression, bookmarkTitle, createdAt, updatedAt,
+               originDeviceId, lastModifiedByDeviceId, deleted, lastSyncedAt,
+               embeddedFigures, imageHref, imageSvg, imageBytes, originFontFamily)
+            VALUES
+              ('a-new','s1','i1','HIGHLIGHT','epubcfi(/6/2!/4/2,/1:6,/1:12)','green',NULL,
+               'example','','','ch1.xhtml',0,0.6,'',2000,2000,'d1','d1',0,0,
+               NULL,NULL,NULL,NULL,'Georgia, serif')
+            """.trimIndent()
+        )
+        db.query("SELECT originFontFamily FROM annotations WHERE id = 'a-new'").use { c ->
+            assertTrue(c.moveToFirst())
+            assertEquals("Georgia, serif", c.getString(0))
         }
         db.close()
     }

--- a/core/database/src/main/kotlin/com/riffle/core/database/AnnotationDao.kt
+++ b/core/database/src/main/kotlin/com/riffle/core/database/AnnotationDao.kt
@@ -107,6 +107,27 @@ interface AnnotationDao {
     @Query("UPDATE annotations SET bookmarkTitle = :title, updatedAt = :updatedAt, lastModifiedByDeviceId = :deviceId WHERE id = :id AND type = 'BOOKMARK'")
     suspend fun renameBookmark(id: String, title: String, updatedAt: Long, deviceId: String)
 
+    /**
+     * Backfill `originFontFamily` for every legacy null-font row on this book (issue #484). Fires
+     * when the reader opens the source book and the WebView reports its computed body font.
+     * `deleted = 0` guards against pushing tombs back to peers on account of a font-only change,
+     * and `updatedAt`/`lastModifiedByDeviceId` bumps ensure the change propagates through sync.
+     * Only runs for rows where the column is still null: subsequent opens are cheap no-ops.
+     */
+    @Query(
+        "UPDATE annotations SET originFontFamily = :fontFamily, updatedAt = :updatedAt, " +
+            "lastModifiedByDeviceId = :deviceId " +
+            "WHERE sourceId = :sourceId AND itemId = :itemId AND deleted = 0 " +
+            "AND originFontFamily IS NULL"
+    )
+    suspend fun backfillNullOriginFontFamily(
+        sourceId: String,
+        itemId: String,
+        fontFamily: String,
+        updatedAt: Long,
+        deviceId: String,
+    ): Int
+
     /** Pending-row count for one book — live Flow for reader-chrome and per-book status. */
     @Query("SELECT COUNT(*) FROM annotations WHERE sourceId = :sourceId AND itemId = :itemId AND updatedAt > lastSyncedAt")
     fun observePendingCountForBook(sourceId: String, itemId: String): Flow<Int>

--- a/core/database/src/main/kotlin/com/riffle/core/database/AnnotationEntity.kt
+++ b/core/database/src/main/kotlin/com/riffle/core/database/AnnotationEntity.kt
@@ -68,6 +68,14 @@ data class AnnotationEntity(
      * Publication's container to be loaded.
      */
     val imageBytes: String? = null,
+    /**
+     * Computed `font-family` at the annotation's source range (start-element `getComputedStyle`
+     * result). Captured at creation time so the Annotations View can render each excerpt in the
+     * face the reader saw in the origin, even when the origin came from publisher CSS. Nullable
+     * because rows created before this column existed (and W3C sync ingest) have no value;
+     * lazy-backfilled on source-chapter load in FullBook mode.
+     */
+    val originFontFamily: String? = null,
 ) {
     companion object {
         const val TYPE_HIGHLIGHT = "HIGHLIGHT"

--- a/core/database/src/main/kotlin/com/riffle/core/database/RiffleDatabase.kt
+++ b/core/database/src/main/kotlin/com/riffle/core/database/RiffleDatabase.kt
@@ -30,7 +30,7 @@ import androidx.sqlite.db.SupportSQLiteDatabase
         LocalFilesFolderEntity::class,
         LocalFilesFileEntity::class,
     ],
-    version = 50,
+    version = 51,
     exportSchema = true,
 )
 abstract class RiffleDatabase : RoomDatabase() {
@@ -1325,6 +1325,15 @@ abstract class RiffleDatabase : RoomDatabase() {
         val MIGRATION_49_50 = object : Migration(49, 50) {
             override fun migrate(db: SupportSQLiteDatabase) {
                 db.execSQL("ALTER TABLE `library_items` ADD COLUMN `seriesSequence` TEXT")
+            }
+        }
+
+        // Origin-font capture per annotation: computed `font-family` at the source range, so the
+        // Annotations View renders each excerpt in the face the reader saw in the origin. Nullable
+        // so existing rows survive the ALTER; lazy-backfilled on source-chapter load.
+        val MIGRATION_50_51 = object : Migration(50, 51) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("ALTER TABLE annotations ADD COLUMN originFontFamily TEXT")
             }
         }
     }

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/Annotation.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/Annotation.kt
@@ -23,6 +23,12 @@ data class Annotation(
     val imageHref: String? = null,
     val imageSvg: String? = null,
     val imageBytes: String? = null,
+    /**
+     * Computed `font-family` at the annotation's source range, captured at creation time so the
+     * Annotations View renders each excerpt in the origin's face (issue #484). Nullable because
+     * rows created before this field existed (and W3C sync ingest) have no value.
+     */
+    val originFontFamily: String? = null,
 )
 
 /**

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/AnnotationStore.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/AnnotationStore.kt
@@ -70,6 +70,18 @@ interface AnnotationStore {
         color: String = DEFAULT_COLOR,
     ): Annotation
 
+    /**
+     * Backfill `originFontFamily` on every legacy null-font annotation on this book with the
+     * book's computed body font (issue #484). Called once per Publication load once the reader
+     * WebView has reported its `getComputedStyle(document.body).fontFamily`. Returns the number
+     * of rows updated (0 on subsequent opens once the whole book is populated).
+     */
+    suspend fun backfillNullOriginFontFamily(
+        sourceId: String,
+        itemId: String,
+        fontFamily: String,
+    ): Int
+
     suspend fun delete(id: String)
     suspend fun recolor(id: String, color: String)
     suspend fun updateNote(id: String, note: String?)

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/AnnotationStore.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/AnnotationStore.kt
@@ -30,6 +30,11 @@ interface AnnotationStore {
         /** Figures enclosed by the highlight's CFI range (Task 7), or null when none / not yet
          *  resolved. An empty list is normalized to null on the persisted entity. */
         embeddedFigures: List<EmbeddedFigure>? = null,
+        /** Computed `font-family` at the source range's start element (per [issue 484](
+         *  https://github.com/pkmetski/riffle/issues/484)). Non-null contract: the reader's
+         *  write path must resolve this from the WebView's `getComputedStyle` at selection
+         *  time and fall back to the book's body font — never null in production. */
+        originFontFamily: String,
     ): Annotation
 
     suspend fun createBookmark(
@@ -41,6 +46,9 @@ interface AnnotationStore {
         spineIndex: Int,
         progression: Double,
         bookmarkTitle: String,
+        /** Computed `font-family` at the bookmark's anchor element. Same non-null contract as
+         *  [createHighlight]. */
+        originFontFamily: String,
     ): Annotation
 
     /**


### PR DESCRIPTION
Closes #484

## Summary

The Annotations View (elided view) rendered every excerpt — plus the chapter title, notes, and figcaptions — in ReadiumCSS's default serif, even when the source book shipped a sans-serif via publisher CSS. Now the elided view inherits the origin's face across the whole document, with per-annotation fidelity where captured.

## What changed

**Per-annotation origin font capture.**
- New nullable `AnnotationEntity.originFontFamily` column (Room v50→v51; renumbered from v50 during rebase after a merge-window collision with the `seriesSequence` migration on main).
- `SELECTION_SPAN_TRACKER_JS` reads `getComputedStyle(range.startElement).fontFamily` at selection time and stashes it. Continuous mode reads via the existing selection JSON payload; paginated mode receives it through a new `RiffleSelBridge.onFontFamily` bridge method.
- `AnnotationStore.createHighlight`/`createBookmark` grow a required non-null `originFontFamily: String` param; impl `require`s non-blank at write time. Sync ingest and image-annotation writes stay nullable.

**WebView body-font probe + retroactive backfill.**
- `SELECTION_SPAN_TRACKER_JS` installer also reads `getComputedStyle(document.body).fontFamily` once per chapter load; stashes on `window.__riffleBookBodyFont` and bridges to Kotlin.
- Paginated: routed through `RiffleSelectionRectBridge.onBookBodyFont`. Continuous: `ChapterWebView.onPageFinished` reads the stash via `evaluateJavascript` and fires `onBookBodyFont`.
- New `AnnotationDao.backfillNullOriginFontFamily` — one UPDATE per book, populates every legacy null-font row with the probed value; bumps `updatedAt`/`lastModifiedByDeviceId` so it syncs.
- VM invokes it set-once per (session, book) on the first non-blank probe.

**Elided render inline styles.**
- `HighlightsPublicationFactory.renderChapterHtml` emits a `<style>` block with `body, h1, h2, h3, h4, h5, h6, aside, figcaption, .riffle-fig { font-family: <book> !important; }` — the `!important` is load-bearing because ReadiumCSS-default.css sets heading font-family via `--RS__*Font*` variables at higher specificity.
- Per-excerpt `<p>` inline `font-family: <captured> !important` — inline `!important` beats stylesheet `!important` at equal specificity, so the annotation-specific font wins for its own excerpt.
- Values sanitized against a strict allowlist before write so a malformed DB row can't inject CSS.

**Rebase resolution.**
- Renumbered the migration mechanically (v49→v50 → v49→v50 seriesSequence on main, v50→v51 originFontFamily here). Test + `DatabaseModule` chain + schema JSON regenerated.

## Test plan

- [x] `./gradlew test` — all JVM suites green.
- [x] New unit tests: `HighlightsPublicationFactoryTest` (inline font per excerpt, body/heading `<style>` block, plurality fallback, malicious-value drop), `AnnotationStoreImplTest` (round-trip highlights/bookmarks, blank-input rejection).
- [x] New instrumentation test: `MigrationTest.migration50To51_addsOriginFontFamilyColumnToAnnotations` + append to `migrateFullChain`. `AnnotationDaoTest.originFontFamily_roundTripsAndDefaultsNull`.
- [ ] **On-device verification pending**: build+install this branch; confirm on a sans-serif book that (a) the chapter title, notes, and legacy annotation excerpts inherit sans (not serif), (b) new highlights render in their captured face, (c) legacy rows get backfilled by the DB after a FullBook chapter opens.